### PR TITLE
sessionctx/variable: put TiDBOptRangeMaxSize to right place and set default value to 0

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -843,12 +843,12 @@ func TestGetSetNoopVars(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, "[variable:1231]Variable 'tidb_enable_noop_variables' can't be set to the value of 'warn'", err.Error())
 
-	tk.MustQuery("select @@tidb_opt_range_max_size").Check(testkit.Rows("67108864"))
+	tk.MustQuery("select @@tidb_opt_range_max_size").Check(testkit.Rows("0"))
+	tk.MustExec("set global tidb_opt_range_max_size = 1048576")
+	tk.MustQuery("select @@global.tidb_opt_range_max_size").Check(testkit.Rows("1048576"))
 	tk.MustExec("set global tidb_opt_range_max_size = -1")
 	tk.MustQuery("show warnings").Check(testkit.RowsWithSep("|", "Warning|1292|Truncated incorrect tidb_opt_range_max_size value: '-1'"))
 	tk.MustQuery("select @@global.tidb_opt_range_max_size").Check(testkit.Rows("0"))
-	tk.MustExec("set global tidb_opt_range_max_size = 1048576")
-	tk.MustQuery("select @@global.tidb_opt_range_max_size").Check(testkit.Rows("1048576"))
 	tk.MustExec("set session tidb_opt_range_max_size = 2097152")
 	tk.MustQuery("select @@session.tidb_opt_range_max_size").Check(testkit.Rows("2097152"))
 }

--- a/sessionctx/variable/BUILD.bazel
+++ b/sessionctx/variable/BUILD.bazel
@@ -47,7 +47,6 @@ go_library(
         "//util/memory",
         "//util/paging",
         "//util/rowcodec",
-        "//util/size",
         "//util/stmtsummary",
         "//util/stringutil",
         "//util/tableutil",

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable/featuretag/concurrencyddl"
 	"github.com/pingcap/tidb/util/paging"
-	"github.com/pingcap/tidb/util/size"
 	"go.uber.org/atomic"
 )
 
@@ -746,6 +745,11 @@ const (
 	// TiDBEnableForeignKey indicates whether to enable foreign key feature.
 	// TODO(crazycs520): remove this after foreign key GA.
 	TiDBEnableForeignKey = "tidb_enable_foreign_key"
+
+	// TiDBOptRangeMaxSize is the max memory limit for ranges. When the optimizer estimates that the memory usage of complete
+	// ranges would exceed the limit, it chooses less accurate ranges such as full range. 0 indicates that there is no memory
+	// limit for ranges.
+	TiDBOptRangeMaxSize = "tidb_opt_range_max_size"
 )
 
 // TiDB vars that have only global scope
@@ -818,10 +822,6 @@ const (
 	TiDBDDLEnableFastReorg = "tidb_ddl_enable_fast_reorg"
 	// TiDBDDLDiskQuota used to set disk quota for lightning add index.
 	TiDBDDLDiskQuota = "tidb_ddl_disk_quota"
-	// TiDBOptRangeMaxSize is the max memory limit for ranges. When the optimizer estimates that the memory usage of complete
-	// ranges would exceed the limit, it chooses less accurate ranges such as full range. 0 indicates that there is no memory
-	// limit for ranges.
-	TiDBOptRangeMaxSize = "tidb_opt_range_max_size"
 )
 
 // TiDB intentional limits
@@ -1052,7 +1052,7 @@ const (
 	DefTiDBRcWriteCheckTs                           = false
 	DefTiDBConstraintCheckInPlacePessimistic        = true
 	DefTiDBForeignKeyChecks                         = false
-	DefTiDBOptRangeMaxSize                          = 64 * int64(size.MB) // 64 MB
+	DefTiDBOptRangeMaxSize                          = 0
 )
 
 // Process global variables.


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #37176

Problem Summary:

### What is changed and how it works?
1. Put `TiDBOptRangeMaxSize` to the right place. It was with vars having only global scope. Now we put it with vars having both global and session scope.
2. Since range mem control mechanism is not GA for v6.3, we change the default value of `TiDBOptRangeMaxSize`, which indicates no range mem limit.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
