### PR TITLE
planner: PhysicalPlan memory trace 5

### DIFF
--- a/planner/core/binary_plan_test.go
+++ b/planner/core/binary_plan_test.go
@@ -17,12 +17,6 @@ package core_test
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"regexp"
-	"strings"
-	"testing"
-
 	"github.com/golang/snappy"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/parser/auth"
@@ -34,6 +28,11 @@ import (
 	"github.com/pingcap/tidb/util/stmtsummary"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 )
 
 func simplifyAndCheckBinaryPlan(t *testing.T, pb *tipb.ExplainData) {

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1104,6 +1104,19 @@ func (p *PhysicalHashJoin) ExtractCorrelatedCols() []*expression.CorrelatedColum
 	return corCols
 }
 
+// MemoryUsage return the memory usage of PhysicalHashJoin
+func (p *PhysicalHashJoin) MemoryUsage() (sum int64) {
+	if p == nil {
+		return
+	}
+	sum = p.basePhysicalJoin.MemoryUsage() + size.SizeOfUint + size.SizeOfBool*2 + size.SizeOfUint8 + size.SizeOfSlice
+
+	for _, expr := range p.EqualConditions {
+		sum += expr.MemoryUsage()
+	}
+	return
+}
+
 // NewPhysicalHashJoin creates a new PhysicalHashJoin from LogicalJoin.
 func NewPhysicalHashJoin(p *LogicalJoin, innerIdx int, useOuterToBuild bool, newStats *property.StatsInfo, prop ...*property.PhysicalProperty) *PhysicalHashJoin {
 	leftJoinKeys, rightJoinKeys, isNullEQ, _ := p.GetJoinKeys()

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1166,6 +1166,24 @@ type PhysicalIndexJoin struct {
 	InnerHashKeys []*expression.Column
 }
 
+// MemoryUsage return the memory usage of PhysicalIndexJoin
+func (p *PhysicalIndexJoin) MemoryUsage() (sum int64) {
+	if p == nil {
+		return
+	}
+
+	sum = p.basePhysicalJoin.MemoryUsage() + size.SizeOfInterface*2 +
+		int64(cap(p.KeyOff2IdxOff)+cap(p.IdxColLens))*size.SizeOfInt + p.CompareFilters.MemoryUsage()
+
+	for _, col := range p.OuterHashKeys {
+		sum += col.MemoryUsage()
+	}
+	for _, col := range p.InnerHashKeys {
+		sum += col.MemoryUsage()
+	}
+	return
+}
+
 // PhysicalIndexMergeJoin represents the plan of index look up merge join.
 type PhysicalIndexMergeJoin struct {
 	PhysicalIndexJoin

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1191,6 +1191,15 @@ type PhysicalIndexHashJoin struct {
 	KeepOuterOrder bool
 }
 
+// MemoryUsage return the memory usage of PhysicalIndexHashJoin
+func (p *PhysicalIndexHashJoin) MemoryUsage() (sum int64) {
+	if p == nil {
+		return
+	}
+
+	return p.PhysicalIndexJoin.MemoryUsage() + size.SizeOfBool
+}
+
 // PhysicalMergeJoin represents merge join implementation of LogicalJoin.
 type PhysicalMergeJoin struct {
 	basePhysicalJoin
@@ -1198,6 +1207,15 @@ type PhysicalMergeJoin struct {
 	CompareFuncs []expression.CompareFunc
 	// Desc means whether inner child keep desc order.
 	Desc bool
+}
+
+// MemoryUsage return the memory usage of PhysicalMergeJoin
+func (p *PhysicalMergeJoin) MemoryUsage() (sum int64) {
+	if p == nil {
+		return
+	}
+
+	return p.basePhysicalJoin.MemoryUsage() + int64(cap(p.CompareFuncs))*size.SizeOfFunc + size.SizeOfBool
 }
 
 // PhysicalExchangeReceiver accepts connection and receives data passively.

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1018,6 +1018,43 @@ func (p *basePhysicalJoin) ExtractCorrelatedCols() []*expression.CorrelatedColum
 	return corCols
 }
 
+const emptyBasePhysicalJoinSize = int64(unsafe.Sizeof(basePhysicalJoin{}))
+
+// MemoryUsage return the memory usage of basePhysicalJoin
+func (p *basePhysicalJoin) MemoryUsage() (sum int64) {
+	if p == nil {
+		return
+	}
+
+	sum = emptyPartitionInfoSize + p.physicalSchemaProducer.MemoryUsage() + int64(cap(p.IsNullEQ))*size.SizeOfBool
+
+	for _, cond := range p.LeftConditions {
+		sum += cond.MemoryUsage()
+	}
+	for _, cond := range p.RightConditions {
+		sum += cond.MemoryUsage()
+	}
+	for _, cond := range p.OtherConditions {
+		sum += cond.MemoryUsage()
+	}
+	for _, col := range p.LeftJoinKeys {
+		sum += col.MemoryUsage()
+	}
+	for _, col := range p.RightJoinKeys {
+		sum += col.MemoryUsage()
+	}
+	for _, col := range p.InnerJoinKeys {
+		sum += col.MemoryUsage()
+	}
+	for _, col := range p.OuterJoinKeys {
+		sum += col.MemoryUsage()
+	}
+	for _, datum := range p.DefaultValues {
+		sum += datum.MemUsage()
+	}
+	return
+}
+
 // PhysicalHashJoin represents hash join implementation of LogicalJoin.
 type PhysicalHashJoin struct {
 	basePhysicalJoin

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1173,7 +1173,10 @@ func (p *PhysicalIndexJoin) MemoryUsage() (sum int64) {
 	}
 
 	sum = p.basePhysicalJoin.MemoryUsage() + size.SizeOfInterface*2 +
-		int64(cap(p.KeyOff2IdxOff)+cap(p.IdxColLens))*size.SizeOfInt + p.CompareFilters.MemoryUsage()
+		int64(cap(p.KeyOff2IdxOff)+cap(p.IdxColLens))*size.SizeOfInt
+	if p.CompareFilters != nil {
+		sum += p.CompareFilters.MemoryUsage()
+	}
 
 	for _, col := range p.OuterHashKeys {
 		sum += col.MemoryUsage()
@@ -1199,6 +1202,17 @@ type PhysicalIndexMergeJoin struct {
 	NeedOuterSort bool
 	// Desc means whether inner child keep desc order.
 	Desc bool
+}
+
+// MemoryUsage return the memory usage of PhysicalIndexMergeJoin
+func (p *PhysicalIndexMergeJoin) MemoryUsage() (sum int64) {
+	if p == nil {
+		return
+	}
+
+	sum = p.PhysicalIndexJoin.MemoryUsage() + int64(cap(p.KeyOff2KeyOffOrderByIdx))*size.SizeOfInt +
+		int64(cap(p.CompareFuncs)+cap(p.OuterCompareFuncs))*size.SizeOfFunc + size.SizeOfBool*2
+	return
 }
 
 // PhysicalIndexHashJoin represents the plan of index look up hash join.

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1109,6 +1109,7 @@ func (p *PhysicalHashJoin) MemoryUsage() (sum int64) {
 	if p == nil {
 		return
 	}
+
 	sum = p.basePhysicalJoin.MemoryUsage() + size.SizeOfUint + size.SizeOfBool*2 + size.SizeOfUint8 + size.SizeOfSlice
 
 	for _, expr := range p.EqualConditions {

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1026,7 +1026,7 @@ func (p *basePhysicalJoin) MemoryUsage() (sum int64) {
 		return
 	}
 
-	sum = emptyPartitionInfoSize + p.physicalSchemaProducer.MemoryUsage() + int64(cap(p.IsNullEQ))*size.SizeOfBool
+	sum = emptyBasePhysicalJoinSize + p.physicalSchemaProducer.MemoryUsage() + int64(cap(p.IsNullEQ))*size.SizeOfBool
 
 	for _, cond := range p.LeftConditions {
 		sum += cond.MemoryUsage()

--- a/util/size/size.go
+++ b/util/size/size.go
@@ -66,4 +66,7 @@ const (
 
 	// SizeOfUint8 is the memory each uint occupied
 	SizeOfUint8 = int64(unsafe.Sizeof(*new(uint8)))
+
+	// SizeOfFunc is the memory each function occupied
+	SizeOfFunc = int64(unsafe.Sizeof(*new(func())))
 )

--- a/util/size/size.go
+++ b/util/size/size.go
@@ -60,4 +60,10 @@ const (
 
 	// SizeOfInt is the memory each int occupied
 	SizeOfInt = int64(unsafe.Sizeof(*new(int)))
+
+	// SizeOfUint is the memory each uint occupied
+	SizeOfUint = int64(unsafe.Sizeof(*new(uint)))
+
+	// SizeOfUint8 is the memory each uint occupied
+	SizeOfUint8 = int64(unsafe.Sizeof(*new(uint8)))
 )


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #37632 

Problem Summary:

### What is changed and how it works?
Implement MemoryUsage() for
* PhysicalHashJoin
* PhysicalIndexHashJoin 
* PhysicalIndexJoin 
* PhysicalIndexMergeJoin 
* PhysicalMergeJoin 
* basePhysicalJoin
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
