### PR TITLE
datum: json is not equal with NULL

### DIFF
--- a/types/datum.go
+++ b/types/datum.go
@@ -855,6 +855,11 @@ func (d *Datum) compareMysqlSet(sc *stmtctx.StatementContext, set Set, comparer 
 }
 
 func (d *Datum) compareMysqlJSON(_ *stmtctx.StatementContext, target BinaryJSON) (int, error) {
+	// json is not equal with NULL
+	if d.k == KindNull {
+		return 1, nil
+	}
+
 	origin, err := d.ToMysqlJSON()
 	if err != nil {
 		return 0, errors.Trace(err)

--- a/types/datum_test.go
+++ b/types/datum_test.go
@@ -676,3 +676,31 @@ func TestProduceDecWithSpecifiedTp(t *testing.T) {
 		}
 	}
 }
+
+func TestNULLNotEqualWithOthers(t *testing.T) {
+	datums := []Datum{
+		NewIntDatum(0),
+		NewUintDatum(0),
+		NewFloat32Datum(0),
+		NewFloat64Datum(0),
+		NewDatum(math.Inf(0)),
+		NewDecimalDatum(NewDecFromStringForTest("0")),
+		NewStringDatum(""),
+		NewCollationStringDatum("", charset.CollationBin),
+		NewDurationDatum(Duration{Duration: time.Duration(0)}),
+		NewTimeDatum(ZeroTime),
+		NewBytesDatum([]byte("")),
+		NewBinaryLiteralDatum([]byte{}),
+		NewMysqlBitDatum(NewBinaryLiteralFromUint(0, 4)),
+		NewJSONDatum(CreateBinaryJSON(nil)),
+		MinNotNullDatum(),
+		MaxValueDatum(),
+	}
+	nullDatum := NewDatum(nil)
+	sc := new(stmtctx.StatementContext)
+	for _, d := range datums {
+		result, err := d.Compare(sc, &nullDatum, collate.GetBinaryCollator())
+		require.NoError(t, err)
+		require.NotEqual(t, 0, result)
+	}
+}


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #37852 

Problem Summary:

The json `null` is regarded the same with NULL, and then TiDB refuses to update it :thinking:. It expected that they are not equal in any senerio (not only for `update`, but also in `select j = NULL from t;`, and other cases).

### What is changed and how it works?

Add a special condition to return 1 for comparing json and NULL.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Fix the issue that the user cannot update from json 'null' to NULL
```
