### PR TITLE
ddl, transaction: DDL won't affect transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ checkdep:
 
 tools/bin/megacheck: tools/check/go.mod
 	cd tools/check; \
-	$(GO) build -o ../bin/megacheck honnef.co/go/tools/cmd/megacheck
+	$(GO) build -o ../bin/megacheck honnef.co/go/tools/cmd/megacheck@v0.0.1-2020.1.6
 
 tools/bin/revive: tools/check/go.mod
 	cd tools/check; \

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ vet:
 	$(GO) vet -all $(PACKAGES) 2>&1 | $(FAIL_ON_STDOUT)
 
 staticcheck:
-	$(GO) get honnef.co/go/tools/cmd/staticcheck
+	$(GO) get honnef.co/go/tools/cmd/staticcheck@v0.0.1-2020.1.6
 	$(STATICCHECK) ./...
 
 tidy:

--- a/domain/schema_validator.go
+++ b/domain/schema_validator.go
@@ -227,8 +227,9 @@ func (s *schemaValidator) Check(txnTS uint64, schemaVer int64, relatedPhysicalTa
 
 	// Schema changed, result decided by whether related tables change.
 	if schemaVer < s.latestSchemaVer {
-		// The DDL relatedPhysicalTableIDs is empty.
-		if len(relatedPhysicalTableIDs) == 0 {
+		// When a transaction executes a DDL, relatedPhysicalTableIDs is nil.
+		// When a transaction only contains DML on temporary tables, relatedPhysicalTableIDs is [].
+		if relatedPhysicalTableIDs == nil {
 			logutil.BgLogger().Info("the related physical table ID is empty", zap.Int64("schemaVer", schemaVer),
 				zap.Int64("latestSchemaVer", s.latestSchemaVer))
 			return nil, ResultFail

--- a/domain/schema_validator_test.go
+++ b/domain/schema_validator_test.go
@@ -16,15 +16,12 @@ package domain
 import (
 	"math/rand"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/oracle"
-	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 )
 
@@ -109,26 +106,6 @@ func (*testSuite) TestSchemaValidator(c *C) {
 
 	close(exit)
 	wg.Wait()
-}
-
-func (*testSuite) TestSchemaValidator2(c *C) {
-	tk := testkit.NewTestKitWithInit(c, s.store)
-	tk1 := testkit.NewTestKitWithInit(c, s.store)
-	// create table
-	tk.MustExec("create table t1(a int, b int);")
-	tk.MustExec("create table t2(a int, b int);")
-	tk.MustExec("insert into t1 value(1,1);")
-	tk.MustExec("insert into t2 value(1,1);")
-
-	// The schema version is out of date in the first transaction, and the SQL can't be retried.
-	atomic.StoreUint32(&session.SchemaChangedWithoutRetry, 1)
-	defer func() {
-		atomic.StoreUint32(&session.SchemaChangedWithoutRetry, 0)
-	}()
-	tk.MustExec(`begin;`)
-	tk.MustExec("update t1, t2 set t1.a = t2.b;")
-	tk1.MustExec("create table t3(a int, b int);")
-	tk.MustExec(`commit;`)
 }
 
 func getGreaterVersionItem(c *C, lease time.Duration, leaseGrantCh chan leaseGrantItem, currVer int64) leaseGrantItem {

--- a/session/session_fail_test.go
+++ b/session/session_fail_test.go
@@ -147,8 +147,7 @@ func (s *testSessionSerialSuite) TestClusterTableSendError(c *C) {
 func (s *testSessionSerialSuite) TestSchemaValidator2(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk1 := testkit.NewTestKitWithInit(c, s.store)
-	// create table
-	tk.MustExec("create database test")
+
 	tk.MustExec("use test")
 	tk.MustExec("create table t1(a int, b int);")
 	tk.MustExec("create table t2(a int, b int);")

--- a/session/session_fail_test.go
+++ b/session/session_fail_test.go
@@ -148,7 +148,8 @@ func (s *testSessionSerialSuite) TestSchemaValidator2(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk1 := testkit.NewTestKitWithInit(c, s.store)
 	// create table
-	tk.MustExec("create database ")
+	tk.MustExec("create database test")
+	tk.MustExec("use test")
 	tk.MustExec("create table t1(a int, b int);")
 	tk.MustExec("create table t2(a int, b int);")
 	tk.MustExec("insert into t1 value(1,1);")
@@ -161,6 +162,7 @@ func (s *testSessionSerialSuite) TestSchemaValidator2(c *C) {
 	}()
 	tk.MustExec(`begin;`)
 	tk.MustExec("update t1, t2 set t1.a = t2.b;")
+	tk1.MustExec("use test")
 	tk1.MustExec("create table t3(a int, b int);")
 	tk.MustExec(`commit;`)
 }

--- a/session/session_fail_test.go
+++ b/session/session_fail_test.go
@@ -144,7 +144,7 @@ func (s *testSessionSerialSuite) TestClusterTableSendError(c *C) {
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings()[0].Err, ErrorMatches, ".*TiDB server timeout, address is.*")
 }
 
-func (*testSessionSerialSuite) TestSchemaValidator2(c *C) {
+func (s *testSessionSerialSuite) TestSchemaValidator2(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk1 := testkit.NewTestKitWithInit(c, s.store)
 	// create table


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

When a transaction executes a DDL, relatedPhysicalTableIDs is nil.
When a transaction only contains DML, relatedPhysicalTableIDs is [].

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
