### PR TITLE
planner: fix nil pointer in plan cache LRU

### DIFF
--- a/planner/core/plan_cache_lru.go
+++ b/planner/core/plan_cache_lru.go
@@ -169,6 +169,9 @@ func (l *LRUPlanCache) SetCapacity(capacity uint) error {
 // removeOldest removes the oldest element from the cache.
 func (l *LRUPlanCache) removeOldest() {
 	lru := l.lruList.Back()
+	if lru == nil {
+		return
+	}
 	if l.onEvict != nil {
 		l.onEvict(lru.Value.(*planCacheEntry).PlanKey, lru.Value.(*planCacheEntry).PlanValue)
 	}

--- a/planner/core/plan_cache_lru.go
+++ b/planner/core/plan_cache_lru.go
@@ -191,7 +191,7 @@ func (l *LRUPlanCache) memoryControl() {
 	}
 
 	memUsed, _ := memory.InstanceMemUsed()
-	for memUsed > uint64(float64(l.quota)*(1.0-l.guard)) {
+	for memUsed > uint64(float64(l.quota)*(1.0-l.guard)) && l.size > 0 {
 		l.removeOldest()
 		memUsed, _ = memory.InstanceMemUsed()
 	}

--- a/planner/core/plan_cache_lru_test.go
+++ b/planner/core/plan_cache_lru_test.go
@@ -330,5 +330,7 @@ func TestIssue37914(t *testing.T) {
 		tps:  pTypes,
 	}
 
-	lru.Put(key, val, pTypes)
+	require.NotPanics(t, func() {
+		lru.Put(key, val, pTypes)
+	})
 }

--- a/planner/core/plan_cache_lru_test.go
+++ b/planner/core/plan_cache_lru_test.go
@@ -319,3 +319,16 @@ func TestLRUPCSetCapacity(t *testing.T) {
 	err = lru.SetCapacity(0)
 	require.Error(t, err, "capacity of LRU cache should be at least 1")
 }
+
+func TestIssue37914(t *testing.T) {
+	lru := NewLRUPlanCache(3, 0.1, 1, pickFromBucket)
+
+	pTypes := []*types.FieldType{types.NewFieldType(mysql.TypeFloat), types.NewFieldType(mysql.TypeDouble)}
+	key := newMockHashKey(int64(1))
+	val := &fakePlan{
+		plan: int64(1),
+		tps:  pTypes,
+	}
+
+	lru.Put(key, val, pTypes)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->
Forget consider the cache size when trigger memoryControl

Issue Number: close #37914 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
