### PR TITLE
test,ddl: fix data race in `TestCancel`

### DIFF
--- a/ddl/callback_test.go
+++ b/ddl/callback_test.go
@@ -138,6 +138,11 @@ func (tc *TestDDLCallback) OnGetJobAfter(jobType string, job *model.Job) {
 	tc.BaseCallback.OnGetJobAfter(jobType, job)
 }
 
+// Clone copies the callback and take its reference
+func (tc *TestDDLCallback) Clone() *TestDDLCallback {
+	return &*tc
+}
+
 func TestCallback(t *testing.T) {
 	cb := &BaseCallback{}
 	require.Nil(t, cb.OnChanged(nil))

--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -80,7 +80,7 @@ func TestColumnAdd(t *testing.T) {
 			require.NoError(t, checkAddPublic(ct, writeOnlyTable, publicTable))
 		}
 	}
-	d.SetHook(tc)
+	d.SetHook(tc.Clone())
 	tk.MustExec("alter table t add column c3 int default 3")
 	tb := publicTable
 	v := getSchemaVer(t, tk.Session())
@@ -105,7 +105,7 @@ func TestColumnAdd(t *testing.T) {
 			}
 		}
 	}
-	d.SetHook(tc)
+	d.SetHook(tc.Clone())
 	tk.MustExec("alter table t drop column c3")
 	v = getSchemaVer(t, tk.Session())
 	// Don't check column, so it's ok to use tb.


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

1. Some variables in the test is used concurrently. I used an atomic variable to read/write them to fix the data race
2. The callback struct is also concurrently modified. I add a clone method to copy it explicitly. 
    I have also considered other solutions, for example using non-pointer receiver to implement the callback, so it can be copied automatically when passing into the functions. However, as this struct contains a `*BaseCallback`, it could cause more problem when misused.

Issue Number: close #37757 

