### PR TITLE
config: introduce AtomicString for config items

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -59,6 +59,31 @@ func TestAtomicBoolUnmarshal(t *testing.T) {
 	require.EqualError(t, err, "Invalid value for bool type: 1")
 }
 
+func TestAtomicStringUnmarshal(t *testing.T) {
+	type data struct {
+		As AtomicString `toml:"as"`
+	}
+	var d data
+	var firstBuffer bytes.Buffer
+	_, err := toml.Decode("as=\"a_string_value\"", &d)
+	require.NoError(t, err)
+	require.Equal(t, "a_string_value", d.As.Load())
+	err = toml.NewEncoder(&firstBuffer).Encode(d)
+	require.NoError(t, err)
+	require.Equal(t, "as = \"a_string_value\"\n", firstBuffer.String())
+	firstBuffer.Reset()
+
+	_, err = toml.Decode("as=\"\"", &d)
+	require.NoError(t, err)
+	require.Equal(t, "", d.As.Load())
+	err = toml.NewEncoder(&firstBuffer).Encode(d)
+	require.NoError(t, err)
+	require.Equal(t, "as = \"\"\n", firstBuffer.String())
+
+	_, err = toml.Decode("as = ", &d)
+	require.Error(t, err)
+}
+
 func TestNullableBoolUnmarshal(t *testing.T) {
 	var nb = nullableBool{false, false}
 	data, err := json.Marshal(nb)

--- a/config/config_util.go
+++ b/config/config_util.go
@@ -18,7 +18,9 @@ import (
 	"encoding/json"
 	"reflect"
 
+	"github.com/pingcap/errors"
 	tikvcfg "github.com/tikv/client-go/v2/config"
+	atomicutil "go.uber.org/atomic"
 )
 
 // CloneConf deeply clones this config.
@@ -128,4 +130,125 @@ func flatten(flatMap map[string]interface{}, nested interface{}, prefix string) 
 // GetTxnScopeFromConfig extracts @@txn_scope value from the config.
 func GetTxnScopeFromConfig() string {
 	return tikvcfg.GetTxnScopeFromConfig()
+}
+
+// nullableBool defaults unset bool options to unset instead of false, which enables us to know if the user has set 2
+// conflict options at the same time.
+type nullableBool struct {
+	IsValid bool
+	IsTrue  bool
+}
+
+func (b *nullableBool) toBool() bool {
+	return b.IsValid && b.IsTrue
+}
+
+func (b nullableBool) MarshalJSON() ([]byte, error) {
+	switch b {
+	case nbTrue:
+		return json.Marshal(true)
+	case nbFalse:
+		return json.Marshal(false)
+	default:
+		return json.Marshal(nil)
+	}
+}
+
+func (b *nullableBool) UnmarshalText(text []byte) error {
+	str := string(text)
+	switch str {
+	case "", "null":
+		*b = nbUnset
+		return nil
+	case "true":
+		*b = nbTrue
+	case "false":
+		*b = nbFalse
+	default:
+		*b = nbUnset
+		return errors.New("Invalid value for bool type: " + str)
+	}
+	return nil
+}
+
+func (b nullableBool) MarshalText() ([]byte, error) {
+	if !b.IsValid {
+		return []byte(""), nil
+	}
+	if b.IsTrue {
+		return []byte("true"), nil
+	}
+	return []byte("false"), nil
+}
+
+func (b *nullableBool) UnmarshalJSON(data []byte) error {
+	var err error
+	var v interface{}
+	if err = json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	switch raw := v.(type) {
+	case bool:
+		*b = nullableBool{true, raw}
+	default:
+		*b = nbUnset
+	}
+	return err
+}
+
+// AtomicBool is a helper type for atomic operations on a boolean value.
+type AtomicBool struct {
+	atomicutil.Bool
+}
+
+// NewAtomicBool creates an AtomicBool.
+func NewAtomicBool(v bool) *AtomicBool {
+	return &AtomicBool{*atomicutil.NewBool(v)}
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+func (b AtomicBool) MarshalText() ([]byte, error) {
+	if b.Load() {
+		return []byte("true"), nil
+	}
+	return []byte("false"), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (b *AtomicBool) UnmarshalText(text []byte) error {
+	str := string(text)
+	switch str {
+	case "", "null":
+		*b = AtomicBool{*atomicutil.NewBool(false)}
+	case "true":
+		*b = AtomicBool{*atomicutil.NewBool(true)}
+	case "false":
+		*b = AtomicBool{*atomicutil.NewBool(false)}
+	default:
+		*b = AtomicBool{*atomicutil.NewBool(false)}
+		return errors.New("Invalid value for bool type: " + str)
+	}
+	return nil
+}
+
+// AtomicString is a helper type for atomic operations on a string value.
+type AtomicString struct {
+	atomicutil.String
+}
+
+// NewAtomicString creates an AtomicString
+func NewAtomicString(v string) *AtomicString {
+	return &AtomicString{*atomicutil.NewString(v)}
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+func (s AtomicString) MarshalText() ([]byte, error) {
+	return []byte(s.Load()), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (s *AtomicString) UnmarshalText(text []byte) error {
+	str := string(text)
+	*s = AtomicString{*atomicutil.NewString(str)}
+	return nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38034

Problem Summary:

In `config` module, we only implement `AtomicBool`. As in https://github.com/pingcap/tidb/pull/36849#discussion_r947628628, we need to implement `tmpdir` as an atomic string config. I would like to implement it in this separate PR.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
