### PR TITLE
parser: allow drop stats of multiple tables

### DIFF
--- a/executor/simpletest/simple_test.go
+++ b/executor/simpletest/simple_test.go
@@ -1000,6 +1000,7 @@ partition by range (a) (
 	checkPartitionStats("global", "p0", "p1", "global")
 
 	tk.MustExec("drop stats test_drop_gstats partition p0")
+	tk.MustQuery("show warnings").Check(testkit.RowsWithSep("|", "Warning|1681|'DROP STATS ... PARTITION ...' is deprecated and will be removed in a future release."))
 	checkPartitionStats("global", "p1", "global")
 
 	err := tk.ExecToErr("drop stats test_drop_gstats partition abcde")
@@ -1010,6 +1011,7 @@ partition by range (a) (
 	checkPartitionStats("global", "p1")
 
 	tk.MustExec("drop stats test_drop_gstats global")
+	tk.MustQuery("show warnings").Check(testkit.RowsWithSep("|", "Warning|1287|'DROP STATS ... GLOBAL' is deprecated and will be removed in a future release. Please use DROP STATS ... instead"))
 	checkPartitionStats("p1")
 
 	tk.MustExec("analyze table test_drop_gstats")
@@ -1054,5 +1056,52 @@ func TestDropStats(t *testing.T) {
 	require.Nil(t, h.Update(is))
 	statsTbl = h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.Pseudo)
+	h.SetLease(0)
+}
+
+func TestDropStatsForMultipleTable(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	testKit := testkit.NewTestKit(t, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("create table t1 (c1 int, c2 int)")
+	testKit.MustExec("create table t2 (c1 int, c2 int)")
+
+	is := dom.InfoSchema()
+	tbl1, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
+	require.NoError(t, err)
+	tableInfo1 := tbl1.Meta()
+
+	tbl2, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t2"))
+	require.NoError(t, err)
+	tableInfo2 := tbl2.Meta()
+
+	h := dom.StatsHandle()
+	h.Clear()
+	testKit.MustExec("analyze table t1, t2")
+	statsTbl1 := h.GetTableStats(tableInfo1)
+	require.False(t, statsTbl1.Pseudo)
+	statsTbl2 := h.GetTableStats(tableInfo2)
+	require.False(t, statsTbl2.Pseudo)
+
+	testKit.MustExec("drop stats t1, t2")
+	require.Nil(t, h.Update(is))
+	statsTbl1 = h.GetTableStats(tableInfo1)
+	require.True(t, statsTbl1.Pseudo)
+	statsTbl2 = h.GetTableStats(tableInfo2)
+	require.True(t, statsTbl2.Pseudo)
+
+	testKit.MustExec("analyze table t1, t2")
+	statsTbl1 = h.GetTableStats(tableInfo1)
+	require.False(t, statsTbl1.Pseudo)
+	statsTbl2 = h.GetTableStats(tableInfo2)
+	require.False(t, statsTbl2.Pseudo)
+
+	h.SetLease(1)
+	testKit.MustExec("drop stats t1, t2")
+	require.Nil(t, h.Update(is))
+	statsTbl1 = h.GetTableStats(tableInfo1)
+	require.True(t, statsTbl1.Pseudo)
+	statsTbl2 = h.GetTableStats(tableInfo2)
+	require.True(t, statsTbl2.Pseudo)
 	h.SetLease(0)
 }

--- a/parser/ast/misc_test.go
+++ b/parser/ast/misc_test.go
@@ -75,7 +75,11 @@ func TestMiscVisitorCover(t *testing.T) {
 		&ast.PrivElem{},
 		&ast.VariableAssignment{Value: valueExpr},
 		&ast.KillStmt{},
-		&ast.DropStatsStmt{Table: &ast.TableName{}},
+		&ast.DropStatsStmt{
+			Tables: []*ast.TableName{
+				{},
+			},
+		},
 		&ast.ShutdownStmt{},
 	}
 

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -4779,21 +4779,25 @@ DropRoleStmt:
 	}
 
 DropStatsStmt:
-	"DROP" "STATS" TableName
+	"DROP" "STATS" TableNameList
 	{
-		$$ = &ast.DropStatsStmt{Table: $3.(*ast.TableName)}
+		$$ = &ast.DropStatsStmt{Tables: $3.([]*ast.TableName)}
 	}
 |	"DROP" "STATS" TableName "PARTITION" PartitionNameList
 	{
+		yylex.AppendError(ErrWarnDeprecatedSyntaxNoReplacement.FastGenByArgs("DROP STATS ... PARTITION ..."))
+		parser.lastErrorAsWarn()
 		$$ = &ast.DropStatsStmt{
-			Table:          $3.(*ast.TableName),
+			Tables:         []*ast.TableName{$3.(*ast.TableName)},
 			PartitionNames: $5.([]model.CIStr),
 		}
 	}
 |	"DROP" "STATS" TableName "GLOBAL"
 	{
+		yylex.AppendError(ErrWarnDeprecatedSyntax.FastGenByArgs("DROP STATS ... GLOBAL", "DROP STATS ..."))
+		parser.lastErrorAsWarn()
 		$$ = &ast.DropStatsStmt{
-			Table:         $3.(*ast.TableName),
+			Tables:        []*ast.TableName{$3.(*ast.TableName)},
 			IsGlobalStats: true,
 		}
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2660,9 +2660,10 @@ func TestDDL(t *testing.T) {
 		{"drop view if exists xxx", true, "DROP VIEW IF EXISTS `xxx`"},
 		{"drop view if exists xxx, yyy", true, "DROP VIEW IF EXISTS `xxx`, `yyy`"},
 		{"drop stats t", true, "DROP STATS `t`"},
+		{"drop stats t1, t2, t3", true, "DROP STATS `t1`, `t2`, `t3`"},
+		{"drop stats t global", true, "DROP STATS `t` GLOBAL"},
 		{"drop stats t partition p0", true, "DROP STATS `t` PARTITION `p0`"},
 		{"drop stats t partition p0, p1, p2", true, "DROP STATS `t` PARTITION `p0`,`p1`,`p2`"},
-		{"drop stats t global", true, "DROP STATS `t` GLOBAL"},
 		// for issue 974
 		{`CREATE TABLE address (
 		id bigint(20) NOT NULL AUTO_INCREMENT,

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -52,6 +52,8 @@ var (
 	ErrUnknownAlterAlgorithm = terror.ClassParser.NewStd(mysql.ErrUnknownAlterAlgorithm)
 	// ErrWrongValue returns for wrong value
 	ErrWrongValue = terror.ClassParser.NewStd(mysql.ErrWrongValue)
+	// ErrWarnDeprecatedSyntax return when the syntax was deprecated
+	ErrWarnDeprecatedSyntax = terror.ClassParser.NewStd(mysql.ErrWarnDeprecatedSyntax)
 	// ErrWarnDeprecatedSyntaxNoReplacement return when the syntax was deprecated and there is no replacement.
 	ErrWarnDeprecatedSyntaxNoReplacement = terror.ClassParser.NewStd(mysql.ErrWarnDeprecatedSyntaxNoReplacement)
 	// ErrWarnDeprecatedIntegerDisplayWidth share the same code 1681, and it will be returned when length is specified in integer.


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #37872 

Problem Summary:

`DROP STATS` doesn't allow dropping stats of multiple tables now.

### What is changed and how it works?

This PR modifies the parser and executors to allow dropping multiple tables without partitions. 

The grammar should be discussed, as the `DROP STATS t1, t2 GLOBAL` and `DROP STATS t PARTITION xxx` is not consistent now. I'm not sure whether it's expected, or I shouldn't allow dropping multiple tables with `GLOBAL` at the end?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Allow dropping stats of multiple tables
```
