### PR TITLE
copr: enable region load balance for MPP

### DIFF
--- a/executor/tiflashtest/BUILD.bazel
+++ b/executor/tiflashtest/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "tiflash_test.go",
     ],
     flaky = True,
+    race = "on",
     deps = [
         "//config",
         "//domain",

--- a/executor/tiflashtest/tiflash_test.go
+++ b/executor/tiflashtest/tiflash_test.go
@@ -467,7 +467,7 @@ func TestPartitionTable(t *testing.T) {
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t(a int not null primary key, b int not null) partition by hash(a+1) partitions 4")
 	// Looks like setting replica number of a region is not supported in mock store, a region always has n replicas(where n
-	// is the number of stores), in this test, there are 2 TiFlash store, so the TiFlash replica is always 2, so change the
+	// is the number of stores), in this test, there are 2 TiFlash store, so the TiFlash replica is always 2, change the
 	// TiFlash replica to 2 to make it consist with mock store.
 	tk.MustExec("alter table t set tiflash replica 2")
 	tb := external.GetTableByName(t, tk, "test", "t")

--- a/executor/tiflashtest/tiflash_test.go
+++ b/executor/tiflashtest/tiflash_test.go
@@ -733,6 +733,7 @@ func TestMppUnionAll(t *testing.T) {
 	tk.MustExec("set tidb_opt_mpp_outer_join_fixed_build_side=1")
 
 	// test join + union (join + select)
+	failpoint.Disable("github.com/pingcap/tidb/executor/checkTotalMPPTasks")
 	tk.MustQuery("select x1.a, x.a from x1 left join (select x2.b a, x1.b from x1 join x2 on x1.a = x2.b union all select * from x1 ) x on x1.a = x.a order by x1.a").Check(testkit.Rows("1 1", "1 1", "2 2", "2 2", "3 3", "3 3", "4 4", "4 4"))
 	tk.MustQuery("select x1.a, x.a from x1 left join (select count(*) a, sum(b) b from x1 group by a union all select * from x2 ) x on x1.a = x.a order by x1.a").Check(testkit.Rows("1 1", "1 1", "1 1", "1 1", "2 2", "3 3", "4 4"))
 

--- a/executor/tiflashtest/tiflash_test.go
+++ b/executor/tiflashtest/tiflash_test.go
@@ -207,7 +207,7 @@ func TestMppExecution(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int not null primary key, b int not null)")
-	tk.MustExec("alter table t set tiflash replica 1")
+	tk.MustExec("alter table t set tiflash replica 2")
 	tb := external.GetTableByName(t, tk, "test", "t")
 	err := domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
 	require.NoError(t, err)
@@ -216,7 +216,7 @@ func TestMppExecution(t *testing.T) {
 	tk.MustExec("insert into t values(3,0)")
 
 	tk.MustExec("create table t1(a int primary key, b int not null)")
-	tk.MustExec("alter table t1 set tiflash replica 1")
+	tk.MustExec("alter table t1 set tiflash replica 2")
 	tb = external.GetTableByName(t, tk, "test", "t1")
 	err = domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
 	require.NoError(t, err)
@@ -466,7 +466,10 @@ func TestPartitionTable(t *testing.T) {
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t(a int not null primary key, b int not null) partition by hash(a+1) partitions 4")
-	tk.MustExec("alter table t set tiflash replica 1")
+	// Looks like setting replica number of a region is not supported in mock store, a region always has n replicas(where n
+	// is the number of stores), in this test, there are 2 TiFlash store, so the TiFlash replica is always 2, so change the
+	// TiFlash replica to 2 to make it consist with mock store.
+	tk.MustExec("alter table t set tiflash replica 2")
 	tb := external.GetTableByName(t, tk, "test", "t")
 	err := domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
 	require.NoError(t, err)
@@ -480,7 +483,7 @@ func TestPartitionTable(t *testing.T) {
 	// mock executor does not support use outer table as build side for outer join, so need to
 	// force the inner table as build side
 	tk.MustExec("set tidb_opt_mpp_outer_join_fixed_build_side=1")
-	failpoint.Enable("github.com/pingcap/tidb/executor/checkTotalMPPTasks", `return(1)`)
+	failpoint.Enable("github.com/pingcap/tidb/executor/checkTotalMPPTasks", `return(2)`)
 	tk.MustQuery("select count(*) from t").Check(testkit.Rows("4"))
 	failpoint.Disable("github.com/pingcap/tidb/executor/checkTotalMPPTasks")
 	tk.MustExec("set @@session.tidb_partition_prune_mode='static-only'")
@@ -490,7 +493,7 @@ func TestPartitionTable(t *testing.T) {
 	failpoint.Enable("github.com/pingcap/tidb/executor/checkUseMPP", `return(true)`)
 
 	tk.MustExec("create table t1(a int not null primary key, b int not null) partition by hash(a) partitions 4")
-	tk.MustExec("alter table t1 set tiflash replica 1")
+	tk.MustExec("alter table t1 set tiflash replica 2")
 	tb = external.GetTableByName(t, tk, "test", "t1")
 	err = domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
 	require.NoError(t, err)
@@ -502,7 +505,7 @@ func TestPartitionTable(t *testing.T) {
 	tk.MustExec("set @@session.tidb_isolation_read_engines=\"tiflash\"")
 	tk.MustExec("set @@session.tidb_allow_mpp=ON")
 	// test if it is really work.
-	failpoint.Enable("github.com/pingcap/tidb/executor/checkTotalMPPTasks", `return(2)`)
+	failpoint.Enable("github.com/pingcap/tidb/executor/checkTotalMPPTasks", `return(4)`)
 	tk.MustQuery("select count(*) from t1 , t where t1.a = t.a").Check(testkit.Rows("4"))
 	// test partition prune
 	tk.MustQuery("select count(*) from t1 , t where t1.a = t.a and t1.a < 2 and t.a < 2").Check(testkit.Rows("1"))
@@ -510,7 +513,7 @@ func TestPartitionTable(t *testing.T) {
 	failpoint.Disable("github.com/pingcap/tidb/executor/checkTotalMPPTasks")
 	// test multi-way join
 	tk.MustExec("create table t2(a int not null primary key, b int not null)")
-	tk.MustExec("alter table t2 set tiflash replica 1")
+	tk.MustExec("alter table t2 set tiflash replica 2")
 	tb = external.GetTableByName(t, tk, "test", "t2")
 	err = domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
 	require.NoError(t, err)
@@ -520,7 +523,7 @@ func TestPartitionTable(t *testing.T) {
 	tk.MustExec("insert into t2 values(3,0)")
 	tk.MustExec("insert into t2 values(4,0)")
 	// test with no partition table
-	failpoint.Enable("github.com/pingcap/tidb/executor/checkTotalMPPTasks", `return(3)`)
+	failpoint.Enable("github.com/pingcap/tidb/executor/checkTotalMPPTasks", `return(5)`)
 	tk.MustQuery("select count(*) from t1 , t, t2 where t1.a = t.a and t2.a = t.a").Check(testkit.Rows("4"))
 	failpoint.Disable("github.com/pingcap/tidb/executor/checkTotalMPPTasks")
 
@@ -530,7 +533,7 @@ func TestPartitionTable(t *testing.T) {
 		PARTITION p2 VALUES LESS THAN (5),
 		PARTITION p3 VALUES LESS THAN (7)
 	);`)
-	tk.MustExec("alter table t3 set tiflash replica 1")
+	tk.MustExec("alter table t3 set tiflash replica 2")
 	tb = external.GetTableByName(t, tk, "test", "t3")
 	err = domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
 	require.NoError(t, err)
@@ -540,10 +543,10 @@ func TestPartitionTable(t *testing.T) {
 	tk.MustExec("insert into t3 values(3,4)")
 	tk.MustExec("insert into t3 values(4,6)")
 
-	failpoint.Enable("github.com/pingcap/tidb/executor/checkTotalMPPTasks", `return(2)`)
+	failpoint.Enable("github.com/pingcap/tidb/executor/checkTotalMPPTasks", `return(4)`)
 	tk.MustQuery("select count(*) from t, t3 where t3.a = t.a and t3.b <= 4").Check(testkit.Rows("3"))
 	failpoint.Disable("github.com/pingcap/tidb/executor/checkTotalMPPTasks")
-	failpoint.Enable("github.com/pingcap/tidb/executor/checkTotalMPPTasks", `return(2)`)
+	failpoint.Enable("github.com/pingcap/tidb/executor/checkTotalMPPTasks", `return(3)`)
 	tk.MustQuery("select count(*) from t, t3 where t3.a = t.a and t3.b > 10").Check(testkit.Rows("0"))
 	failpoint.Disable("github.com/pingcap/tidb/executor/checkTotalMPPTasks")
 	failpoint.Disable("github.com/pingcap/tidb/executor/checkUseMPP")
@@ -715,10 +718,10 @@ func TestMppUnionAll(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists x1")
 	tk.MustExec("create table x1(a int , b int);")
-	tk.MustExec("alter table x1 set tiflash replica 1")
+	tk.MustExec("alter table x1 set tiflash replica 2")
 	tk.MustExec("drop table if exists x2")
 	tk.MustExec("create table x2(a int , b int);")
-	tk.MustExec("alter table x2 set tiflash replica 1")
+	tk.MustExec("alter table x2 set tiflash replica 2")
 	tb := external.GetTableByName(t, tk, "test", "x1")
 	err := domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
 	require.NoError(t, err)

--- a/executor/tiflashtest/tiflash_test.go
+++ b/executor/tiflashtest/tiflash_test.go
@@ -733,7 +733,6 @@ func TestMppUnionAll(t *testing.T) {
 	tk.MustExec("set tidb_opt_mpp_outer_join_fixed_build_side=1")
 
 	// test join + union (join + select)
-	failpoint.Disable("github.com/pingcap/tidb/executor/checkTotalMPPTasks")
 	tk.MustQuery("select x1.a, x.a from x1 left join (select x2.b a, x1.b from x1 join x2 on x1.a = x2.b union all select * from x1 ) x on x1.a = x.a order by x1.a").Check(testkit.Rows("1 1", "1 1", "2 2", "2 2", "3 3", "3 3", "4 4", "4 4"))
 	tk.MustQuery("select x1.a, x.a from x1 left join (select count(*) a, sum(b) b from x1 group by a union all select * from x2 ) x on x1.a = x.a order by x1.a").Check(testkit.Rows("1 1", "1 1", "1 1", "1 1", "2 2", "3 3", "4 4"))
 

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/tdakkota/asciicheck v0.1.1
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.1-0.20220921101651-ce9203ef66e9
+	github.com/tikv/client-go/v2 v2.0.1-0.20220923061703-33efe476e022
 	github.com/tikv/pd/client v0.0.0-20220725055910-7187a7ab72db
 	github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144
 	github.com/twmb/murmur3 v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -901,8 +901,8 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
-github.com/tikv/client-go/v2 v2.0.1-0.20220921101651-ce9203ef66e9 h1:GJNu6XDT8W2Oahh+w/fhb37PNhFr4EZjdehIklZnhU4=
-github.com/tikv/client-go/v2 v2.0.1-0.20220921101651-ce9203ef66e9/go.mod h1:6pedLz7wiINLHXwCT1+yMZmzuG42+ubtBkkfcwoukIo=
+github.com/tikv/client-go/v2 v2.0.1-0.20220923061703-33efe476e022 h1:TxDSQAmtGdE34BvOaYF35mRrAXePeZEq8quvuAwrKsI=
+github.com/tikv/client-go/v2 v2.0.1-0.20220923061703-33efe476e022/go.mod h1:6pedLz7wiINLHXwCT1+yMZmzuG42+ubtBkkfcwoukIo=
 github.com/tikv/pd/client v0.0.0-20220725055910-7187a7ab72db h1:r1eMh9Rny3hfWuBuxOnbsCRrR4FhthiNxLQ5rAUtaww=
 github.com/tikv/pd/client v0.0.0-20220725055910-7187a7ab72db/go.mod h1:ew8kS0yIcEaSetuuywkTLIUBR+sz3J5XvAYRae11qwc=
 github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144 h1:kl4KhGNsJIbDHS9/4U9yQo1UcPQM0kOMJHn29EoH/Ro=

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -575,9 +575,9 @@ func buildBatchCopTasksCore(bo *backoff.Backoffer, store *kvStore, rangesForEach
 
 		storeTaskMap := make(map[string]*batchCopTask)
 		needRetry := false
-		//isMPP := mppStoreLastFailTime != nil
+		isMPP := mppStoreLastFailTime != nil
 		for _, task := range tasks {
-			rpcCtx, err := cache.GetTiFlashRPCContext(bo.TiKVBackoffer(), task.region, true)
+			rpcCtx, err := cache.GetTiFlashRPCContext(bo.TiKVBackoffer(), task.region, isMPP)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -575,8 +575,9 @@ func buildBatchCopTasksCore(bo *backoff.Backoffer, store *kvStore, rangesForEach
 
 		storeTaskMap := make(map[string]*batchCopTask)
 		needRetry := false
+		isMPP := mppStoreLastFailTime != nil
 		for _, task := range tasks {
-			rpcCtx, err := cache.GetTiFlashRPCContext(bo.TiKVBackoffer(), task.region, false)
+			rpcCtx, err := cache.GetTiFlashRPCContext(bo.TiKVBackoffer(), task.region, isMPP)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -577,7 +577,7 @@ func buildBatchCopTasksCore(bo *backoff.Backoffer, store *kvStore, rangesForEach
 		needRetry := false
 		//isMPP := mppStoreLastFailTime != nil
 		for _, task := range tasks {
-			rpcCtx, err := cache.GetTiFlashRPCContext(bo.TiKVBackoffer(), task.region, false)
+			rpcCtx, err := cache.GetTiFlashRPCContext(bo.TiKVBackoffer(), task.region, true)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -575,9 +575,9 @@ func buildBatchCopTasksCore(bo *backoff.Backoffer, store *kvStore, rangesForEach
 
 		storeTaskMap := make(map[string]*batchCopTask)
 		needRetry := false
-		isMPP := mppStoreLastFailTime != nil
+		//isMPP := mppStoreLastFailTime != nil
 		for _, task := range tasks {
-			rpcCtx, err := cache.GetTiFlashRPCContext(bo.TiKVBackoffer(), task.region, isMPP)
+			rpcCtx, err := cache.GetTiFlashRPCContext(bo.TiKVBackoffer(), task.region, false)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/store/mockstore/unistore/rpc.go
+++ b/store/mockstore/unistore/rpc.go
@@ -276,6 +276,8 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 	case tikvrpc.CmdMPPCancel:
 	case tikvrpc.CmdMvccGetByKey:
 		resp.Resp, err = c.usSvr.MvccGetByKey(ctx, req.MvccGetByKey())
+	case tikvrpc.CmdMPPAlive:
+		resp.Resp, err = c.usSvr.IsAlive(ctx, req.IsMPPAlive())
 	case tikvrpc.CmdMvccGetByStartTs:
 		resp.Resp, err = c.usSvr.MvccGetByStartTs(ctx, req.MvccGetByStartTs())
 	case tikvrpc.CmdSplitRegion:
@@ -293,7 +295,7 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		return nil, err
 	}
 	var regErr *errorpb.Error
-	if req.Type != tikvrpc.CmdBatchCop && req.Type != tikvrpc.CmdMPPConn && req.Type != tikvrpc.CmdMPPTask {
+	if req.Type != tikvrpc.CmdBatchCop && req.Type != tikvrpc.CmdMPPConn && req.Type != tikvrpc.CmdMPPTask && req.Type != tikvrpc.CmdMPPAlive {
 		regErr, err = resp.GetRegionError()
 	}
 	if err != nil {

--- a/store/mockstore/unistore/tikv/server.go
+++ b/store/mockstore/unistore/tikv/server.go
@@ -649,7 +649,7 @@ func (mrm *MockRegionManager) removeMPPTaskHandler(taskID int64, storeID uint64)
 
 // IsAlive implements the tikvpb.TikvServer interface.
 func (svr *Server) IsAlive(_ context.Context, _ *mpp.IsAliveRequest) (*mpp.IsAliveResponse, error) {
-	panic("todo")
+	return &mpp.IsAliveResponse{Available: true}, nil
 }
 
 // DispatchMPPTask implements the tikvpb.TikvServer interface.


### PR DESCRIPTION
Signed-off-by: xufei <xufeixw@mail.ustc.edu.cn>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38113

Problem Summary:

The whole story is like this:
1. At the very beginning, TiDB can only access TiFlash in cop mode, in cop mode, each cop request only access data in one region. If the region has multiple TiFlash replicas, then each time the region is accessed, it will choose the next replica to serve, so the load is balanced between TiFlash nodes.
2. After introducing MPP and BatchCop, TiDB can access TiFlash in BatchCop/MPP mode, compared to cop mode, BatchCop/MPP mode does not access data by region, instead, it access data by TiFlash node. That is to say, each BatchCop/MPP request will read a batch of regions in on TiFlash node. BatchCop/MPP can reduce the rpc calls greatly but it also meet some problems, especially when some TiFlash nodes are temporary unavailable: in cop mode, TiDB can just retry using the next replica, while in BatchCop/MPP mode, the cost of retry is unacceptable because each BatchCop/MPP request may contain hundreds or even thousands of regions. So in order to avoid sending request to unavailable TiFlash node, for TiFlash region, if one of the replica is availale, TiDB will always use this replica for BatchCop/MPP request.(by set `loadBalance` to false in [here](https://github.com/pingcap/tidb/blob/5fe93790117e5f59d5f906c9bc1d0f9f7b6e768a/store/copr/batch_coprocessor.go#L579).) 
3.  After disable per region's load balance, we found that MPP's load is unbalanced even if the TiFlash table has multiple replicas. There is two level of unbalance
  - intra query's unbalance: considering a query like `select * from t`, assuming the cluster has 2 TiFlash nodes, `t` has two TiFlash replica, and t contans 100 regions, it is possible that the query only access the regions from one TiFlash node, the other TiFlash node is completely ignored 
  - inter query's unbalance: still considering a query like `select * from t`, the cluster has 2 TiFlash nodes, `t` has two TiFlash replica, this time assuming t only contains 1 region, and the query concurrency is 100, then it is possible that all the 100 queries read from one TiFlash node.
4. In order to solve the intra query's unbalance, we introduce [`balanceBatchCopTask `](https://github.com/pingcap/tidb/blob/5fe93790117e5f59d5f906c9bc1d0f9f7b6e768a/store/copr/batch_coprocessor.go#L296),  it will balance the region access between different TiFlash's node for each query.
5. In some tests, we found even if we disable per region's load balance, there is still a risk of access unavailable TiFlash node, in order to solve the problem totally, we come up a new solution: when construct MPP request, TiDB will check the availability of each TiFlash node, and only construct MPP request on the `live` node.

So, as we can see, due to disable per region's load balance, BatchCop/MPP still suffer from inter-query's unbalance preblem. But for MPP request, there is no `unavailable node` problems, we actually do not need disable per region's load balance. This pr enable per region's load balance for MPP request.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
