### PR TITLE
expression: change ParamMarker.GetUserVar's func body avoid out of range

### DIFF
--- a/br/cmd/br/restore.go
+++ b/br/cmd/br/restore.go
@@ -160,5 +160,6 @@ func newStreamRestoreCommand() *cobra.Command {
 	}
 	task.DefineFilterFlags(command, filterOutSysAndMemTables, true)
 	task.DefineStreamRestoreFlags(command)
+	command.Hidden = true
 	return command
 }

--- a/br/cmd/br/stream.go
+++ b/br/cmd/br/stream.go
@@ -55,6 +55,7 @@ func NewStreamCommand() *cobra.Command {
 		command.Root().HelpFunc()(command, strings)
 	})
 
+	command.Hidden = true
 	return command
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -115,8 +115,6 @@ var (
 			map[string]string{
 				"check-mb4-value-in-utf8":       "tidb_check_mb4_value_in_utf8",
 				"enable-collect-execution-info": "tidb_enable_collect_execution_info",
-				"plugin.load":                   "plugin_load",
-				"plugin.dir":                    "plugin_dir",
 			},
 		},
 		{
@@ -132,6 +130,13 @@ var (
 			map[string]string{
 				"force-priority":           "tidb_force_priority",
 				"memory-usage-alarm-ratio": "tidb_memory_usage_alarm_ratio",
+			},
+		},
+		{
+			"plugin",
+			map[string]string{
+				"load": "plugin_load",
+				"dir":  "plugin_dir",
 			},
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -859,8 +859,8 @@ var defaultConf = Config{
 		HeaderTimeout: 5,
 	},
 	PreparedPlanCache: PreparedPlanCache{
-		Enabled:          false,
-		Capacity:         1000,
+		Enabled:          true,
+		Capacity:         100,
 		MemoryGuardRatio: 0.1,
 	},
 	OpenTracing: OpenTracing{

--- a/config/config.go
+++ b/config/config.go
@@ -766,6 +766,8 @@ var defaultConf = Config{
 	OOMUseTmpStorage:             true,
 	TempStorageQuota:             -1,
 	TempStoragePath:              tempStorageDirName,
+	MemQuotaQuery:                1 << 30,
+	OOMAction:                    "cancel",
 	EnableBatchDML:               false,
 	CheckMb4ValueInUTF8:          *NewAtomicBool(true),
 	MaxIndexLength:               3072,
@@ -796,6 +798,7 @@ var defaultConf = Config{
 		EnableErrorStack:    nbUnset, // If both options are nbUnset, getDisableErrorStack() returns true
 		EnableTimestamp:     nbUnset,
 		DisableTimestamp:    nbUnset, // If both options are nbUnset, getDisableTimestamp() returns false
+		QueryLogMaxLen:      logutil.DefaultQueryLogMaxLen,
 		RecordPlanInSlowLog: logutil.DefaultRecordPlanInSlowLog,
 		EnableSlowLog:       *NewAtomicBool(logutil.DefaultTiDBEnableSlowLog),
 	},
@@ -844,6 +847,7 @@ var defaultConf = Config{
 		TxnTotalSizeLimit:     DefTxnTotalSizeLimit,
 		DistinctAggPushDown:   false,
 		ProjectionPushDown:    false,
+		CommitterConcurrency:  defTiKVCfg.CommitterConcurrency,
 		MaxTxnTTL:             defTiKVCfg.MaxTxnTTL, // 1hour
 		// TODO: set indexUsageSyncLease to 60s.
 		IndexUsageSyncLease:      "0s",
@@ -853,6 +857,7 @@ var defaultConf = Config{
 		StatsLoadConcurrency:     5,
 		StatsLoadQueueSize:       1000,
 		EnableStatsCacheMemQuota: false,
+		RunAutoAnalyze:           true,
 	},
 	ProxyProtocol: ProxyProtocol{
 		Networks:      "",

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -645,6 +645,114 @@ create table log_message_1 (
 	tk.MustQuery(`select * from t where a < X'0D' order by a`).Check(testkit.Rows("\x0B", "\x0C"))
 }
 
+func TestPartitionRangeColumnsCollate(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create schema PartitionRangeColumnsCollate")
+	tk.MustExec("use PartitionRangeColumnsCollate")
+	tk.MustExec(`create table t (a varchar(255) charset utf8mb4 collate utf8mb4_bin) partition by range columns (a)
+ (partition p0A values less than ("A"),
+ partition p1AA values less than ("AA"),
+ partition p2Aa values less than ("Aa"),
+ partition p3BB values less than ("BB"),
+ partition p4Bb values less than ("Bb"),
+ partition p5aA values less than ("aA"),
+ partition p6aa values less than ("aa"),
+ partition p7bB values less than ("bB"),
+ partition p8bb values less than ("bb"),
+ partition pMax values less than (MAXVALUE))`)
+	tk.MustExec(`insert into t values ("A"),("a"),("b"),("B"),("aa"),("AA"),("aA"),("Aa"),("BB"),("Bb"),("bB"),("bb"),("AB"),("BA"),("Ab"),("Ba"),("aB"),("bA"),("ab"),("ba")`)
+	tk.MustQuery(`explain select * from t where a = "AA" collate utf8mb4_general_ci`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:all data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  eq(partitionrangecolumnscollate.t.a, "AA")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a = "AA" collate utf8mb4_general_ci`).Sort().Check(testkit.Rows("AA", "Aa", "aA", "aa"))
+	tk.MustQuery(`explain select * from t where a = "aa" collate utf8mb4_general_ci`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:all data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  eq(partitionrangecolumnscollate.t.a, "aa")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a = "aa" collate utf8mb4_general_ci`).Sort().Check(testkit.Rows("AA", "Aa", "aA", "aa"))
+	tk.MustQuery(`explain select * from t where a >= "aa" collate utf8mb4_general_ci`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:all data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  ge(partitionrangecolumnscollate.t.a, "aa")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a >= "aa" collate utf8mb4_general_ci`).Sort().Check(testkit.Rows(
+		"AA", "AB", "Aa", "Ab", "B", "BA", "BB", "Ba", "Bb", "aA", "aB", "aa", "ab", "b", "bA", "bB", "ba", "bb"))
+	tk.MustQuery(`explain select * from t where a > "aa" collate utf8mb4_general_ci`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:all data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  gt(partitionrangecolumnscollate.t.a, "aa")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a > "aa" collate utf8mb4_general_ci`).Sort().Check(testkit.Rows(
+		"AB", "Ab", "B", "BA", "BB", "Ba", "Bb", "aB", "ab", "b", "bA", "bB", "ba", "bb"))
+	tk.MustQuery(`explain select * from t where a <= "aa" collate utf8mb4_general_ci`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:all data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  le(partitionrangecolumnscollate.t.a, "aa")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a <= "aa" collate utf8mb4_general_ci`).Sort().Check(testkit.Rows(
+		"A", "AA", "Aa", "a", "aA", "aa"))
+	tk.MustQuery(`explain select * from t where a < "aa" collate utf8mb4_general_ci`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:all data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  lt(partitionrangecolumnscollate.t.a, "aa")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a < "aa" collate utf8mb4_general_ci`).Sort().Check(testkit.Rows(
+		"A", "a"))
+
+	tk.MustExec("drop table t")
+	tk.MustExec(` create table t (a varchar(255) charset utf8mb4 collate utf8mb4_general_ci) partition by range columns (a)
+(partition p0 values less than ("A"),
+ partition p1 values less than ("aa"),
+ partition p2 values less than ("AAA"),
+ partition p3 values less than ("aaaa"),
+ partition p4 values less than ("B"),
+ partition p5 values less than ("bb"),
+ partition pMax values less than (MAXVALUE))`)
+	tk.MustExec(`insert into t values ("A"),("a"),("b"),("B"),("aa"),("AA"),("aA"),("Aa"),("BB"),("Bb"),("bB"),("bb"),("AB"),("BA"),("Ab"),("Ba"),("aB"),("bA"),("ab"),("ba"),("ä"),("ÄÄÄ")`)
+	tk.MustQuery(`explain select * from t where a = "aa" collate utf8mb4_general_ci`).Check(testkit.Rows(
+		`TableReader_7 10.00 root partition:p2 data:Selection_6`,
+		`└─Selection_6 10.00 cop[tikv]  eq(partitionrangecolumnscollate.t.a, "aa")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a = "aa" collate utf8mb4_general_ci`).Sort().Check(testkit.Rows(
+		"AA", "Aa", "aA", "aa"))
+	tk.MustQuery(`explain select * from t where a = "aa" collate utf8mb4_bin`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:p2 data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  eq(partitionrangecolumnscollate.t.a, "aa")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a = "aa" collate utf8mb4_bin`).Sort().Check(testkit.Rows("aa"))
+	// 'a' < 'b' < 'ä' in _bin
+	tk.MustQuery(`explain select * from t where a = "ä" collate utf8mb4_bin`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:p1 data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  eq(partitionrangecolumnscollate.t.a, "ä")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a = "ä" collate utf8mb4_bin`).Sort().Check(testkit.Rows("ä"))
+	tk.MustQuery(`explain select * from t where a = "b" collate utf8mb4_bin`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:p5 data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  eq(partitionrangecolumnscollate.t.a, "b")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a = "b" collate utf8mb4_bin`).Sort().Check(testkit.Rows("b"))
+	tk.MustQuery(`explain select * from t where a <= "b" collate utf8mb4_bin`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:all data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  le(partitionrangecolumnscollate.t.a, "b")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a <= "b" collate utf8mb4_bin`).Sort().Check(testkit.Rows("A", "AA", "AB", "Aa", "Ab", "B", "BA", "BB", "Ba", "Bb", "a", "aA", "aB", "aa", "ab", "b"))
+	tk.MustQuery(`explain select * from t where a < "b" collate utf8mb4_bin`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:all data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  lt(partitionrangecolumnscollate.t.a, "b")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	// Missing upper case B if not p5 is included!
+	tk.MustQuery(`select * from t where a < "b" collate utf8mb4_bin`).Sort().Check(testkit.Rows("A", "AA", "AB", "Aa", "Ab", "B", "BA", "BB", "Ba", "Bb", "a", "aA", "aB", "aa", "ab"))
+	tk.MustQuery(`explain select * from t where a >= "b" collate utf8mb4_bin`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:all data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  ge(partitionrangecolumnscollate.t.a, "b")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a >= "b" collate utf8mb4_bin`).Sort().Check(testkit.Rows("b", "bA", "bB", "ba", "bb", "ÄÄÄ", "ä"))
+	tk.MustQuery(`explain select * from t where a > "b" collate utf8mb4_bin`).Check(testkit.Rows(
+		`TableReader_7 8000.00 root partition:all data:Selection_6`,
+		`└─Selection_6 8000.00 cop[tikv]  gt(partitionrangecolumnscollate.t.a, "b")`,
+		`  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo`))
+	tk.MustQuery(`select * from t where a > "b" collate utf8mb4_bin`).Sort().Check(testkit.Rows("bA", "bB", "ba", "bb", "ÄÄÄ", "ä"))
+}
+
 func TestDisableTablePartition(t *testing.T) {
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()

--- a/ddl/sanity_check.go
+++ b/ddl/sanity_check.go
@@ -92,7 +92,7 @@ func (d *ddl) checkDeleteRangeCnt(job *model.Job) {
 		var physicalTableIDs []int64
 		var ruleIDs []string
 		if err := job.DecodeArgs(&startKey, &physicalTableIDs, &ruleIDs); err != nil {
-			panic("should not happened")
+			panic("Error in drop/truncate table, please report a bug with this stack trace and how it happened")
 		}
 		checkRangeCntByTableIDs(physicalTableIDs, cnt)
 	case model.ActionDropTablePartition, model.ActionTruncateTablePartition:

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -641,8 +641,9 @@ func (is *InfoSyncer) ReportMinStartTS(store kv.Storage) {
 	now := oracle.GetTimeFromTS(currentVer.Ver)
 	// GCMaxWaitTime is in seconds, GCMaxWaitTime * 1000 converts it to milliseconds.
 	startTSLowerLimit := oracle.GoTimeToLowerLimitStartTS(now, variable.GCMaxWaitTime.Load()*1000)
-
 	minStartTS := oracle.GoTimeToTS(now)
+	logutil.BgLogger().Debug("ReportMinStartTS", zap.Uint64("initial minStartTS", minStartTS),
+		zap.Uint64("StartTSLowerLimit", startTSLowerLimit))
 	for _, info := range pl {
 		if info.CurTxnStartTS > startTSLowerLimit && info.CurTxnStartTS < minStartTS {
 			minStartTS = info.CurTxnStartTS
@@ -650,6 +651,7 @@ func (is *InfoSyncer) ReportMinStartTS(store kv.Storage) {
 	}
 
 	for _, innerTS := range innerSessionStartTSList {
+		logutil.BgLogger().Debug("ReportMinStartTS", zap.Uint64("Internal Session Transaction StartTS", innerTS))
 		kv.PrintLongTimeInternalTxn(now, innerTS, false)
 		if innerTS > startTSLowerLimit && innerTS < minStartTS {
 			minStartTS = innerTS
@@ -662,6 +664,7 @@ func (is *InfoSyncer) ReportMinStartTS(store kv.Storage) {
 	if err != nil {
 		logutil.BgLogger().Error("update minStartTS failed", zap.Error(err))
 	}
+	logutil.BgLogger().Debug("ReportMinStartTS", zap.Uint64("final minStartTS", is.minStartTS))
 }
 
 // Done returns a channel that closes when the info syncer is no longer being refreshed.

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -175,7 +175,7 @@ func (e *AnalyzeExec) Next(ctx context.Context, req *chunk.Chunk) error {
 				}
 			}
 		}
-		if err1 := statsHandle.SaveTableStatsToStorage(results, results.TableID.IsPartitionTable() && needGlobalStats); err1 != nil {
+		if err1 := statsHandle.SaveTableStatsToStorage(results, results.TableID.IsPartitionTable()); err1 != nil {
 			err = err1
 			logutil.Logger(ctx).Error("save table stats to storage failed", zap.Error(err))
 			finishJobWithLog(e.ctx, results.Job, err)

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -3282,3 +3282,83 @@ PARTITION BY RANGE ( a ) (
 	require.Greater(t, tbl.Version, lastVersion)
 	require.Equal(t, 2, len(tbl.Indices[tableInfo.Indices[0].ID].Buckets))
 }
+
+func TestIssue35056(t *testing.T) {
+	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@session.tidb_analyze_version = 1")
+	createTable := `CREATE TABLE t (id int, a int, b varchar(10))
+PARTITION BY RANGE ( id ) (
+		PARTITION p0 VALUES LESS THAN (10),
+		PARTITION p1 VALUES LESS THAN (20)
+)`
+	tk.MustExec(createTable)
+	tk.MustExec("set @@session.tidb_partition_prune_mode = 'static'")
+	tk.MustExec("insert into t values (1,1,1),(2,2,2),(3,3,3),(4,4,4),(7,7,7),(9,9,9)")
+	tk.MustExec("insert into t values (11,11,11),(12,12,12),(14,14,14)")
+	h := dom.StatsHandle()
+	oriLease := h.Lease()
+	h.SetLease(1)
+	defer func() {
+		h.SetLease(oriLease)
+	}()
+	is := dom.InfoSchema()
+	h.HandleAutoAnalyze(is)
+	tk.MustExec("create index idxa on t (a)")
+	tk.MustExec("create index idxb on t (b)")
+	table, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	tableInfo := table.Meta()
+	pi := tableInfo.GetPartitionInfo()
+	require.NotNil(t, pi)
+	tk.MustExec("analyze table t partition p0 index idxa")
+	tk.MustExec("analyze table t partition p1 index idxb")
+	tk.MustExec("set @@session.tidb_partition_prune_mode = 'dynamic'")
+	tk.MustExec("analyze table t partition p0")
+	tk.MustQuery("show warnings").Sort().Check(testkit.Rows(
+		"Warning 8244 Build table: `t` column: `id` global-level stats failed due to missing partition-level column stats, please run analyze table to refresh columns of all partitions",
+		"Warning 8244 Build table: `t` index: `idxa` global-level stats failed due to missing partition-level column stats, please run analyze table to refresh columns of all partitions",
+	))
+}
+
+func TestIssue35056Related(t *testing.T) {
+	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@session.tidb_analyze_version = 2")
+	createTable := `CREATE TABLE t (id int)
+PARTITION BY RANGE ( id ) (
+		PARTITION p0 VALUES LESS THAN (10),
+		PARTITION p1 VALUES LESS THAN (20)
+)`
+	tk.MustExec(createTable)
+	tk.MustExec("set @@session.tidb_partition_prune_mode = 'static'")
+	tk.MustExec("insert into t values (1),(2),(3),(4),(7),(9)")
+	tk.MustExec("insert into t values (11),(12),(14)")
+	h := dom.StatsHandle()
+	oriLease := h.Lease()
+	h.SetLease(1)
+	defer func() {
+		h.SetLease(oriLease)
+	}()
+	is := dom.InfoSchema()
+	h.HandleAutoAnalyze(is)
+	tk.MustExec("alter table t add column a int")
+	tk.MustExec("alter table t add column b int")
+	table, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	tableInfo := table.Meta()
+	pi := tableInfo.GetPartitionInfo()
+	require.NotNil(t, pi)
+	tk.MustExec("analyze table t partition p0 columns id,a")
+	tk.MustExec("analyze table t partition p1 columns id,b")
+	tk.MustExec("set @@session.tidb_partition_prune_mode = 'dynamic'")
+	tk.MustExec("analyze table t partition p0")
+	tk.MustQuery("show warnings").Sort().Check(testkit.Rows(
+		"Note 1105 Analyze use auto adjusted sample rate 1.000000 for table test.t's partition p0",
+		"Warning 8244 Build table: `t` column: `a` global-level stats failed due to missing partition-level column stats, please run analyze table to refresh columns of all partitions",
+	))
+}

--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -899,12 +899,12 @@ func TestGlobalStatsAndSQLBinding(t *testing.T) {
 		partition p2 values less than (600),
 		partition p3 values less than (800),
 		partition p4 values less than (1001))`)
-	tk.MustExec(`create table tlist(a int, b int, key(a)) partition by list (a) (
+	tk.MustExec(`create table tlist (a int, b int, key(a)) partition by list (a) (
 		partition p0 values in (0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
-		partition p0 values in (10, 11, 12, 13, 14, 15, 16, 17, 18, 19),
-		partition p0 values in (20, 21, 22, 23, 24, 25, 26, 27, 28, 29),
-		partition p0 values in (30, 31, 32, 33, 34, 35, 36, 37, 38, 39),
-		partition p0 values in (40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50))`)
+		partition p1 values in (10, 11, 12, 13, 14, 15, 16, 17, 18, 19),
+		partition p2 values in (20, 21, 22, 23, 24, 25, 26, 27, 28, 29),
+		partition p3 values in (30, 31, 32, 33, 34, 35, 36, 37, 38, 39),
+		partition p4 values in (40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50))`)
 
 	// construct some special data distribution
 	vals := make([]string, 0, 1000)
@@ -3019,6 +3019,8 @@ func TestIssue21731(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists p, t")
+	tk.MustExec("set @@tidb_enable_list_partition = OFF")
+	// Notice that this does not really test the issue #21731
 	tk.MustExec("create table t (a int, b int, unique index idx(a)) partition by list columns(b) (partition p0 values in (1), partition p1 values in (2));")
 }
 

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -636,6 +636,13 @@ func TestSetVar(t *testing.T) {
 	// for read-only instance scoped system variables.
 	tk.MustGetErrCode("set @@global.plugin_load = ''", errno.ErrIncorrectGlobalLocalVar)
 	tk.MustGetErrCode("set @@global.plugin_dir = ''", errno.ErrIncorrectGlobalLocalVar)
+
+	// test for tidb_max_auto_analyze_time
+	tk.MustQuery("select @@tidb_max_auto_analyze_time").Check(testkit.Rows(strconv.Itoa(variable.DefTiDBMaxAutoAnalyzeTime)))
+	tk.MustExec("set global tidb_max_auto_analyze_time = 60")
+	tk.MustQuery("select @@tidb_max_auto_analyze_time").Check(testkit.Rows("60"))
+	tk.MustExec("set global tidb_max_auto_analyze_time = -1")
+	tk.MustQuery("select @@tidb_max_auto_analyze_time").Check(testkit.Rows("0"))
 }
 
 func TestTruncateIncorrectIntSessionVar(t *testing.T) {

--- a/executor/tiflash_test.go
+++ b/executor/tiflash_test.go
@@ -1199,3 +1199,30 @@ func TestTiflashPartitionTableScan(t *testing.T) {
 	tk.MustQuery("select count(*) from t where a < 12;").Check(testkit.Rows("2"))
 	wg.Wait()
 }
+
+func TestAggPushDownCountStar(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t, withMockTiFlash(2))
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists c")
+	tk.MustExec("drop table if exists o")
+	tk.MustExec("create table c(c_id bigint primary key)")
+	tk.MustExec("create table o(o_id bigint primary key, c_id bigint not null)")
+	tk.MustExec("alter table c set tiflash replica 1")
+	tb := external.GetTableByName(t, tk, "test", "c")
+	err := domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
+	require.NoError(t, err)
+	tk.MustExec("alter table o set tiflash replica 1")
+	tb = external.GetTableByName(t, tk, "test", "o")
+	err = domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
+	require.NoError(t, err)
+	tk.MustExec("insert into c values(1),(2),(3),(4),(5)")
+	tk.MustExec("insert into o values(1,1),(2,1),(3,2),(4,2),(5,2)")
+
+	tk.MustExec("set @@tidb_enforce_mpp=1")
+	tk.MustExec("set @@tidb_opt_agg_push_down=1")
+
+	tk.MustQuery("select count(*) from c, o where c.c_id=o.c_id").Check(testkit.Rows("5"))
+}

--- a/expression/collation.go
+++ b/expression/collation.go
@@ -157,7 +157,7 @@ const (
 	UNICODE = ASCII | EXTENDED
 )
 
-func deriveCoercibilityForScarlarFunc(sf *ScalarFunction) Coercibility {
+func deriveCoercibilityForScalarFunc(sf *ScalarFunction) Coercibility {
 	panic("this function should never be called")
 }
 

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -88,7 +88,10 @@ type ParamMarker struct {
 // GetUserVar returns the corresponding user variable presented in the `EXECUTE` statement or `COM_EXECUTE` command.
 func (d *ParamMarker) GetUserVar() types.Datum {
 	sessionVars := d.ctx.GetSessionVars()
-	return sessionVars.PreparedParams[d.order]
+	if len(sessionVars.PreparedParams) > d.order {
+		return sessionVars.PreparedParams[d.order]
+	}
+	return types.Datum{}
 }
 
 // String implements fmt.Stringer interface.

--- a/expression/constant_test.go
+++ b/expression/constant_test.go
@@ -508,3 +508,19 @@ func TestSpecificConstant(t *testing.T) {
 	require.Equal(t, null.RetType.GetFlen(), 1)
 	require.Equal(t, null.RetType.GetDecimal(), 0)
 }
+
+func TestParamMarkerGetUserVar(t *testing.T) {
+	ctx := mock.NewContext()
+	ctx.GetSessionVars().PreparedParams = []types.Datum{
+		types.NewIntDatum(1),
+	}
+	con := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}}
+	typ := con.ParamMarker.GetUserVar()
+	require.Equal(t, typ, ctx.GetSessionVars().PreparedParams[0])
+
+	ctx = mock.NewContext()
+	ctx.GetSessionVars().PreparedParams = []types.Datum{}
+	con = &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}}
+	typ = con.ParamMarker.GetUserVar()
+	require.Equal(t, typ, types.Datum{})
+}

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -648,7 +648,7 @@ func TestStringBuiltin(t *testing.T) {
 	result = tk.MustQuery("select ord('123'), ord(123), ord(''), ord('你好'), ord(NULL), ord('👍')")
 	result.Check(testkit.Rows("49 49 0 14990752 <nil> 4036989325"))
 	result = tk.MustQuery("select ord(X''), ord(X'6161'), ord(X'e4bd'), ord(X'e4bda0'), ord(_ascii'你'), ord(_latin1'你')")
-	result.Check(testkit.Rows("0 97 228 228 228 14990752"))
+	result.Check(testkit.Rows("0 97 228 228 228 228"))
 
 	// for space
 	result = tk.MustQuery(`select space(0), space(2), space(-1), space(1.1), space(1.9)`)

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -560,7 +560,7 @@ func (sf *ScalarFunction) GetSingleColumn(reverse bool) (*Column, bool) {
 // Coercibility returns the coercibility value which is used to check collations.
 func (sf *ScalarFunction) Coercibility() Coercibility {
 	if !sf.Function.HasCoercibility() {
-		sf.SetCoercibility(deriveCoercibilityForScarlarFunc(sf))
+		sf.SetCoercibility(deriveCoercibilityForScalarFunc(sf))
 	}
 	return sf.Function.Coercibility()
 }

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.2-0.20220504104629-106ec21d14df
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.1-0.20220518162527-de7ca289ac77
+	github.com/tikv/client-go/v2 v2.0.1-0.20220531092439-efebaeb9fe53
 	github.com/tikv/pd/client v0.0.0-20220307081149-841fa61e9710
 	github.com/twmb/murmur3 v1.1.3
 	github.com/uber/jaeger-client-go v2.22.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -755,8 +755,8 @@ github.com/stretchr/testify v1.7.2-0.20220504104629-106ec21d14df/go.mod h1:6Fq8o
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
-github.com/tikv/client-go/v2 v2.0.1-0.20220518162527-de7ca289ac77 h1:baRGhZtEp4wY3qh/0bscTCZ+97MVTZekBg5rOdgopQc=
-github.com/tikv/client-go/v2 v2.0.1-0.20220518162527-de7ca289ac77/go.mod h1:VTlli8fRRpcpISj9I2IqroQmcAFfaTyBquiRhofOcDs=
+github.com/tikv/client-go/v2 v2.0.1-0.20220531092439-efebaeb9fe53 h1:zalDvjC3IhixTcqU1HQYJQtTI3npketLDprwLw1eGqI=
+github.com/tikv/client-go/v2 v2.0.1-0.20220531092439-efebaeb9fe53/go.mod h1:VTlli8fRRpcpISj9I2IqroQmcAFfaTyBquiRhofOcDs=
 github.com/tikv/pd/client v0.0.0-20220307081149-841fa61e9710 h1:jxgmKOscXSjaFEKQGRyY5qOpK8hLqxs2irb/uDJMtwk=
 github.com/tikv/pd/client v0.0.0-20220307081149-841fa61e9710/go.mod h1:AtvppPwkiyUgQlR1W9qSqfTB+OsOIu19jDCOxOsPkmU=
 github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev3vTo=

--- a/parser/charset/encoding_latin1.go
+++ b/parser/charset/encoding_latin1.go
@@ -14,11 +14,12 @@
 package charset
 
 import (
+	"bytes"
 	"golang.org/x/text/encoding"
 )
 
 // EncodingLatin1Impl is the instance of encodingLatin1.
-// In TiDB, latin1 is an alias for utf8, so uses utf8 implementation for latin1.
+// TiDB uses utf8 implementation for latin1 charset because of the backward compatibility.
 var EncodingLatin1Impl = &encodingLatin1{encodingUTF8{encodingBase{enc: encoding.Nop}}}
 
 func init() {
@@ -33,4 +34,26 @@ type encodingLatin1 struct {
 // Name implements Encoding interface.
 func (e *encodingLatin1) Name() string {
 	return CharsetLatin1
+}
+
+// Peek implements Encoding interface.
+func (e *encodingLatin1) Peek(src []byte) []byte {
+	if len(src) == 0 {
+		return src
+	}
+	return src[:1]
+}
+
+// IsValid implements Encoding interface.
+func (e *encodingLatin1) IsValid(src []byte) bool {
+	return true
+}
+
+// Tp implements Encoding interface.
+func (e *encodingLatin1) Tp() EncodingTp {
+	return EncodingTpLatin1
+}
+
+func (e *encodingLatin1) Transform(dest *bytes.Buffer, src []byte, op Op) ([]byte, error) {
+	return src, nil
 }

--- a/parser/mysql/charset.go
+++ b/parser/mysql/charset.go
@@ -593,9 +593,9 @@ const (
 	MaxBytesOfCharacter = 4
 )
 
-// IsUTF8Charset checks if charset is utf8, utf8mb4 or latin1.
+// IsUTF8Charset checks if charset is utf8, utf8mb4.
 func IsUTF8Charset(charset string) bool {
-	return charset == UTF8Charset || charset == UTF8MB4Charset || charset == Latin1Charset
+	return charset == UTF8Charset || charset == UTF8MB4Charset
 }
 
 // RangeGraph defines valid unicode characters to use in column names. It strictly follows MySQL's definition.

--- a/planner/core/enforce_mpp_test.go
+++ b/planner/core/enforce_mpp_test.go
@@ -384,3 +384,57 @@ func TestEnforceMPPWarning4(t *testing.T) {
 		require.Equal(t, output[i].Warn, testdata.ConvertSQLWarnToStrings(tk.Session().GetSessionVars().StmtCtx.GetWarnings()))
 	}
 }
+
+// Test agg push down for MPP mode
+func TestMPP2PhaseAggPushDown(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+
+	// test table
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists c")
+	tk.MustExec("drop table if exists o")
+	tk.MustExec("create table c(c_id bigint)")
+	tk.MustExec("create table o(o_id bigint, c_id bigint not null)")
+
+	// Create virtual tiflash replica info.
+	dom := domain.GetDomain(tk.Session())
+	is := dom.InfoSchema()
+	db, exists := is.SchemaByName(model.NewCIStr("test"))
+	require.True(t, exists)
+	for _, tblInfo := range db.Tables {
+		if tblInfo.Name.L == "c" || tblInfo.Name.L == "o" {
+			tblInfo.TiFlashReplica = &model.TiFlashReplicaInfo{
+				Count:     1,
+				Available: true,
+			}
+		}
+	}
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+		Warn []string
+	}
+	enforceMPPSuiteData := plannercore.GetEnforceMPPSuiteData()
+	enforceMPPSuiteData.GetTestCases(t, &input, &output)
+	for i, tt := range input {
+		testdata.OnRecord(func() {
+			output[i].SQL = tt
+		})
+		if strings.HasPrefix(tt, "set") || strings.HasPrefix(tt, "UPDATE") {
+			tk.MustExec(tt)
+			continue
+		}
+		testdata.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = testdata.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+			output[i].Warn = testdata.ConvertSQLWarnToStrings(tk.Session().GetSessionVars().StmtCtx.GetWarnings())
+		})
+		res := tk.MustQuery(tt)
+		res.Check(testkit.Rows(output[i].Plan...))
+		require.Equal(t, output[i].Warn, testdata.ConvertSQLWarnToStrings(tk.Session().GetSessionVars().StmtCtx.GetWarnings()))
+	}
+}

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -2589,6 +2589,11 @@ func (la *LogicalAggregation) tryToGetMppHashAggs(prop *property.PhysicalPropert
 	if prop.MPPPartitionTp == property.BroadcastType {
 		return nil
 	}
+
+	// Is this aggregate a final stage aggregate?
+	// Final agg can't be split into multi-stage aggregate
+	hasFinalAgg := len(la.AggFuncs) > 0 && la.AggFuncs[0].Mode == aggregation.FinalMode
+
 	if len(la.GroupByItems) > 0 {
 		partitionCols := la.GetPotentialPartitionKeys()
 		// trying to match the required parititions.
@@ -2612,6 +2617,11 @@ func (la *LogicalAggregation) tryToGetMppHashAggs(prop *property.PhysicalPropert
 			hashAggs = append(hashAggs, agg)
 		}
 
+		// Final agg can't be split into multi-stage aggregate, so exit early
+		if hasFinalAgg {
+			return
+		}
+
 		// 2-phase agg
 		childProp := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, MPPPartitionTp: property.AnyType, RejectSort: true}
 		agg := NewPhysicalHashAgg(la, la.stats.ScaleByExpectCnt(prop.ExpectedCnt), childProp)
@@ -2628,7 +2638,7 @@ func (la *LogicalAggregation) tryToGetMppHashAggs(prop *property.PhysicalPropert
 			agg.MppRunMode = MppTiDB
 			hashAggs = append(hashAggs, agg)
 		}
-	} else {
+	} else if !hasFinalAgg {
 		// TODO: support scalar agg in MPP, merge the final result to one node
 		childProp := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, RejectSort: true}
 		agg := NewPhysicalHashAgg(la, la.stats.ScaleByExpectCnt(prop.ExpectedCnt), childProp)
@@ -2671,6 +2681,7 @@ func (la *LogicalAggregation) getHashAggs(prop *property.PhysicalProperty) []Phy
 	if prop.IsFlashProp() {
 		taskTypes = []property.TaskType{prop.TaskTp}
 	}
+
 	for _, taskTp := range taskTypes {
 		if taskTp == property.MppTaskType {
 			mppAggs := la.tryToGetMppHashAggs(prop)

--- a/planner/core/integration_partition_test.go
+++ b/planner/core/integration_partition_test.go
@@ -1068,6 +1068,7 @@ func TestIssue27070(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("create database issue_27070")
 	tk.MustExec("use issue_27070")
+	tk.MustExec("set @@tidb_enable_list_partition = OFF")
 	tk.MustExec(`create table if not exists t (id int,   create_date date NOT NULL DEFAULT '2000-01-01',   PRIMARY KEY (id,create_date)  ) PARTITION BY list COLUMNS(create_date) (   PARTITION p20210506 VALUES IN ("20210507"),   PARTITION p20210507 VALUES IN ("20210508") )`)
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 8200 Unsupported partition type LIST, treat as normal table"))
 }

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -1097,7 +1097,7 @@ func TestPartitionTableDynamicModeUnderNewCollation(t *testing.T) {
 	tk.MustQuery("select * from strrange where a in ('a', 'y')").Sort().Check(testkit.Rows("A 1", "Y 1", "a 1", "y 1"))
 
 	// list partition and partitioned by utf8mb4_general_ci
-	tk.MustExec(`create table strlist(a varchar(10) charset utf8mb4 collate utf8mb4_general_ci, b int) partition by list(a) (
+	tk.MustExec(`create table strlist(a varchar(10) charset utf8mb4 collate utf8mb4_general_ci, b int) partition by list columns (a) (
 						partition p0 values in ('a', 'b'),
 						partition p1 values in ('c', 'd'),
 						partition p2 values in ('e', 'f'))`)

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/mathutil"
 	"github.com/pingcap/tidb/util/plancodec"
 	"github.com/pingcap/tidb/util/ranger"
@@ -1575,13 +1576,23 @@ func (p *rangeColumnsPruner) partitionRangeForExpr(sctx sessionctx.Context, expr
 		return 0, len(p.data), false
 	}
 
-	start, end := p.pruneUseBinarySearch(sctx, opName, con, op)
+	// If different collation, we can only prune if:
+	// - expression is binary collation (can only be found in one partition)
+	// - EQ operator, consider values 'a','b','ä' where 'ä' would be in the same partition as 'a' if general_ci, but is binary after 'b'
+	// otherwise return all partitions / no pruning
+	_, exprColl := expr.CharsetAndCollation()
+	colColl := p.partCol.RetType.GetCollate()
+	if exprColl != colColl && (opName != ast.EQ || !collate.IsBinCollation(exprColl)) {
+		return 0, len(p.data), true
+	}
+	start, end := p.pruneUseBinarySearch(sctx, opName, con)
 	return start, end, true
 }
 
-func (p *rangeColumnsPruner) pruneUseBinarySearch(sctx sessionctx.Context, op string, data *expression.Constant, f *expression.ScalarFunction) (start int, end int) {
+func (p *rangeColumnsPruner) pruneUseBinarySearch(sctx sessionctx.Context, op string, data *expression.Constant) (start int, end int) {
 	var err error
 	var isNull bool
+	charSet, collation := p.partCol.RetType.GetCharset(), p.partCol.RetType.GetCollate()
 	compare := func(ith int, op string, v *expression.Constant) bool {
 		if ith == len(p.data)-1 {
 			if p.maxvalue {
@@ -1590,7 +1601,7 @@ func (p *rangeColumnsPruner) pruneUseBinarySearch(sctx sessionctx.Context, op st
 		}
 		var expr expression.Expression
 		expr, err = expression.NewFunctionBase(sctx, op, types.NewFieldType(mysql.TypeLonglong), p.data[ith], v)
-		expr.SetCharsetAndCollation(f.CharsetAndCollation())
+		expr.SetCharsetAndCollation(charSet, collation)
 		var val int64
 		val, isNull, err = expr.EvalInt(sctx, chunk.Row{})
 		return val > 0

--- a/planner/core/testdata/enforce_mpp_suite_in.json
+++ b/planner/core/testdata/enforce_mpp_suite_in.json
@@ -85,5 +85,14 @@
       "explain select a from t where t.a>1 or t.a not in (select a from t); -- now it's supported -- 8. anti left outer semi join",
       "explain select a from t where t.a not in (select a from s where t.a<1); -- 9. non left join has left conditions"
     ]
+  },
+  {
+    "name": "TestMPP2PhaseAggPushDown",
+    "cases": [
+      "set @@tidb_allow_mpp=1;set @@tidb_enforce_mpp=1;set @@tidb_opt_agg_push_down=1;",
+      "EXPLAIN select count(*) from c, o where c.c_id=o.c_id; -- 1. test agg push down, scalar aggregate",
+      "EXPLAIN select o.o_id, count(*) from c, o where c.c_id=o.c_id group by o.o_id; -- 2. test agg push down, group by non-join column",
+      "EXPLAIN select o.c_id, count(*) from c, o where c.c_id=o.c_id group by o.c_id; -- 3. test agg push down, group by join column"
+    ]
   }
 ]

--- a/planner/core/testdata/enforce_mpp_suite_out.json
+++ b/planner/core/testdata/enforce_mpp_suite_out.json
@@ -634,5 +634,80 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestMPP2PhaseAggPushDown",
+    "Cases": [
+      {
+        "SQL": "set @@tidb_allow_mpp=1;set @@tidb_enforce_mpp=1;set @@tidb_opt_agg_push_down=1;",
+        "Plan": null,
+        "Warn": null
+      },
+      {
+        "SQL": "EXPLAIN select count(*) from c, o where c.c_id=o.c_id; -- 1. test agg push down, scalar aggregate",
+        "Plan": [
+          "HashAgg_13 1.00 root  funcs:count(Column#7)->Column#6",
+          "└─TableReader_35 9990.00 root  data:ExchangeSender_34",
+          "  └─ExchangeSender_34 9990.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_14 9990.00 mpp[tiflash]  inner join, equal:[eq(test.c.c_id, test.o.c_id)]",
+          "      ├─ExchangeReceiver_26(Build) 8000.00 mpp[tiflash]  ",
+          "      │ └─ExchangeSender_25 8000.00 mpp[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Projection_24 8000.00 mpp[tiflash]  Column#7, test.o.c_id",
+          "      │     └─HashAgg_19 8000.00 mpp[tiflash]  group by:test.o.c_id, funcs:count(1)->Column#7, funcs:firstrow(test.o.c_id)->test.o.c_id",
+          "      │       └─ExchangeReceiver_23 10000.00 mpp[tiflash]  ",
+          "      │         └─ExchangeSender_22 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.o.c_id, collate: binary]",
+          "      │           └─TableFullScan_21 10000.00 mpp[tiflash] table:o keep order:false, stats:pseudo",
+          "      └─Selection_18(Probe) 9990.00 mpp[tiflash]  not(isnull(test.c.c_id))",
+          "        └─TableFullScan_17 10000.00 mpp[tiflash] table:c keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "EXPLAIN select o.o_id, count(*) from c, o where c.c_id=o.c_id group by o.o_id; -- 2. test agg push down, group by non-join column",
+        "Plan": [
+          "TableReader_78 8000.00 root  data:ExchangeSender_77",
+          "└─ExchangeSender_77 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection_10 8000.00 mpp[tiflash]  test.o.o_id, Column#6",
+          "    └─Projection_76 8000.00 mpp[tiflash]  Column#6, test.o.o_id",
+          "      └─HashAgg_75 8000.00 mpp[tiflash]  group by:test.o.o_id, funcs:count(Column#7)->Column#6, funcs:firstrow(Column#8)->test.o.o_id",
+          "        └─ExchangeReceiver_71 9990.00 mpp[tiflash]  ",
+          "          └─ExchangeSender_70 9990.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.o.o_id, collate: binary]",
+          "            └─HashJoin_69 9990.00 mpp[tiflash]  inner join, equal:[eq(test.c.c_id, test.o.c_id)]",
+          "              ├─ExchangeReceiver_27(Build) 8000.00 mpp[tiflash]  ",
+          "              │ └─ExchangeSender_26 8000.00 mpp[tiflash]  ExchangeType: Broadcast",
+          "              │   └─Projection_25 8000.00 mpp[tiflash]  Column#7, Column#8, test.o.o_id, test.o.c_id",
+          "              │     └─HashAgg_20 8000.00 mpp[tiflash]  group by:test.o.c_id, test.o.o_id, funcs:count(1)->Column#7, funcs:firstrow(test.o.o_id)->Column#8, funcs:firstrow(test.o.o_id)->test.o.o_id, funcs:firstrow(test.o.c_id)->test.o.c_id",
+          "              │       └─ExchangeReceiver_24 10000.00 mpp[tiflash]  ",
+          "              │         └─ExchangeSender_23 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.o.o_id, collate: binary], [name: test.o.c_id, collate: binary]",
+          "              │           └─TableFullScan_22 10000.00 mpp[tiflash] table:o keep order:false, stats:pseudo",
+          "              └─Selection_19(Probe) 9990.00 mpp[tiflash]  not(isnull(test.c.c_id))",
+          "                └─TableFullScan_18 10000.00 mpp[tiflash] table:c keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "EXPLAIN select o.c_id, count(*) from c, o where c.c_id=o.c_id group by o.c_id; -- 3. test agg push down, group by join column",
+        "Plan": [
+          "TableReader_78 8000.00 root  data:ExchangeSender_77",
+          "└─ExchangeSender_77 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection_10 8000.00 mpp[tiflash]  test.o.c_id, Column#6",
+          "    └─Projection_76 8000.00 mpp[tiflash]  Column#6, test.o.c_id",
+          "      └─HashAgg_75 8000.00 mpp[tiflash]  group by:test.o.c_id, funcs:count(Column#7)->Column#6, funcs:firstrow(Column#8)->test.o.c_id",
+          "        └─ExchangeReceiver_71 9990.00 mpp[tiflash]  ",
+          "          └─ExchangeSender_70 9990.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.o.c_id, collate: binary]",
+          "            └─HashJoin_69 9990.00 mpp[tiflash]  inner join, equal:[eq(test.c.c_id, test.o.c_id)]",
+          "              ├─ExchangeReceiver_27(Build) 8000.00 mpp[tiflash]  ",
+          "              │ └─ExchangeSender_26 8000.00 mpp[tiflash]  ExchangeType: Broadcast",
+          "              │   └─Projection_25 8000.00 mpp[tiflash]  Column#7, Column#8, test.o.c_id",
+          "              │     └─HashAgg_20 8000.00 mpp[tiflash]  group by:test.o.c_id, funcs:count(1)->Column#7, funcs:firstrow(test.o.c_id)->Column#8, funcs:firstrow(test.o.c_id)->test.o.c_id",
+          "              │       └─ExchangeReceiver_24 10000.00 mpp[tiflash]  ",
+          "              │         └─ExchangeSender_23 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.o.c_id, collate: binary]",
+          "              │           └─TableFullScan_22 10000.00 mpp[tiflash] table:o keep order:false, stats:pseudo",
+          "              └─Selection_19(Probe) 9990.00 mpp[tiflash]  not(isnull(test.c.c_id))",
+          "                └─TableFullScan_18 10000.00 mpp[tiflash] table:c keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      }
+    ]
   }
 ]

--- a/plugin/audit.go
+++ b/plugin/audit.go
@@ -16,7 +16,9 @@ package plugin
 
 import (
 	"context"
+	"strings"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx/variable"
 )
 
@@ -30,7 +32,35 @@ const (
 	Completed
 	// Error represents a GeneralEvent that has error (and typically couldn't start)
 	Error
+	// GeneralEventCount is the count for the general events
+	// The new events MUST be added before it
+	GeneralEventCount
 )
+
+// GeneralEventFromString gets the `GeneralEvent` from the given string
+func GeneralEventFromString(s string) (GeneralEvent, error) {
+	upperStr := strings.ToUpper(s)
+	for i := 0; i < int(GeneralEventCount); i++ {
+		event := GeneralEvent(i)
+		if event.String() == upperStr {
+			return event, nil
+		}
+	}
+	return 0, errors.Errorf("Invalid general event: %s", s)
+}
+
+// String returns the string for the `GeneralEvent`
+func (e GeneralEvent) String() string {
+	switch e {
+	case Starting:
+		return "STARTING"
+	case Completed:
+		return "COMPLETED"
+	case Error:
+		return "ERROR"
+	}
+	return ""
+}
 
 // ConnectionEvent presents TiDB connection event.
 type ConnectionEvent byte

--- a/plugin/const_test.go
+++ b/plugin/const_test.go
@@ -16,6 +16,7 @@ package plugin
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,4 +42,44 @@ func TestConstToString(t *testing.T) {
 	for key, value := range kinds {
 		require.Equal(t, value, key.String())
 	}
+
+	generalEvents := map[fmt.Stringer]string{
+		// GeneralEvent
+		Starting:  "STARTING",
+		Completed: "COMPLETED",
+		Error:     "ERROR",
+	}
+	require.Equal(t, int(GeneralEventCount), len(generalEvents))
+	for key, value := range generalEvents {
+		require.Equal(t, value, key.String())
+	}
+}
+
+func TestGeneralEventString(t *testing.T) {
+	for i := 0; i < int(GeneralEventCount); i++ {
+		event := GeneralEvent(i)
+		str := event.String()
+		// event string should be upper case
+		require.Equal(t, strings.ToUpper(str), str)
+		// GeneralEventFromString return the right event
+		got, err := GeneralEventFromString(event.String())
+		require.NoError(t, err)
+		require.Equal(t, got, event)
+	}
+
+	// case insensitive
+	event, err := GeneralEventFromString("starting")
+	require.NoError(t, err)
+	require.Equal(t, Starting, event)
+
+	event, err = GeneralEventFromString("starTing")
+	require.NoError(t, err)
+	require.Equal(t, Starting, event)
+
+	// invalid string
+	_, err = GeneralEventFromString("")
+	require.Error(t, err)
+
+	_, err = GeneralEventFromString("xx")
+	require.Error(t, err)
 }

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -709,6 +709,7 @@ func TestConnExecutionTimeout(t *testing.T) {
 		clients: map[uint64]*clientConn{
 			connID: cc,
 		},
+		dom: dom,
 	}
 	handle := dom.ExpensiveQueryHandle().SetSessionManager(srv)
 	go handle.Run()

--- a/server/server.go
+++ b/server/server.go
@@ -833,8 +833,12 @@ func (s *Server) GetInternalSessionStartTSList() []uint64 {
 	s.sessionMapMutex.Lock()
 	defer s.sessionMapMutex.Unlock()
 	tsList := make([]uint64, 0, len(s.internalSessions))
+	analyzeProcID := util.GetAutoAnalyzeProcID(s.ServerID)
 	for se := range s.internalSessions {
-		if ts := session.GetStartTSFromSession(se); ts != 0 {
+		if ts, processInfoID := session.GetStartTSFromSession(se); ts != 0 {
+			if processInfoID == analyzeProcID {
+				continue
+			}
 			tsList = append(tsList, ts)
 		}
 	}

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1835,15 +1835,6 @@ func upgradeToVer89(s Session, ver int64) {
 // to the error log. The message is important since the behavior is weird
 // (changes to the config file will no longer take effect past this point).
 func importConfigOption(s Session, configName, svName, valStr string) {
-	if valStr == "" || valStr == "0" {
-		// We can't technically detect from config if there was no value set. i.e.
-		// a boolean is true/false, not true/false/null.
-		// *However* if there was no value, it does guarantee that it was
-		// not set in the config file. We don't want to import NULL values,
-		// because the behavior will be wrong.
-		// See: https://github.com/pingcap/tidb/issues/34847
-		return
-	}
 	message := fmt.Sprintf("%s is now configured by the system variable %s. One-time importing the value specified in tidb.toml file", configName, svName)
 	logutil.BgLogger().Warn(message, zap.String("value", valStr))
 	// We use insert ignore, since if its a duplicate we don't want to overwrite any user-set values.

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1835,6 +1835,15 @@ func upgradeToVer89(s Session, ver int64) {
 // to the error log. The message is important since the behavior is weird
 // (changes to the config file will no longer take effect past this point).
 func importConfigOption(s Session, configName, svName, valStr string) {
+	if valStr == "" || valStr == "0" {
+		// We can't technically detect from config if there was no value set. i.e.
+		// a boolean is true/false, not true/false/null.
+		// *However* if there was no value, it does guarantee that it was
+		// not set in the config file. We don't want to import NULL values,
+		// because the behavior will be wrong.
+		// See: https://github.com/pingcap/tidb/issues/34847
+		return
+	}
 	message := fmt.Sprintf("%s is now configured by the system variable %s. One-time importing the value specified in tidb.toml file", configName, svName)
 	logutil.BgLogger().Warn(message, zap.String("value", valStr))
 	// We use insert ignore, since if its a duplicate we don't want to overwrite any user-set values.
@@ -1851,7 +1860,7 @@ func upgradeToVer90(s Session, ver int64) {
 	importConfigOption(s, "enable-batch-dml", variable.TiDBEnableBatchDML, valStr)
 	valStr = fmt.Sprint(config.GetGlobalConfig().MemQuotaQuery)
 	importConfigOption(s, "mem-quota-query", variable.TiDBMemQuotaQuery, valStr)
-	valStr = fmt.Sprint((config.GetGlobalConfig().Log.QueryLogMaxLen), 10)
+	valStr = fmt.Sprint(config.GetGlobalConfig().Log.QueryLogMaxLen)
 	importConfigOption(s, "query-log-max-len", variable.TiDBQueryLogMaxLen, valStr)
 	valStr = fmt.Sprint(config.GetGlobalConfig().Performance.CommitterConcurrency)
 	importConfigOption(s, "committer-concurrency", variable.TiDBCommitterConcurrency, valStr)

--- a/session/session.go
+++ b/session/session.go
@@ -3230,12 +3230,16 @@ func (s *session) ShowProcess() *util.ProcessInfo {
 }
 
 // GetStartTSFromSession returns the startTS in the session `se`
-func GetStartTSFromSession(se interface{}) uint64 {
-	var startTS uint64
+func GetStartTSFromSession(se interface{}) (uint64, uint64) {
+	var startTS, processInfoID uint64
 	tmp, ok := se.(*session)
 	if !ok {
 		logutil.BgLogger().Error("GetStartTSFromSession failed, can't transform to session struct")
-		return 0
+		return 0, 0
+	}
+	processInfo := tmp.ShowProcess()
+	if processInfo != nil {
+		processInfoID = processInfo.ID
 	}
 	txnInfo := tmp.TxnInfo()
 	if txnInfo != nil {
@@ -3246,7 +3250,7 @@ func GetStartTSFromSession(se interface{}) uint64 {
 		"GetStartTSFromSession getting startTS of internal session",
 		zap.Uint64("startTS", startTS), zap.Time("start time", oracle.GetTimeFromTS(startTS)))
 
-	return startTS
+	return startTS, processInfoID
 }
 
 // logStmt logs some crucial SQL including: CREATE USER/GRANT PRIVILEGE/CHANGE PASSWORD/DDL etc and normal SQL

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -790,6 +790,18 @@ var defaultSysVars = []*SysVar{
 			OOMAction.Store(val)
 			return nil
 		}},
+	{Scope: ScopeGlobal, Name: TiDBMaxAutoAnalyzeTime, Value: strconv.Itoa(DefTiDBMaxAutoAnalyzeTime), Type: TypeInt, MinValue: 0, MaxValue: math.MaxInt32,
+		GetGlobal: func(s *SessionVars) (string, error) {
+			return strconv.FormatInt(MaxAutoAnalyzeTime.Load(), 10), nil
+		},
+		SetGlobal: func(s *SessionVars, val string) error {
+			num, err := strconv.ParseInt(val, 10, 64)
+			if err == nil {
+				MaxAutoAnalyzeTime.Store(num)
+			}
+			return err
+		},
+	},
 
 	/* The system variables below have GLOBAL and SESSION scope  */
 	{Scope: ScopeGlobal | ScopeSession, Name: SQLSelectLimit, Value: "18446744073709551615", Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxUint64, SetSession: func(s *SessionVars, val string) error {

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1411,6 +1411,7 @@ var defaultSysVars = []*SysVar{
 		newMode := strings.ToLower(strings.TrimSpace(val))
 		if PartitionPruneMode(s.PartitionPruneMode.Load()) == Static && PartitionPruneMode(newMode) == Dynamic {
 			s.StmtCtx.AppendWarning(errors.New("Please analyze all partition tables again for consistency between partition and global stats"))
+			s.StmtCtx.AppendWarning(errors.New("Please avoid setting partition prune mode to dynamic at session level and set partition prune mode to dynamic at global level"))
 		}
 		s.PartitionPruneMode.Store(newMode)
 		return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1172,7 +1172,7 @@ var defaultSysVars = []*SysVar{
 		s.EnableTablePartition = val
 		return nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableListTablePartition, Value: Off, Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableListTablePartition, Value: On, Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
 		s.EnableListTablePartition = TiDBOptOn(val)
 		return nil
 	}},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -701,6 +701,9 @@ const (
 	TiDBPrepPlanCacheSize = "tidb_prepared_plan_cache_size"
 	// TiDBPrepPlanCacheMemoryGuardRatio is used to prevent [performance.max-memory] from being exceeded
 	TiDBPrepPlanCacheMemoryGuardRatio = "tidb_prepared_plan_cache_memory_guard_ratio"
+	// TiDBMaxAutoAnalyzeTime is the max time that auto analyze can run. If auto analyze runs longer than the value, it
+	// will be killed. 0 indicates that there is no time limit.
+	TiDBMaxAutoAnalyzeTime = "tidb_max_auto_analyze_time"
 )
 
 // TiDB intentional limits
@@ -885,6 +888,7 @@ const (
 	DefTiDBMemQuotaAnalyze                       = -1
 	DefTiDBEnableAutoAnalyze                     = true
 	DefTiDBMemOOMAction                          = "CANCEL"
+	DefTiDBMaxAutoAnalyzeTime                    = 12 * 60 * 60
 	DefTiDBEnablePrepPlanCache                   = true
 	DefTiDBPrepPlanCacheSize                     = 100
 	DefTiDBPrepPlanCacheMemoryGuardRatio         = 0.1
@@ -928,6 +932,7 @@ var (
 	GCMaxWaitTime                         = atomic.NewInt64(DefTiDBGCMaxWaitTime)
 	StatsCacheMemQuota                    = atomic.NewInt64(DefTiDBStatsCacheMemQuota)
 	OOMAction                             = atomic.NewString(DefTiDBMemOOMAction)
+	MaxAutoAnalyzeTime                    = atomic.NewInt64(DefTiDBMaxAutoAnalyzeTime)
 	// variables for plan cache
 	EnablePreparedPlanCache           = atomic.NewBool(DefTiDBEnablePrepPlanCache)
 	PreparedPlanCacheSize             = atomic.NewUint64(DefTiDBPrepPlanCacheSize)

--- a/sessionctx/variable/variable.go
+++ b/sessionctx/variable/variable.go
@@ -535,7 +535,7 @@ func (sv *SysVar) SkipInit() bool {
 func (sv *SysVar) SkipSysvarCache() bool {
 	switch sv.Name {
 	case TiDBGCEnable, TiDBGCRunInterval, TiDBGCLifetime,
-		TiDBGCConcurrency, TiDBGCScanLockMode, TiDBGCMaxWaitTime:
+		TiDBGCConcurrency, TiDBGCScanLockMode:
 		return true
 	}
 	return false

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -473,7 +473,7 @@ func (h *Handle) mergePartitionStats2GlobalStats(sc sessionctx.Context, opts map
 		}
 		for i := 0; i < globalStats.Num; i++ {
 			count, hg, cms, topN, fms := partitionStats.GetStatsInfo(histIDs[i], isIndex == 1)
-			// partition is not empty but column stats(hist, topn) is missing
+			// partition stats is not empty but column stats(hist, topn) is missing
 			if partitionStats.Count > 0 && (hg == nil || hg.TotalRowCount() <= 0) && (topN == nil || topN.TotalCount() <= 0) {
 				var errMsg string
 				if isIndex == 0 {

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -3156,17 +3156,19 @@ func TestIssues24401(t *testing.T) {
 	testKit.MustExec("create table tp(a int, index(a)) partition by hash(a) partitions 3")
 	testKit.MustExec("insert into tp values (1), (2), (3)")
 	testKit.MustExec("analyze table tp")
-	testKit.MustQuery("select * from mysql.stats_fm_sketch").Check(testkit.Rows())
+	rows := testKit.MustQuery("select * from mysql.stats_fm_sketch").Rows()
+	require.Equal(t, 6, len(rows))
 
 	// normal table with dynamic prune mode
 	testKit.MustExec("set @@tidb_partition_prune_mode='dynamic'")
 	defer testKit.MustExec("set @@tidb_partition_prune_mode='static'")
 	testKit.MustExec("analyze table t")
-	testKit.MustQuery("select * from mysql.stats_fm_sketch").Check(testkit.Rows())
+	rows = testKit.MustQuery("select * from mysql.stats_fm_sketch").Rows()
+	require.Equal(t, 6, len(rows))
 
 	// partition table with dynamic prune mode
 	testKit.MustExec("analyze table tp")
-	rows := testKit.MustQuery("select * from mysql.stats_fm_sketch").Rows()
+	rows = testKit.MustQuery("select * from mysql.stats_fm_sketch").Rows()
 	lenRows := len(rows)
 	require.Equal(t, 6, lenRows)
 

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -298,11 +298,17 @@ func (t *Table) ColumnByName(colName string) *Column {
 // GetStatsInfo returns their statistics according to the ID of the column or index, including histogram, CMSketch, TopN and FMSketch.
 func (t *Table) GetStatsInfo(ID int64, isIndex bool) (int64, *Histogram, *CMSketch, *TopN, *FMSketch) {
 	if isIndex {
-		idxStatsInfo := t.Indices[ID]
-		return int64(idxStatsInfo.TotalRowCount()), idxStatsInfo.Histogram.Copy(), idxStatsInfo.CMSketch.Copy(), idxStatsInfo.TopN.Copy(), idxStatsInfo.FMSketch.Copy()
+		if idxStatsInfo, ok := t.Indices[ID]; ok {
+			return int64(idxStatsInfo.TotalRowCount()), idxStatsInfo.Histogram.Copy(), idxStatsInfo.CMSketch.Copy(), idxStatsInfo.TopN.Copy(), idxStatsInfo.FMSketch.Copy()
+		}
+		// newly added index which is not analyzed yet
+		return 0, nil, nil, nil, nil
 	}
-	colStatsInfo := t.Columns[ID]
-	return int64(colStatsInfo.TotalRowCount()), colStatsInfo.Histogram.Copy(), colStatsInfo.CMSketch.Copy(), colStatsInfo.TopN.Copy(), colStatsInfo.FMSketch.Copy()
+	if colStatsInfo, ok := t.Columns[ID]; ok {
+		return int64(colStatsInfo.TotalRowCount()), colStatsInfo.Histogram.Copy(), colStatsInfo.CMSketch.Copy(), colStatsInfo.TopN.Copy(), colStatsInfo.FMSketch.Copy()
+	}
+	// newly added column which is not analyzed yet
+	return 0, nil, nil, nil, nil
 }
 
 // GetColRowCount tries to get the row count of the a column if possible.

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -42,6 +42,8 @@ type tikvTxn struct {
 	*tikv.KVTxn
 	idxNameCache        map[int64]*model.TableInfo
 	snapshotInterceptor kv.SnapshotInterceptor
+	// columnMapsCache is a cache used for the mutation checker
+	columnMapsCache interface{}
 }
 
 // NewTiKVTxn returns a new Transaction.
@@ -52,7 +54,7 @@ func NewTiKVTxn(txn *tikv.KVTxn) kv.Transaction {
 	totalLimit := atomic.LoadUint64(&kv.TxnTotalSizeLimit)
 	txn.GetUnionStore().SetEntrySizeLimit(entryLimit, totalLimit)
 
-	return &tikvTxn{txn, make(map[int64]*model.TableInfo), nil}
+	return &tikvTxn{txn, make(map[int64]*model.TableInfo), nil, nil}
 }
 
 func (txn *tikvTxn) GetTableInfo(id int64) *model.TableInfo {
@@ -237,6 +239,8 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 		txn.KVTxn.SetRPCInterceptor(val.(interceptor.RPCInterceptor))
 	case kv.AssertionLevel:
 		txn.KVTxn.SetAssertionLevel(val.(kvrpcpb.AssertionLevel))
+	case kv.TableToColumnMaps:
+		txn.columnMapsCache = val
 	}
 }
 
@@ -246,6 +250,8 @@ func (txn *tikvTxn) GetOption(opt int) interface{} {
 		return !txn.KVTxn.IsCasualConsistency()
 	case kv.TxnScope:
 		return txn.KVTxn.GetScope()
+	case kv.TableToColumnMaps:
+		return txn.columnMapsCache
 	default:
 		return nil
 	}

--- a/table/tables/mutation_checker.go
+++ b/table/tables/mutation_checker.go
@@ -90,13 +90,16 @@ func CheckDataConsistency(
 
 	columnMaps := getColumnMaps(txn, t)
 
-	if rowToInsert != nil {
-		if err := checkRowInsertionConsistency(
-			sessVars, rowToInsert, rowInsertion, columnMaps.ColumnIDToInfo, columnMaps.ColumnIDToFieldType, t.Meta().Name.O,
-		); err != nil {
-			return errors.Trace(err)
-		}
-	}
+	// Row insertion consistency check contributes the least to defending data-index consistency, but costs most CPU resources.
+	// So we disable it for now.
+	//
+	// if rowToInsert != nil {
+	// 	if err := checkRowInsertionConsistency(
+	// 		sessVars, rowToInsert, rowInsertion, columnMaps.ColumnIDToInfo, columnMaps.ColumnIDToFieldType, t.Meta().Name.O,
+	// 	); err != nil {
+	// 		return errors.Trace(err)
+	// 	}
+	// }
 
 	if err != nil {
 		return err

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -554,10 +554,6 @@ func setGlobalVars() {
 					cfg.Instance.CheckMb4ValueInUTF8.Store(cfg.CheckMb4ValueInUTF8.Load())
 				case "enable-collect-execution-info":
 					cfg.Instance.EnableCollectExecutionInfo = cfg.EnableCollectExecutionInfo
-				case "plugin.load":
-					cfg.Instance.PluginLoad = cfg.Plugin.Load
-				case "plugin.dir":
-					cfg.Instance.PluginDir = cfg.Plugin.Dir
 				}
 			case "log":
 				switch oldName {
@@ -574,6 +570,13 @@ func setGlobalVars() {
 					cfg.Instance.ForcePriority = cfg.Performance.ForcePriority
 				case "memory-usage-alarm-ratio":
 					cfg.Instance.MemoryUsageAlarmRatio = cfg.Performance.MemoryUsageAlarmRatio
+				}
+			case "plugin":
+				switch oldName {
+				case "load":
+					cfg.Instance.PluginLoad = cfg.Plugin.Load
+				case "dir":
+					cfg.Instance.PluginDir = cfg.Plugin.Dir
 				}
 			default:
 			}

--- a/util/expensivequery/expensivequery.go
+++ b/util/expensivequery/expensivequery.go
@@ -70,9 +70,18 @@ func (eqh *Handle) Run() {
 					logExpensiveQuery(costTime, info)
 					info.ExceedExpensiveTimeThresh = true
 				}
-
 				if info.MaxExecutionTime > 0 && costTime > time.Duration(info.MaxExecutionTime)*time.Millisecond {
+					logutil.BgLogger().Warn("execution timeout, kill it", zap.Duration("costTime", costTime),
+						zap.Duration("maxExecutionTime", time.Duration(info.MaxExecutionTime)*time.Millisecond), zap.String("processInfo", info.String()))
 					sm.Kill(info.ID, true)
+				}
+				if info.ID == util.GetAutoAnalyzeProcID(sm.ServerID) {
+					maxAutoAnalyzeTime := variable.MaxAutoAnalyzeTime.Load()
+					if maxAutoAnalyzeTime > 0 && costTime > time.Duration(maxAutoAnalyzeTime)*time.Second {
+						logutil.BgLogger().Warn("auto analyze timeout, kill it", zap.Duration("costTime", costTime),
+							zap.Duration("maxAutoAnalyzeTime", time.Duration(maxAutoAnalyzeTime)*time.Second), zap.String("processInfo", info.String()))
+						sm.Kill(info.ID, true)
+					}
 				}
 			}
 			threshold = atomic.LoadUint64(&variable.ExpensiveQueryTimeThreshold)

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -88,6 +88,11 @@ func (pi *ProcessInfo) ToRowForShow(full bool) []interface{} {
 	}
 }
 
+func (pi *ProcessInfo) String() string {
+	rows := pi.ToRowForShow(false)
+	return fmt.Sprintf("{id:%v, user:%v, host:%v, db:%v, command:%v, time:%v, state:%v, info:%v}", rows...)
+}
+
 func (pi *ProcessInfo) txnStartTs(tz *time.Location) (txnStart string) {
 	if pi.CurTxnStartTS > 0 {
 		physicalTime := oracle.GetTimeFromTS(pi.CurTxnStartTS)


### PR DESCRIPTION
### What problem does this PR solve?


Issue Number: close #38116

Problem Summary:

```
call sessionVars.PreparedParams out of range 0
```

### What is changed and how it works?

check the slice length and when slice.length > order size, then return the value, 
else return default value: `types.Datum`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
