### PR TITLE
ddl: skip delay for async commit during merging temp index

### DIFF
--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -202,7 +202,8 @@ func (w *worker) runReorgJob(rh *reorgHandler, reorgInfo *reorgInfo, tblInfo *mo
 		// Since reorg job will be interrupted for polling the cancel action outside. we don't need to wait for 2.5s
 		// for the later entrances.
 		// lease = 0 means it's in an integration test. In this case we don't delay so the test won't run too slowly.
-		if lease > 0 {
+		// We don't need to wait in merging temp index because all the async commit txns should be committed in previous reorg phase.
+		if lease > 0 && !reorgInfo.mergingTmpIdx {
 			delayForAsyncCommit()
 		}
 		// This job is cancelling, we should return ErrCancelledDDLJob directly.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #35983

Problem Summary:

After `@@tidb_ddl_enable_fast_reorg` is enabled, there will be two reorganization steps: backfilll and merge. Because DDL has waited 2.5 seconds in the backfill step, it is guaranteed that none of the async commit transactions with old schema info(the newly adding index's schema state is none) are active. Thus, we don't have to wait another 2.5 seconds in the merge step. 

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  Before this PR, adding index takes 6 seconds even the table is empty:
  ```
  mysql> set @@global.tidb_ddl_enable_fast_reorg = 1;
  Query OK, 0 rows affected (0.03 sec)

  mysql> alter table t add index idx(a);
  Query OK, 0 rows affected (6.17 sec)
  ```
  After this PR, it takes about 3 seconds:
  ```
  alter table t add index idx(a);
  Query OK, 0 rows affected (3.11 sec)
  ```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
