### PR TITLE
lightning: add truncate flag to lightning

### DIFF
--- a/br/pkg/lightning/common/errors.go
+++ b/br/pkg/lightning/common/errors.go
@@ -91,6 +91,7 @@ var (
 	ErrUnknownColumns       = errors.Normalize("unknown columns in header (%s) for table %s", errors.RFCCodeText("Lightning:Restore:ErrUnknownColumns"))
 	ErrChecksumMismatch     = errors.Normalize("checksum mismatched remote vs local => (checksum: %d vs %d) (total_kvs: %d vs %d) (total_bytes:%d vs %d)", errors.RFCCodeText("Lighting:Restore:ErrChecksumMismatch"))
 	ErrRestoreTable         = errors.Normalize("restore table %s failed", errors.RFCCodeText("Lightning:Restore:ErrRestoreTable"))
+	ErrTruncateTable        = errors.Normalize("truncate table %s failed", errors.RFCCodeText("Lightning:Restore:ErrTruncateTable"))
 	ErrEncodeKV             = errors.Normalize("encode kv error in file %s at offset %d", errors.RFCCodeText("Lightning:Restore:ErrEncodeKV"))
 	ErrAllocTableRowIDs     = errors.Normalize("allocate table row id error", errors.RFCCodeText("Lightning:Restore:ErrAllocTableRowIDs"))
 	ErrInvalidMetaStatus    = errors.Normalize("invalid meta status: '%s'", errors.RFCCodeText("Lightning:Restore:ErrInvalidMetaStatus"))

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -455,6 +455,7 @@ type MydumperRuntime struct {
 	FileRouters      []*FileRouteRule `toml:"files" json:"files"`
 	// Deprecated: only used to keep the compatibility.
 	NoSchema         bool             `toml:"no-schema" json:"no-schema"`
+	Truncate         bool             `toml:"truncate" json:"truncate"`
 	CaseSensitive    bool             `toml:"case-sensitive" json:"case-sensitive"`
 	StrictFormat     bool             `toml:"strict-format" json:"strict-format"`
 	DefaultFileRules bool             `toml:"default-file-rules" json:"default-file-rules"`
@@ -749,6 +750,7 @@ func (cfg *Config) LoadFromGlobal(global *GlobalConfig) error {
 	cfg.TiDB.StatusPort = global.TiDB.StatusPort
 	cfg.TiDB.PdAddr = global.TiDB.PdAddr
 	cfg.Mydumper.NoSchema = global.Mydumper.NoSchema
+	cfg.Mydumper.Truncate = global.Mydumper.Truncate
 	cfg.Mydumper.SourceDir = global.Mydumper.SourceDir
 	cfg.Mydumper.Filter = global.Mydumper.Filter
 	cfg.TikvImporter.Backend = global.TikvImporter.Backend

--- a/br/pkg/lightning/config/global.go
+++ b/br/pkg/lightning/config/global.go
@@ -54,6 +54,7 @@ type GlobalMydumper struct {
 	SourceDir string `toml:"data-source-dir" json:"data-source-dir"`
 	// Deprecated
 	NoSchema      bool             `toml:"no-schema" json:"no-schema"`
+	Truncate      bool             `toml:"truncate" json:"truncate"`
 	Filter        []string         `toml:"filter" json:"filter"`
 	IgnoreColumns []*IgnoreColumns `toml:"ignore-columns" json:"ignore-columns"`
 }
@@ -100,7 +101,8 @@ func NewGlobalConfig() *GlobalConfig {
 			LogLevel:   "error",
 		},
 		Mydumper: GlobalMydumper{
-			Filter: DefaultFilter,
+			Filter:   DefaultFilter,
+			Truncate: false,
 		},
 		TikvImporter: GlobalImporter{
 			Backend: "",
@@ -156,6 +158,7 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	sortedKVDir := fs.String("sorted-kv-dir", "", "path for KV pairs when local backend enabled")
 	enableCheckpoint := fs.Bool("enable-checkpoint", true, "whether to enable checkpoints")
 	noSchema := fs.Bool("no-schema", false, "ignore schema files, get schema directly from TiDB instead")
+	truncate := fs.Bool("truncate", false, "truncate Table before load data")
 	checksum := flagext.ChoiceVar(fs, "checksum", "", "compare checksum after importing.", "", "required", "optional", "off", "true", "false")
 	analyze := flagext.ChoiceVar(fs, "analyze", "", "analyze table after importing", "", "required", "optional", "off", "true", "false")
 	checkRequirements := fs.Bool("check-requirements", true, "check cluster version before starting")
@@ -240,6 +243,9 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	}
 	if *noSchema {
 		cfg.Mydumper.NoSchema = true
+	}
+	if *truncate {
+		cfg.Mydumper.Truncate = true
 	}
 	if *checksum != "" {
 		_ = cfg.PostRestore.Checksum.FromStringValue(*checksum)

--- a/br/pkg/lightning/restore/restore.go
+++ b/br/pkg/lightning/restore/restore.go
@@ -2094,8 +2094,10 @@ func (rc *Controller) DataCheck(ctx context.Context) error {
 		}
 	}
 
-	if err := rc.checkTableEmpty(ctx); err != nil {
-		return common.ErrCheckTableEmpty.Wrap(err).GenWithStackByArgs()
+	if !rc.cfg.Mydumper.Truncate {
+		if err := rc.checkTableEmpty(ctx); err != nil {
+			return common.ErrCheckTableEmpty.Wrap(err).GenWithStackByArgs()
+		}
 	}
 	if err := rc.checkCSVHeader(ctx); err != nil {
 		return common.ErrCheckCSVHeader.Wrap(err).GenWithStackByArgs()

--- a/br/pkg/lightning/restore/table_restore.go
+++ b/br/pkg/lightning/restore/table_restore.go
@@ -1010,6 +1010,13 @@ func (tr *TableRestore) analyzeTable(ctx context.Context, g glue.SQLExecutor) er
 	return err
 }
 
+func (tr *TableRestore) truncateTable(ctx context.Context, g glue.SQLExecutor) error {
+	task := tr.logger.Begin(zap.InfoLevel, "truncate")
+	err := g.ExecuteWithLog(ctx, "TRUNCATE TABLE "+tr.tableName, "truncate table", tr.logger)
+	task.End(zap.ErrorLevel, err)
+	return err
+}
+
 // estimate SST files compression threshold by total row file size
 // with a higher compression threshold, the compression time increases, but the iteration time decreases.
 // Try to limit the total SST files number under 500. But size compress 32GB SST files cost about 20min,


### PR DESCRIPTION
Issue Number: close #38148

Problem Summary:

### What is changed and how it works?
1. add `truncate` flag to lightning command line args.
2. if truncate is true, do truncate before loading data.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

