### PR TITLE
executor,sessionctx: remove useless internal system variable tx_isolation_one_shot

### DIFF
--- a/executor/set.go
+++ b/executor/set.go
@@ -171,8 +171,7 @@ func (e *SetExecutor) setSysVariable(ctx context.Context, name string, v *expres
 		}
 	}
 	if sessionVars.InTxn() {
-		if name == variable.TxnIsolationOneShot ||
-			name == variable.TiDBTxnReadTS {
+		if name == variable.TiDBTxnReadTS {
 			return errors.Trace(ErrCantChangeTxCharacteristics)
 		}
 		if name == variable.TiDBSnapshot && sessionVars.TxnCtx.IsStaleness {

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -213,18 +213,6 @@ var defaultSysVars = []*SysVar{
 		s.EnableChunkRPC = TiDBOptOn(val)
 		return nil
 	}},
-	{Scope: ScopeSession, Name: TxnIsolationOneShot, Value: "", skipInit: true, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
-		return checkIsolationLevel(vars, normalizedValue, originalValue, scope)
-	}, SetSession: func(s *SessionVars, val string) error {
-		s.txnIsolationLevelOneShot.state = oneShotSet
-		s.txnIsolationLevelOneShot.value = val
-		return nil
-	}, GetStateValue: func(s *SessionVars) (string, bool, error) {
-		if s.txnIsolationLevelOneShot.state != oneShotDef {
-			return s.txnIsolationLevelOneShot.value, true, nil
-		}
-		return "", false, nil
-	}},
 	{Scope: ScopeSession, Name: TiDBOptimizerSelectivityLevel, Value: strconv.Itoa(DefTiDBOptimizerSelectivityLevel), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxInt32, SetSession: func(s *SessionVars, val string) error {
 		s.OptimizerSelectivityLevel = tidbOptPositiveInt32(val, DefTiDBOptimizerSelectivityLevel)
 		return nil
@@ -2204,8 +2192,6 @@ const (
 	TxnIsolation = "tx_isolation"
 	// TransactionIsolation is the name of the 'transaction_isolation' system variable.
 	TransactionIsolation = "transaction_isolation"
-	// TxnIsolationOneShot is the name of the 'tx_isolation_one_shot' system variable.
-	TxnIsolationOneShot = "tx_isolation_one_shot"
 	// MaxExecutionTime is the name of the 'max_execution_time' system variable.
 	MaxExecutionTime = "max_execution_time"
 	// ReadOnly is the name of the 'read_only' system variable.

--- a/sessionctx/variable/variable_test.go
+++ b/sessionctx/variable/variable_test.go
@@ -492,7 +492,6 @@ func TestSkipInitIsUsed(t *testing.T) {
 			case TiDBTxnScope,
 				TiDBSnapshot,
 				TiDBEnableChunkRPC,
-				TxnIsolationOneShot,
 				TiDBDDLReorgPriority,
 				TiDBSlowQueryFile,
 				TiDBWaitSplitRegionFinish,


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38203

Problem Summary:

`tx_isolation_one_shot` is first introduced in https://github.com/pingcap/tidb/pull/6175 to implement the "session transaction isolation level" statement.

It's an internal system variable, not meant to exposed to the user.

And after several iterations of refactoring, it's useless now. 

### What is changed and how it works?

Instead of document for it, I'd like to remove it:

- This is an internal variable which should never be exposed to the user.
- And it's useless now.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
