### PR TITLE
expression: make a copy when retrieving json path expression from cache

### DIFF
--- a/types/json_path_expr.go
+++ b/types/json_path_expr.go
@@ -92,6 +92,12 @@ type JSONPathExpression struct {
 	flags jsonPathExpressionFlag
 }
 
+func (pe JSONPathExpression) clone() JSONPathExpression {
+	legs := make([]jsonPathLeg, len(pe.legs))
+	copy(legs, pe.legs)
+	return JSONPathExpression{legs: legs, flags: pe.flags}
+}
+
 var peCache JSONPathExpressionCache
 
 type jsonPathExpressionKey string
@@ -362,7 +368,7 @@ func ParseJSONPathExpr(pathExpr string) (JSONPathExpression, error) {
 	val, ok := peCache.cache.Get(jsonPathExpressionKey(pathExpr))
 	if ok {
 		peCache.mu.Unlock()
-		return val.(JSONPathExpression), nil
+		return val.(JSONPathExpression).clone(), nil
 	}
 	peCache.mu.Unlock()
 


### PR DESCRIPTION
Signed-off-by: xiongjiwei <xiongjiwei1996@outlook.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/38230

Problem Summary:

there is some evidence that shows the data in json path cache is broken, we'd better make a copy when retrieving it

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
