### PR TITLE
domain, statistics: clean zombie analyze jobs terminated by server down

### DIFF
--- a/statistics/analyze_jobs.go
+++ b/statistics/analyze_jobs.go
@@ -47,7 +47,7 @@ func (p *AnalyzeProgress) Update(rowCount int64) (dumpCount int64) {
 	defer p.Unlock()
 	p.deltaCount += rowCount
 	t := time.Now()
-	const maxDelta int64 = 10000000
+	const maxDelta int64 = 1000000
 	const dumpTimeInterval = 5 * time.Second
 	if p.deltaCount > maxDelta && t.Sub(p.lastDumpTime) > dumpTimeInterval {
 		dumpCount = p.deltaCount


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35292

Problem Summary:

### What is changed and how it works?
Check `mysql.analyze_jobs` periodically.
1. If the server's own unfinished analyze job occurs in `mysql.analyze_jobs` but doesn't occur in processlist, update the job status to `failed`.
2. If the server is owner and finds some unfinished analyze job whose server is not in cluster, update the job status to `failed`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
