### PR TITLE
planner: `getDefaultValue` should clone field type

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/parser/auth"
@@ -7661,4 +7662,17 @@ func TestPlanCacheForIndexJoinRangeFallback(t *testing.T) {
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 Memory capacity of 1275 bytes for 'tidb_opt_range_max_size' exceeded when building ranges. Less accurate ranges such as full range are chosen"))
 	tk.MustExec("execute stmt2 using @a, @b, @c, @d, @e")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+}
+
+// https://github.com/pingcap/tidb/issues/38295.
+func TestIssue38295(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("CREATE TABLE t0(c0 BLOB(298) , c1 BLOB(182) , c2 NUMERIC);")
+	tk.MustExec("CREATE VIEW v0(c0) AS SELECT t0.c1 FROM t0;")
+	tk.MustExec("INSERT INTO t0 VALUES (-1, 'a', '2046549365');")
+	tk.MustExec("CREATE INDEX i0 ON t0(c2);")
+	tk.MustGetErrCode("SELECT t0.c1, t0.c2 FROM t0 GROUP BY MOD(t0.c0, DEFAULT(t0.c2));", errno.ErrFieldNotInGroupBy)
+	tk.MustExec("UPDATE t0 SET c2=1413;")
 }

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -3436,7 +3436,7 @@ func (b *PlanBuilder) getDefaultValue(col *table.Column) (*expression.Constant, 
 	if err != nil {
 		return nil, err
 	}
-	return &expression.Constant{Value: value, RetType: &col.FieldType}, nil
+	return &expression.Constant{Value: value, RetType: col.FieldType.Clone()}, nil
 }
 
 // resolveGeneratedColumns resolves generated columns with their generation


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38295

Problem Summary:

This is a pointer leak bug that causes the field type of a column changed after a "SELECT" statement is executed.

```
SELECT t0.c1, t0.c2 FROM t0 GROUP BY MOD(t0.c0, DEFAULT(t0.c2));
```

When TiDB evaluates the "DEFAULT" expression, the table in infoschema is used:

```
tbl, er.err = er.b.is.TableByName(dbName, name.OrigTblName)
...
col := table.FindCol(tbl.Cols(), colName)
```

Furthermore, the reference to this column's field type is passed to the `Constant` struct:

https://github.com/pingcap/tidb/blob/20e749ecbeafb1a8967cda3bddf4052005f6f630/planner/core/planbuilder.go#L3439

And it is changed in the type propagation during rewrite:

```
types.(*FieldType).SetDecimalUnderLimit (field_type.go:167) github.com/pingcap/tidb/parser/types
expression.PropagateType (expression.go:1450) github.com/pingcap/tidb/expression
expression.(*castAsRealFunctionClass).getFunction (builtin_cast.go:196) github.com/pingcap/tidb/expression
expression.BuildCastFunction (builtin_cast.go:1939) github.com/pingcap/tidb/expression
expression.WrapWithCastAsReal (builtin_cast.go:1988) github.com/pingcap/tidb/expression
expression.newBaseBuiltinFuncWithTp (builtin.go:162) github.com/pingcap/tidb/expression
expression.(*arithmeticModFunctionClass).getFunction (builtin_arithmetic.go:916) github.com/pingcap/tidb/expression
expression.newFunctionImpl (scalar_function.go:223) github.com/pingcap/tidb/expression
expression.NewFunction (scalar_function.go:254) github.com/pingcap/tidb/expression
core.(*expressionRewriter).newFunction (expression_rewriter.go:1307) github.com/pingcap/tidb/planner/core
core.(*expressionRewriter).binaryOpToExpression (expression_rewriter.go:1450) github.com/pingcap/tidb/planner/core
core.(*expressionRewriter).Leave (expression_rewriter.go:1174) github.com/pingcap/tidb/planner/core
ast.(*BinaryOperationExpr).Accept (expressions.go:223) github.com/pingcap/tidb/parser/ast
core.(*PlanBuilder).rewriteExprNode (expression_rewriter.go:199) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).rewriteWithPreprocess (expression_rewriter.go:145) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).rewrite (expression_rewriter.go:113) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).resolveGbyExprs (logical_plan_builder.go:3409) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).buildSelect (logical_plan_builder.go:3909) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).Build (planbuilder.go:788) github.com/pingcap/tidb/planner/core
planner.buildLogicalPlan (optimize.go:439) github.com/pingcap/tidb/planner
planner.optimize (optimize.go:362) github.com/pingcap/tidb/planner
planner.Optimize (optimize.go:245) github.com/pingcap/tidb/planner
executor.(*Compiler).Compile (compiler.go:98) github.com/pingcap/tidb/executor
session.(*session).ExecuteStmt (session.go:2035) github.com/pingcap/tidb/session
server.(*TiDBContext).ExecuteStmt (driver_tidb.go:231) github.com/pingcap/tidb/server
server.(*clientConn).handleStmt (conn.go:2049) github.com/pingcap/tidb/server
server.(*clientConn).handleQuery (conn.go:1904) github.com/pingcap/tidb/server
server.(*clientConn).dispatch (conn.go:1359) github.com/pingcap/tidb/server
server.(*clientConn).Run (conn.go:1104) github.com/pingcap/tidb/server
server.(*Server).onConn (server.go:563) github.com/pingcap/tidb/server
server.(*Server).startNetworkListener.func2 (server.go:454) github.com/pingcap/tidb/server
runtime.goexit (asm_arm64.s:1165) runtime
 - Async Stack Trace
server.(*Server).startNetworkListener (server.go:454) github.com/pingcap/tidb/server
```

### What is changed and how it works?

Clone the field type.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
