### PR TITLE
*: add statistic lock/unlock function

### DIFF
--- a/ddl/cluster_test.go
+++ b/ddl/cluster_test.go
@@ -49,7 +49,8 @@ func TestGetFlashbackKeyRanges(t *testing.T) {
 	// 3: (stats_extended)
 	// 4: (stats_fm_sketch)
 	// 5: (stats_history, stats_meta_history)
-	require.Len(t, kvRanges, 6)
+	// 6: (stats_table_locked)
+	require.Len(t, kvRanges, 7)
 
 	tk.MustExec("use test")
 	tk.MustExec("CREATE TABLE employees (" +
@@ -73,6 +74,7 @@ func TestGetFlashbackKeyRanges(t *testing.T) {
 	tk.MustExec("truncate table mysql.stats_fm_sketch")
 	tk.MustExec("truncate table mysql.stats_history")
 	tk.MustExec("truncate table mysql.stats_meta_history")
+	tk.MustExec("truncate table mysql.stats_table_locked")
 	kvRanges, err = ddl.GetFlashbackKeyRanges(se)
 	require.NoError(t, err)
 	require.Len(t, kvRanges, 2)

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1811,6 +1811,7 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 	gcStatsTicker := time.NewTicker(100 * lease)
 	dumpFeedbackTicker := time.NewTicker(200 * lease)
 	loadFeedbackTicker := time.NewTicker(5 * lease)
+	loadLockedTablesTicker := time.NewTicker(5 * lease)
 	dumpColStatsUsageTicker := time.NewTicker(100 * lease)
 	readMemTricker := time.NewTicker(memory.ReadMemInterval)
 	statsHandle := do.StatsHandle()
@@ -1850,6 +1851,11 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 			err := statsHandle.HandleUpdateStats(do.InfoSchema())
 			if err != nil {
 				logutil.BgLogger().Debug("update stats using feedback failed", zap.Error(err))
+			}
+		case <-loadLockedTablesTicker.C:
+			err := statsHandle.LoadLockedTables()
+			if err != nil {
+				logutil.BgLogger().Debug("load locked table failed", zap.Error(err))
 			}
 		case <-dumpFeedbackTicker.C:
 			err := statsHandle.DumpStatsFeedbackToKV()

--- a/executor/BUILD.bazel
+++ b/executor/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "joiner.go",
         "load_data.go",
         "load_stats.go",
+        "lock_stats.go",
         "mem_reader.go",
         "memtable_reader.go",
         "merge_join.go",

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -82,19 +82,89 @@ const (
 
 // Next implements the Executor Next interface.
 func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
+	statsHandle := domain.GetDomain(e.ctx).StatsHandle()
+	var tasks []*analyzeTask
+	tids := make([]int64, 0)
+	skipedTables := make([]string, 0)
+	is := e.ctx.GetInfoSchema().(infoschema.InfoSchema)
+	for _, task := range e.tasks {
+		var tableID statistics.AnalyzeTableID
+		switch task.taskType {
+		case colTask:
+			tableID = task.colExec.tableID
+		case idxTask:
+			tableID = task.idxExec.tableID
+		case fastTask:
+			tableID = task.fastExec.tableID
+		case pkIncrementalTask:
+			tableID = task.colIncrementalExec.tableID
+		case idxIncrementalTask:
+			tableID = task.idxIncrementalExec.tableID
+		}
+		// skip locked tables
+		if !statsHandle.IsTableLocked(tableID.TableID) {
+			tasks = append(tasks, task)
+		}
+		// generate warning message
+		dup := false
+		for _, id := range tids {
+			if id == tableID.TableID {
+				dup = true
+				break
+			}
+		}
+		//avoid generate duplicate tables
+		if !dup {
+			if statsHandle.IsTableLocked(tableID.TableID) {
+				tbl, ok := is.TableByID(tableID.TableID)
+				if !ok {
+					return nil
+				}
+				skipedTables = append(skipedTables, tbl.Meta().Name.L)
+			}
+			tids = append(tids, tableID.TableID)
+		}
+	}
+
+	if len(skipedTables) > 0 {
+		tables := skipedTables[0]
+		for i, table := range skipedTables {
+			if i == 0 {
+				continue
+			}
+			tables += ", " + table
+		}
+		var msg string
+		if len(tids) > 1 {
+			if len(tids) > len(skipedTables) {
+				msg = "skip analyze locked tables: " + tables + ", other tables will be analyzed"
+			} else {
+				msg = "skip analyze locked tables: " + tables
+			}
+		} else {
+			msg = "skip analyze locked table: " + tables
+		}
+
+		e.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.New(msg))
+	}
+
+	if len(tasks) == 0 {
+		return nil
+	}
+
 	concurrency, err := getBuildStatsConcurrency(e.ctx)
 	if err != nil {
 		return err
 	}
-	taskCh := make(chan *analyzeTask, len(e.tasks))
-	resultsCh := make(chan *statistics.AnalyzeResults, len(e.tasks))
-	if len(e.tasks) < concurrency {
-		concurrency = len(e.tasks)
+	taskCh := make(chan *analyzeTask, len(tasks))
+	resultsCh := make(chan *statistics.AnalyzeResults, len(tasks))
+	if len(tasks) < concurrency {
+		concurrency = len(tasks)
 	}
 	for i := 0; i < concurrency; i++ {
 		e.wg.Run(func() { e.analyzeWorker(taskCh, resultsCh) })
 	}
-	for _, task := range e.tasks {
+	for _, task := range tasks {
 		prepareV2AnalyzeJobInfo(task.colExec, false)
 		AddNewAnalyzeJob(e.ctx, task.job)
 	}
@@ -102,7 +172,7 @@ func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 		dom := domain.GetDomain(e.ctx)
 		dom.SysProcTracker().KillSysProcess(util.GetAutoAnalyzeProcID(dom.ServerID))
 	})
-	for _, task := range e.tasks {
+	for _, task := range tasks {
 		taskCh <- task
 	}
 	close(taskCh)
@@ -113,7 +183,7 @@ func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	needGlobalStats := pruneMode == variable.Dynamic
 	globalStatsMap := make(map[globalStatsKey]globalStatsInfo)
 	err = e.handleResultsError(ctx, concurrency, needGlobalStats, globalStatsMap, resultsCh)
-	for _, task := range e.tasks {
+	for _, task := range tasks {
 		if task.colExec != nil && task.colExec.memTracker != nil {
 			task.colExec.memTracker.Detach()
 		}
@@ -135,7 +205,6 @@ func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	if err != nil {
 		e.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
 	}
-	statsHandle := domain.GetDomain(e.ctx).StatsHandle()
 	if e.ctx.GetSessionVars().InRestrictedSQL {
 		return statsHandle.Update(e.ctx.GetInfoSchema().(infoschema.InfoSchema))
 	}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -201,6 +201,10 @@ func (b *executorBuilder) build(p plannercore.Plan) Executor {
 		return b.buildLoadData(v)
 	case *plannercore.LoadStats:
 		return b.buildLoadStats(v)
+	case *plannercore.LockStats:
+		return b.buildLockStats(v)
+	case *plannercore.UnlockStats:
+		return b.buildUnlockStats(v)
 	case *plannercore.IndexAdvise:
 		return b.buildIndexAdvise(v)
 	case *plannercore.PlanReplayer:
@@ -956,6 +960,22 @@ func (b *executorBuilder) buildLoadStats(v *plannercore.LoadStats) Executor {
 	e := &LoadStatsExec{
 		baseExecutor: newBaseExecutor(b.ctx, nil, v.ID()),
 		info:         &LoadStatsInfo{v.Path, b.ctx},
+	}
+	return e
+}
+
+func (b *executorBuilder) buildLockStats(v *plannercore.LockStats) Executor {
+	e := &LockStatsExec{
+		baseExecutor: newBaseExecutor(b.ctx, nil, v.ID()),
+		Tables:       v.Tables,
+	}
+	return e
+}
+
+func (b *executorBuilder) buildUnlockStats(v *plannercore.UnlockStats) Executor {
+	e := &UnlockStatsExec{
+		baseExecutor: newBaseExecutor(b.ctx, nil, v.ID()),
+		Tables:       v.Tables,
 	}
 	return e
 }

--- a/executor/infoschema_cluster_table_test.go
+++ b/executor/infoschema_cluster_table_test.go
@@ -290,7 +290,7 @@ func TestTableStorageStats(t *testing.T) {
 		"test 2",
 	))
 	rows := tk.MustQuery("select TABLE_NAME from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql';").Rows()
-	result := 39
+	result := 40
 	require.Len(t, rows, result)
 
 	// More tests about the privileges.

--- a/executor/lock_stats.go
+++ b/executor/lock_stats.go
@@ -1,0 +1,157 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/parser/ast"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+var _ Executor = &LockStatsExec{}
+var _ Executor = &UnlockStatsExec{}
+
+// LockStatsExec represents a lock statistic executor.
+type LockStatsExec struct {
+	baseExecutor
+	Tables []*ast.TableName
+}
+
+// lockStatsVarKeyType is a dummy type to avoid naming collision in context.
+type lockStatsVarKeyType int
+
+// String defines a Stringer function for debugging and pretty printing.
+func (k lockStatsVarKeyType) String() string {
+	return "lock_stats_var"
+}
+
+// LockStatsVarKey is a variable key for lock statistic.
+const LockStatsVarKey lockStatsVarKeyType = 0
+
+// Next implements the Executor Next interface.
+func (e *LockStatsExec) Next(ctx context.Context, req *chunk.Chunk) error {
+	do := domain.GetDomain(e.ctx)
+	is := do.InfoSchema()
+	h := do.StatsHandle()
+	if h == nil {
+		return errors.New("Lock Stats: handle is nil")
+	}
+
+	tableNum := len(e.Tables)
+	if tableNum == 0 {
+		return errors.New("Lock Stats: table should not empty ")
+	}
+
+	tids := make([]int64, 0, len(e.Tables))
+	pids := make([]int64, 0)
+	for _, table := range e.Tables {
+		tbl, err := is.TableByName(table.Schema, table.Name)
+		if err != nil {
+			return err
+		}
+		tids = append(tids, tbl.Meta().ID)
+
+		pi := tbl.Meta().GetPartitionInfo()
+		if pi == nil {
+			continue
+		}
+		for _, p := range pi.Definitions {
+			pids = append(pids, p.ID)
+		}
+	}
+	msg, err := h.AddLockedTables(tids, pids, e.Tables)
+	if msg != "" {
+		e.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.New(msg))
+	}
+	return err
+}
+
+// Close implements the Executor Close interface.
+func (e *LockStatsExec) Close() error {
+	return nil
+}
+
+// Open implements the Executor Open interface.
+func (e *LockStatsExec) Open(ctx context.Context) error {
+	return nil
+}
+
+// UnlockStatsExec represents a unlock statistic executor.
+type UnlockStatsExec struct {
+	baseExecutor
+	Tables []*ast.TableName
+}
+
+// unlockStatsVarKeyType is a dummy type to avoid naming collision in context.
+type unlockStatsVarKeyType int
+
+// String defines a Stringer function for debugging and pretty printing.
+func (k unlockStatsVarKeyType) String() string {
+	return "unlock_stats_var"
+}
+
+// UnlockStatsVarKey is a variable key for unlock statistic.
+const UnlockStatsVarKey unlockStatsVarKeyType = 0
+
+// Next implements the Executor Next interface.
+func (e *UnlockStatsExec) Next(ctx context.Context, req *chunk.Chunk) error {
+	do := domain.GetDomain(e.ctx)
+	is := do.InfoSchema()
+	h := do.StatsHandle()
+	if h == nil {
+		return errors.New("Unlock Stats: handle is nil")
+	}
+
+	tableNum := len(e.Tables)
+	if tableNum == 0 {
+		return errors.New("Unlock Stats: table should not empty ")
+	}
+
+	tids := make([]int64, 0, len(e.Tables))
+	pids := make([]int64, 0)
+	for _, table := range e.Tables {
+		tbl, err := is.TableByName(table.Schema, table.Name)
+		if err != nil {
+			return err
+		}
+		tids = append(tids, tbl.Meta().ID)
+
+		pi := tbl.Meta().GetPartitionInfo()
+		if pi == nil {
+			continue
+		}
+		for _, p := range pi.Definitions {
+			pids = append(pids, p.ID)
+		}
+	}
+	msg, err := h.RemoveLockedTables(tids, pids, e.Tables)
+	if msg != "" {
+		e.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.New(msg))
+	}
+	return err
+}
+
+// Close implements the Executor Close interface.
+func (e *UnlockStatsExec) Close() error {
+	return nil
+}
+
+// Open implements the Executor Open interface.
+func (e *UnlockStatsExec) Open(ctx context.Context) error {
+	return nil
+}

--- a/executor/show.go
+++ b/executor/show.go
@@ -226,6 +226,8 @@ func (e *ShowExec) fetchAll(ctx context.Context) error {
 	case ast.ShowStatsHealthy:
 		e.fetchShowStatsHealthy()
 		return nil
+	case ast.ShowStatsLocked:
+		return e.fetchShowStatsLocked()
 	case ast.ShowHistogramsInFlight:
 		e.fetchShowHistogramsInFlight()
 		return nil

--- a/executor/show_stats_test.go
+++ b/executor/show_stats_test.go
@@ -44,6 +44,24 @@ func TestShowStatsMeta(t *testing.T) {
 	require.Equal(t, "t", result.Rows()[0][1])
 }
 
+func TestShowStatsLocked(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t, t1")
+	tk.MustExec("create table t (a int, b int)")
+	tk.MustExec("create table t1 (a int, b int)")
+	tk.MustExec("lock stats t, t1")
+	result := tk.MustQuery("show stats_locked")
+	require.Len(t, result.Rows(), 2)
+	require.Equal(t, "t", result.Rows()[0][1])
+	require.Equal(t, "t1", result.Rows()[1][1])
+	result = tk.MustQuery("show stats_locked where table_name = 't'")
+	require.Len(t, result.Rows(), 1)
+	require.Equal(t, "t", result.Rows()[0][1])
+}
+
 func TestShowStatsHistograms(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 

--- a/parser/ast/dml.go
+++ b/parser/ast/dml.go
@@ -2738,6 +2738,7 @@ const (
 	ShowStatsTopN
 	ShowStatsBuckets
 	ShowStatsHealthy
+	ShowStatsLocked
 	ShowHistogramsInFlight
 	ShowColumnStatsUsage
 	ShowPlugins
@@ -2909,6 +2910,11 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 		}
 	case ShowStatsMeta:
 		ctx.WriteKeyWord("STATS_META")
+		if err := restoreShowLikeOrWhereOpt(); err != nil {
+			return err
+		}
+	case ShowStatsLocked:
+		ctx.WriteKeyWord("STATS_LOCKED")
 		if err := restoreShowLikeOrWhereOpt(); err != nil {
 			return err
 		}

--- a/parser/ast/stats.go
+++ b/parser/ast/stats.go
@@ -259,3 +259,79 @@ func (n *LoadStatsStmt) Accept(v Visitor) (Node, bool) {
 	n = newNode.(*LoadStatsStmt)
 	return v.Leave(n)
 }
+
+// LockStatsStmt is the statement node for lock table statistic
+type LockStatsStmt struct {
+	stmtNode
+
+	Tables []*TableName
+}
+
+// Restore implements Node interface.
+func (n *LockStatsStmt) Restore(ctx *format.RestoreCtx) error {
+	ctx.WriteKeyWord("LOCK STATS ")
+	for index, table := range n.Tables {
+		if index != 0 {
+			ctx.WritePlain(", ")
+		}
+		if err := table.Restore(ctx); err != nil {
+			return errors.Annotatef(err, "An error occurred while restore LockStatsStmt.Tables[%d]", index)
+		}
+	}
+	return nil
+}
+
+// Accept implements Node Accept interface.
+func (n *LockStatsStmt) Accept(v Visitor) (Node, bool) {
+	newNode, skipChildren := v.Enter(n)
+	if skipChildren {
+		return v.Leave(newNode)
+	}
+	n = newNode.(*LockStatsStmt)
+	for i, val := range n.Tables {
+		node, ok := val.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.Tables[i] = node.(*TableName)
+	}
+	return v.Leave(n)
+}
+
+// UnlockStatsStmt is the statement node for unlock table statistic
+type UnlockStatsStmt struct {
+	stmtNode
+
+	Tables []*TableName
+}
+
+// Restore implements Node interface.
+func (n *UnlockStatsStmt) Restore(ctx *format.RestoreCtx) error {
+	ctx.WriteKeyWord("UNLOCK STATS ")
+	for index, table := range n.Tables {
+		if index != 0 {
+			ctx.WritePlain(", ")
+		}
+		if err := table.Restore(ctx); err != nil {
+			return errors.Annotatef(err, "An error occurred while restore UnlockStatsStmt.Tables[%d]", index)
+		}
+	}
+	return nil
+}
+
+// Accept implements Node Accept interface.
+func (n *UnlockStatsStmt) Accept(v Visitor) (Node, bool) {
+	newNode, skipChildren := v.Enter(n)
+	if skipChildren {
+		return v.Leave(newNode)
+	}
+	n = newNode.(*UnlockStatsStmt)
+	for i, val := range n.Tables {
+		node, ok := val.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.Tables[i] = node.(*TableName)
+	}
+	return v.Leave(n)
+}

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -681,6 +681,7 @@ var tokenMap = map[string]int{
 	"STATS_HISTOGRAMS":         statsHistograms,
 	"STATS_TOPN":               statsTopN,
 	"STATS_META":               statsMeta,
+	"STATS_LOCKED":             statsLocked,
 	"HISTOGRAMS_IN_FLIGHT":     histogramsInFlight,
 	"STATS_PERSISTENT":         statsPersistent,
 	"STATS_SAMPLE_PAGES":       statsSamplePages,

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -752,6 +752,7 @@ import (
 	statsBuckets               "STATS_BUCKETS"
 	statsHealthy               "STATS_HEALTHY"
 	statsTopN                  "STATS_TOPN"
+	statsLocked                "STATS_LOCKED"
 	histogramsInFlight         "HISTOGRAMS_IN_FLIGHT"
 	telemetry                  "TELEMETRY"
 	telemetryID                "TELEMETRY_ID"
@@ -914,6 +915,8 @@ import (
 	KillStmt                   "Kill statement"
 	LoadDataStmt               "Load data statement"
 	LoadStatsStmt              "Load statistic statement"
+	LockStatsStmt              "Lock statistic statement"
+	UnlockStatsStmt            "Unlock statistic statement"
 	LockTablesStmt             "Lock tables statement"
 	NonTransactionalDMLStmt    "Non-transactional DML statement"
 	PlanReplayerStmt           "Plan replayer statement"
@@ -6414,6 +6417,7 @@ TiDBKeyword:
 |	"STATS_TOPN"
 |	"STATS_BUCKETS"
 |	"STATS_HEALTHY"
+|	"STATS_LOCKED"
 |	"HISTOGRAMS_IN_FLIGHT"
 |	"TELEMETRY"
 |	"TELEMETRY_ID"
@@ -11090,6 +11094,10 @@ ShowTargetFilterable:
 	{
 		$$ = &ast.ShowStmt{Tp: ast.ShowStatsHealthy}
 	}
+|	"STATS_LOCKED" 
+	{
+		$$ = &ast.ShowStmt{Tp: ast.ShowStatsLocked, Table: &ast.TableName{Name: model.NewCIStr("STATS_TABLE_LOCKED"), Schema: model.NewCIStr(mysql.SystemDB)}}
+	}
 |	"HISTOGRAMS_IN_FLIGHT"
 	{
 		$$ = &ast.ShowStmt{Tp: ast.ShowHistogramsInFlight}
@@ -11382,6 +11390,8 @@ Statement:
 |	KillStmt
 |	LoadDataStmt
 |	LoadStatsStmt
+|	LockStatsStmt
+|	UnlockStatsStmt
 |	PlanReplayerStmt
 |	PreparedStmt
 |	PurgeImportStmt
@@ -13926,6 +13936,22 @@ LoadStatsStmt:
 	{
 		$$ = &ast.LoadStatsStmt{
 			Path: $3,
+		}
+	}
+
+LockStatsStmt:
+	"LOCK" "STATS" TableNameList
+	{
+		$$ = &ast.LockStatsStmt{
+			Tables: $3.([]*ast.TableName),
+		}
+	}
+
+UnlockStatsStmt:
+	"UNLOCK" "STATS" TableNameList
+	{
+		$$ = &ast.UnlockStatsStmt{
+			Tables: $3.([]*ast.TableName),
 		}
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1135,6 +1135,9 @@ func TestDBAStmt(t *testing.T) {
 		// for show stats_meta.
 		{"show stats_meta", true, "SHOW STATS_META"},
 		{"show stats_meta where table_name = 't'", true, "SHOW STATS_META WHERE `table_name`=_UTF8MB4't'"},
+		// for show stats_locked.
+		{"show stats_locked", true, "SHOW STATS_LOCKED"},
+		{"show stats_locked where table_name = 't'", true, "SHOW STATS_LOCKED WHERE `table_name`=_UTF8MB4't'"},
 		// for show stats_histograms
 		{"show stats_histograms", true, "SHOW STATS_HISTOGRAMS"},
 		{"show stats_histograms where col_name = 'a'", true, "SHOW STATS_HISTOGRAMS WHERE `col_name`=_UTF8MB4'a'"},
@@ -1174,6 +1177,12 @@ func TestDBAStmt(t *testing.T) {
 
 		// for load stats
 		{"load stats '/tmp/stats.json'", true, "LOAD STATS '/tmp/stats.json'"},
+		// for lock stats
+		{"lock stats test.t", true, "LOCK STATS `test`.`t`"},
+		{"lock stats t, t2", true, "LOCK STATS `t`, `t2`"},
+		// for unlock stats
+		{"unlock stats test.t", true, "UNLOCK STATS `test`.`t`"},
+		{"unlock stats t, t2", true, "UNLOCK STATS `t`, `t2`"},
 		// set
 		// user defined
 		{"SET @ = 1", true, "SET @``=1"},

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -566,6 +566,20 @@ type LoadStats struct {
 	Path string
 }
 
+// LockStats represents a lock stats for table
+type LockStats struct {
+	baseSchemaProducer
+
+	Tables []*ast.TableName
+}
+
+// UnlockStats represents a unlock stats for table
+type UnlockStats struct {
+	baseSchemaProducer
+
+	Tables []*ast.TableName
+}
+
 // PlanReplayer represents a plan replayer plan.
 type PlanReplayer struct {
 	baseSchemaProducer

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -119,6 +119,267 @@ type Handle struct {
 	sysProcTracker sessionctx.SysProcTracker
 	// serverIDGetter is used to get server ID for generating auto analyze ID.
 	serverIDGetter func() uint64
+	// tableLocked used to store locked tables
+	tableLocked []int64
+}
+
+// GetTableLockedAndClearForTest for unit test only
+func (h *Handle) GetTableLockedAndClearForTest() []int64 {
+	tableLocked := h.tableLocked
+	h.tableLocked = make([]int64, 0)
+	return tableLocked
+}
+
+// LoadLockedTables load locked tables from store
+func (h *Handle) LoadLockedTables() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	rows, _, err := h.execRestrictedSQL(ctx, "select table_id from mysql.stats_table_locked")
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	h.tableLocked = make([]int64, len(rows))
+	for i, row := range rows {
+		h.tableLocked[i] = row.GetInt64(0)
+	}
+
+	return nil
+}
+
+// AddLockedTables add locked tables id  to store
+func (h *Handle) AddLockedTables(tids []int64, pids []int64, tables []*ast.TableName) (string, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+
+	exec := h.mu.ctx.(sqlexec.SQLExecutor)
+
+	_, err := exec.ExecuteInternal(ctx, "begin pessimistic")
+	if err != nil {
+		return "", err
+	}
+
+	//load tables to check duplicate when insert
+	rows, _, err := h.execRestrictedSQL(ctx, "select table_id from mysql.stats_table_locked")
+	if err != nil {
+		return "", err
+	}
+
+	dupTables := make([]string, 0)
+	tableLocked := make([]int64, 0)
+	for _, row := range rows {
+		tableLocked = append(tableLocked, row.GetInt64(0))
+	}
+
+	strTids := fmt.Sprintf("%v", tids)
+	logutil.BgLogger().Info("[stats] lock table ", zap.String("tableIDs", strTids))
+	for i, tid := range tids {
+		_, err = exec.ExecuteInternal(ctx, "insert into mysql.stats_table_locked(table_id) select %? from dual where not exists(select table_id from mysql.stats_table_locked where table_id = %?)", tid, tid)
+		if err != nil {
+			logutil.BgLogger().Error("[stats] error occurred when insert mysql.stats_table_locked ", zap.Error(err))
+			return "", err
+		}
+		// update handle
+		if !isTableLocked(tableLocked, tid) {
+			tableLocked = append(tableLocked, tid)
+		} else {
+			dupTables = append(dupTables, tables[i].Schema.L+"."+tables[i].Name.L)
+		}
+	}
+
+	//insert related partitions while don't warning duplicate partitions
+	for _, tid := range pids {
+		_, err = exec.ExecuteInternal(ctx, "insert into mysql.stats_table_locked(table_id) select %? from dual where not exists(select table_id from mysql.stats_table_locked where table_id = %?)", tid, tid)
+		if err != nil {
+			logutil.BgLogger().Error("[stats] error occurred when insert mysql.stats_table_locked ", zap.Error(err))
+			return "", err
+		}
+		if !isTableLocked(tableLocked, tid) {
+			tableLocked = append(tableLocked, tid)
+		}
+	}
+
+	err = finishTransaction(ctx, exec, err)
+	if err != nil {
+		return "", err
+	}
+	// update handle.tableLocked after transaction success, if txn failed, tableLocked won't be updated
+	h.tableLocked = tableLocked
+
+	if len(dupTables) > 0 {
+		tables := dupTables[0]
+		for i, table := range dupTables {
+			if i == 0 {
+				continue
+			}
+			tables += ", " + table
+		}
+		var msg string
+		if len(tids) > 1 {
+			if len(tids) > len(dupTables) {
+				msg = "skip locking locked tables: " + tables + ", other tables locked successfully"
+			} else {
+				msg = "skip locking locked tables: " + tables
+			}
+		} else {
+			msg = "skip locking locked table: " + tables
+		}
+		return msg, err
+	}
+	return "", err
+}
+
+// getStatsDeltaFromTableLocked get count, modify_count and version for the given table from mysql.stats_table_locked.
+func (h *Handle) getStatsDeltaFromTableLocked(ctx context.Context, tableID int64) (int64, int64, uint64, error) {
+	rows, _, err := h.execRestrictedSQL(ctx, "select count, modify_count, version from mysql.stats_table_locked where table_id = %?", tableID)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	if len(rows) == 0 {
+		return 0, 0, 0, nil
+	}
+	count := rows[0].GetInt64(0)
+	modifyCount := rows[0].GetInt64(1)
+	version := rows[0].GetUint64(2)
+	return count, modifyCount, version, nil
+}
+
+// RemoveLockedTables remove tables from table locked array
+func (h *Handle) RemoveLockedTables(tids []int64, pids []int64, tables []*ast.TableName) (string, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+
+	exec := h.mu.ctx.(sqlexec.SQLExecutor)
+	_, err := exec.ExecuteInternal(ctx, "begin pessimistic")
+	if err != nil {
+		return "", err
+	}
+
+	//load tables to check unlock the unlock table
+	rows, _, err := h.execRestrictedSQL(ctx, "select table_id from mysql.stats_table_locked")
+	if err != nil {
+		return "", err
+	}
+
+	nonlockedTables := make([]string, 0)
+	tableLocked := make([]int64, 0)
+	for _, row := range rows {
+		tableLocked = append(tableLocked, row.GetInt64(0))
+	}
+
+	strTids := fmt.Sprintf("%v", tids)
+	logutil.BgLogger().Info("[stats] unlock table ", zap.String("tableIDs", strTids))
+	for i, tid := range tids {
+		// get stats delta during table locked
+		count, modifyCount, version, err := h.getStatsDeltaFromTableLocked(ctx, tid)
+		if err != nil {
+			logutil.BgLogger().Error("[stats] error occurred when getStatsDeltaFromTableLocked", zap.Error(err))
+			return "", err
+		}
+		// update stats_meta with stats delta
+		_, err = exec.ExecuteInternal(ctx, "update mysql.stats_meta set version = %?, count = count + %?, modify_count = modify_count + %? where table_id = %?", version, count, modifyCount, tid)
+		if err != nil {
+			logutil.BgLogger().Error("[stats] error occurred when update mysql.stats_meta", zap.Error(err))
+			return "", err
+		}
+
+		_, err = exec.ExecuteInternal(ctx, "delete from mysql.stats_table_locked where table_id = %?", tid)
+		if err != nil {
+			logutil.BgLogger().Error("[stats] error occurred when delete from mysql.stats_table_locked ", zap.Error(err))
+			return "", err
+		}
+		var exist bool
+		exist, tableLocked = removeIfTableLocked(tableLocked, tid)
+		if !exist {
+			nonlockedTables = append(nonlockedTables, tables[i].Schema.L+"."+tables[i].Name.L)
+		}
+	}
+	//delete related partitions while don't warning delete empty partitions
+	for _, tid := range pids {
+		// get stats delta during table locked
+		count, modifyCount, version, err := h.getStatsDeltaFromTableLocked(ctx, tid)
+		if err != nil {
+			logutil.BgLogger().Error("[stats] error occurred when getStatsDeltaFromTableLocked", zap.Error(err))
+			return "", err
+		}
+		// update stats_meta with stats delta
+		_, err = exec.ExecuteInternal(ctx, "update mysql.stats_meta set version = %?, count = count + %?, modify_count = modify_count + %? where table_id = %?", version, count, modifyCount, tid)
+		if err != nil {
+			logutil.BgLogger().Error("[stats] error occurred when update mysql.stats_meta", zap.Error(err))
+			return "", err
+		}
+
+		_, err = exec.ExecuteInternal(ctx, "delete from mysql.stats_table_locked where table_id = %?", tid)
+		if err != nil {
+			logutil.BgLogger().Error("[stats] error occurred when delete from mysql.stats_table_locked ", zap.Error(err))
+			return "", err
+		}
+		_, tableLocked = removeIfTableLocked(tableLocked, tid)
+	}
+
+	err = finishTransaction(ctx, exec, err)
+	if err != nil {
+		return "", err
+	}
+	// update handle.tableLocked after transaction success, if txn failed, tableLocked won't be updated
+	h.tableLocked = tableLocked
+
+	if len(nonlockedTables) > 0 {
+		tables := nonlockedTables[0]
+		for i, table := range nonlockedTables {
+			if i == 0 {
+				continue
+			}
+			tables += ", " + table
+		}
+		var msg string
+		if len(tids) > 1 {
+			if len(tids) > len(nonlockedTables) {
+				msg = "skip unlocking non-locked tables: " + tables + ", other tables unlocked successfully"
+			} else {
+				msg = "skip unlocking non-locked tables: " + tables
+			}
+		} else {
+			msg = "skip unlocking non-locked table: " + tables
+		}
+		return msg, err
+	}
+	return "", err
+}
+
+// IsTableLocked check whether table is locked in handle
+func (h *Handle) IsTableLocked(tableID int64) bool {
+	return isTableLocked(h.tableLocked, tableID)
+}
+
+// isTableLocked check whether table is locked
+func isTableLocked(tableLocked []int64, tableID int64) bool {
+	return lockTableIndexOf(tableLocked, tableID) > -1
+}
+
+// lockTableIndexOf get the locked table's index in the array
+func lockTableIndexOf(tableLocked []int64, tableID int64) int {
+	for idx, id := range tableLocked {
+		if id == tableID {
+			return idx
+		}
+	}
+	return -1
+}
+
+// removeIfTableLocked try to remove the table from table locked array
+func removeIfTableLocked(tableLocked []int64, tableID int64) (bool, []int64) {
+	idx := lockTableIndexOf(tableLocked, tableID)
+	if idx > -1 {
+		tableLocked = append(tableLocked[:idx], tableLocked[idx+1:]...)
+	}
+	return idx > -1, tableLocked
 }
 
 func (h *Handle) withRestrictedSQLExecutor(ctx context.Context, fn func(context.Context, sqlexec.RestrictedSQLExecutor) ([]chunk.Row, []*ast.ResultField, error)) ([]chunk.Row, []*ast.ResultField, error) {

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -3425,3 +3425,119 @@ func TestUninitializedStatsStatus(t *testing.T) {
 	tk.MustExec("set @@tidb_enable_pseudo_for_outdated_stats = false")
 	checkStatsPseudo()
 }
+
+func TestStatsLockAndUnlockTable(t *testing.T) {
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Performance.EnableStatsCacheMemQuota = true
+	})
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set @@tidb_analyze_version = 1")
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b varchar(10), index idx_b (b))")
+	tk.MustExec("analyze table test.t")
+	tbl, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.Nil(t, err)
+
+	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	tblStats := handle.GetTableStats(tbl.Meta())
+	for _, col := range tblStats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+	tk.MustExec("lock stats t")
+
+	rows := tk.MustQuery("select count(*) from mysql.stats_table_locked").Rows()
+	num, _ := strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, num, 1)
+
+	tk.MustExec("insert into t(a, b) values(1,'a')")
+	tk.MustExec("insert into t(a, b) values(2,'b')")
+
+	tk.MustExec("analyze table test.t")
+	tblStats1 := handle.GetTableStats(tbl.Meta())
+	require.Equal(t, tblStats, tblStats1)
+
+	tableLocked1 := handle.GetTableLockedAndClearForTest()
+	err = handle.LoadLockedTables()
+	require.Nil(t, err)
+	tableLocked2 := handle.GetTableLockedAndClearForTest()
+	require.Equal(t, tableLocked1, tableLocked2)
+
+	tk.MustExec("unlock stats t")
+	rows = tk.MustQuery("select count(*) from mysql.stats_table_locked").Rows()
+	num, _ = strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, num, 0)
+
+	tk.MustExec("analyze table test.t")
+	tblStats2 := handle.GetTableStats(tbl.Meta())
+	require.Equal(t, int64(2), tblStats2.Count)
+}
+
+func TestStatsLockAndUnlockTables(t *testing.T) {
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Performance.EnableStatsCacheMemQuota = true
+	})
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set @@tidb_analyze_version = 1")
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t1(a int, b varchar(10), index idx_b (b))")
+	tk.MustExec("create table t2(a int, b varchar(10), index idx_b (b))")
+	tk.MustExec("analyze table test.t1, test.t2")
+	tbl1, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
+	require.Nil(t, err)
+	tbl2, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t2"))
+	require.Nil(t, err)
+
+	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	tbl1Stats := handle.GetTableStats(tbl1.Meta())
+	for _, col := range tbl1Stats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+	tbl2Stats := handle.GetTableStats(tbl2.Meta())
+	for _, col := range tbl2Stats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+
+	tk.MustExec("lock stats t1, t2")
+
+	rows := tk.MustQuery("select count(*) from mysql.stats_table_locked").Rows()
+	num, _ := strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, num, 2)
+
+	tk.MustExec("insert into t1(a, b) values(1,'a')")
+	tk.MustExec("insert into t1(a, b) values(2,'b')")
+
+	tk.MustExec("insert into t2(a, b) values(1,'a')")
+	tk.MustExec("insert into t2(a, b) values(2,'b')")
+
+	tk.MustExec("analyze table test.t1, test.t2")
+	tbl1Stats1 := handle.GetTableStats(tbl1.Meta())
+	require.Equal(t, tbl1Stats, tbl1Stats1)
+	tbl2Stats1 := handle.GetTableStats(tbl2.Meta())
+	require.Equal(t, tbl2Stats, tbl2Stats1)
+
+	tableLocked1 := handle.GetTableLockedAndClearForTest()
+	err = handle.LoadLockedTables()
+	require.Nil(t, err)
+	tableLocked2 := handle.GetTableLockedAndClearForTest()
+	require.Equal(t, tableLocked1, tableLocked2)
+
+	tk.MustExec("unlock stats test.t1, test.t2")
+	rows = tk.MustQuery("select count(*) from mysql.stats_table_locked").Rows()
+	num, _ = strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, num, 0)
+
+	tk.MustExec("analyze table test.t1, test.t2")
+	tbl1Stats2 := handle.GetTableStats(tbl1.Meta())
+	require.Equal(t, int64(2), tbl1Stats2.Count)
+	tbl2Stats2 := handle.GetTableStats(tbl2.Meta())
+	require.Equal(t, int64(2), tbl2Stats2.Count)
+}

--- a/statistics/handle/update_test.go
+++ b/statistics/handle/update_test.go
@@ -2398,3 +2398,225 @@ func TestEnableAndDisableColumnTracking(t *testing.T) {
 	tk.MustExec("set global tidb_enable_column_tracking = 0")
 	tk.MustQuery("show column_stats_usage where db_name = 'test' and table_name = 't' and last_used_at is not null").Check(testkit.Rows())
 }
+
+func TestStatsLockUnlockForAutoAnalyze(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	oriStart := tk.MustQuery("select @@tidb_auto_analyze_start_time").Rows()[0][0].(string)
+	oriEnd := tk.MustQuery("select @@tidb_auto_analyze_end_time").Rows()[0][0].(string)
+	handle.AutoAnalyzeMinCnt = 0
+	defer func() {
+		handle.AutoAnalyzeMinCnt = 1000
+		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_start_time='%v'", oriStart))
+		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_end_time='%v'", oriEnd))
+	}()
+
+	h := dom.StatsHandle()
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int)")
+	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
+	tk.MustExec("insert into t values (1)" + strings.Repeat(", (1)", 19))
+	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
+	is := dom.InfoSchema()
+	require.NoError(t, h.Update(is))
+	// To pass the stats.Pseudo check in autoAnalyzeTable
+	tk.MustExec("analyze table t")
+	tk.MustExec("explain select * from t where a = 1")
+	require.NoError(t, h.LoadNeededHistograms())
+	tk.MustExec("set global tidb_auto_analyze_start_time='00:00 +0000'")
+	tk.MustExec("set global tidb_auto_analyze_end_time='23:59 +0000'")
+
+	tk.MustExec("insert into t values (1)" + strings.Repeat(", (1)", 10))
+	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
+	require.NoError(t, h.Update(is))
+	require.True(t, h.HandleAutoAnalyze(is))
+
+	tbl, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.Nil(t, err)
+
+	tblStats := h.GetTableStats(tbl.Meta())
+	for _, col := range tblStats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+
+	tk.MustExec("lock stats t")
+
+	tk.MustExec("delete from t limit 12")
+	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
+	require.NoError(t, h.Update(is))
+	require.False(t, h.HandleAutoAnalyze(is))
+
+	tblStats1 := h.GetTableStats(tbl.Meta())
+	require.Equal(t, tblStats, tblStats1)
+
+	tk.MustExec("unlock stats t")
+
+	tk.MustExec("delete from t limit 4")
+
+	rows := tk.MustQuery("select count(*) from t").Rows()
+	num, _ := strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, num, 15)
+
+	tk.MustExec("analyze table t")
+
+	tblStats2 := h.GetTableStats(tbl.Meta())
+	require.Equal(t, int64(15), tblStats2.Count)
+}
+
+func TestStatsLockForFeedback(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	testKit := testkit.NewTestKit(t, store)
+	testKit.MustExec("use test")
+
+	// TODO(tiancaiamao): query feedback is broken when paging is on.
+	testKit.MustExec("set @@tidb_enable_paging = off")
+
+	testKit.MustExec("set @@session.tidb_analyze_version = 0")
+	testKit.MustExec("create table t (a bigint(64), b bigint(64), primary key(a), index idx(b))")
+	testKit.MustExec("insert into t values (1,2),(2,2),(4,5)")
+	testKit.MustExec("analyze table t with 0 topn")
+	testKit.MustExec("insert into t values (3,4)")
+	for i := 5; i < 20; i++ {
+		testKit.MustExec(fmt.Sprintf("insert into t values(%d, %d)", i, i+1))
+	}
+
+	h := dom.StatsHandle()
+	oriProbability := statistics.FeedbackProbability.Load()
+	oriNumber := statistics.MaxNumberOfRanges
+	oriMinLogCount := handle.MinLogScanCount.Load()
+	oriErrorRate := handle.MinLogErrorRate.Load()
+	defer func() {
+		statistics.FeedbackProbability.Store(oriProbability)
+		statistics.MaxNumberOfRanges = oriNumber
+		handle.MinLogScanCount.Store(oriMinLogCount)
+		handle.MinLogErrorRate.Store(oriErrorRate)
+	}()
+	statistics.FeedbackProbability.Store(1)
+	handle.MinLogScanCount.Store(0)
+	handle.MinLogErrorRate.Store(0)
+	tests := []struct {
+		sql  string
+		hist string
+	}{
+		{
+			// test primary key feedback
+			sql: "select * from t where t.a <= 4 order by a desc",
+			hist: "column:1 ndv:4 totColSize:0\n" +
+				"num: 1 lower_bound: -9223372036854775808 upper_bound: 2 repeats: 0 ndv: 0\n" +
+				"num: 2 lower_bound: 2 upper_bound: 4 repeats: 0 ndv: 0\n" +
+				"num: 1 lower_bound: 4 upper_bound: 4 repeats: 1 ndv: 0",
+		},
+		//run 1st sql after table locked, hist should not changed
+		{
+			sql: "select * from t where t.a <= 8 order by a desc",
+			hist: "column:1 ndv:4 totColSize:0\n" +
+				"num: 1 lower_bound: -9223372036854775808 upper_bound: 2 repeats: 0 ndv: 0\n" +
+				"num: 2 lower_bound: 2 upper_bound: 4 repeats: 0 ndv: 0\n" +
+				"num: 1 lower_bound: 4 upper_bound: 4 repeats: 1 ndv: 0",
+		},
+		//run 2nd sql after table unlocked, hist should not changed
+		{
+			sql: "select * from t where t.a <= 12 order by a desc",
+			hist: "column:1 ndv:12 totColSize:0\n" +
+				"num: 1 lower_bound: -9223372036854775808 upper_bound: 2 repeats: 0 ndv: 0\n" +
+				"num: 2 lower_bound: 2 upper_bound: 4 repeats: 0 ndv: 0\n" +
+				"num: 9 lower_bound: 4 upper_bound: 12 repeats: 0 ndv: 0",
+		},
+		//run 4th sql after table locked, hist should not changed
+		{
+			sql: "select * from t",
+			hist: "column:1 ndv:12 totColSize:0\n" +
+				"num: 1 lower_bound: -9223372036854775808 upper_bound: 2 repeats: 0 ndv: 0\n" +
+				"num: 2 lower_bound: 2 upper_bound: 4 repeats: 0 ndv: 0\n" +
+				"num: 9 lower_bound: 4 upper_bound: 12 repeats: 0 ndv: 0",
+		},
+	}
+	is := dom.InfoSchema()
+	table, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	for i, test := range tests {
+		testKit.MustQuery(test.sql)
+		require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
+		require.NoError(t, h.DumpStatsFeedbackToKV())
+		require.NoError(t, h.HandleUpdateStats(dom.InfoSchema()))
+		require.NoError(t, err)
+		require.NoError(t, h.Update(is))
+		tblInfo := table.Meta()
+		tbl := h.GetTableStats(tblInfo)
+		//fmt.Printf("\n i: %d, exp: %s, \nact: %s\n", i, tests[i].hist, tbl.Columns[tblInfo.Columns[0].ID].ToString(0))
+		require.Equal(t, tests[i].hist, tbl.Columns[tblInfo.Columns[0].ID].ToString(0))
+		// add table lock after 2nd
+		if i == 0 {
+			testKit.MustExec("lock stats t")
+		} else if i == 1 {
+			testKit.MustExec("unlock stats t")
+		} else if i == 2 {
+			testKit.MustExec("lock stats t")
+		}
+	}
+}
+
+func TestStatsLockForDelta(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	testKit := testkit.NewTestKit(t, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("set @@session.tidb_analyze_version = 1")
+	testKit.MustExec("create table t1 (c1 int, c2 int)")
+	testKit.MustExec("create table t2 (c1 int, c2 int)")
+
+	is := dom.InfoSchema()
+	tbl1, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
+	require.NoError(t, err)
+	tableInfo1 := tbl1.Meta()
+	h := dom.StatsHandle()
+
+	testKit.MustExec("lock stats t1")
+
+	rowCount1 := 10
+	rowCount2 := 20
+	for i := 0; i < rowCount1; i++ {
+		testKit.MustExec("insert into t1 values(1, 2)")
+	}
+	for i := 0; i < rowCount2; i++ {
+		testKit.MustExec("insert into t2 values(1, 2)")
+	}
+
+	err = h.HandleDDLEvent(<-h.DDLEventCh())
+	require.NoError(t, err)
+	err = h.HandleDDLEvent(<-h.DDLEventCh())
+	require.NoError(t, err)
+
+	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
+	require.NoError(t, h.Update(is))
+	stats1 := h.GetTableStats(tableInfo1)
+	require.Equal(t, stats1.Count, int64(0))
+
+	tbl2, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t2"))
+	require.NoError(t, err)
+	tableInfo2 := tbl2.Meta()
+	stats2 := h.GetTableStats(tableInfo2)
+	require.Equal(t, int64(rowCount2), stats2.Count)
+
+	testKit.MustExec("analyze table t1")
+	for i := 0; i < rowCount1; i++ {
+		testKit.MustExec("insert into t1 values(1, 2)")
+	}
+	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
+	require.NoError(t, h.Update(is))
+	stats1 = h.GetTableStats(tableInfo1)
+	require.Equal(t, stats1.Count, int64(0))
+
+	testKit.MustExec("unlock stats t1")
+
+	testKit.MustExec("analyze table t1")
+	stats1 = h.GetTableStats(tableInfo1)
+	require.Equal(t, int64(20), stats1.Count)
+
+	for i := 0; i < rowCount1; i++ {
+		testKit.MustExec("insert into t1 values(1, 2)")
+	}
+	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
+	require.NoError(t, h.Update(is))
+	stats1 = h.GetTableStats(tableInfo1)
+	require.Equal(t, int64(30), stats1.Count)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:
Sometime peformance drop due to the explain change that caused by statistic info change after data changes in table.
So we want to introduce table statistic lock/unlock function to avoid unexpected peformance drop by statistic changes.

### What is changed and how it works?
The main idea is adding new table mysql.stats_table_locked to record which table is locked, and when doing manual/auto table analyze, check whether table is locked, if locked, skip analyse. And I also filter the locked table in session stat collector operations, that session stat collector  won't collect the statistic data of locked table.
Add SQL syntax 'lock/unlock stats xxx(table name)'  to add/remove table name to/from mysql.stats_table_locked.

- Add new table mysql.stats_table_locked
- Add lock/unlock function on statistic handle 
- Filter locked table on manual/auto statistic analyze
- Filter locked table on session stats collector
- Add unlock/unlock on SQL parser/Planner/Executor

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support `LOCK STATS` and `UNLOCK STATS` SQL statements.
```
