### PR TITLE
store/tikv: clear intersecting regions in the cache when inserting a region

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ vet:
 	$(GO) vet -all $(PACKAGES) 2>&1 | $(FAIL_ON_STDOUT)
 
 staticcheck:
-	$(GO) get honnef.co/go/tools/cmd/staticcheck
+	$(GO) get honnef.co/go/tools/cmd/staticcheck@v0.2.0
 	$(STATICCHECK) ./...
 
 tidy:

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200824191128-ae9734ed278b
 	go.uber.org/atomic v1.8.0
 	go.uber.org/automaxprocs v1.2.0
+	go.uber.org/goleak v0.10.0 // indirect
 	go.uber.org/zap v1.17.0
 	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37141

Problem Summary:

Our region cache B-Tree uses the start key of the region as the entry key. So, `insertRegionToCache` only replaces the region with the same start key:
https://github.com/tikv/client-go/blob/516cfcdecce865d90ec05dd1cc1de060c35438dc/internal/locate/region_cache.go#L1287

Considering there's a table with lots of regions, the user removes all data from the table. So, PD will finally merge all regions into one. In our region cache implementation, only the first region (containing the table head) is updated, while all other regions still exist in the cache.

When we locate a key near the end of the table, `DescendLessOrEqual` will iterate over all regions that are left in the cache. This will waste a lot of CPU and make region search really slow, and it is also possible to cause lots of unnecessary PD `loadRegion` RPCs.

To solve the problem, when we do `insertRegionToCache`, we should iterate the B-Tree for all regions that intersect with the inserted region and remove them.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Optimize the performance of the region cache after merging many regions.
```
