### PR TITLE
util/paging: use unlimited paging size as default min/max value

### DIFF
--- a/util/paging/paging.go
+++ b/util/paging/paging.go
@@ -22,10 +22,10 @@ import "math"
 // if it's not drained, then the paging size grows, the new range is calculated like (r100, r200), then send a request again.
 // Compare with the common unary request, paging request allows early access of data, it offers a streaming-like way processing data.
 const (
-	MinPagingSize      uint64 = 128
+	MinPagingSize      uint64 = 50000000
 	maxPagingSizeShift        = 7
 	pagingSizeGrow            = 2
-	MaxPagingSize             = 50000
+	MaxPagingSize             = 50000000
 	pagingGrowingSum          = ((2 << maxPagingSizeShift) - 1) * MinPagingSize
 	Threshold          uint64 = 960
 )

--- a/util/paging/paging.go
+++ b/util/paging/paging.go
@@ -25,7 +25,7 @@ const (
 	MinPagingSize      uint64 = 50000000
 	maxPagingSizeShift        = 7
 	pagingSizeGrow            = 2
-	MaxPagingSize             = 50000000
+	MaxPagingSize             = 100000000
 	pagingGrowingSum          = ((2 << maxPagingSizeShift) - 1) * MinPagingSize
 	Threshold          uint64 = 960
 )


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37768

Problem Summary:

### What is changed and how it works?

It seems the root cause is not the copr cache cost...
**vectorized** seems to be the root cause.

With paging, table read usually become faster.
But for HashAgg, vectorizd evaluation become poor, because of the chunk batch size.

Take query `select count(l_quantity), sum(l_quantity) from (select * from lineitem limit 3000000) t group by l_partkey;` for example:

```
mysql> select @@tidb_enable_paging;
+----------------------+
| @@tidb_enable_paging |
+----------------------+
|                    1 |
+----------------------+
1 row in set (0.16 sec)
mysql> explain analyze select count(l_quantity), sum(l_quantity) from (select * from lineitem limit 3000000) t group by l_partkey;
+------------------------------+------------+---------+-----------+----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+---------+------+
| id                           | estRows    | actRows | task      | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                    | operator info                                                                                                                      | memory  | disk |
+------------------------------+------------+---------+-----------+----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+---------+------+
| HashAgg_9                    | 3000000.00 | 2593449 | root      |                | time:2.59s, loops:2537, partial_worker:{wall_time:708.751468ms, concurrency:5, task_num:2934, tot_wait:59.711293ms, tot_exec:3.016739474s, tot_time:3.509379678s, max:708.668258ms, p95:708.668258ms}, final_worker:{wall_time:2.587220042s, concurrency:5, task_num:25, tot_wait:3.476123163s, tot_exec:9.00390897s, tot_time:12.480064183s, max:2.587177172s, p95:2.587177172s} | group by:test.lineitem.l_partkey, funcs:count(test.lineitem.l_quantity)->Column#18, funcs:sum(test.lineitem.l_quantity)->Column#19 | 1.25 GB | N/A  |
| └─Limit_10                   | 3000000.00 | 3000000 | root      |                | time:37.3ms, loops:2935                                                                                                                                                                                                                                                                                                                                                           | offset:0, count:3000000                                                                                                            | N/A     | N/A  |
|   └─TableReader_14           | 3000000.00 | 3000128 | root      |                | time:34.9ms, loops:2934, cop_task: {num: 174, max: 75.2ms, min: 2.46ms, avg: 28ms, p95: 69.4ms, max_proc_keys: 50144, p95_proc_keys: 50144, tot_proc: 4.28s, rpc_num: 174, rpc_time: 4.86s, copr_cache_hit_ratio: 0.00, distsql_concurrency: 15}                                                                                                                                  | data:Limit_13                                                                                                                      | 36.8 MB | N/A  |
|     └─Limit_13               | 3000000.00 | 3038016 | cop[tikv] |                | tikv_task:{proc max:70ms, min:0s, avg: 22.9ms, p80:50ms, p95:60ms, iters:3642, tasks:174}, scan_detail: {total_process_keys: 3038016, total_process_keys_size: 603407654, total_keys: 3038190, get_snapshot_time: 15.3ms, rocksdb: {key_skipped_count: 3038016, block: {cache_hit_count: 10199}}}                                                                                 | offset:0, count:3000000                                                                                                            | N/A     | N/A  |
|       └─TableFullScan_12     | 3000000.00 | 3038016 | cop[tikv] | table:lineitem | tikv_task:{proc max:70ms, min:0s, avg: 22.9ms, p80:50ms, p95:60ms, iters:3642, tasks:174}                                                                                                                                                                                                                                                                                         | keep order:false                                                                                                                   | N/A     | N/A  |
+------------------------------+------------+---------+-----------+----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+---------+------+
5 rows in set (2.62 sec)

mysql> set @@tidb_enable_paging = 0;
Query OK, 0 rows affected (0.03 sec)

mysql> explain analyze select count(l_quantity), sum(l_quantity) from (select * from lineitem limit 3000000) t group by l_partkey;
+------------------------------+------------+---------+-----------+----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+----------+------+
| id                           | estRows    | actRows | task      | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                    | operator info                                                                                                                      | memory   | disk |
+------------------------------+------------+---------+-----------+----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+----------+------+
| HashAgg_9                    | 3000000.00 | 2593056 | root      |                | time:3.68s, loops:2535, partial_worker:{wall_time:1.59901746s, concurrency:5, task_num:2932, tot_wait:3.843466462s, tot_exec:3.590551266s, tot_time:7.938140011s, max:1.59892654s, p95:1.59892654s}, final_worker:{wall_time:3.685099546s, concurrency:5, task_num:25, tot_wait:7.884582845s, tot_exec:10.314794017s, tot_time:18.199404652s, max:3.685027386s, p95:3.685027386s} | group by:test.lineitem.l_partkey, funcs:count(test.lineitem.l_quantity)->Column#18, funcs:sum(test.lineitem.l_quantity)->Column#19 | 1.25 GB  | N/A  |
| └─Limit_10                   | 3000000.00 | 3000000 | root      |                | time:781.3ms, loops:2933                                                                                                                                                                                                                                                                                                                                                          | offset:0, count:3000000                                                                                                            | N/A      | N/A  |
|   └─TableReader_14           | 3000000.00 | 3000573 | root      |                | time:777.5ms, loops:2932, cop_task: {num: 6, max: 827.2ms, min: 764.7ms, avg: 792.5ms, p95: 827.2ms, max_proc_keys: 528061, p95_proc_keys: 528061, tot_proc: 3.53s, rpc_num: 6, rpc_time: 4.75s, copr_cache_hit_ratio: 0.00, distsql_concurrency: 15}                                                                                                                             | data:Limit_13                                                                                                                      | 338.6 MB | N/A  |
|     └─Limit_13               | 3000000.00 | 3168102 | cop[tikv] |                | tikv_task:{proc max:570ms, min:520ms, avg: 540ms, p80:560ms, p95:570ms, iters:3120, tasks:6}, scan_detail: {total_process_keys: 3168102, total_process_keys_size: 629338575, total_keys: 3168108, get_snapshot_time: 4.31ms, rocksdb: {key_skipped_count: 3168102, block: {cache_hit_count: 10290}}}                                                                              | offset:0, count:3000000                                                                                                            | N/A      | N/A  |
|       └─TableFullScan_12     | 3000000.00 | 3168102 | cop[tikv] | table:lineitem | tikv_task:{proc max:570ms, min:520ms, avg: 540ms, p80:560ms, p95:570ms, iters:3120, tasks:6}                                                                                                                                                                                                                                                                                      | keep order:false                                                                                                                   | N/A      | N/A  |
+------------------------------+------------+---------+-----------+----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+----------+------+
5 rows in set (3.75 sec)
``` 

Now query on the whole `lineitem` dataset, without limit 3000000

```
mysql> select @@tidb_enable_paging;
+----------------------+
| @@tidb_enable_paging |
+----------------------+
|                    0 |
+----------------------+
1 row in set (0.16 sec)

mysql> explain analyze select count(l_quantity), sum(l_quantity) from lineitem  group by l_partkey;
+---------------------------+--------------+-----------+-----------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+----------+------+
| id                        | estRows      | actRows   | task      | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                                               | operator info                                                                                                                      | memory   | disk |
+---------------------------+--------------+-----------+-----------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+----------+------+
| HashAgg_9                 | 9965568.00   | 10000000  | root      |                | time:1m23.8s, loops:9770, partial_worker:{wall_time:1m1.67050296s, concurrency:5, task_num:568, tot_wait:6.200819541s, tot_exec:4m49.179332801s, tot_time:5m7.0103181s, max:1m1.670331238s, p95:1m1.670331238s}, final_worker:{wall_time:1m23.817725751s, concurrency:5, task_num:25, tot_wait:5m5.867337252s, tot_exec:1m48.148087252s, tot_time:6m54.015453444s, max:1m23.817631081s, p95:1m23.817631081s} | group by:test.lineitem.l_partkey, funcs:count(Column#20)->Column#18, funcs:sum(Column#21)->Column#19                               | 11.6 GB  | N/A  |
| └─TableReader_10          | 9965568.00   | 292254470 | root      |                | time:6.29s, loops:569, cop_task: {num: 569, max: 2.22s, min: 937.2µs, avg: 909.5ms, p95: 1.13s, max_proc_keys: 618925, p95_proc_keys: 528090, tot_proc: 7m28.6s, tot_wait: 34ms, rpc_num: 569, rpc_time: 8m37.5s, copr_cache_hit_ratio: 0.00, distsql_concurrency: 15}                                                                                                                                       | data:HashAgg_5                                                                                                                     | 384.6 MB | N/A  |
|   └─HashAgg_5             | 9965568.00   | 292254470 | cop[tikv] |                | tikv_task:{proc max:900ms, min:0s, avg: 754.2ms, p80:770ms, p95:840ms, iters:293178, tasks:569}, scan_detail: {total_process_keys: 300005811, total_process_keys_size: 59595430182, total_keys: 300006380, get_snapshot_time: 226.8ms, rocksdb: {key_skipped_count: 300005811, block: {cache_hit_count: 974419}}}                                                                                            | group by:test.lineitem.l_partkey, funcs:count(test.lineitem.l_quantity)->Column#20, funcs:sum(test.lineitem.l_quantity)->Column#21 | N/A      | N/A  |
|     └─TableFullScan_8     | 300005811.00 | 300005811 | cop[tikv] | table:lineitem | tikv_task:{proc max:590ms, min:0s, avg: 471.4ms, p80:500ms, p95:540ms, iters:293178, tasks:569}                                                                                                                                                                                                                                                                                                              | keep order:false                                                                                                                   | N/A      | N/A  |
+---------------------------+--------------+-----------+-----------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+----------+------+
4 rows in set (1 min 23.87 sec)

mysql> select @@tidb_min_paging_size;
+------------------------+
| @@tidb_min_paging_size |
+------------------------+
|                    128 |
+------------------------+
1 row in set (0.04 sec)

mysql> select @@tidb_max_paging_size;
+------------------------+
| @@tidb_max_paging_size |
+------------------------+
|                  50000 |
+------------------------+
1 row in set (0.03 sec)

mysql> set @@tidb_enable_paging = 1;
Query OK, 0 rows affected (0.03 sec)

mysql> explain analyze select count(l_quantity), sum(l_quantity) from lineitem  group by l_partkey;
+---------------------------+--------------+-----------+-----------+----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+---------+------+
| id                        | estRows      | actRows   | task      | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                                                        | operator info                                                                                                                      | memory  | disk |
+---------------------------+--------------+-----------+-----------+----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+---------+------+
| HashAgg_9                 | 9965568.00   | 10000000  | root      |                | time:1m57.8s, loops:9770, partial_worker:{wall_time:1m34.044849521s, concurrency:5, task_num:10740, tot_wait:261.62694ms, tot_exec:7m36.595789245s, tot_time:7m49.583789094s, max:1m34.044758581s, p95:1m34.044758581s}, final_worker:{wall_time:1m57.841322617s, concurrency:5, task_num:25, tot_wait:7m49.103540492s, tot_exec:1m54.232435876s, tot_time:9m43.336006268s, max:1m57.841272036s, p95:1m57.841272036s} | group by:test.lineitem.l_partkey, funcs:count(Column#20)->Column#18, funcs:sum(Column#21)->Column#19                               | 11.5 GB | N/A  |
| └─TableReader_10          | 9965568.00   | 299320315 | root      |                | time:846.4ms, loops:10741, cop_task: {num: 10741, max: 209.6ms, min: 437µs, avg: 44ms, p95: 76.1ms, max_proc_keys: 50176, p95_proc_keys: 50176, tot_proc: 6m54.1s, tot_wait: 5ms, rpc_num: 10741, rpc_time: 7m52.4s, copr_cache_hit_ratio: 0.01, distsql_concurrency: 15}                                                                                                                                             | data:HashAgg_5                                                                                                                     | 42.8 MB | N/A  |
|   └─HashAgg_5             | 9965568.00   | 299320315 | cop[tikv] |                | tikv_task:{proc max:140ms, min:0s, avg: 38ms, p80:60ms, p95:70ms, iters:293178, tasks:10741}, scan_detail: {total_process_keys: 297237939, total_process_keys_size: 59045681657, total_keys: 297248600, get_snapshot_time: 420.7ms, rocksdb: {key_skipped_count: 297237939, block: {cache_hit_count: 985653}}}                                                                                                        | group by:test.lineitem.l_partkey, funcs:count(test.lineitem.l_quantity)->Column#20, funcs:sum(test.lineitem.l_quantity)->Column#21 | N/A     | N/A  |
|     └─TableFullScan_8     | 300005811.00 | 300005811 | cop[tikv] | table:lineitem | tikv_task:{proc max:110ms, min:0s, avg: 27.4ms, p80:50ms, p95:60ms, iters:293178, tasks:10741}                                                                                                                                                                                                                                                                                                                        | keep order:false                                                                                                                   | N/A     | N/A  |
+---------------------------+--------------+-----------+-----------+----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+---------+------+
4 rows in set (1 min 57.97 sec)
```

So the conclusion: on small dataset, vectorized does not play an important role, paging is viable.
on large dataset like TPCH 50G, vectorized execution play such a important role that the bigger batch, the better performance.


I'm tired of tuning this kind of regression ... let's just workaound the performance regression by setting the min/max paging size suitable for AP workload.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

`set @@tidb_enable_paging = 0` vs 
`set @@tidb_enable_paging = 1; set @@tidb_min_paging_size = 500000; set @@tidb_max_paging_size = 500000` 

Time cost of TPCH Q17  are basicly the same, at least the difference is acceptable now.

```
+--------------------------------------+--------------+-----------+-----------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+----------+---------+
| id                                   | estRows      | actRows   | task      | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                                               | operator info                                                                                                                                  | memory   | disk    |
+--------------------------------------+--------------+-----------+-----------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+----------+---------+
| Projection_17                        | 1.00         | 1         | root      |                | time:1m28.4s, loops:2, Concurrency:OFF                                                                                                                                                                                                                                                                                                                                                                       | div(Column#46, 7.0)->Column#47                                                                                                                 | 1.40 KB  | N/A     |
| └─HashAgg_18                         | 1.00         | 1         | root      |                | time:1m28.4s, loops:2, partial_worker:{wall_time:1m28.350150753s, concurrency:5, task_num:30, tot_wait:7m21.747167549s, tot_exec:2.663681ms, tot_time:7m21.74988017s, max:1m28.349990922s, p95:1m28.349990922s}, final_worker:{wall_time:1m28.350179674s, concurrency:5, task_num:5, tot_wait:7m21.749604618s, tot_exec:23.25µs, tot_time:7m21.749637458s, max:1m28.349946932s, p95:1m28.349946932s}         | funcs:sum(test.lineitem.l_extendedprice)->Column#46                                                                                            | 568.2 KB | N/A     |
|   └─HashJoin_22                      | 295731.76    | 26963     | root      |                | time:1m28.3s, loops:31, build_hash_table:{total:36.2s, fetch:36.1s, build:142.3ms}, probe:{concurrency:5, total:7m21.7s, max:1m28.3s, probe:2.52s, fetch:7m19.2s}                                                                                                                                                                                                                                            | inner join, equal:[eq(test.part.p_partkey, test.lineitem.l_partkey)], other cond:lt(test.lineitem.l_quantity, mul(0.2, Column#44))             | 30.7 MB  | 0 Bytes |
|     ├─HashJoin_35(Build)             | 295731.76    | 299664    | root      |                | time:36.2s, loops:297, build_hash_table:{total:766.2ms, fetch:757.8ms, build:8.38ms}, probe:{concurrency:5, total:3m1s, max:36.2s, probe:2m5.4s, fetch:55.5s}                                                                                                                                                                                                                                                | inner join, equal:[eq(test.part.p_partkey, test.lineitem.l_partkey)]                                                                           | 1.09 MB  | 0 Bytes |
|     │ ├─TableReader_40(Build)        | 9823.59      | 9989      | root      |                | time:762.6ms, loops:11, cop_task: {num: 16, max: 773.2ms, min: 1.68ms, avg: 120.3ms, p95: 773.2ms, max_proc_keys: 648138, p95_proc_keys: 648138, tot_proc: 1.89s, rpc_num: 16, rpc_time: 1.92s, copr_cache_hit_ratio: 0.81, distsql_concurrency: 15}                                                                                                                                                         | data:Selection_39                                                                                                                              | 564.8 KB | N/A     |
|     │ │ └─Selection_39               | 9823.59      | 9989      | cop[tikv] |                | tikv_task:{proc max:1.08s, min:370ms, avg: 960.6ms, p80:1.05s, p95:1.08s, iters:9837, tasks:16}, scan_detail: {total_process_keys: 1575492, total_process_keys_size: 257474623, total_keys: 1575495, get_snapshot_time: 12.3ms, rocksdb: {key_skipped_count: 1575492, block: {cache_hit_count: 4267}}}                                                                                                       | eq(test.part.p_brand, "Brand#44"), eq(test.part.p_container, "WRAP PKG")                                                                       | N/A      | N/A     |
|     │ │   └─TableFullScan_38         | 10000000.00  | 10000000  | cop[tikv] | table:part     | tikv_task:{proc max:1.02s, min:340ms, avg: 883.1ms, p80:1s, p95:1.02s, iters:9837, tasks:16}                                                                                                                                                                                                                                                                                                                 | keep order:false                                                                                                                               | N/A      | N/A     |
|     │ └─TableReader_37(Probe)        | 300005811.00 | 300005811 | root      |                | time:10.2s, loops:293180, cop_task: {num: 646, max: 2.98s, min: 426.2µs, avg: 702.2ms, p95: 1.03s, max_proc_keys: 618925, p95_proc_keys: 528086, tot_proc: 5m21.6s, tot_wait: 94ms, rpc_num: 646, rpc_time: 7m33.6s, copr_cache_hit_ratio: 0.12, distsql_concurrency: 15}                                                                                                                                    | data:TableFullScan_36                                                                                                                          | 310.3 MB | N/A     |
|     │   └─TableFullScan_36           | 300005811.00 | 300005811 | cop[tikv] | table:lineitem | tikv_task:{proc max:600ms, min:0s, avg: 431.6ms, p80:510ms, p95:540ms, iters:295761, tasks:646}, scan_detail: {total_process_keys: 297204563, total_process_keys_size: 59038978426, total_keys: 297205132, get_snapshot_time: 139.3ms, rocksdb: {key_skipped_count: 297204563, block: {cache_hit_count: 965332}}}                                                                                            | keep order:false                                                                                                                               | N/A      | N/A     |
|     └─HashAgg_45(Probe)              | 9965568.00   | 10000000  | root      |                | time:1m28.3s, loops:9770, partial_worker:{wall_time:1m1.131137241s, concurrency:5, task_num:653, tot_wait:1.624652779s, tot_exec:4m50.10564118s, tot_time:5m3.892064439s, max:1m1.13102713s, p95:1m1.13102713s}, final_worker:{wall_time:1m28.349158075s, concurrency:5, task_num:25, tot_wait:5m2.073795566s, tot_exec:2m17.761341338s, tot_time:7m19.835168764s, max:1m28.349047395s, p95:1m28.349047395s} | group by:test.lineitem.l_partkey, funcs:avg(Column#50, Column#51)->Column#44, funcs:firstrow(test.lineitem.l_partkey)->test.lineitem.l_partkey | 12.0 GB  | N/A     |
|       └─TableReader_46               | 9965568.00   | 292332790 | root      |                | time:4.54s, loops:654, cop_task: {num: 654, max: 1.51s, min: 392.2µs, avg: 808.2ms, p95: 1.12s, max_proc_keys: 618925, p95_proc_keys: 528086, tot_proc: 7m25.3s, tot_wait: 24ms, rpc_num: 654, rpc_time: 8m48.5s, copr_cache_hit_ratio: 0.13, distsql_concurrency: 15}                                                                                                                                       | data:HashAgg_41                                                                                                                                | 302.2 MB | N/A     |
|         └─HashAgg_41                 | 9965568.00   | 292332790 | cop[tikv] |                | tikv_task:{proc max:870ms, min:0s, avg: 658.2ms, p80:770ms, p95:810ms, iters:293178, tasks:654}, scan_detail: {total_process_keys: 297968051, total_process_keys_size: 59190695622, total_keys: 297968620, get_snapshot_time: 99.7ms, rocksdb: {key_skipped_count: 297968051, block: {cache_hit_count: 967824}}}                                                                                             | group by:test.lineitem.l_partkey, funcs:count(test.lineitem.l_quantity)->Column#50, funcs:sum(test.lineitem.l_quantity)->Column#51             | N/A      | N/A     |
|           └─TableFullScan_44         | 300005811.00 | 300005811 | cop[tikv] | table:lineitem | tikv_task:{proc max:590ms, min:0s, avg: 409.8ms, p80:490ms, p95:520ms, iters:293178, tasks:654}                                                                                                                                                                                                                                                                                                              | keep order:false                                                                                                                               | N/A      | N/A     |
+--------------------------------------+--------------+-----------+-----------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+----------+---------+
13 rows in set (1 min 28.44 sec)
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
