### PR TITLE
tests: use atomic values for flushed epoch in `streamhelper_test`

### DIFF
--- a/br/pkg/streamhelper/basic_lib_for_test.go
+++ b/br/pkg/streamhelper/basic_lib_for_test.go
@@ -32,7 +32,7 @@ type flushSimulator struct {
 	enabled      bool
 }
 
-func (c flushSimulator) makeError(requestedEpoch uint64) *errorpb.Error {
+func (c *flushSimulator) makeError(requestedEpoch uint64) *errorpb.Error {
 	if !c.enabled {
 		return nil
 	}
@@ -51,7 +51,7 @@ func (c flushSimulator) makeError(requestedEpoch uint64) *errorpb.Error {
 	return nil
 }
 
-func (c flushSimulator) fork() flushSimulator {
+func (c *flushSimulator) fork() flushSimulator {
 	return flushSimulator{
 		enabled: c.enabled,
 	}
@@ -369,7 +369,7 @@ func (r *region) String() string {
 		hex.EncodeToString(r.rng.EndKey),
 		r.checkpoint.Load(),
 		r.leader,
-		r.fsim.flushedEpoch)
+		r.fsim.flushedEpoch.Load())
 }
 
 func (f *fakeStore) String() string {


### PR DESCRIPTION
Signed-off-by: hillium <yujuncen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: (hopefully) close #37482

Problem Summary:
The `lastFlushedEpoch` might get shared between cores but not guarded with atomic.

### What is changed and how it works?
Make it an atomic variable.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test (Who test tests?)

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
