### PR TITLE
executor: record the retry start time at first round for processing pessimistic lock error

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -886,9 +886,11 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, lockErr error
 		return nil, errors.New("pessimistic lock retry limit reached")
 	}
 	a.retryCount++
-	a.retryStartTime = time.Now()
+	if a.retryStartTime.IsZero() {
+		a.retryStartTime = time.Now()
+	}
 	failpoint.Inject("getPessimisticLockErrorStartRetryTime", func() {
-		sessiontxn.GetPessmisticLockErrRetryStartTime(a.Ctx, a.retryStartTime)
+		sessiontxn.SetPessmisticLockErrRetryStartTime(a.Ctx, a.retryStartTime, a.retryCount)
 	})
 
 	err = txnManager.OnStmtRetry(ctx)

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -887,6 +887,9 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, lockErr error
 	}
 	a.retryCount++
 	a.retryStartTime = time.Now()
+	failpoint.Inject("getPessimisticLockErrorStartRetryTime", func() {
+		sessiontxn.GetPessmisticLockErrRetryStartTime(a.Ctx, a.retryStartTime)
+	})
 
 	err = txnManager.OnStmtRetry(ctx)
 	if err != nil {

--- a/sessiontxn/failpoint.go
+++ b/sessiontxn/failpoint.go
@@ -56,6 +56,9 @@ var TsoUseConstantCount stringutil.StringerStr = "tsoUseConstantCount"
 // Only for test
 var AssertLockErr stringutil.StringerStr = "assertLockError"
 
+// PessmiticLockErrRetryStartTime is used to store retry start time of processing the pessmistic lock error.
+var PessmiticLockErrRetryStartTime stringutil.StringerStr = "pessmiticLockErrRetryTime"
+
 // RecordAssert is used only for test
 func RecordAssert(sctx sessionctx.Context, name string, value interface{}) {
 	records, ok := sctx.Value(AssertRecordsKey).(map[string]interface{})
@@ -151,6 +154,12 @@ func TsoUseConstantCountInc(sctx sessionctx.Context) {
 	}
 	count++
 	sctx.SetValue(TsoUseConstantCount, count)
+}
+
+// GetPessmisticLockErrRetryTime is used only for test.
+// When it is called, gets the retry time for processing the pessimitic lock error.
+func GetPessmisticLockErrRetryStartTime(sctx sessionctx.Context, retryTime time.Time) {
+	sctx.SetValue(PessmiticLockErrRetryStartTime, retryTime)
 }
 
 // ExecTestHook is used only for test. It consumes hookKey in session wait do what it gets from it.

--- a/sessiontxn/failpoint.go
+++ b/sessiontxn/failpoint.go
@@ -56,8 +56,13 @@ var TsoUseConstantCount stringutil.StringerStr = "tsoUseConstantCount"
 // Only for test
 var AssertLockErr stringutil.StringerStr = "assertLockError"
 
-// PessmiticLockErrRetryStartTime is used to store retry start time of processing the pessmistic lock error.
-var PessmiticLockErrRetryStartTime stringutil.StringerStr = "pessmiticLockErrRetryTime"
+// PessmiticLockErrRetryStartTime is used to store retry info of processing the pessmistic lock error.
+var PessmiticLockErrRetryInfo stringutil.StringerStr = "pessmiticLockErrRetryTime"
+
+type pessLockErrRretrInfo struct {
+	retryStartTime time.Time
+	retryCount     uint
+}
 
 // RecordAssert is used only for test
 func RecordAssert(sctx sessionctx.Context, name string, value interface{}) {
@@ -157,9 +162,20 @@ func TsoUseConstantCountInc(sctx sessionctx.Context) {
 }
 
 // GetPessmisticLockErrRetryTime is used only for test.
-// When it is called, gets the retry time for processing the pessimitic lock error.
-func GetPessmisticLockErrRetryStartTime(sctx sessionctx.Context, retryTime time.Time) {
-	sctx.SetValue(PessmiticLockErrRetryStartTime, retryTime)
+// When it is called, sets the retry info of processing the pessimitic lock error.
+func SetPessmisticLockErrRetryStartTime(sctx sessionctx.Context,
+	retryTime time.Time, retryCount uint) {
+	sctx.SetValue(PessmiticLockErrRetryInfo, pessLockErrRretrInfo{retryTime, retryCount})
+}
+
+// GetPessmisticLockErrRetryStartTime is used to get the retry info of processing the pessimitic lock error.
+func GetPessmisticLockErrRetryStartTime(
+	sctx sessionctx.Context) (time.Time, uint) {
+	info, ok := sctx.Value(PessmiticLockErrRetryInfo).(pessLockErrRretrInfo)
+	if !ok {
+		return time.Time{}, 0
+	}
+	return info.retryStartTime, info.retryCount
 }
 
 // ExecTestHook is used only for test. It consumes hookKey in session wait do what it gets from it.

--- a/sessiontxn/txn_context_test.go
+++ b/sessiontxn/txn_context_test.go
@@ -848,7 +848,7 @@ func TestPessimisticRetryTime(t *testing.T) {
 
 		realRetryStartTime, retryCount := sessiontxn.GetPessmisticLockErrRetryStartTime(session2)
 		tk2.MustExec("commit")
-		require.Equal(t, 2, retryCount)
+		require.Equal(t, uint(2), retryCount)
 		require.True(t, firstRetryStartTime.After(realRetryStartTime))
 	})
 }

--- a/testkit/stepped.go
+++ b/testkit/stepped.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/util/breakpoint"
 	"github.com/stretchr/testify/require"
 )
@@ -253,4 +254,9 @@ func (tk *SteppedTestKit) GetQueryResult() *Result {
 	tk.ExpectIdle()
 	require.IsType(tk.t, &Result{}, tk.cmdResult)
 	return tk.cmdResult.(*Result)
+}
+
+// Session return the session associated with the testkit
+func (tk *SteppedTestKit) Session() session.Session {
+	return tk.tk.Session()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38470

Problem Summary:

### What is changed and how it works?
In the past , TiDB updates the retry start time at every round for processing pessimistic lock error. Now, TiDB updates it only at first round.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
