### PR TITLE
br: fix the broken incremental backup  integration test

### DIFF
--- a/br/tests/br_incremental_ddl/run.sh
+++ b/br/tests/br_incremental_ddl/run.sh
@@ -73,13 +73,11 @@ last_backup_ts=$(run_br validate decode --field="end-version" -s "local://$TEST_
 run_br --pd $PD_ADDR backup db -s "local://$TEST_DIR/$DB/inc" --db $DB --lastbackupts $last_backup_ts --log-file $LOG
 
 # when we doing incremental backup, we should close domain in one shot session.
-# so we can check the log count of `one shot domain closed` to be 2.
-# we will call UseOneShotSession twice
-# 1. to get the value global variable.
-# 2. to get all ddl jobs with session.
+# so we can check the log count of `one shot domain closed` to be 1.
+# we will call UseOneShotSession once to get the value global variable.
 one_shot_session_count=$(cat $LOG | grep "one shot session closed" | wc -l | xargs)
 one_shot_domain_count=$(cat $LOG | grep "one shot domain closed" | wc -l | xargs)
-if [ "${one_shot_session_count}" -ne "2" ] || [ "$one_shot_domain_count" -ne "2" ];then
+if [ "${one_shot_session_count}" -ne "1" ] || [ "$one_shot_domain_count" -ne "1" ];then
     echo "TEST: [$TEST_NAME] fail on one shot session check during inc backup, $one_shot_session_count, $one_shot_domain_count"
     exit 1
 fi


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Problem Summary:
The [change](https://github.com/pingcap/tidb/pull/32169/files) of concurrent ddl didn't pick to release-6.1. so the incrmental backup will invoke `UseOneShotSession` once and the test `br_incremental_ddl` is different from master.

### What is changed and how it works?
fix the broken test by update the check logic.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
