### PR TITLE
planner: remove SortItemsForPartition from physical property

### DIFF
--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -2391,9 +2391,6 @@ func (lw *LogicalWindow) GetPartitionKeys() []*property.MPPPartitionColumn {
 }
 
 func (lw *LogicalWindow) tryToGetMppWindows(prop *property.PhysicalProperty) []PhysicalPlan {
-	if !prop.IsSortItemAllForPartition() {
-		return nil
-	}
 	if prop.TaskTp != property.RootTaskType && prop.TaskTp != property.MppTaskType {
 		return nil
 	}
@@ -2434,11 +2431,10 @@ func (lw *LogicalWindow) tryToGetMppWindows(prop *property.PhysicalProperty) []P
 	byItems = append(byItems, lw.PartitionBy...)
 	byItems = append(byItems, lw.OrderBy...)
 	childProperty := &property.PhysicalProperty{
-		ExpectedCnt:           math.MaxFloat64,
-		CanAddEnforcer:        true,
-		SortItems:             byItems,
-		TaskTp:                property.MppTaskType,
-		SortItemsForPartition: byItems,
+		ExpectedCnt:    math.MaxFloat64,
+		CanAddEnforcer: true,
+		SortItems:      byItems,
+		TaskTp:         property.MppTaskType,
 	}
 	if !prop.IsPrefix(childProperty) {
 		return nil

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -411,7 +411,6 @@ func (p *baseLogicalPlan) findBestTask(prop *property.PhysicalProperty, planCoun
 		// Then, we use the empty property to get physicalPlans and
 		// try to get the task with an enforced sort.
 		newProp.SortItems = []property.SortItem{}
-		newProp.SortItemsForPartition = []property.SortItem{}
 		newProp.ExpectedCnt = math.MaxFloat64
 		newProp.MPPPartitionCols = nil
 		newProp.MPPPartitionTp = property.AnyType

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -451,13 +451,7 @@ func setupFineGrainedShuffleInternal(plan PhysicalPlan, helper *fineGrainedShuff
 		helper.updateTarget(window, &x.basePhysicalPlan)
 		setupFineGrainedShuffleInternal(x.children[0], helper, streamCount)
 	case *PhysicalSort:
-		if x.IsPartialSort {
-			// Partial sort will keep the data partition.
-			helper.plans = append(helper.plans, &x.basePhysicalPlan)
-		} else {
-			// Global sort will break the data partition.
-			helper.clear()
-		}
+		helper.plans = append(helper.plans, &x.basePhysicalPlan)
 		setupFineGrainedShuffleInternal(x.children[0], helper, streamCount)
 	case *PhysicalSelection:
 		helper.plans = append(helper.plans, &x.basePhysicalPlan)

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1792,15 +1792,11 @@ type PhysicalSort struct {
 	basePhysicalPlan
 
 	ByItems []*util.ByItems
-	// whether this operator only need to sort the data of one partition.
-	// it is true only if it is used to sort the sharded data of the window function.
-	IsPartialSort bool
 }
 
 // Clone implements PhysicalPlan interface.
 func (ls *PhysicalSort) Clone() (PhysicalPlan, error) {
 	cloned := new(PhysicalSort)
-	cloned.IsPartialSort = ls.IsPartialSort
 	base, err := ls.basePhysicalPlan.cloneWithSelf(cloned)
 	if err != nil {
 		return nil, err

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -90,8 +90,7 @@ func enforceProperty(p *property.PhysicalProperty, tsk task, ctx sessionctx.Cont
 	}
 	sortReqProp := &property.PhysicalProperty{TaskTp: property.RootTaskType, SortItems: p.SortItems, ExpectedCnt: math.MaxFloat64}
 	sort := PhysicalSort{
-		ByItems:       make([]*util.ByItems, 0, len(p.SortItems)),
-		IsPartialSort: true, // TODO: remove IsPartialSort, which is not used in executor
+		ByItems: make([]*util.ByItems, 0, len(p.SortItems)),
 	}.Init(ctx, tsk.plan().statsInfo(), tsk.plan().SelectBlockOffset(), sortReqProp)
 	for _, col := range p.SortItems {
 		sort.ByItems = append(sort.ByItems, &util.ByItems{Expr: col.Col, Desc: col.Desc})

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -80,10 +80,6 @@ func enforceProperty(p *property.PhysicalProperty, tsk task, ctx sessionctx.Cont
 		if !ok || mpp.invalid() {
 			return invalidTask
 		}
-		if !p.IsSortItemAllForPartition() {
-			ctx.GetSessionVars().RaiseWarningWhenMPPEnforced("MPP mode may be blocked because operator `Sort` is not supported now.")
-			return invalidTask
-		}
 		tsk = mpp.enforceExchanger(p)
 	}
 	if p.IsSortItemEmpty() || tsk.plan() == nil {
@@ -95,7 +91,7 @@ func enforceProperty(p *property.PhysicalProperty, tsk task, ctx sessionctx.Cont
 	sortReqProp := &property.PhysicalProperty{TaskTp: property.RootTaskType, SortItems: p.SortItems, ExpectedCnt: math.MaxFloat64}
 	sort := PhysicalSort{
 		ByItems:       make([]*util.ByItems, 0, len(p.SortItems)),
-		IsPartialSort: p.IsSortItemAllForPartition(),
+		IsPartialSort: true, // TODO: remove IsPartialSort, which is not used in executor
 	}.Init(ctx, tsk.plan().statsInfo(), tsk.plan().SelectBlockOffset(), sortReqProp)
 	for _, col := range p.SortItems {
 		sort.ByItems = append(sort.ByItems, &util.ByItems{Expr: col.Col, Desc: col.Desc})

--- a/planner/core/plan_to_pb.go
+++ b/planner/core/plan_to_pb.go
@@ -571,10 +571,6 @@ func (p *PhysicalWindow) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*
 
 // ToPB implements PhysicalPlan ToPB interface.
 func (p *PhysicalSort) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*tipb.Executor, error) {
-	if !p.IsPartialSort {
-		return nil, errors.Errorf("sort %s can't convert to pb, because it isn't a partial sort", p.basePlan.ExplainID())
-	}
-
 	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
 
@@ -582,8 +578,6 @@ func (p *PhysicalSort) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*ti
 	for _, item := range p.ByItems {
 		sortExec.ByItems = append(sortExec.ByItems, expression.SortByItemToPB(sc, client, item.Expr, item.Desc))
 	}
-	isPartialSort := p.IsPartialSort
-	sortExec.IsPartialSort = &isPartialSort
 
 	var err error
 	sortExec.Child, err = p.children[0].ToPB(ctx, storeType)

--- a/planner/core/testdata/window_push_down_suite_out.json
+++ b/planner/core/testdata/window_push_down_suite_out.json
@@ -89,10 +89,10 @@
       {
         "SQL": "explain select *, row_number() over w, rank() over w from employee window w as (partition by deptid) -- 5. different kinds, multi functions, same window",
         "Plan": [
-          "TableReader_36 10000.00 root  data:ExchangeSender_35",
-          "└─ExchangeSender_35 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader_38 10000.00 root  data:ExchangeSender_37",
+          "└─ExchangeSender_37 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
           "  └─Projection_9 10000.00 mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, Column#8, Column#7, stream_count: 8",
-          "    └─Window_34 10000.00 mpp[tiflash]  row_number()->Column#8 over(partition by test.employee.deptid rows between current row and current row), stream_count: 8",
+          "    └─Window_36 10000.00 mpp[tiflash]  row_number()->Column#8 over(partition by test.employee.deptid rows between current row and current row), stream_count: 8",
           "      └─Window_12 10000.00 mpp[tiflash]  rank()->Column#7 over(partition by test.employee.deptid), stream_count: 8",
           "        └─Sort_17 10000.00 mpp[tiflash]  test.employee.deptid, stream_count: 8",
           "          └─ExchangeReceiver_16 10000.00 mpp[tiflash]  stream_count: 8",
@@ -456,10 +456,10 @@
       {
         "SQL": "explain select row_number() over w2, row_number() over w1 from employee window w2 as (order by deptid), w1 as (partition by deptid);",
         "Plan": [
-          "TableReader_37 10000.00 root  data:ExchangeSender_36",
-          "└─ExchangeSender_36 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader_40 10000.00 root  data:ExchangeSender_39",
+          "└─ExchangeSender_39 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
           "  └─Projection_10 10000.00 mpp[tiflash]  Column#8, Column#7",
-          "    └─Window_35 10000.00 mpp[tiflash]  row_number()->Column#8 over(order by test.employee.deptid rows between current row and current row)",
+          "    └─Window_38 10000.00 mpp[tiflash]  row_number()->Column#8 over(order by test.employee.deptid rows between current row and current row)",
           "      └─Sort_20 10000.00 mpp[tiflash]  test.employee.deptid",
           "        └─ExchangeReceiver_19 10000.00 mpp[tiflash]  ",
           "          └─ExchangeSender_18 10000.00 mpp[tiflash]  ExchangeType: PassThrough",


### PR DESCRIPTION
### What problem does this PR solve?
remove SortItemsForPartition from physical property.

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
