### PR TITLE
executor: fix issue of foreign key cascade delete very slow

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -639,7 +639,6 @@ func (a *ExecStmt) handleForeignKeyCascade(ctx context.Context, fkc *FKCascadeEx
 			return err
 		}
 	}
-	return nil
 }
 
 // prepareFKCascadeContext records a transaction savepoint for foreign key cascade when this ExecStmt has foreign key

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -627,6 +627,10 @@ func (a *ExecStmt) handleForeignKeyCascade(ctx context.Context, fkc *FKCascadeEx
 		if err != nil {
 			return err
 		}
+		err = e.Close()
+		if err != nil {
+			return err
+		}
 		// Call `StmtCommit` uses to flush the fk cascade executor change into txn mem-buffer,
 		// then the later fk cascade executors can see the mem-buffer changes.
 		a.Ctx.StmtCommit()

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -614,22 +614,28 @@ func (a *ExecStmt) handleForeignKeyCascade(ctx context.Context, fkc *FKCascadeEx
 	if depth > maxForeignKeyCascadeDepth {
 		return ErrForeignKeyCascadeDepthExceeded.GenWithStackByArgs(maxForeignKeyCascadeDepth)
 	}
-	e, err := fkc.buildExecutor(ctx)
-	if err != nil || e == nil {
-		return err
+	for {
+		e, err := fkc.buildExecutor(ctx)
+		if err != nil || e == nil {
+			return err
+		}
+		if err := e.Open(ctx); err != nil {
+			terror.Call(e.Close)
+			return err
+		}
+		err = Next(ctx, e, newFirstChunk(e))
+		if err != nil {
+			return err
+		}
+		// Call `StmtCommit` uses to flush the fk cascade executor change into txn mem-buffer,
+		// then the later fk cascade executors can see the mem-buffer changes.
+		a.Ctx.StmtCommit()
+		err = a.handleForeignKeyTrigger(ctx, e, depth+1)
+		if err != nil {
+			return err
+		}
 	}
-	if err := e.Open(ctx); err != nil {
-		terror.Call(e.Close)
-		return err
-	}
-	err = Next(ctx, e, newFirstChunk(e))
-	if err != nil {
-		return err
-	}
-	// Call `StmtCommit` uses to flush the fk cascade executor change into txn mem-buffer,
-	// then the later fk cascade executors can see the mem-buffer changes.
-	a.Ctx.StmtCommit()
-	return a.handleForeignKeyTrigger(ctx, e, depth+1)
+	return nil
 }
 
 // prepareFKCascadeContext records a transaction savepoint for foreign key cascade when this ExecStmt has foreign key

--- a/executor/fktest/foreign_key_test.go
+++ b/executor/fktest/foreign_key_test.go
@@ -1254,7 +1254,10 @@ func TestForeignKeyOnDeleteCascadeSQL(t *testing.T) {
 		{types.NewDatum(1), types.NewDatum("a")},
 		{types.NewDatum(2), types.NewDatum("b")},
 	}
-	sql, err := executor.GenCascadeDeleteSQL(model.NewCIStr("test"), model.NewCIStr("t"), fk, fkValues)
+	sql, err := executor.GenCascadeDeleteSQL(model.NewCIStr("test"), model.NewCIStr("t"), model.NewCIStr(""), fk, fkValues)
 	require.NoError(t, err)
 	require.Equal(t, "DELETE FROM `test`.`t` WHERE (`c0`, `c1`) IN ((1,'a'), (2,'b'))", sql)
+	sql, err = executor.GenCascadeDeleteSQL(model.NewCIStr("test"), model.NewCIStr("t"), model.NewCIStr("idx"), fk, fkValues)
+	require.NoError(t, err)
+	require.Equal(t, "DELETE FROM `test`.`t` USE INDEX(`idx`) WHERE (`c0`, `c1`) IN ((1,'a'), (2,'b'))", sql)
 }

--- a/executor/foreign_key.go
+++ b/executor/foreign_key.go
@@ -588,7 +588,7 @@ func (fkc *FKCascadeExec) buildExecutor(ctx context.Context) (Executor, error) {
 	return e, fkc.b.err
 }
 
-var maxHandleFKValueInOneCascade = 128
+var maxHandleFKValueInOneCascade = 1024
 
 func (fkc *FKCascadeExec) buildFKCascadePlan(ctx context.Context) (plannercore.Plan, error) {
 	if len(fkc.fkValues) == 0 {
@@ -643,7 +643,7 @@ func (fkc *FKCascadeExec) buildFKCascadePlan(ctx context.Context) (plannercore.P
 
 // GenCascadeDeleteSQL uses to generate cascade delete SQL, export for test.
 func GenCascadeDeleteSQL(schema, table, idx model.CIStr, fk *model.FKInfo, fkValues [][]types.Datum) (string, error) {
-	buf := bytes.NewBuffer(make([]byte, 0, 32+4*len(fkValues)))
+	buf := bytes.NewBuffer(make([]byte, 0, 48+8*len(fkValues)))
 	buf.WriteString("DELETE FROM `")
 	buf.WriteString(schema.L)
 	buf.WriteString("`.`")


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38631

Problem Summary: fix issue of foreign key cascade delete very slow.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
