### PR TITLE
*: skip log timeout on maxExecutiontime as slow query for DDL statement.

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -507,7 +507,6 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 				sql = ss.SecureText()
 			}
 		}
-
 		maxExecutionTime := getMaxExecutionTime(sctx)
 		// Update processinfo, ShowProcess() will use it.
 		if a.Ctx.GetSessionVars().StmtCtx.StmtType == "" {

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -513,7 +513,7 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 			a.Ctx.GetSessionVars().StmtCtx.StmtType = ast.GetStmtLabel(a.StmtNode)
 		}
 		// Since maxExecutionTime is used only for query statement, here we limit it affect scope.
-		if !isQueryStmt(a.Ctx.GetSessionVars().StmtCtx.StmtType) {
+		if !a.IsReadOnly(a.Ctx.GetSessionVars()) {
 			maxExecutionTime = 0
 		}
 		pi.SetProcessInfo(sql, time.Now(), cmd, maxExecutionTime)
@@ -558,14 +558,6 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		stmt:       a,
 		txnStartTS: txnStartTS,
 	}, nil
-}
-
-// check statement type with nodeType string from stmtNode.
-func isQueryStmt(nodeType string) bool {
-	if nodeType == "Select" || nodeType == "Execute" {
-		return true
-	}
-	return false
 }
 
 func (a *ExecStmt) handleStmtForeignKeyTrigger(ctx context.Context, e Executor) error {

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -729,6 +729,11 @@ func TestConnExecutionTimeout(t *testing.T) {
 
 	err = cc.handleQuery(context.Background(), "select /*+ MAX_EXECUTION_TIME(100)*/  * FROM testTable2 WHERE  SLEEP(1);")
 	require.NoError(t, err)
+
+	tk.MustExec("set @@max_execution_time = 500;")
+
+	err = cc.handleQuery(context.Background(), "alter table testTable2 add index idx(age);")
+	require.NoError(t, err)
 }
 
 func TestShutDown(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

When user issue an long run DDL statement, it should not be checked in maxExecutionTime for slow query checking mechanism.

Issue Number: close #38580

Problem Summary:
Just Skip none query type statements max execution time checking and kill them.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

```release-note
None
```
