### PR TITLE
planner: fix outer join's bad change to inner join depend on wrong null-reject check logic

### DIFF
--- a/planner/core/plan_test.go
+++ b/planner/core/plan_test.go
@@ -1104,5 +1104,8 @@ func TestIssue38430(t *testing.T) {
 
 	tk.MustQuery("SELECT * FROM t0 RIGHT JOIN t1 ON t0.c0;").Check(testkit.Rows("<nil> 1"))
 	tk.MustQuery("SELECT ((NOT ('i'))AND(t0.c0)) IS NULL FROM  t0 RIGHT JOIN t1 ON t0.c0;").Check(testkit.Rows("1"))
+	// outer join can't be an inner join case.
 	tk.MustQuery("SELECT * FROM t0 RIGHT JOIN t1 ON t0.c0 WHERE ((NOT ('i'))AND(t0.c0)) IS NULL;").Check(testkit.Rows("<nil> 1"))
+	// outer join to inner join case.
+	tk.MustQuery("SELECT * FROM t0 RIGHT JOIN t1 ON t0.c0 WHERE ((NOT NOT ('i'))AND(t0.c0)) IS NULL;").Check(testkit.Rows())
 }


### PR DESCRIPTION

Signed-off-by: AilinKid <314806019@qq.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/38654

Problem Summary:

### What is changed and how it works?

// case: null AND 1 we should keep the null value's continuity, the final result can be determinant as null.
// case: null OR 0 we should keep the null value's continuity, the final result can be determinant as null.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix outer join's bad change to inner join depend on wrong null-reject check logic
```
