### PR TITLE
ci: prefer to set bazel repo cache in CI worker

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -116,5 +116,5 @@ TEST_COVERAGE_DIR := "test_coverage"
 
 ifneq ("$(CI)", "0")
 	BAZEL_GLOBAL_CONFIG := --output_user_root=/home/jenkins/.tidb/tmp --host_jvm_args=-XX:+UnlockExperimentalVMOptions --host_jvm_args=-XX:+UseZGC
-	BAZEL_CMD_CONFIG := --config=ci --repository_cache=/home/jenkins/.tidb/tmp
+	BAZEL_CMD_CONFIG := --config=ci
 endif


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. ci: 

-->

### What problem does this PR solve?

Prefer set Bazel repo cache args in CI worker rather than the git repo

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

- delete `--repository_cache=/home/jenkins/.tidb/tmp` bazel build arg in make task.
- prefer set it by `$HOME/.bazelrc` file in CI worker, it will be inherited when run `bazel build` or `bazel test`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
