### PR TITLE
br: check whether the restored tables already exist in the target cluster

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -926,7 +926,7 @@ outer:
 // CheckTableExists checks whether the restored tables already exist in the target cluster.
 func (rc *Client) CheckTableExists(ctx context.Context) error {
 	userDBs := GetExistedUserDBs(rc.dom)
-	if len(userDBs) == 0 {
+	if len(userDBs) == 0 || rc.IsIncremental() {
 		return nil
 	}
 
@@ -2708,6 +2708,7 @@ func NewMockRestoreClient(
 	keepaliveConf keepalive.ClientParameters,
 	isRawKv bool,
 	dbs map[string]*utils.Database,
+	backupMeta *backuppb.BackupMeta,
 ) *Client {
 	return &Client{
 		pdClient:           pdClient,
@@ -2718,6 +2719,7 @@ func NewMockRestoreClient(
 		deleteRangeQuery:   make([]string, 0),
 		deleteRangeQueryCh: make(chan string, 10),
 		databases:          dbs,
+		backupMeta:         backupMeta,
 	}
 }
 

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -923,6 +923,56 @@ outer:
 	return errors.Annotate(berrors.ErrRestoreNotFreshCluster, "user db/tables: "+strings.Join(userTableOrDBNames, ", "))
 }
 
+// CheckTableExists checks whether the restored tables already exist in the target cluster.
+func (rc *Client) CheckTableExists(ctx context.Context) error {
+	userDBs := GetExistedUserDBs(rc.dom)
+	if len(userDBs) == 0 {
+		return nil
+	}
+
+	userTablesMap := make(map[string]struct{})
+	for _, userDB := range userDBs {
+		if utils.IsSysDB(userDB.Name.O) {
+			continue
+		}
+
+		for _, tbl := range userDB.Tables {
+			tblName := utils.EncloseDBAndTable(userDB.Name.L, tbl.Name.L)
+			userTablesMap[tblName] = struct{}{}
+			log.Info("user table", zap.String("db name", userDB.Name.O),
+				zap.String("table name", tbl.Name.O), zap.String("EncloseDBAndTable", tblName))
+		}
+	}
+
+	existedTables := make([]string, 0)
+	for _, db := range rc.databases {
+		if dbCIStrName, ok := utils.GetSysDBCIStrName(db.Info.Name); ok && utils.IsSysDB(dbCIStrName.O) {
+			continue
+		}
+
+		for _, tbl := range db.Tables {
+			if tbl.Info == nil {
+				// we may back up empty database.
+				continue
+			}
+
+			tblName := utils.EncloseDBAndTable(db.Info.Name.L, tbl.Info.Name.L)
+			if _, ok := userTablesMap[tblName]; ok {
+				existedTables = append(existedTables, utils.EncloseDBAndTable(db.Info.Name.O, tbl.Info.Name.O))
+			}
+			log.Info("restore table", zap.String("db name", db.Info.Name.O),
+				zap.String("table name", tbl.Info.Name.O), zap.String("EncloseDBAndTable", tblName))
+		}
+	}
+
+	if len(existedTables) != 0 {
+		return errors.Annotatef(berrors.ErrDatabasesAlreadyExisted,
+			"tables %s existed in restored cluster, please drop them before execute restore",
+			strings.Join(existedTables, ","))
+	}
+	return nil
+}
+
 func (rc *Client) CheckSysTableCompatibility(dom *domain.Domain, tables []*metautil.Table) error {
 	log.Info("checking target cluster system table compatibility with backed up data")
 	privilegeTablesInBackup := make([]*metautil.Table, 0)
@@ -2649,6 +2699,26 @@ func (rc *Client) SetWithSysTable(withSysTable bool) {
 // MockClient create a fake client used to test.
 func MockClient(dbs map[string]*utils.Database) *Client {
 	return &Client{databases: dbs}
+}
+
+// NewMockRestoreClient returns a new Mock RestoreClient.
+func NewMockRestoreClient(
+	pdClient pd.Client,
+	tlsConf *tls.Config,
+	keepaliveConf keepalive.ClientParameters,
+	isRawKv bool,
+	dbs map[string]*utils.Database,
+) *Client {
+	return &Client{
+		pdClient:           pdClient,
+		toolClient:         split.NewSplitClient(pdClient, tlsConf, isRawKv),
+		tlsConf:            tlsConf,
+		keepaliveConf:      keepaliveConf,
+		switchCh:           make(chan struct{}),
+		deleteRangeQuery:   make([]string, 0),
+		deleteRangeQueryCh: make(chan string, 10),
+		databases:          dbs,
+	}
 }
 
 // TidyOldSchemas produces schemas information.

--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -1665,7 +1665,7 @@ func prepareClusterAndClient(t *testing.T,
 	for dbName, tables := range backupDB2Tables {
 		backupDBs[dbName] = &utils.Database{
 			Info: &model.DBInfo{
-				ID:   int64(dbID),
+				ID:   dbID,
 				Name: model.NewCIStr(dbName),
 			},
 			Tables: make([]*metautil.Table, len(tables)),

--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -1565,3 +1565,159 @@ func TestCheckNewCollationEnable(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckTablesExists(t *testing.T) {
+	caseList := []struct {
+		userDB2Tables   map[string][]string
+		backupDB2Tables map[string][]string
+		isErr           bool
+	}{
+		{
+			userDB2Tables: map[string][]string{
+				mysql.SystemDB: {"db", "tables_priv"},
+				"test":         {"T1", "T2"},
+			},
+			backupDB2Tables: map[string][]string{
+				"__TiDB_BR_Temporary_mysql": {"db", "tables_priv"},
+				"test":                      {"T1", "T2"},
+			},
+			isErr: true,
+		},
+		{
+			userDB2Tables: map[string][]string{
+				mysql.SystemDB: {"db", "tables_priv"},
+				"test":         {"T1"},
+			},
+			backupDB2Tables: map[string][]string{
+				"__TiDB_BR_Temporary_mysql": {"db", "tables_priv"},
+				"test":                      {"T1", "T2"},
+			},
+			isErr: true,
+		},
+		{
+			userDB2Tables: map[string][]string{
+				mysql.SystemDB: {"db", "tables_priv"},
+				"test":         {"T1", "T2"},
+			},
+			backupDB2Tables: map[string][]string{
+				"__TiDB_BR_Temporary_mysql": {"db", "tables_priv"},
+				"items":                     {"T1", "T2"},
+			},
+			isErr: false,
+		},
+		{
+			userDB2Tables: map[string][]string{
+				mysql.SystemDB: {"db", "tables_priv"},
+				"test":         {"T1", "T2"},
+			},
+			backupDB2Tables: map[string][]string{
+				"__TiDB_BR_Temporary_mysql": {"db", "tables_priv"},
+				"test":                      {"T3", "T4"},
+			},
+			isErr: false,
+		},
+		{
+			userDB2Tables: map[string][]string{
+				mysql.SystemDB: {"db", "tables_priv"},
+				"test":         {"T1", "T2"},
+			},
+			backupDB2Tables: map[string][]string{
+				"__TiDB_BR_Temporary_mysql": {"db", "tables_priv"},
+				"test":                      {"T2", "T3"},
+			},
+			isErr: true,
+		},
+		{
+			userDB2Tables: map[string][]string{
+				"test": {"T1", "T2"},
+			},
+			backupDB2Tables: map[string][]string{
+				"test": {"t2", "t3"},
+			},
+			isErr: true,
+		},
+	}
+
+	ctx := context.Background()
+	for i, ca := range caseList {
+		t.Run(fmt.Sprintf("case %d:", i), func(t *testing.T) {
+			m, client := prepareClusterAndClient(t, ca.userDB2Tables, ca.backupDB2Tables)
+			defer m.Stop()
+
+			err := client.CheckTableExists(ctx)
+			t.Logf("err: %v\n", err)
+			if ca.isErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func prepareClusterAndClient(t *testing.T,
+	userDB2Tables, backupDB2Tables map[string][]string) (*mock.Cluster, *restore.Client) {
+	m := getStartedMockedCluster(t)
+
+	// prepare backup tables
+	backupDBs := make(map[string]*utils.Database)
+	var dbID int64 = 1
+	for dbName, tables := range backupDB2Tables {
+		backupDBs[dbName] = &utils.Database{
+			Info: &model.DBInfo{
+				ID:   int64(dbID),
+				Name: model.NewCIStr(dbName),
+			},
+			Tables: make([]*metautil.Table, len(tables)),
+		}
+		dbID++
+
+		for i, tableName := range tables {
+			backupDBs[dbName].Tables[i] = &metautil.Table{
+				Info: &model.TableInfo{
+					Name: model.NewCIStr(tableName),
+				},
+			}
+		}
+	}
+
+	client := restore.NewMockRestoreClient(m.PDClient, nil, defaultKeepaliveCfg, false, backupDBs)
+	g := gluetidb.New()
+	err := client.Init(g, m.Storage)
+	require.NoError(t, err)
+
+	// create tables
+	info, err := m.Domain.GetSnapshotInfoSchema(math.MaxUint64)
+	require.NoError(t, err)
+
+	client.SetBatchDdlSize(1)
+	for dbName, tableNameList := range userDB2Tables {
+		dbSchema, isExist := info.SchemaByName(model.NewCIStr(dbName))
+		require.True(t, isExist)
+
+		tables := make([]*metautil.Table, len(tableNameList))
+		intField := types.NewFieldType(mysql.TypeLong)
+		intField.SetCharset("binary")
+		for i := len(tables) - 1; i >= 0; i-- {
+			tables[i] = &metautil.Table{
+				DB: dbSchema,
+				Info: &model.TableInfo{
+					ID:   int64(i),
+					Name: model.NewCIStr(tableNameList[i]),
+					Columns: []*model.ColumnInfo{{
+						ID:        1,
+						Name:      model.NewCIStr("id"),
+						FieldType: *intField,
+						State:     model.StatePublic,
+					}},
+					Charset: "utf8mb4",
+					Collate: "utf8mb4_bin",
+				},
+			}
+		}
+		_, _, err = client.CreateTables(m.Domain, tables, 0)
+		require.NoError(t, err)
+	}
+
+	return m, client
+}

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -568,6 +568,10 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		}
 	}
 
+	if err = client.CheckTableExists(ctx); err != nil {
+		return errors.Trace(err)
+	}
+
 	sp := utils.BRServiceSafePoint{
 		BackupTS: restoreTS,
 		TTL:      utils.DefaultBRGCSafePointTTL,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32615, close #35215

Problem Summary:
if the restored table already exists in the target cluster, it will be failed => `BR:Restore:ErrRestoreChecksumMismatch`.

we should check it before executing restore to save the user time.

### What is changed and how it works?
Add `CheckTableExists` func to check whether the restored tables already exist in the target cluster before executing restore.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Manual Test
case 1
- CREATE TABLE person (id INT(11), name VARCHAR(255), birthday DATE);
- INSERT INTO person VALUES(1, 'tom', '20170912');
- br backup full;
- truncate table person;
- br restore => Failed
`Error: tables demo.person existed in restored cluster, please drop them before execute restore: [BR:Restore:ErrDatabasesAlreadyExisted]databases already existed in restored cluster`

case 2
- create table books (id bigint auto_increment,name char(64), primary key (id));
- insert some records into books
- br backup full
- alter table books and insert some records
- run incremental backup
- br restore full
- br incremental restore => success

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Check whether the restored tables already exist in the target cluster before executing restore.
```
