### PR TITLE
*: fix panic when reusing `OptimisticTxnContextProvider`

### DIFF
--- a/session/txnmanager.go
+++ b/session/txnmanager.go
@@ -51,7 +51,7 @@ type txnManager struct {
 	ctxProvider sessiontxn.TxnContextProvider
 
 	// We always reuse the same OptimisticTxnContextProvider in one session to reduce memory allocation cost for every new txn.
-	reservedOptimisticProvider isolation.OptimisticTxnContextProvider
+	reservedOptimisticProviders [2]isolation.OptimisticTxnContextProvider
 }
 
 func newTxnManager(sctx sessionctx.Context) *txnManager {
@@ -241,8 +241,13 @@ func (m *txnManager) newProviderWithRequest(r *sessiontxn.EnterNewTxnRequest) (s
 	switch txnMode {
 	case "", ast.Optimistic:
 		// When txnMode is 'OPTIMISTIC' or '', the transaction should be optimistic
-		m.reservedOptimisticProvider.ResetForNewTxn(m.sctx, r.CausalConsistencyOnly)
-		return &m.reservedOptimisticProvider, nil
+		provider := &m.reservedOptimisticProviders[0]
+		if old, ok := m.ctxProvider.(*isolation.OptimisticTxnContextProvider); ok && old == provider {
+			// We should make sure the new provider is not the same with the old one
+			provider = &m.reservedOptimisticProviders[1]
+		}
+		provider.ResetForNewTxn(m.sctx, r.CausalConsistencyOnly)
+		return provider, nil
 	case ast.Pessimistic:
 		// When txnMode is 'PESSIMISTIC', the provider should be determined by the isolation level
 		switch sessVars.IsolationLevelForNewTxn() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38951

Problem Summary:

To reduce space allocation, we used to reserve `OptimisticTxnContextProvider` to txnManager that cause the old and new `OptimisticTxnContextProvider` be the same. After `ResetForNewTxn` , the old provider's state will be corrputed. 

It is triggered when new MDL codes merged, see: https://github.com/pingcap/tidb/pull/38926#issuecomment-1305198324

### What is changed and how it works?

Reserve two `OptimisticTxnContextProvider` and make the old and the new one not the same.

### Check List

- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
