### PR TITLE
*: update client-go for v5.3.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.0-alpha.0.20220614073506-266c33cb2c82
+	github.com/tikv/client-go/v2 v2.0.0-alpha.0.20221012075447-4a4b4104966e
 	github.com/tikv/pd v1.1.0-beta.0.20211104095303-69c86d05d379
 	github.com/twmb/murmur3 v1.1.3
 	github.com/uber/jaeger-client-go v2.22.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -713,8 +713,8 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfK
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tikv/client-go/v2 v2.0.0-alpha.0.20220614073506-266c33cb2c82 h1:+/JRZpY+9VMVxurapYe0yXDToHHzyWS9W74s60wE10Q=
-github.com/tikv/client-go/v2 v2.0.0-alpha.0.20220614073506-266c33cb2c82/go.mod h1:gdd4S4uS3/apOF9iet/DIYUdr6J4WzGLWyDgn6SMtg0=
+github.com/tikv/client-go/v2 v2.0.0-alpha.0.20221012075447-4a4b4104966e h1:Z+I/venVRTEdsyCgISPlFbuU5Fj0tLe8YVUykQLQQL8=
+github.com/tikv/client-go/v2 v2.0.0-alpha.0.20221012075447-4a4b4104966e/go.mod h1:gdd4S4uS3/apOF9iet/DIYUdr6J4WzGLWyDgn6SMtg0=
 github.com/tikv/pd v1.1.0-beta.0.20211029083450-e65f0c55b6ae/go.mod h1:varH0IE0jJ9E9WN2Ei/N6pajMlPkcXdDEf7f5mmsUVQ=
 github.com/tikv/pd v1.1.0-beta.0.20211104095303-69c86d05d379 h1:nFm1jQDz1iRktoyV2SyM5zVk6+PJHQNunJZ7ZJcqzAo=
 github.com/tikv/pd v1.1.0-beta.0.20211104095303-69c86d05d379/go.mod h1:y+09hAUXJbrd4c0nktL74zXDDuD7atGtfOKxL90PCOE=


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37141

Problem Summary:

Our region cache B-Tree uses the start key of the region as the entry key. So, insertRegionToCache only replaces the region with the same start key:
https://github.com/tikv/client-go/blob/516cfcdecce865d90ec05dd1cc1de060c35438dc/internal/locate/region_cache.go#L1287

Considering there's a table with lots of regions, the user removes all data from the table. So, PD will finally merge all regions into one. In our region cache implementation, only the first region (containing the table head) is updated, while all other regions still exist in the cache.

When we locate a key near the end of the table, DescendLessOrEqual will iterate over all regions that are left in the cache. This will waste a lot of CPU and make region search really slow, and it is also possible to cause lots of unnecessary PD loadRegion RPCs.


### What is changed and how it works?

To solve the problem, when we do insertRegionToCache, we should iterate the B-Tree for all regions that intersect with the inserted region and remove them.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Optimize the performance of the region cache after merging many regions.
```
