### PR TITLE
*: fix variable problem during initialization

### DIFF
--- a/sessionctx/variable/BUILD.bazel
+++ b/sessionctx/variable/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
     ],
     embed = [":variable"],
     flaky = True,
+    shard_count = 2,
     deps = [
         "//config",
         "//kv",

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -746,7 +746,8 @@ var defaultSysVars = []*SysVar{
 			if floatValue < 0 && floatValue > 0.9 {
 				return "", ErrWrongValueForVar.GenWithStackByArgs(TiDBGOGCTunerThreshold, normalizedValue)
 			}
-			if globalMemoryLimitTuner < floatValue+0.05 {
+			// globalMemoryLimitTuner must not be 0. it will be 0 when tidb_server_memory_limit_gc_trigger is not set during startup.
+			if globalMemoryLimitTuner != 0 && globalMemoryLimitTuner < floatValue+0.05 {
 				return "", errors.New("tidb_gogc_tuner_threshold should be less than tidb_server_memory_limit_gc_trigger - 0.05")
 			}
 			return strconv.FormatFloat(floatValue, 'f', -1, 64), nil
@@ -827,7 +828,8 @@ var defaultSysVars = []*SysVar{
 			if floatValue < 0.51 && floatValue > 1 { // 51% ~ 100%
 				return "", ErrWrongValueForVar.GenWithStackByArgs(TiDBServerMemoryLimitGCTrigger, normalizedValue)
 			}
-			if floatValue < gogcTunerThreshold+0.05 {
+			// gogcTunerThreshold must not be 0. it will be 0 when tidb_gogc_tuner_threshold is not set during startup.
+			if gogcTunerThreshold != 0 && floatValue < gogcTunerThreshold+0.05 {
 				return "", errors.New("tidb_server_memory_limit_gc_trigger should be greater than tidb_gogc_tuner_threshold + 0.05")
 			}
 

--- a/sessionctx/variable/variable_test.go
+++ b/sessionctx/variable/variable_test.go
@@ -436,14 +436,15 @@ func TestDefaultValuesAreSettable(t *testing.T) {
 	for _, sv := range GetSysVars() {
 		if sv.HasSessionScope() && !sv.ReadOnly {
 			val, err := sv.Validate(vars, sv.Value, ScopeSession)
-			require.Equal(t, val, sv.Value)
 			require.NoError(t, err)
+			require.Equal(t, val, sv.Value)
+
 		}
 
 		if sv.HasGlobalScope() && !sv.ReadOnly {
 			val, err := sv.Validate(vars, sv.Value, ScopeGlobal)
-			require.Equal(t, val, sv.Value)
 			require.NoError(t, err)
+			require.Equal(t, val, sv.Value)
 		}
 	}
 }

--- a/sessionctx/variable/variable_test.go
+++ b/sessionctx/variable/variable_test.go
@@ -438,7 +438,6 @@ func TestDefaultValuesAreSettable(t *testing.T) {
 			val, err := sv.Validate(vars, sv.Value, ScopeSession)
 			require.NoError(t, err)
 			require.Equal(t, val, sv.Value)
-
 		}
 
 		if sv.HasGlobalScope() && !sv.ReadOnly {
@@ -447,6 +446,10 @@ func TestDefaultValuesAreSettable(t *testing.T) {
 			require.Equal(t, val, sv.Value)
 		}
 	}
+}
+
+func TestLimitBetweenVariable(t *testing.T) {
+	require.Less(t, DefTiDBGOGCTunerThreshold+0.05, DefTiDBServerMemoryLimitGCTrigger)
 }
 
 // TestSysVarNameIsLowerCase tests that no new sysvars are added with uppercase characters.


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38973

Problem Summary:

### What is changed and how it works?

We have limit between tidb_server_memory_limit_gc_trigger and tidb_gogc_tuner_threshold.
But we init the one of them and the other is not inited. it will have problem.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
