### PR TITLE
executor: fix string pk bug when fast analyze

### DIFF
--- a/executor/analyze_fast.go
+++ b/executor/analyze_fast.go
@@ -256,7 +256,7 @@ func (e *AnalyzeFastExec) decodeValues(handle kv.Handle, sValue []byte, wantCols
 		handleColIDs[i] = c.ID
 		wantCols[c.ID] = c.RetType
 	}
-	return tablecodec.DecodeHandleToDatumMap(handle, handleColIDs, wantCols, loc, values)
+	return tablecodec.DecodeHandleToDatumMapIfSkip(handle, handleColIDs, wantCols, loc, values, false)
 }
 
 func (e *AnalyzeFastExec) getValueByInfo(colInfo *model.ColumnInfo, values map[int64]types.Datum) (types.Datum, error) {

--- a/executor/analyzetest/analyze_test.go
+++ b/executor/analyzetest/analyze_test.go
@@ -159,6 +159,26 @@ func TestClusterIndexAnalyze(t *testing.T) {
 	tk.MustExec("drop table t;")
 }
 
+func TestIssue38935(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t2")
+	//Fast analyze under test int primary key
+	tk.MustExec("CREATE TABLE `t2` (`pk` int(11) NOT NULL,PRIMARY KEY (`pk`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+	tk.MustExec("INSERT INTO `t2` VALUES (1892)")
+	tk.MustExec("set tidb_enable_fast_analyze=on")
+	tk.MustExec("set tidb_analyze_version=1")
+	tk.MustExec("analyze table t2")
+	//Fast analyze under test string primary key
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("CREATE TABLE `t2` (`pk` varchar(15) NOT NULL,PRIMARY KEY (`pk`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+	tk.MustExec("INSERT INTO `t2` VALUES ('1892')")
+	tk.MustExec("set tidb_enable_fast_analyze=on")
+	tk.MustExec("set tidb_analyze_version=1")
+	tk.MustExec("analyze table t2")
+}
+
 func TestAnalyzeRestrict(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -497,6 +497,11 @@ func DecodeRowToDatumMap(b []byte, cols map[int64]*types.FieldType, loc *time.Lo
 // DecodeHandleToDatumMap decodes a handle into datum map.
 func DecodeHandleToDatumMap(handle kv.Handle, handleColIDs []int64,
 	cols map[int64]*types.FieldType, loc *time.Location, row map[int64]types.Datum) (map[int64]types.Datum, error) {
+	return DecodeHandleToDatumMapIfSkip(handle, handleColIDs, cols, loc, row, true)
+}
+
+func DecodeHandleToDatumMapIfSkip(handle kv.Handle, handleColIDs []int64,
+	cols map[int64]*types.FieldType, loc *time.Location, row map[int64]types.Datum, dtSkip bool) (map[int64]types.Datum, error) {
 	if handle == nil || len(handleColIDs) == 0 {
 		return row, nil
 	}
@@ -508,7 +513,7 @@ func DecodeHandleToDatumMap(handle kv.Handle, handleColIDs []int64,
 			if id != hid {
 				continue
 			}
-			if types.NeedRestoredData(ft) {
+			if dtSkip && types.NeedRestoredData(ft) {
 				continue
 			}
 			d, err := decodeHandleToDatum(handle, ft, idx)

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -502,7 +502,7 @@ func DecodeHandleToDatumMap(handle kv.Handle, handleColIDs []int64,
 
 // DecodeHandleToDatumMapIfSkip  exists to skip NeedRestoredData when exec DecodeHandleToDatumMap,such fast analyze
 func DecodeHandleToDatumMapIfSkip(handle kv.Handle, handleColIDs []int64,
-	cols map[int64]*types.FieldType, loc *time.Location, row map[int64]types.Datum, dtSkip bool) (map[int64]types.Datum, error) {
+	cols map[int64]*types.FieldType, loc *time.Location, row map[int64]types.Datum, needCheckRestore bool) (map[int64]types.Datum, error) {
 	if handle == nil || len(handleColIDs) == 0 {
 		return row, nil
 	}
@@ -514,7 +514,7 @@ func DecodeHandleToDatumMapIfSkip(handle kv.Handle, handleColIDs []int64,
 			if id != hid {
 				continue
 			}
-			if dtSkip && types.NeedRestoredData(ft) {
+			if needCheckRestore && types.NeedRestoredData(ft) {
 				continue
 			}
 			d, err := decodeHandleToDatum(handle, ft, idx)

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -500,6 +500,7 @@ func DecodeHandleToDatumMap(handle kv.Handle, handleColIDs []int64,
 	return DecodeHandleToDatumMapIfSkip(handle, handleColIDs, cols, loc, row, true)
 }
 
+// DecodeHandleToDatumMapIfSkip  exists to skip NeedRestoredData when exec DecodeHandleToDatumMap,such fast analyze
 func DecodeHandleToDatumMapIfSkip(handle kv.Handle, handleColIDs []int64,
 	cols map[int64]*types.FieldType, loc *time.Location, row map[int64]types.Datum, dtSkip bool) (map[int64]types.Datum, error) {
 	if handle == nil || len(handleColIDs) == 0 {


### PR DESCRIPTION
Signed-off-by: x-shadow-man <1494445739@qq.com>


### What problem does this PR solve?
fix bug  "Primary key column not found" error report when fast analyze


Issue Number: close #38935

Problem Summary:

### What is changed and how it works?

analyze_fast.go use  DecodeHandleToDatumMap to parse col, this method will skip the primary key of string type, overload this method, and choose not to skip in the fast analyze scenario.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note


```release-note
None
```
