### PR TITLE
server: set the keepalive MinTime for gRPC server

### DIFF
--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -55,6 +55,12 @@ func NewRPCServer(config *config.Config, dom *domain.Domain, sm util.SessionMana
 			Time:    time.Duration(config.Status.GRPCKeepAliveTime) * time.Second,
 			Timeout: time.Duration(config.Status.GRPCKeepAliveTimeout) * time.Second,
 		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			// Allow clients send consecutive pings in every 5 seconds.
+			// The default value of MinTime is 5 minutes,
+			// which is too long compared with 10 seconds of TiDB's keepalive time.
+			MinTime: 5 * time.Second,
+		}),
 		grpc.MaxConcurrentStreams(uint32(config.Status.GRPCConcurrentStreams)),
 		grpc.InitialWindowSize(int32(config.Status.GRPCInitialWindowSize)),
 		grpc.MaxSendMsgSize(config.Status.GRPCMaxSendMsgSize),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38983

Problem Summary:

`keepalive.EnforcementPolicy.MinTime` is the minimum amount of time a client should wait before sending a keepalive ping. Currently, it is unset and the default value is 5 minutes, which is too long, since TopSQL gRPC client sends pings to the server every 10 seconds. As a result, "too many pings" is reported too frequently.

### What is changed and how it works?

This PR changes this argument to 5 seconds.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
