### PR TITLE
br: refine IsLogBackupEnabled

### DIFF
--- a/br/pkg/utils/db.go
+++ b/br/pkg/utils/db.go
@@ -71,7 +71,7 @@ func CheckLogBackupEnabled(ctx sessionctx.Context) bool {
 // we use `sqlexec.RestrictedSQLExecutor` as parameter because it's easy to mock.
 // it should return error.
 func IsLogBackupEnabled(ctx sqlexec.RestrictedSQLExecutor) (bool, error) {
-	valStr := "show config where name = 'log-backup.enable'"
+	valStr := "show config where name = 'log-backup.enable' and type = 'tikv'"
 	internalCtx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBR)
 	rows, fields, errSQL := ctx.ExecRestrictedSQL(internalCtx, nil, valStr)
 	if errSQL != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #39012

Problem Summary:

TiDB is stuck in accessing self instance. Because the bootstrap has not completed, the status port is not available. However, the bootstrap process uses `show config`, which needs to access the status port.

![img_v2_a04c6cc0-74ff-45e0-93c4-43e3136d2f3g](https://user-images.githubusercontent.com/24713065/200761824-d6b767e3-daf3-44f8-916c-28687c1bfb18.jpg)


### What is changed and how it works?

Filter the TiKV nodes for `CheckLogBackupEnabled`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
    Run `make integration_test` in binlog repo.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
