### PR TITLE
util: support intermediate certs when use TLS

### DIFF
--- a/util/security.go
+++ b/util/security.go
@@ -231,9 +231,21 @@ func NewTLSConfig(opts ...TLSConfigOption) (*tls.Config, error) {
 			return err
 		}
 
+		intermediates := x509.NewCertPool()
+		for _, certBytes := range rawCerts[1:] {
+			c, err2 := x509.ParseCertificate(certBytes)
+			if err2 != nil {
+				return err2
+			}
+			intermediates.AddCert(c)
+		}
+
 		certPoolMu.RLock()
 		defer certPoolMu.RUnlock()
-		if _, err = cert.Verify(x509.VerifyOptions{Roots: certPool}); err != nil {
+		if _, err = cert.Verify(x509.VerifyOptions{
+			Roots:         certPool,
+			Intermediates: intermediates,
+		}); err != nil {
 			return errors.Wrap(err, "can't verify certificate, maybe different CA is used")
 		}
 		return nil


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->


- [x] Manual test (add detailed scripts or steps below)
   use dumpling to connection TiDB cloud serverless

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug that can not connect server if server returns intermediate certs 
```
