### PR TITLE
types: Make use of the new time.ZoneBounds function in go-1.19

### DIFF
--- a/types/core_time.go
+++ b/types/core_time.go
@@ -203,8 +203,8 @@ func (t CoreTime) AdjustedGoTime(loc *gotime.Location) (gotime.Time, error) {
 	if tm.Sub(start).Abs() <= tm.Sub(end).Abs() {
 		return start, nil
 	}
-	panic("ever true?")
-	return end, nil
+	return end, errors.Trace(ErrWrongValue.GenWithStackByArgs(TimeStr, tm))
+	//return end, nil
 }
 
 // IsLeapYear returns if it's leap year.

--- a/types/core_time.go
+++ b/types/core_time.go
@@ -184,42 +184,6 @@ func (t CoreTime) GoTime(loc *gotime.Location) (gotime.Time, error) {
 	return tm, nil
 }
 
-// FindZoneTransition check for one Time Zone transition within +/- 4h
-// Currently the needed functions are not exported, if gotime.Location.lookup would be exported
-// then it would be easy to use that directly
-func FindZoneTransition(tIn gotime.Time) (gotime.Time, error) {
-	// Check most common case first, DST transition on full hour.
-	// round truncates away from zero!
-	t2 := tIn.Round(gotime.Hour).Add(-1 * gotime.Hour)
-	t1 := t2.Add(-1 * gotime.Second)
-	_, offset1 := t1.Zone()
-	_, offset2 := t2.Zone()
-	if offset1 != offset2 {
-		return t2, nil
-	}
-
-	// Check if any offset change?
-	t1 = tIn.Add(-4 * gotime.Hour)
-	t2 = tIn.Add(4 * gotime.Hour)
-	_, offset1 = t1.Zone()
-	_, offset2 = t2.Zone()
-	if offset1 == offset2 {
-		return tIn, errors.Trace(ErrWrongValue.GenWithStackByArgs(TimeStr, tIn))
-	}
-
-	// Check generic case, like for 'Australia/Lord_Howe'
-	for t2.After(t1.Add(gotime.Second)) {
-		t := t1.Add(t2.Sub(t1) / 2).Round(gotime.Second)
-		_, offset := t.Zone()
-		if offset == offset1 {
-			t1 = t
-		} else {
-			t2 = t
-		}
-	}
-	return t2, nil
-}
-
 // AdjustedGoTime converts Time to GoTime and adjust for invalid DST times
 // like during the DST change with increased offset,
 // normally moving to Daylight Saving Time.
@@ -230,11 +194,17 @@ func (t CoreTime) AdjustedGoTime(loc *gotime.Location) (gotime.Time, error) {
 		return tm, nil
 	}
 
-	tAdj, err2 := FindZoneTransition(tm)
-	if err2 == nil {
-		return tAdj, nil
+	start, end := tm.ZoneBounds()
+	// time zone transitions are normally 1 hour, allow up to 4 hours before returning error
+	if start.Sub(tm).Abs().Hours() > 4.0 && end.Sub(tm).Abs().Hours() > 4.0 {
+		return tm, errors.Trace(ErrWrongValue.GenWithStackByArgs(TimeStr, tm))
 	}
-	return tm, err
+	// use the closest transition time (in practice always start).
+	if tm.Sub(start).Abs() <= tm.Sub(end).Abs() {
+		return start, nil
+	}
+	panic("ever true?")
+	return end, nil
 }
 
 // IsLeapYear returns if it's leap year.

--- a/types/core_time.go
+++ b/types/core_time.go
@@ -194,17 +194,18 @@ func (t CoreTime) AdjustedGoTime(loc *gotime.Location) (gotime.Time, error) {
 		return tm, nil
 	}
 
+	// The converted go time did not map back to the same time, probably it was between a
+	// daylight saving transition, adjust the time to the closes Zone bound.
 	start, end := tm.ZoneBounds()
 	// time zone transitions are normally 1 hour, allow up to 4 hours before returning error
 	if start.Sub(tm).Abs().Hours() > 4.0 && end.Sub(tm).Abs().Hours() > 4.0 {
 		return tm, errors.Trace(ErrWrongValue.GenWithStackByArgs(TimeStr, tm))
 	}
-	// use the closest transition time (in practice always start).
+	// use the closest transition time
 	if tm.Sub(start).Abs() <= tm.Sub(end).Abs() {
 		return start, nil
 	}
-	return end, errors.Trace(ErrWrongValue.GenWithStackByArgs(TimeStr, tm))
-	//return end, nil
+	return end, nil
 }
 
 // IsLeapYear returns if it's leap year.

--- a/types/core_time.go
+++ b/types/core_time.go
@@ -195,7 +195,7 @@ func (t CoreTime) AdjustedGoTime(loc *gotime.Location) (gotime.Time, error) {
 	}
 
 	// The converted go time did not map back to the same time, probably it was between a
-	// daylight saving transition, adjust the time to the closes Zone bound.
+	// daylight saving transition, adjust the time to the closest Zone bound.
 	start, end := tm.ZoneBounds()
 	// time zone transitions are normally 1 hour, allow up to 4 hours before returning error
 	if start.Sub(tm).Abs().Hours() > 4.0 && end.Sub(tm).Abs().Hours() > 4.0 {

--- a/types/core_time_test.go
+++ b/types/core_time_test.go
@@ -293,45 +293,6 @@ func TestWeekday(t *testing.T) {
 	}
 }
 
-func TestFindZoneTransition(t *testing.T) {
-	tests := []struct {
-		TZ      string
-		dt      string
-		Expect  string
-		Success bool
-	}{
-		{"Australia/Lord_Howe", "2020-06-29 03:45:00", "", false},
-		{"Australia/Lord_Howe", "2020-10-04 02:15:00", "2020-10-04 02:30:00 +11 +1100", true},
-		{"Australia/Lord_Howe", "2020-10-04 02:29:59", "2020-10-04 02:30:00 +11 +1100", true},
-		{"Australia/Lord_Howe", "2020-10-04 02:29:59.99", "2020-10-04 02:30:00 +11 +1100", true},
-		{"Australia/Lord_Howe", "2020-10-04 02:30:00.0001", "2020-10-04 02:30:00 +11 +1100", true},
-		{"Australia/Lord_Howe", "2020-10-04 02:30:00", "2020-10-04 02:30:00 +11 +1100", true},
-		{"Australia/Lord_Howe", "2020-10-04 02:30:01", "2020-10-04 02:30:00 +11 +1100", true},
-		{"Europe/Vilnius", "2020-03-29 03:45:00", "2020-03-29 04:00:00 EEST +0300", true},
-		{"Europe/Vilnius", "2020-10-25 03:45:00", "2020-10-25 03:00:00 EET +0200", true},
-		{"Europe/Vilnius", "2020-06-29 03:45:00", "", false},
-		{"Europe/Amsterdam", "2020-03-29 02:45:00", "2020-03-29 03:00:00 CEST +0200", true},
-		{"Europe/Amsterdam", "2020-10-25 02:35:00", "2020-10-25 02:00:00 CET +0100", true},
-		{"Europe/Amsterdam", "2020-03-29 02:59:59", "2020-03-29 03:00:00 CEST +0200", true},
-		{"Europe/Amsterdam", "2020-03-29 02:59:59.999999999", "2020-03-29 03:00:00 CEST +0200", true},
-		{"Europe/Amsterdam", "2020-03-29 03:00:00.000000001", "2020-03-29 03:00:00 CEST +0200", true},
-	}
-
-	for _, tt := range tests {
-		loc, err := time.LoadLocation(tt.TZ)
-		require.NoError(t, err)
-		tm, err := time.ParseInLocation("2006-01-02 15:04:05", tt.dt, loc)
-		require.NoError(t, err)
-		tp, err := FindZoneTransition(tm)
-		if !tt.Success {
-			require.Error(t, err)
-		} else {
-			require.NoError(t, err)
-			require.Equal(t, tt.Expect, tp.Format("2006-01-02 15:04:05.999999999 MST -0700"))
-		}
-	}
-}
-
 func TestAdjustedGoTime(t *testing.T) {
 	tests := []struct {
 		TZ      string
@@ -361,9 +322,9 @@ func TestAdjustedGoTime(t *testing.T) {
 		require.NoError(t, err)
 		tp, err := tt.dt.AdjustedGoTime(loc)
 		if !tt.Success {
-			require.Error(t, err)
+			require.Error(t, err, tp.Format("2006-01-02 15:04:05.999999999 MST -0700"))
 		} else {
-			require.NoError(t, err)
+			require.NoError(t, err, tp.Format("2006-01-02 15:04:05.999999999 MST -0700"))
 			require.Equal(t, tt.Expect, tp.Format("2006-01-02 15:04:05.999999999 MST -0700"))
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #39037

Problem Summary:
Our request of accessing time zone bounds in the go time pkg has been implemented, and simplifies our time zone check code.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
