### PR TITLE
*: separate auto_increment ID allocator from _tidb_rowid allocator when AUTO_ID_CACHE=1

### DIFF
--- a/autoid_service/autoid.go
+++ b/autoid_service/autoid.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/metrics"
+	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/owner"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mathutil"
@@ -73,7 +74,7 @@ func (alloc *autoIDValue) alloc4Unsigned(ctx context.Context, store kv.Storage, 
 
 		ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMeta)
 		err := kv.RunInNewTxn(ctx, store, true, func(ctx context.Context, txn kv.Transaction) error {
-			idAcc := meta.NewMeta(txn).GetAutoIDAccessors(dbID, tblID).RowID()
+			idAcc := meta.NewMeta(txn).GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion4 + 1)
 			var err1 error
 			newBase, err1 = idAcc.Get()
 			if err1 != nil {
@@ -134,7 +135,7 @@ func (alloc *autoIDValue) alloc4Signed(ctx context.Context,
 
 		ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMeta)
 		err := kv.RunInNewTxn(ctx, store, true, func(ctx context.Context, txn kv.Transaction) error {
-			idAcc := meta.NewMeta(txn).GetAutoIDAccessors(dbID, tblID).RowID()
+			idAcc := meta.NewMeta(txn).GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion4 + 1)
 			var err1 error
 			newBase, err1 = idAcc.Get()
 			if err1 != nil {
@@ -185,7 +186,7 @@ func (alloc *autoIDValue) rebase4Unsigned(ctx context.Context,
 	startTime := time.Now()
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMeta)
 	err := kv.RunInNewTxn(ctx, store, true, func(ctx context.Context, txn kv.Transaction) error {
-		idAcc := meta.NewMeta(txn).GetAutoIDAccessors(dbID, tblID).RowID()
+		idAcc := meta.NewMeta(txn).GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion4 + 1)
 		currentEnd, err1 := idAcc.Get()
 		if err1 != nil {
 			return err1
@@ -218,7 +219,7 @@ func (alloc *autoIDValue) rebase4Signed(ctx context.Context, store kv.Storage, d
 	var newBase, newEnd int64
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMeta)
 	err := kv.RunInNewTxn(ctx, store, true, func(ctx context.Context, txn kv.Transaction) error {
-		idAcc := meta.NewMeta(txn).GetAutoIDAccessors(dbID, tblID).RowID()
+		idAcc := meta.NewMeta(txn).GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion4 + 1)
 		currentEnd, err1 := idAcc.Get()
 		if err1 != nil {
 			return err1
@@ -418,7 +419,7 @@ func (s *Service) allocAutoID(ctx context.Context, req *autoid.AutoIDRequest) (*
 func (alloc *autoIDValue) forceRebase(ctx context.Context, store kv.Storage, dbID, tblID, requiredBase int64, isUnsigned bool) error {
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMeta)
 	err := kv.RunInNewTxn(ctx, store, true, func(ctx context.Context, txn kv.Transaction) error {
-		idAcc := meta.NewMeta(txn).GetAutoIDAccessors(dbID, tblID).RowID()
+		idAcc := meta.NewMeta(txn).GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion4 + 1)
 		currentEnd, err1 := idAcc.Get()
 		if err1 != nil {
 			return err1

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -380,10 +380,13 @@ func BuildBackupRangeAndSchema(
 				zap.String("table", tableInfo.Name.O),
 			)
 
-			tblVer := autoid.AllocOptionTableInfoVersion(tableInfo.Version)
-			idAlloc := autoid.NewAllocator(storage, dbInfo.ID, tableInfo.ID, false, autoid.RowIDAllocType, tblVer)
-			seqAlloc := autoid.NewAllocator(storage, dbInfo.ID, tableInfo.ID, false, autoid.SequenceType, tblVer)
-			randAlloc := autoid.NewAllocator(storage, dbInfo.ID, tableInfo.ID, false, autoid.AutoRandomType, tblVer)
+			// tblVer := autoid.AllocOptionTableInfoVersion(tableInfo.Version)
+			// idAlloc := autoid.NewAllocator(storage, dbInfo.ID, tableInfo.ID, false, autoid.RowIDAllocType, tblVer)
+			// seqAlloc := autoid.NewAllocator(storage, dbInfo.ID, tableInfo.ID, false, autoid.SequenceType, tblVer)
+			// randAlloc := autoid.NewAllocator(storage, dbInfo.ID, tableInfo.ID, false, autoid.AutoRandomType, tblVer)
+			idAlloc := autoid.NewAllocator(storage, dbInfo.ID, tableInfo.ID, false, autoid.RowIDAllocType)
+			seqAlloc := autoid.NewAllocator(storage, dbInfo.ID, tableInfo.ID, false, autoid.SequenceType)
+			randAlloc := autoid.NewAllocator(storage, dbInfo.ID, tableInfo.ID, false, autoid.AutoRandomType)
 
 			var globalAutoID int64
 			switch {

--- a/br/pkg/lightning/backend/kv/allocator.go
+++ b/br/pkg/lightning/backend/kv/allocator.go
@@ -34,6 +34,7 @@ type panickingAllocator struct {
 func NewPanickingAllocators(base int64) autoid.Allocators {
 	sharedBase := &base
 	return autoid.NewAllocators(
+		false,
 		&panickingAllocator{base: sharedBase, ty: autoid.RowIDAllocType},
 		&panickingAllocator{base: sharedBase, ty: autoid.AutoIncrementType},
 		&panickingAllocator{base: sharedBase, ty: autoid.AutoRandomType},

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -2690,6 +2690,7 @@ func TestCreateTableWithAutoIdCache(t *testing.T) {
 	// Test both auto_increment and rowid exist.
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("drop table if exists t1;")
+	fmt.Println("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	tk.MustExec("create table t(a int null, b int auto_increment unique) auto_id_cache 100")
 	_, err = dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -2923,6 +2923,7 @@ func TestAutoIncrementForce(t *testing.T) {
 	tk.MustExec("create table t (a int);")
 	tk.MustExec("alter table t force auto_increment = 2;")
 	tk.MustExec("insert into t values (1),(2);")
+	fmt.Println("6666666666666666666666666666")
 	tk.MustQuery("select a, _tidb_rowid from t;").Check(testkit.Rows("1 2", "2 3"))
 	// Cannot set next global ID to 0.
 	tk.MustGetErrCode("alter table t force auto_increment = 0;", errno.ErrAutoincReadFailed)

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -744,6 +744,7 @@ func TestRebaseAutoID(t *testing.T) {
 	tk.MustExec("create table tidb.test (a int auto_increment primary key, b int);")
 	tk.MustExec("insert tidb.test values (null, 1);")
 	tk.MustQuery("select * from tidb.test").Check(testkit.Rows("1 1"))
+	fmt.Println("=====================================")
 	tk.MustExec("alter table tidb.test auto_increment = 6000;")
 	tk.MustExec("insert tidb.test values (null, 1);")
 	tk.MustQuery("select * from tidb.test").Check(testkit.Rows("1 1", "6000 1"))

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2147,7 +2147,7 @@ func checkPartitionDefinitionConstraints(ctx sessionctx.Context, tbInfo *model.T
 
 // checkTableInfoValid uses to check table info valid. This is used to validate table info.
 func checkTableInfoValid(tblInfo *model.TableInfo) error {
-	_, err := tables.TableFromMeta(nil, tblInfo)
+	_, err := tables.TableFromMeta(autoid.Allocators{}, tblInfo)
 	if err != nil {
 		return err
 	}
@@ -3445,6 +3445,8 @@ func (d *ddl) RebaseAutoID(ctx sessionctx.Context, ident ast.Ident, newBase int6
 		actionType = model.ActionRebaseAutoRandomBase
 	case autoid.RowIDAllocType:
 		actionType = model.ActionRebaseAutoID
+	default:
+		panic("fuck!")
 	}
 
 	if !force {

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -1232,7 +1232,8 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 	case model.ActionTruncateTable:
 		ver, err = onTruncateTable(d, t, job)
 	case model.ActionRebaseAutoID:
-		ver, err = onRebaseRowIDType(d, t, job)
+		fmt.Println("yyyyyyyyyyyyyyyyyyyyyyyyyyy rebase auto id??")
+		ver, err = onRebaseAutoIncrementIDType(d, t, job)
 	case model.ActionRebaseAutoRandomBase:
 		ver, err = onRebaseAutoRandomType(d, t, job)
 	case model.ActionRenameTable:

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -812,8 +812,8 @@ func onTruncateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ erro
 	return ver, nil
 }
 
-func onRebaseRowIDType(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {
-	return onRebaseAutoID(d, d.store, t, job, autoid.RowIDAllocType)
+func onRebaseAutoIncrementIDType(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {
+	return onRebaseAutoID(d, d.store, t, job, autoid.AutoIncrementType)
 }
 
 func onRebaseAutoRandomType(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {
@@ -862,7 +862,7 @@ func onRebaseAutoID(d *ddlCtx, store kv.Storage, t *meta.Meta, job *model.Job, t
 		newBase = newBaseTemp
 	}
 
-	if tp == autoid.RowIDAllocType {
+	if tp == autoid.AutoIncrementType {
 		tblInfo.AutoIncID = newBase
 	} else {
 		tblInfo.AutoRandID = newBase

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -158,7 +158,7 @@ func testGetTableWithError(store kv.Storage, schemaID, tableID int64) (table.Tab
 		return nil, errors.New("table not found")
 	}
 	alloc := autoid.NewAllocator(store, schemaID, tblInfo.ID, false, autoid.RowIDAllocType)
-	tbl, err := table.TableFromMeta(autoid.NewAllocators(alloc), tblInfo)
+	tbl, err := table.TableFromMeta(autoid.NewAllocators(false, alloc), tblInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -397,7 +397,7 @@ func (e *ShowNextRowIDExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	tblMeta := tbl.Meta()
 
 	allocators := tbl.Allocators(e.ctx)
-	for _, alloc := range allocators {
+	for _, alloc := range allocators.Allocs {
 		nextGlobalID, err := alloc.NextGlobalAutoID()
 		if err != nil {
 			return err

--- a/executor/executor_issue_test.go
+++ b/executor/executor_issue_test.go
@@ -1235,3 +1235,26 @@ func TestIssue33214(t *testing.T) {
 		}
 	}
 }
+
+func TestIssue982(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t;")
+	fmt.Println("88888888888888")
+	tk.MustExec("create table t (c int auto_increment, key(c)) auto_id_cache 1;")
+	tk.MustExec("insert into t values();")
+	tk.MustExec("insert into t values();")
+	tk.MustQuery("select * from t;").Check(testkit.Rows("1","2"))
+}
+
+func TestIssue24627(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table test(id float primary key AUTO_INCREMENT, col1 int) auto_id_cache 1;")
+	tk.MustExec("replace into test(col1) values(1);")
+	tk.MustExec("replace into test(col1) values(2);")
+	tk.MustQuery("select * from test;").Check(testkit.Rows("1 1", "2 2"))
+}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1904,7 +1904,7 @@ func TestCheckIndex(t *testing.T) {
 	tbInfo := tbl.Meta()
 
 	alloc := autoid.NewAllocator(store, dbInfo.ID, tbInfo.ID, false, autoid.RowIDAllocType)
-	tb, err := tables.TableFromMeta(autoid.NewAllocators(alloc), tbInfo)
+	tb, err := tables.TableFromMeta(autoid.NewAllocators(false, alloc), tbInfo)
 	require.NoError(t, err)
 
 	_, err = se.Execute(context.Background(), "admin check index t c")

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -386,7 +386,7 @@ func getAutoIncrementID(ctx sessionctx.Context, schema *model.DBInfo, tblInfo *m
 	if err != nil {
 		return 0, err
 	}
-	return tbl.Allocators(ctx).Get(autoid.RowIDAllocType).Base() + 1, nil
+	return tbl.Allocators(ctx).Get(autoid.AutoIncrementType).Base() + 1, nil
 }
 
 func hasPriv(ctx sessionctx.Context, priv mysql.PrivilegeType) bool {

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -778,7 +778,8 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 		}
 		// Use the value if it's not null and not 0.
 		if recordID != 0 {
-			err = e.Table.Allocators(e.ctx).Get(autoid.RowIDAllocType).Rebase(ctx, recordID, true)
+			alloc := e.Table.Allocators(e.ctx).Get(autoid.AutoIncrementType)
+			err = alloc.Rebase(ctx, recordID, true)
 			if err != nil {
 				return nil, err
 			}
@@ -871,7 +872,7 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 	}
 	// Use the value if it's not null and not 0.
 	if recordID != 0 {
-		err = e.Table.Allocators(e.ctx).Get(autoid.RowIDAllocType).Rebase(ctx, recordID, true)
+		err = e.Table.Allocators(e.ctx).Get(autoid.AutoIncrementType).Rebase(ctx, recordID, true)
 		if err != nil {
 			return types.Datum{}, err
 		}

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -816,6 +816,7 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 			// AllocBatchAutoIncrementValue allocates batch N consecutive autoIDs.
 			// The max value can be derived from adding the increment value to min for cnt-1 times.
 			min, increment, err := table.AllocBatchAutoIncrementValue(ctx, e.Table, e.ctx, cnt)
+			fmt.Println("here min, increment ==", min, increment)
 			if e.handleErr(col, &autoDatum, cnt, err) != nil {
 				return nil, err
 			}

--- a/executor/write.go
+++ b/executor/write.go
@@ -115,7 +115,7 @@ func updateRecord(ctx context.Context, sctx sessionctx.Context, h kv.Handle, old
 				if err != nil {
 					return false, err
 				}
-				if err = t.Allocators(sctx).Get(autoid.RowIDAllocType).Rebase(ctx, recordID, true); err != nil {
+				if err = t.Allocators(sctx).Get(autoid.AutoIncrementType).Rebase(ctx, recordID, true); err != nil {
 					return false, err
 				}
 			}

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -693,18 +693,20 @@ func (b *Builder) applyCreateTable(m *meta.Meta, dbInfo *model.DBInfo, tableID i
 	ConvertCharsetCollateToLowerCaseIfNeed(tblInfo)
 	ConvertOldVersionUTF8ToUTF8MB4IfNeed(tblInfo)
 
-	if len(allocs) == 0 {
+	if len(allocs.Allocs) == 0 {
 		allocs = autoid.NewAllocatorsFromTblInfo(b.store, dbInfo.ID, tblInfo)
 	} else {
-		tblVer := autoid.AllocOptionTableInfoVersion(tblInfo.Version)
+		// tblVer := autoid.AllocOptionTableInfoVersion(tblInfo.Version)
 		switch tp {
 		case model.ActionRebaseAutoID, model.ActionModifyTableAutoIdCache:
 			idCacheOpt := autoid.CustomAutoIncCacheOption(tblInfo.AutoIdCache)
-			newAlloc := autoid.NewAllocator(b.store, dbInfo.ID, tblInfo.ID, tblInfo.IsAutoIncColUnsigned(), autoid.RowIDAllocType, tblVer, idCacheOpt)
-			allocs = append(allocs, newAlloc)
+			// newAlloc := autoid.NewAllocator(b.store, dbInfo.ID, tblInfo.ID, tblInfo.IsAutoIncColUnsigned(), autoid.RowIDAllocType, tblVer, idCacheOpt)
+			newAlloc := autoid.NewAllocator(b.store, dbInfo.ID, tblInfo.ID, tblInfo.IsAutoIncColUnsigned(), autoid.RowIDAllocType, idCacheOpt)
+			allocs = allocs.Append(newAlloc)
 		case model.ActionRebaseAutoRandomBase:
-			newAlloc := autoid.NewAllocator(b.store, dbInfo.ID, tblInfo.ID, tblInfo.IsAutoRandomBitColUnsigned(), autoid.AutoRandomType, tblVer)
-			allocs = append(allocs, newAlloc)
+			// newAlloc := autoid.NewAllocator(b.store, dbInfo.ID, tblInfo.ID, tblInfo.IsAutoRandomBitColUnsigned(), autoid.AutoRandomType, tblVer)
+			newAlloc := autoid.NewAllocator(b.store, dbInfo.ID, tblInfo.ID, tblInfo.IsAutoRandomBitColUnsigned(), autoid.AutoRandomType)
+			allocs = allocs.Append(newAlloc)
 		case model.ActionModifyColumn:
 			// Change column attribute from auto_increment to auto_random.
 			if tblInfo.ContainsAutoRandomBits() && allocs.Get(autoid.AutoRandomType) == nil {
@@ -712,8 +714,9 @@ func (b *Builder) applyCreateTable(m *meta.Meta, dbInfo *model.DBInfo, tableID i
 				allocs = allocs.Filter(func(a autoid.Allocator) bool {
 					return a.GetType() != autoid.AutoIncrementType && a.GetType() != autoid.RowIDAllocType
 				})
-				newAlloc := autoid.NewAllocator(b.store, dbInfo.ID, tblInfo.ID, tblInfo.IsAutoRandomBitColUnsigned(), autoid.AutoRandomType, tblVer)
-				allocs = append(allocs, newAlloc)
+				// newAlloc := autoid.NewAllocator(b.store, dbInfo.ID, tblInfo.ID, tblInfo.IsAutoRandomBitColUnsigned(), autoid.AutoRandomType, tblVer)
+				newAlloc := autoid.NewAllocator(b.store, dbInfo.ID, tblInfo.ID, tblInfo.IsAutoRandomBitColUnsigned(), autoid.AutoRandomType)
+				allocs = allocs.Append(newAlloc)
 			}
 		}
 	}

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -270,7 +270,7 @@ func (is *infoSchema) TableByID(id int64) (val table.Table, ok bool) {
 func (is *infoSchema) AllocByID(id int64) (autoid.Allocators, bool) {
 	tbl, ok := is.TableByID(id)
 	if !ok {
-		return nil, false
+		return autoid.Allocators{}, false
 	}
 	return tbl.Allocators(nil), true
 }

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -2131,7 +2131,7 @@ func (it *infoschemaTable) UpdateRecord(gctx context.Context, ctx sessionctx.Con
 
 // Allocators implements table.Table Allocators interface.
 func (it *infoschemaTable) Allocators(_ sessionctx.Context) autoid.Allocators {
-	return nil
+	return autoid.Allocators{}
 }
 
 // Meta implements table.Table Meta interface.
@@ -2214,7 +2214,7 @@ func (vt *VirtualTable) UpdateRecord(ctx context.Context, sctx sessionctx.Contex
 
 // Allocators implements table.Table Allocators interface.
 func (vt *VirtualTable) Allocators(_ sessionctx.Context) autoid.Allocators {
-	return nil
+	return autoid.Allocators{}
 }
 
 // Meta implements table.Table Meta interface.

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -234,7 +234,10 @@ func (all Allocators) Get(allocType AllocatorType) Allocator {
 		}
 	}
 
+	fmt.Println("Get alloc ===", allocType)
+
 	for _, a := range all.Allocs {
+		fmt.Println("alloc a==", a, a.GetType())
 		if a.GetType() == allocType {
 			return a
 		}
@@ -622,6 +625,7 @@ func NewAllocator(store kv.Storage, dbID, tbID int64, isUnsigned bool,
 
 	// Use the MySQL compatible AUTO_INCREMENT mode.
 	if allocType == AutoIncrementType && alloc.customStep && alloc.step == 1 {
+		fmt.Println("single point alloc ...")
 		alloc1 := newSinglePointAlloc(store, dbID, tbID, isUnsigned)
 		if alloc1 != nil {
 			return alloc1
@@ -655,8 +659,14 @@ func NewAllocatorsFromTblInfo(store kv.Storage, schemaID int64, tblInfo *model.T
 
 	hasRowID := !tblInfo.PKIsHandle && !tblInfo.IsCommonHandle
 	hasAutoIncID := tblInfo.GetAutoIncrementColInfo() != nil
+	fmt.Println("hasAutoIncID ===", hasAutoIncID )
 	if hasRowID || hasAutoIncID {
 		alloc := NewAllocator(store, dbID, tblInfo.ID, tblInfo.IsAutoIncColUnsigned(), RowIDAllocType, idCacheOpt, tblVer)
+		allocs = append(allocs, alloc)
+	}
+	if hasAutoIncID {
+		fmt.Println("run here ... and new ??")
+		alloc := NewAllocator(store, dbID, tblInfo.ID, tblInfo.IsAutoIncColUnsigned(), AutoIncrementType, idCacheOpt, tblVer)
 		allocs = append(allocs, alloc)
 	}
 	hasAutoRandID := tblInfo.ContainsAutoRandomBits()

--- a/meta/autoid/autoid_service.go
+++ b/meta/autoid/autoid_service.go
@@ -232,5 +232,5 @@ func (sp *singlePointAlloc) NextGlobalAutoID() (int64, error) {
 }
 
 func (*singlePointAlloc) GetType() AllocatorType {
-	return RowIDAllocType
+	return AutoIncrementType
 }

--- a/meta/autoid/memid.go
+++ b/meta/autoid/memid.go
@@ -26,11 +26,15 @@ func NewAllocatorFromTempTblInfo(tblInfo *model.TableInfo) Allocator {
 	hasRowID := !tblInfo.PKIsHandle && !tblInfo.IsCommonHandle
 	hasAutoIncID := tblInfo.GetAutoIncrementColInfo() != nil
 	var alloc Allocator
+	allocType := RowIDAllocType
+	if hasAutoIncID {
+		allocType = AutoIncrementType
+	}
 	// Temporary tables don't support auto_random and sequence.
 	if hasRowID || hasAutoIncID {
 		alloc = &inMemoryAllocator{
 			isUnsigned: tblInfo.IsAutoIncColUnsigned(),
-			allocType:  RowIDAllocType,
+			allocType:  allocType,
 		}
 	}
 	// Rebase the allocator if the base is specified.

--- a/meta/autoid/memid.go
+++ b/meta/autoid/memid.go
@@ -27,9 +27,9 @@ func NewAllocatorFromTempTblInfo(tblInfo *model.TableInfo) Allocator {
 	hasAutoIncID := tblInfo.GetAutoIncrementColInfo() != nil
 	var alloc Allocator
 	allocType := RowIDAllocType
-	if hasAutoIncID {
-		allocType = AutoIncrementType
-	}
+	// if hasAutoIncID {
+	// 	allocType = AutoIncrementType
+	// }
 	// Temporary tables don't support auto_random and sequence.
 	if hasRowID || hasAutoIncID {
 		alloc = &inMemoryAllocator{

--- a/meta/meta_autoid.go
+++ b/meta/meta_autoid.go
@@ -15,7 +15,9 @@
 package meta
 
 import (
+	"fmt"
 	"strconv"
+	"runtime/debug"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/parser/model"
@@ -42,18 +44,23 @@ type autoIDAccessor struct {
 // Get implements the interface AutoIDAccessor.
 func (a *autoIDAccessor) Get() (int64, error) {
 	m := a.m
-	return m.txn.HGetInt64(m.dbKey(a.databaseID), a.idEncodeFn(a.tableID))
+	ret, err := m.txn.HGetInt64(m.dbKey(a.databaseID), a.idEncodeFn(a.tableID))
+	fmt.Println("get ==", a.databaseID, a.tableID, ret)
+	return ret, err
 }
 
 // Put implements the interface AutoIDAccessor.
 func (a *autoIDAccessor) Put(val int64) error {
 	m := a.m
+	fmt.Println("id accessor put ===", val)
 	return m.txn.HSet(m.dbKey(a.databaseID), a.idEncodeFn(a.tableID), []byte(strconv.FormatInt(val, 10)))
 }
 
 // Inc implements the interface AutoIDAccessor.
 func (a *autoIDAccessor) Inc(step int64) (int64, error) {
 	m := a.m
+	fmt.Println("id accessor inc ===", step, a.databaseID, a.tableID)
+	debug.PrintStack()
 	dbKey := m.dbKey(a.databaseID)
 	if err := m.checkDBExists(dbKey); err != nil {
 		return 0, errors.Trace(err)
@@ -120,6 +127,7 @@ func (a *autoIDAccessors) Get() (autoIDs AutoIDGroup, err error) {
 
 // Put implements the interface AutoIDAccessors.
 func (a *autoIDAccessors) Put(autoIDs AutoIDGroup) error {
+	fmt.Println("id accessors put ===", autoIDs)
 	if err := a.RowID().Put(autoIDs.RowID); err != nil {
 		return err
 	}

--- a/table/table.go
+++ b/table/table.go
@@ -219,7 +219,8 @@ func AllocAutoIncrementValue(ctx context.Context, t Table, sctx sessionctx.Conte
 func AllocBatchAutoIncrementValue(ctx context.Context, t Table, sctx sessionctx.Context, N int) (firstID int64, increment int64, err error) {
 	increment = int64(sctx.GetSessionVars().AutoIncrementIncrement)
 	offset := int64(sctx.GetSessionVars().AutoIncrementOffset)
-	min, max, err := t.Allocators(sctx).Get(autoid.AutoIncrementType).Alloc(ctx, uint64(N), increment, offset)
+	alloc := t.Allocators(sctx).Get(autoid.AutoIncrementType)
+	min, max, err := alloc.Alloc(ctx, uint64(N), increment, offset)
 	if err != nil {
 		return min, max, err
 	}

--- a/table/table.go
+++ b/table/table.go
@@ -206,7 +206,8 @@ func AllocAutoIncrementValue(ctx context.Context, t Table, sctx sessionctx.Conte
 	}
 	increment := sctx.GetSessionVars().AutoIncrementIncrement
 	offset := sctx.GetSessionVars().AutoIncrementOffset
-	_, max, err := t.Allocators(sctx).Get(autoid.RowIDAllocType).Alloc(ctx, uint64(1), int64(increment), int64(offset))
+	alloc := t.Allocators(sctx).Get(autoid.AutoIncrementType)
+	_, max, err := alloc.Alloc(ctx, uint64(1), int64(increment), int64(offset))
 	if err != nil {
 		return 0, err
 	}
@@ -218,7 +219,7 @@ func AllocAutoIncrementValue(ctx context.Context, t Table, sctx sessionctx.Conte
 func AllocBatchAutoIncrementValue(ctx context.Context, t Table, sctx sessionctx.Context, N int) (firstID int64, increment int64, err error) {
 	increment = int64(sctx.GetSessionVars().AutoIncrementIncrement)
 	offset := int64(sctx.GetSessionVars().AutoIncrementOffset)
-	min, max, err := t.Allocators(sctx).Get(autoid.RowIDAllocType).Alloc(ctx, uint64(N), increment, offset)
+	min, max, err := t.Allocators(sctx).Get(autoid.AutoIncrementType).Alloc(ctx, uint64(N), increment, offset)
 	if err != nil {
 		return min, max, err
 	}

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -85,7 +85,7 @@ func MockTableFromMeta(tblInfo *model.TableInfo) table.Table {
 	}
 
 	var t TableCommon
-	initTableCommon(&t, tblInfo, tblInfo.ID, columns, nil)
+	initTableCommon(&t, tblInfo, tblInfo.ID, columns, autoid.Allocators{})
 	if tblInfo.TableCacheStatusType != model.TableCacheStatusDisable {
 		ret, err := newCachedTable(&t)
 		if err != nil {
@@ -1543,7 +1543,10 @@ func (t *TableCommon) Allocators(ctx sessionctx.Context) autoid.Allocators {
 		if t.meta.TempTableType == model.TempTableGlobal {
 			if alloc := ctx.GetSessionVars().GetTemporaryTable(t.meta).GetAutoIDAllocator(); alloc != nil {
 				fmt.Println("global temporary table ... change auto inc to ", alloc)
-				return autoid.Allocators{alloc}
+				// return &autoid.Allocators{
+				// 	allocs: alloc,
+				// }
+				return autoid.NewAllocators(false, alloc)
 			}
 			// If the session is not in a txn, for example, in "show create table", use the original allocator.
 			// Otherwise the would be a nil pointer dereference.
@@ -1553,8 +1556,9 @@ func (t *TableCommon) Allocators(ctx sessionctx.Context) autoid.Allocators {
 
 	// Replace the row id allocator with the one in session variables.
 	sessAlloc := ctx.GetSessionVars().IDAllocator
-	retAllocs := make([]autoid.Allocator, 0, len(t.allocs))
-	copy(retAllocs, t.allocs)
+	allocs := t.allocs.Allocs
+	retAllocs := make([]autoid.Allocator, 0, len(allocs))
+	copy(retAllocs, allocs)
 
 	overwritten := false
 	for i, a := range retAllocs {
@@ -1567,7 +1571,7 @@ func (t *TableCommon) Allocators(ctx sessionctx.Context) autoid.Allocators {
 	if !overwritten {
 		retAllocs = append(retAllocs, sessAlloc)
 	}
-	return retAllocs
+	return autoid.NewAllocators(t.allocs.SepAutoInc, retAllocs...)
 }
 
 // Type implements table.Table Type interface.
@@ -1921,7 +1925,7 @@ func maxIndexLen(idxA, idxB *model.IndexColumn) *model.IndexColumn {
 }
 
 func getSequenceAllocator(allocs autoid.Allocators) (autoid.Allocator, error) {
-	for _, alloc := range allocs {
+	for _, alloc := range allocs.Allocs {
 		if alloc.GetType() == autoid.SequenceType {
 			return alloc, nil
 		}

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -1542,6 +1542,7 @@ func (t *TableCommon) Allocators(ctx sessionctx.Context) autoid.Allocators {
 		// Use an independent allocator for global temporary tables.
 		if t.meta.TempTableType == model.TempTableGlobal {
 			if alloc := ctx.GetSessionVars().GetTemporaryTable(t.meta).GetAutoIDAllocator(); alloc != nil {
+				fmt.Println("global temporary table ... change auto inc to ", alloc)
 				return autoid.Allocators{alloc}
 			}
 			// If the session is not in a txn, for example, in "show create table", use the original allocator.

--- a/table/temptable/ddl.go
+++ b/table/temptable/ddl.go
@@ -182,7 +182,7 @@ func newTemporaryTableFromTableInfo(sctx sessionctx.Context, tbInfo *model.Table
 	if alloc != nil {
 		allocs = append(allocs, alloc)
 	}
-	return tables.TableFromMeta(allocs, tbInfo)
+	return tables.TableFromMeta(autoid.NewAllocators(false, allocs...), tbInfo)
 }
 
 // GetTemporaryTableDDL gets the temptable.TemporaryTableDDL from session context


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #982

Problem Summary:

In the past, both _row_id and auto_increment_id share the same allocator, so the behaviour is not compatible with MySQL.
We try to solve it in the past https://github.com/pingcap/tidb/pull/20708/, but that increase the risk of been incompatible to the old TiDB. So we mark it as won't fix. (I have to mention that clustered index relieve some of the cases, and clustered index is enabled by default now, through it does not solve all the issues)

Now we are trying to introduce a MySQL-compatible mode https://github.com/pingcap/tidb/pull/38449, this is a good time to fix the behaviour. With table option `AUTO_ID_CACHE 1`, the new implementation is used.

### What is changed and how it works?

Seperate auto_increment ID allocator from _tidb_rowid allocator oinly when table option AUTO_ID_CACHE=1 is used.

1. `create table ... AUTO_ID_CACHE 1 ...` would set the `SepAutoInc` field on model.TableInfo
2. Correct the calling side of RowID and AutoIncrementID
3. If `Allocators.Get()` find `SepAutoInc` is not set, it changes `AutoIncrementID` to `RowID`; otherwise `AutoIncrementID` is used

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
