### PR TITLE
lightning: update autoid cache step to avoid enabling experimental feature

### DIFF
--- a/br/pkg/lightning/restore/meta_manager.go
+++ b/br/pkg/lightning/restore/meta_manager.go
@@ -1186,9 +1186,12 @@ func getGlobalAutoIDAlloc(store kv.Storage, dbID int64, tblInfo *model.TableInfo
 		return nil, errors.New("internal error: dbID should not be 0")
 	}
 
-	// We don't need the cache here because we allocate all IDs at once.
-	// The argument for CustomAutoIncCacheOption is the cache step. step 1 means no cache.
-	noCache := autoid.CustomAutoIncCacheOption(1)
+	// We don't need autoid cache here because we allocate all IDs at once.
+	// The argument for CustomAutoIncCacheOption is the cache step. Step 1 means no cache,
+	// but step 1 will enable an experimental feature, so we use step 2 here.
+	//
+	// See https://github.com/pingcap/tidb/issues/38442 for more details.
+	noCache := autoid.CustomAutoIncCacheOption(2)
 	tblVer := autoid.AllocOptionTableInfoVersion(tblInfo.Version)
 
 	hasRowID := common.TableHasAutoRowID(tblInfo)


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/38956

Problem Summary:
https://github.com/pingcap/tidb/issues/38442 added special logic for auto cache step 1. It's still an experimental feature.

### What is changed and how it works?

Set autoid cache step to 2.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
