### PR TITLE
ddl: refine logic of OwnerCheckAllVersions

### DIFF
--- a/ddl/syncer/syncer.go
+++ b/ddl/syncer/syncer.go
@@ -284,18 +284,16 @@ func (s *schemaVersionSyncer) OwnerCheckAllVersions(ctx context.Context, jobID i
 			// Set updatedMap according to the serverInfos, and remove some invalid serverInfos.
 			for _, info := range serverInfos {
 				instance := fmt.Sprintf("%s:%d", info.IP, info.Port)
-				insertSererInfo := func() {
-					updatedMap[info.ID] = fmt.Sprintf("instance ip %s, port %d, id %s", info.IP, info.Port, info.ID)
-					instance2id[instance] = info.ID
-				}
 				if id, ok := instance2id[instance]; ok {
 					if info.StartTimestamp > serverInfos[id].StartTimestamp {
 						// Replace it.
 						delete(updatedMap, id)
-						insertSererInfo()
+						updatedMap[info.ID] = fmt.Sprintf("instance ip %s, port %d, id %s", info.IP, info.Port, info.ID)
+						instance2id[instance] = info.ID
 					}
 				} else {
-					insertSererInfo()
+					updatedMap[info.ID] = fmt.Sprintf("instance ip %s, port %d, id %s", info.IP, info.Port, info.ID)
+					instance2id[instance] = info.ID
 				}
 			}
 		}

--- a/ddl/syncer/syncer.go
+++ b/ddl/syncer/syncer.go
@@ -262,7 +262,7 @@ func (s *schemaVersionSyncer) OwnerCheckAllVersions(ctx context.Context, jobID i
 	// If MDL is enabled, updatedMap is used to check if all the servers report the least version.
 	// updatedMap is initialed to record all the server in every loop. We delete a server from the map if it gets the metadata lock(the key version equal the given version.
 	// updatedMap should be empty if all the servers get the metadata lock.
-	updatedMap := make(map[string]struct{})
+	updatedMap := make(map[string]string)
 	for {
 		if util.IsContextDone(ctx) {
 			// ctx is canceled or timeout.
@@ -278,9 +278,25 @@ func (s *schemaVersionSyncer) OwnerCheckAllVersions(ctx context.Context, jobID i
 			if err != nil {
 				return err
 			}
-			updatedMap = make(map[string]struct{})
+			updatedMap = make(map[string]string)
+			instance2id := make(map[string]string)
+
+			// Set updatedMap according to the serverInfos, and remove some invalid serverInfos.
 			for _, info := range serverInfos {
-				updatedMap[info.ID] = struct{}{}
+				instance := fmt.Sprintf("%s:%d", info.IP, info.Port)
+				insertSererInfo := func() {
+					updatedMap[info.ID] = fmt.Sprintf("instance ip %s, port %d, id %s", info.IP, info.Port, info.ID)
+					instance2id[instance] = info.ID
+				}
+				if id, ok := instance2id[instance]; ok {
+					if info.StartTimestamp > serverInfos[id].StartTimestamp {
+						// Replace it.
+						delete(updatedMap, id)
+						insertSererInfo()
+					}
+				} else {
+					insertSererInfo()
+				}
 			}
 		}
 
@@ -315,6 +331,9 @@ func (s *schemaVersionSyncer) OwnerCheckAllVersions(ctx context.Context, jobID i
 			}
 			if len(updatedMap) > 0 {
 				succ = false
+				for _, info := range updatedMap {
+					logutil.BgLogger().Info("[ddl] syncer check all versions, someone is not synced", zap.String("info", info), zap.Any("ddl id", jobID), zap.Any("ver", latestVer))
+				}
 			}
 		} else {
 			for _, kv := range resp.Kvs {
@@ -337,7 +356,7 @@ func (s *schemaVersionSyncer) OwnerCheckAllVersions(ctx context.Context, jobID i
 					notMatchVerCnt++
 					break
 				}
-				updatedMap[string(kv.Key)] = struct{}{}
+				updatedMap[string(kv.Key)] = ""
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

cluster_info may return invalid TiDB info, in OwnerCheckAllVersions, it doesn't need to check the invalid TiDB info.
If two instances have the same address and port, we know that the one started earlier is invalid.

``` SQL
mysql> select * from information_schema.cluster_info;
+------+---------------------+---------------------+-------------+------------------------------------------+---------------------------+---------------+-----------+
| TYPE | INSTANCE            | STATUS_ADDRESS      | VERSION     | GIT_HASH                                 | START_TIME                | UPTIME        | SERVER_ID |
+------+---------------------+---------------------+-------------+------------------------------------------+---------------------------+---------------+-----------+
| tidb | 192.168.0.102:50002 | 192.168.0.102:28002 | 6.3.0-alpha | 94aa80409637d0f970b917c5ca6cec8876e78fb3 | 2022-11-10T17:01:04+08:00 | 45.575834s    |    724453 |
| tidb | 192.168.0.102:50003 | 192.168.0.102:28003 | 6.3.0-alpha | 94aa80409637d0f970b917c5ca6cec8876e78fb3 | 2022-11-10T17:01:18+08:00 | 31.575837s    |   3596895 |
| tidb | 192.168.0.102:50001 | 192.168.0.102:28001 | 6.3.0-alpha | 94aa80409637d0f970b917c5ca6cec8876e78fb3 | 2022-11-10T17:01:43+08:00 | 6.575845s     |   2636387 |
| tidb | :4000               | :10080              | None        | None                                     | 2022-11-10T17:01:02+08:00 | 47.575848s    |   3272260 |
| tidb | 192.168.0.102:50003 | 192.168.0.102:28003 | 6.3.0-alpha | 94aa80409637d0f970b917c5ca6cec8876e78fb3 | 2022-11-10T17:01:05+08:00 | 44.575849s    |   1515429 |
| tidb | 127.0.0.1:4001      | 127.0.0.1:10081     | 6.3.0-alpha | 94aa80409637d0f970b917c5ca6cec8876e78fb3 | 2022-11-10T16:34:21+08:00 | 27m28.57585s  |     20915 |
| tidb | 127.0.0.1:4000      | 127.0.0.1:10080     | 6.3.0-alpha | 94aa80409637d0f970b917c5ca6cec8876e78fb3 | 2022-11-10T16:34:21+08:00 | 27m28.57585s  |    116956 |
| tidb | 192.168.0.102:50001 | 192.168.0.102:28001 | 6.3.0-alpha | 94aa80409637d0f970b917c5ca6cec8876e78fb3 | 2022-11-10T17:01:02+08:00 | 47.575851s    |    110384 |
| tidb | 192.168.0.102:50001 | 192.168.0.102:28001 | 6.3.0-alpha | 94aa80409637d0f970b917c5ca6cec8876e78fb3 | 2022-11-10T17:01:30+08:00 | 19.575852s    |   1788048 |
| tidb | 127.0.0.1:4002      | 127.0.0.1:10082     | 6.3.0-alpha | 94aa80409637d0f970b917c5ca6cec8876e78fb3 | 2022-11-10T16:34:20+08:00 | 27m29.575853s |   2794409 |
| pd   | 127.0.0.1:2379      | 127.0.0.1:2379      | 6.5.0-alpha | 91f16642cfa3dc53da5aafa481afa63159224aaf | 2022-11-10T16:33:59+08:00 | 27m50.575855s |         0 |
| tikv | 127.0.0.1:20161     | 127.0.0.1:20181     | 6.5.0-alpha | f2e89a4e80e2b99d7ac2abe74d38d4f6eac9ceb6 | 2022-11-10T16:34:03+08:00 | 27m46.575858s |         0 |
| tikv | 127.0.0.1:20162     | 127.0.0.1:20182     | 6.5.0-alpha | f2e89a4e80e2b99d7ac2abe74d38d4f6eac9ceb6 | 2022-11-10T16:34:03+08:00 | 27m46.575859s |         0 |
| tikv | 127.0.0.1:20160     | 127.0.0.1:20180     | 6.5.0-alpha | f2e89a4e80e2b99d7ac2abe74d38d4f6eac9ceb6 | 2022-11-10T16:34:03+08:00 | 27m46.57586s  |         0 |
+------+---------------------+---------------------+-------------+------------------------------------------+---------------------------+---------------+-----------+
```

### What is changed and how it works?
Don't check the invalid TiDB in OwnerCheckAllVersions

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
Pass the intergration_ddl test.
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
