### PR TITLE
stmtctx: remove the empty values in `StatementContext.Tables`

### DIFF
--- a/extension/event_listener_test.go
+++ b/extension/event_listener_test.go
@@ -308,6 +308,21 @@ func TestExtensionStmtEvents(t *testing.T) {
 				{DB: "test", Table: "t2"},
 			},
 		},
+		{
+			sql:        "create database db1",
+			redactText: "create database `db1`",
+			tables: []stmtctx.TableEntry{
+				{DB: "db1", Table: ""},
+			},
+		},
+		{
+			sql:        "kill query 1",
+			redactText: "kill query ?",
+		},
+		{
+			sql:        "create placement policy p1 followers=1",
+			redactText: "create placement policy `p1` followers = ?",
+		},
 	}
 
 	for i, c := range cases {

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -644,6 +644,12 @@ func GetDBTableInfo(visitInfo []visitInfo) []stmtctx.TableEntry {
 		return false
 	}
 	for _, v := range visitInfo {
+		if v.db == "" && v.table == "" {
+			// when v.db == "" and v.table == "", it means this visitInfo is for dynamic privilege,
+			// so it is not related to any database or table.
+			continue
+		}
+
 		tbl := &stmtctx.TableEntry{DB: v.db, Table: v.table}
 		if !existsFunc(tables, tbl) {
 			tables = append(tables, *tbl)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38493

Problem Summary:

The `StatementContext.Tables` records the all tables/databases we are accessing in the statement. But some times it have some empty value (db == "" and table == "").

The reason is that the tables are from `planBuilder.visitInfos` , but it not only contains database/tables, it also contains some dynamic privilege visitInfos, so we should filter those visitInfos out.

### What is changed and how it works?

filter out the visitInfos with dynamic privilege out.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
