### PR TITLE
planner: fold constant for IFNULL in preprocessor

### DIFF
--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -595,6 +595,14 @@ func (p *preprocessor) Leave(in ast.Node) (out ast.Node, ok bool) {
 			break
 		}
 
+		if x.FnName.L == ast.Ifnull && len(x.Args) == 2 {
+			// If the first argument is a constant, we should rewrite it to a constant.
+			// See https://dev.mysql.com/doc/refman/8.0/en/flow-control-functions.html#function_ifnull for details.
+			if ve, isValueExpr := x.Args[0].(*driver.ValueExpr); isValueExpr && !ve.Datum.IsNull() {
+				return x.Args[0], p.err == nil
+			}
+		}
+
 		// no need sleep when retry transaction and avoid unexpect sleep caused by retry.
 		if p.flag&inTxnRetry > 0 && x.FnName.L == ast.Sleep {
 			if len(x.Args) == 1 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

For the SQLs that contain large amount of `ifnull` built-in functions like

```sql
insert into t values (ifnull('0', '')),(ifnull('1', '')),(ifnull('2', '')), ..., (ifnull('1000000', ''));
```

It takes a lot of time/memory to instantiate the `ifNullFunction` even if they can be fold in the stage of preprocess.

### What is changed and how it works?

Before this PR:

![image](https://user-images.githubusercontent.com/24713065/201597191-90d956f2-1756-4780-9af3-b4662112b28b.png)

After this PR:
![image](https://user-images.githubusercontent.com/24713065/201597315-df054d2f-4248-4edd-b1b8-1d0592f94f6f.png)

The CPU cost is reduced from 17% to 9.9%.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
