### PR TITLE
br: modify collate.newCollationEnabled according to the config of the cluster

### DIFF
--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -303,7 +303,8 @@ func (gs *tidbSession) showCreatePlacementPolicy(policy *model.PolicyInfo) strin
 
 // mockSession is used for test.
 type mockSession struct {
-	se session.Session
+	se         session.Session
+	globalVars map[string]string
 }
 
 // GetSessionCtx implements glue.Glue
@@ -368,12 +369,16 @@ func (s *mockSession) Close() {
 
 // GetGlobalVariables implements glue.Session.
 func (s *mockSession) GetGlobalVariable(name string) (string, error) {
+	if ret, ok := s.globalVars[name]; ok {
+		return ret, nil
+	}
 	return "True", nil
 }
 
 // MockGlue only used for test
 type MockGlue struct {
-	se session.Session
+	se         session.Session
+	GlobalVars map[string]string
 }
 
 func (m *MockGlue) SetSession(se session.Session) {
@@ -388,7 +393,8 @@ func (*MockGlue) GetDomain(store kv.Storage) (*domain.Domain, error) {
 // CreateSession implements glue.Glue.
 func (m *MockGlue) CreateSession(store kv.Storage) (glue.Session, error) {
 	glueSession := &mockSession{
-		se: m.se,
+		se:         m.se,
+		globalVars: m.GlobalVars,
 	}
 	return glueSession, nil
 }

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -368,7 +368,7 @@ func (s *mockSession) Close() {
 
 // GetGlobalVariables implements glue.Session.
 func (s *mockSession) GetGlobalVariable(name string) (string, error) {
-	return "true", nil
+	return "True", nil
 }
 
 // MockGlue only used for test

--- a/br/pkg/restore/BUILD.bazel
+++ b/br/pkg/restore/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "//tablecodec",
         "//util",
         "//util/codec",
+        "//util/collate",
         "//util/hack",
         "//util/mathutil",
         "//util/table-filter",

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -2687,7 +2687,7 @@ func CheckNewCollationEnable(
 	if newCollationEnable == "True" {
 		enabled = true
 	}
-	// modify collate.newCollationEnabled according to the configuration of the cluster
+	// modify collate.newCollationEnabled according to the config of the cluster
 	collate.SetNewCollationEnabledForTest(enabled)
 	log.Info("set new_collation_enabled", zap.Bool("new_collation_enabled", enabled))
 	return nil

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -2683,10 +2683,7 @@ func CheckNewCollationEnable(
 	// collate.newCollationEnabled is set to 1 when the collate package is initialized,
 	// so we need to modify this value according to the config of the cluster
 	// before using the collate package.
-	enabled := false
-	if newCollationEnable == "True" {
-		enabled = true
-	}
+	enabled := newCollationEnable == "True"
 	// modify collate.newCollationEnabled according to the config of the cluster
 	collate.SetNewCollationEnabledForTest(enabled)
 	log.Info("set new_collation_enabled", zap.Bool("new_collation_enabled", enabled))

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -51,6 +51,7 @@ import (
 	"github.com/pingcap/tidb/store/pdtypes"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/mathutil"
 	filter "github.com/pingcap/tidb/util/table-filter"
 	"github.com/tikv/client-go/v2/oracle"
@@ -2643,4 +2644,47 @@ func TidyOldSchemas(sr *stream.SchemasReplace) *backup.Schemas {
 		}
 	}
 	return schemas
+}
+
+func CheckNewCollationEnable(
+	backupNewCollationEnable string,
+	g glue.Glue,
+	storage kv.Storage,
+	CheckRequirements bool,
+) error {
+	if backupNewCollationEnable == "" {
+		if CheckRequirements {
+			return errors.Annotatef(berrors.ErrUnknown,
+				"the config 'new_collations_enabled_on_first_bootstrap' not found in backupmeta. "+
+					"you can use \"show config WHERE name='new_collations_enabled_on_first_bootstrap';\" to manually check the config. "+
+					"if you ensure the config 'new_collations_enabled_on_first_bootstrap' in backup cluster is as same as restore cluster, "+
+					"use --check-requirements=false to skip this check")
+		}
+		log.Warn("the config 'new_collations_enabled_on_first_bootstrap' is not in backupmeta")
+		return nil
+	}
+
+	se, err := g.CreateSession(storage)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	newCollationEnable, err := se.GetGlobalVariable(utils.GetTidbNewCollationEnabled())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if !strings.EqualFold(backupNewCollationEnable, newCollationEnable) {
+		return errors.Annotatef(berrors.ErrUnknown,
+			"the config 'new_collations_enabled_on_first_bootstrap' not match, upstream:%v, downstream: %v",
+			backupNewCollationEnable, newCollationEnable)
+	}
+
+	enabled := false
+	if newCollationEnable == "True" {
+		enabled = true
+	}
+	collate.SetNewCollationEnabledForTest(enabled)
+	log.Info("set new_collation_enabled", zap.Bool("new_collation_enabled", enabled))
+	return nil
 }

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -2680,10 +2680,14 @@ func CheckNewCollationEnable(
 			backupNewCollationEnable, newCollationEnable)
 	}
 
+	// collate.newCollationEnabled is set to 1 when the collate package is initialized,
+	// so we need to modify this value according to the config of the cluster
+	// before using the collate package.
 	enabled := false
 	if newCollationEnable == "True" {
 		enabled = true
 	}
+	// modify collate.newCollationEnabled according to the configuration of the cluster
 	collate.SetNewCollationEnabledForTest(enabled)
 	log.Info("set new_collation_enabled", zap.Bool("new_collation_enabled", enabled))
 	return nil

--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -1550,7 +1550,6 @@ func TestCheckNewCollationEnable(t *testing.T) {
 		g := &gluetidb.MockGlue{
 			GlobalVars: map[string]string{"new_collation_enabled": ca.newCollationEnableInCluster},
 		}
-
 		err := restore.CheckNewCollationEnable(ca.backupMeta.GetNewCollationsEnabled(), g, nil, ca.CheckRequirements)
 
 		t.Logf("[%d] Got Error: %v\n", i, err)

--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -1488,3 +1488,76 @@ func TestApplyKVFilesWithBatchMethod4(t *testing.T) {
 		},
 	)
 }
+
+func TestCheckNewCollationEnable(t *testing.T) {
+	caseList := []struct {
+		backupMeta                  *backuppb.BackupMeta
+		newCollationEnableInCluster string
+		CheckRequirements           bool
+		isErr                       bool
+	}{
+		{
+			backupMeta:                  &backuppb.BackupMeta{NewCollationsEnabled: "True"},
+			newCollationEnableInCluster: "True",
+			CheckRequirements:           true,
+			isErr:                       false,
+		},
+		{
+			backupMeta:                  &backuppb.BackupMeta{NewCollationsEnabled: "True"},
+			newCollationEnableInCluster: "False",
+			CheckRequirements:           true,
+			isErr:                       true,
+		},
+		{
+			backupMeta:                  &backuppb.BackupMeta{NewCollationsEnabled: "False"},
+			newCollationEnableInCluster: "True",
+			CheckRequirements:           true,
+			isErr:                       true,
+		},
+		{
+			backupMeta:                  &backuppb.BackupMeta{NewCollationsEnabled: "False"},
+			newCollationEnableInCluster: "false",
+			CheckRequirements:           true,
+			isErr:                       false,
+		},
+		{
+			backupMeta:                  &backuppb.BackupMeta{NewCollationsEnabled: "False"},
+			newCollationEnableInCluster: "True",
+			CheckRequirements:           false,
+			isErr:                       true,
+		},
+		{
+			backupMeta:                  &backuppb.BackupMeta{NewCollationsEnabled: "True"},
+			newCollationEnableInCluster: "False",
+			CheckRequirements:           false,
+			isErr:                       true,
+		},
+		{
+			backupMeta:                  &backuppb.BackupMeta{NewCollationsEnabled: ""},
+			newCollationEnableInCluster: "True",
+			CheckRequirements:           false,
+			isErr:                       false,
+		},
+		{
+			backupMeta:                  &backuppb.BackupMeta{NewCollationsEnabled: ""},
+			newCollationEnableInCluster: "True",
+			CheckRequirements:           true,
+			isErr:                       true,
+		},
+	}
+
+	for i, ca := range caseList {
+		g := &gluetidb.MockGlue{
+			GlobalVars: map[string]string{"new_collation_enabled": ca.newCollationEnableInCluster},
+		}
+
+		err := restore.CheckNewCollationEnable(ca.backupMeta.GetNewCollationsEnabled(), g, nil, ca.CheckRequirements)
+
+		t.Logf("[%d] Got Error: %v\n", i, err)
+		if ca.isErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}

--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -308,12 +308,12 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 
 	var newCollationEnable string
 	err = g.UseOneShotSession(mgr.GetStorage(), !needDomain, func(se glue.Session) error {
-		newCollationEnable, err = se.GetGlobalVariable(tidbNewCollationEnabled)
+		newCollationEnable, err = se.GetGlobalVariable(utils.GetTidbNewCollationEnabled())
 		if err != nil {
 			return errors.Trace(err)
 		}
 		log.Info("get new_collations_enabled_on_first_bootstrap config from system table",
-			zap.String(tidbNewCollationEnabled, newCollationEnable))
+			zap.String(utils.GetTidbNewCollationEnabled(), newCollationEnable))
 		return nil
 	})
 	if err != nil {

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -96,8 +96,6 @@ const (
 	crypterAES192KeyLen = 24
 	crypterAES256KeyLen = 32
 
-	tidbNewCollationEnabled = "new_collation_enabled"
-
 	flagFullBackupType = "type"
 )
 

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/mathutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -474,6 +475,13 @@ func CheckNewCollationEnable(
 			"the config 'new_collations_enabled_on_first_bootstrap' not match, upstream:%v, downstream: %v",
 			backupNewCollationEnable, newCollationEnable)
 	}
+
+	enabled := false
+	if newCollationEnable == "True" {
+		enabled = true
+	}
+	collate.SetNewCollationEnabledForTest(enabled)
+	log.Info("set new_collation_enabled", zap.Bool("new_collation_enabled", enabled))
 	return nil
 }
 

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -556,7 +556,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 			return errors.Trace(versionErr)
 		}
 	}
-	if err = CheckNewCollationEnable(backupMeta.GetNewCollationsEnabled(), g, mgr.GetStorage(), cfg.CheckRequirements); err != nil {
+	if err = restore.CheckNewCollationEnable(backupMeta.GetNewCollationsEnabled(), g, mgr.GetStorage(), cfg.CheckRequirements); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/br/pkg/task/restore_test.go
+++ b/br/pkg/task/restore_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/encryptionpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/br/pkg/conn"
-	"github.com/pingcap/tidb/br/pkg/gluetidb"
 	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/restore"
 	"github.com/pingcap/tidb/br/pkg/storage"
@@ -244,58 +243,5 @@ func mockBackupMeta(mockSchemas []*backuppb.Schema, mockFiles []*backuppb.File) 
 	return &backuppb.BackupMeta{
 		Files:   mockFiles,
 		Schemas: mockSchemas,
-	}
-}
-
-func TestCheckNewCollationEnable(t *testing.T) {
-	caseList := []struct {
-		backupMeta        *backuppb.BackupMeta
-		CheckRequirements bool
-		isErr             bool
-	}{
-		{
-			backupMeta:        &backuppb.BackupMeta{NewCollationsEnabled: "True"},
-			CheckRequirements: true,
-			isErr:             false,
-		},
-		{
-			backupMeta:        &backuppb.BackupMeta{NewCollationsEnabled: "False"},
-			CheckRequirements: true,
-			isErr:             true,
-		},
-		{
-			backupMeta:        &backuppb.BackupMeta{NewCollationsEnabled: "False"},
-			CheckRequirements: false,
-			isErr:             true,
-		},
-		{
-			backupMeta:        &backuppb.BackupMeta{NewCollationsEnabled: ""},
-			CheckRequirements: false,
-			isErr:             false,
-		},
-		{
-			backupMeta:        &backuppb.BackupMeta{NewCollationsEnabled: ""},
-			CheckRequirements: true,
-			isErr:             true,
-		},
-	}
-
-	g := &gluetidb.MockGlue{}
-	se, err := g.CreateSession(nil)
-	require.NoError(t, err)
-
-	enabled, err := se.GetGlobalVariable("new_collation_enabled")
-	require.NoError(t, err)
-	require.Equal(t, enabled, "True")
-
-	for i, ca := range caseList {
-		err = CheckNewCollationEnable(ca.backupMeta.GetNewCollationsEnabled(), g, nil, ca.CheckRequirements)
-
-		t.Logf("[%d] Got Error: %v\n", i, err)
-		if ca.isErr {
-			require.Error(t, err)
-		} else {
-			require.NoError(t, err)
-		}
 	}
 }

--- a/br/pkg/utils/db.go
+++ b/br/pkg/utils/db.go
@@ -15,6 +15,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	tidbNewCollationEnabled = "new_collation_enabled"
+)
+
 var (
 	// check sql.DB and sql.Conn implement QueryExecutor and DBExecutor
 	_ DBExecutor = &sql.DB{}
@@ -116,4 +120,8 @@ func CheckLogBackupTaskExist() bool {
 // IsLogBackupInUse checks the log backup task existed.
 func IsLogBackupInUse(ctx sessionctx.Context) bool {
 	return CheckLogBackupEnabled(ctx) && CheckLogBackupTaskExist()
+}
+
+func GetTidbNewCollationEnabled() string {
+	return tidbNewCollationEnabled
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #39150

Problem Summary:
The `collate.newCollationEnabled` variable is set to 1 when the collate package is initialized. When using this package, this value is not modified according to the config of the TiDB cluster (i.e., `new_collations_enabled_on_first_bootstrap`).

As a result, the user sets `new_collations_enabled_on_first_bootstrap` to `false` in the TiDB cluster, and it is still treated as `true` when br is executed.

### What is changed and how it works?
Modify `collate.newCollationEnabled` according to the config of the cluster.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Manual test
- create a cluster with tidb config `new_collations_enabled_on_first_bootstrap: false`.
- create a table with collation 'utf8mb4_0900_ai_ci': `create table books (id bigint auto_increment,name varchar(64), primary key (id)) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci`;
- insert several records to the table.
- execute a full backup
- create another cluster tidb config `new_collations_enabled_on_first_bootstrap: false`.
- restore the backup to the new cluster => success

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug that: "Error Unsupported collation when new collation is enabled: 'utf8mb4_0900_ai_ci'" even if new_collation_enabled is false.
```
