### PR TITLE
lightning: make some s3/gcs external storage fields public

### DIFF
--- a/br/pkg/restore/stream_metas_test.go
+++ b/br/pkg/restore/stream_metas_test.go
@@ -317,7 +317,7 @@ func TestTruncateSafepointForGCS(t *testing.T) {
 		CredentialsBlob: "Fake Credentials",
 	}
 
-	l, err := storage.NewGCSStorageForTest(ctx, gcs, &storage.ExternalStorageOptions{
+	l, err := storage.NewGCSStorage(ctx, gcs, &storage.ExternalStorageOptions{
 		SendCredentials:  false,
 		CheckPermissions: []storage.Permission{storage.AccessBuckets},
 		HTTPClient:       server.HTTPClient(),

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -90,24 +90,36 @@ func (options *GCSBackendOptions) parseFromFlags(flags *pflag.FlagSet) error {
 	return nil
 }
 
-type gcsStorage struct {
+// GCSStorage defines some standard operations for BR/Lightning on the GCS storage.
+// It implements the `ExternalStorage` interface.
+type GCSStorage struct {
 	gcs    *backuppb.GCS
 	bucket *storage.BucketHandle
 }
 
+// GetBucketHandle gets the handle to the GCS API on the bucket.
+func (s *GCSStorage) GetBucketHandle() *storage.BucketHandle {
+	return s.bucket
+}
+
+// GetOptions gets the external storage operations for the GCS.
+func (s *GCSStorage) GetOptions() *backuppb.GCS {
+	return s.gcs
+}
+
 // DeleteFile delete the file in storage
-func (s *gcsStorage) DeleteFile(ctx context.Context, name string) error {
+func (s *GCSStorage) DeleteFile(ctx context.Context, name string) error {
 	object := s.objectName(name)
 	err := s.bucket.Object(object).Delete(ctx)
 	return errors.Trace(err)
 }
 
-func (s *gcsStorage) objectName(name string) string {
+func (s *GCSStorage) objectName(name string) string {
 	return path.Join(s.gcs.Prefix, name)
 }
 
 // WriteFile writes data to a file to storage.
-func (s *gcsStorage) WriteFile(ctx context.Context, name string, data []byte) error {
+func (s *GCSStorage) WriteFile(ctx context.Context, name string, data []byte) error {
 	object := s.objectName(name)
 	wc := s.bucket.Object(object).NewWriter(ctx)
 	wc.StorageClass = s.gcs.StorageClass
@@ -120,7 +132,7 @@ func (s *gcsStorage) WriteFile(ctx context.Context, name string, data []byte) er
 }
 
 // ReadFile reads the file from the storage and returns the contents.
-func (s *gcsStorage) ReadFile(ctx context.Context, name string) ([]byte, error) {
+func (s *GCSStorage) ReadFile(ctx context.Context, name string) ([]byte, error) {
 	object := s.objectName(name)
 	rc, err := s.bucket.Object(object).NewReader(ctx)
 	if err != nil {
@@ -143,7 +155,7 @@ func (s *gcsStorage) ReadFile(ctx context.Context, name string) ([]byte, error) 
 }
 
 // FileExists return true if file exists.
-func (s *gcsStorage) FileExists(ctx context.Context, name string) (bool, error) {
+func (s *GCSStorage) FileExists(ctx context.Context, name string) (bool, error) {
 	object := s.objectName(name)
 	_, err := s.bucket.Object(object).Attrs(ctx)
 	if err != nil {
@@ -156,7 +168,7 @@ func (s *gcsStorage) FileExists(ctx context.Context, name string) (bool, error) 
 }
 
 // Open a Reader by file path.
-func (s *gcsStorage) Open(ctx context.Context, path string) (ExternalFileReader, error) {
+func (s *GCSStorage) Open(ctx context.Context, path string) (ExternalFileReader, error) {
 	object := s.objectName(path)
 	handle := s.bucket.Object(object)
 
@@ -182,7 +194,7 @@ func (s *gcsStorage) Open(ctx context.Context, path string) (ExternalFileReader,
 // The first argument is the file path that can be used in `Open`
 // function; the second argument is the size in byte of the file determined
 // by path.
-func (s *gcsStorage) WalkDir(ctx context.Context, opt *WalkOption, fn func(string, int64) error) error {
+func (s *GCSStorage) WalkDir(ctx context.Context, opt *WalkOption, fn func(string, int64) error) error {
 	if opt == nil {
 		opt = &WalkOption{}
 	}
@@ -221,12 +233,12 @@ func (s *gcsStorage) WalkDir(ctx context.Context, opt *WalkOption, fn func(strin
 	return nil
 }
 
-func (s *gcsStorage) URI() string {
+func (s *GCSStorage) URI() string {
 	return "gcs://" + s.gcs.Bucket + "/" + s.gcs.Prefix
 }
 
 // Create implements ExternalStorage interface.
-func (s *gcsStorage) Create(ctx context.Context, name string) (ExternalFileWriter, error) {
+func (s *GCSStorage) Create(ctx context.Context, name string) (ExternalFileWriter, error) {
 	object := s.objectName(name)
 	wc := s.bucket.Object(object).NewWriter(ctx)
 	wc.StorageClass = s.gcs.StorageClass
@@ -235,7 +247,7 @@ func (s *gcsStorage) Create(ctx context.Context, name string) (ExternalFileWrite
 }
 
 // Rename file name from oldFileName to newFileName.
-func (s *gcsStorage) Rename(ctx context.Context, oldFileName, newFileName string) error {
+func (s *GCSStorage) Rename(ctx context.Context, oldFileName, newFileName string) error {
 	data, err := s.ReadFile(ctx, oldFileName)
 	if err != nil {
 		return errors.Trace(err)
@@ -247,7 +259,8 @@ func (s *gcsStorage) Rename(ctx context.Context, oldFileName, newFileName string
 	return s.DeleteFile(ctx, oldFileName)
 }
 
-func newGCSStorage(ctx context.Context, gcs *backuppb.GCS, opts *ExternalStorageOptions) (*gcsStorage, error) {
+// NewGCSStorage creates a GCS external storage implementation.
+func NewGCSStorage(ctx context.Context, gcs *backuppb.GCS, opts *ExternalStorageOptions) (*GCSStorage, error) {
 	var clientOps []option.ClientOption
 	if opts.NoCredentials {
 		clientOps = append(clientOps, option.WithoutAuthentication())
@@ -301,12 +314,7 @@ func newGCSStorage(ctx context.Context, gcs *backuppb.GCS, opts *ExternalStorage
 		// so we need find sst in slash directory
 		gcs.Prefix += "//"
 	}
-	return &gcsStorage{gcs: gcs, bucket: bucket}, nil
-}
-
-// only for unit test
-func NewGCSStorageForTest(ctx context.Context, gcs *backuppb.GCS, opts *ExternalStorageOptions) (*gcsStorage, error) {
-	return newGCSStorage(ctx, gcs, opts)
+	return &GCSStorage{gcs: gcs, bucket: bucket}, nil
 }
 
 func hasSSTFiles(ctx context.Context, bucket *storage.BucketHandle, prefix string) bool {
@@ -332,7 +340,7 @@ func hasSSTFiles(ctx context.Context, bucket *storage.BucketHandle, prefix strin
 
 // gcsObjectReader wrap storage.Reader and add the `Seek` method.
 type gcsObjectReader struct {
-	storage   *gcsStorage
+	storage   *GCSStorage
 	name      string
 	objHandle *storage.ObjectHandle
 	reader    io.ReadCloser

--- a/br/pkg/storage/gcs_test.go
+++ b/br/pkg/storage/gcs_test.go
@@ -32,7 +32,7 @@ func TestGCS(t *testing.T) {
 		PredefinedAcl:   "private",
 		CredentialsBlob: "Fake Credentials",
 	}
-	stg, err := newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+	stg, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 		SendCredentials:  false,
 		CheckPermissions: []Permission{AccessBuckets},
 		HTTPClient:       server.HTTPClient(),
@@ -86,7 +86,7 @@ func TestGCS(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, exist)
 
-	checkWalkDir := func(stg *gcsStorage, opt *WalkOption) {
+	checkWalkDir := func(stg *GCSStorage, opt *WalkOption) {
 		var totalSize int64 = 0
 		err = stg.WalkDir(ctx, opt, func(name string, size int64) error {
 			totalSize += size
@@ -112,7 +112,7 @@ func TestGCS(t *testing.T) {
 			PredefinedAcl:   "private",
 			CredentialsBlob: "Fake Credentials",
 		}
-		stg, err := newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+		stg, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  false,
 			CheckPermissions: []Permission{AccessBuckets},
 			HTTPClient:       server.HTTPClient(),
@@ -130,7 +130,7 @@ func TestGCS(t *testing.T) {
 			PredefinedAcl:   "private",
 			CredentialsBlob: "Fake Credentials",
 		}
-		stg, err := newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+		stg, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  false,
 			CheckPermissions: []Permission{AccessBuckets},
 			HTTPClient:       server.HTTPClient(),
@@ -147,7 +147,7 @@ func TestGCS(t *testing.T) {
 			PredefinedAcl:   "private",
 			CredentialsBlob: "Fake Credentials",
 		}
-		stg, err := newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+		stg, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  false,
 			CheckPermissions: []Permission{AccessBuckets},
 			HTTPClient:       server.HTTPClient(),
@@ -254,7 +254,7 @@ func TestNewGCSStorage(t *testing.T) {
 			PredefinedAcl:   "private",
 			CredentialsBlob: "FakeCredentials",
 		}
-		_, err := newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+		_, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  true,
 			CheckPermissions: []Permission{AccessBuckets},
 			HTTPClient:       server.HTTPClient(),
@@ -271,7 +271,7 @@ func TestNewGCSStorage(t *testing.T) {
 			PredefinedAcl:   "private",
 			CredentialsBlob: "FakeCredentials",
 		}
-		_, err := newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+		_, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  false,
 			CheckPermissions: []Permission{AccessBuckets},
 			HTTPClient:       server.HTTPClient(),
@@ -302,7 +302,7 @@ func TestNewGCSStorage(t *testing.T) {
 			PredefinedAcl:   "private",
 			CredentialsBlob: "",
 		}
-		_, err = newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+		_, err = NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  true,
 			CheckPermissions: []Permission{AccessBuckets},
 			HTTPClient:       server.HTTPClient(),
@@ -333,7 +333,7 @@ func TestNewGCSStorage(t *testing.T) {
 			PredefinedAcl:   "private",
 			CredentialsBlob: "",
 		}
-		s, err := newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+		s, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  false,
 			CheckPermissions: []Permission{AccessBuckets},
 			HTTPClient:       server.HTTPClient(),
@@ -352,7 +352,7 @@ func TestNewGCSStorage(t *testing.T) {
 			PredefinedAcl:   "private",
 			CredentialsBlob: "",
 		}
-		_, err := newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+		_, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  true,
 			CheckPermissions: []Permission{AccessBuckets},
 			HTTPClient:       server.HTTPClient(),
@@ -368,7 +368,7 @@ func TestNewGCSStorage(t *testing.T) {
 			PredefinedAcl:   "private",
 			CredentialsBlob: "FakeCredentials",
 		}
-		s, err := newGCSStorage(ctx, gcs, &ExternalStorageOptions{
+		s, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  false,
 			CheckPermissions: []Permission{AccessBuckets},
 			HTTPClient:       server.HTTPClient(),

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -173,14 +173,14 @@ func New(ctx context.Context, backend *backuppb.StorageBackend, opts *ExternalSt
 		if backend.S3 == nil {
 			return nil, errors.Annotate(berrors.ErrStorageInvalidConfig, "s3 config not found")
 		}
-		return newS3Storage(backend.S3, opts)
+		return NewS3Storage(backend.S3, opts)
 	case *backuppb.StorageBackend_Noop:
 		return newNoopStorage(), nil
 	case *backuppb.StorageBackend_Gcs:
 		if backend.Gcs == nil {
 			return nil, errors.Annotate(berrors.ErrStorageInvalidConfig, "GCS config not found")
 		}
-		return newGCSStorage(ctx, backend.Gcs, opts)
+		return NewGCSStorage(ctx, backend.Gcs, opts)
 	case *backuppb.StorageBackend_AzureBlobStorage:
 		return newAzureBlobStorage(ctx, backend.AzureBlobStorage, opts)
 	default:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #39204 

Problem Summary:

### What is changed and how it works?
* Expose the constructor for S3 / GCS external storage implementations.
* Expose the GCS external storage implementation public.
* Expose some fields for these implementations.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
   Write an external program to construct an S3 / GCS storage implementation, and use the newly exposed fields to achieve some S3 / GCS operations.  
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
