### PR TITLE
parser: use alter table remove ttl spec

### DIFF
--- a/parser/ast/ddl_test.go
+++ b/parser/ast/ddl_test.go
@@ -844,7 +844,7 @@ func TestFlashBackDatabaseRestore(t *testing.T) {
 func TestTableOptionTTLRestore(t *testing.T) {
 	sourceSQL1 := "create table t (created_at datetime) ttl = created_at + INTERVAL 1 YEAR"
 	sourceSQL2 := "alter table t ttl_enable = 'OFF'"
-	sourceSQL3 := "alter table t no_ttl"
+	sourceSQL3 := "alter table t remove ttl"
 	cases := []struct {
 		sourceSQL string
 		flags     format.RestoreFlags
@@ -854,8 +854,8 @@ func TestTableOptionTTLRestore(t *testing.T) {
 		{sourceSQL1, format.DefaultRestoreFlags | format.RestoreTiDBSpecialComment, "CREATE TABLE `t` (`created_at` DATETIME) /*T![ttl] TTL = `created_at` + INTERVAL 1 YEAR */"},
 		{sourceSQL2, format.DefaultRestoreFlags, "ALTER TABLE `t` TTL_ENABLE = 'OFF'"},
 		{sourceSQL2, format.DefaultRestoreFlags | format.RestoreTiDBSpecialComment, "ALTER TABLE `t` /*T![ttl] TTL_ENABLE = 'OFF' */"},
-		{sourceSQL3, format.DefaultRestoreFlags, "ALTER TABLE `t` NO_TTL"},
-		{sourceSQL3, format.DefaultRestoreFlags | format.RestoreTiDBSpecialComment, "ALTER TABLE `t` /*T![ttl] NO_TTL */"},
+		{sourceSQL3, format.DefaultRestoreFlags, "ALTER TABLE `t` REMOVE TTL"},
+		{sourceSQL3, format.DefaultRestoreFlags | format.RestoreTiDBSpecialComment, "ALTER TABLE `t` /*T![ttl] REMOVE TTL */"},
 	}
 
 	extractNodeFunc := func(node Node) Node {

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -761,7 +761,6 @@ var tokenMap = map[string]int{
 	"TRUE_CARD_COST":           trueCardCost,
 	"TTL":                      ttl,
 	"TTL_ENABLE":               ttlEnable,
-	"NO_TTL":                   nottl,
 	"TYPE":                     tp,
 	"UNBOUNDED":                unbounded,
 	"UNCOMMITTED":              uncommitted,

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -480,7 +480,6 @@ import (
 	nominvalue            "NOMINVALUE"
 	nonclustered          "NONCLUSTERED"
 	none                  "NONE"
-	nottl                 "NO_TTL"
 	nowait                "NOWAIT"
 	nvarcharType          "NVARCHAR"
 	nulls                 "NULLS"
@@ -969,7 +968,7 @@ import (
 	AdminStmtLimitOpt                      "Admin show ddl jobs limit option"
 	AllOrPartitionNameList                 "All or partition name list"
 	AlgorithmClause                        "Alter table algorithm"
-	AlterTablePartitionOpt                 "Alter table partition option"
+	AlterTableSpecSingleOpt                "Alter table single option"
 	AlterTableSpec                         "Alter table specification"
 	AlterTableSpecList                     "Alter table specification list"
 	AlterTableSpecListOpt                  "Alter table specification list optional"
@@ -1513,7 +1512,7 @@ Start:
  * See https://dev.mysql.com/doc/refman/5.7/en/alter-table.html
  *******************************************************************************************/
 AlterTableStmt:
-	"ALTER" IgnoreOptional "TABLE" TableName AlterTableSpecListOpt AlterTablePartitionOpt
+	"ALTER" IgnoreOptional "TABLE" TableName AlterTableSpecListOpt AlterTableSpecSingleOpt
 	{
 		specs := $5.([]*ast.AlterTableSpec)
 		if $6 != nil {
@@ -1672,7 +1671,8 @@ StatsOptionsOpt:
 		$$ = &ast.StatsOptionsSpec{Default: false, StatsOptions: $3}
 	}
 
-AlterTablePartitionOpt:
+// Some spec can only have one, but not in a list
+AlterTableSpecSingleOpt:
 	PartitionOpt
 	{
 		if $1 != nil {
@@ -1735,6 +1735,12 @@ AlterTablePartitionOpt:
 			Tp:             ast.AlterTablePartitionOptions,
 			PartitionNames: []model.CIStr{model.NewCIStr($2)},
 			Options:        $3.([]*ast.TableOption),
+		}
+	}
+|	"REMOVE" "TTL"
+	{
+		$$ = &ast.AlterTableSpec{
+			Tp: ast.AlterTableRemoveTTL,
 		}
 	}
 
@@ -6396,7 +6402,6 @@ UnReservedKeyword:
 |	"TOKEN_ISSUER"
 |	"TTL"
 |	"TTL_ENABLE"
-|	"NO_TTL"
 
 TiDBKeyword:
 	"ADMIN"
@@ -11767,12 +11772,12 @@ TableOption:
 		// Parse it but will ignore it
 		$$ = &ast.TableOption{Tp: ast.TableOptionEncryption, StrValue: $3}
 	}
-|	"TTL" EqOpt Identifier '+' "INTERVAL" Expression TimeUnit
+|	"TTL" EqOpt Identifier '+' "INTERVAL" Literal TimeUnit
 	{
 		$$ = &ast.TableOption{
 			Tp:            ast.TableOptionTTL,
 			ColumnName:    &ast.ColumnName{Name: model.NewCIStr($3)},
-			Expression:    $6,
+			Value:         ast.NewValueExpr($6, parser.charset, parser.collation),
 			TimeUnitValue: &ast.TimeUnitExpr{Unit: $7.(ast.TimeUnitType)},
 		}
 	}
@@ -11787,10 +11792,6 @@ TableOption:
 			yylex.AppendError(yylex.Errorf("The TTL_ENABLE option has to be set 'ON' or 'OFF'"))
 			return 1
 		}
-	}
-|	"NO_TTL"
-	{
-		$$ = &ast.TableOption{Tp: ast.TableOptionNoTTL}
 	}
 
 ForceOpt:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -7011,8 +7011,7 @@ func TestIntervalPartition(t *testing.T) {
 func TestTTLTableOption(t *testing.T) {
 	table := []testCase{
 		// create table with various temporal interval
-		{"create table t (created_at datetime) TTL = created_at + INTERVAL CAST(6/4 AS DECIMAL(3,1)) HOUR_MINUTE", true, "CREATE TABLE `t` (`created_at` DATETIME) TTL = `created_at` + INTERVAL CAST(6/4 AS DECIMAL(3, 1)) HOUR_MINUTE"},
-		{"create table t (created_at datetime) TTL = created_at + INTERVAL 6/4 HOUR_MINUTE", true, "CREATE TABLE `t` (`created_at` DATETIME) TTL = `created_at` + INTERVAL 6/4 HOUR_MINUTE"},
+		{"create table t (created_at datetime) TTL = created_at + INTERVAL 3.1415 YEAR", true, "CREATE TABLE `t` (`created_at` DATETIME) TTL = `created_at` + INTERVAL 3.1415 YEAR"},
 		{"create table t (created_at datetime) TTL = created_at + INTERVAL '1 1:1:1' DAY_SECOND", true, "CREATE TABLE `t` (`created_at` DATETIME) TTL = `created_at` + INTERVAL _UTF8MB4'1 1:1:1' DAY_SECOND"},
 		{"create table t (created_at datetime) TTL = created_at + INTERVAL 1 YEAR", true, "CREATE TABLE `t` (`created_at` DATETIME) TTL = `created_at` + INTERVAL 1 YEAR"},
 		{"create table t (created_at datetime) TTL = created_at + INTERVAL 1 YEAR TTL_ENABLE = 'OFF'", true, "CREATE TABLE `t` (`created_at` DATETIME) TTL = `created_at` + INTERVAL 1 YEAR TTL_ENABLE = 'OFF'"},
@@ -7027,7 +7026,7 @@ func TestTTLTableOption(t *testing.T) {
 		{"alter table t /*T![ttl] ttl=created_at + INTERVAL 1 YEAR ttl_enable='ON'*/", true, "ALTER TABLE `t` TTL = `created_at` + INTERVAL 1 YEAR TTL_ENABLE = 'ON'"},
 
 		// alter table to remove ttl settings
-		{"alter table t NO_TTL", true, "ALTER TABLE `t` NO_TTL"},
+		{"alter table t remove ttl", true, "ALTER TABLE `t` REMOVE TTL"},
 
 		// validate invalid TTL_ENABLE settings
 		{"create table t (created_at datetime) TTL_ENABLE = 'test_case'", false, ""},


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #39340

Problem Summary:

Use `alter table remove ttl` instead of `alter table no_ttl`. And remove the support of arbitrary expression, but only support valueExpr from Literal.

### What is changed and how it works?

It changed three things:

1. Change the name of `AlterTablePartitionOpt` to `AlterTableSingleSpecOpt` and add a `"REMOVE" "TTL"` branch to it. We cannot add `"REMOVE" "TTL"` to other rules or `AlterTableSpec` because `yacc` has to know whether to reduce the `AlterTableSpec` and moving forward to `AlterTablePartitionOpt`, or try to `"REMOVE" "TTL"`
2. Change the value of "TTL" config to `valueExpr`. Maybe we could modify it to `DefaultValueExpr` or other wider range grammar later, but supporing number / string literal is enough for today.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Change grammar to remove ttl from `ALTER table NO_TTL` to `ALTER table REMOVE TTL`
```
