### PR TITLE
executor: add debug log for analyze

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -325,8 +325,9 @@ func (e *AnalyzeExec) handleResultsError(ctx context.Context, concurrency int, n
 		handleGlobalStats(needGlobalStats, globalStatsMap, results)
 
 		if err1 := statsHandle.SaveTableStatsToStorage(results, e.ctx.GetSessionVars().EnableAnalyzeSnapshot); err1 != nil {
+			tableID := results.TableID.TableID
 			err = err1
-			logutil.Logger(ctx).Error("save table stats to storage failed", zap.Error(err))
+			logutil.Logger(ctx).Error("save table stats to storage failed", zap.Error(err), zap.Int64("tableID", tableID))
 			finishJobWithLog(e.ctx, results.Job, err)
 		} else {
 			finishJobWithLog(e.ctx, results.Job, nil)

--- a/executor/analyze_col_v2.go
+++ b/executor/analyze_col_v2.go
@@ -202,7 +202,7 @@ func (e *AnalyzeColumnsExecV2) decodeSampleDataWithVirtualColumn(
 
 func printAnalyzeMergeCollectorLog(oldRootCount, newRootCount, subCount, tableID, partitionID int64, isPartition bool, info string, index int) {
 	if index < 0 {
-		logutil.BgLogger().Info(info,
+		logutil.BgLogger().Debug(info,
 			zap.Int64("tableID", tableID),
 			zap.Int64("partitionID", partitionID),
 			zap.Bool("isPartitionTable", isPartition),
@@ -210,7 +210,7 @@ func printAnalyzeMergeCollectorLog(oldRootCount, newRootCount, subCount, tableID
 			zap.Int64("newRootCount", newRootCount),
 			zap.Int64("subCount", subCount))
 	} else {
-		logutil.BgLogger().Info(info,
+		logutil.BgLogger().Debug(info,
 			zap.Int64("tableID", tableID),
 			zap.Int64("partitionID", partitionID),
 			zap.Bool("isPartitionTable", isPartition),

--- a/executor/analyze_col_v2.go
+++ b/executor/analyze_col_v2.go
@@ -200,6 +200,27 @@ func (e *AnalyzeColumnsExecV2) decodeSampleDataWithVirtualColumn(
 	return nil
 }
 
+func printAnalyzeMergeCollectorLog(oldRootCount, newRootCount, subCount, tableID, partitionID int64, isPartition bool, info string, index int) {
+	if index < 0 {
+		logutil.BgLogger().Info(info,
+			zap.Int64("tableID", tableID),
+			zap.Int64("partitionID", partitionID),
+			zap.Bool("isPartitionTable", isPartition),
+			zap.Int64("oldRootCount", oldRootCount),
+			zap.Int64("newRootCount", newRootCount),
+			zap.Int64("subCount", subCount))
+	} else {
+		logutil.BgLogger().Info(info,
+			zap.Int64("tableID", tableID),
+			zap.Int64("partitionID", partitionID),
+			zap.Bool("isPartitionTable", isPartition),
+			zap.Int64("oldRootCount", oldRootCount),
+			zap.Int64("newRootCount", newRootCount),
+			zap.Int64("subCount", subCount),
+			zap.Int("subCollectorIndex", index))
+	}
+}
+
 func (e *AnalyzeColumnsExecV2) buildSamplingStats(
 	ranges []*ranger.Range,
 	needExtStats bool,
@@ -236,7 +257,7 @@ func (e *AnalyzeColumnsExecV2) buildSamplingStats(
 	e.samplingMergeWg = &util.WaitGroupWrapper{}
 	e.samplingMergeWg.Add(statsConcurrency)
 	for i := 0; i < statsConcurrency; i++ {
-		go e.subMergeWorker(mergeResultCh, mergeTaskCh, l, i == 0)
+		go e.subMergeWorker(mergeResultCh, mergeTaskCh, l, i)
 	}
 	if err = readDataAndSendTask(e.ctx, e.resultHandler, mergeTaskCh, e.memTracker); err != nil {
 		return 0, nil, nil, nil, nil, getAnalyzePanicErr(err)
@@ -256,7 +277,12 @@ func (e *AnalyzeColumnsExecV2) buildSamplingStats(
 			continue
 		}
 		oldRootCollectorSize := rootRowCollector.Base().MemSize
+		oldRootCollectorCount := rootRowCollector.Base().Count
 		rootRowCollector.MergeCollector(mergeResult.collector)
+		newRootCollectorCount := rootRowCollector.Base().Count
+		printAnalyzeMergeCollectorLog(oldRootCollectorCount, newRootCollectorCount,
+			mergeResult.collector.Base().Count, e.tableID.TableID, e.tableID.PartitionID, e.tableID.IsPartitionTable(),
+			"merge subMergeWorker in AnalyzeColumnsExecV2", -1)
 		e.memTracker.Consume(rootRowCollector.Base().MemSize - oldRootCollectorSize - mergeResult.collector.Base().MemSize)
 	}
 	defer e.memTracker.Release(rootRowCollector.Base().MemSize)
@@ -545,7 +571,8 @@ func (e *AnalyzeColumnsExecV2) buildSubIndexJobForSpecialIndex(indexInfos []*mod
 	return tasks
 }
 
-func (e *AnalyzeColumnsExecV2) subMergeWorker(resultCh chan<- *samplingMergeResult, taskCh <-chan []byte, l int, isClosedChanThread bool) {
+func (e *AnalyzeColumnsExecV2) subMergeWorker(resultCh chan<- *samplingMergeResult, taskCh <-chan []byte, l int, index int) {
+	isClosedChanThread := index == 0
 	defer func() {
 		if r := recover(); r != nil {
 			logutil.BgLogger().Error("analyze worker panicked", zap.Any("recover", r), zap.Stack("stack"))
@@ -590,7 +617,12 @@ func (e *AnalyzeColumnsExecV2) subMergeWorker(resultCh chan<- *samplingMergeResu
 		subCollector.Base().FromProto(colResp.RowCollector, e.memTracker)
 		UpdateAnalyzeJob(e.ctx, e.job, subCollector.Base().Count)
 		oldRetCollectorSize := retCollector.Base().MemSize
+		oldRetCollectorCount := retCollector.Base().Count
 		retCollector.MergeCollector(subCollector)
+		newRetCollectorCount := retCollector.Base().Count
+		printAnalyzeMergeCollectorLog(oldRetCollectorCount, newRetCollectorCount, subCollector.Base().Count,
+			e.tableID.TableID, e.tableID.PartitionID, e.TableID.IsPartitionTable(),
+			"merge subCollector in concurrency in AnalyzeColumnsExecV2", index)
 		newRetCollectorSize := retCollector.Base().MemSize
 		subCollectorSize := subCollector.Base().MemSize
 		e.memTracker.Consume(newRetCollectorSize - oldRetCollectorSize - subCollectorSize)

--- a/executor/analyze_global_stats.go
+++ b/executor/analyze_global_stats.go
@@ -73,7 +73,8 @@ func (e *AnalyzeExec) handleGlobalStats(ctx context.Context, needGlobalStats boo
 					globalStatsID.tableID, info.isIndex, info.histIDs,
 					tableAllPartitionStats)
 				if err != nil {
-					logutil.BgLogger().Error("merge global stats failed", zap.String("info", job.JobInfo), zap.Error(err))
+					logutil.BgLogger().Error("merge global stats failed",
+						zap.String("info", job.JobInfo), zap.Error(err), zap.Int64("tableID", tableID))
 					if types.ErrPartitionStatsMissing.Equal(err) || types.ErrPartitionColumnStatsMissing.Equal(err) {
 						// When we find some partition-level stats are missing, we need to report warning.
 						e.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
@@ -95,7 +96,8 @@ func (e *AnalyzeExec) handleGlobalStats(ctx context.Context, needGlobalStats boo
 						true,
 					)
 					if err != nil {
-						logutil.Logger(ctx).Error("save global-level stats to storage failed", zap.String("info", job.JobInfo), zap.Int64("histID", hg.ID), zap.Error(err))
+						logutil.Logger(ctx).Error("save global-level stats to storage failed", zap.String("info", job.JobInfo),
+							zap.Int64("histID", hg.ID), zap.Error(err), zap.Int64("tableID", tableID))
 					}
 					// Dump stats to historical storage.
 					if err1 := recordHistoricalStats(e.ctx, globalStatsID.tableID); err1 != nil {


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: 

Problem Summary:

### What is changed and how it works?

add debug log for analyze


```sql
mysql> CREATE TABLE t (a int, b int, index idx(b))
    -> PARTITION BY RANGE ( a ) (
    ->   PARTITION p0 VALUES LESS THAN (6),
    ->   PARTITION p1 VALUES LESS THAN (11)
    -> );
Query OK, 0 rows affected (0.02 sec)

mysql> set @@tidb_build_stats_concurrency=1;
Query OK, 0 rows affected (0.00 sec)

mysql> analyze table t;
Query OK, 0 rows affected, 2 warnings (0.10 sec)

```

```txt
[2022/11/24 13:37:26.118 +08:00] [INFO] [analyze_col_v2.go:213] ["merge subCollector in concurrency in AnalyzeColumnsExecV2"] [tableID=87] [partitionID=88] [isPartitionTable=true] [oldRootCount=0] [newRootCount=1] [subCount=1] [subCollectorIndex=0]
[2022/11/24 13:37:26.118 +08:00] [INFO] [analyze_col_v2.go:205] ["merge subMergeWorker in AnalyzeColumnsExecV2"] [tableID=87] [partitionID=88] [isPartitionTable=true] [oldRootCount=0] [newRootCount=1] [subCount=1]
[2022/11/24 13:37:26.119 +08:00] [INFO] [analyze_col_v2.go:213] ["merge subCollector in concurrency in AnalyzeColumnsExecV2"] [tableID=87] [partitionID=89] [isPartitionTable=true] [oldRootCount=0] [newRootCount=1] [subCount=1] [subCollectorIndex=0]
[2022/11/24 13:37:26.119 +08:00] [INFO] [analyze_col_v2.go:205] ["merge subMergeWorker in AnalyzeColumnsExecV2"] [tableID=87] [partitionID=89] [isPartitionTable=true] [oldRootCount=0] [newRootCount=1] [subCount=1]
[2022/11/24 13:37:26.120 +08:00] [INFO] [handle.go:1690] ["[stats] incrementally update modifyCount"] [tableID=88] [curModifyCnt=0] [results.BaseModifyCnt=0] [modifyCount=0]
[2022/11/24 13:37:26.120 +08:00] [INFO] [handle.go:1712] ["[stats] directly update count"] [tableID=88] [results.Count=1] [count=1]
[2022/11/24 13:37:26.134 +08:00] [INFO] [analyze.go:587] ["analyze table `test`.`t` has finished"] [partition=p0] ["job info"="analyze table all columns with 256 buckets, 500 topn, 1 samplerate"] ["start time"=2022/11/24 13:37:26.115 +08:00] ["end time"=2022/11/24 13:37:26.134 +08:00] [cost=18.846254ms]
[2022/11/24 13:37:26.135 +08:00] [INFO] [handle.go:1690] ["[stats] incrementally update modifyCount"] [tableID=89] [curModifyCnt=0] [results.BaseModifyCnt=0] [modifyCount=0]
[2022/11/24 13:37:26.135 +08:00] [INFO] [handle.go:1712] ["[stats] directly update count"] [tableID=89] [results.Count=1] [count=1]
[2022/11/24 13:37:26.148 +08:00] [INFO] [analyze.go:587] ["analyze table `test`.`t` has finished"] [partition=p1] ["job info"="analyze table all columns with 256 buckets, 500 topn, 1 samplerate"] ["start time"=2022/11/24 13:37:26.118 +08:00] ["end time"=2022/11/24 13:37:26.148 +08:00] [cost=29.650575ms]
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
