### PR TITLE
ddl: fix tidb_ddl_enable_fast_reorg default on ut failed problem

### DIFF
--- a/ddl/backfilling.go
+++ b/ddl/backfilling.go
@@ -725,7 +725,7 @@ func (b *backfillScheduler) adjustWorkerSize() error {
 	if b.copReqSenderPool != nil {
 		b.copReqSenderPool.adjustSize(len(b.workers))
 	}
-	return injectCheckBackfillWorkerNum(len(b.workers))
+	return injectCheckBackfillWorkerNum(len(b.workers), b.tp == typeAddIndexMergeTmpWorker)
 }
 
 func (b *backfillScheduler) initCopReqSenderPool() {
@@ -871,7 +871,10 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sessionPool, t table.Physic
 	return nil
 }
 
-func injectCheckBackfillWorkerNum(curWorkerSize int) error {
+func injectCheckBackfillWorkerNum(curWorkerSize int, isMergeWorker bool) error {
+	if isMergeWorker {
+		return nil
+	}
 	failpoint.Inject("checkBackfillWorkerNum", func(val failpoint.Value) {
 		//nolint:forcetypeassert
 		if val.(bool) {

--- a/ddl/cancel_test.go
+++ b/ddl/cancel_test.go
@@ -232,8 +232,6 @@ func TestCancel(t *testing.T) {
 
 	// Prepare schema.
 	tk.MustExec("use test")
-	// TODO: Will check why tidb_ddl_enable_fast_reorg could not default be on in another PR.
-	tk.MustExec("set global tidb_ddl_enable_fast_reorg = 0;")
 	tk.MustExec("drop table if exists t_partition;")
 	tk.MustExec(`create table t_partition (
 		c1 int, c2 int, c3 int

--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -1719,8 +1719,6 @@ func TestCreateUniqueExpressionIndex(t *testing.T) {
 
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	// TODO: will check why tidb_ddl_enable_fast_reorg could not default be on in another pr.pr.
-	tk.MustExec("set global tidb_ddl_enable_fast_reorg = 0;")
 	tk.MustExec("create table t(a int default 0, b int default 0)")
 	tk.MustExec("insert into t values (1, 1), (2, 2), (3, 3), (4, 4)")
 

--- a/ddl/failtest/fail_db_test.go
+++ b/ddl/failtest/fail_db_test.go
@@ -320,8 +320,6 @@ func TestRunDDLJobPanicEnableClusteredIndex(t *testing.T) {
 	s := createFailDBSuite(t)
 	testAddIndexWorkerNum(t, s, func(tk *testkit.TestKit) {
 		tk.Session().GetSessionVars().EnableClusteredIndex = variable.ClusteredIndexDefModeOn
-		// TODO: will check why tidb_ddl_enable_fast_reorg could not default be on in another pr.
-		tk.MustExec("set global tidb_ddl_enable_fast_reorg = 0;")
 		tk.MustExec("create table test_add_index (c1 bigint, c2 bigint, c3 bigint, primary key(c1, c3))")
 	})
 }
@@ -330,8 +328,6 @@ func TestRunDDLJobPanicEnableClusteredIndex(t *testing.T) {
 func TestRunDDLJobPanicDisableClusteredIndex(t *testing.T) {
 	s := createFailDBSuite(t)
 	testAddIndexWorkerNum(t, s, func(tk *testkit.TestKit) {
-		// TODO: will check why tidb_ddl_enable_fast_reorg could not default be on in another pr.
-		tk.MustExec("set global tidb_ddl_enable_fast_reorg = 0;")
 		tk.MustExec("create table test_add_index (c1 bigint, c2 bigint, c3 bigint, primary key(c1))")
 	})
 }
@@ -424,7 +420,6 @@ func TestPartitionAddIndexGC(t *testing.T) {
 	s := createFailDBSuite(t)
 	tk := testkit.NewTestKit(t, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set global tidb_ddl_enable_fast_reorg = 0;")
 	tk.MustExec(`create table partition_add_idx (
 	id int not null,
 	hired date not null

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -802,13 +802,13 @@ func doReorgWorkForCreateIndex(w *worker, d *ddlCtx, t *meta.Meta, job *model.Jo
 			bc, err = ingest.LitBackCtxMgr.Register(w.ctx, indexInfo.Unique, job.ID, job.ReorgMeta.SQLMode)
 			if err != nil {
 				tryFallbackToTxnMerge(job, err)
-				return false, ver, errors.Trace(err)
+				return false, ver, nil
 			}
 			done, ver, err = runReorgJobAndHandleErr(w, d, t, job, tbl, indexInfo, false)
 			if err != nil {
 				ingest.LitBackCtxMgr.Unregister(job.ID)
 				tryFallbackToTxnMerge(job, err)
-				return false, ver, errors.Trace(err)
+				return false, ver, nil
 			}
 			if !done {
 				return false, ver, nil
@@ -823,7 +823,7 @@ func doReorgWorkForCreateIndex(w *worker, d *ddlCtx, t *meta.Meta, job *model.Jo
 					tryFallbackToTxnMerge(job, err)
 				}
 				ingest.LitBackCtxMgr.Unregister(job.ID)
-				return false, ver, errors.Trace(err)
+				return false, ver, nil
 			}
 			bc.SetDone()
 		case model.ReorgTypeTxnMerge:

--- a/ddl/index_change_test.go
+++ b/ddl/index_change_test.go
@@ -37,8 +37,6 @@ func TestIndexChange(t *testing.T) {
 	ddl.SetWaitTimeWhenErrorOccurred(1 * time.Microsecond)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	// TODO: Will check why tidb_ddl_enable_fast_reorg could not default be on in another PR.
-	tk.MustExec("set global tidb_ddl_enable_fast_reorg = 0;")
 	tk.MustExec("create table t (c1 int primary key, c2 int)")
 	tk.MustExec("insert t values (1, 1), (2, 2), (3, 3);")
 
@@ -221,6 +219,7 @@ func checkAddWriteOnlyForAddIndex(ctx sessionctx.Context, delOnlyTbl, writeOnlyT
 }
 
 func checkAddPublicForAddIndex(ctx sessionctx.Context, writeTbl, publicTbl table.Table) error {
+	var err1 error
 	// WriteOnlyTable: insert t values (6, 6)
 	err := sessiontxn.NewTxn(context.Background(), ctx)
 	if err != nil {
@@ -231,7 +230,11 @@ func checkAddPublicForAddIndex(ctx sessionctx.Context, writeTbl, publicTbl table
 		return errors.Trace(err)
 	}
 	err = checkIndexExists(ctx, publicTbl, 6, 6, true)
-	if err != nil {
+	if ddl.IsEnableFastReorg() {
+		// Need check temp index also.
+		err1 = checkIndexExists(ctx, writeTbl, 6, 6, true)
+	}
+	if err != nil && err1 != nil {
 		return errors.Trace(err)
 	}
 	// PublicTable: insert t values (7, 7)
@@ -250,10 +253,18 @@ func checkAddPublicForAddIndex(ctx sessionctx.Context, writeTbl, publicTbl table
 		return errors.Trace(err)
 	}
 	err = checkIndexExists(ctx, publicTbl, 5, 7, true)
-	if err != nil {
+	if ddl.IsEnableFastReorg() {
+		// Need check temp index also.
+		err1 = checkIndexExists(ctx, writeTbl, 5, 7, true)
+	}
+	if err != nil && err1 != nil {
 		return errors.Trace(err)
 	}
-	err = checkIndexExists(ctx, publicTbl, 7, 7, false)
+	if ddl.IsEnableFastReorg() {
+		err = checkIndexExists(ctx, writeTbl, 7, 7, false)
+	} else {
+		err = checkIndexExists(ctx, publicTbl, 7, 7, false)
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -283,7 +294,11 @@ func checkAddPublicForAddIndex(ctx sessionctx.Context, writeTbl, publicTbl table
 		idxVal := row[1].GetInt64()
 		handle := row[0].GetInt64()
 		err = checkIndexExists(ctx, publicTbl, idxVal, handle, true)
-		if err != nil {
+		if ddl.IsEnableFastReorg() {
+			// Need check temp index also.
+			err1 = checkIndexExists(ctx, writeTbl, idxVal, handle, true)
+		}
+		if err != nil && err1 != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/ddl/ingest/env.go
+++ b/ddl/ingest/env.go
@@ -47,6 +47,13 @@ const maxMemoryQuota = 2 * size.GB
 // InitGlobalLightningEnv initialize Lightning backfill environment.
 func InitGlobalLightningEnv() {
 	log.SetAppLogger(logutil.BgLogger())
+	globalCfg := config.GetGlobalConfig()
+	if globalCfg.Store != "tikv" {
+		logutil.BgLogger().Warn(LitWarnEnvInitFail,
+			zap.String("storage limitation", "only support TiKV storage"),
+			zap.String("current storage", globalCfg.Store),
+			zap.Bool("lightning is initialized", LitInitialized))
+	}
 	sPath, err := genLightningDataDir()
 	if err != nil {
 		logutil.BgLogger().Warn(LitWarnEnvInitFail, zap.Error(err),

--- a/ddl/multi_schema_change_test.go
+++ b/ddl/multi_schema_change_test.go
@@ -568,8 +568,6 @@ func TestMultiSchemaChangeAddIndexesCancelled(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	// TODO: will check why tidb_ddl_enable_fast_reorg could not default be on in another pr.
-	tk.MustExec("set global tidb_ddl_enable_fast_reorg = 0;")
 	originHook := dom.DDL().GetHook()
 
 	// Test cancel successfully.

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -432,8 +432,6 @@ func TestCancelAddIndexPanic(t *testing.T) {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/errorMockPanic"))
 	}()
 	tk.MustExec("use test")
-	// TODO: will check why tidb_ddl_enable_fast_reorg could not default be on in another pr.
-	tk.MustExec("set global tidb_ddl_enable_fast_reorg = 0;")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(c1 int, c2 int)")
 

--- a/ddl/stat_test.go
+++ b/ddl/stat_test.go
@@ -52,8 +52,6 @@ func TestDDLStatsInfo(t *testing.T) {
 	tblInfo, err := testTableInfo(store, "t", 2)
 	require.NoError(t, err)
 	testCreateTable(t, ctx, d, dbInfo, tblInfo)
-	// TODO: will check why tidb_ddl_enable_fast_reorg could not default be on in another pr.
-	tk.MustExec("set global tidb_ddl_enable_fast_reorg = 0;")
 	err = sessiontxn.NewTxn(context.Background(), ctx)
 	require.NoError(t, err)
 

--- a/executor/batch_checker.go
+++ b/executor/batch_checker.go
@@ -180,6 +180,9 @@ func getKeysNeedCheckOneRow(ctx sessionctx.Context, t table.Table, row []types.D
 		if !distinct {
 			continue
 		}
+		if v.Meta().BackfillState == model.BackfillStateRunning {
+			_, key, _ = tables.GenTempIdxKeyByState(v.Meta(), key)
+		}
 		colValStr, err1 := formatDataForDupError(colVals)
 		if err1 != nil {
 			return nil, err1

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -15,6 +15,7 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -31,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -263,6 +265,10 @@ func (e *InsertExec) batchUpdateDupRows(ctx context.Context, newRows [][]types.D
 					continue
 				}
 				return err
+			}
+			rowVal := val[:len(val)-1]
+			if bytes.Equal(rowVal, tables.DeleteMarkerUnique) {
+				continue
 			}
 			handle, err := tablecodec.DecodeHandleInUniqueIndexValue(val, uk.commonHandle)
 			if err != nil {

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -15,6 +15,7 @@
 package tables
 
 import (
+	"bytes"
 	"context"
 	"sync"
 
@@ -127,7 +128,7 @@ func (c *index) Create(sctx sessionctx.Context, txn kv.Transaction, indexedValue
 		keyIsTempIdxKey bool
 	)
 	if !opt.FromBackFill {
-		key, tempKey, keyVer = genTempIdxKeyByState(c.idxInfo, key)
+		key, tempKey, keyVer = GenTempIdxKeyByState(c.idxInfo, key)
 		if keyVer == TempIndexKeyTypeBackfill {
 			key, tempKey = tempKey, nil
 			keyIsTempIdxKey = true
@@ -230,7 +231,19 @@ func (c *index) Create(sctx sessionctx.Context, txn kv.Transaction, indexedValue
 			idxVal = append(idxVal, keyVer)
 		}
 		if lazyCheck {
-			flags := []kv.FlagsOp{kv.SetPresumeKeyNotExists}
+			var (
+				needPresumeKey int
+				flags          []kv.FlagsOp
+			)
+			if !opt.FromBackFill {
+				needPresumeKey, _, err = KeyExistInTempIndex(txn, key, distinct, h, c.tblInfo.IsCommonHandle)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if needPresumeKey != KeyInTempIndexIsDeleted {
+				flags = []kv.FlagsOp{kv.SetPresumeKeyNotExists}
+			}
 			if !vars.ConstraintCheckInPlacePessimistic && vars.TxnCtx.IsPessimistic && vars.InTxn() &&
 				!vars.InRestrictedSQL && vars.ConnectionID > 0 {
 				flags = append(flags, kv.SetNeedConstraintCheckInPrewrite)
@@ -285,7 +298,7 @@ func (c *index) Delete(sc *stmtctx.StatementContext, txn kv.Transaction, indexed
 		return err
 	}
 
-	key, tempKey, tempKeyVer := genTempIdxKeyByState(c.idxInfo, key)
+	key, tempKey, tempKeyVer := GenTempIdxKeyByState(c.idxInfo, key)
 
 	if distinct {
 		if len(key) > 0 {
@@ -336,9 +349,9 @@ const (
 	TempIndexKeyTypeMerge byte = 'm'
 )
 
-// genTempIdxKeyByState is used to get the key version and the temporary key.
+// GenTempIdxKeyByState is used to get the key version and the temporary key.
 // The tempKeyVer means the temp index key/value version.
-func genTempIdxKeyByState(indexInfo *model.IndexInfo, indexKey kv.Key) (key, tempKey kv.Key, tempKeyVer byte) {
+func GenTempIdxKeyByState(indexInfo *model.IndexInfo, indexKey kv.Key) (key, tempKey kv.Key, tempKeyVer byte) {
 	if indexInfo.State != model.StatePublic {
 		switch indexInfo.BackfillState {
 		case model.BackfillStateInapplicable:
@@ -362,6 +375,28 @@ func (c *index) Exist(sc *stmtctx.StatementContext, txn kv.Transaction, indexedV
 	key, distinct, err := c.GenIndexKey(sc, indexedValues, h, nil)
 	if err != nil {
 		return false, nil, err
+	}
+
+	var (
+		tempKey []byte
+		keyVer  byte
+	)
+	key, tempKey, keyVer = GenTempIdxKeyByState(c.idxInfo, key)
+	if keyVer != TempIndexKeyTypeNone {
+		if len(tempKey) > 0 {
+			KeyExistInfo, h1, err1 := KeyExistInTempIndex(txn, tempKey, distinct, h, c.tblInfo.IsCommonHandle)
+			if err1 != nil {
+				return false, nil, err
+			}
+			switch KeyExistInfo {
+			case KeyInTempIndexNotExist, KeyInTempIndexIsDeleted:
+				return false, nil, nil
+			case KeyInTempIndexConflict:
+				return true, h1, kv.ErrKeyExists
+			case KeyInTempIndexIsItself:
+				return true, h, nil
+			}
+		}
 	}
 
 	value, err := txn.Get(context.TODO(), key)
@@ -462,4 +497,53 @@ func TryAppendCommonHandleRowcodecColInfos(colInfo []rowcodec.ColInfo, tblInfo *
 		}
 	}
 	return colInfo
+}
+
+const (
+	// KeyInTempIndexUnknown whether the key exists or not in temp index is unknown.
+	KeyInTempIndexUnknown = 0
+	// KeyInTempIndexNotExist the key is not exist in temp index.
+	KeyInTempIndexNotExist = 1
+	// KeyInTempIndexIsDeleted the key is marked deleted in temp index.
+	KeyInTempIndexIsDeleted = 2
+	// KeyInTempIndexIsItself the key is correlated to itself in temp index.
+	KeyInTempIndexIsItself = 3
+	// KeyInTempIndexConflict the key is conflict in temp index.
+	KeyInTempIndexConflict = 4
+)
+
+// KeyExistInTempIndex is used to check if there is unique key is marked delete in temp index.
+func KeyExistInTempIndex(txn kv.Transaction, key kv.Key, distinct bool, h kv.Handle, IsCommonHandle bool) (int, kv.Handle, error) {
+	value, err := txn.Get(context.TODO(), key)
+	if kv.IsErrNotFound(err) {
+		return KeyInTempIndexNotExist, nil, nil
+	}
+	if err != nil {
+		return KeyInTempIndexUnknown, nil, err
+	}
+
+	length := len(value)
+	value = value[:length-1]
+	if distinct {
+		if bytes.Equal(value, DeleteMarkerUnique) {
+			return KeyInTempIndexIsDeleted, nil, nil
+		}
+	} else {
+		if bytes.Equal(value, DeleteMarker) {
+			return KeyInTempIndexIsDeleted, nil, nil
+		}
+	}
+
+	// Check if handle equal?
+	var handle kv.Handle
+	if distinct {
+		handle, err = tablecodec.DecodeHandleInUniqueIndexValue(value, IsCommonHandle)
+		if err != nil {
+			return KeyInTempIndexUnknown, nil, err
+		}
+		if !handle.Equal(h) {
+			return KeyInTempIndexConflict, handle, kv.ErrKeyExists
+		}
+	}
+	return KeyInTempIndexIsItself, handle, nil
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #39321

Problem Summary:
When set fast reorg variable on, some ut will failed.

What is changed and how it works?

> TestCreateUniqueExpressionIndex

This Case should check key in correct index and skip deleted key.

> TestCancel
> TestMultiSchemaChangeAddIndexesCancelled
> TestCancelAddIndexPanic
> TestDDLStatsInfo
> TestPartitionAddIndexGC

This four case is dur to pd create rollback DDL, we set err to nil and DDL task will be resumed and executed later

> TestRunDDLJobPanicEnableClusteredIndex
> TestRunDDLJobPanicDisableClusteredIndex

skip merge woker number checker.

> TestIndexChange

The key exist check logic should be changed according the index status.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
