### PR TITLE
planner: fix index prefix matching

### DIFF
--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1111,7 +1111,8 @@ func (b *PlanBuilder) detectSelectWindow(sel *ast.SelectStmt) bool {
 }
 
 func getPathByIndexName(paths []*util.AccessPath, idxName model.CIStr, tblInfo *model.TableInfo) *util.AccessPath {
-	var primaryIdxPath *util.AccessPath
+	var primaryIdxPath, indexPrefixPath *util.AccessPath
+	prefixMatches := 0
 	for _, path := range paths {
 		if path.StoreType == kv.TiFlash {
 			continue
@@ -1123,9 +1124,18 @@ func getPathByIndexName(paths []*util.AccessPath, idxName model.CIStr, tblInfo *
 		if path.Index.Name.L == idxName.L {
 			return path
 		}
+		if strings.HasPrefix(path.Index.Name.L, idxName.L) {
+			indexPrefixPath = path
+			prefixMatches++
+		}
 	}
 	if isPrimaryIndex(idxName) && tblInfo.HasClusteredIndex() {
 		return primaryIdxPath
+	}
+
+	// Return only unique prefix matches
+	if prefixMatches == 1 {
+		return indexPrefixPath
 	}
 	return nil
 }

--- a/planner/core/planbuilder_test.go
+++ b/planner/core/planbuilder_test.go
@@ -91,6 +91,11 @@ func TestGetPathByIndexName(t *testing.T) {
 	require.NotNil(t, path)
 	require.Equal(t, accessPath[1], path)
 
+	// "id" is a prefix of "idx"
+	path := getPathByIndexName(accessPath, model.NewCIStr("id"), tblInfo)
+	require.NotNil(t, path)
+	require.Equal(t, accessPath[1], path)
+
 	path = getPathByIndexName(accessPath, model.NewCIStr("primary"), tblInfo)
 	require.NotNil(t, path)
 	require.Equal(t, accessPath[0], path)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #14581

Problem Summary: Fix prefix matching of indexes

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
`USE INDEX` and `FORCE INDEX` were improved to match indexes based on prefix to improve MySQL Compatibility
```
