### PR TITLE
ddl: don't reuse the chunk until underlying memory is not referenced

### DIFF
--- a/ddl/index_cop.go
+++ b/ddl/index_cop.go
@@ -95,7 +95,9 @@ type copReqSenderPool struct {
 	senders []*copReqSender
 	wg      sync.WaitGroup
 
-	idxBufPool sync.Pool
+	idxBufPool sync.Pool // []*indexRecord
+	srcChkPool sync.Pool // *chunk.Chunk
+	binding    map[*[]*indexRecord]*chunk.Chunk
 }
 
 type copReqSender struct {
@@ -108,7 +110,6 @@ type copReqSender struct {
 func (c *copReqSender) run() {
 	p := c.senderPool
 	defer p.wg.Done()
-	srcChk := renewChunk(nil, p.copCtx.fieldTps)
 	for {
 		if util.HasCancelled(c.ctx) {
 			return
@@ -127,9 +128,7 @@ func (c *copReqSender) run() {
 		var done bool
 		var total int
 		for !done {
-			idxRec := p.idxBufPool.Get().([]*indexRecord)
-			idxRec = idxRec[:0]
-			srcChk = renewChunk(srcChk, p.copCtx.fieldTps)
+			idxRec, srcChk := p.getIndexRecordsAndChunks()
 			idxRec, done, err = p.copCtx.fetchTableScanResult(p.ctx, rs, srcChk, idxRec)
 			if err != nil {
 				p.resultsCh <- idxRecResult{id: task.id, err: err}
@@ -139,17 +138,6 @@ func (c *copReqSender) run() {
 			p.resultsCh <- idxRecResult{id: task.id, records: idxRec, done: done, total: total}
 		}
 	}
-}
-
-// renewChunk creates a new chunk when the reorg batch size is changed.
-func renewChunk(oldChk *chunk.Chunk, fts []*types.FieldType) *chunk.Chunk {
-	newSize := variable.GetDDLReorgBatchSize()
-	newCap := int(newSize) * copReadBatchFactor
-	if oldChk == nil || oldChk.Capacity() != newCap {
-		return chunk.NewChunkWithCapacity(fts, newCap)
-	}
-	oldChk.Reset()
-	return oldChk
 }
 
 func newCopReqSenderPool(ctx context.Context, copCtx *copContext, startTS uint64) *copReqSenderPool {
@@ -167,6 +155,12 @@ func newCopReqSenderPool(ctx context.Context, copCtx *copContext, startTS uint64
 				return make([]*indexRecord, 0, int(variable.GetDDLReorgBatchSize())*copReadBatchFactor)
 			},
 		},
+		srcChkPool: sync.Pool{
+			New: func() any {
+				return chunk.NewChunkWithCapacity(copCtx.fieldTps, int(variable.GetDDLReorgBatchSize())*copReadBatchFactor)
+			},
+		},
+		binding: make(map[*[]*indexRecord]*chunk.Chunk),
 	}
 }
 
@@ -205,12 +199,24 @@ func (c *copReqSenderPool) close() {
 	close(c.resultsCh)
 }
 
+func (c *copReqSenderPool) getIndexRecordsAndChunks() ([]*indexRecord, *chunk.Chunk) {
+	ir, chk := c.idxBufPool.Get().([]*indexRecord), c.srcChkPool.Get().(*chunk.Chunk)
+	newCap := int(variable.GetDDLReorgBatchSize()) * copReadBatchFactor
+	if chk.Capacity() != newCap {
+		chk = chunk.NewChunkWithCapacity(c.copCtx.fieldTps, newCap)
+	}
+	chk.Reset()
+	c.binding[&ir] = chk
+	return ir[:0], chk
+}
+
 // recycleIdxRecords puts the index record slice back to the pool for reuse.
 func (c *copReqSenderPool) recycleIdxRecords(idxRecs []*indexRecord) {
-	if len(idxRecs) == 0 {
+	if idxRecs == nil {
 		return
 	}
 	c.idxBufPool.Put(idxRecs[:0])
+	c.srcChkPool.Put(c.binding[&idxRecs])
 }
 
 // copContext contains the information that is needed when building a coprocessor request.
@@ -410,8 +416,7 @@ func (c *copContext) fetchTableScanResult(ctx context.Context, result distsql.Se
 		rsData := tables.TryGetHandleRestoredDataWrapper(c.tblInfo, hdDt, nil, c.idxInfo)
 		buf = append(buf, &indexRecord{handle: handle, key: nil, vals: idxDt, rsData: rsData, skip: false})
 	}
-	done := chk.NumRows() < chk.Capacity()
-	return buf, done, nil
+	return buf, false, nil
 }
 
 func buildDAGPB(sCtx sessionctx.Context, tblInfo *model.TableInfo, colInfos []*model.ColumnInfo) (*tipb.DAGRequest, error) {

--- a/ddl/index_cop_test.go
+++ b/ddl/index_cop_test.go
@@ -45,7 +45,7 @@ func TestAddIndexFetchRowsFromCoprocessor(t *testing.T) {
 		require.NoError(t, err)
 		idxRec, done, err := ddl.FetchRowsFromCop4Test(copCtx, startKey, endKey, txn.StartTS(), 10)
 		require.NoError(t, err)
-		require.True(t, done)
+		require.False(t, done)
 		require.NoError(t, txn.Rollback())
 
 		handles := make([]kv.Handle, 0, len(idxRec))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #39308

Problem Summary:

The issue could be reproduced easily when the data set is large enough.

```diff
diff --git a/ddl/index.go b/ddl/index.go
index c3c3ffd37c..f5ed601d2b 100644
--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1548,6 +1548,13 @@ func (w *addIndexWorker) BackfillDataInTxn(handleRange reorgBackfillTask) (taskC
                        } else { // The lightning environment is ready.
                                vars := w.sessCtx.GetSessionVars()
                                sCtx, writeBufs := vars.StmtCtx, vars.GetWriteStmtBufs()
+                               logutil.BgLogger().Info("write", zap.String("handle", idxRecord.handle.String()),
+                                       zap.String("idxVal", idxRecord.vals[0].GetString()),
+                                       zap.String("addr", fmt.Sprintf("%p", idxRecords)),
+                                       zap.String("idxAddr", fmt.Sprintf("%p", idxRecord)),
+                                       zap.String("idxDtAddr", fmt.Sprintf("%p", idxRecord.vals)),
+                                       zap.String("idxDt0Addr", fmt.Sprintf("%p", &idxRecord.vals[0])),
+                                       zap.String("d.b", fmt.Sprintf("%p", idxRecord.vals[0].GetBytes())))
                                key, distinct, err := w.index.GenIndexKey(sCtx, idxRecord.vals, idxRecord.handle, writeBufs.IndexKeyBuf)
@@ -291,10 +295,17 @@ func (c *copContext) fetchTableScanResult(ctx context.Context, result distsql.Se
                        return nil, false, errors.Trace(err)
                }
                rsData := tables.TryGetHandleRestoredDataWrapper(c.tblInfo, hdDt, nil, c.idxInfo)
-               buf = append(buf, &indexRecord{handle: handle, key: nil, vals: idxDt, rsData: rsData, skip: false})
+               idxRec := &indexRecord{handle: handle, key: nil, vals: idxDt, rsData: rsData, skip: false}
+               buf = append(buf, idxRec)
+               logutil.BgLogger().Info("rows", zap.String("val", row.ToString(c.fieldTps)),
+                       zap.String("handle", handle.String()),
+                       zap.String("addr", fmt.Sprintf("%p", buf)),
+                       zap.String("idxAddr", fmt.Sprintf("%p", idxRec)),
+                       zap.String("idxDtAddr", fmt.Sprintf("%p", idxRec.vals)),
+                       zap.String("idxDt0Addr", fmt.Sprintf("%p", &idxRec.vals[0])),
+                       zap.String("d.b", fmt.Sprintf("%p", idxRec.vals[0].GetBytes())))
        }
```

```
[2022/11/25 01:27:51.107 +08:00] [INFO] [index_cop.go:300] [rows] [val="32644160646-97332178411-20202217618-32930568818-43901782951-91030404202-17535639422-27973945537-69415721036-64437459094, 2561"] [handle=2561] [addr=0x1400182e000] [idxAddr=0x14003662c60] [idxDtAddr=0x14003b562d0] [idxDt0Addr=0x14003b562d0] [d.b=0x14001e60000]

[2022/11/25 01:27:51.107 +08:00] [INFO] [index.go:1551] [write] [handle=1] [idxVal=32644160646-97332178411-20202217618-32930568818-43901782951-91030404202-17535639422-27973945537-69415721036-64437459094] [addr=0x14000e57000] [idxAddr=0x1400069cde0] [idxDtAddr=0x140015381b0] [idxDt0Addr=0x140015381b0] [d.b=0x14001e60000]
```

The actual data underlying `types.Datum` is referenced by two different goroutines, because when we initialize the datum from the chunk, we use `GetString()` for varchar columns.

```sql
// GetString gets string value.
func (d *Datum) GetString() string {
	return string(hack.String(d.b))
}
```

The string is not copied here!

### What is changed and how it works?

Similar to `idxBufPool`, this PR adds a chunk `sync.Pool` to manage & reuse the memory as soon as possible.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
   It is too hard to write a suitable unit test, because it needs a large amount of data and the concurrency. I test it with sysbench, no data inconsistency is found anymore.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
