### PR TITLE
statistics: remove 1min no write check for unanalyzed table in auto analyze

### DIFF
--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -45,7 +45,6 @@ import (
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/timeutil"
-	"github.com/tikv/client-go/v2/oracle"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
@@ -1000,9 +999,7 @@ func TableAnalyzed(tbl *statistics.Table) bool {
 func NeedAnalyzeTable(tbl *statistics.Table, limit time.Duration, autoAnalyzeRatio float64) (bool, string) {
 	analyzed := TableAnalyzed(tbl)
 	if !analyzed {
-		t := time.UnixMilli(oracle.ExtractPhysical(tbl.Version))
-		dur := time.Since(t)
-		return dur >= limit, fmt.Sprintf("table unanalyzed, time since last updated %v", dur)
+		return true, "table unanalyzed"
 	}
 	// Auto analyze is disabled.
 	if autoAnalyzeRatio == 0 {

--- a/statistics/handle/update_test.go
+++ b/statistics/handle/update_test.go
@@ -1391,8 +1391,8 @@ func TestNeedAnalyzeTable(t *testing.T) {
 			tbl:    &statistics.Table{Version: oracle.GoTimeToTS(time.Now())},
 			limit:  time.Hour,
 			ratio:  0,
-			result: false,
-			reason: "",
+			result: true,
+			reason: "table unanalyzed",
 		},
 		// table was already analyzed but auto analyze is disabled
 		{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

Same as #39179

When we decide whether a table needs to be auto analzyzed, if the table has never been analyzed and there is no write to the table in the last minute, we trigger auto analyze for the table. The condition of no write in the last minute may prevent the table from auto analyze and the optimizer may choose wrong plans using pseudo stats. Hence the pr removes the condition. The condition of no write in the last minute was first introduced for the following case. When loading data, auto analyze v1 is triggered and preempts CPU and other resources with loading data. However, after auto analyze v2 is introduced, the resource consumption of analyze is reduced so it would not be a problem to trigger auto analyze when loading data.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
