### PR TITLE
types: handle io.EOF error when to parse datatime

### DIFF
--- a/executor/executor_issue_test.go
+++ b/executor/executor_issue_test.go
@@ -684,6 +684,11 @@ func TestIssue22231(t *testing.T) {
 	tk.MustQuery("select cast('2020-05-28 23:59:59 00:00:00' as datetime)").Check(testkit.Rows("2020-05-28 23:59:59"))
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1292 Truncated incorrect datetime value: '2020-05-28 23:59:59 00:00:00'"))
 	tk.MustExec("drop table if exists t_issue_22231")
+
+	tk.MustQuery("SELECT CAST(\"1111111111-\" AS DATE);")
+	tk.MustQuery("SHOW WARNINGS").
+		Check(
+			testkit.Rows("Warning 1292 Incorrect datetime value: '1111111111-'"))
 }
 
 // TestIssue2612 is related with https://github.com/pingcap/tidb/issues/2612

--- a/executor/executor_issue_test.go
+++ b/executor/executor_issue_test.go
@@ -686,9 +686,7 @@ func TestIssue22231(t *testing.T) {
 	tk.MustExec("drop table if exists t_issue_22231")
 
 	tk.MustQuery("SELECT CAST(\"1111111111-\" AS DATE);")
-	tk.MustQuery("SHOW WARNINGS").
-		Check(
-			testkit.Rows("Warning 1292 Incorrect datetime value: '1111111111-'"))
+	tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect datetime value: '1111111111-'"))
 }
 
 // TestIssue2612 is related with https://github.com/pingcap/tidb/issues/2612

--- a/types/time.go
+++ b/types/time.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"regexp"
 	"strconv"
@@ -1155,6 +1156,9 @@ func parseDatetime(sc *stmtctx.StatementContext, str string, fsp int, isFloat bo
 		hhmmss = true
 	}
 	if err != nil {
+		if err == io.EOF {
+			return ZeroDatetime, errors.Trace(ErrWrongValue.GenWithStackByArgs(DateTimeStr, str))
+		}
 		return ZeroDatetime, errors.Trace(err)
 	}
 

--- a/types/time.go
+++ b/types/time.go
@@ -1156,7 +1156,7 @@ func parseDatetime(sc *stmtctx.StatementContext, str string, fsp int, isFloat bo
 		hhmmss = true
 	}
 	if err != nil {
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
+		if err == io.EOF {
 			return ZeroDatetime, errors.Trace(ErrWrongValue.GenWithStackByArgs(DateTimeStr, str))
 		}
 		return ZeroDatetime, errors.Trace(err)

--- a/types/time.go
+++ b/types/time.go
@@ -1156,7 +1156,7 @@ func parseDatetime(sc *stmtctx.StatementContext, str string, fsp int, isFloat bo
 		hhmmss = true
 	}
 	if err != nil {
-		if err == io.EOF {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			return ZeroDatetime, errors.Trace(ErrWrongValue.GenWithStackByArgs(DateTimeStr, str))
 		}
 		return ZeroDatetime, errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35678

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
