### PR TITLE
*: fix goleak in the statisticstest

### DIFF
--- a/tests/realtikvtest/statisticstest/BUILD.bazel
+++ b/tests/realtikvtest/statisticstest/BUILD.bazel
@@ -12,9 +12,7 @@ go_test(
     deps = [
         "//statistics/handle",
         "//testkit",
-        "//testkit/testsetup",
         "//tests/realtikvtest",
         "@com_github_stretchr_testify//require",
-        "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/tests/realtikvtest/statisticstest/main_test.go
+++ b/tests/realtikvtest/statisticstest/main_test.go
@@ -17,20 +17,9 @@ package statisticstest
 import (
 	"testing"
 
-	"github.com/pingcap/tidb/testkit/testsetup"
 	"github.com/pingcap/tidb/tests/realtikvtest"
-	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
-	opts := []goleak.Option{
-		goleak.IgnoreTopFunction("github.com/golang/glog.(*loggingT).flushDaemon"),
-		goleak.IgnoreTopFunction("github.com/lestrrat-go/httprc.runFetchWorker"),
-		goleak.IgnoreTopFunction("google.golang.org/grpc.(*ccBalancerWrapper).watcher"),
-		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
-		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
-	}
-	testsetup.SetupForCommonTest()
-	goleak.VerifyTestMain(m, opts...)
 	realtikvtest.RunTestMain(m)
 }


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #39502

Problem Summary:

### What is changed and how it works?

In fact, the old limit is useless. they are defined in the ```RunTestMain```.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
