### PR TITLE
planner: throw error when create not supported binding from history

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -1471,3 +1471,25 @@ func TestCreateBindingForPrepareFromHistory(t *testing.T) {
 	tk.MustExec("execute stmt using @a")
 	tk.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
 }
+
+func TestErrorCasesCreateBindingFromHistory(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil))
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t1(id int)")
+	tk.MustExec("create table t2(id int)")
+	tk.MustExec("create table t3(id int)")
+
+	sql := "select * from t1 where t1.id in (select id from t2)"
+	tk.MustExec(sql)
+	planDigest := tk.MustQuery(fmt.Sprintf("select plan_digest from information_schema.statements_summary where query_sample_text = '%s'", sql)).Rows()
+	tk.MustGetErrMsg(fmt.Sprintf("create binding from history using plan digest '%s'", planDigest[0][0]), "can't create binding for query with sub query")
+
+	sql = "select * from t1, t2, t3 where t1.id = t2.id and t2.id = t3.id"
+	tk.MustExec(sql)
+	planDigest = tk.MustQuery(fmt.Sprintf("select plan_digest from information_schema.statements_summary where query_sample_text = '%s'", sql)).Rows()
+	tk.MustGetErrMsg(fmt.Sprintf("create binding from history using plan digest '%s'", planDigest[0][0]), "can't create binding for query with more than two table join")
+}

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1054,7 +1054,9 @@ func (b *PlanBuilder) buildCreateBindPlanFromPlanDigest(v *ast.CreateBindingStmt
 	if err != nil {
 		return nil, errors.Errorf("binding failed: %v", err)
 	}
-
+	if err = hint.CheckBindingFromHistoryBindable(originNode, bindableStmt.PlanHint); err != nil {
+		return nil, err
+	}
 	bindSQL := bindinfo.GenerateBindSQL(context.TODO(), originNode, bindableStmt.PlanHint, true, bindableStmt.Schema)
 	var hintNode ast.StmtNode
 	hintNode, err = parser4binding.ParseOneStmt(bindSQL, bindableStmt.Charset, bindableStmt.Collation)

--- a/util/hint/hint_processor.go
+++ b/util/hint/hint_processor.go
@@ -16,6 +16,7 @@ package hint
 
 import (
 	"fmt"
+	"github.com/pingcap/errors"
 	"strconv"
 	"strings"
 
@@ -616,4 +617,58 @@ func GenerateQBName(nodeType NodeType, blockOffset int) (model.CIStr, error) {
 		return model.NewCIStr(""), fmt.Errorf("Unexpected NodeType %d when block offset is 0", nodeType)
 	}
 	return model.NewCIStr(fmt.Sprintf("%s%d", defaultSelectBlockPrefix, blockOffset)), nil
+}
+
+// CheckBindingFromHistoryBindable checks whether the ast and hint string from history is bindable.
+// Not support:
+// 1. query use tiFlash engine
+// 2. query with sub query
+// 3. query with more than 2 table join
+func CheckBindingFromHistoryBindable(node ast.Node, hintStr string) error {
+	// check tiflash
+	contain := strings.Contains(hintStr, "tiflash")
+	if contain {
+		return errors.New("can't create binding for query with tiflash engine")
+	}
+
+	checker := bindableChecker{
+		bindable: true,
+		tables:   make(map[model.CIStr]struct{}, 2),
+	}
+	node.Accept(&checker)
+	return checker.reason
+}
+
+// bindableChecker checks whether a binding from history can be created.
+type bindableChecker struct {
+	bindable bool
+	reason   error
+	tables   map[model.CIStr]struct{}
+}
+
+// Enter implements Visitor interface.
+func (checker *bindableChecker) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+	switch node := in.(type) {
+	case *ast.ExistsSubqueryExpr, *ast.SubqueryExpr:
+		checker.bindable = false
+		checker.reason = errors.New("can't create binding for query with sub query")
+		return in, true
+	case *ast.TableName:
+		if _, ok := checker.tables[node.Schema]; !ok {
+			checker.tables[node.Name] = struct{}{}
+		}
+		if len(checker.tables) >= 3 {
+			checker.bindable = false
+			checker.reason = errors.New("can't create binding for query with more than two table join")
+			return in, true
+		}
+	case *ast.Join:
+		return in, false
+	}
+	return in, false
+}
+
+// Leave implements Visitor interface.
+func (checker *bindableChecker) Leave(in ast.Node) (out ast.Node, ok bool) {
+	return in, checker.bindable
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #39199

Problem Summary:
Currently, extract hint from plan is not perfect, some plan can 't be fixed by binding.
### What is changed and how it works?
For not supported queries, throw error when create binding from history.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
