### PR TITLE
br: fix integration test cases with `--with-sys-table`

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -988,24 +988,27 @@ func (rc *Client) CheckSysTableCompatibility(dom *domain.Domain, tables []*metau
 					backupCol.Name, backupCol.FieldType.String())
 			}
 		}
-		// check whether the columns of table in cluster are less than the backup data
-		clusterColMap := make(map[string]*model.ColumnInfo)
-		for i := range ti.Columns {
-			col := ti.Columns[i]
-			clusterColMap[col.Name.L] = col
-		}
-		// order can be different
-		for i := range backupTi.Columns {
-			col := backupTi.Columns[i]
-			clusterCol := clusterColMap[col.Name.L]
-			if clusterCol == nil {
-				log.Error("missing column in cluster data",
-					zap.Stringer("table", table.Info.Name),
-					zap.String("col", fmt.Sprintf("%s %s", col.Name, col.FieldType.String())))
-				return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
-					"missing column in cluster data, table: %s, col: %s %s",
-					table.Info.Name.O,
-					col.Name, col.FieldType.String())
+
+		if backupTi.Name.L == sysUserTableName {
+			// check whether the columns of table in cluster are less than the backup data
+			clusterColMap := make(map[string]*model.ColumnInfo)
+			for i := range ti.Columns {
+				col := ti.Columns[i]
+				clusterColMap[col.Name.L] = col
+			}
+			// order can be different
+			for i := range backupTi.Columns {
+				col := backupTi.Columns[i]
+				clusterCol := clusterColMap[col.Name.L]
+				if clusterCol == nil {
+					log.Error("missing column in cluster data",
+						zap.Stringer("table", table.Info.Name),
+						zap.String("col", fmt.Sprintf("%s %s", col.Name, col.FieldType.String())))
+					return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+						"missing column in cluster data, table: %s, col: %s %s",
+						table.Info.Name.O,
+						col.Name, col.FieldType.String())
+				}
 			}
 		}
 	}

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -988,6 +988,26 @@ func (rc *Client) CheckSysTableCompatibility(dom *domain.Domain, tables []*metau
 					backupCol.Name, backupCol.FieldType.String())
 			}
 		}
+		// check whether the columns of table in cluster are less than the backup data
+		clusterColMap := make(map[string]*model.ColumnInfo)
+		for i := range ti.Columns {
+			col := ti.Columns[i]
+			clusterColMap[col.Name.L] = col
+		}
+		// order can be different
+		for i := range backupTi.Columns {
+			col := backupTi.Columns[i]
+			clusterCol := clusterColMap[col.Name.L]
+			if clusterCol == nil {
+				log.Error("missing column in cluster data",
+					zap.Stringer("table", table.Info.Name),
+					zap.String("col", fmt.Sprintf("%s %s", col.Name, col.FieldType.String())))
+				return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+					"missing column in cluster data, table: %s, col: %s %s",
+					table.Info.Name.O,
+					col.Name, col.FieldType.String())
+			}
+		}
 	}
 	return nil
 }

--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -203,6 +203,16 @@ func TestCheckSysTableCompatibility(t *testing.T) {
 		Info: mockedUserTI,
 	}})
 	require.NoError(t, err)
+	userTI.Columns = userTI.Columns[:len(userTI.Columns)-1]
+
+	// user table in cluster have less columns(failed)
+	mockedUserTI = userTI.Clone()
+	mockedUserTI.Columns = append(mockedUserTI.Columns, &model.ColumnInfo{Name: model.NewCIStr("new-name")})
+	err = client.CheckSysTableCompatibility(cluster.Domain, []*metautil.Table{{
+		DB:   tmpSysDB,
+		Info: mockedUserTI,
+	}})
+	require.True(t, berrors.ErrRestoreIncompatibleSys.Equal(err))
 
 	// column order mismatch(success)
 	mockedUserTI = userTI.Clone()

--- a/br/tests/br_full_cluster_restore/run.sh
+++ b/br/tests/br_full_cluster_restore/run.sh
@@ -55,7 +55,8 @@ restart_services
 # mock incompatible manually
 run_sql "alter table mysql.user add column xx int;"
 run_br restore full --with-sys-table --log-file $br_log_file -s "local://$backup_dir" > $res_file 2>&1 || true
-check_contains "the target cluster is not compatible with the backup data"
+run_sql "select count(*) from mysql.user"
+check_contains "count(*): 6"
 
 echo "--> incompatible system table: less column on target cluster"
 restart_services


### PR DESCRIPTION
Signed-off-by: zhanggaoming <gaoming.zhang@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #39692

Problem Summary:


### What is changed and how it works?
Fix integration test cases with `--with-sys-table`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Manual test
case 1:
- br backup full
- In restore cluster, execute `alter table mysql.user add column xx int;`
- br restore full
- success

case 2:
- In backup cluster, execute `alter table mysql.user add column xx int;`
- br backup full
- br restore full
- failed, `Error: missing column in cluster data, table: user, col: xx int(11): [BR:Restore:ErrRestoreIncompatibleSys]incompatible system table`


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
