### PR TITLE
*: fix revive false positive with generics

### DIFF
--- a/build/linter/allrevive/analyzer.go
+++ b/build/linter/allrevive/analyzer.go
@@ -65,7 +65,6 @@ var defaultRules = []lint.Rule{
 	&rule.TimeNamingRule{},
 	//&rule.ContextKeysType{},
 	&rule.ContextAsArgumentRule{},
-	&rule.ReceiverNamingRule{},
 }
 
 var allRules = append([]lint.Rule{
@@ -119,7 +118,6 @@ var allRules = append([]lint.Rule{
 	&rule.TimeEqualRule{},
 	//&rule.BannedCharsRule{},
 	&rule.OptimizeOperandsOrderRule{},
-	&rule.ReceiverNamingRule{},
 }, defaultRules...)
 
 func run(pass *analysis.Pass) (any, error) {

--- a/build/linter/allrevive/analyzer.go
+++ b/build/linter/allrevive/analyzer.go
@@ -65,6 +65,7 @@ var defaultRules = []lint.Rule{
 	&rule.TimeNamingRule{},
 	//&rule.ContextKeysType{},
 	&rule.ContextAsArgumentRule{},
+	&rule.ReceiverNamingRule{},
 }
 
 var allRules = append([]lint.Rule{
@@ -118,6 +119,7 @@ var allRules = append([]lint.Rule{
 	&rule.TimeEqualRule{},
 	//&rule.BannedCharsRule{},
 	&rule.OptimizeOperandsOrderRule{},
+	&rule.ReceiverNamingRule{},
 }, defaultRules...)
 
 func run(pass *analysis.Pass) (any, error) {

--- a/tools/check/revive.toml
+++ b/tools/check/revive.toml
@@ -29,7 +29,7 @@ warningCode = -1
 [rule.var-naming]
 [rule.package-comments]
 [rule.range]
-[rule.receiver-naming]
+#[rule.receiver-naming]
 [rule.indent-error-flow]
 [rule.superfluous-else]
 [rule.modifies-parameter]


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

it is found by https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftidb%2Fghpr_check/detail/ghpr_check/6720/pipeline.

the revive which run by cli is old. so that we disable it to fix. It has been enabled in the bazel nogo.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
