### PR TITLE
planner: rename 'tidb_enable_general_plan_cache' and 'tidb_general_plan_cache_size' to 'tidb_enable_non_prepared_plan_cache' and 'tidb_non_prepared_plan_cache_size'

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -766,35 +766,35 @@ func TestSetVar(t *testing.T) {
 	tk.MustGetErrCode("set global init_connect = 'invalidstring'", mysql.ErrWrongTypeForVar)
 	tk.MustExec("set global init_connect = 'select now(); select timestamp()'")
 
-	// test variable 'tidb_enable_general_plan_cache'
+	// test variable 'tidb_enable_non_prepared_plan_cache'
 	// global scope
-	tk.MustQuery("select @@global.tidb_enable_general_plan_cache").Check(testkit.Rows("0")) // default value
-	tk.MustExec("set global tidb_enable_general_plan_cache = 1")
-	tk.MustQuery("select @@global.tidb_enable_general_plan_cache").Check(testkit.Rows("1"))
-	tk.MustExec("set global tidb_enable_general_plan_cache = 0")
-	tk.MustQuery("select @@global.tidb_enable_general_plan_cache").Check(testkit.Rows("0"))
+	tk.MustQuery("select @@global.tidb_enable_non_prepared_plan_cache").Check(testkit.Rows("0")) // default value
+	tk.MustExec("set global tidb_enable_non_prepared_plan_cache = 1")
+	tk.MustQuery("select @@global.tidb_enable_non_prepared_plan_cache").Check(testkit.Rows("1"))
+	tk.MustExec("set global tidb_enable_non_prepared_plan_cache = 0")
+	tk.MustQuery("select @@global.tidb_enable_non_prepared_plan_cache").Check(testkit.Rows("0"))
 	// session scope
-	tk.MustQuery("select @@session.tidb_enable_general_plan_cache").Check(testkit.Rows("0")) // default value
-	tk.MustExec("set session tidb_enable_general_plan_cache = 1")
-	tk.MustQuery("select @@session.tidb_enable_general_plan_cache").Check(testkit.Rows("1"))
-	tk.MustExec("set session tidb_enable_general_plan_cache = 0")
-	tk.MustQuery("select @@session.tidb_enable_general_plan_cache").Check(testkit.Rows("0"))
+	tk.MustQuery("select @@session.tidb_enable_non_prepared_plan_cache").Check(testkit.Rows("0")) // default value
+	tk.MustExec("set session tidb_enable_non_prepared_plan_cache = 1")
+	tk.MustQuery("select @@session.tidb_enable_non_prepared_plan_cache").Check(testkit.Rows("1"))
+	tk.MustExec("set session tidb_enable_non_prepared_plan_cache = 0")
+	tk.MustQuery("select @@session.tidb_enable_non_prepared_plan_cache").Check(testkit.Rows("0"))
 
-	// test variable 'tidb_general_plan_cache-size'
+	// test variable 'tidb_non_prepared_plan_cache-size'
 	// global scope
-	tk.MustQuery("select @@global.tidb_general_plan_cache_size").Check(testkit.Rows("100")) // default value
-	tk.MustExec("set global tidb_general_plan_cache_size = 200")
-	tk.MustQuery("select @@global.tidb_general_plan_cache_size").Check(testkit.Rows("200"))
-	tk.MustExec("set global tidb_general_plan_cache_size = 200000000") // overflow
-	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1292 Truncated incorrect tidb_general_plan_cache_size value: '200000000'"))
-	tk.MustQuery("select @@global.tidb_general_plan_cache_size").Check(testkit.Rows("100000"))
+	tk.MustQuery("select @@global.tidb_non_prepared_plan_cache_size").Check(testkit.Rows("100")) // default value
+	tk.MustExec("set global tidb_non_prepared_plan_cache_size = 200")
+	tk.MustQuery("select @@global.tidb_non_prepared_plan_cache_size").Check(testkit.Rows("200"))
+	tk.MustExec("set global tidb_non_prepared_plan_cache_size = 200000000") // overflow
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1292 Truncated incorrect tidb_non_prepared_plan_cache_size value: '200000000'"))
+	tk.MustQuery("select @@global.tidb_non_prepared_plan_cache_size").Check(testkit.Rows("100000"))
 	// session scope
-	tk.MustQuery("select @@session.tidb_general_plan_cache_size").Check(testkit.Rows("100")) // default value
-	tk.MustExec("set session tidb_general_plan_cache_size = 300")
-	tk.MustQuery("select @@session.tidb_general_plan_cache_size").Check(testkit.Rows("300"))
-	tk.MustExec("set session tidb_general_plan_cache_size = -1") // underflow
-	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1292 Truncated incorrect tidb_general_plan_cache_size value: '-1'"))
-	tk.MustQuery("select @@session.tidb_general_plan_cache_size").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@session.tidb_non_prepared_plan_cache_size").Check(testkit.Rows("100")) // default value
+	tk.MustExec("set session tidb_non_prepared_plan_cache_size = 300")
+	tk.MustQuery("select @@session.tidb_non_prepared_plan_cache_size").Check(testkit.Rows("300"))
+	tk.MustExec("set session tidb_non_prepared_plan_cache_size = -1") // underflow
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1292 Truncated incorrect tidb_non_prepared_plan_cache_size value: '-1'"))
+	tk.MustQuery("select @@session.tidb_non_prepared_plan_cache_size").Check(testkit.Rows("1"))
 
 	// test variable 'foreign_key_checks'
 	// global scope

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -101,11 +101,11 @@ func TestNonPreparedPlanCacheBasically(t *testing.T) {
 	}
 
 	for _, query := range queries {
-		tk.MustExec(`set tidb_enable_general_plan_cache=0`)
+		tk.MustExec(`set tidb_enable_non_prepared_plan_cache=0`)
 		resultNormal := tk.MustQuery(query).Sort()
 		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
 
-		tk.MustExec(`set tidb_enable_general_plan_cache=1`)
+		tk.MustExec(`set tidb_enable_non_prepared_plan_cache=1`)
 		tk.MustQuery(query)                                                    // first process
 		tk.MustQuery(query).Sort().Check(resultNormal.Rows())                  // equal to the result without plan-cache
 		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1")) // this plan is from plan-cache

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1062,11 +1062,11 @@ var defaultSysVars = []*SysVar{
 	}, GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 		return strconv.FormatFloat(PreparedPlanCacheMemoryGuardRatio.Load(), 'f', -1, 64), nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableGeneralPlanCache, Value: BoolToOnOff(DefTiDBEnableGeneralPlanCache), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableNonPreparedPlanCache, Value: BoolToOnOff(DefTiDBEnableNonPreparedPlanCache), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
 		s.EnableNonPreparedPlanCache = TiDBOptOn(val)
 		return nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBGeneralPlanCacheSize, Value: strconv.FormatUint(uint64(DefTiDBGeneralPlanCacheSize), 10), Type: TypeUnsigned, MinValue: 1, MaxValue: 100000, SetSession: func(s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBNonPreparedPlanCacheSize, Value: strconv.FormatUint(uint64(DefTiDBNonPreparedPlanCacheSize), 10), Type: TypeUnsigned, MinValue: 1, MaxValue: 100000, SetSession: func(s *SessionVars, val string) error {
 		uVal, err := strconv.ParseUint(val, 10, 64)
 		if err == nil {
 			s.NonPreparedPlanCacheSize = uVal

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -751,10 +751,10 @@ const (
 	// TiDBEnablePrepPlanCacheMemoryMonitor indicates whether to enable prepared plan cache monitor
 	TiDBEnablePrepPlanCacheMemoryMonitor = "tidb_enable_prepared_plan_cache_memory_monitor"
 
-	// TiDBEnableGeneralPlanCache indicates whether to enable general plan cache.
-	TiDBEnableGeneralPlanCache = "tidb_enable_general_plan_cache"
-	// TiDBGeneralPlanCacheSize controls the size of general plan cache.
-	TiDBGeneralPlanCacheSize = "tidb_general_plan_cache_size"
+	// TiDBEnableNonPreparedPlanCache indicates whether to enable non-prepared plan cache.
+	TiDBEnableNonPreparedPlanCache = "tidb_enable_non_prepared_plan_cache"
+	// TiDBNonPreparedPlanCacheSize controls the size of non-prepared plan cache.
+	TiDBNonPreparedPlanCacheSize = "tidb_non_prepared_plan_cache_size"
 
 	// TiDBConstraintCheckInPlacePessimistic controls whether to skip certain kinds of pessimistic locks.
 	TiDBConstraintCheckInPlacePessimistic = "tidb_constraint_check_in_place_pessimistic"
@@ -1114,8 +1114,8 @@ const (
 	DefTiDBEnableFastReorg                         = true
 	DefTiDBDDLDiskQuota                            = 100 * 1024 * 1024 * 1024 // 100GB
 	DefExecutorConcurrency                         = 5
-	DefTiDBEnableGeneralPlanCache                  = false
-	DefTiDBGeneralPlanCacheSize                    = 100
+	DefTiDBEnableNonPreparedPlanCache              = false
+	DefTiDBNonPreparedPlanCacheSize                = 100
 	DefTiDBEnableTiFlashReadForWriteStmt           = false
 	// MaxDDLReorgBatchSize is exported for testing.
 	MaxDDLReorgBatchSize                  int32  = 10240


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary: rename 'tidb_enable_general_plan_cache' and 'tidb_general_plan_cache_size' to 'tidb_enable_non_prepared_plan_cache' and 'tidb_non_prepared_plan_cache_size'

### What is changed and how it works?

rename 'tidb_enable_general_plan_cache' and 'tidb_general_plan_cache_size' to 'tidb_enable_non_prepared_plan_cache' and 'tidb_non_prepared_plan_cache_size'

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
