### PR TITLE
ttl: TTL support split scan ranges for some primary key with more than one columns

### DIFF
--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -17776,9 +17776,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(tidb_server_ttl_job_status{k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (type)",
+          "expr": "sum(tidb_server_ttl_job_status{k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (type, instance)",
           "interval": "",
-          "legendFormat": "{{ type }}",
+          "legendFormat": "{{ instance }} {{ type }}",
           "queryType": "randomWalk",
           "refId": "A"
         }

--- a/ttl/cache/split_test.go
+++ b/ttl/cache/split_test.go
@@ -233,6 +233,10 @@ func createTTLTable(t *testing.T, tk *testkit.TestKit, name string, option strin
 	return createTTLTableWithSQL(t, tk, name, fmt.Sprintf("create table test.%s(id %s primary key, t timestamp) TTL = `t` + interval 1 day", name, option))
 }
 
+func create2PKTTLTable(t *testing.T, tk *testkit.TestKit, name string, option string) *cache.PhysicalTable {
+	return createTTLTableWithSQL(t, tk, name, fmt.Sprintf("create table test.%s(id %s, id2 int, t timestamp, primary key(id, id2)) TTL = `t` + interval 1 day", name, option))
+}
+
 func createTTLTableWithSQL(t *testing.T, tk *testkit.TestKit, name string, sql string) *cache.PhysicalTable {
 	tk.MustExec(sql)
 	is, ok := tk.Session().GetDomainInfoSchema().(infoschema.InfoSchema)
@@ -273,6 +277,7 @@ func TestSplitTTLScanRangesWithSignedInt(t *testing.T) {
 		createTTLTable(t, tk, "t4", "int"),
 		createTTLTable(t, tk, "t5", "bigint"),
 		createTTLTable(t, tk, "t6", ""), // no clustered
+		create2PKTTLTable(t, tk, "t7", "tinyint"),
 	}
 
 	tikvStore := newMockTiKVStore(t)
@@ -334,6 +339,7 @@ func TestSplitTTLScanRangesWithUnsignedInt(t *testing.T) {
 		createTTLTable(t, tk, "t3", "mediumint unsigned"),
 		createTTLTable(t, tk, "t4", "int unsigned"),
 		createTTLTable(t, tk, "t5", "bigint unsigned"),
+		create2PKTTLTable(t, tk, "t6", "tinyint unsigned"),
 	}
 
 	tikvStore := newMockTiKVStore(t)
@@ -397,6 +403,7 @@ func TestSplitTTLScanRangesWithBytes(t *testing.T) {
 		createTTLTable(t, tk, "t2", "char(32) CHARACTER SET BINARY"),
 		createTTLTable(t, tk, "t3", "varchar(32) CHARACTER SET BINARY"),
 		createTTLTable(t, tk, "t4", "bit(32)"),
+		create2PKTTLTable(t, tk, "t5", "binary(32)"),
 	}
 
 	tikvStore := newMockTiKVStore(t)
@@ -446,6 +453,7 @@ func TestNoTTLSplitSupportTables(t *testing.T) {
 		createTTLTable(t, tk, "t2", "varchar(32) CHARACTER SET UTF8MB4"),
 		createTTLTable(t, tk, "t3", "double"),
 		createTTLTable(t, tk, "t4", "decimal(32, 2)"),
+		create2PKTTLTable(t, tk, "t5", "char(32)  CHARACTER SET UTF8MB4"),
 	}
 
 	tikvStore := newMockTiKVStore(t)
@@ -525,6 +533,14 @@ func TestGetNextBytesHandleDatum(t *testing.T) {
 		{
 			key:    buildBytesRowKey([]byte{1, 2, 3, 4, 5, 6, 7, 8, 0}),
 			result: []byte{1, 2, 3, 4, 5, 6, 7, 8, 0},
+		},
+		{
+			key:    append(buildBytesRowKey([]byte{1, 2, 3, 4, 5, 6, 7, 8, 0}), 0),
+			result: []byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0},
+		},
+		{
+			key:    append(buildBytesRowKey([]byte{1, 2, 3, 4, 5, 6, 7, 8, 0}), 1),
+			result: []byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0},
 		},
 		{
 			key:    []byte{},
@@ -613,7 +629,7 @@ func TestGetNextBytesHandleDatum(t *testing.T) {
 				bs[len(bs)-10] = 254
 				return bs
 			},
-			result: []byte{1, 2, 3, 4, 5, 6, 7},
+			result: []byte{1, 2, 3, 4, 5, 6, 7, 0},
 		},
 		{
 			// recordPrefix + bytesFlag + [1, 2, 3, 4, 5, 6, 7, 0, 253, 9, 0, 0, 0, 0, 0, 0, 0, 248]
@@ -717,6 +733,18 @@ func TestGetNextIntHandle(t *testing.T) {
 		{
 			key:    tablecodec.EncodeRowKeyWithHandle(tblID, kv.IntHandle(math.MinInt64)),
 			result: math.MinInt64,
+		},
+		{
+			key:    append(tablecodec.EncodeRowKeyWithHandle(tblID, kv.IntHandle(7)), 0),
+			result: 8,
+		},
+		{
+			key:    append(tablecodec.EncodeRowKeyWithHandle(tblID, kv.IntHandle(math.MaxInt64)), 0),
+			isNull: true,
+		},
+		{
+			key:    append(tablecodec.EncodeRowKeyWithHandle(tblID, kv.IntHandle(math.MinInt64)), 0),
+			result: math.MinInt64 + 1,
 		},
 		{
 			key:    []byte{},

--- a/ttl/sqlbuilder/sql.go
+++ b/ttl/sqlbuilder/sql.go
@@ -319,16 +319,12 @@ type ScanQueryGenerator struct {
 
 // NewScanQueryGenerator creates a new ScanQueryGenerator
 func NewScanQueryGenerator(tbl *cache.PhysicalTable, expire time.Time, rangeStart []types.Datum, rangeEnd []types.Datum) (*ScanQueryGenerator, error) {
-	if len(rangeStart) > 0 {
-		if err := tbl.ValidateKey(rangeStart); err != nil {
-			return nil, err
-		}
+	if err := tbl.ValidateKeyPrefix(rangeStart); err != nil {
+		return nil, err
 	}
 
-	if len(rangeEnd) > 0 {
-		if err := tbl.ValidateKey(rangeEnd); err != nil {
-			return nil, err
-		}
+	if err := tbl.ValidateKeyPrefix(rangeEnd); err != nil {
+		return nil, err
 	}
 
 	return &ScanQueryGenerator{
@@ -393,11 +389,11 @@ func (g *ScanQueryGenerator) setStack(key []types.Datum) error {
 		return nil
 	}
 
-	if err := g.tbl.ValidateKey(key); err != nil {
+	if err := g.tbl.ValidateKeyPrefix(key); err != nil {
 		return err
 	}
 
-	g.stack = g.stack[:cap(g.stack)]
+	g.stack = g.stack[:len(key)]
 	for i := 0; i < len(key); i++ {
 		g.stack[i] = key[0 : i+1]
 	}
@@ -440,7 +436,7 @@ func (g *ScanQueryGenerator) buildSQL() (string, error) {
 	}
 
 	if len(g.keyRangeEnd) > 0 {
-		if err := b.WriteCommonCondition(g.tbl.KeyColumns, "<", g.keyRangeEnd); err != nil {
+		if err := b.WriteCommonCondition(g.tbl.KeyColumns[0:len(g.keyRangeEnd)], "<", g.keyRangeEnd); err != nil {
 			return "", err
 		}
 	}

--- a/ttl/sqlbuilder/sql_test.go
+++ b/ttl/sqlbuilder/sql_test.go
@@ -702,6 +702,54 @@ func TestScanQueryGenerator(t *testing.T) {
 				},
 			},
 		},
+		{
+			tbl:        t2,
+			expire:     time.UnixMilli(0).In(time.UTC),
+			rangeStart: d(1),
+			rangeEnd:   d(100),
+			path: [][]interface{}{
+				{
+					nil, 5,
+					"SELECT LOW_PRIORITY `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` >= 1 AND `a` < 100 AND `time` < '1970-01-01 00:00:00' ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+				},
+				{
+					result(d(1, "x", []byte{0x1a}), 5), 5,
+					"SELECT LOW_PRIORITY `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'x' AND `c` > x'1a' AND `a` < 100 AND `time` < '1970-01-01 00:00:00' ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+				},
+				{
+					result(d(1, "x", []byte{0x20}), 4), 5,
+					"SELECT LOW_PRIORITY `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` > 'x' AND `a` < 100 AND `time` < '1970-01-01 00:00:00' ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+				},
+				{
+					result(d(1, "y", []byte{0x0a}), 4), 5,
+					"SELECT LOW_PRIORITY `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` > 1 AND `a` < 100 AND `time` < '1970-01-01 00:00:00' ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+				},
+			},
+		},
+		{
+			tbl:        t2,
+			expire:     time.UnixMilli(0).In(time.UTC),
+			rangeStart: d(1, "x"),
+			rangeEnd:   d(100, "z"),
+			path: [][]interface{}{
+				{
+					nil, 5,
+					"SELECT LOW_PRIORITY `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` >= 'x' AND (`a`, `b`) < (100, 'z') AND `time` < '1970-01-01 00:00:00' ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+				},
+				{
+					result(d(1, "x", []byte{0x1a}), 5), 5,
+					"SELECT LOW_PRIORITY `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'x' AND `c` > x'1a' AND (`a`, `b`) < (100, 'z') AND `time` < '1970-01-01 00:00:00' ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+				},
+				{
+					result(d(1, "x", []byte{0x20}), 4), 5,
+					"SELECT LOW_PRIORITY `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` > 'x' AND (`a`, `b`) < (100, 'z') AND `time` < '1970-01-01 00:00:00' ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+				},
+				{
+					result(d(1, "y", []byte{0x0a}), 4), 5,
+					"SELECT LOW_PRIORITY `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` > 1 AND (`a`, `b`) < (100, 'z') AND `time` < '1970-01-01 00:00:00' ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+				},
+			},
+		},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #39895

### What is changed and how it works?

TTL support more tables that can be split to scan. In this PR, if a table's primary key's first column is int or binary, it can be split.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
