### PR TITLE
ttl: add log in the whole lifecycle of a job

### DIFF
--- a/ttl/ttlworker/job.go
+++ b/ttl/ttlworker/job.go
@@ -96,8 +96,8 @@ func (job *ttlJob) updateState(ctx context.Context, se session.Session) error {
 }
 
 // peekScanTask returns the next scan task, but doesn't promote the iterator
-func (job *ttlJob) peekScanTask() (*ttlScanTask, error) {
-	return job.tasks[job.taskIter], nil
+func (job *ttlJob) peekScanTask() *ttlScanTask {
+	return job.tasks[job.taskIter]
 }
 
 // nextScanTask promotes the iterator

--- a/ttl/ttlworker/job_test.go
+++ b/ttl/ttlworker/job_test.go
@@ -27,8 +27,7 @@ func TestIterScanTask(t *testing.T) {
 		tbl:   tbl,
 		tasks: []*ttlScanTask{{}},
 	}
-	scanTask, err := job.peekScanTask()
-	assert.NoError(t, err)
+	scanTask := job.peekScanTask()
 	assert.NotNil(t, scanTask)
 	assert.Len(t, job.tasks, 1)
 


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #39930

Problem Summary:

### What is changed and how it works?

1. Some levels of the log decreased to `Info`, but not `Debug`.
2. Add more logs when the job is created and appended to the `runningJobs`.
3. Remove redundant removing of job (without log and cancel) in the `localJobs`.
4. Add more fields to the log, so that we'll know what's exactly happending in that situation.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
