### PR TITLE
ttl: initialize notifyStateCh in ttl job manager

### DIFF
--- a/ttl/ttlworker/job_manager.go
+++ b/ttl/ttlworker/job_manager.go
@@ -90,6 +90,7 @@ func NewJobManager(id string, sessPool sessionPool, store kv.Storage) (manager *
 	manager.store = store
 	manager.sessPool = sessPool
 	manager.delCh = make(chan *ttlDeleteTask)
+	manager.notifyStateCh = make(chan interface{}, 1)
 
 	manager.init(manager.jobLoop)
 	manager.ctx = logutil.WithKeyValue(manager.ctx, "ttl-worker", "manager")


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #39955

### What is changed and how it works?

Initialize the `notifyStateCh` while initializing the job manager. It'll make the recycle of scan worker much faster.

Using a channel with bound 1 is good enough, as the scan worker will actually be blocked by `PollTaskResult`. If the manager didn't call `PollTaskResult`, it will not be scheduled anything.