### PR TITLE
sysvar: allow modifying 'tidb_allow_remove_auto_inc' when SEM is ON

### DIFF
--- a/sessionctx/sessionstates/session_states_test.go
+++ b/sessionctx/sessionstates/session_states_test.go
@@ -133,7 +133,7 @@ func TestSystemVars(t *testing.T) {
 		{
 			// sem invisible variable
 			inSessionStates: false,
-			varName:         variable.TiDBAllowRemoveAutoInc,
+			varName:         variable.TiDBConfig,
 		},
 		{
 			// noop variables

--- a/util/sem/sem.go
+++ b/util/sem/sem.go
@@ -136,7 +136,6 @@ func IsInvisibleStatusVar(varName string) bool {
 func IsInvisibleSysVar(varNameInLower string) bool {
 	switch varNameInLower {
 	case variable.TiDBDDLSlowOprThreshold, // ddl_slow_threshold
-		variable.TiDBAllowRemoveAutoInc,
 		variable.TiDBCheckMb4ValueInUTF8,
 		variable.TiDBConfig,
 		variable.TiDBEnableSlowLog,

--- a/util/sem/sem_test.go
+++ b/util/sem/sem_test.go
@@ -81,8 +81,8 @@ func TestIsInvisibleSysVar(t *testing.T) {
 
 	assert.False(IsInvisibleSysVar(variable.Hostname))                   // changes the value to default, but is not invisible
 	assert.False(IsInvisibleSysVar(variable.TiDBEnableEnhancedSecurity)) // should be able to see the mode is on.
+	assert.False(IsInvisibleSysVar(variable.TiDBAllowRemoveAutoInc))
 
-	assert.True(IsInvisibleSysVar(variable.TiDBAllowRemoveAutoInc))
 	assert.True(IsInvisibleSysVar(variable.TiDBCheckMb4ValueInUTF8))
 	assert.True(IsInvisibleSysVar(variable.TiDBConfig))
 	assert.True(IsInvisibleSysVar(variable.TiDBEnableSlowLog))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #38238

Problem Summary:

When SEM is ON, we want to modify `tidb_allow_remove_auto_inc` without  the `RESTRICTED_VARIABLES_ADMIN` privilege.

### What is changed and how it works?

Make `tidb_allow_remove_auto_inc` visible and modifiable when SEM is ON.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test (existent cases)
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
> Setting `[security].enable-sem = true` in `config.toml` to enable SEM, and modify `tidb_allow_remove_auto_inc` successfully.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
