### PR TITLE
server: return error for new statement after opening cursor

### DIFF
--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -1042,6 +1042,7 @@ const (
 	ErrSetTTLEnableForNonTTLTable          = 8150
 	ErrTempTableNotAllowedWithTTL          = 8151
 	ErrUnsupportedTTLReferencedByFK        = 8152
+	ErrNotAllowedWithActiveCursor          = 8153
 
 	// Error codes used by TiDB ddl package
 	ErrUnsupportedDDLOperation            = 8200

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -923,6 +923,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrInvalidRequiresSingleReference:                        mysql.Message("In recursive query block of Recursive Common Table Expression '%s', the recursive table must be referenced only once, and not in any subquery", nil),
 	ErrCTEMaxRecursionDepth:                                  mysql.Message("Recursive query aborted after %d iterations. Try increasing @@cte_max_recursion_depth to a larger value", nil),
 	ErrTableWithoutPrimaryKey:                                mysql.Message("Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set. Add a primary key to the table or unset this variable to avoid this message. Note that tables without a primary key can cause performance problems in row-based replication, so please consult your DBA before changing this setting.", nil),
+	ErrNotAllowedWithActiveCursor:                            mysql.Message("Commands other than CLOSE and FETCH are not allowed with active cursor", nil),
 	// MariaDB errors.
 	ErrOnlyOneDefaultPartionAllowed:         mysql.Message("Only one DEFAULT partition allowed", nil),
 	ErrWrongPartitionTypeExpectedSystemTime: mysql.Message("Wrong partitioning type, expected type: `SYSTEM_TIME`", nil),

--- a/server/server.go
+++ b/server/server.go
@@ -98,19 +98,20 @@ func init() {
 }
 
 var (
-	errUnknownFieldType        = dbterror.ClassServer.NewStd(errno.ErrUnknownFieldType)
-	errInvalidSequence         = dbterror.ClassServer.NewStd(errno.ErrInvalidSequence)
-	errInvalidType             = dbterror.ClassServer.NewStd(errno.ErrInvalidType)
-	errNotAllowedCommand       = dbterror.ClassServer.NewStd(errno.ErrNotAllowedCommand)
-	errAccessDenied            = dbterror.ClassServer.NewStd(errno.ErrAccessDenied)
-	errAccessDeniedNoPassword  = dbterror.ClassServer.NewStd(errno.ErrAccessDeniedNoPassword)
-	errConCount                = dbterror.ClassServer.NewStd(errno.ErrConCount)
-	errSecureTransportRequired = dbterror.ClassServer.NewStd(errno.ErrSecureTransportRequired)
-	errMultiStatementDisabled  = dbterror.ClassServer.NewStd(errno.ErrMultiStatementDisabled)
-	errNewAbortingConnection   = dbterror.ClassServer.NewStd(errno.ErrNewAbortingConnection)
-	errNotSupportedAuthMode    = dbterror.ClassServer.NewStd(errno.ErrNotSupportedAuthMode)
-	errNetPacketTooLarge       = dbterror.ClassServer.NewStd(errno.ErrNetPacketTooLarge)
-	errMustChangePassword      = dbterror.ClassServer.NewStd(errno.ErrMustChangePassword)
+	errUnknownFieldType           = dbterror.ClassServer.NewStd(errno.ErrUnknownFieldType)
+	errInvalidSequence            = dbterror.ClassServer.NewStd(errno.ErrInvalidSequence)
+	errInvalidType                = dbterror.ClassServer.NewStd(errno.ErrInvalidType)
+	errNotAllowedCommand          = dbterror.ClassServer.NewStd(errno.ErrNotAllowedCommand)
+	errAccessDenied               = dbterror.ClassServer.NewStd(errno.ErrAccessDenied)
+	errAccessDeniedNoPassword     = dbterror.ClassServer.NewStd(errno.ErrAccessDeniedNoPassword)
+	errConCount                   = dbterror.ClassServer.NewStd(errno.ErrConCount)
+	errSecureTransportRequired    = dbterror.ClassServer.NewStd(errno.ErrSecureTransportRequired)
+	errMultiStatementDisabled     = dbterror.ClassServer.NewStd(errno.ErrMultiStatementDisabled)
+	errNewAbortingConnection      = dbterror.ClassServer.NewStd(errno.ErrNewAbortingConnection)
+	errNotSupportedAuthMode       = dbterror.ClassServer.NewStd(errno.ErrNotSupportedAuthMode)
+	errNetPacketTooLarge          = dbterror.ClassServer.NewStd(errno.ErrNetPacketTooLarge)
+	errMustChangePassword         = dbterror.ClassServer.NewStd(errno.ErrMustChangePassword)
+	errNotAllowedWithActiveCursor = dbterror.ClassServer.NewStd(errno.ErrNotAllowedWithActiveCursor)
 )
 
 // DefaultCapability is the capability of the server when it is created using the default configuration.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1339,6 +1339,9 @@ type SessionVars struct {
 
 	// ProtectedTSList holds a list of timestamps that should delay GC.
 	ProtectedTSList protectedTSList
+
+	// ActiveCursorStmtID indicates the stmtID of the active cursor. If it's 0, there is no active cursor
+	ActiveCursorStmtID int
 }
 
 // planReplayerSessionFinishedTaskKeyLen is used to control the max size for the finished plan replayer task key in session


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #40094, close #39148, close #38116

Problem Summary:

Run statement after opening a cursor will make the sate (session variable, etc) hard to predict. The current implementation of cursor fetch in TiDB doesn't allow creating multiple cursor at the same time. 

### What is changed and how it works?

This PR add a check to return error when the command other than fetching/closing the active cursor arrives. The user will have to close the existing statement before running another commands.

The user forgot to close the statement may fail to run existing program ()

### Check List

Tests

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

If the user forgot to close the statement explicitly before running other queries, the program will not continue to work with this patch. However, the former behavior is both unsafe (can cause panic in TiDB) and unpredictable (can read unpredictable data).

### Release note

```release-note
Previously, executing queries after opening an cursor will cause unpredictable behavior when reading the cursor. From now on, TiDB will not allow executing queries other than fetch and close after opening an cursor.
```
