### PR TITLE
restore: 6.5 fix prealloc

### DIFF
--- a/br/pkg/restore/db.go
+++ b/br/pkg/restore/db.go
@@ -285,6 +285,14 @@ func (db *DB) tableIDAllocFilter() ddl.AllocTableIDIf {
 			return true
 		}
 		prealloced := db.preallocedIDs.Prealloced(ti.ID)
+		if ti.Partition != nil && ti.Partition.Definitions != nil {
+			for _, part := range ti.Partition.Definitions {
+				if !db.preallocedIDs.Prealloced(part.ID) {
+					prealloced = false
+					break
+				}
+			}
+		}
 		if prealloced {
 			log.Info("reusing table ID", zap.Stringer("table", ti.Name))
 		}

--- a/br/pkg/restore/db.go
+++ b/br/pkg/restore/db.go
@@ -284,15 +284,7 @@ func (db *DB) tableIDAllocFilter() ddl.AllocTableIDIf {
 		if db.preallocedIDs == nil {
 			return true
 		}
-		prealloced := db.preallocedIDs.Prealloced(ti.ID)
-		if ti.Partition != nil && ti.Partition.Definitions != nil {
-			for _, part := range ti.Partition.Definitions {
-				if !db.preallocedIDs.Prealloced(part.ID) {
-					prealloced = false
-					break
-				}
-			}
-		}
+		prealloced := db.preallocedIDs.PreallocedFor(ti)
 		if prealloced {
 			log.Info("reusing table ID", zap.Stringer("table", ti.Name))
 		}

--- a/br/pkg/restore/prealloc_table_id/BUILD.bazel
+++ b/br/pkg/restore/prealloc_table_id/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["alloc.go"],
     importpath = "github.com/pingcap/tidb/br/pkg/restore/prealloc_table_id",
     visibility = ["//visibility:public"],
-    deps = ["//br/pkg/metautil"],
+    deps = [
+        "//br/pkg/metautil",
+        "//parser/model",
+    ],
 )
 
 go_test(

--- a/br/pkg/restore/prealloc_table_id/alloc.go
+++ b/br/pkg/restore/prealloc_table_id/alloc.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/pingcap/tidb/br/pkg/metautil"
+	"github.com/pingcap/tidb/parser/model"
 )
 
 const (
@@ -93,4 +94,18 @@ func (p *PreallocIDs) Alloc(m Allocator) error {
 // Prealloced checks whether a table ID has been successfully allocated.
 func (p *PreallocIDs) Prealloced(tid int64) bool {
 	return p.allocedFrom <= tid && tid < p.end
+}
+
+func (p *PreallocIDs) PreallocedFor(ti *model.TableInfo) bool {
+	if !p.Prealloced(ti.ID) {
+		return false
+	}
+	if ti.Partition != nil && ti.Partition.Definitions != nil {
+		for _, part := range ti.Partition.Definitions {
+			if !p.Prealloced(part.ID) {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/br/pkg/restore/prealloc_table_id/alloc.go
+++ b/br/pkg/restore/prealloc_table_id/alloc.go
@@ -48,6 +48,14 @@ func New(tables []*metautil.Table) *PreallocIDs {
 		if t.Info.ID > max && t.Info.ID < insaneTableIDThreshold {
 			max = t.Info.ID
 		}
+
+		if t.Info.Partition != nil && t.Info.Partition.Definitions != nil {
+			for _, part := range t.Info.Partition.Definitions {
+				if part.ID > max && part.ID < insaneTableIDThreshold {
+					max = part.ID
+				}
+			}
+		}
 	}
 	return &PreallocIDs{
 		end: max + 1,


### PR DESCRIPTION
cherry-picking #40176

===

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40177

Problem Summary:
We have ignored partition tables when preallocating table IDs. (!) This may lead to data corrupt once the table baked up with hugest table ID is partition table.

### What is changed and how it works?
Consider them.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed a bug that may cause restored cluster corrupted when using BR with partition tables.
```
