### PR TITLE
ttl: fix change status sql argument

### DIFF
--- a/ttl/ttlworker/BUILD.bazel
+++ b/ttl/ttlworker/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     name = "ttlworker_test",
     srcs = [
         "del_test.go",
+        "job_integration_test.go",
         "job_manager_integration_test.go",
         "job_manager_test.go",
         "job_test.go",

--- a/ttl/ttlworker/job.go
+++ b/ttl/ttlworker/job.go
@@ -47,7 +47,7 @@ const finishJobTemplate = `UPDATE mysql.tidb_ttl_table_status
 const updateJobStateTemplate = "UPDATE mysql.tidb_ttl_table_status SET current_job_state = %? WHERE table_id = %? AND current_job_id = %? AND current_job_owner_id = %?"
 
 func updateJobCurrentStatusSQL(tableID int64, oldStatus cache.JobStatus, newStatus cache.JobStatus, jobID string) (string, []interface{}) {
-	return updateJobCurrentStatusTemplate, []interface{}{newStatus, tableID, oldStatus, jobID}
+	return updateJobCurrentStatusTemplate, []interface{}{string(newStatus), tableID, string(oldStatus), jobID}
 }
 
 func finishJobSQL(tableID int64, finishTime time.Time, summary string, jobID string) (string, []interface{}) {

--- a/ttl/ttlworker/job_integration_test.go
+++ b/ttl/ttlworker/job_integration_test.go
@@ -1,0 +1,41 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttlworker_test
+
+import (
+	"context"
+	"testing"
+
+	dbsession "github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/ttl/cache"
+	"github.com/pingcap/tidb/ttl/session"
+	"github.com/pingcap/tidb/ttl/ttlworker"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeStatus(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	dbSession, err := dbsession.CreateSession4Test(store)
+	require.NoError(t, err)
+	se := session.NewSession(dbSession, dbSession, nil)
+
+	job := ttlworker.NewTTLJob(&cache.PhysicalTable{ID: 0}, "0", cache.JobStatusWaiting)
+	tk.MustExec("insert into mysql.tidb_ttl_table_status(table_id,current_job_id,current_job_status) VALUES(0, '0', 'waiting')")
+	require.NoError(t, job.ChangeStatus(context.Background(), se, cache.JobStatusRunning))
+	tk.MustQuery("select current_job_status from mysql.tidb_ttl_table_status").Check(testkit.Rows("running"))
+}

--- a/ttl/ttlworker/job_test.go
+++ b/ttl/ttlworker/job_test.go
@@ -15,11 +15,26 @@
 package ttlworker
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/ttl/cache"
+	"github.com/pingcap/tidb/ttl/session"
 	"github.com/stretchr/testify/assert"
 )
+
+func NewTTLJob(tbl *cache.PhysicalTable, id string, status cache.JobStatus) *ttlJob {
+	return &ttlJob{
+		tbl:    tbl,
+		id:     id,
+		status: status,
+	}
+}
+
+func (j *ttlJob) ChangeStatus(ctx context.Context, se session.Session, status cache.JobStatus) error {
+	return j.changeStatus(ctx, se, status)
+}
 
 func TestIterScanTask(t *testing.T) {
 	tbl := newMockTTLTbl(t, "t1")


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #40231 

The TTL always fails to update job status. It's actually not a big problem as ttl didn't depend on the status to schedule.

This problem is caused by a custom-defined type argument (even if the underlying type is a string) cannot be handled by the `escapeSQL`. The funny thing is that the initial 'waiting' is inlined in the SQL, so the job status could be 'waiting' :smiley: .

### What is changed and how it works?

Convert the argument to string

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Fix the issue that ttl job status will never be changed.
```
