### PR TITLE
planner: remove the unnecessary skip-plan-cache flag in StmtCtx

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1586,7 +1586,7 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 		} else {
 			return args
 		}
-	} else if ctx.GetSessionVars().StmtCtx.SkipPlanCache {
+	} else if !ctx.GetSessionVars().StmtCtx.UseCache {
 		// We should remove the mutable constant for correctness, because its value may be changed.
 		RemoveMutableConst(ctx, args)
 	}

--- a/expression/util.go
+++ b/expression/util.go
@@ -1241,7 +1241,7 @@ func ContainCorrelatedColumn(exprs []Expression) bool {
 // TODO: Do more careful check here.
 func MaybeOverOptimized4PlanCache(ctx sessionctx.Context, exprs []Expression) bool {
 	// If we do not enable plan cache, all the optimization can work correctly.
-	if !ctx.GetSessionVars().StmtCtx.UseCache || ctx.GetSessionVars().StmtCtx.SkipPlanCache {
+	if !ctx.GetSessionVars().StmtCtx.UseCache {
 		return false
 	}
 	return containMutableConst(ctx, exprs)

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1567,7 +1567,7 @@ func (er *expressionRewriter) inToExpression(lLen int, not bool, tp *types.Field
 					} else {
 						continue
 					}
-				} else if er.sctx.GetSessionVars().StmtCtx.SkipPlanCache {
+				} else if !er.sctx.GetSessionVars().StmtCtx.UseCache {
 					// We should remove the mutable constant for correctness, because its value may be changed.
 					expression.RemoveMutableConst(er.sctx, []expression.Expression{c})
 				}

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -280,7 +280,7 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 	if containTableDual(p) && paramNum > 0 {
 		stmtCtx.SetSkipPlanCache(errors.New("skip plan-cache: get a TableDual plan"))
 	}
-	if stmtAst.UseCache && !ignorePlanCache {
+	if stmtCtx.UseCache && !ignorePlanCache {
 		// rebuild key to exclude kv.TiFlash when stmt is not read only
 		if _, isolationReadContainTiFlash := sessVars.IsolationReadEngines[kv.TiFlash]; isolationReadContainTiFlash && !IsReadOnly(stmtAst.Stmt, sessVars) {
 			delete(sessVars.IsolationReadEngines, kv.TiFlash)

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -280,7 +280,7 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 	if containTableDual(p) && paramNum > 0 {
 		stmtCtx.SetSkipPlanCache(errors.New("skip plan-cache: get a TableDual plan"))
 	}
-	if stmtAst.UseCache && !stmtCtx.SkipPlanCache && !ignorePlanCache {
+	if stmtAst.UseCache && !ignorePlanCache {
 		// rebuild key to exclude kv.TiFlash when stmt is not read only
 		if _, isolationReadContainTiFlash := sessVars.IsolationReadEngines[kv.TiFlash]; isolationReadContainTiFlash && !IsReadOnly(stmtAst.Stmt, sessVars) {
 			delete(sessVars.IsolationReadEngines, kv.TiFlash)
@@ -640,7 +640,7 @@ func CheckPreparedPriv(sctx sessionctx.Context, stmt *PlanCacheStmt, is infosche
 // short paths for these executions, currently "point select" and "point update"
 func tryCachePointPlan(_ context.Context, sctx sessionctx.Context,
 	stmt *PlanCacheStmt, _ infoschema.InfoSchema, p Plan) error {
-	if !sctx.GetSessionVars().StmtCtx.UseCache || sctx.GetSessionVars().StmtCtx.SkipPlanCache {
+	if !sctx.GetSessionVars().StmtCtx.UseCache {
 		return nil
 	}
 	var (

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -172,7 +172,6 @@ type StatementContext struct {
 	InNullRejectCheck             bool
 	AllowInvalidDate              bool
 	IgnoreNoPartition             bool
-	SkipPlanCache                 bool
 	IgnoreExplainIDSuffix         bool
 	SkipUTF8Check                 bool
 	SkipASCIICheck                bool
@@ -611,10 +610,10 @@ func (sc *StatementContext) SetPlanHint(hint string) {
 
 // SetSkipPlanCache sets to skip the plan cache and records the reason.
 func (sc *StatementContext) SetSkipPlanCache(reason error) {
-	if sc.UseCache && sc.SkipPlanCache {
+	if !sc.UseCache {
 		return // avoid unnecessary warnings
 	}
-	sc.SkipPlanCache = true
+	sc.UseCache = false
 	sc.AppendWarning(reason)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary: planner: remove the unnecessary skip-plan-cache flag in StmtCtx

### What is changed and how it works?

planner: remove the unnecessary skip-plan-cache flag in StmtCtx

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
