### PR TITLE
server, tidb-server: kill auto analyze when gracefully shutting down

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -790,6 +790,17 @@ func killConn(conn *clientConn) {
 	}
 }
 
+// KillSysProcesses kill sys processes such as auto analyze.
+func (s *Server) KillSysProcesses() {
+	if s.dom == nil {
+		return
+	}
+	sysProcTracker := s.dom.SysProcTracker()
+	for connID := range sysProcTracker.GetSysProcessList() {
+		sysProcTracker.KillSysProcess(connID)
+	}
+}
+
 // KillAllConnections kills all connections when server is not gracefully shutdown.
 func (s *Server) KillAllConnections() {
 	logutil.BgLogger().Info("[server] kill all connections.")
@@ -804,12 +815,7 @@ func (s *Server) KillAllConnections() {
 		killConn(conn)
 	}
 
-	if s.dom != nil {
-		sysProcTracker := s.dom.SysProcTracker()
-		for connID := range sysProcTracker.GetSysProcessList() {
-			sysProcTracker.KillSysProcess(connID)
-		}
-	}
+	s.KillSysProcesses()
 }
 
 var gracefulCloseConnectionsTimeout = 15 * time.Second

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -828,6 +828,9 @@ func cleanup(svr *server.Server, storage kv.Storage, dom *domain.Domain, gracefu
 	if graceful {
 		done := make(chan struct{})
 		svr.GracefulDown(context.Background(), done)
+		// Kill sys processes such as auto analyze. Otherwise, tidb-server cannot exit until auto analyze is finished.
+		// See https://github.com/pingcap/tidb/issues/40038 for details.
+		svr.KillSysProcesses()
 	} else {
 		svr.TryGracefulDown()
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40038

Problem Summary:
When tidb-server recives SIGTERM, it doesn't exit until auto analyze is finished.

### What is changed and how it works?

When tidb-server is gracefully shutting down, kill sys processes(including auto analyze). In this way, it can exit quickly.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Set up a cluster and import tpcc data. When finding one tidb-server starts to auto analyze a large table(such as `order_line` or `stock`), kill the tidb-server. Before the PR, the tidb-server would not exit until auto analyze is finished. After the PR, auto analyze would be killed and the tidb-server can exit quickly.

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
