### PR TITLE
util: use go-deadlock to find deadlock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ bazel_test: failpoint-enable bazel_ci_prepare
 
 bazel_coverage_test: failpoint-enable bazel_ci_prepare
 	bazel $(BAZEL_GLOBAL_CONFIG) coverage $(BAZEL_CMD_CONFIG) \
-		--build_event_json_file=bazel_1.json --@io_bazel_rules_go//go/config:cover_format=go_cover \
+		--build_event_json_file=bazel_1.json --@io_bazel_rules_go//go/config:cover_format=go_cover --define gotags=deadlock \
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//br/pkg/task:task_test -//tests/realtikvtest/...
 

--- a/domain/BUILD.bazel
+++ b/domain/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "//util/replayer",
         "//util/servermemorylimit",
         "//util/sqlexec",
+        "//util/syncutil",
         "@com_github_burntsushi_toml//:toml",
         "@com_github_ngaut_pools//:pools",
         "@com_github_pingcap_errors//:errors",

--- a/domain/sysvar_cache.go
+++ b/domain/sysvar_cache.go
@@ -17,13 +17,13 @@ package domain
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/sqlexec"
+	"github.com/pingcap/tidb/util/syncutil"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
 )
@@ -36,10 +36,10 @@ import (
 
 // sysVarCache represents the cache of system variables broken up into session and global scope.
 type sysVarCache struct {
-	sync.RWMutex // protects global and session maps
-	global       map[string]string
-	session      map[string]string
-	rebuildLock  sync.Mutex // protects concurrent rebuild
+	syncutil.RWMutex // protects global and session maps
+	global           map[string]string
+	session          map[string]string
+	rebuildLock      syncutil.Mutex // protects concurrent rebuild
 }
 
 func (do *Domain) rebuildSysVarCacheIfNeeded() (err error) {

--- a/executor/autoidtest/BUILD.bazel
+++ b/executor/autoidtest/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
+    shard_count = 5,
     deps = [
         "//autoid_service",
         "//config",

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.39.0
 	github.com/prometheus/prometheus v0.0.0-20190525122359-d20e84d0fb64
+	github.com/sasha-s/go-deadlock v0.0.0-20161201235124-341000892f3d
 	github.com/shirou/gopsutil/v3 v3.22.9
 	github.com/shurcooL/httpgzip v0.0.0-20190720172056-320755c1c1b0
 	github.com/soheilhy/cmux v0.1.5
@@ -203,6 +204,7 @@ require (
 	github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/petermattis/goid v0.0.0-20170504144140-0ded85884ba5 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712 // indirect
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 // indirect

--- a/go.sum
+++ b/go.sum
@@ -755,6 +755,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea/go.mod h1:1VcHEd3ro4QMoHfiNl/j7Jkln9+KQuorp0PItHMJYNg=
+github.com/petermattis/goid v0.0.0-20170504144140-0ded85884ba5 h1:rUMC+oZ89Om6l9wvUNjzI0ZrKrSnXzV+opsgAohYUNc=
 github.com/petermattis/goid v0.0.0-20170504144140-0ded85884ba5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
@@ -861,6 +862,7 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20161028232340-1d7be4effb13/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+github.com/sasha-s/go-deadlock v0.0.0-20161201235124-341000892f3d h1:yVBZEAirqhDYAc7xftf/swe8eHcg63jqfwdqN8KSoR8=
 github.com/sasha-s/go-deadlock v0.0.0-20161201235124-341000892f3d/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -198,6 +198,7 @@ go_test(
         "//util/resourcegrouptag",
         "//util/rowcodec",
         "//util/sqlexec",
+        "//util/syncutil",
         "//util/topsql",
         "//util/topsql/collector",
         "//util/topsql/collector/mock",

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -84,7 +84,6 @@ go_library(
         "//util/printer",
         "//util/replayer",
         "//util/sqlexec",
-        "//util/syncutil",
         "//util/sys/linux",
         "//util/timeutil",
         "//util/tls",

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -84,6 +84,7 @@ go_library(
         "//util/printer",
         "//util/replayer",
         "//util/sqlexec",
+        "//util/syncutil",
         "//util/sys/linux",
         "//util/timeutil",
         "//util/tls",

--- a/server/server.go
+++ b/server/server.go
@@ -69,6 +69,7 @@ import (
 	"github.com/pingcap/tidb/util/dbterror"
 	"github.com/pingcap/tidb/util/fastrand"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/syncutil"
 	"github.com/pingcap/tidb/util/sys/linux"
 	"github.com/pingcap/tidb/util/timeutil"
 	"go.uber.org/zap"
@@ -128,7 +129,7 @@ type Server struct {
 	driver            IDriver
 	listener          net.Listener
 	socket            net.Listener
-	rwlock            sync.RWMutex
+	rwlock            syncutil.RWMutex
 	concurrentLimiter *TokenLimiter
 	clients           map[uint64]*clientConn
 	capability        uint32

--- a/server/server.go
+++ b/server/server.go
@@ -69,7 +69,6 @@ import (
 	"github.com/pingcap/tidb/util/dbterror"
 	"github.com/pingcap/tidb/util/fastrand"
 	"github.com/pingcap/tidb/util/logutil"
-	"github.com/pingcap/tidb/util/syncutil"
 	"github.com/pingcap/tidb/util/sys/linux"
 	"github.com/pingcap/tidb/util/timeutil"
 	"go.uber.org/zap"
@@ -129,7 +128,7 @@ type Server struct {
 	driver            IDriver
 	listener          net.Listener
 	socket            net.Listener
-	rwlock            syncutil.RWMutex
+	rwlock            sync.RWMutex
 	concurrentLimiter *TokenLimiter
 	clients           map[uint64]*clientConn
 	capability        uint32

--- a/server/tidb_library_test.go
+++ b/server/tidb_library_test.go
@@ -49,7 +49,7 @@ func TestMemoryLeak(t *testing.T) {
 	runtime.ReadMemStats(&memStat)
 	// before the fix, initAndCloseTiDB for 20 times will cost 900 MB memory, so we test for a quite loose upper bound.
 	if syncutil.EnableDeadlock {
-		require.Less(t, memStat.HeapInuse-oldHeapInUse, uint64(units.GiB))
+		require.Less(t, memStat.HeapInuse-oldHeapInUse, uint64(1027*units.MiB))
 	} else {
 		require.Less(t, memStat.HeapInuse-oldHeapInUse, uint64(300*units.MiB))
 	}

--- a/server/tidb_library_test.go
+++ b/server/tidb_library_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/util/syncutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,5 +48,9 @@ func TestMemoryLeak(t *testing.T) {
 	runtime.GC()
 	runtime.ReadMemStats(&memStat)
 	// before the fix, initAndCloseTiDB for 20 times will cost 900 MB memory, so we test for a quite loose upper bound.
-	require.Less(t, memStat.HeapInuse-oldHeapInUse, uint64(300*units.MiB))
+	if syncutil.EnableDeadlock {
+		require.Less(t, memStat.HeapInuse-oldHeapInUse, uint64(units.GiB))
+	} else {
+		require.Less(t, memStat.HeapInuse-oldHeapInUse, uint64(300*units.MiB))
+	}
 }

--- a/server/tidb_library_test.go
+++ b/server/tidb_library_test.go
@@ -49,7 +49,7 @@ func TestMemoryLeak(t *testing.T) {
 	runtime.ReadMemStats(&memStat)
 	// before the fix, initAndCloseTiDB for 20 times will cost 900 MB memory, so we test for a quite loose upper bound.
 	if syncutil.EnableDeadlock {
-		require.Less(t, memStat.HeapInuse-oldHeapInUse, uint64(1027*units.MiB))
+		require.Less(t, memStat.HeapInuse-oldHeapInUse, uint64(1100*units.MiB))
 	} else {
 		require.Less(t, memStat.HeapInuse-oldHeapInUse, uint64(300*units.MiB))
 	}

--- a/session/BUILD.bazel
+++ b/session/BUILD.bazel
@@ -83,6 +83,7 @@ go_library(
         "//util/sem",
         "//util/sli",
         "//util/sqlexec",
+        "//util/syncutil",
         "//util/tableutil",
         "//util/timeutil",
         "//util/topsql",

--- a/session/session.go
+++ b/session/session.go
@@ -99,6 +99,7 @@ import (
 	"github.com/pingcap/tidb/util/sem"
 	"github.com/pingcap/tidb/util/sli"
 	"github.com/pingcap/tidb/util/sqlexec"
+	"github.com/pingcap/tidb/util/syncutil"
 	"github.com/pingcap/tidb/util/tableutil"
 	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tidb/util/topsql"
@@ -274,7 +275,7 @@ type session struct {
 	idxUsageCollector *handle.SessionIndexUsageCollector
 
 	functionUsageMu struct {
-		sync.RWMutex
+		syncutil.RWMutex
 		builtinFunctionUsage telemetry.BuiltinFunctionsUsage
 	}
 	// allowed when tikv disk full happened.

--- a/util/syncutil/BUILD.bazel
+++ b/util/syncutil/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "syncutil",
+    srcs = [
+        "mutex_deadlock.go",
+        "mutex_sync.go",
+    ],
+    importpath = "github.com/pingcap/tidb/util/syncutil",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_sasha_s_go_deadlock//:go-deadlock"],
+)

--- a/util/syncutil/mutex_deadlock.go
+++ b/util/syncutil/mutex_deadlock.go
@@ -1,4 +1,4 @@
-// Copyright 2022 PingCAP, Inc.
+// Copyright 2023 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/util/syncutil/mutex_deadlock.go
+++ b/util/syncutil/mutex_deadlock.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	deadlock.Opts.DeadlockTimeout = 5 * time.Minute
+	deadlock.Opts.DeadlockTimeout = 20 * time.Second
 }
 
 // A Mutex is a mutual exclusion lock.

--- a/util/syncutil/mutex_deadlock.go
+++ b/util/syncutil/mutex_deadlock.go
@@ -22,6 +22,9 @@ import (
 	deadlock "github.com/sasha-s/go-deadlock"
 )
 
+// EnableDeadlock is a flag to enable deadlock detection.
+const EnableDeadlock = true
+
 func init() {
 	deadlock.Opts.DeadlockTimeout = 20 * time.Second
 }

--- a/util/syncutil/mutex_deadlock.go
+++ b/util/syncutil/mutex_deadlock.go
@@ -1,0 +1,41 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build deadlock
+
+package syncutil
+
+import (
+	"time"
+
+	deadlock "github.com/sasha-s/go-deadlock"
+)
+
+func init() {
+	deadlock.Opts.DeadlockTimeout = 5 * time.Minute
+}
+
+// A Mutex is a mutual exclusion lock.
+type Mutex struct {
+	deadlock.Mutex
+}
+
+// AssertHeld is a no-op for deadlock mutexes.
+func (m *Mutex) AssertHeld() {
+}
+
+// An RWMutex is a reader/writer mutual exclusion lock.
+type RWMutex struct {
+	deadlock.RWMutex
+}

--- a/util/syncutil/mutex_deadlock.go
+++ b/util/syncutil/mutex_deadlock.go
@@ -31,10 +31,6 @@ type Mutex struct {
 	deadlock.Mutex
 }
 
-// AssertHeld is a no-op for deadlock mutexes.
-func (m *Mutex) AssertHeld() {
-}
-
 // An RWMutex is a reader/writer mutual exclusion lock.
 type RWMutex struct {
 	deadlock.RWMutex

--- a/util/syncutil/mutex_sync.go
+++ b/util/syncutil/mutex_sync.go
@@ -1,4 +1,4 @@
-// Copyright 2022 PingCAP, Inc.
+// Copyright 2023 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/util/syncutil/mutex_sync.go
+++ b/util/syncutil/mutex_sync.go
@@ -23,17 +23,6 @@ type Mutex struct {
 	sync.Mutex
 }
 
-// AssertHeld may panic if the mutex is not locked (but it is not required to
-// do so). Functions which require that their callers hold a particular lock
-// may use this to enforce this requirement more directly than relying on the
-// race detector.
-//
-// Note that we do not require the lock to be held by any particular thread,
-// just that some thread holds the lock. This is both more efficient and allows
-// for rare cases where a mutex is locked in one thread and used in another.
-func (m *Mutex) AssertHeld() {
-}
-
 // An RWMutex is a reader/writer mutual exclusion lock.
 type RWMutex struct {
 	sync.RWMutex

--- a/util/syncutil/mutex_sync.go
+++ b/util/syncutil/mutex_sync.go
@@ -1,0 +1,40 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !deadlock
+
+package syncutil
+
+import "sync"
+
+// A Mutex is a mutual exclusion lock.
+type Mutex struct {
+	sync.Mutex
+}
+
+// AssertHeld may panic if the mutex is not locked (but it is not required to
+// do so). Functions which require that their callers hold a particular lock
+// may use this to enforce this requirement more directly than relying on the
+// race detector.
+//
+// Note that we do not require the lock to be held by any particular thread,
+// just that some thread holds the lock. This is both more efficient and allows
+// for rare cases where a mutex is locked in one thread and used in another.
+func (m *Mutex) AssertHeld() {
+}
+
+// An RWMutex is a reader/writer mutual exclusion lock.
+type RWMutex struct {
+	sync.RWMutex
+}

--- a/util/syncutil/mutex_sync.go
+++ b/util/syncutil/mutex_sync.go
@@ -18,6 +18,9 @@ package syncutil
 
 import "sync"
 
+// EnableDeadlock is a flag to enable deadlock detection.
+const EnableDeadlock = false
+
 // A Mutex is a mutual exclusion lock.
 type Mutex struct {
 	sync.Mutex


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40293

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

We can find this log in the CI. It has been fixed in the https://github.com/pingcap/tidb/issues/40240
```
POTENTIAL DEADLOCK:

Previous place where the lock was grabbed

goroutine 273418 lock 0xc005e863b0

domain/sysvar_cache.go:121 domain.(*Domain).rebuildSysVarCache ??? <<<<<

domain/sysvar_cache.go:51 domain.(*Domain).rebuildSysVarCacheIfNeeded ???

domain/sysvar_cache.go:75 domain.(*Domain).GetGlobalVar ???

domain/domain.go:1541 domain.(*Domain).globalBindHandleWorkerLoop.func1 ???


Have been trying to lock it again for more than 20s

goroutine 261135 lock 0xc005e863b0

domain/sysvar_cache.go:121 domain.(*Domain).rebuildSysVarCache ??? <<<<<

domain/domain.go:2199 domain.(*Domain).NotifyUpdateSysVarCache ???

session/session.go:1450 session.(*session).replaceGlobalVariablesTableValue ???

session/session.go:1528 session.(*session).SetGlobalSysVarOnly ???

sessionctx/variable/varsutil.go:536 variable.updatePasswordValidationLength ???

sessionctx/variable/sysvar.go:553 variable.glob..func109 ???

sessionctx/variable/variable.go:361 variable.(*SysVar).ValidateWithRelaxedValidation ???

domain/sysvar_cache.go:146 domain.(*Domain).rebuildSysVarCache ???

domain/sysvar_cache.go:51 domain.(*Domain).rebuildSysVarCacheIfNeeded ???

domain/sysvar_cache.go:62 domain.(*Domain).GetSessionCache ???

session/session.go:3651 session.(*session).loadCommonGlobalVariablesIfNeeded ???

session/session.go:2140 session.(*session).ExecuteStmt ???

session/session.go:1674 session.(*session).ExecuteInternal ???

domain/domain.go:1310 domain.(*Domain).LoadPrivilegeLoop ???

session/session.go:3329 session.BootstrapSession ???

testkit/mockstore.go:84 testkit.bootstrap ???

testkit/mockstore.go:69 testkit.CreateMockStoreAndDomain ???

testkit/mockstore.go:61 testkit.CreateMockStore ???

executor/union_scan_test.go:419 executor_test.TestIssue28073 ???
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
