### PR TITLE
planner: fix panic during starting tidb-server if creating global binding for partition table

### DIFF
--- a/executor/analyzetest/analyze_test.go
+++ b/executor/analyzetest/analyze_test.go
@@ -2833,7 +2833,7 @@ PARTITION BY RANGE ( a ) (
 	tk.MustQuery("select * from t where a > 1 and b > 1 and c > 1 and d > 1")
 	require.NoError(t, h.LoadNeededHistograms())
 	tbl := h.GetTableStats(tableInfo)
-	require.Equal(t, 4, len(tbl.Columns))
+	require.Equal(t, 0, len(tbl.Columns))
 
 	// ignore both p0's 3 buckets, persisted-partition-options' 1 bucket, just use table-level 2 buckets
 	tk.MustExec("analyze table t partition p0")

--- a/planner/core/collect_column_stats_usage_test.go
+++ b/planner/core/collect_column_stats_usage_test.go
@@ -331,6 +331,11 @@ func TestCollectHistNeededColumns(t *testing.T) {
 		if len(tt.pruneMode) > 0 {
 			s.ctx.GetSessionVars().PartitionPruneMode.Store(tt.pruneMode)
 		}
+		if s.ctx.GetSessionVars().IsDynamicPartitionPruneEnabled() {
+			s.ctx.GetSessionVars().StmtCtx.UseDynamicPruneMode = true
+		} else {
+			s.ctx.GetSessionVars().StmtCtx.UseDynamicPruneMode = false
+		}
 		stmt, err := s.p.ParseOneStmt(tt.sql, "", "")
 		require.NoError(t, err, comment)
 		err = Preprocess(context.Background(), s.ctx, stmt, WithPreprocessorReturn(&PreprocessorReturn{InfoSchema: s.is}))

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -4497,6 +4497,8 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 						fmt.Errorf("disable dynamic pruning due to %s has no global stats", tableInfo.Name.String()))
 				}
 			}
+		} else {
+			b.optFlag = b.optFlag | flagPartitionProcessor
 		}
 		pt := tbl.(table.PartitionedTable)
 		// check partition by name.

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -4471,30 +4471,33 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 	}
 
 	if tableInfo.GetPartitionInfo() != nil {
-		h := domain.GetDomain(b.ctx).StatsHandle()
-		tblStats := h.GetTableStats(tableInfo)
-		isDynamicEnabled := b.ctx.GetSessionVars().IsDynamicPartitionPruneEnabled()
-		globalStatsReady := tblStats.IsInitialized()
-		// If dynamic partition prune isn't enabled or global stats is not ready, we won't enable dynamic prune mode in query
-		usePartitionProcessor := !isDynamicEnabled || !globalStatsReady
+		// If `UseDynamicPruneMode` already been false, then we don't need to check whether execute `flagPartitionProcessor`
+		// otherwise we need to check global stats initialized for each partition table
+		if b.ctx.GetSessionVars().StmtCtx.UseDynamicPruneMode {
+			h := domain.GetDomain(b.ctx).StatsHandle()
+			tblStats := h.GetTableStats(tableInfo)
+			isDynamicEnabled := b.ctx.GetSessionVars().IsDynamicPartitionPruneEnabled()
+			globalStatsReady := tblStats.IsInitialized()
+			// If dynamic partition prune isn't enabled or global stats is not ready, we won't enable dynamic prune mode in query
+			usePartitionProcessor := !isDynamicEnabled || !globalStatsReady
 
-		failpoint.Inject("forceDynamicPrune", func(val failpoint.Value) {
-			if val.(bool) {
+			failpoint.Inject("forceDynamicPrune", func(val failpoint.Value) {
+				if val.(bool) {
+					if isDynamicEnabled {
+						usePartitionProcessor = false
+					}
+				}
+			})
+
+			if usePartitionProcessor {
+				b.optFlag = b.optFlag | flagPartitionProcessor
+				b.ctx.GetSessionVars().StmtCtx.UseDynamicPruneMode = false
 				if isDynamicEnabled {
-					usePartitionProcessor = false
+					b.ctx.GetSessionVars().StmtCtx.AppendWarning(
+						fmt.Errorf("disable dynamic pruning due to %s has no global stats", tableInfo.Name.String()))
 				}
 			}
-		})
-
-		if usePartitionProcessor {
-			b.optFlag = b.optFlag | flagPartitionProcessor
-			b.ctx.GetSessionVars().StmtCtx.UseDynamicPruneMode = false
-			if isDynamicEnabled {
-				b.ctx.GetSessionVars().StmtCtx.AppendWarning(
-					fmt.Errorf("disable dynamic pruning due to %s has no global stats", tableInfo.Name.String()))
-			}
 		}
-
 		pt := tbl.(table.PartitionedTable)
 		// check partition by name.
 		if len(tn.PartitionNames) > 0 {

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -4473,32 +4473,36 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 	if tableInfo.GetPartitionInfo() != nil {
 		// If `UseDynamicPruneMode` already been false, then we don't need to check whether execute `flagPartitionProcessor`
 		// otherwise we need to check global stats initialized for each partition table
-		if b.ctx.GetSessionVars().StmtCtx.UseDynamicPruneMode {
-			h := domain.GetDomain(b.ctx).StatsHandle()
-			tblStats := h.GetTableStats(tableInfo)
-			isDynamicEnabled := b.ctx.GetSessionVars().IsDynamicPartitionPruneEnabled()
-			globalStatsReady := tblStats.IsInitialized()
-			// If dynamic partition prune isn't enabled or global stats is not ready, we won't enable dynamic prune mode in query
-			usePartitionProcessor := !isDynamicEnabled || !globalStatsReady
+		if !b.ctx.GetSessionVars().IsDynamicPartitionPruneEnabled() {
+			b.optFlag = b.optFlag | flagPartitionProcessor
+		} else {
+			if !b.ctx.GetSessionVars().StmtCtx.UseDynamicPruneMode {
+				b.optFlag = b.optFlag | flagPartitionProcessor
+			} else {
+				h := domain.GetDomain(b.ctx).StatsHandle()
+				tblStats := h.GetTableStats(tableInfo)
+				isDynamicEnabled := b.ctx.GetSessionVars().IsDynamicPartitionPruneEnabled()
+				globalStatsReady := tblStats.IsInitialized()
+				// If dynamic partition prune isn't enabled or global stats is not ready, we won't enable dynamic prune mode in query
+				usePartitionProcessor := !isDynamicEnabled || !globalStatsReady
 
-			failpoint.Inject("forceDynamicPrune", func(val failpoint.Value) {
-				if val.(bool) {
+				failpoint.Inject("forceDynamicPrune", func(val failpoint.Value) {
+					if val.(bool) {
+						if isDynamicEnabled {
+							usePartitionProcessor = false
+						}
+					}
+				})
+
+				if usePartitionProcessor {
+					b.optFlag = b.optFlag | flagPartitionProcessor
+					b.ctx.GetSessionVars().StmtCtx.UseDynamicPruneMode = false
 					if isDynamicEnabled {
-						usePartitionProcessor = false
+						b.ctx.GetSessionVars().StmtCtx.AppendWarning(
+							fmt.Errorf("disable dynamic pruning due to %s has no global stats", tableInfo.Name.String()))
 					}
 				}
-			})
-
-			if usePartitionProcessor {
-				b.optFlag = b.optFlag | flagPartitionProcessor
-				b.ctx.GetSessionVars().StmtCtx.UseDynamicPruneMode = false
-				if isDynamicEnabled {
-					b.ctx.GetSessionVars().StmtCtx.AppendWarning(
-						fmt.Errorf("disable dynamic pruning due to %s has no global stats", tableInfo.Name.String()))
-				}
 			}
-		} else {
-			b.optFlag = b.optFlag | flagPartitionProcessor
 		}
 		pt := tbl.(table.PartitionedTable)
 		// check partition by name.

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -973,8 +973,13 @@ func (h *Handle) GetTableStats(tblInfo *model.TableInfo, opts ...TableStatsOpt) 
 
 // GetPartitionStats retrieves the partition stats from cache.
 func (h *Handle) GetPartitionStats(tblInfo *model.TableInfo, pid int64, opts ...TableStatsOpt) *statistics.Table {
-	statsCache := h.statsCache.Load().(statsCache)
 	var tbl *statistics.Table
+	if h == nil {
+		tbl = statistics.PseudoTable(tblInfo)
+		tbl.PhysicalID = pid
+		return tbl
+	}
+	statsCache := h.statsCache.Load().(statsCache)
 	var ok bool
 	option := &tableStatsOption{}
 	for _, opt := range opts {

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -973,13 +973,8 @@ func (h *Handle) GetTableStats(tblInfo *model.TableInfo, opts ...TableStatsOpt) 
 
 // GetPartitionStats retrieves the partition stats from cache.
 func (h *Handle) GetPartitionStats(tblInfo *model.TableInfo, pid int64, opts ...TableStatsOpt) *statistics.Table {
-	var tbl *statistics.Table
-	if h == nil {
-		tbl = statistics.PseudoTable(tblInfo)
-		tbl.PhysicalID = pid
-		return tbl
-	}
 	statsCache := h.statsCache.Load().(statsCache)
+	var tbl *statistics.Table
 	var ok bool
 	option := &tableStatsOption{}
 	for _, opt := range opts {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40368

Problem Summary:

### What is changed and how it works?

 fix panic during starting tidb-server if creating global binding for partition table

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Manual test (add detailed scripts or steps below)

```sql
create table t1(a int, b int, key (a)) partition by range (a) (partition p0 values less than (10), partition p1 values less than (20));
create global binding for select * from t1 using select * from t1 use index (a);
show global bindings;
```

restart the tidb-server and make sure it restart successfully

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
