### PR TITLE
statistics: skip calculating fmsketch when collecting statistics

### DIFF
--- a/statistics/builder.go
+++ b/statistics/builder.go
@@ -266,6 +266,7 @@ func BuildHistAndTopN(
 	}
 	count := collector.Count
 	ndv := collector.FMSketch.NDV()
+	ndv = count / 100
 	nullCount := collector.NullCount
 	if ndv > count {
 		ndv = count

--- a/statistics/row_sampler.go
+++ b/statistics/row_sampler.go
@@ -176,6 +176,9 @@ func (s *RowSampleBuilder) Collect() (RowSampleCollector, error) {
 		}
 		collector.Base().Count += int64(chk.NumRows())
 		for row := it.Begin(); row != it.End(); row = it.Next() {
+			if s.Rng.Float64() > s.SampleRate {
+				continue
+			}
 			datums := RowToDatums(row, s.RecordSet.Fields())
 			newCols := make([]types.Datum, len(datums))
 			// sizes are used to calculate the total size information. We calculate the sizes here because we need the
@@ -222,22 +225,22 @@ func (s *baseCollector) collectColumns(sc *stmtctx.StatementContext, cols []type
 		}
 		// Minus one is to remove the flag byte.
 		s.TotalSizes[i] += sizes[i] - 1
-		err := s.FMSketches[i].InsertValue(sc, col)
-		if err != nil {
-			return err
-		}
+		//err := s.FMSketches[i].InsertValue(sc, col)
+		//if err != nil {
+		//	return err
+		//}
 	}
 	return nil
 }
 
 func (s *baseCollector) collectColumnGroups(sc *stmtctx.StatementContext, cols []types.Datum, colGroups [][]int64, sizes []int64) error {
 	colLen := len(cols)
-	datumBuffer := make([]types.Datum, 0, len(cols))
+	//datumBuffer := make([]types.Datum, 0, len(cols))
 	for i, group := range colGroups {
-		datumBuffer = datumBuffer[:0]
+		//datumBuffer = datumBuffer[:0]
 		hasNull := true
 		for _, c := range group {
-			datumBuffer = append(datumBuffer, cols[c])
+			//datumBuffer = append(datumBuffer, cols[c])
 			hasNull = hasNull && cols[c].IsNull()
 			s.TotalSizes[colLen+i] += sizes[c] - 1
 		}
@@ -246,10 +249,10 @@ func (s *baseCollector) collectColumnGroups(sc *stmtctx.StatementContext, cols [
 			s.NullCount[colLen+i]++
 			continue
 		}
-		err := s.FMSketches[colLen+i].InsertRowValue(sc, datumBuffer)
-		if err != nil {
-			return err
-		}
+		//err := s.FMSketches[colLen+i].InsertRowValue(sc, datumBuffer)
+		//if err != nil {
+		//	return err
+		//}
 	}
 	return nil
 }
@@ -427,9 +430,9 @@ func NewBernoulliRowSampleCollector(sampleRate float64, totalLen int) *Bernoulli
 }
 
 func (s *BernoulliRowSampleCollector) sampleRow(row []types.Datum, rng *rand.Rand) {
-	if rng.Float64() > s.SampleRate {
-		return
-	}
+	//if rng.Float64() > s.SampleRate {
+	//	return
+	//}
 	s.baseCollector.Samples = append(s.baseCollector.Samples, &ReservoirRowSampleItem{
 		Columns: row,
 		Weight:  0,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

The PR is to test whether calculating fmsketch is the bottleneck of analyze.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
