### PR TITLE
nt-txn: support complex aliased join and concurrency runner |tidb-test=release-6.5

### DIFF
--- a/parser/ast/dml.go
+++ b/parser/ast/dml.go
@@ -2441,10 +2441,11 @@ var _ ShardableDMLStmt = &InsertStmt{}
 type NonTransactionalDMLStmt struct {
 	dmlNode
 
-	DryRun      int         // 0: no dry run, 1: dry run the query, 2: dry run split DMLs
-	ShardColumn *ColumnName // if it's nil, the handle column is automatically chosen for it
-	Limit       uint64
-	DMLStmt     ShardableDMLStmt
+	DryRun             int         // 0: no dry run, 1: dry run the query, 2: dry run split DMLs
+	ShardColumn        *ColumnName // if it's nil, the handle column is automatically chosen for it
+	Limit              uint64
+	DMLStmt            ShardableDMLStmt
+	TransferFromInsert bool
 }
 
 // Restore implements Node interface.

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -24,9 +24,11 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/extension"
+	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/charset"
+	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/planner/core"
@@ -244,7 +246,11 @@ func (tc *TiDBContext) ExecuteStmt(ctx context.Context, stmt ast.StmtNode) (Resu
 	if s, ok := stmt.(*ast.NonTransactionalDMLStmt); ok {
 		rs, err = session.HandleNonTransactionalDML(ctx, s, tc.Session)
 	} else {
-		rs, err = tc.Session.ExecuteStmt(ctx, stmt)
+		if shardedInsert := tc.tryETL(stmt); shardedInsert != nil {
+			rs, err = session.HandleNonTransactionalDML(ctx, shardedInsert, tc.Session)
+		} else {
+			rs, err = tc.Session.ExecuteStmt(ctx, stmt)
+		}
 	}
 	if err != nil {
 		tc.Session.GetSessionVars().StmtCtx.AppendError(err)
@@ -542,4 +548,243 @@ func convertColumnInfo(fld *ast.ResultField) (ci *ColumnInfo) {
 		ci.Type = mysql.TypeVarString
 	}
 	return
+}
+
+func (tc *TiDBContext) tryETL(stmt ast.StmtNode) *ast.NonTransactionalDMLStmt {
+	sessVars := tc.Session.GetSessionVars()
+	if sessVars.ETLConcurrency == 0 {
+		return nil
+	}
+	if !(sessVars.IsAutocommit() && !sessVars.InTxn()) {
+		return nil
+	}
+
+	var extractTbls func(parent *ast.SelectStmt, stmt ast.ResultSetNode, tbl2sel map[string]*ast.SelectStmt, sel2parent map[*ast.SelectStmt]*ast.SelectStmt, inJoin bool) []*ast.TableSource
+	extractTbls = func(parent *ast.SelectStmt, stmt ast.ResultSetNode, tbl2sel map[string]*ast.SelectStmt, sel2parent map[*ast.SelectStmt]*ast.SelectStmt, inJoin bool) []*ast.TableSource {
+		if stmt == nil {
+			return nil
+		}
+		tbls := make([]*ast.TableSource, 0)
+		switch v := stmt.(type) {
+		case *ast.Join:
+			lefts, rights := extractTbls(parent, v.Left, tbl2sel, sel2parent, true), extractTbls(parent, v.Right, tbl2sel, sel2parent, true)
+			tbls = append(tbls, lefts...)
+			tbls = append(tbls, rights...)
+		case *ast.TableSource:
+			switch x := v.Source.(type) {
+			case *ast.TableName:
+				tbls = append(tbls, v)
+			case *ast.SelectStmt:
+				if x.From == nil {
+					return tbls
+				}
+				if parent != nil {
+					sel2parent[x] = parent
+				}
+				if tblSource, ok := x.From.TableRefs.Left.(*ast.TableSource); ok && x.From.TableRefs.Right == nil {
+					if tblName, ok := tblSource.Source.(*ast.TableName); ok {
+						if inJoin {
+							tbls = append(tbls, tblSource)
+							tbl2sel[tblName.Name.L] = x
+						}
+						return tbls
+					}
+				}
+				subTbls := extractTbls(x, x.From.TableRefs, tbl2sel, sel2parent, false)
+				tbls = append(tbls, subTbls...)
+			}
+		}
+		return tbls
+	}
+
+	findSchema := func(lower string) *model.DBInfo {
+		is := tc.Session.GetDomainInfoSchema().(infoschema.InfoSchema)
+		currDB, ok := is.SchemaByName(model.NewCIStr(sessVars.CurrentDB))
+		if ok {
+			for _, t := range currDB.Tables {
+				if t.Name.L == lower {
+					return currDB
+				}
+			}
+		}
+		schemas := is.AllSchemas()
+		for _, s := range schemas {
+			if currDB != nil {
+				if s.Name.L == currDB.Name.L {
+					continue
+				}
+			}
+			for _, t := range s.Tables {
+				if t.Name.L == lower {
+					return s
+				}
+			}
+		}
+		return nil
+	}
+
+	insert, ok := stmt.(*ast.InsertStmt)
+	if !ok {
+		return nil
+	}
+	if insert.Table == nil || insert.Table.TableRefs == nil || insert.Table.TableRefs.Left == nil {
+		return nil
+	}
+	insertTable, ok := insert.Table.TableRefs.Left.(*ast.TableSource)
+	if !ok {
+		return nil
+	}
+	insertTableName, ok := insertTable.Source.(*ast.TableName)
+	if !ok {
+		return nil
+	}
+	if insert.Select == nil {
+		return nil
+	}
+	selectStmt, ok := insert.Select.(*ast.SelectStmt)
+	if !ok {
+		return nil
+	}
+	if selectStmt.From == nil || selectStmt.From.TableRefs == nil {
+		return nil
+	}
+	tbl2sel := make(map[string]*ast.SelectStmt)
+	sel2parent := make(map[*ast.SelectStmt]*ast.SelectStmt)
+	tbls := extractTbls(nil, selectStmt.From.TableRefs, tbl2sel, sel2parent, false)
+	if len(tbls) == 0 {
+		return nil
+	}
+
+	// do not apply nt-txn to self-insert.
+	for _, tbl := range tbls {
+		tblName, ok := tbl.Source.(*ast.TableName)
+		if !ok {
+			continue
+		}
+		if tblName.Name.L == insertTableName.Name.L {
+			return nil
+		}
+	}
+	var (
+		leftMostTbl *ast.TableSource
+		finalTbl    *ast.TableSource
+	)
+	for _, tbl := range tbls {
+		tblName, ok := tbl.Source.(*ast.TableName)
+		if !ok {
+			continue
+		}
+		if leftMostTbl == nil {
+			leftMostTbl = tbl
+		}
+		if finalTbl == nil {
+			sel, ok := tbl2sel[tblName.Name.L]
+			if ok {
+				_, ok = sel2parent[sel]
+				if !ok {
+					finalTbl = tbl
+				}
+			}
+		}
+	}
+	if finalTbl == nil {
+		finalTbl = leftMostTbl
+	}
+	schema := findSchema(finalTbl.Source.(*ast.TableName).Name.L)
+	if schema == nil {
+		return nil
+	}
+
+	ntStmt := new(ast.NonTransactionalDMLStmt)
+	ntStmt.TransferFromInsert = true
+	ntStmt.DMLStmt = insert
+	if sessVars.ETLBatchSize > 0 {
+		ntStmt.Limit = uint64(sessVars.ETLBatchSize)
+	} else {
+		ntStmt.Limit = 1000
+	}
+
+	var colName model.CIStr
+	var tableInfo *model.TableInfo
+	for _, t := range schema.Tables {
+		if t.Name.L == finalTbl.Source.(*ast.TableName).Name.L {
+			tableInfo = t
+			break
+		}
+	}
+	if tableInfo == nil {
+		return nil
+	}
+	if tableInfo.GetPrimaryKey() != nil {
+		colName = model.NewCIStr(tableInfo.GetPrimaryKey().Columns[0].Name.L)
+	} else {
+		colName = model.NewCIStr("_tidb_rowid")
+		sel, ok := tbl2sel[finalTbl.Source.(*ast.TableName).Name.L]
+		if !ok {
+			return nil
+		}
+		var table model.CIStr
+		if finalTbl.AsName.L != "" {
+			table = model.NewCIStr(finalTbl.AsName.L)
+		} else {
+			table = model.NewCIStr(finalTbl.Source.(*ast.TableName).Name.L)
+		}
+		rowidField := &ast.SelectField{
+			Expr: &ast.ColumnNameExpr{
+				Name: &ast.ColumnName{
+					Table: table,
+					Name:  colName,
+				},
+			},
+		}
+		sel.Fields.Fields = append(sel.Fields.Fields, rowidField)
+
+		sel, ok = sel2parent[sel]
+		if ok {
+			// expose _tidb_rowid to upper selects.
+			for {
+				parent, ok := sel2parent[sel]
+				if !ok {
+					break
+				}
+				tblSource, ok := sel.From.TableRefs.Left.(*ast.TableSource)
+				if !ok {
+					break
+				}
+				var rowidField *ast.SelectField
+				if tblSource.AsName.L != "" {
+					rowidField = &ast.SelectField{
+						Expr: &ast.ColumnNameExpr{
+							Name: &ast.ColumnName{
+								Table: model.NewCIStr(tblSource.AsName.L),
+								Name:  model.NewCIStr("_tidb_rowid"),
+							},
+						},
+					}
+				} else {
+					tblName, ok := tblSource.Source.(*ast.TableName)
+					if !ok {
+						break
+					}
+					rowidField = &ast.SelectField{
+						Expr: &ast.ColumnNameExpr{
+							Name: &ast.ColumnName{
+								Table: model.NewCIStr(tblName.Name.L),
+								Name:  model.NewCIStr("_tidb_rowid"),
+							},
+						},
+					}
+				}
+				sel.Fields.Fields = append(sel.Fields.Fields, rowidField)
+				sel = parent
+			}
+		}
+	}
+
+	ntStmt.ShardColumn = &ast.ColumnName{
+		Schema: schema.Name,
+		Table:  finalTbl.Source.(*ast.TableName).Name,
+		Name:   colName,
+	}
+	return ntStmt
 }

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -552,6 +552,9 @@ func convertColumnInfo(fld *ast.ResultField) (ci *ColumnInfo) {
 
 func (tc *TiDBContext) tryETL(stmt ast.StmtNode) *ast.NonTransactionalDMLStmt {
 	sessVars := tc.Session.GetSessionVars()
+	if sessVars.InRestrictedSQL {
+		return nil
+	}
 	if sessVars.ETLConcurrency == 0 {
 		return nil
 	}

--- a/session/nontransactional.go
+++ b/session/nontransactional.go
@@ -745,7 +745,7 @@ func buildShardJobs(ctx context.Context, stmt *ast.NonTransactionalDMLStmt, se S
 	}
 
 	// _tidb_rowid may be null in join, handle this case
-	if stmt.ShardColumn.Name.L == "_tidb_rowid" {
+	if stmt.ShardColumn.Name.L == "_tidb_rowid" && stmt.TransferFromInsert {
 		var nullStart, nullEnd types.Datum
 		nullStart.SetNull()
 		nullEnd.SetNull()

--- a/session/nontransactional.go
+++ b/session/nontransactional.go
@@ -933,6 +933,9 @@ func collectTableSourcesInJoin(node ast.ResultSetNode, tableSources []*ast.Table
 				subSources = make([]*ast.TableSource, 0)
 				err        error
 			)
+			if v.From == nil {
+				return tableSources, aliases, nil
+			}
 			subSources, aliases, err = collectTableSourcesInJoin(v.From.TableRefs, subSources, aliases)
 			if err != nil {
 				return nil, nil, err

--- a/session/nontransactional.go
+++ b/session/nontransactional.go
@@ -18,7 +18,11 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -117,10 +121,13 @@ func HandleNonTransactionalDML(ctx context.Context, stmt *ast.NonTransactionalDM
 	memTracker.AttachTo(se.GetSessionVars().MemTracker)
 	se.GetSessionVars().MemTracker.SetBytesLimit(se.GetSessionVars().MemQuotaQuery)
 	defer memTracker.Detach()
+	buildJobStart := time.Now()
 	jobs, err := buildShardJobs(ctx, stmt, se, selectSQL, shardColumnInfo, memTracker)
 	if err != nil {
 		return nil, err
 	}
+	logutil.Logger(ctx).Warn("Non-transactional DML build job",
+		zap.Int("count", len(jobs)), zap.Duration("duration", time.Since(buildJobStart)))
 
 	splitStmts, err := runJobs(ctx, jobs, stmt, tableName, se, stmt.DMLStmt.WhereExpr())
 	if err != nil {
@@ -128,6 +135,10 @@ func HandleNonTransactionalDML(ctx context.Context, stmt *ast.NonTransactionalDM
 	}
 	if stmt.DryRun == ast.DryRunSplitDml {
 		return buildDryRunResults(stmt.DryRun, splitStmts, se.GetSessionVars().BatchSize.MaxChunkSize)
+	}
+	if stmt.TransferFromInsert {
+		// affected rows will be set in `runJobs`
+		return nil, nil
 	}
 	return buildExecuteResults(ctx, jobs, se.GetSessionVars().BatchSize.MaxChunkSize, se.GetSessionVars().EnableRedactLog)
 }
@@ -264,7 +275,73 @@ func checkReadClauses(limit *ast.Limit, order *ast.OrderByClause) error {
 
 // single-threaded worker. work on the key range [start, end]
 func runJobs(ctx context.Context, jobs []job, stmt *ast.NonTransactionalDMLStmt,
-	tableName *ast.TableName, se Session, originalCondition ast.ExprNode) ([]string, error) {
+	tableName *ast.TableName, se Session, originalCondition ast.ExprNode) (rs []string, err error) {
+	concurrency := se.GetSessionVars().ETLConcurrency
+	// no concurrency for dry run.
+	if stmt.DryRun != ast.NoDryRun {
+		concurrency = 0
+	}
+
+	var (
+		jobCh        chan *job
+		errCh        chan error
+		wg           sync.WaitGroup
+		affectedRows uint64
+	)
+	if concurrency > 0 {
+		// shuffle jobs to avoid hot spot.
+		rand.Shuffle(len(jobs), func(i, j int) {
+			// do not shuffle first job, because it may be (null, null), a large job, run it at the beginning.
+			if i > 0 && j > 0 {
+				jobs[i], jobs[j] = jobs[j], jobs[i]
+			}
+		})
+		var sb strings.Builder
+		err = stmt.DMLStmt.Restore(format.NewRestoreCtx(format.DefaultRestoreFlags|
+			format.RestoreNameBackQuotes|
+			format.RestoreSpacesAroundBinaryOperation|
+			format.RestoreBracketAroundBinaryOperation|
+			format.RestoreStringWithoutCharset, &sb))
+		if err != nil {
+			logutil.Logger(ctx).Error("Non-transactional DML, failed to restore the DML statement", zap.Error(err))
+			se.Close()
+			wg.Done()
+			return nil, err
+		}
+		if concurrency > len(jobs) {
+			concurrency = len(jobs)
+		}
+		logutil.Logger(ctx).Warn("Non-transactional DML execute concurrently", zap.Int("concurrency", concurrency))
+		dmlSQL := sb.String()
+		jobCh = make(chan *job, 2*concurrency)
+		errCh = make(chan error, 2*concurrency)
+		wg.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			if err = jobWorker(ctx, se, jobCh, errCh, len(jobs), stmt, dmlSQL, tableName, originalCondition, &wg, &affectedRows); err != nil {
+				return nil, err
+			}
+		}
+
+		defer func() {
+			close(jobCh)
+			wg.Wait()
+			// in case all worker is exited with error.
+			for range jobCh {
+			}
+			select {
+			case e := <-errCh:
+				if e != nil {
+					err = e
+				}
+			default:
+			}
+			close(errCh)
+			for range errCh {
+			}
+			se.GetSessionVars().StmtCtx.AddAffectedRows(affectedRows)
+		}()
+	}
+
 	// prepare for the construction of statement
 	var shardColumnRefer *ast.ResultField
 	var shardColumnType types.FieldType
@@ -301,6 +378,10 @@ func runJobs(ctx context.Context, jobs []job, stmt *ast.NonTransactionalDMLStmt,
 					zap.Int("finished", i), zap.Int("total", len(jobs)), zap.Strings("errors found", failedJobs))
 			}
 			return nil, ctx.Err()
+		case e := <-errCh:
+			logutil.Logger(ctx).Warn("Non-transactional DML worker exit because error found",
+				zap.Int("finished", i), zap.Int("total", len(jobs)), zap.Error(e))
+			return nil, e
 		default:
 		}
 
@@ -327,7 +408,12 @@ func runJobs(ctx context.Context, jobs []job, stmt *ast.NonTransactionalDMLStmt,
 			splitStmt := doOneJob(ctx, &jobs[i], len(jobs), stmtBuildInfo, se, true)
 			splitStmts = append(splitStmts, splitStmt)
 		} else {
-			doOneJob(ctx, &jobs[i], len(jobs), stmtBuildInfo, se, false)
+			if concurrency == 0 {
+				doOneJob(ctx, &jobs[i], len(jobs), stmtBuildInfo, se, false)
+			} else {
+				j := jobs[i]
+				jobCh <- &j
+			}
 		}
 
 		// if the first job failed, there is a large chance that all jobs will fail. So return early.
@@ -341,9 +427,115 @@ func runJobs(ctx context.Context, jobs []job, stmt *ast.NonTransactionalDMLStmt,
 	return splitStmts, nil
 }
 
+func jobWorker(ctx context.Context, s Session, jobCh <-chan *job, errCh chan<- error, totalJobCount int,
+	stmt *ast.NonTransactionalDMLStmt, dmlSQL string, tableName *ast.TableName, originalCondition ast.ExprNode, wg *sync.WaitGroup, affectedRows *uint64) error {
+	se, err := CreateSession(s.GetStore())
+	if err != nil {
+		wg.Done()
+		return err
+	}
+	se.GetSessionVars().CurrentDB = s.GetSessionVars().CurrentDB
+	se.GetSessionVars().EnableWindowFunction = true
+	se.GetSessionVars().ETLConcurrency = 0
+
+	dml, err := se.ParseWithParams(ctx, dmlSQL)
+	if err != nil {
+		se.Close()
+		wg.Done()
+
+		start := 0
+		for start < len(dmlSQL) {
+			end := start + 2000
+			if end > len(dmlSQL) {
+				end = len(dmlSQL)
+			}
+			part := dmlSQL[start:end]
+			start += 2000
+			logutil.Logger(ctx).Info("Non-transactional DML stmt parse err", zap.String("sql", part), zap.Error(err))
+		}
+		return err
+	}
+	var dmlStmt ast.ShardableDMLStmt
+	switch v := dml.(type) {
+	case *ast.InsertStmt:
+		dmlStmt = v
+	case *ast.DeleteStmt:
+		dmlStmt = v
+	case *ast.UpdateStmt:
+		dmlStmt = v
+	default:
+		se.Close()
+		wg.Done()
+		return errors.Errorf("unexpected type %T", v)
+	}
+	// copy stmt to avoid race.
+	stmt = &ast.NonTransactionalDMLStmt{
+		DryRun: stmt.DryRun,
+		ShardColumn: &ast.ColumnName{
+			Schema: stmt.ShardColumn.Schema,
+			Table:  stmt.ShardColumn.Table,
+			Name:   stmt.ShardColumn.Name,
+		},
+		Limit:   stmt.Limit,
+		DMLStmt: dmlStmt,
+	}
+
+	// prepare for the construction of statement
+	var shardColumnRefer *ast.ResultField
+	var shardColumnType types.FieldType
+	for _, col := range tableName.TableInfo.Columns {
+		if col.Name.L == stmt.ShardColumn.Name.L {
+			shardColumnRefer = &ast.ResultField{
+				Column:    col,
+				Table:     tableName.TableInfo,
+				DBName:    tableName.Schema,
+				TableName: tableName,
+			}
+			shardColumnType = col.FieldType
+		}
+	}
+	if shardColumnRefer == nil && stmt.ShardColumn.Name.L != model.ExtraHandleName.L {
+		wg.Done()
+		se.Close()
+		return errors.New("Non-transactional DML, shard column not found")
+	}
+
+	go func() {
+		defer func() {
+			se.Close()
+			wg.Done()
+		}()
+		for j := range jobCh {
+			// _tidb_rowid
+			if shardColumnRefer == nil {
+				shardColumnType = *types.NewFieldType(mysql.TypeLonglong)
+				shardColumnRefer = &ast.ResultField{
+					Column:    model.NewExtraHandleColInfo(),
+					Table:     tableName.TableInfo,
+					DBName:    tableName.Schema,
+					TableName: tableName,
+				}
+			}
+			stmtBuildInfo := statementBuildInfo{
+				stmt:              stmt,
+				shardColumnType:   shardColumnType,
+				shardColumnRefer:  shardColumnRefer,
+				originalCondition: originalCondition,
+			}
+			doOneJob(ctx, j, totalJobCount, stmtBuildInfo, se, false)
+			if j.err != nil {
+				errCh <- j.err
+				return
+			}
+			subAffectedRows := se.AffectedRows()
+			atomic.AddUint64(affectedRows, subAffectedRows)
+		}
+	}()
+	return nil
+}
+
 func doOneJob(ctx context.Context, job *job, totalJobCount int, options statementBuildInfo, se Session, dryRun bool) string {
 	var whereCondition ast.ExprNode
-
 	if job.start.IsNull() {
 		isNullCondition := &ast.IsNullExpr{
 			Expr: &ast.ColumnNameExpr{
@@ -486,7 +678,6 @@ func buildShardJobs(ctx context.Context, stmt *ast.NonTransactionalDMLStmt, se S
 	jobs := make([]job, 0)
 	currentSize := 0
 	var currentStart, currentEnd types.Datum
-
 	chk := rs.NewChunk(nil)
 	for {
 		err = rs.Next(ctx, chk)
@@ -537,6 +728,18 @@ func buildShardJobs(ctx context.Context, stmt *ast.NonTransactionalDMLStmt, se S
 		currentStart = *currentStart.Clone()
 	}
 
+	// _tidb_rowid may be null in join, handle this case
+	if stmt.ShardColumn.Name.L == "_tidb_rowid" {
+		var nullStart, nullEnd types.Datum
+		nullStart.SetNull()
+		nullEnd.SetNull()
+		jobs = appendNewJob(jobs, 0, nullStart, nullEnd, 1, memTracker)
+		if len(jobs) > 1 {
+			lastIdx := len(jobs) - 1
+			jobs[0], jobs[lastIdx] = jobs[lastIdx], jobs[0]
+		}
+	}
+
 	return jobs, nil
 }
 
@@ -554,7 +757,8 @@ func buildSelectSQL(stmt *ast.NonTransactionalDMLStmt, se Session) (
 		return nil, "", nil, nil, errors.New("Non-transactional DML, table source not found")
 	}
 	tableSources := make([]*ast.TableSource, 0)
-	tableSources, err := collectTableSourcesInJoin(join, tableSources)
+	aliases := make(map[string]*ast.TableName)
+	tableSources, aliases, err := collectTableSourcesInJoin(join, tableSources, aliases)
 	if err != nil {
 		return nil, "", nil, nil, err
 	}
@@ -567,7 +771,7 @@ func buildSelectSQL(stmt *ast.NonTransactionalDMLStmt, se Session) (
 		return nil, "", nil, nil, errors.New("Non-transactional DML, table name not found")
 	}
 
-	shardColumnInfo, tableName, err := selectShardColumn(stmt, se, tableSources, leftMostTableName, leftMostTableSource)
+	shardColumnInfo, tableName, alias, err := selectShardColumn(stmt, se, tableSources, aliases, leftMostTableName, leftMostTableSource)
 	if err != nil {
 		return nil, "", nil, nil, err
 	}
@@ -589,39 +793,44 @@ func buildSelectSQL(stmt *ast.NonTransactionalDMLStmt, se Session) (
 	// assure NULL values are placed first
 	selectSQL := fmt.Sprintf("SELECT `%s` FROM `%s`.`%s` WHERE %s ORDER BY IF(ISNULL(`%s`),0,1),`%s`",
 		stmt.ShardColumn.Name.O, tableName.DBInfo.Name.O, tableName.Name.O, sb.String(), stmt.ShardColumn.Name.O, stmt.ShardColumn.Name.O)
+	if alias != "" {
+		stmt.ShardColumn.Schema = model.NewCIStr("")
+		stmt.ShardColumn.Table = model.NewCIStr(alias)
+	}
 	return tableName, selectSQL, shardColumnInfo, tableSources, nil
 }
 
-func selectShardColumn(stmt *ast.NonTransactionalDMLStmt, se Session, tableSources []*ast.TableSource,
+func selectShardColumn(stmt *ast.NonTransactionalDMLStmt, se Session, tableSources []*ast.TableSource, aliases map[string]*ast.TableName,
 	leftMostTableName *ast.TableName, leftMostTableSource *ast.TableSource) (
-	*model.ColumnInfo, *ast.TableName, error) {
+	*model.ColumnInfo, *ast.TableName, string, error) {
 	var indexed bool
 	var shardColumnInfo *model.ColumnInfo
 	var selectedTableName *ast.TableName
+	var alias string
 
 	if len(tableSources) == 1 {
 		// single table
 		leftMostTable, err := domain.GetDomain(se).InfoSchema().TableByName(leftMostTableName.Schema, leftMostTableName.Name)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, "", err
 		}
 		selectedTableName = leftMostTableName
 		indexed, shardColumnInfo, err = selectShardColumnFromTheOnlyTable(
 			stmt, leftMostTableName, leftMostTableSource.AsName, leftMostTable)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, "", err
 		}
 	} else {
 		// multi table join
 		if stmt.ShardColumn == nil {
 			leftMostTable, err := domain.GetDomain(se).InfoSchema().TableByName(leftMostTableName.Schema, leftMostTableName.Name)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, "", err
 			}
 			selectedTableName = leftMostTableName
 			indexed, shardColumnInfo, err = selectShardColumnAutomatically(stmt, leftMostTable, leftMostTableName, leftMostTableSource.AsName)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, "", err
 			}
 		} else if stmt.ShardColumn.Schema.L != "" && stmt.ShardColumn.Table.L != "" && stmt.ShardColumn.Name.L != "" {
 			specifiedDbName := stmt.ShardColumn.Schema
@@ -643,9 +852,25 @@ func selectShardColumn(stmt *ast.NonTransactionalDMLStmt, se Session, tableSourc
 					chosenTableName = tableSourceName.Name
 					break
 				}
+				if tableSourceName.Schema.L == specifiedDbName.L && tableSourceName.Name.L == specifiedTableName.L {
+					tableInJoin = true
+					selectedTableName = tableSourceName
+					chosenTableName = tableSourceName.Name
+					break
+				}
 			}
 			if !tableInJoin {
-				return nil, nil,
+				sources := []string{}
+				for _, table := range tableSources {
+					asName := table.AsName.L
+					if tblName, ok := table.Source.(*ast.TableName); ok {
+						sources = append(sources, tblName.Schema.L+"."+tblName.Name.L+" as "+asName)
+					}
+				}
+				logutil.BgLogger().Error("Non-transactional DML, table not found",
+					zap.String("tbl", specifiedDbName.L+"."+specifiedTableName.L),
+					zap.Strings("tbls", sources))
+				return nil, nil, "",
 					errors.Errorf(
 						"Non-transactional DML, shard column %s.%s.%s is not in the tables involved in the join",
 						specifiedDbName.L, specifiedTableName.L, specifiedColName.L,
@@ -654,49 +879,89 @@ func selectShardColumn(stmt *ast.NonTransactionalDMLStmt, se Session, tableSourc
 
 			tbl, err := domain.GetDomain(se).InfoSchema().TableByName(specifiedDbName, chosenTableName)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, "", err
 			}
 			indexed, shardColumnInfo, err = selectShardColumnByGivenName(specifiedColName.L, tbl)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, "", err
+			}
+			for a, aliasedTbl := range aliases {
+				if aliasedTbl.Name.L == selectedTableName.Name.L {
+					alias = a
+					break
+				}
 			}
 		} else {
-			return nil, nil, errors.New(
+			return nil, nil, "", errors.New(
 				"Non-transactional DML, shard column must be fully specified (i.e. `BATCH ON dbname.tablename.colname`) when multiple tables are involved",
 			)
 		}
 	}
 	if !indexed {
-		return nil, nil, errors.Errorf("Non-transactional DML, shard column %s is not indexed", stmt.ShardColumn.Name.L)
+		return nil, nil, "", errors.Errorf("Non-transactional DML, shard column %s is not indexed", stmt.ShardColumn.Name.L)
 	}
-	return shardColumnInfo, selectedTableName, nil
+	return shardColumnInfo, selectedTableName, alias, nil
 }
 
-func collectTableSourcesInJoin(node ast.ResultSetNode, tableSources []*ast.TableSource) ([]*ast.TableSource, error) {
+func collectTableSourcesInJoin(node ast.ResultSetNode, tableSources []*ast.TableSource, aliases map[string]*ast.TableName) ([]*ast.TableSource, map[string]*ast.TableName, error) {
 	if node == nil {
-		return tableSources, nil
+		return tableSources, aliases, nil
 	}
 	switch x := node.(type) {
 	case *ast.Join:
-		var err error
-		tableSources, err = collectTableSourcesInJoin(x.Left, tableSources)
+		var (
+			err error
+		)
+		tableSources, aliases, err = collectTableSourcesInJoin(x.Left, tableSources, aliases)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		tableSources, err = collectTableSourcesInJoin(x.Right, tableSources)
+		tableSources, aliases, err = collectTableSourcesInJoin(x.Right, tableSources, aliases)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	case *ast.TableSource:
 		// assert it's a table name
-		if _, ok := x.Source.(*ast.TableName); !ok {
-			return nil, errors.New("Non-transactional DML, table name not found in join")
+		switch v := x.Source.(type) {
+		case *ast.TableName:
+			tableSources = append(tableSources, x)
+			if x.AsName.L != "" {
+				aliases[x.AsName.L] = v
+			}
+		case *ast.SelectStmt:
+			var (
+				subSources = make([]*ast.TableSource, 0)
+				err        error
+			)
+			subSources, aliases, err = collectTableSourcesInJoin(v.From.TableRefs, subSources, aliases)
+			if err != nil {
+				return nil, nil, err
+			}
+			tableSources = append(tableSources, subSources...)
+			if x.AsName.L != "" {
+				if ss, ok := v.From.TableRefs.Left.(*ast.TableSource); ok {
+					if st, ok := ss.Source.(*ast.TableName); ok {
+						dupAlias := ""
+						for alias, tbl := range aliases {
+							if tbl == st {
+								dupAlias = alias
+								break
+							}
+						}
+						if dupAlias != "" {
+							delete(aliases, dupAlias)
+						}
+						aliases[x.AsName.L] = st
+					}
+				}
+			}
+		default:
+			// ignore the rest.
 		}
-		tableSources = append(tableSources, x)
 	default:
-		return nil, errors.Errorf("Non-transactional DML, unknown type %T in table refs", node)
+		return nil, nil, errors.Errorf("Non-transactional DML, unknown type %T in table refs", node)
 	}
-	return tableSources, nil
+	return tableSources, aliases, nil
 }
 
 // it attempts to auto-select a shard column from handle if not specified, and fills back the corresponding info in the stmt,

--- a/session/nontransactional_test.go
+++ b/session/nontransactional_test.go
@@ -1012,3 +1012,24 @@ func TestNameAmbiguity(t *testing.T) {
 	tk.MustExec("batch on id limit 1 insert into t select * from test2.t")
 	tk.MustQuery("select * from t").Check(testkit.Rows("1 1 1", "2 2 2"))
 }
+
+func TestJoinWithAlias(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t, t1, t2")
+	tk.MustExec("create table t(id int primary key, v1 int, v2 int)")
+	tk.MustExec("create table t1(id int primary key, v int)")
+	tk.MustExec("create table t2(id int primary key, v int)")
+	tk.MustExec("insert into t1 values(1, 1), (2, 2), (3, 3), (5, 5), (6, 6), (7, 70)")
+	tk.MustExec("insert into t2 values(1, 1), (2, 2), (3, 3), (4, 4), (6, 60), (7, 7)")
+	tk.MustExec("batch on test.t1.id limit 1 insert into t " +
+		"select tmp1.id, tmp1.v, tmp2.v from (select * from t1) tmp1 join (select * from t2) tmp2 on tmp1.id = tmp2.id")
+	tk.MustQuery("select * from t").Sort().Check(testkit.Rows("1 1 1", "2 2 2", "3 3 3", "6 6 60", "7 70 7"))
+
+	tk.MustExec("truncate table t")
+
+	tk.MustExec("batch on test.t1.id limit 1 insert into t " +
+		"select tmp1.id, tmp1.v, tmp2.v from (select * from t1 g) tmp1 join (select * from t2 n) tmp2 on tmp1.id = tmp2.id")
+	tk.MustQuery("select * from t").Sort().Check(testkit.Rows("1 1 1", "2 2 2", "3 3 3", "6 6 60", "7 70 7"))
+}

--- a/session/nontransactional_test.go
+++ b/session/nontransactional_test.go
@@ -722,7 +722,8 @@ func TestNonTransactionalWithCheckConstraint(t *testing.T) {
 	err = tk.ExecToErr("batch limit 1 insert into t select 1, 1")
 	require.EqualError(t, err, "table reference is nil")
 	err = tk.ExecToErr("batch limit 1 insert into t select * from (select 1, 2) tmp")
-	require.EqualError(t, err, "Non-transactional DML, table name not found in join")
+	// we tolerance no table name in join now.
+	require.EqualError(t, err, "Non-transactional DML, no tables found in table refs")
 }
 
 func TestNonTransactionalWithOptimizerHints(t *testing.T) {

--- a/session/session.go
+++ b/session/session.go
@@ -1771,7 +1771,6 @@ func (s *session) ParseWithParams(ctx context.Context, sql string, args ...inter
 		stmts, warns, err = s.ParseSQL(ctx, sql, s.sessionVars.GetParseParams()...)
 	}
 	if len(stmts) != 1 {
-		logutil.Logger(ctx).Error("multiple stmt internal error", zap.Int("len", len(stmts)), zap.Error(err))
 		err = errors.New("run multiple statements internally is not supported")
 	}
 	if err != nil {

--- a/session/session.go
+++ b/session/session.go
@@ -168,6 +168,8 @@ type Session interface {
 	ExecuteStmt(context.Context, ast.StmtNode) (sqlexec.RecordSet, error)
 	// Parse is deprecated, use ParseWithParams() instead.
 	Parse(ctx context.Context, sql string) ([]ast.StmtNode, error)
+	// ParseWithParams parses sql and returns the ast.
+	ParseWithParams(ctx context.Context, sql string, args ...interface{}) (ast.StmtNode, error)
 	// ExecuteInternal is a helper around ParseWithParams() and ExecuteStmt(). It is not allowed to execute multiple statements.
 	ExecuteInternal(context.Context, string, ...interface{}) (sqlexec.RecordSet, error)
 	String() string // String is used to debug.
@@ -1769,6 +1771,7 @@ func (s *session) ParseWithParams(ctx context.Context, sql string, args ...inter
 		stmts, warns, err = s.ParseSQL(ctx, sql, s.sessionVars.GetParseParams()...)
 	}
 	if len(stmts) != 1 {
+		logutil.Logger(ctx).Error("multiple stmt internal error", zap.Int("len", len(stmts)), zap.Error(err))
 		err = errors.New("run multiple statements internally is not supported")
 	}
 	if err != nil {

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1322,6 +1322,12 @@ type SessionVars struct {
 
 	// tmp for liantong, this is a fake dynamic partition pruning
 	EnableDynamicPartitionPruning bool
+
+	// ETLConcurrency increases the speed of ETL operations.
+	ETLConcurrency int
+
+	// ETLBatchSize is the non-transactional batch size of ETL operations.
+	ETLBatchSize int
 }
 
 // GetNewChunkWithCapacity Attempt to request memory from the chunk pool

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -2242,6 +2242,20 @@ var defaultSysVars = []*SysVar{
 			s.EnableDynamicPartitionPruning = TiDBOptOn(val)
 			return nil
 		}},
+	{
+		Scope: ScopeGlobal | ScopeSession, Name: TiDBETLConcurrency, Value: strconv.FormatInt(DefTiDBETLConcurrency, 10),
+		Type: TypeInt, MinValue: 0, MaxValue: 10240, SetSession: func(s *SessionVars, val string) error {
+			s.ETLConcurrency = TidbOptInt(val, DefTiDBETLConcurrency)
+			return nil
+		},
+	},
+	{
+		Scope: ScopeGlobal | ScopeSession, Name: TiDBETLBatchSize, Value: strconv.FormatInt(DefTiDBETLBatchSize, 10),
+		Type: TypeInt, MinValue: 1, MaxValue: 1000000, SetSession: func(s *SessionVars, val string) error {
+			s.ETLBatchSize = TidbOptInt(val, DefTiDBETLBatchSize)
+			return nil
+		},
+	},
 }
 
 // FeedbackProbability points to the FeedbackProbability in statistics package.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -1159,7 +1159,7 @@ const (
 	DefTiDBTTLDeleteWorkerCount                      = 4
 	DefEnableDynamicPartitionPruning                 = false
 	DefTiDBETLConcurrency                            = 64
-	DefTiDBETLBatchSize                              = 1000
+	DefTiDBETLBatchSize                              = 2000
 )
 
 // Process global variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -894,6 +894,10 @@ const (
 	PasswordReuseTime = "password_reuse_interval"
 	// EnableDynamicPartitionPruning tmp for liantong poc
 	EnableDynamicPartitionPruning = "enable_dynamic_partition_pruning"
+	// TiDBETLConcurrency increases the speed of ETL operations.
+	TiDBETLConcurrency = "tidb_etl_concurrency"
+	// TiDBETLBatchSize controls the non-transaction batch of ETL operations.
+	TiDBETLBatchSize = "tidb_etl_batch_size"
 )
 
 // TiDB intentional limits
@@ -1154,6 +1158,8 @@ const (
 	DefTiDBTTLScanWorkerCount                        = 4
 	DefTiDBTTLDeleteWorkerCount                      = 4
 	DefEnableDynamicPartitionPruning                 = false
+	DefTiDBETLConcurrency                            = 64
+	DefTiDBETLBatchSize                              = 1000
 )
 
 // Process global variables.


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

This PR generally made three changes:

- Add global/variable `tidb_etl_concurrency` and `tidb_etl_batch_size`.
- Rewrite `insert into ... select ...` stmts into nt-txn forms.
- Accelerate insert speed by concurrent execution of nt-txn jobs. 

The rewrite is only enabled for valid stmts when `tidb_etl_concurrency > 0`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
