### PR TITLE
planner: rewrite to make FULL JOIN executable

### DIFF
--- a/parser/ast/dml.go
+++ b/parser/ast/dml.go
@@ -65,6 +65,8 @@ const (
 	LeftJoin
 	// RightJoin is right Join type.
 	RightJoin
+	// FullJoin is the full outer join type.
+	FullJoin
 )
 
 // Join represents table join.
@@ -187,6 +189,8 @@ func (n *Join) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord(" LEFT")
 	case RightJoin:
 		ctx.WriteKeyWord(" RIGHT")
+	case FullJoin:
+		ctx.WriteKeyWord(" FULL")
 	}
 	if n.StraightJoin {
 		ctx.WriteKeyWord(" STRAIGHT_JOIN ")

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -137,6 +137,7 @@ import (
 	force             "FORCE"
 	foreign           "FOREIGN"
 	from              "FROM"
+	full              "FULL"
 	fulltext          "FULLTEXT"
 	generated         "GENERATED"
 	grant             "GRANT"
@@ -409,7 +410,6 @@ import (
 	flush                 "FLUSH"
 	following             "FOLLOWING"
 	format                "FORMAT"
-	full                  "FULL"
 	function              "FUNCTION"
 	general               "GENERAL"
 	global                "GLOBAL"
@@ -6125,7 +6125,6 @@ UnReservedKeyword:
 |	"FLUSH"
 |	"FOLLOWING"
 |	"FORMAT"
-|	"FULL"
 |	"GENERAL"
 |	"GLOBAL"
 |	"HASH"
@@ -9272,7 +9271,11 @@ JoinTable:
 	}
 
 JoinType:
-	"LEFT"
+	"FULL"
+	{
+		$$ = ast.FullJoin
+	}
+|	"LEFT"
 	{
 		$$ = ast.LeftJoin
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -43,7 +43,7 @@ func TestSimple(t *testing.T) {
 		"current_timestamp", "current_user", "database", "databases", "day_hour", "day_microsecond",
 		"day_minute", "day_second", "decimal", "default", "delete", "desc", "describe",
 		"distinct", "distinctRow", "div", "double", "drop", "dual", "else", "enclosed", "escaped",
-		"exists", "explain", "false", "float", "fetch", "for", "force", "foreign", "from",
+		"exists", "explain", "false", "float", "fetch", "for", "force", "foreign", "from", "full",
 		"fulltext", "grant", "group", "having", "hour_microsecond", "hour_minute",
 		"hour_second", "if", "ignore", "in", "index", "infile", "inner", "insert", "int", "into", "integer",
 		"interval", "is", "join", "key", "keys", "kill", "leading", "left", "like", "limit", "lines", "load",
@@ -82,7 +82,7 @@ func TestSimple(t *testing.T) {
 	// Testcase for unreserved keywords
 	unreservedKws := []string{
 		"auto_increment", "after", "begin", "bit", "bool", "boolean", "charset", "columns", "commit",
-		"date", "datediff", "datetime", "deallocate", "do", "from_days", "end", "engine", "engines", "execute", "extended", "first", "file", "full",
+		"date", "datediff", "datetime", "deallocate", "do", "from_days", "end", "engine", "engines", "execute", "extended", "first", "file",
 		"local", "names", "offset", "password", "prepare", "quick", "rollback", "savepoint", "session", "signed",
 		"start", "global", "tables", "tablespace", "target", "text", "time", "timestamp", "tidb", "transaction", "truncate", "unknown",
 		"value", "warnings", "year", "now", "substr", "subpartition", "subpartitions", "substring", "mode", "any", "some", "user", "identified",
@@ -2200,9 +2200,9 @@ func TestIdentifier(t *testing.T) {
 		{"use select", false, "USE `select`"},
 		{`select * from t as a`, true, "SELECT * FROM `t` AS `a`"},
 		{"select 1 full, 1 row, 1 abs", false, ""},
-		{"select 1 full, 1 `row`, 1 abs", true, "SELECT 1 AS `full`,1 AS `row`,1 AS `abs`"},
+		{"select 1 `full`, 1 `row`, 1 abs", true, "SELECT 1 AS `full`,1 AS `row`,1 AS `abs`"},
 		{"select * from t full, t1 row, t2 abs", false, ""},
-		{"select * from t full, t1 `row`, t2 abs", true, "SELECT * FROM ((`t` AS `full`) JOIN `t1` AS `row`) JOIN `t2` AS `abs`"},
+		{"select * from t `full`, t1 `row`, t2 abs", true, "SELECT * FROM ((`t` AS `full`) JOIN `t1` AS `row`) JOIN `t2` AS `abs`"},
 		// for issue 1878, identifiers may begin with digit.
 		{"create database 123test", true, "CREATE DATABASE `123test`"},
 		{"create database 123", false, "CREATE DATABASE `123`"},

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -8135,3 +8135,15 @@ func TestAutoIncrementCheckWithCheckConstraint(t *testing.T) {
 		KEY idx_autoinc_id (id)
 	)`)
 }
+
+func TestFullJoinSimple(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1(a int)")
+	tk.MustExec("create table t2(a int)")
+	tk.MustExec("insert into t1 values(1), (2)")
+	tk.MustExec("insert into t2 values(2), (3)")
+	tk.MustQuery("select * from t1 full join t2 on t1.a=t2.a").Sort().Check(testkit.Rows("1 <nil>", "2 2", "<nil> 3"))
+	tk.MustQuery("select * from t1 full outer join t2 on t1.a=t2.a").Sort().Check(testkit.Rows("1 <nil>", "2 2", "<nil> 3"))
+}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -995,7 +995,8 @@ func (b *PlanBuilder) rewriteFullJoin(ctx context.Context, joinNode *ast.Join) (
 	topProj := LogicalProjection{
 		Exprs: expression.Column2Exprs(unionAll.Schema().Columns),
 	}.Init(b.ctx, b.getSelectOffset())
-	topProj.SetSchema(expression.MergeSchema(lChild2.Schema(), rChild2.Schema()))
+	topProj.SetSchema(leftJoinPlan.schema.Clone())
+	resetNotNullFlag(topProj.schema, 0, topProj.schema.Len())
 	topProj.SetOutputNames(leftJoinPlan.OutputNames())
 	topProj.SetChildren(unionAll)
 	return topProj, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

rewrite `t1 full join t2 on COND` to `t1 left join t2 on COND union all select null, null, ... null, t2.* from t2 where not exists(select 1 from t1 where COND)`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
