### PR TITLE
*: Adding tidb_enable_plan_cache_with_dynamic_prune_mode

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -2106,5 +2106,5 @@ func TestPlanCacheWithDynamicPruneMode(t *testing.T) {
 	tk.MustQuery("select @@session.tidb_enable_plan_cache_with_dynamic_prune_mode").Check(testkit.Rows("0"))
 
 	// error value
-	tk.MustGetErrCode("set @@tidb_enable_reuse_chunk=s", errno.ErrWrongValueForVar)
+	tk.MustGetErrCode("set @@tidb_enable_plan_cache_with_dynamic_prune_mode=s", errno.ErrWrongValueForVar)
 }

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -148,9 +148,7 @@ func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren 
 				// is fixed and additional tests with dynamic partition prune mode has been added.
 				// This is enabled again as an experiment for a Proof-of-Concept, with a new
 				// system variable 'tidb_enable_plan_cache_with_dynamic_prune_mode'
-				if checker.sctx == nil ||
-					(checker.sctx.GetSessionVars().IsDynamicPartitionPruneEnabled() &&
-						!checker.sctx.GetSessionVars().PlanCacheWithDynamicPruneMode) {
+				if checker.sctx == nil || !checker.sctx.GetSessionVars().IsPlanCacheWithDynamicPruneMode() {
 					checker.cacheable = false
 					checker.reason = "query accesses partitioned tables is un-cacheable"
 					return in, true

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -1127,11 +1127,11 @@ func TestPrepareCacheForPartition(t *testing.T) {
 		tk.MustExec(`set @a=112, @b=-2, @c=-5, @d=33`)
 		tk.MustQuery(`execute stmt using @d,@a,@b,@c`).Check(testkit.Rows("-5 7 33"))
 		tk.MustQuery(`execute stmt using @d,@a,@b,@c`).Check(testkit.Rows("-5 7 33"))
-		if pruneMode.(string) == string(variable.Dynamic) && planCache.(string) == "0" {
+		if pruneMode.(string) == string(variable.Dynamic) && planCache.(string) == "1" {
 			// When the temporary disabling of prepared plan cache for dynamic partition prune mode is disabled, change this to 1!
-			tk.MustQuery(`select @@last_plan_from_cache /* pruneMode = ` + pruneMode.(string) + ` planCache = ` + planCache.(string) + ` */`).Check(testkit.Rows("0"))
-		} else {
 			tk.MustQuery(`select @@last_plan_from_cache /* pruneMode = ` + pruneMode.(string) + ` planCache = ` + planCache.(string) + ` */`).Check(testkit.Rows("1"))
+		} else {
+			tk.MustQuery(`select @@last_plan_from_cache /* pruneMode = ` + pruneMode.(string) + ` planCache = ` + planCache.(string) + ` */`).Check(testkit.Rows("0"))
 		}
 	}
 }

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -1008,8 +1008,12 @@ func TestPrepareCacheForPartition(t *testing.T) {
 	tk.MustExec(`set tidb_enable_prepared_plan_cache=1`)
 
 	tk.MustExec("use test")
-	for _, pruneMode := range []string{string(variable.Static), string(variable.Dynamic)} {
-		tk.MustExec("set @@tidb_partition_prune_mode = '" + pruneMode + "'")
+	for _, sysVar := range []string{
+		"set @@session.tidb_enable_plan_cache_with_dynamic_prune_mode = 1 ; set @@session.tidb_partition_prune_mode = " + string(variable.Static),
+		"set @@session.tidb_enable_plan_cache_with_dynamic_prune_mode = 1 ; set @@session.tidb_partition_prune_mode = " + string(variable.Dynamic),
+		"set @@session.tidb_enable_plan_cache_with_dynamic_prune_mode = 0 ; set @@session.tidb_partition_prune_mode = " + string(variable.Static),
+		"set @@session.tidb_enable_plan_cache_with_dynamic_prune_mode = 0 ; set @@session.tidb_partition_prune_mode = " + string(variable.Dynamic)} {
+		tk.MustExec(sysVar)
 		// Test for PointGet and IndexRead.
 		tk.MustExec("drop table if exists t_index_read")
 		tk.MustExec("create table t_index_read (id int, k int, c varchar(10), primary key (id, k)) partition by hash(id+k) partitions 10")
@@ -1112,6 +1116,8 @@ func TestPrepareCacheForPartition(t *testing.T) {
 		tk.MustQuery("execute stmt8 using @id").Check(testkit.Rows())
 
 		// https://github.com/pingcap/tidb/issues/33031
+		planCache := tk.MustQuery(`select @@tidb_enable_plan_cache_with_dynamic_prune_mode`).Rows()[0][0]
+		pruneMode := tk.MustQuery(`select @@tidb_partition_prune_mode`).Rows()[0][0]
 		tk.MustExec(`drop table if exists Issue33031`)
 		tk.MustExec(`CREATE TABLE Issue33031 (COL1 int(16) DEFAULT '29' COMMENT 'NUMERIC UNIQUE INDEX', COL2 bigint(20) DEFAULT NULL, UNIQUE KEY UK_COL1 (COL1)) PARTITION BY RANGE (COL1) (PARTITION P0 VALUES LESS THAN (0))`)
 		tk.MustExec(`insert into Issue33031 values(-5, 7)`)
@@ -1120,9 +1126,12 @@ func TestPrepareCacheForPartition(t *testing.T) {
 		tk.MustQuery(`execute stmt using @d,@a,@b,@c`).Check(testkit.Rows())
 		tk.MustExec(`set @a=112, @b=-2, @c=-5, @d=33`)
 		tk.MustQuery(`execute stmt using @d,@a,@b,@c`).Check(testkit.Rows("-5 7 33"))
-		if pruneMode == string(variable.Dynamic) {
+		tk.MustQuery(`execute stmt using @d,@a,@b,@c`).Check(testkit.Rows("-5 7 33"))
+		if pruneMode.(string) == string(variable.Dynamic) && planCache.(string) == "0" {
 			// When the temporary disabling of prepared plan cache for dynamic partition prune mode is disabled, change this to 1!
-			tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+			tk.MustQuery(`select @@last_plan_from_cache /* pruneMode = ` + pruneMode.(string) + ` planCache = ` + planCache.(string) + ` */`).Check(testkit.Rows("0"))
+		} else {
+			tk.MustQuery(`select @@last_plan_from_cache /* pruneMode = ` + pruneMode.(string) + ` planCache = ` + planCache.(string) + ` */`).Check(testkit.Rows("1"))
 		}
 	}
 }

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1116,6 +1116,9 @@ type SessionVars struct {
 	// PartitionPruneMode indicates how and when to prune partitions.
 	PartitionPruneMode atomic2.String
 
+	// PlanCacheWithDynamicPruneMode indicates how and when to prune partitions.
+	PlanCacheWithDynamicPruneMode bool
+
 	// TxnScope indicates the scope of the transactions. It should be `global` or equal to the value of key `zone` in config.Labels.
 	TxnScope kv.TxnScopeVar
 
@@ -1454,6 +1457,17 @@ func (s *SessionVars) IsDynamicPartitionPruneEnabled() bool {
 	return PartitionPruneMode(s.PartitionPruneMode.Load()) == Dynamic
 }
 
+// IsPlanCacheWithDynamicPruneMode indicates whether dynamic partition prune mode will allow
+// plan cache to be used for partitioned table (PoC only code, not to be merged into Master)
+// Note that: IsPlanCacheWithDynamicPruneMode will allow potentially bad results,
+// see https://github.com/pingcap/tidb/issues/33031 since it has not yet been fixed.
+func (s *SessionVars) IsPlanCacheWithDynamicPruneMode() bool {
+	if s.IsDynamicPartitionPruneEnabled() {
+		return s.PlanCacheWithDynamicPruneMode
+	}
+	return false
+}
+
 // BuildParserConfig generate parser.ParserConfig for initial parser
 func (s *SessionVars) BuildParserConfig() parser.ParserConfig {
 	return parser.ParserConfig{
@@ -1647,6 +1661,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		ShardAllocateStep:             DefTiDBShardAllocateStep,
 		EnableAmendPessimisticTxn:     DefTiDBEnableAmendPessimisticTxn,
 		PartitionPruneMode:            *atomic2.NewString(DefTiDBPartitionPruneMode),
+		PlanCacheWithDynamicPruneMode: DefTiDBPlanCacheWithDynamicPruneMode,
 		TxnScope:                      kv.NewDefaultTxnScopeVar(),
 		EnabledRateLimitAction:        DefTiDBEnableRateLimitAction,
 		EnableAsyncCommit:             DefTiDBEnableAsyncCommit,

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1825,6 +1825,10 @@ var defaultSysVars = []*SysVar{
 		}
 		return nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBPlanCacheWithDynamicPruneMode, Value: BoolToOnOff(DefTiDBPlanCacheWithDynamicPruneMode), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.PlanCacheWithDynamicPruneMode = TiDBOptOn(val)
+		return nil
+	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBRedactLog, Value: BoolToOnOff(DefTiDBRedactLog), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
 		s.EnableRedactLog = TiDBOptOn(val)
 		errors.RedactLogEnabled.Store(s.EnableRedactLog)

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -578,6 +578,10 @@ const (
 	// TiDBPartitionPruneMode indicates the partition prune mode used.
 	TiDBPartitionPruneMode = "tidb_partition_prune_mode"
 
+	// TiDBPlanCacheWithDynamicPruneMode enables the plan cache for partitioned tables,
+	// when dynamic prune mode is enabled.
+	TiDBPlanCacheWithDynamicPruneMode = "tidb_enable_plan_cache_with_dynamic_prune_mode"
+
 	// TiDBRedactLog indicates that whether redact log.
 	TiDBRedactLog = "tidb_redact_log"
 
@@ -1027,6 +1031,7 @@ const (
 	DefTiDBEnableParallelApply                     = false
 	DefTiDBEnableAmendPessimisticTxn               = false
 	DefTiDBPartitionPruneMode                      = "dynamic"
+	DefTiDBPlanCacheWithDynamicPruneMode           = false
 	DefTiDBEnableRateLimitAction                   = false
 	DefTiDBEnableAsyncCommit                       = false
 	DefTiDBEnable1PC                               = false


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #33031

Problem Summary:
Enable plan cache when tidb_partition_prune_mode = dynamic

### What is changed and how it works?
Adding a new system variable (both global and session) tidb_enable_plan_cache_with_dynamic_prune_mode = <on|off>
to allow testing even when https://github.com/pingcap/tidb/issues/33031 is not fixed.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
