### PR TITLE
br: reset cloud_admin and root after ebs restoration (#39986)

### DIFF
--- a/br/pkg/restore/BUILD.bazel
+++ b/br/pkg/restore/BUILD.bazel
@@ -115,6 +115,7 @@ go_test(
         "search_test.go",
         "split_test.go",
         "stream_metas_test.go",
+        "systable_restore_test.go",
         "util_test.go",
     ],
     embed = [":restore"],

--- a/br/pkg/restore/systable_restore_test.go
+++ b/br/pkg/restore/systable_restore_test.go
@@ -1,0 +1,72 @@
+// Copyright 2020 PingCAP, Inc. Licensed under Apache-2.0.
+
+package restore
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/pingcap/tidb/br/pkg/utils"
+	"github.com/pingcap/tidb/parser/model"
+	"github.com/stretchr/testify/require"
+)
+
+func testTableInfo(name string) *model.TableInfo {
+	return &model.TableInfo{
+		Name: model.NewCIStr(name),
+	}
+}
+
+func TestGenerateResetSQL(t *testing.T) {
+	// case #1: ignore non-mysql databases
+	mockDB := &database{
+		ExistingTables: map[string]*model.TableInfo{},
+		Name:           model.NewCIStr("non-mysql"),
+		TemporaryName:  utils.TemporaryDBName("non-mysql"),
+	}
+	for name := range sysPrivilegeTableMap {
+		mockDB.ExistingTables[name] = testTableInfo(name)
+	}
+	resetUsers := []string{"cloud_admin", "root"}
+	require.Equal(t, 0, len(generateResetSQLs(mockDB, resetUsers)))
+
+	// case #2: ignore non expected table
+	mockDB = &database{
+		ExistingTables: map[string]*model.TableInfo{},
+		Name:           model.NewCIStr("mysql"),
+		TemporaryName:  utils.TemporaryDBName("mysql"),
+	}
+	for name := range sysPrivilegeTableMap {
+		name += "non_available"
+		mockDB.ExistingTables[name] = testTableInfo(name)
+	}
+	resetUsers = []string{"cloud_admin", "root"}
+	require.Equal(t, 0, len(generateResetSQLs(mockDB, resetUsers)))
+
+	// case #3: only reset cloud admin account
+	for name := range sysPrivilegeTableMap {
+		mockDB.ExistingTables[name] = testTableInfo(name)
+	}
+	resetUsers = []string{"cloud_admin"}
+	sqls := generateResetSQLs(mockDB, resetUsers)
+	require.Equal(t, 8, len(sqls))
+	for _, sql := range sqls {
+		// for cloud_admin we only generate DELETE sql
+		require.Regexp(t, regexp.MustCompile("DELETE*"), sql)
+	}
+
+	// case #4: reset cloud admin/other account
+	resetUsers = []string{"cloud_admin", "cloud_other"}
+	sqls = generateResetSQLs(mockDB, resetUsers)
+	require.Equal(t, 16, len(sqls))
+	for _, sql := range sqls {
+		// for cloud_admin/cloud_other we only generate DELETE sql
+		require.Regexp(t, regexp.MustCompile("DELETE*"), sql)
+	}
+
+	// case #5: reset cloud admin && root account
+	resetUsers = []string{"cloud_admin", "root"}
+	sqls = generateResetSQLs(mockDB, resetUsers)
+	// 8 DELETE sqls for cloud admin and 1 UPDATE sql for root
+	require.Equal(t, 9, len(sqls))
+}

--- a/br/pkg/task/restore_data.go
+++ b/br/pkg/task/restore_data.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/br/pkg/summary"
 	"github.com/pingcap/tidb/br/pkg/utils"
+	tidbconfig "github.com/pingcap/tidb/config"
 	"go.uber.org/zap"
 )
 
@@ -71,6 +72,11 @@ func RunResolveKvData(c context.Context, g glue.Glue, cmdName string, cfg *Resto
 	defer mgr.Close()
 
 	keepaliveCfg.PermitWithoutStream = true
+	tc := tidbconfig.GetGlobalConfig()
+	tc.SkipRegisterToDashboard = true
+	tc.EnableGlobalKill = false
+	tidbconfig.StoreGlobalConfig(tc)
+
 	client := restore.NewRestoreClient(mgr.GetPDClient(), mgr.GetTLSConfig(), keepaliveCfg, false)
 
 	restoreTS, err := client.GetTS(ctx)
@@ -153,6 +159,18 @@ func RunResolveKvData(c context.Context, g glue.Glue, cmdName string, cfg *Resto
 
 	//TODO: restore volume type into origin type
 	//ModifyVolume(*ec2.ModifyVolumeInput) (*ec2.ModifyVolumeOutput, error) by backupmeta
+	// this is used for cloud restoration
+	err = client.Init(g, mgr.GetStorage())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer client.Close()
+	log.Info("start to clear system user for cloud")
+	err = client.ClearSystemUsers(ctx, cfg.ResetSysUsers)
+
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	progress.Close()
 	summary.CollectDuration("restore duration", time.Since(startAll))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/40418

Problem Summary:
1. For ebs volume-snapshot restore, we need to reset some accounts otherwise db_initializer will fail due to accounts existing.

### What is changed and how it works?
1. add a new config `reset-sys-users`. in case we need to reset more users in future.
2. remove cloud_admin by default
3. reset the root password and let cloud_admin control it.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
