### PR TITLE
privilege: add a session-level cache for global privileges

### DIFF
--- a/executor/grant.go
+++ b/executor/grant.go
@@ -155,9 +155,10 @@ func (e *GrantExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		if err != nil {
 			return err
 		}
-		if !exists && e.ctx.GetSessionVars().SQLMode.HasNoAutoCreateUserMode() {
-			return ErrCantCreateUserWithGrant
-		} else if !exists {
+		if !exists {
+			if e.ctx.GetSessionVars().SQLMode.HasNoAutoCreateUserMode() {
+				return ErrCantCreateUserWithGrant
+			}
 			// This code path only applies if mode NO_AUTO_CREATE_USER is unset.
 			// It is required for compatibility with 5.7 but removed from 8.0
 			// since it results in a massive security issue:

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -634,7 +634,7 @@ func buildRangeForIndexScan(sctx sessionctx.Context, is *PhysicalIndexScan) (err
 func CheckPreparedPriv(sctx sessionctx.Context, stmt *PlanCacheStmt, is infoschema.InfoSchema) error {
 	if pm := privilege.GetPrivilegeManager(sctx); pm != nil {
 		visitInfo := VisitInfo4PrivCheck(is, stmt.PreparedAst.Stmt, stmt.VisitInfos)
-		if err := CheckPrivilege(sctx.GetSessionVars().ActiveRoles, pm, visitInfo); err != nil {
+		if err := CheckPrivilege(sctx, pm, visitInfo); err != nil {
 			return err
 		}
 	}

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -393,13 +393,12 @@ func optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 		return nil, nil, 0, err
 	}
 
-	activeRoles := sctx.GetSessionVars().ActiveRoles
 	// Check privilege. Maybe it's better to move this to the Preprocess, but
 	// we need the table information to check privilege, which is collected
 	// into the visitInfo in the logical plan builder.
 	if pm := privilege.GetPrivilegeManager(sctx); pm != nil {
 		visitInfo := core.VisitInfo4PrivCheck(is, node, builder.GetVisitInfo())
-		if err := core.CheckPrivilege(activeRoles, pm, visitInfo); err != nil {
+		if err := core.CheckPrivilege(sctx, pm, visitInfo); err != nil {
 			return nil, nil, 0, err
 		}
 	}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1327,6 +1327,9 @@ type SessionVars struct {
 
 	// ProtectedTSList holds a list of timestamps that should delay GC.
 	ProtectedTSList protectedTSList
+
+	// RevokedGlobalPrivileges records the revoked global privileges from the current user in the session.
+	RevokedGlobalPrivileges map[string]struct{}
 }
 
 // planReplayerSessionFinishedTaskKeyLen is used to control the max size for the finished plan replayer task key in session
@@ -1701,6 +1704,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		EnableReuseCheck:              DefTiDBEnableReusechunk,
 		preUseChunkAlloc:              DefTiDBUseAlloc,
 		ChunkPool:                     ReuseChunkPool{Alloc: nil},
+		RevokedGlobalPrivileges:       make(map[string]struct{}),
 	}
 	vars.KVVars = tikvstore.NewVariables(&vars.Killed)
 	vars.Concurrency = Concurrency{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #39356

Problem Summary:

In MySQL, after revoking one global privilege from the current user, the user can grant it back to itself if only in the current session. TiDB is not compatible with this behavior.

### What is changed and how it works?

Add a `RevokedGlobalPrivileges` in `SessionVariables` to cache the revoked global privileges.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
