### PR TITLE
planner: fix the children of `ShuffleReceiver` not displayed in execution plan in stmt summary and slow query

### DIFF
--- a/planner/core/encode.go
+++ b/planner/core/encode.go
@@ -133,6 +133,8 @@ func (pn *planEncoder) encodePlan(p Plan, isRoot bool, store kv.StoreType, depth
 		if copPlan.tablePlan != nil {
 			pn.encodePlan(copPlan.tablePlan, false, store, depth)
 		}
+	case *PhysicalShuffleReceiverStub:
+		pn.encodePlan(copPlan.DataSource, false, store, depth)
 	case *PhysicalCTE:
 		pn.ctes = append(pn.ctes, copPlan)
 	}

--- a/planner/core/encode.go
+++ b/planner/core/encode.go
@@ -134,7 +134,7 @@ func (pn *planEncoder) encodePlan(p Plan, isRoot bool, store kv.StoreType, depth
 			pn.encodePlan(copPlan.tablePlan, false, store, depth)
 		}
 	case *PhysicalShuffleReceiverStub:
-		pn.encodePlan(copPlan.DataSource, false, store, depth)
+		pn.encodePlan(copPlan.DataSource, isRoot, store, depth)
 	case *PhysicalCTE:
 		pn.ctes = append(pn.ctes, copPlan)
 	}

--- a/planner/core/plan_test.go
+++ b/planner/core/plan_test.go
@@ -223,6 +223,7 @@ func TestEncodeDecodePlan(t *testing.T) {
 	planTree = getPlanTree()
 	require.Contains(t, planTree, "Shuffle")
 	require.Contains(t, planTree, "ShuffleReceiver")
+	require.Contains(t, planTree, "TableFullScan")
 }
 
 func TestNormalizedDigest(t *testing.T) {


### PR DESCRIPTION


### What problem does this PR solve?


Issue Number: ref #35687

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
