### PR TITLE
Explain : Change the time unit of measurement in TiFlashScanContext

### DIFF
--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -407,9 +407,9 @@ func (crs *CopRuntimeStats) RecordOneCopTask(address string, summary *tipb.Execu
 				totalDmfileSkippedPacks:            summary.GetTiflashScanContext().GetTotalDmfileSkippedPacks(),
 				totalDmfileScannedRows:             summary.GetTiflashScanContext().GetTotalDmfileScannedRows(),
 				totalDmfileSkippedRows:             summary.GetTiflashScanContext().GetTotalDmfileSkippedRows(),
-				totalDmfileRoughSetIndexLoadTimeMs: summary.GetTiflashScanContext().GetTotalDmfileRoughSetIndexLoadTimeMs(),
-				totalDmfileReadTimeMs:              summary.GetTiflashScanContext().GetTotalDmfileReadTimeMs(),
-				totalCreateSnapshotTimeMs:          summary.GetTiflashScanContext().GetTotalCreateSnapshotTimeMs()}}, threads: int32(summary.GetConcurrency()),
+				totalDmfileRoughSetIndexLoadTimeNs: summary.GetTiflashScanContext().GetTotalDmfileRoughSetIndexLoadTimeNs(),
+				totalDmfileReadTimeNs:              summary.GetTiflashScanContext().GetTotalDmfileReadTimeNs(),
+				totalCreateSnapshotTimeNs:          summary.GetTiflashScanContext().GetTotalCreateSnapshotTimeNs()}}, threads: int32(summary.GetConcurrency()),
 		totalTasks: 1,
 	})
 }
@@ -535,9 +535,9 @@ type TiFlashScanContext struct {
 	totalDmfileScannedRows             uint64
 	totalDmfileSkippedPacks            uint64
 	totalDmfileSkippedRows             uint64
-	totalDmfileRoughSetIndexLoadTimeMs uint64
-	totalDmfileReadTimeMs              uint64
-	totalCreateSnapshotTimeMs          uint64
+	totalDmfileRoughSetIndexLoadTimeNs uint64
+	totalDmfileReadTimeNs              uint64
+	totalCreateSnapshotTimeNs          uint64
 }
 
 // Clone implements the deep copy of * TiFlashshScanContext
@@ -547,13 +547,13 @@ func (context *TiFlashScanContext) Clone() TiFlashScanContext {
 		totalDmfileScannedRows:             context.totalDmfileScannedRows,
 		totalDmfileSkippedPacks:            context.totalDmfileSkippedPacks,
 		totalDmfileSkippedRows:             context.totalDmfileSkippedRows,
-		totalDmfileRoughSetIndexLoadTimeMs: context.totalDmfileRoughSetIndexLoadTimeMs,
-		totalDmfileReadTimeMs:              context.totalDmfileReadTimeMs,
-		totalCreateSnapshotTimeMs:          context.totalCreateSnapshotTimeMs,
+		totalDmfileRoughSetIndexLoadTimeNs: context.totalDmfileRoughSetIndexLoadTimeNs,
+		totalDmfileReadTimeNs:              context.totalDmfileReadTimeNs,
+		totalCreateSnapshotTimeNs:          context.totalCreateSnapshotTimeNs,
 	}
 }
 func (context *TiFlashScanContext) String() string {
-	return fmt.Sprintf("tiflash_scan:{dtfile:{total_scanned_packs:%d, total_skipped_packs:%d, total_scanned_rows:%d, total_skipped_rows:%d, total_rs_index_load_time: %dms, total_read_time: %dms}, total_create_snapshot_time: %dms}", context.totalDmfileScannedPacks, context.totalDmfileSkippedPacks, context.totalDmfileScannedRows, context.totalDmfileSkippedRows, context.totalDmfileRoughSetIndexLoadTimeMs, context.totalDmfileReadTimeMs, context.totalCreateSnapshotTimeMs)
+	return fmt.Sprintf("tiflash_scan:{dtfile:{total_scanned_packs:%d, total_skipped_packs:%d, total_scanned_rows:%d, total_skipped_rows:%d, total_rs_index_load_time: %dms, total_read_time: %dms}, total_create_snapshot_time: %dms}", context.totalDmfileScannedPacks, context.totalDmfileSkippedPacks, context.totalDmfileScannedRows, context.totalDmfileSkippedRows, context.totalDmfileRoughSetIndexLoadTimeNs/1000000, context.totalDmfileReadTimeNs/1000000, context.totalCreateSnapshotTimeNs/1000000)
 }
 
 // Merge make sum to merge the information in TiFlashScanContext
@@ -562,9 +562,9 @@ func (context *TiFlashScanContext) Merge(other TiFlashScanContext) {
 	context.totalDmfileScannedRows += other.totalDmfileScannedRows
 	context.totalDmfileSkippedPacks += other.totalDmfileSkippedPacks
 	context.totalDmfileSkippedRows += other.totalDmfileSkippedRows
-	context.totalDmfileRoughSetIndexLoadTimeMs += other.totalDmfileRoughSetIndexLoadTimeMs
-	context.totalDmfileReadTimeMs += other.totalDmfileReadTimeMs
-	context.totalCreateSnapshotTimeMs += other.totalCreateSnapshotTimeMs
+	context.totalDmfileRoughSetIndexLoadTimeNs += other.totalDmfileRoughSetIndexLoadTimeNs
+	context.totalDmfileReadTimeNs += other.totalDmfileReadTimeNs
+	context.totalCreateSnapshotTimeNs += other.totalCreateSnapshotTimeNs
 }
 
 // Empty check whether TiFlashScanContext is Empty, if scan no pack and skip no pack, we regard it as empty

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -135,15 +135,15 @@ func mockExecutorExecutionSummary(TimeProcessedNs, NumProducedRows, NumIteration
 		NumIterations: &NumIterations, XXX_unrecognized: nil}
 }
 
-func mockExecutorExecutionSummaryForTiFlash(TimeProcessedNs, NumProducedRows, NumIterations, Concurrency, totalDmfileScannedPacks, totalDmfileScannedRows, totalDmfileSkippedPacks, totalDmfileSkippedRows, totalDmfileRoughSetIndexLoadTimeMs, totalDmfileReadTimeMs, totalCreateSnapshotTimeMs uint64, ExecutorID string) *tipb.ExecutorExecutionSummary {
+func mockExecutorExecutionSummaryForTiFlash(TimeProcessedNs, NumProducedRows, NumIterations, Concurrency, totalDmfileScannedPacks, totalDmfileScannedRows, totalDmfileSkippedPacks, totalDmfileSkippedRows, totalDmfileRoughSetIndexLoadTimeNs, totalDmfileReadTimeNs, totalCreateSnapshotTimeNs uint64, ExecutorID string) *tipb.ExecutorExecutionSummary {
 	tiflashScanContext := tipb.TiFlashScanContext{
 		TotalDmfileScannedPacks:            &totalDmfileScannedPacks,
 		TotalDmfileSkippedPacks:            &totalDmfileSkippedPacks,
 		TotalDmfileScannedRows:             &totalDmfileScannedRows,
 		TotalDmfileSkippedRows:             &totalDmfileSkippedRows,
-		TotalDmfileRoughSetIndexLoadTimeMs: &totalDmfileRoughSetIndexLoadTimeMs,
-		TotalDmfileReadTimeMs:              &totalDmfileReadTimeMs,
-		TotalCreateSnapshotTimeMs:          &totalCreateSnapshotTimeMs,
+		TotalDmfileRoughSetIndexLoadTimeNs: &totalDmfileRoughSetIndexLoadTimeNs,
+		TotalDmfileReadTimeNs:              &totalDmfileReadTimeNs,
+		TotalCreateSnapshotTimeNs:          &totalCreateSnapshotTimeNs,
 	}
 	return &tipb.ExecutorExecutionSummary{TimeProcessedNs: &TimeProcessedNs, NumProducedRows: &NumProducedRows,
 		NumIterations: &NumIterations, Concurrency: &Concurrency, ExecutorId: &ExecutorID, DetailInfo: &tipb.ExecutorExecutionSummary_TiflashScanContext{TiflashScanContext: &tiflashScanContext}, XXX_unrecognized: nil}
@@ -208,10 +208,10 @@ func TestCopRuntimeStatsForTiFlash(t *testing.T) {
 	tableScanID := 1
 	aggID := 2
 	tableReaderID := 3
-	stats.RecordOneCopTask(aggID, "tiflash", "8.8.8.8", mockExecutorExecutionSummaryForTiFlash(1, 1, 1, 1, 1, 8192, 0, 0, 15, 200, 40, "tablescan_"+strconv.Itoa(tableScanID)))
-	stats.RecordOneCopTask(aggID, "tiflash", "8.8.8.9", mockExecutorExecutionSummaryForTiFlash(2, 2, 2, 1, 0, 0, 0, 0, 0, 2, 0, "tablescan_"+strconv.Itoa(tableScanID)))
-	stats.RecordOneCopTask(tableScanID, "tiflash", "8.8.8.8", mockExecutorExecutionSummaryForTiFlash(3, 3, 3, 1, 2, 12000, 1, 6000, 60, 1000, 20, "aggregation_"+strconv.Itoa(aggID)))
-	stats.RecordOneCopTask(tableScanID, "tiflash", "8.8.8.9", mockExecutorExecutionSummaryForTiFlash(4, 4, 4, 1, 1, 8192, 10, 80000, 40, 2000, 30, "aggregation_"+strconv.Itoa(aggID)))
+	stats.RecordOneCopTask(aggID, "tiflash", "8.8.8.8", mockExecutorExecutionSummaryForTiFlash(1, 1, 1, 1, 1, 8192, 0, 0, 15000000, 200000000, 40000000, "tablescan_"+strconv.Itoa(tableScanID)))
+	stats.RecordOneCopTask(aggID, "tiflash", "8.8.8.9", mockExecutorExecutionSummaryForTiFlash(2, 2, 2, 1, 0, 0, 0, 0, 0, 2000000, 0, "tablescan_"+strconv.Itoa(tableScanID)))
+	stats.RecordOneCopTask(tableScanID, "tiflash", "8.8.8.8", mockExecutorExecutionSummaryForTiFlash(3, 3, 3, 1, 2, 12000, 1, 6000, 60000000, 1000000000, 20000000, "aggregation_"+strconv.Itoa(aggID)))
+	stats.RecordOneCopTask(tableScanID, "tiflash", "8.8.8.9", mockExecutorExecutionSummaryForTiFlash(4, 4, 4, 1, 1, 8192, 10, 80000, 40000000, 2000000000, 30000000, "aggregation_"+strconv.Itoa(aggID)))
 	scanDetail := &util.ScanDetail{
 		TotalKeys:                 10,
 		ProcessedKeys:             10,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #39273

Problem Summary:

### What is changed and how it works?
Change the time unit of measurement in TiFlashScanContext

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
