### PR TITLE
hint: fix the problem that set var hint is invalid when create binding

### DIFF
--- a/bindinfo/BUILD.bazel
+++ b/bindinfo/BUILD.bazel
@@ -71,7 +71,6 @@ go_test(
         "//server",
         "//sessionctx/variable",
         "//testkit",
-        "//testkit/testdata",
         "//testkit/testsetup",
         "//util",
         "//util/hack",

--- a/bindinfo/BUILD.bazel
+++ b/bindinfo/BUILD.bazel
@@ -71,6 +71,7 @@ go_test(
         "//server",
         "//sessionctx/variable",
         "//testkit",
+        "//testkit/testdata",
         "//testkit/testsetup",
         "//util",
         "//util/hack",

--- a/bindinfo/session_handle_test.go
+++ b/bindinfo/session_handle_test.go
@@ -16,7 +16,6 @@ package bindinfo_test
 
 import (
 	"context"
-	"github.com/pingcap/tidb/testkit/testdata"
 	"strconv"
 	"testing"
 	"time"
@@ -28,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/parser/auth"
 	"github.com/pingcap/tidb/server"
 	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/testkit/testdata"
 	"github.com/pingcap/tidb/util/stmtsummary"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"

--- a/bindinfo/session_handle_test.go
+++ b/bindinfo/session_handle_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/parser/auth"
 	"github.com/pingcap/tidb/server"
 	"github.com/pingcap/tidb/testkit"
-	"github.com/pingcap/tidb/testkit/testdata"
 	"github.com/pingcap/tidb/util/stmtsummary"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
@@ -531,11 +530,5 @@ func TestSetVarBinding(t *testing.T) {
 	tk.MustExec("insert into t1 values (1, '111111111111111')")
 	tk.MustExec("insert into t1 values (2, '222222222222222')")
 	tk.MustExec("create binding for select group_concat(b) from test.t1 using select /*+ SET_VAR(group_concat_max_len = 4) */ group_concat(b) from test.t1 ;")
-	explainStrings := testdata.ConvertRowsToStrings(tk.MustQuery("select group_concat(b) from test.t1").Rows())
-	if len(explainStrings) == 1 && explainStrings[0] == "1111" {
-		t.Log("Set var in hint")
-	} else {
-		t.Log("The result is error")
-		t.Fail()
-	}
+	tk.MustQuery("select group_concat(b) from test.t1").Check(testkit.Rows("1111"))
 }

--- a/parser/ast/misc.go
+++ b/parser/ast/misc.go
@@ -3816,9 +3816,9 @@ func (n *TableOptimizerHint) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteString(hintData.To)
 	case "set_var":
 		hintData := n.HintData.(HintSetVar)
-		ctx.WriteString(hintData.VarName)
-		ctx.WritePlain(", ")
-		ctx.WriteString(hintData.Value)
+		ctx.WritePlain(hintData.VarName)
+		ctx.WritePlain(" = ")
+		ctx.WritePlain(hintData.Value)
 	}
 	ctx.WritePlain(")")
 	return nil

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -215,6 +215,13 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 			hint.BindHint(stmtNode, binding.Hint)
 			curStmtHints, _, curWarns := handleStmtHints(binding.Hint.GetFirstTableHints())
 			sessVars.StmtCtx.StmtHints = curStmtHints
+			// update session var by hint /set_var/
+			for name, val := range sessVars.StmtCtx.StmtHints.SetVars {
+				err := sessVars.SetStmtVar(name, val)
+				if err != nil {
+					sessVars.StmtCtx.AppendWarning(err)
+				}
+			}
 			plan, curNames, cost, err := optimize(ctx, sctx, node, is)
 			if err != nil {
 				binding.Status = bindinfo.Invalid


### PR DESCRIPTION
### What problem does this PR solve?

set var hint is invalid when create binding

Issue Number: close #40570

Problem Summary:

### What is changed and how it works?

1. After finding the binding sql, you also need to update the value of the session var
2. Only session vars with ```IsHintUpdatable:true``` set can be updated
3. When obtaining session var, you cannot directly read attributes, you need to use the function ```GetSessionFromHook```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
