### PR TITLE
planner: introduce a new variable to adjust the penalty double read cost of IndexJoin

### DIFF
--- a/planner/core/plan_cost_ver2.go
+++ b/planner/core/plan_cost_ver2.go
@@ -597,7 +597,7 @@ func (p *PhysicalIndexJoin) getIndexJoinCostVer2(taskType property.TaskType, opt
 	probeCost := divCostVer2(mulCostVer2(probeChildCost, buildRows), batchRatio)
 
 	// Double Read Cost
-	var doubleReadCost costVer2
+	doubleReadCost := zeroCostVer2
 	if p.ctx.GetSessionVars().IndexJoinDoubleReadPenaltyCostRate > 0 {
 		batchSize := float64(p.ctx.GetSessionVars().IndexJoinBatchSize)
 		taskPerBatch := 1024.0 // TODO: remove this magic number

--- a/planner/core/plan_cost_ver2.go
+++ b/planner/core/plan_cost_ver2.go
@@ -600,7 +600,7 @@ func (p *PhysicalIndexJoin) getIndexJoinCostVer2(taskType property.TaskType, opt
 	var doubleReadCost costVer2
 	if p.ctx.GetSessionVars().IndexJoinDoubleReadPenaltyCostRate > 0 {
 		batchSize := float64(p.ctx.GetSessionVars().IndexJoinBatchSize)
-		taskPerBatch := 32.0 // TODO: remove this magic number
+		taskPerBatch := 1024.0 // TODO: remove this magic number
 		doubleReadTasks := buildRows / batchSize * taskPerBatch
 		doubleReadCost = doubleReadCostVer2(option, doubleReadTasks, requestFactor)
 		doubleReadCost = mulCostVer2(doubleReadCost, p.ctx.GetSessionVars().IndexJoinDoubleReadPenaltyCostRate)

--- a/planner/core/plan_cost_ver2.go
+++ b/planner/core/plan_cost_ver2.go
@@ -598,7 +598,8 @@ func (p *PhysicalIndexJoin) getIndexJoinCostVer2(taskType property.TaskType, opt
 
 	// Double Read Cost
 	doubleReadCost := zeroCostVer2
-	if p.ctx.GetSessionVars().IndexJoinDoubleReadPenaltyCostRate > 0 {
+	if p.ctx.GetSessionVars().IndexJoinDoubleReadPenaltyCostRate > 0 &&
+		buildRows > 10000 { // ignore double-read costs for small IndexJoin
 		batchSize := float64(p.ctx.GetSessionVars().IndexJoinBatchSize)
 		taskPerBatch := 1024.0 // TODO: remove this magic number
 		doubleReadTasks := buildRows / batchSize * taskPerBatch

--- a/planner/core/plan_cost_ver2.go
+++ b/planner/core/plan_cost_ver2.go
@@ -597,7 +597,7 @@ func (p *PhysicalIndexJoin) getIndexJoinCostVer2(taskType property.TaskType, opt
 	probeCost := divCostVer2(mulCostVer2(probeChildCost, buildRows), batchRatio)
 
 	// Double Read Cost
-	doubleReadCost := zeroCostVer2
+	doubleReadCost := newZeroCostVer2(traceCost(option))
 	if p.ctx.GetSessionVars().IndexJoinDoubleReadPenaltyCostRate > 0 &&
 		buildRows > 10000 { // ignore double-read costs for small IndexJoin
 		batchSize := float64(p.ctx.GetSessionVars().IndexJoinBatchSize)

--- a/planner/core/plan_cost_ver2_test.go
+++ b/planner/core/plan_cost_ver2_test.go
@@ -257,6 +257,7 @@ func TestIndexJoinPenaltyCost(t *testing.T) {
 	tk.MustExec(`create table t2 (a int, key(a))`)
 
 	// default value 0
+	tk.MustExec("set tidb_index_join_double_read_penalty_cost_rate=0")
 	tk.MustQuery("select @@tidb_index_join_double_read_penalty_cost_rate").Check(testkit.Rows("0"))
 	//tk.MustQuery("select global @@tidb_index_join_double_read_penalty_cost_rate").Check(testkit.Rows("0"))
 

--- a/planner/core/plan_cost_ver2_test.go
+++ b/planner/core/plan_cost_ver2_test.go
@@ -249,6 +249,35 @@ func TestCostModelTraceVer2(t *testing.T) {
 	}
 }
 
+func TestIndexJoinPenaltyCost(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t1 (a int, key(a))`)
+	tk.MustExec(`create table t2 (a int, key(a))`)
+
+	// default value 0
+	tk.MustQuery("select @@tidb_index_join_double_read_penalty_cost_rate").Check(testkit.Rows("0"))
+	//tk.MustQuery("select global @@tidb_index_join_double_read_penalty_cost_rate").Check(testkit.Rows("0"))
+
+	rs1 := tk.MustQuery("explain format='verbose' select /*+ tidb_inlj(t1, t2) */ * from t1, t2 where t1.a=t2.a").Rows()
+	cost1, err := strconv.ParseFloat(rs1[0][2].(string), 64)
+	require.Nil(t, err)
+
+	tk.MustExec("set tidb_index_join_double_read_penalty_cost_rate=0.5")
+	rs2 := tk.MustQuery("explain format='verbose' select /*+ tidb_inlj(t1, t2) */ * from t1, t2 where t1.a=t2.a").Rows()
+	cost2, err := strconv.ParseFloat(rs2[0][2].(string), 64)
+	require.Nil(t, err)
+
+	tk.MustExec("set tidb_index_join_double_read_penalty_cost_rate=1")
+	rs3 := tk.MustQuery("explain format='verbose' select /*+ tidb_inlj(t1, t2) */ * from t1, t2 where t1.a=t2.a").Rows()
+	cost3, err := strconv.ParseFloat(rs3[0][2].(string), 64)
+	require.Nil(t, err)
+
+	require.Greater(t, cost2, cost1)
+	require.Greater(t, cost3, cost2)
+}
+
 func BenchmarkGetPlanCost(b *testing.B) {
 	store := testkit.CreateMockStore(b)
 	tk := testkit.NewTestKit(b, store)

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1207,6 +1207,9 @@ type SessionVars struct {
 	EnableNewCostInterface bool
 	// CostModelVersion is a internal switch to indicates the Cost Model Version.
 	CostModelVersion int
+	// IndexJoinDoubleReadPenaltyCostRate indicates whether to add some penalty cost to IndexJoin and how much of it.
+	IndexJoinDoubleReadPenaltyCostRate float64
+
 	// BatchPendingTiFlashCount shows the threshold of pending TiFlash tables when batch adding.
 	BatchPendingTiFlashCount int
 	// RcWriteCheckTS indicates whether some special write statements don't get latest tso from PD at RC

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1981,7 +1981,7 @@ var defaultSysVars = []*SysVar{
 			return nil
 		},
 	},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBIndexJoinDoubleReadPenaltyCostRate, Value: strconv.Itoa(0), Hidden: false, Type: TypeFloat, MinValue: 0, MaxValue: math.MaxUint64,
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBIndexJoinDoubleReadPenaltyCostRate, Value: strconv.Itoa(1), Hidden: false, Type: TypeFloat, MinValue: 0, MaxValue: math.MaxUint64,
 		SetSession: func(vars *SessionVars, s string) error {
 			vars.IndexJoinDoubleReadPenaltyCostRate = tidbOptFloat64(s, 0)
 			return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1981,6 +1981,12 @@ var defaultSysVars = []*SysVar{
 			return nil
 		},
 	},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBIndexJoinDoubleReadPenaltyCostRate, Value: strconv.Itoa(0), Hidden: false, Type: TypeFloat, MinValue: 0, MaxValue: math.MaxUint64,
+		SetSession: func(vars *SessionVars, s string) error {
+			vars.IndexJoinDoubleReadPenaltyCostRate = tidbOptFloat64(s, 0)
+			return nil
+		},
+	},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBRCWriteCheckTs, Type: TypeBool, Value: BoolToOnOff(DefTiDBRcWriteCheckTs), SetSession: func(s *SessionVars, val string) error {
 		s.RcWriteCheckTS = TiDBOptOn(val)
 		return nil

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -700,6 +700,12 @@ const (
 	// TiDBCostModelVersion is a internal switch to indicates the cost model version.
 	TiDBCostModelVersion = "tidb_cost_model_version"
 
+	// TiDBIndexJoinDoubleReadPenaltyCostRate indicates whether to add some penalty cost to IndexJoin and how much of it.
+	// IndexJoin can cause plenty of extra double read tasks, which consume lots of resources and take a long time.
+	// Since the number of double read tasks is hard to estimated accurately, we leave this variable to let us can adjust this
+	// part of cost manually.
+	TiDBIndexJoinDoubleReadPenaltyCostRate = "tidb_index_join_double_read_penalty_cost_rate"
+
 	// TiDBBatchPendingTiFlashCount indicates the maximum count of non-available TiFlash tables.
 	TiDBBatchPendingTiFlashCount = "tidb_batch_pending_tiflash_count"
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40556

Problem Summary: planner: introduce a new variable to adjust the penalty double read cost of IndexJoin

### What is changed and how it works?

IndexJoin can cause plenty of extra double-read tasks, which consume lots of resources and take a long time.

Since the number of double-read tasks is hard to be estimated accurately, we introduce a new variable to let us have the ability to adjust this part of the cost manually.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
