### PR TITLE
planner: add switch for prepare statement with parameterized limit and subquery cacheable

### DIFF
--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1250,6 +1250,13 @@ type SessionVars struct {
 	// PreparedPlanCacheMonitor indicates whether to enable prepared plan cache monitor.
 	EnablePreparedPlanCacheMemoryMonitor bool
 
+	// EnablePreparedPlanCacheForParameterizedLimit controls whether the prepare statement with parameterized limit
+	// can be cached
+	EnablePreparedPlanCacheForParameterizedLimit bool
+
+	// EnablePreparedPlanCacheForSubquery controls whether the prepare statement with subquery can be cached
+	EnablePreparedPlanCacheForSubquery bool
+
 	// EnableNonPreparedPlanCache indicates whether to enable non-prepared plan cache.
 	EnableNonPreparedPlanCache bool
 

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -2258,6 +2258,14 @@ var defaultSysVars = []*SysVar{
 		s.PessimisticTransactionAggressiveLocking = TiDBOptOn(val)
 		return nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnablePrepPlanCacheForParameterizedLimit, Value: BoolToOnOff(DefTiDBEnablePrepPlanCacheForParameterizedLimit), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.EnablePreparedPlanCacheForParameterizedLimit = TiDBOptOn(val)
+		return nil
+	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnablePrepPlanCacheForSubquery, Value: BoolToOnOff(DefTiDBEnablePrepPlanCacheForSubquery), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.EnablePreparedPlanCacheForSubquery = TiDBOptOn(val)
+		return nil
+	}},
 }
 
 // FeedbackProbability points to the FeedbackProbability in statistics package.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -790,6 +790,13 @@ const (
 	// TiDBPessimisticTransactionAggressiveLocking controls whether aggressive locking for pessimistic transaction
 	// is enabled.
 	TiDBPessimisticTransactionAggressiveLocking = "tidb_pessimistic_txn_aggressive_locking"
+
+	// TiDBEnablePrepPlanCacheForParameterizedLimit controls whether prepare statement with parameterized limit
+	//can be cached
+	TiDBEnablePrepPlanCacheForParameterizedLimit = "tidb_enable_prepared_plan_cache_for_parameterized_limit"
+
+	// TiDBEnablePrepPlanCacheForSubquery controls whether prepare statement with subquery can be cached
+	TiDBEnablePrepPlanCacheForSubquery = "tidb_enable_prepared_plan_cache_for_subquery"
 )
 
 // TiDB vars that have only global scope
@@ -1134,33 +1141,35 @@ const (
 	DefTiDBServerMemoryLimitGCTrigger            = 0.7
 	DefTiDBEnableGOGCTuner                       = true
 	// DefTiDBGOGCTunerThreshold is to limit TiDBGOGCTunerThreshold.
-	DefTiDBGOGCTunerThreshold                      float64 = 0.6
-	DefTiDBOptPrefixIndexSingleScan                        = true
-	DefTiDBExternalTS                                      = 0
-	DefTiDBEnableExternalTSRead                            = false
-	DefTiDBEnableReusechunk                                = true
-	DefTiDBUseAlloc                                        = false
-	DefTiDBEnablePlanReplayerCapture                       = false
-	DefTiDBIndexMergeIntersectionConcurrency               = ConcurrencyUnset
-	DefTiDBTTLJobEnable                                    = true
-	DefTiDBTTLScanBatchSize                                = 500
-	DefTiDBTTLScanBatchMaxSize                             = 10240
-	DefTiDBTTLScanBatchMinSize                             = 1
-	DefTiDBTTLDeleteBatchSize                              = 100
-	DefTiDBTTLDeleteBatchMaxSize                           = 10240
-	DefTiDBTTLDeleteBatchMinSize                           = 1
-	DefTiDBTTLDeleteRateLimit                              = 0
-	DefPasswordReuseHistory                                = 0
-	DefPasswordReuseTime                                   = 0
-	DefTiDBStoreBatchSize                                  = 0
-	DefTiDBHistoricalStatsDuration                         = 7 * 24 * time.Hour
-	DefTiDBEnableHistoricalStatsForCapture                 = false
-	DefTiDBTTLJobScheduleWindowStartTime                   = "00:00 +0000"
-	DefTiDBTTLJobScheduleWindowEndTime                     = "23:59 +0000"
-	DefTiDBTTLScanWorkerCount                              = 4
-	DefTiDBTTLDeleteWorkerCount                            = 4
-	DefTiDBEnableResourceControl                           = false
-	DefTiDBPessimisticTransactionAggressiveLocking         = false
+	DefTiDBGOGCTunerThreshold                       float64 = 0.6
+	DefTiDBOptPrefixIndexSingleScan                         = true
+	DefTiDBExternalTS                                       = 0
+	DefTiDBEnableExternalTSRead                             = false
+	DefTiDBEnableReusechunk                                 = true
+	DefTiDBUseAlloc                                         = false
+	DefTiDBEnablePlanReplayerCapture                        = false
+	DefTiDBIndexMergeIntersectionConcurrency                = ConcurrencyUnset
+	DefTiDBTTLJobEnable                                     = true
+	DefTiDBTTLScanBatchSize                                 = 500
+	DefTiDBTTLScanBatchMaxSize                              = 10240
+	DefTiDBTTLScanBatchMinSize                              = 1
+	DefTiDBTTLDeleteBatchSize                               = 100
+	DefTiDBTTLDeleteBatchMaxSize                            = 10240
+	DefTiDBTTLDeleteBatchMinSize                            = 1
+	DefTiDBTTLDeleteRateLimit                               = 0
+	DefPasswordReuseHistory                                 = 0
+	DefPasswordReuseTime                                    = 0
+	DefTiDBStoreBatchSize                                   = 0
+	DefTiDBHistoricalStatsDuration                          = 7 * 24 * time.Hour
+	DefTiDBEnableHistoricalStatsForCapture                  = false
+	DefTiDBTTLJobScheduleWindowStartTime                    = "00:00 +0000"
+	DefTiDBTTLJobScheduleWindowEndTime                      = "23:59 +0000"
+	DefTiDBTTLScanWorkerCount                               = 4
+	DefTiDBTTLDeleteWorkerCount                             = 4
+	DefTiDBEnableResourceControl                            = false
+	DefTiDBPessimisticTransactionAggressiveLocking          = false
+	DefTiDBEnablePrepPlanCacheForParameterizedLimit         = true
+	DefTiDBEnablePrepPlanCacheForSubquery                   = true
 )
 
 // Process global variables.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40219

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
