### PR TITLE
executor: fix concurrent use of `testkit` in tests and add nil check

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5556,6 +5556,8 @@ func TestAdmin(t *testing.T) {
 	}))
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
+	tk2 := testkit.NewTestKit(t, store)
+	tk2.MustExec("use test")
 	tk.MustExec("drop table if exists admin_test")
 	tk.MustExec("create table admin_test (c1 int, c2 int, c3 int default 1, index (c1))")
 	tk.MustExec("insert admin_test (c1) values (1),(2),(NULL)")
@@ -5680,7 +5682,7 @@ func TestAdmin(t *testing.T) {
 		// check that the result set has no duplication
 		defer wg.Done()
 		for i := 0; i < 10; i++ {
-			result := tk.MustQuery(`admin show ddl job queries 20`)
+			result := tk2.MustQuery(`admin show ddl job queries 20`)
 			rows := result.Rows()
 			rowIDs := make(map[string]struct{})
 			for _, row := range rows {
@@ -5711,7 +5713,7 @@ func TestAdmin(t *testing.T) {
 		// check that the result set has no duplication
 		defer wg2.Done()
 		for i := 0; i < 10; i++ {
-			result := tk.MustQuery(`admin show ddl job queries limit 3 offset 2`)
+			result := tk2.MustQuery(`admin show ddl job queries limit 3 offset 2`)
 			rows := result.Rows()
 			rowIDs := make(map[string]struct{})
 			for _, row := range rows {

--- a/planner/core/encode.go
+++ b/planner/core/encode.go
@@ -262,6 +262,9 @@ type planDigester struct {
 
 // NormalizeFlatPlan normalizes a FlatPhysicalPlan and generates plan digest.
 func NormalizeFlatPlan(flat *FlatPhysicalPlan) (normalized string, digest *parser.Digest) {
+	if flat == nil {
+		return "", parser.NewDigest(nil)
+	}
 	selectPlan, selectPlanOffset := flat.Main.GetSelectPlan()
 	if len(selectPlan) == 0 || !selectPlan[0].IsPhysicalPlan {
 		return "", parser.NewDigest(nil)


### PR DESCRIPTION

### What problem does this PR solve?


Issue Number: close #40206

Problem Summary:

A `TestKit` contains one `Session`, so we can't concurrently use a `TestKit` to execute SQLs.

### What is changed and how it works?

- Use another `TestKit` to concurrently run SQLs in `TestAdmin`
- Add a nil check in `NormalizeFlatPlan`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
