### PR TITLE
ddl: cancel job，after met DropTableOrView error

### DIFF
--- a/ddl/table.go
+++ b/ddl/table.go
@@ -301,6 +301,7 @@ func onCreateView(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) 
 		if oldTbInfoID > 0 && orReplace {
 			err = t.DropTableOrView(schemaID, oldTbInfoID)
 			if err != nil {
+				job.State = model.JobStateCancelled
 				return ver, errors.Trace(err)
 			}
 			err = t.GetAutoIDAccessors(schemaID, oldTbInfoID).Del()


### PR DESCRIPTION
Signed-off-by: ystaticy <y_static_y@sina.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/40783

Problem Summary:
I met the error when TiDB call `upgradeToVer94`, upgrade from TiDB 6.2 to TiDB 6.4. 
If the `create and replace view` ddl job in `upgradeToVer94` is interrupted ,  we may encounter `table doesn't exist`(In fact, the old view has been dropped ) in `DropTableOrView` when we restart tidb and the rerun the job by old view info.

### What is changed and how it works?
If we encounter `table doesn't exist`(the old view has been dropped ) the job.State need to be set to `model.JobStateCancelled`


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix create and replace view job state
```
