### PR TITLE
planner: disable plan-cache for plans with IndexMerge accessing Multi-Valued Index

### DIFF
--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1136,6 +1136,7 @@ func (ds *DataSource) convertToIndexMergeScan(prop *property.PhysicalProperty, c
 	cop.tablePlan = ts
 	cop.idxMergePartPlans = scans
 	cop.idxMergeIsIntersection = path.IndexMergeIsIntersection
+	cop.idxMergeAccessMVIndex = path.IndexMergeAccessMVIndex
 	if remainingFilters != nil {
 		cop.rootTaskConds = remainingFilters
 	}

--- a/planner/core/indexmerge_path.go
+++ b/planner/core/indexmerge_path.go
@@ -618,7 +618,7 @@ func (ds *DataSource) generateIndexMerge4MVIndex(normalPathCnt int, filters []ex
 
 // buildPartialPathUp4MVIndex builds these partial paths up to a complete index merge path.
 func (ds *DataSource) buildPartialPathUp4MVIndex(partialPaths []*util.AccessPath, isIntersection bool, remainingFilters []expression.Expression) *util.AccessPath {
-	indexMergePath := &util.AccessPath{PartialIndexPaths: partialPaths, AccessMVIndex: true}
+	indexMergePath := &util.AccessPath{PartialIndexPaths: partialPaths, IndexMergeAccessMVIndex: true}
 	indexMergePath.IndexMergeIsIntersection = isIntersection
 	indexMergePath.TableFilters = remainingFilters
 

--- a/planner/core/indexmerge_path.go
+++ b/planner/core/indexmerge_path.go
@@ -618,7 +618,7 @@ func (ds *DataSource) generateIndexMerge4MVIndex(normalPathCnt int, filters []ex
 
 // buildPartialPathUp4MVIndex builds these partial paths up to a complete index merge path.
 func (ds *DataSource) buildPartialPathUp4MVIndex(partialPaths []*util.AccessPath, isIntersection bool, remainingFilters []expression.Expression) *util.AccessPath {
-	indexMergePath := &util.AccessPath{PartialIndexPaths: partialPaths}
+	indexMergePath := &util.AccessPath{PartialIndexPaths: partialPaths, AccessMVIndex: true}
 	indexMergePath.IndexMergeIsIntersection = isIntersection
 	indexMergePath.TableFilters = remainingFilters
 

--- a/planner/core/indexmerge_path_test.go
+++ b/planner/core/indexmerge_path_test.go
@@ -136,3 +136,16 @@ index i_int((cast(j->'$.int' as signed array))))`)
 		result.Check(testkit.Rows(output[i].Plan...))
 	}
 }
+
+func TestMVIndexIndexMergePlanCache(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t(j json, index kj((cast(j as signed array))))`)
+
+	tk.MustExec("prepare st from 'select /*+ use_index_merge(t, kj) */ * from t where (1 member of (j))'")
+	tk.MustExec("execute st")
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustExec("execute st")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+}

--- a/planner/core/indexmerge_path_test.go
+++ b/planner/core/indexmerge_path_test.go
@@ -144,8 +144,8 @@ func TestMVIndexIndexMergePlanCache(t *testing.T) {
 	tk.MustExec(`create table t(j json, index kj((cast(j as signed array))))`)
 
 	tk.MustExec("prepare st from 'select /*+ use_index_merge(t, kj) */ * from t where (1 member of (j))'")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip plan-cache: query accesses generated columns is un-cacheable"))
 	tk.MustExec("execute st")
-	tk.MustQuery("show warnings").Check(testkit.Rows())
 	tk.MustExec("execute st")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 }

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -1001,26 +1001,6 @@ func propagateProbeParents(plan PhysicalPlan, probeParents []PhysicalPlan) {
 	}
 }
 
-// useTiFlash used to check whether the plan use the TiFlash engine.
-func useTiFlash(p PhysicalPlan) bool {
-	switch x := p.(type) {
-	case *PhysicalTableReader:
-		switch x.StoreType {
-		case kv.TiFlash:
-			return true
-		default:
-			return false
-		}
-	default:
-		if len(p.Children()) > 0 {
-			for _, plan := range p.Children() {
-				return useTiFlash(plan)
-			}
-		}
-	}
-	return false
-}
-
 func enableParallelApply(sctx sessionctx.Context, plan PhysicalPlan) PhysicalPlan {
 	if !sctx.GetSessionVars().EnableParallelApply {
 		return plan

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -551,6 +551,8 @@ type PhysicalIndexMergeReader struct {
 	// IsIntersectionType means whether it's intersection type or union type.
 	// Intersection type is for expressions connected by `AND` and union type is for `OR`.
 	IsIntersectionType bool
+	// AccessMVIndex indicates whether this IndexMergeReader access a MVIndex.
+	AccessMVIndex bool
 
 	// PartialPlans flats the partialPlans to construct executor pb.
 	PartialPlans [][]PhysicalPlan

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -286,7 +286,9 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 	}
 
 	// check whether this plan is cacheable.
-	checkPlanCacheability(sctx, p, len(paramTypes))
+	if stmtCtx.UseCache {
+		checkPlanCacheability(sctx, p, len(paramTypes))
+	}
 
 	// put this plan into the plan cache.
 	if stmtCtx.UseCache {

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -86,6 +86,7 @@ type copTask struct {
 
 	idxMergePartPlans      []PhysicalPlan
 	idxMergeIsIntersection bool
+	idxMergeAccessMVIndex  bool
 
 	// rootTaskConds stores select conditions containing virtual columns.
 	// These conditions can't push to TiKV, so we have to add a selection for rootTask
@@ -688,6 +689,7 @@ func (t *copTask) convertToRootTaskImpl(ctx sessionctx.Context) *rootTask {
 			partialPlans:       t.idxMergePartPlans,
 			tablePlan:          t.tablePlan,
 			IsIntersectionType: t.idxMergeIsIntersection,
+			AccessMVIndex:      t.idxMergeAccessMVIndex,
 		}.Init(ctx, t.idxMergePartPlans[0].SelectBlockOffset())
 		p.PartitionInfo = t.partitionInfo
 		setTableScanToTableRowIDScan(p.tablePlan)

--- a/planner/util/path.go
+++ b/planner/util/path.go
@@ -54,6 +54,8 @@ type AccessPath struct {
 	// It's only valid for a IndexMerge path.
 	// Intersection type is for expressions connected by `AND` and union type is for `OR`.
 	IndexMergeIsIntersection bool
+	// IndexMergeAccessMVIndex indicates whether this IndexMerge path accesses a MVIndex.
+	IndexMergeAccessMVIndex bool
 
 	StoreType kv.StoreType
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40191

Problem Summary: planner: disable plan-cache for plans with IndexMerge accessing Multi-Valued Index

### What is changed and how it works?

planner: disable plan-cache for plans with IndexMerge accessing Multi-Valued Index

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
