### PR TITLE
*: add a new I_S table and support show create for resource groups

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -778,6 +778,7 @@ func (b *executorBuilder) buildShow(v *plannercore.PhysicalShow) Executor {
 		Partition:             v.Partition,
 		Column:                v.Column,
 		IndexName:             v.IndexName,
+		ResourceGroupName:     model.NewCIStr(v.ResourceGroupName),
 		Flag:                  v.Flag,
 		Roles:                 v.Roles,
 		User:                  v.User,
@@ -1930,7 +1931,8 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executo
 			strings.ToLower(infoschema.TableMemoryUsage),
 			strings.ToLower(infoschema.TableMemoryUsageOpsHistory),
 			strings.ToLower(infoschema.ClusterTableMemoryUsage),
-			strings.ToLower(infoschema.ClusterTableMemoryUsageOpsHistory):
+			strings.ToLower(infoschema.ClusterTableMemoryUsageOpsHistory),
+			strings.ToLower(infoschema.TableResourceGroups):
 			return &MemTableReaderExec{
 				baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ID()),
 				table:        v.Table,

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -3395,7 +3395,7 @@ func (e *memtableRetriever) setDataFromResourceGroups(sctx sessionctx.Context) e
 	for _, group := range resourceGroups {
 		row := types.MakeDatums(
 			group.ID,
-			group.Name.L,
+			group.Name.O,
 			group.RRURate,
 			group.WRURate,
 		)

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -184,6 +184,8 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 			err = e.setDataForMemoryUsageOpsHistory(sctx)
 		case infoschema.ClusterTableMemoryUsageOpsHistory:
 			err = e.setDataForClusterMemoryUsageOpsHistory(sctx)
+		case infoschema.TableResourceGroups:
+			err = e.setDataFromResourceGroups(sctx)
 		}
 		if err != nil {
 			return nil, err
@@ -3379,6 +3381,23 @@ func (e *memtableRetriever) setDataFromPlacementPolicies(sctx sessionctx.Context
 			policy.PlacementSettings.Schedule,
 			followerCnt,
 			policy.PlacementSettings.Learners,
+		)
+		rows = append(rows, row)
+	}
+	e.rows = rows
+	return nil
+}
+
+func (e *memtableRetriever) setDataFromResourceGroups(sctx sessionctx.Context) error {
+	is := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema()
+	resourceGroups := is.AllResourceGroups()
+	rows := make([][]types.Datum, 0, len(resourceGroups))
+	for _, group := range resourceGroups {
+		row := types.MakeDatums(
+			group.ID,
+			group.Name.L,
+			group.RRURate,
+			group.WRURate,
 		)
 		rows = append(rows, row)
 	}

--- a/executor/show.go
+++ b/executor/show.go
@@ -1455,8 +1455,8 @@ func ConstructResultOfShowCreatePlacementPolicy(policyInfo *model.PolicyInfo) st
 	return fmt.Sprintf("CREATE PLACEMENT POLICY `%s` %s", policyInfo.Name.O, policyInfo.PlacementSettings.String())
 }
 
-// ConstructResultOfShowCreateResourceGroup constructs the result for show create resource group.
-func ConstructResultOfShowCreateResourceGroup(resourceGroup *model.ResourceGroupInfo) string {
+// constructResultOfShowCreateResourceGroup constructs the result for show create resource group.
+func constructResultOfShowCreateResourceGroup(resourceGroup *model.ResourceGroupInfo) string {
 	return fmt.Sprintf("CREATE RESOURCE GROUP `%s` %s", resourceGroup.Name.O, resourceGroup.ResourceGroupSettings.String())
 }
 
@@ -1499,7 +1499,7 @@ func (e *ShowExec) fetchShowCreateResourceGroup() error {
 	if !found {
 		return infoschema.ErrResourceGroupNotExists.GenWithStackByArgs(e.ResourceGroupName.O)
 	}
-	showCreate := ConstructResultOfShowCreateResourceGroup(group)
+	showCreate := constructResultOfShowCreateResourceGroup(group)
 	e.appendRow([]interface{}{e.ResourceGroupName.O, showCreate})
 	return nil
 }

--- a/executor/show.go
+++ b/executor/show.go
@@ -81,16 +81,17 @@ var etcdDialTimeout = 5 * time.Second
 type ShowExec struct {
 	baseExecutor
 
-	Tp        ast.ShowStmtType // Databases/Tables/Columns/....
-	DBName    model.CIStr
-	Table     *ast.TableName       // Used for showing columns.
-	Partition model.CIStr          // Used for showing partition
-	Column    *ast.ColumnName      // Used for `desc table column`.
-	IndexName model.CIStr          // Used for show table regions.
-	Flag      int                  // Some flag parsed from sql, such as FULL.
-	Roles     []*auth.RoleIdentity // Used for show grants.
-	User      *auth.UserIdentity   // Used by show grants, show create user.
-	Extractor plannercore.ShowPredicateExtractor
+	Tp                ast.ShowStmtType // Databases/Tables/Columns/....
+	DBName            model.CIStr
+	Table             *ast.TableName       // Used for showing columns.
+	Partition         model.CIStr          // Used for showing partition
+	Column            *ast.ColumnName      // Used for `desc table column`.
+	IndexName         model.CIStr          // Used for show table regions.
+	ResourceGroupName model.CIStr          // Used for showing resource group
+	Flag              int                  // Some flag parsed from sql, such as FULL.
+	Roles             []*auth.RoleIdentity // Used for show grants.
+	User              *auth.UserIdentity   // Used by show grants, show create user.
+	Extractor         plannercore.ShowPredicateExtractor
 
 	is infoschema.InfoSchema
 
@@ -182,6 +183,8 @@ func (e *ShowExec) fetchAll(ctx context.Context) error {
 		return e.fetchShowCreateDatabase()
 	case ast.ShowCreatePlacementPolicy:
 		return e.fetchShowCreatePlacementPolicy()
+	case ast.ShowCreateResourceGroup:
+		return e.fetchShowCreateResourceGroup()
 	case ast.ShowDatabases:
 		return e.fetchShowDatabases()
 	case ast.ShowDrainerStatus:
@@ -1452,6 +1455,11 @@ func ConstructResultOfShowCreatePlacementPolicy(policyInfo *model.PolicyInfo) st
 	return fmt.Sprintf("CREATE PLACEMENT POLICY `%s` %s", policyInfo.Name.O, policyInfo.PlacementSettings.String())
 }
 
+// ConstructResultOfShowCreateResourceGroup constructs the result for show create resource group.
+func ConstructResultOfShowCreateResourceGroup(resourceGroup *model.ResourceGroupInfo) string {
+	return fmt.Sprintf("CREATE RESOURCE GROUP `%s` %s", resourceGroup.Name.O, resourceGroup.ResourceGroupSettings.String())
+}
+
 // fetchShowCreateDatabase composes show create database result.
 func (e *ShowExec) fetchShowCreateDatabase() error {
 	checker := privilege.GetPrivilegeManager(e.ctx)
@@ -1482,6 +1490,17 @@ func (e *ShowExec) fetchShowCreatePlacementPolicy() error {
 	}
 	showCreate := ConstructResultOfShowCreatePlacementPolicy(policy)
 	e.appendRow([]interface{}{e.DBName.O, showCreate})
+	return nil
+}
+
+// fetchShowCreateResourceGroup composes show create resource group result.
+func (e *ShowExec) fetchShowCreateResourceGroup() error {
+	group, found := e.is.ResourceGroupByName(e.ResourceGroupName)
+	if !found {
+		return infoschema.ErrResourceGroupNotExists.GenWithStackByArgs(e.ResourceGroupName.O)
+	}
+	showCreate := ConstructResultOfShowCreateResourceGroup(group)
+	e.appendRow([]interface{}{e.ResourceGroupName.O, showCreate})
 	return nil
 }
 

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -1908,6 +1908,7 @@ func (e *SimpleExec) executeAlterUser(ctx context.Context, s *ast.AlterUserStmt)
 			if !variable.EnableResourceControl.Load() {
 				return infoschema.ErrResourceGroupSupportDisabled
 			}
+
 			// check if specified resource group exists
 			if s.ResourceGroupNameOption.Value != "default" && s.ResourceGroupNameOption.Value != "" {
 				_, exists := e.is.ResourceGroupByName(model.NewCIStr(s.ResourceGroupNameOption.Value))

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -1098,6 +1098,14 @@ func (e *SimpleExec) executeCreateUser(ctx context.Context, s *ast.CreateUserStm
 		if s.ResourceGroupNameOption.Type == ast.UserResourceGroupName {
 			resourceGroupName = s.ResourceGroupNameOption.Value
 		}
+
+		// check if specified resource group exists
+		if resourceGroupName != "default" && resourceGroupName != "" {
+			_, exists := e.is.ResourceGroupByName(model.NewCIStr(resourceGroupName))
+			if !exists {
+				return infoschema.ErrResourceGroupNotExists
+			}
+		}
 	}
 	userAttributes = append(userAttributes, fmt.Sprintf("\"resource_group\": \"%s\"", resourceGroupName))
 	// If FAILED_LOGIN_ATTEMPTS and PASSWORD_LOCK_TIME are both specified to 0, a string of 0 length is generated.
@@ -1900,6 +1908,14 @@ func (e *SimpleExec) executeAlterUser(ctx context.Context, s *ast.AlterUserStmt)
 			if !variable.EnableResourceControl.Load() {
 				return infoschema.ErrResourceGroupSupportDisabled
 			}
+			// check if specified resource group exists
+			if s.ResourceGroupNameOption.Value != "default" && s.ResourceGroupNameOption.Value != "" {
+				_, exists := e.is.ResourceGroupByName(model.NewCIStr(s.ResourceGroupNameOption.Value))
+				if !exists {
+					return infoschema.ErrResourceGroupNotExists
+				}
+			}
+
 			newAttributes = append(newAttributes, fmt.Sprintf(`"resource_group": "%s"`, s.ResourceGroupNameOption.Value))
 		}
 		if passwordLockingStr != "" {

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -129,6 +129,7 @@ func TestUserAttributes(t *testing.T) {
 	rootTK.MustExec("alter user usr1 comment 'comment1'")
 	rootTK.MustQuery("select user_attributes from mysql.user where user = 'usr1'").Check(testkit.Rows(`{"metadata": {"comment": "comment1"}, "resource_group": "default"}`))
 	rootTK.MustExec("set global tidb_enable_resource_control = 'on'")
+	rootTK.MustExec("CREATE RESOURCE GROUP rg1 rru_per_sec = 100 wru_per_sec = 200")
 	rootTK.MustExec("alter user usr1 resource group rg1")
 	rootTK.MustQuery("select user_attributes from mysql.user where user = 'usr1'").Check(testkit.Rows(`{"metadata": {"comment": "comment1"}, "resource_group": "rg1"}`))
 }

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -296,6 +296,7 @@ func TestInfoTables(t *testing.T) {
 		"DEADLOCKS",
 		"PLACEMENT_POLICIES",
 		"TRX_SUMMARY",
+		"RESOURCE_GROUPS",
 	}
 	for _, tbl := range infoTables {
 		tb, err1 := is.TableByName(util.InformationSchemaName, model.NewCIStr(tbl))

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -198,6 +198,8 @@ const (
 	TableMemoryUsage = "MEMORY_USAGE"
 	// TableMemoryUsageOpsHistory is the memory control operators history.
 	TableMemoryUsageOpsHistory = "MEMORY_USAGE_OPS_HISTORY"
+	// TableResourceGroups is the metadata of resource groups.
+	TableResourceGroups = "RESOURCE_GROUPS"
 )
 
 const (
@@ -304,6 +306,7 @@ var tableIDMap = map[string]int64{
 	TableMemoryUsageOpsHistory:           autoid.InformationSchemaDBID + 85,
 	ClusterTableMemoryUsage:              autoid.InformationSchemaDBID + 86,
 	ClusterTableMemoryUsageOpsHistory:    autoid.InformationSchemaDBID + 87,
+	TableResourceGroups:                  autoid.InformationSchemaDBID + 88,
 }
 
 // columnInfo represents the basic column information of all kinds of INFORMATION_SCHEMA tables
@@ -1586,6 +1589,14 @@ var tableMemoryUsageOpsHistoryCols = []columnInfo{
 	{name: "SQL_TEXT", tp: mysql.TypeVarchar, size: 256},
 }
 
+var tableResourceGroupsCols = []columnInfo{
+	{name: "GROUP_ID", tp: mysql.TypeLonglong, size: 64, flag: mysql.NotNullFlag},
+	{name: "GROUP_NAME", tp: mysql.TypeVarchar, size: 512, flag: mysql.NotNullFlag},
+	{name: "RRU_PER_SECOND", tp: mysql.TypeLonglong, size: 64},
+	{name: "WRU_PER_SECOND", tp: mysql.TypeLonglong, size: 64},
+	// {name: "BURSTABLE", tp: mysql.TypeVarchar, size: 10},
+}
+
 // GetShardingInfo returns a nil or description string for the sharding information of given TableInfo.
 // The returned description string may be:
 //   - "NOT_SHARDED": for tables that SHARD_ROW_ID_BITS is not specified.
@@ -2048,6 +2059,7 @@ var tableNameToColumns = map[string][]columnInfo{
 	TableUserAttributes:                     tableUserAttributesCols,
 	TableMemoryUsage:                        tableMemoryUsageCols,
 	TableMemoryUsageOpsHistory:              tableMemoryUsageOpsHistoryCols,
+	TableResourceGroups:                     tableResourceGroupsCols,
 }
 
 func createInfoSchemaTable(_ autoid.Allocators, meta *model.TableInfo) (table.Table, error) {

--- a/parser/ast/dml.go
+++ b/parser/ast/dml.go
@@ -2771,6 +2771,7 @@ const (
 	ShowPlacementForPartition
 	ShowPlacementLabels
 	ShowSessionStates
+	ShowCreateResourceGroup
 )
 
 const (
@@ -2791,19 +2792,20 @@ const (
 type ShowStmt struct {
 	dmlNode
 
-	Tp          ShowStmtType // Databases/Tables/Columns/....
-	DBName      string
-	Table       *TableName  // Used for showing columns.
-	Partition   model.CIStr // Used for showing partition.
-	Column      *ColumnName // Used for `desc table column`.
-	IndexName   model.CIStr
-	Flag        int // Some flag parsed from sql, such as FULL.
-	Full        bool
-	User        *auth.UserIdentity   // Used for show grants/create user.
-	Roles       []*auth.RoleIdentity // Used for show grants .. using
-	IfNotExists bool                 // Used for `show create database if not exists`
-	Extended    bool                 // Used for `show extended columns from ...`
-	Limit       *Limit               // Used for partial Show STMTs to limit Result Set row numbers.
+	Tp                ShowStmtType // Databases/Tables/Columns/....
+	DBName            string
+	Table             *TableName  // Used for showing columns.
+	Partition         model.CIStr // Used for showing partition.
+	Column            *ColumnName // Used for `desc table column`.
+	IndexName         model.CIStr
+	ResourceGroupName string // used for showing resource group
+	Flag              int    // Some flag parsed from sql, such as FULL.
+	Full              bool
+	User              *auth.UserIdentity   // Used for show grants/create user.
+	Roles             []*auth.RoleIdentity // Used for show grants .. using
+	IfNotExists       bool                 // Used for `show create database if not exists`
+	Extended          bool                 // Used for `show extended columns from ...`
+	Limit             *Limit               // Used for partial Show STMTs to limit Result Set row numbers.
 
 	CountWarningsOrErrors bool // Used for showing count(*) warnings | errors
 
@@ -2879,6 +2881,9 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 	case ShowCreatePlacementPolicy:
 		ctx.WriteKeyWord("CREATE PLACEMENT POLICY ")
 		ctx.WriteName(n.DBName)
+	case ShowCreateResourceGroup:
+		ctx.WriteKeyWord("CREATE RESOURCE GROUP ")
+		ctx.WriteName(n.ResourceGroupName)
 	case ShowCreateUser:
 		ctx.WriteKeyWord("CREATE USER ")
 		if err := n.User.Restore(ctx); err != nil {

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -10789,6 +10789,13 @@ ShowStmt:
 			DBName: $5,
 		}
 	}
+|	"SHOW" "CREATE" "RESOURCE" "GROUP" ResourceGroupName
+	{
+		$$ = &ast.ShowStmt{
+			Tp:     ast.ShowCreateResourceGroup,
+			ResourceGroupName: $5,
+		}
+	}
 |	"SHOW" "CREATE" "USER" Username
 	{
 		// See https://dev.mysql.com/doc/refman/5.7/en/show-create-user.html

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -1878,15 +1878,16 @@ func ExtractCorColumnsBySchema4PhysicalPlan(p PhysicalPlan, schema *expression.S
 
 // ShowContents stores the contents for the `SHOW` statement.
 type ShowContents struct {
-	Tp        ast.ShowStmtType // Databases/Tables/Columns/....
-	DBName    string
-	Table     *ast.TableName  // Used for showing columns.
-	Partition model.CIStr     // Use for showing partition
-	Column    *ast.ColumnName // Used for `desc table column`.
-	IndexName model.CIStr
-	Flag      int                  // Some flag parsed from sql, such as FULL.
-	User      *auth.UserIdentity   // Used for show grants.
-	Roles     []*auth.RoleIdentity // Used for show grants.
+	Tp                ast.ShowStmtType // Databases/Tables/Columns/....
+	DBName            string
+	Table             *ast.TableName  // Used for showing columns.
+	Partition         model.CIStr     // Use for showing partition
+	Column            *ast.ColumnName // Used for `desc table column`.
+	IndexName         model.CIStr
+	ResourceGroupName string               // Used for showing resource group
+	Flag              int                  // Some flag parsed from sql, such as FULL.
+	User              *auth.UserIdentity   // Used for show grants.
+	Roles             []*auth.RoleIdentity // Used for show grants.
 
 	CountWarningsOrErrors bool // Used for showing count(*) warnings | errors
 

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -3189,6 +3189,7 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (Plan, 
 			Partition:             show.Partition,
 			Column:                show.Column,
 			IndexName:             show.IndexName,
+			ResourceGroupName:     show.ResourceGroupName,
 			Flag:                  show.Flag,
 			User:                  show.User,
 			Roles:                 show.Roles,
@@ -5038,6 +5039,8 @@ func buildShowSchema(s *ast.ShowStmt, isView bool, isSequence bool) (schema *exp
 		}
 	case ast.ShowCreatePlacementPolicy:
 		names = []string{"Policy", "Create Policy"}
+	case ast.ShowCreateResourceGroup:
+		names = []string{"Resource_Group", "Create Resource Group"}
 	case ast.ShowCreateUser:
 		if s.User != nil {
 			names = []string{fmt.Sprintf("CREATE USER for %s", s.User)}

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -516,6 +516,7 @@ func TestAlterUserStmt(t *testing.T) {
 	tk.MustExec("GRANT SYSTEM_USER ON *.* to semuser3") // user is both restricted + has SYSTEM_USER (or super)
 
 	tk.MustExec("set global tidb_enable_resource_control = 'on'")
+	tk.MustExec("CREATE RESOURCE GROUP rg1 rru_per_sec=1000 wru_per_sec=2000")
 	tk.MustExec(`ALTER USER 'semuser1' RESOURCE GROUP rg1`)
 	tk.MustQuery(`SELECT User_attributes FROM mysql.user WHERE User = "semuser1"`).Check(testkit.Rows("{\"resource_group\": \"rg1\"}"))
 
@@ -1137,6 +1138,7 @@ func TestCreateDropUser(t *testing.T) {
 	tk.MustExec(`DROP USER usr1`)
 
 	tk.MustExec("set global tidb_enable_resource_control = 'on'")
+	tk.MustExec("CREATE RESOURCE GROUP rg1 rru_per_sec=1000 wru_per_sec=2000")
 	tk.MustExec(`CREATE USER usr1 RESOURCE GROUP rg1`)
 	tk.MustQuery(`SELECT User_attributes FROM mysql.user WHERE User = "usr1"`).Check(testkit.Rows("{\"resource_group\": \"rg1\"}"))
 	tk.MustExec(`DROP USER usr1`)

--- a/session/session.go
+++ b/session/session.go
@@ -2686,6 +2686,7 @@ func (s *session) Auth(user *auth.UserIdentity, authentication, salt []byte) err
 	} else {
 		s.sessionVars.ResourceGroupName = ""
 	}
+
 	if info.InSandBoxMode {
 		// Enter sandbox mode, only execute statement for resetting password.
 		s.EnableSandBoxMode()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: Close #39781

Problem Summary:

### What is changed and how it works?

1.  A new mem table information_schema.resource_groups
2. Support to `show create resource group` command
3. Fix problem of binding user to non existent resource group

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
