### PR TITLE
resourcemanager: scheduler subtask in the pool's task

### DIFF
--- a/resourcemanager/pooltask/BUILD.bazel
+++ b/resourcemanager/pooltask/BUILD.bazel
@@ -10,7 +10,10 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/resourcemanager/pooltask",
     visibility = ["//visibility:public"],
-    deps = ["@org_uber_go_atomic//:atomic"],
+    deps = [
+        "//resourcemanager/util",
+        "@org_uber_go_atomic//:atomic",
+    ],
 )
 
 go_test(

--- a/resourcemanager/pooltask/BUILD.bazel
+++ b/resourcemanager/pooltask/BUILD.bazel
@@ -10,10 +10,7 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/resourcemanager/pooltask",
     visibility = ["//visibility:public"],
-    deps = [
-        "//resourcemanager/util",
-        "@org_uber_go_atomic//:atomic",
-    ],
+    deps = ["@org_uber_go_atomic//:atomic"],
 )
 
 go_test(

--- a/resourcemanager/pooltask/BUILD.bazel
+++ b/resourcemanager/pooltask/BUILD.bazel
@@ -5,6 +5,8 @@ go_library(
     srcs = [
         "task.go",
         "task_manager.go",
+        "task_manager_iterator.go",
+        "task_manager_scheduler.go",
     ],
     importpath = "github.com/pingcap/tidb/resourcemanager/pooltask",
     visibility = ["//visibility:public"],

--- a/resourcemanager/pooltask/task_manager.go
+++ b/resourcemanager/pooltask/task_manager.go
@@ -32,15 +32,15 @@ type tContainer[T any, U any, C any, CT any, TF Context[CT]] struct {
 	task *TaskBox[T, U, C, CT, TF]
 }
 
-type meta struct {
+type meta[T any, U any, C any, CT any, TF Context[CT]] struct {
 	stats    *list.List
 	createTS time.Time
 	origin   int32
 	running  atomic.Int32
 }
 
-func newStats(concurrency int32) *meta {
-	s := &meta{
+func newStats[T any, U any, C any, CT any, TF Context[CT]](concurrency int32) *meta[T, U, C, CT, TF] {
+	s := &meta[T, U, C, CT, TF]{
 		createTS: time.Now(),
 		stats:    list.New(),
 		origin:   concurrency,
@@ -48,13 +48,13 @@ func newStats(concurrency int32) *meta {
 	return s
 }
 
-func (m *meta) getOriginConcurrency() int32 {
+func (m *meta[T, U, C, CT, TF]) getOriginConcurrency() int32 {
 	return m.origin
 }
 
 // TaskStatusContainer is a container that can control or watch the pool.
 type TaskStatusContainer[T any, U any, C any, CT any, TF Context[CT]] struct {
-	stats map[uint64]*meta
+	stats map[uint64]*meta[T, U, C, CT, TF]
 	rw    sync.RWMutex
 }
 
@@ -70,7 +70,7 @@ func NewTaskManager[T any, U any, C any, CT any, TF Context[CT]](c int32) TaskMa
 	task := make([]TaskStatusContainer[T, U, C, CT, TF], shard)
 	for i := 0; i < shard; i++ {
 		task[i] = TaskStatusContainer[T, U, C, CT, TF]{
-			stats: make(map[uint64]*meta),
+			stats: make(map[uint64]*meta[T, U, C, CT, TF]),
 		}
 	}
 	return TaskManager[T, U, C, CT, TF]{
@@ -83,7 +83,7 @@ func NewTaskManager[T any, U any, C any, CT any, TF Context[CT]](c int32) TaskMa
 func (t *TaskManager[T, U, C, CT, TF]) RegisterTask(taskID uint64, concurrency int32) {
 	id := getShardID(taskID)
 	t.task[id].rw.Lock()
-	t.task[id].stats[taskID] = newStats(concurrency)
+	t.task[id].stats[taskID] = newStats[T, U, C, CT, TF](concurrency)
 	t.task[id].rw.Unlock()
 }
 

--- a/resourcemanager/pooltask/task_manager.go
+++ b/resourcemanager/pooltask/task_manager.go
@@ -33,23 +33,23 @@ type tContainer[T any, U any, C any, CT any, TF Context[CT]] struct {
 }
 
 type meta[T any, U any, C any, CT any, TF Context[CT]] struct {
-	stats    *list.List
-	createTS time.Time
-	origin   int32
-	running  atomic.Int32
+	stats              *list.List
+	createTS           time.Time
+	initialConcurrency int32
+	running            atomic.Int32
 }
 
 func newStats[T any, U any, C any, CT any, TF Context[CT]](concurrency int32) *meta[T, U, C, CT, TF] {
 	s := &meta[T, U, C, CT, TF]{
-		createTS: time.Now(),
-		stats:    list.New(),
-		origin:   concurrency,
+		createTS:           time.Now(),
+		stats:              list.New(),
+		initialConcurrency: concurrency,
 	}
 	return s
 }
 
 func (m *meta[T, U, C, CT, TF]) getOriginConcurrency() int32 {
-	return m.origin
+	return m.initialConcurrency
 }
 
 // TaskStatusContainer is a container that can control or watch the pool.

--- a/resourcemanager/pooltask/task_manager_iterator.go
+++ b/resourcemanager/pooltask/task_manager_iterator.go
@@ -1,4 +1,4 @@
-// Copyright 2022 PingCAP, Inc.
+// Copyright 2023 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resourcemanager/pooltask/task_manager_iterator.go
+++ b/resourcemanager/pooltask/task_manager_iterator.go
@@ -17,6 +17,8 @@ package pooltask
 import (
 	"container/list"
 	"time"
+
+	"github.com/pingcap/tidb/resourcemanager/util"
 )
 
 func (t *TaskManager[T, U, C, CT, TF]) getBoostTask() (tid uint64, result *TaskBox[T, U, C, CT, TF]) {
@@ -97,8 +99,8 @@ func canPause[T any, U any, C any, CT any, TF Context[CT]](m *meta[T, U, C, CT, 
 }
 
 func canBoost[T any, U any, C any, CT any, TF Context[CT]](m *meta[T, U, C, CT, TF], min time.Time) (result *list.Element, isBreak bool) {
-	if m.running.Load() >= m.initialConcurrency {
-		return nil, true
+	if m.running.Load() >= m.initialConcurrency+util.MaxBoostTask {
+		return nil, false
 	}
 	if m.createTS.After(min) {
 		box := getTask[T, U, C, CT, TF](m)

--- a/resourcemanager/pooltask/task_manager_iterator.go
+++ b/resourcemanager/pooltask/task_manager_iterator.go
@@ -1,0 +1,132 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pooltask
+
+import (
+	"time"
+)
+
+var startTime = time.Now()
+
+func (t *TaskManager[T, U, C, CT, TF]) getNeedToBoostTask() (tid uint64, result *TaskBox[T, U, C, CT, TF]) {
+	// boost task,
+	// 1、less run time, more possible to boost
+	// 2、the count of running task is less than concurrency
+	var minTS = startTime
+	for i := 0; i < shard; i++ {
+		isBreak := func(index int) bool {
+			t.task[i].rw.RLock()
+			defer t.task[i].rw.RUnlock()
+			for id, stats := range t.task[i].stats {
+				newResult, min, breakFund := canBoost[T, U, C, CT, TF](stats, minTS)
+				if breakFund {
+					result = newResult // set nil
+					return true
+				}
+				if newResult != nil {
+					result = newResult
+					minTS = min
+					tid = id
+				}
+			}
+			return false
+		}(i)
+		if isBreak {
+			break
+		}
+	}
+	return tid, result
+}
+
+func canBoost[T any, U any, C any, CT any, TF Context[CT]](m *meta, min time.Time) (*TaskBox[T, U, C, CT, TF], time.Time, bool) {
+
+	// need to add
+	if m.createTS.After(min) {
+		box := getTask[T, U, C, CT, TF](m)
+		if box != nil {
+			return box, m.createTS, false
+		}
+	}
+	return nil, startTime, false
+}
+
+func (t *TaskManager[T, U, C, CT, TF]) pauseTask() {
+	// pause task,
+	// 1、more run time, more possible to pause
+	// 2、if task have been boosted, first to pause.
+	var maxDuration time.Duration
+	var result *TaskBox[T, U, C, CT, TF]
+	for i := 0; i < shard; i++ {
+		isBoost := func(index int) (isBoost bool) {
+			t.task[i].rw.RLock()
+			defer t.task[i].rw.RUnlock()
+			for _, stats := range t.task[i].stats {
+				newResult, newMaxDuration, isBoost := canPause[T, U, C, CT, TF](stats, maxDuration)
+				if isBoost {
+					result = newResult
+					return true
+				}
+				if newResult != nil {
+					result = newResult
+					maxDuration = newMaxDuration
+				}
+			}
+			return false
+		}(i)
+		if isBoost {
+			break
+		}
+	}
+	if result != nil {
+		result.status.CompareAndSwap(RunningTask, StopTask)
+	}
+}
+
+func canPause[T any, U any, C any, CT any, TF Context[CT]](m *meta, max time.Duration) (result *TaskBox[T, U, C, CT, TF], nm time.Duration, isBool bool) {
+	if m.origin < m.running.Load() {
+		box := findTask[T, U, C, CT, TF](m, RunningTask)
+		if box != nil {
+			return box, nm, true
+		}
+	}
+	d := time.Since(m.createTS)
+	if d > max {
+		box := findTask[T, U, C, CT, TF](m, RunningTask)
+		if box != nil {
+			return box, nm, true
+		}
+	}
+	return nil, nm, false
+}
+
+func findTask[T any, U any, C any, CT any, TF Context[CT]](m *meta, status int32) *TaskBox[T, U, C, CT, TF] {
+	for e := m.stats.Front(); e != nil; e = e.Next() {
+		if box, ok := e.Value.(*TaskBox[T, U, C, CT, TF]); ok {
+			if box.status.Load() == status {
+				return box
+			}
+		}
+	}
+	return nil
+}
+
+func getTask[T any, U any, C any, CT any, TF Context[CT]](m *meta) *TaskBox[T, U, C, CT, TF] {
+	for e := m.stats.Front(); e != nil; e = e.Next() {
+		if box, ok := e.Value.(*TaskBox[T, U, C, CT, TF]); ok {
+			return box
+		}
+	}
+	return nil
+}

--- a/resourcemanager/pooltask/task_manager_iterator.go
+++ b/resourcemanager/pooltask/task_manager_iterator.go
@@ -17,8 +17,6 @@ package pooltask
 import (
 	"container/list"
 	"time"
-
-	"github.com/pingcap/tidb/resourcemanager/util"
 )
 
 func (t *TaskManager[T, U, C, CT, TF]) getBoostTask() (tid uint64, result *TaskBox[T, U, C, CT, TF]) {
@@ -99,8 +97,11 @@ func canPause[T any, U any, C any, CT any, TF Context[CT]](m *meta[T, U, C, CT, 
 }
 
 func canBoost[T any, U any, C any, CT any, TF Context[CT]](m *meta[T, U, C, CT, TF], min time.Time) (result *list.Element, isBreak bool) {
-	if m.running.Load() >= m.initialConcurrency+util.MaxBoostTask {
-		return nil, false
+	if m.running.Load() < m.initialConcurrency {
+		box := getTask[T, U, C, CT, TF](m)
+		if box != nil {
+			return box, true
+		}
 	}
 	if m.createTS.After(min) {
 		box := getTask[T, U, C, CT, TF](m)

--- a/resourcemanager/pooltask/task_manager_iterator.go
+++ b/resourcemanager/pooltask/task_manager_iterator.go
@@ -97,7 +97,7 @@ func canPause[T any, U any, C any, CT any, TF Context[CT]](m *meta[T, U, C, CT, 
 }
 
 func canBoost[T any, U any, C any, CT any, TF Context[CT]](m *meta[T, U, C, CT, TF], min time.Time) (result *list.Element, isBreak bool) {
-	if m.running.Load() < m.initialConcurrency {
+	if m.running.Load() >= m.initialConcurrency {
 		return nil, true
 	}
 	if m.createTS.After(min) {

--- a/resourcemanager/pooltask/task_manager_scheduler.go
+++ b/resourcemanager/pooltask/task_manager_scheduler.go
@@ -14,15 +14,15 @@
 
 package pooltask
 
-// Boost is to increase the concurrency of pool.
-func (t *TaskManager[T, U, C, CT, TF]) Boost() (tid uint64, task *TaskBox[T, U, C, CT, TF]) {
+// Overclock is to increase the concurrency of pool.
+func (t *TaskManager[T, U, C, CT, TF]) Overclock() (tid uint64, task *TaskBox[T, U, C, CT, TF]) {
 	if t.concurrency > t.running.Load() {
-		return t.getNeedToBoostTask()
+		return t.getBoostTask()
 	}
 	return 0, nil
 }
 
-// Decrease is to decrease the concurrency of pool.
-func (t *TaskManager[T, U, C, CT, TF]) Decrease() {
+// Downclock is to decrease the concurrency of pool.
+func (t *TaskManager[T, U, C, CT, TF]) Downclock() {
 	t.pauseTask()
 }

--- a/resourcemanager/pooltask/task_manager_scheduler.go
+++ b/resourcemanager/pooltask/task_manager_scheduler.go
@@ -1,0 +1,28 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pooltask
+
+// Boost is to increase the concurrency of pool.
+func (t *TaskManager[T, U, C, CT, TF]) Boost() (tid uint64, task *TaskBox[T, U, C, CT, TF]) {
+	if t.concurrency > t.running.Load() {
+		return t.getNeedToBoostTask()
+	}
+	return 0, nil
+}
+
+// Decrease is to decrease the concurrency of pool.
+func (t *TaskManager[T, U, C, CT, TF]) Decrease() {
+	t.pauseTask()
+}

--- a/resourcemanager/rm.go
+++ b/resourcemanager/rm.go
@@ -78,7 +78,7 @@ func (r *ResourceManager) Stop() {
 }
 
 // Register is to register pool into resource manager
-func (r *ResourceManager) Register(pool util.GorotinuePool, name string, component util.Component) error {
+func (r *ResourceManager) Register(pool util.GoroutinePool, name string, component util.Component) error {
 	p := util.PoolContainer{Pool: pool, Component: component}
 	return r.registerPool(name, &p)
 }

--- a/resourcemanager/schedule.go
+++ b/resourcemanager/schedule.go
@@ -52,14 +52,14 @@ func (*ResourceManager) exec(pool *util.PoolContainer, cmd scheduler.Command) {
 		switch cmd {
 		case scheduler.Downclock:
 			concurrency := con - 1
-			log.Info("downclock goroutine pool",
+			log.Info("[resource manager] downclock goroutine pool",
 				zap.Int("origin concurrency", con),
 				zap.Int("concurrency", concurrency),
 				zap.String("name", pool.Pool.Name()))
 			pool.Pool.Tune(concurrency)
 		case scheduler.Overclock:
 			concurrency := con + 1
-			log.Info("overclock goroutine pool",
+			log.Info("[resource manager] overclock goroutine pool",
 				zap.Int("origin concurrency", con),
 				zap.Int("concurrency", concurrency),
 				zap.String("name", pool.Pool.Name()))

--- a/resourcemanager/scheduler/cpu_scheduler.go
+++ b/resourcemanager/scheduler/cpu_scheduler.go
@@ -30,7 +30,7 @@ func NewCPUScheduler() *CPUScheduler {
 }
 
 // Tune is to tune the goroutine pool
-func (*CPUScheduler) Tune(_ util.Component, pool util.GorotinuePool) Command {
+func (*CPUScheduler) Tune(_ util.Component, pool util.GoroutinePool) Command {
 	if time.Since(pool.LastTunerTs()) < util.MinSchedulerInterval.Load() {
 		return Hold
 	}

--- a/resourcemanager/scheduler/scheduler.go
+++ b/resourcemanager/scheduler/scheduler.go
@@ -32,5 +32,5 @@ const (
 
 // Scheduler is a scheduler interface
 type Scheduler interface {
-	Tune(component util.Component, p util.GorotinuePool) Command
+	Tune(component util.Component, p util.GoroutinePool) Command
 }

--- a/resourcemanager/util/util.go
+++ b/resourcemanager/util/util.go
@@ -22,12 +22,11 @@ import (
 
 var (
 	// MinSchedulerInterval is the minimum interval between two scheduling.
-	MinSchedulerInterval       = atomic.NewDuration(200 * time.Millisecond)
-	MaxBoostTask         int32 = 1
+	MinSchedulerInterval = atomic.NewDuration(200 * time.Millisecond)
 )
 
-// GorotinuePool is a pool interface
-type GorotinuePool interface {
+// GoroutinePool is a pool interface
+type GoroutinePool interface {
 	ReleaseAndWait()
 	Tune(size int)
 	LastTunerTs() time.Time
@@ -38,7 +37,7 @@ type GorotinuePool interface {
 
 // PoolContainer is a pool container
 type PoolContainer struct {
-	Pool      GorotinuePool
+	Pool      GoroutinePool
 	Component Component
 }
 

--- a/resourcemanager/util/util.go
+++ b/resourcemanager/util/util.go
@@ -22,7 +22,8 @@ import (
 
 var (
 	// MinSchedulerInterval is the minimum interval between two scheduling.
-	MinSchedulerInterval = atomic.NewDuration(200 * time.Millisecond)
+	MinSchedulerInterval       = atomic.NewDuration(200 * time.Millisecond)
+	MaxBoostTask         int32 = 1
 )
 
 // GorotinuePool is a pool interface

--- a/util/gpool/spmc/spmcpool.go
+++ b/util/gpool/spmc/spmcpool.go
@@ -152,7 +152,7 @@ func (p *Pool[T, U, C, CT, TF]) Tune(size int) {
 			return
 		}
 		p.cond.Broadcast()
-
+		return
 	}
 	if size < capacity {
 		p.taskManager.Downclock()

--- a/util/gpool/spmc/spmcpool.go
+++ b/util/gpool/spmc/spmcpool.go
@@ -146,6 +146,14 @@ func (p *Pool[T, U, C, CT, TF]) Tune(size int) {
 			return
 		}
 		p.cond.Broadcast()
+		if tid, boostTask := p.taskManager.Overclock(); boostTask != nil {
+			p.addWaitingTask()
+			p.taskManager.AddSubTask(tid, boostTask.Clone())
+			p.taskCh <- boostTask
+		}
+	}
+	if size < capacity {
+		p.taskManager.Downclock()
 	}
 }
 

--- a/util/gpool/spmc/spmcpool.go
+++ b/util/gpool/spmc/spmcpool.go
@@ -140,17 +140,19 @@ func (p *Pool[T, U, C, CT, TF]) Tune(size int) {
 	p.SetLastTuneTs(time.Now())
 	p.capacity.Store(int32(size))
 	if size > capacity {
-		// boost
+		for i := 0; i < size-capacity; i++ {
+			if tid, boostTask := p.taskManager.Overclock(); boostTask != nil {
+				p.addWaitingTask()
+				p.taskManager.AddSubTask(tid, boostTask.Clone())
+				p.taskCh <- boostTask
+			}
+		}
 		if size-capacity == 1 {
 			p.cond.Signal()
 			return
 		}
 		p.cond.Broadcast()
-		if tid, boostTask := p.taskManager.Overclock(); boostTask != nil {
-			p.addWaitingTask()
-			p.taskManager.AddSubTask(tid, boostTask.Clone())
-			p.taskCh <- boostTask
-		}
+
 	}
 	if size < capacity {
 		p.taskManager.Downclock()

--- a/util/gpool/spmc/spmcpool_test.go
+++ b/util/gpool/spmc/spmcpool_test.go
@@ -122,14 +122,31 @@ func TestStopPool(t *testing.T) {
 	pool.ReleaseAndWait()
 }
 
-func TestTunePool(t *testing.T) {
+func TestTuneSimplePool(t *testing.T) {
+	testTunePool(t, "TestTuneSimplePool")
+}
+
+func TestTuneMultiPool(t *testing.T) {
+	var concurrency = 5
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			testTunePool(t, "TestTuneSimplePool"+string(1))
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func testTunePool(t *testing.T, name string) {
 	type ConstArgs struct {
 		a int
 	}
 	myArgs := ConstArgs{a: 10}
 	// init the pool
 	// input type， output type, constArgs type
-	pool, err := NewSPMCPool[int, int, ConstArgs, any, pooltask.NilContext]("TestStopPool", 10, rmutil.UNKNOWN)
+	pool, err := NewSPMCPool[int, int, ConstArgs, any, pooltask.NilContext](name, 10, rmutil.UNKNOWN)
 	require.NoError(t, err)
 	pool.SetConsumerFunc(func(task int, constArgs ConstArgs, ctx any) int {
 		return task + constArgs.a

--- a/util/gpool/spmc/spmcpool_test.go
+++ b/util/gpool/spmc/spmcpool_test.go
@@ -15,6 +15,7 @@
 package spmc
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -131,10 +132,10 @@ func TestTuneMultiPool(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(concurrency)
 	for i := 0; i < concurrency; i++ {
-		go func() {
-			testTunePool(t, "TestTuneSimplePool"+string(1))
+		go func(id int) {
+			testTunePool(t, fmt.Sprintf("TestTuneMultiPool%d", id))
 			wg.Done()
-		}()
+		}(i)
 	}
 	wg.Wait()
 }

--- a/util/gpool/spmc/worker.go
+++ b/util/gpool/spmc/worker.go
@@ -67,7 +67,7 @@ func (w *goWorker[T, U, C, CT, TF]) run() {
 				for t := range f.GetTaskCh() {
 					if f.GetStatus() == pooltask.StopTask {
 						f.Done()
-						continue
+						break
 					}
 					f.GetResultCh() <- w.pool.consumerFunc(t.Task, f.ConstArgs(), ctx)
 					f.Done()


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40719

Problem Summary:

### What is changed and how it works?

Now, we can control the concurrency of the pool. But we need to wait for the subtask to finish when we need to downclock the pool, then we can exit the worker in the pool. if we want to overclock the pool, we need to create a subtask for adding concurrency to the task. so we have the ability to control the subtask to make itself exiting or creating.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
