### PR TITLE
Revert "planner: show un-cacheable reasons for execute statements"

### DIFF
--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -127,7 +127,7 @@ func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
 	sessVars := sctx.GetSessionVars()
 	stmtCtx := sessVars.StmtCtx
 	stmtAst := stmt.PreparedAst
-	stmtCtx.UseCache = true
+	stmtCtx.UseCache = stmt.StmtCacheable
 	if !stmt.StmtCacheable {
 		stmtCtx.SetSkipPlanCache(errors.Errorf("skip plan-cache: %s", stmt.UncacheableReason))
 	}

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -503,18 +503,3 @@ func TestPlanCacheWithLimit(t *testing.T) {
 	tk.MustExec("execute stmt using @a")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip plan-cache: limit count more than 10000"))
 }
-
-func TestUncacheableReason(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t")
-	tk.MustExec("create table t(a int)")
-
-	tk.MustExec("prepare st from 'select /*+ ignore_plan_cache() */ * from t'")
-	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip plan-cache: ignore plan cache by hint"))
-	tk.MustExec("execute st") // show the un-cacheable reason when executing the statement
-	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip plan-cache: ignore plan cache by hint"))
-	tk.MustExec("execute st")
-	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
-}


### PR DESCRIPTION
Issue Number: ref https://github.com/pingcap/tidb/issues/36598

Reverts pingcap/tidb#40651

This PR can cause some CI failures, so revert it temporarily, and I'll submit another PR after.


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```