### PR TITLE
json: implement json unary not with comparing to json(0)

### DIFF
--- a/cmd/explaintest/r/select.result
+++ b/cmd/explaintest/r/select.result
@@ -658,3 +658,11 @@ insert into t3 values ('a');
 select * from t3 where a > 0x80;
 Error 1105 (HY000): Cannot convert string '\x80' from binary to utf8mb4
 set @@tidb_enable_outer_join_reorder=false;
+drop table if exists t1;
+create table t1(j json);
+insert into t1 values ('{"a":"b"}');
+explain format = 'brief' select * from t1 WHERE NOT t1.j;
+id	estRows	task	access object	operator info
+Selection	8000.00	root		eq(test.t1.j, "0")
+└─TableReader	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo

--- a/cmd/explaintest/t/select.test
+++ b/cmd/explaintest/t/select.test
@@ -283,3 +283,8 @@ insert into t3 values ('a');
 --error 1105
 select * from t3 where a > 0x80;
 set @@tidb_enable_outer_join_reorder=false;
+
+drop table if exists t1;
+create table t1(j json);
+insert into t1 values ('{"a":"b"}');
+explain format = 'brief' select * from t1 WHERE NOT t1.j;

--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -922,6 +922,7 @@ const (
 	ErrFunctionalIndexNotApplicable                          = 3909
 	ErrDynamicPrivilegeNotRegistered                         = 3929
 	ErUserAccessDeniedForUserAccountBlockedByPasswordLock    = 3955
+	ErrJSONInBooleanContext                                  = 3986
 	ErrTableWithoutPrimaryKey                                = 3750
 	// MariaDB errors.
 	ErrOnlyOneDefaultPartionAllowed         = 4030

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -924,6 +924,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrInvalidRequiresSingleReference:                        mysql.Message("In recursive query block of Recursive Common Table Expression '%s', the recursive table must be referenced only once, and not in any subquery", nil),
 	ErrCTEMaxRecursionDepth:                                  mysql.Message("Recursive query aborted after %d iterations. Try increasing @@cte_max_recursion_depth to a larger value", nil),
 	ErrTableWithoutPrimaryKey:                                mysql.Message("Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set. Add a primary key to the table or unset this variable to avoid this message. Note that tables without a primary key can cause performance problems in row-based replication, so please consult your DBA before changing this setting.", nil),
+	ErrJSONInBooleanContext:                                  mysql.Message("Evaluating a JSON value in SQL boolean context does an implicit comparison against JSON integer 0; if this is not what you want, consider converting JSON to a SQL numeric type with JSON_VALUE RETURNING", nil),
 	// MariaDB errors.
 	ErrOnlyOneDefaultPartionAllowed:         mysql.Message("Only one DEFAULT partition allowed", nil),
 	ErrWrongPartitionTypeExpectedSystemTime: mysql.Message("Wrong partitioning type, expected type: `SYSTEM_TIME`", nil),

--- a/expression/builtin_op_test.go
+++ b/expression/builtin_op_test.go
@@ -462,6 +462,8 @@ func TestUnaryNot(t *testing.T) {
 		{[]interface{}{"0.3"}, 0, false, false},
 		{[]interface{}{types.NewDecFromFloatForTest(0.3)}, 0, false, false},
 		{[]interface{}{nil}, 0, true, false},
+		{[]interface{}{types.CreateBinaryJSON(int64(0))}, 1, false, false},
+		{[]interface{}{types.CreateBinaryJSON(map[string]interface{}{"test": "test"})}, 0, false, false},
 
 		{[]interface{}{errors.New("must error")}, 0, false, true},
 	}

--- a/expression/errors.go
+++ b/expression/errors.go
@@ -60,6 +60,7 @@ var (
 	errSpecificAccessDenied          = dbterror.ClassExpression.NewStd(mysql.ErrSpecificAccessDenied)
 	errUserLockDeadlock              = dbterror.ClassExpression.NewStd(mysql.ErrUserLockDeadlock)
 	errUserLockWrongName             = dbterror.ClassExpression.NewStd(mysql.ErrUserLockWrongName)
+	errJSONInBooleanContext          = dbterror.ClassExpression.NewStd(mysql.ErrJSONInBooleanContext)
 
 	// Sequence usage privilege check.
 	errSequenceAccessDenied      = dbterror.ClassExpression.NewStd(mysql.ErrTableaccessDenied)

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -234,6 +234,12 @@ func newFunctionImpl(ctx sessionctx.Context, fold int, funcName string, retType 
 	if builtinRetTp := f.getRetTp(); builtinRetTp.GetType() != mysql.TypeUnspecified || retType.GetType() == mysql.TypeUnspecified {
 		retType = builtinRetTp
 	}
+	// TODO: add a method for functions to get a name, or use other ways to replace this special case
+	// not(json) is implemented with comparing json with json 0. If we don't overwrite the funcName,
+	// the explain information will be `not(json, "0")`. We prefer to make it `eq(json, "0")`
+	if funcName == ast.UnaryNot && funcArgs[0].GetType().GetType() == mysql.TypeJSON {
+		funcName = ast.EQ
+	}
 	sf := &ScalarFunction{
 		FuncName: model.NewCIStr(funcName),
 		RetType:  retType,


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #40683

Problem Summary:

The behavior of unary not for json value is different between TiDB and MySQL. TiDB converts the json to double and run unary not on it. MySQL compares the JSON with json integer 0.

### What is changed and how it works?

I changed the behavior to be compatible with MySQL. The only concern is that I don't know whether returning a function in other function class is expected. I only noticed the `funcName` is different so I added a very ugly condition to overwrite the `funcName`, but I'm not sure whether it will have other problems (at least, I cannot overwrite the `funcName` for the caller...).

Or anyone can provide better idea?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Fix the issue that unary not with comparing to json(0) is not compatible with MySQL.
```
