### PR TITLE
resourcemanager: avoid to get nil after task finished when to stop task

### DIFF
--- a/resourcemanager/pooltask/task_manager.go
+++ b/resourcemanager/pooltask/task_manager.go
@@ -139,8 +139,12 @@ func (t *TaskManager[T, U, C, CT, TF]) StopTask(taskID uint64) {
 	shardID := getShardID(taskID)
 	t.task[shardID].rw.Lock()
 	defer t.task[shardID].rw.Unlock()
-	l := t.task[shardID].stats[taskID].stats
-	for e := l.Front(); e != nil; e = e.Next() {
-		e.Value.(tContainer[T, U, C, CT, TF]).task.SetStatus(StopTask)
+	// When call the StopTask, the task may have been deleted from the manager.
+	s, ok := t.task[shardID].stats[taskID]
+	if ok {
+		l := s.stats
+		for e := l.Front(); e != nil; e = e.Next() {
+			e.Value.(tContainer[T, U, C, CT, TF]).task.SetStatus(StopTask)
+		}
 	}
 }

--- a/util/gpool/spmc/spmcpool_test.go
+++ b/util/gpool/spmc/spmcpool_test.go
@@ -114,6 +114,8 @@ func TestStopPool(t *testing.T) {
 	control.Stop()
 	close(exit)
 	control.Wait()
+	// it should pass. Stop can be used after the pool is closed. we should prevent it from panic.
+	control.Stop()
 	wg.Wait()
 	// close pool
 	pool.ReleaseAndWait()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40700

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
