### PR TITLE
parser: support syntax for pause and resume ddl

### DIFF
--- a/parser/ast/misc.go
+++ b/parser/ast/misc.go
@@ -2236,6 +2236,8 @@ const (
 	AdminResetTelemetryID
 	AdminReloadStatistics
 	AdminFlushPlanCache
+	AdminPause
+	AdminResume
 )
 
 // HandleRange represents a range where handle value >= Begin and < End.
@@ -2331,6 +2333,8 @@ type AdminStmt struct {
 	Where          ExprNode
 	StatementScope StatementScope
 	LimitSimple    LimitSimple
+	TaskType       string
+	Force          bool
 }
 
 // Restore implements Node interface.
@@ -2479,6 +2483,15 @@ func (n *AdminStmt) Restore(ctx *format.RestoreCtx) error {
 		} else if n.StatementScope == StatementScopeGlobal {
 			ctx.WriteKeyWord("FLUSH GLOBAL PLAN_CACHE")
 		}
+	case AdminPause:
+		ctx.WriteKeyWord("PAUSE ")
+		ctx.WriteKeyWord(strings.ToUpper(n.TaskType))
+		if n.Force {
+			ctx.WriteKeyWord("FORCE")
+		}
+	case AdminResume:
+		ctx.WriteKeyWord("RESUME ")
+		ctx.WriteKeyWord(strings.ToUpper(n.TaskType))
 	default:
 		return errors.New("Unsupported AdminStmt type")
 	}

--- a/parser/ast/misc.go
+++ b/parser/ast/misc.go
@@ -2485,13 +2485,13 @@ func (n *AdminStmt) Restore(ctx *format.RestoreCtx) error {
 		}
 	case AdminPause:
 		ctx.WriteKeyWord("PAUSE ")
-		ctx.WriteKeyWord(strings.ToUpper(n.TaskType))
+		ctx.WritePlain(strings.ToUpper(n.TaskType))
 		if n.Force {
 			ctx.WriteKeyWord("FORCE")
 		}
 	case AdminResume:
 		ctx.WriteKeyWord("RESUME ")
-		ctx.WriteKeyWord(strings.ToUpper(n.TaskType))
+		ctx.WritePlain(strings.ToUpper(n.TaskType))
 	default:
 		return errors.New("Unsupported AdminStmt type")
 	}

--- a/parser/ast/misc.go
+++ b/parser/ast/misc.go
@@ -2487,7 +2487,7 @@ func (n *AdminStmt) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord("PAUSE ")
 		ctx.WritePlain(strings.ToUpper(n.TaskType))
 		if n.Force {
-			ctx.WriteKeyWord("FORCE")
+			ctx.WriteKeyWord(" FORCE")
 		}
 	case AdminResume:
 		ctx.WriteKeyWord("RESUME ")

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -541,6 +541,7 @@ var tokenMap = map[string]int{
 	"PARTITIONING":             partitioning,
 	"PARTITIONS":               partitions,
 	"PASSWORD":                 password,
+	"PAUSE":                    pause,
 	"PERCENT":                  percent,
 	"PER_DB":                   per_db,
 	"PER_TABLE":                per_table,

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -502,6 +502,7 @@ import (
 	partitioning          "PARTITIONING"
 	partitions            "PARTITIONS"
 	password              "PASSWORD"
+	pause                 "PAUSE"
 	percent               "PERCENT"
 	per_db                "PER_DB"
 	per_table             "PER_TABLE"
@@ -6491,6 +6492,7 @@ UnReservedKeyword:
 |	"PASSWORD_LOCK_TIME"
 |	"DIGEST"
 |	"REUSE" %prec lowerThanEq
+|	"PAUSE"
 
 TiDBKeyword:
 	"ADMIN"
@@ -10565,6 +10567,21 @@ AdminStmt:
 			JobIDs: $5.([]int64),
 		}
 	}
+|	"ADMIN" "PAUSE" Identifier ForceOpt
+	{
+		$$ = &ast.AdminStmt{
+			Tp:       ast.AdminPause,
+			TaskType: strings.ToUpper($3),
+			Force:    $4.(bool),
+		}
+	}
+|	"ADMIN" "RESUME" Identifier
+	{
+		$$ = &ast.AdminStmt{
+			Tp:       ast.AdminResume,
+			TaskType: strings.ToUpper($3),
+		}
+	}
 |	"ADMIN" "SHOW" "DDL" "JOB" "QUERIES" NumList
 	{
 		$$ = &ast.AdminStmt{
@@ -10795,7 +10812,7 @@ ShowStmt:
 |	"SHOW" "CREATE" "RESOURCE" "GROUP" ResourceGroupName
 	{
 		$$ = &ast.ShowStmt{
-			Tp:     ast.ShowCreateResourceGroup,
+			Tp:                ast.ShowCreateResourceGroup,
 			ResourceGroupName: $5,
 		}
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -7142,3 +7142,26 @@ func TestTTLTableOption(t *testing.T) {
 
 	RunTest(t, table, false)
 }
+
+func TestAdminPauseResumeOption(t *testing.T) {
+	table := []testCase{
+		{"admin pause ddl", true, "ADMIN PAUSE DDL"},
+		{"admin pause ddl force", true, "ADMIN PAUSE DDL FORCE"},
+		{"admin pause abc", true, "ADMIN PAUSE ABC"},
+		{"admin resume ddl", true, "ADMIN RESUME DDL"},
+		{"admin resume ttl", true, "ADMIN RESUME TTL"},
+		{"admin pause ttl", true, "ADMIN PAUSE TTL"},
+		{"admin PAUSE ttl force", true, "ADMIN PAUSE TTL FORCE"},
+		{"admin pause backgroundTask", true, "ADMIN PAUSE BACKGROUNDTASK"},
+		{"admin pause backgroundTask force", true, "ADMIN PAUSE BACKGROUNDTASK FORCE"},
+		{"admin resume backup", true, "ADMIN RESUME BACKUP"},
+		{"admin pause analyzing", true, "ADMIN PAUSE ANALYZING"},
+		{"admin pause analyzing force", true, "ADMIN PAUSE ANALYZING FORCE"},
+		{"admin resume analyzing", true, "ADMIN RESUME ANALYZING"},
+		{"admin pause checksum", true, "ADMIN PAUSE CHECKSUM"},
+		{"admin pause checksum force", true, "ADMIN PAUSE CHECKSUM FORCE"},
+		{"admin resume checksum", true, "ADMIN RESUME CHECKSUM"},
+	}
+
+	RunTest(t, table, false)
+}


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref #40041

Problem Summary:
The PR is finished first one to do below things:
- ADD parser for pause|resume command

Commands:
```
admin pause {DDL} [force];
admin resume {DDL}; 
```
### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
