### PR TITLE
Optimizer: add test cases for predicate simplifications.

### DIFF
--- a/planner/core/predicate_simplification_test.go
+++ b/planner/core/predicate_simplification_test.go
@@ -1,0 +1,63 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/parser"
+	"github.com/pingcap/tidb/parser/model"
+	"github.com/pingcap/tidb/planner"
+	"github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/sessiontxn"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/testkit/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveRedundantPredicates(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_cost_model_version=2")
+	tk.MustExec("set tidb_opt_limit_push_down_threshold=0")
+	var input []string
+	var output []struct {
+		SQL  string
+		Best string
+	}
+	planSuiteData := core.GetPlanSuiteData()
+	planSuiteData.LoadTestCases(t, &input, &output)
+	p := parser.New()
+	is := infoschema.MockInfoSchema([]*model.TableInfo{core.MockSignedTable(), core.MockUnsignedTable()})
+	for i, tt := range input {
+		comment := fmt.Sprintf("case: %v, sql: %s", i, tt)
+		stmt, err := p.ParseOneStmt(tt, "", "")
+		require.NoError(t, err, comment)
+		require.NoError(t, sessiontxn.NewTxn(context.Background(), tk.Session()))
+		p, _, err := planner.Optimize(context.TODO(), tk.Session(), stmt, is)
+		require.NoError(t, err)
+		testdata.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Best = core.ToString(p)
+		})
+		require.Equal(t, output[i].Best, core.ToString(p), comment)
+	}
+}
+

--- a/planner/core/testdata/plan_suite_in.json
+++ b/planner/core/testdata/plan_suite_in.json
@@ -1186,5 +1186,22 @@
       "select a, count(*) from t group by a -- shouldn't be rewritten",
       "select sum(a) from t -- sum shouldn't be rewritten"
     ]
+  },
+  {
+    // Test redundant condition in select.
+    "name": "TestRemoveRedundantPredicates",
+    "cases":[
+      "select f from t use index() where f = 1 and f = 1 -- simple redundancy of exact condition",
+      "select f from t use index() where f = 1 and f = 2 -- unsatisfiable condition",
+      "select f from t use index() where f = 1 and f in (1,2,3)  -- intersection of in and =",
+      "select f from t use index() where f = 1 and f <> 1  -- intersection of = and <>",
+      "select f from t use index() where f not in (1,2,3) and f = 3 -- intersection of not in list and =",
+      "select f from t use index() where f <> 3 and f <> 3 -- intersection of two not in values.",
+      "select t1.f /* merge_join(t1, t2) */ from t t1, t t2 where t1.a=t2.a and t1.a=t2.a -- exact redundancy in joins",
+      "select f from t use index() where f in (1,2,3) and f <> 2 -- intersection of in and <>. Not done yet see issue 39676",
+      "select f from t use index() where f in (1,2,3) and f in (3,4,5) -- intersection of two in. Not done yet",
+      "select f from t use index() where f not in (1,2,3) and f not in (3,4,5) -- intersection of two not in. Not done yet",
+      "select f from t use index() where f not in (1,2,3) and f in (1,2,3) -- intersection of in and not in. Not done yet"
+    ]
   }
 ]

--- a/planner/core/testdata/plan_suite_out.json
+++ b/planner/core/testdata/plan_suite_out.json
@@ -1180,7 +1180,7 @@
         "Best": "IndexLookUp(Index(t.c_d_e)[[NULL,+inf]], Table(t))"
       },
       {
-        "SQL": "select f from t use index() where f = 1",
+        "SQL": "select f from t use index() where f = 2",
         "Best": "TableReader(Table(t)->Sel([eq(test.t.f, 1)]))"
       },
       {
@@ -7499,6 +7499,55 @@
           "        └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warning": null
+      }
+    ]
+  },
+  {
+    "Name": "TestRemoveRedundantPredicates",
+    "Cases": [
+      {
+        "SQL": "select f from t use index() where f = 1 and f = 1 -- simple redundancy of exact condition",
+        "Best": "TableReader(Table(t)->Sel([eq(test.t.f, 1)]))"
+      },
+      {
+        "SQL": "select f from t use index() where f = 1 and f = 2 -- unsatisfiable condition",
+        "Best": "Dual"
+      },
+      {
+        "SQL": "select f from t use index() where f = 1 and f in (1,2,3)  -- intersection of in and =",
+        "Best": "TableReader(Table(t)->Sel([eq(test.t.f, 1)]))"
+      },
+      {
+        "SQL": "select f from t use index() where f = 1 and f <> 1  -- intersection of = and <>",
+        "Best": "Dual"
+      },
+      {
+        "SQL": "select f from t use index() where f not in (1,2,3) and f = 3 -- intersection of not in list and =",
+        "Best": "Dual"
+      },
+      {
+        "SQL": "select f from t use index() where f <> 3 and f <> 3 -- intersection of two not in values.",
+        "Best": "TableReader(Table(t)->Sel([ne(test.t.f, 3)]))"
+      },
+      {
+        "SQL": "select t1.f /* merge_join(t1, t2) */ from t t1, t t2 where t1.a=t2.a and t1.a=t2.a -- exact redundancy in joins",
+        "Best": "MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(test.t.a,test.t.a)"
+      },
+      {
+        "SQL": "select f from t use index() where f in (1,2,3) and f <> 2 -- intersection of in and <>. Not done yet see issue 39676",
+        "Best": "TableReader(Table(t)->Sel([in(test.t.f, 1, 2, 3) ne(test.t.f, 2)]))"
+      },
+      {
+        "SQL": "select f from t use index() where f in (1,2,3) and f in (3,4,5) -- intersection of two in. Not done yet",
+        "Best": "TableReader(Table(t)->Sel([in(test.t.f, 1, 2, 3) in(test.t.f, 3, 4, 5)]))"
+      },
+      {
+        "SQL": "select f from t use index() where f not in (1,2,3) and f not in (3,4,5) -- intersection of two not in. Not done yet",
+        "Best": "TableReader(Table(t)->Sel([not(in(test.t.f, 1, 2, 3)) not(in(test.t.f, 3, 4, 5))]))"
+      },
+      {
+        "SQL": "select f from t use index() where f not in (1,2,3) and f in (1,2,3) -- intersection of in and not in. Not done yet",
+        "Best": "TableReader(Table(t)->Sel([not(in(test.t.f, 1, 2, 3)) in(test.t.f, 1, 2, 3)]))"
       }
     ]
   }


### PR DESCRIPTION
 Issue Number: ref #40221

Problem Summary:
This PR just adds tests of various predicate simplification optimizations cases. The purpose of the test is to 
(1) document existing cases. This include (a) removing redundancy for identical simple predicates 
      like =, <>, > and <, >= and <=, (b) un-satisfiable conditions like x=1 and x <> 1 (c) intersection of two in lists.
(2) list cases not working currently and should be addressed in future optimizations. These cases cover 
     the use case in https://github.com/pingcap/tidb/issues/40221) and more like intersection of two "not in" lists.
(3) establish a place holder for predicate simplification is a general optimizer rewrite rule and sub-rules. 

Tests 
- [ X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects: None

Documentation: Noting needed 

Release note
`None`