### PR TITLE
lightning/parser: support STARTING BY and IGNORE n LINES

### DIFF
--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -455,6 +455,9 @@ type CSVConfig struct {
 	TrimLastSep     bool   `toml:"trim-last-separator" json:"trim-last-separator"`
 	NotNull         bool   `toml:"not-null" json:"not-null"`
 	BackslashEscape bool   `toml:"backslash-escape" json:"backslash-escape"`
+	// hide these options for lightning configuration file, they can only be used lu LOAD DATA
+	StartingBy  string `toml:"-" json:"-"`
+	IgnoreLines int    `toml:"-" json:"-"`
 }
 
 type MydumperRuntime struct {

--- a/br/pkg/lightning/mydump/bytes.go
+++ b/br/pkg/lightning/mydump/bytes.go
@@ -28,7 +28,7 @@ func (as *byteSet) contains(c byte) bool {
 }
 
 // IndexAnyByte returns the byte index of the first occurrence in s of any of the byte
-// points in chars. It returns -1 if  there is no code point in common.
+// points in chars. It returns -1 if there is no code point in common.
 func IndexAnyByte(s []byte, as *byteSet) int {
 	for i, c := range s {
 		if as.contains(c) {

--- a/br/pkg/lightning/mydump/csv_parser.go
+++ b/br/pkg/lightning/mydump/csv_parser.go
@@ -394,7 +394,7 @@ func (parser *CSVParser) readUntil(chars *byteSet) ([]byte, byte, error) {
 	}
 }
 
-func (parser *CSVParser) readRecords(dst []string) ([]string, error) {
+func (parser *CSVParser) readRecord(dst []string) ([]string, error) {
 	var (
 		isEmptyLine    bool
 		whitespaceLine bool
@@ -602,7 +602,7 @@ func (parser *CSVParser) ReadRow() error {
 	row.RowID++
 
 	for parser.ignoreLines > 0 {
-		_, err := parser.readRecords(parser.lastRecord)
+		_, err := parser.readRecord(parser.lastRecord)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -618,26 +618,26 @@ func (parser *CSVParser) ReadRow() error {
 		parser.shouldParseHeader = false
 	}
 
-	records, err := parser.readRecords(parser.lastRecord)
+	record, err := parser.readRecord(parser.lastRecord)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	parser.lastRecord = records
+	parser.lastRecord = record
 	// remove the last empty value
 	if parser.cfg.TrimLastSep {
-		i := len(records) - 1
-		if i >= 0 && len(records[i]) == 0 {
-			records = records[:i]
+		i := len(record) - 1
+		if i >= 0 && len(record[i]) == 0 {
+			record = record[:i]
 		}
 	}
 
 	row.Row = parser.acquireDatumSlice()
-	if cap(row.Row) >= len(records) {
-		row.Row = row.Row[:len(records)]
+	if cap(row.Row) >= len(record) {
+		row.Row = row.Row[:len(record)]
 	} else {
-		row.Row = make([]types.Datum, len(records))
+		row.Row = make([]types.Datum, len(record))
 	}
-	for i, record := range records {
+	for i, record := range record {
 		row.Length += len(record)
 		unescaped, isNull, err := parser.unescapeString(record)
 		if err != nil {
@@ -655,7 +655,7 @@ func (parser *CSVParser) ReadRow() error {
 
 // ReadColumns reads the columns of this CSV file.
 func (parser *CSVParser) ReadColumns() error {
-	columns, err := parser.readRecords(nil)
+	columns, err := parser.readRecord(nil)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/lightning/mydump/csv_parser.go
+++ b/br/pkg/lightning/mydump/csv_parser.go
@@ -602,7 +602,8 @@ func (parser *CSVParser) ReadRow() error {
 	row.RowID++
 
 	for parser.ignoreLines > 0 {
-		_, err := parser.readRecord(parser.lastRecord)
+		// IGNORE N LINES will directly find (line) terminator without checking it's inside quotes
+		_, err := parser.ReadUntilTerminator()
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/br/pkg/lightning/mydump/csv_parser_test.go
+++ b/br/pkg/lightning/mydump/csv_parser_test.go
@@ -1128,7 +1128,7 @@ func TestIgnoreLines(t *testing.T) {
 			expected: [][]types.Datum{},
 		},
 	}
-	//runTestCasesCSV(t, &cfg, 1, testCases)
+	runTestCasesCSV(t, &cfg, 1, testCases)
 }
 
 func TestCharsetConversion(t *testing.T) {

--- a/br/pkg/lightning/mydump/csv_parser_test.go
+++ b/br/pkg/lightning/mydump/csv_parser_test.go
@@ -967,7 +967,8 @@ something xxx"def",2
 		{
 			input: `xxxabc,1
 something xxxdef,2
-ghi,3`,
+ghi,3
+"bad syntax"aaa`,
 			expected: [][]types.Datum{
 				{types.NewStringDatum("abc"), types.NewStringDatum("1")},
 				{types.NewStringDatum("def"), types.NewStringDatum("2")},
@@ -1112,6 +1113,18 @@ func TestIgnoreLines(t *testing.T) {
 	}
 	runTestCasesCSV(t, &cfg, 1, testCases)
 
+	testCases = []testCase{
+		{
+			input: `"bad syntax"1
+"b",2
+"c",3`,
+			expected: [][]types.Datum{
+				{types.NewStringDatum("c"), types.NewStringDatum("3")},
+			},
+		},
+	}
+	runTestCasesCSV(t, &cfg, 1, testCases)
+
 	cfg = config.MydumperRuntime{
 		CSV: config.CSVConfig{
 			Separator:   ",",
@@ -1126,6 +1139,31 @@ func TestIgnoreLines(t *testing.T) {
 2,2
 3,3`,
 			expected: [][]types.Datum{},
+		},
+	}
+	runTestCasesCSV(t, &cfg, 1, testCases)
+
+	// test IGNORE N LINES will directly find (line) terminator without checking it's inside quotes
+
+	cfg = config.MydumperRuntime{
+		CSV: config.CSVConfig{
+			Separator:   ",",
+			Delimiter:   `"`,
+			Terminator:  "\n",
+			IgnoreLines: 2,
+		},
+	}
+	testCases = []testCase{
+		{
+			input: `"a
+",1
+"b
+",2
+"c",3`,
+			expected: [][]types.Datum{
+				{types.NewStringDatum("b\n"), types.NewStringDatum("2")},
+				{types.NewStringDatum("c"), types.NewStringDatum("3")},
+			},
 		},
 	}
 	runTestCasesCSV(t, &cfg, 1, testCases)

--- a/br/pkg/lightning/mydump/region.go
+++ b/br/pkg/lightning/mydump/region.go
@@ -397,7 +397,7 @@ func SplitLargeFile(
 		if err != nil {
 			return 0, nil, nil, err
 		}
-		parser, err := NewCSVParser(ctx, &cfg.Mydumper.CSV, r, int64(cfg.Mydumper.ReadBlockSize), ioWorker, true, charsetConvertor)
+		parser, err := NewCSVParser(ctx, &cfg.Mydumper.CSV, r, int64(cfg.Mydumper.ReadBlockSize), ioWorker, true, charsetConvertor, 0)
 		if err != nil {
 			return 0, nil, nil, err
 		}
@@ -424,7 +424,7 @@ func SplitLargeFile(
 			if err != nil {
 				return 0, nil, nil, err
 			}
-			parser, err := NewCSVParser(ctx, &cfg.Mydumper.CSV, r, int64(cfg.Mydumper.ReadBlockSize), ioWorker, false, charsetConvertor)
+			parser, err := NewCSVParser(ctx, &cfg.Mydumper.CSV, r, int64(cfg.Mydumper.ReadBlockSize), ioWorker, false, charsetConvertor, 0)
 			if err != nil {
 				return 0, nil, nil, err
 			}

--- a/br/pkg/lightning/restore/chunk_restore_test.go
+++ b/br/pkg/lightning/restore/chunk_restore_test.go
@@ -404,7 +404,7 @@ func (s *chunkRestoreSuite) TestEncodeLoopDeliverLimit() {
 	reader, err := store.Open(ctx, fileName)
 	require.NoError(s.T(), err)
 	w := worker.NewPool(ctx, 1, "io")
-	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, false, nil)
+	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, false, nil, 0)
 	require.NoError(s.T(), err)
 	s.cr.parser = p
 
@@ -479,7 +479,7 @@ func (s *chunkRestoreSuite) TestEncodeLoopColumnsMismatch() {
 	reader, err := store.Open(ctx, fileName)
 	require.NoError(s.T(), err)
 	w := worker.NewPool(ctx, 5, "io")
-	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, false, nil)
+	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, false, nil, 0)
 	require.NoError(s.T(), err)
 
 	err = s.cr.parser.Close()
@@ -574,7 +574,7 @@ func (s *chunkRestoreSuite) testEncodeLoopIgnoreColumnsCSV(
 	reader, err := store.Open(ctx, fileName)
 	require.NoError(s.T(), err)
 	w := worker.NewPool(ctx, 5, "io")
-	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, cfg.Mydumper.CSV.Header, nil)
+	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, cfg.Mydumper.CSV.Header, nil, 0)
 	require.NoError(s.T(), err)
 
 	err = s.cr.parser.Close()

--- a/br/pkg/lightning/restore/get_pre_info.go
+++ b/br/pkg/lightning/restore/get_pre_info.go
@@ -464,7 +464,7 @@ func (p *PreRestoreInfoGetterImpl) ReadFirstNRowsByFileMeta(ctx context.Context,
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
-		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, hasHeader, charsetConvertor)
+		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, hasHeader, charsetConvertor, 0)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
@@ -616,7 +616,7 @@ func (p *PreRestoreInfoGetterImpl) sampleDataFromTable(
 		if err != nil {
 			return 0.0, false, errors.Trace(err)
 		}
-		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, hasHeader, charsetConvertor)
+		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, hasHeader, charsetConvertor, 0)
 		if err != nil {
 			return 0.0, false, errors.Trace(err)
 		}

--- a/br/pkg/lightning/restore/restore.go
+++ b/br/pkg/lightning/restore/restore.go
@@ -2222,7 +2222,20 @@ func newChunkRestore(
 		if err != nil {
 			return nil, err
 		}
-		parser, err = mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, blockBufSize, ioWorkers, hasHeader, charsetConvertor)
+		ignoreLines := 0
+		if chunk.Chunk.Offset == 0 {
+			ignoreLines = cfg.Mydumper.CSV.IgnoreLines
+		}
+		parser, err = mydump.NewCSVParser(
+			ctx,
+			&cfg.Mydumper.CSV,
+			reader,
+			blockBufSize,
+			ioWorkers,
+			hasHeader,
+			charsetConvertor,
+			ignoreLines,
+		)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40499

Problem Summary:

### What is changed and how it works?

- STARTING BY: add token. When meet it reset the state of parser
- IGNORE n LINES: skip output for n times readRecords

Hide these configuration for lightning, only prepare for future LOAD DATA integration

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
