### PR TITLE
ddl: fix create exists resource group

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -7617,10 +7617,12 @@ func (d *ddl) CreateResourceGroup(ctx sessionctx.Context, stmt *ast.CreateResour
 			return err
 		}
 	}
-	if !stmt.IfNotExists {
-		if _, ok := d.GetInfoSchemaWithInterceptor(ctx).ResourceGroupByName(groupName); ok {
-			return infoschema.ErrResourceGroupExists.GenWithStackByArgs(groupName)
+
+	if _, ok := d.GetInfoSchemaWithInterceptor(ctx).ResourceGroupByName(groupName); ok {
+		if stmt.IfNotExists {
+			return nil
 		}
+		return infoschema.ErrResourceGroupExists.GenWithStackByArgs(groupName)
 	}
 
 	if groupName.L == defaultResourceGroupName {

--- a/ddl/resource_group_test.go
+++ b/ddl/resource_group_test.go
@@ -72,6 +72,14 @@ func TestResourceGroupBasic(t *testing.T) {
 	g := testResourceGroupNameFromIS(t, tk.Session(), "x")
 	checkFunc(g)
 
+	// test create if not exists
+	tk.MustExec("create resource group if not exists x " +
+		"RRU_PER_SEC=10000 " +
+		"WRU_PER_SEC=20000")
+	// Check the resource group is not changed
+	g = testResourceGroupNameFromIS(t, tk.Session(), "x")
+	checkFunc(g)
+
 	tk.MustExec("set global tidb_enable_resource_control = DEFAULT")
 	tk.MustGetErrCode("alter resource group x "+
 		"RRU_PER_SEC=2000 "+


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38825

Problem Summary:

Fix the bug that `CREATE RESOURCE GROUP IF NOT EXISTS` overrides the original resource group

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Side effects


Documentation


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
