### PR TITLE
planner: forbid using IndexFullScan on multi-valued indexes

### DIFF
--- a/planner/core/indexmerge_path.go
+++ b/planner/core/indexmerge_path.go
@@ -587,8 +587,7 @@ func (ds *DataSource) generateIndexMerge4MVIndex(normalPathCnt int, filters []ex
 		}
 
 		accessFilters, remainingFilters := ds.collectFilters4MVIndex(filters, idxCols)
-		if len(accessFilters) == 0 && // cannot use any filter on this MVIndex
-			!ds.possibleAccessPaths[idx].Forced { // whether this index is forced by use-index hint
+		if len(accessFilters) == 0 { // cannot use any filter on this MVIndex
 			continue
 		}
 

--- a/planner/core/testdata/index_merge_suite_in.json
+++ b/planner/core/testdata/index_merge_suite_in.json
@@ -7,7 +7,11 @@
       "select /*+ use_index(t, kj) */ * from t where a<10",
       "select /*+ use_index(t, kj) */ * from t where (1 member of (j))",
       "select /*+ use_index(t, kj) */ * from t where (1 member of (j)) and a=10",
-      "select /*+ use_index(t, kj) */ * from t where (1 member of (j)) or a=10"
+      "select /*+ use_index(t, kj) */ * from t where (1 member of (j)) or a=10",
+      "select /*+ use_index_merge(t, kj) */ * from t",
+      "select /*+ use_index_merge(t, kj) */ a from t",
+      "select /*+ use_index_merge(t, kj) */ * from t where a<10",
+      "select /*+ use_index_merge(t, kj) */ * from t where (1 member of (j)) or a=10"
     ]
   },
   {

--- a/planner/core/testdata/index_merge_suite_out.json
+++ b/planner/core/testdata/index_merge_suite_out.json
@@ -4,28 +4,18 @@
     "Cases": [
       {
         "SQL": "select /*+ use_index(t, kj) */ * from t",
-        "Plan": [
-          "IndexMerge 10000.00 root  type: union",
-          "├─IndexFullScan(Build) 10000.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) keep order:false, stats:pseudo",
-          "└─TableRowIDScan(Probe) 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
-        ]
+        "Plan": null,
+        "Err": "[planner:1815]Internal : Can't find a proper physical plan for this query"
       },
       {
         "SQL": "select /*+ use_index(t, kj) */ a from t",
-        "Plan": [
-          "IndexMerge 10000.00 root  type: union",
-          "├─IndexFullScan(Build) 10000.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) keep order:false, stats:pseudo",
-          "└─TableRowIDScan(Probe) 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
-        ]
+        "Plan": null,
+        "Err": "[planner:1815]Internal : Can't find a proper physical plan for this query"
       },
       {
         "SQL": "select /*+ use_index(t, kj) */ * from t where a<10",
-        "Plan": [
-          "IndexMerge 3323.33 root  type: union",
-          "├─IndexFullScan(Build) 10000.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) keep order:false, stats:pseudo",
-          "└─Selection(Probe) 3323.33 cop[tikv]  lt(test.t.a, 10)",
-          "  └─TableRowIDScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
-        ]
+        "Plan": null,
+        "Err": "[planner:1815]Internal : Can't find a proper physical plan for this query"
       },
       {
         "SQL": "select /*+ use_index(t, kj) */ * from t where (1 member of (j))",
@@ -34,7 +24,8 @@
           "└─IndexMerge 10.00 root  type: union",
           "  ├─IndexRangeScan(Build) 10.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
           "  └─TableRowIDScan(Probe) 10.00 cop[tikv] table:t keep order:false, stats:pseudo"
-        ]
+        ],
+        "Err": ""
       },
       {
         "SQL": "select /*+ use_index(t, kj) */ * from t where (1 member of (j)) and a=10",
@@ -44,16 +35,47 @@
           "  ├─IndexRangeScan(Build) 10.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
           "  └─Selection(Probe) 0.01 cop[tikv]  eq(test.t.a, 10)",
           "    └─TableRowIDScan 10.00 cop[tikv] table:t keep order:false, stats:pseudo"
-        ]
+        ],
+        "Err": ""
       },
       {
         "SQL": "select /*+ use_index(t, kj) */ * from t where (1 member of (j)) or a=10",
+        "Plan": null,
+        "Err": "[planner:1815]Internal : Can't find a proper physical plan for this query"
+      },
+      {
+        "SQL": "select /*+ use_index_merge(t, kj) */ * from t",
+        "Plan": [
+          "TableReader 10000.00 root  data:TableFullScan",
+          "└─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Err": ""
+      },
+      {
+        "SQL": "select /*+ use_index_merge(t, kj) */ a from t",
+        "Plan": [
+          "TableReader 10000.00 root  data:TableFullScan",
+          "└─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Err": ""
+      },
+      {
+        "SQL": "select /*+ use_index_merge(t, kj) */ * from t where a<10",
+        "Plan": [
+          "TableReader 3323.33 root  data:Selection",
+          "└─Selection 3323.33 cop[tikv]  lt(test.t.a, 10)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Err": ""
+      },
+      {
+        "SQL": "select /*+ use_index_merge(t, kj) */ * from t where (1 member of (j)) or a=10",
         "Plan": [
           "Selection 8000.00 root  or(json_memberof(cast(1, json BINARY), test.t.j), eq(test.t.a, 10))",
-          "└─IndexMerge 10000.00 root  type: union",
-          "  ├─IndexFullScan(Build) 10000.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) keep order:false, stats:pseudo",
-          "  └─TableRowIDScan(Probe) 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
-        ]
+          "└─TableReader 10000.00 root  data:TableFullScan",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Err": ""
       }
     ]
   },


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40191

Problem Summary: planner: forbid using IndexFullScan on multi-valued indexes

### What is changed and how it works?

Using IndexFullScan on multi-valued indexes may not see all rows.

```
create table t(j json, index kj((cast(j as signed array))));
insert into t values ('[]');
```

For example, the row above is invisible to `IndexFullScan(kj)` since the `j` in this row has no element and then `kj` has no record of this row.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
