### PR TITLE
ttl: don't fetch ttl scan task after it finished

### DIFF
--- a/ttl/cache/task.go
+++ b/ttl/cache/task.go
@@ -59,7 +59,7 @@ func SelectFromTTLTaskWithID(jobID string, scanID int64) (string, []interface{})
 
 // PeekWaitingTTLTask returns an SQL statement to get `limit` waiting ttl task
 func PeekWaitingTTLTask(limit int, hbExpire time.Time) (string, []interface{}) {
-	return selectFromTTLTask + " WHERE status = 'waiting' OR owner_hb_time < %? ORDER BY created_time ASC LIMIT %?", []interface{}{hbExpire.Format("2006-01-02 15:04:05"), limit}
+	return selectFromTTLTask + " WHERE status = 'waiting' OR (owner_hb_time < %? AND status = 'running') ORDER BY created_time ASC LIMIT %?", []interface{}{hbExpire.Format("2006-01-02 15:04:05"), limit}
 }
 
 // InsertIntoTTLTask returns an SQL statement to insert a ttl task into mysql.tidb_ttl_task

--- a/ttl/ttlworker/task_manager_test.go
+++ b/ttl/ttlworker/task_manager_test.go
@@ -54,6 +54,24 @@ func (m *taskManager) ReportMetrics() {
 	m.reportMetrics()
 }
 
+// CheckFinishedTask is an exported version of checkFinishedTask
+func (m *taskManager) CheckFinishedTask(se session.Session, now time.Time) {
+	m.checkFinishedTask(se, now)
+}
+
+// ReportTaskFinished is an exported version of reportTaskFinished
+func (m *taskManager) GetRunningTasks() []*runningScanTask {
+	return m.runningTasks
+}
+
+// ReportTaskFinished is an exported version of reportTaskFinished
+func (t *runningScanTask) SetResult(err error) {
+	t.result = &ttlScanTaskExecResult{
+		task: t.ttlScanTask,
+		err:  err,
+	}
+}
+
 func TestResizeWorkers(t *testing.T) {
 	tbl := newMockTTLTbl(t, "t1")
 


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #40918

Problem Summary:

Don't fetch ttl scan tasks, if the task has finished. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Fix the issue that a ttl scan task will be restarted by other nodes.
```
