### PR TITLE
ttl: add resource group for ttl query

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -743,21 +743,21 @@ func (e *DDLExec) executeAlterPlacementPolicy(s *ast.AlterPlacementPolicyStmt) e
 }
 
 func (e *DDLExec) executeCreateResourceGroup(s *ast.CreateResourceGroupStmt) error {
-	if !variable.EnableResourceControl.Load() {
+	if !variable.EnableResourceControl.Load() && !e.ctx.GetSessionVars().InRestrictedSQL {
 		return infoschema.ErrResourceGroupSupportDisabled
 	}
 	return domain.GetDomain(e.ctx).DDL().AddResourceGroup(e.ctx, s)
 }
 
 func (e *DDLExec) executeAlterResourceGroup(s *ast.AlterResourceGroupStmt) error {
-	if !variable.EnableResourceControl.Load() {
+	if !variable.EnableResourceControl.Load() && !e.ctx.GetSessionVars().InRestrictedSQL {
 		return infoschema.ErrResourceGroupSupportDisabled
 	}
 	return domain.GetDomain(e.ctx).DDL().AlterResourceGroup(e.ctx, s)
 }
 
 func (e *DDLExec) executeDropResourceGroup(s *ast.DropResourceGroupStmt) error {
-	if !variable.EnableResourceControl.Load() {
+	if !variable.EnableResourceControl.Load() && !e.ctx.GetSessionVars().InRestrictedSQL {
 		return infoschema.ErrResourceGroupSupportDisabled
 	}
 	return domain.GetDomain(e.ctx).DDL().DropResourceGroup(e.ctx, s)

--- a/telemetry/data_feature_usage_test.go
+++ b/telemetry/data_feature_usage_test.go
@@ -356,12 +356,13 @@ func TestPlacementPolicies(t *testing.T) {
 
 func TestResourceGroups(t *testing.T) {
 	store := testkit.CreateMockStore(t)
+	systemResourceGroupCount := 1
 
 	tk := testkit.NewTestKit(t, store)
 
 	usage, err := telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
-	require.Equal(t, uint64(0), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, uint64(systemResourceGroupCount), usage.ResourceControlUsage.NumResourceGroups)
 	require.Equal(t, false, usage.ResourceControlUsage.Enabled)
 
 	tk.MustExec("set global tidb_enable_resource_control = 'ON'")
@@ -369,27 +370,27 @@ func TestResourceGroups(t *testing.T) {
 	usage, err = telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
 	require.Equal(t, true, usage.ResourceControlUsage.Enabled)
-	require.Equal(t, uint64(1), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, uint64(systemResourceGroupCount+1), usage.ResourceControlUsage.NumResourceGroups)
 
 	tk.MustExec("create resource group y ru_per_sec=100")
 	usage, err = telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
-	require.Equal(t, uint64(2), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, uint64(systemResourceGroupCount+2), usage.ResourceControlUsage.NumResourceGroups)
 
 	tk.MustExec("alter resource group y ru_per_sec=200")
 	usage, err = telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
-	require.Equal(t, uint64(2), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, uint64(systemResourceGroupCount+2), usage.ResourceControlUsage.NumResourceGroups)
 
 	tk.MustExec("drop resource group y")
 	usage, err = telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, uint64(systemResourceGroupCount+1), usage.ResourceControlUsage.NumResourceGroups)
 
 	tk.MustExec("set global tidb_enable_resource_control = 'OFF'")
 	usage, err = telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, uint64(systemResourceGroupCount+1), usage.ResourceControlUsage.NumResourceGroups)
 	require.Equal(t, false, usage.ResourceControlUsage.Enabled)
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #40928

Problem Summary:

Add resource group `tidb_ttl` for the ttl query. The user can tune the configuration for this resource group through `alter resource group`.

I was running some experiments to get a more proper RU value. 

### What is changed and how it works?

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

WIP

### Release note

```release-note
Attach resource group for the TTL queries. The user can modify the priority and limitation of the TTL through configuring the resource group.
```
