### PR TITLE
ttl: fix data race in TTL manager and test

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -127,7 +127,7 @@ type Domain struct {
 	expiredTimeStamp4PC   types.Time
 	logBackupAdvancer     *daemon.OwnerDaemon
 	historicalStatsWorker *HistoricalStatsWorker
-	ttlJobManager         *ttlworker.JobManager
+	ttlJobManager         atomic.Pointer[ttlworker.JobManager]
 
 	serverID             uint64
 	serverIDSession      *concurrency.Session
@@ -2494,7 +2494,7 @@ func (do *Domain) StartTTLJobManager() {
 		}()
 
 		ttlJobManager := ttlworker.NewJobManager(do.ddl.GetID(), do.sysSessionPool, do.store, do.etcdClient)
-		do.ttlJobManager = ttlJobManager
+		do.ttlJobManager.Store(ttlJobManager)
 		ttlJobManager.Start()
 
 		<-do.exit
@@ -2509,7 +2509,7 @@ func (do *Domain) StartTTLJobManager() {
 
 // TTLJobManager returns the ttl job manager on this domain
 func (do *Domain) TTLJobManager() *ttlworker.JobManager {
-	return do.ttlJobManager
+	return do.ttlJobManager.Load()
 }
 
 func init() {


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #40944

Problem Summary:

Fix the data race to read and initialize the TTL job manager.

### What is changed and how it works?

Use the atomic pointer to store the TTL job manager.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
