### PR TITLE
util: fix memory leak in chunk allocator

### DIFF
--- a/util/chunk/alloc.go
+++ b/util/chunk/alloc.go
@@ -129,11 +129,12 @@ func (a *allocator) Reset() {
 
 	//column objects and put them to the column allocator for reuse.
 	for id, pool := range a.columnAlloc.pool {
-		for _, col := range pool.allocColumns {
+		for i, col := range pool.allocColumns {
 			if (len(pool.freeColumns) < a.columnAlloc.freeColumnsPerType) && checkColumnType(id, col) {
 				col.reset()
 				pool.freeColumns = append(pool.freeColumns, col)
 			}
+			pool.allocColumns[i] = nil
 		}
 		pool.allocColumns = pool.allocColumns[:0]
 	}
@@ -196,6 +197,7 @@ func (cList *columnList) pop() *Column {
 		return nil
 	}
 	col := cList.freeColumns[len(cList.freeColumns)-1]
+	cList.freeColumns[len(cList.freeColumns)-1] = nil
 	cList.freeColumns = cList.freeColumns[:len(cList.freeColumns)-1]
 	return col
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/40987

Problem Summary:

### What is changed and how it works?

Unlink the reference to the chunk for freeColumns.allocColumns and freeColumns.freeColumns. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
![image](https://user-images.githubusercontent.com/14054293/216275546-d14779e0-3bf3-4f74-8679-a3bad9517e30.png)



- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the potential memory leak when enable tidb_enable_reuse_chunk.
```
