### PR TITLE
planner: not allow the optimizer to use `json_contains(j, '[]')` as access conditions on MVIndex

### DIFF
--- a/planner/core/indexmerge_path.go
+++ b/planner/core/indexmerge_path.go
@@ -668,7 +668,7 @@ func (ds *DataSource) buildPartialPaths4MVIndex(accessFilters []expression.Expre
 	case ast.JSONContains: // (json_contains(a->'$.zip', '[1, 2, 3]')
 		isIntersection = true
 		virColVals, ok = jsonArrayExpr2Exprs(ds.ctx, sf.GetArgs()[1], jsonType)
-		if !ok {
+		if !ok || len(virColVals) == 0 { // json_contains(JSON, '[]') is TRUE
 			return nil, false, false, nil
 		}
 	case ast.JSONOverlaps: // (json_overlaps(a->'$.zip', '[1, 2, 3]')
@@ -682,7 +682,7 @@ func (ds *DataSource) buildPartialPaths4MVIndex(accessFilters []expression.Expre
 		}
 		var ok bool
 		virColVals, ok = jsonArrayExpr2Exprs(ds.ctx, sf.GetArgs()[1-jsonPathIdx], jsonType)
-		if !ok {
+		if !ok || len(virColVals) == 0 { // forbid empty array for safety
 			return nil, false, false, nil
 		}
 	default:

--- a/planner/core/indexmerge_path_test.go
+++ b/planner/core/indexmerge_path_test.go
@@ -302,6 +302,31 @@ func TestMVIndexFullScan(t *testing.T) {
 	tk.MustGetErrMsg(`select /*+ use_index(t, kj) */ count(*) from t`, "[planner:1815]Internal : Can't find a proper physical plan for this query")
 }
 
+func TestMVIndexEmptyArray(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t(j json, index kj((cast(j as signed array))))`)
+	tk.MustExec(`insert into t values ('[1]')`)
+	tk.MustExec(`insert into t values ('[1, 2]')`)
+	tk.MustExec(`insert into t values ('[]')`)
+	tk.MustExec(`insert into t values (NULL)`)
+
+	for _, cond := range []string{
+		"json_contains(j, '[]')",
+		"json_contains(j, '[1]')",
+		"json_contains(j, '[1, 2]')",
+		"json_contains(j, '[1, 10]')",
+		"json_overlaps(j, '[]')",
+		"json_overlaps(j, '[1]')",
+		"json_overlaps(j, '[1, 2]')",
+		"json_overlaps(j, '[1, 10]')",
+	} {
+		tk.MustQuery(fmt.Sprintf("select /*+ use_index_merge(t) */ * from t where %v", cond)).Sort().Check(
+			tk.MustQuery(fmt.Sprintf("select /*+ ignore_index(t, kj) */ * from t where %v", cond)).Sort().Rows())
+	}
+}
+
 func TestMVIndexRandom(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -364,12 +389,21 @@ func randMVIndexCond(condType int, valOpts randMVIndexValOpts) string {
 	case 0: // member_of
 		return fmt.Sprintf(`(%v member of (j))`, randMVIndexValue(valOpts))
 	case 1: // json_contains
-		return fmt.Sprintf(`json_contains(j, '[%v, %v]')`, randMVIndexValue(valOpts), randMVIndexValue(valOpts))
+		return fmt.Sprintf(`json_contains(j, '%v')`, randArray(valOpts))
 	case 2: // json_overlaps
-		return fmt.Sprintf(`json_overlaps(j, '[%v, %v]')`, randMVIndexValue(valOpts), randMVIndexValue(valOpts))
+		return fmt.Sprintf(`json_overlaps(j, '%v')`, randArray(valOpts))
 	default: // others
 		return fmt.Sprintf(`a < %v`, rand.Intn(valOpts.distinct))
 	}
+}
+
+func randArray(opts randMVIndexValOpts) string {
+	n := rand.Intn(5) // n can be 0
+	var vals []string
+	for i := 0; i < n; i++ {
+		vals = append(vals, randMVIndexValue(opts))
+	}
+	return "[" + strings.Join(vals, ", ") + "]"
 }
 
 type randMVIndexValOpts struct {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40191

Problem Summary: planner: planner: not allow the optimizer to use `json_contains(j, '[]')` as access conditions on MVIndex

### What is changed and how it works?

On the current MVIndex Implementation, if the optimizer meets `json_contains(j, '[]')`, it'll generate a TableDual plan since the JSON array is empty, and then it'll return an empty result.

But actually, `json_contains(j, '[]')` is always `true`, so all rows should be returned instead of an empty result.

```
mysql> select json_contains('[1]', '[]');
+----------------------------+
| json_contains('[1]', '[]') |
+----------------------------+
|                          1 |
+----------------------------+
1 row in set (0.01 sec)
```

To solve this issue, we don't allow the optimizer to use `json_contains` with an empty array as an argument as an access condition to construct the IndexMerge.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
