### PR TITLE
resourcemanager: fix TaskController.Stop() can't make producer exit in spmcpool 

### DIFF
--- a/resourcemanager/pooltask/BUILD.bazel
+++ b/resourcemanager/pooltask/BUILD.bazel
@@ -10,7 +10,10 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/resourcemanager/pooltask",
     visibility = ["//visibility:public"],
-    deps = ["@org_uber_go_atomic//:atomic"],
+    deps = [
+        "//util/channel",
+        "@org_uber_go_atomic//:atomic",
+    ],
 )
 
 go_test(

--- a/resourcemanager/pooltask/task.go
+++ b/resourcemanager/pooltask/task.go
@@ -17,6 +17,8 @@ package pooltask
 import (
 	"sync"
 	"sync/atomic"
+
+	"github.com/pingcap/tidb/util/channel"
 )
 
 // Context is a interface that can be used to create a context.
@@ -160,6 +162,7 @@ func (t *TaskController[T, U, C, CT, TF]) Stop() {
 	close(t.productCloseCh)
 	t.prodWg.Wait()
 	t.pool.StopTask(t.TaskID())
+	channel.Clear(t.resultCh)
 }
 
 // TaskID is to get the task id.

--- a/resourcemanager/pooltask/task.go
+++ b/resourcemanager/pooltask/task.go
@@ -131,18 +131,20 @@ type TaskController[T any, U any, C any, CT any, TF Context[CT]] struct {
 	closeCh        chan struct{}
 	productCloseCh chan struct{}
 	wg             *sync.WaitGroup
+	prodWg         *sync.WaitGroup
 	taskID         uint64
 	resultCh       chan U
 }
 
 // NewTaskController create a controller to deal with pooltask's status.
-func NewTaskController[T any, U any, C any, CT any, TF Context[CT]](p GPool[T, U, C, CT, TF], taskID uint64, closeCh, productCloseCh chan struct{}, wg *sync.WaitGroup, resultCh chan U) TaskController[T, U, C, CT, TF] {
+func NewTaskController[T any, U any, C any, CT any, TF Context[CT]](p GPool[T, U, C, CT, TF], taskID uint64, closeCh, productCloseCh chan struct{}, wg, prodWg *sync.WaitGroup, resultCh chan U) TaskController[T, U, C, CT, TF] {
 	return TaskController[T, U, C, CT, TF]{
 		pool:           p,
 		taskID:         taskID,
 		closeCh:        closeCh,
 		productCloseCh: productCloseCh,
 		wg:             wg,
+		prodWg:         prodWg,
 		resultCh:       resultCh,
 	}
 }
@@ -158,6 +160,7 @@ func (t *TaskController[T, U, C, CT, TF]) Wait() {
 // Stop is to send stop command to the task. But you still need to wait the task to stop.
 func (t *TaskController[T, U, C, CT, TF]) Stop() {
 	close(t.productCloseCh)
+	t.wg.Wait()
 	t.pool.StopTask(t.TaskID())
 }
 

--- a/resourcemanager/pooltask/task.go
+++ b/resourcemanager/pooltask/task.go
@@ -158,6 +158,7 @@ func (t *TaskController[T, U, C, CT, TF]) Wait() {
 // Stop is to send stop command to the task. But you still need to wait the task to stop.
 func (t *TaskController[T, U, C, CT, TF]) Stop() {
 	close(t.productCloseCh)
+	t.pool.StopTask(t.TaskID())
 }
 
 // TaskID is to get the task id.

--- a/resourcemanager/pooltask/task.go
+++ b/resourcemanager/pooltask/task.go
@@ -127,27 +127,29 @@ type GPool[T any, U any, C any, CT any, TF Context[CT]] interface {
 
 // TaskController is a controller that can control or watch the pool.
 type TaskController[T any, U any, C any, CT any, TF Context[CT]] struct {
-	pool     GPool[T, U, C, CT, TF]
-	close    chan struct{}
-	wg       *sync.WaitGroup
-	taskID   uint64
-	resultCh chan U
+	pool           GPool[T, U, C, CT, TF]
+	closeCh        chan struct{}
+	productCloseCh chan struct{}
+	wg             *sync.WaitGroup
+	taskID         uint64
+	resultCh       chan U
 }
 
 // NewTaskController create a controller to deal with pooltask's status.
-func NewTaskController[T any, U any, C any, CT any, TF Context[CT]](p GPool[T, U, C, CT, TF], taskID uint64, closeCh chan struct{}, wg *sync.WaitGroup, resultCh chan U) TaskController[T, U, C, CT, TF] {
+func NewTaskController[T any, U any, C any, CT any, TF Context[CT]](p GPool[T, U, C, CT, TF], taskID uint64, closeCh, productCloseCh chan struct{}, wg *sync.WaitGroup, resultCh chan U) TaskController[T, U, C, CT, TF] {
 	return TaskController[T, U, C, CT, TF]{
-		pool:     p,
-		taskID:   taskID,
-		close:    closeCh,
-		wg:       wg,
-		resultCh: resultCh,
+		pool:           p,
+		taskID:         taskID,
+		closeCh:        closeCh,
+		productCloseCh: productCloseCh,
+		wg:             wg,
+		resultCh:       resultCh,
 	}
 }
 
 // Wait is to wait the pool task to stop.
 func (t *TaskController[T, U, C, CT, TF]) Wait() {
-	<-t.close
+	<-t.closeCh
 	t.wg.Wait()
 	close(t.resultCh)
 	t.pool.DeleteTask(t.taskID)
@@ -155,7 +157,7 @@ func (t *TaskController[T, U, C, CT, TF]) Wait() {
 
 // Stop is to send stop command to the task. But you still need to wait the task to stop.
 func (t *TaskController[T, U, C, CT, TF]) Stop() {
-	t.pool.StopTask(t.TaskID())
+	close(t.productCloseCh)
 }
 
 // TaskID is to get the task id.

--- a/resourcemanager/pooltask/task.go
+++ b/resourcemanager/pooltask/task.go
@@ -158,7 +158,7 @@ func (t *TaskController[T, U, C, CT, TF]) Wait() {
 // Stop is to send stop command to the task. But you still need to wait the task to stop.
 func (t *TaskController[T, U, C, CT, TF]) Stop() {
 	close(t.productCloseCh)
-	t.wg.Wait()
+	t.prodWg.Wait()
 	t.pool.StopTask(t.TaskID())
 }
 

--- a/util/gpool/spmc/BUILD.bazel
+++ b/util/gpool/spmc/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     embed = [":spmc"],
     flaky = True,
     race = "on",
+    shard_count = 2,
     deps = [
         "//resourcemanager/pooltask",
         "//resourcemanager/util",

--- a/util/gpool/spmc/BUILD.bazel
+++ b/util/gpool/spmc/BUILD.bazel
@@ -34,7 +34,6 @@ go_test(
     embed = [":spmc"],
     flaky = True,
     race = "on",
-    shard_count = 2,
     deps = [
         "//resourcemanager/pooltask",
         "//resourcemanager/util",

--- a/util/gpool/spmc/option.go
+++ b/util/gpool/spmc/option.go
@@ -103,8 +103,8 @@ func loadTaskOptions(options ...TaskOption) *TaskOptions {
 	if opts.ResultChanLen == 0 {
 		opts.ResultChanLen = uint64(opts.Concurrency)
 	}
-	if opts.ResultChanLen == 0 {
-		opts.ResultChanLen = uint64(opts.Concurrency)
+	if opts.TaskChanLen == 0 {
+		opts.TaskChanLen = uint64(opts.Concurrency)
 	}
 	return opts
 }

--- a/util/gpool/spmc/option.go
+++ b/util/gpool/spmc/option.go
@@ -18,6 +18,8 @@ import (
 	"time"
 )
 
+const defaultTaskChanLen = 1
+
 // Option represents the optional function.
 type Option func(opts *Options)
 
@@ -104,7 +106,7 @@ func loadTaskOptions(options ...TaskOption) *TaskOptions {
 		opts.ResultChanLen = uint64(opts.Concurrency)
 	}
 	if opts.TaskChanLen == 0 {
-		opts.TaskChanLen = uint64(opts.Concurrency)
+		opts.TaskChanLen = defaultTaskChanLen
 	}
 	return opts
 }

--- a/util/gpool/spmc/spmcpool.go
+++ b/util/gpool/spmc/spmcpool.go
@@ -262,7 +262,7 @@ func (p *Pool[T, U, C, CT, TF]) AddProduceBySlice(producer func() ([]T, error), 
 	result := make(chan U, opt.ResultChanLen)
 	productCloseCh := make(chan struct{})
 	inputCh := make(chan pooltask.Task[T], opt.TaskChanLen)
-	tc := pooltask.NewTaskController[T, U, C, CT, TF](p, taskID, productCloseCh, &wg, &prodWg, result)
+	tc := pooltask.NewTaskController[T, U, C, CT, TF](p, taskID, productCloseCh, &wg, &prodWg, inputCh, result)
 	p.taskManager.RegisterTask(taskID, int32(opt.Concurrency))
 	for i := 0; i < opt.Concurrency; i++ {
 		err := p.run()
@@ -320,7 +320,7 @@ func (p *Pool[T, U, C, CT, TF]) AddProducer(producer func() (T, error), constArg
 	productCloseCh := make(chan struct{})
 	inputCh := make(chan pooltask.Task[T], opt.TaskChanLen)
 	p.taskManager.RegisterTask(taskID, int32(opt.Concurrency))
-	tc := pooltask.NewTaskController[T, U, C, CT, TF](p, taskID, productCloseCh, &wg, &prodWg, result)
+	tc := pooltask.NewTaskController[T, U, C, CT, TF](p, taskID, productCloseCh, &wg, &prodWg, inputCh, result)
 	for i := 0; i < opt.Concurrency; i++ {
 		err := p.run()
 		if err == gpool.ErrPoolClosed {

--- a/util/gpool/spmc/spmcpool.go
+++ b/util/gpool/spmc/spmcpool.go
@@ -298,11 +298,11 @@ func (p *Pool[T, U, C, CT, TF]) AddProduceBySlice(producer func() ([]T, error), 
 					Task: task,
 				}
 				inputCh <- task
-			}
-			select {
-			case <-productCloseCh:
-				return
-			default:
+				select {
+				case <-productCloseCh:
+					return
+				default:
+				}
 			}
 		}
 	}()

--- a/util/gpool/spmc/spmcpool_test.go
+++ b/util/gpool/spmc/spmcpool_test.go
@@ -114,10 +114,7 @@ func TestStopPool(t *testing.T) {
 	}()
 	// Waiting task finishing
 	control.Stop()
-	close(exit)
 	control.Wait()
-	// it should pass. Stop can be used after the pool is closed. we should prevent it from panic.
-	control.Stop()
 	wg.Wait()
 	// close pool
 	pool.ReleaseAndWait()
@@ -193,7 +190,7 @@ func testTunePool(t *testing.T, name string) {
 	}
 
 	// exit test
-	close(exit)
+	control.Stop()
 	control.Wait()
 	wg.Wait()
 	// close pool


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41015

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
