### PR TITLE
lightning: make pre-load mechanism for parquet adjustable

### DIFF
--- a/br/pkg/lightning/mydump/BUILD.bazel
+++ b/br/pkg/lightning/mydump/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//util/regexpr-router",
         "//util/slice",
         "//util/table-filter",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_pingcap_errors//:errors",
         "@com_github_spkg_bom//:bom",
         "@com_github_xitongsys_parquet_go//parquet",

--- a/br/pkg/lightning/mydump/parquet_parser.go
+++ b/br/pkg/lightning/mydump/parquet_parser.go
@@ -125,7 +125,7 @@ func OpenParquetReader(
 	if smallParquetFileThreshold < 0 {
 		smallParquetFileThreshold = defaultSmallParquetFileThreshold
 	}
-	if size <= int64(smallParquetFileThreshold) {
+	if size <= smallParquetFileThreshold {
 		fileBytes, err := store.ReadFile(ctx, path)
 		if err != nil {
 			return nil, err

--- a/br/pkg/lightning/mydump/parquet_parser_test.go
+++ b/br/pkg/lightning/mydump/parquet_parser_test.go
@@ -372,5 +372,4 @@ func TestOpenParquetReaderWithThreshold(t *testing.T) {
 	defer parser2.Close()
 
 	verifySimpleData(t, parser2)
-
 }

--- a/br/pkg/lightning/restore/get_pre_info.go
+++ b/br/pkg/lightning/restore/get_pre_info.go
@@ -449,7 +449,7 @@ func (p *PreRestoreInfoGetterImpl) ReadFirstNRowsByTableName(ctx context.Context
 // ReadFirstNRowsByFileMeta reads the first N rows of an data file.
 // It implements the PreRestoreInfoGetter interface.
 func (p *PreRestoreInfoGetterImpl) ReadFirstNRowsByFileMeta(ctx context.Context, dataFileMeta mydump.SourceFileMeta, n int) ([]string, [][]types.Datum, error) {
-	reader, err := openReader(ctx, dataFileMeta, p.srcStorage)
+	reader, err := openReader(ctx, dataFileMeta, p.srcStorage, openReaderScenarioPreviewData)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -587,7 +587,7 @@ func (p *PreRestoreInfoGetterImpl) sampleDataFromTable(
 		return resultIndexRatio, isRowOrdered, nil
 	}
 	sampleFile := tableMeta.DataFiles[0].FileMeta
-	reader, err := openReader(ctx, sampleFile, p.srcStorage)
+	reader, err := openReader(ctx, sampleFile, p.srcStorage, openReaderScenarioPreviewData)
 	if err != nil {
 		return 0.0, false, errors.Trace(err)
 	}

--- a/br/pkg/lightning/restore/restore.go
+++ b/br/pkg/lightning/restore/restore.go
@@ -2836,7 +2836,7 @@ func openReader(ctx context.Context, fileMeta mydump.SourceFileMeta, store stora
 		switch scenario {
 		case openReaderScenarioPreviewData:
 			// For preview scenario, no need to download a large parquet file,
-			// becuase we only need to get some first pages of the parquet file.
+			// because we only need to get some first pages of the parquet file.
 			smallFileThreshold = 16 * units.MiB
 		}
 		reader, err = mydump.OpenParquetReader(ctx, store, fileMeta.Path, fileMeta.FileSize, int64(smallFileThreshold))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41051 

Problem Summary:

### What is changed and how it works?
Added some adaptive logic on different scenarios when opening a parquet file for read:
* For data previewing scenario, only parquet files less than 16MB will be pre-loaded
* For data restoring scenario, keep the current logic: files less than 256MB will be pre-loaded

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
