### PR TITLE
lightning: fix panic when nextKey twice (#40959)

### DIFF
--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -1615,6 +1615,9 @@ func (local *local) ImportEngine(ctx context.Context, engineUUID uuid.UUID, regi
 		// the table when table is created.
 		needSplit := len(unfinishedRanges) > 1 || lfTotalSize > regionSplitSize || lfLength > regionSplitKeys
 		// split region by given ranges
+		failpoint.Inject("failToSplit", func(_ failpoint.Value) {
+			needSplit = true
+		})
 		for i := 0; i < maxRetryTimes; i++ {
 			err = local.SplitAndScatterRegionInBatches(ctx, unfinishedRanges, lf.tableInfo, needSplit, regionSplitSize, maxBatchSplitRanges)
 			if err == nil || common.IsContextCanceledError(err) {
@@ -2004,7 +2007,8 @@ func nextKey(key []byte) []byte {
 
 	// in tikv <= 4.x, tikv will truncate the row key, so we should fetch the next valid row key
 	// See: https://github.com/tikv/tikv/blob/f7f22f70e1585d7ca38a59ea30e774949160c3e8/components/raftstore/src/coprocessor/split_observer.rs#L36-L41
-	if tablecodec.IsRecordKey(key) {
+	// we only do this for IntHandle, which is checked by length
+	if tablecodec.IsRecordKey(key) && len(key) == tablecodec.RecordRowKeyLen {
 		tableID, handle, _ := tablecodec.DecodeRecordKey(key)
 		nextHandle := handle.Next()
 		// int handle overflow, use the next table prefix as nextKey
@@ -2014,7 +2018,7 @@ func nextKey(key []byte) []byte {
 		return tablecodec.EncodeRowKeyWithHandle(tableID, nextHandle)
 	}
 
-	// if key is an index, directly append a 0x00 to the key.
+	// for index key and CommonHandle, directly append a 0x00 to the key.
 	res := make([]byte, 0, len(key)+1)
 	res = append(res, key...)
 	res = append(res, 0)

--- a/br/pkg/lightning/backend/local/local_test.go
+++ b/br/pkg/lightning/backend/local/local_test.go
@@ -113,9 +113,20 @@ func TestNextKey(t *testing.T) {
 		require.NoError(t, err)
 		nextHdl, err := tidbkv.NewCommonHandle(nextKeyBytes)
 		require.NoError(t, err)
-		expectNextKey := []byte(tablecodec.EncodeRowKeyWithHandle(1, nextHdl))
-		require.Equal(t, expectNextKey, nextKey(key))
+		nextValidKey := []byte(tablecodec.EncodeRowKeyWithHandle(1, nextHdl))
+		// nextKey may return a key that can't be decoded, but it must not be larger than the valid next key.
+		require.True(t, bytes.Compare(nextKey(key), nextValidKey) <= 0, "datums: %v", datums)
 	}
+
+	// a special case that when len(string datum) % 8 == 7, nextKey twice should not panic.
+	keyBytes, err := codec.EncodeKey(stmtCtx, nil, types.NewStringDatum("1234567"))
+	require.NoError(t, err)
+	h, err := tidbkv.NewCommonHandle(keyBytes)
+	require.NoError(t, err)
+	key = tablecodec.EncodeRowKeyWithHandle(1, h)
+	nextOnce := nextKey(key)
+	// should not panic
+	_ = nextKey(nextOnce)
 
 	// dIAAAAAAAAD/PV9pgAAAAAD/AAABA4AAAAD/AAAAAQOAAAD/AAAAAAEAAAD8
 	// a index key with: table: 61, index: 1, int64: 1, int64: 1

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	sst "github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -379,7 +380,14 @@ func fetchTableRegionSizeStats(ctx context.Context, db *sql.DB, tableID int64) (
 	return stats, errors.Trace(err)
 }
 
-func (local *local) BatchSplitRegions(ctx context.Context, region *split.RegionInfo, keys [][]byte) (*split.RegionInfo, []*split.RegionInfo, error) {
+func (local *local) BatchSplitRegions(
+	ctx context.Context,
+	region *split.RegionInfo,
+	keys [][]byte,
+) (*split.RegionInfo, []*split.RegionInfo, error) {
+	failpoint.Inject("failToSplit", func(_ failpoint.Value) {
+		failpoint.Return(nil, nil, errors.New("retryable error"))
+	})
 	region, newRegions, err := local.splitCli.BatchSplitRegionsWithOrigin(ctx, region, keys)
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "batch split regions failed")

--- a/br/tests/lightning_local_backend/data/cpeng.a-schema.sql
+++ b/br/tests/lightning_local_backend/data/cpeng.a-schema.sql
@@ -1,1 +1,1 @@
-create table a (c int);
+create table a (c VARCHAR(20) PRIMARY KEY);

--- a/br/tests/lightning_local_backend/data/cpeng.a.1.sql
+++ b/br/tests/lightning_local_backend/data/cpeng.a.1.sql
@@ -1,1 +1,1 @@
-insert into a values (1);
+insert into a values ('0000001');

--- a/br/tests/lightning_local_backend/data/cpeng.a.2.sql
+++ b/br/tests/lightning_local_backend/data/cpeng.a.2.sql
@@ -1,1 +1,1 @@
-insert into a values (2);
+insert into a values ('0000002');

--- a/br/tests/lightning_local_backend/data/cpeng.a.3.sql
+++ b/br/tests/lightning_local_backend/data/cpeng.a.3.sql
@@ -1,1 +1,1 @@
-insert into a values (3),(4);
+insert into a values ('0000003'),('0000004');

--- a/br/tests/lightning_local_backend/run.sh
+++ b/br/tests/lightning_local_backend/run.sh
@@ -36,10 +36,11 @@ grep -Fq 'table(s) [`cpeng`.`a`, `cpeng`.`b`] are not empty' $TEST_DIR/lightning
 
 
 # First, verify that inject with not leader error is fine.
-export GO_FAILPOINTS='github.com/pingcap/tidb/br/pkg/lightning/backend/local/FailIngestMeta=1*return("notleader")'
+export GO_FAILPOINTS='github.com/pingcap/tidb/br/pkg/lightning/backend/local/FailIngestMeta=1*return("notleader");github.com/pingcap/tidb/br/pkg/lightning/backend/local/failToSplit=2*return("")'
 rm -f "$TEST_DIR/lightning-local.log"
 run_sql 'DROP DATABASE IF EXISTS cpeng;'
-run_lightning --backend local --enable-checkpoint=1 --log-file "$TEST_DIR/lightning-local.log" --config "tests/$TEST_NAME/config.toml"
+run_lightning --backend local --enable-checkpoint=1 --log-file "$TEST_DIR/lightning-local.log" --config "tests/$TEST_NAME/config.toml" -L debug
+grep -Eq "split regions.*retryable error" "$TEST_DIR/lightning-local.log"
 
 # Check that everything is correctly imported
 run_sql 'SELECT count(*), sum(c) FROM cpeng.a'

--- a/kv/key.go
+++ b/kv/key.go
@@ -149,6 +149,7 @@ type Handle interface {
 	// IntValue returns the int64 value if IsInt is true, it panics if IsInt returns false.
 	IntValue() int64
 	// Next returns the minimum handle that is greater than this handle.
+	// The returned handle is not guaranteed to be able to decode.
 	Next() Handle
 	// Equal returns if the handle equals to another handle, it panics if the types are different.
 	Equal(h Handle) bool
@@ -299,6 +300,7 @@ func (*CommonHandle) IntValue() int64 {
 }
 
 // Next implements the Handle interface.
+// Note that the returned encoded field is not guaranteed to be able to decode.
 func (ch *CommonHandle) Next() Handle {
 	return &CommonHandle{
 		encoded:       Key(ch.encoded).PrefixNext(),


### PR DESCRIPTION
manually cherry-pick #40959 

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40934

Problem Summary:

### What is changed and how it works?

Avoid to let CommonHandle++ and decode it because the result may not be a valid value. The string datum encoding will not be ended with 0xff and we may increase 0xfe to 0xff.

https://github.com/pingcap/tidb/blob/151cd7ed605c934aa8fed6907762130147caed4d/util/codec/bytes.go#L35-L49

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Run the changed tests and failpoints will trigger this panic. And after the fix it is avoided.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0x34e93e5]

goroutine 436 [running]:
github.com/pingcap/tidb/br/pkg/lightning/backend/local.nextKey({0xc000874f18, 0x0?, 0x119?})
        /home/lance/Projects/tidb/br/pkg/lightning/backend/local/local.go:2069 +0x85
github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*local).SplitAndScatterRegionByRanges(0xc000fe6dc0, {0x4fc3aa8?, 0xc001150140?}, {0xc0011a4900, 0x1, 0x576921f?}, 0xc00069e330, 0x1, 0x6000000)
        /home/lance/Projects/tidb/br/pkg/lightning/backend/local/localhelper.go:328 +0x1dd9
github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*local).SplitAndScatterRegionInBatches(0x489294d?, {0x4fc3aa8, 0xc001150140}, {0xc0011a4900, 0x1, 0x1}, 0xc000fde240?, 0x1b?, 0x0?, 0x1000)
        /home/lance/Projects/tidb/br/pkg/lightning/backend/local/localhelper.go:80 +0x125
github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*local).ImportEngine(0xc000fe6dc0, {0x4fc3aa8, 0xc001150140}, {0xf, 0x31, 0x82, 0xea, 0x38, 0xf9, 0x59, ...}, ...)
        /home/lance/Projects/tidb/br/pkg/lightning/backend/local/local.go:1661 +0x13ed
github.com/pingcap/tidb/br/pkg/lightning/backend.(*ClosedEngine).Import(0xc0006da960, {0x4fc3aa8, 0xc001150140}, 0xc0005370a0?, 0x0?)
        /home/lance/Projects/tidb/br/pkg/lightning/backend/backend.go:477 +0x23b
github.com/pingcap/tidb/br/pkg/lightning/restore.(*TableRestore).importKV(0xc000deaf80, {0x4fc3aa8, 0xc001150140}, 0xc0006da960, 0xc0009ff6c0, 0x7523580?)
        /home/lance/Projects/tidb/br/pkg/lightning/restore/table_restore.go:1004 +0x207
github.com/pingcap/tidb/br/pkg/lightning/restore.(*TableRestore).importEngine(0xc001254540?, {0x4fc3aa8?, 0xc001150140}, 0x0?, 0xc0009ff6c0, 0x0?, 0x0?)
        /home/lance/Projects/tidb/br/pkg/lightning/restore/table_restore.go:703 +0x4c
github.com/pingcap/tidb/br/pkg/lightning/restore.(*TableRestore).restoreEngines.func3(0x0?, 0x0, 0xc0005a1400)
        /home/lance/Projects/tidb/br/pkg/lightning/restore/table_restore.go:331 +0x2ed
created by github.com/pingcap/tidb/br/pkg/lightning/restore.(*TableRestore).restoreEngines
        /home/lance/Projects/tidb/br/pkg/lightning/restore/table_restore.go:322 +0x1499
make: *** [Makefile:324: br_integration_test] Error 2
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

