### PR TITLE
store/copr: add log for buildBatchCopTasksConsistentHash

### DIFF
--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -1257,7 +1257,7 @@ func buildBatchCopTasksConsistentHashForPD(bo *backoff.Backoffer,
 			return nil, err
 		}
 		if rpcCtxs == nil {
-			logutil.BgLogger().Info("buildBatchCopTasksConsistentHash retry because rcpCtx is nil", zap.Int("retryNum", retryNum))
+			logutil.BgLogger().Info("buildBatchCopTasksConsistentHashForPD retry because rcpCtx is nil", zap.Int("retryNum", retryNum))
 			err := bo.Backoff(tikv.BoTiFlashRPC(), errors.New("Cannot find region with TiFlash peer"))
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -1291,7 +1291,7 @@ func buildBatchCopTasksConsistentHashForPD(bo *backoff.Backoffer,
 				res = append(res, batchTask)
 			}
 		}
-		logutil.BgLogger().Info("buildBatchCopTasksConsistentHash done", zap.Any("len(tasks)", len(taskMap)), zap.Any("len(tiflash_compute)", len(stores)))
+		logutil.BgLogger().Info("buildBatchCopTasksConsistentHashForPD done", zap.Any("len(tasks)", len(taskMap)), zap.Any("len(tiflash_compute)", len(stores)))
 		if log.GetLevel() <= zap.DebugLevel {
 			debugStores := make([]string, 0, len(stores))
 			for _, s := range stores {
@@ -1301,7 +1301,7 @@ func buildBatchCopTasksConsistentHashForPD(bo *backoff.Backoffer,
 			for s, b := range taskMap {
 				debugTaskMap[s] = fmt.Sprintf("addr: %s; regionInfos: %v", b.storeAddr, b.regionInfos)
 			}
-			logutil.BgLogger().Debug("detailed info buildBatchCopTasksConsistentHash", zap.Any("taskMap", debugTaskMap), zap.Any("allStores", debugStores))
+			logutil.BgLogger().Debug("detailed info buildBatchCopTasksConsistentHashForPD", zap.Any("taskMap", debugTaskMap), zap.Any("allStores", debugStores))
 		}
 		break
 	}

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -612,9 +612,11 @@ func buildBatchCopTasksConsistentHash(
 	cache := kvStore.GetRegionCache()
 	fetchTopoBo := backoff.NewBackofferWithVars(ctx, fetchTopoMaxBackoff, nil)
 
-	var retryNum int
-	var rangesLen int
-	var storesStr []string
+	var (
+		retryNum  int
+		rangesLen int
+		storesStr []string
+	)
 
 	tasks := make([]*copTask, 0)
 	regionIDs := make([]tikv.RegionVerID, 0)
@@ -704,8 +706,8 @@ func buildBatchCopTasksConsistentHash(
 		logutil.BgLogger().Warn("buildBatchCopTasksConsistentHash takes too much time",
 			zap.Duration("total elapsed", elapsed),
 			zap.Int("retryNum", retryNum),
-			zap.Duration("SplitKeyRangesByLocations", splitKeyElapsed),
-			zap.Duration("fetchTopo", fetchTopoElapsed),
+			zap.Duration("splitKeyElapsed", splitKeyElapsed),
+			zap.Duration("fetchTopoElapsed", fetchTopoElapsed),
 			zap.Int("range len", rangesLen),
 			zap.Int("copTaskNum", len(tasks)),
 			zap.Int("batchCopTaskNum", len(res)))
@@ -1207,11 +1209,13 @@ func buildBatchCopTasksConsistentHashForPD(bo *backoff.Backoffer,
 	storeType kv.StoreType,
 	ttl time.Duration) (res []*batchCopTask, err error) {
 	const cmdType = tikvrpc.CmdBatchCop
-	var retryNum int
-	var rangesLen int
-	var copTaskNum int
-	var splitKeyElapsed time.Duration
-	var getStoreElapsed time.Duration
+	var (
+		retryNum        int
+		rangesLen       int
+		copTaskNum      int
+		splitKeyElapsed time.Duration
+		getStoreElapsed time.Duration
+	)
 	cache := kvStore.GetRegionCache()
 	start := time.Now()
 


### PR DESCRIPTION
Signed-off-by: guo-shaoge <shaoge1994@163.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41102

Problem Summary:Add log when build cop task takes too long, just like https://github.com/pingcap/tidb/blob/master/store/copr/batch_coprocessor.go#L814

### What is changed and how it works?
We have following logs:
```
[2023/02/07 11:20:38.812 +08:00] [DEBUG] [batch_coprocessor.go:1304] ["detailed info buildBatchCopTasksConsistentHash"] [taskMap="{\"10.71.221.179:39809\":\"addr: 10.71.221.179:39809; regionInfos: [{{107 2 50} id:107 start_key:\\\"t\\\\200\\\\000\\\\000\\\\000\\\\000\\\\000\\\\000U_r\\\" end_key:\\\"t\\\\200\\\\000\\\\000\\\\000\\\\000\\\\000\\\\000V\\\" region_epoch:\\u003cconf_ver:2 version:50 \\u003e peers:\\u003cid:108 store_id:1 \\u003e peers:\\u003cid:116 store_id:104 role:Learner \\u003e  [\\\"7480000000000000555f720000000000000000\\\", \\\"7480000000000000555f72ffffffffffffffff00\\\"] [117] 0}]\"}"] [allStores="[10.71.221.179:39809]"]
[2023/02/07 11:20:38.812 +08:00] [WARN] [batch_coprocessor.go:1310] ["buildBatchCopTasksConsistentHashForPD takes too much time"] ["total elapsed"=3.451637ms] [retryNum=1] [splitKeyElapsed=14.522µs] [getStoreElapsed=3.196231ms] ["range len"=1] [copTaskNum=1] [batchCopTaskNum=1]
```
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
