### PR TITLE
util: fix dropped error

### DIFF
--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -920,6 +920,9 @@ func DecodeAsFloat32(b []byte, tp byte) (remain []byte, d types.Datum, err error
 	}
 	var v float64
 	b, v, err = DecodeFloat(b)
+	if err != nil {
+		return nil, d, err
+	}
 	d.SetFloat32FromF64(v)
 	return b, d, nil
 }


### PR DESCRIPTION
This fixes a dropped `err` in the `util/codec` package.

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```