### PR TITLE
executor: fix unreasonable CPU time in HashJoin probe phash

### DIFF
--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -241,10 +241,14 @@ func (c *hashRowContainer) GetMatchedRowsAndPtrs(probeKey uint64, probeRow chunk
 		matchedDataSize                  = int64(cap(matched))*rowSize + int64(cap(matchedPtrs))*rowPtrSize
 		lastChunkBufPointer *chunk.Chunk = nil
 		memDelta            int64        = 0
+		trackMemUsage                    = cap(innerPtrs) > signalCheckpointForJoin
 	)
 	c.chkBuf = nil
-	c.memTracker.Consume(-c.chkBufSizeForOneProbe + int64(cap(innerPtrs))*rowPtrSize)
-	defer c.memTracker.Consume(-int64(cap(innerPtrs))*rowPtrSize + memDelta)
+	c.memTracker.Consume(-c.chkBufSizeForOneProbe)
+	if trackMemUsage {
+		c.memTracker.Consume(int64(cap(innerPtrs)) * rowPtrSize)
+		defer c.memTracker.Consume(-int64(cap(innerPtrs))*rowPtrSize + memDelta)
+	}
 	c.chkBufSizeForOneProbe = 0
 
 	for i, ptr := range innerPtrs {
@@ -257,13 +261,13 @@ func (c *hashRowContainer) GetMatchedRowsAndPtrs(probeKey uint64, probeRow chunk
 		if err != nil {
 			return nil, nil, err
 		}
-		if c.chkBuf != lastChunkBufPointer && lastChunkBufPointer != nil {
+		if trackMemUsage && c.chkBuf != lastChunkBufPointer && lastChunkBufPointer != nil {
 			lastChunkSize := lastChunkBufPointer.MemoryUsage()
 			c.chkBufSizeForOneProbe += lastChunkSize
 			memDelta += lastChunkSize
 		}
 		lastChunkBufPointer = c.chkBuf
-		if i&signalCheckpointForJoin == 0 {
+		if trackMemUsage && (i&signalCheckpointForJoin == (signalCheckpointForJoin - 1)) {
 			// Trigger Consume for checking the OOM Action signal
 			memDelta += int64(cap(matched))*rowSize + int64(cap(matchedPtrs))*rowPtrSize - matchedDataSize
 			matchedDataSize = int64(cap(matched))*rowSize + int64(cap(matchedPtrs))*rowPtrSize

--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -240,8 +240,8 @@ func (c *hashRowContainer) GetMatchedRowsAndPtrs(probeKey uint64, probeRow chunk
 	var (
 		matchedDataSize                  = int64(cap(matched))*rowSize + int64(cap(matchedPtrs))*rowPtrSize
 		lastChunkBufPointer *chunk.Chunk = nil
-		memDelta          int64 = 0
-		needTrackMemUsage       = cap(innerPtrs) > signalCheckpointForJoin
+		memDelta            int64        = 0
+		needTrackMemUsage                = cap(innerPtrs) > signalCheckpointForJoin
 	)
 	c.chkBuf = nil
 	c.memTracker.Consume(-c.chkBufSizeForOneProbe)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/41263

Problem Summary:

### What is changed and how it works?


Fix the regression caused by https://github.com/pingcap/tidb/pull/41081

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
Before PR 41081:
BenchmarkHashJoinExec
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-32         	       2	 638092875 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32           	      16	  64674572 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)-32            	       2	 534752048 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                       	   27391	     48713 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-32                	      66	  17792798 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                  	      79	  15881121 ns/op
PASS

Master:
BenchmarkHashJoinExec
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-32         	       2	 642957092 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32           	      14	  72674317 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)-32            	       2	 540769374 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                       	   24026	     52469 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-32                	      25	  48275854 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                  	      24	  46435713 ns/op
PASS

After This PR:
BenchmarkHashJoinExec
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-32         	       2	 624429226 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32           	      16	  64781758 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)-32            	       2	 536424771 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                       	   26091	     49160 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-32                	      66	  18142143 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                  	      79	  15681714 ns/op
PASS
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
