### PR TITLE
ddl: Improve ErrTooLongKey message

### DIFF
--- a/ddl/index.go
+++ b/ddl/index.go
@@ -101,7 +101,7 @@ func buildIndexColumns(ctx sessionctx.Context, columns []*model.ColumnInfo, inde
 			// The multiple column index and the unique index in which the length sum exceeds the maximum size
 			// will return an error instead produce a warning.
 			if ctx == nil || ctx.GetSessionVars().StrictSQLMode || mysql.HasUniKeyFlag(col.GetFlag()) || len(indexPartSpecifications) > 1 {
-				return nil, false, dbterror.ErrTooLongKey.GenWithStackByArgs(maxIndexLength)
+				return nil, false, dbterror.ErrTooLongKey.GenWithStackByArgs(sumLength, maxIndexLength)
 			}
 			// truncate index length and produce warning message in non-restrict sql mode.
 			colLenPerUint, err := getIndexColumnLength(col, 1)
@@ -110,7 +110,7 @@ func buildIndexColumns(ctx sessionctx.Context, columns []*model.ColumnInfo, inde
 			}
 			indexColLen = maxIndexLength / colLenPerUint
 			// produce warning message
-			ctx.GetSessionVars().StmtCtx.AppendWarning(dbterror.ErrTooLongKey.FastGenByArgs(maxIndexLength))
+			ctx.GetSessionVars().StmtCtx.AppendWarning(dbterror.ErrTooLongKey.FastGenByArgs(sumLength, maxIndexLength))
 		}
 
 		idxParts = append(idxParts, &model.IndexColumn{
@@ -149,7 +149,7 @@ func checkIndexPrefixLength(columns []*model.ColumnInfo, idxColumns []*model.Ind
 		return err
 	}
 	if idxLen > config.GetGlobalConfig().MaxIndexLength {
-		return dbterror.ErrTooLongKey.GenWithStackByArgs(config.GetGlobalConfig().MaxIndexLength)
+		return dbterror.ErrTooLongKey.GenWithStackByArgs(idxLen, config.GetGlobalConfig().MaxIndexLength)
 	}
 	return nil
 }
@@ -211,7 +211,7 @@ func checkIndexColumn(ctx sessionctx.Context, col *model.ColumnInfo, indexColumn
 	maxIndexLength := config.GetGlobalConfig().MaxIndexLength
 	if indexColumnLen > maxIndexLength && (ctx == nil || ctx.GetSessionVars().StrictSQLMode) {
 		// return error in strict sql mode
-		return dbterror.ErrTooLongKey.GenWithStackByArgs(maxIndexLength)
+		return dbterror.ErrTooLongKey.GenWithStackByArgs(indexColumnLen, maxIndexLength)
 	}
 	return nil
 }

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -102,7 +102,7 @@ func TestChangeMaxIndexLength(t *testing.T) {
 	tk.MustExec("create table t (c1 varchar(3073), index(c1)) charset = ascii")
 	tk.MustExec(fmt.Sprintf("create table t1 (c1 varchar(%d), index(c1)) charset = ascii;", config.DefMaxOfMaxIndexLength))
 	err := tk.ExecToErr(fmt.Sprintf("create table t2 (c1 varchar(%d), index(c1)) charset = ascii;", config.DefMaxOfMaxIndexLength+1))
-	require.EqualError(t, err, "[ddl:1071]Specified key was too long; max key length is 12288 bytes")
+	require.EqualError(t, err, "[ddl:1071]Specified key was too long (12289 bytes); max key length is 12288 bytes")
 }
 
 func TestCreateTableWithLike(t *testing.T) {

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -92,7 +92,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrMultiplePriKey:                           mysql.Message("Multiple primary key defined", nil),
 	ErrTooManyKeys:                              mysql.Message("Too many keys specified; max %d keys allowed", nil),
 	ErrTooManyKeyParts:                          mysql.Message("Too many key parts specified; max %d parts allowed", nil),
-	ErrTooLongKey:                               mysql.Message("Specified key was too long; max key length is %d bytes", nil),
+	ErrTooLongKey:                               mysql.Message("Specified key was too long (%d bytes); max key length is %d bytes", nil),
 	ErrKeyColumnDoesNotExits:                    mysql.Message("Key column '%-.192s' doesn't exist in table", nil),
 	ErrBlobUsedAsKey:                            mysql.Message("BLOB column '%-.192s' can't be used in key specification with the used table type", nil),
 	ErrTooBigFieldlength:                        mysql.Message("Column length too big for column '%-.192s' (max = %d); use BLOB or TEXT instead", nil),

--- a/errors.toml
+++ b/errors.toml
@@ -668,7 +668,7 @@ Too many keys specified; max %d keys allowed
 
 ["ddl:1071"]
 error = '''
-Specified key was too long; max key length is %d bytes
+Specified key was too long (%d bytes); max key length is %d bytes
 '''
 
 ["ddl:1072"]

--- a/parser/mysql/errname.go
+++ b/parser/mysql/errname.go
@@ -97,7 +97,7 @@ var MySQLErrName = map[uint16]*ErrMessage{
 	ErrMultiplePriKey:                           Message("Multiple primary key defined", nil),
 	ErrTooManyKeys:                              Message("Too many keys specified; max %d keys allowed", nil),
 	ErrTooManyKeyParts:                          Message("Too many key parts specified; max %d parts allowed", nil),
-	ErrTooLongKey:                               Message("Specified key was too long; max key length is %d bytes", nil),
+	ErrTooLongKey:                               Message("Specified key was too long (%d bytes); max key length is %d bytes", nil),
 	ErrKeyColumnDoesNotExits:                    Message("Key column '%-.192s' doesn't exist in table", nil),
 	ErrBlobUsedAsKey:                            Message("BLOB column '%-.192s' can't be used in key specification with the used table type", nil),
 	ErrTooBigFieldlength:                        Message("Column length too big for column '%-.192s' (max = %d); use BLOB or TEXT instead", nil),


### PR DESCRIPTION
### What problem does this PR solve?

Prefix indexes are specified in characters while this error message returns a limit in bytes. By adding the byte length in the message this is makes it easier to understand. Note that a limit of 3072 bytes means a limit of 768 characters for UTF-8 (768×4=3072).

This would deviate a little bit from the message in MySQL.

Before:
```
sql> CREATE TABLE t1(id int primary key, c1 text, key(c1(1000)));
ERROR: 1071 (42000): Specified key was too long; max key length is 3072 bytes
```

After:
```
sql> CREATE TABLE t1(id int primary key, c1 text, key(c1(1000)));
ERROR: 1071 (42000): Specified key was too long (4000 bytes); max key length is 3072 bytes
```


<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41272 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The error message for a too long index has been improved
```
