### PR TITLE
ddl: return panic when to get tiflash sync progress failed in test

### DIFF
--- a/ddl/ddl_tiflash_api.go
+++ b/ddl/ddl_tiflash_api.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/store/helper"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/intest"
 	"github.com/pingcap/tidb/util/logutil"
 	atomicutil "go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -398,6 +399,10 @@ func pollAvailableTableProgress(schemas infoschema.InfoSchema, ctx sessionctx.Co
 				zap.Int64("tableID", availableTableID.ID),
 				zap.Bool("IsPartition", availableTableID.IsPartition),
 			)
+			if intest.InTest {
+				// https://github.com/pingcap/tidb/issues/39949
+				panic(err)
+			}
 			continue
 		}
 		err = infosync.UpdateTiFlashProgressCache(availableTableID.ID, progress)

--- a/ddl/ddl_tiflash_api.go
+++ b/ddl/ddl_tiflash_api.go
@@ -400,7 +400,10 @@ func pollAvailableTableProgress(schemas infoschema.InfoSchema, ctx sessionctx.Co
 				zap.Bool("IsPartition", availableTableID.IsPartition),
 			)
 			if intest.InTest {
-				// https://github.com/pingcap/tidb/issues/39949
+				// In the test, the server cannot start up because the port is occupied.
+				// Although the port is random. so we need to quickly return when to
+				// fail to get tiflash sync.
+				//https://github.com/pingcap/tidb/issues/39949
 				panic(err)
 			}
 			continue

--- a/ddl/ddl_tiflash_api.go
+++ b/ddl/ddl_tiflash_api.go
@@ -403,7 +403,7 @@ func pollAvailableTableProgress(schemas infoschema.InfoSchema, ctx sessionctx.Co
 				// In the test, the server cannot start up because the port is occupied.
 				// Although the port is random. so we need to quickly return when to
 				// fail to get tiflash sync.
-				//https://github.com/pingcap/tidb/issues/39949
+				// https://github.com/pingcap/tidb/issues/39949
 				panic(err)
 			}
 			continue

--- a/ddl/tiflashtest/BUILD.bazel
+++ b/ddl/tiflashtest/BUILD.bazel
@@ -7,6 +7,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
+    shard_count = 30,
     deps = [
         "//config",
         "//ddl",

--- a/ddl/tiflashtest/BUILD.bazel
+++ b/ddl/tiflashtest/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "tiflashtest_test",
+    timeout = "short",
     srcs = [
         "ddl_tiflash_test.go",
         "main_test.go",


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #39949

Problem Summary:

### What is changed and how it works?

In the test, the server cannot start up because the port is occupied. Although the port is random. so we need to quickly return when to fail to get tiflash sync.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
