### PR TITLE
br: fix backup ci

### DIFF
--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -566,7 +566,7 @@ func BuildBackupRangeAndSchema(
 			var globalAutoID int64
 			switch {
 			case tableInfo.IsSequence():
-				globalAutoID, err = autoIDAccess.SequenceCycle().Get()
+				globalAutoID, err = autoIDAccess.SequenceValue().Get()
 			case tableInfo.IsView() || !utils.NeedAutoID(tableInfo):
 				// no auto ID for views or table without either rowID nor auto_increment ID.
 			default:

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -841,7 +841,7 @@ func (bc *Client) BackupRange(
 	} else {
 		for _, store := range allStores {
 			for _, label := range store.Labels {
-				if val, ok := replicaReadLabel[label.Key]; !ok && val == label.Value {
+				if val, ok := replicaReadLabel[label.Key]; ok && val == label.Value {
 					targetStores = append(targetStores, store) // send backup push down request to stores that match replica read label
 					targetStoreIds[store.GetId()] = struct{}{} // record store id for fine grained backup
 				}


### PR DESCRIPTION
Signed-off-by: Leavrth <jianjun.liao@outlook.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40404 #40898 

Problem Summary:
1. We need to use `autoIDAccess.SequenceValue().Get()` instead of `autoIDAccess.SequenceCycle().Get()`.
refer to 
https://github.com/pingcap/tidb/blob/48bc046fe1a92c5861ae11584f5a131debc471ff/meta/autoid/autoid.go#L1162-L1175
2. fix condition when fetch replica label
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
