### PR TITLE
*: reduce the allocation of error constructing in `DecodeTableID`

### DIFF
--- a/tablecodec/BUILD.bazel
+++ b/tablecodec/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//util/rowcodec",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
+        "@com_github_tikv_client_go_v2//tikv",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -286,6 +286,9 @@ func DecodeTableID(key kv.Key) int64 {
 			return 0
 		}
 		key = k
+		if !key.HasPrefix(tablePrefix) {
+			return 0
+		}
 	}
 	key = key[len(tablePrefix):]
 	_, tableID, err := codec.DecodeInt(key)

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -278,13 +278,14 @@ func DecodeKeyHead(key kv.Key) (tableID int64, indexID int64, isRecordKey bool, 
 
 // DecodeTableID decodes the table ID of the key, if the key is not table key, returns 0.
 func DecodeTableID(key kv.Key) int64 {
-	// If the key is in API V2, then ignore the prefix
-	_, k, err := tikv.DecodeKey(key, kvrpcpb.APIVersion_V2)
-	if err == nil {
-		key = k
-	}
 	if !key.HasPrefix(tablePrefix) {
-		return 0
+		// If the key is in API V2, then ignore the prefix
+		_, k, err := tikv.DecodeKey(key, kvrpcpb.APIVersion_V2)
+		if err != nil {
+			terror.Log(errors.Trace(err))
+			return 0
+		}
+		key = k
 	}
 	key = key[len(tablePrefix):]
 	_, tableID, err := codec.DecodeInt(key)

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -708,4 +708,12 @@ func TestV2TableCodec(t *testing.T) {
 	key = c.EncodeKey(key)
 	tbid := DecodeTableID(key)
 	require.Equal(t, tableID, tbid)
+
+	key = []byte("x001HelloWorld")
+	tbid = DecodeTableID(key)
+	require.Equal(t, int64(0), tbid)
+
+	key = []byte("x001x001t123")
+	tbid = DecodeTableID(key)
+	require.Equal(t, int64(0), tbid)
 }

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/rowcodec"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/tikv"
 )
 
 // TestTableCodec  tests some functions in package tablecodec
@@ -697,4 +698,14 @@ func TestTempIndexValueCodec(t *testing.T) {
 	require.Equal(t, result[0].Handle.IntValue(), int64(100))
 	require.Equal(t, result[1].Handle.IntValue(), int64(100))
 	require.Equal(t, result[2].Handle.IntValue(), int64(101))
+}
+
+func TestV2TableCodec(t *testing.T) {
+	const tableID int64 = 31415926
+	key := EncodeTablePrefix(tableID)
+	c, err := tikv.NewCodecV2(tikv.ModeTxn, 271828)
+	require.NoError(t, err)
+	key = c.EncodeKey(key)
+	tbid := DecodeTableID(key)
+	require.Equal(t, tableID, tbid)
 }


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41300

Problem Summary:

The original decode process checks if the key is API v2 first, which will always fail while the user is using API V1. This will cause the code will read the stack every time it decodes the key, which is CPU/MEM expensive.

### What is changed and how it works?

This pull request checks if the key is API V1 first, if it's not, then try API v2 decoding.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviours
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
*: reduce the allocation of error constructing in `DecodeTableID`
```
