### PR TITLE
log-backup: added cache for sst_importer client

### DIFF
--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -960,6 +960,7 @@ func (importer *FileImporter) downloadAndApplyKVFile(
 			StorageBackend: importer.backend,
 			RewriteRules:   rewriteRules,
 			Context:        reqCtx,
+			StorageCacheId: importer.cacheKey,
 		}
 	} else {
 		req = &import_sstpb.ApplyRequest{
@@ -967,6 +968,7 @@ func (importer *FileImporter) downloadAndApplyKVFile(
 			StorageBackend: importer.backend,
 			RewriteRule:    *rewriteRules[0],
 			Context:        reqCtx,
+			StorageCacheId: importer.cacheKey,
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: hillium <yujuncen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41328

Problem Summary:
There are too many tiny files while doing log restore, however the import API is stateless, hence we must create one TLS connection for each download, which has poor performance. 

### What is changed and how it works?
This PR added cache for log restore. It have reused the cache functionality of full restore.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Manual test (add detailed scripts or steps below)
![img_v2_d44f8373-a93f-4820-b0b8-663e6d70cd7g](https://user-images.githubusercontent.com/36239017/218265769-698fbeaf-605d-47df-83fe-4831fb6c958e.jpg)

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Now, PITR uses less CPU.
```
