### PR TITLE
br: increase the sleep time in the `waitForSend` function

### DIFF
--- a/br/pkg/restore/batcher_test.go
+++ b/br/pkg/restore/batcher_test.go
@@ -49,7 +49,7 @@ func (sender *drySender) Close() {
 }
 
 func waitForSend() {
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 }
 
 func (sender *drySender) Ranges() []rtree.Range {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41210 

Problem Summary:

### What is changed and how it works?
When `Batcher.Len` reaches the threshold, it will call `asyncSend`, then call `Send` in `sendWorker`, and then call `RestoreBatch` to append `*ranges.RewriteRules` to `sender.rewriteRules`, the whole process may not be completed within 10ms, forming a flaky test(`require.True(t, sender.HasRewriteRuleOfKey("a"))` should be true, but false), so we need to increase the sleep time in the `waitForSend` function.
Note: `waitForSend` is only used for test.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
