### PR TITLE
parser: add NULL DEFINED BY and FORMAT to LOAD DATA

### DIFF
--- a/parser/ast/dml.go
+++ b/parser/ast/dml.go
@@ -1825,6 +1825,7 @@ type LoadDataStmt struct {
 	Columns           []*ColumnName
 	FieldsInfo        *FieldsClause
 	LinesInfo         *LinesClause
+	NullInfo          *NullDefinedBy
 	IgnoreLines       uint64
 	ColumnAssignments []*Assignment
 
@@ -1852,6 +1853,9 @@ func (n *LoadDataStmt) Restore(ctx *format.RestoreCtx) error {
 	}
 	n.FieldsInfo.Restore(ctx)
 	n.LinesInfo.Restore(ctx)
+	if n.NullInfo != nil {
+		n.NullInfo.Restore(ctx)
+	}
 	if n.IgnoreLines != 0 {
 		ctx.WriteKeyWord(" IGNORE ")
 		ctx.WritePlainf("%d", n.IgnoreLines)
@@ -1991,6 +1995,21 @@ func (n *LinesClause) Restore(ctx *format.RestoreCtx) error {
 		}
 	}
 	return nil
+}
+
+// NullDefinedBy represent a syntax that extends MySQL's standard
+type NullDefinedBy struct {
+	NullDef     string
+	OptEnclosed bool
+}
+
+// Restore for NullDefinedBy
+func (n *NullDefinedBy) Restore(ctx *format.RestoreCtx) {
+	ctx.WriteKeyWord(" NULL DEFINED BY ")
+	ctx.WriteString(n.NullDef)
+	if n.OptEnclosed {
+		ctx.WriteKeyWord(" OPTIONALLY ENCLOSED")
+	}
 }
 
 // CallStmt represents a call procedure query node.

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -284,6 +284,7 @@ var tokenMap = map[string]int{
 	"DEC":                      decimalType,
 	"DECIMAL":                  decimalType,
 	"DEFAULT":                  defaultKwd,
+	"DEFINED":                  defined,
 	"DEFINER":                  definer,
 	"DELAY_KEY_WRITE":          delayKeyWrite,
 	"DELAYED":                  delayed,

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -661,6 +661,7 @@ import (
 	curDate               "CURDATE"
 	dateAdd               "DATE_ADD"
 	dateSub               "DATE_SUB"
+	defined               "DEFINED"
 	dotType               "DOT"
 	dump                  "DUMP"
 	exact                 "EXACT"
@@ -1120,6 +1121,7 @@ import (
 	LockClause                             "Alter table lock clause"
 	LogTypeOpt                             "Optional log type used in FLUSH statements"
 	MaxValPartOpt                          "MAXVALUE partition option"
+	NullDefinedByClause                    "NULL DEFINED BY clause in LOAD DATA statement"
 	NullPartOpt                            "NULL Partition option"
 	NumLiteral                             "Num/Int/Float/Decimal Literal"
 	NoWriteToBinLogAliasOpt                "NO_WRITE_TO_BINLOG alias LOCAL or empty"
@@ -1446,6 +1448,7 @@ import (
 	HashString                      "Hashed string"
 	LikeEscapeOpt                   "like escape option"
 	LinesTerminated                 "Lines terminated by"
+	NullDef                         "NULL definition in LOAD DATA statement"
 	OptCharset                      "Optional Character setting"
 	OptCollate                      "Optional Collate setting"
 	PasswordOpt                     "Password option"
@@ -1600,19 +1603,19 @@ ResourceGroupOptionList:
 |	ResourceGroupOptionList DirectResourceGroupOption
 	{
 		if $1.([]*ast.ResourceGroupOption)[0].Tp == $2.(*ast.ResourceGroupOption).Tp ||
-		   (len($1.([]*ast.ResourceGroupOption)) > 1 && $1.([]*ast.ResourceGroupOption)[1].Tp == $2.(*ast.ResourceGroupOption).Tp) {
+			(len($1.([]*ast.ResourceGroupOption)) > 1 && $1.([]*ast.ResourceGroupOption)[1].Tp == $2.(*ast.ResourceGroupOption).Tp) {
 			yylex.AppendError(yylex.Errorf("Dupliated options specified"))
-            return 1
+			return 1
 		}
 		$$ = append($1.([]*ast.ResourceGroupOption), $2.(*ast.ResourceGroupOption))
 	}
 |	ResourceGroupOptionList ',' DirectResourceGroupOption
 	{
 		if $1.([]*ast.ResourceGroupOption)[0].Tp == $3.(*ast.ResourceGroupOption).Tp ||
-    	   (len($1.([]*ast.ResourceGroupOption)) > 1 && $1.([]*ast.ResourceGroupOption)[1].Tp == $3.(*ast.ResourceGroupOption).Tp) {
-    		 yylex.AppendError(yylex.Errorf("Dupliated options specified"))
-             return 1
-    	}
+			(len($1.([]*ast.ResourceGroupOption)) > 1 && $1.([]*ast.ResourceGroupOption)[1].Tp == $3.(*ast.ResourceGroupOption).Tp) {
+			yylex.AppendError(yylex.Errorf("Dupliated options specified"))
+			return 1
+		}
 		$$ = append($1.([]*ast.ResourceGroupOption), $3.(*ast.ResourceGroupOption))
 	}
 
@@ -1622,9 +1625,9 @@ DirectResourceGroupOption:
 		$$ = &ast.ResourceGroupOption{Tp: ast.ResourceRURate, UintValue: $3.(uint64)}
 	}
 |	"BURSTABLE"
-    {
-    	$$ = &ast.ResourceGroupOption{Tp: ast.ResourceBurstableOpiton, BoolValue: true}
-    }
+	{
+		$$ = &ast.ResourceGroupOption{Tp: ast.ResourceBurstableOpiton, BoolValue: true}
+	}
 
 PlacementOptionList:
 	DirectPlacementOption
@@ -6555,6 +6558,7 @@ NotKeywordToken:
 |	"CURDATE"
 |	"DATE_ADD"
 |	"DATE_SUB"
+|	"DEFINED"
 |	"DOT"
 |	"DUMP"
 |	"EXTRACT"
@@ -13770,15 +13774,15 @@ RevokeRoleStmt:
  * See https://dev.mysql.com/doc/refman/5.7/en/load-data.html
  *******************************************************************************************/
 LoadDataStmt:
-	"LOAD" "DATA" LocalOpt "INFILE" stringLit DuplicateOpt "INTO" "TABLE" TableName CharsetOpt Fields Lines IgnoreLines ColumnNameOrUserVarListOptWithBrackets LoadDataSetSpecOpt
+	"LOAD" "DATA" LocalOpt "INFILE" stringLit DuplicateOpt "INTO" "TABLE" TableName CharsetOpt Fields Lines NullDefinedByClause IgnoreLines ColumnNameOrUserVarListOptWithBrackets LoadDataSetSpecOpt
 	{
 		x := &ast.LoadDataStmt{
 			FileLocRef:         ast.FileLocServerOrRemote,
 			Path:               $5,
 			OnDuplicate:        $6.(ast.OnDuplicateKeyHandlingType),
 			Table:              $9.(*ast.TableName),
-			ColumnsAndUserVars: $14.([]*ast.ColumnNameOrUserVar),
-			IgnoreLines:        $13.(uint64),
+			ColumnsAndUserVars: $15.([]*ast.ColumnNameOrUserVar),
+			IgnoreLines:        $14.(uint64),
 		}
 		if $3 != nil {
 			x.FileLocRef = ast.FileLocClient
@@ -13794,8 +13798,11 @@ LoadDataStmt:
 		if $12 != nil {
 			x.LinesInfo = $12.(*ast.LinesClause)
 		}
-		if $15 != nil {
-			x.ColumnAssignments = $15.([]*ast.Assignment)
+		if $13 != nil {
+			x.NullInfo = $13.(*ast.NullDefinedBy)
+		}
+		if $16 != nil {
+			x.ColumnAssignments = $16.([]*ast.Assignment)
 		}
 		columns := []*ast.ColumnName{}
 		for _, v := range x.ColumnsAndUserVars {
@@ -13968,6 +13975,30 @@ LinesTerminated:
 |	"TERMINATED" "BY" FieldTerminator
 	{
 		$$ = $3
+	}
+
+NullDef:
+	stringLit
+|	hexLit
+	{
+		$$ = $1.(ast.BinaryLiteral).ToString()
+	}
+|	bitLit
+	{
+		$$ = $1.(ast.BinaryLiteral).ToString()
+	}
+
+NullDefinedByClause:
+	{
+		$$ = nil
+	}
+|	"NULL" "DEFINED" "BY" NullDef
+	{
+		$$ = &ast.NullDefinedBy{NullDef: $4}
+	}
+|	"NULL" "DEFINED" "BY" NullDef "OPTIONALLY" "ENCLOSED"
+	{
+		$$ = &ast.NullDefinedBy{NullDef: $4, OptEnclosed: true}
 	}
 
 LoadDataSetSpecOpt:

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1449,7 +1449,6 @@ import (
 	HashString                      "Hashed string"
 	LikeEscapeOpt                   "like escape option"
 	LinesTerminated                 "Lines terminated by"
-	NullDef                         "NULL definition in LOAD DATA statement"
 	OptCharset                      "Optional Character setting"
 	OptCollate                      "Optional Collate setting"
 	PasswordOpt                     "Password option"
@@ -14013,28 +14012,17 @@ LinesTerminated:
 		$$ = $3
 	}
 
-NullDef:
-	stringLit
-|	hexLit
-	{
-		$$ = $1.(ast.BinaryLiteral).ToString()
-	}
-|	bitLit
-	{
-		$$ = $1.(ast.BinaryLiteral).ToString()
-	}
-
 NullDefinedByClause:
 	{
 		$$ = nil
 	}
-|	"NULL" "DEFINED" "BY" NullDef
+|	"NULL" "DEFINED" "BY" TextString
 	{
-		$$ = &ast.NullDefinedBy{NullDef: $4}
+		$$ = &ast.NullDefinedBy{NullDef: $4.(*ast.TextString).Value}
 	}
-|	"NULL" "DEFINED" "BY" NullDef "OPTIONALLY" "ENCLOSED"
+|	"NULL" "DEFINED" "BY" TextString "OPTIONALLY" "ENCLOSED"
 	{
-		$$ = &ast.NullDefinedBy{NullDef: $4, OptEnclosed: true}
+		$$ = &ast.NullDefinedBy{NullDef: $4.(*ast.TextString).Value, OptEnclosed: true}
 	}
 
 LoadDataSetSpecOpt:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -671,6 +671,8 @@ func TestDMLStmt(t *testing.T) {
 		{"load data infile '/tmp/t.csv' into table t null defined by 'nil'", true, "LOAD DATA INFILE '/tmp/t.csv' INTO TABLE `t` NULL DEFINED BY 'nil'"},
 		{"load data infile '/tmp/t.csv' into table t null defined by X'00'", true, "LOAD DATA INFILE '/tmp/t.csv' INTO TABLE `t` NULL DEFINED BY '\x00'"},
 		{"load data infile '/tmp/t.csv' into table t null defined by 'NULL' optionally enclosed ignore 1 lines", true, "LOAD DATA INFILE '/tmp/t.csv' INTO TABLE `t` NULL DEFINED BY 'NULL' OPTIONALLY ENCLOSED IGNORE 1 LINES"},
+		{"load data local infile '/tmp/t.sql' format 'sql' replace into table t (a,b)", true, "LOAD DATA LOCAL INFILE '/tmp/t.sql' FORMAT 'sql' REPLACE INTO TABLE `t` (`a`,`b`)"},
+		{"load data infile '/tmp/t.parquet' format 'parquet' into table t (column1, @var1) SET column2 = @var1/100", true, "LOAD DATA INFILE '/tmp/t.parquet' FORMAT 'parquet' INTO TABLE `t` (`column1`,@`var1`) SET `column2`=@`var1`/100"},
 
 		// select for update/share
 		{"select * from t for update", true, "SELECT * FROM `t` FOR UPDATE"},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -668,6 +668,9 @@ func TestDMLStmt(t *testing.T) {
 		{"LOAD DATA LOCAL INFILE '/tmp/t.csv' REPLACE INTO TABLE t1 FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n';", true, "LOAD DATA LOCAL INFILE '/tmp/t.csv' REPLACE INTO TABLE `t1` FIELDS TERMINATED BY ','"},
 
 		{"load data infile 's3://bucket-name/t.csv' into table t", true, "LOAD DATA INFILE 's3://bucket-name/t.csv' INTO TABLE `t`"},
+		{"load data infile '/tmp/t.csv' into table t null defined by 'nil'", true, "LOAD DATA INFILE '/tmp/t.csv' INTO TABLE `t` NULL DEFINED BY 'nil'"},
+		{"load data infile '/tmp/t.csv' into table t null defined by X'00'", true, "LOAD DATA INFILE '/tmp/t.csv' INTO TABLE `t` NULL DEFINED BY '\x00'"},
+		{"load data infile '/tmp/t.csv' into table t null defined by 'NULL' optionally enclosed ignore 1 lines", true, "LOAD DATA INFILE '/tmp/t.csv' INTO TABLE `t` NULL DEFINED BY 'NULL' OPTIONALLY ENCLOSED IGNORE 1 LINES"},
 
 		// select for update/share
 		{"select * from t for update", true, "SELECT * FROM `t` FOR UPDATE"},


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40499

Problem Summary:

add parser support for `NULL DEFINED BY`

```
LOAD DATA ... [LINES ...] [NULL DEFINED BY <string> [OPTIONALLY ENCLOSED]] [IGNORE ...]
```

add parser support for `FORMAT`

```
LOAD DATA ... INFILE 'string' FORMAT 'string' ...
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
