### PR TITLE
planner, store/copr: allow limit on range partitioned table

### DIFF
--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -622,7 +622,7 @@ func TestOrderByAndLimit(t *testing.T) {
 		require.True(t, tk.HasPlan(queryRangePartition, "Limit")) // check if order property is pushed
 		require.True(t, tk.HasPlan(queryHashPartition, "Limit"))
 		require.True(t, tk.HasPlan(queryListPartition, "Limit"))
-		require.True(t, tk.HasPlan(queryRangePartition, "TopN")) // but not fully pushed
+		require.False(t, tk.HasPlan(queryRangePartition, "TopN")) // but not fully pushed
 		require.True(t, tk.HasPlan(queryHashPartition, "TopN"))
 		require.True(t, tk.HasPlan(queryListPartition, "TopN"))
 		regularResult = tk.MustQuery(queryRegular).Rows()
@@ -635,21 +635,21 @@ func TestOrderByAndLimit(t *testing.T) {
 		queryPartitionWithTiFlash := fmt.Sprintf("select /*+ read_from_storage(tiflash[trange_intpk]) */ * from trange_intpk where a > %v order by a limit %v", x, y)
 		// check if tiflash is used
 		require.True(t, tk.HasTiFlashPlan(queryPartitionWithTiFlash), fmt.Sprintf("%v", tk.MustQuery("explain "+queryPartitionWithTiFlash).Rows()))
-		// but order is not pushed
-		require.False(t, tk.HasPlan(queryPartitionWithTiFlash, "Limit"), fmt.Sprintf("%v", tk.MustQuery("explain "+queryPartitionWithTiFlash).Rows()))
+		// and order is pushed
+		require.True(t, tk.HasPlan(queryPartitionWithTiFlash, "Limit"), fmt.Sprintf("%v", tk.MustQuery("explain "+queryPartitionWithTiFlash).Rows()))
 		queryPartitionWithTiFlash = fmt.Sprintf("select /*+ read_from_storage(tiflash[trange_intpk]) */ /*+ LIMIT_TO_COP() */ * from trange_intpk where a > %v order by a limit %v", x, y)
 		// check if tiflash is used
 		require.True(t, tk.HasTiFlashPlan(queryPartitionWithTiFlash), fmt.Sprintf("%v", tk.MustQuery("explain "+queryPartitionWithTiFlash).Rows()))
-		// but order is not pushed
-		require.False(t, tk.HasPlan(queryPartitionWithTiFlash, "Limit"), fmt.Sprintf("%v", tk.MustQuery("explain "+queryPartitionWithTiFlash).Rows()))
+		// and order is pushed
+		require.True(t, tk.HasPlan(queryPartitionWithTiFlash, "Limit"), fmt.Sprintf("%v", tk.MustQuery("explain "+queryPartitionWithTiFlash).Rows()))
 		queryPartitionWithTiFlash = fmt.Sprintf("select /*+ read_from_storage(tiflash[trange_clustered]) */ * from trange_clustered where a > %v order by a limit %v", x, y)
 		// check if tiflash is used
 		require.True(t, tk.HasTiFlashPlan(queryPartitionWithTiFlash), fmt.Sprintf("%v", tk.MustQuery("explain "+queryPartitionWithTiFlash).Rows()))
 		queryPartitionWithTiFlash = fmt.Sprintf("select /*+ read_from_storage(tiflash[trange_clustered]) */ /*+ LIMIT_TO_COP() */ * from trange_clustered where a > %v order by a limit %v", x, y)
 		// check if tiflash is used
 		require.True(t, tk.HasTiFlashPlan(queryPartitionWithTiFlash))
-		// but order is not pushed
-		require.False(t, tk.HasPlan(queryPartitionWithTiFlash, "Limit"), fmt.Sprintf("%v", tk.MustQuery("explain "+queryPartitionWithTiFlash).Rows()))
+		// and order is pushed
+		require.True(t, tk.HasPlan(queryPartitionWithTiFlash, "Limit"), fmt.Sprintf("%v", tk.MustQuery("explain "+queryPartitionWithTiFlash).Rows()))
 		queryPartitionWithTiFlash = fmt.Sprintf("select /*+ read_from_storage(tiflash[thash_intpk]) */ * from thash_intpk where a > %v order by a limit %v", x, y)
 		// check if tiflash is used
 		require.True(t, tk.HasTiFlashPlan(queryPartitionWithTiFlash), fmt.Sprintf("%v", tk.MustQuery("explain "+queryPartitionWithTiFlash).Rows()))

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -312,7 +312,11 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 		return nil, err
 	}
 	kvReq.KeyRanges.SortByFunc(func(i, j kv.KeyRange) bool {
-		return bytes.Compare(i.StartKey, j.StartKey) < 0
+		cmp := bytes.Compare(i.StartKey, j.StartKey) < 0
+		if e.desc {
+			return !cmp
+		}
+		return cmp
 	})
 	e.kvRanges = kvReq.KeyRanges.AppendSelfTo(e.kvRanges)
 

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -472,21 +472,29 @@ func (rr *KeyRanges) PartitionNum() int {
 	return len(rr.ranges)
 }
 
-// IsFullySorted checks whether the ranges are sorted inside partition and each partition is also sorated.
-func (rr *KeyRanges) IsFullySorted() bool {
+// IsFullySorted checks whether the ranges are sorted inside partition and each partition is also sorted.
+func (rr *KeyRanges) IsFullySorted(desc bool) bool {
 	sortedByPartition := slices.IsSortedFunc(rr.ranges, func(i, j []KeyRange) bool {
 		// A simple short-circuit since the empty range actually won't make anything wrong.
 		if len(i) == 0 || len(j) == 0 {
 			return true
 		}
-		return bytes.Compare(i[0].StartKey, j[0].StartKey) < 0
+		cmp := bytes.Compare(i[0].StartKey, j[0].StartKey) < 0
+		if desc {
+			return !cmp
+		}
+		return cmp
 	})
 	if !sortedByPartition {
 		return false
 	}
 	for _, ranges := range rr.ranges {
 		if !slices.IsSortedFunc(ranges, func(i, j KeyRange) bool {
-			return bytes.Compare(i.StartKey, j.StartKey) < 0
+			cmp := bytes.Compare(i.StartKey, j.StartKey) < 0
+			if desc {
+				return !cmp
+			}
+			return cmp
 		}) {
 			return false
 		}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -2080,8 +2080,8 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, candid
 	task = copTask
 	if candidate.isMatchProp {
 		copTask.keepOrder = true
-		// TableScan on partition table can't keep order.
-		if ds.tableInfo.GetPartitionInfo() != nil {
+		// TableScan on partition table can't keep order, except range partition.
+		if pi := ds.tableInfo.GetPartitionInfo(); pi != nil && pi.Type != model.PartitionTypeRange {
 			return invalidTask, nil
 		}
 	}

--- a/planner/core/testdata/integration_partition_suite_in.json
+++ b/planner/core/testdata/integration_partition_suite_in.json
@@ -171,6 +171,7 @@
       "explain format='brief' select a from thash use index (ia) where a > 10 and c = 10 order by a limit 10",
       "explain format='brief' select a from t use index () where b > 10 order by b limit 10",
       "explain format='brief' select a from trange use index () where b > 10 order by b limit 10",
+      "explain format='brief' select a from trange use index () where b > 100 order by b limit 10",
       "explain format='brief' select a from tlist use index () where b > 10 order by b limit 10",
       "explain format='brief' select a from thash use index () where b > 10 order by b limit 10",
       "explain format='brief' select a from t use index () where a > 10 order by b limit 10",

--- a/planner/core/testdata/integration_partition_suite_out.json
+++ b/planner/core/testdata/integration_partition_suite_out.json
@@ -1341,10 +1341,20 @@
         "SQL": "explain format='brief' select a from trange use index () where b > 10 order by b limit 10",
         "Plan": [
           "Projection 10.00 root  test.trange.a",
-          "└─TopN 10.00 root  test.trange.b, offset:0, count:10",
+          "└─Limit 10.00 root  offset:0, count:10",
           "  └─TableReader 10.00 root partition:all data:Limit",
           "    └─Limit 10.00 cop[tikv]  offset:0, count:10",
           "      └─TableRangeScan 10.00 cop[tikv] table:trange range:(10,+inf], keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain format='brief' select a from trange use index () where b > 100 order by b limit 10",
+        "Plan": [
+          "Projection 10.00 root  test.trange.a",
+          "└─Limit 10.00 root  offset:0, count:10",
+          "  └─TableReader 10.00 root partition:p2,p3 data:Limit",
+          "    └─Limit 10.00 cop[tikv]  offset:0, count:10",
+          "      └─TableRangeScan 10.00 cop[tikv] table:trange range:(100,+inf], keep order:true, stats:pseudo"
         ]
       },
       {
@@ -1382,7 +1392,7 @@
         "SQL": "explain format='brief' select a from trange use index () where a > 10 order by b limit 10",
         "Plan": [
           "Projection 10.00 root  test.trange.a",
-          "└─TopN 10.00 root  test.trange.b, offset:0, count:10",
+          "└─Limit 10.00 root  offset:0, count:10",
           "  └─TableReader 10.00 root partition:all data:Limit",
           "    └─Limit 10.00 cop[tikv]  offset:0, count:10",
           "      └─Selection 10.00 cop[tikv]  gt(test.trange.a, 10)",

--- a/planner/core/testdata/ordered_result_mode_suite_out.json
+++ b/planner/core/testdata/ordered_result_mode_suite_out.json
@@ -454,16 +454,14 @@
       },
       {
         "Plan": [
-          "Sort_6 2.00 root  test.trange.a",
-          "└─TableReader_9 2.00 root partition:p0,p2 data:TableRangeScan_8",
-          "  └─TableRangeScan_8 2.00 cop[tikv] table:trange range:[1,1], [200,200], keep order:false, stats:pseudo"
+          "TableReader_11 2.00 root partition:p0,p2 data:TableRangeScan_10",
+          "└─TableRangeScan_10 2.00 cop[tikv] table:trange range:[1,1], [200,200], keep order:true, stats:pseudo"
         ]
       },
       {
         "Plan": [
-          "Sort_6 100.00 root  test.trange.a",
-          "└─TableReader_9 100.00 root partition:p0,p1 data:TableRangeScan_8",
-          "  └─TableRangeScan_8 100.00 cop[tikv] table:trange range:[50,150], keep order:false, stats:pseudo"
+          "TableReader_11 100.00 root partition:p0,p1 data:TableRangeScan_10",
+          "└─TableRangeScan_10 100.00 cop[tikv] table:trange range:[50,150], keep order:true, stats:pseudo"
         ]
       }
     ]

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -122,7 +122,7 @@ func (c *CopClient) BuildCopIterator(ctx context.Context, req *kv.Request, vars 
 	}
 	failpoint.Inject("checkKeyRangeSortedForPaging", func(_ failpoint.Value) {
 		if req.Paging.Enable {
-			if !req.KeyRanges.IsFullySorted() {
+			if !req.KeyRanges.IsFullySorted(req.Desc) {
 				logutil.BgLogger().Fatal("distsql request key range not sorted!")
 			}
 		}


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #41480

Problem Summary:

Currently we when there is `order by xx limit n` statement over a partitioned table, and the `xx` is the partitioned PK, we still use a TopN plan which read across all related partitions, but there is a chance to stop earlier when the partition type is range.

### What is changed and how it works?

Use a limit plan when the table is range partitioned.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support limit on range partitioned table, which speeds up limit-n statements.
```
