### PR TITLE
cgroup: improve test to find cgroup compatibility issues 

### DIFF
--- a/util/cgroup/cgroup_cpu.go
+++ b/util/cgroup/cgroup_cpu.go
@@ -21,6 +21,8 @@ import (
 	"github.com/pingcap/errors"
 )
 
+var noCPUControllerDetected = errors.New("no cpu controller detected")
+
 // Helper function for getCgroupCPU. Root is always "/", except in tests.
 func getCgroupCPU(root string) (CPUUsage, error) {
 	path, err := detectControlPath(filepath.Join(root, procPathCGroup), "cpu,cpuacct")
@@ -30,7 +32,7 @@ func getCgroupCPU(root string) (CPUUsage, error) {
 
 	// No CPU controller detected
 	if path == "" {
-		return CPUUsage{}, errors.New("no cpu controller detected")
+		return CPUUsage{}, noCPUControllerDetected
 	}
 
 	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "cpu,cpuacct")

--- a/util/cgroup/cgroup_cpu.go
+++ b/util/cgroup/cgroup_cpu.go
@@ -21,6 +21,8 @@ import (
 	"github.com/pingcap/errors"
 )
 
+const noCPUControllerDetected = errors.New("no cpu controller detected")
+
 // Helper function for getCgroupCPU. Root is always "/", except in tests.
 func getCgroupCPU(root string) (CPUUsage, error) {
 	path, err := detectControlPath(filepath.Join(root, procPathCGroup), "cpu,cpuacct")
@@ -30,7 +32,7 @@ func getCgroupCPU(root string) (CPUUsage, error) {
 
 	// No CPU controller detected
 	if path == "" {
-		return CPUUsage{}, errors.New("no cpu controller detected")
+		return CPUUsage{}, noCPUControllerDetected
 	}
 
 	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "cpu,cpuacct")

--- a/util/cgroup/cgroup_cpu.go
+++ b/util/cgroup/cgroup_cpu.go
@@ -21,30 +21,19 @@ import (
 	"github.com/pingcap/errors"
 )
 
-var noCPUControllerDetected = errors.New("no cpu controller detected")
-
 // Helper function for getCgroupCPU. Root is always "/", except in tests.
 func getCgroupCPU(root string) (CPUUsage, error) {
-	cu, err := getCgroupCPUInternal(root, "cpu,cpuacct")
-	if err == nil {
-		return cu, nil
-	}
-	return getCgroupCPUInternal(root, "cpuacct,cpu")
-}
-
-// getCgroupCPUInternal is to deal with different control keyword
-func getCgroupCPUInternal(root, controlKeyword string) (CPUUsage, error) {
-	path, err := detectControlPath(filepath.Join(root, procPathCGroup), controlKeyword)
+	path, err := detectControlPath(filepath.Join(root, procPathCGroup), "cpu,cpuacct")
 	if err != nil {
 		return CPUUsage{}, err
 	}
 
 	// No CPU controller detected
 	if path == "" {
-		return CPUUsage{}, noCPUControllerDetected
+		return CPUUsage{}, errors.New("no cpu controller detected")
 	}
 
-	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, controlKeyword)
+	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "cpu,cpuacct")
 	if err != nil {
 		return CPUUsage{}, err
 	}

--- a/util/cgroup/cgroup_cpu.go
+++ b/util/cgroup/cgroup_cpu.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/errors"
 )
 
-const noCPUControllerDetected = errors.New("no cpu controller detected")
+var noCPUControllerDetected = errors.New("no cpu controller detected")
 
 // Helper function for getCgroupCPU. Root is always "/", except in tests.
 func getCgroupCPU(root string) (CPUUsage, error) {

--- a/util/cgroup/cgroup_cpu.go
+++ b/util/cgroup/cgroup_cpu.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/errors"
 )
 
-var noCPUControllerDetected = errors.New("no cpu controller detected")
+var errNoCPUControllerDetected = errors.New("no cpu controller detected")
 
 // Helper function for getCgroupCPU. Root is always "/", except in tests.
 func getCgroupCPU(root string) (CPUUsage, error) {
@@ -32,7 +32,7 @@ func getCgroupCPU(root string) (CPUUsage, error) {
 
 	// No CPU controller detected
 	if path == "" {
-		return CPUUsage{}, noCPUControllerDetected
+		return CPUUsage{}, errNoCPUControllerDetected
 	}
 
 	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "cpu,cpuacct")

--- a/util/cgroup/cgroup_cpu_test.go
+++ b/util/cgroup/cgroup_cpu_test.go
@@ -42,7 +42,7 @@ func TestGetCgroupCPU(t *testing.T) {
 		}()
 	}
 	cpu, err := GetCgroupCPU()
-	if err == noCPUControllerDetected {
+	if err == errNoCPUControllerDetected {
 		require.False(t, InContainer(), "Please check linux version. This is related to cgroup compatibility.")
 	} else {
 		require.NoError(t, err)

--- a/util/cgroup/cgroup_cpu_test.go
+++ b/util/cgroup/cgroup_cpu_test.go
@@ -43,7 +43,7 @@ func TestGetCgroupCPU(t *testing.T) {
 	}
 	cpu, err := GetCgroupCPU()
 	if err == noCPUControllerDetected {
-		require.false(t, InContainer())
+		require.False(t, InContainer())
 	} else {
 		require.NoError(t, err)
 		require.NotZero(t, cpu.Period)

--- a/util/cgroup/cgroup_cpu_test.go
+++ b/util/cgroup/cgroup_cpu_test.go
@@ -43,7 +43,7 @@ func TestGetCgroupCPU(t *testing.T) {
 	}
 	cpu, err := GetCgroupCPU()
 	if err == errNoCPUControllerDetected {
-		require.False(t, InContainer(), "Please check linux version. This is related to cgroup compatibility.")
+		require.False(t, InContainer(), "Please check linux version > v4.7.x. This is related to cgroup compatibility.")
 	} else {
 		require.NoError(t, err)
 		require.NotZero(t, cpu.Period)

--- a/util/cgroup/cgroup_cpu_test.go
+++ b/util/cgroup/cgroup_cpu_test.go
@@ -41,6 +41,7 @@ func TestGetCgroupCPU(t *testing.T) {
 			}
 		}()
 	}
+	require.True(t, InContainer())
 	cpu, err := GetCgroupCPU()
 	require.NoError(t, err)
 	require.NotZero(t, cpu.Period)

--- a/util/cgroup/cgroup_cpu_test.go
+++ b/util/cgroup/cgroup_cpu_test.go
@@ -41,11 +41,14 @@ func TestGetCgroupCPU(t *testing.T) {
 			}
 		}()
 	}
-	require.True(t, InContainer())
 	cpu, err := GetCgroupCPU()
-	require.NoError(t, err)
-	require.NotZero(t, cpu.Period)
-	require.Less(t, int64(1), cpu.Period)
+	if err == noCPUControllerDetected {
+		require.false(t, InContainer())
+	} else {
+		require.NoError(t, err)
+		require.NotZero(t, cpu.Period)
+		require.Less(t, int64(1), cpu.Period)
+	}
 	close(exit)
 	wg.Wait()
 }

--- a/util/cgroup/cgroup_cpu_test.go
+++ b/util/cgroup/cgroup_cpu_test.go
@@ -43,7 +43,7 @@ func TestGetCgroupCPU(t *testing.T) {
 	}
 	cpu, err := GetCgroupCPU()
 	if err == noCPUControllerDetected {
-		require.False(t, InContainer())
+		require.False(t, InContainer(), "Please check linux version. This is related to cgroup compatibility.")
 	} else {
 		require.NoError(t, err)
 		require.NotZero(t, cpu.Period)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #39786

Problem Summary:

### What is changed and how it works?

If you are in the linux 3.x, Your cgroup path is different from the latest version.
the path of CPU cgroup is ```cpu,cpuacct```. But the old is ```cpuacct,cpu```. it just is a small problem. But it has a more serious problem. the path in old version is nonexistent like 
```cpuacct.usage_sys``` and ```cpuacct.usage_user``` which is created at the Linux 4.x.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
