### PR TITLE
planner: stabilize tests in `binary_plan_test.go`

### DIFF
--- a/planner/core/BUILD.bazel
+++ b/planner/core/BUILD.bazel
@@ -158,7 +158,7 @@ go_library(
 
 go_test(
     name = "core_test",
-    timeout = "moderate",
+    timeout = "short",
     srcs = [
         "binary_plan_test.go",
         "cbo_test.go",


### PR DESCRIPTION
### What problem does this PR solve?


Issue Number: close #40004  close #41297

Problem Summary:

Try to fix the above two unstable test cases.

### What is changed and how it works?

1. `TestTooLongBinaryPlan`: I'm unable to reproduce this fail. But I suspect this is because this case is affected by other cases. So I disable and then enable stmt summary in this case to trigger clear the stmt summary in memory, hoping this can fix the problem.
2. `TestLongBinaryPlan`: I added a rather strict check when I wrote this test case. It looks like this is too strict and even small changes might break this case. So I removed some non-necessary checks.
3. I also reset the global variables in the test cases of this file to reduce the possibility of test cases affecting each other.
4. As @hawkingrei advised, update timeout of planner/core to "short".

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
