### PR TITLE
br: reused table id is disabled when restore a brand-new cluster

### DIFF
--- a/br/pkg/glue/glue.go
+++ b/br/pkg/glue/glue.go
@@ -52,7 +52,7 @@ type Session interface {
 
 // BatchCreateTableSession is an interface to batch create table parallelly
 type BatchCreateTableSession interface {
-	CreateTables(ctx context.Context, tables map[string][]*model.TableInfo, cs ddl.CreateTableWithInfoConfigurier) error
+	CreateTables(ctx context.Context, tables map[string][]*model.TableInfo, cs ...ddl.CreateTableWithInfoConfigurier) error
 }
 
 // Progress is an interface recording the current execution progress.

--- a/br/pkg/glue/glue.go
+++ b/br/pkg/glue/glue.go
@@ -52,7 +52,7 @@ type Session interface {
 
 // BatchCreateTableSession is an interface to batch create table parallelly
 type BatchCreateTableSession interface {
-	CreateTables(ctx context.Context, tables map[string][]*model.TableInfo, cs ...ddl.CreateTableWithInfoConfigurier) error
+	CreateTables(ctx context.Context, tables map[string][]*model.TableInfo, cs ddl.CreateTableWithInfoConfigurier) error
 }
 
 // Progress is an interface recording the current execution progress.

--- a/br/pkg/gluetidb/BUILD.bazel
+++ b/br/pkg/gluetidb/BUILD.bazel
@@ -28,8 +28,10 @@ go_library(
 
 go_test(
     name = "gluetidb_test",
+    timeout = "short",
     srcs = ["glue_test.go"],
     embed = [":gluetidb"],
+    flaky = True,
     deps = [
         "//ddl",
         "//kv",

--- a/br/pkg/gluetidb/BUILD.bazel
+++ b/br/pkg/gluetidb/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//parser/model",
         "//sessionctx",
         "//testkit",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/br/pkg/gluetidb/BUILD.bazel
+++ b/br/pkg/gluetidb/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "gluetidb",
@@ -23,5 +23,20 @@ go_library(
         "@com_github_pingcap_log//:log",
         "@com_github_tikv_pd_client//:client",
         "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "gluetidb_test",
+    srcs = ["glue_test.go"],
+    embed = [":gluetidb"],
+    deps = [
+        "//ddl",
+        "//kv",
+        "//meta",
+        "//parser/model",
+        "//sessionctx",
+        "//testkit",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -28,8 +28,9 @@ import (
 
 // Asserting Glue implements glue.ConsoleGlue and glue.Glue at compile time.
 var (
-	_ glue.ConsoleGlue = Glue{}
-	_ glue.Glue        = Glue{}
+	_ glue.ConsoleGlue             = Glue{}
+	_ glue.Glue                    = Glue{}
+	_ glue.BatchCreateTableSession = &tidbSession{}
 )
 
 const (

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -424,10 +424,6 @@ type MockGlue struct {
 	GlobalVars map[string]string
 }
 
-func (m *MockGlue) SetSession(se session.Session) {
-	m.se = se
-}
-
 // GetDomain implements glue.Glue.
 func (*MockGlue) GetDomain(store kv.Storage) (*domain.Domain, error) {
 	return nil, nil

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -165,6 +165,11 @@ func (gs *tidbSession) GetSessionCtx() sessionctx.Context {
 	return gs.se
 }
 
+// SetSession implements for Unit Test
+func (gs *tidbSession) SetSession(session session.Session) {
+	gs.se = session
+}
+
 // Execute implements glue.Session.
 func (gs *tidbSession) Execute(ctx context.Context, sql string) error {
 	return gs.ExecuteInternal(ctx, sql)
@@ -226,11 +231,11 @@ func (gs *tidbSession) SplitBatchCreateTable(schema model.CIStr, info []*model.T
 			return err
 		}
 		mid := len(info) / 2
-		err = gs.SplitBatchCreateTable(schema, info[:mid])
+		err = gs.SplitBatchCreateTable(schema, info[:mid], cs...)
 		if err != nil {
 			return err
 		}
-		err = gs.SplitBatchCreateTable(schema, info[mid:])
+		err = gs.SplitBatchCreateTable(schema, info[mid:], cs...)
 		if err != nil {
 			return err
 		}
@@ -268,7 +273,7 @@ func (gs *tidbSession) CreateTables(ctx context.Context, tables map[string][]*mo
 			cloneTables = append(cloneTables, table)
 		}
 		gs.se.SetValue(sessionctx.QueryString, queryBuilder.String())
-		if err := gs.SplitBatchCreateTable(dbName, cloneTables); err != nil {
+		if err := gs.SplitBatchCreateTable(dbName, cloneTables, cs...); err != nil {
 			//It is possible to failure when TiDB does not support model.ActionCreateTables.
 			//In this circumstance, BatchCreateTableWithInfo returns errno.ErrInvalidDDLJob,
 			//we fall back to old way that creating table one by one

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -165,11 +165,6 @@ func (gs *tidbSession) GetSessionCtx() sessionctx.Context {
 	return gs.se
 }
 
-// SetSession implements for Unit Test
-func (gs *tidbSession) SetSession(session session.Session) {
-	gs.se = session
-}
-
 // Execute implements glue.Session.
 func (gs *tidbSession) Execute(ctx context.Context, sql string) error {
 	return gs.ExecuteInternal(ctx, sql)

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -419,6 +419,10 @@ type MockGlue struct {
 	GlobalVars map[string]string
 }
 
+func (m *MockGlue) SetSession(se session.Session) {
+	m.se = se
+}
+
 // GetDomain implements glue.Glue.
 func (*MockGlue) GetDomain(store kv.Storage) (*domain.Domain, error) {
 	return nil, nil

--- a/br/pkg/gluetidb/glue_test.go
+++ b/br/pkg/gluetidb/glue_test.go
@@ -1,0 +1,89 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gluetidb
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/pingcap/tidb/ddl"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta"
+	"github.com/pingcap/tidb/parser/model"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchCreateTables(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists table_1")
+
+	d := dom.DDL()
+	require.NotNil(t, d)
+
+	infos1 := []*model.TableInfo{}
+	infos1 = append(infos1, &model.TableInfo{
+		ID:   124,
+		Name: model.NewCIStr("table_id_resued"),
+	})
+
+	se := &tidbSession{se: tk.Session()}
+
+	// keep/reused table id verification
+	tk.Session().SetValue(sessionctx.QueryString, "skip")
+
+	err := se.SplitBatchCreateTable(model.NewCIStr("test"), infos1, ddl.AllocTableIDIf(func(ti *model.TableInfo) bool {
+		return false
+	}))
+	require.NoError(t, err)
+
+	tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'table_id_resued'").Check(testkit.Rows("124"))
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnOthers)
+
+	// allocate new table id verification
+	// query the global id
+	var id int64
+	err = kv.RunInNewTxn(ctx, store, true, func(_ context.Context, txn kv.Transaction) error {
+		m := meta.NewMeta(txn)
+		var err error
+		id, err = m.GenGlobalID()
+		return err
+	})
+
+	require.NoError(t, err)
+
+	infos2 := []*model.TableInfo{}
+	infos2 = append(infos2, &model.TableInfo{
+		ID:   124,
+		Name: model.NewCIStr("table_id_new"),
+	})
+
+	tk.Session().SetValue(sessionctx.QueryString, "skip")
+
+	err = se.SplitBatchCreateTable(model.NewCIStr("test"), infos2, ddl.AllocTableIDIf(func(ti *model.TableInfo) bool {
+		return true
+	}))
+	require.NoError(t, err)
+
+	idGen, ok := tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'table_id_new'").Rows()[0][0].(string)
+	require.True(t, ok)
+	idGenNum, err := strconv.ParseInt(idGen, 10, 64)
+	require.NoError(t, err)
+	require.Greater(t, idGenNum, id)
+}

--- a/br/pkg/gluetidb/glue_test.go
+++ b/br/pkg/gluetidb/glue_test.go
@@ -33,7 +33,8 @@ func TestSplitBatchCreateTable(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	tk.MustExec("drop table if exists table_1")
+	tk.MustExec("drop table if exists table_id_resued")
+	tk.MustExec("drop table if exists table_id_new")
 
 	d := dom.DDL()
 	require.NotNil(t, d)

--- a/br/pkg/gluetidb/glue_test.go
+++ b/br/pkg/gluetidb/glue_test.go
@@ -28,7 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBatchCreateTables(t *testing.T) {
+// batch create table with table id reused
+func TestSplitBatchCreateTable(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")

--- a/br/pkg/gluetidb/glue_test.go
+++ b/br/pkg/gluetidb/glue_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc.
+// Copyright 2023 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/br/pkg/gluetidb/glue_test.go
+++ b/br/pkg/gluetidb/glue_test.go
@@ -101,7 +101,6 @@ func TestSplitBatchCreateTableWithTableId(t *testing.T) {
 		return false
 	}))
 	require.NoError(t, err)
-
 }
 
 // batch create table with table id reused

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2561,7 +2561,6 @@ func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 		if len(infos) > injectBatchSize {
 			failpoint.Return(kv.ErrEntryTooLarge)
 		}
-
 	})
 	c := GetCreateTableWithInfoConfig(cs)
 

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2557,11 +2557,11 @@ func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 	cs ...CreateTableWithInfoConfigurier,
 ) error {
 	failpoint.Inject("RestoreBatchCreateTableEntryTooLarge", func(val failpoint.Value) {
-		if val.(bool) {
-			if len(infos) > 1 {
-				failpoint.Return(kv.ErrEntryTooLarge)
-			}
+		injectBatchSize := val.(int)
+		if len(infos) > injectBatchSize {
+			failpoint.Return(kv.ErrEntryTooLarge)
 		}
+
 	})
 	c := GetCreateTableWithInfoConfig(cs)
 

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2556,6 +2556,13 @@ func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 	infos []*model.TableInfo,
 	cs ...CreateTableWithInfoConfigurier,
 ) error {
+	failpoint.Inject("RestoreBatchCreateTableEntryTooLarge", func(val failpoint.Value) {
+		if val.(bool) {
+			if len(infos) > 1 {
+				failpoint.Return(kv.ErrEntryTooLarge)
+			}
+		}
+	})
 	c := GetCreateTableWithInfoConfig(cs)
 
 	jobs := &model.Job{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41333 

Problem Summary:
when restoring to a brand-new cluster, reused table id was disabled, which caused restore to consume more resources.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
