### PR TITLE
br: reused table id is disabled when restore a brand-new cluster

### DIFF
--- a/br/pkg/gluetidb/BUILD.bazel
+++ b/br/pkg/gluetidb/BUILD.bazel
@@ -28,8 +28,10 @@ go_library(
 
 go_test(
     name = "gluetidb_test",
+    timeout = "short",
     srcs = ["glue_test.go"],
     embed = [":gluetidb"],
+    flaky = True,
     deps = [
         "//ddl",
         "//kv",

--- a/br/pkg/gluetidb/BUILD.bazel
+++ b/br/pkg/gluetidb/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "gluetidb",
@@ -23,5 +23,21 @@ go_library(
         "@com_github_pingcap_log//:log",
         "@com_github_tikv_pd_client//:client",
         "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "gluetidb_test",
+    srcs = ["glue_test.go"],
+    embed = [":gluetidb"],
+    deps = [
+        "//ddl",
+        "//kv",
+        "//meta",
+        "//parser/model",
+        "//sessionctx",
+        "//testkit",
+        "@com_github_pingcap_failpoint//:failpoint",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -218,19 +218,21 @@ func (gs *tidbSession) CreatePlacementPolicy(ctx context.Context, policy *model.
 // SplitBatchCreateTable provide a way to split batch into small batch when batch size is large than 6 MB.
 // The raft entry has limit size of 6 MB, a batch of CreateTables may hit this limitation
 // TODO: shall query string be set for each split batch create, it looks does not matter if we set once for all.
-func (gs *tidbSession) SplitBatchCreateTable(schema model.CIStr, info []*model.TableInfo, cs ...ddl.CreateTableWithInfoConfigurier) error {
+func (gs *tidbSession) SplitBatchCreateTable(schema model.CIStr, infos []*model.TableInfo, cs ...ddl.CreateTableWithInfoConfigurier) error {
 	var err error
 	d := domain.GetDomain(gs.se).DDL()
-	if err = d.BatchCreateTableWithInfo(gs.se, schema, info, append(cs, ddl.OnExistIgnore)...); kv.ErrEntryTooLarge.Equal(err) {
-		if len(info) == 1 {
+
+	if err = d.BatchCreateTableWithInfo(gs.se, schema, infos, append(cs, ddl.OnExistIgnore)...); kv.ErrEntryTooLarge.Equal(err) {
+		log.Info("entry too large, split batch create table", zap.Int("num table", len(infos)))
+		if len(infos) == 1 {
 			return err
 		}
-		mid := len(info) / 2
-		err = gs.SplitBatchCreateTable(schema, info[:mid])
+		mid := len(infos) / 2
+		err = gs.SplitBatchCreateTable(schema, infos[:mid], cs...)
 		if err != nil {
 			return err
 		}
-		err = gs.SplitBatchCreateTable(schema, info[mid:])
+		err = gs.SplitBatchCreateTable(schema, infos[mid:], cs...)
 		if err != nil {
 			return err
 		}
@@ -268,7 +270,7 @@ func (gs *tidbSession) CreateTables(ctx context.Context, tables map[string][]*mo
 			cloneTables = append(cloneTables, table)
 		}
 		gs.se.SetValue(sessionctx.QueryString, queryBuilder.String())
-		if err := gs.SplitBatchCreateTable(dbName, cloneTables); err != nil {
+		if err := gs.SplitBatchCreateTable(dbName, cloneTables, cs...); err != nil {
 			//It is possible to failure when TiDB does not support model.ActionCreateTables.
 			//In this circumstance, BatchCreateTableWithInfo returns errno.ErrInvalidDDLJob,
 			//we fall back to old way that creating table one by one

--- a/br/pkg/gluetidb/glue_test.go
+++ b/br/pkg/gluetidb/glue_test.go
@@ -1,0 +1,208 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gluetidb
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/ddl"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta"
+	"github.com/pingcap/tidb/parser/model"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+// batch create table with table id reused
+func TestSplitBatchCreateTableWithTableId(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists table_id_resued1")
+	tk.MustExec("drop table if exists table_id_resued2")
+	tk.MustExec("drop table if exists table_id_new")
+
+	d := dom.DDL()
+	require.NotNil(t, d)
+
+	infos1 := []*model.TableInfo{}
+	infos1 = append(infos1, &model.TableInfo{
+		ID:   124,
+		Name: model.NewCIStr("table_id_resued1"),
+	})
+	infos1 = append(infos1, &model.TableInfo{
+		ID:   125,
+		Name: model.NewCIStr("table_id_resued2"),
+	})
+
+	se := &tidbSession{se: tk.Session()}
+
+	// keep/reused table id verification
+	tk.Session().SetValue(sessionctx.QueryString, "skip")
+	err := se.SplitBatchCreateTable(model.NewCIStr("test"), infos1, ddl.AllocTableIDIf(func(ti *model.TableInfo) bool {
+		return false
+	}))
+	require.NoError(t, err)
+
+	tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'table_id_resued1'").Check(testkit.Rows("124"))
+	tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'table_id_resued2'").Check(testkit.Rows("125"))
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnOthers)
+
+	// allocate new table id verification
+	// query the global id
+	var id int64
+	err = kv.RunInNewTxn(ctx, store, true, func(_ context.Context, txn kv.Transaction) error {
+		m := meta.NewMeta(txn)
+		var err error
+		id, err = m.GenGlobalID()
+		return err
+	})
+
+	require.NoError(t, err)
+
+	infos2 := []*model.TableInfo{}
+	infos2 = append(infos2, &model.TableInfo{
+		ID:   124,
+		Name: model.NewCIStr("table_id_new"),
+	})
+
+	tk.Session().SetValue(sessionctx.QueryString, "skip")
+	err = se.SplitBatchCreateTable(model.NewCIStr("test"), infos2, ddl.AllocTableIDIf(func(ti *model.TableInfo) bool {
+		return true
+	}))
+	require.NoError(t, err)
+
+	idGen, ok := tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'table_id_new'").Rows()[0][0].(string)
+	require.True(t, ok)
+	idGenNum, err := strconv.ParseInt(idGen, 10, 64)
+	require.NoError(t, err)
+	require.Greater(t, idGenNum, id)
+
+	// a empty table info with len(info3) = 0
+	infos3 := []*model.TableInfo{}
+
+	err = se.SplitBatchCreateTable(model.NewCIStr("test"), infos3, ddl.AllocTableIDIf(func(ti *model.TableInfo) bool {
+		return false
+	}))
+	require.NoError(t, err)
+}
+
+// batch create table with table id reused
+func TestSplitBatchCreateTable(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists table_1")
+	tk.MustExec("drop table if exists table_2")
+	tk.MustExec("drop table if exists table_3")
+
+	d := dom.DDL()
+	require.NotNil(t, d)
+
+	infos := []*model.TableInfo{}
+	infos = append(infos, &model.TableInfo{
+		ID:   1234,
+		Name: model.NewCIStr("tables_1"),
+	})
+	infos = append(infos, &model.TableInfo{
+		ID:   1235,
+		Name: model.NewCIStr("tables_2"),
+	})
+	infos = append(infos, &model.TableInfo{
+		ID:   1236,
+		Name: model.NewCIStr("tables_3"),
+	})
+
+	se := &tidbSession{se: tk.Session()}
+
+	// keep/reused table id verification
+	tk.Session().SetValue(sessionctx.QueryString, "skip")
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/RestoreBatchCreateTableEntryTooLarge", "return(1)"))
+	err := se.SplitBatchCreateTable(model.NewCIStr("test"), infos, ddl.AllocTableIDIf(func(ti *model.TableInfo) bool {
+		return false
+	}))
+
+	require.NoError(t, err)
+	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))
+	jobs := tk.MustQuery("admin show ddl jobs").Rows()
+	require.Greater(t, len(jobs), 3)
+	// check table_1
+	job1 := jobs[0]
+	require.Equal(t, "test", job1[1])
+	require.Equal(t, "tables_3", job1[2])
+	require.Equal(t, "create tables", job1[3])
+	require.Equal(t, "public", job1[4])
+
+	// check table_2
+	job2 := jobs[1]
+	require.Equal(t, "test", job2[1])
+	require.Equal(t, "tables_2", job2[2])
+	require.Equal(t, "create tables", job2[3])
+	require.Equal(t, "public", job2[4])
+
+	// check table_3
+	job3 := jobs[2]
+	require.Equal(t, "test", job3[1])
+	require.Equal(t, "tables_1", job3[2])
+	require.Equal(t, "create tables", job3[3])
+	require.Equal(t, "public", job3[4])
+
+	// check reused table id
+	tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'tables_1'").Check(testkit.Rows("1234"))
+	tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'tables_2'").Check(testkit.Rows("1235"))
+	tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'tables_3'").Check(testkit.Rows("1236"))
+
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/RestoreBatchCreateTableEntryTooLarge"))
+}
+
+// batch create table with table id reused
+func TestSplitBatchCreateTableFailWithEntryTooLarge(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists table_1")
+	tk.MustExec("drop table if exists table_2")
+	tk.MustExec("drop table if exists table_3")
+
+	d := dom.DDL()
+	require.NotNil(t, d)
+
+	infos := []*model.TableInfo{}
+	infos = append(infos, &model.TableInfo{
+		Name: model.NewCIStr("tables_1"),
+	})
+	infos = append(infos, &model.TableInfo{
+		Name: model.NewCIStr("tables_2"),
+	})
+	infos = append(infos, &model.TableInfo{
+		Name: model.NewCIStr("tables_3"),
+	})
+
+	se := &tidbSession{se: tk.Session()}
+
+	tk.Session().SetValue(sessionctx.QueryString, "skip")
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/RestoreBatchCreateTableEntryTooLarge", "return(0)"))
+	err := se.SplitBatchCreateTable(model.NewCIStr("test"), infos, ddl.AllocTableIDIf(func(ti *model.TableInfo) bool {
+		return true
+	}))
+
+	require.True(t, kv.ErrEntryTooLarge.Equal(err))
+
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/RestoreBatchCreateTableEntryTooLarge"))
+}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2556,6 +2556,12 @@ func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 	infos []*model.TableInfo,
 	cs ...CreateTableWithInfoConfigurier,
 ) error {
+	failpoint.Inject("RestoreBatchCreateTableEntryTooLarge", func(val failpoint.Value) {
+		injectBatchSize := val.(int)
+		if len(infos) > injectBatchSize {
+			failpoint.Return(kv.ErrEntryTooLarge)
+		}
+	})
 	c := GetCreateTableWithInfoConfig(cs)
 
 	jobs := &model.Job{


### PR DESCRIPTION

Cherry-picking (Unmerged) https://github.com/pingcap/tidb/pull/41358.

===

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41333 

Problem Summary:
when restoring to a brand-new cluster, reused table id was disabled, which caused restore to consume more resources.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
