### PR TITLE
ddl: make `reorgCtx` safer to use

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -537,18 +537,13 @@ func (dc *ddlCtx) newReorgCtx(jobID int64, startKey []byte, currElement *meta.El
 	rc.references.Add(1)
 	dc.reorgCtx.Lock()
 	defer dc.reorgCtx.Unlock()
+	existedRC, ok := dc.reorgCtx.reorgCtxMap[jobID]
+	if ok {
+		existedRC.references.Add(1)
+		return existedRC
+	}
 	dc.reorgCtx.reorgCtxMap[jobID] = rc
 	return rc
-}
-
-func (dc *ddlCtx) setReorgCtxForBackfill(bfJob *BackfillJob) {
-	rc := dc.getReorgCtx(bfJob.JobID)
-	if rc == nil {
-		ele := &meta.Element{ID: bfJob.EleID, TypeKey: bfJob.EleKey}
-		dc.newReorgCtx(bfJob.JobID, bfJob.Meta.StartKey, ele, bfJob.Meta.RowCount)
-	} else {
-		rc.references.Add(1)
-	}
 }
 
 func (dc *ddlCtx) removeReorgCtx(jobID int64) {

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -526,6 +526,13 @@ func (dc *ddlCtx) getReorgCtx(jobID int64) *reorgCtx {
 }
 
 func (dc *ddlCtx) newReorgCtx(jobID int64, startKey []byte, currElement *meta.Element, rowCount int64) *reorgCtx {
+	dc.reorgCtx.Lock()
+	defer dc.reorgCtx.Unlock()
+	existedRC, ok := dc.reorgCtx.reorgCtxMap[jobID]
+	if ok {
+		existedRC.references.Add(1)
+		return existedRC
+	}
 	rc := &reorgCtx{}
 	rc.doneCh = make(chan error, 1)
 	// initial reorgCtx
@@ -535,13 +542,6 @@ func (dc *ddlCtx) newReorgCtx(jobID int64, startKey []byte, currElement *meta.El
 	rc.mu.warnings = make(map[errors.ErrorID]*terror.Error)
 	rc.mu.warningsCount = make(map[errors.ErrorID]int64)
 	rc.references.Add(1)
-	dc.reorgCtx.Lock()
-	defer dc.reorgCtx.Unlock()
-	existedRC, ok := dc.reorgCtx.reorgCtxMap[jobID]
-	if ok {
-		existedRC.references.Add(1)
-		return existedRC
-	}
 	dc.reorgCtx.reorgCtxMap[jobID] = rc
 	return rc
 }

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -44,7 +44,6 @@ type DDLForTest interface {
 	// SetInterceptor sets the interceptor.
 	SetInterceptor(h Interceptor)
 	NewReorgCtx(jobID int64, startKey []byte, currElement *meta.Element, rowCount int64) *reorgCtx
-	SetReorgCtxForBackfill(bfJob *BackfillJob)
 	GetReorgCtx(jobID int64) *reorgCtx
 	RemoveReorgCtx(id int64)
 }
@@ -65,11 +64,6 @@ func (rc *reorgCtx) IsReorgCanceled() bool {
 // NewReorgCtx exports for testing.
 func (d *ddl) NewReorgCtx(jobID int64, startKey []byte, currElement *meta.Element, rowCount int64) *reorgCtx {
 	return d.newReorgCtx(jobID, startKey, currElement, rowCount)
-}
-
-// SetReorgCtxForBackfill exports for testing.
-func (d *ddl) SetReorgCtxForBackfill(bfJob *BackfillJob) {
-	d.setReorgCtxForBackfill(bfJob)
 }
 
 // GetReorgCtx exports for testing.

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -317,10 +317,10 @@ func TestUsingReorgCtx(t *testing.T) {
 	wg := util.WaitGroupWrapper{}
 	wg.Run(func() {
 		jobID := int64(1)
-		m := &model.BackfillMeta{StartKey: []byte("skey"), RowCount: 1}
-		bfJob := &ddl.BackfillJob{JobID: jobID, EleID: 1, EleKey: nil, Meta: m}
-		for i := 0; i < 100; i++ {
-			d.(ddl.DDLForTest).SetReorgCtxForBackfill(bfJob)
+		startKey := []byte("skey")
+		ele := &meta.Element{ID: 1, TypeKey: nil}
+		for i := 0; i < 500; i++ {
+			d.(ddl.DDLForTest).NewReorgCtx(jobID, startKey, ele, 0)
 			d.(ddl.DDLForTest).GetReorgCtx(jobID).IsReorgCanceled()
 			d.(ddl.DDLForTest).RemoveReorgCtx(jobID)
 		}
@@ -329,7 +329,7 @@ func TestUsingReorgCtx(t *testing.T) {
 		jobID := int64(1)
 		startKey := []byte("skey")
 		ele := &meta.Element{ID: 1, TypeKey: nil}
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 500; i++ {
 			d.(ddl.DDLForTest).NewReorgCtx(jobID, startKey, ele, 0)
 			d.(ddl.DDLForTest).GetReorgCtx(jobID).IsReorgCanceled()
 			d.(ddl.DDLForTest).RemoveReorgCtx(jobID)

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -402,7 +402,7 @@ func (d *ddl) loadBackfillJobAndRun() {
 		return
 	}
 	// TODO: Adjust how the non-owner uses ReorgCtx.
-	d.setReorgCtxForBackfill(bfJob)
+	d.newReorgCtx(bfJob.JobID, bfJob.Meta.StartKey, &meta.Element{ID: bfJob.EleID, TypeKey: bfJob.EleKey}, bfJob.Meta.RowCount)
 	d.wg.Run(func() {
 		defer func() {
 			tidbutil.Recover(metrics.LabelDistReorg, "runBackfillJobs", nil, false)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/41418

Problem Summary:
`newReorgCtx` and `setReorgCtxForBackfill` are no problem when used with dist-reorg, because `newReorgCtx` must be called before `setReorgCtxForBackfill` when using the same jobID.
However, the code has been changed to prevent other ways of using it in the future and to test for stability, so change the code


### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
