### PR TITLE
session, com_stmt: store and restore the params for cursor fetch

### DIFF
--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -304,6 +304,11 @@ func (cc *clientConn) executePreparedStmtAndWriteResult(ctx context.Context, stm
 			rs = &rsWithHooks{ResultSet: rs, onClosed: unhold}
 		}
 		stmt.StoreResultSet(rs)
+		// also store the preparedParams in the stmt, so we could restore the params in the following fetch command
+		// the params should have been parsed in `(&cc.ctx).ExecuteStmt(ctx, execStmt)`.
+		stmt.StorePreparedCtx(&PreparedStatementCtx{
+			Params: vars.PreparedParams,
+		})
 		if err = cc.writeColumnInfo(rs.Columns()); err != nil {
 			return false, err
 		}
@@ -346,6 +351,9 @@ func (cc *clientConn) handleStmtFetch(ctx context.Context, data []byte) (err err
 		return errors.Annotate(mysql.NewErr(mysql.ErrUnknownStmtHandler,
 			strconv.FormatUint(uint64(stmtID), 10), "stmt_fetch"), cc.preparedStmt2String(stmtID))
 	}
+
+	cc.ctx.GetSessionVars().PreparedParams = stmt.GetPreparedCtx().Params
+
 	if topsqlstate.TopSQLEnabled() {
 		prepareObj, _ := cc.preparedStmtID2CachePreparedStmt(stmtID)
 		if prepareObj != nil && prepareObj.SQLDigest != nil {

--- a/server/conn_stmt_test.go
+++ b/server/conn_stmt_test.go
@@ -485,3 +485,53 @@ func TestCursorReadWithRCCheckTS(t *testing.T) {
 		tk.MustExec("rollback")
 	}
 }
+
+func TestCursorWithParams(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	srv := CreateMockServer(t, store)
+	srv.SetDomain(dom)
+	defer srv.Close()
+
+	appendUint32 := binary.LittleEndian.AppendUint32
+	ctx := context.Background()
+	c := CreateMockConn(t, srv).(*mockConn)
+
+	tk := testkit.NewTestKitWithSession(t, store, c.Context().Session)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id_1 int, id_2 int)")
+	tk.MustExec("insert into t values (1, 1), (1, 2)")
+
+	stmt1, _, _, err := c.Context().Prepare("select * from t where id_1 = ? and id_2 = ?")
+	require.NoError(t, err)
+	stmt2, _, _, err := c.Context().Prepare("select * from t where id_1 = ?")
+	require.NoError(t, err)
+
+	// `execute stmt1 using 1,2` with cursor
+	require.NoError(t, c.Dispatch(ctx, append(
+		appendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt1.ID())),
+		mysql.CursorTypeReadOnly, 0x1, 0x0, 0x0, 0x0,
+		0x0, 0x1, 0x3, 0x0, 0x3, 0x0,
+		0x1, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0,
+	)))
+
+	// `execute stmt2 using 1` with cursor
+	require.NoError(t, c.Dispatch(ctx, append(
+		appendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt2.ID())),
+		mysql.CursorTypeReadOnly, 0x1, 0x0, 0x0, 0x0,
+		0x0, 0x1, 0x3, 0x0,
+		0x1, 0x0, 0x0, 0x0,
+	)))
+
+	// fetch stmt2 with fetch size 256
+	require.NoError(t, c.Dispatch(ctx, append(
+		appendUint32([]byte{mysql.ComStmtFetch}, uint32(stmt2.ID())),
+		0x0, 0x1, 0x0, 0x0,
+	)))
+
+	// fetch stmt1 with fetch size 256, as it has more params, if we didn't restore the parameters, it will panic.
+	require.NoError(t, c.Dispatch(ctx, append(
+		appendUint32([]byte{mysql.ComStmtFetch}, uint32(stmt1.ID())),
+		0x0, 0x1, 0x0, 0x0,
+	)))
+}

--- a/server/driver.go
+++ b/server/driver.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/extension"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/chunk"
 )
 
@@ -27,6 +28,17 @@ import (
 type IDriver interface {
 	// OpenCtx opens an IContext with connection id, client capability, collation, dbname and optionally the tls state.
 	OpenCtx(connID uint64, capability uint32, collation uint8, dbname string, tlsState *tls.ConnectionState, extensions *extension.SessionExtensions) (*TiDBContext, error)
+}
+
+// PreparedStatementCtx stores the context generated in `execute` statement for a prepared statement
+// subsequent stmt fetching could restore the session variables from this context
+type PreparedStatementCtx struct {
+	// Params is the params used in `execute` statement
+	Params variable.PreparedParams
+	// TODO: store and restore variables, but be careful that we'll also need to restore the variables after FETCH
+	// a cleaner way to solve this problem is to always reading params from a statement scope (but not session scope)
+	// context. But switching in/out related context is simpler on current code base, and the affected radius is more
+	// controllable.
 }
 
 // PreparedStatement is the interface to use a prepared statement.
@@ -57,6 +69,12 @@ type PreparedStatement interface {
 
 	// GetResultSet gets ResultSet associated this statement
 	GetResultSet() ResultSet
+
+	// StorePreparedCtx stores context in `execute` statement for subsequent stmt fetching
+	StorePreparedCtx(ctx *PreparedStatementCtx)
+
+	// GetPreparedParams gets the prepared params associated this statement
+	GetPreparedCtx() *PreparedStatementCtx
 
 	// Reset removes all bound parameters.
 	Reset()

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -68,6 +68,8 @@ type TiDBStatement struct {
 	ctx         *TiDBContext
 	rs          ResultSet
 	sql         string
+
+	preparedStatementCtx *PreparedStatementCtx
 }
 
 // ID implements PreparedStatement ID method.
@@ -140,6 +142,16 @@ func (ts *TiDBStatement) StoreResultSet(rs ResultSet) {
 // GetResultSet gets ResultSet associated this statement
 func (ts *TiDBStatement) GetResultSet() ResultSet {
 	return ts.rs
+}
+
+// StorePreparedCtx implements PreparedStatement StorePreparedCtx method.
+func (ts *TiDBStatement) StorePreparedCtx(ctx *PreparedStatementCtx) {
+	ts.preparedStatementCtx = ctx
+}
+
+// GetPreparedCtx implements PreparedStatement GetPreparedCtx method.
+func (ts *TiDBStatement) GetPreparedCtx() *PreparedStatementCtx {
+	return ts.preparedStatementCtx
 }
 
 // Reset implements PreparedStatement Reset method.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #40094 

Problem Summary:

TiDB cannot handle concurrently running statements. This PR stores and restores the params.

### What is changed and how it works?

Store and restore the prepared params in session

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

The following JDBC codes run without panic:

```java
import java.sql.*;

public class Example {
    public static void main(String[] args) throws SQLException, InterruptedException {
        Connection conn = DriverManager.getConnection("jdbc:mysql://127.0.0.1:4000/test?useCursorFetch=true&useServerPrepStmts=true&useSSL=false", "root", "");

        conn.setAutoCommit(false); // must set

        conn.prepareStatement("drop table if exists t").execute();
        conn.prepareStatement("create table t (id int auto_increment primary key, id_2 int)").execute();
        conn.prepareStatement("insert into t values (1,1)").execute();
        conn.prepareStatement("insert into t values (2,2)").execute();

        // submit a statement with more arguments:
        PreparedStatement statement1 = conn.prepareStatement("" +
                "select * " +
                "from " +
                "t " +
                "where id = ? and id_2 = ?");
        statement1.setFetchSize(500);
        statement1.setInt(1, 1);
        statement1.setInt(2, 2);
        ResultSet rs_1 = statement1.executeQuery();

        // submit a statement with less arguments:
        PreparedStatement statement2 = conn.prepareStatement("" +
                "select * " +
                "from " +
                "t " +
                "where (id = ?)");
        statement2.setFetchSize(500);
        statement2.setInt(1, 1);
        ResultSet rs_2 = statement2.executeQuery();

        // fetch the result from the first argument
        while (rs_1.next()) {
            int result = rs_1.getInt(1);

            System.out.println(result);
        }
        while (rs_2.next()) {
            int result = rs_2.getInt(1);

            System.out.println(result);
        }

        statement1.close();
        statement2.close();
        conn.commit();
        conn.close();

    }
}
```

### Release note

```release-note
Fix the issue that the prepared params are lost while executing another statement between EXECUTE and FETCH command.
```
