### PR TITLE
ddl: correct the remain ranges check for adding index

### DIFF
--- a/ddl/backfilling.go
+++ b/ddl/backfilling.go
@@ -1072,7 +1072,7 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sessionPool, t table.Physic
 	}
 
 	for {
-		if startKey.Cmp(endKey) >= 0 {
+		if startKey.Cmp(endKey) > 0 {
 			break
 		}
 		kvRanges, err := splitTableRanges(t, reorgInfo.d.store, startKey, endKey, backfillTaskChanSize)

--- a/ddl/backfilling.go
+++ b/ddl/backfilling.go
@@ -825,7 +825,12 @@ type backfillScheduler struct {
 	copReqSenderPool *copReqSenderPool // for add index in ingest way.
 }
 
-const backfillTaskChanSize = 1024
+var backfillTaskChanSize = 1024
+
+// SetBackfillTaskChanSizeForTest is only used for test.
+func SetBackfillTaskChanSizeForTest(n int) {
+	backfillTaskChanSize = n
+}
 
 func newBackfillScheduler(ctx context.Context, info *reorgInfo, sessPool *sessionPool,
 	tp backfillerType, tbl table.PhysicalTable, decColMap map[int64]decoder.Column,
@@ -1067,12 +1072,18 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sessionPool, t table.Physic
 	}
 
 	for {
+		if startKey.Cmp(endKey) >= 0 {
+			break
+		}
 		kvRanges, err := splitTableRanges(t, reorgInfo.d.store, startKey, endKey, backfillTaskChanSize)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		scheduler.setMaxWorkerSize(len(kvRanges))
+		if len(kvRanges) == 0 {
+			break
+		}
 
+		scheduler.setMaxWorkerSize(len(kvRanges))
 		err = scheduler.adjustWorkerSize()
 		if err != nil {
 			return errors.Trace(err)
@@ -1095,14 +1106,15 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sessionPool, t table.Physic
 		if err != nil {
 			return errors.Trace(err)
 		}
-
-		if len(remains) == 0 {
-			if ingestBeCtx != nil {
-				ingestBeCtx.EngMgr.ResetWorkers(ingestBeCtx, job.ID, reorgInfo.currElement.ID)
-			}
-			break
+		if len(remains) > 0 {
+			startKey = remains[0].StartKey
+		} else {
+			lastFinishedKey := kvRanges[len(kvRanges)-1].EndKey
+			startKey = lastFinishedKey.Next()
 		}
-		startKey = remains[0].StartKey
+	}
+	if ingestBeCtx != nil {
+		ingestBeCtx.EngMgr.ResetWorkers(ingestBeCtx, job.ID, reorgInfo.currElement.ID)
 	}
 	return nil
 }

--- a/ddl/backfilling.go
+++ b/ddl/backfilling.go
@@ -1072,7 +1072,7 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sessionPool, t table.Physic
 	}
 
 	for {
-		if startKey.Cmp(endKey) > 0 {
+		if startKey.Cmp(endKey) >= 0 {
 			break
 		}
 		kvRanges, err := splitTableRanges(t, reorgInfo.d.store, startKey, endKey, backfillTaskChanSize)

--- a/ddl/backfilling.go
+++ b/ddl/backfilling.go
@@ -1072,9 +1072,6 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sessionPool, t table.Physic
 	}
 
 	for {
-		if startKey.Cmp(endKey) >= 0 {
-			break
-		}
 		kvRanges, err := splitTableRanges(t, reorgInfo.d.store, startKey, endKey, backfillTaskChanSize)
 		if err != nil {
 			return errors.Trace(err)
@@ -1110,6 +1107,9 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sessionPool, t table.Physic
 			startKey = remains[0].StartKey
 		} else {
 			startKey = kvRanges[len(kvRanges)-1].EndKey
+		}
+		if startKey.Cmp(endKey) >= 0 {
+			break
 		}
 	}
 	if ingestBeCtx != nil {

--- a/ddl/backfilling.go
+++ b/ddl/backfilling.go
@@ -1109,8 +1109,7 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sessionPool, t table.Physic
 		if len(remains) > 0 {
 			startKey = remains[0].StartKey
 		} else {
-			lastFinishedKey := kvRanges[len(kvRanges)-1].EndKey
-			startKey = lastFinishedKey.Next()
+			startKey = kvRanges[len(kvRanges)-1].EndKey
 		}
 	}
 	if ingestBeCtx != nil {

--- a/tests/realtikvtest/addindextest/integration_test.go
+++ b/tests/realtikvtest/addindextest/integration_test.go
@@ -461,6 +461,9 @@ func TestAddIndexSplitTableRanges(t *testing.T) {
 	ddl.SetBackfillTaskChanSizeForTest(4)
 	tk.MustExec("alter table t add index idx(b);")
 	tk.MustExec("admin check table t;")
+	ddl.SetBackfillTaskChanSizeForTest(7)
+	tk.MustExec("alter table t add index idx_2(b);")
+	tk.MustExec("admin check table t;")
 	ddl.SetBackfillTaskChanSizeForTest(1024)
 }
 

--- a/tests/realtikvtest/addindextest/integration_test.go
+++ b/tests/realtikvtest/addindextest/integration_test.go
@@ -444,6 +444,26 @@ func TestAddIndexIngestCancel(t *testing.T) {
 	require.Empty(t, ingest.LitBackCtxMgr.Keys())
 }
 
+func TestAddIndexSplitTableRanges(t *testing.T) {
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("drop database if exists addindexlit;")
+	tk.MustExec("create database addindexlit;")
+	tk.MustExec("use addindexlit;")
+	tk.MustExec(`set global tidb_ddl_enable_fast_reorg=on;`)
+
+	tk.MustExec("create table t (a int primary key, b int);")
+	for i := 0; i < 8; i++ {
+		tk.MustExec(fmt.Sprintf("insert into t values (%d, %d);", i*10000, i*10000))
+	}
+	tk.MustQuery("split table t between (0) and (80000) regions 7;").Check(testkit.Rows("6 1"))
+
+	ddl.SetBackfillTaskChanSizeForTest(4)
+	tk.MustExec("alter table t add index idx(b);")
+	tk.MustExec("admin check table t;")
+	ddl.SetBackfillTaskChanSizeForTest(1024)
+}
+
 type testCallback struct {
 	ddl.Callback
 	OnJobRunBeforeExported func(job *model.Job)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41459

Problem Summary:

The condition `remains == 0` does not indicate the whole task is finished after #40411.

### What is changed and how it works?

Correct the remain check code.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
