### PR TITLE
cgroup: refine the handling of errNoCPUControllerDetected

### DIFF
--- a/util/cgroup/cgroup_cpu_test.go
+++ b/util/cgroup/cgroup_cpu_test.go
@@ -17,12 +17,53 @@
 package cgroup
 
 import (
+	"fmt"
+	"regexp"
 	"runtime"
+	"strconv"
 	"sync"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func checkKernelVersionNewerThan(t *testing.T, major, minor int) bool {
+	u := syscall.Utsname{}
+	err := syscall.Uname(&u)
+	require.NoError(t, err)
+	releaseBs := make([]byte, 0, len(u.Release))
+	for _, v := range u.Release {
+		if v == 0 {
+			break
+		}
+		releaseBs = append(releaseBs, byte(v))
+	}
+	releaseStr := string(releaseBs)
+	t.Log("kernel release string:", releaseStr)
+	versionInfoRE := regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+`)
+	kernelVerion := versionInfoRE.FindAllString(releaseStr, 1)
+	require.Equal(t, 1, len(kernelVerion), fmt.Sprintf("release str is %s", releaseStr))
+	kernelVersionPartRE := regexp.MustCompile(`[0-9]+`)
+	kernelVersionParts := kernelVersionPartRE.FindAllString(kernelVerion[0], -1)
+	require.Equal(t, 3, len(kernelVersionParts), fmt.Sprintf("kernel verion str is %s", kernelVerion[0]))
+	t.Logf("parsed kernel version parts: major %s, minor %s, patch %s",
+		kernelVersionParts[0], kernelVersionParts[1], kernelVersionParts[2])
+	mustConvInt := func(s string) int {
+		i, err := strconv.Atoi(s)
+		require.NoError(t, err, s)
+		return i
+	}
+	versionNewerThanFlag := false
+	if mustConvInt(kernelVersionParts[0]) > major {
+		versionNewerThanFlag = true
+	} else {
+		if mustConvInt(kernelVersionParts[0]) == major && mustConvInt(kernelVersionParts[1]) > minor {
+			versionNewerThanFlag = true
+		}
+	}
+	return versionNewerThanFlag
+}
 
 func TestGetCgroupCPU(t *testing.T) {
 	exit := make(chan struct{})
@@ -43,7 +84,12 @@ func TestGetCgroupCPU(t *testing.T) {
 	}
 	cpu, err := GetCgroupCPU()
 	if err == errNoCPUControllerDetected {
-		require.False(t, InContainer(), "Please check linux version > v4.7.x. This is related to cgroup compatibility.")
+		// for more information, please refer https://github.com/pingcap/tidb/pull/41347
+		if checkKernelVersionNewerThan(t, 4, 7) {
+			require.NoError(t, err, "linux version > v4.7 and err still happens")
+		} else {
+			t.Logf("the error '%s' is ignored because the kernel is too old", err)
+		}
 	} else {
 		require.NoError(t, err)
 		require.NotZero(t, cpu.Period)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue. 

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/39786

Problem Summary:

### What is changed and how it works?

Refine the handling of errNoCPUControllerDetected: ignore errNoCPUControllerDetected on old kernel but still panic on new kernel. Thanks a lot for the advice from @nolouch.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
