### PR TITLE
stmtv2: flush the last window before shutdown

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -871,6 +871,7 @@ func cleanup(svr *server.Server, storage kv.Storage, dom *domain.Domain, gracefu
 	plugin.Shutdown(context.Background())
 	closeDomainAndStorage(storage, dom)
 	disk.CleanUp()
+	closeStmtSummary()
 	topsql.Close()
 }
 
@@ -898,5 +899,12 @@ func setupStmtSummary() {
 		if err != nil {
 			logutil.BgLogger().Error("failed to setup statements summary", zap.Error(err))
 		}
+	}
+}
+
+func closeStmtSummary() {
+	instanceCfg := config.GetGlobalConfig().Instance
+	if instanceCfg.StmtSummaryEnablePersistent {
+		stmtsummaryv2.Close()
 	}
 }

--- a/util/stmtsummary/v2/logger.go
+++ b/util/stmtsummary/v2/logger.go
@@ -66,6 +66,10 @@ func (s *stmtLogStorage) persist(w *stmtWindow, end time.Time) {
 	w.evicted.Unlock()
 }
 
+func (s *stmtLogStorage) sync() error {
+	return s.logger.Sync()
+}
+
 func (s *stmtLogStorage) log(r *StmtRecord) {
 	b, err := json.Marshal(r)
 	if err != nil {

--- a/util/stmtsummary/v2/stmtsummary.go
+++ b/util/stmtsummary/v2/stmtsummary.go
@@ -325,10 +325,10 @@ func (s *StmtSummary) flush() {
 
 	if window.lru.Size() > 0 {
 		s.storage.persist(window, now)
-		err := s.storage.sync()
-		if err != nil {
-			logutil.BgLogger().Error("sync stmt summary failed", zap.Error(err))
-		}
+	}
+	err := s.storage.sync()
+	if err != nil {
+		logutil.BgLogger().Error("sync stmt summary failed", zap.Error(err))
 	}
 }
 

--- a/util/stmtsummary/v2/stmtsummary.go
+++ b/util/stmtsummary/v2/stmtsummary.go
@@ -314,11 +314,16 @@ func (s *StmtSummary) Close() {
 }
 
 func (s *StmtSummary) flush() {
+	now := timeNow()
+
 	s.windowLock.Lock()
-	if s.window.lru.Size() > 0 {
-		s.storage.persist(s.window, timeNow())
-	}
+	window := s.window
+	s.window = newStmtWindow(now, uint(s.MaxStmtCount()))
 	s.windowLock.Unlock()
+
+	if window.lru.Size() > 0 {
+		s.storage.persist(window, now)
+	}
 }
 
 // GetMoreThanCntBindableStmt is used to get bindable statements.

--- a/util/stmtsummary/v2/stmtsummary.go
+++ b/util/stmtsummary/v2/stmtsummary.go
@@ -523,7 +523,7 @@ func (s *mockStmtStorage) persist(w *stmtWindow, _ time.Time) {
 	s.Unlock()
 }
 
-func (s *mockStmtStorage) sync() error {
+func (*mockStmtStorage) sync() error {
 	return nil
 }
 

--- a/util/stmtsummary/v2/stmtsummary_test.go
+++ b/util/stmtsummary/v2/stmtsummary_test.go
@@ -65,3 +65,31 @@ func TestStmtSummary(t *testing.T) {
 	ss.Clear()
 	require.Equal(t, 0, w.lru.Size())
 }
+
+func TestStmtSummaryFlush(t *testing.T) {
+	storage := &mockStmtStorage{}
+	ss := NewStmtSummary4Test(1000)
+	ss.storage = storage
+
+	ss.Add(GenerateStmtExecInfo4Test("digest1"))
+	ss.Add(GenerateStmtExecInfo4Test("digest2"))
+	ss.Add(GenerateStmtExecInfo4Test("digest3"))
+
+	ss.rotate(timeNow())
+
+	ss.Add(GenerateStmtExecInfo4Test("digest1"))
+	ss.Add(GenerateStmtExecInfo4Test("digest2"))
+	ss.Add(GenerateStmtExecInfo4Test("digest3"))
+
+	ss.rotate(timeNow())
+
+	ss.Add(GenerateStmtExecInfo4Test("digest1"))
+	ss.Add(GenerateStmtExecInfo4Test("digest2"))
+	ss.Add(GenerateStmtExecInfo4Test("digest3"))
+
+	ss.Close()
+
+	storage.Lock()
+	require.Equal(t, 3, len(storage.windows))
+	storage.Unlock()
+}

--- a/util/stmtsummary/v2/tests/main_test.go
+++ b/util/stmtsummary/v2/tests/main_test.go
@@ -28,6 +28,7 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/lestrrat-go/httprc.runFetchWorker"),
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 	}
 	goleak.VerifyTestMain(m, opts...)
 }

--- a/util/stmtsummary/v2/tests/table_test.go
+++ b/util/stmtsummary/v2/tests/table_test.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"fmt"
 	"math"
+	"os"
 	"testing"
 
 	"github.com/pingcap/failpoint"
@@ -520,4 +521,5 @@ func closeStmtSummary() {
 	})
 	stmtsummaryv2.GlobalStmtSummary.Close()
 	stmtsummaryv2.GlobalStmtSummary = nil
+	_ = os.Remove(config.GetGlobalConfig().Instance.StmtSummaryFilename)
 }


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: close #41485

Problem Summary:

### What is changed and how it works?

Flush the current window when gracefully shutdown.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
