### PR TITLE
BR: move check_cdc to public pkg

### DIFF
--- a/br/pkg/lightning/restore/precheck_impl.go
+++ b/br/pkg/lightning/restore/precheck_impl.go
@@ -785,7 +785,7 @@ func (ci *CDCPITRCheckItem) Check(ctx context.Context) (*CheckResult, error) {
 	}
 
 	if !nameSet.Empty() {
-		errorMsg = append(errorMsg, nameSet.String())
+		errorMsg = append(errorMsg, nameSet.MessageToUser())
 	}
 
 	if len(errorMsg) > 0 {

--- a/br/pkg/lightning/restore/precheck_impl.go
+++ b/br/pkg/lightning/restore/precheck_impl.go
@@ -779,7 +779,7 @@ func (ci *CDCPITRCheckItem) Check(ctx context.Context) (*CheckResult, error) {
 		errorMsg = append(errorMsg, fmt.Sprintf("found PiTR log streaming task(s): %v,", names))
 	}
 
-	nameSet, err := utils.GetCDCNameSet(ctx, ci.etcdCli)
+	nameSet, err := utils.GetCDCChangefeedNameSet(ctx, ci.etcdCli)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/br/pkg/lightning/restore/precheck_impl_test.go
+++ b/br/pkg/lightning/restore/precheck_impl_test.go
@@ -650,7 +650,7 @@ func (s *precheckImplSuite) TestCDCPITRCheckItem() {
 	s.Require().NoError(err)
 	s.Require().False(result.Passed)
 	s.Require().Equal("found PiTR log streaming task(s): [br_name],\n"+
-		"found CDC changefeed(s): cluster/namespace: default/default changefeed(s): [test],\n"+
+		"found CDC changefeed(s): cluster/namespace: default/default changefeed(s): [test], \n"+
 		"local backend is not compatible with them. Please switch to tidb backend then try again.",
 		result.Message)
 
@@ -671,7 +671,7 @@ func (s *precheckImplSuite) TestCDCPITRCheckItem() {
 	s.Require().NoError(err)
 	s.Require().False(result.Passed)
 	s.Require().Equal("found PiTR log streaming task(s): [br_name],\n"+
-		"found CDC changefeed(s): cluster/namespace: <nil> changefeed(s): [test],\n"+
+		"found CDC changefeed(s): cluster/namespace: <nil> changefeed(s): [test], \n"+
 		"local backend is not compatible with them. Please switch to tidb backend then try again.",
 		result.Message)
 

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1065,7 +1065,7 @@ func checkTaskExists(ctx context.Context, cfg *RestoreConfig) error {
 		return err
 	}
 	if !nameSet.Empty() {
-		return errors.Errorf("%s please stop changefeed(s) before restore")
+		return errors.Errorf("%s please stop changefeed(s) before restore", nameSet.String())
 	}
 	return nil
 }

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1059,8 +1059,8 @@ func checkTaskExists(ctx context.Context, cfg *RestoreConfig) error {
 		return errors.Errorf("log backup task is running: %s, please stop the task before restore, and after PITR operation finished, create log-backup task again and create a full backup on this cluster", tasks[0].Info.Name)
 	}
 
-	// check cdc task
-	nameSet, err := utils.GetCDCNameSet(ctx, etcdCLI)
+	// check cdc changefeed
+	nameSet, err := utils.GetCDCChangefeedNameSet(ctx, etcdCLI)
 	if err != nil {
 		return err
 	}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1065,7 +1065,7 @@ func checkTaskExists(ctx context.Context, cfg *RestoreConfig) error {
 		return err
 	}
 	if !nameSet.Empty() {
-		return errors.Errorf("%s please stop changefeed(s) before restore", nameSet.String())
+		return errors.Errorf("%s please stop changefeed(s) before restore", nameSet.MessageToUser())
 	}
 	return nil
 }

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1050,12 +1050,22 @@ func checkTaskExists(ctx context.Context, cfg *RestoreConfig) error {
 			log.Error("failed to close the etcd client", zap.Error(err))
 		}
 	}()
+	// check log backup task
 	tasks, err := cli.GetAllTasks(ctx)
 	if err != nil {
 		return err
 	}
 	if len(tasks) > 0 {
 		return errors.Errorf("log backup task is running: %s, please stop the task before restore, and after PITR operation finished, create log-backup task again and create a full backup on this cluster", tasks[0].Info.Name)
+	}
+
+	// check cdc task
+	nameSet, err := utils.GetCDCNameSet(ctx, etcdCLI)
+	if err != nil {
+		return err
+	}
+	if !nameSet.Empty() {
+		return errors.Errorf("%s please stop changefeed(s) before restore")
 	}
 	return nil
 }

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1065,7 +1065,7 @@ func checkTaskExists(ctx context.Context, cfg *RestoreConfig) error {
 		return err
 	}
 	if !nameSet.Empty() {
-		return errors.Errorf("%s please stop changefeed(s) before restore", nameSet.MessageToUser())
+		return errors.Errorf("%splease stop changefeed(s) before restore", nameSet.MessageToUser())
 	}
 	return nil
 }

--- a/br/pkg/utils/BUILD.bazel
+++ b/br/pkg/utils/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "utils",
     srcs = [
         "backoff.go",
+        "cdc.go",
         "db.go",
         "dyn_pprof_other.go",
         "dyn_pprof_unix.go",
@@ -47,6 +48,7 @@ go_library(
         "@com_github_pingcap_log//:log",
         "@com_github_tikv_client_go_v2//oracle",
         "@com_github_tikv_pd_client//:client",
+        "@io_etcd_go_etcd_client_v3//:client",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//backoff",
         "@org_golang_google_grpc//codes",
@@ -67,6 +69,7 @@ go_test(
     timeout = "short",
     srcs = [
         "backoff_test.go",
+        "cdc_test.go",
         "db_test.go",
         "env_test.go",
         "json_test.go",
@@ -103,6 +106,8 @@ go_test(
         "@com_github_pingcap_kvproto//pkg/encryptionpb",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_pd_client//:client",
+        "@io_etcd_go_etcd_client_v3//:client",
+        "@io_etcd_go_etcd_tests_v3//integration",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
         "@org_uber_go_goleak//:goleak",

--- a/br/pkg/utils/cdc.go
+++ b/br/pkg/utils/cdc.go
@@ -45,7 +45,7 @@ func (s *CDCNameSet) String() string {
 	return changefeedMsgBuf.String()
 }
 
-func GetCDCNameSet(ctx context.Context, cli *clientv3.Client) (*CDCNameSet, error) {
+func GetCDCChangefeedNameSet(ctx context.Context, cli *clientv3.Client) (*CDCNameSet, error) {
 	nameSet := make(map[string][]string, 1)
 	// check etcd KV of CDC >= v6.2
 	resp, err := cli.Get(ctx, CDCPrefix, clientv3.WithPrefix())

--- a/br/pkg/utils/cdc.go
+++ b/br/pkg/utils/cdc.go
@@ -1,0 +1,112 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+)
+
+const (
+	CDCPrefix      = "/tidb/cdc/"
+	ChangefeedPath = "/changefeed/info/"
+	CDCPrefixV61   = "/tidb/cdc/changefeed/info/"
+)
+
+type CDCNameSet struct {
+	nameSet map[string][]string
+}
+
+func (s *CDCNameSet) Empty() bool {
+	return len(s.nameSet) == 0
+}
+
+func (s *CDCNameSet) String() string {
+	var changefeedMsgBuf strings.Builder
+	changefeedMsgBuf.WriteString("found CDC changefeed(s): ")
+	isFirst := true
+	for clusterID, captureIDs := range s.nameSet {
+		if !isFirst {
+			changefeedMsgBuf.WriteString(", ")
+		}
+		isFirst = false
+		changefeedMsgBuf.WriteString("cluster/namespace: ")
+		changefeedMsgBuf.WriteString(clusterID)
+		changefeedMsgBuf.WriteString(" changefeed(s): ")
+		changefeedMsgBuf.WriteString(fmt.Sprintf("%v", captureIDs))
+	}
+	changefeedMsgBuf.WriteString(",")
+	return changefeedMsgBuf.String()
+}
+
+func GetCDCNameSet(ctx context.Context, cli *clientv3.Client) (*CDCNameSet, error) {
+	nameSet := make(map[string][]string, 1)
+	// check etcd KV of CDC >= v6.2
+	resp, err := cli.Get(ctx, CDCPrefix, clientv3.WithPrefix())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	for _, kv := range resp.Kvs {
+		// example: /tidb/cdc/<clusterID>/<namespace>/changefeed/info/<changefeedID>
+		k := kv.Key[len(CDCPrefix):]
+		clusterAndNamespace, changefeedID, found := bytes.Cut(k, []byte(ChangefeedPath))
+		if !found {
+			continue
+		}
+		if !isActiveCDCChangefeed(kv.Value) {
+			continue
+		}
+
+		nameSet[string(clusterAndNamespace)] = append(nameSet[string(clusterAndNamespace)], string(changefeedID))
+	}
+	if len(nameSet) == 0 {
+		// check etcd KV of CDC <= v6.1
+		resp, err = cli.Get(ctx, CDCPrefixV61, clientv3.WithPrefix())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		for _, kv := range resp.Kvs {
+			// example: /tidb/cdc/changefeed/info/<changefeedID>
+			k := kv.Key[len(CDCPrefixV61):]
+			if len(k) == 0 {
+				continue
+			}
+			if !isActiveCDCChangefeed(kv.Value) {
+				continue
+			}
+
+			nameSet["<nil>"] = append(nameSet["<nil>"], string(k))
+		}
+	}
+
+	return &CDCNameSet{nameSet}, nil
+}
+
+type onlyState struct {
+	State string `json:"state"`
+}
+
+func isActiveCDCChangefeed(jsonBytes []byte) bool {
+	s := onlyState{}
+	err := json.Unmarshal(jsonBytes, &s)
+	if err != nil {
+		// maybe a compatible issue, skip this key
+		log.L().Error("unmarshal etcd value failed when check CDC changefeed, will skip this key",
+			zap.ByteString("value", jsonBytes),
+			zap.Error(err))
+		return false
+	}
+	switch s.State {
+	case "normal", "stopped", "error":
+		return true
+	default:
+		return false
+	}
+}

--- a/br/pkg/utils/cdc.go
+++ b/br/pkg/utils/cdc.go
@@ -19,15 +19,19 @@ const (
 	CDCPrefixV61   = "/tidb/cdc/changefeed/info/"
 )
 
+// CDCNameSet saves CDC changefeed's information.
+// nameSet maps `cluster/namespace` to `changefeed`s
 type CDCNameSet struct {
 	nameSet map[string][]string
 }
 
+// that the nameSet is empty means no changefeed exists.
 func (s *CDCNameSet) Empty() bool {
 	return len(s.nameSet) == 0
 }
 
-func (s *CDCNameSet) String() string {
+// MessageToUser convert the map `nameSet` to a readable message to user.
+func (s *CDCNameSet) MessageToUser() string {
 	var changefeedMsgBuf strings.Builder
 	changefeedMsgBuf.WriteString("found CDC changefeed(s): ")
 	isFirst := true
@@ -45,6 +49,9 @@ func (s *CDCNameSet) String() string {
 	return changefeedMsgBuf.String()
 }
 
+// GetCDCChangefeedNameSet gets CDC changefeed information and wraps them to a map
+// for CDC >= v6.2, the etcd key format is /tidb/cdc/<clusterID>/<namespace>/changefeed/info/<changefeedID>
+// for CDC <= v6.1, the etcd key format is /tidb/cdc/changefeed/info/<changefeedID>
 func GetCDCChangefeedNameSet(ctx context.Context, cli *clientv3.Client) (*CDCNameSet, error) {
 	nameSet := make(map[string][]string, 1)
 	// check etcd KV of CDC >= v6.2

--- a/br/pkg/utils/cdc.go
+++ b/br/pkg/utils/cdc.go
@@ -1,3 +1,16 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/br/pkg/utils/cdc.go
+++ b/br/pkg/utils/cdc.go
@@ -47,18 +47,13 @@ func (s *CDCNameSet) Empty() bool {
 func (s *CDCNameSet) MessageToUser() string {
 	var changefeedMsgBuf strings.Builder
 	changefeedMsgBuf.WriteString("found CDC changefeed(s): ")
-	isFirst := true
 	for clusterID, captureIDs := range s.nameSet {
-		if !isFirst {
-			changefeedMsgBuf.WriteString(", ")
-		}
-		isFirst = false
 		changefeedMsgBuf.WriteString("cluster/namespace: ")
 		changefeedMsgBuf.WriteString(clusterID)
 		changefeedMsgBuf.WriteString(" changefeed(s): ")
 		changefeedMsgBuf.WriteString(fmt.Sprintf("%v", captureIDs))
+		changefeedMsgBuf.WriteString(", ")
 	}
-	changefeedMsgBuf.WriteString(",")
 	return changefeedMsgBuf.String()
 }
 

--- a/br/pkg/utils/cdc_test.go
+++ b/br/pkg/utils/cdc_test.go
@@ -52,7 +52,7 @@ func TestGetCDCChangefeedNameSet(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, nameSet.Empty())
 	require.Equal(t, "found CDC changefeed(s): cluster/namespace: default/default changefeed(s): [test],",
-		nameSet.String())
+		nameSet.MessageToUser())
 
 	_, err = cli.Delete(ctx, "/tidb/cdc/", clientv3.WithPrefix())
 	require.NoError(t, err)
@@ -71,5 +71,5 @@ func TestGetCDCChangefeedNameSet(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, nameSet.Empty())
 	require.Equal(t, "found CDC changefeed(s): cluster/namespace: <nil> changefeed(s): [test],",
-		nameSet.String())
+		nameSet.MessageToUser())
 }

--- a/br/pkg/utils/cdc_test.go
+++ b/br/pkg/utils/cdc_test.go
@@ -1,0 +1,75 @@
+package utils_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tidb/br/pkg/utils"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/integration"
+)
+
+func TestGetCDCNameSet(t *testing.T) {
+	integration.BeforeTestExternal(t)
+	testEtcdCluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
+	defer testEtcdCluster.Terminate(t)
+
+	ctx := context.Background()
+	cli := testEtcdCluster.RandClient()
+	checkEtcdPut := func(key string, vals ...string) {
+		val := ""
+		if len(vals) == 1 {
+			val = vals[0]
+		}
+		_, err := cli.Put(ctx, key, val)
+		require.NoError(t, err)
+	}
+
+	nameSet, err := utils.GetCDCNameSet(ctx, cli)
+	require.NoError(t, err)
+	require.True(t, nameSet.Empty())
+
+	// TiCDC >= v6.2
+	checkEtcdPut("/tidb/cdc/default/__cdc_meta__/capture/3ecd5c98-0148-4086-adfd-17641995e71f")
+	checkEtcdPut("/tidb/cdc/default/__cdc_meta__/meta/meta-version")
+	checkEtcdPut("/tidb/cdc/default/__cdc_meta__/meta/ticdc-delete-etcd-key-count")
+	checkEtcdPut("/tidb/cdc/default/__cdc_meta__/owner/22318498f4dd6639")
+	checkEtcdPut(
+		"/tidb/cdc/default/default/changefeed/info/test",
+		`{"upstream-id":7195826648407968958,"namespace":"default","changefeed-id":"test-1","sink-uri":"mysql://root@127.0.0.1:3306?time-zone=","create-time":"2023-02-03T15:23:34.773768+08:00","start-ts":439198420741652483,"target-ts":0,"admin-job-type":0,"sort-engine":"unified","sort-dir":"","config":{"memory-quota":1073741824,"case-sensitive":true,"enable-old-value":true,"force-replicate":false,"check-gc-safe-point":true,"enable-sync-point":false,"bdr-mode":false,"sync-point-interval":600000000000,"sync-point-retention":86400000000000,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"event-filters":null},"mounter":{"worker-num":16},"sink":{"transaction-atomicity":"","protocol":"","dispatchers":null,"csv":{"delimiter":",","quote":"\"","null":"\\N","include-commit-ts":false},"column-selectors":null,"schema-registry":"","encoder-concurrency":16,"terminator":"\r\n","date-separator":"none","enable-partition-separator":false},"consistent":{"level":"none","max-log-size":64,"flush-interval":2000,"storage":""},"scheduler":{"region-per-span":0}},"state":"normal","error":null,"creator-version":"v6.5.0-master-dirty"}`,
+	)
+	checkEtcdPut(
+		"/tidb/cdc/default/default/changefeed/info/test-1",
+		`{"upstream-id":7195826648407968958,"namespace":"default","changefeed-id":"test-1","sink-uri":"mysql://root@127.0.0.1:3306?time-zone=","create-time":"2023-02-03T15:23:34.773768+08:00","start-ts":439198420741652483,"target-ts":0,"admin-job-type":0,"sort-engine":"unified","sort-dir":"","config":{"memory-quota":1073741824,"case-sensitive":true,"enable-old-value":true,"force-replicate":false,"check-gc-safe-point":true,"enable-sync-point":false,"bdr-mode":false,"sync-point-interval":600000000000,"sync-point-retention":86400000000000,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"event-filters":null},"mounter":{"worker-num":16},"sink":{"transaction-atomicity":"","protocol":"","dispatchers":null,"csv":{"delimiter":",","quote":"\"","null":"\\N","include-commit-ts":false},"column-selectors":null,"schema-registry":"","encoder-concurrency":16,"terminator":"\r\n","date-separator":"none","enable-partition-separator":false},"consistent":{"level":"none","max-log-size":64,"flush-interval":2000,"storage":""},"scheduler":{"region-per-span":0}},"state":"failed","error":null,"creator-version":"v6.5.0-master-dirty"}`,
+	)
+	checkEtcdPut("/tidb/cdc/default/default/changefeed/status/test")
+	checkEtcdPut("/tidb/cdc/default/default/changefeed/status/test-1")
+	checkEtcdPut("/tidb/cdc/default/default/task/position/3ecd5c98-0148-4086-adfd-17641995e71f/test-1")
+	checkEtcdPut("/tidb/cdc/default/default/upstream/7168358383033671922")
+
+	nameSet, err = utils.GetCDCNameSet(ctx, cli)
+	require.NoError(t, err)
+	require.False(t, nameSet.Empty())
+	require.Equal(t, "found CDC changefeed(s): cluster/namespace: default/default changefeed(s): [test],",
+		nameSet.String())
+
+	_, err = cli.Delete(ctx, "/tidb/cdc/", clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	// TiCDC <= v6.1
+	checkEtcdPut("/tidb/cdc/capture/f14cb04d-5ba1-410e-a59b-ccd796920e9d")
+	checkEtcdPut(
+		"/tidb/cdc/changefeed/info/test",
+		`{"upstream-id":7195826648407968958,"namespace":"default","changefeed-id":"test-1","sink-uri":"mysql://root@127.0.0.1:3306?time-zone=","create-time":"2023-02-03T15:23:34.773768+08:00","start-ts":439198420741652483,"target-ts":0,"admin-job-type":0,"sort-engine":"unified","sort-dir":"","config":{"memory-quota":1073741824,"case-sensitive":true,"enable-old-value":true,"force-replicate":false,"check-gc-safe-point":true,"enable-sync-point":false,"bdr-mode":false,"sync-point-interval":600000000000,"sync-point-retention":86400000000000,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null,"event-filters":null},"mounter":{"worker-num":16},"sink":{"transaction-atomicity":"","protocol":"","dispatchers":null,"csv":{"delimiter":",","quote":"\"","null":"\\N","include-commit-ts":false},"column-selectors":null,"schema-registry":"","encoder-concurrency":16,"terminator":"\r\n","date-separator":"none","enable-partition-separator":false},"consistent":{"level":"none","max-log-size":64,"flush-interval":2000,"storage":""},"scheduler":{"region-per-span":0}},"state":"stopped","error":null,"creator-version":"v6.5.0-master-dirty"}`,
+	)
+	checkEtcdPut("/tidb/cdc/job/test")
+	checkEtcdPut("/tidb/cdc/owner/223184ad80a88b0b")
+	checkEtcdPut("/tidb/cdc/task/position/f14cb04d-5ba1-410e-a59b-ccd796920e9d/test")
+
+	nameSet, err = utils.GetCDCNameSet(ctx, cli)
+	require.NoError(t, err)
+	require.False(t, nameSet.Empty())
+	require.Equal(t, "found CDC changefeed(s): cluster/namespace: <nil> changefeed(s): [test],",
+		nameSet.String())
+}

--- a/br/pkg/utils/cdc_test.go
+++ b/br/pkg/utils/cdc_test.go
@@ -10,7 +10,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/integration"
 )
 
-func TestGetCDCNameSet(t *testing.T) {
+func TestGetCDCChangefeedNameSet(t *testing.T) {
 	integration.BeforeTestExternal(t)
 	testEtcdCluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
 	defer testEtcdCluster.Terminate(t)
@@ -26,7 +26,7 @@ func TestGetCDCNameSet(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	nameSet, err := utils.GetCDCNameSet(ctx, cli)
+	nameSet, err := utils.GetCDCChangefeedNameSet(ctx, cli)
 	require.NoError(t, err)
 	require.True(t, nameSet.Empty())
 
@@ -48,7 +48,7 @@ func TestGetCDCNameSet(t *testing.T) {
 	checkEtcdPut("/tidb/cdc/default/default/task/position/3ecd5c98-0148-4086-adfd-17641995e71f/test-1")
 	checkEtcdPut("/tidb/cdc/default/default/upstream/7168358383033671922")
 
-	nameSet, err = utils.GetCDCNameSet(ctx, cli)
+	nameSet, err = utils.GetCDCChangefeedNameSet(ctx, cli)
 	require.NoError(t, err)
 	require.False(t, nameSet.Empty())
 	require.Equal(t, "found CDC changefeed(s): cluster/namespace: default/default changefeed(s): [test],",
@@ -67,7 +67,7 @@ func TestGetCDCNameSet(t *testing.T) {
 	checkEtcdPut("/tidb/cdc/owner/223184ad80a88b0b")
 	checkEtcdPut("/tidb/cdc/task/position/f14cb04d-5ba1-410e-a59b-ccd796920e9d/test")
 
-	nameSet, err = utils.GetCDCNameSet(ctx, cli)
+	nameSet, err = utils.GetCDCChangefeedNameSet(ctx, cli)
 	require.NoError(t, err)
 	require.False(t, nameSet.Empty())
 	require.Equal(t, "found CDC changefeed(s): cluster/namespace: <nil> changefeed(s): [test],",

--- a/br/pkg/utils/cdc_test.go
+++ b/br/pkg/utils/cdc_test.go
@@ -1,3 +1,16 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils_test
 
 import (

--- a/br/pkg/utils/cdc_test.go
+++ b/br/pkg/utils/cdc_test.go
@@ -64,7 +64,7 @@ func TestGetCDCChangefeedNameSet(t *testing.T) {
 	nameSet, err = utils.GetCDCChangefeedNameSet(ctx, cli)
 	require.NoError(t, err)
 	require.False(t, nameSet.Empty())
-	require.Equal(t, "found CDC changefeed(s): cluster/namespace: default/default changefeed(s): [test],",
+	require.Equal(t, "found CDC changefeed(s): cluster/namespace: default/default changefeed(s): [test], ",
 		nameSet.MessageToUser())
 
 	_, err = cli.Delete(ctx, "/tidb/cdc/", clientv3.WithPrefix())
@@ -83,6 +83,6 @@ func TestGetCDCChangefeedNameSet(t *testing.T) {
 	nameSet, err = utils.GetCDCChangefeedNameSet(ctx, cli)
 	require.NoError(t, err)
 	require.False(t, nameSet.Empty())
-	require.Equal(t, "found CDC changefeed(s): cluster/namespace: <nil> changefeed(s): [test],",
+	require.Equal(t, "found CDC changefeed(s): cluster/namespace: <nil> changefeed(s): [test], ",
 		nameSet.MessageToUser())
 }

--- a/br/pkg/utils/tools_check.go
+++ b/br/pkg/utils/tools_check.go
@@ -1,1 +1,0 @@
-package utils

--- a/br/pkg/utils/tools_check.go
+++ b/br/pkg/utils/tools_check.go
@@ -1,0 +1,1 @@
+package utils


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41504 

Problem Summary:
BR restore should be failed when the cluster has cdc changefeed running
### What is changed and how it works?
Currently lightning has the step to check whether the cdc changefeed is running. Move the step to public pkg so that BR restore can directly use it.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
