### PR TITLE
meta/autoid: fix AutoID allocation metrics for AUTO_ID_CACHE=1

### DIFF
--- a/meta/autoid/autoid_service.go
+++ b/meta/autoid/autoid_service.go
@@ -134,6 +134,7 @@ retry:
 		Offset:     offset,
 		IsUnsigned: sp.isUnsigned,
 	})
+	metrics.AutoIDHistogram.WithLabelValues(metrics.TableAutoIDAlloc, metrics.RetLabel(err)).Observe(time.Since(start).Seconds())
 	if err != nil {
 		if strings.Contains(err.Error(), "rpc error") {
 			time.Sleep(backoffDuration)
@@ -186,7 +187,10 @@ func (sp *singlePointAlloc) Rebase(ctx context.Context, newBase int64, _ bool) e
 	r, ctx := tracing.StartRegionEx(ctx, "autoid.Rebase")
 	defer r.End()
 
-	return sp.rebase(ctx, newBase, false)
+	start := time.Now()
+	err := sp.rebase(ctx, newBase, false)
+	metrics.AutoIDHistogram.WithLabelValues(metrics.TableAutoIDRebase, metrics.RetLabel(err)).Observe(time.Since(start).Seconds())
+	return err
 }
 
 func (sp *singlePointAlloc) rebase(ctx context.Context, newBase int64, force bool) error {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/40322

Problem Summary:

### What is changed and how it works?

`AUTO_ID_CACHE = 1` use a different implementation, this metric in the new code path is missing

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

Run the sysbench and check the dashboard:

![image](https://user-images.githubusercontent.com/1420062/219318681-8b420ef0-1347-47bc-81e3-5ceb17fd2417.png)


- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
