### PR TITLE
executor: detach memTracker when open executor

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -254,6 +254,7 @@ func (e *HashAggExec) Close() error {
 		e.partialResultMap = nil
 		if e.memTracker != nil {
 			e.memTracker.ReplaceBytesUsed(0)
+			e.memTracker.Detach()
 		}
 		if e.listInDisk != nil {
 			firstErr = e.listInDisk.Close()
@@ -288,6 +289,9 @@ func (e *HashAggExec) Close() error {
 		if e.memTracker != nil {
 			e.memTracker.ReplaceBytesUsed(0)
 		}
+	}
+	if e.memTracker != nil {
+		e.memTracker.Detach()
 	}
 	return e.baseExecutor.Close()
 }
@@ -1305,6 +1309,9 @@ func (e *StreamAggExec) Close() error {
 		e.childResult = nil
 	}
 	e.groupChecker.reset()
+	if e.memTracker != nil {
+		e.memTracker.Detach()
+	}
 	return e.baseExecutor.Close()
 }
 

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -1295,7 +1295,6 @@ func (e *StreamAggExec) Open(ctx context.Context) error {
 	if e.memTracker != nil {
 		e.memTracker.Reset()
 	} else {
-
 		// bytesLimit <= 0 means no limit, for now we just track the memory footprint
 		e.memTracker = memory.NewTracker(e.id, -1)
 	}

--- a/executor/cte.go
+++ b/executor/cte.go
@@ -112,7 +112,11 @@ func (e *CTEExec) Open(ctx context.Context) (err error) {
 		return err
 	}
 
-	e.memTracker = memory.NewTracker(e.id, -1)
+	if e.memTracker != nil {
+		e.memTracker.Reset()
+	} else {
+		e.memTracker = memory.NewTracker(e.id, -1)
+	}
 	e.diskTracker = disk.NewTracker(e.id, -1)
 	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
 	e.diskTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.DiskTracker)
@@ -221,10 +225,6 @@ func (e *CTEExec) Close() (err error) {
 		if err = e.reopenTbls(); err != nil {
 			return err
 		}
-	}
-
-	if e.memTracker != nil {
-		e.memTracker.Detach()
 	}
 	return e.baseExecutor.Close()
 }

--- a/executor/cte.go
+++ b/executor/cte.go
@@ -223,6 +223,9 @@ func (e *CTEExec) Close() (err error) {
 		}
 	}
 
+	if e.memTracker != nil {
+		e.memTracker.Detach()
+	}
 	return e.baseExecutor.Close()
 }
 

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -229,9 +229,6 @@ func (e *IndexReaderExecutor) Close() (err error) {
 		return nil
 	}
 	e.ctx.StoreQueryFeedback(e.feedback)
-	if e.memTracker != nil {
-		e.memTracker.Detach()
-	}
 	return err
 }
 
@@ -318,7 +315,12 @@ func (e *IndexReaderExecutor) open(ctx context.Context, kvRanges []kv.KeyRange) 
 		return nil
 	}
 
-	e.memTracker = memory.NewTracker(e.id, -1)
+	if e.memTracker != nil {
+		e.memTracker.Reset()
+	} else {
+
+		e.memTracker = memory.NewTracker(e.id, -1)
+	}
 	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
 	slices.SortFunc(kvRanges, func(i, j kv.KeyRange) bool {
 		return bytes.Compare(i.StartKey, j.StartKey) < 0

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -229,6 +229,9 @@ func (e *IndexReaderExecutor) Close() (err error) {
 		return nil
 	}
 	e.ctx.StoreQueryFeedback(e.feedback)
+	if e.memTracker != nil {
+		e.memTracker.Detach()
+	}
 	return err
 }
 

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -318,7 +318,6 @@ func (e *IndexReaderExecutor) open(ctx context.Context, kvRanges []kv.KeyRange) 
 	if e.memTracker != nil {
 		e.memTracker.Reset()
 	} else {
-
 		e.memTracker = memory.NewTracker(e.id, -1)
 	}
 	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1629,6 +1629,9 @@ func (e *SelectionExec) Close() error {
 		e.childResult = nil
 	}
 	e.selected = nil
+	if e.memTracker != nil {
+		e.memTracker.Detach()
+	}
 	return e.baseExecutor.Close()
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1609,7 +1609,11 @@ func (e *SelectionExec) Open(ctx context.Context) error {
 }
 
 func (e *SelectionExec) open(ctx context.Context) error {
-	e.memTracker = memory.NewTracker(e.id, -1)
+	if e.memTracker != nil {
+		e.memTracker.Reset()
+	} else {
+		e.memTracker = memory.NewTracker(e.id, -1)
+	}
 	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
 	e.childResult = tryNewCacheChunk(e.children[0])
 	e.memTracker.Consume(e.childResult.MemoryUsage())
@@ -1629,9 +1633,6 @@ func (e *SelectionExec) Close() error {
 		e.childResult = nil
 	}
 	e.selected = nil
-	if e.memTracker != nil {
-		e.memTracker.Detach()
-	}
 	return e.baseExecutor.Close()
 }
 

--- a/executor/index_lookup_hash_join.go
+++ b/executor/index_lookup_hash_join.go
@@ -307,6 +307,9 @@ func (e *IndexNestedLoopHashJoin) Close() error {
 	e.joinChkResourceCh = nil
 	e.finished.Store(false)
 	e.prepared = false
+	if e.memTracker != nil {
+		e.memTracker.Detach()
+	}
 	return e.baseExecutor.Close()
 }
 

--- a/executor/index_lookup_hash_join.go
+++ b/executor/index_lookup_hash_join.go
@@ -128,7 +128,11 @@ func (e *IndexNestedLoopHashJoin) Open(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	e.memTracker = memory.NewTracker(e.id, -1)
+	if e.memTracker != nil {
+		e.memTracker.Reset()
+	} else {
+		e.memTracker = memory.NewTracker(e.id, -1)
+	}
 	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
 	e.cancelFunc = nil
 	e.innerPtrBytes = make([][]byte, 0, 8)
@@ -307,9 +311,6 @@ func (e *IndexNestedLoopHashJoin) Close() error {
 	e.joinChkResourceCh = nil
 	e.finished.Store(false)
 	e.prepared = false
-	if e.memTracker != nil {
-		e.memTracker.Detach()
-	}
 	return e.baseExecutor.Close()
 }
 

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -174,7 +174,11 @@ func (e *IndexMergeReaderExecutor) Open(ctx context.Context) (err error) {
 	}
 	e.finished = make(chan struct{})
 	e.resultCh = make(chan *indexMergeTableTask, atomic.LoadInt32(&LookupTableTaskChannelSize))
-	e.memTracker = memory.NewTracker(e.id, -1)
+	if e.memTracker != nil {
+		e.memTracker.Reset()
+	} else {
+		e.memTracker = memory.NewTracker(e.id, -1)
+	}
 	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
 	return nil
 }
@@ -795,9 +799,6 @@ func (e *IndexMergeReaderExecutor) Close() error {
 	e.processWorkerWg.Wait()
 	e.finished = nil
 	e.workerStarted = false
-	if e.memTracker != nil {
-		e.memTracker = nil
-	}
 	// TODO: how to store e.feedbacks
 	return nil
 }

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -795,6 +795,9 @@ func (e *IndexMergeReaderExecutor) Close() error {
 	e.processWorkerWg.Wait()
 	e.finished = nil
 	e.workerStarted = false
+	if e.memTracker != nil {
+		e.memTracker = nil
+	}
 	// TODO: how to store e.feedbacks
 	return nil
 }

--- a/executor/join.go
+++ b/executor/join.go
@@ -187,6 +187,9 @@ func (e *HashJoinExec) Close() error {
 	if e.stats != nil {
 		defer e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(e.id, e.stats)
 	}
+	if e.memTracker != nil {
+		e.memTracker.Detach()
+	}
 	err := e.baseExecutor.Close()
 	return err
 }

--- a/executor/join.go
+++ b/executor/join.go
@@ -187,9 +187,6 @@ func (e *HashJoinExec) Close() error {
 	if e.stats != nil {
 		defer e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(e.id, e.stats)
 	}
-	if e.memTracker != nil {
-		e.memTracker.Detach()
-	}
 	err := e.baseExecutor.Close()
 	return err
 }
@@ -202,7 +199,11 @@ func (e *HashJoinExec) Open(ctx context.Context) error {
 		return err
 	}
 	e.prepared = false
-	e.hashJoinCtx.memTracker = memory.NewTracker(e.id, -1)
+	if e.hashJoinCtx.memTracker != nil {
+		e.hashJoinCtx.memTracker.Reset()
+	} else {
+		e.hashJoinCtx.memTracker = memory.NewTracker(e.id, -1)
+	}
 	e.hashJoinCtx.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
 
 	e.diskTracker = disk.NewTracker(e.id, -1)

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -98,7 +98,11 @@ func (e *ProjectionExec) open(_ context.Context) error {
 	e.prepared = false
 	e.parentReqRows = int64(e.maxChunkSize)
 
-	e.memTracker = memory.NewTracker(e.id, -1)
+	if e.memTracker != nil {
+		e.memTracker.Reset()
+	} else {
+		e.memTracker = memory.NewTracker(e.id, -1)
+	}
 	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
 
 	// For now a Projection can not be executed vectorially only because it
@@ -326,9 +330,6 @@ func (e *ProjectionExec) Close() error {
 			runtimeStats.SetConcurrencyInfo(execdetails.NewConcurrencyInfo("Concurrency", int(e.numWorkers)))
 		}
 		e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(e.id, runtimeStats)
-	}
-	if e.memTracker != nil {
-		e.memTracker.Detach()
 	}
 	return e.baseExecutor.Close()
 }

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -327,6 +327,9 @@ func (e *ProjectionExec) Close() error {
 		}
 		e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(e.id, runtimeStats)
 	}
+	if e.memTracker != nil {
+		e.memTracker.Detach()
+	}
 	return e.baseExecutor.Close()
 }
 

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -272,6 +272,9 @@ func (e *TableReaderExecutor) Close() error {
 		return nil
 	}
 	e.ctx.StoreQueryFeedback(e.feedback)
+	if e.memTracker != nil {
+		e.memTracker.Detach()
+	}
 	return err
 }
 

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -142,7 +142,11 @@ func (e *TableReaderExecutor) Open(ctx context.Context) error {
 		time.Sleep(time.Millisecond * time.Duration(ms))
 	})
 
-	e.memTracker = memory.NewTracker(e.id, -1)
+	if e.memTracker != nil {
+		e.memTracker.Reset()
+	} else {
+		e.memTracker = memory.NewTracker(e.id, -1)
+	}
 	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
 
 	var err error
@@ -272,9 +276,6 @@ func (e *TableReaderExecutor) Close() error {
 		return nil
 	}
 	e.ctx.StoreQueryFeedback(e.feedback)
-	if e.memTracker != nil {
-		e.memTracker.Detach()
-	}
 	return err
 }
 

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -739,8 +739,14 @@ func (t *Tracker) DetachFromGlobalTracker() {
 
 // ReplaceBytesUsed replace bytesConsume for the tracker
 func (t *Tracker) ReplaceBytesUsed(bytes int64) {
-	t.Consume(-t.BytesConsumed())
-	t.Consume(bytes)
+	t.Consume(bytes - t.BytesConsumed())
+}
+
+// Reset detach the tracker from the old parent and clear the old children. The label and byteLimit would not be reset.
+func (t *Tracker) Reset() {
+	t.Detach()
+	t.ReplaceBytesUsed(0)
+	t.mu.children = nil
 }
 
 func (t *Tracker) getParent() *Tracker {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41476 

Problem Summary:

### What is changed and how it works?
Detach memTracker from the parent executor in Open.
Apply will open and close the child executor over and over again, if the memory tracker is not detached, there will be too many small Tracker objects held by the parent, and thus cause high memory pressure.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
steps: https://github.com/pingcap/tidb/issues/41476#issuecomment-1434308990
before this commit:
<img width="1696" alt="截屏2023-02-17 22 26 07" src="https://user-images.githubusercontent.com/9039012/219681507-16253055-7926-4f98-9134-9158537b5302.png">

after this commit:
<img width="1831" alt="截屏2023-02-20 11 56 56" src="https://user-images.githubusercontent.com/9039012/220006047-be1380a3-e086-4f4b-9686-0de92d42cfed.png">



- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
