### PR TITLE
ddl: move some dist-reorg code to dist_* files and add the generate prefix key function 

### DIFF
--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -85,7 +85,7 @@ var NewSession = newSession
 // GetJobWithoutPartition is only used for test.
 const GetJobWithoutPartition = getJobWithoutPartition
 
-// BackfillJobPrefixKeyString is onley used for test.
+// BackfillJobPrefixKeyString is only used for test.
 func BackfillJobPrefixKeyString(ddlJobID int64, eleKey kv.Key, eleID int64) string {
 	return backfillJobPrefixKeyString(ddlJobID, eleKey, eleID)
 }

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -85,6 +85,11 @@ var NewSession = newSession
 // GetJobWithoutPartition is only used for test.
 const GetJobWithoutPartition = getJobWithoutPartition
 
+// BackfillJobPrefixKeyString is onley used for test.
+func BackfillJobPrefixKeyString(ddlJobID int64, eleKey kv.Key, eleID int64) string {
+	return backfillJobPrefixKeyString(ddlJobID, eleKey, eleID)
+}
+
 // GetDDLCtx returns ddlCtx for test.
 func GetDDLCtx(d DDL) *ddlCtx {
 	return d.(*ddl).ddlCtx

--- a/ddl/dist_backfilling.go
+++ b/ddl/dist_backfilling.go
@@ -79,7 +79,7 @@ type BackfillJob struct {
 
 // PrefixKeyString returns the BackfillJob's prefix key.
 func (bj *BackfillJob) PrefixKeyString() string {
-	return fmt.Sprintf(backfillJobPrefixKey, bj.JobID, hex.EncodeToString(bj.EleKey), bj.EleID)
+	return backfillJobPrefixKeyString(bj.JobID, bj.EleKey, bj.EleID)
 }
 
 func (bj *BackfillJob) keyString() string {

--- a/ddl/dist_backfilling.go
+++ b/ddl/dist_backfilling.go
@@ -41,6 +41,7 @@ import (
 
 const (
 	getJobWithoutPartition = -1
+	backfillJobPrefixKey   = "%d_%s_%d_%%"
 
 	// InstanceLease is the instance lease.
 	InstanceLease                = 1 * time.Minute
@@ -55,6 +56,10 @@ const (
 
 // RetrySQLInterval is export for test.
 var RetrySQLInterval = 300 * time.Millisecond
+
+func backfillJobPrefixKeyString(ddlJobID int64, eleKey kv.Key, eleID int64) string {
+	return fmt.Sprintf(backfillJobPrefixKey, ddlJobID, hex.EncodeToString(eleKey), eleID)
+}
 
 // BackfillJob is for a tidb_background_subtask table's record.
 type BackfillJob struct {
@@ -74,7 +79,11 @@ type BackfillJob struct {
 
 // PrefixKeyString returns the BackfillJob's prefix key.
 func (bj *BackfillJob) PrefixKeyString() string {
-	return fmt.Sprintf("%d_%s_%d_%%", bj.JobID, hex.EncodeToString(bj.EleKey), bj.EleID)
+	return fmt.Sprintf(backfillJobPrefixKey, bj.JobID, hex.EncodeToString(bj.EleKey), bj.EleID)
+}
+
+func (bj *BackfillJob) keyString() string {
+	return fmt.Sprintf("%d_%s_%d_%d", bj.JobID, hex.EncodeToString(bj.EleKey), bj.EleID, bj.ID)
 }
 
 // AbbrStr returns the BackfillJob's info without the Meta info.

--- a/ddl/dist_owner.go
+++ b/ddl/dist_owner.go
@@ -500,7 +500,7 @@ func GetBackfillErr(sess *session, bjPrefixKey string) error {
 	var err error
 	var metas []*model.BackfillMeta
 	for i := 0; i < retrySQLTimes; i++ {
-		metas, err = GetBackfillMetas(sess, BackgroundSubtaskHistoryTable, bjPrefixKey, "get_backfill_job_metas")
+		metas, err = GetBackfillMetas(sess, BackgroundSubtaskHistoryTable, fmt.Sprintf("task_key like '%s'", bjPrefixKey), "get_backfill_job_metas")
 		if err == nil {
 			for _, m := range metas {
 				if m.Error != nil {

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1374,8 +1374,7 @@ func (w *baseIndexWorker) UpdateTask(bfJob *BackfillJob) error {
 	s := newSession(w.backfillCtx.sessCtx)
 
 	return s.runInTxn(func(se *session) error {
-		jobs, err := GetBackfillJobs(se, BackgroundSubtaskTable, fmt.Sprintf("task_key = '%d_%s_%d_%d'",
-			bfJob.JobID, hex.EncodeToString(bfJob.EleKey), bfJob.EleID, bfJob.ID), "update_backfill_task")
+		jobs, err := GetBackfillJobs(se, BackgroundSubtaskTable, fmt.Sprintf("task_key = '%s'", bfJob.keyString()), "update_backfill_task")
 		if err != nil {
 			return err
 		}

--- a/ddl/job_table_test.go
+++ b/ddl/job_table_test.go
@@ -597,9 +597,9 @@ func TestSimpleExecBackfillJobs(t *testing.T) {
 	tk.MustQuery(fmt.Sprintf("select exec_id, exec_expired from mysql.tidb_background_subtask where task_key like \"%%%d\" and  %s", bJobs1[1].ID, getIdxConditionStr(jobID1, eleID1))).
 		Check(testkit.Rows(" 0000-00-00 00:00:00"))
 	// test GetBackfillMetas
-	bfErr := ddl.GetBackfillErr(se, jobID1, eleID1, eleKey)
+	bfErr := ddl.GetBackfillErr(se, getIdxConditionStr(jobID1, eleID1))
 	require.Error(t, bfErr, dbterror.ErrCancelledDDLJob)
-	bfErr = ddl.GetBackfillErr(se, jobID2, eleID2, eleKey)
+	bfErr = ddl.GetBackfillErr(se, getIdxConditionStr(jobID2, eleID2))
 	require.NoError(t, bfErr)
 
 	bJobs1[0].State = model.JobStateNone


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/41576

Problem Summary:

- Move some dist-reorg code from backfilling.go to dist_* files (The code hasn't changed at all)
- Add the function of generating prefix key and key, unified generating backfill job key.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
