### PR TITLE
txn: fix the point get data read for RC

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2216,7 +2216,10 @@ func (b *executorBuilder) updateForUpdateTSIfNeeded(selectPlan plannercore.Physi
 	if !txnCtx.IsPessimistic {
 		return nil
 	}
-	if _, ok := selectPlan.(*plannercore.PointGetPlan); ok {
+
+	// The `forUpdateTS` should be refreshed for RC, or the `pointGetExecutor` may not read
+	// the latest data and no pessimistic locks would be acquired, thus the result is unexpected.
+	if _, ok := selectPlan.(*plannercore.PointGetPlan); ok && !b.ctx.GetSessionVars().IsPessimisticReadConsistency() {
 		return nil
 	}
 	// Activate the invalid txn, use the txn startTS as newForUpdateTS


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41581 

Problem Summary:
The point get read result is unexpected if RC is used with DML statements.

### What is changed and how it works?
Update the `forUpdateTS` when building `insert/delete/update/select for update` executors, to ensure the `pointGetExecutor` may use the correct timestamp to read.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

Documentation


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the incorrect result when RC is used with update.
```
