### PR TITLE
ttl: Add a http api to trigger TTL job manually for test

### DIFF
--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "//table",
         "//table/tables",
         "//tablecodec",
+        "//ttl/client",
         "//types",
         "//util",
         "//util/arena",

--- a/server/http_handler_serial_test.go
+++ b/server/http_handler_serial_test.go
@@ -604,7 +604,8 @@ func TestTTL(t *testing.T) {
 			selectSQL += " where status = '" + status + "'"
 		}
 
-		rs := dbt.MustQuery(selectSQL)
+		rs, err := db.Query(selectSQL)
+		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, rs.Close())
 		}()

--- a/server/http_handler_serial_test.go
+++ b/server/http_handler_serial_test.go
@@ -605,15 +605,18 @@ func TestTTL(t *testing.T) {
 		}
 
 		rs := dbt.MustQuery(selectSQL)
-		require.NoError(t, rs.Err())
 		defer func() {
 			require.NoError(t, rs.Close())
 		}()
 
 		cnt := -1
-		require.True(t, rs.Next())
+		rowNum := 0
+		for rs.Next() {
+			rowNum++
+			require.Equal(t, 1, rowNum)
+			require.NoError(t, rs.Scan(&cnt))
+		}
 		require.NoError(t, rs.Err())
-		require.NoError(t, rs.Scan(&cnt))
 		return cnt
 	}
 
@@ -654,6 +657,7 @@ func TestTTL(t *testing.T) {
 		require.Equal(t, expectedJobCnt, getJobCnt(""))
 		waitAllJobsFinish()
 		obj, err = doTrigger()
+		require.NoError(t, err)
 		expectedJobCnt++
 	}
 

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -417,6 +417,9 @@ func (s *Server) startHTTPServer() {
 	// ddlHook is enabled only for tests so we can substitute the callback in the DDL.
 	router.Handle("/test/ddl/hook", &ddlHookHandler{tikvHandlerTool.Store.(kv.Storage)})
 
+	// ttlJobTriggerHandler is enabled only for tests, so we can accelerate the schedule of TTL job
+	router.Handle("/test/ttl/trigger/{db}/{table}", &ttlJobTriggerHandler{tikvHandlerTool.Store.(kv.Storage)})
+
 	var (
 		httpRouterPage bytes.Buffer
 		pathTemplate   string


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41597

Problem Summary:

Expose a http api to trigger TTL job manually to make it easier for some integration tests. You can do it like this:

```
curl -X POST http://127.0.0.1:10081/test/ttl/trigger/test/t1
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
