### PR TITLE
distsql: refine code for setting LimitSize of kvRequest

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -153,13 +153,15 @@ func (builder *RequestBuilder) SetDAGRequest(dag *tipb.DAGRequest) *RequestBuild
 		builder.Request.Cacheable = true
 		builder.Request.Data, builder.err = dag.Marshal()
 	}
-	// When the DAG is just simple scan and small limit, set concurrency to 1 would be sufficient.
-	if len(dag.Executors) == 2 && dag.Executors[1].GetLimit() != nil {
-		limit := dag.Executors[1].GetLimit()
-		if limit != nil && limit.Limit < estimatedRegionRowCount {
-			builder.Request.Concurrency = 1
-		}
+	if execCnt := len(dag.Executors); execCnt != 0 && dag.Executors[execCnt-1].GetLimit() != nil {
+		limit := dag.Executors[execCnt-1].GetLimit()
 		builder.Request.LimitSize = limit.GetLimit()
+		// When the DAG is just simple scan and small limit, set concurrency to 1 would be sufficient.
+		if execCnt == 2 {
+			if limit.Limit < estimatedRegionRowCount {
+				builder.Request.Concurrency = 1
+			}
+		}
 	}
 	return builder
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41591 

Problem Summary:

### What is changed and how it works?
https://github.com/pingcap/tidb/pull/41120 fix the problem partly.
This PR refines the code of check logic.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Before:
``` sql
+----------------------------------+----------+---------+-----------+--------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------+----------+------+
| TopN_9                           | 0.07     | 100     | root      |                                                  | time:3.28s, loops:2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | test.present.deadline_time, offset:0, count:100 | 7.73 KB  | N/A  |
| └─IndexLookUp_17                 | 0.07     | 6700    | root      | partition:p0                                     | time:3.28s, loops:9, index_task: {total_time: 2.9s, fetch_handle: 2.9s, build: 24.2µs, wait: 63.6µs}, table_task: {total_time: 1.35s, num: 7, concurrency: 5}, next: {wait_index: 1.97s, wait_table_lookup_build: 4.46ms, wait_table_lookup_resp: 1.3s}                                                                                                                                                                                                                                                                                                         |                                                 | 404.0 KB | N/A  |
|   ├─Limit_16(Build)              | 0.07     | 6700    | cop[tikv] |                                                  | time:2.89s, loops:13, cop_task: {num: 67, max: 128.9ms, min: 39.6ms, avg: 43.3ms, p95: 44.1ms, max_proc_keys: 224, p95_proc_keys: 224, rpc_num: 67, rpc_time: 2.9s, copr_cache_hit_ratio: 0.00, build_task_duration: 58.7µs, max_distsql_concurrency: 1}, tikv_task:{proc max:1ms, min:0s, avg: 134.3µs, p80:0s, p95:1ms, iters:201, tasks:67}, scan_detail: {total_process_keys: 15000, total_process_keys_size: 1260000, total_keys: 15067, get_snapshot_time: 1.8ms, rocksdb: {key_skipped_count: 15000, block: {cache_hit_count: 151}}}                     | offset:0, count:100                             | N/A      | N/A  |
|   │ └─Selection_15               | 0.07     | 15000   | cop[tikv] |                                                  | tikv_task:{proc max:1ms, min:0s, avg: 134.3µs, p80:0s, p95:1ms, iters:201, tasks:67}                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | eq(test.present.delete_time, 0)                 | N/A      | N/A  |
|   │   └─IndexRangeScan_13        | 25093.65 | 15000   | cop[tikv] | table:present, index:idx(user_id, deadline_time) | tikv_task:{proc max:1ms, min:0s, avg: 134.3µs, p80:0s, p95:1ms, iters:201, tasks:67}                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | range:[1,1], keep order:false                   | N/A      | N/A  |
|   └─TableRowIDScan_14(Probe)     | 0.07     | 6700    | cop[tikv] | table:present                                    | time:1.35s, loops:18, cop_task: {num: 7, max: 543ms, min: 41.4ms, avg: 192.5ms, p95: 543ms, max_proc_keys: 3200, p95_proc_keys: 3200, tot_proc: 128ms, rpc_num: 7, rpc_time: 1.35s, copr_cache_hit_ratio: 0.43, build_task_duration: 306.9µs, max_distsql_concurrency: 1}, tikv_task:{proc max:79ms, min:4ms, avg: 22.6ms, p80:27ms, p95:79ms, iters:33, tasks:7}, scan_detail: {total_process_keys: 5700, total_process_keys_size: 353400, total_keys: 11400, get_snapshot_time: 357µs, rocksdb: {key_skipped_count: 5700, block: {cache_hit_count: 22800}}}   | keep order:false                                | N/A      | N/A  |
+----------------------------------+----------+---------+-----------+--------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------+----------+------+
6 rows in set (3.33 sec)
```

After:
``` sql
+----------------------------------+----------+---------+-----------+--------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------+---------+------+
| id                               | estRows  | actRows | task      | access object                                    | execution info                                                                                                                                                                                                                                                                                                                                                                                                                | operator info                                   | memory  | disk |
+----------------------------------+----------+---------+-----------+--------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------+---------+------+
| TopN_9                           | 0.07     | 100     | root      |                                                  | time:85.7ms, loops:2                                                                                                                                                                                                                                                                                                                                                                                                          | test.present.deadline_time, offset:0, count:100 | 5.82 KB | N/A  |
| └─IndexLookUp_17                 | 0.07     | 100     | root      | partition:p0                                     | time:85.6ms, loops:2, index_task: {total_time: 42.2ms, fetch_handle: 42.1ms, build: 1.65µs, wait: 5.94µs}, table_task: {total_time: 43.2ms, num: 1, concurrency: 5}, next: {wait_index: 42.4ms, wait_table_lookup_build: 161.1µs, wait_table_lookup_resp: 43ms}                                                                                                                                                               |                                                 | 8.63 KB | N/A  |
|   ├─Limit_16(Build)              | 0.07     | 100     | cop[tikv] |                                                  | time:42ms, loops:2, cop_task: {num: 1, max: 41.9ms, proc_keys: 224, rpc_num: 1, rpc_time: 41.8ms, copr_cache_hit_ratio: 0.00, build_task_duration: 90.9µs, max_distsql_concurrency: 1}, tikv_task:{time:0s, loops:3}, scan_detail: {total_process_keys: 224, total_process_keys_size: 18816, total_keys: 225, get_snapshot_time: 41.2µs, rocksdb: {key_skipped_count: 224, block: {cache_hit_count: 2}}}                      | offset:0, count:100                             | N/A     | N/A  |
|   │ └─Selection_15               | 0.07     | 224     | cop[tikv] |                                                  | tikv_task:{time:0s, loops:3}                                                                                                                                                                                                                                                                                                                                                                                                  | eq(test.present.delete_time, 0)                 | N/A     | N/A  |
|   │   └─IndexRangeScan_13        | 25093.65 | 224     | cop[tikv] | table:present, index:idx(user_id, deadline_time) | tikv_task:{time:0s, loops:3}                                                                                                                                                                                                                                                                                                                                                                                                  | range:[1,1], keep order:false                   | N/A     | N/A  |
|   └─TableRowIDScan_14(Probe)     | 0.07     | 100     | cop[tikv] | table:present                                    | time:42.9ms, loops:2, cop_task: {num: 1, max: 42.8ms, proc_keys: 100, tot_proc: 2ms, rpc_num: 1, rpc_time: 42.7ms, copr_cache_hit_ratio: 0.00, build_task_duration: 22.9µs, max_distsql_concurrency: 1}, tikv_task:{time:2ms, loops:3}, scan_detail: {total_process_keys: 100, total_process_keys_size: 6200, total_keys: 200, get_snapshot_time: 75.4µs, rocksdb: {key_skipped_count: 100, block: {cache_hit_count: 400}}}   | keep order:false                                | N/A     | N/A  |
+----------------------------------+----------+---------+-----------+--------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------+---------+------+
6 rows in set (0.13 sec)
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
