### PR TITLE
*: visible default resource group

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -88,6 +88,8 @@ const (
 	// Once tiflashCheckPendingTablesLimit is reached, we trigger a limiter detection.
 	tiflashCheckPendingTablesLimit = 100
 	tiflashCheckPendingTablesRetry = 7
+	// DefaultResourceGroupName is the default resource group name.
+	DefaultResourceGroupName = "default"
 )
 
 func (d *ddl) CreateSchema(ctx sessionctx.Context, stmt *ast.CreateDatabaseStmt) (err error) {
@@ -7826,10 +7828,6 @@ func (d *ddl) AddResourceGroup(ctx sessionctx.Context, stmt *ast.CreateResourceG
 		return infoschema.ErrResourceGroupExists.GenWithStackByArgs(groupName)
 	}
 
-	if groupName.L == variable.DefaultResourceGroupName {
-		return errors.Trace(infoschema.ErrReservedSyntax.GenWithStackByArgs(groupName))
-	}
-
 	if err := d.checkResourceGroupValidation(groupInfo); err != nil {
 		return err
 	}
@@ -7860,6 +7858,9 @@ func (d *ddl) checkResourceGroupValidation(groupInfo *model.ResourceGroupInfo) e
 // DropResourceGroup implements the DDL interface.
 func (d *ddl) DropResourceGroup(ctx sessionctx.Context, stmt *ast.DropResourceGroupStmt) (err error) {
 	groupName := stmt.ResourceGroupName
+	if groupName.L == DefaultResourceGroupName {
+		return resourcegroup.ErrDroppingInternalResourceGroup
+	}
 	is := d.GetInfoSchemaWithInterceptor(ctx)
 	// Check group existence.
 	group, ok := is.ResourceGroupByName(groupName)

--- a/ddl/resourcegroup/errors.go
+++ b/ddl/resourcegroup/errors.go
@@ -31,6 +31,4 @@ var (
 	ErrUnknownResourceGroupMode = errors.New("unknown resource group mode")
 	// ErrDroppingInternalResourceGroup is from group.go
 	ErrDroppingInternalResourceGroup = errors.New("can't drop internal resource groups")
-	// ErrRUOutOfRang is from group.go
-	ErrRUOutOfRang = errors.Errorf("RU_PER_SEC must be an integer in [%d, %d]", MinRUFillRate, MaxRUFillRate)
 )

--- a/ddl/resourcegroup/errors.go
+++ b/ddl/resourcegroup/errors.go
@@ -29,4 +29,8 @@ var (
 	ErrInvalidResourceGroupDuplicatedMode = errors.New("cannot set RU mode and Raw mode options at the same time")
 	// ErrUnknownResourceGroupMode is from group.go.
 	ErrUnknownResourceGroupMode = errors.New("unknown resource group mode")
+	// ErrDroppingInternalResourceGroup is from group.go
+	ErrDroppingInternalResourceGroup = errors.New("can't drop internal resource groups")
+	// ErrRUOutOfRang is from group.go
+	ErrRUOutOfRang = errors.Errorf("RU_PER_SEC must be an integer in [%d, %d]", MinRUFillRate, MaxRUFillRate)
 )

--- a/ddl/resourcegroup/errors.go
+++ b/ddl/resourcegroup/errors.go
@@ -30,5 +30,5 @@ var (
 	// ErrUnknownResourceGroupMode is from group.go.
 	ErrUnknownResourceGroupMode = errors.New("unknown resource group mode")
 	// ErrDroppingInternalResourceGroup is from group.go
-	ErrDroppingInternalResourceGroup = errors.New("can't drop internal resource groups")
+	ErrDroppingInternalResourceGroup = errors.New("can't drop reserved resource group")
 )

--- a/ddl/resourcegroup/group.go
+++ b/ddl/resourcegroup/group.go
@@ -22,12 +22,6 @@ import (
 // MaxGroupNameLength is max length of the name of a resource group
 const MaxGroupNameLength = 32
 
-// MinRUFillRate defines the lower boundary of RU fill rate
-const MinRUFillRate = 1
-
-// MaxRUFillRate defines the higher boundary of RU fill rate
-const MaxRUFillRate = 10000000
-
 // NewGroupFromOptions creates a new resource group from the given options.
 func NewGroupFromOptions(groupName string, options *model.ResourceGroupSettings) (*rmpb.ResourceGroup, error) {
 	if options == nil {
@@ -41,9 +35,6 @@ func NewGroupFromOptions(groupName string, options *model.ResourceGroupSettings)
 		Name: groupName,
 	}
 	if options.RURate > 0 {
-		if options.RURate > MaxRUFillRate || options.RURate < MinRUFillRate {
-			return nil, ErrRUOutOfRang
-		}
 		group.Mode = rmpb.GroupMode_RUMode
 		group.RUSettings = &rmpb.GroupRequestUnitSettings{
 			RU: &rmpb.TokenBucket{

--- a/ddl/resourcegroup/group.go
+++ b/ddl/resourcegroup/group.go
@@ -22,6 +22,12 @@ import (
 // MaxGroupNameLength is max length of the name of a resource group
 const MaxGroupNameLength = 32
 
+// MinRUFillRate defines the lower boundary of RU fill rate
+const MinRUFillRate = 1
+
+// MaxRUFillRate defines the higher boundary of RU fill rate
+const MaxRUFillRate = 10000000
+
 // NewGroupFromOptions creates a new resource group from the given options.
 func NewGroupFromOptions(groupName string, options *model.ResourceGroupSettings) (*rmpb.ResourceGroup, error) {
 	if options == nil {
@@ -30,10 +36,14 @@ func NewGroupFromOptions(groupName string, options *model.ResourceGroupSettings)
 	if len(groupName) > MaxGroupNameLength {
 		return nil, ErrTooLongResourceGroupName
 	}
+
 	group := &rmpb.ResourceGroup{
 		Name: groupName,
 	}
 	if options.RURate > 0 {
+		if options.RURate > MaxRUFillRate || options.RURate < MinRUFillRate {
+			return nil, ErrRUOutOfRang
+		}
 		group.Mode = rmpb.GroupMode_RUMode
 		group.RUSettings = &rmpb.GroupRequestUnitSettings{
 			RU: &rmpb.TokenBucket{

--- a/ddl/resourcegrouptest/resource_group_test.go
+++ b/ddl/resourcegrouptest/resource_group_test.go
@@ -50,7 +50,7 @@ func TestResourceGroupBasic(t *testing.T) {
 	hook.OnJobUpdatedExported.Store(&onJobUpdatedExportedFunc)
 	dom.DDL().SetHook(hook)
 
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 10000000 YES"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000000 YES"))
 
 	tk.MustExec("set global tidb_enable_resource_control = 'off'")
 	tk.MustGetErrCode("create user usr1 resource group rg1", mysql.ErrResourceGroupSupportDisabled)
@@ -62,7 +62,7 @@ func TestResourceGroupBasic(t *testing.T) {
 
 	tk.MustExec("alter resource group `default` ru_per_sec=10000")
 	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 10000 NO"))
-	tk.MustContainErrMsg("drop resource group `default`", "can't drop reserved resource group")
+	tk.MustContainErrMsg("drop resource group `default`", "can't drop internal resource groups")
 
 	tk.MustExec("create resource group x RU_PER_SEC=1000")
 	checkFunc := func(groupInfo *model.ResourceGroupInfo) {
@@ -91,7 +91,6 @@ func TestResourceGroupBasic(t *testing.T) {
 	tk.MustExec("set global tidb_enable_resource_control = DEFAULT")
 
 	tk.MustGetErrCode("create resource group x RU_PER_SEC=1000 ", mysql.ErrResourceGroupExists)
-	tk.MustContainErrMsg("create resource group large_rg RU_PER_SEC=20000000", "RU_PER_SEC must be an integer in")
 
 	tk.MustExec("alter resource group x RU_PER_SEC=2000 BURSTABLE")
 	g = testResourceGroupNameFromIS(t, tk.Session(), "x")

--- a/ddl/resourcegrouptest/resource_group_test.go
+++ b/ddl/resourcegrouptest/resource_group_test.go
@@ -62,7 +62,7 @@ func TestResourceGroupBasic(t *testing.T) {
 
 	tk.MustExec("alter resource group `default` ru_per_sec=10000")
 	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 10000 NO"))
-	tk.MustContainErrMsg("drop resource group `default`", "can't drop internal resource groups")
+	tk.MustContainErrMsg("drop resource group `default`", "can't drop reserved resource group")
 
 	tk.MustExec("create resource group x RU_PER_SEC=1000")
 	checkFunc := func(groupInfo *model.ResourceGroupInfo) {

--- a/ddl/resourcegrouptest/resource_group_test.go
+++ b/ddl/resourcegrouptest/resource_group_test.go
@@ -91,6 +91,7 @@ func TestResourceGroupBasic(t *testing.T) {
 	tk.MustExec("set global tidb_enable_resource_control = DEFAULT")
 
 	tk.MustGetErrCode("create resource group x RU_PER_SEC=1000 ", mysql.ErrResourceGroupExists)
+	tk.MustContainErrMsg("create resource group large_rg RU_PER_SEC=20000000", "RU_PER_SEC must be an integer in")
 
 	tk.MustExec("alter resource group x RU_PER_SEC=2000 BURSTABLE")
 	g = testResourceGroupNameFromIS(t, tk.Session(), "x")

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -744,21 +744,21 @@ func (e *DDLExec) executeAlterPlacementPolicy(s *ast.AlterPlacementPolicyStmt) e
 }
 
 func (e *DDLExec) executeCreateResourceGroup(s *ast.CreateResourceGroupStmt) error {
-	if !variable.EnableResourceControl.Load() {
+	if !variable.EnableResourceControl.Load() && !e.ctx.GetSessionVars().InRestrictedSQL {
 		return infoschema.ErrResourceGroupSupportDisabled
 	}
 	return domain.GetDomain(e.ctx).DDL().AddResourceGroup(e.ctx, s)
 }
 
 func (e *DDLExec) executeAlterResourceGroup(s *ast.AlterResourceGroupStmt) error {
-	if !variable.EnableResourceControl.Load() {
+	if !variable.EnableResourceControl.Load() && !e.ctx.GetSessionVars().InRestrictedSQL {
 		return infoschema.ErrResourceGroupSupportDisabled
 	}
 	return domain.GetDomain(e.ctx).DDL().AlterResourceGroup(e.ctx, s)
 }
 
 func (e *DDLExec) executeDropResourceGroup(s *ast.DropResourceGroupStmt) error {
-	if !variable.EnableResourceControl.Load() {
+	if !variable.EnableResourceControl.Load() && !e.ctx.GetSessionVars().InRestrictedSQL {
 		return infoschema.ErrResourceGroupSupportDisabled
 	}
 	return domain.GetDomain(e.ctx).DDL().DropResourceGroup(e.ctx, s)

--- a/session/BUILD.bazel
+++ b/session/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//config",
         "//ddl",
         "//ddl/placement",
+        "//ddl/resourcegroup",
         "//ddl/schematracker",
         "//domain",
         "//domain/infosync",

--- a/session/BUILD.bazel
+++ b/session/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//config",
         "//ddl",
         "//ddl/placement",
-        "//ddl/resourcegroup",
         "//ddl/schematracker",
         "//domain",
         "//domain/infosync",

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -834,7 +834,7 @@ const (
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version136
+var currentBootstrapVersion int64 = version137
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pingcap/tidb/bindinfo"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
-	resourcegroup "github.com/pingcap/tidb/ddl/resourcegroup"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tidb/expression"
@@ -565,11 +564,9 @@ const (
 		step INT(11),
 		key(state)
 	);`
-)
 
-var (
 	// CreateDefaultResourceGroup is the statement to create the default resource group
-	CreateDefaultResourceGroup = fmt.Sprintf("CREATE RESOURCE GROUP IF NOT EXISTS `default` RU_PER_SEC=%d BURSTABLE", resourcegroup.MaxRUFillRate)
+	CreateDefaultResourceGroup = "CREATE RESOURCE GROUP IF NOT EXISTS `default` RU_PER_SEC=1000000 BURSTABLE;"
 )
 
 // bootstrap initiates system DB for a store.

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -568,6 +568,7 @@ const (
 )
 
 var (
+	// CreateDefaultResourceGroup is the statement to create the default resource group
 	CreateDefaultResourceGroup = fmt.Sprintf("CREATE RESOURCE GROUP `default` RU_PER_SEC=%d BURSTABLE", resourcegroup.MaxRUFillRate)
 )
 

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -569,7 +569,7 @@ const (
 
 var (
 	// CreateDefaultResourceGroup is the statement to create the default resource group
-	CreateDefaultResourceGroup = fmt.Sprintf("CREATE RESOURCE GROUP `default` RU_PER_SEC=%d BURSTABLE", resourcegroup.MaxRUFillRate)
+	CreateDefaultResourceGroup = fmt.Sprintf("CREATE RESOURCE GROUP IF NOT EXISTS `default` RU_PER_SEC=%d BURSTABLE", resourcegroup.MaxRUFillRate)
 )
 
 // bootstrap initiates system DB for a store.

--- a/session/session.go
+++ b/session/session.go
@@ -2193,7 +2193,7 @@ func (s *session) ExecuteStmt(ctx context.Context, stmtNode ast.StmtNode) (sqlex
 	// Observe the resource group query total counter if the resource control is enabled and the
 	// current session is attached with a resource group.
 	resourceGroupName := s.GetSessionVars().ResourceGroupName
-	if len(resourceGroupName) > 0 && resourceGroupName != variable.DefaultResourceGroupName {
+	if len(resourceGroupName) > 0 {
 		metrics.ResourceGroupQueryTotalCounter.WithLabelValues(resourceGroupName).Inc()
 	}
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -66,9 +66,6 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// DefaultResourceGroupName is the default resource group name.
-const DefaultResourceGroupName = "default"
-
 var (
 	// PreparedStmtCount is exported for test.
 	PreparedStmtCount int64

--- a/telemetry/data_feature_usage_test.go
+++ b/telemetry/data_feature_usage_test.go
@@ -362,7 +362,7 @@ func TestResourceGroups(t *testing.T) {
 	usage, err := telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), usage.ResourceControlUsage.NumResourceGroups)
-	require.Equal(t, false, usage.ResourceControlUsage.Enabled)
+	require.Equal(t, true, usage.ResourceControlUsage.Enabled)
 
 	tk.MustExec("set global tidb_enable_resource_control = 'ON'")
 	tk.MustExec("create resource group x ru_per_sec=100")

--- a/telemetry/data_feature_usage_test.go
+++ b/telemetry/data_feature_usage_test.go
@@ -361,35 +361,35 @@ func TestResourceGroups(t *testing.T) {
 
 	usage, err := telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
-	require.Equal(t, uint64(0), usage.ResourceControlUsage.NumResourceGroups)
-	require.Equal(t, true, usage.ResourceControlUsage.Enabled)
+	require.Equal(t, uint64(1), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, false, usage.ResourceControlUsage.Enabled)
 
 	tk.MustExec("set global tidb_enable_resource_control = 'ON'")
 	tk.MustExec("create resource group x ru_per_sec=100")
 	usage, err = telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
 	require.Equal(t, true, usage.ResourceControlUsage.Enabled)
-	require.Equal(t, uint64(1), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, uint64(2), usage.ResourceControlUsage.NumResourceGroups)
 
 	tk.MustExec("create resource group y ru_per_sec=100")
 	usage, err = telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
-	require.Equal(t, uint64(2), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, uint64(3), usage.ResourceControlUsage.NumResourceGroups)
 
 	tk.MustExec("alter resource group y ru_per_sec=200")
 	usage, err = telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
-	require.Equal(t, uint64(2), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, uint64(3), usage.ResourceControlUsage.NumResourceGroups)
 
 	tk.MustExec("drop resource group y")
 	usage, err = telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, uint64(2), usage.ResourceControlUsage.NumResourceGroups)
 
 	tk.MustExec("set global tidb_enable_resource_control = 'OFF'")
 	usage, err = telemetry.GetFeatureUsage(tk.Session())
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), usage.ResourceControlUsage.NumResourceGroups)
+	require.Equal(t, uint64(2), usage.ResourceControlUsage.NumResourceGroups)
 	require.Equal(t, false, usage.ResourceControlUsage.Enabled)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40875

Problem Summary:

### What is changed and how it works?

Initialize the default resource group to resource manager, and let it readable and changeable  but not droppable. 

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Simulate the upgrade from 6.6 to nightly to verify default resource group will be created.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
