### PR TITLE
exeuctor: fix coprocessor goroutine leak for IndexMerge

### DIFF
--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -363,7 +363,7 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 
 				selectResults := make([]distsql.SelectResult, 0, len(keyRanges))
 				defer func() {
-					// Goroutine may panic and SelectResult.Close() will be ignored unexpectedly.
+					// To make sure SelectResult.Close() is called even got panic in fetchHandles().
 					for _, s := range selectResults {
 						terror.Call(s.Close)
 					}
@@ -486,7 +486,7 @@ func (e *IndexMergeReaderExecutor) startPartialTableWorker(ctx context.Context, 
 
 				var tableReaderClosed bool
 				defer func() {
-					// Goroutine may panic and SelectResult.Close() will be ignored unexpectedly.
+					// To make sure SelectResult.Close() is called even got panic in fetchHandles().
 					if !tableReaderClosed {
 						terror.Call(worker.tableReader.Close)
 					}

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -393,7 +393,7 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 					}
 					selectResults = append(selectResults, result)
 					failpoint.Inject("testIndexMergePartialIndexWorkerCoprLeak", func(v failpoint.Value) {
-						time.Sleep(time.Duration(v.(int)))
+						time.Sleep(time.Second * time.Duration(v.(int)))
 						panic("testIndexMergePartialIndexWorkerCoprLeak")
 					})
 					worker.batchSize = e.maxChunkSize
@@ -511,7 +511,7 @@ func (e *IndexMergeReaderExecutor) startPartialTableWorker(ctx context.Context, 
 						break
 					}
 					failpoint.Inject("testIndexMergePartialTableWorkerCoprLeak", func(v failpoint.Value) {
-						time.Sleep(time.Duration(v.(int)))
+						time.Sleep(time.Second * time.Duration(v.(int)))
 						panic("testIndexMergePartialTableWorkerCoprLeak")
 					})
 					tableReaderClosed = false

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -363,6 +363,7 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 
 				var notClosedSelectResult distsql.SelectResult
 				defer func() {
+					// To make sure SelectResult.Close() is called even got panic in fetchHandles().
 					if notClosedSelectResult != nil {
 						terror.Call(notClosedSelectResult.Close)
 					}
@@ -391,10 +392,7 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 						return
 					}
 					notClosedSelectResult = result
-					failpoint.Inject("testIndexMergePartialIndexWorkerCoprLeak", func(v failpoint.Value) {
-						time.Sleep(time.Second * time.Duration(v.(int)))
-						panic("testIndexMergePartialIndexWorkerCoprLeak")
-					})
+					failpoint.Inject("testIndexMergePartialIndexWorkerCoprLeak", nil)
 					worker.batchSize = e.maxChunkSize
 					if worker.batchSize > worker.maxBatchSize {
 						worker.batchSize = worker.maxBatchSize
@@ -509,10 +507,7 @@ func (e *IndexMergeReaderExecutor) startPartialTableWorker(ctx context.Context, 
 						syncErr(ctx, e.finished, fetchCh, err)
 						break
 					}
-					failpoint.Inject("testIndexMergePartialTableWorkerCoprLeak", func(v failpoint.Value) {
-						time.Sleep(time.Second * time.Duration(v.(int)))
-						panic("testIndexMergePartialTableWorkerCoprLeak")
-					})
+					failpoint.Inject("testIndexMergePartialTableWorkerCoprLeak", nil)
 					tableReaderClosed = false
 					worker.batchSize = e.maxChunkSize
 					if worker.batchSize > worker.maxBatchSize {

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -409,10 +409,10 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 					if fetchErr != nil { // this error is synced in fetchHandles(), don't sync it again
 						e.feedbacks[workID].Invalidate()
 					}
+					notClosedSelectResult = nil
 					if err := result.Close(); err != nil {
 						logutil.Logger(ctx).Error("close Select result failed:", zap.Error(err))
 					}
-					notClosedSelectResult = nil
 					cancel()
 					e.ctx.StoreQueryFeedback(e.feedbacks[workID])
 					if fetchErr != nil {
@@ -531,10 +531,10 @@ func (e *IndexMergeReaderExecutor) startPartialTableWorker(ctx context.Context, 
 
 					// release related resources
 					cancel()
+					tableReaderClosed = true
 					if err = worker.tableReader.Close(); err != nil {
 						logutil.Logger(ctx).Error("close Select result failed:", zap.Error(err))
 					}
-					tableReaderClosed = true
 					e.ctx.StoreQueryFeedback(e.feedbacks[workID])
 					if fetchErr != nil {
 						break

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -361,11 +361,10 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 					SetFromInfoSchema(e.ctx.GetInfoSchema()).
 					SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.ctx, &builder.Request, e.partialNetDataSizes[workID]))
 
-				selectResults := make([]distsql.SelectResult, 0, len(keyRanges))
+				var notClosedSelectResult distsql.SelectResult
 				defer func() {
-					// To make sure SelectResult.Close() is called even got panic in fetchHandles().
-					for _, s := range selectResults {
-						terror.Call(s.Close)
+					if notClosedSelectResult != nil {
+						terror.Call(notClosedSelectResult.Close)
 					}
 				}()
 				for parTblIdx, keyRange := range keyRanges {
@@ -391,7 +390,7 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 						syncErr(ctx, e.finished, fetchCh, err)
 						return
 					}
-					selectResults = append(selectResults, result)
+					notClosedSelectResult = result
 					failpoint.Inject("testIndexMergePartialIndexWorkerCoprLeak", func(v failpoint.Value) {
 						time.Sleep(time.Second * time.Duration(v.(int)))
 						panic("testIndexMergePartialIndexWorkerCoprLeak")
@@ -413,7 +412,7 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 					if err := result.Close(); err != nil {
 						logutil.Logger(ctx).Error("close Select result failed:", zap.Error(err))
 					}
-					selectResults = selectResults[:len(selectResults)-1]
+					notClosedSelectResult = nil
 					cancel()
 					e.ctx.StoreQueryFeedback(e.feedbacks[workID])
 					if fetchErr != nil {

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -391,6 +391,10 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 						syncErr(ctx, e.finished, fetchCh, err)
 						return
 					}
+					failpoint.Inject("testIndexMergePartialIndexWorkerCoprLeak", func(v failpoint.Value) {
+						time.Sleep(time.Duration(v.(int)))
+						panic("testIndexMergePartialIndexWorkerCoprLeak")
+					})
 					selectResults = append(selectResults, result)
 					worker.batchSize = e.maxChunkSize
 					if worker.batchSize > worker.maxBatchSize {
@@ -506,6 +510,10 @@ func (e *IndexMergeReaderExecutor) startPartialTableWorker(ctx context.Context, 
 						syncErr(ctx, e.finished, fetchCh, err)
 						break
 					}
+					failpoint.Inject("testIndexMergePartialTableWorkerCoprLeak", func(v failpoint.Value) {
+						time.Sleep(time.Duration(v.(int)))
+						panic("testIndexMergePartialTableWorkerCoprLeak")
+					})
 					tableReaderClosed = false
 					worker.batchSize = e.maxChunkSize
 					if worker.batchSize > worker.maxBatchSize {

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -391,11 +391,11 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 						syncErr(ctx, e.finished, fetchCh, err)
 						return
 					}
+					selectResults = append(selectResults, result)
 					failpoint.Inject("testIndexMergePartialIndexWorkerCoprLeak", func(v failpoint.Value) {
 						time.Sleep(time.Duration(v.(int)))
 						panic("testIndexMergePartialIndexWorkerCoprLeak")
 					})
-					selectResults = append(selectResults, result)
 					worker.batchSize = e.maxChunkSize
 					if worker.batchSize > worker.maxBatchSize {
 						worker.batchSize = worker.maxBatchSize

--- a/executor/index_merge_reader_test.go
+++ b/executor/index_merge_reader_test.go
@@ -881,3 +881,37 @@ func TestIndexMergePanic(t *testing.T) {
 		require.NoError(t, failpoint.Disable(fp))
 	}
 }
+
+func TestIndexMergeCoprGoroutinesLeak(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1(c1 int, c2 bigint, c3 bigint, primary key(c1), key(c2), key(c3));")
+	insertStr := "insert into t1 values(0, 0, 0)"
+	for i := 1; i < 1000; i++ {
+		insertStr += fmt.Sprintf(", (%d, %d, %d)", i, i, i)
+	}
+	tk.MustExec(insertStr)
+	tk.MustExec("analyze table t1;")
+	tk.MustExec("set tidb_partition_prune_mode = 'dynamic'")
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/testIndexMergePartialTableWorkerCoprLeak", "return(3)"))
+
+	sql := fmt.Sprintf("select /*+ use_index_merge(t1) */ c1 from t1 where c1 < 900 or c2 < 1000;")
+	res := tk.MustQuery("explain " + sql).Rows()
+	require.Contains(t, res[1][0], "IndexMerge")
+
+	err := tk.QueryToErr(sql)
+	require.Contains(t, err.Error(), "testIndexMergePartialTableWorkerCoprLeak")
+
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/executor/testIndexMergePartialTableWorkerCoprLeak"))
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/testIndexMergePartialIndexWorkerCoprLeak", "return(3)"))
+
+	err = tk.QueryToErr(sql)
+	require.Contains(t, err.Error(), "testIndexMergePartialIndexWorkerCoprLeak")
+
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/executor/testIndexMergePartialIndexWorkerCoprLeak"))
+}

--- a/executor/index_merge_reader_test.go
+++ b/executor/index_merge_reader_test.go
@@ -903,12 +903,12 @@ func TestIndexMergeCoprGoroutinesLeak(t *testing.T) {
 	require.Contains(t, res[1][0], "IndexMerge")
 
 	// If got goroutines leak in coprocessor, ci will fail.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/testIndexMergePartialTableWorkerCoprLeak", "return(3)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/testIndexMergePartialTableWorkerCoprLeak", `panic("testIndexMergePartialTableWorkerCoprLeak")`))
 	err = tk.QueryToErr(sql)
 	require.Contains(t, err.Error(), "testIndexMergePartialTableWorkerCoprLeak")
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/executor/testIndexMergePartialTableWorkerCoprLeak"))
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/testIndexMergePartialIndexWorkerCoprLeak", "return(3)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/testIndexMergePartialIndexWorkerCoprLeak", `panic("testIndexMergePartialIndexWorkerCoprLeak")`))
 	err = tk.QueryToErr(sql)
 	require.Contains(t, err.Error(), "testIndexMergePartialIndexWorkerCoprLeak")
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/executor/testIndexMergePartialIndexWorkerCoprLeak"))

--- a/executor/index_merge_reader_test.go
+++ b/executor/index_merge_reader_test.go
@@ -897,12 +897,14 @@ func TestIndexMergeCoprGoroutinesLeak(t *testing.T) {
 	tk.MustExec("analyze table t1;")
 	tk.MustExec("set tidb_partition_prune_mode = 'dynamic'")
 
-	// If got goroutines leak in coprocessor, ci will fail.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/testIndexMergePartialTableWorkerCoprLeak", "return(3)"))
+	var err error
 	sql := fmt.Sprintf("select /*+ use_index_merge(t1) */ c1 from t1 where c1 < 900 or c2 < 1000;")
 	res := tk.MustQuery("explain " + sql).Rows()
 	require.Contains(t, res[1][0], "IndexMerge")
-	err := tk.QueryToErr(sql)
+
+	// If got goroutines leak in coprocessor, ci will fail.
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/testIndexMergePartialTableWorkerCoprLeak", "return(3)"))
+	err = tk.QueryToErr(sql)
 	require.Contains(t, err.Error(), "testIndexMergePartialTableWorkerCoprLeak")
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/executor/testIndexMergePartialTableWorkerCoprLeak"))
 

--- a/executor/index_merge_reader_test.go
+++ b/executor/index_merge_reader_test.go
@@ -898,7 +898,7 @@ func TestIndexMergeCoprGoroutinesLeak(t *testing.T) {
 	tk.MustExec("set tidb_partition_prune_mode = 'dynamic'")
 
 	var err error
-	sql := fmt.Sprintf("select /*+ use_index_merge(t1) */ c1 from t1 where c1 < 900 or c2 < 1000;")
+	sql := "select /*+ use_index_merge(t1) */ c1 from t1 where c1 < 900 or c2 < 1000;"
 	res := tk.MustQuery("explain " + sql).Rows()
 	require.Contains(t, res[1][0], "IndexMerge")
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41605

Problem Summary: As issue said, for partialIndexWorker and partialTableWorker of IndexMerge, we may failed to call `SelectResult.Close` when got panic(oom) in `IndexMerge.fetchHandles()`. Therefore goroutines in coprocessor that tries to send copResp will stuck, because receiver already panic and `copIterator.finishCh` is never closed.

### What is changed and how it works?


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
exeuctor: fix coprocessor goroutine leak for IndexMerge
```
