### PR TITLE
executor: optimize update multi-valued index performance

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -442,9 +442,10 @@ func TestInsertForMultiValuedIndex(t *testing.T) {
 	tk.MustQuery(`select * from t1;`).Check(testkit.Rows(`[1, 11] 1`, `[2, 22] 2`))
 	tk.MustExec(`insert into t1 values ('[2]', 2) on duplicate key update b = 10;`)
 	tk.MustQuery(`select * from t1;`).Check(testkit.Rows(`[1, 11] 1`, `[2, 22] 10`))
-	tk.MustGetErrMsg(`insert into t1 values ('[2, 1]', 2) on duplicate key update a = '[1,2]';`, "[kv:1062]Duplicate entry '[1, 2]' for key 't1.idx'")
-	tk.MustGetErrMsg(`insert into t1 values ('[1,2]', 2) on duplicate key update a = '[1,2]';`, "[kv:1062]Duplicate entry '[1, 2]' for key 't1.idx'")
-	tk.MustGetErrMsg(`insert into t1 values ('[11, 22]', 2) on duplicate key update a = '[1,2]';`, "[kv:1062]Duplicate entry '[1, 2]' for key 't1.idx'")
+	tk.MustGetErrMsg(`insert into t1 values ('[2, 1]', 2) on duplicate key update a = '[1,2]';`, "[kv:1062]Duplicate entry '[1]' for key 't1.idx'")
+	tk.MustGetErrMsg(`insert into t1 values ('[1,2]', 2) on duplicate key update a = '[1,2]';`, "[kv:1062]Duplicate entry '[2]' for key 't1.idx'")
+	tk.MustGetErrMsg(`insert into t1 values ('[11, 22]', 2) on duplicate key update a = '[1,2]';`, "[kv:1062]Duplicate entry '[2]' for key 't1.idx'")
+	tk.MustGetErrMsg(`insert into t1 values ('[22, 11]', 2) on duplicate key update a = '[1,2]';`, "[kv:1062]Duplicate entry '[1]' for key 't1.idx'")
 }
 
 func TestInsertDateTimeWithTimeZone(t *testing.T) {

--- a/expression/multi_valued_index_test.go
+++ b/expression/multi_valued_index_test.go
@@ -217,6 +217,16 @@ func TestMultiValuedIndexDML(t *testing.T) {
 		tk.MustGetErrCode(`insert into t values (json_array(cast("2022-02-02" as date)));`, errno.ErrInvalidJSONValueForFuncIndex)
 		tk.MustExec(`insert into t values (json_array(cast("2022-02-02 11:00:00" as datetime)));`)
 		tk.MustGetErrCode(`insert into t values (json_array(cast('{"a":1}' as json)));`, errno.ErrInvalidJSONValueForFuncIndex)
+
+		tk.MustExec(`drop table if exists t;`)
+		tk.MustExec(`create table t(a json, index idx((cast(a as signed array))));`)
+		tk.MustExec(`insert into t values ('[1,2,3]');`)
+		tk.MustExec(`insert into t values ('[-1]');`)
+		tk.MustExec(`insert into t values ('[]');`)
+		tk.MustExec(`insert into t values (null);`)
+		tk.MustExec(`admin check table t`)
+		tk.MustExec(`update t set a = '[2,3,-1]'`)
+		tk.MustExec(`admin check table t`)
 	}
 }
 

--- a/expression/multi_valued_index_test.go
+++ b/expression/multi_valued_index_test.go
@@ -227,6 +227,8 @@ func TestMultiValuedIndexDML(t *testing.T) {
 		tk.MustExec(`admin check table t`)
 		tk.MustExec(`update t set a = '[2,3,-1]'`)
 		tk.MustExec(`admin check table t`)
+		tk.MustExec(`update t set a = null`)
+		tk.MustExec(`admin check table t`)
 	}
 }
 

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -596,12 +596,12 @@ func buildExceptSet(left, right types.BinaryJSON) (r, i types.BinaryJSON) {
 		}
 	}
 
-	ra := make([]types.BinaryJSON, 0, len(leftMap))
+	ra := make([]any, 0, len(leftMap))
 	for _, e := range leftMap {
 		ra = append(ra, e)
 	}
 
-	ia := make([]types.BinaryJSON, 0, len(rightMap))
+	ia := make([]any, 0, len(rightMap))
 	for _, e := range rightMap {
 		ia = append(ia, e)
 	}

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -552,7 +552,7 @@ func (t *TableCommon) rebuildIndices(ctx sessionctx.Context, txn kv.Transaction,
 
 		if oldVs, ok := idxExceptMap[idx.Meta().ID]; ok {
 			for i := range oldVs {
-				if oldVs[i].Kind() == types.KindMysqlJSON {
+				if oldVs[i].Kind() == types.KindMysqlJSON && newVs[i].Kind() == types.KindMysqlJSON {
 					oj, nj := oldVs[i].GetMysqlJSON(), newVs[i].GetMysqlJSON()
 					oj, nj = buildExceptSet(oj, nj)
 					oldVs[i].SetMysqlJSON(oj)

--- a/types/json_binary.go
+++ b/types/json_binary.go
@@ -282,6 +282,16 @@ func (bj BinaryJSON) ArrayGetElem(idx int) BinaryJSON {
 	return bj.valEntryGet(headerSize + idx*valEntrySize)
 }
 
+// ToArray return a JSON array of JSONTypeCodeArray.
+func (bj BinaryJSON) ToArray() []BinaryJSON {
+	arr := make([]BinaryJSON, 0, bj.GetElemCount())
+	for i := 0; i < bj.GetElemCount(); i++ {
+		arr = append(arr, bj.ArrayGetElem(i))
+	}
+
+	return arr
+}
+
 func (bj BinaryJSON) objectGetKey(i int) []byte {
 	keyOff := int(jsonEndian.Uint32(bj.Value[headerSize+i*keyEntrySize:]))
 	keyLen := int(jsonEndian.Uint16(bj.Value[headerSize+i*keyEntrySize+keyLenOff:]))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/41619

Problem Summary:

for update `[1,2]` ==> `[2,3]`, the current implementation is removing the index of `1, 2` and rebuilding the index `2,3`, in fact, we can only remove index `1` and add the index `3` instead. this optimization can improve lot of performance when there are hundreds of elements in the array and only update few of them

before
![image](https://user-images.githubusercontent.com/20839912/221500720-9664ebe9-d59d-42c4-95af-02f4a8d33669.png)
after
![image](https://user-images.githubusercontent.com/20839912/221500771-dbfe173c-bbe1-4367-bc78-2899d29e176b.png)


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
