### PR TITLE
store/copr: set concurrency to partition number for limit statements

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -159,7 +159,11 @@ func (builder *RequestBuilder) SetDAGRequest(dag *tipb.DAGRequest) *RequestBuild
 		// When the DAG is just simple scan and small limit, set concurrency to 1 would be sufficient.
 		if execCnt == 2 {
 			if limit.Limit < estimatedRegionRowCount {
-				builder.Request.Concurrency = 1
+				if kr := builder.Request.KeyRanges; kr != nil {
+					builder.Request.Concurrency = kr.PartitionNum()
+				} else {
+					builder.Request.Concurrency = 1
+				}
 			}
 		}
 	}
@@ -273,9 +277,13 @@ func (*RequestBuilder) getKVPriority(sv *variable.SessionVars) int {
 // "Concurrency", "IsolationLevel", "NotFillCache", "TaskID", "Priority", "ReplicaRead",
 // "ResourceGroupTagger", "ResourceGroupName"
 func (builder *RequestBuilder) SetFromSessionVars(sv *variable.SessionVars) *RequestBuilder {
+	distsqlConcurrency := sv.DistSQLScanConcurrency()
 	if builder.Request.Concurrency == 0 {
-		// Concurrency may be set to 1 by SetDAGRequest
-		builder.Request.Concurrency = sv.DistSQLScanConcurrency()
+		// Concurrency unset.
+		builder.Request.Concurrency = distsqlConcurrency
+	} else if builder.Request.Concurrency > distsqlConcurrency {
+		// Concurrency is set in SetDAGRequest, check the upper limit.
+		builder.Request.Concurrency = distsqlConcurrency
 	}
 	replicaReadType := sv.GetReplicaRead()
 	if sv.StmtCtx.WeakConsistency {

--- a/executor/distsqltest/BUILD.bazel
+++ b/executor/distsqltest/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "distsqltest_test",
+    srcs = [
+        "distsql_test.go",
+        "main_test.go",
+    ],
+    deps = [
+        "//config",
+        "//kv",
+        "//meta/autoid",
+        "//testkit",
+        "@com_github_stretchr_testify//require",
+        "@com_github_tikv_client_go_v2//tikv",
+        "@org_uber_go_goleak//:goleak",
+    ],
+)

--- a/executor/distsqltest/BUILD.bazel
+++ b/executor/distsqltest/BUILD.bazel
@@ -2,10 +2,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "distsqltest_test",
+    timeout = "short",
     srcs = [
         "distsql_test.go",
         "main_test.go",
     ],
+    flaky = True,
+    race = "on",
     deps = [
         "//config",
         "//kv",

--- a/executor/distsqltest/distsql_test.go
+++ b/executor/distsqltest/distsql_test.go
@@ -1,0 +1,78 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distsql_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDistsqlPartitionTableConcurrency(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1, t2, t3")
+	tk.MustExec("create table t1(id int primary key , val int)")
+	partitions := make([]string, 0, 20)
+	for i := 0; i < 20; i++ {
+		pid := i + 1
+		partitions = append(partitions, fmt.Sprintf("PARTITION p%d VALUES LESS THAN (%d00)", pid, pid))
+	}
+	tk.MustExec("create table t2(id int primary key, val int)" +
+		"partition by range(id)" +
+		"(" + strings.Join(partitions[:10], ",") + ")")
+	tk.MustExec("create table t3(id int primary key, val int)" +
+		"partition by range(id)" +
+		"(" + strings.Join(partitions, ",") + ")")
+	for i := 0; i < 20; i++ {
+		for _, tbl := range []string{"t1", "t2", "t3"} {
+			tk.MustExec(fmt.Sprintf("insert into %s values(%d, %d)", tbl, i*50, i*50))
+		}
+	}
+	tk.MustExec("analyze table t1, t2, t3")
+	// non-partitioned table checker
+	ctx1 := context.WithValue(context.Background(), "CheckSelectRequestHook", func(req *kv.Request) {
+		require.Equal(t, req.KeyRanges.PartitionNum(), 1)
+		require.Equal(t, req.Concurrency, 1)
+	})
+	// 10-ranges-partitioned table checker
+	ctx2 := context.WithValue(context.Background(), "CheckSelectRequestHook", func(req *kv.Request) {
+		require.Equal(t, req.KeyRanges.PartitionNum(), 10)
+		require.Equal(t, req.Concurrency, 10)
+	})
+	// 20-ranges-partitioned table checker
+	ctx3 := context.WithValue(context.Background(), "CheckSelectRequestHook", func(req *kv.Request) {
+		require.Equal(t, req.KeyRanges.PartitionNum(), 20)
+		require.Equal(t, req.Concurrency, 15)
+	})
+	ctxs := []context.Context{ctx1, ctx2, ctx3}
+	for i, tbl := range []string{"t1", "t2", "t3"} {
+		ctx := ctxs[i]
+		tk.MustQueryWithContext(ctx, fmt.Sprintf("select * from %s order by id asc limit 1", tbl)).
+			Check(testkit.Rows("0 0"))
+		tk.MustQueryWithContext(ctx, fmt.Sprintf("select * from %s order by id asc limit 5", tbl)).
+			Check(testkit.Rows("0 0", "50 50", "100 100", "150 150", "200 200"))
+		tk.MustQueryWithContext(ctx, fmt.Sprintf("select * from %s order by id desc limit 1", tbl)).
+			Check(testkit.Rows("950 950"))
+		tk.MustQueryWithContext(ctx, fmt.Sprintf("select * from %s order by id desc limit 5", tbl)).
+			Check(testkit.Rows("950 950", "900 900", "850 850", "800 800", "750 750"))
+	}
+}

--- a/executor/distsqltest/main_test.go
+++ b/executor/distsqltest/main_test.go
@@ -1,0 +1,44 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distsql_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/meta/autoid"
+	"github.com/tikv/client-go/v2/tikv"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	autoid.SetStep(5000)
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Log.SlowThreshold = 30000 // 30s
+		conf.TiKVClient.AsyncCommit.SafeWindow = 0
+		conf.TiKVClient.AsyncCommit.AllowedClockDrift = 0
+		conf.Experimental.AllowsExpressionIndex = true
+	})
+	tikv.EnableFailpoints()
+
+	opts := []goleak.Option{
+		goleak.IgnoreTopFunction("github.com/golang/glog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/lestrrat-go/httprc.runFetchWorker"),
+		goleak.IgnoreTopFunction("go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		goleak.IgnoreTopFunction("github.com/tikv/client-go/v2/txnkv/transaction.keepAlive"),
+	}
+	goleak.VerifyTestMain(m, opts...)
+}

--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -270,7 +270,9 @@ func TestListColumnsPartitionPrunerRandom(t *testing.T) {
 
 func TestIssue22635(t *testing.T) {
 	failpoint.Enable("github.com/pingcap/tidb/planner/core/forceDynamicPrune", `return(true)`)
-	defer failpoint.Disable("github.com/pingcap/tidb/planner/core/forceDynamicPrune")
+	defer func() {
+		failpoint.Disable("github.com/pingcap/tidb/planner/core/forceDynamicPrune")
+	}()
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("USE test;")
@@ -282,19 +284,19 @@ CREATE TABLE t1 (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 PARTITION BY HASH( a )
 PARTITIONS 4`)
-	tk.MustQuery("SELECT (SELECT tt.a FROM t1  tt LIMIT 1) aa, COUNT(DISTINCT b) FROM t1  GROUP BY aa").Check(testkit.Rows()) // work fine without any error
+	tk.MustQuery("SELECT (SELECT tt.a FROM t1 tt ORDER BY a ASC LIMIT 1) aa, COUNT(DISTINCT b) FROM t1 GROUP BY aa").Check(testkit.Rows()) // work fine without any error
 
 	tk.MustExec("insert into t1 values (1, 1)")
-	tk.MustQuery("SELECT (SELECT tt.a FROM t1  tt LIMIT 1) aa, COUNT(DISTINCT b) FROM t1  GROUP BY aa").Check(testkit.Rows("1 1"))
+	tk.MustQuery("SELECT (SELECT tt.a FROM t1 tt ORDER BY a ASC LIMIT 1) aa, COUNT(DISTINCT b) FROM t1 GROUP BY aa").Check(testkit.Rows("1 1"))
 
 	tk.MustExec("insert into t1 values (2, 2), (2, 2)")
-	tk.MustQuery("SELECT (SELECT tt.a FROM t1  tt LIMIT 1) aa, COUNT(DISTINCT b) FROM t1  GROUP BY aa").Check(testkit.Rows("1 2"))
+	tk.MustQuery("SELECT (SELECT tt.a FROM t1 tt ORDER BY a ASC LIMIT 1) aa, COUNT(DISTINCT b) FROM t1 GROUP BY aa").Check(testkit.Rows("1 2"))
 
 	tk.MustExec("insert into t1 values (3, 3), (3, 3), (3, 3)")
-	tk.MustQuery("SELECT (SELECT tt.a FROM t1  tt LIMIT 1) aa, COUNT(DISTINCT b) FROM t1  GROUP BY aa").Check(testkit.Rows("1 3"))
+	tk.MustQuery("SELECT (SELECT tt.a FROM t1 tt ORDER BY a ASC LIMIT 1) aa, COUNT(DISTINCT b) FROM t1 GROUP BY aa").Check(testkit.Rows("1 3"))
 
 	tk.MustExec("insert into t1 values (4, 4), (4, 4), (4, 4), (4, 4)")
-	tk.MustQuery("SELECT (SELECT tt.a FROM t1  tt LIMIT 1) aa, COUNT(DISTINCT b) FROM t1  GROUP BY aa").Check(testkit.Rows("4 4"))
+	tk.MustQuery("SELECT (SELECT tt.a FROM t1 tt ORDER BY a DESC LIMIT 1) aa, COUNT(DISTINCT b) FROM t1 GROUP BY aa").Check(testkit.Rows("4 4"))
 }
 
 func TestIssue22898(t *testing.T) {

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -224,7 +224,14 @@ func (c *CopClient) BuildCopIterator(ctx context.Context, req *kv.Request, vars 
 		// For ReqTypeAnalyze, we keep its concurrency to avoid slow analyze(see https://github.com/pingcap/tidb/issues/40162 for details).
 		if it.concurrency > 2 && it.req.Tp != kv.ReqTypeAnalyze {
 			oldConcurrency := it.concurrency
+			partitionNum := req.KeyRanges.PartitionNum()
+			if partitionNum > it.concurrency {
+				partitionNum = it.concurrency
+			}
 			it.concurrency = 2
+			if it.concurrency < partitionNum {
+				it.concurrency = partitionNum
+			}
 
 			failpoint.Inject("testRateLimitActionMockConsumeAndAssert", func(val failpoint.Value) {
 				if val.(bool) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #41480

Problem Summary:

The [distsql concurrency of limit statement is set to 1](https://github.com/pingcap/tidb/blob/f9e1845849bf2b1f9f2e35cd0f5a5c8e397f2405/distsql/request_builder.go#L159-L161) before, but with partitioned table, it may affect performance, see the case in #41480.

### What is changed and how it works?

Cherry pick #41500 to master.

Set the concurrency to the number of partitions, with a upper limit of distsql concurrency(default to 15).

```sql
MySQL [test]> CREATE TABLE t(id int PRIMARY KEY, val int)
    -> PARTITION BY RANGE (id)
    -> (PARTITION p1 VALUES LESS THAN (100),
    ->  PARTITION p2 VALUES LESS THAN (200),
    ->  PARTITION p3 VALUES LESS THAN (300),
    ->  PARTITION p4 VALUES LESS THAN (400),
    ->  PARTITION p5 VALUES LESS THAN (500),
    ->  PARTITION p6 VALUES LESS THAN (600),
    ->  PARTITION p7 VALUES LESS THAN (700),
    ->  PARTITION p8 VALUES LESS THAN (800),
    ->  PARTITION p9 VALUES LESS THAN (900),
    ->  PARTITION p10 VALUES LESS THAN (1000),
    ->  PARTITION p11 VALUES LESS THAN (1100),
    ->  PARTITION p12 VALUES LESS THAN (1200),
    ->  PARTITION p13 VALUES LESS THAN (1300),
    ->  PARTITION p14 VALUES LESS THAN (1400),
    ->  PARTITION p15 VALUES LESS THAN (1500));
Query OK, 0 rows affected (0.134 sec)

MySQL [test]> 
MySQL [test]> INSERT INTO t VALUES(50, 50), (150, 150), (250, 250);
Query OK, 3 rows affected (0.004 sec)
Records: 3  Duplicates: 0  Warnings: 0

MySQL [test]> ANALYZE TABLE t;
Query OK, 0 rows affected, 30 warnings (1.414 sec)

## Before this PR
MySQL [test]> EXPLAIN ANALYZE SELECT * FROM t ORDER BY id ASC LIMIT 1;
+----------------------------+---------+---------+-----------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------+-----------+------+
| id                         | estRows | actRows | task      | access object | execution info                                                                                                                                                                                                                                   | operator info                | memory    | disk |
+----------------------------+---------+---------+-----------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------+-----------+------+
| TopN_7                     | 1.00    | 1       | root      |               | time:10.6ms, loops:2                                                                                                                                                                                                                             | test.t.id, offset:0, count:1 | 280 Bytes | N/A  |
| └─TableReader_14           | 1.00    | 3       | root      | partition:all | time:10.6ms, loops:3, cop_task: {num: 18, max: 869.7µs, min: 423.9µs, avg: 536.6µs, p95: 869.7µs, max_proc_keys: 1, p95_proc_keys: 1, rpc_num: 18, rpc_time: 9.25ms, copr_cache_hit_ratio: 0.00, distsql_concurrency: 1}                         | data:Limit_13                | 319 Bytes | N/A  |
|   └─Limit_13               | 1.00    | 3       | cop[tikv] |               | tikv_task:{proc max:1ms, min:0s, avg: 55.6µs, p80:0s, p95:1ms, iters:18, tasks:18}, scan_detail: {total_process_keys: 3, total_process_keys_size: 113, total_keys: 21, get_snapshot_time: 495.3µs, rocksdb: {key_skipped_count: 3, block: {}}}   | offset:0, count:1            | N/A       | N/A  |
|     └─TableFullScan_12     | 3.00    | 3       | cop[tikv] | table:t       | tikv_task:{proc max:1ms, min:0s, avg: 55.6µs, p80:0s, p95:1ms, iters:18, tasks:18}                                                                                                                                                               | keep order:false             | N/A       | N/A  |
+----------------------------+---------+---------+-----------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------+-----------+------+
4 rows in set (0.012 sec)

## After this PR
MySQL [test]> EXPLAIN ANALYZE SELECT * FROM t ORDER BY id ASC LIMIT 1;
+----------------------------+---------+---------+-----------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------+-----------+------+
| id                         | estRows | actRows | task      | access object | execution info                                                                                                                                                                                                                            | operator info                | memory    | disk |
+----------------------------+---------+---------+-----------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------+-----------+------+
| TopN_7                     | 1.00    | 1       | root      |               | time:1.47ms, loops:2                                                                                                                                                                                                                      | test.t.id, offset:0, count:1 | 280 Bytes | N/A  |
| └─TableReader_14           | 1.00    | 3       | root      | partition:all | time:1.43ms, loops:3, cop_task: {num: 15, max: 1.11ms, min: 891.7µs, avg: 982.6µs, p95: 1.11ms, max_proc_keys: 1, p95_proc_keys: 1, rpc_num: 15, rpc_time: 13.9ms, copr_cache_hit_ratio: 0.00, distsql_concurrency: 15}                   | data:Limit_13                | 2.92 KB   | N/A  |
|   └─Limit_13               | 1.00    | 3       | cop[tikv] |               | tikv_task:{proc max:0s, min:0s, avg: 0s, p80:0s, p95:0s, iters:15, tasks:15}, scan_detail: {total_process_keys: 3, total_process_keys_size: 113, total_keys: 18, get_snapshot_time: 654.6µs, rocksdb: {key_skipped_count: 3, block: {}}}  | offset:0, count:1            | N/A       | N/A  |
|     └─TableFullScan_12     | 3.00    | 3       | cop[tikv] | table:t       | tikv_task:{proc max:0s, min:0s, avg: 0s, p80:0s, p95:0s, iters:15, tasks:15}                                                                                                                                                              | keep order:true              | N/A       | N/A  |
+----------------------------+---------+---------+-----------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------+-----------+------+
4 rows in set (0.003 sec)
```


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
