### PR TITLE
planner: skip plan cache if the query has filters like `year <cmp> const`

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1565,19 +1565,29 @@ func allowCmpArgsRefining4PlanCache(ctx sessionctx.Context, args []Expression) (
 		return true // plan-cache disabled or no parameter in these args
 	}
 
-	// For these 2 cases below which may affect the index selection a lot, skip plan-cache,
-	// and for all other cases, skip the refining.
-	// 1. int-expr <cmp> string-const
-	// 2. int-expr <cmp> float/double/decimal-const
+	// For these 2 cases below, we skip the refining:
+	// 1. year-expr <cmp> const
+	// 2. int-expr <cmp> string/float/double/decimal-const
 	for conIdx := 0; conIdx < 2; conIdx++ {
-		if args[1-conIdx].GetType().EvalType() != types.ETInt {
-			continue // not a int-expr
-		}
 		if _, isCon := args[conIdx].(*Constant); !isCon {
 			continue // not a constant
 		}
+
+		// case 1: year-expr <cmp> const
+		// refine `year < 12` to `year < 2012` to guarantee the correctness.
+		// see https://github.com/pingcap/tidb/issues/41626 for more details.
+		exprType := args[1-conIdx].GetType()
+		if exprType.GetType() == mysql.TypeYear {
+			reason := errors.Errorf("skip plan-cache: '%v' may be converted to INT", args[conIdx].String())
+			ctx.GetSessionVars().StmtCtx.SetSkipPlanCache(reason)
+			return true
+		}
+
+		// case 2: int-expr <cmp> string/float/double/decimal-const
+		// refine `int_key < 1.1` to `int_key < 2` to generate RangeScan instead of FullScan.
 		conType := args[conIdx].GetType().EvalType()
-		if conType == types.ETString || conType == types.ETReal || conType == types.ETDecimal {
+		if exprType.EvalType() == types.ETInt &&
+			(conType == types.ETString || conType == types.ETReal || conType == types.ETDecimal) {
 			reason := errors.Errorf("skip plan-cache: '%v' may be converted to INT", args[conIdx].String())
 			ctx.GetSessionVars().StmtCtx.SetSkipPlanCache(reason)
 			return true

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -432,7 +432,7 @@ func TestIssue41626(t *testing.T) {
 	tk.MustExec(`prepare st from 'select * from t where a<?'`)
 	tk.MustExec(`set @a=12`)
 	tk.MustQuery(`execute st using @a`).Check(testkit.Rows("2000"))
-	tk.MustQuery(`show warnings`).Check(testkit.Rows())
+	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1105 skip plan-cache: '12' may be converted to INT"))
 }
 
 func TestIssue38269(t *testing.T) {

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -423,6 +423,18 @@ func TestNonPreparedPlanCacheSelectLimit(t *testing.T) {
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 }
 
+func TestIssue41626(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table t (a year)`)
+	tk.MustExec(`insert into t values (2000)`)
+	tk.MustExec(`prepare st from 'select * from t where a<?'`)
+	tk.MustExec(`set @a=12`)
+	tk.MustQuery(`execute st using @a`).Check(testkit.Rows("2000"))
+	tk.MustQuery(`show warnings`).Check(testkit.Rows())
+}
+
 func TestIssue38269(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41626

Problem Summary: planner: skip plan cache if the query has filters like `year <cmp> const`

### What is changed and how it works?

planner: skip plan cache if the query has filters like `year <cmp> const`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
