### PR TITLE
store/copr: parallel build cop tasks

### DIFF
--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -313,6 +313,7 @@ func (builder *RequestBuilder) SetFromSessionVars(sv *variable.SessionVars) *Req
 	builder.Request.StoreBusyThreshold = sv.LoadBasedReplicaReadThreshold
 	builder.Request.RunawayChecker = sv.StmtCtx.RunawayChecker
 	builder.Request.TiKVClientReadTimeout = sv.GetTiKVClientReadTimeout()
+	builder.Request.ParallelBuildTask = !sv.InRestrictedSQL && sv.DistSQLParallelBuild
 	return builder
 }
 

--- a/pkg/distsql/select_result.go
+++ b/pkg/distsql/select_result.go
@@ -519,11 +519,6 @@ func (r *selectResult) updateCopRuntimeStats(ctx context.Context, copStats *copr
 			rpcStat:            tikv.NewRegionRequestRuntimeStats(),
 			distSQLConcurrency: r.distSQLConcurrency,
 		}
-		if ci, ok := r.resp.(copr.CopInfo); ok {
-			conc, extraConc := ci.GetConcurrency()
-			r.stats.distSQLConcurrency = conc
-			r.stats.extraConcurrency = extraConc
-		}
 	}
 	r.stats.mergeCopRuntimeStats(copStats, respTime)
 
@@ -611,6 +606,9 @@ func (r *selectResult) Close() error {
 				if batched != 0 || fallback != 0 {
 					r.stats.storeBatchedNum, r.stats.storeBatchedFallbackNum = batched, fallback
 				}
+				conc, extraConc := ci.GetConcurrency()
+				r.stats.distSQLConcurrency = conc
+				r.stats.extraConcurrency = extraConc
 			}
 			r.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(r.rootPlanID, r.stats)
 		}()

--- a/pkg/executor/test/oomtest/oom_test.go
+++ b/pkg/executor/test/oomtest/oom_test.go
@@ -197,8 +197,10 @@ func TestMemTracker4DeleteExec(t *testing.T) {
 	oom.AddMessageFilter("memory exceeds quota, rateLimitAction delegate to fallback action")
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/copr/disableFixedRowCountHint", "return"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/copr/testRateLimitActionWithCapacity", "return(1)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/copr/disableFixedRowCountHint"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/copr/testRateLimitActionWithCapacity"))
 	}()
 	tk.Session().GetSessionVars().EnabledRateLimitAction = true
 	tk.Session().GetSessionVars().MemQuotaQuery = 10000

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -514,6 +514,11 @@ func (rr *KeyRanges) TotalRangeNum() int {
 	return ret
 }
 
+// HasHint checks if there are hints.
+func (rr *KeyRanges) HasHint() bool {
+	return rr.rowCountHints != nil
+}
+
 // Request represents a kv request.
 type Request struct {
 	// Tp is the request type.
@@ -595,8 +600,12 @@ type Request struct {
 
 	// ConnID stores the session connection id.
 	ConnID uint64
+
 	// ConnAlias stores the session connection alias.
 	ConnAlias string
+
+	// ParallelBuildTask indicates whether the request's tasks are built in parallel mode.
+	ParallelBuildTask bool
 }
 
 // CoprRequestAdjuster is used to check and adjust a copr request according to specific rules.

--- a/pkg/resourcemanager/BUILD.bazel
+++ b/pkg/resourcemanager/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/resourcemanager/util",
         "//pkg/util",
         "//pkg/util/cpu",
+        "//pkg/util/intest",
         "@com_github_google_uuid//:uuid",
         "@com_github_pingcap_log//:log",
         "@org_uber_go_zap//:zap",

--- a/pkg/resourcemanager/pool/spool/BUILD.bazel
+++ b/pkg/resourcemanager/pool/spool/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "spool",
     srcs = [
+        "dynamic_worker.go",
         "option.go",
         "spool.go",
     ],
@@ -25,13 +26,14 @@ go_test(
     name = "spool_test",
     timeout = "short",
     srcs = [
+        "dynamic_worker_test.go",
         "main_test.go",
         "spool_test.go",
     ],
     embed = [":spool"],
     flaky = True,
     race = "on",
-    shard_count = 6,
+    shard_count = 8,
     deps = [
         "//pkg/resourcemanager/pool",
         "//pkg/resourcemanager/util",

--- a/pkg/resourcemanager/pool/spool/dynamic_worker.go
+++ b/pkg/resourcemanager/pool/spool/dynamic_worker.go
@@ -1,0 +1,123 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spool
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/pingcap/tidb/pkg/resourcemanager/pool"
+	"github.com/pingcap/tidb/pkg/resourcemanager/poolmanager"
+)
+
+// RunWithDynamicalConcurrency runs a function in the pool with dynamically concurrency.
+func RunWithDynamicalConcurrency[T any, W Worker[T]](ctx context.Context, p *Pool, create func() W, least, concurrency int32) (*DynamicConcurrencyHandle[T, W], error) {
+	// Don't need to check the pool capacity by `Pool.checkAndAddRunning` because the pool is not shared now. This avoids mutex lock.
+	if p.isStop.Load() {
+		return nil, pool.ErrPoolClosed
+	}
+	if least > concurrency {
+		least = concurrency
+	}
+	taskID := p.GenTaskID()
+	exitCh := make(chan struct{})
+	// hack: use a closed channel to avoid blocking runTask when tuning.
+	close(exitCh)
+	meta := poolmanager.NewMeta(taskID, exitCh, nil, least)
+	p.taskManager.RegisterTask(meta)
+	ctx, cancel := context.WithCancel(ctx)
+	handle := &DynamicConcurrencyHandle[T, W]{
+		ctx:      ctx,
+		cancel:   cancel,
+		capacity: concurrency,
+		taskID:   taskID,
+		p:        p,
+		taskCh:   make(chan T, concurrency),
+		create:   create,
+	}
+	for n := int32(0); n < least; n++ {
+		p.run(handle.run)
+	}
+	return handle, nil
+}
+
+// Worker interface.
+type Worker[task any] interface {
+	HandleTask(context.Context, task)
+	Close()
+}
+
+// DynamicConcurrencyHandle is the handle of dynamic concurrency worker.
+type DynamicConcurrencyHandle[T any, W Worker[T]] struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	running  atomic.Int32
+	capacity int32
+	taskID   uint64
+	p        *Pool
+	taskCh   chan T
+	create   func() W
+}
+
+// Send a task to the pool, spawn new worker if required.
+func (d *DynamicConcurrencyHandle[T, W]) Send(task T) {
+	poolSize := d.p.Running()
+	spawn := poolSize < d.capacity && len(d.taskCh) > 0 || d.running.Load() == poolSize
+	d.taskCh <- task
+	if spawn {
+		// spawn new runner.
+		d.p.run(d.run)
+	}
+}
+
+// Close stop the tasks, if cancel is true, the queued tasks will be dropped.
+func (d *DynamicConcurrencyHandle[T, W]) Close(cancel bool) {
+	close(d.taskCh)
+	if cancel {
+		d.cancel()
+	}
+}
+
+func (d *DynamicConcurrencyHandle[T, W]) run() {
+	d.p.running.Add(1)
+	worker := d.create()
+	defer worker.Close()
+	doneCh := d.ctx.Done()
+	for {
+		var (
+			task T
+			ok   bool
+		)
+		select {
+		case task, ok = <-d.taskCh:
+		case <-doneCh:
+			return
+		}
+		if !ok {
+			return
+		}
+		d.running.Add(1)
+		worker.HandleTask(d.ctx, task)
+		d.running.Add(-1)
+	}
+}
+
+// Volume returns the capacity of the handler.
+func (d *DynamicConcurrencyHandle[T, W]) Volume() int {
+	if d == nil {
+		return 0
+	}
+	return int(d.p.Running())
+}

--- a/pkg/resourcemanager/pool/spool/dynamic_worker_test.go
+++ b/pkg/resourcemanager/pool/spool/dynamic_worker_test.go
@@ -1,0 +1,84 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spool
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/resourcemanager/util"
+	"github.com/stretchr/testify/require"
+)
+
+type DummyIntWorker struct {
+	receive chan int
+}
+
+func (d *DummyIntWorker) HandleTask(_ context.Context, task int) {
+	d.receive <- task
+}
+
+func (d *DummyIntWorker) Close() {}
+
+func NewDummyIntWorker(receive chan int) *DummyIntWorker {
+	return &DummyIntWorker{
+		receive: receive,
+	}
+}
+
+func TestDynamicConcurrencyOneshot(t *testing.T) {
+	p, err := NewPool("TestDynamicConcurrencyOneshot", int32(1), util.UNKNOWN, WithBlocking(false))
+	require.NoErrorf(t, err, "create TestDynamicConcurrencyOneshot pool failed: %v", err)
+	defer p.ReleaseAndWait()
+	receive := make(chan int)
+	handle, err := RunWithDynamicalConcurrency[int, *DummyIntWorker](context.Background(), p, func() *DummyIntWorker {
+		return NewDummyIntWorker(receive)
+	}, 0, 1)
+	require.NoError(t, err)
+	handle.Send(1)
+	require.Equal(t, 1, <-receive)
+	handle.Close(false)
+	p.wg.Wait()
+	require.Zero(t, p.Running())
+}
+
+func TestDynamicConcurrencyMultiTask(t *testing.T) {
+	p, err := NewPool("TestDynamicConcurrencyMultiTask", int32(1), util.UNKNOWN, WithBlocking(false))
+	require.NoErrorf(t, err, "create TestDynamicConcurrencyMultiTask pool failed: %v", err)
+	defer p.ReleaseAndWait()
+	receive := make(chan int, 200)
+	handle, err := RunWithDynamicalConcurrency[int, *DummyIntWorker](context.Background(), p, func() *DummyIntWorker {
+		return NewDummyIntWorker(receive)
+	}, 0, 1)
+	require.NoError(t, err)
+
+	results := make(map[int]struct{}, 100)
+	for i := 0; i < 100; i++ {
+		results[i] = struct{}{}
+		handle.Send(i)
+	}
+	handle.Close(false)
+	for i := 0; i < 100; i++ {
+		r, ok := <-receive
+		require.True(t, ok)
+		_, ok = results[r]
+		require.True(t, ok)
+		delete(results, r)
+	}
+	require.Len(t, receive, 0)
+	close(receive)
+	p.wg.Wait()
+	require.Zero(t, p.Running())
+}

--- a/pkg/resourcemanager/pool/spool/option.go
+++ b/pkg/resourcemanager/pool/spool/option.go
@@ -28,6 +28,9 @@ func loadOptions(options ...Option) *Options {
 // Options contains all options which will be applied when instantiating an pool.
 type Options struct {
 	Blocking bool
+	// IgnoreMetric indicates whether the metric of the pool should NOT be count.
+	// Because there are some drop-after-used pools, we should ignore the metrics.
+	IgnoreMetric bool
 }
 
 // DefaultOption is the default option.
@@ -41,5 +44,12 @@ func DefaultOption() *Options {
 func WithBlocking(blocking bool) Option {
 	return func(opts *Options) {
 		opts.Blocking = blocking
+	}
+}
+
+// WithIgnoreMetric indicates whether the pool is ignoring metric.
+func WithIgnoreMetric(ignoreMetric bool) Option {
+	return func(opts *Options) {
+		opts.IgnoreMetric = ignoreMetric
 	}
 }

--- a/pkg/resourcemanager/pool/spool/spool_test.go
+++ b/pkg/resourcemanager/pool/spool/spool_test.go
@@ -147,7 +147,7 @@ func TestRunOverload(t *testing.T) {
 	// p is full now.
 	require.NoError(t, p.Run(longRunningFunc), "submit when pool is not full shouldn't return error")
 	require.EqualError(t, p.Run(demoFunc), pool.ErrPoolOverload.Error(),
-		"blocking submit when pool reach max blocking submit should return ErrPoolOverload")
+		"blocking submit when pool reach capacity blocking submit should return ErrPoolOverload")
 }
 
 func TestRunWithNotEnough(t *testing.T) {

--- a/pkg/resourcemanager/scheduler/cpu_scheduler.go
+++ b/pkg/resourcemanager/scheduler/cpu_scheduler.go
@@ -30,7 +30,13 @@ func NewCPUScheduler() *CPUScheduler {
 }
 
 // Tune is to tune the goroutine pool
-func (*CPUScheduler) Tune(_ util.Component, pool util.GoroutinePool) Command {
+func (*CPUScheduler) Tune(component util.Component, pool util.GoroutinePool) Command {
+	switch component {
+	// ignore tuning some components.
+	case util.Coprocessor:
+		return Hold
+	default:
+	}
 	if time.Since(pool.LastTunerTs()) < util.MinSchedulerInterval.Load() {
 		return Hold
 	}

--- a/pkg/resourcemanager/util/util.go
+++ b/pkg/resourcemanager/util/util.go
@@ -59,4 +59,6 @@ const (
 	CheckTable
 	// ImportInto is for import into component.
 	ImportInto
+	// Coprocessor is for handling coprocessor tasks.
+	Coprocessor
 )

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1580,8 +1580,8 @@ type SessionVars struct {
 	// overwritten if this value is not 0.
 	TxnEntrySizeLimit uint64
 
-	// DistSQLParallel indicates whether to build distsql task in parallel mode. If it is true, the region-cache-miss tasks will be built
-	// in the coprocessor's sender goroutine and won't block the region-cache-hit to be processed.
+	// DistSQLParallelBuild indicates whether to build distsql task in parallel mode.
+	// If it is true, the distsql tasks will be built in sender thread, so that the slow build won't block the tasks being sent to stores.
 	DistSQLParallelBuild bool
 }
 

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1579,6 +1579,10 @@ type SessionVars struct {
 	// TxnEntrySizeLimit indicates indicates the max size of a entry in membuf. The default limit (from config) will be
 	// overwritten if this value is not 0.
 	TxnEntrySizeLimit uint64
+
+	// DistSQLParallel indicates whether to build distsql task in parallel mode. If it is true, the region-cache-miss tasks will be built
+	// in the coprocessor's sender goroutine and won't block the region-cache-hit to be processed.
+	DistSQLParallelBuild bool
 }
 
 // GetOptimizerFixControlMap returns the specified value of the optimizer fix control.

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -3079,6 +3079,10 @@ var defaultSysVars = []*SysVar{
 			}
 			return errors.Errorf("unsupport DML type: %s", val)
 		}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDistSQLParallelBuild, Value: BoolToOnOff(DefTiDBDistSQLParallelBuild), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.DistSQLParallelBuild = TiDBOptOn(val)
+		return nil
+	}},
 }
 
 // GlobalSystemVariableInitialValue gets the default value for a system variable including ones that are dynamically set (e.g. based on the store)

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1487,7 +1487,7 @@ const (
 	DefTiDBSchemaCacheSize                            = 0
 	DefTiDBLowResolutionTSOUpdateInterval             = 2000
 	DefTiDBDMLType                                    = "STANDARD"
-	DefTiDBDistSQLParallelBuild                       = false
+	DefTiDBDistSQLParallelBuild                       = true
 )
 
 // Process global variables.

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1158,6 +1158,8 @@ const (
 	// The value can be STANDARD, BULK.
 	// Currently, the BULK mode only affects auto-committed DML.
 	TiDBDMLType = "tidb_dml_type"
+	// TiDBDistSQLParallelBuild indicates whether enable parallel building distsql.
+	TiDBDistSQLParallelBuild = "tidb_distsql_parallel_build"
 )
 
 // TiDB intentional limits
@@ -1485,6 +1487,7 @@ const (
 	DefTiDBSchemaCacheSize                            = 0
 	DefTiDBLowResolutionTSOUpdateInterval             = 2000
 	DefTiDBDMLType                                    = "STANDARD"
+	DefTiDBDistSQLParallelBuild                       = false
 )
 
 // Process global variables.

--- a/pkg/store/copr/BUILD.bazel
+++ b/pkg/store/copr/BUILD.bazel
@@ -24,6 +24,8 @@ go_library(
         "//pkg/kv",
         "//pkg/metrics",
         "//pkg/parser/terror",
+        "//pkg/resourcemanager/pool/spool",
+        "//pkg/resourcemanager/util",
         "//pkg/sessionctx/variable",
         "//pkg/store/copr/metrics",
         "//pkg/store/driver/backoff",

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -138,7 +138,7 @@ func (c *CopClient) BuildCopIterator(ctx context.Context, req *kv.Request, vars 
 	reqType := "null"
 	if req.ClosestReplicaReadAdjuster != nil {
 		// When closest replica read is enabled, we build the tasks in unparalleled mode.
-		// TODO: support parallel build in closest replica read mode.
+		// TODO: support parallel build in closest adaptive read mode.
 		if err := taskBuilder.Build(); err != nil {
 			return nil, copErrorResponse{err}
 		}

--- a/pkg/store/copr/store.go
+++ b/pkg/store/copr/store.go
@@ -127,6 +127,11 @@ func (s *Store) GetMPPClient() kv.MPPClient {
 	}
 }
 
+// Go runs the function in the store's goroutine pool.
+func (s *Store) Go(f func()) error {
+	return s.store.Go(f)
+}
+
 func getEndPointType(t kv.StoreType) tikvrpc.EndpointType {
 	switch t {
 	case kv.TiKV:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #14320, close #40441

Problem Summary:

In some cases, build cop tasks may takes a non-negligible duration, which directly increases the latency of coprocessor tasks.

### What is changed and how it works?

Before this PR, the coprocessor tasks are built in [the preparation stage](https://github.com/pingcap/tidb/blob/a39d7fb09b7b3a7c6694ef8aab7d1d7d8e817f57/store/copr/coprocessor.go#L151-L170) in TiDB,
if the build is slow(there may be region misses and need to load from PD), the query latency may increase, this PR makes the build tasks run in [the sender goroutine](https://github.com/pingcap/tidb/blob/a39d7fb09b7b3a7c6694ef8aab7d1d7d8e817f57/store/copr/coprocessor.go#L845), so that some tasks can be started before all tasks are built.

Without a pre-built task slice, it's hard to determine the execution concurrency, so this PR also introduces `util/workers`, which creates workers dynamically during the execution, do not spawn useless workers, and also avoids suffering from worker starvation.

![diagram](https://user-images.githubusercontent.com/9587680/223039706-182e907c-3c76-404a-8153-1188c20616e2.png)

In a index lookup test(1 index scan with 100 1row-table lookup tasks), the avg duration of the query is decreased from 6.38ms to 5.30ms.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Benchmark result


|Case|Nightly|This PR Without Parallel Build|Diff|
|-|-|-|-|
| sysbench read only| 129272 qps|129831 qps|+0.4%|

|Case|Nightly|This PR With Parallel Build|Diff|
|-|-|-|-|
|sysbench read only(range size 100, default)| 129272 qps| 125528 qps|+0.4%|
|sysbench read only(range size 1,000)| 25467 qps | 25954 qps|+1.9%|
|sysbench read only(range size 10,000)| 9554 qps| 10063 qps|+5.3%|

Larger range read cost longer time in building task phase, thus the benefits of parallel building is more significant.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
store/copr: support parallel building coprocessor tasks, reduce the latency when region cache misses frequently.
```
