### PR TITLE
metric: fix panic when status.record-db-label enable

### DIFF
--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -216,26 +216,37 @@ func getStmtDbLabel(stmtNode ast.StmtNode) map[string]struct{} {
 
 	switch x := stmtNode.(type) {
 	case *ast.AlterTableStmt:
-		dbLabel := x.Table.Schema.O
-		dbLabelSet[dbLabel] = struct{}{}
+		if x.Table != nil {
+			dbLabel := x.Table.Schema.O
+			dbLabelSet[dbLabel] = struct{}{}
+		}
 	case *ast.CreateIndexStmt:
-		dbLabel := x.Table.Schema.O
-		dbLabelSet[dbLabel] = struct{}{}
+		if x.Table != nil {
+			dbLabel := x.Table.Schema.O
+			dbLabelSet[dbLabel] = struct{}{}
+		}
 	case *ast.CreateTableStmt:
-		dbLabel := x.Table.Schema.O
-		dbLabelSet[dbLabel] = struct{}{}
+		if x.Table != nil {
+			dbLabel := x.Table.Schema.O
+			dbLabelSet[dbLabel] = struct{}{}
+		}
 	case *ast.InsertStmt:
-		dbLabels := getDbFromResultNode(x.Table.TableRefs)
-		for _, db := range dbLabels {
-			dbLabelSet[db] = struct{}{}
+		var dbLabels []string
+		if x.Table != nil {
+			dbLabels = getDbFromResultNode(x.Table.TableRefs)
+			for _, db := range dbLabels {
+				dbLabelSet[db] = struct{}{}
+			}
 		}
 		dbLabels = getDbFromResultNode(x.Select)
 		for _, db := range dbLabels {
 			dbLabelSet[db] = struct{}{}
 		}
 	case *ast.DropIndexStmt:
-		dbLabel := x.Table.Schema.O
-		dbLabelSet[dbLabel] = struct{}{}
+		if x.Table != nil {
+			dbLabel := x.Table.Schema.O
+			dbLabelSet[dbLabel] = struct{}{}
+		}
 	case *ast.DropTableStmt:
 		tables := x.Tables
 		for _, table := range tables {
@@ -329,7 +340,9 @@ func getDbFromResultNode(resultNode ast.ResultSetNode) []string { // may have du
 			return getDbFromResultNode(x.From.TableRefs)
 		}
 	case *ast.TableName:
-		dbLabels = append(dbLabels, x.DBInfo.Name.O)
+		if x.DBInfo != nil {
+			dbLabels = append(dbLabels, x.DBInfo.Name.O)
+		}
 	case *ast.Join:
 		if x.Left != nil {
 			dbs := getDbFromResultNode(x.Left)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2163,7 +2163,7 @@ func (cli *testServerClient) runTestDBStmtCount(t *testing.T) {
 		require.Equal(t, originStmtCnt["Insert"]+5, currentStmtCnt["Insert"])
 		require.Equal(t, originStmtCnt["Delete"]+1, currentStmtCnt["Delete"])
 		require.Equal(t, originStmtCnt["Update"]+2, currentStmtCnt["Update"])
-		require.Equal(t, originStmtCnt["Select"]+3, currentStmtCnt["Select"])
+		require.Equal(t, originStmtCnt["Select"]+4, currentStmtCnt["Select"])
 		require.Equal(t, originStmtCnt["Prepare"]+2, currentStmtCnt["Prepare"])
 		require.Equal(t, originStmtCnt["Execute"]+0, currentStmtCnt["Execute"])
 		require.Equal(t, originStmtCnt["Replace"]+1, currentStmtCnt["Replace"])

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2155,6 +2155,8 @@ func (cli *testServerClient) runTestDBStmtCount(t *testing.T) {
 		dbt.MustExec("prepare stmt2 from 'select * from test'")
 		dbt.MustExec("execute stmt2")
 		dbt.MustExec("replace into test(a) values(6);")
+		// test for CTE
+		dbt.MustExec("WITH RECURSIVE cte (n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM cte WHERE n < 5) SELECT * FROM cte;")
 
 		currentStmtCnt := getStmtCnt(string(cli.getMetrics(t)))
 		require.Equal(t, originStmtCnt["CreateTable"]+1, currentStmtCnt["CreateTable"])


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41688 

Problem Summary:  meet panic when status.record-db-label enable
![image](https://user-images.githubusercontent.com/39378935/220868232-b8d330c5-2b76-47bc-a45a-215070d45948.png)

### What is changed and how it works?

add nil check

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] 
![image](https://user-images.githubusercontent.com/39378935/220876285-58e01e33-7ab3-4c37-9460-a467ecefa7b7.png)

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
