### PR TITLE
adapter, txn: Move aggressive locking controlling logic to handlePessimisticXXX functions to avoid some potential misuses

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -890,13 +890,13 @@ func (a *ExecStmt) handlePessimisticSelectForUpdate(ctx context.Context, e Execu
 	}
 
 	txnManager := sessiontxn.GetTxnManager(a.Ctx)
-	err := txnManager.OnHandlePessimisticStmtStart(ctx)
+	err := txnManager.OnPessimisticStmtStart(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer func() {
 		isSuccessful := retErr == nil
-		err1 := txnManager.OnHandlePessimisticStmtEnd(ctx, isSuccessful)
+		err1 := txnManager.OnPessimisticStmtEnd(ctx, isSuccessful)
 		if retErr == nil && err1 != nil {
 			retErr = err1
 		}
@@ -1018,13 +1018,13 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e Executor) (err er
 	}()
 
 	txnManager := sessiontxn.GetTxnManager(a.Ctx)
-	err = txnManager.OnHandlePessimisticStmtStart(ctx)
+	err = txnManager.OnPessimisticStmtStart(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		isSuccessful := err == nil
-		err1 := txnManager.OnHandlePessimisticStmtEnd(ctx, isSuccessful)
+		err1 := txnManager.OnPessimisticStmtEnd(ctx, isSuccessful)
 		if err == nil && err1 != nil {
 			err = err1
 		}

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -1118,11 +1118,7 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, lockErr error
 	}()
 
 	txnManager := sessiontxn.GetTxnManager(a.Ctx)
-	err = txnManager.OnPessimisticLockError(ctx, lockErr)
-	if err != nil {
-		return nil, err
-	}
-	action, err := txnManager.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, lockErr)
+	action, err := txnManager.OnStmtErrorForNextAction(ctx, sessiontxn.StmtErrAfterPessimisticLock, lockErr)
 	if err != nil {
 		return nil, err
 	}

--- a/server/conn.go
+++ b/server/conn.go
@@ -1886,7 +1886,7 @@ func (cc *clientConn) handleQuery(ctx context.Context, sql string) (err error) {
 		}
 		retryable, err = cc.handleStmt(ctx, stmt, parserWarns, i == len(stmts)-1)
 		if err != nil {
-			action, txnErr := sessiontxn.GetTxnManager(&cc.ctx).OnStmtErrorForNextAction(sessiontxn.StmtErrAfterQuery, err)
+			action, txnErr := sessiontxn.GetTxnManager(&cc.ctx).OnStmtErrorForNextAction(ctx, sessiontxn.StmtErrAfterQuery, err)
 			if txnErr != nil {
 				err = txnErr
 				break

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -223,7 +223,7 @@ func (cc *clientConn) executePlanCacheStmt(ctx context.Context, stmt interface{}
 	ctx = context.WithValue(ctx, util.ExecDetailsKey, &util.ExecDetails{})
 	retryable, err := cc.executePreparedStmtAndWriteResult(ctx, stmt.(PreparedStatement), args, useCursor)
 	if err != nil {
-		action, txnErr := sessiontxn.GetTxnManager(&cc.ctx).OnStmtErrorForNextAction(sessiontxn.StmtErrAfterQuery, err)
+		action, txnErr := sessiontxn.GetTxnManager(&cc.ctx).OnStmtErrorForNextAction(ctx, sessiontxn.StmtErrAfterQuery, err)
 		if txnErr != nil {
 			return txnErr
 		}

--- a/session/txnmanager.go
+++ b/session/txnmanager.go
@@ -184,6 +184,24 @@ func (m *txnManager) OnHandlePessimisticStmtStart(ctx context.Context) error {
 	return m.ctxProvider.OnHandlePessimisticStmtStart(ctx)
 }
 
+// OnPessimisticLockError is the hook that should be called when lock error happens during a pessimistic DML or
+// select-for-update statement.
+func (m *txnManager) OnPessimisticLockError(ctx context.Context, lockErr error) error {
+	if m.ctxProvider == nil {
+		return errors.New("context provider not set")
+	}
+	return m.ctxProvider.OnPessimisticLockError(ctx, lockErr)
+}
+
+// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
+// select-for-update statement.
+func (m *txnManager) OnHandlePessimisticStmtEnd(ctx context.Context, isSuccessful bool) error {
+	if m.ctxProvider == nil {
+		return errors.New("context provider not set")
+	}
+	return m.ctxProvider.OnHandlePessimisticStmtEnd(ctx, isSuccessful)
+}
+
 // OnStmtErrorForNextAction is the hook that should be called when a new statement get an error
 func (m *txnManager) OnStmtErrorForNextAction(point sessiontxn.StmtErrorHandlePoint, err error) (sessiontxn.StmtErrorAction, error) {
 	if m.ctxProvider == nil {

--- a/session/txnmanager.go
+++ b/session/txnmanager.go
@@ -175,22 +175,22 @@ func (m *txnManager) OnStmtStart(ctx context.Context, node ast.StmtNode) error {
 	return m.ctxProvider.OnStmtStart(ctx, m.stmtNode)
 }
 
-// OnHandlePessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
+// OnPessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
 // a pessimistic select-for-update statements.
-func (m *txnManager) OnHandlePessimisticStmtStart(ctx context.Context) error {
+func (m *txnManager) OnPessimisticStmtStart(ctx context.Context) error {
 	if m.ctxProvider == nil {
 		return errors.New("context provider not set")
 	}
-	return m.ctxProvider.OnHandlePessimisticStmtStart(ctx)
+	return m.ctxProvider.OnPessimisticStmtStart(ctx)
 }
 
-// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
+// OnPessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
 // select-for-update statement.
-func (m *txnManager) OnHandlePessimisticStmtEnd(ctx context.Context, isSuccessful bool) error {
+func (m *txnManager) OnPessimisticStmtEnd(ctx context.Context, isSuccessful bool) error {
 	if m.ctxProvider == nil {
 		return errors.New("context provider not set")
 	}
-	return m.ctxProvider.OnHandlePessimisticStmtEnd(ctx, isSuccessful)
+	return m.ctxProvider.OnPessimisticStmtEnd(ctx, isSuccessful)
 }
 
 // OnStmtErrorForNextAction is the hook that should be called when a new statement get an error

--- a/session/txnmanager.go
+++ b/session/txnmanager.go
@@ -184,15 +184,6 @@ func (m *txnManager) OnHandlePessimisticStmtStart(ctx context.Context) error {
 	return m.ctxProvider.OnHandlePessimisticStmtStart(ctx)
 }
 
-// OnPessimisticLockError is the hook that should be called when lock error happens during a pessimistic DML or
-// select-for-update statement.
-func (m *txnManager) OnPessimisticLockError(ctx context.Context, lockErr error) error {
-	if m.ctxProvider == nil {
-		return errors.New("context provider not set")
-	}
-	return m.ctxProvider.OnPessimisticLockError(ctx, lockErr)
-}
-
 // OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
 // select-for-update statement.
 func (m *txnManager) OnHandlePessimisticStmtEnd(ctx context.Context, isSuccessful bool) error {
@@ -203,11 +194,11 @@ func (m *txnManager) OnHandlePessimisticStmtEnd(ctx context.Context, isSuccessfu
 }
 
 // OnStmtErrorForNextAction is the hook that should be called when a new statement get an error
-func (m *txnManager) OnStmtErrorForNextAction(point sessiontxn.StmtErrorHandlePoint, err error) (sessiontxn.StmtErrorAction, error) {
+func (m *txnManager) OnStmtErrorForNextAction(ctx context.Context, point sessiontxn.StmtErrorHandlePoint, err error) (sessiontxn.StmtErrorAction, error) {
 	if m.ctxProvider == nil {
 		return sessiontxn.NoIdea()
 	}
-	return m.ctxProvider.OnStmtErrorForNextAction(point, err)
+	return m.ctxProvider.OnStmtErrorForNextAction(ctx, point, err)
 }
 
 // ActivateTxn decides to activate txn according to the parameter `active`

--- a/sessiontxn/interface.go
+++ b/sessiontxn/interface.go
@@ -136,12 +136,12 @@ type TxnContextProvider interface {
 	OnInitialize(ctx context.Context, enterNewTxnType EnterNewTxnType) error
 	// OnStmtStart is the hook that should be called when a new statement started
 	OnStmtStart(ctx context.Context, node ast.StmtNode) error
-	// OnHandlePessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
+	// OnPessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
 	// a pessimistic select-for-update statement.
-	OnHandlePessimisticStmtStart(ctx context.Context) error
-	// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
+	OnPessimisticStmtStart(ctx context.Context) error
+	// OnPessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
 	// select-for-update statement.
-	OnHandlePessimisticStmtEnd(ctx context.Context, isSuccessful bool) error
+	OnPessimisticStmtEnd(ctx context.Context, isSuccessful bool) error
 	// OnStmtErrorForNextAction is the hook that should be called when a new statement get an error
 	OnStmtErrorForNextAction(ctx context.Context, point StmtErrorHandlePoint, err error) (StmtErrorAction, error)
 	// OnStmtRetry is the hook that should be called when a statement is retried internally.
@@ -188,12 +188,12 @@ type TxnManager interface {
 	OnTxnEnd()
 	// OnStmtStart is the hook that should be called when a new statement started
 	OnStmtStart(ctx context.Context, node ast.StmtNode) error
-	// OnHandlePessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
+	// OnPessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
 	// a pessimistic select-for-update statement.
-	OnHandlePessimisticStmtStart(ctx context.Context) error
-	// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
+	OnPessimisticStmtStart(ctx context.Context) error
+	// OnPessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
 	// select-for-update statement.
-	OnHandlePessimisticStmtEnd(ctx context.Context, isSuccessful bool) error
+	OnPessimisticStmtEnd(ctx context.Context, isSuccessful bool) error
 	// OnStmtErrorForNextAction is the hook that should be called when a new statement get an error
 	// This method is not required to be called for every error in the statement,
 	// it is only required to be called for some errors handled in some specified points given by the parameter `point`.

--- a/sessiontxn/interface.go
+++ b/sessiontxn/interface.go
@@ -139,14 +139,11 @@ type TxnContextProvider interface {
 	// OnHandlePessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
 	// a pessimistic select-for-update statement.
 	OnHandlePessimisticStmtStart(ctx context.Context) error
-	// OnPessimisticLockError is the hook that should be called when lock error happens during a pessimistic DML or
-	// select-for-update statement.
-	OnPessimisticLockError(ctx context.Context, lockErr error) error
 	// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
 	// select-for-update statement.
 	OnHandlePessimisticStmtEnd(ctx context.Context, isSuccessful bool) error
 	// OnStmtErrorForNextAction is the hook that should be called when a new statement get an error
-	OnStmtErrorForNextAction(point StmtErrorHandlePoint, err error) (StmtErrorAction, error)
+	OnStmtErrorForNextAction(ctx context.Context, point StmtErrorHandlePoint, err error) (StmtErrorAction, error)
 	// OnStmtRetry is the hook that should be called when a statement is retried internally.
 	OnStmtRetry(ctx context.Context) error
 	// OnStmtCommit is the hook that should be called when a statement is executed successfully.
@@ -194,9 +191,6 @@ type TxnManager interface {
 	// OnHandlePessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
 	// a pessimistic select-for-update statement.
 	OnHandlePessimisticStmtStart(ctx context.Context) error
-	// OnPessimisticLockError is the hook that should be called when lock error happens during a pessimistic DML or
-	// select-for-update statement.
-	OnPessimisticLockError(ctx context.Context, lockErr error) error
 	// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
 	// select-for-update statement.
 	OnHandlePessimisticStmtEnd(ctx context.Context, isSuccessful bool) error
@@ -204,7 +198,7 @@ type TxnManager interface {
 	// This method is not required to be called for every error in the statement,
 	// it is only required to be called for some errors handled in some specified points given by the parameter `point`.
 	// When the return error is not nil the return action is 'StmtActionError' and vice versa.
-	OnStmtErrorForNextAction(point StmtErrorHandlePoint, err error) (StmtErrorAction, error)
+	OnStmtErrorForNextAction(ctx context.Context, point StmtErrorHandlePoint, err error) (StmtErrorAction, error)
 	// OnStmtRetry is the hook that should be called when a statement retry
 	OnStmtRetry(ctx context.Context) error
 	// OnStmtCommit is the hook that should be called when a statement is executed successfully.

--- a/sessiontxn/interface.go
+++ b/sessiontxn/interface.go
@@ -137,8 +137,14 @@ type TxnContextProvider interface {
 	// OnStmtStart is the hook that should be called when a new statement started
 	OnStmtStart(ctx context.Context, node ast.StmtNode) error
 	// OnHandlePessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
-	// a pessimistic select-for-update statements.
+	// a pessimistic select-for-update statement.
 	OnHandlePessimisticStmtStart(ctx context.Context) error
+	// OnPessimisticLockError is the hook that should be called when lock error happens during a pessimistic DML or
+	// select-for-update statement.
+	OnPessimisticLockError(ctx context.Context, lockErr error) error
+	// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
+	// select-for-update statement.
+	OnHandlePessimisticStmtEnd(ctx context.Context, isSuccessful bool) error
 	// OnStmtErrorForNextAction is the hook that should be called when a new statement get an error
 	OnStmtErrorForNextAction(point StmtErrorHandlePoint, err error) (StmtErrorAction, error)
 	// OnStmtRetry is the hook that should be called when a statement is retried internally.
@@ -186,8 +192,14 @@ type TxnManager interface {
 	// OnStmtStart is the hook that should be called when a new statement started
 	OnStmtStart(ctx context.Context, node ast.StmtNode) error
 	// OnHandlePessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
-	// a pessimistic select-for-update statements.
+	// a pessimistic select-for-update statement.
 	OnHandlePessimisticStmtStart(ctx context.Context) error
+	// OnPessimisticLockError is the hook that should be called when lock error happens during a pessimistic DML or
+	// select-for-update statement.
+	OnPessimisticLockError(ctx context.Context, lockErr error) error
+	// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
+	// select-for-update statement.
+	OnHandlePessimisticStmtEnd(ctx context.Context, isSuccessful bool) error
 	// OnStmtErrorForNextAction is the hook that should be called when a new statement get an error
 	// This method is not required to be called for every error in the statement,
 	// it is only required to be called for some errors handled in some specified points given by the parameter `point`.

--- a/sessiontxn/isolation/base.go
+++ b/sessiontxn/isolation/base.go
@@ -207,15 +207,15 @@ func (p *baseTxnContextProvider) OnStmtStart(ctx context.Context, _ ast.StmtNode
 	return nil
 }
 
-// OnHandlePessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
+// OnPessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
 // a pessimistic select-for-update statements.
-func (p *baseTxnContextProvider) OnHandlePessimisticStmtStart(_ context.Context) error {
+func (p *baseTxnContextProvider) OnPessimisticStmtStart(_ context.Context) error {
 	return nil
 }
 
-// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
+// OnPessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
 // select-for-update statement.
-func (p *baseTxnContextProvider) OnHandlePessimisticStmtEnd(_ context.Context, _ bool) error {
+func (p *baseTxnContextProvider) OnPessimisticStmtEnd(_ context.Context, _ bool) error {
 	return nil
 }
 
@@ -510,10 +510,10 @@ type basePessimisticTxnContextProvider struct {
 	baseTxnContextProvider
 }
 
-// OnHandlePessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
+// OnPessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
 // a pessimistic select-for-update statements.
-func (p *basePessimisticTxnContextProvider) OnHandlePessimisticStmtStart(ctx context.Context) error {
-	if err := p.baseTxnContextProvider.OnHandlePessimisticStmtStart(ctx); err != nil {
+func (p *basePessimisticTxnContextProvider) OnPessimisticStmtStart(ctx context.Context) error {
+	if err := p.baseTxnContextProvider.OnPessimisticStmtStart(ctx); err != nil {
 		return err
 	}
 	if p.sctx.GetSessionVars().PessimisticTransactionAggressiveLocking &&
@@ -527,10 +527,10 @@ func (p *basePessimisticTxnContextProvider) OnHandlePessimisticStmtStart(ctx con
 	return nil
 }
 
-// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
+// OnPessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
 // select-for-update statement.
-func (p *basePessimisticTxnContextProvider) OnHandlePessimisticStmtEnd(ctx context.Context, isSuccessful bool) error {
-	if err := p.baseTxnContextProvider.OnHandlePessimisticStmtEnd(ctx, isSuccessful); err != nil {
+func (p *basePessimisticTxnContextProvider) OnPessimisticStmtEnd(ctx context.Context, isSuccessful bool) error {
+	if err := p.baseTxnContextProvider.OnPessimisticStmtEnd(ctx, isSuccessful); err != nil {
 		return err
 	}
 	if p.txn != nil && p.txn.IsInAggressiveLockingMode() {

--- a/sessiontxn/isolation/base.go
+++ b/sessiontxn/isolation/base.go
@@ -555,3 +555,12 @@ func (p *basePessimisticTxnContextProvider) retryAggressiveLockingIfNeeded(ctx c
 	}
 	return nil
 }
+
+func (p *basePessimisticTxnContextProvider) cancelAggressiveLockingIfNeeded(ctx context.Context) error {
+	if p.txn != nil && p.txn.IsInAggressiveLockingMode() {
+		if err := p.txn.CancelAggressiveLocking(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/sessiontxn/isolation/optimistic_test.go
+++ b/sessiontxn/isolation/optimistic_test.go
@@ -180,7 +180,7 @@ func TestOptimisticHandleError(t *testing.T) {
 
 	for _, c := range cases {
 		require.NoError(t, provider.OnStmtStart(context.TODO(), nil))
-		action, err := provider.OnStmtErrorForNextAction(c.point, c.err)
+		action, err := provider.OnStmtErrorForNextAction(context.Background(), c.point, c.err)
 		if c.point == sessiontxn.StmtErrAfterPessimisticLock {
 			require.Error(t, err)
 			require.Same(t, c.err, err)
@@ -199,7 +199,7 @@ func TestOptimisticHandleError(t *testing.T) {
 
 			// OnStmtErrorForNextAction again
 			require.NoError(t, provider.OnStmtStart(context.TODO(), nil))
-			action, err = provider.OnStmtErrorForNextAction(c.point, c.err)
+			action, err = provider.OnStmtErrorForNextAction(context.Background(), c.point, c.err)
 			require.NoError(t, err)
 			require.Equal(t, sessiontxn.StmtActionNoIdea, action)
 

--- a/sessiontxn/isolation/readcommitted.go
+++ b/sessiontxn/isolation/readcommitted.go
@@ -227,7 +227,7 @@ func (p *PessimisticRCTxnContextProvider) handleAfterPessimisticLockError(ctx co
 		retryable = true
 
 		// Exit aggressive locking in single-statement-deadlock case, otherwise the lock won't be released after retrying.
-		if err := p.txn.CancelAggressiveLocking(ctx); err != nil {
+		if err := p.cancelAggressiveLockingIfNeeded(ctx); err != nil {
 			return sessiontxn.ErrorAction(err)
 		}
 	} else if terror.ErrorEqual(kv.ErrWriteConflict, lockErr) {

--- a/sessiontxn/isolation/readcommitted.go
+++ b/sessiontxn/isolation/readcommitted.go
@@ -118,14 +118,14 @@ func NeedSetRCCheckTSFlag(ctx sessionctx.Context, node ast.Node) bool {
 }
 
 // OnStmtErrorForNextAction is the hook that should be called when a new statement get an error
-func (p *PessimisticRCTxnContextProvider) OnStmtErrorForNextAction(point sessiontxn.StmtErrorHandlePoint, err error) (sessiontxn.StmtErrorAction, error) {
+func (p *PessimisticRCTxnContextProvider) OnStmtErrorForNextAction(ctx context.Context, point sessiontxn.StmtErrorHandlePoint, err error) (sessiontxn.StmtErrorAction, error) {
 	switch point {
 	case sessiontxn.StmtErrAfterQuery:
 		return p.handleAfterQueryError(err)
 	case sessiontxn.StmtErrAfterPessimisticLock:
-		return p.handleAfterPessimisticLockError(err)
+		return p.handleAfterPessimisticLockError(ctx, err)
 	default:
-		return p.basePessimisticTxnContextProvider.OnStmtErrorForNextAction(point, err)
+		return p.basePessimisticTxnContextProvider.OnStmtErrorForNextAction(ctx, point, err)
 	}
 }
 
@@ -215,7 +215,11 @@ func (p *PessimisticRCTxnContextProvider) handleAfterQueryError(queryErr error) 
 	return sessiontxn.RetryReady()
 }
 
-func (p *PessimisticRCTxnContextProvider) handleAfterPessimisticLockError(lockErr error) (sessiontxn.StmtErrorAction, error) {
+func (p *PessimisticRCTxnContextProvider) handleAfterPessimisticLockError(ctx context.Context, lockErr error) (sessiontxn.StmtErrorAction, error) {
+	if err := p.basePessimisticTxnContextProvider.retryAggressiveLockingIfNeeded(ctx); err != nil {
+		return sessiontxn.ErrorAction(err)
+	}
+
 	txnCtx := p.sctx.GetSessionVars().TxnCtx
 	retryable := false
 	if deadlock, ok := errors.Cause(lockErr).(*tikverr.ErrDeadlock); ok && deadlock.IsRetryable {

--- a/sessiontxn/isolation/readcommitted_test.go
+++ b/sessiontxn/isolation/readcommitted_test.go
@@ -84,7 +84,7 @@ func TestPessimisticRCTxnContextProviderRCCheck(t *testing.T) {
 	require.Equal(t, rcCheckTS, ts)
 
 	// error will invalidate the rc check
-	nextAction, err := provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterQuery, kv.ErrWriteConflict)
+	nextAction, err := provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterQuery, kv.ErrWriteConflict)
 	require.NoError(t, err)
 	require.Equal(t, sessiontxn.StmtActionRetryReady, nextAction)
 	compareTS = getOracleTS(t, se)
@@ -103,7 +103,7 @@ func TestPessimisticRCTxnContextProviderRCCheck(t *testing.T) {
 	require.Equal(t, rcCheckTS, ts)
 
 	// other error also invalidate rc check but not retry
-	nextAction, err = provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterQuery, errors.New("err"))
+	nextAction, err = provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterQuery, errors.New("err"))
 	require.NoError(t, err)
 	require.Equal(t, sessiontxn.StmtActionNoIdea, nextAction)
 	require.NoError(t, executor.ResetContextOfStmt(se, readOnlyStmt))
@@ -118,7 +118,7 @@ func TestPessimisticRCTxnContextProviderRCCheck(t *testing.T) {
 	ts, err = provider.GetStmtReadTS()
 	require.NoError(t, err)
 	require.Equal(t, rcCheckTS, ts)
-	nextAction, err = provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, kv.ErrWriteConflict)
+	nextAction, err = provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterPessimisticLock, kv.ErrWriteConflict)
 	require.NoError(t, err)
 	require.Equal(t, sessiontxn.StmtActionRetryReady, nextAction)
 	compareTS = getOracleTS(t, se)
@@ -136,7 +136,7 @@ func TestPessimisticRCTxnContextProviderRCCheck(t *testing.T) {
 	ts, err = provider.GetStmtReadTS()
 	require.NoError(t, err)
 	require.Greater(t, ts, compareTS)
-	nextAction, err = provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterQuery, kv.ErrWriteConflict)
+	nextAction, err = provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterQuery, kv.ErrWriteConflict)
 	require.NoError(t, err)
 	require.Equal(t, sessiontxn.StmtActionNoIdea, nextAction)
 }
@@ -220,7 +220,7 @@ func TestPessimisticRCTxnContextProviderLockError(t *testing.T) {
 	} {
 		require.NoError(t, executor.ResetContextOfStmt(se, stmt))
 		require.NoError(t, provider.OnStmtStart(context.TODO(), stmt))
-		nextAction, err := provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, lockErr)
+		nextAction, err := provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterPessimisticLock, lockErr)
 		require.NoError(t, err)
 		require.Equal(t, sessiontxn.StmtActionRetryReady, nextAction)
 	}
@@ -232,7 +232,7 @@ func TestPessimisticRCTxnContextProviderLockError(t *testing.T) {
 	} {
 		require.NoError(t, executor.ResetContextOfStmt(se, stmt))
 		require.NoError(t, provider.OnStmtStart(context.TODO(), stmt))
-		nextAction, err := provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, lockErr)
+		nextAction, err := provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterPessimisticLock, lockErr)
 		require.Same(t, lockErr, err)
 		require.Equal(t, sessiontxn.StmtActionError, nextAction)
 	}
@@ -277,7 +277,7 @@ func TestPessimisticRCTxnContextProviderTS(t *testing.T) {
 	require.Greater(t, readTS, compareTS)
 
 	// if we should retry, the ts should be updated
-	nextAction, err := provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, kv.ErrWriteConflict)
+	nextAction, err := provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterPessimisticLock, kv.ErrWriteConflict)
 	require.NoError(t, err)
 	require.Equal(t, sessiontxn.StmtActionRetryReady, nextAction)
 	compareTS = getOracleTS(t, se)

--- a/sessiontxn/isolation/repeatable_read.go
+++ b/sessiontxn/isolation/repeatable_read.go
@@ -250,7 +250,7 @@ func (p *PessimisticRRTxnContextProvider) handleAfterPessimisticLockError(ctx co
 			zap.Uint64("deadlockKeyHash", deadlock.DeadlockKeyHash))
 
 		// Exit aggressive locking in single-statement-deadlock case, otherwise the lock won't be released after retrying.
-		if err := p.txn.CancelAggressiveLocking(ctx); err != nil {
+		if err := p.cancelAggressiveLockingIfNeeded(ctx); err != nil {
 			return sessiontxn.ErrorAction(err)
 		}
 	} else if terror.ErrorEqual(kv.ErrWriteConflict, lockErr) {

--- a/sessiontxn/isolation/repeatable_read.go
+++ b/sessiontxn/isolation/repeatable_read.go
@@ -235,7 +235,6 @@ func notNeedGetLatestTSFromPD(plan plannercore.Plan, inLockOrWriteStmt bool) boo
 }
 
 func (p *PessimisticRRTxnContextProvider) handleAfterPessimisticLockError(ctx context.Context, lockErr error) (sessiontxn.StmtErrorAction, error) {
-
 	sessVars := p.sctx.GetSessionVars()
 	txnCtx := sessVars.TxnCtx
 

--- a/sessiontxn/isolation/repeatable_read.go
+++ b/sessiontxn/isolation/repeatable_read.go
@@ -249,7 +249,10 @@ func (p *PessimisticRRTxnContextProvider) handleAfterPessimisticLockError(ctx co
 			zap.Stringer("lockKey", kv.Key(deadlock.LockKey)),
 			zap.Uint64("deadlockKeyHash", deadlock.DeadlockKeyHash))
 
-		// Exit aggressive locking in single-statement-deadlock case, otherwise the lock won't be released after retrying.
+		// In aggressive locking mode, when statement retry happens, `retryAggressiveLockingIfNeeded` should be
+		// called to make its state ready for retrying. But single-statement deadlock is an exception. We need to exit
+		// aggressive locking in single-statement-deadlock case, otherwise the lock this statement has acquired won't be
+		// released after retrying, so it still blocks another transaction and the deadlock won't be resolved.
 		if err := p.cancelAggressiveLockingIfNeeded(ctx); err != nil {
 			return sessiontxn.ErrorAction(err)
 		}

--- a/sessiontxn/isolation/repeatable_read_test.go
+++ b/sessiontxn/isolation/repeatable_read_test.go
@@ -56,7 +56,7 @@ func TestPessimisticRRErrorHandle(t *testing.T) {
 
 	compareTS := getOracleTS(t, se)
 	lockErr = kv.ErrWriteConflict
-	nextAction, err := provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, lockErr)
+	nextAction, err := provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterPessimisticLock, lockErr)
 	require.NoError(t, err)
 	require.Equal(t, sessiontxn.StmtActionRetryReady, nextAction)
 	err = provider.OnStmtRetry(context.TODO())
@@ -72,7 +72,7 @@ func TestPessimisticRRErrorHandle(t *testing.T) {
 	// Update compareTS for the next comparison
 	compareTS = getOracleTS(t, se)
 	lockErr = kv.ErrWriteConflict
-	nextAction, err = provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, lockErr)
+	nextAction, err = provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterPessimisticLock, lockErr)
 	require.NoError(t, err)
 	require.Equal(t, sessiontxn.StmtActionRetryReady, nextAction)
 	err = provider.OnStmtStart(context.TODO(), nil)
@@ -86,14 +86,14 @@ func TestPessimisticRRErrorHandle(t *testing.T) {
 	require.Greater(t, ts, compareTS2)
 
 	lockErr = newDeadLockError(false)
-	nextAction, err = provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, lockErr)
+	nextAction, err = provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterPessimisticLock, lockErr)
 	require.Equal(t, lockErr, err)
 	require.Equal(t, sessiontxn.StmtActionError, nextAction)
 
 	// Update compareTS for the next comparison
 	compareTS = getOracleTS(t, se)
 	lockErr = newDeadLockError(true)
-	nextAction, err = provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, lockErr)
+	nextAction, err = provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterPessimisticLock, lockErr)
 	require.NoError(t, err)
 	require.Equal(t, sessiontxn.StmtActionRetryReady, nextAction)
 	err = provider.OnStmtRetry(context.TODO())
@@ -109,7 +109,7 @@ func TestPessimisticRRErrorHandle(t *testing.T) {
 	// Update compareTS for the next comparison
 	compareTS = getOracleTS(t, se)
 	lockErr = newDeadLockError(true)
-	nextAction, err = provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, lockErr)
+	nextAction, err = provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterPessimisticLock, lockErr)
 	require.NoError(t, err)
 	require.Equal(t, sessiontxn.StmtActionRetryReady, nextAction)
 	err = provider.OnStmtStart(context.TODO(), nil)
@@ -124,13 +124,13 @@ func TestPessimisticRRErrorHandle(t *testing.T) {
 
 	// StmtErrAfterLock: other errors should only update forUpdateTS but not retry
 	lockErr = errors.New("other error")
-	nextAction, err = provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, lockErr)
+	nextAction, err = provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterPessimisticLock, lockErr)
 	require.Equal(t, lockErr, err)
 	require.Equal(t, sessiontxn.StmtActionError, nextAction)
 
 	// StmtErrAfterQuery: always not retry and not update forUpdateTS
 	lockErr = kv.ErrWriteConflict
-	nextAction, err = provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterQuery, lockErr)
+	nextAction, err = provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterQuery, lockErr)
 	require.Equal(t, sessiontxn.StmtActionNoIdea, nextAction)
 	require.Nil(t, err)
 }
@@ -421,7 +421,7 @@ func TestOptimizeWithPlanInPessimisticRR(t *testing.T) {
 
 		// retry
 		if c.shouldOptimize {
-			action, err = provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, kv.ErrWriteConflict)
+			action, err = provider.OnStmtErrorForNextAction(context.Background(), sessiontxn.StmtErrAfterPessimisticLock, kv.ErrWriteConflict)
 			require.NoError(t, err)
 			require.Equal(t, sessiontxn.StmtActionRetryReady, action)
 			err = provider.OnStmtRetry(context.TODO())

--- a/sessiontxn/isolation/serializable_test.go
+++ b/sessiontxn/isolation/serializable_test.go
@@ -77,6 +77,7 @@ func TestPessimisticSerializableTxnContextProviderLockError(t *testing.T) {
 	defer tk.MustExec("rollback")
 	se := tk.Session()
 	provider := initializePessimisticSerializableProvider(t, tk)
+	ctx := context.Background()
 
 	stmts, _, err := parser.New().Parse("select * from t for update", "", "")
 	require.NoError(t, err)
@@ -89,7 +90,7 @@ func TestPessimisticSerializableTxnContextProviderLockError(t *testing.T) {
 	} {
 		require.NoError(t, executor.ResetContextOfStmt(se, stmt))
 		require.NoError(t, provider.OnStmtStart(context.TODO(), nil))
-		nextAction, err := provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, lockErr)
+		nextAction, err := provider.OnStmtErrorForNextAction(ctx, sessiontxn.StmtErrAfterPessimisticLock, lockErr)
 		require.Same(t, lockErr, err)
 		require.Equal(t, sessiontxn.StmtActionError, nextAction)
 	}
@@ -101,7 +102,7 @@ func TestPessimisticSerializableTxnContextProviderLockError(t *testing.T) {
 	} {
 		require.NoError(t, executor.ResetContextOfStmt(se, stmt))
 		require.NoError(t, provider.OnStmtStart(context.TODO(), nil))
-		nextAction, err := provider.OnStmtErrorForNextAction(sessiontxn.StmtErrAfterPessimisticLock, lockErr)
+		nextAction, err := provider.OnStmtErrorForNextAction(ctx, sessiontxn.StmtErrAfterPessimisticLock, lockErr)
 		require.Same(t, lockErr, err)
 		require.Equal(t, sessiontxn.StmtActionError, nextAction)
 	}

--- a/sessiontxn/staleread/provider.go
+++ b/sessiontxn/staleread/provider.go
@@ -164,15 +164,15 @@ func (p *StalenessTxnContextProvider) OnStmtStart(ctx context.Context, _ ast.Stm
 	return nil
 }
 
-// OnHandlePessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
+// OnPessimisticStmtStart is the hook that should be called when starts handling a pessimistic DML or
 // a pessimistic select-for-update statements.
-func (p *StalenessTxnContextProvider) OnHandlePessimisticStmtStart(_ context.Context) error {
+func (p *StalenessTxnContextProvider) OnPessimisticStmtStart(_ context.Context) error {
 	return nil
 }
 
-// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
+// OnPessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
 // select-for-update statement.
-func (p *StalenessTxnContextProvider) OnHandlePessimisticStmtEnd(_ context.Context, _ bool) error {
+func (p *StalenessTxnContextProvider) OnPessimisticStmtEnd(_ context.Context, _ bool) error {
 	return nil
 }
 

--- a/sessiontxn/staleread/provider.go
+++ b/sessiontxn/staleread/provider.go
@@ -170,12 +170,6 @@ func (p *StalenessTxnContextProvider) OnHandlePessimisticStmtStart(_ context.Con
 	return nil
 }
 
-// OnPessimisticLockError is the hook that should be called when lock error happens during a pessimistic DML or
-// select-for-update statement.
-func (p *StalenessTxnContextProvider) OnPessimisticLockError(_ context.Context, _ error) error {
-	return nil
-}
-
 // OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
 // select-for-update statement.
 func (p *StalenessTxnContextProvider) OnHandlePessimisticStmtEnd(_ context.Context, _ bool) error {
@@ -204,7 +198,7 @@ func (p *StalenessTxnContextProvider) ActivateTxn() (kv.Transaction, error) {
 }
 
 // OnStmtErrorForNextAction is the hook that should be called when a new statement get an error
-func (p *StalenessTxnContextProvider) OnStmtErrorForNextAction(_ sessiontxn.StmtErrorHandlePoint, _ error) (sessiontxn.StmtErrorAction, error) {
+func (p *StalenessTxnContextProvider) OnStmtErrorForNextAction(ctx context.Context, point sessiontxn.StmtErrorHandlePoint, err error) (sessiontxn.StmtErrorAction, error) {
 	return sessiontxn.NoIdea()
 }
 

--- a/sessiontxn/staleread/provider.go
+++ b/sessiontxn/staleread/provider.go
@@ -170,6 +170,18 @@ func (p *StalenessTxnContextProvider) OnHandlePessimisticStmtStart(_ context.Con
 	return nil
 }
 
+// OnPessimisticLockError is the hook that should be called when lock error happens during a pessimistic DML or
+// select-for-update statement.
+func (p *StalenessTxnContextProvider) OnPessimisticLockError(_ context.Context, _ error) error {
+	return nil
+}
+
+// OnHandlePessimisticStmtEnd is the hook that should be called when finishes handling a pessimistic DML or
+// select-for-update statement.
+func (p *StalenessTxnContextProvider) OnHandlePessimisticStmtEnd(_ context.Context, _ bool) error {
+	return nil
+}
+
 // ActivateTxn activates the transaction.
 func (p *StalenessTxnContextProvider) ActivateTxn() (kv.Transaction, error) {
 	if p.txn != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41724 

Problem Summary:

### What is changed and how it works?

This PR moves invokations of aggressive locking starting/retrying/exiting to single functions (`handlePessimisticDML` and `handlePessimisticSelectForUpdate`). These two functions will enter aggressive locking if needed, and exit aggressive locking when it returns. Previously we exits aggressive locking in `StmtCommit` and `StmtRollback`. However in issue #41724 we founds that sometimes TiDB doesn't evaluate the condition to call `StmtCommit`/`StmtRollback` correctly, causing the aggressive locking state leak to the next statement. This PR avoids this leaking by exiting aggressive locking within the function that starts the aggressive locking.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that sometimes query fails when `tidb_pessimistic_txn_aggressive_locking` is enabled and prepare-execute is used on `select ... (select ... for update)` statements (select statements with select-for-update subquery).
```
