### PR TITLE
parser/model: move reorg related types to a new file

### DIFF
--- a/parser/model/BUILD.bazel
+++ b/parser/model/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "ddl.go",
         "flags.go",
         "model.go",
+        "reorg.go",
     ],
     importpath = "github.com/pingcap/tidb/parser/model",
     visibility = ["//visibility:public"],

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -16,12 +16,10 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
 )
 
@@ -226,60 +224,6 @@ func (h *HistoryInfo) Clean() {
 	h.MultipleTableInfos = nil
 }
 
-// DDLReorgMeta is meta info of DDL reorganization.
-type DDLReorgMeta struct {
-	// EndHandle is the last handle of the adding indices table.
-	// We should only backfill indices in the range [startHandle, EndHandle].
-	EndHandle int64 `json:"end_handle"`
-
-	SQLMode       mysql.SQLMode                    `json:"sql_mode"`
-	Warnings      map[errors.ErrorID]*terror.Error `json:"warnings"`
-	WarningsCount map[errors.ErrorID]int64         `json:"warnings_count"`
-	Location      *TimeZoneLocation                `json:"location"`
-	ReorgTp       ReorgType                        `json:"reorg_tp"`
-	IsDistReorg   bool                             `json:"is_dist_reorg"`
-}
-
-// ReorgType indicates which process is used for the data reorganization.
-type ReorgType int8
-
-const (
-	// ReorgTypeNone means the backfill task is not started yet.
-	ReorgTypeNone ReorgType = iota
-	// ReorgTypeTxn means the index records are backfill with transactions.
-	// All the index KVs are written through the transaction interface.
-	// This is the original backfill implementation.
-	ReorgTypeTxn
-	// ReorgTypeLitMerge means the index records are backfill with lightning.
-	// The index KVs are encoded to SST files and imported to the storage directly.
-	// The incremental index KVs written by DML are redirected to a temporary index.
-	// After the backfill is finished, the temporary index records are merged back to the original index.
-	ReorgTypeLitMerge
-	// ReorgTypeTxnMerge means backfill with transactions and merge incremental changes.
-	// The backfill index KVs are written through the transaction interface.
-	// The incremental index KVs written by DML are redirected to a temporary index.
-	// After the backfill is finished, the temporary index records are merged back to the original index.
-	ReorgTypeTxnMerge
-)
-
-// NeedMergeProcess means the incremental changes need to be merged.
-func (tp ReorgType) NeedMergeProcess() bool {
-	return tp == ReorgTypeLitMerge || tp == ReorgTypeTxnMerge
-}
-
-// String implements fmt.Stringer interface.
-func (tp ReorgType) String() string {
-	switch tp {
-	case ReorgTypeTxn:
-		return "txn"
-	case ReorgTypeLitMerge:
-		return "ingest"
-	case ReorgTypeTxnMerge:
-		return "txn-merge"
-	}
-	return ""
-}
-
 // TimeZoneLocation represents a single time zone.
 type TimeZoneLocation struct {
 	Name     string `json:"name"`
@@ -300,13 +244,6 @@ func (tz *TimeZoneLocation) GetLocation() (*time.Location, error) {
 		tz.location = time.FixedZone(tz.Name, tz.Offset)
 	}
 	return tz.location, err
-}
-
-// NewDDLReorgMeta new a DDLReorgMeta.
-func NewDDLReorgMeta() *DDLReorgMeta {
-	return &DDLReorgMeta{
-		EndHandle: math.MaxInt64,
-	}
 }
 
 // MultiSchemaInfo keeps some information for multi schema change.
@@ -433,36 +370,6 @@ type JobMeta struct {
 	Query string `json:"query"`
 	// Priority is only used to set the operation priority of adding indices.
 	Priority int `json:"priority"`
-}
-
-// BackfillMeta is meta info of the backfill job.
-type BackfillMeta struct {
-	IsUnique   bool          `json:"is_unique"`
-	EndInclude bool          `json:"end_include"`
-	Error      *terror.Error `json:"err"`
-
-	SQLMode       mysql.SQLMode                    `json:"sql_mode"`
-	Warnings      map[errors.ErrorID]*terror.Error `json:"warnings"`
-	WarningsCount map[errors.ErrorID]int64         `json:"warnings_count"`
-	Location      *TimeZoneLocation                `json:"location"`
-	ReorgTp       ReorgType                        `json:"reorg_tp"`
-	RowCount      int64                            `json:"row_count"`
-	StartKey      []byte                           `json:"start_key"`
-	EndKey        []byte                           `json:"end_key"`
-	CurrKey       []byte                           `json:"curr_key"`
-	*JobMeta      `json:"job_meta"`
-}
-
-// Encode encodes BackfillMeta with json format.
-func (bm *BackfillMeta) Encode() ([]byte, error) {
-	b, err := json.Marshal(bm)
-	return b, errors.Trace(err)
-}
-
-// Decode decodes BackfillMeta from the json buffer.
-func (bm *BackfillMeta) Decode(b []byte) error {
-	err := json.Unmarshal(b, bm)
-	return errors.Trace(err)
 }
 
 // Job is for a DDL operation.

--- a/parser/model/model.go
+++ b/parser/model/model.go
@@ -77,41 +77,6 @@ func (s SchemaState) String() string {
 	}
 }
 
-// BackfillState is the state used by the backfill-merge process.
-type BackfillState byte
-
-const (
-	// BackfillStateInapplicable means the backfill-merge process is not used.
-	BackfillStateInapplicable BackfillState = iota
-	// BackfillStateRunning is the state that the backfill process is running.
-	// In this state, the index's write and delete operations are redirected to a temporary index.
-	BackfillStateRunning
-	// BackfillStateReadyToMerge is the state that the temporary index's records are ready to be merged back
-	// to the origin index.
-	// In this state, the index's write and delete operations are copied to a temporary index.
-	// This state is used to make sure that all the TiDB instances are aware of the copy during the merge(BackfillStateMerging).
-	BackfillStateReadyToMerge
-	// BackfillStateMerging is the state that the temp index is merging back to the origin index.
-	// In this state, the index's write and delete operations are copied to a temporary index.
-	BackfillStateMerging
-)
-
-// String implements fmt.Stringer interface.
-func (s BackfillState) String() string {
-	switch s {
-	case BackfillStateRunning:
-		return "backfill state running"
-	case BackfillStateReadyToMerge:
-		return "backfill state ready to merge"
-	case BackfillStateMerging:
-		return "backfill state merging"
-	case BackfillStateInapplicable:
-		return "backfill state inapplicable"
-	default:
-		return "backfill state unknown"
-	}
-}
-
 const (
 	// ColumnInfoVersion0 means the column info version is 0.
 	ColumnInfoVersion0 = uint64(0)

--- a/parser/model/reorg.go
+++ b/parser/model/reorg.go
@@ -1,0 +1,149 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"math"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/parser/mysql"
+	"github.com/pingcap/tidb/parser/terror"
+)
+
+// DDLReorgMeta is meta info of DDL reorganization.
+type DDLReorgMeta struct {
+	// EndHandle is the last handle of the adding indices table.
+	// We should only backfill indices in the range [startHandle, EndHandle].
+	EndHandle int64 `json:"end_handle"`
+
+	SQLMode       mysql.SQLMode                    `json:"sql_mode"`
+	Warnings      map[errors.ErrorID]*terror.Error `json:"warnings"`
+	WarningsCount map[errors.ErrorID]int64         `json:"warnings_count"`
+	Location      *TimeZoneLocation                `json:"location"`
+	ReorgTp       ReorgType                        `json:"reorg_tp"`
+	IsDistReorg   bool                             `json:"is_dist_reorg"`
+}
+
+// NewDDLReorgMeta new a DDLReorgMeta.
+func NewDDLReorgMeta() *DDLReorgMeta {
+	return &DDLReorgMeta{
+		EndHandle: math.MaxInt64,
+	}
+}
+
+// ReorgType indicates which process is used for the data reorganization.
+type ReorgType int8
+
+const (
+	// ReorgTypeNone means the backfill task is not started yet.
+	ReorgTypeNone ReorgType = iota
+	// ReorgTypeTxn means the index records are backfill with transactions.
+	// All the index KVs are written through the transaction interface.
+	// This is the original backfill implementation.
+	ReorgTypeTxn
+	// ReorgTypeLitMerge means the index records are backfill with lightning.
+	// The index KVs are encoded to SST files and imported to the storage directly.
+	// The incremental index KVs written by DML are redirected to a temporary index.
+	// After the backfill is finished, the temporary index records are merged back to the original index.
+	ReorgTypeLitMerge
+	// ReorgTypeTxnMerge means backfill with transactions and merge incremental changes.
+	// The backfill index KVs are written through the transaction interface.
+	// The incremental index KVs written by DML are redirected to a temporary index.
+	// After the backfill is finished, the temporary index records are merged back to the original index.
+	ReorgTypeTxnMerge
+)
+
+// NeedMergeProcess means the incremental changes need to be merged.
+func (tp ReorgType) NeedMergeProcess() bool {
+	return tp == ReorgTypeLitMerge || tp == ReorgTypeTxnMerge
+}
+
+// String implements fmt.Stringer interface.
+func (tp ReorgType) String() string {
+	switch tp {
+	case ReorgTypeTxn:
+		return "txn"
+	case ReorgTypeLitMerge:
+		return "ingest"
+	case ReorgTypeTxnMerge:
+		return "txn-merge"
+	}
+	return ""
+}
+
+// BackfillState is the state used by the backfill-merge process.
+type BackfillState byte
+
+const (
+	// BackfillStateInapplicable means the backfill-merge process is not used.
+	BackfillStateInapplicable BackfillState = iota
+	// BackfillStateRunning is the state that the backfill process is running.
+	// In this state, the index's write and delete operations are redirected to a temporary index.
+	BackfillStateRunning
+	// BackfillStateReadyToMerge is the state that the temporary index's records are ready to be merged back
+	// to the origin index.
+	// In this state, the index's write and delete operations are copied to a temporary index.
+	// This state is used to make sure that all the TiDB instances are aware of the copy during the merge(BackfillStateMerging).
+	BackfillStateReadyToMerge
+	// BackfillStateMerging is the state that the temp index is merging back to the origin index.
+	// In this state, the index's write and delete operations are copied to a temporary index.
+	BackfillStateMerging
+)
+
+// String implements fmt.Stringer interface.
+func (s BackfillState) String() string {
+	switch s {
+	case BackfillStateRunning:
+		return "backfill state running"
+	case BackfillStateReadyToMerge:
+		return "backfill state ready to merge"
+	case BackfillStateMerging:
+		return "backfill state merging"
+	case BackfillStateInapplicable:
+		return "backfill state inapplicable"
+	default:
+		return "backfill state unknown"
+	}
+}
+
+// BackfillMeta is meta info of the backfill job.
+type BackfillMeta struct {
+	IsUnique   bool          `json:"is_unique"`
+	EndInclude bool          `json:"end_include"`
+	Error      *terror.Error `json:"err"`
+
+	SQLMode       mysql.SQLMode                    `json:"sql_mode"`
+	Warnings      map[errors.ErrorID]*terror.Error `json:"warnings"`
+	WarningsCount map[errors.ErrorID]int64         `json:"warnings_count"`
+	Location      *TimeZoneLocation                `json:"location"`
+	ReorgTp       ReorgType                        `json:"reorg_tp"`
+	RowCount      int64                            `json:"row_count"`
+	StartKey      []byte                           `json:"start_key"`
+	EndKey        []byte                           `json:"end_key"`
+	CurrKey       []byte                           `json:"curr_key"`
+	*JobMeta      `json:"job_meta"`
+}
+
+// Encode encodes BackfillMeta with json format.
+func (bm *BackfillMeta) Encode() ([]byte, error) {
+	b, err := json.Marshal(bm)
+	return b, errors.Trace(err)
+}
+
+// Decode decodes BackfillMeta from the json buffer.
+func (bm *BackfillMeta) Decode(b []byte) error {
+	err := json.Unmarshal(b, bm)
+	return errors.Trace(err)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

### What is changed and how it works?

This PR moves the reorg and backfill related types and functions to a new file to prevent `model/ddl.go` being too large.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
