### PR TITLE
br: add <Code>RequestTimeout</Code> to list of retryable errors

### DIFF
--- a/br/pkg/utils/retry.go
+++ b/br/pkg/utils/retry.go
@@ -25,6 +25,7 @@ var retryableServerError = []string{
 	"put object timeout",
 	"internalerror",
 	"not read from or written to within the timeout period",
+	"<code>requesttimeout</code>",
 }
 
 // RetryableFunc presents a retryable operation.

--- a/br/tests/br_full/run.sh
+++ b/br/tests/br_full/run.sh
@@ -52,7 +52,7 @@ test_log="${TEST_DIR}/${DB}_test.log"
 error_str="not read from or written to within the timeout period"
 unset BR_LOG_TO_TERM
 
-export GO_FAILPOINTS="github.com/pingcap/tidb/br/pkg/backup/backup-storage-error=1*return(\"connection refused\")->1*return(\"InternalError\");github.com/pingcap/tidb/br/pkg/backup/backup-timeout-error=1*return(\"not read from or written to within the timeout period\")"
+export GO_FAILPOINTS="github.com/pingcap/tidb/br/pkg/backup/backup-storage-error=1*return(\"connection refused\")->1*return(\"InternalError\");github.com/pingcap/tidb/br/pkg/backup/backup-timeout-error=1*return(\"<Code>RequestTimeout</Code>\")->1*return(\"not read from or written to within the timeout period\")"
 run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/$DB-lz4" --concurrency 4 --compression lz4 --log-file $test_log
 export GO_FAILPOINTS=""
 size_lz4=$(du -d 0 $TEST_DIR/$DB-lz4 | awk '{print $1}')


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #41756

Problem Summary:

Some S3-compatible external storage does not return an error response with a human-readable `<Message>` tag. BR relied on its content and thus failed to recognize a RequestTimeout error is in fact retryable.

### What is changed and how it works?

Added the error code into the list of phrases to check.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
BR can now properly retry on RequestTimeout transient errors when backing up to Baidu Object Storage (BOS).
```
