### PR TITLE
executor: fix revoke USAGE

### DIFF
--- a/executor/grant.go
+++ b/executor/grant.go
@@ -453,6 +453,9 @@ func (e *GrantExec) grantLevelPriv(priv *ast.PrivElem, user *ast.UserSpec, inter
 	if priv.Priv == mysql.ExtendedPriv {
 		return e.grantDynamicPriv(priv.Name, user, internalSession)
 	}
+	if priv.Priv == mysql.UsagePriv {
+		return nil
+	}
 	switch e.Level.Level {
 	case ast.GrantLevelGlobal:
 		return e.grantGlobalLevel(priv, user, internalSession)
@@ -491,10 +494,6 @@ func (e *GrantExec) grantDynamicPriv(privName string, user *ast.UserSpec, intern
 
 // grantGlobalLevel manipulates mysql.user table.
 func (e *GrantExec) grantGlobalLevel(priv *ast.PrivElem, user *ast.UserSpec, internalSession sessionctx.Context) error {
-	if priv.Priv == 0 || priv.Priv == mysql.UsagePriv {
-		return nil
-	}
-
 	sql := new(strings.Builder)
 	sqlexec.MustFormatSQL(sql, `UPDATE %n.%n SET `, mysql.SystemDB, mysql.UserTable)
 	err := composeGlobalPrivUpdate(sql, priv.Priv, "Y")
@@ -510,9 +509,6 @@ func (e *GrantExec) grantGlobalLevel(priv *ast.PrivElem, user *ast.UserSpec, int
 
 // grantDBLevel manipulates mysql.db table.
 func (e *GrantExec) grantDBLevel(priv *ast.PrivElem, user *ast.UserSpec, internalSession sessionctx.Context) error {
-	if priv.Priv == mysql.UsagePriv {
-		return nil
-	}
 	for _, v := range mysql.StaticGlobalOnlyPrivs {
 		if v == priv.Priv {
 			return ErrWrongUsage.GenWithStackByArgs("DB GRANT", "GLOBAL PRIVILEGES")
@@ -539,9 +535,6 @@ func (e *GrantExec) grantDBLevel(priv *ast.PrivElem, user *ast.UserSpec, interna
 
 // grantTableLevel manipulates mysql.tables_priv table.
 func (e *GrantExec) grantTableLevel(priv *ast.PrivElem, user *ast.UserSpec, internalSession sessionctx.Context) error {
-	if priv.Priv == mysql.UsagePriv {
-		return nil
-	}
 	dbName := e.Level.DBName
 	if len(dbName) == 0 {
 		dbName = e.ctx.GetSessionVars().CurrentDB

--- a/executor/revoke.go
+++ b/executor/revoke.go
@@ -180,6 +180,9 @@ func (e *RevokeExec) revokeOneUser(internalSession sessionctx.Context, user, hos
 }
 
 func (e *RevokeExec) revokePriv(internalSession sessionctx.Context, priv *ast.PrivElem, user, host string) error {
+	if priv.Priv == mysql.UsagePriv {
+		return nil
+	}
 	switch e.Level.Level {
 	case ast.GrantLevelGlobal:
 		return e.revokeGlobalPriv(internalSession, priv, user, host)

--- a/executor/revoke_test.go
+++ b/executor/revoke_test.go
@@ -274,9 +274,7 @@ func TestRevokeOnNonExistTable(t *testing.T) {
 
 // Check https://github.com/pingcap/tidb/issues/41773.
 func TestIssue41773(t *testing.T) {
-	store, clean := testkit.CreateMockStore(t)
-	defer clean()
-
+	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table if not exists xx (id int)")

--- a/executor/revoke_test.go
+++ b/executor/revoke_test.go
@@ -271,3 +271,20 @@ func TestRevokeOnNonExistTable(t *testing.T) {
 	tk.MustExec("DROP TABLE t1;")
 	tk.MustExec("REVOKE ALTER ON d1.t1 FROM issue28533;")
 }
+
+// Check https://github.com/pingcap/tidb/issues/41773.
+func TestIssue41773(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table if not exists xx (id int)")
+	tk.MustExec("CREATE USER 't1234'@'%' IDENTIFIED BY 'sNGNQo12fEHe0n3vU';")
+	tk.MustExec("GRANT USAGE ON * TO 't1234'@'%';")
+	tk.MustExec("GRANT USAGE ON test.* TO 't1234'@'%';")
+	tk.MustExec("GRANT USAGE ON test.xx TO 't1234'@'%';")
+	tk.MustExec("REVOKE USAGE ON * FROM 't1234'@'%';")
+	tk.MustExec("REVOKE USAGE ON test.* FROM 't1234'@'%';")
+	tk.MustExec("REVOKE USAGE ON test.xx FROM 't1234'@'%';")
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41773 

Problem Summary: Should skip `USAGE`, which is `0`. It does not have coressponding column on priv table.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix error on 'REVOKE USAGE ...'
```
