### PR TITLE
types: clip to zero when convert negative decimal to uint

### DIFF
--- a/types/convert.go
+++ b/types/convert.go
@@ -263,8 +263,7 @@ func convertDecimalStrToUint(sc *stmtctx.StatementContext, str string, upperBoun
 		round++
 	}
 
-	upperBound -= round
-	upperStr := strconv.FormatUint(upperBound, 10)
+	upperStr := strconv.FormatUint(upperBound-round, 10)
 	if len(intStr) > len(upperStr) ||
 		(len(intStr) == len(upperStr) && intStr > upperStr) {
 		return upperBound, overflow(str, tp)

--- a/types/convert.go
+++ b/types/convert.go
@@ -254,7 +254,7 @@ func convertDecimalStrToUint(sc *stmtctx.StatementContext, str string, upperBoun
 	if intStr == "" {
 		intStr = "0"
 	}
-	if sc.ShouldClipToZero() && intStr[0] == '-' {
+	if intStr[0] == '-' {
 		return 0, overflow(str, tp)
 	}
 

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -1275,8 +1275,9 @@ func TestConvertDecimalStrToUint(t *testing.T) {
 		{"9223372036854775807.4999", 9223372036854775807, true},
 		{"18446744073709551614.55", 18446744073709551615, true},
 		{"18446744073709551615.344", 18446744073709551615, true},
-		{"18446744073709551615.544", 0, false},
+		{"18446744073709551615.544", 18446744073709551615, false},
 		{"-111.111", 0, false},
+		{"-10000000000000000000.0", 0, false},
 	}
 	for _, ca := range cases {
 		result, err := convertDecimalStrToUint(&stmtctx.StatementContext{}, ca.input, math.MaxUint64, 0)
@@ -1284,7 +1285,7 @@ func TestConvertDecimalStrToUint(t *testing.T) {
 			require.Error(t, err)
 		} else {
 			require.NoError(t, err)
-			require.Equal(t, ca.result, result)
 		}
+		require.Equal(t, ca.result, result, "input=%v", ca.input)
 	}
 }

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -1288,4 +1288,12 @@ func TestConvertDecimalStrToUint(t *testing.T) {
 		}
 		require.Equal(t, ca.result, result, "input=%v", ca.input)
 	}
+
+	result, err := convertDecimalStrToUint(&stmtctx.StatementContext{}, "-99.0", math.MaxUint8, 0)
+	require.Error(t, err)
+	require.Equal(t, uint64(0), result)
+
+	result, err = convertDecimalStrToUint(&stmtctx.StatementContext{}, "-100.0", math.MaxUint8, 0)
+	require.Error(t, err)
+	require.Equal(t, uint64(0), result)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/41736

Problem Summary:

see https://github.com/pingcap/tidb/issues/41736#issuecomment-1449271739


### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a compare incorrect issue cause by fault convert 
```
