### PR TITLE
planner: resolve the compatibility problems for the join hint

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -689,9 +689,8 @@ func (p *LogicalJoin) setPreferredJoinTypeAndOrder(hintInfo *tableHintInfo) {
 	}
 }
 
-// setPreferredJoinType4PhysicalOp generates hint information for the logicalJoin based on the hint information of its left and right children.
-// This information is used for selecting the physical operator.
-func (p *LogicalJoin) setPreferredJoinType4PhysicalOp() {
+// setPreferredJoinType generates hint information for the logicalJoin based on the hint information of its left and right children.
+func (p *LogicalJoin) setPreferredJoinType() {
 	leftHintInfo := p.leftPreferJoinType
 	rightHintInfo := p.rightPreferJoinType
 	if leftHintInfo == 0 && rightHintInfo == 0 {
@@ -710,8 +709,8 @@ func (p *LogicalJoin) setPreferredJoinType4PhysicalOp() {
 			p.preferJoinType = rightHintInfo
 		}
 		preferJoinType := uint(0)
-		// Some implementations of physical operators are dependent on the direction,
-		// and adjustments need to be made based on the direction.
+		// Some implementations of physical joins are dependent on the direction,
+		// so adjustments need to be made based on the direction.
 		switch p.preferJoinType {
 		case preferINLJ:
 			if leftHintInfo != 0 {
@@ -725,37 +724,34 @@ func (p *LogicalJoin) setPreferredJoinType4PhysicalOp() {
 				preferJoinType |= preferLeftAsINLHJInner
 			}
 			if rightHintInfo != 0 {
-				preferJoinType |= preferLeftAsINLHJInner
+				preferJoinType |= preferRightAsINLHJInner
 			}
 		case preferINLMJ:
 			if leftHintInfo != 0 {
 				preferJoinType |= preferLeftAsINLMJInner
 			}
 			if rightHintInfo != 0 {
-				preferJoinType |= preferLeftAsINLMJInner
+				preferJoinType |= preferRightAsINLMJInner
 			}
 		case preferHJBuild:
 			if leftHintInfo != 0 {
 				preferJoinType |= preferLeftAsHJBuild
 			}
 			if rightHintInfo != 0 {
-				preferJoinType |= preferLeftAsHJBuild
+				preferJoinType |= preferRightAsHJBuild
 			}
 		case preferHJProbe:
 			if leftHintInfo != 0 {
 				preferJoinType |= preferLeftAsHJProbe
 			}
 			if rightHintInfo != 0 {
-				preferJoinType |= preferLeftAsHJProbe
+				preferJoinType |= preferRightAsHJProbe
 			}
 		default:
 			preferJoinType = p.preferJoinType
 		}
 		p.preferJoinType = preferJoinType
 	}
-	// Clear information from left and right child nodes to prevent multiple calls to this function.
-	p.leftPreferJoinType = 0
-	p.rightPreferJoinType = 0
 }
 
 func (ds *DataSource) setPreferredStoreType(hintInfo *tableHintInfo) {

--- a/planner/core/rule_join_reorder.go
+++ b/planner/core/rule_join_reorder.go
@@ -33,31 +33,65 @@ import (
 //
 // For example: "InnerJoin(InnerJoin(a, b), LeftJoin(c, d))"
 // results in a join group {a, b, c, d}.
-func extractJoinGroup(p LogicalPlan) (group []LogicalPlan, eqEdges []*expression.ScalarFunction,
-	otherConds []expression.Expression, joinTypes []*joinTypeWithExtMsg, hintInfo []*tableHintInfo, hasOuterJoin bool) {
+func extractJoinGroup(p LogicalPlan) *joinGroupResult {
+	joinMethodHintInfo := make(map[int]*joinMethodHint)
+	var (
+		group             []LogicalPlan
+		joinOrderHintInfo []*tableHintInfo
+		eqEdges           []*expression.ScalarFunction
+		otherConds        []expression.Expression
+		joinTypes         []*joinTypeWithExtMsg
+		hasOuterJoin      bool
+	)
 	join, isJoin := p.(*LogicalJoin)
 	if isJoin && join.preferJoinOrder {
 		// When there is a leading hint, the hint may not take effect for other reasons.
 		// For example, the join type is cross join or straight join, or exists the join algorithm hint, etc.
 		// We need to return the hint information to warn
-		hintInfo = append(hintInfo, join.hintInfo)
+		joinOrderHintInfo = append(joinOrderHintInfo, join.hintInfo)
 	}
-	if !isJoin || join.preferJoinType > uint(0) || join.StraightJoin ||
+	// If the variable `tidb_opt_advanced_join_hint` is false and the join node has the join method hint, we will not split the current join node to join reorder process.
+	if !isJoin || (join.preferJoinType > uint(0) && !p.SCtx().GetSessionVars().EnableAdvancedJoinHint) || join.StraightJoin ||
 		(join.JoinType != InnerJoin && join.JoinType != LeftOuterJoin && join.JoinType != RightOuterJoin) ||
 		((join.JoinType == LeftOuterJoin || join.JoinType == RightOuterJoin) && join.EqualConditions == nil) {
-		if hintInfo != nil {
+		if joinOrderHintInfo != nil {
 			// The leading hint can not work for some reasons. So clear it in the join node.
 			join.hintInfo = nil
 		}
-		return []LogicalPlan{p}, nil, nil, nil, hintInfo, false
+		return &joinGroupResult{
+			group:              []LogicalPlan{p},
+			joinOrderHintInfo:  joinOrderHintInfo,
+			basicJoinGroupInfo: &basicJoinGroupInfo{},
+		}
 	}
 	// If the session var is set to off, we will still reject the outer joins.
 	if !p.SCtx().GetSessionVars().EnableOuterJoinReorder && (join.JoinType == LeftOuterJoin || join.JoinType == RightOuterJoin) {
-		return []LogicalPlan{p}, nil, nil, nil, hintInfo, false
+		return &joinGroupResult{
+			group:              []LogicalPlan{p},
+			joinOrderHintInfo:  joinOrderHintInfo,
+			basicJoinGroupInfo: &basicJoinGroupInfo{},
+		}
+	}
+	// `leftHasHint` and `rightHasHint` are used to record whether the left child and right child are set by the join method hint.
+	leftHasHint, rightHasHint := false, false
+	if isJoin && p.SCtx().GetSessionVars().EnableAdvancedJoinHint && join.preferJoinType > uint(0) {
+		// If the current join node has the join method hint, we should store the hint information and restore it when we have finished the join reorder process.
+		if join.leftPreferJoinType > uint(0) {
+			joinMethodHintInfo[join.children[0].ID()] = &joinMethodHint{join.leftPreferJoinType, join.hintInfo}
+			leftHasHint = true
+		}
+		if join.rightPreferJoinType > uint(0) {
+			joinMethodHintInfo[join.children[1].ID()] = &joinMethodHint{join.rightPreferJoinType, join.hintInfo}
+			rightHasHint = true
+		}
 	}
 	hasOuterJoin = hasOuterJoin || (join.JoinType != InnerJoin)
-	if join.JoinType != RightOuterJoin {
-		lhsGroup, lhsEqualConds, lhsOtherConds, lhsJoinTypes, lhsHintInfo, lhsHasOuterJoin := extractJoinGroup(join.children[0])
+	// If the left child has the hint, it means there are some join method hints want to specify the join method based on the left child.
+	// For example: `select .. from t1 join t2 join (select .. from t3 join t4) t5 where ..;` If there are some join method hints related to `t5`, we can't split `t5` into `t3` and `t4`.
+	// So we don't need to split the left child part. The right child part is the same.
+	if join.JoinType != RightOuterJoin && !leftHasHint {
+		lhsJoinGroupResult := extractJoinGroup(join.children[0])
+		lhsGroup, lhsEqualConds, lhsOtherConds, lhsJoinTypes, lhsJoinOrderHintInfo, lhsJoinMethodHintInfo, lhsHasOuterJoin := lhsJoinGroupResult.group, lhsJoinGroupResult.eqEdges, lhsJoinGroupResult.otherConds, lhsJoinGroupResult.joinTypes, lhsJoinGroupResult.joinOrderHintInfo, lhsJoinGroupResult.joinMethodHintInfo, lhsJoinGroupResult.hasOuterJoin
 		noExpand := false
 		// If the filters of the outer join is related with multiple leaves of the outer join side. We don't reorder it for now.
 		if join.JoinType == LeftOuterJoin {
@@ -80,20 +114,28 @@ func extractJoinGroup(p LogicalPlan) (group []LogicalPlan, eqEdges []*expression
 			}
 		}
 		if noExpand {
-			return []LogicalPlan{p}, nil, nil, nil, nil, false
+			return &joinGroupResult{
+				group:              []LogicalPlan{p},
+				basicJoinGroupInfo: &basicJoinGroupInfo{},
+			}
 		}
 		group = append(group, lhsGroup...)
 		eqEdges = append(eqEdges, lhsEqualConds...)
 		otherConds = append(otherConds, lhsOtherConds...)
 		joinTypes = append(joinTypes, lhsJoinTypes...)
-		hintInfo = append(hintInfo, lhsHintInfo...)
+		joinOrderHintInfo = append(joinOrderHintInfo, lhsJoinOrderHintInfo...)
+		for ID, joinMethodHint := range lhsJoinMethodHintInfo {
+			joinMethodHintInfo[ID] = joinMethodHint
+		}
 		hasOuterJoin = hasOuterJoin || lhsHasOuterJoin
 	} else {
 		group = append(group, join.children[0])
 	}
 
-	if join.JoinType != LeftOuterJoin {
-		rhsGroup, rhsEqualConds, rhsOtherConds, rhsJoinTypes, rhsHintInfo, rhsHasOuterJoin := extractJoinGroup(join.children[1])
+	// You can see the comments in the upside part which we try to split the left child part. It's the same here.
+	if join.JoinType != LeftOuterJoin && !rightHasHint {
+		rhsJoinGroupResult := extractJoinGroup(join.children[1])
+		rhsGroup, rhsEqualConds, rhsOtherConds, rhsJoinTypes, rhsJoinOrderHintInfo, rhsJoinMethodHintInfo, rhsHasOuterJoin := rhsJoinGroupResult.group, rhsJoinGroupResult.eqEdges, rhsJoinGroupResult.otherConds, rhsJoinGroupResult.joinTypes, rhsJoinGroupResult.joinOrderHintInfo, rhsJoinGroupResult.joinMethodHintInfo, rhsJoinGroupResult.hasOuterJoin
 		noExpand := false
 		// If the filters of the outer join is related with multiple leaves of the outer join side. We don't reorder it for now.
 		if join.JoinType == RightOuterJoin {
@@ -116,13 +158,19 @@ func extractJoinGroup(p LogicalPlan) (group []LogicalPlan, eqEdges []*expression
 			}
 		}
 		if noExpand {
-			return []LogicalPlan{p}, nil, nil, nil, nil, false
+			return &joinGroupResult{
+				group:              []LogicalPlan{p},
+				basicJoinGroupInfo: &basicJoinGroupInfo{},
+			}
 		}
 		group = append(group, rhsGroup...)
 		eqEdges = append(eqEdges, rhsEqualConds...)
 		otherConds = append(otherConds, rhsOtherConds...)
 		joinTypes = append(joinTypes, rhsJoinTypes...)
-		hintInfo = append(hintInfo, rhsHintInfo...)
+		joinOrderHintInfo = append(joinOrderHintInfo, rhsJoinOrderHintInfo...)
+		for ID, joinMethodHint := range rhsJoinMethodHintInfo {
+			joinMethodHintInfo[ID] = joinMethodHint
+		}
 		hasOuterJoin = hasOuterJoin || rhsHasOuterJoin
 	} else {
 		group = append(group, join.children[1])
@@ -148,8 +196,17 @@ func extractJoinGroup(p LogicalPlan) (group []LogicalPlan, eqEdges []*expression
 		}
 		otherConds = append(otherConds, tmpOtherConds...)
 	}
-
-	return group, eqEdges, otherConds, joinTypes, hintInfo, hasOuterJoin
+	return &joinGroupResult{
+		group:             group,
+		hasOuterJoin:      hasOuterJoin,
+		joinOrderHintInfo: joinOrderHintInfo,
+		basicJoinGroupInfo: &basicJoinGroupInfo{
+			eqEdges:            eqEdges,
+			otherConds:         otherConds,
+			joinTypes:          joinTypes,
+			joinMethodHintInfo: joinMethodHintInfo,
+		},
+	}
 }
 
 type joinReOrderSolver struct {
@@ -178,7 +235,8 @@ func (s *joinReOrderSolver) optimize(_ context.Context, p LogicalPlan, opt *logi
 func (s *joinReOrderSolver) optimizeRecursive(ctx sessionctx.Context, p LogicalPlan, tracer *joinReorderTrace) (LogicalPlan, error) {
 	var err error
 
-	curJoinGroup, eqEdges, otherConds, joinTypes, hintInfo, hasOuterJoin := extractJoinGroup(p)
+	result := extractJoinGroup(p)
+	curJoinGroup, joinTypes, joinOrderHintInfo, hasOuterJoin := result.group, result.joinTypes, result.joinOrderHintInfo, result.hasOuterJoin
 	if len(curJoinGroup) > 1 {
 		for i := range curJoinGroup {
 			curJoinGroup[i], err = s.optimizeRecursive(ctx, curJoinGroup[i], tracer)
@@ -198,16 +256,14 @@ func (s *joinReOrderSolver) optimizeRecursive(ctx sessionctx.Context, p LogicalP
 		}
 
 		baseGroupSolver := &baseSingleGroupJoinOrderSolver{
-			ctx:        ctx,
-			otherConds: otherConds,
-			eqEdges:    eqEdges,
-			joinTypes:  joinTypes,
+			ctx:                ctx,
+			basicJoinGroupInfo: result.basicJoinGroupInfo,
 		}
 
 		joinGroupNum := len(curJoinGroup)
 		useGreedy := joinGroupNum > ctx.GetSessionVars().TiDBOptJoinReorderThreshold || !isSupportDP
 
-		leadingHintInfo, hasDiffLeadingHint := checkAndGenerateLeadingHint(hintInfo)
+		leadingHintInfo, hasDiffLeadingHint := checkAndGenerateLeadingHint(joinOrderHintInfo)
 		if hasDiffLeadingHint {
 			ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInternal.GenWithStack("We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid"))
 		}
@@ -261,7 +317,7 @@ func (s *joinReOrderSolver) optimizeRecursive(ctx sessionctx.Context, p LogicalP
 		}
 		return p, nil
 	}
-	if len(curJoinGroup) == 1 && hintInfo != nil {
+	if len(curJoinGroup) == 1 && joinOrderHintInfo != nil {
 		ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInternal.GenWithStack("leading hint is inapplicable, check the join type or the join algorithm hint"))
 	}
 	newChildren := make([]LogicalPlan, 0, len(p.Children()))
@@ -303,14 +359,35 @@ func checkAndGenerateLeadingHint(hintInfo []*tableHintInfo) (*tableHintInfo, boo
 	return leadingHintInfo, hasDiffLeadingHint
 }
 
+type joinMethodHint struct {
+	preferredJoinMethod uint
+	joinMethodHintInfo  *tableHintInfo
+}
+
+// basicJoinGroupInfo represents basic information for a join group in the join reorder process.
+type basicJoinGroupInfo struct {
+	eqEdges    []*expression.ScalarFunction
+	otherConds []expression.Expression
+	joinTypes  []*joinTypeWithExtMsg
+	// `joinMethodHintInfo` is used to map the sub-plan's ID to the join method hint.
+	// The sub-plan will join the join reorder process to build the new plan.
+	// So after we have finished the join reorder process, we can reset the join method hint based on the sub-plan's ID.
+	joinMethodHintInfo map[int]*joinMethodHint
+}
+
+type joinGroupResult struct {
+	group             []LogicalPlan
+	hasOuterJoin      bool
+	joinOrderHintInfo []*tableHintInfo
+	*basicJoinGroupInfo
+}
+
 // nolint:structcheck
 type baseSingleGroupJoinOrderSolver struct {
 	ctx              sessionctx.Context
 	curJoinGroup     []*jrNode
-	otherConds       []expression.Expression
-	eqEdges          []*expression.ScalarFunction
-	joinTypes        []*joinTypeWithExtMsg
 	leadingJoinGroup LogicalPlan
+	*basicJoinGroupInfo
 }
 
 func (s *baseSingleGroupJoinOrderSolver) generateLeadingJoinGroup(curJoinGroup []LogicalPlan, hintInfo *tableHintInfo, hasOuterJoin bool) (bool, []LogicalPlan) {
@@ -483,6 +560,7 @@ func (s *baseSingleGroupJoinOrderSolver) newCartesianJoin(lChild, rChild Logical
 	}.Init(s.ctx, offset)
 	join.SetSchema(expression.MergeSchema(lChild.Schema(), rChild.Schema()))
 	join.SetChildren(lChild, rChild)
+	s.setNewJoinWithHint(join)
 	return join
 }
 
@@ -495,6 +573,23 @@ func (s *baseSingleGroupJoinOrderSolver) newJoinWithEdges(lChild, rChild Logical
 	newJoin.RightConditions = rightConds
 	newJoin.JoinType = joinType
 	return newJoin
+}
+
+// setNewJoinWithHint sets the join method hint for the join node.
+// Before the join reorder process, we split the join node and collect the join method hint.
+// And we record the join method hint and reset the hint after we have finished the join reorder process.
+func (s *baseSingleGroupJoinOrderSolver) setNewJoinWithHint(newJoin *LogicalJoin) {
+	lChild := newJoin.Children()[0]
+	rChild := newJoin.Children()[1]
+	if joinMethodHint, ok := s.joinMethodHintInfo[lChild.ID()]; ok {
+		newJoin.leftPreferJoinType = joinMethodHint.preferredJoinMethod
+		newJoin.hintInfo = joinMethodHint.joinMethodHintInfo
+	}
+	if joinMethodHint, ok := s.joinMethodHintInfo[rChild.ID()]; ok {
+		newJoin.rightPreferJoinType = joinMethodHint.preferredJoinMethod
+		newJoin.hintInfo = joinMethodHint.joinMethodHintInfo
+	}
+	newJoin.setPreferredJoinType()
 }
 
 // calcJoinCumCost calculates the cumulative cost of the join node.

--- a/planner/core/rule_join_reorder_dp_test.go
+++ b/planner/core/rule_join_reorder_dp_test.go
@@ -186,9 +186,12 @@ func TestDPReorderTPCHQ5(t *testing.T) {
 		require.True(t, isSF)
 		eqEdges = append(eqEdges, sf)
 	}
-	baseGroupSolver := &baseSingleGroupJoinOrderSolver{
-		ctx:     ctx,
+	basicJoinGroupInfo := &basicJoinGroupInfo{
 		eqEdges: eqEdges,
+	}
+	baseGroupSolver := &baseSingleGroupJoinOrderSolver{
+		ctx:                ctx,
+		basicJoinGroupInfo: basicJoinGroupInfo,
 	}
 	solver := &joinReorderDPSolver{
 		baseSingleGroupJoinOrderSolver: baseGroupSolver,
@@ -214,7 +217,8 @@ func TestDPReorderAllCartesian(t *testing.T) {
 	joinGroup = append(joinGroup, newDataSource(ctx, "d", 100))
 	solver := &joinReorderDPSolver{
 		baseSingleGroupJoinOrderSolver: &baseSingleGroupJoinOrderSolver{
-			ctx: ctx,
+			ctx:                ctx,
+			basicJoinGroupInfo: &basicJoinGroupInfo{},
 		},
 		newJoin: newMockJoin(ctx, statsMap),
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/36600

Problem Summary:
resolve the compatibility problems for the join hint

### What is changed and how it works?
1. Record the hint information before the join reorder. Use map[plan-ID] = hintInfo to record the hint information for sub-plan.
2. After the join reorder, restore the hint information from the map.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
The switch is off, so we hope the original test can be passed. And in the next PR, we will enable the switch and try to add and modify more test cases.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
