### PR TITLE
planner: optimize `ifnull(not-null-column, ...)` to a cast instead of eliminating it. tidb-test=pr/2098

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -537,25 +537,27 @@ Projection	10000.00	root		ifnull(test.t.a, 0)->Column#5
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(nb, 0) from t;
 id	estRows	task	access object	operator info
-TableReader	10000.00	root		data:TableFullScan
-└─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Projection	10000.00	root		cast(test.t.nb, bigint(11) BINARY)->Column#5
+└─TableReader	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(nb, 0), ifnull(nc, 0) from t;
 id	estRows	task	access object	operator info
-TableReader	10000.00	root		data:TableFullScan
-└─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Projection	10000.00	root		cast(test.t.nb, bigint(11) BINARY)->Column#5, cast(test.t.nc, bigint(11) BINARY)->Column#6
+└─TableReader	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(a, 0), ifnull(nb, 0) from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		ifnull(test.t.a, 0)->Column#5, test.t.nb
+Projection	10000.00	root		ifnull(test.t.a, 0)->Column#5, cast(test.t.nb, bigint(11) BINARY)->Column#6
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(nb, 0), ifnull(nb, 0) from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		test.t.nb, test.t.nb
+Projection	10000.00	root		cast(test.t.nb, bigint(11) BINARY)->Column#5, cast(test.t.nb, bigint(11) BINARY)->Column#6
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select 1+ifnull(nb, 0) from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		plus(1, test.t.nb)->Column#5
+Projection	10000.00	root		plus(1, cast(test.t.nb, bigint(11) BINARY))->Column#5
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select 1+ifnull(a, 0) from t;
@@ -565,48 +567,49 @@ Projection	10000.00	root		plus(1, ifnull(test.t.a, 0))->Column#5
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select 1+ifnull(nb, 0) from t where nb=1;
 id	estRows	task	access object	operator info
-Projection	10.00	root		plus(1, test.t.nb)->Column#5
+Projection	10.00	root		plus(1, cast(test.t.nb, bigint(11) BINARY))->Column#5
 └─TableReader	10.00	root		data:Selection
   └─Selection	10.00	cop[tikv]		eq(test.t.nb, 1)
     └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select * from t ta left outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(ta.nb, 1) or ta.nb is null;
 id	estRows	task	access object	operator info
-HashJoin	8320.83	root		left outer join, equal:[eq(test.t.nb, test.t.nb)], left cond:[gt(test.t.a, 1)]
-├─TableReader(Build)	6656.67	root		data:Selection
-│ └─Selection	6656.67	cop[tikv]		or(test.t.nb, 0)
+HashJoin	10000.00	root		left outer join, equal:[eq(test.t.nb, test.t.nb)], left cond:[gt(test.t.a, 1)]
+├─TableReader(Build)	8000.00	root		data:Selection
+│ └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
 │   └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
-└─TableReader(Probe)	6656.67	root		data:Selection
-  └─Selection	6656.67	cop[tikv]		or(test.t.nb, 0)
+└─TableReader(Probe)	8000.00	root		data:Selection
+  └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
     └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 explain format = 'brief' select * from t ta right outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
 id	estRows	task	access object	operator info
-HashJoin	6656.67	root		right outer join, equal:[eq(test.t.nb, test.t.nb)]
-├─TableReader(Build)	2218.89	root		data:Selection
-│ └─Selection	2218.89	cop[tikv]		gt(test.t.a, 1), or(test.t.nb, 0)
+HashJoin	8000.00	root		right outer join, equal:[eq(test.t.nb, test.t.nb)]
+├─TableReader(Build)	2666.67	root		data:Selection
+│ └─Selection	2666.67	cop[tikv]		gt(test.t.a, 1), or(cast(test.t.nb, bigint(11) BINARY), 0)
 │   └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
-└─TableReader(Probe)	6656.67	root		data:Selection
-  └─Selection	6656.67	cop[tikv]		or(test.t.nb, 0)
+└─TableReader(Probe)	8000.00	root		data:Selection
+  └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
     └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 explain format = 'brief' select * from t ta inner join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
 id	estRows	task	access object	operator info
-HashJoin	2773.61	root		inner join, equal:[eq(test.t.nb, test.t.nb)]
-├─TableReader(Build)	2218.89	root		data:Selection
-│ └─Selection	2218.89	cop[tikv]		gt(test.t.a, 1), or(test.t.nb, 0)
+HashJoin	3333.33	root		inner join, equal:[eq(test.t.nb, test.t.nb)]
+├─TableReader(Build)	2666.67	root		data:Selection
+│ └─Selection	2666.67	cop[tikv]		gt(test.t.a, 1), or(cast(test.t.nb, bigint(11) BINARY), 0)
 │   └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
-└─TableReader(Probe)	6656.67	root		data:Selection
-  └─Selection	6656.67	cop[tikv]		or(test.t.nb, 0)
+└─TableReader(Probe)	8000.00	root		data:Selection
+  └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
     └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(t.nc, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#22
-└─Apply	10000.00	root		left outer semi join, equal:[eq(test.t.nc, Column#21)]
-  ├─TableReader(Build)	10000.00	root		data:TableFullScan
-  │ └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-  └─HashAgg(Probe)	10000.00	root		funcs:count(Column#23)->Column#21
+└─Apply	10000.00	root		left outer semi join, equal:[eq(Column#23, Column#21)]
+  ├─Projection(Build)	10000.00	root		test.t.a, cast(test.t.nc, bigint(11) BINARY)->Column#23
+  │ └─TableReader	10000.00	root		data:TableFullScan
+  │   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─HashAgg(Probe)	10000.00	root		funcs:count(Column#25)->Column#21
     └─HashJoin	99900.00	root		inner join, equal:[eq(test.t.a, test.t.a)]
-      ├─HashAgg(Build)	79920.00	root		group by:test.t.a, funcs:count(Column#24)->Column#23, funcs:firstrow(test.t.a)->test.t.a
+      ├─HashAgg(Build)	79920.00	root		group by:test.t.a, funcs:count(Column#26)->Column#25, funcs:firstrow(test.t.a)->test.t.a
       │ └─TableReader	79920.00	root		data:HashAgg
-      │   └─HashAgg	79920.00	cop[tikv]		group by:test.t.a, funcs:count(1)->Column#24
+      │   └─HashAgg	79920.00	cop[tikv]		group by:test.t.a, funcs:count(1)->Column#26
       │     └─Selection	99900.00	cop[tikv]		eq(test.t.a, test.t.a), not(isnull(test.t.a))
       │       └─TableFullScan	100000000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
       └─TableReader(Probe)	99900.00	root		data:Selection

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1899,7 +1899,7 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 		}
 		// if expr1 is a column with not null flag, then we can optimize it as a cast.
 		if isColumn && !isEnumSet && mysql.HasNotNullFlag(col.RetType.GetFlag()) {
-			retTp, err := expression.InferType4ControlFuncs(er.sctx, ast.Ifnull, lhs, er.ctxStack[stackLen-1])
+			retTp, err := expression.InferType4ControlFuncs(er.sctx, ast.Ifnull, lhs, rhs)
 			if err != nil {
 				er.err = err
 				return true

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1883,7 +1883,7 @@ func (er *expressionRewriter) betweenToExpression(v *ast.BetweenExpr) {
 // Otherwise it should return false to indicate (the caller) that original behavior needs to be performed.
 func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 	switch v.FnName.L {
-	// when column is not null, ifnull on such column is not necessary.
+	// when column is not null, ifnull on such column can be optimized to a cast.
 	case ast.Ifnull:
 		if len(v.Args) != 2 {
 			er.err = expression.ErrIncorrectParameterCount.GenWithStackByArgs(v.FnName.O)
@@ -1896,13 +1896,16 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 		if arg1.GetType().GetType() == mysql.TypeEnum || arg1.GetType().GetType() == mysql.TypeSet {
 			isEnumSet = true
 		}
-		// if expr1 is a column and column has not null flag, then we can eliminate ifnull on
-		// this column.
+		// if expr1 is a column with not null flag, then we can optimize it as a cast.
 		if isColumn && !isEnumSet && mysql.HasNotNullFlag(col.RetType.GetFlag()) {
-			name := er.ctxNameStk[stackLen-2]
-			newCol := col.Clone().(*expression.Column)
+			retTp, err := expression.InferType4ControlFuncs(er.sctx, ast.Ifnull, arg1, er.ctxStack[stackLen-1])
+			if err != nil {
+				er.err = err
+				return true
+			}
 			er.ctxStackPop(len(v.Args))
-			er.ctxStackAppend(newCol, name)
+			casted := expression.BuildCastFunction(er.sctx, arg1, retTp)
+			er.ctxStackAppend(casted, types.EmptyName)
 			return true
 		}
 

--- a/planner/core/expression_rewriter_test.go
+++ b/planner/core/expression_rewriter_test.go
@@ -377,3 +377,18 @@ func TestInsertOnDuplicateLazyMoreThan1Row(t *testing.T) {
 	tk.MustExec("INSERT INTO t2 (a) VALUES (1) ON DUPLICATE KEY UPDATE a= (SELECT b FROM source);")
 	tk.MustExec("DROP TABLE if exists t1, t2, source;")
 }
+
+func TestConvertIfNullToCast(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("DROP TABLE if exists t1;")
+	tk.MustExec("CREATE TABLE t1(cnotnull tinyint not null, cnull tinyint null);")
+	tk.MustExec("INSERT INTO t1 VALUES(1, 1);")
+	tk.MustQuery("select CAST(IFNULL(cnull, '1') AS DATE), CAST(IFNULL(cnotnull, '1') AS DATE) from t1;").Check(testkit.Rows("<nil> <nil>"))
+	tk.MustQuery("explain format=\"brief\" select IFNULL(cnotnull, '1') from t1;").Check(testkit.Rows(
+		"Projection 10000.00 root  cast(test.t1.cnotnull, varchar(4) BINARY CHARACTER SET utf8mb4 COLLATE utf8mb4_bin)->Column#4]\n" +
+			"[└─TableReader 10000.00 root  data:TableFullScan]\n" +
+			"[  └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+	))
+}

--- a/planner/core/testdata/plan_suite_unexported_out.json
+++ b/planner/core/testdata/plan_suite_unexported_out.json
@@ -163,7 +163,7 @@
       "UnionAll{DataScan(t)->TopN([test.t.a test.t.b],0,5)->Projection->DataScan(s)->TopN([test.t.a test.t.b],0,5)->Projection}->TopN([Column#25 Column#26],0,5)",
       "UnionAll{DataScan(t)->TopN([test.t.a test.t.b],0,10)->Projection->DataScan(s)->TopN([test.t.a test.t.b],0,10)->Projection}->TopN([Column#25 Column#26],5,5)",
       "UnionAll{DataScan(t)->Limit->Projection->DataScan(s)->TopN([test.t.a],0,5)->Projection}->Limit",
-      "Join{DataScan(t1)->TopN([test.t.b],0,5)->DataScan(t2)}(test.t.e,test.t.e)->TopN([test.t.b],0,5)->Projection",
+      "Join{DataScan(t1)->TopN([cast(test.t.b, int(11) BINARY)],0,5)->DataScan(t2)}(test.t.e,test.t.e)->TopN([cast(test.t.b, int(11) BINARY)],0,5)->Projection->Projection",
       "Join{DataScan(t1)->DataScan(t2)}(test.t.e,test.t.e)->TopN([ifnull(test.t.h, test.t.b)],0,5)->Projection->Projection"
     ]
   },

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -848,7 +848,7 @@ func TestIndexRangeEliminatedProjection(t *testing.T) {
 	testKit.MustExec("create table t(a int not null, b int not null, primary key(a,b))")
 	testKit.MustExec("insert into t values(1,2)")
 	testKit.MustExec("analyze table t")
-	testKit.MustQuery("explain format = 'brief' select * from (select * from t union all select ifnull(a,b), b from t) sub where a > 0").Check(testkit.Rows(
+	testKit.MustQuery("explain format = 'brief' select * from (select * from t union all select a, b from t) sub where a > 0").Check(testkit.Rows(
 		"Union 2.00 root  ",
 		"├─IndexReader 1.00 root  index:IndexRangeScan",
 		"│ └─IndexRangeScan 1.00 cop[tikv] table:t, index:PRIMARY(a, b) range:(0,+inf], keep order:false",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/41734

Problem Summary:  see https://github.com/pingcap/tidb/issues/41734#issuecomment-1449475900

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
