### PR TITLE
log-backup: fix the issue that gc-worker owner cannot check log-backup task existed.

### DIFF
--- a/br/pkg/streamhelper/advancer_daemon.go
+++ b/br/pkg/streamhelper/advancer_daemon.go
@@ -26,10 +26,13 @@ func (c *CheckpointAdvancer) OnTick(ctx context.Context) (err error) {
 	return c.tick(ctx)
 }
 
-// OnStart implements daemon.Interface.
 func (c *CheckpointAdvancer) OnStart(ctx context.Context) {
-	metrics.AdvancerOwner.Set(1.0)
 	c.StartTaskListener(ctx)
+}
+
+// OnStart implements daemon.Interface.
+func (c *CheckpointAdvancer) OnBecomeOwner(ctx context.Context) {
+	metrics.AdvancerOwner.Set(1.0)
 	c.spawnSubscriptionHandler(ctx)
 	go func() {
 		<-ctx.Done()

--- a/br/pkg/streamhelper/advancer_daemon.go
+++ b/br/pkg/streamhelper/advancer_daemon.go
@@ -26,11 +26,12 @@ func (c *CheckpointAdvancer) OnTick(ctx context.Context) (err error) {
 	return c.tick(ctx)
 }
 
+// OnStart implements daemon.Interface, which will be called when log backup service starts.
 func (c *CheckpointAdvancer) OnStart(ctx context.Context) {
 	c.StartTaskListener(ctx)
 }
 
-// OnStart implements daemon.Interface.
+// OnBecomeOwner implements daemon.Interface. If the tidb-server become owner, this function will be called.
 func (c *CheckpointAdvancer) OnBecomeOwner(ctx context.Context) {
 	metrics.AdvancerOwner.Set(1.0)
 	c.spawnSubscriptionHandler(ctx)

--- a/br/pkg/streamhelper/daemon/interface.go
+++ b/br/pkg/streamhelper/daemon/interface.go
@@ -6,9 +6,11 @@ import "context"
 
 // Interface describes the lifetime hook of a daemon application.
 type Interface interface {
-	// OnStart would be called once become the owner.
-	// The context passed in would be canceled once it is no more the owner.
+	// OnStart start the service whatever the tidb-server is owner or not.
 	OnStart(ctx context.Context)
+	// OnBecomeOwner would be called once become the owner.
+	// The context passed in would be canceled once it is no more the owner.
+	OnBecomeOwner(ctx context.Context)
 	// OnTick would be called periodically.
 	// The error can be recorded.
 	OnTick(ctx context.Context) error

--- a/br/pkg/streamhelper/daemon/owner_daemon.go
+++ b/br/pkg/streamhelper/daemon/owner_daemon.go
@@ -55,7 +55,7 @@ func (od *OwnerDaemon) ownerTick(ctx context.Context) {
 		od.cancel = cancel
 		log.Info("daemon became owner", zap.String("id", od.manager.ID()), zap.String("daemon-id", od.daemon.Name()))
 		// Note: maybe save the context so we can cancel the tick when we are not owner?
-		od.daemon.OnStart(cx)
+		od.daemon.OnBecomeOwner(cx)
 	}
 
 	// Tick anyway.
@@ -72,6 +72,10 @@ func (od *OwnerDaemon) Begin(ctx context.Context) (func(), error) {
 		return nil, err
 	}
 
+	// start the service.
+	od.daemon.OnStart(ctx)
+
+	// tick starts.
 	tick := time.NewTicker(od.tickInterval)
 	loop := func() {
 		log.Info("begin running daemon", zap.String("id", od.manager.ID()), zap.String("daemon-id", od.daemon.Name()))

--- a/br/pkg/streamhelper/daemon/owner_daemon_test.go
+++ b/br/pkg/streamhelper/daemon/owner_daemon_test.go
@@ -16,7 +16,8 @@ import (
 
 type anApp struct {
 	sync.Mutex
-	begun bool
+	serviceStart bool
+	begun        bool
 
 	tickingMessenger     chan struct{}
 	tickingMessengerOnce *sync.Once
@@ -35,6 +36,7 @@ func newTestApp(t *testing.T) *anApp {
 
 // OnStart implements daemon.Interface.
 func (a *anApp) OnStart(ctx context.Context) {
+	a.serviceStart = true
 }
 
 // OOnBecomeOwner would be called once become the owner.
@@ -91,6 +93,10 @@ func (a *anApp) Running() bool {
 	return a.begun
 }
 
+func (a *anApp) AssertService(req *require.Assertions, serviceStart bool) {
+	req.True(a.serviceStart == serviceStart)
+}
+
 func (a *anApp) AssertTick(timeout time.Duration) {
 	a.Lock()
 	messenger := a.tickingMessenger
@@ -133,8 +139,10 @@ func TestDaemon(t *testing.T) {
 	ow := owner.NewMockManager(ctx, "owner_daemon_test")
 	d := daemon.New(app, ow, 100*time.Millisecond)
 
+	app.AssertService(req, false)
 	f, err := d.Begin(ctx)
 	req.NoError(err)
+	app.AssertService(req, true)
 	go f()
 	app.AssertStart(1 * time.Second)
 	app.AssertTick(1 * time.Second)

--- a/br/pkg/streamhelper/daemon/owner_daemon_test.go
+++ b/br/pkg/streamhelper/daemon/owner_daemon_test.go
@@ -33,10 +33,11 @@ func newTestApp(t *testing.T) *anApp {
 	}
 }
 
+// OnStart implements daemon.Interface.
 func (a *anApp) OnStart(ctx context.Context) {
 }
 
-// OnStart would be called once become the owner.
+// OOnBecomeOwner would be called once become the owner.
 // The context passed in would be canceled once it is no more the owner.
 func (a *anApp) OnBecomeOwner(ctx context.Context) {
 	a.Lock()

--- a/br/pkg/streamhelper/daemon/owner_daemon_test.go
+++ b/br/pkg/streamhelper/daemon/owner_daemon_test.go
@@ -33,9 +33,12 @@ func newTestApp(t *testing.T) *anApp {
 	}
 }
 
+func (a *anApp) OnStart(ctx context.Context) {
+}
+
 // OnStart would be called once become the owner.
 // The context passed in would be canceled once it is no more the owner.
-func (a *anApp) OnStart(ctx context.Context) {
+func (a *anApp) OnBecomeOwner(ctx context.Context) {
 	a.Lock()
 	defer a.Unlock()
 	if a.begun {

--- a/br/pkg/utils/BUILD.bazel
+++ b/br/pkg/utils/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "@org_golang_google_grpc//status",
         "@org_golang_x_net//http/httpproxy",
         "@org_golang_x_sync//errgroup",
+        "@org_uber_go_atomic//:atomic",
         "@org_uber_go_multierr//:multierr",
         "@org_uber_go_zap//:zap",
         "@org_uber_go_zap//zapcore",

--- a/br/pkg/utils/db.go
+++ b/br/pkg/utils/db.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
@@ -16,6 +15,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/sqlexec"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
 
@@ -28,8 +28,7 @@ var (
 	_ DBExecutor = &sql.DB{}
 	_ DBExecutor = &sql.Conn{}
 
-	LogBackupTaskMutex sync.Mutex
-	logBackupTaskCount int
+	logBackupTaskCount = atomic.NewInt32(0)
 )
 
 // QueryExecutor is a interface for exec query
@@ -203,26 +202,24 @@ func SetGcRatio(ctx sqlexec.RestrictedSQLExecutor, ratio string) error {
 
 // LogBackupTaskCountInc increases the count of log backup task.
 func LogBackupTaskCountInc() {
-	LogBackupTaskMutex.Lock()
-	logBackupTaskCount++
-	LogBackupTaskMutex.Unlock()
+	logBackupTaskCount.Inc()
+	log.Debug("inc log backup task", zap.Int32("count", logBackupTaskCount.Load()))
 }
 
 // LogBackupTaskCountDec decreases the count of log backup task.
 func LogBackupTaskCountDec() {
-	LogBackupTaskMutex.Lock()
-	logBackupTaskCount--
-	LogBackupTaskMutex.Unlock()
+	logBackupTaskCount.Dec()
+	log.Debug("dec log backup task", zap.Int32("count", logBackupTaskCount.Load()))
 }
 
 // CheckLogBackupTaskExist checks that whether log-backup is existed.
 func CheckLogBackupTaskExist() bool {
-	return logBackupTaskCount > 0
+	return logBackupTaskCount.Load() > 0
 }
 
 // IsLogBackupInUse checks the log backup task existed.
 func IsLogBackupInUse(ctx sessionctx.Context) bool {
-	return CheckLogBackupEnabled(ctx) && CheckLogBackupTaskExist()
+	return CheckLogBackupTaskExist()
 }
 
 // GetTidbNewCollationEnabled returns the variable name of NewCollationEnabled.

--- a/br/pkg/utils/db.go
+++ b/br/pkg/utils/db.go
@@ -203,13 +203,13 @@ func SetGcRatio(ctx sqlexec.RestrictedSQLExecutor, ratio string) error {
 // LogBackupTaskCountInc increases the count of log backup task.
 func LogBackupTaskCountInc() {
 	logBackupTaskCount.Inc()
-	log.Debug("inc log backup task", zap.Int32("count", logBackupTaskCount.Load()))
+	log.Info("inc log backup task", zap.Int32("count", logBackupTaskCount.Load()))
 }
 
 // LogBackupTaskCountDec decreases the count of log backup task.
 func LogBackupTaskCountDec() {
 	logBackupTaskCount.Dec()
-	log.Debug("dec log backup task", zap.Int32("count", logBackupTaskCount.Load()))
+	log.Info("dec log backup task", zap.Int32("count", logBackupTaskCount.Load()))
 }
 
 // CheckLogBackupTaskExist checks that whether log-backup is existed.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/41806
close https://github.com/pingcap/tidb/issues/41642

Problem Summary:
If the gc-worker owner and the pitr owner is not the same node, the gc-worker owner cannot check the log-backup task existed.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

## Manual test
- Create a TiDB cluster with the 3 tidb-server, 3 pd-server and 3 tikv-server.
- Create a log-backup task, Search the log in all of tidb-server, the log like this
```
2023-03-01 16:38:04 (UTC+08:00)TiDB 10.2.5.20:4100[db.go:206] ["inc log backup task"] [count=1]
2023-03-01 16:38:07 (UTC+08:00)TiDB 10.2.5.31:4100[db.go:206] ["inc log backup task"] [count=1]
2023-03-01 16:38:10 (UTC+08:00)TiDB 10.2.5.32:4100[db.go:206] ["inc log backup task"] [count=1]
```
- restart all of tidb-server, and search the log
```
2023-03-01 17:11:27 (UTC+08:00)TiDB 10.2.5.31:4100[db.go:206] ["inc log backup task"] [count=1]
2023-03-01 17:11:27 (UTC+08:00)TiDB 10.2.5.32:4100[db.go:206] ["inc log backup task"] [count=1]
2023-03-01 17:11:27 (UTC+08:00)TiDB 10.2.5.20:4100[db.go:206] ["inc log backup task"] [count=1]
```

- stop a log-backup task. Search the log
```
2023-03-01 17:13:02 (UTC+08:00)TiDB 10.2.5.32:4100[db.go:212] ["dec log backup task"] [count=0]
2023-03-01 17:13:02 (UTC+08:00)TiDB 10.2.5.20:4100[db.go:212] ["dec log backup task"] [count=0]
2023-03-01 17:13:02 (UTC+08:00)TiDB 10.2.5.31:4100[db.go:212] ["dec log backup task"] [count=0]
```
- start the log-backup task again, and search the log
```
2023-03-01 17:13:50 (UTC+08:00)TiDB 10.2.5.32:4100[db.go:206] ["inc log backup task"] [count=1]
2023-03-01 17:13:50 (UTC+08:00)TiDB 10.2.5.31:4100[db.go:206] ["inc log backup task"] [count=1]
2023-03-01 17:13:50 (UTC+08:00)TiDB 10.2.5.20:4100[db.go:206] ["inc log backup task"] [count=1]
```


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix the issue that gc owner cannot check log-backup task existed
```
