### PR TITLE
ttl: fix upgrade from 6.5 to 6.6 configuration default value

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -1274,7 +1274,11 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 		err = restoreCtx.WriteWithSpecialComments(tidb.FeatureIDTTL, func() error {
 			restoreCtx.WriteKeyWord("TTL_JOB_INTERVAL")
 			restoreCtx.WritePlain("=")
-			restoreCtx.WriteString(tableInfo.TTLInfo.JobInterval)
+			if len(tableInfo.TTLInfo.JobInterval) == 0 {
+				restoreCtx.WriteString(model.DefaultJobInterval.String())
+			} else {
+				restoreCtx.WriteString(tableInfo.TTLInfo.JobInterval)
+			}
 			return nil
 		})
 

--- a/parser/model/BUILD.bazel
+++ b/parser/model/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//parser/auth",
         "//parser/charset",
+        "//parser/duration",
         "//parser/mysql",
         "//parser/terror",
         "//parser/types",

--- a/parser/model/model.go
+++ b/parser/model/model.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/parser/auth"
 	"github.com/pingcap/tidb/parser/charset"
+	"github.com/pingcap/tidb/parser/duration"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/types"
 )
@@ -1724,6 +1725,9 @@ func (p *PolicyInfo) Clone() *PolicyInfo {
 	return &cloned
 }
 
+// DefaultJobInterval sets the default interval between TTL jobs
+const DefaultJobInterval = time.Hour
+
 // TTLInfo records the TTL config
 type TTLInfo struct {
 	ColumnName      CIStr  `json:"column"`
@@ -1732,6 +1736,7 @@ type TTLInfo struct {
 	IntervalTimeUnit int  `json:"interval_time_unit"`
 	Enable           bool `json:"enable"`
 	// JobInterval is the interval between two TTL scan jobs.
+	// It's suggested to get a duration with `(*TTLInfo).GetJobInterval`
 	JobInterval string `json:"job_interval"`
 }
 
@@ -1739,6 +1744,19 @@ type TTLInfo struct {
 func (t *TTLInfo) Clone() *TTLInfo {
 	cloned := *t
 	return &cloned
+}
+
+// GetJobInterval parses the job interval and return
+// if the job interval is an empty string, the "1h" will be returned, to keep compatible with 6.5 (in which
+// TTL_JOB_INTERVAL attribute doesn't exist)
+// Didn't set TTL_JOB_INTERVAL during upgrade and bootstrap because setting default value here is much simpler
+// and could avoid bugs blocking users from upgrading or bootstrapping the cluster.
+func (t *TTLInfo) GetJobInterval() (time.Duration, error) {
+	if len(t.JobInterval) == 0 {
+		return DefaultJobInterval, nil
+	}
+
+	return duration.ParseDuration(t.JobInterval)
 }
 
 func writeSettingItemToBuilder(sb *strings.Builder, item string) {

--- a/parser/model/model_test.go
+++ b/parser/model/model_test.go
@@ -805,3 +805,16 @@ func TestTTLInfoClone(t *testing.T) {
 	require.Equal(t, 5, ttlInfo.IntervalTimeUnit)
 	require.Equal(t, true, ttlInfo.Enable)
 }
+
+func TestTTLJobInterval(t *testing.T) {
+	ttlInfo := &TTLInfo{}
+
+	interval, err := ttlInfo.GetJobInterval()
+	require.NoError(t, err)
+	require.Equal(t, time.Hour, interval)
+
+	ttlInfo = &TTLInfo{JobInterval: "200h"}
+	interval, err = ttlInfo.GetJobInterval()
+	require.NoError(t, err)
+	require.Equal(t, time.Hour*200, interval)
+}

--- a/ttl/ttlworker/BUILD.bazel
+++ b/ttl/ttlworker/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//kv",
-        "//parser/duration",
         "//parser/terror",
         "//sessionctx",
         "//sessionctx/variable",

--- a/ttl/ttlworker/job_manager.go
+++ b/ttl/ttlworker/job_manager.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/parser/duration"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/ttl/cache"
@@ -521,13 +520,12 @@ func (m *JobManager) couldTrySchedule(tableStatus *cache.TableStatus, table *cac
 
 	startTime := tableStatus.LastJobStartTime
 
-	interval := table.TTLInfo.JobInterval
-	d, err := duration.ParseDuration(interval)
+	interval, err := table.TTLInfo.GetJobInterval()
 	if err != nil {
-		logutil.Logger(m.ctx).Warn("illegal job interval", zap.String("interval", interval))
+		logutil.Logger(m.ctx).Warn("illegal job interval", zap.Error(err))
 		return false
 	}
-	return startTime.Add(d).Before(now)
+	return startTime.Add(interval).Before(now)
 }
 
 // occupyNewJob tries to occupy a new job in the ttl_table_status table. If it locks successfully, it will create a new


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #41865

### What is changed and how it works?

If the value of `TTL_JOB_INTERVAL` is not set, use `1h` instead. 

Actually the `TTL_JOB_INTERVAL` will be set to `1h` during the DDL. However, if the user created the table at 6.5 and upgrade the cluster to 6.6, the attribute is empty.

I'm not sure whether this is the best (and most suggested) way to fix this problem. If you have more suggestion, feel free to point out.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Fix the issue that an TTL table upgraded from old version could have 0 job interval and the TTl job will keep running.
```
