### PR TITLE
planner: fix the issue that cached IndexMerge plans can return wrong results in some cases

### DIFF
--- a/executor/explainfor_test.go
+++ b/executor/explainfor_test.go
@@ -768,7 +768,7 @@ func TestIndexMerge4PlanCache(t *testing.T) {
 	ps := []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
 	res := tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.Len(t, res.Rows(), 6)
+	require.Len(t, res.Rows(), 7)
 	require.Regexp(t, ".*IndexMerge.*", res.Rows()[1][0])
 	require.Regexp(t, ".*IndexRangeScan.*", res.Rows()[3][0])
 	require.Equal(t, "range:(NULL,\"mm\"), (\"mm\",+inf], keep order:false, stats:pseudo", res.Rows()[3][4])

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -1100,6 +1100,26 @@ func TestPlanCacheWithSubquery(t *testing.T) {
 	}
 }
 
+func TestIssue41828(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE IDT_MULTI15840STROBJSTROBJ (
+  COL1 enum('aa', 'zzz') DEFAULT NULL,
+  COL2 smallint(6) DEFAULT NULL,
+  COL3 date DEFAULT NULL,
+  KEY U_M_COL4 (COL1,COL2),
+  KEY U_M_COL5 (COL3,COL2))`)
+
+	tk.MustExec(`INSERT INTO IDT_MULTI15840STROBJSTROBJ VALUES ('zzz',1047,'6115-06-05'),('zzz',-23221,'4250-09-03'),('zzz',27138,'1568-07-30'),('zzz',-30903,'6753-08-21'),('zzz',-26875,'6117-10-10')`)
+	tk.MustExec(`prepare stmt from 'select * from IDT_MULTI15840STROBJSTROBJ where col3 <=> ? or col1 in (?, ?, ?) and col2 not between ? and ?'`)
+	tk.MustExec(`set @a="0051-12-23", @b="none", @c="none", @d="none", @e=-32757, @f=-32757`)
+	tk.MustQuery(`execute stmt using @a,@b,@c,@d,@e,@f`).Check(testkit.Rows())
+	tk.MustQuery(`show warnings`).Check(testkit.Rows(`Warning 1105 skip plan-cache: IndexMerge plan with full-scan is un-cacheable`))
+	tk.MustExec(`set @a="9795-01-10", @b="aa", @c="aa", @d="aa", @e=31928, @f=31928`)
+	tk.MustQuery(`execute stmt using @a,@b,@c,@d,@e,@f`).Check(testkit.Rows())
+}
+
 func TestPlanCacheSubquerySPMEffective(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -376,11 +376,12 @@ func isPlanCacheable(sctx sessionctx.Context, p Plan, paramNum, limitParamNum in
 	if limitParamNum != 0 && !sctx.GetSessionVars().EnablePlanCacheForParamLimit {
 		return false, "skip plan-cache: the switch 'tidb_enable_plan_cache_for_param_limit' is off"
 	}
-	return isPhysicalPlanCacheable(sctx, pp, paramNum, limitParamNum)
+	return isPhysicalPlanCacheable(sctx, pp, paramNum, limitParamNum, false)
 }
 
 // isPhysicalPlanCacheable returns whether this physical plan is cacheable and return the reason if not.
-func isPhysicalPlanCacheable(sctx sessionctx.Context, p PhysicalPlan, paramNum, limitParamNum int) (cacheable bool, reason string) {
+func isPhysicalPlanCacheable(sctx sessionctx.Context, p PhysicalPlan, paramNum, limitParamNum int, underIndexMerge bool) (cacheable bool, reason string) {
+	var subPlans []PhysicalPlan
 	switch x := p.(type) {
 	case *PhysicalTableDual:
 		if paramNum > 0 {
@@ -398,12 +399,23 @@ func isPhysicalPlanCacheable(sctx sessionctx.Context, p PhysicalPlan, paramNum, 
 		if x.AccessMVIndex {
 			return false, "skip plan-cache: the plan with IndexMerge accessing Multi-Valued Index is un-cacheable"
 		}
+		underIndexMerge = true
+		subPlans = append(subPlans, x.partialPlans...)
+	case *PhysicalIndexScan:
+		if underIndexMerge && x.isFullScan() {
+			return false, "skip plan-cache: IndexMerge plan with full-scan is un-cacheable"
+		}
+	case *PhysicalTableScan:
+		if underIndexMerge && x.isFullScan() {
+			return false, "skip plan-cache: IndexMerge plan with full-scan is un-cacheable"
+		}
 	case *PhysicalApply:
 		return false, "skip plan-cache: PhysicalApply plan is un-cacheable"
 	}
 
-	for _, c := range p.Children() {
-		if cacheable, reason = isPhysicalPlanCacheable(sctx, c, paramNum, limitParamNum); !cacheable {
+	subPlans = append(subPlans, p.Children()...)
+	for _, c := range subPlans {
+		if cacheable, reason = isPhysicalPlanCacheable(sctx, c, paramNum, limitParamNum, underIndexMerge); !cacheable {
 			return cacheable, reason
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41828

Problem Summary: planner: fix the issue that cached IndexMerge plans can return wrong results in some cases

### What is changed and how it works?

Fix the issue that cached IndexMerge plans can return wrong results in some cases
Two enhancements here:
1. keep all conditions with parameters as a part of table filters for cached IndexMerge for safety.
2. don't put IndexMerge plans with full-scans into the plan-cache for safety.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
