### PR TITLE
parser: Add special formatter for extract(unit FROM date)

### DIFF
--- a/parser/ast/functions.go
+++ b/parser/ast/functions.go
@@ -550,6 +550,13 @@ func (n *FuncCallExpr) specialFormatArgs(w io.Writer) bool {
 		n.Args[1].Format(w)
 		fmt.Fprint(w, ")")
 		return true
+	case Extract:
+		fmt.Fprintf(w, "%s(", n.FnName.L)
+		n.Args[0].Format(w)
+		fmt.Fprint(w, " FROM ")
+		n.Args[1].Format(w)
+		fmt.Fprint(w, ")")
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41800 

Problem Summary:
Internally the expression was regenerated with a comma instead of 'FROM':
`extract(YEAR, '1998-01-01')` which should be `extract(YEAR FROM '1998-01-01')`

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
