### PR TITLE
ddl: never write untouched index values to temp index

### DIFF
--- a/ddl/indexmergetest/merge_test.go
+++ b/ddl/indexmergetest/merge_test.go
@@ -897,3 +897,44 @@ func TestAddIndexDuplicateAndWriteConflict(t *testing.T) {
 	tk.MustExec("admin check table t;")
 	tk.MustQuery("select * from t;").Check(testkit.Rows("1 1", "2 1"))
 }
+
+func TestAddIndexUpdateUntouchedValues(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(id int primary key, b int, k int);")
+	tk.MustExec("insert into t values (1, 1, 1);")
+
+	tk1 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+
+	d := dom.DDL()
+	originalCallback := d.GetHook()
+	defer d.SetHook(originalCallback)
+	callback := &callback.TestDDLCallback{}
+	var runDML bool
+	callback.OnJobRunAfterExported = func(job *model.Job) {
+		if t.Failed() || runDML {
+			return
+		}
+		switch job.SchemaState {
+		case model.StateWriteReorganization:
+			_, err := tk1.Exec("begin;")
+			assert.NoError(t, err)
+			_, err = tk1.Exec("update t set k=k+1 where id = 1;")
+			assert.NoError(t, err)
+			_, err = tk1.Exec("insert into t values (2, 1, 2);")
+			// Should not report "invalid temp index value".
+			assert.NoError(t, err)
+			_, err = tk1.Exec("commit;")
+			assert.NoError(t, err)
+			runDML = true
+		}
+	}
+	d.SetHook(callback)
+
+	tk.MustGetErrCode("alter table t add unique index idx(b);", errno.ErrDupEntry)
+	tk.MustExec("admin check table t;")
+	tk.MustQuery("select * from t;").Check(testkit.Rows("1 1 2", "2 1 2"))
+}

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -239,7 +239,12 @@ func (c *index) Create(sctx sessionctx.Context, txn kv.Transaction, indexedValue
 
 		if !distinct || skipCheck || opt.Untouched {
 			val := idxVal
-			if keyIsTempIdxKey && !opt.Untouched { // Untouched key-values never occur in the storage.
+			if opt.Untouched && (keyIsTempIdxKey || len(tempKey) > 0) {
+				// Untouched key-values never occur in the storage and the temp index is not public.
+				// It is unnecessary to write the untouched temp index key-values.
+				continue
+			}
+			if keyIsTempIdxKey {
 				tempVal := tablecodec.TempIndexValueElem{Value: idxVal, KeyVer: keyVer, Distinct: distinct}
 				val = tempVal.Encode(nil)
 			}
@@ -248,10 +253,8 @@ func (c *index) Create(sctx sessionctx.Context, txn kv.Transaction, indexedValue
 				return nil, err
 			}
 			if len(tempKey) > 0 {
-				if !opt.Untouched { // Untouched key-values never occur in the storage.
-					tempVal := tablecodec.TempIndexValueElem{Value: idxVal, KeyVer: keyVer, Distinct: distinct}
-					val = tempVal.Encode(nil)
-				}
+				tempVal := tablecodec.TempIndexValueElem{Value: idxVal, KeyVer: keyVer, Distinct: distinct}
+				val = tempVal.Encode(nil)
 				err = txn.GetMemBuffer().Set(tempKey, val)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41880

Problem Summary:

Previously, for untouched temp index key, TiDB writes it to the memory buffer and never commits it to TiKV(by checking if the last byte is the uncommited flag). 

https://github.com/pingcap/tidb/pull/40749 introduced a new temp index value encoding: for each insertion, TiDB appends the new temp index value to the end based on the old value. As a result, the "uncommitted flag" is not the last byte anymore and the key-value will be incorrectly committed to TiKV. The encoding becomes invalid.

### What is changed and how it works?

Check the untouched values before writting to the temp index. Because the untouched values is only used for speeding up the index reading, and the temp index is never visible to the users, we can skip writting a untouched value to the temp index. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
