### PR TITLE
stmtsummary: stmtsummary with keyspace

### DIFF
--- a/executor/BUILD.bazel
+++ b/executor/BUILD.bazel
@@ -117,6 +117,7 @@ go_library(
         "//expression",
         "//expression/aggregation",
         "//infoschema",
+        "//keyspace",
         "//kv",
         "//meta",
         "//meta/autoid",

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/keyspace"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/parser"
@@ -1946,6 +1947,15 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 
 	resultRows := GetResultRowsCount(stmtCtx, a.Plan)
 
+	var (
+		keyspaceName string
+		keyspaceID   uint32
+	)
+	keyspaceName = keyspace.GetKeyspaceNameBySettings()
+	if !keyspace.IsKeyspaceNameEmpty(keyspaceName) {
+		keyspaceID = uint32(a.Ctx.GetStore().GetCodec().GetKeyspaceID())
+	}
+
 	stmtExecInfo := &stmtsummary.StmtExecInfo{
 		SchemaName:          strings.ToLower(sessVars.CurrentDB),
 		OriginalSQL:         sql,
@@ -1978,6 +1988,8 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 		ResultRows:          resultRows,
 		TiKVExecDetails:     tikvExecDetail,
 		Prepared:            a.isPreparedStmt,
+		KeyspaceName:        keyspaceName,
+		KeyspaceID:          keyspaceID,
 	}
 	if a.retryCount > 0 {
 		stmtExecInfo.ExecRetryTime = costTime - sessVars.DurationParse - sessVars.DurationCompile - time.Since(a.retryStartTime)

--- a/util/stmtsummary/statement_summary.go
+++ b/util/stmtsummary/statement_summary.go
@@ -246,6 +246,8 @@ type StmtExecInfo struct {
 	ResultRows      int64
 	TiKVExecDetails util.ExecDetails
 	Prepared        bool
+	KeyspaceName    string
+	KeyspaceID      uint32
 }
 
 // newStmtSummaryByDigestMap creates an empty stmtSummaryByDigestMap.

--- a/util/stmtsummary/v2/reader.go
+++ b/util/stmtsummary/v2/reader.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/config"
-	"github.com/pingcap/tidb/keyspace"
 	"github.com/pingcap/tidb/parser/auth"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/types"
@@ -444,9 +443,8 @@ func (c *stmtChecker) needStop(curBegin int64) bool {
 }
 
 type stmtTinyRecord struct {
-	Begin        int64  `json:"begin"`
-	End          int64  `json:"end"`
-	KeyspaceName string `json:"keyspace_name,omitempty"`
+	Begin int64 `json:"begin"`
+	End   int64 `json:"end"`
 }
 
 type stmtFile struct {
@@ -718,9 +716,6 @@ func (*stmtScanWorker) parse(raw []byte) (*stmtTinyRecord, error) {
 }
 
 func (w *stmtScanWorker) needStop(record *stmtTinyRecord) bool {
-	if keyspace.GetKeyspaceNameBySettings() != record.KeyspaceName {
-		return false
-	}
 	return w.checker.needStop(record.Begin)
 }
 

--- a/util/stmtsummary/v2/reader.go
+++ b/util/stmtsummary/v2/reader.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/keyspace"
 	"github.com/pingcap/tidb/parser/auth"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/types"
@@ -443,8 +444,9 @@ func (c *stmtChecker) needStop(curBegin int64) bool {
 }
 
 type stmtTinyRecord struct {
-	Begin int64 `json:"begin"`
-	End   int64 `json:"end"`
+	Begin        int64  `json:"begin"`
+	End          int64  `json:"end"`
+	KeyspaceName string `json:"keyspace_name,omitempty"`
 }
 
 type stmtFile struct {
@@ -716,6 +718,9 @@ func (*stmtScanWorker) parse(raw []byte) (*stmtTinyRecord, error) {
 }
 
 func (w *stmtScanWorker) needStop(record *stmtTinyRecord) bool {
+	if keyspace.GetKeyspaceNameBySettings() != record.KeyspaceName {
+		return false
+	}
 	return w.checker.needStop(record.Begin)
 }
 

--- a/util/stmtsummary/v2/record.go
+++ b/util/stmtsummary/v2/record.go
@@ -145,8 +145,8 @@ type StmtRecord struct {
 	ExecRetryCount uint          `json:"exec_retry_count"`
 	ExecRetryTime  time.Duration `json:"exec_retry_time"`
 
-	KeyspaceName string `json:"keyspace_name"`
-	KeyspaceID   uint32 `json:"keyspace_id"`
+	KeyspaceName string `json:"keyspace_name,omitempty"`
+	KeyspaceID   uint32 `json:"keyspace_id,omitempty"`
 }
 
 // NewStmtRecord creates a new StmtRecord from StmtExecInfo.

--- a/util/stmtsummary/v2/record.go
+++ b/util/stmtsummary/v2/record.go
@@ -656,10 +656,12 @@ func GenerateStmtExecInfo4Test(digest string) *stmtsummary.StmtExecInfo {
 			Tables:     tables,
 			IndexNames: indexes,
 		},
-		MemMax:    10000,
-		DiskMax:   10000,
-		StartTime: time.Date(2019, 1, 1, 10, 10, 10, 10, time.UTC),
-		Succeed:   true,
+		MemMax:       10000,
+		DiskMax:      10000,
+		StartTime:    time.Date(2019, 1, 1, 10, 10, 10, 10, time.UTC),
+		Succeed:      true,
+		KeyspaceName: "keyspace_a",
+		KeyspaceID:   1,
 	}
 	stmtExecInfo.StmtCtx.AddAffectedRows(10000)
 	return stmtExecInfo

--- a/util/stmtsummary/v2/record.go
+++ b/util/stmtsummary/v2/record.go
@@ -144,6 +144,9 @@ type StmtRecord struct {
 	// Pessimistic execution retry information.
 	ExecRetryCount uint          `json:"exec_retry_count"`
 	ExecRetryTime  time.Duration `json:"exec_retry_time"`
+
+	KeyspaceName string `json:"keyspace_name"`
+	KeyspaceID   uint32 `json:"keyspace_id"`
 }
 
 // NewStmtRecord creates a new StmtRecord from StmtExecInfo.
@@ -209,6 +212,8 @@ func NewStmtRecord(info *stmtsummary.StmtExecInfo) *StmtRecord {
 		Prepared:         info.Prepared,
 		FirstSeen:        info.StartTime,
 		LastSeen:         info.StartTime,
+		KeyspaceName:     info.KeyspaceName,
+		KeyspaceID:       info.KeyspaceID,
 	}
 }
 

--- a/util/stmtsummary/v2/record_test.go
+++ b/util/stmtsummary/v2/record_test.go
@@ -39,6 +39,8 @@ func TestStmtRecord(t *testing.T) {
 	require.Equal(t, info.Prepared, record1.Prepared)
 	require.Equal(t, info.StartTime, record1.FirstSeen)
 	require.Equal(t, info.StartTime, record1.LastSeen)
+	require.Equal(t, info.KeyspaceName, record1.KeyspaceName)
+	require.Equal(t, info.KeyspaceID, record1.KeyspaceID)
 	require.Empty(t, record1.AuthUsers)
 	require.Zero(t, record1.ExecCount)
 	require.Zero(t, record1.SumLatency)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41881

Problem Summary:

### What is changed and how it works?
StmtsummaryV2 with keyspace

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Maual test

1. start tidb with config
```
keyspace-name = "keyspace_a"
[instance]
tidb_stmt_summary_enable_persistent = true
tidb_stmt_summary_file_max_size = 25
tidb_stmt_summary_file_max_backups = 3
```
2. execute `set @@global.tidb_stmt_summary_refresh_interval=30;`
3. view log file, keyspace found in log file
![image](https://user-images.githubusercontent.com/50103576/223016328-6320895a-a07e-4dca-a3fc-acd45b522d8c.png)

//==============

1. start tidb with config
```
[instance]
tidb_stmt_summary_enable_persistent = true
tidb_stmt_summary_file_max_size = 25
tidb_stmt_summary_file_max_backups = 3
```
2. execute `set @@global.tidb_stmt_summary_refresh_interval=30;`
3. view log file, keyspace didn't found in log file
![image](https://user-images.githubusercontent.com/50103576/223016890-89c34454-e853-40c0-9749-d6a0fe192ceb.png)

Side effects

No

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
stmtsummary with keyspace
```
