### PR TITLE
planner: don't lock schema if an error happens

### DIFF
--- a/ddl/metadatalocktest/mdl_test.go
+++ b/ddl/metadatalocktest/mdl_test.go
@@ -332,6 +332,7 @@ func TestMDLRRUpdateSchema(t *testing.T) {
 	tk.MustExec("begin")
 	tkDDL.MustExec("alter table test.t modify column a char(10);")
 	tk.MustGetErrCode("select * from t", mysql.ErrInfoSchemaChanged)
+	tk.MustGetErrCode("select * from t", mysql.ErrInfoSchemaChanged)
 	tk.MustExec("commit")
 	tk.MustQuery("select * from t").Check(testkit.Rows("1 <nil>"))
 

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -1833,6 +1833,9 @@ func tryLockMDLAndUpdateSchemaIfNecessary(sctx sessionctx.Context, dbName model.
 		var err error
 		tbl, err = domainSchema.TableByName(dbName, tableInfo.Name)
 		if err != nil {
+			if !skipLock {
+				sctx.GetSessionVars().GetRelatedTableForMDL().Delete(tableInfo.ID)
+			}
 			return nil, err
 		}
 		if !skipLock {
@@ -1879,6 +1882,9 @@ func tryLockMDLAndUpdateSchemaIfNecessary(sctx sessionctx.Context, dbName model.
 					}
 				}
 				if found {
+					if !skipLock {
+						sctx.GetSessionVars().GetRelatedTableForMDL().Delete(tableInfo.ID)
+					}
 					return nil, domain.ErrInfoSchemaChanged.GenWithStack("public column %s has changed", col.Name)
 				}
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41797

Problem Summary:
Previously, if there was an error when updating the transaction schema, we locked the schema. But it may skip the checking because `sctx.GetSessionVars().GetRelatedTableForMDL().Load(tableInfo.ID) is true`.

### What is changed and how it works?
Unlock the schema if an error happens.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
