### PR TITLE
lightning: gcs reader seekend should has an positive offset

### DIFF
--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -398,6 +398,9 @@ func (r *gcsObjectReader) Seek(offset int64, whence int) (int64, error) {
 			return 0, errors.Annotatef(berrors.ErrInvalidArgument, "Seek: offset '%v' should be negative.", offset)
 		}
 		realOffset = offset + r.totalSize
+		if realOffset < 0 {
+			return 0, errors.Annotatef(berrors.ErrInvalidArgument, "Seek: offset '%v' out of range when length is '%v'", offset, r.totalSize)
+		}
 	default:
 		return 0, errors.Annotatef(berrors.ErrStorageUnknown, "Seek: invalid whence '%d'", whence)
 	}

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -385,25 +385,20 @@ func (r *gcsObjectReader) Seek(offset int64, whence int) (int64, error) {
 	var realOffset int64
 	switch whence {
 	case io.SeekStart:
-		if offset < 0 {
-			return 0, errors.Annotatef(berrors.ErrInvalidArgument, "Seek: offset '%v' out of range.", offset)
-		}
 		realOffset = offset
 	case io.SeekCurrent:
 		realOffset = r.pos + offset
-		if realOffset < 0 {
-			return 0, errors.Annotatef(berrors.ErrInvalidArgument, "Seek: offset '%v' out of range. current pos is '%v'.", offset, r.pos)
-		}
 	case io.SeekEnd:
 		if offset > 0 {
 			return 0, errors.Annotatef(berrors.ErrInvalidArgument, "Seek: offset '%v' should be negative.", offset)
 		}
 		realOffset = offset + r.totalSize
-		if realOffset < 0 {
-			return 0, errors.Annotatef(berrors.ErrInvalidArgument, "Seek: offset '%v' out of range when length is '%v'", offset, r.totalSize)
-		}
 	default:
 		return 0, errors.Annotatef(berrors.ErrStorageUnknown, "Seek: invalid whence '%d'", whence)
+	}
+
+	if realOffset < 0 {
+		return 0, errors.Annotatef(berrors.ErrInvalidArgument, "Seek: offset '%v' out of range. current pos is '%v'. total size is '%v'", offset, r.pos, r.totalSize)
 	}
 
 	if realOffset == r.pos {

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -175,6 +175,11 @@ func (s *GCSStorage) Open(ctx context.Context, path string) (ExternalFileReader,
 
 	attrs, err := handle.Attrs(ctx)
 	if err != nil {
+		if errors.Cause(err) == storage.ErrObjectNotExist { // nolint:errorlint
+			return nil, errors.Annotatef(err,
+				"the object doesn't exist, file info: input.bucket='%s', input.key='%s'",
+				s.gcs.Bucket, path)
+		}
 		return nil, errors.Annotatef(err,
 			"failed to get gcs file attribute, file info: input.bucket='%s', input.key='%s'",
 			s.gcs.Bucket, path)

--- a/br/pkg/storage/gcs_test.go
+++ b/br/pkg/storage/gcs_test.go
@@ -45,7 +45,8 @@ func TestGCS(t *testing.T) {
 	err = stg.WriteFile(ctx, "key1", []byte("data1"))
 	require.NoError(t, err)
 
-	err = stg.WriteFile(ctx, "key2", []byte("data22223346757222222222289722222"))
+	key2Data := []byte("data22223346757222222222289722222")
+	err = stg.WriteFile(ctx, "key2", key2Data)
 	require.NoError(t, err)
 
 	rc, err := server.Client().Bucket(bucketName).Object("a/b/key").NewReader(ctx)
@@ -226,8 +227,24 @@ func TestGCS(t *testing.T) {
 	require.Equal(t, 5, n)
 	require.Equal(t, "97222", string(p))
 
-	_, err = efr.Seek(int64(0), io.SeekEnd)
-	require.Error(t, err)
+	offs, err = efr.Seek(int64(100), io.SeekStart)
+	require.NoError(t, err)
+	require.Equal(t, int64(100), offs)
+	_, err = efr.Read(p)
+	require.Contains(t, err.Error(), "EOF")
+
+	offs, err = efr.Seek(int64(0), io.SeekEnd)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(key2Data)), offs)
+	_, err = efr.Read(p)
+	require.Contains(t, err.Error(), "EOF")
+
+	offs, err = efr.Seek(int64(0), io.SeekCurrent)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(key2Data)), offs)
+	_, err = efr.Read(p)
+	require.Contains(t, err.Error(), "EOF")
+
 	_, err = efr.Seek(int64(-10000), io.SeekEnd)
 	require.Error(t, err)
 

--- a/br/pkg/storage/gcs_test.go
+++ b/br/pkg/storage/gcs_test.go
@@ -226,6 +226,11 @@ func TestGCS(t *testing.T) {
 	require.Equal(t, 5, n)
 	require.Equal(t, "97222", string(p))
 
+	_, err = efr.Seek(int64(0), io.SeekEnd)
+	require.Error(t, err)
+	_, err = efr.Seek(int64(-10000), io.SeekEnd)
+	require.Error(t, err)
+
 	err = efr.Close()
 	require.NoError(t, err)
 

--- a/br/pkg/storage/gcs_test.go
+++ b/br/pkg/storage/gcs_test.go
@@ -239,9 +239,9 @@ func TestGCS(t *testing.T) {
 	_, err = efr.Read(p)
 	require.Contains(t, err.Error(), "EOF")
 
-	offs, err = efr.Seek(int64(0), io.SeekCurrent)
+	offs, err = efr.Seek(int64(1), io.SeekCurrent)
 	require.NoError(t, err)
-	require.Equal(t, int64(len(key2Data)), offs)
+	require.Equal(t, int64(len(key2Data)+1), offs)
 	_, err = efr.Read(p)
 	require.Contains(t, err.Error(), "EOF")
 

--- a/br/pkg/storage/gcs_test.go
+++ b/br/pkg/storage/gcs_test.go
@@ -216,17 +216,15 @@ func TestGCS(t *testing.T) {
 	require.Equal(t, 5, n)
 	require.Equal(t, "67572", string(p))
 
-	/* Since fake_gcs_server hasn't support for negative offset yet.
 	p = make([]byte, 5)
 	offs, err = efr.Seek(int64(-7), io.SeekEnd)
 	require.NoError(t, err)
-	require.Equal(t, int64(-7), offs)
+	require.Equal(t, int64(26), offs)
 
 	n, err = efr.Read(p)
 	require.NoError(t, err)
 	require.Equal(t, 5, n)
 	require.Equal(t, "97222", string(p))
-	*/
 
 	err = efr.Close()
 	require.NoError(t, err)

--- a/executor/loadremotetest/error_test.go
+++ b/executor/loadremotetest/error_test.go
@@ -60,7 +60,7 @@ func (s *mockGCSSuite) TestErrorMessage() {
 	err = s.tk.ExecToErr(fmt.Sprintf(`LOAD DATA INFILE 'gs://wrong-bucket/p?endpoint=%s'
 		INTO TABLE t;`, gcsEndpoint))
 	checkClientErrorMessage(s.T(), err,
-		"ERROR 8160 (HY000): Failed to read source files. Reason: failed to read gcs file, file info: input.bucket='wrong-bucket', input.key='p'. Please check the INFILE path is correct")
+		"ERROR 8160 (HY000): Failed to read source files. Reason: the object doesn't exist, file info: input.bucket='wrong-bucket', input.key='p'. Please check the INFILE path is correct")
 
 	s.server.CreateObject(fakestorage.Object{
 		ObjectAttrs: fakestorage.ObjectAttrs{

--- a/executor/loadremotetest/util_test.go
+++ b/executor/loadremotetest/util_test.go
@@ -34,9 +34,12 @@ type mockGCSSuite struct {
 }
 
 var (
-	gcsHost     = "127.0.0.1"
-	gcsPort     = uint16(4443)
-	gcsEndpoint = fmt.Sprintf("http://%s:%d", gcsHost, gcsPort)
+	gcsHost = "127.0.0.1"
+	gcsPort = uint16(4443)
+	// for fake gcs server, we must use this endpoint format
+	// NOTE: must end with '/'
+	gcsEndpointFormat = "http://%s:%d/storage/v1/"
+	gcsEndpoint       = fmt.Sprintf(gcsEndpointFormat, gcsHost, gcsPort)
 )
 
 func TestLoadRemote(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41899 

Problem Summary:
gcs reader seekend should has an positive offset
### What is changed and how it works?
get the total size of the object then file open.
return the `totalSize+offset` instead of `offset`.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
