### PR TITLE
store/copr: disable store batch copr for internal requests

### DIFF
--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -1951,14 +1951,14 @@ func checkStoreBatchCopr(req *kv.Request) bool {
 	}
 	// TODO: support keep-order batch
 	if req.ReplicaRead != kv.ReplicaReadLeader || req.KeepOrder {
-		// disable batch copr for follower read
+		// Disable batch copr for follower read
 		return false
 	}
-	// disable batch copr when paging is enabled.
+	// Disable batch copr when paging is enabled.
 	if req.Paging.Enable {
 		return false
 	}
-	// disable it for internal requests to avoid regression.
+	// Disable it for internal requests to avoid regression.
 	if req.RequestSource.RequestSourceInternal {
 		return false
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41562

Problem Summary:

Add index has 5% regression in the latest tidb, and it's probably caused by batched copr.

### What is changed and how it works?

Disable batch for internal requests.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

I ran it 4 times with this PR and the time used are: 5453s, 5470s, 5459s, 5462s. Compare with the duration before, confirm that the regression is fixed.

![image](https://user-images.githubusercontent.com/9587680/222887531-48f705f0-d18a-4782-bc61-088578a36832.png)


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
