### PR TITLE
br: continuing retry when pitr met the error about memory is limited

### DIFF
--- a/br/pkg/restore/import_retry.go
+++ b/br/pkg/restore/import_retry.go
@@ -91,9 +91,9 @@ func (o *OverRegionsInRangeController) handleInRegionError(ctx context.Context, 
 		if strings.Contains(result.StoreError.GetMessage(), "memory is limited") {
 			sleepDuration := 15 * time.Second
 
-			failpoint.Inject("hint-memoryIsLimited-sleep", func(val failpoint.Value) {
+			failpoint.Inject("hint-memory-is-limited", func(val failpoint.Value) {
 				if val.(bool) {
-					logutil.CL(ctx).Debug("failpoint hint-memoryIsLimited-sleep injected.")
+					logutil.CL(ctx).Debug("failpoint hint-memory-is-limited injected.")
 					sleepDuration = 100 * time.Microsecond
 				}
 			})

--- a/br/pkg/restore/import_retry.go
+++ b/br/pkg/restore/import_retry.go
@@ -4,6 +4,7 @@ package restore
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -85,6 +86,13 @@ func (o *OverRegionsInRangeController) tryFindLeader(ctx context.Context, region
 
 // handleInRegionError handles the error happens internal in the region. Update the region info, and perform a suitable backoff.
 func (o *OverRegionsInRangeController) handleInRegionError(ctx context.Context, result RPCResult, region *split.RegionInfo) (cont bool) {
+	if result.StoreError.GetServerIsBusy() != nil {
+		if strings.Contains(result.StoreError.GetMessage(), "memory is limited") {
+			time.Sleep(15 * time.Second)
+			return true
+		}
+	}
+
 	if nl := result.StoreError.GetNotLeader(); nl != nil {
 		if nl.Leader != nil {
 			region.Leader = nl.Leader

--- a/br/pkg/restore/import_retry_test.go
+++ b/br/pkg/restore/import_retry_test.go
@@ -168,9 +168,9 @@ func TestServerIsBusy(t *testing.T) {
 }
 
 func TestServerIsBusyWithMemoryIsLimited(t *testing.T) {
-	_ = failpoint.Enable("github.com/pingcap/tidb/br/pkg/restore/hint-memoryIsLimited-sleep", "return(true)")
+	_ = failpoint.Enable("github.com/pingcap/tidb/br/pkg/restore/hint-memory-is-limited", "return(true)")
 	defer func() {
-		_ = failpoint.Disable("github.com/pingcap/tidb/br/pkg/restore/hint-memoryIsLimited-sleep")
+		_ = failpoint.Disable("github.com/pingcap/tidb/br/pkg/restore/hint-memory-is-limited")
 	}()
 
 	// region: [, aay), [aay, bba), [bba, bbh), [bbh, cca), [cca, )

--- a/br/pkg/restore/import_retry_test.go
+++ b/br/pkg/restore/import_retry_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
@@ -163,6 +164,48 @@ func TestServerIsBusy(t *testing.T) {
 	require.NoError(t, err)
 	assertRegions(t, idEqualsTo2Regions, "aay", "bba")
 	assertRegions(t, meetRegions, "", "aay", "bba", "bbh", "cca", "")
+	require.Equal(t, rs.RetryTimes(), 1)
+}
+
+func TestServerIsBusyWithMemoryIsLimited(t *testing.T) {
+	_ = failpoint.Enable("github.com/pingcap/tidb/br/pkg/restore/hint-memoryIsLimited-sleep", "return(true)")
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/tidb/br/pkg/restore/hint-memoryIsLimited-sleep")
+	}()
+
+	// region: [, aay), [aay, bba), [bba, bbh), [bbh, cca), [cca, )
+	cli := initTestClient(false)
+	rs := utils.InitialRetryState(2, 0, 0)
+	ctl := restore.OverRegionsInRange([]byte(""), []byte(""), cli, &rs)
+	ctx := context.Background()
+
+	serverIsBusy := errorpb.Error{
+		Message: "memory is limited",
+		ServerIsBusy: &errorpb.ServerIsBusy{
+			Reason: "",
+		},
+	}
+	// record the regions we didn't touch.
+	meetRegions := []*split.RegionInfo{}
+	// record all regions we meet with id == 2.
+	idEqualsTo2Regions := []*split.RegionInfo{}
+	theFirstRun := true
+	err := ctl.Run(ctx, func(ctx context.Context, r *split.RegionInfo) restore.RPCResult {
+		if theFirstRun && r.Region.Id == 2 {
+			idEqualsTo2Regions = append(idEqualsTo2Regions, r)
+			theFirstRun = false
+			return restore.RPCResult{
+				StoreError: &serverIsBusy,
+			}
+		}
+		meetRegions = append(meetRegions, r)
+		return restore.RPCResultOK()
+	})
+
+	require.NoError(t, err)
+	assertRegions(t, idEqualsTo2Regions, "aay", "bba")
+	assertRegions(t, meetRegions, "", "aay", "bba", "bbh", "cca", "")
+	require.Equal(t, rs.RetryTimes(), 0)
 }
 
 func printRegion(name string, infos []*split.RegionInfo) {

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -86,6 +86,12 @@ func (rs *RetryState) RecordRetry() {
 	rs.retryTimes++
 }
 
+// RetryTimes returns the retry times.
+// usage: unit test.
+func (rs *RetryState) RetryTimes() int {
+	return rs.retryTimes
+}
+
 // Attempt implements the `Backoffer`.
 // TODO: Maybe use this to replace the `exponentialBackoffer` (which is nearly homomorphic to this)?
 func (rs *RetryState) Attempt() int {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/41983

Problem Summary:
- If the config `tikv.import.memory-use-ratio` is too low, `tikv-server` would report the error "memory is limited" to `BR` when PITR restore, and the PITR restore failed finally because the retry times exceeds the threshold.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that failed to restore log with the error "memory is limited".
```
