### PR TITLE
statistics/handle: use StatementContext with TimeZone in initStatsBuckets4Chunk

### DIFF
--- a/statistics/handle/handletest/handle_test.go
+++ b/statistics/handle/handletest/handle_test.go
@@ -488,6 +488,23 @@ func TestInitStatsVer2(t *testing.T) {
 	h.SetLease(0)
 }
 
+func TestInitStatsIssue41938(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@global.tidb_analyze_version=1")
+	tk.MustExec("set @@session.tidb_analyze_version=1")
+	tk.MustExec("create table t1 (a timestamp primary key)")
+	tk.MustExec("insert into t1 values ('2023-03-07 14:24:30'), ('2023-03-07 14:24:31'), ('2023-03-07 14:24:32'), ('2023-03-07 14:24:33')")
+	tk.MustExec("analyze table t1 with 0 topn")
+	h := dom.StatsHandle()
+	// `InitStats` is only called when `Lease` is not 0, so here we just change it.
+	h.SetLease(time.Millisecond)
+	h.Clear()
+	require.NoError(t, h.InitStats(dom.InfoSchema()))
+	h.SetLease(0)
+}
+
 func TestReloadExtStatsLockRelease(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41938

Problem Summary:

### What is changed and how it works?

Use a newly-created `StatementContext` with `UTC` `TimeZone` when calling `(*Datum).ConvertTo` for upper/lower bounds in `initStatsBuckets4Chunk`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
