### PR TITLE
*: display tiflash_write in cluster_info

### DIFF
--- a/ddl/placement/common.go
+++ b/ddl/placement/common.go
@@ -59,7 +59,7 @@ const (
 	// it's the lable of tiflash_compute nodes.
 	EngineLabelTiFlashCompute = "tiflash_compute"
 	// EngineRoleLabelKey is the label that indicates if the TiFlash instance is a write node.
-	EngineRoleLabelKey = "engine-role"
+	EngineRoleLabelKey = "engine_role"
 	// EngineRoleLabelWrite is for disaggregated tiflash write node.
 	EngineRoleLabelWrite = "write"
 )

--- a/ddl/placement/common.go
+++ b/ddl/placement/common.go
@@ -58,4 +58,8 @@ const (
 	// EngineLabelTiFlashCompute is for disaggregated tiflash mode,
 	// it's the lable of tiflash_compute nodes.
 	EngineLabelTiFlashCompute = "tiflash_compute"
+	// EngineRoleLabelKey is the label that indicates if the TiFlash instance is a write node.
+	EngineRoleLabelKey = "engine-role"
+	// EngineRoleLabelWrite is for disaggregated tiflash write node.
+	EngineRoleLabelWrite = "write"
 )

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1851,23 +1851,21 @@ func GetPDServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 }
 
 func isTiFlashStore(store *metapb.Store) bool {
-	isTiFlash := false
 	for _, label := range store.Labels {
 		if label.GetKey() == placement.EngineLabelKey && label.GetValue() == placement.EngineLabelTiFlash {
-			isTiFlash = true
+			return true
 		}
 	}
-	return isTiFlash
+	return false
 }
 
 func isTiFlashWriteNode(store *metapb.Store) bool {
-	isTiFlashWriteNode := false
 	for _, label := range store.Labels {
 		if label.GetKey() == placement.EngineRoleLabelKey && label.GetValue() == placement.EngineRoleLabelWrite {
-			isTiFlashWriteNode = true
+			return true
 		}
 	}
-	return isTiFlashWriteNode
+	return false
 }
 
 // GetStoreServerInfo returns all store nodes(TiKV or TiFlash) cluster information

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1850,6 +1850,26 @@ func GetPDServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 	return servers, nil
 }
 
+func isTiFlashStore(store *metapb.Store) bool {
+	isTiFlash := false
+	for _, label := range store.Labels {
+		if label.GetKey() == placement.EngineLabelKey && label.GetValue() == placement.EngineLabelTiFlash {
+			isTiFlash = true
+		}
+	}
+	return isTiFlash
+}
+
+func isTiFlashWriteNode(store *metapb.Store) bool {
+	isTiFlashWriteNode := false
+	for _, label := range store.Labels {
+		if label.GetKey() == placement.EngineRoleLabelKey && label.GetValue() == placement.EngineRoleLabelWrite {
+			isTiFlashWriteNode = true
+		}
+	}
+	return isTiFlashWriteNode
+}
+
 // GetStoreServerInfo returns all store nodes(TiKV or TiFlash) cluster information
 func GetStoreServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 	failpoint.Inject("mockStoreServerInfo", func(val failpoint.Value) {
@@ -1869,16 +1889,6 @@ func GetStoreServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 			failpoint.Return(servers, nil)
 		}
 	})
-
-	isTiFlashStore := func(store *metapb.Store) bool {
-		isTiFlash := false
-		for _, label := range store.Labels {
-			if label.GetKey() == placement.EngineLabelKey && label.GetValue() == placement.EngineLabelTiFlash {
-				isTiFlash = true
-			}
-		}
-		return isTiFlash
-	}
 
 	store := ctx.GetStore()
 	// Get TiKV servers info.
@@ -1907,7 +1917,12 @@ func GetStoreServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 		}
 		var tp string
 		if isTiFlashStore(store) {
-			tp = kv.TiFlash.Name()
+			if isTiFlashWriteNode(store) {
+				// tiflash_write is not a storeType in client-go, so we just judge based on the label here.
+				tp = "tiflash_write"
+			} else {
+				tp = kv.TiFlash.Name()
+			}
 		} else {
 			tp = tikv.GetStoreTypeByMeta(store).Name()
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42064

Problem Summary:
https://github.com/pingcap/tiflash/issues/7007
When the label of TiFlash contains `engine_role`:`write`, it means that this TiFlash is a `tiflash_write` node. So `tiflash_write` should be displayed in `information_schema.cluster_info`.
### What is changed and how it works?
Check the label and display `tiflash_write`.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
![image](https://user-images.githubusercontent.com/14118780/223972462-2c6603c4-4d1f-4d27-961f-7f7c28286056.png)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
