### PR TITLE
sysvar: set the default value of resource control switch to false

### DIFF
--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -1132,7 +1132,9 @@ func TestSetJobScheduleWindow(t *testing.T) {
 
 func TestTiDBEnableResourceControl(t *testing.T) {
 	// setup the hooks for test
-	enable := true
+	// NOTE: the default system variable is true but the switch is false
+	// It is initialized at the first call of `rebuildSysVarCache`
+	enable := false
 	EnableGlobalResourceControlFunc = func() { enable = true }
 	DisableGlobalResourceControlFunc = func() { enable = false }
 	setGlobalResourceControlFunc := func(enable bool) {
@@ -1152,18 +1154,25 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 
 	// Default true
 	require.Equal(t, resourceControlEnabled.Value, On)
+	require.Equal(t, enable, false)
+
+	// Set to On(init at start)
+	err := mock.SetGlobalSysVar(context.Background(), TiDBEnableResourceControl, On)
+	require.NoError(t, err)
+	val, err1 := mock.GetGlobalSysVar(TiDBEnableResourceControl)
+	require.NoError(t, err1)
+	require.Equal(t, On, val)
 	require.Equal(t, enable, true)
 
 	// Set to Off
-	err := mock.SetGlobalSysVar(context.Background(), TiDBEnableResourceControl, Off)
-
+	err = mock.SetGlobalSysVar(context.Background(), TiDBEnableResourceControl, Off)
 	require.NoError(t, err)
-	val, err1 := mock.GetGlobalSysVar(TiDBEnableResourceControl)
+	val, err1 = mock.GetGlobalSysVar(TiDBEnableResourceControl)
 	require.NoError(t, err1)
 	require.Equal(t, Off, val)
 	require.Equal(t, enable, false)
 
-	// Set to On
+	// Set to On again
 	err = mock.SetGlobalSysVar(context.Background(), TiDBEnableResourceControl, On)
 	require.NoError(t, err)
 	val, err1 = mock.GetGlobalSysVar(TiDBEnableResourceControl)

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -1295,8 +1295,9 @@ var (
 	MaxPreparedStmtCountValue          = atomic.NewInt64(DefMaxPreparedStmtCount)
 	HistoricalStatsDuration            = atomic.NewDuration(DefTiDBHistoricalStatsDuration)
 	EnableHistoricalStatsForCapture    = atomic.NewBool(DefTiDBEnableHistoricalStatsForCapture)
-	EnableResourceControl              = atomic.NewBool(DefTiDBEnableResourceControl)
 	TTLRunningTasks                    = atomic.NewInt32(DefTiDBTTLRunningTasks)
+	// always set the default value to false because the resource control in kv-client is not inited
+	EnableResourceControl = atomic.NewBool(false)
 )
 
 var (

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -1297,6 +1297,7 @@ var (
 	EnableHistoricalStatsForCapture    = atomic.NewBool(DefTiDBEnableHistoricalStatsForCapture)
 	TTLRunningTasks                    = atomic.NewInt32(DefTiDBTTLRunningTasks)
 	// always set the default value to false because the resource control in kv-client is not inited
+	// It will be initialized to the right value after the first call of `rebuildSysVarCache`
 	EnableResourceControl = atomic.NewBool(false)
 )
 

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -244,7 +244,7 @@ func main() {
 	svr := createServer(storage, dom)
 	err = driver.TrySetupGlobalResourceController(context.Background(), dom.ServerID(), storage)
 	if err != nil {
-		terror.MustNil(errors.Wrap(err, "failed to setup global resource controller"))
+		logutil.BgLogger().Warn("failed to setup global resource controller", zap.Error(err))
 	}
 
 	// Register error API is not thread-safe, the caller MUST NOT register errors after initialization.

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -244,7 +244,7 @@ func main() {
 	svr := createServer(storage, dom)
 	err = driver.TrySetupGlobalResourceController(context.Background(), dom.ServerID(), storage)
 	if err != nil {
-		logutil.BgLogger().Warn("failed to setup global resource controller", zap.Error(err))
+		terror.MustNil(errors.Wrap(err, "failed to setup global resource controller"))
 	}
 
 	// Register error API is not thread-safe, the caller MUST NOT register errors after initialization.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #41962

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)
 - before this change, when set `tidb_resource_control = on` and restart tidb instance, the resource controller in kv-client is not initialized and kv request are not limit by ru. The resource control metrics has no data.
 - After this change, the resource control behaved as expected.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
