### PR TITLE
ddl: move adding index encoding work from readers to writers

### DIFF
--- a/ddl/BUILD.bazel
+++ b/ddl/BUILD.bazel
@@ -257,6 +257,7 @@ go_test(
         "//testkit/testutil",
         "//types",
         "//util",
+        "//util/chunk",
         "//util/codec",
         "//util/collate",
         "//util/dbterror",

--- a/ddl/export_test.go
+++ b/ddl/export_test.go
@@ -16,11 +16,14 @@ package ddl
 
 import (
 	"context"
+	"time"
 
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 )
 
 func SetBatchInsertDeleteRangeSize(i int) {
@@ -30,7 +33,7 @@ func SetBatchInsertDeleteRangeSize(i int) {
 var NewCopContext4Test = newCopContext
 
 func FetchRowsFromCop4Test(copCtx *copContext, tbl table.PhysicalTable, startKey, endKey kv.Key, store kv.Storage,
-	batchSize int) ([]*indexRecord, bool, error) {
+	batchSize int) (*chunk.Chunk, bool, error) {
 	variable.SetDDLReorgBatchSize(int32(batchSize))
 	task := &reorgBackfillTask{
 		id:            1,
@@ -41,17 +44,14 @@ func FetchRowsFromCop4Test(copCtx *copContext, tbl table.PhysicalTable, startKey
 	pool := newCopReqSenderPool(context.Background(), copCtx, store)
 	pool.adjustSize(1)
 	pool.tasksCh <- task
-	idxRec, _, _, done, err := pool.fetchRowColValsFromCop(*task)
+	copChunk, _, done, err := pool.fetchRowColValsFromCop(*task)
 	pool.close()
-	return idxRec, done, err
+	return copChunk, done, err
 }
 
-type IndexRecord4Test = *indexRecord
-
-func (i IndexRecord4Test) GetHandle() kv.Handle {
-	return i.handle
-}
-
-func (i IndexRecord4Test) GetIndexValues() []types.Datum {
-	return i.vals
+func ConvertRowToHandleAndIndexDatum(row chunk.Row, copCtx *copContext) (kv.Handle, []types.Datum, error) {
+	idxData := extractDatumByOffsets(row, copCtx.idxColOutputOffsets, copCtx.expColInfos, nil)
+	handleData := extractDatumByOffsets(row, copCtx.handleOutputOffsets, copCtx.expColInfos, nil)
+	handle, err := buildHandle(handleData, copCtx.tblInfo, copCtx.pkInfo, &stmtctx.StatementContext{TimeZone: time.Local})
+	return handle, idxData, err
 }

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -41,6 +41,8 @@ import (
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
@@ -1636,11 +1638,6 @@ func genKeyExistsErr(key, value []byte, idxInfo *model.IndexInfo, tblInfo *model
 }
 
 func (w *addIndexWorker) batchCheckUniqueKey(txn kv.Transaction, idxRecords []*indexRecord) error {
-	if w.writerCtx != nil {
-		// For the ingest mode, we use lightning local backend's local check and remote check
-		// to implement the duplicate key detection.
-		return nil
-	}
 	idxInfo := w.index.Meta()
 	if !idxInfo.Unique {
 		// non-unique key need not to check, just overwrite it,
@@ -1705,6 +1702,71 @@ func (w *addIndexWorker) batchCheckUniqueKey(txn kv.Transaction, idxRecords []*i
 	return nil
 }
 
+func (w *addIndexWorker) writeIndexKVsToLocal(handleRange reorgBackfillTask) (backfillTaskContext, error) {
+	var taskCtx backfillTaskContext
+	oprStartTime := time.Now()
+	defer func() {
+		logSlowOperations(time.Since(oprStartTime), "writeIndexKVsToLocal", 3000)
+	}()
+	copChunk, nextKey, taskDone, err := w.copReqSenderPool.fetchRowColValsFromCop(handleRange)
+	if err != nil {
+		return taskCtx, err
+	}
+	defer w.copReqSenderPool.recycleChunk(copChunk)
+
+	copCtx := w.copReqSenderPool.copCtx
+	vars := w.sessCtx.GetSessionVars()
+	err = writeChunkToLocal(w.writerCtx, w.index, copCtx, vars, copChunk)
+	if err != nil {
+		return taskCtx, err
+	}
+	taskCtx.nextKey = nextKey
+	taskCtx.done = taskDone
+	return taskCtx, nil
+}
+
+func writeChunkToLocal(writerCtx *ingest.WriterContext,
+	index table.Index, copCtx *copContext, vars *variable.SessionVars,
+	copChunk *chunk.Chunk) error {
+	sCtx, writeBufs := vars.StmtCtx, vars.GetWriteStmtBufs()
+	iter := chunk.NewIterator4Chunk(copChunk)
+	idxDataBuf := make([]types.Datum, len(copCtx.idxColOutputOffsets))
+	handleDataBuf := make([]types.Datum, len(copCtx.handleOutputOffsets))
+	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		idxDataBuf, handleDataBuf = idxDataBuf[:0], handleDataBuf[:0]
+		idxDataBuf = extractDatumByOffsets(row, copCtx.idxColOutputOffsets, copCtx.expColInfos, idxDataBuf)
+		handleDataBuf := extractDatumByOffsets(row, copCtx.handleOutputOffsets, copCtx.expColInfos, handleDataBuf)
+		handle, err := buildHandle(handleDataBuf, copCtx.tblInfo, copCtx.pkInfo, sCtx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		rsData := getRestoreData(copCtx.tblInfo, copCtx.idxInfo, copCtx.pkInfo, handleDataBuf)
+		err = writeOneKVToLocal(writerCtx, index, sCtx, writeBufs, idxDataBuf, rsData, handle)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func writeOneKVToLocal(writerCtx *ingest.WriterContext,
+	index table.Index, sCtx *stmtctx.StatementContext, writeBufs *variable.WriteStmtBufs,
+	idxDt, rsData []types.Datum, handle kv.Handle) error {
+	iter := index.GenIndexKVIter(sCtx, idxDt, handle, rsData)
+	for iter.Valid() {
+		key, idxVal, _, err := iter.Next(writeBufs.IndexKeyBuf)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = writerCtx.WriteRow(key, idxVal, handle)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		writeBufs.IndexKeyBuf = key
+	}
+	return nil
+}
+
 // BackfillDataInTxn will backfill table index in a transaction. A lock corresponds to a rowKey if the value of rowKey is changed,
 // Note that index columns values may change, and an index is not allowed to be added, so the txn will rollback and retry.
 // BackfillDataInTxn will add w.batchCnt indices once, default value of w.batchCnt is 128.
@@ -1716,7 +1778,9 @@ func (w *addIndexWorker) BackfillDataInTxn(handleRange reorgBackfillTask) (taskC
 		}
 	})
 
-	needMergeTmpIdx := w.index.Meta().BackfillState != model.BackfillStateInapplicable
+	if w.copReqSenderPool != nil && w.writerCtx != nil {
+		return w.writeIndexKVsToLocal(handleRange)
+	}
 
 	oprStartTime := time.Now()
 	jobID := handleRange.getJobID()
@@ -1730,18 +1794,7 @@ func (w *addIndexWorker) BackfillDataInTxn(handleRange reorgBackfillTask) (taskC
 			txn.SetOption(kv.ResourceGroupTagger, tagger)
 		}
 
-		var (
-			idxRecords []*indexRecord
-			copChunk   *chunk.Chunk // only used by the coprocessor request sender.
-			nextKey    kv.Key
-			taskDone   bool
-		)
-		if w.copReqSenderPool != nil {
-			idxRecords, copChunk, nextKey, taskDone, err = w.copReqSenderPool.fetchRowColValsFromCop(handleRange)
-			defer w.copReqSenderPool.recycleIdxRecordsAndChunk(idxRecords, copChunk)
-		} else {
-			idxRecords, nextKey, taskDone, err = w.fetchRowColVals(txn, handleRange)
-		}
+		idxRecords, nextKey, taskDone, err := w.fetchRowColVals(txn, handleRange)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1761,43 +1814,20 @@ func (w *addIndexWorker) BackfillDataInTxn(handleRange reorgBackfillTask) (taskC
 				continue
 			}
 
-			// When the backfill-merge process is used, the writes from DML are redirected to a temp index.
-			// The write-conflict will be handled by the merge worker. Thus, the locks are unnecessary.
-			if !needMergeTmpIdx {
-				// We need to add this lock to make sure pessimistic transaction can realize this operation.
-				// For the normal pessimistic transaction, it's ok. But if async commit is used, it may lead to inconsistent data and index.
-				err := txn.LockKeys(context.Background(), new(kv.LockCtx), idxRecord.key)
-				if err != nil {
-					return errors.Trace(err)
-				}
+			// We need to add this lock to make sure pessimistic transaction can realize this operation.
+			// For the normal pessimistic transaction, it's ok. But if async commit is used, it may lead to inconsistent data and index.
+			err := txn.LockKeys(context.Background(), new(kv.LockCtx), idxRecord.key)
+			if err != nil {
+				return errors.Trace(err)
 			}
 
-			// Create the index.
-			if w.writerCtx == nil {
-				handle, err := w.index.Create(w.sessCtx, txn, idxRecord.vals, idxRecord.handle, idxRecord.rsData, table.WithIgnoreAssertion, table.FromBackfill)
-				if err != nil {
-					if kv.ErrKeyExists.Equal(err) && idxRecord.handle.Equal(handle) {
-						// Index already exists, skip it.
-						continue
-					}
-
-					return errors.Trace(err)
+			handle, err := w.index.Create(w.sessCtx, txn, idxRecord.vals, idxRecord.handle, idxRecord.rsData, table.WithIgnoreAssertion, table.FromBackfill)
+			if err != nil {
+				if kv.ErrKeyExists.Equal(err) && idxRecord.handle.Equal(handle) {
+					// Index already exists, skip it.
+					continue
 				}
-			} else { // The lightning environment is ready.
-				vars := w.sessCtx.GetSessionVars()
-				sCtx, writeBufs := vars.StmtCtx, vars.GetWriteStmtBufs()
-				iter := w.index.GenIndexKVIter(sCtx, idxRecord.vals, idxRecord.handle, idxRecord.rsData)
-				for iter.Valid() {
-					key, idxVal, _, err := iter.Next(writeBufs.IndexKeyBuf)
-					if err != nil {
-						return errors.Trace(err)
-					}
-					err = w.writerCtx.WriteRow(key, idxVal, idxRecord.handle)
-					if err != nil {
-						return errors.Trace(err)
-					}
-					writeBufs.IndexKeyBuf = key
-				}
+				return errors.Trace(err)
 			}
 			taskCtx.addedCount++
 		}

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1712,6 +1712,11 @@ func (w *addIndexWorker) writeIndexKVsToLocal(handleRange reorgBackfillTask) (ba
 	if err != nil {
 		return taskCtx, err
 	}
+	taskCtx.nextKey = nextKey
+	taskCtx.done = taskDone
+	if copChunk == nil {
+		return taskCtx, nil
+	}
 	defer w.copReqSenderPool.recycleChunk(copChunk)
 
 	copCtx := w.copReqSenderPool.copCtx
@@ -1722,8 +1727,6 @@ func (w *addIndexWorker) writeIndexKVsToLocal(handleRange reorgBackfillTask) (ba
 	}
 	taskCtx.scanCount = count
 	taskCtx.addedCount = count
-	taskCtx.nextKey = nextKey
-	taskCtx.done = taskDone
 	return taskCtx, nil
 }
 

--- a/ddl/index_cop.go
+++ b/ddl/index_cop.go
@@ -61,7 +61,7 @@ func copReadChunkPoolSize() int {
 	return 10 * int(variable.GetDDLReorgWorkerCounter())
 }
 
-func (c *copReqSenderPool) fetchRowColValsFromCop(handleRange reorgBackfillTask) ([]*indexRecord, *chunk.Chunk, kv.Key, bool, error) {
+func (c *copReqSenderPool) fetchRowColValsFromCop(handleRange reorgBackfillTask) (*chunk.Chunk, kv.Key, bool, error) {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -70,29 +70,29 @@ func (c *copReqSenderPool) fetchRowColValsFromCop(handleRange reorgBackfillTask)
 			if !ok {
 				logutil.BgLogger().Info("[ddl-ingest] cop-response channel is closed",
 					zap.Int("id", handleRange.id), zap.String("task", handleRange.String()))
-				return nil, nil, handleRange.endKey, true, nil
+				return nil, handleRange.endKey, true, nil
 			}
 			if rs.err != nil {
-				return nil, nil, handleRange.startKey, false, rs.err
+				return nil, handleRange.startKey, false, rs.err
 			}
 			if rs.done {
 				logutil.BgLogger().Info("[ddl-ingest] finish a cop-request task",
-					zap.Int("id", rs.id), zap.Int("total", rs.total))
+					zap.Int("id", rs.id))
 				c.results.Store(rs.id, struct{}{})
 			}
 			if _, found := c.results.Load(handleRange.id); found {
 				logutil.BgLogger().Info("[ddl-ingest] task is found in results",
 					zap.Int("id", handleRange.id), zap.String("task", handleRange.String()))
 				c.results.Delete(handleRange.id)
-				return rs.records, rs.chunk, handleRange.endKey, true, nil
+				return rs.chunk, handleRange.endKey, true, nil
 			}
-			return rs.records, rs.chunk, handleRange.startKey, false, nil
+			return rs.chunk, handleRange.startKey, false, nil
 		case <-ticker.C:
 			logutil.BgLogger().Info("[ddl-ingest] cop-request result channel is empty",
 				zap.Int("id", handleRange.id))
 			if _, found := c.results.Load(handleRange.id); found {
 				c.results.Delete(handleRange.id)
-				return nil, nil, handleRange.endKey, true, nil
+				return nil, handleRange.endKey, true, nil
 			}
 		}
 	}
@@ -110,7 +110,6 @@ type copReqSenderPool struct {
 	senders []*copReqSender
 	wg      sync.WaitGroup
 
-	idxBufPool chan []*indexRecord
 	srcChkPool chan *chunk.Chunk
 }
 
@@ -155,18 +154,16 @@ func (c *copReqSender) run() {
 			}
 		})
 		var done bool
-		var total int
 		for !done {
-			idxRec, srcChk := p.getIndexRecordsAndChunks()
-			idxRec, done, err = p.copCtx.fetchTableScanResult(p.ctx, rs, srcChk, idxRec)
+			srcChk := p.getChunk()
+			done, err = p.copCtx.fetchTableScanResult(p.ctx, rs, srcChk)
 			if err != nil {
 				p.resultsCh <- idxRecResult{id: task.id, err: err}
-				p.recycleIdxRecordsAndChunk(idxRec, srcChk)
+				p.recycleChunk(srcChk)
 				terror.Call(rs.Close)
 				return
 			}
-			total += len(idxRec)
-			p.resultsCh <- idxRecResult{id: task.id, records: idxRec, chunk: srcChk, done: done, total: total}
+			p.resultsCh <- idxRecResult{id: task.id, chunk: srcChk, done: done}
 		}
 		terror.Call(rs.Close)
 	}
@@ -174,10 +171,8 @@ func (c *copReqSender) run() {
 
 func newCopReqSenderPool(ctx context.Context, copCtx *copContext, store kv.Storage) *copReqSenderPool {
 	poolSize := copReadChunkPoolSize()
-	idxBufPool := make(chan []*indexRecord, poolSize)
 	srcChkPool := make(chan *chunk.Chunk, poolSize)
 	for i := 0; i < poolSize; i++ {
-		idxBufPool <- make([]*indexRecord, 0, copReadBatchSize())
 		srcChkPool <- chunk.NewChunkWithCapacity(copCtx.fieldTps, copReadBatchSize())
 	}
 	return &copReqSenderPool{
@@ -189,7 +184,6 @@ func newCopReqSenderPool(ctx context.Context, copCtx *copContext, store kv.Stora
 		store:      store,
 		senders:    make([]*copReqSender, 0, variable.GetDDLReorgWorkerCounter()),
 		wg:         sync.WaitGroup{},
-		idxBufPool: idxBufPool,
 		srcChkPool: srcChkPool,
 	}
 }
@@ -231,34 +225,31 @@ func (c *copReqSenderPool) close() {
 	c.wg.Wait()
 	close(c.resultsCh)
 	cleanupWg.Wait()
-	close(c.idxBufPool)
 	close(c.srcChkPool)
 }
 
 func (c *copReqSenderPool) drainResults() {
 	// Consume the rest results because the writers are inactive anymore.
 	for rs := range c.resultsCh {
-		c.recycleIdxRecordsAndChunk(rs.records, rs.chunk)
+		c.recycleChunk(rs.chunk)
 	}
 }
 
-func (c *copReqSenderPool) getIndexRecordsAndChunks() ([]*indexRecord, *chunk.Chunk) {
-	ir := <-c.idxBufPool
+func (c *copReqSenderPool) getChunk() *chunk.Chunk {
 	chk := <-c.srcChkPool
 	newCap := copReadBatchSize()
 	if chk.Capacity() != newCap {
 		chk = chunk.NewChunkWithCapacity(c.copCtx.fieldTps, newCap)
 	}
 	chk.Reset()
-	return ir[:0], chk
+	return chk
 }
 
-// recycleIdxRecordsAndChunk puts the index record slice and the chunk back to the pool for reuse.
-func (c *copReqSenderPool) recycleIdxRecordsAndChunk(idxRecs []*indexRecord, chk *chunk.Chunk) {
-	if idxRecs == nil || chk == nil {
+// recycleChunk puts the index record slice and the chunk back to the pool for reuse.
+func (c *copReqSenderPool) recycleChunk(chk *chunk.Chunk) {
+	if chk == nil {
 		return
 	}
-	c.idxBufPool <- idxRecs
 	c.srcChkPool <- chk
 }
 
@@ -437,31 +428,19 @@ func (c *copContext) buildTableScan(ctx context.Context, startTS uint64, start, 
 }
 
 func (c *copContext) fetchTableScanResult(ctx context.Context, result distsql.SelectResult,
-	chk *chunk.Chunk, buf []*indexRecord) ([]*indexRecord, bool, error) {
-	sctx := c.sessCtx.GetSessionVars().StmtCtx
+	chk *chunk.Chunk) (bool, error) {
 	err := result.Next(ctx, chk)
 	if err != nil {
-		return nil, false, errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	if chk.NumRows() == 0 {
-		return buf, true, nil
+		return true, nil
 	}
-	iter := chunk.NewIterator4Chunk(chk)
 	err = table.FillVirtualColumnValue(c.virtualColFieldTps, c.virtualColOffsets, c.expColInfos, c.colInfos, c.sessCtx, chk)
 	if err != nil {
-		return nil, false, errors.Trace(err)
+		return false, errors.Trace(err)
 	}
-	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-		idxDt := extractDatumByOffsets(row, c.idxColOutputOffsets, c.expColInfos)
-		hdDt := extractDatumByOffsets(row, c.handleOutputOffsets, c.expColInfos)
-		handle, err := buildHandle(hdDt, c.tblInfo, c.pkInfo, sctx)
-		if err != nil {
-			return nil, false, errors.Trace(err)
-		}
-		rsData := getRestoreData(c.tblInfo, c.idxInfo, c.pkInfo, hdDt)
-		buf = append(buf, &indexRecord{handle: handle, key: nil, vals: idxDt, rsData: rsData, skip: false})
-	}
-	return buf, false, nil
+	return false, nil
 }
 
 func getRestoreData(tblInfo *model.TableInfo, targetIdx, pkIdx *model.IndexInfo, handleDts []types.Datum) []types.Datum {
@@ -515,14 +494,13 @@ func constructTableScanPB(sCtx sessionctx.Context, tblInfo *model.TableInfo, col
 	return &tipb.Executor{Tp: tipb.ExecType_TypeTableScan, TblScan: tblScan}, err
 }
 
-func extractDatumByOffsets(row chunk.Row, offsets []int, expCols []*expression.Column) []types.Datum {
-	datumBuf := make([]types.Datum, 0, len(offsets))
+func extractDatumByOffsets(row chunk.Row, offsets []int, expCols []*expression.Column, buf []types.Datum) []types.Datum {
 	for _, offset := range offsets {
 		c := expCols[offset]
 		rowDt := row.GetDatum(offset, c.GetType())
-		datumBuf = append(datumBuf, rowDt)
+		buf = append(buf, rowDt)
 	}
-	return datumBuf
+	return buf
 }
 
 func buildHandle(pkDts []types.Datum, tblInfo *model.TableInfo,
@@ -539,10 +517,8 @@ func buildHandle(pkDts []types.Datum, tblInfo *model.TableInfo,
 }
 
 type idxRecResult struct {
-	id      int
-	records []*indexRecord
-	chunk   *chunk.Chunk
-	err     error
-	done    bool
-	total   int
+	id    int
+	chunk *chunk.Chunk
+	err   error
+	done  bool
 }

--- a/ddl/index_cop_test.go
+++ b/ddl/index_cop_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,16 +45,19 @@ func TestAddIndexFetchRowsFromCoprocessor(t *testing.T) {
 		endKey := startKey.PrefixNext()
 		txn, err := store.Begin()
 		require.NoError(t, err)
-		idxRec, done, err := ddl.FetchRowsFromCop4Test(copCtx, tbl.(table.PhysicalTable), startKey, endKey, store, 10)
+		copChunk, done, err := ddl.FetchRowsFromCop4Test(copCtx, tbl.(table.PhysicalTable), startKey, endKey, store, 10)
 		require.NoError(t, err)
 		require.False(t, done)
 		require.NoError(t, txn.Rollback())
 
-		handles := make([]kv.Handle, 0, len(idxRec))
-		values := make([][]types.Datum, 0, len(idxRec))
-		for _, rec := range idxRec {
-			handles = append(handles, rec.GetHandle())
-			values = append(values, rec.GetIndexValues())
+		iter := chunk.NewIterator4Chunk(copChunk)
+		handles := make([]kv.Handle, 0, copChunk.NumRows())
+		values := make([][]types.Datum, 0, copChunk.NumRows())
+		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+			handle, idxDatum, err := ddl.ConvertRowToHandleAndIndexDatum(row, copCtx)
+			require.NoError(t, err)
+			handles = append(handles, handle)
+			values = append(values, idxDatum)
 		}
 		return handles, values
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42079

Problem Summary: 

The function `extractDatumByOffset` takes too much memory.

![image](https://user-images.githubusercontent.com/24713065/224038157-6550d62e-82f3-49a4-b506-c73dcc99031f.png)


### What is changed and how it works?

This PR moves the encoding work from the readers to writers. Once the chunk is read, the writers encode index KV and write them to the local engine without using any intermediate data structure.

As a result, the memory allocation in `extractDatumByOffset` could be eliminated.

Before this PR:

![image](https://user-images.githubusercontent.com/24713065/224044862-901c4d01-0605-497a-9e08-c9e5b124fd0a.png)


After this PR:

![image](https://user-images.githubusercontent.com/24713065/224044780-bf8ef39e-ac28-40b5-846b-20b08ada6c7b.png)


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
