### PR TITLE
txn, session: Rename Aggressive Locking to Fair Locking and enable by default for new clusters

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -444,12 +444,12 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 			execDetails := a.Ctx.GetSessionVars().StmtCtx.GetExecDetails()
 			if err == nil && execDetails.LockKeysDetail != nil &&
 				(execDetails.LockKeysDetail.AggressiveLockNewCount > 0 || execDetails.LockKeysDetail.AggressiveLockDerivedCount > 0) {
-				a.Ctx.GetSessionVars().TxnCtx.AggressiveLockingUsed = true
+				a.Ctx.GetSessionVars().TxnCtx.FairLockingUsed = true
 				// If this statement is finished when some of the keys are locked with conflict in the last retry, or
-				// some of the keys are derived from the previous retry, we consider the optimization of aggressive locking
+				// some of the keys are derived from the previous retry, we consider the optimization of fair locking
 				// takes effect on this statement.
 				if execDetails.LockKeysDetail.LockedWithConflictCount > 0 || execDetails.LockKeysDetail.AggressiveLockDerivedCount > 0 {
-					a.Ctx.GetSessionVars().TxnCtx.AggressiveLockingEffective = true
+					a.Ctx.GetSessionVars().TxnCtx.FairLockingEffective = true
 				}
 			}
 			return
@@ -1387,25 +1387,25 @@ func (a *ExecStmt) FinishExecuteStmt(txnTS uint64, err error, hasMoreResults boo
 		metrics.ReadFromTableCacheCounter.Inc()
 	}
 
-	// Update aggressive locking related counters by stmt
+	// Update fair locking related counters by stmt
 	if execDetail.LockKeysDetail != nil {
 		if execDetail.LockKeysDetail.AggressiveLockNewCount > 0 || execDetail.LockKeysDetail.AggressiveLockDerivedCount > 0 {
-			executor_metrics.AggressiveLockingStmtUsedCount.Inc()
+			executor_metrics.FairLockingStmtUsedCount.Inc()
 			// If this statement is finished when some of the keys are locked with conflict in the last retry, or
-			// some of the keys are derived from the previous retry, we consider the optimization of aggressive locking
+			// some of the keys are derived from the previous retry, we consider the optimization of fair locking
 			// takes effect on this statement.
 			if execDetail.LockKeysDetail.LockedWithConflictCount > 0 || execDetail.LockKeysDetail.AggressiveLockDerivedCount > 0 {
-				executor_metrics.AggressiveLockingStmtEffectiveCount.Inc()
+				executor_metrics.FairLockingStmtEffectiveCount.Inc()
 			}
 		}
 	}
-	// If the transaction is committed, update aggressive locking related counters by txn
+	// If the transaction is committed, update fair locking related counters by txn
 	if execDetail.CommitDetail != nil {
-		if sessVars.TxnCtx.AggressiveLockingUsed {
-			executor_metrics.AggressiveLockingTxnUsedCount.Inc()
+		if sessVars.TxnCtx.FairLockingUsed {
+			executor_metrics.FairLockingTxnUsedCount.Inc()
 		}
-		if sessVars.TxnCtx.AggressiveLockingEffective {
-			executor_metrics.AggressiveLockingTxnEffectiveCount.Inc()
+		if sessVars.TxnCtx.FairLockingEffective {
+			executor_metrics.FairLockingTxnEffectiveCount.Inc()
 		}
 	}
 }

--- a/executor/fktest/BUILD.bazel
+++ b/executor/fktest/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//parser/mysql",
         "//planner/core",
         "//testkit",
+        "//tests/realtikvtest",
         "//types",
         "//util/sqlexec",
         "@com_github_stretchr_testify//require",

--- a/executor/fktest/foreign_key_test.go
+++ b/executor/fktest/foreign_key_test.go
@@ -292,8 +292,8 @@ func TestForeignKeyCheckAndLock(t *testing.T) {
 		// Unistore doesn't write lock records on secondary keys with value unchanged, causing it incorrectly ignores
 		// conflicts between transactions on these kinds of keys. This may make the test fail if fair locking is
 		// enabled. So disable it if it's not running with real tikv.
-		tk.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
-		tk2.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
+		tk.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
+		tk2.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 	}
 
 	cases := []struct {

--- a/executor/fktest/foreign_key_test.go
+++ b/executor/fktest/foreign_key_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/parser/mysql"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/tests/realtikvtest"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/stretchr/testify/require"
@@ -286,6 +287,14 @@ func TestForeignKeyCheckAndLock(t *testing.T) {
 	tk2 := testkit.NewTestKit(t, store)
 	tk2.MustExec("set @@foreign_key_checks=1")
 	tk2.MustExec("use test")
+
+	if !*realtikvtest.WithRealTiKV {
+		// Unistore doesn't write lock records on secondary keys with value unchanged, causing it incorrectly ignores
+		// conflicts between transactions on these kinds of keys. This may make the test fail if fair locking is
+		// enabled. So disable it if it's not running with real tikv.
+		tk.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
+		tk2.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
+	}
 
 	cases := []struct {
 		prepareSQLs []string

--- a/executor/metrics/metrics.go
+++ b/executor/metrics/metrics.go
@@ -52,16 +52,16 @@ var (
 	DmlFirstAttemptDuration             prometheus.Observer
 	DmlRetryDuration                    prometheus.Observer
 
-	// AggressiveLockingTxnUsedCount counts transactions where at least one statement has aggressive locking enabled.
-	AggressiveLockingTxnUsedCount prometheus.Counter
-	// AggressiveLockingStmtUsedCount counts statements that have aggressive locking enabled.
-	AggressiveLockingStmtUsedCount prometheus.Counter
-	// AggressiveLockingTxnUsedCount counts transactions where at least one statement has aggressive locking enabled,
+	// FairLockingTxnUsedCount counts transactions where at least one statement has fair locking enabled.
+	FairLockingTxnUsedCount prometheus.Counter
+	// FairLockingStmtUsedCount counts statements that have fair locking enabled.
+	FairLockingStmtUsedCount prometheus.Counter
+	// FairLockingTxnEffectiveCount counts transactions where at least one statement has fair locking enabled,
 	// and it takes effect (which is determined according to whether lock-with-conflict has occurred during execution).
-	AggressiveLockingTxnEffectiveCount prometheus.Counter
-	// AggressiveLockingTxnUsedCount counts statements where at least one statement has aggressive locking enabled,
+	FairLockingTxnEffectiveCount prometheus.Counter
+	// FairLockingStmtEffectiveCount counts statements where at least one statement has fair locking enabled,
 	// and it takes effect (which is determined according to whether lock-with-conflict has occurred during execution).
-	AggressiveLockingStmtEffectiveCount prometheus.Counter
+	FairLockingStmtEffectiveCount prometheus.Counter
 
 	FastAnalyzeHistogramSample        prometheus.Observer
 	FastAnalyzeHistogramAccessRegions prometheus.Observer
@@ -146,10 +146,10 @@ func InitMetricsVars() {
 	DmlFirstAttemptDuration = metrics.PessimisticDMLDurationByAttempt.WithLabelValues("dml", "first-attempt")
 	DmlRetryDuration = metrics.PessimisticDMLDurationByAttempt.WithLabelValues("dml", "retry")
 
-	AggressiveLockingTxnUsedCount = metrics.AggressiveLockingUsageCount.WithLabelValues(metrics.LblAggressiveLockingTxnUsed)
-	AggressiveLockingStmtUsedCount = metrics.AggressiveLockingUsageCount.WithLabelValues(metrics.LblAggressiveLockingStmtUsed)
-	AggressiveLockingTxnEffectiveCount = metrics.AggressiveLockingUsageCount.WithLabelValues(metrics.LblAggressiveLockingTxnEffective)
-	AggressiveLockingStmtEffectiveCount = metrics.AggressiveLockingUsageCount.WithLabelValues(metrics.LblAggressiveLockingStmtEffective)
+	FairLockingTxnUsedCount = metrics.FairLockingUsageCount.WithLabelValues(metrics.LblFairLockingTxnUsed)
+	FairLockingStmtUsedCount = metrics.FairLockingUsageCount.WithLabelValues(metrics.LblFairLockingStmtUsed)
+	FairLockingTxnEffectiveCount = metrics.FairLockingUsageCount.WithLabelValues(metrics.LblFairLockingTxnEffective)
+	FairLockingStmtEffectiveCount = metrics.FairLockingUsageCount.WithLabelValues(metrics.LblFairLockingStmtEffective)
 
 	FastAnalyzeHistogramSample = metrics.FastAnalyzeHistogram.WithLabelValues(metrics.LblGeneral, "sample")
 	FastAnalyzeHistogramAccessRegions = metrics.FastAnalyzeHistogram.WithLabelValues(metrics.LblGeneral, "access_regions")

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -1720,6 +1720,7 @@ func TestVariablesInfo(t *testing.T) {
 		"tidb_enable_collect_execution_info ON OFF", // for test stability
 		"tidb_enable_mutation_checker OFF ON",       // for new installs
 		"tidb_mem_oom_action CANCEL LOG",            // always changed for tests
+		"tidb_pessimistic_txn_fair_locking OFF ON",  // for new instances
 		"tidb_row_format_version 1 2",               // for new installs
 		"tidb_txn_assertion_level OFF FAST",         // for new installs
 		"timestamp 0 123456789",                     // always dynamic

--- a/kv/interface_mock_test.go
+++ b/kv/interface_mock_test.go
@@ -176,11 +176,11 @@ func (t *mockTxn) Mem() uint64 {
 	return 0
 }
 
-func (t *mockTxn) StartAggressiveLocking() error                   { return nil }
-func (t *mockTxn) RetryAggressiveLocking(_ context.Context) error  { return nil }
-func (t *mockTxn) CancelAggressiveLocking(_ context.Context) error { return nil }
-func (t *mockTxn) DoneAggressiveLocking(_ context.Context) error   { return nil }
-func (t *mockTxn) IsInAggressiveLockingMode() bool                 { return false }
+func (t *mockTxn) StartFairLocking() error                   { return nil }
+func (t *mockTxn) RetryFairLocking(_ context.Context) error  { return nil }
+func (t *mockTxn) CancelFairLocking(_ context.Context) error { return nil }
+func (t *mockTxn) DoneFairLocking(_ context.Context) error   { return nil }
+func (t *mockTxn) IsInFairLockingMode() bool                 { return false }
 
 // newMockTxn new a mockTxn.
 func newMockTxn() Transaction {

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -203,7 +203,7 @@ type LockCtx = tikvstore.LockCtx
 type Transaction interface {
 	RetrieverMutator
 	AssertionProto
-	AggressiveLockingController
+	FairLockingController
 	// Size returns sum of keys and values length.
 	Size() int
 	// Mem returns the memory consumption of the transaction.
@@ -282,13 +282,13 @@ type AssertionProto interface {
 	SetAssertion(key []byte, assertion ...FlagsOp) error
 }
 
-// AggressiveLockingController is the interface that defines aggressive locking related operations.
-type AggressiveLockingController interface {
-	StartAggressiveLocking() error
-	RetryAggressiveLocking(ctx context.Context) error
-	CancelAggressiveLocking(ctx context.Context) error
-	DoneAggressiveLocking(ctx context.Context) error
-	IsInAggressiveLockingMode() bool
+// FairLockingController is the interface that defines fair locking related operations.
+type FairLockingController interface {
+	StartFairLocking() error
+	RetryFairLocking(ctx context.Context) error
+	CancelFairLocking(ctx context.Context) error
+	DoneFairLocking(ctx context.Context) error
+	IsInFairLockingMode() bool
 }
 
 // Client is used to send request to KV layer.

--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -6808,7 +6808,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Counters of transactions or statements in which aggressive locking is enabled / takes effect.",
+          "description": "Counters of transactions or statements in which fair locking is enabled / takes effect.",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -6854,7 +6854,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(irate(tidb_session_transaction_aggressive_locking_usage{instance=~\"$instance\"}[30s])) by (type)",
+              "expr": "sum(irate(tidb_session_transaction_fair_locking_usage{instance=~\"$instance\"}[30s])) by (type)",
               "interval": "",
               "legendFormat": "{{type}}",
               "refId": "A"
@@ -6864,7 +6864,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Aggressive Locking Usage",
+          "title": "Fair Locking Usage",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -6907,7 +6907,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Counters of keys involved in aggressive locking.",
+          "description": "Counters of keys involved in fair locking.",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -6963,7 +6963,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Aggressive Locking Keys",
+          "title": "Fair Locking Keys",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -241,7 +241,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(AutoIDReqDuration)
 	prometheus.MustRegister(RegionCheckpointSubscriptionEvent)
 	prometheus.MustRegister(RCCheckTSWriteConfilictCounter)
-	prometheus.MustRegister(AggressiveLockingUsageCount)
+	prometheus.MustRegister(FairLockingUsageCount)
 
 	prometheus.MustRegister(TTLQueryDuration)
 	prometheus.MustRegister(TTLProcessedExpiredRowsCounter)

--- a/metrics/session.go
+++ b/metrics/session.go
@@ -38,7 +38,7 @@ var (
 	LazyPessimisticUniqueCheckSetCount prometheus.Counter
 	PessimisticDMLDurationByAttempt    *prometheus.HistogramVec
 	ResourceGroupQueryTotalCounter     *prometheus.CounterVec
-	AggressiveLockingUsageCount        *prometheus.CounterVec
+	FairLockingUsageCount              *prometheus.CounterVec
 )
 
 // InitSessionMetrics initializes session metrics.
@@ -220,12 +220,12 @@ func InitSessionMetrics() {
 			Help:      "Counter of the total number of queries for the resource group",
 		}, []string{LblName})
 
-	AggressiveLockingUsageCount = NewCounterVec(
+	FairLockingUsageCount = NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "tidb",
 			Subsystem: "server",
-			Name:      "transaction_aggressive_locking_usage",
-			Help:      "The counter of statements and transactions in which aggressive locking is used or takes effect",
+			Name:      "transaction_fair_locking_usage",
+			Help:      "The counter of statements and transactions in which fair locking is used or takes effect",
 		}, []string{LblType})
 }
 
@@ -271,9 +271,9 @@ const (
 
 	LblName = "name"
 
-	LblAggressiveLockingTxnUsed       = "txn-used"
-	LblAggressiveLockingTxnEffective  = "txn-effective"
-	LblAggressiveLockingStmtUsed      = "stmt-used"
-	LblAggressiveLockingStmtEffective = "stmt-effective"
-	LblScope                          = "scope"
+	LblFairLockingTxnUsed       = "txn-used"
+	LblFairLockingTxnEffective  = "txn-effective"
+	LblFairLockingStmtUsed      = "stmt-used"
+	LblFairLockingStmtEffective = "stmt-effective"
+	LblScope                    = "scope"
 )

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -563,24 +563,24 @@ func GetStoreBatchCoprCounter() StoreBatchCoprCounter {
 	}
 }
 
-// AggressiveLockingUsageCounter records the usage of Aggressive Locking feature of pessimistic transaction.
-type AggressiveLockingUsageCounter struct {
-	TxnAggressiveLockingUsed      int64 `json:"txn_aggressive_locking_used"`
-	TxnAggressiveLockingEffective int64 `json:"txn_aggressive_locking_effective"`
+// FairLockingUsageCounter records the usage of Fair Locking feature of pessimistic transaction.
+type FairLockingUsageCounter struct {
+	TxnFairLockingUsed      int64 `json:"txn_fair_locking_used"`
+	TxnFairLockingEffective int64 `json:"txn_fair_locking_effective"`
 }
 
 // Sub returns the difference of two counters.
-func (i AggressiveLockingUsageCounter) Sub(rhs AggressiveLockingUsageCounter) AggressiveLockingUsageCounter {
-	return AggressiveLockingUsageCounter{
-		TxnAggressiveLockingUsed:      i.TxnAggressiveLockingUsed - rhs.TxnAggressiveLockingUsed,
-		TxnAggressiveLockingEffective: i.TxnAggressiveLockingEffective - rhs.TxnAggressiveLockingEffective,
+func (i FairLockingUsageCounter) Sub(rhs FairLockingUsageCounter) FairLockingUsageCounter {
+	return FairLockingUsageCounter{
+		TxnFairLockingUsed:      i.TxnFairLockingUsed - rhs.TxnFairLockingUsed,
+		TxnFairLockingEffective: i.TxnFairLockingEffective - rhs.TxnFairLockingEffective,
 	}
 }
 
-// GetAggressiveLockingUsageCounter returns the Aggressive Locking usage counter.
-func GetAggressiveLockingUsageCounter() AggressiveLockingUsageCounter {
-	return AggressiveLockingUsageCounter{
-		TxnAggressiveLockingUsed:      readCounter(AggressiveLockingUsageCount.WithLabelValues(LblAggressiveLockingTxnUsed)),
-		TxnAggressiveLockingEffective: readCounter(AggressiveLockingUsageCount.WithLabelValues(LblAggressiveLockingTxnEffective)),
+// GetFairLockingUsageCounter returns the Fair Locking usage counter.
+func GetFairLockingUsageCounter() FairLockingUsageCounter {
+	return FairLockingUsageCounter{
+		TxnFairLockingUsed:      readCounter(FairLockingUsageCount.WithLabelValues(LblFairLockingTxnUsed)),
+		TxnFairLockingEffective: readCounter(FairLockingUsageCount.WithLabelValues(LblFairLockingTxnEffective)),
 	}
 }

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/bindinfo"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
@@ -2563,13 +2562,9 @@ func doDMLWorks(s Session) {
 			vVal = variable.AssertionFastStr
 		case variable.TiDBEnableMutationChecker:
 			vVal = variable.On
+		case variable.TiDBPessimisticTransactionAggressiveLocking:
+			vVal = variable.On
 		}
-
-		failpoint.Inject("enableAggressiveLockingOnBootstrap", func() {
-			if v.Name == variable.TiDBPessimisticTransactionAggressiveLocking {
-				vVal = variable.On
-			}
-		})
 
 		// sanitize k and vVal
 		value := fmt.Sprintf(`("%s", "%s")`, sqlexec.EscapeString(k), sqlexec.EscapeString(vVal))

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -2562,7 +2562,7 @@ func doDMLWorks(s Session) {
 			vVal = variable.AssertionFastStr
 		case variable.TiDBEnableMutationChecker:
 			vVal = variable.On
-		case variable.TiDBPessimisticTransactionAggressiveLocking:
+		case variable.TiDBPessimisticTransactionFairLocking:
 			vVal = variable.On
 		}
 

--- a/session/txn.go
+++ b/session/txn.go
@@ -60,7 +60,7 @@ type LazyTxn struct {
 	mutations     map[int64]*binlog.TableMutation
 	writeSLI      sli.TxnWriteThroughputSLI
 
-	enterAggressiveLockingOnValid bool
+	enterFairLockingOnValid bool
 
 	// TxnInfo is added for the lock view feature, the data is frequent modified but
 	// rarely read (just in query select * from information_schema.tidb_trx).
@@ -227,8 +227,8 @@ func (txn *LazyTxn) String() string {
 	}
 	if txn.txnFuture != nil {
 		res := "txnFuture"
-		if txn.enterAggressiveLockingOnValid {
-			res += " (pending aggressive locking)"
+		if txn.enterFairLockingOnValid {
+			res += " (pending fair locking)"
 		}
 		return res
 	}
@@ -289,9 +289,9 @@ func (txn *LazyTxn) changePendingToValid(ctx context.Context) error {
 	txn.Transaction = t
 	txn.initStmtBuf()
 
-	if txn.enterAggressiveLockingOnValid {
-		txn.enterAggressiveLockingOnValid = false
-		err = txn.Transaction.StartAggressiveLocking()
+	if txn.enterFairLockingOnValid {
+		txn.enterFairLockingOnValid = false
+		err = txn.Transaction.StartFairLocking()
 		if err != nil {
 			return err
 		}
@@ -318,7 +318,7 @@ func (txn *LazyTxn) changeToInvalid() {
 	txn.Transaction = nil
 	txn.txnFuture = nil
 
-	txn.enterAggressiveLockingOnValid = false
+	txn.enterFairLockingOnValid = false
 
 	txn.mu.Lock()
 	lastState := txn.mu.TxnInfo.State
@@ -473,78 +473,78 @@ func (txn *LazyTxn) LockKeysFunc(ctx context.Context, lockCtx *kv.LockCtx, fn fu
 	return txn.Transaction.LockKeysFunc(ctx, lockCtx, lockFunc, keys...)
 }
 
-// StartAggressiveLocking wraps the inner transaction to support using aggressive locking with lazy initialization.
-func (txn *LazyTxn) StartAggressiveLocking() error {
+// StartFairLocking wraps the inner transaction to support using fair locking with lazy initialization.
+func (txn *LazyTxn) StartFairLocking() error {
 	if txn.Valid() {
-		return txn.Transaction.StartAggressiveLocking()
+		return txn.Transaction.StartFairLocking()
 	} else if txn.pending() {
-		txn.enterAggressiveLockingOnValid = true
+		txn.enterFairLockingOnValid = true
 	} else {
-		err := errors.New("trying to start aggressive locking on a transaction in invalid state")
-		logutil.BgLogger().Error("unexpected error when starting aggressive locking", zap.Error(err), zap.Stringer("txn", txn))
+		err := errors.New("trying to start fair locking on a transaction in invalid state")
+		logutil.BgLogger().Error("unexpected error when starting fair locking", zap.Error(err), zap.Stringer("txn", txn))
 		return err
 	}
 	return nil
 }
 
-// RetryAggressiveLocking wraps the inner transaction to support using aggressive locking with lazy initialization.
-func (txn *LazyTxn) RetryAggressiveLocking(ctx context.Context) error {
+// RetryFairLocking wraps the inner transaction to support using fair locking with lazy initialization.
+func (txn *LazyTxn) RetryFairLocking(ctx context.Context) error {
 	if txn.Valid() {
-		return txn.Transaction.RetryAggressiveLocking(ctx)
+		return txn.Transaction.RetryFairLocking(ctx)
 	} else if !txn.pending() {
-		err := errors.New("trying to retry aggressive locking on a transaction in invalid state")
-		logutil.BgLogger().Error("unexpected error when retrying aggressive locking", zap.Error(err), zap.Stringer("txnStartTS", txn))
+		err := errors.New("trying to retry fair locking on a transaction in invalid state")
+		logutil.BgLogger().Error("unexpected error when retrying fair locking", zap.Error(err), zap.Stringer("txnStartTS", txn))
 		return err
 	}
 	return nil
 }
 
-// CancelAggressiveLocking wraps the inner transaction to support using aggressive locking with lazy initialization.
-func (txn *LazyTxn) CancelAggressiveLocking(ctx context.Context) error {
+// CancelFairLocking wraps the inner transaction to support using fair locking with lazy initialization.
+func (txn *LazyTxn) CancelFairLocking(ctx context.Context) error {
 	if txn.Valid() {
-		return txn.Transaction.CancelAggressiveLocking(ctx)
+		return txn.Transaction.CancelFairLocking(ctx)
 	} else if txn.pending() {
-		if txn.enterAggressiveLockingOnValid {
-			txn.enterAggressiveLockingOnValid = false
+		if txn.enterFairLockingOnValid {
+			txn.enterFairLockingOnValid = false
 		} else {
-			err := errors.New("trying to cancel aggressive locking when it's not started")
-			logutil.BgLogger().Error("unexpected error when cancelling aggressive locking", zap.Error(err), zap.Stringer("txnStartTS", txn))
+			err := errors.New("trying to cancel fair locking when it's not started")
+			logutil.BgLogger().Error("unexpected error when cancelling fair locking", zap.Error(err), zap.Stringer("txnStartTS", txn))
 			return err
 		}
 	} else {
-		err := errors.New("trying to cancel aggressive locking on a transaction in invalid state")
-		logutil.BgLogger().Error("unexpected error when cancelling aggressive locking", zap.Error(err), zap.Stringer("txnStartTS", txn))
+		err := errors.New("trying to cancel fair locking on a transaction in invalid state")
+		logutil.BgLogger().Error("unexpected error when cancelling fair locking", zap.Error(err), zap.Stringer("txnStartTS", txn))
 		return err
 	}
 	return nil
 }
 
-// DoneAggressiveLocking wraps the inner transaction to support using aggressive locking with lazy initialization.
-func (txn *LazyTxn) DoneAggressiveLocking(ctx context.Context) error {
+// DoneFairLocking wraps the inner transaction to support using fair locking with lazy initialization.
+func (txn *LazyTxn) DoneFairLocking(ctx context.Context) error {
 	if txn.Valid() {
-		return txn.Transaction.DoneAggressiveLocking(ctx)
+		return txn.Transaction.DoneFairLocking(ctx)
 	} else if txn.pending() {
-		if txn.enterAggressiveLockingOnValid {
-			txn.enterAggressiveLockingOnValid = false
+		if txn.enterFairLockingOnValid {
+			txn.enterFairLockingOnValid = false
 		} else {
-			err := errors.New("trying to finish aggressive locking when it's not started")
-			logutil.BgLogger().Error("unexpected error when finishing aggressive locking")
+			err := errors.New("trying to finish fair locking when it's not started")
+			logutil.BgLogger().Error("unexpected error when finishing fair locking")
 			return err
 		}
 	} else {
-		err := errors.New("trying to cancel aggressive locking on a transaction in invalid state")
-		logutil.BgLogger().Error("unexpected error when finishing aggressive locking")
+		err := errors.New("trying to cancel fair locking on a transaction in invalid state")
+		logutil.BgLogger().Error("unexpected error when finishing fair locking")
 		return err
 	}
 	return nil
 }
 
-// IsInAggressiveLockingMode wraps the inner transaction to support using aggressive locking with lazy initialization.
-func (txn *LazyTxn) IsInAggressiveLockingMode() bool {
+// IsInFairLockingMode wraps the inner transaction to support using fair locking with lazy initialization.
+func (txn *LazyTxn) IsInFairLockingMode() bool {
 	if txn.Valid() {
-		return txn.Transaction.IsInAggressiveLockingMode()
+		return txn.Transaction.IsInFairLockingMode()
 	} else if txn.pending() {
-		return txn.enterAggressiveLockingOnValid
+		return txn.enterFairLockingOnValid
 	} else {
 		return false
 	}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -242,13 +242,13 @@ type TxnCtxNoNeedToRestore struct {
 	// relatedTableForMDL records the `lock` table for metadata lock. It maps from int64 to int64(version).
 	relatedTableForMDL *sync.Map
 
-	// AggressiveLockingUsed marking whether at least one of the statements in the transaction was executed in
-	// aggressive locking mode.
-	AggressiveLockingUsed bool
-	// AggressiveLockingEffective marking whether at least one of the statements in the transaction was executed in
-	// aggressive locking mode, and it takes effect (which is determined according to whether lock-with-conflict
+	// FairLockingUsed marking whether at least one of the statements in the transaction was executed in
+	// fair locking mode.
+	FairLockingUsed bool
+	// FairLockingEffective marking whether at least one of the statements in the transaction was executed in
+	// fair locking mode, and it takes effect (which is determined according to whether lock-with-conflict
 	// has occurred during execution of any statement).
-	AggressiveLockingEffective bool
+	FairLockingEffective bool
 }
 
 // SavepointRecord indicates a transaction's savepoint record.
@@ -1367,9 +1367,9 @@ type SessionVars struct {
 	// ProtectedTSList holds a list of timestamps that should delay GC.
 	ProtectedTSList protectedTSList
 
-	// PessimisticTransactionAggressiveLocking controls whether aggressive locking for pessimistic transaction
+	// PessimisticTransactionFairLocking controls whether fair locking for pessimistic transaction
 	// is enabled.
-	PessimisticTransactionAggressiveLocking bool
+	PessimisticTransactionFairLocking bool
 
 	// EnableINLJoinInnerMultiPattern indicates whether enable multi pattern for index join inner side
 	// For now it is not public to user

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -2372,8 +2372,8 @@ var defaultSysVars = []*SysVar{
 	}, GetGlobal: func(ctx context.Context, vars *SessionVars) (string, error) {
 		return BoolToOnOff(EnableResourceControl.Load()), nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBPessimisticTransactionAggressiveLocking, Value: BoolToOnOff(DefTiDBPessimisticTransactionAggressiveLocking), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
-		s.PessimisticTransactionAggressiveLocking = TiDBOptOn(val)
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBPessimisticTransactionFairLocking, Value: BoolToOnOff(DefTiDBPessimisticTransactionFairLocking), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.PessimisticTransactionFairLocking = TiDBOptOn(val)
 		return nil
 	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnablePlanCacheForParamLimit, Value: BoolToOnOff(DefTiDBEnablePlanCacheForParamLimit), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -813,9 +813,9 @@ const (
 	// MppVersion indicates the mpp-version used to build mpp plan
 	MppVersion = "mpp_version"
 
-	// TiDBPessimisticTransactionAggressiveLocking controls whether aggressive locking for pessimistic transaction
+	// TiDBPessimisticTransactionFairLocking controls whether fair locking for pessimistic transaction
 	// is enabled.
-	TiDBPessimisticTransactionAggressiveLocking = "tidb_pessimistic_txn_aggressive_locking"
+	TiDBPessimisticTransactionFairLocking = "tidb_pessimistic_txn_fair_locking"
 
 	// TiDBEnablePlanCacheForParamLimit controls whether prepare statement with parameterized limit can be cached
 	TiDBEnablePlanCacheForParamLimit = "tidb_enable_plan_cache_for_param_limit"
@@ -1191,39 +1191,39 @@ const (
 	DefTiDBServerMemoryLimitGCTrigger            = 0.7
 	DefTiDBEnableGOGCTuner                       = true
 	// DefTiDBGOGCTunerThreshold is to limit TiDBGOGCTunerThreshold.
-	DefTiDBGOGCTunerThreshold                      float64 = 0.6
-	DefTiDBOptPrefixIndexSingleScan                        = true
-	DefTiDBExternalTS                                      = 0
-	DefTiDBEnableExternalTSRead                            = false
-	DefTiDBEnableReusechunk                                = true
-	DefTiDBUseAlloc                                        = false
-	DefTiDBEnablePlanReplayerCapture                       = false
-	DefTiDBIndexMergeIntersectionConcurrency               = ConcurrencyUnset
-	DefTiDBTTLJobEnable                                    = true
-	DefTiDBTTLScanBatchSize                                = 500
-	DefTiDBTTLScanBatchMaxSize                             = 10240
-	DefTiDBTTLScanBatchMinSize                             = 1
-	DefTiDBTTLDeleteBatchSize                              = 100
-	DefTiDBTTLDeleteBatchMaxSize                           = 10240
-	DefTiDBTTLDeleteBatchMinSize                           = 1
-	DefTiDBTTLDeleteRateLimit                              = 0
-	DefTiDBTTLRunningTasks                                 = -1
-	DefPasswordReuseHistory                                = 0
-	DefPasswordReuseTime                                   = 0
-	DefTiDBStoreBatchSize                                  = 4
-	DefTiDBHistoricalStatsDuration                         = 7 * 24 * time.Hour
-	DefTiDBEnableHistoricalStatsForCapture                 = false
-	DefTiDBTTLJobScheduleWindowStartTime                   = "00:00 +0000"
-	DefTiDBTTLJobScheduleWindowEndTime                     = "23:59 +0000"
-	DefTiDBTTLScanWorkerCount                              = 4
-	DefTiDBTTLDeleteWorkerCount                            = 4
-	DefaultExchangeCompressionMode                         = kv.ExchangeCompressionModeUnspecified
-	DefTiDBEnableResourceControl                           = true
-	DefTiDBPessimisticTransactionAggressiveLocking         = false
-	DefTiDBEnablePlanCacheForParamLimit                    = true
-	DefTiFlashComputeDispatchPolicy                        = tiflashcompute.DispatchPolicyConsistentHashStr
-	DefTiDBEnablePlanCacheForSubquery                      = true
-	DefTiDBLoadBasedReplicaReadThreshold                   = 0
+	DefTiDBGOGCTunerThreshold                float64 = 0.6
+	DefTiDBOptPrefixIndexSingleScan                  = true
+	DefTiDBExternalTS                                = 0
+	DefTiDBEnableExternalTSRead                      = false
+	DefTiDBEnableReusechunk                          = true
+	DefTiDBUseAlloc                                  = false
+	DefTiDBEnablePlanReplayerCapture                 = false
+	DefTiDBIndexMergeIntersectionConcurrency         = ConcurrencyUnset
+	DefTiDBTTLJobEnable                              = true
+	DefTiDBTTLScanBatchSize                          = 500
+	DefTiDBTTLScanBatchMaxSize                       = 10240
+	DefTiDBTTLScanBatchMinSize                       = 1
+	DefTiDBTTLDeleteBatchSize                        = 100
+	DefTiDBTTLDeleteBatchMaxSize                     = 10240
+	DefTiDBTTLDeleteBatchMinSize                     = 1
+	DefTiDBTTLDeleteRateLimit                        = 0
+	DefTiDBTTLRunningTasks                           = -1
+	DefPasswordReuseHistory                          = 0
+	DefPasswordReuseTime                             = 0
+	DefTiDBStoreBatchSize                            = 4
+	DefTiDBHistoricalStatsDuration                   = 7 * 24 * time.Hour
+	DefTiDBEnableHistoricalStatsForCapture           = false
+	DefTiDBTTLJobScheduleWindowStartTime             = "00:00 +0000"
+	DefTiDBTTLJobScheduleWindowEndTime               = "23:59 +0000"
+	DefTiDBTTLScanWorkerCount                        = 4
+	DefTiDBTTLDeleteWorkerCount                      = 4
+	DefaultExchangeCompressionMode                   = kv.ExchangeCompressionModeUnspecified
+	DefTiDBEnableResourceControl                     = true
+	DefTiDBPessimisticTransactionFairLocking         = false
+	DefTiDBEnablePlanCacheForParamLimit              = true
+	DefTiFlashComputeDispatchPolicy                  = tiflashcompute.DispatchPolicyConsistentHashStr
+	DefTiDBEnablePlanCacheForSubquery                = true
+	DefTiDBLoadBasedReplicaReadThreshold             = 0
 )
 
 // Process global variables.

--- a/sessiontxn/isolation/base.go
+++ b/sessiontxn/isolation/base.go
@@ -520,11 +520,11 @@ func (p *basePessimisticTxnContextProvider) OnPessimisticStmtStart(ctx context.C
 	if err := p.baseTxnContextProvider.OnPessimisticStmtStart(ctx); err != nil {
 		return err
 	}
-	if p.sctx.GetSessionVars().PessimisticTransactionAggressiveLocking &&
+	if p.sctx.GetSessionVars().PessimisticTransactionFairLocking &&
 		p.txn != nil &&
 		p.sctx.GetSessionVars().ConnectionID != 0 &&
 		!p.sctx.GetSessionVars().InRestrictedSQL {
-		if err := p.txn.StartAggressiveLocking(); err != nil {
+		if err := p.txn.StartFairLocking(); err != nil {
 			return err
 		}
 	}
@@ -537,13 +537,13 @@ func (p *basePessimisticTxnContextProvider) OnPessimisticStmtEnd(ctx context.Con
 	if err := p.baseTxnContextProvider.OnPessimisticStmtEnd(ctx, isSuccessful); err != nil {
 		return err
 	}
-	if p.txn != nil && p.txn.IsInAggressiveLockingMode() {
+	if p.txn != nil && p.txn.IsInFairLockingMode() {
 		if isSuccessful {
-			if err := p.txn.DoneAggressiveLocking(ctx); err != nil {
+			if err := p.txn.DoneFairLocking(ctx); err != nil {
 				return err
 			}
 		} else {
-			if err := p.txn.CancelAggressiveLocking(ctx); err != nil {
+			if err := p.txn.CancelFairLocking(ctx); err != nil {
 				return err
 			}
 		}
@@ -551,18 +551,18 @@ func (p *basePessimisticTxnContextProvider) OnPessimisticStmtEnd(ctx context.Con
 	return nil
 }
 
-func (p *basePessimisticTxnContextProvider) retryAggressiveLockingIfNeeded(ctx context.Context) error {
-	if p.txn != nil && p.txn.IsInAggressiveLockingMode() {
-		if err := p.txn.RetryAggressiveLocking(ctx); err != nil {
+func (p *basePessimisticTxnContextProvider) retryFairLockingIfNeeded(ctx context.Context) error {
+	if p.txn != nil && p.txn.IsInFairLockingMode() {
+		if err := p.txn.RetryFairLocking(ctx); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (p *basePessimisticTxnContextProvider) cancelAggressiveLockingIfNeeded(ctx context.Context) error {
-	if p.txn != nil && p.txn.IsInAggressiveLockingMode() {
-		if err := p.txn.CancelAggressiveLocking(ctx); err != nil {
+func (p *basePessimisticTxnContextProvider) cancelFairLockingIfNeeded(ctx context.Context) error {
+	if p.txn != nil && p.txn.IsInFairLockingMode() {
+		if err := p.txn.CancelFairLocking(ctx); err != nil {
 			return err
 		}
 	}

--- a/sessiontxn/isolation/repeatable_read.go
+++ b/sessiontxn/isolation/repeatable_read.go
@@ -249,11 +249,11 @@ func (p *PessimisticRRTxnContextProvider) handleAfterPessimisticLockError(ctx co
 			zap.Stringer("lockKey", kv.Key(deadlock.LockKey)),
 			zap.Uint64("deadlockKeyHash", deadlock.DeadlockKeyHash))
 
-		// In aggressive locking mode, when statement retry happens, `retryAggressiveLockingIfNeeded` should be
+		// In fair locking mode, when statement retry happens, `retryFairLockingIfNeeded` should be
 		// called to make its state ready for retrying. But single-statement deadlock is an exception. We need to exit
-		// aggressive locking in single-statement-deadlock case, otherwise the lock this statement has acquired won't be
+		// fair locking in single-statement-deadlock case, otherwise the lock this statement has acquired won't be
 		// released after retrying, so it still blocks another transaction and the deadlock won't be resolved.
-		if err := p.cancelAggressiveLockingIfNeeded(ctx); err != nil {
+		if err := p.cancelFairLockingIfNeeded(ctx); err != nil {
 			return sessiontxn.ErrorAction(err)
 		}
 	} else if terror.ErrorEqual(kv.ErrWriteConflict, lockErr) {
@@ -289,7 +289,7 @@ func (p *PessimisticRRTxnContextProvider) handleAfterPessimisticLockError(ctx co
 		return sessiontxn.ErrorAction(lockErr)
 	}
 
-	if err := p.retryAggressiveLockingIfNeeded(ctx); err != nil {
+	if err := p.retryFairLockingIfNeeded(ctx); err != nil {
 		return sessiontxn.ErrorAction(err)
 	}
 	return sessiontxn.RetryReady()

--- a/sessiontxn/isolation/repeatable_read_test.go
+++ b/sessiontxn/isolation/repeatable_read_test.go
@@ -702,11 +702,6 @@ func TestRRWaitTSTimeInSlowLog(t *testing.T) {
 }
 
 func TestIssue41194(t *testing.T) {
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/session/enableAggressiveLockingOnBootstrap", "return"))
-	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/session/enableAggressiveLockingOnBootstrap"))
-	}()
-
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 

--- a/sessiontxn/txn_context_test.go
+++ b/sessiontxn/txn_context_test.go
@@ -738,11 +738,14 @@ func TestStillWriteConflictAfterRetry(t *testing.T) {
 		tk.MustExec("use test")
 		tk.MustExec("truncate table t1")
 		tk.MustExec("insert into t1 values(1, 10)")
+		// Fair locking avoids conflicting again after retry in this case. Disable it for this test.
+		tk.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
 		tk2 := testkit.NewSteppedTestKit(t, store)
 		defer tk2.MustExec("rollback")
 
 		tk2.MustExec("use test")
 		tk2.MustExec("set @@tidb_txn_mode = 'pessimistic'")
+		tk2.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
 		tk2.MustExec(fmt.Sprintf("set tx_isolation = '%s'", testfork.PickEnum(t, ast.RepeatableRead, ast.ReadCommitted)))
 		autocommit := testfork.PickEnum(t, 0, 1)
 		tk2.MustExec(fmt.Sprintf("set autocommit=%d", autocommit))
@@ -823,6 +826,12 @@ func TestOptimisticTxnRetryInPessimisticMode(t *testing.T) {
 		doubleConflictAfterTransfer := testfork.PickEnum(t, true, false)
 		if !conflictAfterTransfer && doubleConflictAfterTransfer {
 			return
+		}
+
+		// If `tidb_pessimistic_txn_aggressive_locking` is enabled, the double conflict case is
+		// avoided. Disable it to run this test.
+		if doubleConflictAfterTransfer {
+			tk2.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
 		}
 
 		tk2.SetBreakPoints(

--- a/sessiontxn/txn_context_test.go
+++ b/sessiontxn/txn_context_test.go
@@ -739,13 +739,13 @@ func TestStillWriteConflictAfterRetry(t *testing.T) {
 		tk.MustExec("truncate table t1")
 		tk.MustExec("insert into t1 values(1, 10)")
 		// Fair locking avoids conflicting again after retry in this case. Disable it for this test.
-		tk.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
+		tk.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 		tk2 := testkit.NewSteppedTestKit(t, store)
 		defer tk2.MustExec("rollback")
 
 		tk2.MustExec("use test")
 		tk2.MustExec("set @@tidb_txn_mode = 'pessimistic'")
-		tk2.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
+		tk2.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 		tk2.MustExec(fmt.Sprintf("set tx_isolation = '%s'", testfork.PickEnum(t, ast.RepeatableRead, ast.ReadCommitted)))
 		autocommit := testfork.PickEnum(t, 0, 1)
 		tk2.MustExec(fmt.Sprintf("set autocommit=%d", autocommit))
@@ -828,10 +828,10 @@ func TestOptimisticTxnRetryInPessimisticMode(t *testing.T) {
 			return
 		}
 
-		// If `tidb_pessimistic_txn_aggressive_locking` is enabled, the double conflict case is
+		// If `tidb_pessimistic_txn_fair_locking` is enabled, the double conflict case is
 		// avoided. Disable it to run this test.
 		if doubleConflictAfterTransfer {
-			tk2.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
+			tk2.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 		}
 
 		tk2.SetBreakPoints(

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -79,7 +79,7 @@ func (txn *tikvTxn) CacheTableInfo(id int64, info *model.TableInfo) {
 
 func (txn *tikvTxn) LockKeys(ctx context.Context, lockCtx *kv.LockCtx, keysInput ...kv.Key) error {
 	keys := toTiKVKeys(keysInput)
-	txn.exitAggressiveLockingIfInapplicable(ctx, keys)
+	txn.exitFairLockingIfInapplicable(ctx, keys)
 	err := txn.KVTxn.LockKeys(ctx, lockCtx, keys...)
 	if err != nil {
 		return txn.extractKeyErr(err)
@@ -89,7 +89,7 @@ func (txn *tikvTxn) LockKeys(ctx context.Context, lockCtx *kv.LockCtx, keysInput
 
 func (txn *tikvTxn) LockKeysFunc(ctx context.Context, lockCtx *kv.LockCtx, fn func(), keysInput ...kv.Key) error {
 	keys := toTiKVKeys(keysInput)
-	txn.exitAggressiveLockingIfInapplicable(ctx, keys)
+	txn.exitFairLockingIfInapplicable(ctx, keys)
 	err := txn.KVTxn.LockKeysFunc(ctx, lockCtx, fn, keys...)
 	if err != nil {
 		return txn.extractKeyErr(err)
@@ -357,11 +357,11 @@ func (txn *tikvTxn) UpdateMemBufferFlags(key []byte, flags ...kv.FlagsOp) {
 	txn.GetUnionStore().GetMemBuffer().UpdateFlags(key, getTiKVFlagsOps(flags)...)
 }
 
-func (txn *tikvTxn) exitAggressiveLockingIfInapplicable(ctx context.Context, keys [][]byte) {
+func (txn *tikvTxn) exitFairLockingIfInapplicable(ctx context.Context, keys [][]byte) {
 	if len(keys) > 1 && txn.IsInAggressiveLockingMode() {
-		// Only allow aggressive locking if it only needs to lock one key. Considering that it's possible that a
-		// statement causes multiple calls to `LockKeys` (which means some keys may have been locked in aggressive
-		// locking mode), here we exit aggressive locking mode by calling DoneAggressiveLocking instead of cancelling.
+		// Only allow fair locking if it only needs to lock one key. Considering that it's possible that a
+		// statement causes multiple calls to `LockKeys` (which means some keys may have been locked in fair
+		// locking mode), here we exit fair locking mode by calling DoneFairLocking instead of cancelling.
 		// Then the previously-locked keys during execution in this statement (if any) will be turned into the state
 		// as if they were locked in normal way.
 		// Note that the issue https://github.com/pingcap/tidb/issues/35682 also exists here.
@@ -392,29 +392,35 @@ func (txn *tikvTxn) generateWriteConflictForLockedWithConflict(lockCtx *kv.LockC
 	return nil
 }
 
-// StartAggressiveLocking adapts the method signature of `KVTxn` to satisfy kv.AggressiveLockingController.
+// StartFairLocking adapts the method signature of `KVTxn` to satisfy kv.FairLockingController.
 // TODO: Update the methods' signatures in client-go to avoid this adaptor functions.
-func (txn *tikvTxn) StartAggressiveLocking() error {
+// TODO: Rename aggressive locking in client-go to fair locking.
+func (txn *tikvTxn) StartFairLocking() error {
 	txn.KVTxn.StartAggressiveLocking()
 	return nil
 }
 
-// RetryAggressiveLocking adapts the method signature of `KVTxn` to satisfy kv.AggressiveLockingController.
-func (txn *tikvTxn) RetryAggressiveLocking(ctx context.Context) error {
+// RetryFairLocking adapts the method signature of `KVTxn` to satisfy kv.FairLockingController.
+func (txn *tikvTxn) RetryFairLocking(ctx context.Context) error {
 	txn.KVTxn.RetryAggressiveLocking(ctx)
 	return nil
 }
 
-// CancelAggressiveLocking adapts the method signature of `KVTxn` to satisfy kv.AggressiveLockingController.
-func (txn *tikvTxn) CancelAggressiveLocking(ctx context.Context) error {
+// CancelFairLocking adapts the method signature of `KVTxn` to satisfy kv.FairLockingController.
+func (txn *tikvTxn) CancelFairLocking(ctx context.Context) error {
 	txn.KVTxn.CancelAggressiveLocking(ctx)
 	return nil
 }
 
-// DoneAggressiveLocking adapts the method signature of `KVTxn` to satisfy kv.AggressiveLockingController.
-func (txn *tikvTxn) DoneAggressiveLocking(ctx context.Context) error {
+// DoneFairLocking adapts the method signature of `KVTxn` to satisfy kv.FairLockingController.
+func (txn *tikvTxn) DoneFairLocking(ctx context.Context) error {
 	txn.KVTxn.DoneAggressiveLocking(ctx)
 	return nil
+}
+
+// IsInFairLockingMode adapts the method signature of `KVTxn` to satisfy kv.FairLockingController.
+func (txn *tikvTxn) IsInFairLockingMode() bool {
+	return txn.KVTxn.IsInAggressiveLockingMode()
 }
 
 // TiDBKVFilter is the filter specific to TiDB to filter out KV pairs that needn't be committed.

--- a/telemetry/data.go
+++ b/telemetry/data.go
@@ -71,7 +71,7 @@ func postReportTelemetryData() {
 	postReportDDLUsage()
 	postReportIndexMergeUsage()
 	postStoreBatchUsage()
-	postReportAggressiveLockingUsageCounter()
+	postReportFairLockingUsageCounter()
 }
 
 // PostReportTelemetryDataForTest is for test.

--- a/telemetry/data_feature_usage_test.go
+++ b/telemetry/data_feature_usage_test.go
@@ -76,13 +76,13 @@ func TestTxnUsageInfo(t *testing.T) {
 		txnUsage = telemetry.GetTxnUsageInfo(tk.Session())
 		require.True(t, txnUsage.RCWriteCheckTS)
 
-		tk.MustExec(fmt.Sprintf("set global %s = 0", variable.TiDBPessimisticTransactionAggressiveLocking))
+		tk.MustExec(fmt.Sprintf("set global %s = 0", variable.TiDBPessimisticTransactionFairLocking))
 		txnUsage = telemetry.GetTxnUsageInfo(tk.Session())
-		require.False(t, txnUsage.AggressiveLocking)
+		require.False(t, txnUsage.FairLocking)
 
-		tk.MustExec(fmt.Sprintf("set global %s = 1", variable.TiDBPessimisticTransactionAggressiveLocking))
+		tk.MustExec(fmt.Sprintf("set global %s = 1", variable.TiDBPessimisticTransactionFairLocking))
 		txnUsage = telemetry.GetTxnUsageInfo(tk.Session())
-		require.True(t, txnUsage.AggressiveLocking)
+		require.True(t, txnUsage.FairLocking)
 	})
 
 	t.Run("Count", func(t *testing.T) {
@@ -894,7 +894,7 @@ func TestStoreBatchCopr(t *testing.T) {
 	require.Equal(t, diff.BatchedFallbackCount, int64(1))
 }
 
-func TestAggressiveLockingUsage(t *testing.T) {
+func TestFairLockingUsage(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk2 := testkit.NewTestKit(t, store)
@@ -905,24 +905,24 @@ func TestAggressiveLockingUsage(t *testing.T) {
 
 	usage, err := telemetry.GetFeatureUsage(tk2.Session())
 	require.NoError(t, err)
-	require.Equal(t, int64(0), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingUsed)
-	require.Equal(t, int64(0), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingEffective)
+	require.Equal(t, int64(0), usage.Txn.FairLockingUsageCounter.TxnFairLockingUsed)
+	require.Equal(t, int64(0), usage.Txn.FairLockingUsageCounter.TxnFairLockingEffective)
 
-	tk.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 1")
+	tk.MustExec("set @@tidb_pessimistic_txn_fair_locking = 1")
 
 	tk.MustExec("begin pessimistic")
 	tk.MustExec("update t set v = v + 1 where id = 1")
 	usage, err = telemetry.GetFeatureUsage(tk2.Session())
 	// Not counted before transaction committing.
 	require.NoError(t, err)
-	require.Equal(t, int64(0), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingUsed)
-	require.Equal(t, int64(0), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingEffective)
+	require.Equal(t, int64(0), usage.Txn.FairLockingUsageCounter.TxnFairLockingUsed)
+	require.Equal(t, int64(0), usage.Txn.FairLockingUsageCounter.TxnFairLockingEffective)
 
 	tk.MustExec("commit")
 	usage, err = telemetry.GetFeatureUsage(tk2.Session())
 	require.NoError(t, err)
-	require.Equal(t, int64(1), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingUsed)
-	require.Equal(t, int64(0), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingEffective)
+	require.Equal(t, int64(1), usage.Txn.FairLockingUsageCounter.TxnFairLockingUsed)
+	require.Equal(t, int64(0), usage.Txn.FairLockingUsageCounter.TxnFairLockingEffective)
 
 	// Counted by transaction instead of by statement.
 	tk.MustExec("begin pessimistic")
@@ -931,8 +931,8 @@ func TestAggressiveLockingUsage(t *testing.T) {
 	tk.MustExec("commit")
 	usage, err = telemetry.GetFeatureUsage(tk2.Session())
 	require.NoError(t, err)
-	require.Equal(t, int64(2), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingUsed)
-	require.Equal(t, int64(0), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingEffective)
+	require.Equal(t, int64(2), usage.Txn.FairLockingUsageCounter.TxnFairLockingUsed)
+	require.Equal(t, int64(0), usage.Txn.FairLockingUsageCounter.TxnFairLockingEffective)
 
 	// Effective only when LockedWithConflict occurs.
 	tk3 := testkit.NewTestKit(t, store)
@@ -959,6 +959,6 @@ func TestAggressiveLockingUsage(t *testing.T) {
 	tk.MustExec("commit")
 	usage, err = telemetry.GetFeatureUsage(tk2.Session())
 	require.NoError(t, err)
-	require.Equal(t, int64(4), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingUsed)
-	require.Equal(t, int64(1), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingEffective)
+	require.Equal(t, int64(4), usage.Txn.FairLockingUsageCounter.TxnFairLockingUsed)
+	require.Equal(t, int64(1), usage.Txn.FairLockingUsageCounter.TxnFairLockingEffective)
 }

--- a/telemetry/data_feature_usage_test.go
+++ b/telemetry/data_feature_usage_test.go
@@ -959,6 +959,6 @@ func TestAggressiveLockingUsage(t *testing.T) {
 	tk.MustExec("commit")
 	usage, err = telemetry.GetFeatureUsage(tk2.Session())
 	require.NoError(t, err)
-	require.Equal(t, int64(3), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingUsed)
+	require.Equal(t, int64(4), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingUsed)
 	require.Equal(t, int64(1), usage.Txn.AggressiveLockingUsageCounter.TxnAggressiveLockingEffective)
 }

--- a/tests/realtikvtest/pessimistictest/pessimistic_test.go
+++ b/tests/realtikvtest/pessimistictest/pessimistic_test.go
@@ -1169,6 +1169,10 @@ func TestPessimisticReadCommitted(t *testing.T) {
 	tk.MustExec("set tidb_txn_mode = 'pessimistic'")
 	tk1.MustExec("set tidb_txn_mode = 'pessimistic'")
 
+	// Avoid issue https://github.com/pingcap/tidb/issues/41792
+	tk.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
+	tk1.MustExec("set @@tidb_pessimistic_txn_aggressive_locking = 0")
+
 	// test SI
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t(i int key);")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42107 , close #42147 

Problem Summary:

This PR does the following changes:

1. Rename the term *Aggressive Locking* to *Fair Locking* for all places, including the system variable, telemetry item and metrics.
2. Enable `tidb_pessimistic_txn_fair_locking` by default for new clusters, but clusters upgraded from older version will still have this option disabled.
3. Adapt some tests that doesn't work well with `tidb_pessimistic_txn_fair_locking` globally enabled.

The term *Aggressive Locking* is also used in client-go which is not updated for now, thus the old term still occurs in code that references to client-go. We will also rename it in client-go later.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Rename variable `tidb_pessimistic_txn_aggressive_locking` into `tidb_pessimistic_txn_fair_locking` and enable by default for new clusters.
```
