### PR TITLE
server: Set default drainClientWait as 15s

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1059,6 +1059,8 @@ func (cc *clientConn) Run(ctx context.Context) {
 	// by CAS operation, it would then take some actions accordingly.
 	for {
 		// Close connection between txn when we are going to shutdown server.
+		// Note the current implementation when shutting down, for an idle connection, the connection may block at readPacket()
+		// consider provider a way to close the connection directly after sometime if we can not read any data.
 		if cc.server.inShutdownMode.Load() {
 			if !cc.ctx.GetSessionVars().InTxn() {
 				return

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -857,17 +857,15 @@ func closeDomainAndStorage(storage kv.Storage, dom *domain.Domain) {
 	terror.Log(errors.Trace(err))
 }
 
+// The amount of time we wait for the ongoing txt to finished.
+// We should better provider a dynamic way to set this value.
 var gracefulCloseConnectionsTimeout = 15 * time.Second
 
-func cleanup(svr *server.Server, storage kv.Storage, dom *domain.Domain, graceful bool) {
+func cleanup(svr *server.Server, storage kv.Storage, dom *domain.Domain, _ bool) {
 	dom.StopAutoAnalyze()
 
-	var drainClientWait time.Duration
-	if graceful {
-		drainClientWait = 1<<63 - 1
-	} else {
-		drainClientWait = gracefulCloseConnectionsTimeout
-	}
+	drainClientWait := gracefulCloseConnectionsTimeout
+
 	cancelClientWait := time.Second * 1
 	svr.DrainClients(drainClientWait, cancelClientWait)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Issue Number: close #32110 

Problem Summary:

### What is changed and how it works?
ref #32111 

Set default drainClientWait as 15s

The default keeps waiting maybe too rigorous, It is easy having little slow txns which we may not want to wait for them, also the idle connections may block the shutdown two.
generally, 15s is enough for an ongoing txn to finish, better provider a dynamic way to set this value. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
