### PR TITLE
br/restore: fail fast when meeting some error during restoration

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1187,7 +1187,12 @@ func (rc *Client) RestoreSSTFiles(
 	for rangeFiles, leftFiles = drainFilesByRange(files, rc.fileImporter.supportMultiIngest); len(rangeFiles) != 0; rangeFiles, leftFiles = drainFilesByRange(leftFiles, rc.fileImporter.supportMultiIngest) {
 		filesReplica := rangeFiles
 		if ectx.Err() != nil {
-			log.Warn("Restoring encountered error and already failed, give up remained files.", zap.Int("remained", len(leftFiles)))
+			log.Warn("Restoring encountered error and already stopped, give up remained files.",
+				zap.Int("remained", len(leftFiles)),
+				logutil.ShortError(ectx.Err()))
+			// We will fetch the error from the errgroup then (If there were).
+			// Also note if the father context has been canceled or something,
+			// breaking here directly is also a reasonable behavior.
 			break
 		}
 		rc.workerPool.ApplyOnErrorGroup(eg,

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1218,10 +1218,7 @@ func (rc *Client) RestoreSSTFiles(
 	// Once the parent context canceled and there is no task running in the errgroup,
 	// we may break the for loop without error in the errgroup. (Will this happen?)
 	// At that time, return the error in the context here.
-	if err := ectx.Err(); err != nil {
-		return err
-	}
-	return nil
+	return ectx.Err()
 }
 
 // RestoreRaw tries to restore raw keys in the specified range.

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1186,6 +1186,10 @@ func (rc *Client) RestoreSSTFiles(
 	var leftFiles []*backuppb.File
 	for rangeFiles, leftFiles = drainFilesByRange(files, rc.fileImporter.supportMultiIngest); len(rangeFiles) != 0; rangeFiles, leftFiles = drainFilesByRange(leftFiles, rc.fileImporter.supportMultiIngest) {
 		filesReplica := rangeFiles
+		if ectx.Err() != nil {
+			log.Warn("Restoring encountered error and already failed, give up remained files.", zap.Int("remained", len(leftFiles)))
+			break
+		}
 		rc.workerPool.ApplyOnErrorGroup(eg,
 			func() error {
 				fileStart := time.Now()

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1218,7 +1218,7 @@ func (rc *Client) RestoreSSTFiles(
 	// Once the parent context canceled and there is no task running in the errgroup,
 	// we may break the for loop without error in the errgroup. (Will this happen?)
 	// At that time, return the error in the context here.
-	return ectx.Err()
+	return ctx.Err()
 }
 
 // RestoreRaw tries to restore raw keys in the specified range.

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1215,6 +1215,12 @@ func (rc *Client) RestoreSSTFiles(
 		)
 		return errors.Trace(err)
 	}
+	// Once the parent context canceled and there is no task running in the errgroup,
+	// we may break the for loop without error in the errgroup. (Will this happen?)
+	// At that time, return the error in the context here.
+	if err := ectx.Err(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1191,7 +1191,7 @@ func (rc *Client) RestoreSSTFiles(
 				zap.Int("remained", len(leftFiles)),
 				logutil.ShortError(ectx.Err()))
 			// We will fetch the error from the errgroup then (If there were).
-			// Also note if the father context has been canceled or something,
+			// Also note if the parent context has been canceled or something,
 			// breaking here directly is also a reasonable behavior.
 			break
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42157

Problem Summary:
As the issue has described, after encountered an error, we still try to fire new requests to the thread pool.

### What is changed and how it works?
This PR would give up issuing new requests to the thread pool when there are failed tasks.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] (Almost) No code
This PR is really hard to test: perhaps we need to figure out a effective way to mock the `restore.Client`.
If you want to verify these changes, you may need to make a environment where download fail very slow. In our case, that is all S3 requests from TiKV has been rejected by a firewall just DROP TCP packets(also not send some RST packet). 

### Release note

```release-note
Fixed a problem that made BR looks like be stuck when there are some network issues.
```
