### PR TITLE
*: add plan hint to slow log files when redaction is enabled

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -116,5 +116,5 @@ TEST_COVERAGE_DIR := "test_coverage"
 
 ifneq ("$(CI)", "0")
 	BAZEL_GLOBAL_CONFIG := --output_user_root=/home/jenkins/.tidb/tmp
-	BAZEL_CMD_CONFIG := --config=ci --repository_cache=/home/jenkins/.tidb/tmp --sandbox_tmpfs_path=/tmp
+	BAZEL_CMD_CONFIG := --config=ci --repository_cache=/home/jenkins/.tidb/tmp
 endif

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -144,7 +144,7 @@ func (a *recordSet) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 			return
 		}
 		err = errors.Errorf("%v", r)
-		logutil.Logger(ctx).Error("execute sql panic", zap.String("sql", a.stmt.GetTextToLog()), zap.Stack("stack"))
+		logutil.Logger(ctx).Error("execute sql panic", zap.String("sql", a.stmt.GetTextToLog(false)), zap.Stack("stack"))
 	}()
 
 	err = a.stmt.next(ctx, a.executor, req)
@@ -459,7 +459,7 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 			panic(r)
 		}
 		err = errors.Errorf("%v", r)
-		logutil.Logger(ctx).Error("execute sql panic", zap.String("sql", a.GetTextToLog()), zap.Stack("stack"))
+		logutil.Logger(ctx).Error("execute sql panic", zap.String("sql", a.GetTextToLog(false)), zap.Stack("stack"))
 	}()
 
 	failpoint.Inject("assertStaleTSO", func(val failpoint.Value) {
@@ -1353,7 +1353,7 @@ func (a *ExecStmt) FinishExecuteStmt(txnTS uint64, err error, hasMoreResults boo
 			metrics.TiFlashQueryTotalCounter.WithLabelValues(metrics.ExecuteErrorToLabel(err), metrics.LblError).Inc()
 		}
 	}
-	sessVars.PrevStmt = FormatSQL(a.GetTextToLog())
+	sessVars.PrevStmt = FormatSQL(a.GetTextToLog(false))
 
 	a.observePhaseDurations(sessVars.InRestrictedSQL, execDetail.CommitDetail)
 	executeDuration := time.Since(sessVars.StartTime) - sessVars.DurationCompile
@@ -1444,7 +1444,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 	if (!enable || costTime < threshold) && !force {
 		return
 	}
-	sql := FormatSQL(a.GetTextToLog())
+	sql := FormatSQL(a.GetTextToLog(true))
 	_, digest := stmtCtx.SQLDigest()
 
 	var indexNames string
@@ -1798,7 +1798,7 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 	copTaskInfo := stmtCtx.CopTasksDetails()
 	memMax := sessVars.MemTracker.MaxConsumed()
 	diskMax := sessVars.DiskTracker.MaxConsumed()
-	sql := a.GetTextToLog()
+	sql := a.GetTextToLog(false)
 	var stmtDetail execdetails.StmtExecDetails
 	stmtDetailRaw := a.GoCtx.Value(execdetails.StmtExecDetailKey)
 	if stmtDetailRaw != nil {
@@ -1872,11 +1872,15 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 }
 
 // GetTextToLog return the query text to log.
-func (a *ExecStmt) GetTextToLog() string {
+func (a *ExecStmt) GetTextToLog(keepHint bool) string {
 	var sql string
 	sessVars := a.Ctx.GetSessionVars()
 	if sessVars.EnableRedactLog {
-		sql, _ = sessVars.StmtCtx.SQLDigest()
+		if keepHint {
+			sql = parser.NormalizeKeepHint(sessVars.StmtCtx.OriginalSQL)
+		} else {
+			sql, _ = sessVars.StmtCtx.SQLDigest()
+		}
 	} else if sensitiveStmt, ok := a.StmtNode.(ast.SensitiveStmtNode); ok {
 		sql = sensitiveStmt.SecureText()
 	} else {

--- a/parser/digester_test.go
+++ b/parser/digester_test.go
@@ -75,6 +75,53 @@ func TestNormalize(t *testing.T) {
 	}
 }
 
+func TestNormalizeKeepHint(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{"select _utf8mb4'123'", "select (_charset) ?"},
+		{"SELECT 1", "select ?"},
+		{"select null", "select ?"},
+		{"select \\N", "select ?"},
+		{"SELECT `null`", "select `null`"},
+		{"select * from b where id = 1", "select * from `b` where `id` = ?"},
+		{"select 1 from b where id in (1, 3, '3', 1, 2, 3, 4)", "select ? from `b` where `id` in ( ... )"},
+		{"select 1 from b where id in (1, a, 4)", "select ? from `b` where `id` in ( ? , `a` , ? )"},
+		{"select 1 from b order by 2", "select ? from `b` order by 2"},
+		{"select /*+ a hint */ 1", "select /*+ a hint */ ?"},
+		{"select /* a hint */ 1", "select ?"},
+		{"select truncate(1, 2)", "select truncate ( ... )"},
+		{"select -1 + - 2 + b - c + 0.2 + (-2) from c where d in (1, -2, +3)", "select ? + ? + `b` - `c` + ? + ( ? ) from `c` where `d` in ( ... )"},
+		{"select * from t where a <= -1 and b < -2 and c = -3 and c > -4 and c >= -5 and e is 1", "select * from `t` where `a` <= ? and `b` < ? and `c` = ? and `c` > ? and `c` >= ? and `e` is ?"},
+		{"select count(a), b from t group by 2", "select count ( `a` ) , `b` from `t` group by 2"},
+		{"select count(a), b, c from t group by 2, 3", "select count ( `a` ) , `b` , `c` from `t` group by 2 , 3"},
+		{"select count(a), b, c from t group by (2, 3)", "select count ( `a` ) , `b` , `c` from `t` group by ( 2 , 3 )"},
+		{"select a, b from t order by 1, 2", "select `a` , `b` from `t` order by 1 , 2"},
+		{"select count(*) from t", "select count ( ? ) from `t`"},
+		{"select * from t Force Index(kk)", "select * from `t` force index ( `kk` )"},
+		{"select * from t USE Index(kk)", "select * from `t` use index ( `kk` )"},
+		{"select * from t Ignore Index(kk)", "select * from `t` ignore index ( `kk` )"},
+		{"select * from t1 straight_join t2 on t1.id=t2.id", "select * from `t1` straight_join `t2` on `t1` . `id` = `t2` . `id`"},
+		{"select * from `table`", "select * from `table`"},
+		{"select * from `30`", "select * from `30`"},
+		{"select * from `select`", "select * from `select`"},
+		{"select * from 🥳", "select * from `🥳`"},
+		// test syntax error, it will be checked by parser, but it should not make normalize dead loop.
+		{"select * from t ignore index(", "select * from `t` ignore index ("},
+		{"select /*+ ", "select "},
+		{"select 1 / 2", "select ? / ?"},
+		{"select * from t where a = 40 limit ?, ?", "select * from `t` where `a` = ? limit ..."},
+		{"select * from t where a > ?", "select * from `t` where `a` > ?"},
+		{"select @a=b from t", "select @a = `b` from `t`"},
+		{"select * from `table", "select * from"},
+	}
+	for _, test := range tests {
+		normalized := parser.NormalizeKeepHint(test.input)
+		require.Equal(t, test.expect, normalized)
+	}
+}
+
 func TestNormalizeDigest(t *testing.T) {
 	tests := []struct {
 		sql        string

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -80,6 +80,9 @@ type Scanner struct {
 
 	// true if a dot follows an identifier
 	identifierDot bool
+
+	// keepHint, if true, Scanner will keep hint when normalizing .
+	keepHint bool
 }
 
 // Errors returns the errors and warns during a scan.
@@ -341,6 +344,11 @@ func (s *Scanner) EnableWindowFunc(val bool) {
 	s.supportWindowFunc = val
 }
 
+// setKeepHint set the keepHint flag when normalizing.
+func (s *Scanner) setKeepHint(val bool) {
+	s.keepHint = val
+}
+
 // InheritScanner returns a new scanner object which inherits configurations from the parent scanner.
 func (s *Scanner) InheritScanner(sql string) *Scanner {
 	return &Scanner{
@@ -533,7 +541,7 @@ func startWithSlash(s *Scanner) (tok int, pos Pos, lit string) {
 
 	case '+': // '/*+' optimizer hints
 		// See https://dev.mysql.com/doc/refman/5.7/en/optimizer-hints.html
-		if _, ok := hintedTokens[s.lastKeyword]; ok {
+		if _, ok := hintedTokens[s.lastKeyword]; ok || s.keepHint {
 			// only recognize optimizers hints directly followed by certain
 			// keywords like SELECT, INSERT, etc., only a special case "FOR UPDATE" needs to be handled
 			// we will report a warning in order to match MySQL's behavior, but the hint content will be ignored

--- a/session/session.go
+++ b/session/session.go
@@ -1210,7 +1210,7 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 			if retryCnt == 0 {
 				// We do not have to log the query every time.
 				// We print the queries at the first try only.
-				sql := sqlForLog(st.GetTextToLog())
+				sql := sqlForLog(st.GetTextToLog(false))
 				if !sessVars.EnableRedactLog {
 					sql += sessVars.PreparedParams.String()
 				}
@@ -3828,7 +3828,7 @@ func logGeneralQuery(execStmt *executor.ExecStmt, s *session, isPrepared bool) {
 		if isPrepared {
 			query = execStmt.OriginText()
 		} else {
-			query = execStmt.GetTextToLog()
+			query = execStmt.GetTextToLog(false)
 		}
 
 		query = executor.QueryReplacer.Replace(query)

--- a/util/sqlexec/restricted_sql_executor.go
+++ b/util/sqlexec/restricted_sql_executor.go
@@ -171,7 +171,7 @@ type Statement interface {
 	OriginText() string
 
 	// GetTextToLog gets the desensitization SQL text for logging.
-	GetTextToLog() string
+	GetTextToLog(keepHint bool) string
 
 	// Exec executes SQL and gets a Recordset.
 	Exec(ctx context.Context) (RecordSet, error)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42169

Problem Summary:
Plan hint will be redacted when enabling the log redaction in slow log files.

### What is changed and how it works?
Add the hint as an item to the slow log files.

An example looks like this:

```
# Time: 2023-03-13T21:47:35.044936+08:00
...
# Plan: tidb_decode_plan('kwPwZTAJMV81CTAJMC44MAllcSh0ZXN0LnQuaSwgc2xlZXAoMSkpCTAJdGltZToxcywgbG9vcHM6MQkzODAgQnl0ZXMJTi9BCjEJMzFfNwkwCTEJZGF0YTpUYWJsZUZ1bGxTY2FuXzYJMQlBHDc5Mi4xwrVzEUd0MiwgY29wX3Rhc2s6IHtudW06IDEsIG1heDogNTY0BSlEcHJvY19rZXlzOiAwLCBycGNfEScBDAB0AZcUIDQ4Ni41BS6AY29wcl9jYWNoZV9oaXRfcmF0aW86IDAuMDAsIGJ1aWxkBWwIX2R1BRoYbjogMzkuNwU68GVtYXhfZGlzdHNxbF9jb25jdXJyZW5jeTogMX0JMTg2IEJ5dGVzCU4vQQoyCTQzXzYJMV8wCTEJdGFibGU6dCwga2VlcCBvcmRlcjpmYWxzZSwgc3RhdHM6cHNldWRvCTEJdGlrdl8F6gB7BbYQNDQ2LjgFeylTKDB9CU4vQQlOL0EK')
# Plan_digest: 21c0867e8b9be5e6cfd2a7cbcf7e9f757942f21798074863465d8cb05f48194e
# Binary_plan: tidb_decode_binary_plan('/wOYCvoDCgtTZWxlY3Rpb25fNRKcAwoNVGFibGVSZWFkZXJfNxKQAQoPBRJQRnVsbFNjYW5fNiGamZmZmVlkQCkABQHwXvA/MAE4AkACSgsKCQoEdGVzdBIBdFIea2VlcCBvcmRlcjpmYWxzZSwgc3RhdHM6cHNldWRvaiJ0aWt2X3Rhc2s6e3RpbWU6NDQ2LjjCtXMsIGxvb3BzOjB9cP//////AQMEAXgBBgUBIAEhXB0TPJgnLjJ/ADQBQAFSFGRhdGE6VGFibB2tMFoWdGltZTo3OTIuMcIZXRgyYqMBY29wCYBEIHtudW06IDEsIG1heDogNTY0BSpEcHJvY19rZXlzOiAwLCBycGNfEScBDAVXFCA0ODYuNQUugGNvcHJfY2FjaGVfaGl0X3JhdGlvOiAwLjAwLCBidWlsZAVsCF9kdQUaGG46IDM5LjcFOnBtYXhfZGlzdHNxbF9jb25jdXJyZW5jeTogMX1wujL6ACRF/RuhjD5QQCmaIYIMmek/OAH4DBZlcSghdkAudC5pLCBzbGVlcCgxKSlaEAWjFDFzLCBsbyFRQDFw/AJ4////////////ARgB')
select /*+ use_index(t, primary) */ * from t use index (`primary`) where i = sleep(?);
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
