### PR TITLE
br: wait more time to wait spitting the region

### DIFF
--- a/br/pkg/restore/split/BUILD.bazel
+++ b/br/pkg/restore/split/BUILD.bazel
@@ -43,10 +43,16 @@ go_library(
 go_test(
     name = "split_test",
     timeout = "short",
-    srcs = ["sum_sorted_test.go"],
+    srcs = [
+        "split_test.go",
+        "sum_sorted_test.go",
+    ],
     flaky = True,
     deps = [
         ":split",
+        "//br/pkg/errors",
+        "//br/pkg/utils",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/br/pkg/restore/split/split_test.go
+++ b/br/pkg/restore/split/split_test.go
@@ -1,0 +1,50 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+package split_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/failpoint"
+	berrors "github.com/pingcap/tidb/br/pkg/errors"
+	"github.com/pingcap/tidb/br/pkg/restore/split"
+	"github.com/pingcap/tidb/br/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanRegionBackOfferWithSuccess(t *testing.T) {
+	var counter int
+	bo := split.NewScanRegionBackoffer()
+
+	err := utils.WithRetry(context.Background(), func() error {
+		defer func() {
+			counter++
+		}()
+
+		if counter == 3 {
+			return nil
+		}
+		return berrors.ErrPDBatchScanRegion
+	}, bo)
+	require.NoError(t, err)
+	require.Equal(t, counter, 4)
+}
+
+func TestScanRegionBackOfferWithFail(t *testing.T) {
+	_ = failpoint.Enable("github.com/pingcap/tidb/br/pkg/restore/split/hint-scan-region-backoff", "return(true)")
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/tidb/br/pkg/restore/split/hint-scan-region-backoff")
+	}()
+
+	var counter int
+	bo := split.NewScanRegionBackoffer()
+
+	err := utils.WithRetry(context.Background(), func() error {
+		defer func() {
+			counter++
+		}()
+		return berrors.ErrPDBatchScanRegion
+	}, bo)
+	require.Error(t, err)
+	require.Equal(t, counter, 150)
+}

--- a/br/pkg/restore/split/split_test.go
+++ b/br/pkg/restore/split/split_test.go
@@ -65,9 +65,8 @@ func TestScanRegionBackOfferWithStopRetry(t *testing.T) {
 
 		if counter < 5 {
 			return berrors.ErrPDBatchScanRegion
-		} else {
-			return berrors.ErrKVUnknown
 		}
+		return berrors.ErrKVUnknown
 	}, bo)
 	require.Error(t, err)
 	require.Equal(t, counter, 6)

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -92,6 +92,10 @@ func (rs *RetryState) Attempt() int {
 	return rs.maxRetry - rs.retryTimes
 }
 
+func (rs *RetryState) StopRetry() {
+	rs.retryTimes = rs.maxRetry
+}
+
 // NextBackoff implements the `Backoffer`.
 func (rs *RetryState) NextBackoff(error) time.Duration {
 	return rs.ExponentialBackoff()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/42001

Problem Summary:
The operation of scanning regions from PD exceeds the retry time. The old backoff is 128s， the new one is 5min

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue, expand the backoff to scan regions from PD
```
