### PR TITLE
spool: fix unstable test TestPoolTuneScaleUpAndDown

### DIFF
--- a/resourcemanager/pool/spool/spool_test.go
+++ b/resourcemanager/pool/spool/spool_test.go
@@ -96,7 +96,7 @@ func TestPoolTuneScaleUpAndDown(t *testing.T) {
 		}()
 	}
 	p.Tune(8)
-	time.Sleep(500 * time.Millisecond)
+	wg.Wait()
 	if n := p.Running(); n != 8 {
 		t.Errorf("expect 8 workers running, but got %d", n)
 	}
@@ -119,7 +119,6 @@ func TestPoolTuneScaleUpAndDown(t *testing.T) {
 		cnt.Add(1)
 	}
 	fnChan := make(chan func(), 10)
-	wg.Wait()
 	err := p.RunWithConcurrency(fnChan, 2)
 	require.NoError(t, err)
 	require.Equal(t, int32(2), p.Running())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42163

Problem Summary:

Some tasks are still increasing after ```Tune```, so we need to wait for all tasks to be completed.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
