### PR TITLE
Optimizer: Fix Merge In and Not Equal ranges #39676

### DIFF
--- a/planner/core/BUILD.bazel
+++ b/planner/core/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "rule_max_min_eliminate.go",
         "rule_partition_processor.go",
         "rule_predicate_push_down.go",
+        "rule_predicate_simplification.go",
         "rule_result_reorder.go",
         "rule_semi_join_rewrite.go",
         "rule_topn_push_down.go",

--- a/planner/core/casetest/main_test.go
+++ b/planner/core/casetest/main_test.go
@@ -48,6 +48,7 @@ func TestMain(m *testing.M) {
 	testDataMap.LoadTestSuiteData("testdata", "binary_plan_suite")
 	testDataMap.LoadTestSuiteData("testdata", "json_plan_suite")
 	testDataMap.LoadTestSuiteData("testdata", "derive_topn_from_window")
+	testDataMap.LoadTestSuiteData("testdata", "predicate_simplification")
 
 	opts := []goleak.Option{
 		goleak.IgnoreTopFunction("github.com/golang/glog.(*loggingT).flushDaemon"),
@@ -132,4 +133,8 @@ func GetJSONPlanSuiteData() testdata.TestData {
 
 func GetDerivedTopNSuiteData() testdata.TestData {
 	return testDataMap["derive_topn_from_window"]
+}
+
+func GetPredicateSimplificationTestData() testdata.TestData {
+	return testDataMap["predicate_simplification"]
 }

--- a/planner/core/casetest/testdata/plan_suite_in.json
+++ b/planner/core/casetest/testdata/plan_suite_in.json
@@ -1205,22 +1205,6 @@
     ]
   },
   {
-    "name": "TestRemoveRedundantPredicates",
-    "cases":[
-      "select f from t use index() where f = 1 and f = 1 -- simple redundancy of exact condition",
-      "select f from t use index() where f = 1 and f = 2 -- unsatisfiable condition",
-      "select f from t use index() where f = 1 and f in (1,2,3)  -- intersection of in and =",
-      "select f from t use index() where f = 1 and f <> 1  -- intersection of = and <>",
-      "select f from t use index() where f not in (1,2,3) and f = 3 -- intersection of not in list and =",
-      "select f from t use index() where f <> 3 and f <> 3 -- intersection of two not in values.",
-      "select t1.f /* merge_join(t1, t2) */ from t t1, t t2 where t1.a=t2.a and t1.a=t2.a -- exact redundancy in joins",
-      "select f from t use index() where f in (1,2,3) and f <> 2 -- intersection of in and <>. Not done yet see issue 39676",
-      "select f from t use index() where f in (1,2,3) and f in (3,4,5) -- intersection of two in. Not done yet",
-      "select f from t use index() where f not in (1,2,3) and f not in (3,4,5) -- intersection of two not in. Not done yet",
-      "select f from t use index() where f not in (1,2,3) and f in (1,2,3) -- intersection of in and not in. Not done yet"
-    ]
-  },
-  {
     "name": "TestIndexMergeOrderPushDown",
     "cases": [
       "select * from t where a = 1 or b = 1 order by c limit 2",

--- a/planner/core/casetest/testdata/plan_suite_out.json
+++ b/planner/core/casetest/testdata/plan_suite_out.json
@@ -7651,55 +7651,6 @@
     ]
   },
   {
-    "Name": "TestRemoveRedundantPredicates",
-    "Cases": [
-      {
-        "SQL": "select f from t use index() where f = 1 and f = 1 -- simple redundancy of exact condition",
-        "Best": "TableReader(Table(t)->Sel([eq(test.t.f, 1)]))"
-      },
-      {
-        "SQL": "select f from t use index() where f = 1 and f = 2 -- unsatisfiable condition",
-        "Best": "Dual"
-      },
-      {
-        "SQL": "select f from t use index() where f = 1 and f in (1,2,3)  -- intersection of in and =",
-        "Best": "TableReader(Table(t)->Sel([eq(test.t.f, 1)]))"
-      },
-      {
-        "SQL": "select f from t use index() where f = 1 and f <> 1  -- intersection of = and <>",
-        "Best": "Dual"
-      },
-      {
-        "SQL": "select f from t use index() where f not in (1,2,3) and f = 3 -- intersection of not in list and =",
-        "Best": "Dual"
-      },
-      {
-        "SQL": "select f from t use index() where f <> 3 and f <> 3 -- intersection of two not in values.",
-        "Best": "TableReader(Table(t)->Sel([ne(test.t.f, 3)]))"
-      },
-      {
-        "SQL": "select t1.f /* merge_join(t1, t2) */ from t t1, t t2 where t1.a=t2.a and t1.a=t2.a -- exact redundancy in joins",
-        "Best": "MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(test.t.a,test.t.a)"
-      },
-      {
-        "SQL": "select f from t use index() where f in (1,2,3) and f <> 2 -- intersection of in and <>. Not done yet see issue 39676",
-        "Best": "TableReader(Table(t)->Sel([in(test.t.f, 1, 2, 3) ne(test.t.f, 2)]))"
-      },
-      {
-        "SQL": "select f from t use index() where f in (1,2,3) and f in (3,4,5) -- intersection of two in. Not done yet",
-        "Best": "TableReader(Table(t)->Sel([in(test.t.f, 1, 2, 3) in(test.t.f, 3, 4, 5)]))"
-      },
-      {
-        "SQL": "select f from t use index() where f not in (1,2,3) and f not in (3,4,5) -- intersection of two not in. Not done yet",
-        "Best": "TableReader(Table(t)->Sel([not(in(test.t.f, 1, 2, 3)) not(in(test.t.f, 3, 4, 5))]))"
-      },
-      {
-        "SQL": "select f from t use index() where f not in (1,2,3) and f in (1,2,3) -- intersection of in and not in. Not done yet",
-        "Best": "TableReader(Table(t)->Sel([not(in(test.t.f, 1, 2, 3)) in(test.t.f, 1, 2, 3)]))"
-      }
-    ]
-  },
-  {
     "Name": "TestIndexMergeOrderPushDown",
     "Cases": [
       {

--- a/planner/core/casetest/testdata/predicate_simplification_in.json
+++ b/planner/core/casetest/testdata/predicate_simplification_in.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "TestRemoveRedundantPredicates",
+    "cases":[
+      "select f from t use index() where f = 1 and f = 1 -- simple redundancy of exact condition",
+      "select f from t use index() where f = 1 and f = 2 -- unsatisfiable condition",
+      "select f from t use index() where f = 1 and f in (1,2,3)  -- intersection of in and =",
+      "select f from t use index() where f = 1 and f <> 1  -- intersection of = and <>",
+      "select f from t use index() where f not in (1,2,3) and f = 3 -- intersection of not in list and =",
+      "select f from t use index() where f <> 3 and f <> 3 -- intersection of two not in values.",
+      "select t1.f /* merge_join(t1, t2) */ from t t1, t t2 where t1.a=t2.a and t1.a=t2.a -- exact redundancy in joins",
+      "select f from t use index() where f in (1,2,3) and f in (3,4,5) -- intersection of two in. Not done yet",
+      "select f from t use index() where f not in (1,2,3) and f not in (3,4,5) -- intersection of two not in. Not done yet",
+      "select f from t use index() where f not in (1,2,3) and f in (1,2,3) -- intersection of in and not in. Not done yet"
+    ]
+  },
+  {
+    "name": "TestInListAndNotEqualSimplification",
+    "cases":[
+      "select f from t use index() where f <> 1 and f in (1,2,3) -- Simple case",
+      "select f from t use index() where f in (1,2,3) and f <> 2 -- Simple case with different order. Test case for issue 39676",
+      "select f from t use index() where f <> 3 and f in (1,2,3) and f <> 2 -- Multiple <> values. All are in inlist",
+      "select f from t use index() where f in (1,2,3) and f <> 2 and f <> 99 -- Multiple <> values. Some are in inlist",
+      "select f from t use index() where f in (1,2,3) and f <> 5 and f <> 33  -- Multiple <> values. None are in inlist",
+      "select f from t use index() where f <> 3 and f in (1,2,3) and f <> 1 and f <> 2 -- Multiple <> values and cover whole inlist. We keep at least one in inlist",
+      "select 1 from t A, t B where A.f <> 3 and B.f in (1,2,3) and A.f <> 1 and A.f <> 2 -- on different columns. No simplification should be done.",
+      "select 1 from t A, t B where B.f <> 2 and A.f <> 3 and B.f in (1,2,3) and A.f in (3,1,4) and A.f <> 1 and A.f <> 2 -- simplification for two columns.",
+      "select f from ts use index() where f <> '1' and f in ('1','2','3') -- Simple case with string type",
+      "select count(*) cnt from ts where f <> '1' and f in ('1','2','3') group by a having cnt > 100  -- aggregate  "
+    ]
+  }
+]

--- a/planner/core/casetest/testdata/predicate_simplification_in.json
+++ b/planner/core/casetest/testdata/predicate_simplification_in.json
@@ -18,6 +18,7 @@
     "name": "TestInListAndNotEqualSimplification",
     "cases":[
       "select f from t use index() where f <> 1 and f in (1,2,3) -- Simple case",
+      "select f from t use index() where f <> 4 and f in (1,2,3) -- No intersection but <> is redundant",
       "select f from t use index() where f in (1,2,3) and f <> 2 -- Simple case with different order. Test case for issue 39676",
       "select f from t use index() where f <> 3 and f in (1,2,3) and f <> 2 -- Multiple <> values. All are in inlist",
       "select f from t use index() where f in (1,2,3) and f <> 2 and f <> 99 -- Multiple <> values. Some are in inlist",

--- a/planner/core/casetest/testdata/predicate_simplification_out.json
+++ b/planner/core/casetest/testdata/predicate_simplification_out.json
@@ -94,6 +94,14 @@
         ]
       },
       {
+        "SQL": "select f from t use index() where f <> 4 and f in (1,2,3) -- No intersection but <> is redundant",
+        "Plan": [
+          "TableReader 30.00 root  data:Selection",
+          "└─Selection 30.00 cop[tikv]  in(test.t.f, 1, 2, 3)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
         "SQL": "select f from t use index() where f in (1,2,3) and f <> 2 -- Simple case with different order. Test case for issue 39676",
         "Plan": [
           "TableReader 20.00 root  data:Selection",
@@ -128,8 +136,8 @@
       {
         "SQL": "select f from t use index() where f <> 3 and f in (1,2,3) and f <> 1 and f <> 2 -- Multiple <> values and cover whole inlist. We keep at least one in inlist",
         "Plan": [
-          "TableReader 10.00 root  data:Selection",
-          "└─Selection 10.00 cop[tikv]  in(test.t.f, 2)",
+          "TableReader 0.00 root  data:Selection",
+          "└─Selection 0.00 cop[tikv]  in(test.t.f, 2), ne(test.t.f, 2)",
           "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
         ]
       },

--- a/planner/core/casetest/testdata/predicate_simplification_out.json
+++ b/planner/core/casetest/testdata/predicate_simplification_out.json
@@ -1,0 +1,183 @@
+[
+  {
+    "Name": "TestRemoveRedundantPredicates",
+    "Cases": [
+      {
+        "SQL": "select f from t use index() where f = 1 and f = 1 -- simple redundancy of exact condition",
+        "Plan": [
+          "TableReader 10.00 root  data:Selection",
+          "└─Selection 10.00 cop[tikv]  eq(test.t.f, 1)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f = 1 and f = 2 -- unsatisfiable condition",
+        "Plan": [
+          "TableDual 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f = 1 and f in (1,2,3)  -- intersection of in and =",
+        "Plan": [
+          "TableReader 10.00 root  data:Selection",
+          "└─Selection 10.00 cop[tikv]  eq(test.t.f, 1)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f = 1 and f <> 1  -- intersection of = and <>",
+        "Plan": [
+          "TableDual 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f not in (1,2,3) and f = 3 -- intersection of not in list and =",
+        "Plan": [
+          "TableDual 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f <> 3 and f <> 3 -- intersection of two not in values.",
+        "Plan": [
+          "TableReader 6656.67 root  data:Selection",
+          "└─Selection 6656.67 cop[tikv]  ne(test.t.f, 3)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select t1.f /* merge_join(t1, t2) */ from t t1, t t2 where t1.a=t2.a and t1.a=t2.a -- exact redundancy in joins",
+        "Plan": [
+          "HashJoin 12487.50 root  inner join, equal:[eq(test.t.a, test.t.a)]",
+          "├─TableReader(Build) 9990.00 root  data:Selection",
+          "│ └─Selection 9990.00 cop[tikv]  not(isnull(test.t.a))",
+          "│   └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) 9990.00 root  data:Selection",
+          "  └─Selection 9990.00 cop[tikv]  not(isnull(test.t.a))",
+          "    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f in (1,2,3) and f in (3,4,5) -- intersection of two in. Not done yet",
+        "Plan": [
+          "TableReader 10.00 root  data:Selection",
+          "└─Selection 10.00 cop[tikv]  in(test.t.f, 1, 2, 3), in(test.t.f, 3, 4, 5)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f not in (1,2,3) and f not in (3,4,5) -- intersection of two not in. Not done yet",
+        "Plan": [
+          "TableReader 3583.33 root  data:Selection",
+          "└─Selection 3583.33 cop[tikv]  not(in(test.t.f, 1, 2, 3)), not(in(test.t.f, 3, 4, 5))",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f not in (1,2,3) and f in (1,2,3) -- intersection of in and not in. Not done yet",
+        "Plan": [
+          "TableReader 0.00 root  data:Selection",
+          "└─Selection 0.00 cop[tikv]  in(test.t.f, 1, 2, 3), not(in(test.t.f, 1, 2, 3))",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "TestInListAndNotEqualSimplification",
+    "Cases": [
+      {
+        "SQL": "select f from t use index() where f <> 1 and f in (1,2,3) -- Simple case",
+        "Plan": [
+          "TableReader 20.00 root  data:Selection",
+          "└─Selection 20.00 cop[tikv]  in(test.t.f, 2, 3)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f in (1,2,3) and f <> 2 -- Simple case with different order. Test case for issue 39676",
+        "Plan": [
+          "TableReader 20.00 root  data:Selection",
+          "└─Selection 20.00 cop[tikv]  in(test.t.f, 1, 3)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f <> 3 and f in (1,2,3) and f <> 2 -- Multiple <> values. All are in inlist",
+        "Plan": [
+          "TableReader 10.00 root  data:Selection",
+          "└─Selection 10.00 cop[tikv]  in(test.t.f, 1)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f in (1,2,3) and f <> 2 and f <> 99 -- Multiple <> values. Some are in inlist",
+        "Plan": [
+          "TableReader 20.00 root  data:Selection",
+          "└─Selection 20.00 cop[tikv]  in(test.t.f, 1, 3)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f in (1,2,3) and f <> 5 and f <> 33  -- Multiple <> values. None are in inlist",
+        "Plan": [
+          "TableReader 30.00 root  data:Selection",
+          "└─Selection 30.00 cop[tikv]  in(test.t.f, 1, 2, 3)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from t use index() where f <> 3 and f in (1,2,3) and f <> 1 and f <> 2 -- Multiple <> values and cover whole inlist. We keep at least one in inlist",
+        "Plan": [
+          "TableReader 10.00 root  data:Selection",
+          "└─Selection 10.00 cop[tikv]  in(test.t.f, 2)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select 1 from t A, t B where A.f <> 3 and B.f in (1,2,3) and A.f <> 1 and A.f <> 2 -- on different columns. No simplification should be done.",
+        "Plan": [
+          "Projection 199700.00 root  1->Column#7",
+          "└─HashJoin 199700.00 root  CARTESIAN inner join",
+          "  ├─TableReader(Build) 30.00 root  data:Selection",
+          "  │ └─Selection 30.00 cop[tikv]  in(test.t.f, 1, 2, 3)",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:B keep order:false, stats:pseudo",
+          "  └─TableReader(Probe) 6656.67 root  data:Selection",
+          "    └─Selection 6656.67 cop[tikv]  ne(test.t.f, 1), ne(test.t.f, 2), ne(test.t.f, 3)",
+          "      └─TableFullScan 10000.00 cop[tikv] table:A keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select 1 from t A, t B where B.f <> 2 and A.f <> 3 and B.f in (1,2,3) and A.f in (3,1,4) and A.f <> 1 and A.f <> 2 -- simplification for two columns.",
+        "Plan": [
+          "Projection 200.00 root  1->Column#7",
+          "└─HashJoin 200.00 root  CARTESIAN inner join",
+          "  ├─TableReader(Build) 10.00 root  data:Selection",
+          "  │ └─Selection 10.00 cop[tikv]  in(test.t.f, 4)",
+          "  │   └─TableFullScan 10000.00 cop[tikv] table:A keep order:false, stats:pseudo",
+          "  └─TableReader(Probe) 20.00 root  data:Selection",
+          "    └─Selection 20.00 cop[tikv]  in(test.t.f, 1, 3)",
+          "      └─TableFullScan 10000.00 cop[tikv] table:B keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from ts use index() where f <> '1' and f in ('1','2','3') -- Simple case with string type",
+        "Plan": [
+          "TableReader 20.00 root  data:Selection",
+          "└─Selection 20.00 cop[tikv]  in(test.ts.f, \"2\", \"3\")",
+          "  └─TableFullScan 10000.00 cop[tikv] table:ts keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select count(*) cnt from ts where f <> '1' and f in ('1','2','3') group by a having cnt > 100  -- aggregate  ",
+        "Plan": [
+          "Selection 12.80 root  gt(Column#4, 100)",
+          "└─HashAgg 16.00 root  group by:test.ts.a, funcs:count(Column#5)->Column#4",
+          "  └─TableReader 16.00 root  data:HashAgg",
+          "    └─HashAgg 16.00 cop[tikv]  group by:test.ts.a, funcs:count(1)->Column#5",
+          "      └─Selection 20.00 cop[tikv]  in(test.ts.f, \"2\", \"3\")",
+          "        └─TableFullScan 10000.00 cop[tikv] table:ts keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  }
+]

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -829,6 +829,7 @@ func (b *PlanBuilder) buildJoin(ctx context.Context, joinNode *ast.Join) (Logica
 	b.optFlag = b.optFlag | flagPredicatePushDown
 	// Add join reorder flag regardless of inner join or outer join.
 	b.optFlag = b.optFlag | flagJoinReOrder
+	b.optFlag |= flagPredicateSimplification
 
 	leftPlan, err := b.buildResultSetNode(ctx, joinNode.Left, false)
 	if err != nil {
@@ -1134,6 +1135,7 @@ func (b *PlanBuilder) coalesceCommonColumns(p *LogicalJoin, leftPlan, rightPlan 
 func (b *PlanBuilder) buildSelection(ctx context.Context, p LogicalPlan, where ast.ExprNode, aggMapper map[*ast.AggregateFuncExpr]int) (LogicalPlan, error) {
 	b.optFlag |= flagPredicatePushDown
 	b.optFlag |= flagDeriveTopNFromWindow
+	b.optFlag |= flagPredicateSimplification
 	if b.curClause != havingClause {
 		b.curClause = whereClause
 	}
@@ -4460,6 +4462,7 @@ func (b *PlanBuilder) buildDataSourceFromCTEMerge(ctx context.Context, cte *ast.
 }
 
 func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, asName *model.CIStr) (LogicalPlan, error) {
+	b.optFlag |= flagPredicateSimplification
 	dbName := tn.Schema
 	sessionVars := b.ctx.GetSessionVars()
 

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -76,6 +76,7 @@ const (
 	flagCollectPredicateColumnsPoint
 	flagPushDownAgg
 	flagDeriveTopNFromWindow
+	flagPredicateSimplification
 	flagPushDownTopN
 	flagSyncWaitStatsLoadPoint
 	flagJoinReOrder
@@ -99,6 +100,7 @@ var optRuleList = []logicalOptRule{
 	&collectPredicateColumnsPoint{},
 	&aggregationPushDownSolver{},
 	&deriveTopNFromWindow{},
+	&predicateSimplification{},
 	&pushDownTopNOptimizer{},
 	&syncWaitStatsLoadPoint{},
 	&joinReOrderSolver{},

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -280,6 +280,9 @@ type LogicalPlan interface {
 	// deriveTopN derives an implicit TopN from a filter on row_number window function..
 	deriveTopN(opt *logicalOptimizeOp) LogicalPlan
 
+	// predicateSimplification consolidates different predcicates on a column and its equivalence classes.
+	predicateSimplification(opt *logicalOptimizeOp) LogicalPlan
+
 	// recursiveDeriveStats derives statistic info between plans.
 	recursiveDeriveStats(colGroups [][]*expression.Column) (*property.StatsInfo, error)
 

--- a/planner/core/rule_predicate_simplification.go
+++ b/planner/core/rule_predicate_simplification.go
@@ -1,0 +1,159 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/parser/ast"
+)
+
+// predicateSimplification consolidates different predcicates on a column and its equivalence classes.  Initial out is for
+// in-list and not equal list intersection.
+type predicateSimplification struct {
+}
+
+type PredicateType = byte
+
+const (
+	InPredicate       PredicateType = 0x00
+	NotEqualPredicate PredicateType = 0x01
+	OtherPredicate    PredicateType = 0x02
+)
+
+func findPredicateType(expr expression.Expression) (*expression.Column, PredicateType) {
+	switch v := expr.(type) {
+	case *expression.ScalarFunction:
+		args := v.GetArgs()
+		col, colOk := args[0].(*expression.Column)
+		if !colOk {
+			return nil, OtherPredicate
+		}
+		if v.FuncName.L == ast.NE {
+			if _, ok := args[1].(*expression.Constant); !ok {
+				return nil, OtherPredicate
+			} else {
+				return col, NotEqualPredicate
+			}
+		}
+		if v.FuncName.L == ast.In {
+			for _, value := range args[1:] {
+				if _, ok := value.(*expression.Constant); !ok {
+					return nil, OtherPredicate
+				}
+			}
+			return col, InPredicate
+		}
+	default:
+		return nil, OtherPredicate
+	}
+	return nil, OtherPredicate
+}
+
+func (s *predicateSimplification) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+	return p.predicateSimplification(opt), nil
+}
+
+func (s *baseLogicalPlan) predicateSimplification(opt *logicalOptimizeOp) LogicalPlan {
+	p := s.self
+	for i, child := range p.Children() {
+		newChild := child.predicateSimplification(opt)
+		p.SetChild(i, newChild)
+	}
+	return p
+}
+
+func updateInPredicate(inPredicate expression.Expression, notEQPredicate expression.Expression) expression.Expression {
+	_, inPredicateType := findPredicateType(inPredicate)
+	_, notEQPredicateType := findPredicateType(notEQPredicate)
+	if inPredicateType != InPredicate || notEQPredicateType != NotEqualPredicate {
+		return inPredicate
+	}
+	v := inPredicate.(*expression.ScalarFunction)
+	notEQValue := notEQPredicate.(*expression.ScalarFunction).GetArgs()[1].(*expression.Constant)
+	newValues := make([]expression.Expression, 0, len(v.GetArgs()))
+	var lastValue *expression.Constant
+	for _, element := range v.GetArgs() {
+		value, valueOK := element.(*expression.Constant)
+		redudantValue := valueOK && value.Equal(v.GetCtx(), notEQValue)
+		if !redudantValue {
+			newValues = append(newValues, element)
+		}
+		if valueOK {
+			lastValue = value
+		}
+	}
+	// Special case if all IN list values are prunned. Ideally, this is False condition
+	// which can be optimized with LogicalDual. But, this ia already done. TODO: the false
+	// optimization and its propagation through query tree will be added part of predicate simplification.
+	if len(newValues) < 2 {
+		newValues = append(newValues, lastValue)
+	}
+	newPred := expression.NewFunctionInternal(v.GetCtx(), v.FuncName.L, v.RetType, newValues...)
+	return newPred
+}
+
+func indexInSlice(index int, list []int) bool {
+	for _, v := range list {
+		if v == index {
+			return true
+			break
+		}
+	}
+	return false
+}
+
+func applyPredicateSimplification(predicates []expression.Expression) []expression.Expression {
+	if len(predicates) <= 1 {
+		return predicates
+	}
+	removeValues := make([]int, 0, len(predicates))
+	for i := range predicates {
+		for j := i + 1; j < len(predicates); j++ {
+			ithPredicate := predicates[i]
+			jthPredicate := predicates[j]
+			iCol, iType := findPredicateType(ithPredicate)
+			jCol, jType := findPredicateType(jthPredicate)
+			if iCol == jCol {
+				if iType == NotEqualPredicate && jType == InPredicate {
+					predicates[j] = updateInPredicate(jthPredicate, ithPredicate)
+					removeValues = append(removeValues, i)
+				} else if iType == InPredicate && jType == NotEqualPredicate {
+					predicates[i] = updateInPredicate(ithPredicate, jthPredicate)
+					removeValues = append(removeValues, j)
+				}
+			}
+		}
+	}
+	newValues := make([]expression.Expression, 0, len(predicates))
+	for i, value := range predicates {
+		if !(indexInSlice(i, removeValues)) {
+			newValues = append(newValues, value)
+		}
+	}
+	return newValues
+}
+
+func (s *DataSource) predicateSimplification(opt *logicalOptimizeOp) LogicalPlan {
+	p := s.self.(*DataSource)
+	p.pushedDownConds = applyPredicateSimplification(p.pushedDownConds)
+	p.allConds = applyPredicateSimplification(p.allConds)
+	return p
+}
+
+func (*predicateSimplification) name() string {
+	return "predicate_simplification"
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #39676

Problem Summary:

### Background

TiDB optimizer has limited predicate simplifications and does not support many cases. One example is filtering redundant conditions across <> and In for same column. For example, a <> 1 and a in (1,2,3) can be simplified to a in (2,3). Also, a <> 5 and a in (1,2,3) can be simplified to a in (1,2,3) 

### Solution 
We added a new place holder logical rewrite optimization for predicate simplification. The general solution is 
1- Process all predicates as a set of ranges for all columns 
2- build equivalence classes for columns based col = col 
3- Merge all ranges of each equivalence class 
4- Build range predicates for each column in each equivalence class
This solution is on the optimizer roadmap and similar to what Teradata did https://docs.teradata.com/r/8mHBBLGP88~HK9Auie2QvQ/dinTQRLUmuWh_KUBr7ffdg

In this PR, we only do <> and In list merge to address the customer issue.  The algorithm is simple and applied only to table scan predicates. The main idea is for each pair of conditions of a <> constant_0 and a in (constant_1, ... constant_n) we 
- Remove the a <> constant_0 since it is always reduntant
- Remove constant_0 from the in list if any. We keep at least one element in the in list and postpone the <dualtable> (no table access) for later on. 

Tests <!-- At least one of them must be included. -->

- [ ] Unit test

Side effects
N/A

Documentation

N/A

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
