### PR TITLE
pitr: skip when rewrite rule not found for ingest recorder

### DIFF
--- a/br/pkg/restore/ingestrec/ingest_recorder.go
+++ b/br/pkg/restore/ingestrec/ingest_recorder.go
@@ -106,12 +106,15 @@ func (i *IngestRecorder) AddJob(job *model.Job) error {
 }
 
 // RerwiteIndexInfo rewrites the table id of the items in the IngestRecorder
-func (i *IngestRecorder) RewriteTableID(rewriteFunc func(tableID int64) (int64, error)) error {
+func (i *IngestRecorder) RewriteTableID(rewriteFunc func(tableID int64) (int64, bool, error)) error {
 	newItems := make(map[int64]map[int64]*IngestIndexInfo)
 	for tableID, item := range i.items {
-		newTableID, err := rewriteFunc(tableID)
+		newTableID, skip, err := rewriteFunc(tableID)
 		if err != nil {
 			return errors.Annotatef(err, "failed to rewrite table id: %d", tableID)
+		}
+		if skip {
+			continue
 		}
 		newItems[newTableID] = item
 	}

--- a/br/pkg/restore/ingestrec/ingest_recorder.go
+++ b/br/pkg/restore/ingestrec/ingest_recorder.go
@@ -105,7 +105,7 @@ func (i *IngestRecorder) AddJob(job *model.Job) error {
 	return nil
 }
 
-// RerwiteIndexInfo rewrites the table id of the items in the IngestRecorder
+// RewriteTableID rewrites the table id of the items in the IngestRecorder
 func (i *IngestRecorder) RewriteTableID(rewriteFunc func(tableID int64) (int64, bool, error)) error {
 	newItems := make(map[int64]map[int64]*IngestIndexInfo)
 	for tableID, item := range i.items {

--- a/br/pkg/restore/ingestrec/ingest_recorder_test.go
+++ b/br/pkg/restore/ingestrec/ingest_recorder_test.go
@@ -373,12 +373,17 @@ func TestRewriteTableID(t *testing.T) {
 	))
 	require.NoError(t, err)
 	recorder.UpdateIndexInfo(allSchemas)
-	recorder.RewriteTableID(func(tableID int64) (int64, error) {
-		return tableID + 1, nil
+	recorder.RewriteTableID(func(tableID int64) (int64, bool, error) {
+		return tableID + 1, false, nil
 	})
 	err = recorder.Iterate(func(tableID, indexID int64, info *ingestrec.IngestIndexInfo) error {
 		require.Equal(t, TableID+1, tableID)
 		return nil
 	})
+	require.NoError(t, err)
+	recorder.RewriteTableID(func(tableID int64) (int64, bool, error) {
+		return tableID + 1, true, nil
+	})
+	err = recorder.Iterate(noItem)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #41668 

Problem Summary:
when rewrite rule not found for ingest recorder, should skip instead of return error
### What is changed and how it works?
skip instead of error
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
