### PR TITLE
*: Fix TiFlash serverType check  in disaggregated mode

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5741,7 +5741,7 @@ func isTableTiFlashSupported(schema *model.DBInfo, tb table.Table) error {
 
 func checkTiFlashReplicaCount(ctx sessionctx.Context, replicaCount uint64) error {
 	// Check the tiflash replica count should be less than the total tiflash stores.
-	tiflashStoreCnt, err := infoschema.GetTiFlashStoreCount(ctx)
+	tiflashStoreCnt, err := infoschema.GetTiFlashWriteStoreCount(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/executor/compact_table.go
+++ b/executor/compact_table.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/infoschema"
-	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/driver/backoff"
@@ -55,7 +54,7 @@ func getTiFlashStores(ctx sessionctx.Context) ([]infoschema.ServerInfo, error) {
 		return nil, err
 	}
 	for _, store := range stores {
-		if store.ServerType == kv.TiFlash.Name() {
+		if infoschema.IsTiFlashWriteRelated(store.ServerType) {
 			aliveTiFlashStores = append(aliveTiFlashStores, store)
 		}
 	}

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1639,6 +1639,11 @@ const (
 	ForeignKeyType = "FOREIGN KEY"
 )
 
+const (
+	// TiFlashWrite is the TiFlash write node in disaggregated mode.
+	TiFlashWrite = "tiflash_write"
+)
+
 // ServerInfo represents the basic server information of single cluster component
 type ServerInfo struct {
 	ServerType     string
@@ -1850,6 +1855,11 @@ func GetPDServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 	return servers, nil
 }
 
+// IsTiFlashWriteRelated check if the TiFlash is non-disaggregated or write node in disaggregated mode.
+func IsTiFlashWriteRelated(serverType string) bool {
+	return serverType == kv.TiFlash.Name() || serverType == TiFlashWrite
+}
+
 func isTiFlashStore(store *metapb.Store) bool {
 	for _, label := range store.Labels {
 		if label.GetKey() == placement.EngineLabelKey && label.GetValue() == placement.EngineLabelTiFlash {
@@ -1917,7 +1927,7 @@ func GetStoreServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 		if isTiFlashStore(store) {
 			if isTiFlashWriteNode(store) {
 				// tiflash_write is not a storeType in client-go, so we just judge based on the label here.
-				tp = "tiflash_write"
+				tp = TiFlashWrite
 			} else {
 				tp = kv.TiFlash.Name()
 			}
@@ -1945,8 +1955,8 @@ func FormatStoreServerVersion(version string) string {
 	return version
 }
 
-// GetTiFlashStoreCount returns the count of tiflash server.
-func GetTiFlashStoreCount(ctx sessionctx.Context) (cnt uint64, err error) {
+// GetTiFlashWriteStoreCount returns the count of tiflash server that is non-disaggregated or write node in disaggregated mode.
+func GetTiFlashWriteStoreCount(ctx sessionctx.Context) (cnt uint64, err error) {
 	failpoint.Inject("mockTiFlashStoreCount", func(val failpoint.Value) {
 		if val.(bool) {
 			failpoint.Return(uint64(10), nil)
@@ -1958,7 +1968,7 @@ func GetTiFlashStoreCount(ctx sessionctx.Context) (cnt uint64, err error) {
 		return cnt, err
 	}
 	for _, store := range stores {
-		if store.ServerType == kv.TiFlash.Name() {
+		if IsTiFlashWriteRelated(store.ServerType) {
 			cnt++
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42245

Problem Summary:
Fix TiFlash serverType check in disaggregated mode.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
`alter table t1 set tiflash replica 1;`
Before modified:
![image](https://user-images.githubusercontent.com/14118780/225225654-5e32b19c-ad4c-45f8-8c7e-6692b71c9a76.png)
After modified:
![image](https://user-images.githubusercontent.com/14118780/225225701-c5fac0c6-8647-425f-85b7-ef461a3d5457.png)

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
