### PR TITLE
planner: fix appropriate index stats may be missed when estimating NDV for inner side of index join

### DIFF
--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -1179,7 +1179,7 @@ func getColsNDVLowerBoundFromHistColl(cols []*expression.Column, histColl *stati
 		orderedIdxCols := make([]int64, len(idxCols))
 		copy(orderedIdxCols, idxCols)
 		slices.Sort(orderedIdxCols)
-		if !slices.Equal(idxCols, colUIDs) {
+		if !slices.Equal(orderedIdxCols, colUIDs) {
 			continue
 		}
 		if idxStats, ok := histColl.Indices[idxID]; ok && idxStats != nil {


### PR DESCRIPTION
### What problem does this PR solve?


Issue Number: ref #31316  #41996

Problem Summary:

Slices are passed to `slices.Equal` without sorting caused by carelessness.

This won't cause any real problems. It just makes #41996 not as effective as expected.

### What is changed and how it works?

Pass the ordered slice to `slices.Equal`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
