### PR TITLE
br: filter resource group in br full restore

### DIFF
--- a/br/tests/br_full_cluster_restore/full_data.sql
+++ b/br/tests/br_full_cluster_restore/full_data.sql
@@ -37,3 +37,7 @@ grant ROLE_ADMIN on *.* to cloud_admin; -- mysql.global_grants
 grant select on db1.* to cloud_admin; -- mysql.db
 grant select on db2.t1 to cloud_admin; -- mysql.tables_priv
 grant select, update(val) on db2.t2 to cloud_admin; -- mysql.tables_priv mysql.columns_priv
+
+-- resource group
+create resource group rg1 ru_per_sec = 100;
+alter user user1 resource group rg1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42266

Problem Summary:

### What is changed and how it works?
Because we decided not to support backup&restore resource control related data in v7.0, this PR try to remove the resource group meta in user_attributes.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
