### PR TITLE
planner: set correct key type of equal condition in pb for null-aware semi join

### DIFF
--- a/planner/core/plan_to_pb.go
+++ b/planner/core/plan_to_pb.go
@@ -416,31 +416,28 @@ func (p *PhysicalIndexScan) ToPB(_ sessionctx.Context, _ kv.StoreType) (*tipb.Ex
 func (p *PhysicalHashJoin) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*tipb.Executor, error) {
 	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
-	var leftJoinKeys, rightJoinKeys []expression.Expression
 
 	if len(p.LeftJoinKeys) > 0 && len(p.LeftNAJoinKeys) > 0 {
 		return nil, errors.Errorf("join key and na join key can not both exist")
 	}
 
 	isNullAwareSemiJoin := len(p.LeftNAJoinKeys) > 0
+	var leftJoinKeys, rightJoinKeys []*expression.Column
 	if isNullAwareSemiJoin {
-		leftJoinKeys = make([]expression.Expression, 0, len(p.LeftNAJoinKeys))
-		rightJoinKeys = make([]expression.Expression, 0, len(p.RightNAJoinKeys))
-		for _, leftKey := range p.LeftNAJoinKeys {
-			leftJoinKeys = append(leftJoinKeys, leftKey)
-		}
-		for _, rightKey := range p.RightNAJoinKeys {
-			rightJoinKeys = append(rightJoinKeys, rightKey)
-		}
+		leftJoinKeys = p.LeftNAJoinKeys
+		rightJoinKeys = p.RightNAJoinKeys
 	} else {
-		leftJoinKeys = make([]expression.Expression, 0, len(p.LeftJoinKeys))
-		rightJoinKeys = make([]expression.Expression, 0, len(p.RightJoinKeys))
-		for _, leftKey := range p.LeftJoinKeys {
-			leftJoinKeys = append(leftJoinKeys, leftKey)
-		}
-		for _, rightKey := range p.RightJoinKeys {
-			rightJoinKeys = append(rightJoinKeys, rightKey)
-		}
+		leftJoinKeys = p.LeftJoinKeys
+		rightJoinKeys = p.RightJoinKeys
+	}
+
+	leftKeys := make([]expression.Expression, 0, len(leftJoinKeys))
+	rightKeys := make([]expression.Expression, 0, len(rightJoinKeys))
+	for _, leftKey := range leftJoinKeys {
+		leftKeys = append(leftKeys, leftKey)
+	}
+	for _, rightKey := range rightJoinKeys {
+		rightKeys = append(rightKeys, rightKey)
 	}
 
 	lChildren, err := p.children[0].ToPB(ctx, storeType)
@@ -452,11 +449,11 @@ func (p *PhysicalHashJoin) ToPB(ctx sessionctx.Context, storeType kv.StoreType) 
 		return nil, errors.Trace(err)
 	}
 
-	left, err := expression.ExpressionsToPBList(sc, leftJoinKeys, client)
+	left, err := expression.ExpressionsToPBList(sc, leftKeys, client)
 	if err != nil {
 		return nil, err
 	}
-	right, err := expression.ExpressionsToPBList(sc, rightJoinKeys, client)
+	right, err := expression.ExpressionsToPBList(sc, rightKeys, client)
 	if err != nil {
 		return nil, err
 	}
@@ -509,9 +506,16 @@ func (p *PhysicalHashJoin) ToPB(ctx sessionctx.Context, storeType kv.StoreType) 
 	case AntiLeftOuterSemiJoin:
 		pbJoinType = tipb.JoinType_TypeAntiLeftOuterSemiJoin
 	}
-	probeFiledTypes := make([]*tipb.FieldType, 0, len(p.EqualConditions))
-	buildFiledTypes := make([]*tipb.FieldType, 0, len(p.EqualConditions))
-	for _, equalCondition := range p.EqualConditions {
+
+	var equalConditions []*expression.ScalarFunction
+	if isNullAwareSemiJoin {
+		equalConditions = p.NAEqualConditions
+	} else {
+		equalConditions = p.EqualConditions
+	}
+	probeFiledTypes := make([]*tipb.FieldType, 0, len(equalConditions))
+	buildFiledTypes := make([]*tipb.FieldType, 0, len(equalConditions))
+	for _, equalCondition := range equalConditions {
 		retType := equalCondition.RetType.Clone()
 		chs, coll := equalCondition.CharsetAndCollation()
 		retType.SetCharset(chs)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/42303

Problem Summary:

### What is changed and how it works?
Test with the case in https://github.com/pingcap/tiflash/issues/7079, the result is correct now.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
