### PR TITLE
*: remove the constraint that auto column must be defined as a key | tidb-test=pr/2104

### DIFF
--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -1280,7 +1280,7 @@ func TestParallelDropIndex(t *testing.T) {
 	sql2 := "alter table t drop index idx2 ;"
 	f := func(err1, err2 error) {
 		require.NoError(t, err1)
-		require.EqualError(t, err2, "[autoid:1075]Incorrect table definition; there can be only one auto column and it must be defined as a key")
+		require.NoError(t, err2)
 	}
 	testControlParallelExecSQL(t, tk, store, dom, "", sql1, sql2, f)
 }

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -543,9 +543,7 @@ func TestErrnoErrorCode(t *testing.T) {
 	tk.MustGetErrCode(sql, errno.ErrPrimaryCantHaveNull)
 	sql = "create table t2 (id int null, age int, primary key(id));"
 	tk.MustGetErrCode(sql, errno.ErrPrimaryCantHaveNull)
-	sql = "create table t2 (id int auto_increment);"
-	tk.MustGetErrCode(sql, errno.ErrWrongAutoKey)
-	sql = "create table t2 (id int auto_increment, a int key);"
+	sql = "create table t2 (id int auto_increment, c int auto_increment);"
 	tk.MustGetErrCode(sql, errno.ErrWrongAutoKey)
 	sql = "create table t2 (a datetime(2) default current_timestamp(3));"
 	tk.MustGetErrCode(sql, errno.ErrInvalidDefault)

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -2261,12 +2261,12 @@ func TestDropAutoIncrementIndex(t *testing.T) {
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1 (a int auto_increment, unique key (a))")
 	dropIndexSQL := "alter table t1 drop index a"
-	tk.MustGetErrCode(dropIndexSQL, errno.ErrWrongAutoKey)
+	tk.MustExec(dropIndexSQL)
 
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1 (a int(11) not null auto_increment, b int(11), c bigint, unique key (a, b, c))")
 	dropIndexSQL = "alter table t1 drop index a"
-	tk.MustGetErrCode(dropIndexSQL, errno.ErrWrongAutoKey)
+	tk.MustExec(dropIndexSQL)
 }
 
 func TestInsertIntoGeneratedColumnWithDefaultExpr(t *testing.T) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -6955,11 +6955,6 @@ func (d *ddl) dropIndex(ctx sessionctx.Context, ti ast.Ident, indexName model.CI
 		return err
 	}
 
-	// Check for drop index on auto_increment column.
-	err = CheckDropIndexOnAutoIncrementColumn(t.Meta(), indexInfo)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	err = checkIndexNeededInForeignKey(is, schema.Name.L, t.Meta(), indexInfo)
 	if err != nil {
 		return err

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1153,13 +1153,6 @@ func checkDropIndex(d *ddlCtx, t *meta.Meta, job *model.Job) (*model.TableInfo, 
 		return nil, nil, ifExists, dbterror.ErrCantDropFieldOrKey.GenWithStack("index %s doesn't exist", indexName)
 	}
 
-	// Double check for drop index on auto_increment column.
-	err = CheckDropIndexOnAutoIncrementColumn(tblInfo, indexInfo)
-	if err != nil {
-		job.State = model.JobStateCancelled
-		return nil, nil, false, autoid.ErrWrongAutoKey
-	}
-
 	// Check that drop primary index will not cause invisible implicit primary index.
 	if err := checkInvisibleIndexesOnPK(tblInfo, []*model.IndexInfo{indexInfo}, job); err != nil {
 		job.State = model.JobStateCancelled

--- a/ddl/schematracker/dm_tracker.go
+++ b/ddl/schematracker/dm_tracker.go
@@ -473,11 +473,6 @@ func (d SchemaTracker) dropIndex(ctx sessionctx.Context, ti ast.Ident, indexName
 		return dbterror.ErrCantDropFieldOrKey.GenWithStack("index %s doesn't exist", indexName)
 	}
 
-	err = ddl.CheckDropIndexOnAutoIncrementColumn(tblInfo, indexInfo)
-	if err != nil {
-		return err
-	}
-
 	newIndices := make([]*model.IndexInfo, 0, len(tblInfo.Indices))
 	for _, idx := range tblInfo.Indices {
 		if idx.Name.L != indexInfo.Name.L {

--- a/planner/core/BUILD.bazel
+++ b/planner/core/BUILD.bazel
@@ -222,7 +222,6 @@ go_test(
         "//expression/aggregation",
         "//infoschema",
         "//kv",
-        "//meta/autoid",
         "//metrics",
         "//parser",
         "//parser/ast",

--- a/planner/core/integration_partition_test.go
+++ b/planner/core/integration_partition_test.go
@@ -560,12 +560,10 @@ func TestListPartitionAutoIncre(t *testing.T) {
 	tk.MustExec("drop table if exists tlist")
 	tk.MustExec(`set tidb_enable_list_partition = 1`)
 
-	err := tk.ExecToErr(`create table tlist (a int, b int AUTO_INCREMENT) partition by list (a) (
+	tk.MustExec(`create table tlist1 (a int, b int AUTO_INCREMENT) partition by list (a) (
     partition p0 values in (0, 1, 2, 3, 4),
     partition p1 values in (5, 6, 7, 8, 9),
     partition p2 values in (10, 11, 12, 13, 14))`)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "it must be defined as a key")
 
 	tk.MustExec(`create table tlist (a int, b int AUTO_INCREMENT, key(b)) partition by list (a) (
     partition p0 values in (0, 1, 2, 3, 4),
@@ -577,12 +575,10 @@ func TestListPartitionAutoIncre(t *testing.T) {
 	tk.MustExec(`insert into tlist (a) values (10)`)
 	tk.MustExec(`insert into tlist (a) values (1)`)
 
-	err = tk.ExecToErr(`create table tcollist (a int, b int AUTO_INCREMENT) partition by list columns (a) (
+	tk.MustExec(`create table tcollist1 (a int, b int AUTO_INCREMENT) partition by list columns (a) (
     partition p0 values in (0, 1, 2, 3, 4),
     partition p1 values in (5, 6, 7, 8, 9),
     partition p2 values in (10, 11, 12, 13, 14))`)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "it must be defined as a key")
 
 	tk.MustExec(`create table tcollist (a int, b int AUTO_INCREMENT, key(b)) partition by list (a) (
     partition p0 values in (0, 1, 2, 3, 4),

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -735,7 +735,7 @@ func (p *preprocessor) checkAutoIncrement(stmt *ast.CreateTableStmt) {
 		p.err = autoid.ErrWrongAutoKey.GenWithStackByArgs()
 		return
 	}
-	for col, _ := range autoIncrementCols {
+	for col := range autoIncrementCols {
 		switch col.Tp.GetType() {
 		case mysql.TypeTiny, mysql.TypeShort, mysql.TypeLong,
 			mysql.TypeFloat, mysql.TypeDouble, mysql.TypeLonglong, mysql.TypeInt24:

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -730,24 +730,12 @@ func (p *preprocessor) checkAutoIncrement(stmt *ast.CreateTableStmt) {
 	if len(autoIncrementCols) < 1 {
 		return
 	}
+	// Only have one auto_increment col.
 	if len(autoIncrementCols) > 1 {
 		p.err = autoid.ErrWrongAutoKey.GenWithStackByArgs()
 		return
 	}
-	// Only have one auto_increment col.
-	for col, isKey := range autoIncrementCols {
-		if !isKey {
-			isKey = isConstraintKeyTp(stmt.Constraints, col)
-		}
-		autoIncrementMustBeKey := true
-		for _, opt := range stmt.Options {
-			if opt.Tp == ast.TableOptionEngine && strings.EqualFold(opt.StrValue, "MyISAM") {
-				autoIncrementMustBeKey = false
-			}
-		}
-		if autoIncrementMustBeKey && !isKey {
-			p.err = autoid.ErrWrongAutoKey.GenWithStackByArgs()
-		}
+	for col, _ := range autoIncrementCols {
 		switch col.Tp.GetType() {
 		case mysql.TypeTiny, mysql.TypeShort, mysql.TypeLong,
 			mysql.TypeFloat, mysql.TypeDouble, mysql.TypeLonglong, mysql.TypeInt24:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40580

Problem Summary:

### What is changed and how it works?

Remove the constraint for auto id column.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [X] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [X] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Remove the constraint that auto column must be defined as a key
```
