### PR TITLE
session,executor: add variables to support set tiflash spill threshold by sql statement

### DIFF
--- a/sessionctx/variable/BUILD.bazel
+++ b/sessionctx/variable/BUILD.bazel
@@ -89,7 +89,7 @@ go_test(
     ],
     embed = [":variable"],
     flaky = True,
-    shard_count = 2,
+    shard_count = 50,
     deps = [
         "//config",
         "//kv",

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -813,6 +813,24 @@ type SessionVars struct {
 	// If the value is bigger than -1, it will be pushed down to tiflash and used to create db context in tiflash.
 	TiFlashMaxThreads int64
 
+	// TiFlashMaxBytesBeforeExternalJoin is the maximum bytes used by a TiFlash join before spill to disk
+	// Default value is -1, means it will not be pushed down to TiFlash
+	// If the value is bigger than -1, it will be pushed down to TiFlash, and if the value is 0, it means
+	// not limit and spill will never happen
+	TiFlashMaxBytesBeforeExternalJoin int64
+
+	// TiFlashMaxBytesBeforeExternalGroupBy is the maximum bytes used by a TiFlash hash aggregation before spill to disk
+	// Default value is -1, means it will not be pushed down to TiFlash
+	// If the value is bigger than -1, it will be pushed down to TiFlash, and if the value is 0, it means
+	// not limit and spill will never happen
+	TiFlashMaxBytesBeforeExternalGroupBy int64
+
+	// TiFlashMaxBytesBeforeExternalSort is the maximum bytes used by a TiFlash sort/TopN before spill to disk
+	// Default value is -1, means it will not be pushed down to TiFlash
+	// If the value is bigger than -1, it will be pushed down to TiFlash, and if the value is 0, it means
+	// not limit and spill will never happen
+	TiFlashMaxBytesBeforeExternalSort int64
+
 	// TiDBAllowAutoRandExplicitInsert indicates whether explicit insertion on auto_random column is allowed.
 	AllowAutoRandExplicitInsert bool
 
@@ -1826,6 +1844,9 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 	vars.HashExchangeWithNewCollation = DefTiDBHashExchangeWithNewCollation
 	vars.enforceMPPExecution = DefTiDBEnforceMPPExecution
 	vars.TiFlashMaxThreads = DefTiFlashMaxThreads
+	vars.TiFlashMaxBytesBeforeExternalJoin = DefTiFlashMaxBytesBeforeExternalJoin
+	vars.TiFlashMaxBytesBeforeExternalGroupBy = DefTiFlashMaxBytesBeforeExternalGroupBy
+	vars.TiFlashMaxBytesBeforeExternalSort = DefTiFlashMaxBytesBeforeExternalSort
 	vars.MPPStoreFailTTL = DefTiDBMPPStoreFailTTL
 	vars.DiskTracker = disk.NewTracker(memory.LabelForSession, -1)
 	vars.MemTracker = memory.NewTracker(memory.LabelForSession, vars.MemQuotaQuery)

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -156,6 +156,18 @@ var defaultSysVars = []*SysVar{
 		s.TiFlashMaxThreads = TidbOptInt64(val, DefTiFlashMaxThreads)
 		return nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBMaxBytesBeforeTiFlashExternalJoin, Type: TypeInt, Value: strconv.Itoa(DefTiFlashMaxBytesBeforeExternalJoin), MinValue: -1, MaxValue: math.MaxInt64, SetSession: func(s *SessionVars, val string) error {
+		s.TiFlashMaxBytesBeforeExternalJoin = TidbOptInt64(val, DefTiFlashMaxBytesBeforeExternalJoin)
+		return nil
+	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBMaxBytesBeforeTiFlashExternalGroupBy, Type: TypeInt, Value: strconv.Itoa(DefTiFlashMaxBytesBeforeExternalGroupBy), MinValue: -1, MaxValue: math.MaxInt64, SetSession: func(s *SessionVars, val string) error {
+		s.TiFlashMaxBytesBeforeExternalGroupBy = TidbOptInt64(val, DefTiFlashMaxBytesBeforeExternalGroupBy)
+		return nil
+	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBMaxBytesBeforeTiFlashExternalSort, Type: TypeInt, Value: strconv.Itoa(DefTiFlashMaxBytesBeforeExternalSort), MinValue: -1, MaxValue: math.MaxInt64, SetSession: func(s *SessionVars, val string) error {
+		s.TiFlashMaxBytesBeforeExternalSort = TidbOptInt64(val, DefTiFlashMaxBytesBeforeExternalSort)
+		return nil
+	}},
 	{Scope: ScopeSession, Name: TiDBSnapshot, Value: "", skipInit: true, SetSession: func(s *SessionVars, val string) error {
 		err := setSnapshotTS(s, val)
 		if err != nil {

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -1165,9 +1165,9 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 	// setup the hooks for test
 	// NOTE: the default system variable is true but the switch is false
 	// It is initialized at the first call of `rebuildSysVarCache`
-	enable := false
-	EnableGlobalResourceControlFunc = func() { enable = true }
-	DisableGlobalResourceControlFunc = func() { enable = false }
+	enable := atomic.Bool{}
+	EnableGlobalResourceControlFunc = func() { enable.Store(true) }
+	DisableGlobalResourceControlFunc = func() { enable.Store(false) }
 	setGlobalResourceControlFunc := func(enable bool) {
 		if enable {
 			EnableGlobalResourceControlFunc()
@@ -1185,7 +1185,7 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 
 	// Default true
 	require.Equal(t, resourceControlEnabled.Value, On)
-	require.Equal(t, enable, false)
+	require.Equal(t, false, enable.Load())
 
 	// Set to On(init at start)
 	err := mock.SetGlobalSysVar(context.Background(), TiDBEnableResourceControl, On)
@@ -1193,7 +1193,7 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 	val, err1 := mock.GetGlobalSysVar(TiDBEnableResourceControl)
 	require.NoError(t, err1)
 	require.Equal(t, On, val)
-	require.Equal(t, enable, true)
+	require.Equal(t, true, enable.Load())
 
 	// Set to Off
 	err = mock.SetGlobalSysVar(context.Background(), TiDBEnableResourceControl, Off)
@@ -1201,7 +1201,7 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 	val, err1 = mock.GetGlobalSysVar(TiDBEnableResourceControl)
 	require.NoError(t, err1)
 	require.Equal(t, Off, val)
-	require.Equal(t, enable, false)
+	require.Equal(t, false, enable.Load())
 
 	// Set to On again
 	err = mock.SetGlobalSysVar(context.Background(), TiDBEnableResourceControl, On)
@@ -1209,5 +1209,5 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 	val, err1 = mock.GetGlobalSysVar(TiDBEnableResourceControl)
 	require.NoError(t, err1)
 	require.Equal(t, On, val)
-	require.Equal(t, enable, true)
+	require.Equal(t, true, enable.Load())
 }

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -1165,9 +1165,9 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 	// setup the hooks for test
 	// NOTE: the default system variable is true but the switch is false
 	// It is initialized at the first call of `rebuildSysVarCache`
-	enable := atomic.Bool{}
-	EnableGlobalResourceControlFunc = func() { enable.Store(true) }
-	DisableGlobalResourceControlFunc = func() { enable.Store(false) }
+	enable := false
+	EnableGlobalResourceControlFunc = func() { enable = true }
+	DisableGlobalResourceControlFunc = func() { enable = false }
 	setGlobalResourceControlFunc := func(enable bool) {
 		if enable {
 			EnableGlobalResourceControlFunc()
@@ -1185,7 +1185,7 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 
 	// Default true
 	require.Equal(t, resourceControlEnabled.Value, On)
-	require.Equal(t, false, enable.Load())
+	require.Equal(t, enable, false)
 
 	// Set to On(init at start)
 	err := mock.SetGlobalSysVar(context.Background(), TiDBEnableResourceControl, On)
@@ -1193,7 +1193,7 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 	val, err1 := mock.GetGlobalSysVar(TiDBEnableResourceControl)
 	require.NoError(t, err1)
 	require.Equal(t, On, val)
-	require.Equal(t, true, enable.Load())
+	require.Equal(t, enable, true)
 
 	// Set to Off
 	err = mock.SetGlobalSysVar(context.Background(), TiDBEnableResourceControl, Off)
@@ -1201,7 +1201,7 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 	val, err1 = mock.GetGlobalSysVar(TiDBEnableResourceControl)
 	require.NoError(t, err1)
 	require.Equal(t, Off, val)
-	require.Equal(t, false, enable.Load())
+	require.Equal(t, enable, false)
 
 	// Set to On again
 	err = mock.SetGlobalSysVar(context.Background(), TiDBEnableResourceControl, On)
@@ -1209,5 +1209,5 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 	val, err1 = mock.GetGlobalSysVar(TiDBEnableResourceControl)
 	require.NoError(t, err1)
 	require.Equal(t, On, val)
-	require.Equal(t, true, enable.Load())
+	require.Equal(t, enable, true)
 }

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -112,7 +112,7 @@ func TestTiFlashMaxBytes(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "100", val)
 
-		val, err = sv.Validate(vars, strconv.FormatUint(uint64(math.MaxInt64)+1, 10), ScopeSession)
+		_, err = sv.Validate(vars, strconv.FormatUint(uint64(math.MaxInt64)+1, 10), ScopeSession)
 		// can not autoconvert because the input is out of the range of Int64
 		require.Error(t, err)
 

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -97,6 +97,37 @@ func TestMaxExecutionTime(t *testing.T) {
 	require.Equal(t, uint64(99999), vars.MaxExecutionTime)
 }
 
+func TestTiFlashMaxBytes(t *testing.T) {
+	varNames := []string{TiDBMaxBytesBeforeTiFlashExternalJoin, TiDBMaxBytesBeforeTiFlashExternalGroupBy, TiDBMaxBytesBeforeTiFlashExternalSort}
+	for index, varName := range varNames {
+		sv := GetSysVar(varName)
+		vars := NewSessionVars(nil)
+		val, err := sv.Validate(vars, "-10", ScopeSession)
+		require.NoError(t, err) // it has autoconvert out of range.
+		require.Equal(t, "-1", val)
+		val, err = sv.Validate(vars, "-10", ScopeGlobal)
+		require.NoError(t, err) // it has autoconvert out of range.
+		require.Equal(t, "-1", val)
+		val, err = sv.Validate(vars, "100", ScopeSession)
+		require.NoError(t, err)
+		require.Equal(t, "100", val)
+
+		val, err = sv.Validate(vars, strconv.FormatUint(uint64(math.MaxInt64)+1, 10), ScopeSession)
+		// can not autoconvert because the input is out of the range of Int64
+		require.Error(t, err)
+
+		require.Nil(t, sv.SetSessionFromHook(vars, "10000")) // sets
+		switch index {
+		case 0:
+			require.Equal(t, int64(10000), vars.TiFlashMaxBytesBeforeExternalJoin)
+		case 1:
+			require.Equal(t, int64(10000), vars.TiFlashMaxBytesBeforeExternalGroupBy)
+		case 2:
+			require.Equal(t, int64(10000), vars.TiFlashMaxBytesBeforeExternalSort)
+		}
+	}
+}
+
 func TestCollationServer(t *testing.T) {
 	sv := GetSysVar(CollationServer)
 	vars := NewSessionVars(nil)

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -382,6 +382,16 @@ const (
 	// Default value is -1, means it will not be pushed down to tiflash.
 	// If the value is bigger than -1, it will be pushed down to tiflash and used to create db context in tiflash.
 	TiDBMaxTiFlashThreads = "tidb_max_tiflash_threads"
+
+	// TiDBMaxBytesBeforeTiFlashExternalJoin is the maximum bytes used by a TiFlash join before spill to disk
+	TiDBMaxBytesBeforeTiFlashExternalJoin = "tidb_max_bytes_before_tiflash_external_join"
+
+	// TiDBMaxBytesBeforeTiFlashExternalGroupBy is the maximum bytes used by a TiFlash hash aggregation before spill to disk
+	TiDBMaxBytesBeforeTiFlashExternalGroupBy = "tidb_max_bytes_before_tiflash_external_group_by"
+
+	// TiDBMaxBytesBeforeTiFlashExternalSort is the maximum bytes used by a TiFlash sort/TopN before spill to disk
+	TiDBMaxBytesBeforeTiFlashExternalSort = "tidb_max_bytes_before_tiflash_external_sort"
+
 	// TiDBMPPStoreFailTTL is the unavailable time when a store is detected failed. During that time, tidb will not send any task to
 	// TiFlash even though the failed TiFlash node has been recovered.
 	TiDBMPPStoreFailTTL = "tidb_mpp_store_fail_ttl"
@@ -1039,6 +1049,9 @@ const (
 	DefTiDBHashExchangeWithNewCollation            = true
 	DefTiDBEnforceMPPExecution                     = false
 	DefTiFlashMaxThreads                           = -1
+	DefTiFlashMaxBytesBeforeExternalJoin           = -1
+	DefTiFlashMaxBytesBeforeExternalGroupBy        = -1
+	DefTiFlashMaxBytesBeforeExternalSort           = -1
 	DefTiDBMPPStoreFailTTL                         = "60s"
 	DefTiDBTxnMode                                 = ""
 	DefTiDBRowFormatV1                             = 1


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42308

Problem Summary:

### What is changed and how it works?
Add 3 session variable to set TiFlash's spill threshold by sql statement
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
