### PR TITLE
executor: add default value for LOAD DATA batch size

### DIFF
--- a/executor/asyncloaddata/show_test.go
+++ b/executor/asyncloaddata/show_test.go
@@ -414,9 +414,8 @@ func (s *mockGCSSuite) TestInternalStatus() {
 	s.enableFailpoint("github.com/pingcap/tidb/executor/AfterCreateLoadDataJob", `sleep(3000)`)
 	s.enableFailpoint("github.com/pingcap/tidb/executor/AfterStartJob", `sleep(3000)`)
 	s.enableFailpoint("github.com/pingcap/tidb/executor/AfterCommitOneTask", `sleep(3000)`)
-	s.tk.MustExec("SET SESSION tidb_dml_batch_size = 1;")
 	sql := fmt.Sprintf(`LOAD DATA INFILE 'gs://test-tsv/t*.tsv?endpoint=%s'
-		INTO TABLE load_tsv.t;`, gcsEndpoint)
+		INTO TABLE load_tsv.t WITH batch_size = 1;`, gcsEndpoint)
 	s.tk.MustExec(sql)
 	wg.Wait()
 }

--- a/executor/importer/import_test.go
+++ b/executor/importer/import_test.go
@@ -176,12 +176,10 @@ func TestAdjustOptions(t *testing.T) {
 	e := LoadDataController{
 		diskQuota:     1,
 		threadCnt:     100000000,
-		batchSize:     1,
 		maxWriteSpeed: 10,
 	}
 	e.adjustOptions()
 	require.Equal(t, minDiskQuota, e.diskQuota)
 	require.Equal(t, int64(runtime.NumCPU()), e.threadCnt)
-	require.Equal(t, minBatchSize, e.batchSize)
 	require.Equal(t, minWriteSpeed, e.maxWriteSpeed)
 }

--- a/executor/importer/import_test.go
+++ b/executor/importer/import_test.go
@@ -39,7 +39,7 @@ func TestInitDefaultOptions(t *testing.T) {
 	require.Equal(t, true, e.addIndex)
 	require.Equal(t, config.OpLevelOptional, e.analyze)
 	require.Equal(t, int64(runtime.NumCPU()), e.threadCnt)
-	require.Equal(t, config.ByteSize(100<<20), e.batchSize)
+	require.Equal(t, int64(1000), e.batchSize)
 	require.Equal(t, unlimitedWriteSpeed, e.maxWriteSpeed)
 	require.Equal(t, false, e.splitFile)
 	require.Equal(t, int64(100), e.maxRecordedErrors)
@@ -97,7 +97,6 @@ func TestInitOptions(t *testing.T) {
 
 		{OptionStr: batchSizeOption + "='aa'", Err: exeerrors.ErrInvalidOptionVal},
 		{OptionStr: batchSizeOption + "='11aa'", Err: exeerrors.ErrInvalidOptionVal},
-		{OptionStr: batchSizeOption + "=false", Err: exeerrors.ErrInvalidOptionVal},
 		{OptionStr: batchSizeOption + "=null", Err: exeerrors.ErrInvalidOptionVal},
 
 		{OptionStr: maxWriteSpeedOption + "='aa'", Err: exeerrors.ErrInvalidOptionVal},
@@ -150,7 +149,7 @@ func TestInitOptions(t *testing.T) {
 		addIndexOption+"=false, "+
 		analyzeOption+"='required', "+
 		threadOption+"='100000', "+
-		batchSizeOption+"='100mib', "+
+		batchSizeOption+"=2000, "+
 		maxWriteSpeedOption+"='200mib', "+
 		splitFileOption+"=true, "+
 		recordErrorsOption+"=123, "+
@@ -165,7 +164,7 @@ func TestInitOptions(t *testing.T) {
 	require.False(t, e.addIndex, sql)
 	require.Equal(t, config.OpLevelRequired, e.analyze, sql)
 	require.Equal(t, int64(runtime.NumCPU()), e.threadCnt, sql)
-	require.Equal(t, config.ByteSize(100<<20), e.batchSize, sql)
+	require.Equal(t, int64(2000), e.batchSize, sql)
 	require.Equal(t, config.ByteSize(200<<20), e.maxWriteSpeed, sql)
 	require.True(t, e.splitFile, sql)
 	require.Equal(t, int64(123), e.maxRecordedErrors, sql)

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -326,7 +326,7 @@ func NewLoadDataWorker(
 		GenExprs:       plan.GenCols.Exprs,
 		isLoadData:     true,
 		txnInUse:       syncutil.Mutex{},
-		maxRowsInBatch: uint64(sctx.GetSessionVars().DMLBatchSize),
+		maxRowsInBatch: uint64(controller.GetBatchSize()),
 	}
 	restrictive := sctx.GetSessionVars().SQLMode.HasStrictMode() &&
 		plan.OnDuplicate != ast.OnDuplicateKeyHandlingIgnore

--- a/executor/loadremotetest/multi_file_test.go
+++ b/executor/loadremotetest/multi_file_test.go
@@ -123,9 +123,8 @@ func (s *mockGCSSuite) TestMultiBatchWithIgnoreLines() {
 		Content: genData(11, 20),
 	})
 
-	s.tk.MustExec("SET SESSION tidb_dml_batch_size = 3;")
 	sql := fmt.Sprintf(`LOAD DATA INFILE 'gs://test-multi-load/multi-batch.*.tsv?endpoint=%s'
-		INTO TABLE multi_load.t2 IGNORE 2 LINES;`, gcsEndpoint)
+		INTO TABLE multi_load.t2 IGNORE 2 LINES WITH batch_size = 3;`, gcsEndpoint)
 	s.tk.MustExec(sql)
 	s.tk.MustQuery("SELECT * FROM multi_load.t2;").Check(testkit.Rows(
 		"3", "4", "5", "6", "7", "8", "9", "10",

--- a/parser/ast/dml_test.go
+++ b/parser/ast/dml_test.go
@@ -477,20 +477,20 @@ func TestLoadDataRestore(t *testing.T) {
 			expectSQL: "LOAD DATA INFILE '/a.csv' INTO TABLE `t` WITH detached",
 		},
 		{
-			sourceSQL: "load data infile '/a.csv' into table `t` with batch_size='10mb',detached",
-			expectSQL: "LOAD DATA INFILE '/a.csv' INTO TABLE `t` WITH batch_size=_UTF8MB4'10mb', detached",
+			sourceSQL: "load data infile '/a.csv' into table `t` with batch_size=999,detached",
+			expectSQL: "LOAD DATA INFILE '/a.csv' INTO TABLE `t` WITH batch_size=999, detached",
 		},
 		{
-			sourceSQL: "load data infile '/a.csv' into table `t` with detached, batch_size='10mb'",
-			expectSQL: "LOAD DATA INFILE '/a.csv' INTO TABLE `t` WITH detached, batch_size=_UTF8MB4'10mb'",
+			sourceSQL: "load data infile '/a.csv' into table `t` with detached, batch_size=999",
+			expectSQL: "LOAD DATA INFILE '/a.csv' INTO TABLE `t` WITH detached, batch_size=999",
 		},
 		{
-			sourceSQL: "load data infile '/a.csv' into table `t` with detached, thread=-100, batch_size='10mb'",
-			expectSQL: "LOAD DATA INFILE '/a.csv' INTO TABLE `t` WITH detached, thread=-100, batch_size=_UTF8MB4'10mb'",
+			sourceSQL: "load data infile '/a.csv' into table `t` with detached, thread=-100, batch_size=999",
+			expectSQL: "LOAD DATA INFILE '/a.csv' INTO TABLE `t` WITH detached, thread=-100, batch_size=999",
 		},
 		{
-			sourceSQL: "load data infile '/a.csv' format 'sql' into table `t` with detached, batch_size='10mb'",
-			expectSQL: "LOAD DATA INFILE '/a.csv' FORMAT 'sql' INTO TABLE `t` WITH detached, batch_size=_UTF8MB4'10mb'",
+			sourceSQL: "load data infile '/a.csv' format 'sql' into table `t` with detached, batch_size=999",
+			expectSQL: "LOAD DATA INFILE '/a.csv' FORMAT 'sql' INTO TABLE `t` WITH detached, batch_size=999",
 		},
 	}
 	extractNodeFunc := func(node Node) Node {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -518,10 +518,9 @@ func (cli *testServerClient) runTestLoadDataAutoRandom(t *testing.T) {
 		config.Params["sql_mode"] = "''"
 	}, "load_data_batch_dml", func(dbt *testkit.DBTestKit) {
 		// Set batch size, and check if load data got a invalid txn error.
-		dbt.MustExec("set @@session.tidb_dml_batch_size = 128")
 		dbt.MustExec("drop table if exists t")
 		dbt.MustExec("create table t(c1 bigint auto_random primary key, c2 bigint, c3 bigint)")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t (c2, c3)", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t (c2, c3) with batch_size = 128", path))
 		rows := dbt.MustQuery("select count(*) from t")
 		cli.checkRows(t, rows, "50000")
 		require.NoError(t, rows.Close())
@@ -576,10 +575,9 @@ func (cli *testServerClient) runTestLoadDataAutoRandomWithSpecialTerm(t *testing
 		config.Params = map[string]string{"sql_mode": "''"}
 	}, "load_data_batch_dml", func(dbt *testkit.DBTestKit) {
 		// Set batch size, and check if load data got a invalid txn error.
-		dbt.MustExec("set @@session.tidb_dml_batch_size = 128")
 		dbt.MustExec("drop table if exists t1")
 		dbt.MustExec("create table t1(c1 bigint auto_random primary key, c2 bigint, c3 bigint)")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t1 fields terminated by ',' enclosed by '\\'' lines terminated by '|' (c2, c3)", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t1 fields terminated by ',' enclosed by '\\'' lines terminated by '|' (c2, c3) with batch_size = 128", path))
 		rows := dbt.MustQuery("select count(*) from t1")
 		cli.checkRows(t, rows, "50000")
 		rows = dbt.MustQuery("select bit_xor(c2), bit_xor(c3) from t1")
@@ -1029,7 +1027,6 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		config.AllowAllFiles = true
 		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
-		dbt.MustExec("set @@tidb_dml_batch_size = 3")
 		dbt.MustExec("create table test (a varchar(255), b varchar(255) default 'default value', c int not null auto_increment, primary key(c))")
 		dbt.MustExec("create view v1 as select 1")
 		dbt.MustExec("create sequence s1")
@@ -1042,7 +1039,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		require.Error(t, err)
 		require.Equal(t, "Error 1288 (HY000): The target table s1 of the LOAD is not updatable", err.Error())
 
-		rs, err1 := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test", path))
+		rs, err1 := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test with batch_size = 3", path))
 		require.NoError(t, err1)
 		lastID, err1 := rs.LastInsertId()
 		require.NoError(t, err1)
@@ -1092,8 +1089,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 
 		// specify faileds and lines
 		dbt.MustExec("delete from test")
-		dbt.MustExec("set @@tidb_dml_batch_size = 3")
-		rs, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test fields terminated by '\t- ' lines starting by 'xxx ' terminated by '\n'", path))
+		rs, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test fields terminated by '\t- ' lines starting by 'xxx ' terminated by '\n' with batch_size = 3", path))
 		require.NoError(t, err)
 		lastID, err = rs.LastInsertId()
 		require.NoError(t, err)
@@ -1136,8 +1132,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 			_, err = fp.WriteString(fmt.Sprintf("xxx row%d_col1	- row%d_col2\n", i, i))
 			require.NoError(t, err)
 		}
-		dbt.MustExec("set @@tidb_dml_batch_size = 3")
-		rs, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test fields terminated by '\t- ' lines starting by 'xxx ' terminated by '\n'", path))
+		rs, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test fields terminated by '\t- ' lines starting by 'xxx ' terminated by '\n' with batch_size = 3", path))
 		require.NoError(t, err)
 		lastID, err = rs.LastInsertId()
 		require.NoError(t, err)
@@ -1149,12 +1144,10 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		require.Truef(t, rows.Next(), "unexpected data")
 		require.NoError(t, rows.Close())
 		// don't support lines terminated is ""
-		dbt.MustExec("set @@tidb_dml_batch_size = 3")
 		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test lines terminated by ''", path))
 		require.NotNil(t, err)
 
 		// infile doesn't exist
-		dbt.MustExec("set @@tidb_dml_batch_size = 3")
 		_, err = dbt.GetDB().Exec("load data local infile '/tmp/nonexistence.csv' into table test")
 		require.NotNil(t, err)
 	})
@@ -1180,8 +1173,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("create table test (str varchar(10) default null, i int default null)")
-		dbt.MustExec("set @@tidb_dml_batch_size = 3")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' enclosed by '"'`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' enclosed by '"' with batch_size = 3`, path))
 		require.NoError(t, err1)
 		var (
 			str string
@@ -1229,8 +1221,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("create table test (a date, b date, c date not null, d date)")
-		dbt.MustExec("set @@tidb_dml_batch_size = 3")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ','`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' with batch_size = 3`, path))
 		require.NoError(t, err1)
 		var (
 			a sql.NullString
@@ -1286,8 +1277,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("create table test (a varchar(20), b varchar(20))")
-		dbt.MustExec("set @@tidb_dml_batch_size = 3")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' enclosed by '"'`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' enclosed by '"' with batch_size = 3`, path))
 		require.NoError(t, err1)
 		var (
 			a sql.NullString
@@ -1333,8 +1323,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		config.AllowAllFiles = true
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("create table test (id INT NOT NULL PRIMARY KEY,  b INT,  c varchar(10))")
-		dbt.MustExec("set @@tidb_dml_batch_size = 3")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' IGNORE 1 LINES`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' IGNORE 1 LINES with batch_size = 3`, path))
 		require.NoError(t, err1)
 		var (
 			a int
@@ -1359,7 +1348,6 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		config.AllowAllFiles = true
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("create table test (a varchar(255), b varchar(255) default 'default value', c int not null auto_increment, primary key(c))")
-		dbt.MustExec("set @@tidb_dml_batch_size = 3")
 		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test", path))
 		require.Error(t, err)
 		checkErrorCode(t, err, errno.ErrNotAllowedCommand)
@@ -1387,8 +1375,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists pn")
 		dbt.MustExec("create table pn (c1 int, c2 int)")
-		dbt.MustExec("set @@tidb_dml_batch_size = 1")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ','`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ','  with batch_size = 1`, path))
 		require.NoError(t, err1)
 		var (
 			a int
@@ -1439,8 +1426,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists pn")
 		dbt.MustExec("create table pn (c1 int, c2 int)")
-		dbt.MustExec("set @@tidb_dml_batch_size = 1")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, c2)`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, c2) with batch_size = 1`, path))
 		require.NoError(t, err1)
 		var (
 			a int
@@ -1483,8 +1469,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists pn")
 		dbt.MustExec("create table pn (c1 int, c2 int, c3 int)")
-		dbt.MustExec("set @@tidb_dml_batch_size = 1")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @dummy)`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @dummy) with batch_size = 1`, path))
 		require.NoError(t, err1)
 		var (
 			a int
@@ -1530,8 +1515,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists pn")
 		dbt.MustExec("create table pn (c1 int, c2 int, c3 int)")
-		dbt.MustExec("set @@tidb_dml_batch_size = 1")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @val1, @val2) SET c3 = @val2 * 100, c2 = CAST(@val1 AS UNSIGNED)`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @val1, @val2) SET c3 = @val2 * 100, c2 = CAST(@val1 AS UNSIGNED) with batch_size = 1`, path))
 		require.NoError(t, err1)
 		var (
 			a int
@@ -1563,8 +1547,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists pn")
 		dbt.MustExec("create table pn (c1 int, c2 int, c3 int)")
-		dbt.MustExec("set @@tidb_dml_batch_size = 1")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @VAL1, @VAL2) SET c3 = @VAL2 * 100, c2 = CAST(@VAL1 AS UNSIGNED)`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @VAL1, @VAL2) SET c3 = @VAL2 * 100, c2 = CAST(@VAL1 AS UNSIGNED) with batch_size = 1`, path))
 		require.NoError(t, err1)
 		var (
 			a int


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40499

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
