### PR TITLE
*:  Fix TiFlash serverType check in disaggregated mode

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5741,7 +5741,7 @@ func isTableTiFlashSupported(schema *model.DBInfo, tb table.Table) error {
 
 func checkTiFlashReplicaCount(ctx sessionctx.Context, replicaCount uint64) error {
 	// Check the tiflash replica count should be less than the total tiflash stores.
-	tiflashStoreCnt, err := infoschema.GetTiFlashWriteStoreCount(ctx)
+	tiflashStoreCnt, err := infoschema.GetTiFlashStoreCount(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/executor/compact_table.go
+++ b/executor/compact_table.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/driver/backoff"
@@ -54,7 +55,7 @@ func getTiFlashStores(ctx sessionctx.Context) ([]infoschema.ServerInfo, error) {
 		return nil, err
 	}
 	for _, store := range stores {
-		if infoschema.IsTiFlashWriteRelated(store.ServerType) {
+		if store.ServerType == kv.TiFlash.Name() {
 			aliveTiFlashStores = append(aliveTiFlashStores, store)
 		}
 	}

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/deadlock"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/pingcap/tidb/ddl/label"
+	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tidb/errno"
@@ -1521,8 +1522,12 @@ func (e *memtableRetriever) dataForTiDBClusterInfo(ctx sessionctx.Context) error
 			startTimeStr = startTime.Format(time.RFC3339)
 			upTimeStr = time.Since(startTime).String()
 		}
+		serverType := server.ServerType
+		if server.ServerType == kv.TiFlash.Name() && server.EngineRole == placement.EngineRoleLabelWrite {
+			serverType = infoschema.TiFlashWrite
+		}
 		row := types.MakeDatums(
-			server.ServerType,
+			serverType,
 			server.Address,
 			server.StatusAddr,
 			server.Version,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42245

Problem Summary:
In https://github.com/pingcap/tidb/pull/41998, I modified `serverType` in `GetStoreServerInfo`, but there are several problems such as #42245. So I think it's better to only modify `serverType` in `dataForTiDBClusterInfo`.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
select * from information_schema.cluster_info;
alter table test.t1 set tiflash replica 1;
select count(*) from TIFLASH_TABLES;
select count(*) from TIFLASH_SEGMENTS;
alter table test.t1 compact tiflash replica ;
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
