### PR TITLE
ddl: skip exist error when create the default resource group

### DIFF
--- a/ddl/resource_group.go
+++ b/ddl/resource_group.go
@@ -33,7 +33,6 @@ import (
 const (
 	defaultInfosyncTimeout = 5 * time.Second
 
-	defaultGroupName = "default"
 	// FIXME: this is a workaround for the compatibility, format the error code.
 	alreadyExists = "already exists"
 )
@@ -70,7 +69,7 @@ func onCreateResourceGroup(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 			logutil.BgLogger().Warn("create resource group failed", zap.String("group-name", groupInfo.Name.L), zap.Error(err))
 			// TiDB will add the group to the resource manager when it bootstraps.
 			// here order to compatible with keyspace mode TiDB to skip the exist error with default group.
-			if !strings.Contains(err.Error(), alreadyExists) || groupInfo.Name.L != defaultGroupName {
+			if !strings.Contains(err.Error(), alreadyExists) || groupInfo.Name.L != DefaultResourceGroupName {
 				return ver, errors.Trace(err)
 			}
 		}

--- a/ddl/resource_group.go
+++ b/ddl/resource_group.go
@@ -16,6 +16,8 @@ package ddl
 
 import (
 	"context"
+	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/ddl/resourcegroup"
@@ -26,6 +28,13 @@ import (
 	"github.com/pingcap/tidb/util/dbterror"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
+)
+
+const (
+	defaultInfosyncTimeout = 5 * time.Second
+
+	defaultGroupName = "default"
+	alreadyExists    = "already exists"
 )
 
 func onCreateResourceGroup(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {
@@ -52,10 +61,17 @@ func onCreateResourceGroup(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
-		err = infosync.AddResourceGroup(context.TODO(), protoGroup)
+
+		ctx, cancel := context.WithTimeout(d.ctx, defaultInfosyncTimeout)
+		defer cancel()
+		err = infosync.AddResourceGroup(ctx, protoGroup)
 		if err != nil {
 			logutil.BgLogger().Warn("create resource group failed", zap.Error(err))
-			return ver, errors.Trace(err)
+			// TiDB will add the group to the resource manager when it bootstraps.
+			// add judge here to compatible with keyspace mode TiDB to skip the exist error with default group.
+			if !strings.Contains(err.Error(), alreadyExists) || groupInfo.Name.L != defaultGroupName {
+				return ver, errors.Trace(err)
+			}
 		}
 		job.SchemaID = groupInfo.ID
 		ver, err = updateSchemaVersion(d, t, job)

--- a/ddl/resource_group.go
+++ b/ddl/resource_group.go
@@ -34,7 +34,8 @@ const (
 	defaultInfosyncTimeout = 5 * time.Second
 
 	defaultGroupName = "default"
-	alreadyExists    = "already exists"
+	// FIXME: this is a workaround for the compatibility, format the error code.
+	alreadyExists = "already exists"
 )
 
 func onCreateResourceGroup(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {
@@ -66,9 +67,9 @@ func onCreateResourceGroup(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		defer cancel()
 		err = infosync.AddResourceGroup(ctx, protoGroup)
 		if err != nil {
-			logutil.BgLogger().Warn("create resource group failed", zap.Error(err))
+			logutil.BgLogger().Warn("create resource group failed", zap.String("group-name", groupInfo.Name.L), zap.Error(err))
 			// TiDB will add the group to the resource manager when it bootstraps.
-			// add judge here to compatible with keyspace mode TiDB to skip the exist error with default group.
+			// here order to compatible with keyspace mode TiDB to skip the exist error with default group.
 			if !strings.Contains(err.Error(), alreadyExists) || groupInfo.Name.L != defaultGroupName {
 				return ver, errors.Trace(err)
 			}

--- a/ddl/resourcegrouptest/BUILD.bazel
+++ b/ddl/resourcegrouptest/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "//parser/model",
         "//sessionctx",
         "//testkit",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/resource_manager",
         "@com_github_stretchr_testify//require",
     ],

--- a/ddl/resourcegrouptest/resource_group_test.go
+++ b/ddl/resourcegrouptest/resource_group_test.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/pingcap/failpoint"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/pingcap/tidb/ddl/internal/callback"
 	"github.com/pingcap/tidb/ddl/resourcegroup"
@@ -206,6 +207,17 @@ func TestResourceGroupHint(t *testing.T) {
 	tk.MustExec("set global tidb_enable_resource_control='off'")
 	tk.MustQuery("select /*+ resource_group(rg1) */ DB, RESOURCE_GROUP from information_schema.processlist").Check(testkit.Rows("test "))
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 8250 Resource control feature is disabled. Run `SET GLOBAL tidb_enable_resource_control='on'` to enable the feature"))
+}
+
+func TestAlreadyExistsDefaultResourceGroup(t *testing.T) {
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/domain/infosync/managerAlreadyCreateSomeGroups", `return(true)`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/domain/infosync/managerAlreadyCreateSomeGroups"))
+	}()
+	testkit.CreateMockStoreAndDomain(t)
+	groups, _ := infosync.ListResourceGroups(context.TODO())
+	fmt.Println("debug", groups)
+	require.Equal(t, 2, len(groups))
 }
 
 func TestNewResourceGroupFromOptions(t *testing.T) {

--- a/ddl/resourcegrouptest/resource_group_test.go
+++ b/ddl/resourcegrouptest/resource_group_test.go
@@ -216,7 +216,6 @@ func TestAlreadyExistsDefaultResourceGroup(t *testing.T) {
 	}()
 	testkit.CreateMockStoreAndDomain(t)
 	groups, _ := infosync.ListResourceGroups(context.TODO())
-	fmt.Println("debug", groups)
 	require.Equal(t, 2, len(groups))
 }
 

--- a/domain/infosync/resource_group_manager.go
+++ b/domain/infosync/resource_group_manager.go
@@ -16,6 +16,7 @@ package infosync
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
@@ -52,6 +53,9 @@ func (m *mockResourceGroupManager) GetResourceGroup(ctx context.Context, name st
 func (m *mockResourceGroupManager) AddResourceGroup(ctx context.Context, group *rmpb.ResourceGroup) (string, error) {
 	m.Lock()
 	defer m.Unlock()
+	if _, ok := m.groups[group.Name]; ok {
+		return "", fmt.Errorf("the group %s already exists", group.Name)
+	}
 	m.groups[group.Name] = group
 	return "Success!", nil
 }

--- a/store/mockstore/unistore/pd.go
+++ b/store/mockstore/unistore/pd.go
@@ -17,6 +17,7 @@ package unistore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -220,6 +221,9 @@ func (c *pdClient) GetResourceGroup(ctx context.Context, name string) (*rmpb.Res
 func (c *pdClient) AddResourceGroup(ctx context.Context, group *rmpb.ResourceGroup) (string, error) {
 	c.resourceGroupManager.Lock()
 	defer c.resourceGroupManager.Unlock()
+	if _, ok := c.resourceGroupManager.groups[group.Name]; ok {
+		return "", fmt.Errorf("the group %s already exists", group.Name)
+	}
 	c.resourceGroupManager.groups[group.Name] = group
 	return "Success!", nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/42324

Problem Summary:
Bootstrap a TiDB with a keyspace-name, then bootstrap a TiDB without a keyspace-name


### What is changed and how it works?

skip the `default` group exists error.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
