### PR TITLE
Lightning: don't use pd port in tidb backend

### DIFF
--- a/br/pkg/lightning/importer/get_pre_info.go
+++ b/br/pkg/lightning/importer/get_pre_info.go
@@ -571,12 +571,6 @@ func (p *PreImportInfoGetterImpl) EstimateSourceDataSize(ctx context.Context, op
 		}
 	}
 
-	replConfig, err := p.targetInfoGetter.GetReplicationConfig(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	sizeWithIndex *= int64(replConfig.MaxReplicas)
-
 	if isLocalBackend(p.cfg) {
 		sizeWithIndex = int64(float64(sizeWithIndex) * compressionRatio)
 		tiflashSize = int64(float64(tiflashSize) * compressionRatio)

--- a/br/pkg/lightning/importer/precheck_impl.go
+++ b/br/pkg/lightning/importer/precheck_impl.go
@@ -154,6 +154,12 @@ func (ci *clusterResourceCheckItem) Check(ctx context.Context) (*CheckResult, er
 		}
 	}
 
+	replicaCount, err := ci.preInfoGetter.GetReplicationConfig(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	tikvSourceSize = tikvSourceSize * replicaCount.MaxReplicas
+
 	if tikvSourceSize <= tikvAvail && tiflashSourceSize <= tiflashAvail {
 		theResult.Message = fmt.Sprintf("The storage space is rich, which TiKV/Tiflash is %s/%s. The estimated storage space is %s/%s.",
 			units.BytesSize(float64(tikvAvail)), units.BytesSize(float64(tiflashAvail)), units.BytesSize(float64(tikvSourceSize)), units.BytesSize(float64(tiflashSourceSize)))

--- a/br/pkg/lightning/importer/table_import_test.go
+++ b/br/pkg/lightning/importer/table_import_test.go
@@ -1442,7 +1442,6 @@ func (s *tableRestoreSuite) TestEstimate() {
 	}
 	ioWorkers := worker.NewPool(context.Background(), 1, "io")
 	mockTarget := restoremock.NewMockTargetInfo()
-	mockTarget.MaxReplicasPerRegion = 3
 
 	preInfoGetter := &PreImportInfoGetterImpl{
 		cfg:              s.cfg,
@@ -1460,13 +1459,13 @@ func (s *tableRestoreSuite) TestEstimate() {
 	s.Require().NoError(err)
 
 	// Because this file is small than region split size so we does not sample it.
-	tikvExpected := 2 * int64(compressionRatio*float64(tblSize)*float64(mockTarget.MaxReplicasPerRegion))
+	tikvExpected := 2 * int64(compressionRatio*float64(tblSize))
 	s.Require().Equal(tikvExpected, estimateResult.SizeWithIndex)
 	tiflashExpected := int64(compressionRatio * float64(tblSize) * float64(tiflashReplica1+tiflashReplica2))
 	s.Require().Equal(tiflashExpected, estimateResult.TiFlashSize)
 
 	s.tableMeta.TotalSize = int64(config.SplitRegionSize)
-	tikvExpected = int64(compressionRatio * float64(config.SplitRegionSize+tblSize) * float64(mockTarget.MaxReplicasPerRegion))
+	tikvExpected = int64(compressionRatio * float64(config.SplitRegionSize+tblSize))
 	estimateResult, err = preInfoGetter.EstimateSourceDataSize(ctx, ropts.ForceReloadCache(true))
 	s.Require().NoError(err)
 	s.Require().Greater(estimateResult.SizeWithIndex, tikvExpected)
@@ -1477,7 +1476,7 @@ func (s *tableRestoreSuite) TestEstimate() {
 	preInfoGetter.cfg.TikvImporter.Backend = config.BackendTiDB
 	estimateResult, err = preInfoGetter.EstimateSourceDataSize(ctx, ropts.ForceReloadCache(true))
 	s.Require().NoError(err)
-	tikvExpected = int64((int(config.SplitRegionSize) + tblSize) * mockTarget.MaxReplicasPerRegion)
+	tikvExpected = int64((int(config.SplitRegionSize) + tblSize))
 	s.Require().Equal(tikvExpected, estimateResult.SizeWithIndex)
 	tiflashExpected = int64(config.SplitRegionSize*tiflashReplica1 + tblSize*tiflashReplica2)
 	s.Require().Equal(tiflashExpected, estimateResult.TiFlashSize)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/42354

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

https://github.com/okJiang/tidb/actions/runs/4445667488/jobs/7805054954

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
