### PR TITLE
br: Skip verify region if the provider is ceph or minio

### DIFF
--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -361,7 +361,7 @@ func NewS3Storage(ctx context.Context, backend *backuppb.S3, opts *ExternalStora
 	c := s3.New(ses, s3CliConfigs...)
 
 	// s3manager.GetBucketRegionWithClient failed to get region from client if the client is ceph or minio
-	// It defaut back to us-west-1 which break the code if a region is already set
+	// It defaults back to us-west-1 which breaks the code if a region is already set
 	if qs.Provider != "ceph" && qs.Provider != "minio" {
 
 		confCred := ses.Config.Credentials


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42033

Problem Summary:

When we use br with our infra, our endpoint didn't provide the correct region to our infra. In fact, it send us no region at all. The region test was failing, so we decided to skip this check for our ceph and minio providers.

### What is changed and how it works?

We skip the region check in br if the provider is ceph or minio

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```