### PR TITLE
test: fix flaky test due to forget to change batch size

### DIFF
--- a/executor/asyncloaddata/operate_test.go
+++ b/executor/asyncloaddata/operate_test.go
@@ -65,7 +65,6 @@ func (s *mockGCSSuite) TestOperateRunningJob() {
 		tk2.MustContainErrMsg(sql, "failed to keepalive")
 	}()
 
-	// TODO: remove this sleep after moving mysql.load_data_jobs to bootstrap
 	time.Sleep(3 * time.Second)
 	rows := s.tk.MustQuery("SHOW LOAD DATA JOBS;").Rows()
 	require.Greater(s.T(), len(rows), 0)
@@ -76,14 +75,14 @@ func (s *mockGCSSuite) TestOperateRunningJob() {
 	// test CANCEL
 
 	sql = fmt.Sprintf(`LOAD DATA INFILE 'gs://test-operate/t.tsv?endpoint=%s'
-		REPLACE INTO TABLE test_operate.t;`, gcsEndpoint)
+		REPLACE INTO TABLE test_operate.t WITH batch_size = 1;`, gcsEndpoint)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		tk2.MustContainErrMsg(sql, "failed to keepalive")
 	}()
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(time.Second)
 	rows = s.tk.MustQuery("SHOW LOAD DATA JOBS;").Rows()
 	require.Greater(s.T(), len(rows), 0)
 	jobID = rows[len(rows)-1][0].(string)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42402

Problem Summary:

### What is changed and how it works?

For default batch_size, the sleep time which failpoint injected is not enough

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
