### PR TITLE
test:  fix ut TestTan due to math.Tan(math.Pi / 4) equals 0.9999999999999998, not 1

### DIFF
--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -985,8 +985,8 @@ func TestTan(t *testing.T) {
 	}{
 		{nil, 0, true, false},
 		{int64(0), float64(0), false, false},
-		{math.Pi / 4, float64(1), false, false},
-		{-math.Pi / 4, float64(-1), false, false},
+		{math.Pi / 4, math.Tan(math.Pi / 4), false, false},
+		{-math.Pi / 4, math.Tan(-math.Pi / 4), false, false},
 		{math.Pi * 3 / 4, math.Tan(math.Pi * 3 / 4), false, false}, // in mysql and golang, it equals -1.0000000000000002, not -1
 		{"0.000", float64(0), false, false},
 		{"sdfgsdfg", 0, false, true},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/42420

Problem Summary:

### What is changed and how it works?
math.Tan(math.Pi / 4)  equals 0.9999999999999998, not 1

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
