### PR TITLE
streamhelper/advancer: Fix owner transfer metric

### DIFF
--- a/br/pkg/streamhelper/advancer_daemon.go
+++ b/br/pkg/streamhelper/advancer_daemon.go
@@ -48,7 +48,7 @@ func (c *CheckpointAdvancer) Name() string {
 
 func (c *CheckpointAdvancer) onStop() {
 	metrics.AdvancerOwner.Set(0.0)
-    metrics.LastCheckpoint.Reset()
+	metrics.LastCheckpoint.Reset()
 	c.stopSubscriber()
 }
 

--- a/br/pkg/streamhelper/advancer_daemon.go
+++ b/br/pkg/streamhelper/advancer_daemon.go
@@ -48,6 +48,7 @@ func (c *CheckpointAdvancer) Name() string {
 
 func (c *CheckpointAdvancer) onStop() {
 	metrics.AdvancerOwner.Set(0.0)
+    metrics.LastCheckpoint.Reset()
 	c.stopSubscriber()
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42419

Problem Summary:
When the owner get evicted but not restarted, its checkpoint metric may consist. 

### What is changed and how it works?
```commit-message
This PR make the owner remove the last checkpoint when it loses its ownership.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
(I think this could be covered by the existing tests in AdvancerDaemon.)
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
(TBD)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed a bug that may cause PITR lag in the metrics grows too high when TiDB stop.
```
