### PR TITLE
session, com_stmt: clone params when fetching and executing statements

### DIFF
--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -165,6 +165,9 @@ func (ts *TiDBStatement) Reset() {
 		terror.Call(ts.rs.Close)
 		ts.rs = nil
 	}
+
+	// Remove the existing params. This is actually not necessary, but we still reset the params to make it clearer.
+	ts.preparedStatementCtx = nil
 }
 
 // Close implements PreparedStatement Close method.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1664,6 +1664,16 @@ func (pps PreparedParams) String() string {
 	return " [arguments: " + types.DatumsToStrNoErr(pps) + "]"
 }
 
+// Clone deep copies the params
+func (pps PreparedParams) Clone() PreparedParams {
+	newParams := make(PreparedParams, 0, len(pps))
+	for _, p := range pps {
+		newParams = append(newParams, *p.Clone())
+	}
+
+	return newParams
+}
+
 // ConnectionInfo presents the connection information, which is mainly used by audit logs.
 type ConnectionInfo struct {
 	ConnectionID      uint64


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #42424

Problem Summary:

We should clone the params in `execute` and `fetch` command, to avoid it being modified by the following queries.

### What is changed and how it works?

Clone the parameters.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
