### PR TITLE
session: make cross-version upgrade succeed

### DIFF
--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -2414,7 +2414,13 @@ func upgradeToVer137(s Session, ver int64) {
 	if ver >= version137 {
 		return
 	}
-	doReentrantDDL(s, CreateDefaultResourceGroup)
+	dom := domain.GetDomain(s)
+	// Default resource group creation ddl statement can be issued when either of following conditions is satisfied:
+	// 1. Current TiDB is DDL owner
+	// 2. Upgrade from version 6.6
+	if dom.DDL().OwnerManager().IsOwner() || getStoreBootstrapVersion(dom.Store()) >= version134 {
+		doReentrantDDL(s, CreateDefaultResourceGroup)
+	}
 }
 
 // For users that upgrade TiDB from a version below 7.0, we want to enable tidb tidb_enable_null_aware_anti_join by default.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42403 

Problem Summary:

### What is changed and how it works?

If upgrading TiDB from version under 6.6, when resource control feature is not there, to version 7.0 or above, the default resource group creation could fail during bootstrapping if current TiDB is not the DDL owner.  In this PR,  the ddl statement is only issued when the TiDB instance is the DDL owner or old version is 6.6.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects
- N/A

Documentation

- N/A

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
