### PR TITLE
util/sqlexec: EscapeSQL support resolve some underlying type

### DIFF
--- a/util/sqlexec/utils.go
+++ b/util/sqlexec/utils.go
@@ -93,10 +93,6 @@ func escapeStringBackslash(buf []byte, v string) []byte {
 	return escapeBytesBackslash(buf, hack.Slice(v))
 }
 
-var (
-	reflectTpTime = reflect.TypeOf(time.Time{})
-)
-
 // escapeSQL is the internal impl of EscapeSQL and FormatSQL.
 func escapeSQL(sql string, args ...interface{}) ([]byte, error) {
 	buf := make([]byte, 0, len(sql))

--- a/util/sqlexec/utils.go
+++ b/util/sqlexec/utils.go
@@ -94,122 +94,22 @@ func escapeStringBackslash(buf []byte, v string) []byte {
 }
 
 var (
-	reflectTpInt      = reflect.TypeOf(int(0))
-	reflectTpInt8     = reflect.TypeOf(int8(0))
-	reflectTpInt16    = reflect.TypeOf(int16(0))
-	reflectTpInt32    = reflect.TypeOf(int32(0))
-	reflectTpInt64    = reflect.TypeOf(int64(0))
-	reflectTpUint     = reflect.TypeOf(uint(0))
-	reflectTpUint8    = reflect.TypeOf(uint8(0))
-	reflectTpUint16   = reflect.TypeOf(uint16(0))
-	reflectTpUint32   = reflect.TypeOf(uint32(0))
-	reflectTpUint64   = reflect.TypeOf(uint64(0))
-	reflectTpFloat32  = reflect.TypeOf(float32(0))
-	reflectTpFloat64  = reflect.TypeOf(float64(0))
-	reflectTpBool     = reflect.TypeOf(false)
 	reflectTpTime     = reflect.TypeOf(time.Time{})
 	reflectTpJSON     = reflect.TypeOf(json.RawMessage{})
 	reflectTpBytes    = reflect.TypeOf([]byte{})
-	reflectTpString   = reflect.TypeOf("")
 	reflectTpStrings  = reflect.TypeOf([]string{})
 	reflectTpFloat32s = reflect.TypeOf([]float32{})
 	reflectTpFloat64s = reflect.TypeOf([]float64{})
 
 	reflectUnderlyingTypes = []reflect.Type{
-		reflectTpInt, reflectTpInt8, reflectTpInt16, reflectTpInt32, reflectTpInt64,
-		reflectTpUint, reflectTpUint8, reflectTpUint16, reflectTpUint32, reflectTpUint64,
-		reflectTpFloat32, reflectTpFloat64, reflectTpBool, reflectTpTime, reflectTpJSON,
-		reflectTpBytes, reflectTpString, reflectTpStrings, reflectTpFloat32s, reflectTpFloat64s,
+		reflectTpTime, reflectTpJSON, reflectTpBytes, reflectTpStrings,
+		reflectTpFloat32s, reflectTpFloat64s,
 	}
 )
 
 // escapeSQL is the internal impl of EscapeSQL and FormatSQL.
 func escapeSQL(sql string, args ...interface{}) ([]byte, error) {
 	buf := make([]byte, 0, len(sql))
-	handleDynTpArg := func(arg interface{}) bool {
-		switch v := arg.(type) {
-		case int:
-			buf = strconv.AppendInt(buf, int64(v), 10)
-		case int8:
-			buf = strconv.AppendInt(buf, int64(v), 10)
-		case int16:
-			buf = strconv.AppendInt(buf, int64(v), 10)
-		case int32:
-			buf = strconv.AppendInt(buf, int64(v), 10)
-		case int64:
-			buf = strconv.AppendInt(buf, v, 10)
-		case uint:
-			buf = strconv.AppendUint(buf, uint64(v), 10)
-		case uint8:
-			buf = strconv.AppendUint(buf, uint64(v), 10)
-		case uint16:
-			buf = strconv.AppendUint(buf, uint64(v), 10)
-		case uint32:
-			buf = strconv.AppendUint(buf, uint64(v), 10)
-		case uint64:
-			buf = strconv.AppendUint(buf, v, 10)
-		case float32:
-			buf = strconv.AppendFloat(buf, float64(v), 'g', -1, 32)
-		case float64:
-			buf = strconv.AppendFloat(buf, v, 'g', -1, 64)
-		case bool:
-			if v {
-				buf = append(buf, '1')
-			} else {
-				buf = append(buf, '0')
-			}
-		case time.Time:
-			if v.IsZero() {
-				buf = append(buf, "'0000-00-00'"...)
-			} else {
-				buf = append(buf, '\'')
-				buf = v.AppendFormat(buf, "2006-01-02 15:04:05.999999")
-				buf = append(buf, '\'')
-			}
-		case json.RawMessage:
-			buf = append(buf, '\'')
-			buf = escapeBytesBackslash(buf, v)
-			buf = append(buf, '\'')
-		case []byte:
-			if v == nil {
-				buf = append(buf, "NULL"...)
-			} else {
-				buf = append(buf, "_binary'"...)
-				buf = escapeBytesBackslash(buf, v)
-				buf = append(buf, '\'')
-			}
-		case string:
-			buf = append(buf, '\'')
-			buf = escapeStringBackslash(buf, v)
-			buf = append(buf, '\'')
-		case []string:
-			for i, k := range v {
-				if i > 0 {
-					buf = append(buf, ',')
-				}
-				buf = append(buf, '\'')
-				buf = escapeStringBackslash(buf, k)
-				buf = append(buf, '\'')
-			}
-		case []float32:
-			for i, k := range v {
-				if i > 0 {
-					buf = append(buf, ',')
-				}
-				buf = strconv.AppendFloat(buf, float64(k), 'g', -1, 32)
-			}
-		case []float64:
-			for i, k := range v {
-				if i > 0 {
-					buf = append(buf, ',')
-				}
-				buf = strconv.AppendFloat(buf, k, 'g', -1, 64)
-			}
-		default:
-			return false
-		}
-		return true
-	}
 	argPos := 0
 	for i := 0; i < len(sql); i++ {
 		q := strings.IndexByte(sql[i:], '%')
@@ -250,20 +150,87 @@ func escapeSQL(sql string, args ...interface{}) ([]byte, error) {
 			if arg == nil {
 				buf = append(buf, "NULL"...)
 			} else {
-				if !handleDynTpArg(arg) {
-					reflectTp := reflect.TypeOf(arg)
-					reflectVal := reflect.ValueOf(arg)
-					tryAgain := false
-					for _, tp := range reflectUnderlyingTypes {
-						if reflectTp.ConvertibleTo(tp) {
-							arg = reflectVal.Convert(tp).Interface()
-							tryAgain = true
-							break
+				reflectTp := reflect.TypeOf(arg)
+				kind := reflectTp.Kind()
+				switch kind {
+				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+					buf = strconv.AppendInt(buf, reflect.ValueOf(arg).Int(), 10)
+				case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+					buf = strconv.AppendUint(buf, reflect.ValueOf(arg).Uint(), 10)
+				case reflect.Float32:
+					buf = strconv.AppendFloat(buf, reflect.ValueOf(arg).Float(), 'g', -1, 32)
+				case reflect.Float64:
+					buf = strconv.AppendFloat(buf, reflect.ValueOf(arg).Float(), 'g', -1, 64)
+				case reflect.Bool:
+					if reflect.ValueOf(arg).Bool() {
+						buf = append(buf, '1')
+					} else {
+						buf = append(buf, '0')
+					}
+				case reflect.String:
+					buf = append(buf, '\'')
+					buf = escapeStringBackslash(buf, reflect.ValueOf(arg).String())
+					buf = append(buf, '\'')
+				case reflect.Struct:
+					t, ok := arg.(time.Time)
+					if !ok {
+						if reflectTp.ConvertibleTo(reflectTpTime) {
+							t = reflect.ValueOf(arg).Convert(reflectTpTime).Interface().(time.Time)
+							ok = true
 						}
 					}
-					if !tryAgain || !handleDynTpArg(arg) {
+					if !ok {
 						return nil, errors.Errorf("unsupported %d-th argument: %v", argPos, arg)
 					}
+					if t.IsZero() {
+						buf = append(buf, "'0000-00-00'"...)
+					} else {
+						buf = append(buf, '\'')
+						buf = t.AppendFormat(buf, "2006-01-02 15:04:05.999999")
+						buf = append(buf, '\'')
+					}
+				case reflect.Slice:
+					switch v := arg.(type) {
+					case json.RawMessage:
+						buf = append(buf, '\'')
+						buf = escapeBytesBackslash(buf, v)
+						buf = append(buf, '\'')
+					case []byte:
+						if v == nil {
+							buf = append(buf, "NULL"...)
+						} else {
+							buf = append(buf, "_binary'"...)
+							buf = escapeBytesBackslash(buf, v)
+							buf = append(buf, '\'')
+						}
+					case []string:
+						for i, k := range v {
+							if i > 0 {
+								buf = append(buf, ',')
+							}
+							buf = append(buf, '\'')
+							buf = escapeStringBackslash(buf, k)
+							buf = append(buf, '\'')
+						}
+					case []float32:
+						for i, k := range v {
+							if i > 0 {
+								buf = append(buf, ',')
+							}
+							buf = strconv.AppendFloat(buf, float64(k), 'g', -1, 32)
+						}
+					case []float64:
+						for i, k := range v {
+							if i > 0 {
+								buf = append(buf, ',')
+							}
+							buf = strconv.AppendFloat(buf, k, 'g', -1, 64)
+						}
+					default:
+						return nil, errors.Errorf("unsupported %d-th argument: %v", argPos, arg)
+					}
+				default:
+					return nil, errors.Errorf("unsupported %d-th argument: %v", argPos, arg)
 				}
 			}
 			i++ // skip specifier

--- a/util/sqlexec/utils.go
+++ b/util/sqlexec/utils.go
@@ -94,17 +94,7 @@ func escapeStringBackslash(buf []byte, v string) []byte {
 }
 
 var (
-	reflectTpTime     = reflect.TypeOf(time.Time{})
-	reflectTpJSON     = reflect.TypeOf(json.RawMessage{})
-	reflectTpBytes    = reflect.TypeOf([]byte{})
-	reflectTpStrings  = reflect.TypeOf([]string{})
-	reflectTpFloat32s = reflect.TypeOf([]float32{})
-	reflectTpFloat64s = reflect.TypeOf([]float64{})
-
-	reflectUnderlyingTypes = []reflect.Type{
-		reflectTpTime, reflectTpJSON, reflectTpBytes, reflectTpStrings,
-		reflectTpFloat32s, reflectTpFloat64s,
-	}
+	reflectTpTime = reflect.TypeOf(time.Time{})
 )
 
 // escapeSQL is the internal impl of EscapeSQL and FormatSQL.

--- a/util/sqlexec/utils.go
+++ b/util/sqlexec/utils.go
@@ -108,7 +108,7 @@ var (
 	reflectTpFloat64  = reflect.TypeOf(float64(0))
 	reflectTpBool     = reflect.TypeOf(false)
 	reflectTpTime     = reflect.TypeOf(time.Time{})
-	reflectTpJson     = reflect.TypeOf(json.RawMessage{})
+	reflectTpJSON     = reflect.TypeOf(json.RawMessage{})
 	reflectTpBytes    = reflect.TypeOf([]byte{})
 	reflectTpString   = reflect.TypeOf("")
 	reflectTpStrings  = reflect.TypeOf([]string{})
@@ -118,7 +118,7 @@ var (
 	reflectUnderlyingTypes = []reflect.Type{
 		reflectTpInt, reflectTpInt8, reflectTpInt16, reflectTpInt32, reflectTpInt64,
 		reflectTpUint, reflectTpUint8, reflectTpUint16, reflectTpUint32, reflectTpUint64,
-		reflectTpFloat32, reflectTpFloat64, reflectTpBool, reflectTpTime, reflectTpJson,
+		reflectTpFloat32, reflectTpFloat64, reflectTpBool, reflectTpTime, reflectTpJSON,
 		reflectTpBytes, reflectTpString, reflectTpStrings, reflectTpFloat32s, reflectTpFloat64s,
 	}
 )

--- a/util/sqlexec/utils_test.go
+++ b/util/sqlexec/utils_test.go
@@ -106,6 +106,9 @@ func TestEscapeBackslash(t *testing.T) {
 }
 
 func TestEscapeSQL(t *testing.T) {
+	type mystr string
+	type mytime time.Time
+	type myfloat64s []float64
 	type TestCase struct {
 		name   string
 		input  string
@@ -385,6 +388,24 @@ func TestEscapeSQL(t *testing.T) {
 			params: []interface{}{[]float64{55.2, 0.66}},
 			output: "select 55.2,0.66",
 		},
+		{
+			name:   "mystr",
+			input:  "select %?",
+			params: []interface{}{mystr("3")},
+			output: "select '3'",
+		},
+		{
+			name:   "mytime",
+			input:  "select %?",
+			params: []interface{}{mytime(time2)},
+			output: "select '2018-01-23 04:03:05'",
+		},
+		{
+			name:   "myfloadt64s",
+			input:  "select %?",
+			params: []interface{}{myfloat64s{55.2, 0.66}},
+			output: "select 55.2,0.66",
+		},
 	}
 	for _, v := range tests {
 		// copy iterator variable into a new variable, see issue #27779
@@ -449,5 +470,19 @@ func TestEscapeString(t *testing.T) {
 	}
 	for _, v := range tests {
 		require.Equal(t, v.output, EscapeString(v.input))
+	}
+}
+
+func BenchmarkEscapeString(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		escapeSQL("select %?", "3")
+	}
+}
+
+type mystr string
+
+func BenchmarkUnderlyingString(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		escapeSQL("select %?", mystr("3"))
 	}
 }

--- a/util/sqlexec/utils_test.go
+++ b/util/sqlexec/utils_test.go
@@ -400,12 +400,6 @@ func TestEscapeSQL(t *testing.T) {
 			params: []interface{}{mytime(time2)},
 			output: "select '2018-01-23 04:03:05'",
 		},
-		{
-			name:   "myfloadt64s",
-			input:  "select %?",
-			params: []interface{}{myfloat64s{55.2, 0.66}},
-			output: "select 55.2,0.66",
-		},
 	}
 	for _, v := range tests {
 		// copy iterator variable into a new variable, see issue #27779

--- a/util/sqlexec/utils_test.go
+++ b/util/sqlexec/utils_test.go
@@ -108,7 +108,6 @@ func TestEscapeBackslash(t *testing.T) {
 func TestEscapeSQL(t *testing.T) {
 	type mystr string
 	type mytime time.Time
-	type myfloat64s []float64
 	type TestCase struct {
 		name   string
 		input  string

--- a/util/sqlexec/utils_test.go
+++ b/util/sqlexec/utils_test.go
@@ -106,6 +106,7 @@ func TestEscapeBackslash(t *testing.T) {
 }
 
 func TestEscapeSQL(t *testing.T) {
+	type myint int
 	type mystr string
 	type mytime time.Time
 	type TestCase struct {
@@ -386,6 +387,12 @@ func TestEscapeSQL(t *testing.T) {
 			input:  "select %?",
 			params: []interface{}{[]float64{55.2, 0.66}},
 			output: "select 55.2,0.66",
+		},
+		{
+			name:   "myint",
+			input:  "select %?",
+			params: []interface{}{myint(3)},
+			output: "select 3",
 		},
 		{
 			name:   "mystr",

--- a/util/sqlexec/utils_test.go
+++ b/util/sqlexec/utils_test.go
@@ -105,10 +105,10 @@ func TestEscapeBackslash(t *testing.T) {
 	}
 }
 
+type myInt int
+type myStr string
+
 func TestEscapeSQL(t *testing.T) {
-	type myint int
-	type mystr string
-	type mytime time.Time
 	type TestCase struct {
 		name   string
 		input  string
@@ -389,22 +389,16 @@ func TestEscapeSQL(t *testing.T) {
 			output: "select 55.2,0.66",
 		},
 		{
-			name:   "myint",
+			name:   "myInt",
 			input:  "select %?",
-			params: []interface{}{myint(3)},
+			params: []interface{}{myInt(3)},
 			output: "select 3",
 		},
 		{
-			name:   "mystr",
+			name:   "myStr",
 			input:  "select %?",
-			params: []interface{}{mystr("3")},
+			params: []interface{}{myStr("3")},
 			output: "select '3'",
-		},
-		{
-			name:   "mytime",
-			input:  "select %?",
-			params: []interface{}{mytime(time2)},
-			output: "select '2018-01-23 04:03:05'",
 		},
 	}
 	for _, v := range tests {
@@ -479,10 +473,20 @@ func BenchmarkEscapeString(b *testing.B) {
 	}
 }
 
-type mystr string
-
 func BenchmarkUnderlyingString(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		escapeSQL("select %?", mystr("3"))
+		escapeSQL("select %?", myStr("3"))
+	}
+}
+
+func BenchmarkEscapeInt(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		escapeSQL("select %?", 3)
+	}
+}
+
+func BenchmarkUnderlyingInt(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		escapeSQL("select %?", myInt(3))
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

Support use customized type whose underlying type is intXXX, uintXXX, floatXX, bool, string in `ExecuteSQL`. Typically this can make ease of using customized enum type when `ExecuteSQL`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


benchmark

at 2137ff3974d9bcf3a90683f72f682d7423cdb3c0

```
goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/util/sqlexec
BenchmarkEscapeString
BenchmarkEscapeString-8       	 4011201	       292.8 ns/op
BenchmarkUnderlyingString
BenchmarkUnderlyingString-8   	 3403500	       351.3 ns/op
BenchmarkEscapeInt
BenchmarkEscapeInt-8          	 6085053	       196.5 ns/op
BenchmarkUnderlyingInt
BenchmarkUnderlyingInt-8      	 4736172	       253.8 ns/op
```

at master

```
goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/util/sqlexec
BenchmarkEscapeString
BenchmarkEscapeString-8   	 4089615	       294.3 ns/op
BenchmarkEscapeInt
BenchmarkEscapeInt-8   	 	 6049938	       198.4 ns/op
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
