### PR TITLE
resource_control: init default resource group without ddl

### DIFF
--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -258,10 +258,10 @@ func initPlacementManager(etcdCli *clientv3.Client) PlacementManager {
 }
 
 func initResourceGroupManager(pdCli pd.Client) (cli pd.ResourceManagerClient) {
-	if pdCli == nil {
-		cli = &mockResourceGroupManager{groups: make(map[string]*rmpb.ResourceGroup)}
-	}
 	cli = pdCli
+	if pdCli == nil {
+		cli = NewMockResourceGroupManager()
+	}
 	failpoint.Inject("managerAlreadyCreateSomeGroups", func(val failpoint.Value) {
 		if val.(bool) {
 			_, err := cli.AddResourceGroup(context.TODO(),

--- a/domain/infosync/resource_group_manager.go
+++ b/domain/infosync/resource_group_manager.go
@@ -28,6 +28,26 @@ type mockResourceGroupManager struct {
 	groups map[string]*rmpb.ResourceGroup
 }
 
+func NewMockResourceGroupManager() pd.ResourceManagerClient {
+	mockMgr := &mockResourceGroupManager{
+		groups: make(map[string]*rmpb.ResourceGroup),
+	}
+	mockMgr.groups["default"] = &rmpb.ResourceGroup{
+		Name: "default",
+		Mode: rmpb.GroupMode_RUMode,
+		RUSettings: &rmpb.GroupRequestUnitSettings{
+			RU: &rmpb.TokenBucket{
+				Settings: &rmpb.TokenLimitSettings{
+					FillRate:   1000000,
+					BurstLimit: -1,
+				},
+			},
+		},
+		Priority: 8,
+	}
+	return mockMgr
+}
+
 var _ pd.ResourceManagerClient = (*mockResourceGroupManager)(nil)
 
 func (m *mockResourceGroupManager) ListResourceGroups(ctx context.Context) ([]*rmpb.ResourceGroup, error) {

--- a/domain/infosync/resource_group_manager.go
+++ b/domain/infosync/resource_group_manager.go
@@ -28,6 +28,7 @@ type mockResourceGroupManager struct {
 	groups map[string]*rmpb.ResourceGroup
 }
 
+// NewMockResourceGroupManager return a mock ResourceManagerClient for test usage.
 func NewMockResourceGroupManager() pd.ResourceManagerClient {
 	mockMgr := &mockResourceGroupManager{
 		groups: make(map[string]*rmpb.ResourceGroup),

--- a/executor/calibrate_resource.go
+++ b/executor/calibrate_resource.go
@@ -132,7 +132,7 @@ type ruConfig struct {
 }
 
 func getRUSettings(ctx context.Context, exec sqlexec.RestrictedSQLExecutor) (*ruConfig, error) {
-	rows, fields, err := exec.ExecRestrictedSQL(ctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession}, "SHOW CONFIG WHERE TYPE = 'pd' AND  name like 'request_unit.%'")
+	rows, fields, err := exec.ExecRestrictedSQL(ctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession}, "SHOW CONFIG WHERE TYPE = 'pd' AND  name like 'controller.request-unit.%'")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -155,7 +155,7 @@ func getRUSettings(ctx context.Context, exec sqlexec.RestrictedSQLExecutor) (*ru
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		name, _ := strings.CutPrefix(row.GetString(nameIdx), "request-unit.")
+		name, _ := strings.CutPrefix(row.GetString(nameIdx), "controller.request-unit.")
 
 		switch name {
 		case "read-base-cost":

--- a/executor/calibrate_resource_test.go
+++ b/executor/calibrate_resource_test.go
@@ -51,11 +51,11 @@ func TestCalibrateResource(t *testing.T) {
 	err = rs.Next(context.Background(), rs.NewChunk(nil))
 	require.ErrorContains(t, err, "PD request-unit config not found")
 
-	confItems = append(confItems, strs2Items("pd", "127.0.0.1:2379", "request-unit.read-base-cost", "0.25"))
-	confItems = append(confItems, strs2Items("pd", "127.0.0.1:2379", "request-unit.read-cost-per-byte", "0.0000152587890625"))
-	confItems = append(confItems, strs2Items("pd", "127.0.0.1:2379", "request-unit.read-cpu-ms-cost", "0.3333333333333333"))
-	confItems = append(confItems, strs2Items("pd", "127.0.0.1:2379", "request-unit.write-base-cost", "1"))
-	confItems = append(confItems, strs2Items("pd", "127.0.0.1:2379", "request-unit.write-cost-per-byte", "0.0009765625"))
+	confItems = append(confItems, strs2Items("pd", "127.0.0.1:2379", "controller.request-unit.read-base-cost", "0.25"))
+	confItems = append(confItems, strs2Items("pd", "127.0.0.1:2379", "controller.request-unit.read-cost-per-byte", "0.0000152587890625"))
+	confItems = append(confItems, strs2Items("pd", "127.0.0.1:2379", "controller.request-unit.read-cpu-ms-cost", "0.3333333333333333"))
+	confItems = append(confItems, strs2Items("pd", "127.0.0.1:2379", "controller.request-unit.write-base-cost", "1"))
+	confItems = append(confItems, strs2Items("pd", "127.0.0.1:2379", "controller.request-unit.write-cost-per-byte", "0.0009765625"))
 
 	// empty metrics error
 	rs, err = tk.Exec("CALIBRATE RESOURCE")

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -1002,6 +1002,7 @@ func (m *Meta) ListResourceGroups() ([]*model.ResourceGroupInfo, error) {
 	return groups, nil
 }
 
+// DefaultGroupMeta4Test return the default group info for test usage.
 func DefaultGroupMeta4Test() *model.ResourceGroupInfo {
 	return defaultRGroupMeta
 }

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -114,15 +114,20 @@ func TestResourceGroup(t *testing.T) {
 
 	// test the independent policy ID allocation.
 	m := meta.NewMeta(txn)
+	groups, err := m.ListResourceGroups()
+	require.NoError(t, err)
+	require.Equal(t, len(groups), 1)
+	require.Equal(t, groups[0], meta.DefaultGroupMeta4Test())
 
+	groupID := int64(2)
 	checkResourceGroup := func(ru uint64) {
-		rg, err := m.GetResourceGroup(1)
+		rg, err := m.GetResourceGroup(groupID)
 		require.NoError(t, err)
 		require.Equal(t, rg.RURate, ru)
 	}
 
 	rg := &model.ResourceGroupInfo{
-		ID:   1,
+		ID:   groupID,
 		Name: model.NewCIStr("aa"),
 		ResourceGroupSettings: &model.ResourceGroupSettings{
 			RURate: 100,
@@ -131,12 +136,16 @@ func TestResourceGroup(t *testing.T) {
 	require.NoError(t, m.AddResourceGroup(rg))
 	checkResourceGroup(100)
 
+	groups, err = m.ListResourceGroups()
+	require.NoError(t, err)
+	require.Equal(t, len(groups), 2)
+
 	rg.RURate = 200
 	require.NoError(t, m.UpdateResourceGroup(rg))
 	checkResourceGroup(200)
 
-	m.DropResourceGroup(1)
-	_, err = m.GetResourceGroup(1)
+	m.DropResourceGroup(groupID)
+	_, err = m.GetResourceGroup(groupID)
 	require.Error(t, err)
 }
 

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -564,9 +564,6 @@ const (
 		key(state)
 	);`
 
-	// CreateDefaultResourceGroup is the statement to create the default resource group
-	CreateDefaultResourceGroup = "CREATE RESOURCE GROUP IF NOT EXISTS `default` RU_PER_SEC=1000000 BURSTABLE;"
-
 	// CreateLoadDataJobs is a table that LOAD DATA uses
 	CreateLoadDataJobs = `CREATE TABLE IF NOT EXISTS mysql.load_data_jobs (
        job_id bigint(64) NOT NULL AUTO_INCREMENT,
@@ -2411,10 +2408,7 @@ func upgradeToVer136(s Session, ver int64) {
 }
 
 func upgradeToVer137(s Session, ver int64) {
-	if ver >= version137 {
-		return
-	}
-	doReentrantDDL(s, CreateDefaultResourceGroup)
+	// NOOP, we don't depend on ddl to init the default group due to backward compatible issue.
 }
 
 // For users that upgrade TiDB from a version below 7.0, we want to enable tidb tidb_enable_null_aware_anti_join by default.
@@ -2544,8 +2538,6 @@ func doDDLWorks(s Session) {
 	mustExecute(s, CreateTTLJobHistory)
 	// Create tidb_global_task table
 	mustExecute(s, CreateGlobalTask)
-	// Create default resource group
-	mustExecute(s, CreateDefaultResourceGroup)
 	// Create load_data_jobs
 	mustExecute(s, CreateLoadDataJobs)
 }

--- a/store/mockstore/unistore/pd.go
+++ b/store/mockstore/unistore/pd.go
@@ -40,23 +40,40 @@ type pdClient struct {
 	gcSafePointMu        sync.Mutex
 	globalConfig         map[string]string
 	externalTimestamp    atomic.Uint64
-	resourceGroupManager struct {
-		sync.RWMutex
-		groups map[string]*rmpb.ResourceGroup
+	resourceGroupManager *resourceGroupManager
+}
+
+type resourceGroupManager struct {
+	sync.RWMutex
+	groups map[string]*rmpb.ResourceGroup
+}
+
+func newResourceGroupManager() *resourceGroupManager {
+	mgr := &resourceGroupManager{
+		groups: make(map[string]*rmpb.ResourceGroup),
 	}
+	mgr.groups["default"] = &rmpb.ResourceGroup{
+		Name: "default",
+		Mode: rmpb.GroupMode_RUMode,
+		RUSettings: &rmpb.GroupRequestUnitSettings{
+			RU: &rmpb.TokenBucket{
+				Settings: &rmpb.TokenLimitSettings{
+					FillRate:   1000000,
+					BurstLimit: -1,
+				},
+			},
+		},
+		Priority: 8,
+	}
+	return mgr
 }
 
 func newPDClient(pd *us.MockPD) *pdClient {
 	return &pdClient{
-		MockPD:            pd,
-		serviceSafePoints: make(map[string]uint64),
-		globalConfig:      make(map[string]string),
-		resourceGroupManager: struct {
-			sync.RWMutex
-			groups map[string]*rmpb.ResourceGroup
-		}{
-			groups: make(map[string]*rmpb.ResourceGroup),
-		},
+		MockPD:               pd,
+		serviceSafePoints:    make(map[string]uint64),
+		globalConfig:         make(map[string]string),
+		resourceGroupManager: newResourceGroupManager(),
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42403

Problem Summary:

### What is changed and how it works?
In the old implementation, we init the default resource group via a ddl job after tidb is bootstraped. This has a compatible issue because there are some instances that is not upgraded, thus these instances can not recognise this ddl and upgrade can be stuck.

This change resolve this issue by init the `default` resource group when first init the resource group manager, after this change the default resource group is not persistented to the storage by default, but this is ok as tidb will create one in memory when the default is not exist. The pd side change is: https://github.com/tikv/pd/pull/6206. With these two changes, we can ensure the default resource group is always inited and there is no compatible issues.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
 - After this change, I manually upgrade a cluster(with 3 tidb instances), all tidb can bootstrap successfully and the default group's behavior is the same as before(at the user's view).  
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
