### PR TITLE
parser, ddl: correct the job type of 'REORGANIZE PARTITION'

### DIFF
--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -758,7 +758,7 @@ func (job *Job) NotStarted() bool {
 // MayNeedReorg indicates that this job may need to reorganize the data.
 func (job *Job) MayNeedReorg() bool {
 	switch job.Type {
-	case ActionAddIndex, ActionAddPrimaryKey:
+	case ActionAddIndex, ActionAddPrimaryKey, ActionReorganizePartition:
 		return true
 	case ActionModifyColumn:
 		if len(job.CtxVars) > 0 {

--- a/parser/model/ddl_test.go
+++ b/parser/model/ddl_test.go
@@ -71,3 +71,34 @@ func TestBackfillMetaCodec(t *testing.T) {
 	bmRet.Decode(bmBytes)
 	require.Equal(t, bm, bmRet)
 }
+
+func TestMayNeedReorg(t *testing.T) {
+	//TODO(bb7133): add more test cases for different ActionType.
+	reorgJobTypes := []model.ActionType{
+		model.ActionReorganizePartition,
+		model.ActionAddIndex,
+		model.ActionAddPrimaryKey,
+	}
+	generalJobTypes := []model.ActionType{
+		model.ActionCreateTable,
+		model.ActionDropTable,
+	}
+	job := &model.Job{
+		ID:              100,
+		Type:            model.ActionCreateTable,
+		SchemaID:        101,
+		TableID:         102,
+		SchemaName:      "test",
+		TableName:       "t",
+		State:           model.JobStateDone,
+		MultiSchemaInfo: nil,
+	}
+	for _, jobType := range reorgJobTypes {
+		job.Type = jobType
+		require.True(t, job.MayNeedReorg())
+	}
+	for _, jobType := range generalJobTypes {
+		job.Type = jobType
+		require.False(t, job.MayNeedReorg())
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #42442

Problem Summary:

### What is changed and how it works?

See the comments in https://github.com/pingcap/tidb/issues/42442:

> The root cause is that we didn't mark "reorganize partition" as ["need backfill"](https://github.com/pingcap/tidb/blob/42957c57e0cbf062ff7c5465e0e4a277ff788a6f/parser/model/ddl.go/#L759) so it is scheduled as the 'general job', and the 'general job' is scheduled in serial(always block each others).

This PR simply fixes this.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Like #42442, concurrently run `CREATE TABLE` and `REORGANIZE PARTITION` in 2 sessions: 
```
session1(first)> alter table t1 reorganize partition p0, p1, p2, p3, p4 into( partition pnew values less than (10000000));
session2(second)> create table t01(a int, b int);
```

We can verify that `create table` will not be blocked anymore.

- [ ] No code

Side effects

- None

Documentation

- None

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
