### PR TITLE
ttl: fix TTL cannot export metrics `tidb_server_ttl_phase_time`

### DIFF
--- a/ttl/metrics/metrics.go
+++ b/ttl/metrics/metrics.go
@@ -112,6 +112,9 @@ func InitMetricsVars() {
 
 	ScanningTaskCnt = metrics.TTLTaskStatus.With(prometheus.Labels{metrics.LblType: "scanning"})
 	DeletingTaskCnt = metrics.TTLTaskStatus.With(prometheus.Labels{metrics.LblType: "deleting"})
+
+	scanWorkerPhases = initWorkerPhases("scan_worker")
+	deleteWorkerPhases = initWorkerPhases("delete_worker")
 }
 
 func initWorkerPhases(workerType string) map[string]prometheus.Counter {
@@ -128,8 +131,8 @@ func initWorkerPhases(workerType string) map[string]prometheus.Counter {
 	}
 }
 
-var scanWorkerPhases = initWorkerPhases("scan_worker")
-var deleteWorkerPhases = initWorkerPhases("delete_worker")
+var scanWorkerPhases map[string]prometheus.Counter
+var deleteWorkerPhases map[string]prometheus.Counter
 
 // PhaseTracer is used to tracer the phases duration
 type PhaseTracer struct {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42515

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code



Manually test steps:

1. start up a ttl server using this PR:
2. `curl http://127.0.0.1:10080/metrics | grep tidb_server_ttl_phase_time` , the metrics output:

```
# TYPE tidb_server_ttl_phase_time counter
tidb_server_ttl_phase_time{phase="begin_txn",type="delete_worker"} 0
tidb_server_ttl_phase_time{phase="begin_txn",type="scan_worker"} 0
tidb_server_ttl_phase_time{phase="check_ttl",type="delete_worker"} 0
tidb_server_ttl_phase_time{phase="check_ttl",type="scan_worker"} 0
tidb_server_ttl_phase_time{phase="commit_txn",type="delete_worker"} 0
tidb_server_ttl_phase_time{phase="commit_txn",type="scan_worker"} 0
tidb_server_ttl_phase_time{phase="dispatch",type="delete_worker"} 0
tidb_server_ttl_phase_time{phase="dispatch",type="scan_worker"} 0
tidb_server_ttl_phase_time{phase="idle",type="delete_worker"} 1300.1193667450007
tidb_server_ttl_phase_time{phase="idle",type="scan_worker"} 1300.0002689579999
tidb_server_ttl_phase_time{phase="other",type="delete_worker"} 0.0021075060000000007
tidb_server_ttl_phase_time{phase="other",type="scan_worker"} 0
tidb_server_ttl_phase_time{phase="query",type="delete_worker"} 0
tidb_server_ttl_phase_time{phase="query",type="scan_worker"} 0
tidb_server_ttl_phase_time{phase="wait_retry",type="delete_worker"} 0
tidb_server_ttl_phase_time{phase="wait_retry",type="scan_worker"} 0
tidb_server_ttl_phase_time{phase="wait_token",type="delete_worker"} 0
tidb_server_ttl_phase_time{phase="wait_token",type="scan_worker"} 0
```

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
