### PR TITLE
parser: allocate a new array for parser result every time

### DIFF
--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -155,7 +155,7 @@ func (parser *Parser) ParseSQL(sql string, params ...ParseParam) (stmt []ast.Stm
 		}
 	}
 	parser.src = sql
-	parser.result = parser.result[:0]
+	parser.result = []ast.StmtNode{}
 
 	var l yyLexer = &parser.lexer
 	yyParse(l, parser)


### PR DESCRIPTION
close pingcap/tidb#42230

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42230 

Problem Summary: 
User has to make a copy of parser result before using it in goroutine to avoid data race which is inconvenient and can be missed if not familiar with how the parser reuses the underlying array for results.

### What is changed and how it works?
Allocate a new array for parser result before parsing, instead of just truncate the slice while reusing the underlying array.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
