### PR TITLE
planner: non-prep plan cache supports regular builtin-functions

### DIFF
--- a/expression/function_traits.go
+++ b/expression/function_traits.go
@@ -19,18 +19,6 @@ import (
 	"github.com/pingcap/tidb/parser/opcode"
 )
 
-// NonPreparedPlanCacheableOp stores function which can be cached to non-prepared plan cache.
-var NonPreparedPlanCacheableOp = map[string]struct{}{
-	ast.LogicAnd: {},
-	ast.LogicOr:  {},
-	ast.GE:       {},
-	ast.LE:       {},
-	ast.EQ:       {},
-	ast.LT:       {},
-	ast.GT:       {},
-	ast.In:       {},
-}
-
 // UnCacheableFunctions stores functions which can not be cached to plan cache.
 var UnCacheableFunctions = map[string]struct{}{
 	ast.Database:             {},

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -342,9 +342,6 @@ func TestNonPreparedPlanCacheReason(t *testing.T) {
 	tk.MustExec(`explain format = 'plan_cache' select * from t where a=1`)
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
 
-	tk.MustExec(`explain format = 'plan_cache' select * from t where a+1=1`)
-	tk.MustQuery(`show warnings`).Check(testkit.Rows(`Warning 1105 skip non-prepared plan-cache: query has some unsupported binary operation`))
-
 	tk.MustExec(`explain format = 'plan_cache' select * from t t1, t t2`)
 	tk.MustQuery(`show warnings`).Check(testkit.Rows(`Warning 1105 skip non-prepared plan-cache: queries that access multiple tables are not supported`))
 
@@ -1492,6 +1489,9 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"select * from t where a in (1, 2) and b < 15",
 		"select * from t where a between 1 and 10",
 		"select * from t where a between 1 and 10 and b < 15",
+		"select * from t where a+b=13",
+		"select * from t where mod(a, 3)=1",
+		"select * from t where d>now()",
 	}
 
 	unsupported := []string{
@@ -1510,9 +1510,6 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"select * from t1 for update",                                                      // lock
 		"select * from t1 where a in (select a from t)",                                    // uncorrelated sub-query
 		"select * from t1 where a in (select a from t where a > t1.a)",                     // correlated sub-query
-		"select * from t where a+b=13",                                                     // '+'
-		"select * from t where mod(a, 3)=1",                                                // mod
-		"select * from t where d>now()",                                                    // now
 		"select * from t where j < 1",                                                      // json
 		"select * from t where a > 1 and j < 1",
 		"select * from t where e < '1'", // enum
@@ -1550,9 +1547,6 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"skip non-prepared plan-cache: queries that have hints, aggregation, window-function, order-by, limit and lock are not supported",
 		"skip non-prepared plan-cache: queries that access partitioning table are not supported",
 		"skip non-prepared plan-cache: queries that access partitioning table are not supported",
-		"skip non-prepared plan-cache: query has some unsupported binary operation",
-		"skip non-prepared plan-cache: query has some unsupported binary operation",
-		"skip non-prepared plan-cache: query has some unsupported Node",
 		"skip non-prepared plan-cache: query has some filters with JSON, Enum, Set or Bit columns",
 		"skip non-prepared plan-cache: query has some filters with JSON, Enum, Set or Bit columns",
 		"skip non-prepared plan-cache: query has some filters with JSON, Enum, Set or Bit columns",
@@ -1656,6 +1650,41 @@ func TestNonPreparedPlanCachePanic(t *testing.T) {
 		require.NoError(t, err)
 		_, _, err = planner.Optimize(context.TODO(), ctx, stmtNode, preprocessorReturn.InfoSchema)
 		require.NoError(t, err) // not panic
+	}
+}
+
+func TestNonPreparedPlanCacheBuiltinFuncs(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`set tidb_enable_non_prepared_plan_cache=1`)
+	tk.MustExec(`create table t (a int, b varchar(32), c datetime, key(a))`)
+
+	// normal builtin functions can be supported
+	supportedCases := []string{
+		`select * from t where mod(a, 5) < 2`,
+		`select * from t where c < now()`,
+		`select date_format(c, '%Y-%m-%d') from t where a < 10`,
+		`select str_to_date(b, '%Y-%m-%d') from t where a < 10`,
+		`select * from t where a-2 < 20`,
+		`select * from t where a+b > 100`,
+	}
+	for _, sql := range supportedCases {
+		tk.MustExec(sql)
+		tk.MustExec(sql)
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	}
+
+	// unsupported cases
+	unsupportedCases := []string{
+		`select * from t where -a > 10`,                  // '-' cannot support
+		`select * from t where a < 1 and b like '%abc%'`, // LIKE
+		`select database() from t`,
+	}
+	for _, sql := range unsupportedCases {
+		tk.MustExec(sql)
+		tk.MustExec(sql)
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
 	}
 }
 

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -291,7 +291,7 @@ func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (out ast.Node
 
 	switch node := in.(type) {
 	case *ast.SelectStmt, *ast.FieldList, *ast.SelectField, *ast.TableRefsClause, *ast.Join, *ast.BetweenExpr,
-		*ast.TableSource, *ast.ColumnNameExpr, *ast.PatternInExpr:
+		*ast.TableSource, *ast.ColumnNameExpr, *ast.PatternInExpr, *ast.BinaryOperationExpr:
 		return in, !checker.cacheable // skip child if un-cacheable
 	case *ast.ColumnName:
 		if checker.filterCnt > 0 {
@@ -306,10 +306,10 @@ func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (out ast.Node
 			}
 		}
 		return in, !checker.cacheable
-	case *ast.BinaryOperationExpr:
-		if _, found := expression.NonPreparedPlanCacheableOp[node.Op.String()]; !found {
+	case *ast.FuncCallExpr:
+		if _, found := expression.UnCacheableFunctions[node.FnName.L]; found {
 			checker.cacheable = false
-			checker.reason = "query has some unsupported binary operation"
+			checker.reason = "query has un-cacheable functions"
 		}
 		return in, !checker.cacheable
 	case *driver.ValueExpr:

--- a/planner/core/plan_cacheable_checker_test.go
+++ b/planner/core/plan_cacheable_checker_test.go
@@ -298,6 +298,9 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 		"select * from test.t where a in (1, 2) and b < 15",
 		"select * from test.t where a between 1 and 10",
 		"select * from test.t where a between 1 and 10 and b < 15",
+		"select * from test.t where a+b=13",      // '+'
+		"select * from test.t where mod(a, 3)=1", // mod
+		"select * from test.t where d>now()",     // now
 	}
 
 	unsupported := []string{
@@ -316,10 +319,6 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 		"select * from test.t1 for update",                                                      // lock
 		"select * from test.t1 where a in (select a from t)",                                    // uncorrelated sub-query
 		"select * from test.t1 where a in (select a from test.t where a > t1.a)",                // correlated sub-query
-
-		"select * from test.t where a+b=13",      // '+'
-		"select * from test.t where mod(a, 3)=1", // mod
-		"select * from test.t where d>now()",     // now
 	}
 
 	for _, q := range unsupported {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36598

Problem Summary: planner: non-prep plan cache supports regular builtin-functions

### What is changed and how it works?

planner: non-prep plan cache supports regular builtin-functions

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
