### PR TITLE
test: fix ut TestTraceAndLocation when run with go test

### DIFF
--- a/parser/terror/terror_test.go
+++ b/parser/terror/terror_test.go
@@ -157,7 +157,7 @@ func TestTraceAndLocation(t *testing.T) {
 		// ```
 		//
 		// So we have to deal with these boundary conditions.
-		if strings.Contains(line, goroot) || strings.Contains(line, "GOROOT") || strings.Contains(line, "runtime.goexit") {
+		if strings.Contains(line, goroot) || strings.Contains(line, "src/runtime") {
 			sysStack++
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close  https://github.com/pingcap/tidb/issues/42557

Problem Summary:
 FAIL TestTraceAndLocation when run with go test. 

```
if strings.Contains(line, goroot) || strings.Contains(line, "GOROOT") || strings.Contains(line, "runtime.goexit") {
	sysStack++
}
```

when you run test case in the bazel. the stack looks like this:
``` go 
testing.tRunner
    GOROOT/src/testing/testing.go:1576
runtime.goexit
    src/runtime/asm_arm64.s:1172
```

the sysStack
```
    GOROOT/src/testing/testing.go:1576
runtime.goexit
```

but run with go test.  the stack looks like this:
```
testing.tRunner
    /Users/pingcap/.gvm/gos/go1.20.1/src/testing/testing.go:1576
runtime.goexit
    /Users/pingcap/.gvm/gos/go1.20.1/src/runtime/asm_arm64.s:1172
```

the sysStack
```
    /Users/pingcap/.gvm/gos/go1.20.1/src/testing/testing.go:1576
runtime.goexit
    /Users/pingcap/.gvm/gos/go1.20.1/src/runtime/asm_arm64.s:1172
```


### What is changed and how it works?
```
if strings.Contains(line, goroot) || strings.Contains(line, "src/runtime") {
	sysStack++
}
```
 when you run with bazel. the sysStack 
```
    GOROOT/src/testing/testing.go:1576
    src/runtime/asm_arm64.s:1172
```

run with go test. the sysStack
```
    /Users/pingcap/.gvm/gos/go1.20.1/src/testing/testing.go:1576
    /Users/pingcap/.gvm/gos/go1.20.1/src/runtime/asm_arm64.s:1172
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
