### PR TITLE
infoschema: fix select temporary table with view will panic problem

### DIFF
--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -751,15 +751,10 @@ func (ts *SessionExtendedInfoSchema) HasTemporaryTable() bool {
 	return ts.LocalTemporaryTables != nil && ts.LocalTemporaryTables.Count() > 0 || ts.InfoSchema.HasTemporaryTable()
 }
 
-// AttachMDLTableInfoSchema attach MDL related table information schema to is
-func AttachMDLTableInfoSchema(is InfoSchema) InfoSchema {
-	mdlTables := NewSessionTables()
-	if iss, ok := is.(*SessionExtendedInfoSchema); ok {
-		iss.MdlTables = mdlTables
-		return iss
-	}
+// DetachTemporaryTableInfoSchema returns a new SessionExtendedInfoSchema without temporary tables
+func (ts *SessionExtendedInfoSchema) DetachTemporaryTableInfoSchema() *SessionExtendedInfoSchema {
 	return &SessionExtendedInfoSchema{
-		InfoSchema: is,
-		MdlTables:  mdlTables,
+		InfoSchema: ts.InfoSchema,
+		MdlTables:  ts.MdlTables,
 	}
 }

--- a/table/temptable/BUILD.bazel
+++ b/table/temptable/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     srcs = [
         "ddl_test.go",
         "interceptor_test.go",
+        "intergration_test.go",
         "main_test.go",
     ],
     embed = [":temptable"],
@@ -42,6 +43,7 @@ go_test(
         "//infoschema",
         "//kv",
         "//meta/autoid",
+        "//parser/auth",
         "//parser/model",
         "//parser/mysql",
         "//sessionctx",
@@ -49,6 +51,7 @@ go_test(
         "//store/mockstore",
         "//table",
         "//tablecodec",
+        "//testkit",
         "//testkit/testsetup",
         "//types",
         "//util/codec",

--- a/table/temptable/infoschema.go
+++ b/table/temptable/infoschema.go
@@ -41,9 +41,7 @@ func AttachLocalTemporaryTableInfoSchema(sctx sessionctx.Context, is infoschema.
 // DetachLocalTemporaryTableInfoSchema detach local temporary table information schema from is
 func DetachLocalTemporaryTableInfoSchema(is infoschema.InfoSchema) infoschema.InfoSchema {
 	if attachedInfoSchema, ok := is.(*infoschema.SessionExtendedInfoSchema); ok {
-		newIs := attachedInfoSchema
-		newIs.LocalTemporaryTables = nil
-		return newIs
+		return attachedInfoSchema.DetachTemporaryTableInfoSchema()
 	}
 
 	return is

--- a/table/temptable/intergration_test.go
+++ b/table/temptable/intergration_test.go
@@ -1,0 +1,39 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package temptable_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/parser/auth"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectTemporaryTableUnionView(t *testing.T) {
+	// see the issue: https://github.com/pingcap/tidb/issues/42563
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil))
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("insert into t values(1)")
+	tk.MustExec("create view tv as select a from t")
+	tk.MustExec("create temporary table t(a int)")
+	tk.MustExec("insert into t values(2)")
+	tk.MustQuery("select * from tv").Check(testkit.Rows("1"))
+	tk.MustQuery("select * from t").Check(testkit.Rows("2"))
+	tk.MustQuery("select * from (select a from t union all select a from tv) t1 order by a").Check(testkit.Rows("1", "2"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42563

It will also close #42307 because it will no longer modify the information schema in session.

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
 fix select temporary table with view will panic problem
```
