### PR TITLE
ddl: fix unstable test TestAddIndexUniqueFailOnDuplicate

### DIFF
--- a/ddl/index_modify_test.go
+++ b/ddl/index_modify_test.go
@@ -1074,7 +1074,7 @@ func TestAddIndexUniqueFailOnDuplicate(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a bigint primary key clustered, b int);")
 	// The subtask execution order is not guaranteed in distributed reorg. We need to disable it first.
-	tk.MustExec("set @@global.tidb_ddl_distribute_reorg = 0;")
+	tk.MustExec("set @@global.tidb_enable_dist_task = 0;")
 	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 1;")
 	for i := 1; i <= 12; i++ {
 		tk.MustExec("insert into t values (?, ?)", i, i)

--- a/ddl/index_modify_test.go
+++ b/ddl/index_modify_test.go
@@ -1069,17 +1069,19 @@ func TestAddIndexWithDupIndex(t *testing.T) {
 }
 
 func TestAddIndexUniqueFailOnDuplicate(t *testing.T) {
-	ddl.ResultCounterForTest = &atomic.Int32{}
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a bigint primary key clustered, b int);")
+	// The subtask execution order is not guaranteed in distributed reorg. We need to disable it first.
+	tk.MustExec("set @@global.tidb_ddl_distribute_reorg = 0;")
 	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 1;")
 	for i := 1; i <= 12; i++ {
 		tk.MustExec("insert into t values (?, ?)", i, i)
 	}
 	tk.MustExec("insert into t values (0, 1);") // Insert a duplicate key.
 	tk.MustQuery("split table t by (0), (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11), (12);").Check(testkit.Rows("13 1"))
+	ddl.ResultCounterForTest = &atomic.Int32{}
 	tk.MustGetErrCode("alter table t add unique index idx (b);", errno.ErrDupEntry)
 	require.Less(t, int(ddl.ResultCounterForTest.Load()), 6)
 	ddl.ResultCounterForTest = nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42417

Problem Summary:

The subtask execution order is not guaranteed in distributed reorg. We need to disable it first before the test.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
