### PR TITLE
gc_worker: remove hex decode for the result of acquring engine type

### DIFF
--- a/store/gcworker/gc_worker.go
+++ b/store/gcworker/gc_worker.go
@@ -864,7 +864,8 @@ func isRaftKv2(ctx context.Context, sctx sessionctx.Context) (bool, error) {
 	// All nodes should have the same type of engine
 	raftVersion, err := hex.DecodeString(row.GetString(3))
 	if err != nil {
-		return false, errors.Trace(err)
+		// If mock store is used, we cannot decode the result, so just return false is ok.
+		return false, nil
 	}
 	return string(raftVersion) == raftKv2, nil
 }

--- a/store/gcworker/gc_worker.go
+++ b/store/gcworker/gc_worker.go
@@ -862,12 +862,8 @@ func isRaftKv2(ctx context.Context, sctx sessionctx.Context) (bool, error) {
 	}
 
 	// All nodes should have the same type of engine
-	raftVersion, err := hex.DecodeString(row.GetString(3))
-	if err != nil {
-		// If mock store is used, we cannot decode the result, so just return false is ok.
-		return false, nil
-	}
-	return string(raftVersion) == raftKv2, nil
+	raftVersion := row.GetString(3)
+	return raftVersion == raftKv2, nil
 }
 
 // deleteRanges processes all delete range records whose ts < safePoint in table `gc_delete_range`


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: Ref #42410

Problem Summary:

Mock store may not support engine type query which leads to decode error.
Ignore the error and treat it as raft-kv version 1.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
