### PR TITLE
disttask: Add `task_key` column to `mysql.tidb_global_task`

### DIFF
--- a/disttask/framework/dispatcher/dispatcher_test.go
+++ b/disttask/framework/dispatcher/dispatcher_test.go
@@ -144,7 +144,7 @@ func TestSimple(t *testing.T) {
 	defer dsp.Stop()
 
 	dispatcher.RegisterTaskFlowHandle(taskTypeExample, NumberExampleHandle{})
-	taskID, err := gTaskMgr.AddNewTask(taskTypeExample, 0, nil)
+	taskID, err := gTaskMgr.AddNewTask("key1", taskTypeExample, 0, nil)
 	require.NoError(t, err)
 
 	// test DispatchTaskLoop

--- a/disttask/framework/proto/task.go
+++ b/disttask/framework/proto/task.go
@@ -53,6 +53,7 @@ const (
 // Task represents the task of distribute framework.
 type Task struct {
 	ID              int64
+	Key             string
 	Type            string
 	State           string
 	Step            int64

--- a/disttask/framework/storage/table_test.go
+++ b/disttask/framework/storage/table_test.go
@@ -48,13 +48,14 @@ func TestGlobalTaskTable(t *testing.T) {
 	gm, err := storage.GetGlobalTaskManager()
 	require.NoError(t, err)
 
-	id, err := gm.AddNewTask("test", 4, []byte("test"))
+	id, err := gm.AddNewTask("key1", "test", 4, []byte("test"))
 	require.NoError(t, err)
 	require.Equal(t, int64(1), id)
 
 	task, err := gm.GetNewTask()
 	require.NoError(t, err)
 	require.Equal(t, int64(1), task.ID)
+	require.Equal(t, "key1", task.Key)
 	require.Equal(t, "test", task.Type)
 	require.Equal(t, proto.TaskStatePending, task.State)
 	require.Equal(t, uint64(4), task.Concurrency)
@@ -82,6 +83,10 @@ func TestGlobalTaskTable(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, task5, 1)
 	require.Equal(t, task, task5[0])
+
+	// test cannot insert task with dup key
+	_, err = gm.AddNewTask("key1", "test2", 4, []byte("test2"))
+	require.EqualError(t, err, "[kv:1062]Duplicate entry 'key1' for key 'tidb_global_task.task_key'")
 }
 
 func TestSubTaskTable(t *testing.T) {

--- a/disttask/framework/storage/task_table.go
+++ b/disttask/framework/storage/task_table.go
@@ -114,25 +114,26 @@ func execSQL(ctx context.Context, se sessionctx.Context, sql string, args ...int
 func row2GlobeTask(r chunk.Row) *proto.Task {
 	task := &proto.Task{
 		ID:           r.GetInt64(0),
-		Type:         r.GetString(1),
-		DispatcherID: r.GetString(2),
-		State:        r.GetString(3),
-		Meta:         r.GetBytes(6),
-		Concurrency:  uint64(r.GetInt64(7)),
-		Step:         r.GetInt64(8),
+		Key:          r.GetString(1),
+		Type:         r.GetString(2),
+		DispatcherID: r.GetString(3),
+		State:        r.GetString(4),
+		Meta:         r.GetBytes(7),
+		Concurrency:  uint64(r.GetInt64(8)),
+		Step:         r.GetInt64(9),
 	}
 	// TODO: convert to local time.
-	task.StartTime, _ = r.GetTime(4).GoTime(time.UTC)
-	task.StateUpdateTime, _ = r.GetTime(5).GoTime(time.UTC)
+	task.StartTime, _ = r.GetTime(5).GoTime(time.UTC)
+	task.StateUpdateTime, _ = r.GetTime(6).GoTime(time.UTC)
 	return task
 }
 
 // AddNewTask adds a new task to global task table.
-func (stm *GlobalTaskManager) AddNewTask(tp string, concurrency int, meta []byte) (int64, error) {
+func (stm *GlobalTaskManager) AddNewTask(key, tp string, concurrency int, meta []byte) (int64, error) {
 	stm.mu.Lock()
 	defer stm.mu.Unlock()
 
-	_, err := execSQL(stm.ctx, stm.se, "insert into mysql.tidb_global_task(type, state, concurrency, meta, state_update_time) values (%?, %?, %?, %?, %?)", tp, proto.TaskStatePending, concurrency, meta, time.Now().UTC().String())
+	_, err := execSQL(stm.ctx, stm.se, "insert into mysql.tidb_global_task(task_key, type, state, concurrency, meta, state_update_time) values (%?, %?, %?, %?, %?, %?)", key, tp, proto.TaskStatePending, concurrency, meta, time.Now().UTC().String())
 	if err != nil {
 		return 0, err
 	}
@@ -150,7 +151,7 @@ func (stm *GlobalTaskManager) GetNewTask() (task *proto.Task, err error) {
 	stm.mu.Lock()
 	defer stm.mu.Unlock()
 
-	rs, err := execSQL(stm.ctx, stm.se, "select * from mysql.tidb_global_task where state = %? limit 1", proto.TaskStatePending)
+	rs, err := execSQL(stm.ctx, stm.se, "select id, task_key, type, dispatcher_id, state, start_time, state_update_time, meta, concurrency, step from mysql.tidb_global_task where state = %? limit 1", proto.TaskStatePending)
 	if err != nil {
 		return task, err
 	}
@@ -185,7 +186,7 @@ func (stm *GlobalTaskManager) GetTasksInStates(states ...interface{}) (task []*p
 		return task, nil
 	}
 
-	rs, err := execSQL(stm.ctx, stm.se, "select * from mysql.tidb_global_task where state in ("+strings.Repeat("%?,", len(states)-1)+"%?)", states...)
+	rs, err := execSQL(stm.ctx, stm.se, "select id, task_key, type, dispatcher_id, state, start_time, state_update_time, meta, concurrency, step from mysql.tidb_global_task where state in ("+strings.Repeat("%?,", len(states)-1)+"%?)", states...)
 	if err != nil {
 		return task, err
 	}
@@ -201,7 +202,7 @@ func (stm *GlobalTaskManager) GetTaskByID(taskID int64) (task *proto.Task, err e
 	stm.mu.Lock()
 	defer stm.mu.Unlock()
 
-	rs, err := execSQL(stm.ctx, stm.se, "select * from mysql.tidb_global_task where id = %?", taskID)
+	rs, err := execSQL(stm.ctx, stm.se, "select id, task_key, type, dispatcher_id, state, start_time, state_update_time, meta, concurrency, step from mysql.tidb_global_task where id = %?", taskID)
 	if err != nil {
 		return task, err
 	}

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -2435,7 +2435,7 @@ func upgradeToVer140(s Session, ver int64) {
 	if ver >= version140 {
 		return
 	}
-	doReentrantDDL(s, "ALTER TABLE mysql.tidb_global_task ADD COLUMN `task_key` VARCHAR(256) NOT NULL", infoschema.ErrColumnExists)
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_global_task ADD COLUMN `task_key` VARCHAR(256) NOT NULL AFTER `id`", infoschema.ErrColumnExists)
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_global_task ADD UNIQUE KEY task_key(task_key)", dbterror.ErrDupKeyName)
 }
 

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -553,6 +553,7 @@ const (
 	// CreateGlobalTask is a table about global task.
 	CreateGlobalTask = `CREATE TABLE IF NOT EXISTS mysql.tidb_global_task (
 		id BIGINT(20) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    	task_key VARCHAR(256) NOT NULL,
 		type VARCHAR(256) NOT NULL,
 		dispatcher_id VARCHAR(256),
 		state VARCHAR(64) NOT NULL,
@@ -561,7 +562,8 @@ const (
 		meta LONGBLOB,
 		concurrency INT(11),
 		step INT(11),
-		key(state)
+		key(state),
+      	UNIQUE KEY task_key(task_key)
 	);`
 
 	// CreateLoadDataJobs is a table that LOAD DATA uses
@@ -850,11 +852,13 @@ const (
 	version138 = 138
 	// version 139 creates mysql.load_data_jobs table for LOAD DATA statement
 	version139 = 139
+	// version 140 add column task_key to mysql.tidb_global_task
+	version140 = 140
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version139
+var currentBootstrapVersion int64 = version140
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -982,6 +986,7 @@ var (
 		upgradeToVer137,
 		upgradeToVer138,
 		upgradeToVer139,
+		upgradeToVer140,
 	}
 )
 
@@ -2424,6 +2429,14 @@ func upgradeToVer139(s Session, ver int64) {
 		return
 	}
 	mustExecute(s, CreateLoadDataJobs)
+}
+
+func upgradeToVer140(s Session, ver int64) {
+	if ver >= version140 {
+		return
+	}
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_global_task ADD COLUMN `task_key` VARCHAR(256) NOT NULL", infoschema.ErrColumnExists)
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_global_task ADD UNIQUE KEY task_key(task_key)", dbterror.ErrDupKeyName)
 }
 
 func writeOOMAction(s Session) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42610

### What is changed and how it works?

A new column `task_key` added to system table `mysql.tidb_global_task`. The `task_key` is defined as unique and defined by user. User can use this field to avoid submitting the duplicated tasks in recover logic.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
