### PR TITLE
planner: initialize charset, collation and repertoire correctly for parameter values | tidb-test=pr/2108

### DIFF
--- a/expression/builtin_other_test.go
+++ b/expression/builtin_other_test.go
@@ -141,7 +141,7 @@ func TestGetVar(t *testing.T) {
 		} else {
 			tp = types.NewFieldType(mysql.TypeVarString)
 		}
-		types.DefaultParamTypeForValue(kv.val, tp)
+		types.InferParamTypeFromUnderlyingValue(kv.val, tp)
 		ctx.GetSessionVars().SetUserVarType(kv.key, tp)
 	}
 

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -132,7 +132,7 @@ func (c *Constant) GetType() *types.FieldType {
 		// so it should avoid data race. We achieve this by returning different FieldType pointer for each call.
 		tp := types.NewFieldType(mysql.TypeUnspecified)
 		dt := c.ParamMarker.GetUserVar()
-		types.DefaultParamTypeForValue(dt.GetValue(), tp)
+		types.InferParamTypeFromDatum(&dt, tp)
 		return tp
 	}
 	return c.RetType

--- a/expression/util.go
+++ b/expression/util.go
@@ -1002,7 +1002,7 @@ func ParamMarkerExpression(ctx sessionctx.Context, v *driver.ParamMarkerExpr, ne
 	useCache := ctx.GetSessionVars().StmtCtx.UseCache
 	isPointExec := ctx.GetSessionVars().StmtCtx.PointExec
 	tp := types.NewFieldType(mysql.TypeUnspecified)
-	types.DefaultParamTypeForValue(v.GetValue(), tp)
+	types.InferParamTypeFromDatum(&v.Datum, tp)
 	value := &Constant{Value: v.Datum, RetType: tp}
 	if useCache || isPointExec || needParam {
 		value.ParamMarker = &ParamMarker{

--- a/planner/core/plan_cache_param.go
+++ b/planner/core/plan_cache_param.go
@@ -136,7 +136,7 @@ func Params2Expressions(params []*driver.ValueExpr) []expression.Expression {
 	exprs := make([]expression.Expression, 0, len(params))
 	for _, p := range params {
 		tp := new(types.FieldType)
-		types.DefaultParamTypeForValue(p.Datum.GetValue(), tp)
+		types.InferParamTypeFromDatum(&p.Datum, tp)
 		exprs = append(exprs, &expression.Constant{
 			Value:   p.Datum,
 			RetType: tp,

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -676,7 +676,7 @@ func parseExecArgs(sc *stmtctx.StatementContext, params []expression.Expression,
 
 	for i := range params {
 		ft := new(types.FieldType)
-		types.DefaultParamTypeForValue(args[i].GetValue(), ft)
+		types.InferParamTypeFromUnderlyingValue(args[i].GetValue(), ft)
 		params[i] = &expression.Constant{Value: args[i], RetType: ft}
 	}
 	return

--- a/types/etc.go
+++ b/types/etc.go
@@ -133,6 +133,11 @@ func IsString(tp byte) bool {
 	return IsTypeChar(tp) || IsTypeBlob(tp) || IsTypeVarchar(tp) || IsTypeUnspecified(tp)
 }
 
+// IsStringKind returns a boolean indicating whether the tp is a string type.
+func IsStringKind(kind byte) bool {
+	return kind == KindString || kind == KindBytes
+}
+
 var kind2Str = map[byte]string{
 	KindNull:          "null",
 	KindInt64:         "bigint",

--- a/types/field_type.go
+++ b/types/field_type.go
@@ -176,8 +176,22 @@ func SetTypeFlag(flag *uint, flagItem uint, on bool) {
 	}
 }
 
-// DefaultParamTypeForValue returns the default FieldType for the parameterized value.
-func DefaultParamTypeForValue(value interface{}, tp *FieldType) {
+// InferParamTypeFromDatum is used for plan cache to infer the type of a parameter from its datum.
+func InferParamTypeFromDatum(d *Datum, tp *FieldType) {
+	InferParamTypeFromUnderlyingValue(d.GetValue(), tp)
+	if IsStringKind(d.k) {
+		// consider charset and collation here
+		c, err := collate.GetCollationByName(d.collation)
+		if err != nil || c == nil {
+			return // use default charset and collation
+		}
+		tp.SetCharset(c.CharsetName)
+		tp.SetCollate(d.collation)
+	}
+}
+
+// InferParamTypeFromUnderlyingValue is used for plan cache to infer the type of a parameter from its underlying value.
+func InferParamTypeFromUnderlyingValue(value interface{}, tp *FieldType) {
 	switch value.(type) {
 	case nil:
 		tp.SetType(mysql.TypeVarString)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36598

Problem Summary: planner: initialize charset, collation and repertoire correctly for parameter values

### What is changed and how it works?

1. Initialize charset and collation when inferring types of parameters;
2. Initialize repertoire when creating constants from parameters;

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
