### PR TITLE
ddl: reimplement the backfill scheduler

### DIFF
--- a/ddl/BUILD.bazel
+++ b/ddl/BUILD.bazel
@@ -86,6 +86,7 @@ go_library(
         "//parser/terror",
         "//parser/types",
         "//privilege",
+        "//resourcemanager/pool/workerpool",
         "//resourcemanager/pooltask",
         "//resourcemanager/util",
         "//sessionctx",

--- a/ddl/backfilling.go
+++ b/ddl/backfilling.go
@@ -821,12 +821,6 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sessionPool, t table.Physic
 			break
 		}
 
-		scheduler.setMaxWorkerSize(len(kvRanges))
-		err = scheduler.adjustWorkerSize()
-		if err != nil {
-			return errors.Trace(err)
-		}
-
 		logutil.BgLogger().Info("[ddl] start backfill workers to reorg record",
 			zap.Stringer("type", bfWorkerType),
 			zap.Int("workerCnt", scheduler.currentWorkerSize()),

--- a/ddl/backfilling_scheduler.go
+++ b/ddl/backfilling_scheduler.go
@@ -300,7 +300,7 @@ func (b *ingestBackfillScheduler) setupWorkers() error {
 		return errors.Trace(err)
 	}
 	b.writerPool = writerPool
-	b.copReqSenderPool.resultsCh = writerPool
+	b.copReqSenderPool.chunkSender = writerPool
 	b.copReqSenderPool.adjustSize(readerCnt)
 	return nil
 }

--- a/ddl/dist_backfilling.go
+++ b/ddl/dist_backfilling.go
@@ -157,10 +157,6 @@ func newBackfillWorkerContext(d *ddl, schemaName string, tbl table.Table, worker
 		var bf backfiller
 		bf, err = bfFunc(newBackfillCtx(d.ddlCtx, 0, se, schemaName, tbl, d.jobContext(jobID), "add_idx_rate", true))
 		if err != nil {
-			if canSkipError(jobID, len(bwCtx.backfillWorkers), err) {
-				err = nil
-				continue
-			}
 			logutil.BgLogger().Error("[ddl] new backfill worker context, do bfFunc failed", zap.Int64("jobID", jobID), zap.Error(err))
 			return nil, errors.Trace(err)
 		}

--- a/ddl/export_test.go
+++ b/ddl/export_test.go
@@ -52,7 +52,7 @@ func FetchChunk4Test(copCtx *copContext, tbl table.PhysicalTable, startKey, endK
 	taskCh := make(chan *reorgBackfillTask, 5)
 	resultCh := make(chan idxRecResult, 5)
 	pool := newCopReqSenderPool(context.Background(), copCtx, store, taskCh)
-	pool.resultsCh = &resultChanForTest{ch: resultCh}
+	pool.chunkSender = &resultChanForTest{ch: resultCh}
 	pool.adjustSize(1)
 	pool.tasksCh <- task
 	rs := <-resultCh

--- a/ddl/export_test.go
+++ b/ddl/export_test.go
@@ -56,6 +56,7 @@ func FetchChunk4Test(copCtx *copContext, tbl table.PhysicalTable, startKey, endK
 	pool.adjustSize(1)
 	pool.tasksCh <- task
 	rs := <-resultCh
+	close(taskCh)
 	pool.close(false)
 	return rs.chunk
 }

--- a/ddl/export_test.go
+++ b/ddl/export_test.go
@@ -32,8 +32,16 @@ func SetBatchInsertDeleteRangeSize(i int) {
 
 var NewCopContext4Test = newCopContext
 
+type resultChanForTest struct {
+	ch chan idxRecResult
+}
+
+func (r *resultChanForTest) AddTask(rs idxRecResult) {
+	r.ch <- rs
+}
+
 func FetchChunk4Test(copCtx *copContext, tbl table.PhysicalTable, startKey, endKey kv.Key, store kv.Storage,
-	batchSize int) (*chunk.Chunk, error) {
+	batchSize int) *chunk.Chunk {
 	variable.SetDDLReorgBatchSize(int32(batchSize))
 	task := &reorgBackfillTask{
 		id:            1,
@@ -41,12 +49,15 @@ func FetchChunk4Test(copCtx *copContext, tbl table.PhysicalTable, startKey, endK
 		endKey:        endKey,
 		physicalTable: tbl,
 	}
-	pool := newCopReqSenderPool(context.Background(), copCtx, store)
+	taskCh := make(chan *reorgBackfillTask, 5)
+	resultCh := make(chan idxRecResult, 5)
+	pool := newCopReqSenderPool(context.Background(), copCtx, store, taskCh)
+	pool.resultsCh = &resultChanForTest{ch: resultCh}
 	pool.adjustSize(1)
 	pool.tasksCh <- task
-	copChunk, err := pool.fetchChunk()
+	rs := <-resultCh
 	pool.close(false)
-	return copChunk, err
+	return rs.chunk
 }
 
 func ConvertRowToHandleAndIndexDatum(row chunk.Row, copCtx *copContext) (kv.Handle, []types.Datum, error) {

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1743,6 +1743,7 @@ func writeChunkToLocal(writerCtx *ingest.WriterContext,
 			return 0, nil, errors.Trace(err)
 		}
 		count++
+		lastHandle = handle
 	}
 	return count, lastHandle, nil
 }

--- a/ddl/index_cop.go
+++ b/ddl/index_cop.go
@@ -129,7 +129,7 @@ func (c *copReqSender) run() {
 				terror.Call(rs.Close)
 				return
 			}
-			p.resultsCh.AddTask(idxRecResult{id: task.id, chunk: srcChk, done: done, end: task.endKey})
+			p.resultsCh.AddTask(idxRecResult{id: task.id, chunk: srcChk, done: done})
 		}
 		terror.Call(rs.Close)
 	}
@@ -474,6 +474,5 @@ type idxRecResult struct {
 	id    int
 	chunk *chunk.Chunk
 	err   error
-	end   kv.Key
 	done  bool
 }

--- a/ddl/index_cop_test.go
+++ b/ddl/index_cop_test.go
@@ -45,7 +45,7 @@ func TestAddIndexFetchRowsFromCoprocessor(t *testing.T) {
 		endKey := startKey.PrefixNext()
 		txn, err := store.Begin()
 		require.NoError(t, err)
-		copChunk, err := ddl.FetchChunk4Test(copCtx, tbl.(table.PhysicalTable), startKey, endKey, store, 10)
+		copChunk := ddl.FetchChunk4Test(copCtx, tbl.(table.PhysicalTable), startKey, endKey, store, 10)
 		require.NoError(t, err)
 		require.NoError(t, txn.Rollback())
 

--- a/ddl/index_merge_tmp.go
+++ b/ddl/index_merge_tmp.go
@@ -139,7 +139,7 @@ func newMergeTempIndexWorker(bfCtx *backfillCtx, t table.PhysicalTable, eleID in
 	}
 }
 
-// BackfillDataInTxn merge temp index data in txn.
+// BackfillData merge temp index data in txn.
 func (w *mergeIndexWorker) BackfillData(taskRange reorgBackfillTask) (taskCtx backfillTaskContext, errInTxn error) {
 	oprStartTime := time.Now()
 	ctx := kv.WithInternalSourceType(context.Background(), w.jobContext.ddlJobSourceType())

--- a/ddl/ingest/backend.go
+++ b/ddl/ingest/backend.go
@@ -89,7 +89,9 @@ func (bc *BackendContext) Flush(indexID int64) error {
 		return err
 	}
 
-	if bc.diskRoot.CurrentUsage() >= uint64(importThreshold*float64(bc.diskRoot.MaxQuota())) {
+	release := ei.AcquireFlushLock()
+	if release != nil && bc.diskRoot.CurrentUsage() >= uint64(importThreshold*float64(bc.diskRoot.MaxQuota())) {
+		defer release()
 		// TODO: it should be changed according checkpoint solution.
 		// Flush writer cached data into local disk for engine first.
 		err := ei.Flush()

--- a/ddl/ingest/engine_mgr.go
+++ b/ddl/ingest/engine_mgr.go
@@ -25,19 +25,19 @@ import (
 )
 
 type engineManager struct {
-	generic.SyncMap[int64, *engineInfo]
+	generic.SyncMap[int64, *EngineInfo]
 	MemRoot  MemRoot
 	DiskRoot DiskRoot
 }
 
 func (m *engineManager) init(memRoot MemRoot, diskRoot DiskRoot) {
-	m.SyncMap = generic.NewSyncMap[int64, *engineInfo](10)
+	m.SyncMap = generic.NewSyncMap[int64, *EngineInfo](10)
 	m.MemRoot = memRoot
 	m.DiskRoot = diskRoot
 }
 
-// Register create a new engineInfo and register it to the engineManager.
-func (m *engineManager) Register(bc *BackendContext, jobID, indexID int64, schemaName, tableName string) (*engineInfo, error) {
+// Register create a new EngineInfo and register it to the engineManager.
+func (m *engineManager) Register(bc *BackendContext, jobID, indexID int64, schemaName, tableName string) (*EngineInfo, error) {
 	// Calculate lightning concurrency degree and set memory usage
 	// and pre-allocate memory usage for worker.
 	m.MemRoot.RefreshConsumption()
@@ -87,7 +87,7 @@ func (m *engineManager) Register(bc *BackendContext, jobID, indexID int64, schem
 	return en, nil
 }
 
-// Unregister delete the engineInfo from the engineManager.
+// Unregister delete the EngineInfo from the engineManager.
 func (m *engineManager) Unregister(jobID, indexID int64) {
 	ei, exist := m.Load(indexID)
 	if !exist {
@@ -101,7 +101,7 @@ func (m *engineManager) Unregister(jobID, indexID int64) {
 	m.MemRoot.Release(StructSizeEngineInfo)
 }
 
-// ResetWorkers reset the writer count of the engineInfo because
+// ResetWorkers reset the writer count of the EngineInfo because
 // the goroutines of backfill workers have been terminated.
 func (m *engineManager) ResetWorkers(bc *BackendContext, jobID, indexID int64) {
 	ei, exist := m.Load(indexID)
@@ -115,7 +115,7 @@ func (m *engineManager) ResetWorkers(bc *BackendContext, jobID, indexID int64) {
 	ei.writerCount = 0
 }
 
-// UnregisterAll delete all engineInfo from the engineManager.
+// UnregisterAll delete all EngineInfo from the engineManager.
 func (m *engineManager) UnregisterAll(jobID int64) {
 	for _, idxID := range m.Keys() {
 		m.Unregister(jobID, idxID)

--- a/ddl/ingest/mem_root.go
+++ b/ddl/ingest/mem_root.go
@@ -45,7 +45,7 @@ var (
 
 func init() {
 	StructSizeBackendCtx = int64(unsafe.Sizeof(BackendContext{}))
-	StructSizeEngineInfo = int64(unsafe.Sizeof(engineInfo{}))
+	StructSizeEngineInfo = int64(unsafe.Sizeof(EngineInfo{}))
 	StructSizeWriterCtx = int64(unsafe.Sizeof(WriterContext{}))
 }
 

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -230,6 +230,9 @@ func (w *worker) runReorgJob(rh *reorgHandler, reorgInfo *reorgInfo, tblInfo *mo
 			return dbterror.ErrCancelledDDLJob
 		}
 		rowCount := rc.getRowCount()
+		if rowCount == 0 {
+			rowCount = job.GetRowCount()
+		}
 		if err != nil {
 			logutil.BgLogger().Warn("[ddl] run reorg job done", zap.Int64("handled rows", rowCount), zap.Error(err))
 		} else {

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -230,9 +230,6 @@ func (w *worker) runReorgJob(rh *reorgHandler, reorgInfo *reorgInfo, tblInfo *mo
 			return dbterror.ErrCancelledDDLJob
 		}
 		rowCount := rc.getRowCount()
-		if rowCount == 0 {
-			rowCount = job.GetRowCount()
-		}
 		if err != nil {
 			logutil.BgLogger().Warn("[ddl] run reorg job done", zap.Int64("handled rows", rowCount), zap.Error(err))
 		} else {

--- a/resourcemanager/pool/workerpool/workerpool.go
+++ b/resourcemanager/pool/workerpool/workerpool.go
@@ -102,11 +102,11 @@ func (p *WorkerPool[T]) handleTaskWithRecover(w Worker[T], task T) {
 }
 
 func (p *WorkerPool[T]) runAWorker() {
+	w := p.createWorker()
+	if w == nil {
+		return // Fail to create worker, quit.
+	}
 	p.wg.Run(func() {
-		w := p.createWorker()
-		if w == nil {
-			return // Fail to create worker, quit.
-		}
 		for {
 			select {
 			case task := <-p.taskChan:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Problem Summary:

This is a refactoring PR, let's skip the issue check.

### What is changed and how it works?

This PR extracts `backfillScheduler` to an interface:

```go
// backfillScheduler is used to manage the lifetime of backfill workers.
type backfillScheduler interface {
	setupWorkers() error
	close(force bool)

	sendTask(task *reorgBackfillTask) error
	drainTasks()
	receiveResult() (*backfillResult, bool)

	setMaxWorkerSize(maxSize int)
	currentWorkerSize() int
	adjustWorkerSize() error
}
```

There are two implementations: 
- `txnBackfillScheduler`: the transaction way to backfill data.
- `ingestBackfillScheduler`: the ingest way to backfill data.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
