### PR TITLE
metrics: fix duplicated "id": 234 in tidb.json

### DIFF
--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -16516,7 +16516,7 @@
             "y": 17
           },
           "hiddenSeries": false,
-          "id": 234,
+          "id": 299,
           "legend": {
             "alignAsTable": true,
             "avg": false,

--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -16516,7 +16516,7 @@
             "y": 17
           },
           "hiddenSeries": false,
-          "id": 299,
+          "id": 305,
           "legend": {
             "alignAsTable": true,
             "avg": false,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42562

Problem Summary:

### What is changed and how it works?
Duplicated id 234 of "Ignore Event Per Minute" and "Stats Cache LRU Cost" panels caused them to be displayed abnormally, sometimes disappeared and sometimes there with expressions confused with each other. The fix is to assign them different ids.

### Check List
The "Ignore Event Per Minute" and "Stats Cache LRU Cost" panels should be displayed normally with the fix.

Tests <!-- At least one of them must be included. -->

The "Ignore Event Per Minute" and "Stats Cache LRU Cost" panels should be displayed normally with the fix.

Side effects

None

Documentation

None

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that "Ignore Event Per Minute" and "Stats Cache LRU Cost" panels might not be displayed normally.
```
