### PR TITLE
executor: lock untouched unique keys on update

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -1029,7 +1029,7 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e Executor) (err er
 		if err1 != nil {
 			return err1
 		}
-		keys = txnCtx.CollectUnchangedRowKeys(keys)
+		keys = txnCtx.CollectUnchangedKeysForLock(keys)
 		if len(keys) == 0 {
 			return nil
 		}

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -1211,7 +1211,7 @@ CheckAndInsert:
 					e.ctx.GetSessionVars().StmtCtx.AppendWarning(r.handleKey.dupErr)
 					if txnCtx := e.ctx.GetSessionVars().TxnCtx; txnCtx.IsPessimistic {
 						// lock duplicated row key on insert-ignore
-						txnCtx.AddUnchangedRowKey(r.handleKey.newKey)
+						txnCtx.AddUnchangedKeyForLock(r.handleKey.newKey)
 					}
 					continue
 				}
@@ -1247,7 +1247,7 @@ CheckAndInsert:
 					e.ctx.GetSessionVars().StmtCtx.AppendWarning(uk.dupErr)
 					if txnCtx := e.ctx.GetSessionVars().TxnCtx; txnCtx.IsPessimistic {
 						// lock duplicated unique key on insert-ignore
-						txnCtx.AddUnchangedRowKey(uk.newKey)
+						txnCtx.AddUnchangedKeyForLock(uk.newKey)
 					}
 					continue CheckAndInsert
 				}
@@ -1301,8 +1301,7 @@ func (e *InsertValues) removeRow(
 		if inReplace {
 			e.ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
 		}
-		_, err := appendUnchangedRowForLock(e.ctx, r.t, handle, oldRow)
-		if err != nil {
+		if _, err := addUnchangedKeysForLockByRow(e.ctx, r.t, handle, oldRow, lockRowKey|lockUniqueKeys); err != nil {
 			return false, err
 		}
 		return true, nil

--- a/parser/model/model.go
+++ b/parser/model/model.go
@@ -1432,6 +1432,11 @@ func (index *IndexInfo) FindColumnByName(nameL string) *IndexColumn {
 	return ret
 }
 
+// IsPublic checks if the index state is public
+func (index *IndexInfo) IsPublic() bool {
+	return index.State == StatePublic
+}
+
 // FindIndexColumnByName finds IndexColumn by name. When IndexColumn is not found, returns (-1, nil).
 func FindIndexColumnByName(indexCols []*IndexColumn, nameL string) (int, *IndexColumn) {
 	for i, ic := range indexCols {

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -278,16 +278,16 @@ func (tc *TransactionContext) updateShard(shardRand *rand.Rand) {
 	tc.currentShard = int64(murmur3.Sum32(buf[:]))
 }
 
-// AddUnchangedRowKey adds an unchanged row key in update statement for pessimistic lock.
-func (tc *TransactionContext) AddUnchangedRowKey(key []byte) {
+// AddUnchangedKeyForLock adds an unchanged key for pessimistic lock.
+func (tc *TransactionContext) AddUnchangedKeyForLock(key []byte) {
 	if tc.unchangedRowKeys == nil {
 		tc.unchangedRowKeys = map[string]struct{}{}
 	}
 	tc.unchangedRowKeys[string(key)] = struct{}{}
 }
 
-// CollectUnchangedRowKeys collects unchanged row keys for pessimistic lock.
-func (tc *TransactionContext) CollectUnchangedRowKeys(buf []kv.Key) []kv.Key {
+// CollectUnchangedKeysForLock collects unchanged keys for pessimistic lock.
+func (tc *TransactionContext) CollectUnchangedKeysForLock(buf []kv.Key) []kv.Key {
 	for key := range tc.unchangedRowKeys {
 		buf = append(buf, kv.Key(key))
 	}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -203,8 +203,8 @@ type TxnCtxNoNeedToRestore struct {
 	shardRemain  int
 	currentShard int64
 
-	// unchangedRowKeys is used to store the unchanged rows that needs to lock for pessimistic transaction.
-	unchangedRowKeys map[string]struct{}
+	// unchangedKeys is used to store the unchanged keys that needs to lock for pessimistic transaction.
+	unchangedKeys map[string]struct{}
 
 	PessimisticCacheHit int
 
@@ -280,18 +280,18 @@ func (tc *TransactionContext) updateShard(shardRand *rand.Rand) {
 
 // AddUnchangedKeyForLock adds an unchanged key for pessimistic lock.
 func (tc *TransactionContext) AddUnchangedKeyForLock(key []byte) {
-	if tc.unchangedRowKeys == nil {
-		tc.unchangedRowKeys = map[string]struct{}{}
+	if tc.unchangedKeys == nil {
+		tc.unchangedKeys = map[string]struct{}{}
 	}
-	tc.unchangedRowKeys[string(key)] = struct{}{}
+	tc.unchangedKeys[string(key)] = struct{}{}
 }
 
 // CollectUnchangedKeysForLock collects unchanged keys for pessimistic lock.
 func (tc *TransactionContext) CollectUnchangedKeysForLock(buf []kv.Key) []kv.Key {
-	for key := range tc.unchangedRowKeys {
+	for key := range tc.unchangedKeys {
 		buf = append(buf, kv.Key(key))
 	}
-	tc.unchangedRowKeys = nil
+	tc.unchangedKeys = nil
 	return buf
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #36438

Problem Summary: Only row keys will be locked after updates (without changing handle), which leads to https://github.com/pingcap/tidb/issues/36438. We tried to solve the issue by https://github.com/pingcap/tidb/pull/36498, however it has been reverted because of the issue of accumulated locks. Since the optimizition described in https://github.com/tikv/tikv/issues/13694 is done, we can now solve the issue again.

### What is changed and how it works?

Also collect untouched unique keys and lock them.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
