### PR TITLE
util: ID pools for global kill 32bit

### DIFF
--- a/util/globalconn/BUILD.bazel
+++ b/util/globalconn/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "globalconn",
+    srcs = [
+        "globalconn.go",
+        "pool.go",
+    ],
+    importpath = "github.com/pingcap/tidb/util/globalconn",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_cznic_mathutil//:mathutil",
+        "@com_github_ngaut_sync2//:sync2",
+    ],
+)
+
+go_test(
+    name = "globalconn_test",
+    srcs = ["pool_test.go"],
+    deps = [
+        ":globalconn",
+        "@com_github_cznic_mathutil//:mathutil",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/util/globalconn/BUILD.bazel
+++ b/util/globalconn/BUILD.bazel
@@ -13,7 +13,9 @@ go_library(
 
 go_test(
     name = "globalconn_test",
+    timeout = "short",
     srcs = ["pool_test.go"],
+    flaky = True,
     deps = [
         ":globalconn",
         "@com_github_cznic_mathutil//:mathutil",

--- a/util/globalconn/BUILD.bazel
+++ b/util/globalconn/BUILD.bazel
@@ -8,10 +8,7 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/util/globalconn",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_cznic_mathutil//:mathutil",
-        "@com_github_ngaut_sync2//:sync2",
-    ],
+    deps = ["@com_github_cznic_mathutil//:mathutil"],
 )
 
 go_test(

--- a/util/globalconn/globalconn.go
+++ b/util/globalconn/globalconn.go
@@ -1,0 +1,49 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalconn
+
+// GlobalConnID is the global connection ID, providing UNIQUE connection IDs across the whole TiDB cluster.
+// Used when GlobalKill feature is enable.
+// See https://github.com/pingcap/tidb/blob/master/docs/design/2020-06-01-global-kill.md
+// 32 bits version:
+//
+//	 31    21 20               1    0
+//	+--------+------------------+------+
+//	|serverID|   local connID   |markup|
+//	| (11b)  |       (20b)      |  =0  |
+//	+--------+------------------+------+
+//
+// 64 bits version:
+//
+//	 63 62                 41 40                                   1   0
+//	+--+---------------------+--------------------------------------+------+
+//	|  |      serverId       |             local connId             |markup|
+//	|=0|       (22b)         |                 (40b)                |  =1  |
+//	+--+---------------------+--------------------------------------+------+
+const (
+	// MaxServerID32 is maximum serverID for 32bits global connection ID.
+	MaxServerID32 = 1<<11 - 1
+	// LocalConnIDBits32 is the number of bits of localConnID for 32bits global connection ID.
+	LocalConnIDBits32 = 20
+	// MaxLocalConnID32 is maximum localConnID for 32bits global connection ID.
+	MaxLocalConnID32 = 1<<LocalConnIDBits32 - 1
+
+	// MaxServerID64 is maximum serverID for 64bits global connection ID.
+	MaxServerID64 = 1<<22 - 1
+	// LocalConnIDBits64 is the number of bits of localConnID for 64bits global connection ID.
+	LocalConnIDBits64 = 40
+	// MaxLocalConnID64 is maximum localConnID for 64bits global connection ID.
+	MaxLocalConnID64 = 1<<LocalConnIDBits64 - 1
+)

--- a/util/globalconn/pool.go
+++ b/util/globalconn/pool.go
@@ -1,0 +1,260 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalconn
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cznic/mathutil"
+	"github.com/ngaut/sync2"
+)
+
+const (
+	// IDPoolInvalidValue indicates invalid value from IDPool.
+	IDPoolInvalidValue = math.MaxUint64
+)
+
+// IDPool is the pool allocating & deallocating IDs.
+type IDPool interface {
+	fmt.Stringer
+	// Init initiates pool.
+	Init(sizeInBits uint32)
+	// Len returns length of available id's in pool.
+	// Note that Len() would return -1 when this method is NOT supported.
+	Len() int
+	// Put puts value to pool. "ok" is false when pool is full.
+	Put(val uint64) (ok bool)
+	// Get gets value from pool. "ok" is false when pool is empty.
+	Get() (val uint64, ok bool)
+}
+
+var (
+	_ IDPool = (*AutoIncPool)(nil)
+	_ IDPool = (*LockFreeCircularPool)(nil)
+)
+
+// AutoIncPool simply do auto-increment to allocate ID. Wrapping will happen.
+type AutoIncPool struct {
+	lastID uint64
+	idMask uint64
+	tryCnt int
+
+	mu      *sync.Mutex
+	existed map[uint64]struct{}
+}
+
+// Init initiates AutoIncPool.
+func (p *AutoIncPool) Init(sizeInBits uint32) {
+	p.InitExt(sizeInBits, false, 1)
+}
+
+// InitExt initiates AutoIncPool with more parameters.
+func (p *AutoIncPool) InitExt(sizeInBits uint32, checkExisted bool, tryCnt int) {
+	p.idMask = 1<<sizeInBits - 1
+	if checkExisted {
+		p.existed = make(map[uint64]struct{})
+		p.mu = &sync.Mutex{}
+	}
+	p.tryCnt = tryCnt
+}
+
+// Get id by auto-increment.
+func (p *AutoIncPool) Get() (id uint64, ok bool) {
+	for i := 0; i < p.tryCnt; i++ {
+		id := atomic.AddUint64(&p.lastID, 1) & p.idMask
+		if p.existed != nil {
+			p.mu.Lock()
+			_, occupied := p.existed[id]
+			if occupied {
+				p.mu.Unlock()
+				continue
+			}
+			p.existed[id] = struct{}{}
+			p.mu.Unlock()
+		}
+		return id, true
+	}
+	return 0, false
+}
+
+// Put id back to pool.
+func (p *AutoIncPool) Put(id uint64) (ok bool) {
+	if p.existed != nil {
+		p.mu.Lock()
+		delete(p.existed, id)
+		p.mu.Unlock()
+	}
+	return true
+}
+
+// Len implements IDPool interface.
+func (p *AutoIncPool) Len() int {
+	if p.existed != nil {
+		p.mu.Lock()
+		length := len(p.existed)
+		p.mu.Unlock()
+		return length
+	}
+	return -1
+}
+
+// String implements IDPool interface.
+func (p AutoIncPool) String() string {
+	return fmt.Sprintf("lastID: %v", p.lastID)
+}
+
+// LockFreeCircularPool is a lock-free circular implementation of IDPool.
+// Note that to reduce memory usage, LockFreeCircularPool supports 32bits IDs ONLY.
+type LockFreeCircularPool struct {
+	_    uint64             // align to 64bits
+	head sync2.AtomicUint32 // first available slot
+	_    uint32             // padding to avoid false sharing
+	tail sync2.AtomicUint32 // first empty slot. `head==tail` means empty.
+	_    uint32             // padding to avoid false sharing
+
+	cap   uint32
+	slots []lockFreePoolItem
+}
+
+type lockFreePoolItem struct {
+	value uint32
+
+	// seq indicates read/write status
+	// Sequence:
+	//   seq==tail: writable ---> doWrite,seq:=tail+1 ---> seq==head+1:written/readable ---> doRead,seq:=head+size
+	//         ^                                                                                        |
+	//         +----------------------------------------------------------------------------------------+
+	//   slot[i].seq: i(writable) ---> i+1(readable) ---> i+cap(writable) ---> i+cap+1(readable) ---> i+2*cap ---> ...
+	seq uint32
+}
+
+// Init implements IDPool interface.
+func (p *LockFreeCircularPool) Init(sizeInBits uint32) {
+	p.InitExt(sizeInBits, 0)
+}
+
+// InitExt initializes LockFreeCircularPool with more parameters.
+// fillCount: fills pool with [1, min(fillCount, 1<<(sizeInBits-1)]. Pass "math.MaxUint32" to fulfill the pool.
+func (p *LockFreeCircularPool) InitExt(sizeInBits uint32, fillCount uint32) {
+	p.cap = 1 << sizeInBits
+	p.slots = make([]lockFreePoolItem, p.cap)
+
+	fillCount = mathutil.MinUint32(p.cap-1, fillCount)
+	var i uint32
+	for i = 0; i < fillCount; i++ {
+		p.slots[i] = lockFreePoolItem{value: i + 1, seq: i + 1}
+	}
+	for ; i < p.cap; i++ {
+		p.slots[i] = lockFreePoolItem{value: math.MaxUint32, seq: i}
+	}
+
+	p.head.Set(0)
+	p.tail.Set(fillCount)
+}
+
+// InitForTest used to unit test overflow of head & tail.
+func (p *LockFreeCircularPool) InitForTest(head uint32, fillCount uint32) {
+	fillCount = mathutil.MinUint32(p.cap-1, fillCount)
+	var i uint32
+	for i = 0; i < fillCount; i++ {
+		p.slots[i] = lockFreePoolItem{value: i + 1, seq: head + i + 1}
+	}
+	for ; i < p.cap; i++ {
+		p.slots[i] = lockFreePoolItem{value: math.MaxUint32, seq: head + i}
+	}
+
+	p.head.Set(head)
+	p.tail.Set(head + fillCount)
+}
+
+// Len implements IDPool interface.
+func (p *LockFreeCircularPool) Len() int {
+	return int(p.tail.Get() - p.head.Get())
+}
+
+// String implements IDPool interface.
+// Notice: NOT thread safe.
+func (p LockFreeCircularPool) String() string {
+	head := p.head.Get()
+	tail := p.tail.Get()
+	headSlot := &p.slots[head&(p.cap-1)]
+	tailSlot := &p.slots[tail&(p.cap-1)]
+	length := tail - head
+
+	return fmt.Sprintf("cap:%v, length:%v; head:%x, slot:{%x,%x}; tail:%x, slot:{%x,%x}",
+		p.cap, length, head, headSlot.value, headSlot.seq, tail, tailSlot.value, tailSlot.seq)
+}
+
+// Put implements IDPool interface.
+func (p *LockFreeCircularPool) Put(val uint64) (ok bool) {
+	for {
+		tail := p.tail.Get() // `tail` should be loaded before `head`, to avoid "false full".
+		head := p.head.Get()
+
+		if tail-head == p.cap-1 { // full
+			return false
+		}
+
+		if !p.tail.CompareAndSwap(tail, tail+1) {
+			continue
+		}
+
+		slot := &p.slots[tail&(p.cap-1)]
+		for {
+			seq := atomic.LoadUint32(&slot.seq)
+
+			if seq == tail { // writable
+				slot.value = uint32(val)
+				atomic.StoreUint32(&slot.seq, tail+1)
+				return true
+			}
+
+			runtime.Gosched()
+		}
+	}
+}
+
+// Get implements IDPool interface.
+func (p *LockFreeCircularPool) Get() (val uint64, ok bool) {
+	for {
+		head := p.head.Get()
+		tail := p.tail.Get()
+		if head == tail { // empty
+			return IDPoolInvalidValue, false
+		}
+
+		if !p.head.CompareAndSwap(head, head+1) {
+			continue
+		}
+
+		slot := &p.slots[head&(p.cap-1)]
+		for {
+			seq := atomic.LoadUint32(&slot.seq)
+
+			if seq == head+1 { // readable
+				val = uint64(slot.value)
+				slot.value = math.MaxUint32
+				atomic.StoreUint32(&slot.seq, head+p.cap)
+				return val, true
+			}
+
+			runtime.Gosched()
+		}
+	}
+}

--- a/util/globalconn/pool_test.go
+++ b/util/globalconn/pool_test.go
@@ -445,9 +445,8 @@ func BenchmarkPoolConcurrency(b *testing.B) {
 		{producers: 1, consumers: 1},
 		{producers: 3, consumers: 3},
 		{producers: 10, consumers: 10},
+		{producers: 20, consumers: 20},
 		{producers: 100, consumers: 100},
-		{producers: 1000, consumers: 1000},
-		{producers: 10000, consumers: 10000},
 	}
 
 	for _, ta := range cases {

--- a/util/globalconn/pool_test.go
+++ b/util/globalconn/pool_test.go
@@ -1,0 +1,494 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalconn_test
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cznic/mathutil"
+	"github.com/pingcap/tidb/util/globalconn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAutoIncPool(t *testing.T) {
+	assert := assert.New(t)
+
+	const SizeInBits uint32 = 8
+	const Size uint64 = 1 << SizeInBits
+	const TryCnt = 4
+
+	var (
+		pool globalconn.AutoIncPool
+		val  uint64
+		ok   bool
+		i    uint64
+	)
+
+	pool.InitExt(SizeInBits, true, TryCnt)
+	assert.Equal(0, pool.Len())
+
+	// get all.
+	for i = 1; i < Size; i++ {
+		val, ok = pool.Get()
+		assert.True(ok)
+		assert.Equal(i, val)
+	}
+	val, ok = pool.Get()
+	assert.True(ok)
+	assert.Equal(uint64(0), val) // wrap around to 0
+	assert.Equal(int(Size), pool.Len())
+
+	_, ok = pool.Get() // exhausted. try TryCnt times, lastID is added to 0+TryCnt.
+	assert.False(ok)
+
+	nextVal := uint64(TryCnt + 1)
+	pool.Put(nextVal)
+	val, ok = pool.Get()
+	assert.True(ok)
+	assert.Equal(nextVal, val)
+
+	nextVal += TryCnt - 1
+	pool.Put(nextVal)
+	val, ok = pool.Get()
+	assert.True(ok)
+	assert.Equal(nextVal, val)
+
+	nextVal += TryCnt + 1
+	pool.Put(nextVal)
+	_, ok = pool.Get()
+	assert.False(ok)
+}
+
+func TestLockFreePoolBasic(t *testing.T) {
+	assert := assert.New(t)
+
+	const SizeInBits uint32 = 8
+	const Size uint64 = 1<<SizeInBits - 1
+
+	var (
+		pool globalconn.LockFreeCircularPool
+		val  uint64
+		ok   bool
+		i    uint64
+	)
+
+	pool.InitExt(SizeInBits, math.MaxUint32)
+	assert.Equal(int(Size), pool.Len())
+
+	// get all.
+	for i = 1; i <= Size; i++ {
+		val, ok = pool.Get()
+		assert.True(ok)
+		assert.Equal(i, val)
+	}
+	_, ok = pool.Get()
+	assert.False(ok)
+	assert.Equal(0, pool.Len())
+
+	// put to full.
+	for i = 1; i <= Size; i++ {
+		ok = pool.Put(i)
+		assert.True(ok)
+	}
+	ok = pool.Put(0)
+	assert.False(ok)
+	assert.Equal(int(Size), pool.Len())
+
+	// get all.
+	for i = 1; i <= Size; i++ {
+		val, ok = pool.Get()
+		assert.True(ok)
+		assert.Equal(i, val)
+	}
+	_, ok = pool.Get()
+	assert.False(ok)
+	assert.Equal(0, pool.Len())
+}
+
+func TestLockFreePoolInitEmpty(t *testing.T) {
+	assert := assert.New(t)
+
+	const SizeInBits uint32 = 8
+	const Size uint64 = 1<<SizeInBits - 1
+
+	var (
+		pool globalconn.LockFreeCircularPool
+		val  uint64
+		ok   bool
+		i    uint64
+	)
+
+	pool.InitExt(SizeInBits, 0)
+	assert.Equal(0, pool.Len())
+
+	// put to full.
+	for i = 1; i <= Size; i++ {
+		ok = pool.Put(i)
+		assert.True(ok)
+	}
+	ok = pool.Put(0)
+	assert.False(ok)
+	assert.Equal(int(Size), pool.Len())
+
+	// get all.
+	for i = 1; i <= Size; i++ {
+		val, ok = pool.Get()
+		assert.True(ok)
+		assert.Equal(i, val)
+	}
+	_, ok = pool.Get()
+	assert.False(ok)
+	assert.Equal(0, pool.Len())
+}
+
+var _ globalconn.IDPool = (*LockBasedCircularPool)(nil)
+
+// LockBasedCircularPool implements IDPool by lock-based manner.
+// For benchmark purpose.
+type LockBasedCircularPool struct {
+	_    uint64 // align to 64bits
+	head uint32 // first available slot
+	_    uint32 // padding to avoid false sharing
+	tail uint32 // first empty slot. `head==tail` means empty.
+	_    uint32 // padding to avoid false sharing
+	cap  uint32
+
+	mu    *sync.Mutex
+	slots []uint32
+}
+
+func (p *LockBasedCircularPool) Init(sizeInBits uint32) {
+	p.InitExt(sizeInBits, 0)
+}
+
+func (p *LockBasedCircularPool) InitExt(sizeInBits uint32, fillCount uint32) {
+	p.mu = &sync.Mutex{}
+
+	p.cap = 1 << sizeInBits
+	p.slots = make([]uint32, p.cap)
+
+	fillCount = mathutil.MinUint32(p.cap-1, fillCount)
+	var i uint32
+	for i = 0; i < fillCount; i++ {
+		p.slots[i] = i + 1
+	}
+	for ; i < p.cap; i++ {
+		p.slots[i] = math.MaxUint32
+	}
+
+	p.head = 0
+	p.tail = fillCount
+}
+
+func (p *LockBasedCircularPool) Len() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return int(p.tail - p.head)
+}
+
+func (p LockBasedCircularPool) String() string {
+	head := p.head
+	tail := p.tail
+	headVal := p.slots[head&(p.cap-1)]
+	tailVal := p.slots[tail&(p.cap-1)]
+	length := tail - head
+
+	return fmt.Sprintf("cap:%v, len:%v; head:%x, slot:{%x}; tail:%x, slot:{%x}",
+		p.cap, length, head, headVal, tail, tailVal)
+}
+
+func (p *LockBasedCircularPool) Put(val uint64) (ok bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.tail-p.head == p.cap-1 { // full
+		return false
+	}
+
+	p.slots[p.tail&(p.cap-1)] = uint32(val)
+	p.tail++
+	return true
+}
+
+func (p *LockBasedCircularPool) Get() (val uint64, ok bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.head == p.tail { // empty
+		return globalconn.IDPoolInvalidValue, false
+	}
+
+	val = uint64(p.slots[p.head&(p.cap-1)])
+	p.head++
+	return val, true
+}
+
+func prepareLockBasedPool(sizeInBits uint32, fillCount uint32) globalconn.IDPool {
+	var pool LockBasedCircularPool
+	pool.InitExt(sizeInBits, fillCount)
+	return &pool
+}
+
+func prepareLockFreePool(sizeInBits uint32, fillCount uint32, headPos uint32) globalconn.IDPool {
+	var pool globalconn.LockFreeCircularPool
+	pool.InitExt(sizeInBits, fillCount)
+	if headPos > 0 {
+		pool.InitForTest(headPos, fillCount)
+	}
+
+	return &pool
+}
+
+func prepareConcurrencyTest(pool globalconn.IDPool, producers int, consumers int, requests int, total *int64) (ready chan struct{}, done chan struct{}, wgProducer *sync.WaitGroup, wgConsumer *sync.WaitGroup) {
+	ready = make(chan struct{})
+	done = make(chan struct{})
+
+	wgProducer = &sync.WaitGroup{}
+	if producers > 0 {
+		reqsPerProducer := (requests + producers - 1) / producers
+		wgProducer.Add(producers)
+		for p := 0; p < producers; p++ {
+			go func(p int) {
+				defer wgProducer.Done()
+				<-ready
+
+				for i := p * reqsPerProducer; i < (p+1)*reqsPerProducer && i < requests; i++ {
+					for !pool.Put(uint64(i)) {
+						runtime.Gosched()
+					}
+				}
+			}(p)
+		}
+	}
+
+	wgConsumer = &sync.WaitGroup{}
+	if consumers > 0 {
+		wgConsumer.Add(consumers)
+		for c := 0; c < consumers; c++ {
+			go func(c int) {
+				defer wgConsumer.Done()
+				<-ready
+
+				var sum int64
+			Loop:
+				for {
+					val, ok := pool.Get()
+					if ok {
+						sum += int64(val)
+						continue
+					}
+					select {
+					case <-done:
+						break Loop
+					default:
+						runtime.Gosched()
+					}
+				}
+				atomic.AddInt64(total, sum)
+			}(c)
+		}
+	}
+
+	return ready, done, wgProducer, wgConsumer
+}
+
+func doConcurrencyTest(ready chan struct{}, done chan struct{}, wgProducer *sync.WaitGroup, wgConsumer *sync.WaitGroup) {
+	// logutil.BgLogger().Info("Init", zap.Stringer("pool", q))
+	close(ready)
+	wgProducer.Wait()
+	// logutil.BgLogger().Info("Snapshot on producing done", zap.Stringer("pool", q))
+	close(done)
+	wgConsumer.Wait()
+	// logutil.BgLogger().Info("Finally", zap.Stringer("pool", q))
+}
+
+func expectedConcurrencyTestResult(poolSizeInBits uint32, fillCount uint32, producers int, consumers int, requests int) (expected int64) {
+	if producers > 0 && consumers > 0 {
+		expected += (int64(requests) - 1) * int64(requests) / 2
+	}
+	if fillCount > 0 {
+		fillCount = mathutil.MinUint32(1<<poolSizeInBits-1, fillCount)
+		expected += (1 + int64(fillCount)) * int64(fillCount) / 2
+	}
+	return expected
+}
+
+func testLockFreePoolConcurrency(poolSizeInBits uint32, fillCount uint32, producers int, consumers int, requests int, headPos uint32) (expected, actual int64) {
+	var total int64
+	pool := prepareLockFreePool(poolSizeInBits, fillCount, headPos)
+	ready, done, wgProducer, wgConsumer := prepareConcurrencyTest(pool, producers, consumers, requests, &total)
+
+	doConcurrencyTest(ready, done, wgProducer, wgConsumer)
+
+	expected = expectedConcurrencyTestResult(poolSizeInBits, fillCount, producers, consumers, requests)
+	return expected, atomic.LoadInt64(&total)
+}
+
+func testLockBasedPoolConcurrency(poolSizeInBits uint32, producers int, consumers int, requests int) (expected, actual int64) {
+	var total int64
+	pool := prepareLockBasedPool(poolSizeInBits, 0)
+	ready, done, wgProducer, wgConsumer := prepareConcurrencyTest(pool, producers, consumers, requests, &total)
+
+	doConcurrencyTest(ready, done, wgProducer, wgConsumer)
+
+	expected = expectedConcurrencyTestResult(poolSizeInBits, 0, producers, consumers, requests)
+	return expected, atomic.LoadInt64(&total)
+}
+
+func TestLockFreePoolBasicConcurrencySafety(t *testing.T) {
+	assert := assert.New(t)
+
+	var (
+		expected int64
+		actual   int64
+	)
+
+	const (
+		sizeInBits = 8
+		fillCount  = 0
+		producers  = 20
+		consumers  = 20
+		requests   = 1 << 20
+		headPos    = uint32(0x1_0000_0000 - (1 << (sizeInBits + 8)))
+	)
+
+	expected, actual = testLockFreePoolConcurrency(sizeInBits, fillCount, producers, consumers, requests, 0)
+	assert.Equal(expected, actual)
+
+	// test overflow of head & tail
+	expected, actual = testLockFreePoolConcurrency(sizeInBits, fillCount, producers, consumers, requests, headPos)
+	assert.Equal(expected, actual)
+}
+
+func TestLockBasedPoolConcurrencySafety(t *testing.T) {
+	var (
+		expected int64
+		actual   int64
+	)
+
+	const (
+		sizeInBits = 8
+		producers  = 20
+		consumers  = 20
+		requests   = 1 << 20
+	)
+
+	expected, actual = testLockBasedPoolConcurrency(sizeInBits, producers, consumers, requests)
+	assert.Equal(t, expected, actual)
+}
+
+type poolConcurrencyTestCase struct {
+	sizeInBits uint32
+	fillCount  uint32
+	producers  int
+	consumers  int
+	requests   int64
+}
+
+func (ta poolConcurrencyTestCase) String() string {
+	return fmt.Sprintf("size:%v, fillCount:%v, producers:%v, consumers:%v, requests:%v",
+		1<<ta.sizeInBits, ta.fillCount, ta.producers, ta.consumers, ta.requests)
+}
+
+func TestLockFreePoolConcurrencySafety(t *testing.T) {
+	const (
+		poolSizeInBits = 16
+		requests       = 1 << 20
+		concurrency    = 1000
+	)
+
+	// Test cases from Anthony Williams, "C++ Concurrency in Action, 2nd", 11.2.2 "Locating concurrency-related bugs by testing":
+	cases := []poolConcurrencyTestCase{
+		// #1 Multiple threads calling pop() on a partially full queue with insufficient items for all threads
+		{sizeInBits: 4, fillCount: 1 << 3, producers: 0, consumers: 32, requests: requests},
+		// #2 Multiple threads calling push() while one thread calls pop() on an empty queue
+		{sizeInBits: poolSizeInBits, fillCount: 0, producers: concurrency, consumers: 1, requests: requests},
+		// #3 Multiple threads calling push() while one thread calls pop() on a full queue
+		{sizeInBits: poolSizeInBits, fillCount: 0xffff_ffff, producers: concurrency, consumers: 1, requests: requests},
+		// #4 Multiple threads calling push() while multiple threads call pop() on an empty queue
+		{sizeInBits: poolSizeInBits, fillCount: 0, producers: concurrency, consumers: concurrency, requests: requests},
+		// #5 Multiple threads calling push() while multiple threads call pop() on a full queue
+		{sizeInBits: poolSizeInBits, fillCount: 0xffff_ffff, producers: concurrency, consumers: concurrency, requests: requests},
+	}
+
+	for i, ca := range cases {
+		expected, actual := testLockFreePoolConcurrency(ca.sizeInBits, ca.fillCount, ca.producers, ca.consumers, requests, 0)
+		assert.Equalf(t, expected, actual, "case #%v: %v", i+1, ca)
+	}
+}
+
+func BenchmarkPoolConcurrency(b *testing.B) {
+	b.ReportAllocs()
+
+	const (
+		poolSizeInBits = 16
+		requests       = 1 << 18
+	)
+
+	cases := []poolConcurrencyTestCase{
+		{producers: 1, consumers: 1},
+		{producers: 3, consumers: 3},
+		{producers: 10, consumers: 10},
+		{producers: 100, consumers: 100},
+		{producers: 1000, consumers: 1000},
+		{producers: 10000, consumers: 10000},
+	}
+
+	for _, ta := range cases {
+		b.Run(fmt.Sprintf("LockBasedCircularPool: P:C: %v:%v", ta.producers, ta.consumers), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				var total int64
+				pool := prepareLockBasedPool(poolSizeInBits, 0)
+				ready, done, wgProducer, wgConsumer := prepareConcurrencyTest(pool, ta.producers, ta.consumers, requests, &total)
+
+				b.StartTimer()
+				doConcurrencyTest(ready, done, wgProducer, wgConsumer)
+				b.StopTimer()
+
+				expected := expectedConcurrencyTestResult(poolSizeInBits, 0, ta.producers, ta.consumers, requests)
+				actual := atomic.LoadInt64(&total)
+				if expected != actual {
+					b.Fatalf("concurrency safety fail, expected:%v, actual:%v", expected, actual)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("LockFreeCircularPool: P:C: %v:%v", ta.producers, ta.consumers), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				var total int64
+				pool := prepareLockFreePool(poolSizeInBits, 0, 0)
+				ready, done, wgProducer, wgConsumer := prepareConcurrencyTest(pool, ta.producers, ta.consumers, requests, &total)
+
+				b.StartTimer()
+				doConcurrencyTest(ready, done, wgProducer, wgConsumer)
+				b.StopTimer()
+
+				expected := expectedConcurrencyTestResult(poolSizeInBits, 0, ta.producers, ta.consumers, requests)
+				actual := atomic.LoadInt64(&total)
+				if expected != actual {
+					b.Fatalf("concurrency safety fail, expected:%v, actual:%v", expected, actual)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #8854

Problem Summary: Support CTRL-C or kill to kill a connection/query by implementing global connection IDs.

### What is changed and how it works?

(This PR is split from #25385  to reduce PR size)

- Implement a simple ID pool (`AutoIncPool`) for 64 bits connection IDs.
- Implement a lock-free ring buffer for 32bits local connection ID allocation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Unit test for concurrency safety

```bash
❯ go test -v -count 100 -run TestLockFreePoolConcurrencySafety github.com/pingcap/tidb/util/globalconn
ok  	github.com/pingcap/tidb/util/globalconn	122.269s
❯ go test -race -count 10 github.com/pingcap/tidb/util/globalconn
ok  	github.com/pingcap/tidb/util/globalconn	507.211s
```

- [x] Benchmark (Lock free v.s. Lock based)

```
go test -benchmem -run=^$ -tags intest,deadlock -bench ^BenchmarkPoolConcurrency$ github.com/pingcap/tidb/util/globalconn

goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/util/globalconn
cpu: Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz
BenchmarkPoolConcurrency/LockBasedCircularPool:_P:C:_1:1-40         	      33	  36586783 ns/op	      52 B/op	       0 allocs/op
BenchmarkPoolConcurrency/LockFreeCircularPool:_P:C:_1:1-40          	      36	  42737761 ns/op	       5 B/op	       0 allocs/op
BenchmarkPoolConcurrency/LockBasedCircularPool:_P:C:_3:3-40         	      10	 112820288 ns/op	     489 B/op	       5 allocs/op
BenchmarkPoolConcurrency/LockFreeCircularPool:_P:C:_3:3-40          	      13	  80592312 ns/op	       0 B/op	       0 allocs/op
BenchmarkPoolConcurrency/LockBasedCircularPool:_P:C:_10:10-40       	       9	 120341741 ns/op	    1813 B/op	      18 allocs/op
BenchmarkPoolConcurrency/LockFreeCircularPool:_P:C:_10:10-40        	      12	  93433006 ns/op	     272 B/op	       1 allocs/op
BenchmarkPoolConcurrency/LockBasedCircularPool:_P:C:_20:20-40       	       9	 119200769 ns/op	    2506 B/op	      26 allocs/op
BenchmarkPoolConcurrency/LockFreeCircularPool:_P:C:_20:20-40        	      13	  86771292 ns/op	     126 B/op	       1 allocs/op
BenchmarkPoolConcurrency/LockBasedCircularPool:_P:C:_100:100-40     	       8	 141185375 ns/op	    2101 B/op	      22 allocs/op
BenchmarkPoolConcurrency/LockFreeCircularPool:_P:C:_100:100-40      	      13	  92735878 ns/op	     244 B/op	       2 allocs/op
PASS
ok  	github.com/pingcap/tidb/util/globalconn	17.650s
```


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
util: ID pools for global kill 32bit.
```
