### PR TITLE
planner: non-prep plan cache supports 2-way joins

### DIFF
--- a/planner/core/plan_cacheable_checker_test.go
+++ b/planner/core/plan_cacheable_checker_test.go
@@ -303,6 +303,14 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 		"select * from test.t where d>now()",     // now
 		"select a+1 from test.t where a<13",
 		"select mod(a, 10) from test.t where a<13",
+
+		// 2-way joins
+		"select * from test.t inner join test.t3 on test.t.a=test.t3.a",
+		"select * from test.t inner join test.t3 on test.t.a=test.t3.a where test.t.a<10",
+		"select * from test.t, test.t3",
+		"select * from test.t, test.t3 where test.t.a=test.t3.a",
+		"select * from test.t, test.t3 where test.t.a=test.t3.a and test.t.b=t3.b",
+		"select * from test.t, test.t3 where test.t.a=test.t3.a and test.t.a<10",
 	}
 
 	unsupported := []string{
@@ -312,7 +320,6 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 		"select a, sum(b) as c from test.t1 where a > 1 and b < 2 group by a having sum(b) > 1", // having
 		"select * from test.t1 limit 1",                                                         // limit
 		"select * from test.t1 order by a",                                                      // order by
-		"select * from test.t1, test.t2",                                                        // join
 		"select * from (select * from test.t1) t",                                               // sub-query
 		"insert into test.t1 values(1, 1)",                                                      // insert
 		"insert into t1(a, b) select a, b from test.t1",                                         // insert into select


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36598

Problem Summary: planner: non-prep plan cache supports 2-way joins

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
