### PR TITLE
statistics: rename Table.Count to Table.RealtimeCount

### DIFF
--- a/executor/analyze_col_v2.go
+++ b/executor/analyze_col_v2.go
@@ -73,10 +73,10 @@ func (e *AnalyzeColumnsExecV2) analyzeColumnsPushDownWithRetryV2() *statistics.A
 	} else {
 		statsTbl = statsHandle.GetPartitionStats(e.tableInfo, tid)
 	}
-	if statsTbl == nil || statsTbl.Count <= 0 {
+	if statsTbl == nil || statsTbl.RealtimeCount <= 0 {
 		return analyzeResult
 	}
-	newSampleRate := math.Min(1, float64(config.DefRowsForSampleRate)/float64(statsTbl.Count))
+	newSampleRate := math.Min(1, float64(config.DefRowsForSampleRate)/float64(statsTbl.RealtimeCount))
 	if newSampleRate >= *e.analyzePB.ColReq.SampleRate {
 		return analyzeResult
 	}

--- a/executor/analyze_fast.go
+++ b/executor/analyze_fast.go
@@ -116,7 +116,7 @@ func (e *AnalyzeFastExec) calculateEstimateSampleStep() (err error) {
 	var historyRowCount uint64
 	hasBeenAnalyzed := len(rows) != 0 && rows[0].GetInt64(0) == statistics.AnalyzeFlag
 	if hasBeenAnalyzed {
-		historyRowCount = uint64(domain.GetDomain(e.ctx).StatsHandle().GetPartitionStats(e.tblInfo, e.tableID.GetStatisticsID()).Count)
+		historyRowCount = uint64(domain.GetDomain(e.ctx).StatsHandle().GetPartitionStats(e.tblInfo, e.tableID.GetStatisticsID()).RealtimeCount)
 	} else {
 		dbInfo, ok := domain.GetDomain(e.ctx).InfoSchema().SchemaByTable(e.tblInfo)
 		if !ok {
@@ -564,7 +564,7 @@ func (e *AnalyzeFastExec) runTasks() ([]*statistics.Histogram, []*statistics.CMS
 	var rowCount int64 = 0
 	if stats.Lease() > 0 {
 		if t := stats.GetPartitionStats(e.tblInfo, e.tableID.GetStatisticsID()); !t.Pseudo {
-			rowCount = t.Count
+			rowCount = t.RealtimeCount
 		}
 	}
 	hists, cms, topNs, fms := make([]*statistics.Histogram, length), make([]*statistics.CMSketch, length), make([]*statistics.TopN, length), make([]*statistics.FMSketch, length)

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2657,25 +2657,25 @@ func (b *executorBuilder) getAdjustedSampleRate(sctx sessionctx.Context, task pl
 		return defaultRate
 	}
 	// If the count in stats_meta is still 0 and there's no information from pd side, we scan all rows.
-	if statsTbl.Count == 0 && !hasPD {
+	if statsTbl.RealtimeCount == 0 && !hasPD {
 		return 1
 	}
 	// we have issue https://github.com/pingcap/tidb/issues/29216.
 	// To do a workaround for this issue, we check the approxiCount from the pd side to do a comparison.
 	// If the count from the stats_meta is extremely smaller than the approximate count from the pd,
 	// we think that we meet this issue and use the approximate count to calculate the sample rate.
-	if float64(statsTbl.Count*5) < approxiCount {
+	if float64(statsTbl.RealtimeCount*5) < approxiCount {
 		// Confirmed by TiKV side, the experience error rate of the approximate count is about 20%.
 		// So we increase the number to 150000 to reduce this error rate.
 		return math.Min(1, 150000/approxiCount)
 	}
 	// If we don't go into the above if branch and we still detect the count is zero. Return 1 to prevent the dividing zero.
-	if statsTbl.Count == 0 {
+	if statsTbl.RealtimeCount == 0 {
 		return 1
 	}
 	// We are expected to scan about 100000 rows or so.
 	// Since there's tiny error rate around the count from the stats meta, we use 110000 to get a little big result
-	return math.Min(1, config.DefRowsForSampleRate/float64(statsTbl.Count))
+	return math.Min(1, config.DefRowsForSampleRate/float64(statsTbl.RealtimeCount))
 }
 
 func (b *executorBuilder) getApproximateTableCountFromStorage(sctx sessionctx.Context, tid int64, task plannercore.AnalyzeColumnsTask) (float64, bool) {

--- a/executor/show_stats.go
+++ b/executor/show_stats.go
@@ -140,7 +140,7 @@ func (e *ShowExec) appendTableForStatsMeta(dbName, tblName, partitionName string
 		partitionName,
 		e.versionToTime(statsTbl.Version),
 		statsTbl.ModifyCount,
-		statsTbl.Count,
+		statsTbl.RealtimeCount,
 	})
 }
 
@@ -223,7 +223,7 @@ func (e *ShowExec) appendTableForStatsHistograms(dbName, tblName, partitionName 
 		if !col.IsStatsInitialized() {
 			continue
 		}
-		e.histogramToRow(dbName, tblName, partitionName, col.Info.Name.O, 0, col.Histogram, col.AvgColSize(statsTbl.Count, false),
+		e.histogramToRow(dbName, tblName, partitionName, col.Info.Name.O, 0, col.Histogram, col.AvgColSize(statsTbl.RealtimeCount, false),
 			col.StatsLoadedStatus.StatusToString(), col.MemoryUsage())
 	}
 	for _, idx := range stableIdxsStats(statsTbl.Indices) {

--- a/planner/core/casetest/integration_test.go
+++ b/planner/core/casetest/integration_test.go
@@ -3219,9 +3219,9 @@ func TestIssue32632(t *testing.T) {
 
 	h := dom.StatsHandle()
 	statsTbl1 := h.GetTableStats(tbl1.Meta())
-	statsTbl1.Count = 800000
+	statsTbl1.RealtimeCount = 800000
 	statsTbl2 := h.GetTableStats(tbl2.Meta())
-	statsTbl2.Count = 10000
+	statsTbl2.RealtimeCount = 10000
 	var input []string
 	var output []struct {
 		SQL  string

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -4320,7 +4320,7 @@ func getStatsTable(ctx sessionctx.Context, tblInfo *model.TableInfo, pid int64) 
 	}
 
 	// 2. table row count from statistics is zero.
-	if statsTbl.Count == 0 {
+	if statsTbl.RealtimeCount == 0 {
 		core_metrics.PseudoEstimationNotAvailable.Inc()
 		return statistics.PseudoTable(tblInfo)
 	}

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -1400,7 +1400,7 @@ func (ds *DataSource) detachCondAndBuildRangeForPath(path *util.AccessPath, cond
 }
 
 func (ds *DataSource) deriveCommonHandleTablePathStats(path *util.AccessPath, conds []expression.Expression, isIm bool) error {
-	path.CountAfterAccess = float64(ds.statisticTable.Count)
+	path.CountAfterAccess = float64(ds.statisticTable.RealtimeCount)
 	path.Ranges = ranger.FullNotNullRange()
 	path.IdxCols, path.IdxColLens = expression.IndexInfo2PrefixCols(ds.Columns, ds.schema.Columns, path.Index)
 	path.FullIdxCols, path.FullIdxColLens = expression.IndexInfo2Cols(ds.Columns, ds.schema.Columns, path.Index)
@@ -1417,7 +1417,7 @@ func (ds *DataSource) deriveCommonHandleTablePathStats(path *util.AccessPath, co
 		if len(accesses) > 0 && ds.statisticTable.Pseudo {
 			path.CountAfterAccess = ds.statisticTable.PseudoAvgCountPerValue()
 		} else {
-			selectivity := path.CountAfterAccess / float64(ds.statisticTable.Count)
+			selectivity := path.CountAfterAccess / float64(ds.statisticTable.RealtimeCount)
 			for i := range accesses {
 				col := path.IdxCols[path.EqOrInCondCount+i]
 				ndv := ds.getColumnNDV(col.ID)
@@ -1432,7 +1432,7 @@ func (ds *DataSource) deriveCommonHandleTablePathStats(path *util.AccessPath, co
 	// If the `CountAfterAccess` is less than `stats.RowCount`, there must be some inconsistent stats info.
 	// We prefer the `stats.RowCount` because it could use more stats info to calculate the selectivity.
 	if path.CountAfterAccess < ds.stats.RowCount && !isIm {
-		path.CountAfterAccess = math.Min(ds.stats.RowCount/SelectionFactor, float64(ds.statisticTable.Count))
+		path.CountAfterAccess = math.Min(ds.stats.RowCount/SelectionFactor, float64(ds.statisticTable.RealtimeCount))
 	}
 	return nil
 }
@@ -1444,7 +1444,7 @@ func (ds *DataSource) deriveTablePathStats(path *util.AccessPath, conds []expres
 		return ds.deriveCommonHandleTablePathStats(path, conds, isIm)
 	}
 	var err error
-	path.CountAfterAccess = float64(ds.statisticTable.Count)
+	path.CountAfterAccess = float64(ds.statisticTable.RealtimeCount)
 	path.TableFilters = conds
 	var pkCol *expression.Column
 	columnLen := len(ds.schema.Columns)
@@ -1512,14 +1512,14 @@ func (ds *DataSource) deriveTablePathStats(path *util.AccessPath, conds []expres
 	// If the `CountAfterAccess` is less than `stats.RowCount`, there must be some inconsistent stats info.
 	// We prefer the `stats.RowCount` because it could use more stats info to calculate the selectivity.
 	if path.CountAfterAccess < ds.stats.RowCount && !isIm {
-		path.CountAfterAccess = math.Min(ds.stats.RowCount/SelectionFactor, float64(ds.statisticTable.Count))
+		path.CountAfterAccess = math.Min(ds.stats.RowCount/SelectionFactor, float64(ds.statisticTable.RealtimeCount))
 	}
 	return err
 }
 
 func (ds *DataSource) fillIndexPath(path *util.AccessPath, conds []expression.Expression) error {
 	path.Ranges = ranger.FullRange()
-	path.CountAfterAccess = float64(ds.statisticTable.Count)
+	path.CountAfterAccess = float64(ds.statisticTable.RealtimeCount)
 	path.IdxCols, path.IdxColLens = expression.IndexInfo2PrefixCols(ds.Columns, ds.schema.Columns, path.Index)
 	path.FullIdxCols, path.FullIdxColLens = expression.IndexInfo2Cols(ds.Columns, ds.schema.Columns, path.Index)
 	if !path.Index.Unique && !path.Index.Primary && len(path.Index.Columns) == len(path.IdxCols) {
@@ -1557,7 +1557,7 @@ func (ds *DataSource) deriveIndexPathStats(path *util.AccessPath, _ []expression
 		if len(accesses) > 0 && ds.statisticTable.Pseudo {
 			path.CountAfterAccess = ds.statisticTable.PseudoAvgCountPerValue()
 		} else {
-			selectivity := path.CountAfterAccess / float64(ds.statisticTable.Count)
+			selectivity := path.CountAfterAccess / float64(ds.statisticTable.RealtimeCount)
 			for i := range accesses {
 				col := path.IdxCols[path.EqOrInCondCount+i]
 				ndv := ds.getColumnNDV(col.ID)
@@ -1575,7 +1575,7 @@ func (ds *DataSource) deriveIndexPathStats(path *util.AccessPath, _ []expression
 	// If the `CountAfterAccess` is less than `stats.RowCount`, there must be some inconsistent stats info.
 	// We prefer the `stats.RowCount` because it could use more stats info to calculate the selectivity.
 	if path.CountAfterAccess < ds.stats.RowCount && !isIm {
-		path.CountAfterAccess = math.Min(ds.stats.RowCount/SelectionFactor, float64(ds.statisticTable.Count))
+		path.CountAfterAccess = math.Min(ds.stats.RowCount/SelectionFactor, float64(ds.statisticTable.RealtimeCount))
 	}
 	if path.IndexFilters != nil {
 		selectivity, _, err := ds.tableStats.HistColl.Selectivity(ds.ctx, path.IndexFilters, nil)

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -62,13 +62,13 @@ func (p *LogicalMemTable) DeriveStats(_ []*property.StatsInfo, selfSchema *expre
 	}
 	statsTable := statistics.PseudoTable(p.TableInfo)
 	stats := &property.StatsInfo{
-		RowCount:     float64(statsTable.Count),
+		RowCount:     float64(statsTable.RealtimeCount),
 		ColNDVs:      make(map[int64]float64, len(p.TableInfo.Columns)),
 		HistColl:     statsTable.GenerateHistCollFromColumnInfo(p.TableInfo.Columns, p.schema.Columns),
 		StatsVersion: statistics.PseudoVersion,
 	}
 	for _, col := range selfSchema.Columns {
-		stats.ColNDVs[col.UniqueID] = float64(statsTable.Count)
+		stats.ColNDVs[col.UniqueID] = float64(statsTable.RealtimeCount)
 	}
 	p.stats = stats
 	return p.stats, nil
@@ -164,10 +164,10 @@ func (p *baseLogicalPlan) DeriveStats(childStats []*property.StatsInfo, selfSche
 func (ds *DataSource) getColumnNDV(colID int64) (ndv float64) {
 	hist, ok := ds.statisticTable.Columns[colID]
 	if ok && hist.Count > 0 {
-		factor := float64(ds.statisticTable.Count) / float64(hist.Count)
+		factor := float64(ds.statisticTable.RealtimeCount) / float64(hist.Count)
 		ndv = float64(hist.Histogram.NDV) * factor
 	} else {
-		ndv = float64(ds.statisticTable.Count) * distinctFactor
+		ndv = float64(ds.statisticTable.RealtimeCount) * distinctFactor
 	}
 	return ndv
 }
@@ -227,7 +227,7 @@ func (ds *DataSource) initStats(colGroups [][]*expression.Column) {
 		ds.statisticTable = getStatsTable(ds.ctx, ds.tableInfo, ds.physicalTableID)
 	}
 	tableStats := &property.StatsInfo{
-		RowCount:     float64(ds.statisticTable.Count),
+		RowCount:     float64(ds.statisticTable.RealtimeCount),
 		ColNDVs:      make(map[int64]float64, ds.schema.Len()),
 		HistColl:     ds.statisticTable.GenerateHistCollFromColumnInfo(ds.Columns, ds.schema.Columns),
 		StatsVersion: ds.statisticTable.Version,
@@ -412,7 +412,7 @@ func (ds *DataSource) DeriveStats(_ []*property.StatsInfo, _ *expression.Schema,
 		return nil, err
 	}
 
-	ds.accessPathMinSelectivity = getMinSelectivityFromPaths(ds.possibleAccessPaths, float64(ds.TblColHists.Count))
+	ds.accessPathMinSelectivity = getMinSelectivityFromPaths(ds.possibleAccessPaths, float64(ds.TblColHists.RealtimeCount))
 
 	return ds.stats, nil
 }

--- a/planner/core/tiflash_selection_late_materialization.go
+++ b/planner/core/tiflash_selection_late_materialization.go
@@ -203,7 +203,7 @@ func removeSpecificExprsFromSelection(physicalSelection *PhysicalSelection, expr
 // @param: physicalTableScan: the PhysicalTableScan to be pushed down to
 func predicatePushDownToTableScanImpl(sctx sessionctx.Context, physicalSelection *PhysicalSelection, physicalTableScan *PhysicalTableScan) {
 	// When the table is small, there is no need to push down the conditions.
-	if physicalTableScan.tblColHists.Count <= tiflashDataPackSize {
+	if physicalTableScan.tblColHists.RealtimeCount <= tiflashDataPackSize {
 		return
 	}
 	conds := physicalSelection.Conditions

--- a/statistics/handle/bootstrap.go
+++ b/statistics/handle/bootstrap.go
@@ -48,7 +48,7 @@ func (h *Handle) initStatsMeta4Chunk(is infoschema.InfoSchema, cache *statsCache
 		newHistColl := statistics.HistColl{
 			PhysicalID:     physicalID,
 			HavePhysicalID: true,
-			Count:          row.GetInt64(3),
+			RealtimeCount:  row.GetInt64(3),
 			ModifyCount:    row.GetInt64(2),
 			Columns:        make(map[int64]*statistics.Column, len(tableInfo.Columns)),
 			Indices:        make(map[int64]*statistics.Index, len(tableInfo.Indices)),

--- a/statistics/handle/ddl_test.go
+++ b/statistics/handle/ddl_test.go
@@ -163,7 +163,7 @@ func TestDDLHistogram(t *testing.T) {
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo)
 	require.False(t, statsTbl.Pseudo)
 	require.True(t, statsTbl.Columns[tableInfo.Columns[5].ID].IsStatsInitialized())
-	require.Equal(t, 3.0, statsTbl.Columns[tableInfo.Columns[5].ID].AvgColSize(statsTbl.Count, false))
+	require.Equal(t, 3.0, statsTbl.Columns[tableInfo.Columns[5].ID].AvgColSize(statsTbl.RealtimeCount, false))
 
 	testKit.MustExec("alter table t add column c6 varchar(15) DEFAULT '123', add column c7 varchar(15) DEFAULT '123'")
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
@@ -230,7 +230,7 @@ PARTITION BY RANGE ( a ) (
 		for _, def := range pi.Definitions {
 			statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 			require.False(t, statsTbl.Pseudo)
-			require.Equal(t, 3.0, statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSize(statsTbl.Count, false))
+			require.Equal(t, 3.0, statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSize(statsTbl.RealtimeCount, false))
 		}
 
 		addPartition := "alter table t add partition (partition p4 values less than (26))"

--- a/statistics/handle/dump_test.go
+++ b/statistics/handle/dump_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func requireTableEqual(t *testing.T, a *statistics.Table, b *statistics.Table) {
-	require.Equal(t, b.Count, a.Count)
+	require.Equal(t, b.RealtimeCount, a.RealtimeCount)
 	require.Equal(t, b.ModifyCount, a.ModifyCount)
 	require.Equal(t, len(b.Columns), len(a.Columns))
 	for i := range a.Columns {

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -611,7 +611,7 @@ func (h *Handle) Update(is infoschema.InfoSchema, opts ...TableStatsOpt) error {
 			continue
 		}
 		tbl.Version = version
-		tbl.Count = count
+		tbl.RealtimeCount = count
 		tbl.ModifyCount = modifyCount
 		tbl.Name = getFullTableName(is, tableInfo)
 		tbl.TblInfoUpdateTS = tableInfo.UpdateTS
@@ -762,7 +762,7 @@ func (h *Handle) mergePartitionStats2GlobalStats(sc sessionctx.Context,
 				return
 			}
 			// partition stats is not empty but column stats(hist, topn) is missing
-			if partitionStats.Count > 0 && (hg == nil || hg.TotalRowCount() <= 0) && (topN == nil || topN.TotalCount() <= 0) {
+			if partitionStats.RealtimeCount > 0 && (hg == nil || hg.TotalRowCount() <= 0) && (topN == nil || topN.TotalCount() <= 0) {
 				var errMsg string
 				if isIndex == 0 {
 					errMsg = fmt.Sprintf("table `%s` partition `%s` column `%s`", tableInfo.Name.L, def.Name.L, tableInfo.FindColumnNameByID(histIDs[i]))
@@ -774,7 +774,7 @@ func (h *Handle) mergePartitionStats2GlobalStats(sc sessionctx.Context,
 			}
 			if i == 0 {
 				// In a partition, we will only update globalStats.Count once
-				globalStats.Count += partitionStats.Count
+				globalStats.Count += partitionStats.RealtimeCount
 				globalStats.ModifyCount += partitionStats.ModifyCount
 			}
 			allHg[i] = append(allHg[i], hg)

--- a/statistics/handle/handletest/handle_test.go
+++ b/statistics/handle/handletest/handle_test.go
@@ -169,7 +169,7 @@ func TestStatsStoreAndLoad(t *testing.T) {
 	require.NoError(t, err)
 	statsTbl2 := do.StatsHandle().GetTableStats(tableInfo)
 	require.False(t, statsTbl2.Pseudo)
-	require.Equal(t, int64(recordCount), statsTbl2.Count)
+	require.Equal(t, int64(recordCount), statsTbl2.RealtimeCount)
 	internal.AssertTableEqual(t, statsTbl1, statsTbl2)
 }
 
@@ -243,39 +243,39 @@ func TestAvgColLen(t *testing.T) {
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
 	statsTbl := do.StatsHandle().GetTableStats(tableInfo)
-	require.Equal(t, 1.0, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSize(statsTbl.Count, false))
-	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSizeListInDisk(statsTbl.Count))
-	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSizeChunkFormat(statsTbl.Count))
+	require.Equal(t, 1.0, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSize(statsTbl.RealtimeCount, false))
+	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSizeListInDisk(statsTbl.RealtimeCount))
+	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSizeChunkFormat(statsTbl.RealtimeCount))
 
 	// The size of varchar type is LEN + BYTE, here is 1 + 7 = 8
-	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSize(statsTbl.Count, false))
-	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSize(statsTbl.Count, false))
-	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSize(statsTbl.Count, false))
-	require.Equal(t, 8.0-3, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSizeListInDisk(statsTbl.Count))
-	require.Equal(t, float64(unsafe.Sizeof(float32(12.3))), statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSizeListInDisk(statsTbl.Count))
-	require.Equal(t, float64(unsafe.Sizeof(types.ZeroTime)), statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSizeListInDisk(statsTbl.Count))
-	require.Equal(t, 8.0-3+8, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSizeChunkFormat(statsTbl.Count))
-	require.Equal(t, float64(unsafe.Sizeof(float32(12.3))), statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSizeChunkFormat(statsTbl.Count))
-	require.Equal(t, float64(unsafe.Sizeof(types.ZeroTime)), statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSizeChunkFormat(statsTbl.Count))
-	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[4].ID].AvgColSizeChunkFormat(statsTbl.Count))
-	require.Equal(t, 0.0, statsTbl.Columns[tableInfo.Columns[4].ID].AvgColSizeListInDisk(statsTbl.Count))
+	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSize(statsTbl.RealtimeCount, false))
+	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSize(statsTbl.RealtimeCount, false))
+	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSize(statsTbl.RealtimeCount, false))
+	require.Equal(t, 8.0-3, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSizeListInDisk(statsTbl.RealtimeCount))
+	require.Equal(t, float64(unsafe.Sizeof(float32(12.3))), statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSizeListInDisk(statsTbl.RealtimeCount))
+	require.Equal(t, float64(unsafe.Sizeof(types.ZeroTime)), statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSizeListInDisk(statsTbl.RealtimeCount))
+	require.Equal(t, 8.0-3+8, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSizeChunkFormat(statsTbl.RealtimeCount))
+	require.Equal(t, float64(unsafe.Sizeof(float32(12.3))), statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSizeChunkFormat(statsTbl.RealtimeCount))
+	require.Equal(t, float64(unsafe.Sizeof(types.ZeroTime)), statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSizeChunkFormat(statsTbl.RealtimeCount))
+	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[4].ID].AvgColSizeChunkFormat(statsTbl.RealtimeCount))
+	require.Equal(t, 0.0, statsTbl.Columns[tableInfo.Columns[4].ID].AvgColSizeListInDisk(statsTbl.RealtimeCount))
 	testKit.MustExec("insert into t values(132, '123456789112', 1232.3, '2018-03-07 19:17:29', NULL)")
 	testKit.MustExec("analyze table t")
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo)
-	require.Equal(t, 1.5, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSize(statsTbl.Count, false))
-	require.Equal(t, 10.5, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSize(statsTbl.Count, false))
-	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSize(statsTbl.Count, false))
-	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSize(statsTbl.Count, false))
-	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSizeListInDisk(statsTbl.Count))
-	require.Equal(t, math.Round((10.5-math.Log2(10.5))*100)/100, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSizeListInDisk(statsTbl.Count))
-	require.Equal(t, float64(unsafe.Sizeof(float32(12.3))), statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSizeListInDisk(statsTbl.Count))
-	require.Equal(t, float64(unsafe.Sizeof(types.ZeroTime)), statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSizeListInDisk(statsTbl.Count))
-	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSizeChunkFormat(statsTbl.Count))
-	require.Equal(t, math.Round((10.5-math.Log2(10.5))*100)/100+8, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSizeChunkFormat(statsTbl.Count))
-	require.Equal(t, float64(unsafe.Sizeof(float32(12.3))), statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSizeChunkFormat(statsTbl.Count))
-	require.Equal(t, float64(unsafe.Sizeof(types.ZeroTime)), statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSizeChunkFormat(statsTbl.Count))
-	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[4].ID].AvgColSizeChunkFormat(statsTbl.Count))
-	require.Equal(t, 0.0, statsTbl.Columns[tableInfo.Columns[4].ID].AvgColSizeListInDisk(statsTbl.Count))
+	require.Equal(t, 1.5, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSize(statsTbl.RealtimeCount, false))
+	require.Equal(t, 10.5, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSize(statsTbl.RealtimeCount, false))
+	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSize(statsTbl.RealtimeCount, false))
+	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSize(statsTbl.RealtimeCount, false))
+	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSizeListInDisk(statsTbl.RealtimeCount))
+	require.Equal(t, math.Round((10.5-math.Log2(10.5))*100)/100, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSizeListInDisk(statsTbl.RealtimeCount))
+	require.Equal(t, float64(unsafe.Sizeof(float32(12.3))), statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSizeListInDisk(statsTbl.RealtimeCount))
+	require.Equal(t, float64(unsafe.Sizeof(types.ZeroTime)), statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSizeListInDisk(statsTbl.RealtimeCount))
+	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[0].ID].AvgColSizeChunkFormat(statsTbl.RealtimeCount))
+	require.Equal(t, math.Round((10.5-math.Log2(10.5))*100)/100+8, statsTbl.Columns[tableInfo.Columns[1].ID].AvgColSizeChunkFormat(statsTbl.RealtimeCount))
+	require.Equal(t, float64(unsafe.Sizeof(float32(12.3))), statsTbl.Columns[tableInfo.Columns[2].ID].AvgColSizeChunkFormat(statsTbl.RealtimeCount))
+	require.Equal(t, float64(unsafe.Sizeof(types.ZeroTime)), statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSizeChunkFormat(statsTbl.RealtimeCount))
+	require.Equal(t, 8.0, statsTbl.Columns[tableInfo.Columns[4].ID].AvgColSizeChunkFormat(statsTbl.RealtimeCount))
+	require.Equal(t, 0.0, statsTbl.Columns[tableInfo.Columns[4].ID].AvgColSizeListInDisk(statsTbl.RealtimeCount))
 }
 
 func TestDurationToTS(t *testing.T) {
@@ -328,7 +328,7 @@ func TestVersion(t *testing.T) {
 	require.NoError(t, h.Update(is))
 	require.Equal(t, offset+uint64(4), h.LastUpdateVersion())
 	statsTbl1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(1), statsTbl1.Count)
+	require.Equal(t, int64(1), statsTbl1.RealtimeCount)
 
 	testKit.MustExec("insert t2 values(1,2)")
 	testKit.MustExec("analyze table t2")
@@ -337,7 +337,7 @@ func TestVersion(t *testing.T) {
 	require.NoError(t, h.Update(is))
 	require.Equal(t, offset+uint64(4), h.LastUpdateVersion())
 	statsTbl2 = h.GetTableStats(tableInfo2)
-	require.Equal(t, int64(1), statsTbl2.Count)
+	require.Equal(t, int64(1), statsTbl2.RealtimeCount)
 
 	testKit.MustExec("insert t2 values(1,2)")
 	testKit.MustExec("analyze table t2")
@@ -346,7 +346,7 @@ func TestVersion(t *testing.T) {
 	require.NoError(t, h.Update(is))
 	require.Equal(t, offset+uint64(4), h.LastUpdateVersion())
 	statsTbl2 = h.GetTableStats(tableInfo2)
-	require.Equal(t, int64(1), statsTbl2.Count)
+	require.Equal(t, int64(1), statsTbl2.RealtimeCount)
 
 	// We add an index and analyze it, but DDL doesn't load.
 	testKit.MustExec("alter table t2 add column c3 int")
@@ -1659,14 +1659,14 @@ partition by range (a) (
 	globalStats := h.GetTableStats(tableInfo)
 	// global.count = p0.count(3) + p1.count(4) + p2.count(2)
 	// modify count is 2 because we didn't analyze p1 after the second insert
-	require.Equal(t, int64(9), globalStats.Count)
+	require.Equal(t, int64(9), globalStats.RealtimeCount)
 	require.Equal(t, int64(2), globalStats.ModifyCount)
 
 	tk.MustExec("analyze table t partition p1;")
 	globalStats = h.GetTableStats(tableInfo)
 	// global.count = p0.count(3) + p1.count(4) + p2.count(4)
 	// The value of modify count is 0 now.
-	require.Equal(t, int64(9), globalStats.Count)
+	require.Equal(t, int64(9), globalStats.RealtimeCount)
 	require.Equal(t, int64(0), globalStats.ModifyCount)
 
 	tk.MustExec("alter table t drop partition p2;")
@@ -1674,7 +1674,7 @@ partition by range (a) (
 	tk.MustExec("analyze table t;")
 	globalStats = h.GetTableStats(tableInfo)
 	// global.count = p0.count(3) + p1.count(4)
-	require.Equal(t, int64(7), globalStats.Count)
+	require.Equal(t, int64(7), globalStats.RealtimeCount)
 }
 
 func TestDDLPartition4GlobalStats(t *testing.T) {
@@ -1710,7 +1710,7 @@ func TestDDLPartition4GlobalStats(t *testing.T) {
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
 	globalStats := h.GetTableStats(tableInfo)
-	require.Equal(t, int64(15), globalStats.Count)
+	require.Equal(t, int64(15), globalStats.RealtimeCount)
 
 	tk.MustExec("alter table t drop partition p3, p5;")
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
@@ -1720,7 +1720,7 @@ func TestDDLPartition4GlobalStats(t *testing.T) {
 	require.Len(t, result, 5)
 	// The value of global.count will be updated automatically after we drop the table partition.
 	globalStats = h.GetTableStats(tableInfo)
-	require.Equal(t, int64(11), globalStats.Count)
+	require.Equal(t, int64(11), globalStats.RealtimeCount)
 
 	tk.MustExec("alter table t truncate partition p2, p4;")
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
@@ -1729,7 +1729,7 @@ func TestDDLPartition4GlobalStats(t *testing.T) {
 	// The value of global.count will not be updated automatically when we truncate the table partition.
 	// Because the partition-stats in the partition table which have been truncated has not been updated.
 	globalStats = h.GetTableStats(tableInfo)
-	require.Equal(t, int64(11), globalStats.Count)
+	require.Equal(t, int64(11), globalStats.RealtimeCount)
 
 	tk.MustExec("analyze table t;")
 	result = tk.MustQuery("show stats_meta where table_name = 't';").Rows()
@@ -1737,7 +1737,7 @@ func TestDDLPartition4GlobalStats(t *testing.T) {
 	require.Len(t, result, 5)
 	// The result for the globalStats.count will be right now
 	globalStats = h.GetTableStats(tableInfo)
-	require.Equal(t, int64(7), globalStats.Count)
+	require.Equal(t, int64(7), globalStats.RealtimeCount)
 }
 
 func TestMergeGlobalTopN(t *testing.T) {
@@ -3437,7 +3437,7 @@ func TestStatsLockAndUnlockTable(t *testing.T) {
 
 	tk.MustExec("analyze table test.t")
 	tblStats2 := handle.GetTableStats(tbl.Meta())
-	require.Equal(t, int64(2), tblStats2.Count)
+	require.Equal(t, int64(2), tblStats2.RealtimeCount)
 }
 
 func TestStatsLockAndUnlockTables(t *testing.T) {
@@ -3501,9 +3501,9 @@ func TestStatsLockAndUnlockTables(t *testing.T) {
 
 	tk.MustExec("analyze table test.t1, test.t2")
 	tbl1Stats2 := handle.GetTableStats(tbl1.Meta())
-	require.Equal(t, int64(2), tbl1Stats2.Count)
+	require.Equal(t, int64(2), tbl1Stats2.RealtimeCount)
 	tbl2Stats2 := handle.GetTableStats(tbl2.Meta())
-	require.Equal(t, int64(2), tbl2Stats2.Count)
+	require.Equal(t, int64(2), tbl2Stats2.RealtimeCount)
 }
 
 func TestIssue39336(t *testing.T) {

--- a/statistics/handle/internal/testutil.go
+++ b/statistics/handle/internal/testutil.go
@@ -23,7 +23,7 @@ import (
 
 // AssertTableEqual is to assert whether two table is equal
 func AssertTableEqual(t *testing.T, a *statistics.Table, b *statistics.Table) {
-	require.Equal(t, b.Count, a.Count)
+	require.Equal(t, b.RealtimeCount, a.RealtimeCount)
 	require.Equal(t, b.ModifyCount, a.ModifyCount)
 	require.Len(t, a.Columns, len(b.Columns))
 	for i := range a.Columns {

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -436,7 +436,7 @@ func (h *Handle) needDumpStatsDelta(is infoschema.InfoSchema, mode dumpMode, id 
 		return true
 	}
 	statsTbl := h.GetPartitionStats(tbl.Meta(), id)
-	if statsTbl.Pseudo || statsTbl.Count == 0 || float64(item.Count)/float64(statsTbl.Count) > DumpStatsDeltaRatio {
+	if statsTbl.Pseudo || statsTbl.RealtimeCount == 0 || float64(item.Count)/float64(statsTbl.RealtimeCount) > DumpStatsDeltaRatio {
 		// Dump the stats when there are many modifications.
 		return true
 	}
@@ -1026,7 +1026,7 @@ func NeedAnalyzeTable(tbl *statistics.Table, limit time.Duration, autoAnalyzeRat
 		return false, ""
 	}
 	// No need to analyze it.
-	tblCnt := float64(tbl.Count)
+	tblCnt := float64(tbl.RealtimeCount)
 	if histCnt := tbl.GetColRowCount(); histCnt > 0 {
 		tblCnt = histCnt
 	}
@@ -1170,7 +1170,7 @@ func (h *Handle) HandleAutoAnalyze(is infoschema.InfoSchema) (analyzed bool) {
 }
 
 func (h *Handle) autoAnalyzeTable(tblInfo *model.TableInfo, statsTbl *statistics.Table, ratio float64, analyzeSnapshot bool, sql string, params ...interface{}) bool {
-	if statsTbl.Pseudo || statsTbl.Count < AutoAnalyzeMinCnt {
+	if statsTbl.Pseudo || statsTbl.RealtimeCount < AutoAnalyzeMinCnt {
 		return false
 	}
 	if needAnalyze, reason := NeedAnalyzeTable(statsTbl, 20*h.Lease(), ratio); needAnalyze {
@@ -1210,7 +1210,7 @@ func (h *Handle) autoAnalyzePartitionTableInDynamicMode(tblInfo *model.TableInfo
 	partitionNames := make([]interface{}, 0, len(pi.Definitions))
 	for _, def := range pi.Definitions {
 		partitionStatsTbl := h.GetPartitionStats(tblInfo, def.ID)
-		if partitionStatsTbl.Pseudo || partitionStatsTbl.Count < AutoAnalyzeMinCnt {
+		if partitionStatsTbl.Pseudo || partitionStatsTbl.RealtimeCount < AutoAnalyzeMinCnt {
 			continue
 		}
 		if needAnalyze, _ := NeedAnalyzeTable(partitionStatsTbl, 20*h.Lease(), ratio); needAnalyze {
@@ -1400,7 +1400,7 @@ func logForIndex(prefix string, t *statistics.Table, idx *statistics.Index, rang
 					zap.String("range", rangeString))
 			}
 		} else {
-			count, err := statistics.GetPseudoRowCountByColumnRanges(sc, float64(t.Count), []*ranger.Range{&rang}, 0)
+			count, err := statistics.GetPseudoRowCountByColumnRanges(sc, float64(t.RealtimeCount), []*ranger.Range{&rang}, 0)
 			if err == nil {
 				logutil.BgLogger().Debug(prefix, zap.String("index", idx.Info.Name.O), zap.Int64("actual", actual[i]),
 					zap.String("equality", equalityString), zap.Uint64("expected equality", equalityCount),
@@ -1431,13 +1431,13 @@ func (h *Handle) logDetailedInfo(q *statistics.QueryFeedback) {
 		if idx == nil || idx.Histogram.Len() == 0 {
 			return
 		}
-		logForIndex(logPrefix, t, idx, ranges, actual, idx.GetIncreaseFactor(t.Count))
+		logForIndex(logPrefix, t, idx, ranges, actual, idx.GetIncreaseFactor(t.RealtimeCount))
 	} else {
 		c := t.Columns[q.Hist.ID]
 		if c == nil || c.Histogram.Len() == 0 {
 			return
 		}
-		logForPK(logPrefix, c, ranges, actual, c.GetIncreaseFactor(t.Count))
+		logForPK(logPrefix, c, ranges, actual, c.GetIncreaseFactor(t.RealtimeCount))
 	}
 }
 
@@ -1491,10 +1491,10 @@ func (h *Handle) RecalculateExpectCount(q *statistics.QueryFeedback, enablePseud
 	expected := 0.0
 	if isIndex {
 		idx := t.Indices[id]
-		expected, err = idx.GetRowCount(sctx, nil, ranges, t.Count, t.ModifyCount)
+		expected, err = idx.GetRowCount(sctx, nil, ranges, t.RealtimeCount, t.ModifyCount)
 	} else {
 		c := t.Columns[id]
-		expected, err = c.GetColumnRowCount(sctx, ranges, t.Count, t.ModifyCount, true)
+		expected, err = c.GetColumnRowCount(sctx, ranges, t.RealtimeCount, t.ModifyCount, true)
 	}
 	q.Expected = int64(expected)
 	return err
@@ -1604,7 +1604,7 @@ func (h *Handle) DumpFeedbackForIndex(q *statistics.QueryFeedback, t *statistics
 			logutil.BgLogger().Debug("encode keys fail", zap.Error(err))
 			continue
 		}
-		equalityCount := float64(idx.QueryBytes(bytes)) * idx.GetIncreaseFactor(t.Count)
+		equalityCount := float64(idx.QueryBytes(bytes)) * idx.GetIncreaseFactor(t.RealtimeCount)
 		rang := &ranger.Range{
 			LowVal:    []types.Datum{ran.LowVal[rangePosition]},
 			HighVal:   []types.Datum{ran.HighVal[rangePosition]},
@@ -1631,7 +1631,7 @@ func (h *Handle) DumpFeedbackForIndex(q *statistics.QueryFeedback, t *statistics
 			continue
 		}
 
-		equalityCount, rangeCount = getNewCountForIndex(equalityCount, rangeCount, float64(t.Count), float64(q.Feedback[i].Count))
+		equalityCount, rangeCount = getNewCountForIndex(equalityCount, rangeCount, float64(t.RealtimeCount), float64(q.Feedback[i].Count))
 		value := types.NewBytesDatum(bytes)
 		q.Feedback[i] = statistics.Feedback{Lower: &value, Upper: &value, Count: int64(equalityCount)}
 		err = h.dumpRangeFeedback(sc, rang, rangeCount, rangeFB)

--- a/statistics/handle/updatetest/update_test.go
+++ b/statistics/handle/updatetest/update_test.go
@@ -71,13 +71,13 @@ func TestSingleSessionInsert(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 := h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1), stats1.Count)
+	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
 	tbl2, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t2"))
 	require.NoError(t, err)
 	tableInfo2 := tbl2.Meta()
 	stats2 := h.GetTableStats(tableInfo2)
-	require.Equal(t, int64(rowCount2), stats2.Count)
+	require.Equal(t, int64(rowCount2), stats2.RealtimeCount)
 
 	testKit.MustExec("analyze table t1")
 	// Test update in a txn.
@@ -87,7 +87,7 @@ func TestSingleSessionInsert(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1*2), stats1.Count)
+	require.Equal(t, int64(rowCount1*2), stats1.RealtimeCount)
 
 	// Test IncreaseFactor.
 	count, err := stats1.ColumnEqualRowCount(testKit.Session(), types.NewIntDatum(1), tableInfo1.Columns[0].ID)
@@ -102,7 +102,7 @@ func TestSingleSessionInsert(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1*3), stats1.Count)
+	require.Equal(t, int64(rowCount1*3), stats1.RealtimeCount)
 
 	testKit.MustExec("begin")
 	for i := 0; i < rowCount1; i++ {
@@ -118,9 +118,9 @@ func TestSingleSessionInsert(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1*3), stats1.Count)
+	require.Equal(t, int64(rowCount1*3), stats1.RealtimeCount)
 	stats2 = h.GetTableStats(tableInfo2)
-	require.Equal(t, int64(rowCount2), stats2.Count)
+	require.Equal(t, int64(rowCount2), stats2.RealtimeCount)
 
 	testKit.MustExec("begin")
 	testKit.MustExec("delete from t1")
@@ -128,7 +128,7 @@ func TestSingleSessionInsert(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(0), stats1.Count)
+	require.Equal(t, int64(0), stats1.RealtimeCount)
 
 	rs := testKit.MustQuery("select modify_count from mysql.stats_meta")
 	rs.Check(testkit.Rows("40", "70"))
@@ -150,7 +150,7 @@ func TestSingleSessionInsert(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1), stats1.Count)
+	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
 	// not dumped
 	testKit.MustExec("insert into t1 values (1,2)")
@@ -158,12 +158,12 @@ func TestSingleSessionInsert(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1), stats1.Count)
+	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
 	h.FlushStats()
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1+1), stats1.Count)
+	require.Equal(t, int64(rowCount1+1), stats1.RealtimeCount)
 }
 
 func TestRollback(t *testing.T) {
@@ -186,7 +186,7 @@ func TestRollback(t *testing.T) {
 	require.NoError(t, h.Update(is))
 
 	stats := h.GetTableStats(tableInfo)
-	require.Equal(t, int64(0), stats.Count)
+	require.Equal(t, int64(0), stats.RealtimeCount)
 	require.Equal(t, int64(0), stats.ModifyCount)
 }
 
@@ -221,7 +221,7 @@ func TestMultiSession(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 := h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1), stats1.Count)
+	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
 	for i := 0; i < rowCount1; i++ {
 		testKit.MustExec("insert into t1 values(1, 2)")
@@ -241,7 +241,7 @@ func TestMultiSession(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1*2), stats1.Count)
+	require.Equal(t, int64(rowCount1*2), stats1.RealtimeCount)
 	testKit.RefreshSession()
 	rs := testKit.MustQuery("select modify_count from mysql.stats_meta")
 	rs.Check(testkit.Rows("60"))
@@ -271,13 +271,13 @@ func TestTxnWithFailure(t *testing.T) {
 	require.NoError(t, h.Update(is))
 	stats1 := h.GetTableStats(tableInfo1)
 	// have not commit
-	require.Equal(t, int64(0), stats1.Count)
+	require.Equal(t, int64(0), stats1.RealtimeCount)
 	testKit.MustExec("commit")
 
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1), stats1.Count)
+	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
 	_, err = testKit.Exec("insert into t1 values(0, 2)")
 	require.Error(t, err)
@@ -285,13 +285,13 @@ func TestTxnWithFailure(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1), stats1.Count)
+	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
 	testKit.MustExec("insert into t1 values(-1, 2)")
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(rowCount1+1), stats1.Count)
+	require.Equal(t, int64(rowCount1+1), stats1.RealtimeCount)
 }
 
 func TestUpdatePartition(t *testing.T) {
@@ -323,7 +323,7 @@ func TestUpdatePartition(t *testing.T) {
 		for _, def := range pi.Definitions {
 			statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 			require.Equal(t, int64(1), statsTbl.ModifyCount)
-			require.Equal(t, int64(1), statsTbl.Count)
+			require.Equal(t, int64(1), statsTbl.RealtimeCount)
 			require.Equal(t, int64(2), statsTbl.Columns[bColID].TotColSize)
 		}
 
@@ -333,7 +333,7 @@ func TestUpdatePartition(t *testing.T) {
 		for _, def := range pi.Definitions {
 			statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 			require.Equal(t, int64(2), statsTbl.ModifyCount)
-			require.Equal(t, int64(1), statsTbl.Count)
+			require.Equal(t, int64(1), statsTbl.RealtimeCount)
 			require.Equal(t, int64(3), statsTbl.Columns[bColID].TotColSize)
 		}
 
@@ -343,14 +343,14 @@ func TestUpdatePartition(t *testing.T) {
 		for _, def := range pi.Definitions {
 			statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 			require.Equal(t, int64(3), statsTbl.ModifyCount)
-			require.Equal(t, int64(0), statsTbl.Count)
+			require.Equal(t, int64(0), statsTbl.RealtimeCount)
 			require.Equal(t, int64(0), statsTbl.Columns[bColID].TotColSize)
 		}
 		// assert WithGetTableStatsByQuery get the same result
 		for _, def := range pi.Definitions {
 			statsTbl := h.GetPartitionStats(tableInfo, def.ID, handle.WithTableStatsByQuery())
 			require.Equal(t, int64(3), statsTbl.ModifyCount)
-			require.Equal(t, int64(0), statsTbl.Count)
+			require.Equal(t, int64(0), statsTbl.RealtimeCount)
 			require.Equal(t, int64(0), statsTbl.Columns[bColID].TotColSize)
 		}
 	})
@@ -381,7 +381,7 @@ func TestAutoUpdate(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, h.Update(is))
 		stats := h.GetTableStats(tableInfo)
-		require.Equal(t, int64(0), stats.Count)
+		require.Equal(t, int64(0), stats.RealtimeCount)
 
 		_, err = testKit.Exec("insert into t values ('ss'), ('ss'), ('ss'), ('ss'), ('ss')")
 		require.NoError(t, err)
@@ -390,7 +390,7 @@ func TestAutoUpdate(t *testing.T) {
 		h.HandleAutoAnalyze(is)
 		require.NoError(t, h.Update(is))
 		stats = h.GetTableStats(tableInfo)
-		require.Equal(t, int64(5), stats.Count)
+		require.Equal(t, int64(5), stats.RealtimeCount)
 		require.Equal(t, int64(0), stats.ModifyCount)
 		for _, item := range stats.Columns {
 			// TotColSize = 5*(2(length of 'ss') + 1(size of len byte)).
@@ -408,7 +408,7 @@ func TestAutoUpdate(t *testing.T) {
 		h.HandleAutoAnalyze(is)
 		require.NoError(t, h.Update(is))
 		stats = h.GetTableStats(tableInfo)
-		require.Equal(t, int64(6), stats.Count)
+		require.Equal(t, int64(6), stats.RealtimeCount)
 		require.Equal(t, int64(1), stats.ModifyCount)
 
 		_, err = testKit.Exec("insert into t values ('fff')")
@@ -418,7 +418,7 @@ func TestAutoUpdate(t *testing.T) {
 		h.HandleAutoAnalyze(is)
 		require.NoError(t, h.Update(is))
 		stats = h.GetTableStats(tableInfo)
-		require.Equal(t, int64(7), stats.Count)
+		require.Equal(t, int64(7), stats.RealtimeCount)
 		require.Equal(t, int64(0), stats.ModifyCount)
 
 		_, err = testKit.Exec("insert into t values ('eee')")
@@ -428,7 +428,7 @@ func TestAutoUpdate(t *testing.T) {
 		h.HandleAutoAnalyze(is)
 		require.NoError(t, h.Update(is))
 		stats = h.GetTableStats(tableInfo)
-		require.Equal(t, int64(8), stats.Count)
+		require.Equal(t, int64(8), stats.RealtimeCount)
 		// Modify count is non-zero means that we do not analyze the table.
 		require.Equal(t, int64(1), stats.ModifyCount)
 		for _, item := range stats.Columns {
@@ -447,7 +447,7 @@ func TestAutoUpdate(t *testing.T) {
 		h.HandleAutoAnalyze(is)
 		require.NoError(t, h.Update(is))
 		stats = h.GetTableStats(tableInfo)
-		require.Equal(t, int64(8), stats.Count)
+		require.Equal(t, int64(8), stats.RealtimeCount)
 		require.Equal(t, int64(0), stats.ModifyCount)
 		hg, ok := stats.Indices[tableInfo.Indices[0].ID]
 		require.True(t, ok)
@@ -484,14 +484,14 @@ func TestAutoUpdatePartition(t *testing.T) {
 
 		require.NoError(t, h.Update(is))
 		stats := h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
-		require.Equal(t, int64(0), stats.Count)
+		require.Equal(t, int64(0), stats.RealtimeCount)
 
 		testKit.MustExec("insert into t values (1)")
 		require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 		require.NoError(t, h.Update(is))
 		h.HandleAutoAnalyze(is)
 		stats = h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
-		require.Equal(t, int64(1), stats.Count)
+		require.Equal(t, int64(1), stats.RealtimeCount)
 		require.Equal(t, int64(0), stats.ModifyCount)
 	})
 }
@@ -636,7 +636,7 @@ func TestAutoAnalyzeOnChangeAnalyzeVer(t *testing.T) {
 	h.HandleAutoAnalyze(is)
 	require.NoError(t, h.Update(is))
 	statsTbl1 = h.GetTableStats(tbl.Meta())
-	require.Equal(t, int64(5), statsTbl1.Count)
+	require.Equal(t, int64(5), statsTbl1.RealtimeCount)
 	// All of its statistics should still be version 1.
 	for _, col := range statsTbl1.Columns {
 		require.Equal(t, int64(1), col.StatsVer)
@@ -1399,7 +1399,7 @@ func TestNeedAnalyzeTable(t *testing.T) {
 		},
 		// table was already analyzed but auto analyze is disabled
 		{
-			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
+			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, RealtimeCount: 1}},
 			limit:  0,
 			ratio:  0,
 			result: false,
@@ -1407,7 +1407,7 @@ func TestNeedAnalyzeTable(t *testing.T) {
 		},
 		// table was already analyzed but modify count is small
 		{
-			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 0, Count: 1}},
+			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 0, RealtimeCount: 1}},
 			limit:  0,
 			ratio:  0.3,
 			result: false,
@@ -1415,7 +1415,7 @@ func TestNeedAnalyzeTable(t *testing.T) {
 		},
 		// table was already analyzed
 		{
-			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
+			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, RealtimeCount: 1}},
 			limit:  0,
 			ratio:  0.3,
 			result: true,
@@ -1423,7 +1423,7 @@ func TestNeedAnalyzeTable(t *testing.T) {
 		},
 		// table was already analyzed
 		{
-			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
+			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, RealtimeCount: 1}},
 			limit:  0,
 			ratio:  0.3,
 			result: true,
@@ -1431,7 +1431,7 @@ func TestNeedAnalyzeTable(t *testing.T) {
 		},
 		// table was already analyzed
 		{
-			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
+			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, RealtimeCount: 1}},
 			limit:  0,
 			ratio:  0.3,
 			result: true,
@@ -1439,7 +1439,7 @@ func TestNeedAnalyzeTable(t *testing.T) {
 		},
 		// table was already analyzed
 		{
-			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
+			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, RealtimeCount: 1}},
 			limit:  0,
 			ratio:  0.3,
 			result: true,
@@ -2159,9 +2159,9 @@ func TestAutoUpdatePartitionInDynamicOnlyMode(t *testing.T) {
 		pi := tableInfo.GetPartitionInfo()
 		globalStats := h.GetTableStats(tableInfo)
 		partitionStats := h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
-		require.Equal(t, int64(6), globalStats.Count)
+		require.Equal(t, int64(6), globalStats.RealtimeCount)
 		require.Equal(t, int64(0), globalStats.ModifyCount)
-		require.Equal(t, int64(2), partitionStats.Count)
+		require.Equal(t, int64(2), partitionStats.RealtimeCount)
 		require.Equal(t, int64(0), partitionStats.ModifyCount)
 
 		testKit.MustExec("insert into t values (3, 'g')")
@@ -2169,18 +2169,18 @@ func TestAutoUpdatePartitionInDynamicOnlyMode(t *testing.T) {
 		require.NoError(t, h.Update(is))
 		globalStats = h.GetTableStats(tableInfo)
 		partitionStats = h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
-		require.Equal(t, int64(7), globalStats.Count)
+		require.Equal(t, int64(7), globalStats.RealtimeCount)
 		require.Equal(t, int64(1), globalStats.ModifyCount)
-		require.Equal(t, int64(3), partitionStats.Count)
+		require.Equal(t, int64(3), partitionStats.RealtimeCount)
 		require.Equal(t, int64(1), partitionStats.ModifyCount)
 
 		h.HandleAutoAnalyze(is)
 		require.NoError(t, h.Update(is))
 		globalStats = h.GetTableStats(tableInfo)
 		partitionStats = h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
-		require.Equal(t, int64(7), globalStats.Count)
+		require.Equal(t, int64(7), globalStats.RealtimeCount)
 		require.Equal(t, int64(0), globalStats.ModifyCount)
-		require.Equal(t, int64(3), partitionStats.Count)
+		require.Equal(t, int64(3), partitionStats.RealtimeCount)
 		require.Equal(t, int64(0), partitionStats.ModifyCount)
 	})
 }
@@ -2475,7 +2475,7 @@ func TestStatsLockUnlockForAutoAnalyze(t *testing.T) {
 	tk.MustExec("analyze table t")
 
 	tblStats2 := h.GetTableStats(tbl.Meta())
-	require.Equal(t, int64(15), tblStats2.Count)
+	require.Equal(t, int64(15), tblStats2.RealtimeCount)
 }
 
 func TestStatsLockForFeedback(t *testing.T) {
@@ -2603,13 +2603,13 @@ func TestStatsLockForDelta(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 := h.GetTableStats(tableInfo1)
-	require.Equal(t, stats1.Count, int64(0))
+	require.Equal(t, stats1.RealtimeCount, int64(0))
 
 	tbl2, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t2"))
 	require.NoError(t, err)
 	tableInfo2 := tbl2.Meta()
 	stats2 := h.GetTableStats(tableInfo2)
-	require.Equal(t, int64(rowCount2), stats2.Count)
+	require.Equal(t, int64(rowCount2), stats2.RealtimeCount)
 
 	testKit.MustExec("analyze table t1")
 	for i := 0; i < rowCount1; i++ {
@@ -2618,13 +2618,13 @@ func TestStatsLockForDelta(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, stats1.Count, int64(0))
+	require.Equal(t, stats1.RealtimeCount, int64(0))
 
 	testKit.MustExec("unlock stats t1")
 
 	testKit.MustExec("analyze table t1")
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(20), stats1.Count)
+	require.Equal(t, int64(20), stats1.RealtimeCount)
 
 	for i := 0; i < rowCount1; i++ {
 		testKit.MustExec("insert into t1 values(1, 2)")
@@ -2632,7 +2632,7 @@ func TestStatsLockForDelta(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
 	require.NoError(t, h.Update(is))
 	stats1 = h.GetTableStats(tableInfo1)
-	require.Equal(t, int64(30), stats1.Count)
+	require.Equal(t, int64(30), stats1.RealtimeCount)
 }
 
 func TestFillMissingStatsMeta(t *testing.T) {

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -1004,7 +1004,7 @@ func (coll *HistColl) NewHistCollBySelectivity(sctx sessionctx.Context, statsNod
 		Indices:       make(map[int64]*Index),
 		Idx2ColumnIDs: coll.Idx2ColumnIDs,
 		ColID2IdxIDs:  coll.ColID2IdxIDs,
-		Count:         coll.Count,
+		RealtimeCount: coll.RealtimeCount,
 	}
 	for _, node := range statsNodes {
 		if node.Tp == IndexType {

--- a/statistics/histogram_test.go
+++ b/statistics/histogram_test.go
@@ -31,9 +31,9 @@ import (
 
 func TestNewHistogramBySelectivity(t *testing.T) {
 	coll := &HistColl{
-		Count:   330,
-		Columns: make(map[int64]*Column),
-		Indices: make(map[int64]*Index),
+		RealtimeCount: 330,
+		Columns:       make(map[int64]*Column),
+		Indices:       make(map[int64]*Index),
 	}
 	ctx := mock.NewContext()
 	sc := ctx.GetSessionVars().StmtCtx

--- a/statistics/index.go
+++ b/statistics/index.go
@@ -380,7 +380,7 @@ func (idx *Index) expBackoffEstimation(sctx sessionctx.Context, coll *HistColl, 
 	l := len(singleColumnEstResults)
 	// Convert the first 4 to selectivity results.
 	for i := 0; i < l && i < 4; i++ {
-		singleColumnEstResults[i] = singleColumnEstResults[i] / float64(coll.Count)
+		singleColumnEstResults[i] = singleColumnEstResults[i] / float64(coll.RealtimeCount)
 	}
 	failpoint.Inject("cleanEstResults", func() {
 		singleColumnEstResults = singleColumnEstResults[:0]

--- a/statistics/interact_with_storage.go
+++ b/statistics/interact_with_storage.go
@@ -463,7 +463,7 @@ func TableStatsFromStorage(reader *StatsReader, tableInfo *model.TableInfo, phys
 		return nil, err
 	}
 	table.ModifyCount = rows[0].GetInt64(0)
-	table.Count = rows[0].GetInt64(1)
+	table.RealtimeCount = rows[0].GetInt64(1)
 
 	rows, _, err = reader.Read("select table_id, is_index, hist_id, distinct_count, version, null_count, tot_col_size, stats_ver, flag, correlation, last_analyze_pos from mysql.stats_histograms where table_id = %?", physicalID)
 	// Check deleted table.

--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -126,7 +126,7 @@ func pseudoSelectivity(coll *HistColl, exprs []expression.Expression) float64 {
 			}
 			colExists[col.Info.Name.L] = true
 			if mysql.HasUniKeyFlag(col.Info.GetFlag()) {
-				return 1.0 / float64(coll.Count)
+				return 1.0 / float64(coll.RealtimeCount)
 			}
 		case ast.GE, ast.GT, ast.LE, ast.LT:
 			minFactor = math.Min(minFactor, 1.0/pseudoLessRate)
@@ -149,7 +149,7 @@ func pseudoSelectivity(coll *HistColl, exprs []expression.Expression) float64 {
 			}
 		}
 		if unique {
-			return 1.0 / float64(coll.Count)
+			return 1.0 / float64(coll.RealtimeCount)
 		}
 	}
 	return minFactor
@@ -181,7 +181,7 @@ func isColEqCorCol(filter expression.Expression) *expression.Column {
 // Currently the time complexity is o(n^2).
 func (coll *HistColl) Selectivity(ctx sessionctx.Context, exprs []expression.Expression, filledPaths []*planutil.AccessPath) (float64, []*StatsNode, error) {
 	// If table's count is zero or conditions are empty, we should return 100% selectivity.
-	if coll.Count == 0 || len(exprs) == 0 {
+	if coll.RealtimeCount == 0 || len(exprs) == 0 {
 		return 1, nil, nil
 	}
 	ret := 1.0
@@ -192,7 +192,7 @@ func (coll *HistColl) Selectivity(ctx sessionctx.Context, exprs []expression.Exp
 	if len(exprs) > 63 || (len(coll.Columns) == 0 && len(coll.Indices) == 0) {
 		ret = pseudoSelectivity(coll, exprs)
 		if sc.EnableOptimizerCETrace {
-			CETraceExpr(ctx, tableID, "Table Stats-Pseudo-Expression", expression.ComposeCNFCondition(ctx, exprs...), ret*float64(coll.Count))
+			CETraceExpr(ctx, tableID, "Table Stats-Pseudo-Expression", expression.ComposeCNFCondition(ctx, exprs...), ret*float64(coll.RealtimeCount))
 		}
 		return ret, nil, nil
 	}
@@ -238,14 +238,14 @@ func (coll *HistColl) Selectivity(ctx sessionctx.Context, exprs []expression.Exp
 				if err != nil {
 					return 0, nil, errors.Trace(err)
 				}
-				nodes[len(nodes)-1].Selectivity = cnt / float64(coll.Count)
+				nodes[len(nodes)-1].Selectivity = cnt / float64(coll.RealtimeCount)
 				continue
 			}
 			cnt, err := coll.GetRowCountByColumnRanges(ctx, id, ranges)
 			if err != nil {
 				return 0, nil, errors.Trace(err)
 			}
-			nodes[len(nodes)-1].Selectivity = cnt / float64(coll.Count)
+			nodes[len(nodes)-1].Selectivity = cnt / float64(coll.RealtimeCount)
 		}
 	}
 	id2Paths := make(map[int64]*planutil.AccessPath)
@@ -276,7 +276,7 @@ func (coll *HistColl) Selectivity(ctx sessionctx.Context, exprs []expression.Exp
 			if err != nil {
 				return 0, nil, errors.Trace(err)
 			}
-			selectivity := cnt / float64(coll.Count)
+			selectivity := cnt / float64(coll.RealtimeCount)
 			nodes = append(nodes, &StatsNode{
 				Tp:          IndexType,
 				ID:          id,
@@ -312,7 +312,7 @@ func (coll *HistColl) Selectivity(ctx sessionctx.Context, exprs []expression.Exp
 				}
 			}
 			expr := expression.ComposeCNFCondition(ctx, curExpr...)
-			CETraceExpr(ctx, tableID, "Table Stats-Expression-CNF", expr, ret*float64(coll.Count))
+			CETraceExpr(ctx, tableID, "Table Stats-Expression-CNF", expr, ret*float64(coll.RealtimeCount))
 		}
 	}
 
@@ -422,7 +422,7 @@ OUTER:
 			selectivity = selectivity + curSelectivity - selectivity*curSelectivity
 			if sc.EnableOptimizerCETrace {
 				// Tracing for the expression estimation results of this DNF.
-				CETraceExpr(ctx, tableID, "Table Stats-Expression-DNF", scalarCond, selectivity*float64(coll.Count))
+				CETraceExpr(ctx, tableID, "Table Stats-Expression-DNF", scalarCond, selectivity*float64(coll.RealtimeCount))
 			}
 		}
 
@@ -435,7 +435,7 @@ OUTER:
 			// Tracing for the expression estimation results after applying the DNF estimation result.
 			curExpr = append(curExpr, remainedExprs[i])
 			expr := expression.ComposeCNFCondition(ctx, curExpr...)
-			CETraceExpr(ctx, tableID, "Table Stats-Expression-CNF", expr, ret*float64(coll.Count))
+			CETraceExpr(ctx, tableID, "Table Stats-Expression-CNF", expr, ret*float64(coll.RealtimeCount))
 		}
 	}
 
@@ -488,7 +488,7 @@ OUTER:
 	if sc.EnableOptimizerCETrace {
 		// Tracing for the expression estimation results after applying the default selectivity.
 		totalExpr := expression.ComposeCNFCondition(ctx, remainedExprs...)
-		CETraceExpr(ctx, tableID, "Table Stats-Expression-CNF", totalExpr, ret*float64(coll.Count))
+		CETraceExpr(ctx, tableID, "Table Stats-Expression-CNF", totalExpr, ret*float64(coll.RealtimeCount))
 	}
 	return ret, nodes, nil
 }

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -200,7 +200,7 @@ func TestPseudoTable(t *testing.T) {
 	ti.Columns = append(ti.Columns, colInfo)
 	tbl := PseudoTable(ti)
 	require.Len(t, tbl.Columns, 1)
-	require.Greater(t, tbl.Count, int64(0))
+	require.Greater(t, tbl.RealtimeCount, int64(0))
 	sctx := mock.NewContext()
 	count := tbl.ColumnLessRowCount(sctx, types.NewIntDatum(100), colInfo.ID)
 	require.Equal(t, 3333, int(count))
@@ -257,8 +257,8 @@ func SubTestColumnRange() func(*testing.T) {
 		}
 		tbl := &Table{
 			HistColl: HistColl{
-				Count:   int64(col.TotalRowCount()),
-				Columns: make(map[int64]*Column),
+				RealtimeCount: int64(col.TotalRowCount()),
+				Columns:       make(map[int64]*Column),
 			},
 		}
 		ran := []*ranger.Range{{
@@ -329,8 +329,8 @@ func SubTestIntColumnRanges() func(*testing.T) {
 		col := &Column{Histogram: *hg, Info: &model.ColumnInfo{}, StatsLoadedStatus: NewStatsFullLoadStatus()}
 		tbl := &Table{
 			HistColl: HistColl{
-				Count:   int64(col.TotalRowCount()),
-				Columns: make(map[int64]*Column),
+				RealtimeCount: int64(col.TotalRowCount()),
+				Columns:       make(map[int64]*Column),
 			},
 		}
 		ran := []*ranger.Range{{
@@ -403,7 +403,7 @@ func SubTestIntColumnRanges() func(*testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, int(count))
 
-		tbl.Count *= 10
+		tbl.RealtimeCount *= 10
 		count, err = tbl.GetRowCountByIntColumnRanges(ctx, 0, ran)
 		require.NoError(t, err)
 		require.Equal(t, 1, int(count))
@@ -425,8 +425,8 @@ func SubTestIndexRanges() func(*testing.T) {
 		idx := &Index{Histogram: *hg, CMSketch: cms, Info: idxInfo}
 		tbl := &Table{
 			HistColl: HistColl{
-				Count:   int64(idx.TotalRowCount()),
-				Indices: make(map[int64]*Index),
+				RealtimeCount: int64(idx.TotalRowCount()),
+				Indices:       make(map[int64]*Index),
 			},
 		}
 		ran := []*ranger.Range{{

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -112,8 +112,9 @@ type HistColl struct {
 	Idx2ColumnIDs map[int64][]int64
 	// ColID2IdxIDs maps the column id to a list index ids whose first column is it. It's used to calculate the selectivity in planner.
 	ColID2IdxIDs map[int64][]int64
-	Count        int64
-	ModifyCount  int64 // Total modify count in a table.
+	// TODO: add AnalyzeCount here
+	RealtimeCount int64 // RealtimeCount is the current table row count, maintained by applying stats delta based on AnalyzeCount.
+	ModifyCount   int64 // Total modify count in a table.
 
 	// HavePhysicalID is true means this HistColl is from single table and have its ID's information.
 	// The physical id is used when try to load column stats from storage.
@@ -310,7 +311,7 @@ func (t *Table) Copy() *Table {
 	newHistColl := HistColl{
 		PhysicalID:     t.PhysicalID,
 		HavePhysicalID: t.HavePhysicalID,
-		Count:          t.Count,
+		RealtimeCount:  t.RealtimeCount,
 		Columns:        make(map[int64]*Column, len(t.Columns)),
 		Indices:        make(map[int64]*Index, len(t.Indices)),
 		Pseudo:         t.Pseudo,
@@ -344,7 +345,7 @@ func (t *Table) Copy() *Table {
 // String implements Stringer interface.
 func (t *Table) String() string {
 	strs := make([]string, 0, len(t.Columns)+1)
-	strs = append(strs, fmt.Sprintf("Table:%d Count:%d", t.PhysicalID, t.Count))
+	strs = append(strs, fmt.Sprintf("Table:%d RealtimeCount:%d", t.PhysicalID, t.RealtimeCount))
 	cols := make([]*Column, 0, len(t.Columns))
 	for _, col := range t.Columns {
 		cols = append(cols, col)
@@ -427,7 +428,7 @@ func (t *Table) GetStatsHealthy() (int64, bool) {
 		return 0, false
 	}
 	var healthy int64
-	count := float64(t.Count)
+	count := float64(t.RealtimeCount)
 	if histCount := t.GetColRowCount(); histCount > 0 {
 		count = histCount
 	}
@@ -495,7 +496,7 @@ func (t *Table) IsInitialized() bool {
 func (t *Table) IsOutdated() bool {
 	rowcount := t.GetColRowCount()
 	if rowcount < 0 {
-		rowcount = float64(t.Count)
+		rowcount = float64(t.RealtimeCount)
 	}
 	if rowcount > 0 && float64(t.ModifyCount)/rowcount > RatioOfPseudoEstimate.Load() {
 		return true
@@ -507,18 +508,18 @@ func (t *Table) IsOutdated() bool {
 func (t *Table) ColumnGreaterRowCount(sctx sessionctx.Context, value types.Datum, colID int64) float64 {
 	c, ok := t.Columns[colID]
 	if !ok || c.IsInvalid(sctx, t.Pseudo) {
-		return float64(t.Count) / pseudoLessRate
+		return float64(t.RealtimeCount) / pseudoLessRate
 	}
-	return c.greaterRowCount(value) * c.GetIncreaseFactor(t.Count)
+	return c.greaterRowCount(value) * c.GetIncreaseFactor(t.RealtimeCount)
 }
 
 // ColumnLessRowCount estimates the row count where the column less than value. Note that null values are not counted.
 func (t *Table) ColumnLessRowCount(sctx sessionctx.Context, value types.Datum, colID int64) float64 {
 	c, ok := t.Columns[colID]
 	if !ok || c.IsInvalid(sctx, t.Pseudo) {
-		return float64(t.Count) / pseudoLessRate
+		return float64(t.RealtimeCount) / pseudoLessRate
 	}
-	return c.lessRowCount(value) * c.GetIncreaseFactor(t.Count)
+	return c.lessRowCount(value) * c.GetIncreaseFactor(t.RealtimeCount)
 }
 
 // ColumnBetweenRowCount estimates the row count where column greater or equal to a and less than b.
@@ -526,7 +527,7 @@ func (t *Table) ColumnBetweenRowCount(sctx sessionctx.Context, a, b types.Datum,
 	sc := sctx.GetSessionVars().StmtCtx
 	c, ok := t.Columns[colID]
 	if !ok || c.IsInvalid(sctx, t.Pseudo) {
-		return float64(t.Count) / pseudoBetweenRate, nil
+		return float64(t.RealtimeCount) / pseudoBetweenRate, nil
 	}
 	aEncoded, err := codec.EncodeKey(sc, nil, a)
 	if err != nil {
@@ -540,21 +541,21 @@ func (t *Table) ColumnBetweenRowCount(sctx sessionctx.Context, a, b types.Datum,
 	if a.IsNull() {
 		count += float64(c.NullCount)
 	}
-	return count * c.GetIncreaseFactor(t.Count), nil
+	return count * c.GetIncreaseFactor(t.RealtimeCount), nil
 }
 
 // ColumnEqualRowCount estimates the row count where the column equals to value.
 func (t *Table) ColumnEqualRowCount(sctx sessionctx.Context, value types.Datum, colID int64) (float64, error) {
 	c, ok := t.Columns[colID]
 	if !ok || c.IsInvalid(sctx, t.Pseudo) {
-		return float64(t.Count) / pseudoEqualRate, nil
+		return float64(t.RealtimeCount) / pseudoEqualRate, nil
 	}
 	encodedVal, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx, nil, value)
 	if err != nil {
 		return 0, err
 	}
 	result, err := c.equalRowCount(sctx, value, encodedVal, t.ModifyCount)
-	result *= c.GetIncreaseFactor(t.Count)
+	result *= c.GetIncreaseFactor(t.RealtimeCount)
 	return result, errors.Trace(err)
 }
 
@@ -570,16 +571,16 @@ func (coll *HistColl) GetRowCountByIntColumnRanges(sctx sessionctx.Context, colI
 			return 0, nil
 		}
 		if intRanges[0].LowVal[0].Kind() == types.KindInt64 {
-			result = getPseudoRowCountBySignedIntRanges(intRanges, float64(coll.Count))
+			result = getPseudoRowCountBySignedIntRanges(intRanges, float64(coll.RealtimeCount))
 		} else {
-			result = getPseudoRowCountByUnsignedIntRanges(intRanges, float64(coll.Count))
+			result = getPseudoRowCountByUnsignedIntRanges(intRanges, float64(coll.RealtimeCount))
 		}
 		if sc.EnableOptimizerCETrace && ok {
 			CETraceRange(sctx, coll.PhysicalID, []string{c.Info.Name.O}, intRanges, "Column Stats-Pseudo", uint64(result))
 		}
 		return result, nil
 	}
-	result, err = c.GetColumnRowCount(sctx, intRanges, coll.Count, coll.ModifyCount, true)
+	result, err = c.GetColumnRowCount(sctx, intRanges, coll.RealtimeCount, coll.ModifyCount, true)
 	if sc.EnableOptimizerCETrace {
 		CETraceRange(sctx, coll.PhysicalID, []string{c.Info.Name.O}, intRanges, "Column Stats", uint64(result))
 	}
@@ -594,13 +595,13 @@ func (coll *HistColl) GetRowCountByColumnRanges(sctx sessionctx.Context, colID i
 		recordUsedItemStatsStatus(sctx, c.StatsLoadedStatus, coll.PhysicalID, colID, false)
 	}
 	if !ok || c.IsInvalid(sctx, coll.Pseudo) {
-		result, err := GetPseudoRowCountByColumnRanges(sc, float64(coll.Count), colRanges, 0)
+		result, err := GetPseudoRowCountByColumnRanges(sc, float64(coll.RealtimeCount), colRanges, 0)
 		if err == nil && sc.EnableOptimizerCETrace && ok {
 			CETraceRange(sctx, coll.PhysicalID, []string{c.Info.Name.O}, colRanges, "Column Stats-Pseudo", uint64(result))
 		}
 		return result, err
 	}
-	result, err := c.GetColumnRowCount(sctx, colRanges, coll.Count, coll.ModifyCount, false)
+	result, err := c.GetColumnRowCount(sctx, colRanges, coll.RealtimeCount, coll.ModifyCount, false)
 	if sc.EnableOptimizerCETrace {
 		CETraceRange(sctx, coll.PhysicalID, []string{c.Info.Name.O}, colRanges, "Column Stats", uint64(result))
 	}
@@ -625,7 +626,7 @@ func (coll *HistColl) GetRowCountByIndexRanges(sctx sessionctx.Context, idxID in
 		if idx != nil && idx.Info.Unique {
 			colsLen = len(idx.Info.Columns)
 		}
-		result, err := getPseudoRowCountByIndexRanges(sc, indexRanges, float64(coll.Count), colsLen)
+		result, err := getPseudoRowCountByIndexRanges(sc, indexRanges, float64(coll.RealtimeCount), colsLen)
 		if err == nil && sc.EnableOptimizerCETrace && ok {
 			CETraceRange(sctx, coll.PhysicalID, colNames, indexRanges, "Index Stats-Pseudo", uint64(result))
 		}
@@ -636,7 +637,7 @@ func (coll *HistColl) GetRowCountByIndexRanges(sctx sessionctx.Context, idxID in
 	if idx.CMSketch != nil && idx.StatsVer == Version1 {
 		result, err = coll.getIndexRowCount(sctx, idxID, indexRanges)
 	} else {
-		result, err = idx.GetRowCount(sctx, coll, indexRanges, coll.Count, coll.ModifyCount)
+		result, err = idx.GetRowCount(sctx, coll, indexRanges, coll.RealtimeCount, coll.ModifyCount)
 	}
 	if sc.EnableOptimizerCETrace {
 		CETraceRange(sctx, coll.PhysicalID, colNames, indexRanges, "Index Stats", uint64(result))
@@ -848,7 +849,7 @@ func (coll *HistColl) GetSelectivityByFilter(sctx sessionctx.Context, filters []
 
 // PseudoAvgCountPerValue gets a pseudo average count if histogram not exists.
 func (t *Table) PseudoAvgCountPerValue() float64 {
-	return float64(t.Count) / pseudoEqualRate
+	return float64(t.RealtimeCount) / pseudoEqualRate
 }
 
 // GetOrdinalOfRangeCond gets the ordinal of the position range condition,
@@ -880,7 +881,7 @@ func (coll *HistColl) ID2UniqueID(columns []*expression.Column) *HistColl {
 		PhysicalID:     coll.PhysicalID,
 		HavePhysicalID: coll.HavePhysicalID,
 		Pseudo:         coll.Pseudo,
-		Count:          coll.Count,
+		RealtimeCount:  coll.RealtimeCount,
 		ModifyCount:    coll.ModifyCount,
 		Columns:        cols,
 	}
@@ -935,7 +936,7 @@ func (coll *HistColl) GenerateHistCollFromColumnInfo(infos []*model.ColumnInfo, 
 		PhysicalID:     coll.PhysicalID,
 		HavePhysicalID: coll.HavePhysicalID,
 		Pseudo:         coll.Pseudo,
-		Count:          coll.Count,
+		RealtimeCount:  coll.RealtimeCount,
 		ModifyCount:    coll.ModifyCount,
 		Columns:        newColHistMap,
 		Indices:        newIdxHistMap,
@@ -1000,7 +1001,7 @@ func (coll *HistColl) crossValidationSelectivity(sctx sessionctx.Context, idx *I
 				Collators:   []collate.Collator{idxPointRange.Collators[i]},
 			}
 
-			rowCount, err := col.GetColumnRowCount(sctx, []*ranger.Range{&rang}, coll.Count, coll.ModifyCount, col.IsHandle)
+			rowCount, err := col.GetColumnRowCount(sctx, []*ranger.Range{&rang}, coll.RealtimeCount, coll.ModifyCount, col.IsHandle)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -1026,7 +1027,7 @@ func (coll *HistColl) getEqualCondSelectivity(sctx sessionctx.Context, idx *Inde
 		// When the value is out of range, we could not found this value in the CM Sketch,
 		// so we use heuristic methods to estimate the selectivity.
 		if idx.NDV > 0 && coverAll {
-			return outOfRangeEQSelectivity(idx.NDV, coll.Count, int64(idx.TotalRowCount())), nil
+			return outOfRangeEQSelectivity(idx.NDV, coll.RealtimeCount, int64(idx.TotalRowCount())), nil
 		}
 		// The equal condition only uses prefix columns of the index.
 		colIDs := coll.Idx2ColumnIDs[idx.ID]
@@ -1039,7 +1040,7 @@ func (coll *HistColl) getEqualCondSelectivity(sctx sessionctx.Context, idx *Inde
 				ndv = mathutil.Max(ndv, col.Histogram.NDV)
 			}
 		}
-		return outOfRangeEQSelectivity(ndv, coll.Count, int64(idx.TotalRowCount())), nil
+		return outOfRangeEQSelectivity(ndv, coll.RealtimeCount, int64(idx.TotalRowCount())), nil
 	}
 
 	minRowCount, crossValidationSelectivity, err := coll.crossValidationSelectivity(sctx, idx, usedColsLen, idxPointRange)
@@ -1072,7 +1073,7 @@ func (coll *HistColl) getIndexRowCount(sctx sessionctx.Context, idxID int64, ind
 		// on single-column index, use previous way as well, because CMSketch does not contain null
 		// values in this case.
 		if rangePosition == 0 || isSingleColIdxNullRange(idx, ran) {
-			count, err := idx.GetRowCount(sctx, nil, []*ranger.Range{ran}, coll.Count, coll.ModifyCount)
+			count, err := idx.GetRowCount(sctx, nil, []*ranger.Range{ran}, coll.RealtimeCount, coll.ModifyCount)
 			if err != nil {
 				return 0, errors.Trace(err)
 			}
@@ -1152,7 +1153,7 @@ const fakePhysicalID int64 = -1
 // PseudoTable creates a pseudo table statistics.
 func PseudoTable(tblInfo *model.TableInfo) *Table {
 	pseudoHistColl := HistColl{
-		Count:          PseudoRowCount,
+		RealtimeCount:  PseudoRowCount,
 		PhysicalID:     tblInfo.ID,
 		HavePhysicalID: true,
 		Columns:        make(map[int64]*Column, len(tblInfo.Columns)),
@@ -1332,23 +1333,23 @@ func getPseudoRowCountByUnsignedIntRanges(intRanges []*ranger.Range, tableRowCou
 // GetAvgRowSize computes average row size for given columns.
 func (coll *HistColl) GetAvgRowSize(ctx sessionctx.Context, cols []*expression.Column, isEncodedKey bool, isForScan bool) (size float64) {
 	sessionVars := ctx.GetSessionVars()
-	if coll.Pseudo || len(coll.Columns) == 0 || coll.Count == 0 {
+	if coll.Pseudo || len(coll.Columns) == 0 || coll.RealtimeCount == 0 {
 		size = pseudoColSize * float64(len(cols))
 	} else {
 		for _, col := range cols {
 			colHist, ok := coll.Columns[col.UniqueID]
 			// Normally this would not happen, it is for compatibility with old version stats which
 			// does not include TotColSize.
-			if !ok || (!colHist.IsHandle && colHist.TotColSize == 0 && (colHist.NullCount != coll.Count)) {
+			if !ok || (!colHist.IsHandle && colHist.TotColSize == 0 && (colHist.NullCount != coll.RealtimeCount)) {
 				size += pseudoColSize
 				continue
 			}
 			// We differentiate if the column is encoded as key or value, because the resulted size
 			// is different.
 			if sessionVars.EnableChunkRPC && !isForScan {
-				size += colHist.AvgColSizeChunkFormat(coll.Count)
+				size += colHist.AvgColSizeChunkFormat(coll.RealtimeCount)
 			} else {
-				size += colHist.AvgColSize(coll.Count, isEncodedKey)
+				size += colHist.AvgColSize(coll.RealtimeCount, isEncodedKey)
 			}
 		}
 	}
@@ -1362,7 +1363,7 @@ func (coll *HistColl) GetAvgRowSize(ctx sessionctx.Context, cols []*expression.C
 
 // GetAvgRowSizeListInDisk computes average row size for given columns.
 func (coll *HistColl) GetAvgRowSizeListInDisk(cols []*expression.Column) (size float64) {
-	if coll.Pseudo || len(coll.Columns) == 0 || coll.Count == 0 {
+	if coll.Pseudo || len(coll.Columns) == 0 || coll.RealtimeCount == 0 {
 		for _, col := range cols {
 			size += float64(chunk.EstimateTypeWidth(col.GetType()))
 		}
@@ -1371,11 +1372,11 @@ func (coll *HistColl) GetAvgRowSizeListInDisk(cols []*expression.Column) (size f
 			colHist, ok := coll.Columns[col.UniqueID]
 			// Normally this would not happen, it is for compatibility with old version stats which
 			// does not include TotColSize.
-			if !ok || (!colHist.IsHandle && colHist.TotColSize == 0 && (colHist.NullCount != coll.Count)) {
+			if !ok || (!colHist.IsHandle && colHist.TotColSize == 0 && (colHist.NullCount != coll.RealtimeCount)) {
 				size += float64(chunk.EstimateTypeWidth(col.GetType()))
 				continue
 			}
-			size += colHist.AvgColSizeListInDisk(coll.Count)
+			size += colHist.AvgColSizeListInDisk(coll.RealtimeCount)
 		}
 	}
 	// Add 8 byte for each column's size record. See `ListInDisk` for details.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42160

Problem Summary:

### What is changed and how it works?

Rename `Table.Count` to `Table.RealtimeCount`. We hope to distinguish between `RealtimeCount` and `AnalyzeCount`(which will be introduced by the following PRs).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
