### PR TITLE
parser: a tiny function optimization follow the advise by ChatGPT

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -628,7 +628,11 @@ func startWithAt(s *Scanner) (tok int, pos Pos, lit string) {
 		tok, lit = scanIdentifierOrString(s)
 		switch tok {
 		case stringLit, quotedIdentifier:
-			tok, lit = doubleAtIdentifier, "@@"+prefix+lit
+			var sb strings.Builder
+			sb.WriteString("@@")
+			sb.WriteString(prefix)
+			sb.WriteString(lit)
+			tok, lit = doubleAtIdentifier, sb.String()
 		case identifier:
 			tok, lit = doubleAtIdentifier, s.r.data(&pos)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42763

Problem Summary:

With the help of AI, we become stronger.
Subtitle: ChatGPT teach me how to write better code.

### What is changed and how it works?

It's amazing!
ChatGPT is right in this case, except for two tiny mistakes:

1. He advise to change this:

```
        for i := 0; i < len(lit); i++ {
                if lit[i] >= 'a' && lit[i] <= 'z' {
                        data[i] = lit[i] + 'A' - 'a'
                } else {
                        data[i] = lit[i]
                }
        }
```

to

```
        for i, c := range lit {
                if c >= 'a' && c <= 'z' {
                        data[i] = c + 'A' - 'a'
                } else {
                        data[i] = c
                }
        }
```

The for-range loop reduce the temporary object declaration avoid repeated lit[i], making better chance for the compiler to generate more optimized code.

**However, the semantic for this code changes.** 
When for-range over a string, `c` is a rune, while in the original code it's iterating the string as bytes.


2.   ChatGPT advise to avoid repeated byte to string convertion here:

```
        dataStr := string(data)

        if checkBtFuncToken {
                if tok := btFuncTokenMap[dataStr]; tok != 0 {
                        return tok
                }
        }
        tok, ok := tokenMap[dataStr]
        if !ok && s.supportWindowFunc {
                tok = windowFuncTokenMap[dataStr]
        }
```

The original code is

```
        if checkBtFuncToken {
                if tok := btFuncTokenMap[string(data)]; tok != 0 {
                        return tok
                }
        }
        tok, ok := tokenMap[string(data)]
        if !ok && s.supportWindowFunc {
                tok = windowFuncTokenMap[string(data)]
        }
```

ChatGPT is **almost correct if it's not for a tricky Go compiler optimization**.
Go has special optimization for `string([]byte)` as map key, and it does not cause string convertion & allocation when written in the original form.
https://github.com/golang/go/issues/3512

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
