### PR TITLE
util/gpool/spmc: make test case TestBenchPool stable

### DIFF
--- a/util/gpool/spmc/spmcpool_test.go
+++ b/util/gpool/spmc/spmcpool_test.go
@@ -453,12 +453,8 @@ func TestBenchPool(t *testing.T) {
 				select {
 				case <-sema:
 					return struct{}{}, nil
-				default:
-					select {
-					case <-exitCh:
-						return struct{}{}, gpool.ErrProducerClosed
-					default:
-					}
+				case <-exitCh:
+					return struct{}{}, gpool.ErrProducerClosed
 				}
 			}
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42721

Problem Summary:

### What is changed and how it works?

**There is a dead loop in the code**, so if there is only 1 cpu, it depends on the preempt scheduling to break the loop.
And even the loop break, which goroutine to run next is choosed by (maybe random) chance.

Here is a simpler reproduce:

```
func TestXXX(t *testing.T) {
        for i:=0; i<500; i++ {
                exitCh := make(chan struct{})
                sema := make(chan struct{}, 10)
                go func() {
                        for i:=0; i<10000; i++{
                                sema <- struct{}{}
                        }
                        close(exitCh)
                }()

                f := func() {
                        for {
                                select {
                                case <-sema:
                                        return
                                default:
                                        select {
                                        case <-exitCh:
                                                return
                                        default:
                                        }
                                }
                        }
                }

                f()
        }
}
```

```
genius@genius-System-Product-Name:~/project/src/sss$ go test  -cpu 16 -run TestXXX
PASS
ok      sss     0.042s
genius@genius-System-Product-Name:~/project/src/sss$ go test  -cpu 8 -run TestXXX
PASS
ok      sss     0.042s
genius@genius-System-Product-Name:~/project/src/sss$ go test  -cpu 4 -run TestXXX
PASS
ok      sss     0.041s
genius@genius-System-Product-Name:~/project/src/sss$ go test  -cpu 2 -run TestXXX
PASS
ok      sss     0.043s
genius@genius-System-Product-Name:~/project/src/sss$ go test  -cpu 1 -run TestXXX
PASS
ok      sss     10.355s
```

B.T.W, I don't see the meaning writing this kind of test code.
Despide the bug of the test code, it test nothing actually.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
