### PR TITLE
disttask: make TestParallelErrFlow more stable

### DIFF
--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -393,9 +393,10 @@ func (d *dispatcher) processNormalFlow(gTask *proto.Task) (err error) {
 	// Special handling for the new tasks.
 	if gTask.State == proto.TaskStatePending {
 		// TODO: Consider using TS.
-		gTask.StartTime = time.Now().UTC()
+		nowTime := time.Now().UTC()
+		gTask.StartTime = nowTime
 		gTask.State = proto.TaskStateRunning
-		gTask.StateUpdateTime = time.Now().UTC()
+		gTask.StateUpdateTime = nowTime
 		retryTimes = nonRetrySQLTime
 	}
 

--- a/disttask/framework/dispatcher/dispatcher_test.go
+++ b/disttask/framework/dispatcher/dispatcher_test.go
@@ -126,7 +126,7 @@ func TestGetInstance(t *testing.T) {
 }
 
 const (
-	subtaskCnt = 10
+	subtaskCnt = 3
 )
 
 func checkDispatch(t *testing.T, taskCnt int, isSucc bool) {
@@ -154,8 +154,8 @@ func checkDispatch(t *testing.T, taskCnt int, isSucc bool) {
 
 	dispatcher.RegisterTaskFlowHandle(taskTypeExample, NumberExampleHandle{})
 
-	// 2s
-	cnt := 40
+	// 3s
+	cnt := 60
 	checkGetRunningGTaskCnt := func() {
 		var retCnt int
 		for i := 0; i < cnt; i++ {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/42791

Problem Summary:
```
[2023/04/04 13:40:01.880 +08:00] [INFO] [dispatcher.go:381] ["process normal flow"] ["task ID"=2] [state=pending] [concurrency=0] [subtasks=10]
[2023/04/04 13:40:02.060 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=1] [cnt=10]
[2023/04/04 13:40:02.185 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=1] [cnt=10]
[2023/04/04 13:40:02.252 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=1] [cnt=10]
[2023/04/04 13:40:02.319 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=1] [cnt=10]
[2023/04/04 13:40:02.482 +08:00] [INFO] [dispatcher.go:186] ["dispatch task loop"] ["task ID"=2] [state=running] [concurrency=16] []
[2023/04/04 13:40:02.483 +08:00] [INFO] [dispatcher_test.go:277] ["progress step init"]
[2023/04/04 13:40:02.483 +08:00] [INFO] [dispatcher.go:381] ["process normal flow"] ["task ID"=3] [state=pending] [concurrency=0] [subtasks=10]
[2023/04/04 13:40:02.503 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=1] [cnt=10]
[2023/04/04 13:40:02.733 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=1] [cnt=10]
[2023/04/04 13:40:02.885 +08:00] [INFO] [info.go:1188] [SetTiFlashGroupConfig]
[2023/04/04 13:40:02.940 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=2] [cnt=10]
[2023/04/04 13:40:03.261 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=1] [cnt=10]
[2023/04/04 13:40:03.361 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=2] [cnt=10]
[2023/04/04 13:40:03.579 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=1] [cnt=10]
[2023/04/04 13:40:03.629 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=2] [cnt=10]
[2023/04/04 13:40:03.862 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=1] [cnt=10]
[2023/04/04 13:40:03.893 +08:00] [INFO] [dispatcher.go:217] ["check task, subtasks aren't finished"] ["task ID"=2] [cnt=10]
    dispatcher_test.go:168:
        	Error Trace:	disttask/framework/dispatcher/dispatcher_test.go:168
        	            				disttask/framework/dispatcher/dispatcher_test.go:179
        	            				disttask/framework/dispatcher/dispatcher_test.go:259
        	Error:      	Not equal:
        	            	expected: 2
        	            	actual  : 3
```
Update a new task almost task 1s. 


### What is changed and how it works?
Update 2s to 3s 
Make fewer subtasks.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
