### PR TITLE
expression: make expression TestGetLock test more stable

### DIFF
--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -229,17 +229,18 @@ func (b *builtinLockSig) evalInt(row chunk.Row) (int64, bool, error) {
 	}
 	err = b.ctx.GetAdvisoryLock(lockName, timeout)
 	if err != nil {
-		switch errors.Cause(err).(*terror.Error).Code() {
-		case mysql.ErrLockWaitTimeout:
-			return 0, false, nil // Another user has the lock
-		case mysql.ErrLockDeadlock:
-			// Currently this code is not reachable because each Advisory Lock
-			// Uses a separate session. Deadlock detection does not work across
-			// independent sessions.
-			return 0, false, errUserLockDeadlock
-		default:
-			return 0, false, err
+		if terr, ok := errors.Cause(err).(*terror.Error); ok {
+			switch terr.Code() {
+			case mysql.ErrLockWaitTimeout:
+				return 0, false, nil // Another user has the lock
+			case mysql.ErrLockDeadlock:
+				// Currently this code is not reachable because each Advisory Lock
+				// Uses a separate session. Deadlock detection does not work across
+				// independent sessions.
+				return 0, false, errUserLockDeadlock
+			}
 		}
+		return 0, false, err
 	}
 	return 1, false, nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35155

Problem Summary:

### What is changed and how it works?

The error is not always terror  `errors.Cause(err).(*terror.Error)`.

The expected error in the test is `mysql.ErrLockWaitTimeout`, but sometimes the error got is 
`errors.New("pessimistic lock retry limit reached")` which is not a terror.

So the assumption cause panic.

```
--- FAIL: TestGetLock (1.88s)
panic: interface conversion: error is *errors.fundamental, not *errors.Error [recovered]
        panic: interface conversion: error is *errors.fundamental, not *errors.Error [recovered]
        panic: interface conversion: error is *errors.fundamental, not *errors.Error

goroutine 100 [running]:
testing.tRunner.func1.2({0x48b9d40, 0xc006f54f90})
        /home/genius/project/go/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
        /home/genius/project/go/src/testing/testing.go:1529 +0x39f
panic({0x48b9d40, 0xc006f54f90})
        /home/genius/project/go/src/runtime/panic.go:884 +0x213
github.com/pingcap/tidb/executor.(*Compiler).Compile.func1()
        /home/genius/project/src/github.com/pingcap/tidb/executor/compiler.go:54 +0x445
panic({0x48b9d40, 0xc006f54f90})
        /home/genius/project/go/src/runtime/panic.go:884 +0x213
github.com/pingcap/tidb/expression.(*builtinLockSig).evalInt(0xc008622d10, {0x0?, 0xc008622d10?})
        /home/genius/project/src/github.com/pingcap/tidb/expression/builtin_miscellaneous.go:232 +0x485
github.com/pingcap/tidb/expression.(*ScalarFunction).EvalInt(0xc004d45ae0, {0x55edc90, 0xc004d7e280}, {0x0?, 0x2718af5?})
        /home/genius/project/src/github.com/pingcap/tidb/expression/scalar_function.go:406 +0x9c
github.com/pingcap/tidb/expression.(*ScalarFunction).Eval(0xc004d45ae0, {0x0?, 0x55edc90?})
        /home/genius/project/src/github.com/pingcap/tidb/expression/scalar_function.go:362 +0x246
github.com/pingcap/tidb/expression.foldConstant({0x55eca40?, 0xc004d45ae0?})
        /home/genius/project/src/github.com/pingcap/tidb/expression/constant_fold.go:221 +0x9f5
github.com/pingcap/tidb/expression.FoldConstant({0x55eca40, 0xc004d45ae0})
        /home/genius/project/src/github.com/pingcap/tidb/expression/constant_fold.go:40 +0x27
github.com/pingcap/tidb/expression.newFunctionImpl({0x55edc90, 0xc004d7e280}, 0x1, {0x4e3d471?, 0x7f2b600e7108?}, 0xc004e4ba20, {0xc0075975e0, 0x2, 0xc006697a40?})
        /home/genius/project/src/github.com/pingcap/tidb/expression/scalar_function.go:243 +0x716
github.com/pingcap/tidb/expression.NewFunction(...)
        /home/genius/project/src/github.com/pingcap/tidb/expression/scalar_function.go:261
github.com/pingcap/tidb/planner/core.(*expressionRewriter).newFunction(0xc00780b860, {0x4e3d471?, 0x4e3d471?}, 0x8?, {0xc0075975e0?, 0x7f2b2c908938?, 0xc004fc1b50?})
        /home/genius/project/src/github.com/pingcap/tidb/planner/core/expression_rewriter.go:1321 +0xa6
github.com/pingcap/tidb/planner/core.(*expressionRewriter).funcCallToExpression(0xc00780b860, 0xc004e4b9e0)
        /home/genius/project/src/github.com/pingcap/tidb/planner/core/expression_rewriter.go:1993 +0x6fb
github.com/pingcap/tidb/planner/core.(*expressionRewriter).Leave(0xc00780b860, {0x558f980?, 0xc004e4b9e0?})
        /home/genius/project/src/github.com/pingcap/tidb/planner/core/expression_rewriter.go:1166 +0x67d
github.com/pingcap/tidb/parser/ast.(*FuncCallExpr).Accept(0xc00780b790?, {0x556b0f8, 0xc00780b860})
        /home/genius/project/src/github.com/pingcap/tidb/parser/ast/functions.go:580 +0x178
github.com/pingcap/tidb/planner/core.(*PlanBuilder).rewriteExprNode(0xc006467380?, 0xc00780b860, {0x559e6a0?, 0xc004e4b9e0?}, 0x1)
        /home/genius/project/src/github.com/pingcap/tidb/planner/core/expression_rewriter.go:200 +0x129
github.com/pingcap/tidb/planner/core.(*PlanBuilder).rewriteWithPreprocess(0xc006467380, {0x55809e8?, 0xc000058078?}, {0x559e6a0, 0xc004e4b9e0}, {0x55be560?, 0xc00780b790?}, 0x0, 0x0, 0x1, ...)
        /home/genius/project/src/github.com/pingcap/tidb/planner/core/expression_rewriter.go:146 +0x173
github.com/pingcap/tidb/planner/core.(*PlanBuilder).buildProjection(0xc006467380, {0x55809e8, 0xc000058078}, {0x55be560?, 0xc00780b790?}, {0xc0070317b8, 0x1, 0x1855805?}, 0x74170a0?, 0x0, ...)
        /home/genius/project/src/github.com/pingcap/tidb/planner/core/logical_plan_builder.go:1446 +0x5f2
github.com/pingcap/tidb/planner/core.(*PlanBuilder).buildSelect(0xc006467380, {0x55809e8, 0xc000058078}, 0xc004e4bb00)
        /home/genius/project/src/github.com/pingcap/tidb/planner/core/logical_plan_builder.go:4162 +0x14bb
github.com/pingcap/tidb/planner/core.(*PlanBuilder).Build(0x1826d52?, {0x55809e8?, 0xc000058078?}, {0x5590ab0?, 0xc004e4bb00?})
        /home/genius/project/src/github.com/pingcap/tidb/planner/core/planbuilder.go:819 +0x34f
github.com/pingcap/tidb/planner.buildLogicalPlan({0x55809e8, 0xc000058078}, {0x55edc90?, 0xc004d7e280}, {0x5590ab0, 0xc004e4bb00}, 0x
c006467380)
        /home/genius/project/src/github.com/pingcap/tidb/planner/optimize.go:511 +0x12c
github.com/pingcap/tidb/planner.optimize({0x55809e8, 0xc000058078}, {0x55edc90?, 0xc004d7e280}, {0x5590ab0?, 0xc004e4bb00?}, {0x55b51
90, 0xc0066edb60})
        /home/genius/project/src/github.com/pingcap/tidb/planner/optimize.go:432 +0x3b3
github.com/pingcap/tidb/planner.Optimize({0x55809e8, 0xc000058078}, {0x55edc90, 0xc004d7e280}, {0x5590ab0, 0xc004e4bb00}, {0x55b5190,
 0xc0066edb60})
        /home/genius/project/src/github.com/pingcap/tidb/planner/optimize.go:295 +0x12de
github.com/pingcap/tidb/executor.(*Compiler).Compile(0xc004fc3728, {0x55809e8?, 0xc000058078?}, {0x5595f48?, 0xc004e4bb00})
        /home/genius/project/src/github.com/pingcap/tidb/executor/compiler.go:98 +0x459
github.com/pingcap/tidb/session.(*session).ExecuteStmt(0xc004d7e280, {0x55809e8?, 0xc000058078?}, {0x5595f48?, 0xc004e4bb00})
        /home/genius/project/src/github.com/pingcap/tidb/session/session.go:2150 +0x4c5
github.com/pingcap/tidb/testkit.(*TestKit).ExecWithContext(0xc004dd4ff0, {0x55809e8, 0xc000058078}, {0x4e3d46a, 0x22}, {0x0, 0x0, 0x0
})
        /home/genius/project/src/github.com/pingcap/tidb/testkit/testkit.go:325 +0x675
github.com/pingcap/tidb/testkit.(*TestKit).MustQueryWithContext(0xc004dd4ff0, {0x55809e8, 0xc000058078}, {0x4e3d46a, 0x22}, {0x0, 0x0
, 0x0})
        /home/genius/project/src/github.com/pingcap/tidb/testkit/testkit.go:156 +0x145
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
