### PR TITLE
planner: keep original select fields names for non-prep plan cache

### DIFF
--- a/parser/ast/dml.go
+++ b/parser/ast/dml.go
@@ -1273,16 +1273,24 @@ func (n *SelectStmt) Restore(ctx *format.RestoreCtx) error {
 				if i != 0 {
 					ctx.WritePlain(",")
 				}
-				if err := field.Restore(ctx); err != nil {
-					return errors.Annotatef(err, "An error occurred while restore SelectStmt.Fields[%d]", i)
+				if ctx.Flags.HasRestoreForNonPrepPlanCache() && len(field.OriginalText()) > 0 {
+					ctx.WritePlain(field.OriginalText())
+				} else {
+					if err := field.Restore(ctx); err != nil {
+						return errors.Annotatef(err, "An error occurred while restore SelectStmt.Fields[%d]", i)
+					}
 				}
 			}
 		}
 
 		if n.From != nil {
 			ctx.WriteKeyWord(" FROM ")
-			if err := n.From.Restore(ctx); err != nil {
-				return errors.Annotate(err, "An error occurred while restore SelectStmt.From")
+			if ctx.Flags.HasRestoreForNonPrepPlanCache() && len(n.From.OriginalText()) > 0 {
+				ctx.WritePlain(n.From.OriginalText())
+			} else {
+				if err := n.From.Restore(ctx); err != nil {
+					return errors.Annotate(err, "An error occurred while restore SelectStmt.From")
+				}
 			}
 		}
 
@@ -2159,8 +2167,12 @@ func (n *InsertStmt) Restore(ctx *format.RestoreCtx) error {
 			if i != 0 {
 				ctx.WritePlain(",")
 			}
-			if err := v.Restore(ctx); err != nil {
-				return errors.Annotatef(err, "An error occurred while restore InsertStmt.Columns[%d]", i)
+			if ctx.Flags.HasRestoreForNonPrepPlanCache() && len(v.OriginalText()) > 0 {
+				ctx.WritePlain(v.OriginalText())
+			} else {
+				if err := v.Restore(ctx); err != nil {
+					return errors.Annotatef(err, "An error occurred while restore InsertStmt.Columns[%d]", i)
+				}
 			}
 		}
 		ctx.WritePlain(")")

--- a/parser/ast/dml.go
+++ b/parser/ast/dml.go
@@ -2167,8 +2167,12 @@ func (n *InsertStmt) Restore(ctx *format.RestoreCtx) error {
 			if i != 0 {
 				ctx.WritePlain(",")
 			}
-			if err := v.Restore(ctx); err != nil {
-				return errors.Annotatef(err, "An error occurred while restore InsertStmt.Columns[%d]", i)
+			if ctx.Flags.HasRestoreForNonPrepPlanCache() && len(v.OriginalText()) > 0 {
+				ctx.WritePlain(v.OriginalText())
+			} else {
+				if err := v.Restore(ctx); err != nil {
+					return errors.Annotatef(err, "An error occurred while restore InsertStmt.Columns[%d]", i)
+				}
 			}
 		}
 		ctx.WritePlain(")")

--- a/parser/ast/dml.go
+++ b/parser/ast/dml.go
@@ -2167,12 +2167,8 @@ func (n *InsertStmt) Restore(ctx *format.RestoreCtx) error {
 			if i != 0 {
 				ctx.WritePlain(",")
 			}
-			if ctx.Flags.HasRestoreForNonPrepPlanCache() && len(v.OriginalText()) > 0 {
-				ctx.WritePlain(v.OriginalText())
-			} else {
-				if err := v.Restore(ctx); err != nil {
-					return errors.Annotatef(err, "An error occurred while restore InsertStmt.Columns[%d]", i)
-				}
+			if err := v.Restore(ctx); err != nil {
+				return errors.Annotatef(err, "An error occurred while restore InsertStmt.Columns[%d]", i)
 			}
 		}
 		ctx.WritePlain(")")

--- a/parser/format/format.go
+++ b/parser/format/format.go
@@ -238,6 +238,7 @@ const (
 	RestoreWithTTLEnableOff
 	RestoreWithoutSchemaName
 	RestoreWithoutTableName
+	RestoreForNonPrepPlanCache
 )
 
 const (
@@ -337,6 +338,12 @@ func (rf RestoreFlags) HasSkipPlacementRuleForRestoreFlag() bool {
 // HasRestoreWithTTLEnableOff returns a boolean indicating whether to force set TTL_ENABLE='OFF' when restoring a TTL table
 func (rf RestoreFlags) HasRestoreWithTTLEnableOff() bool {
 	return rf.has(RestoreWithTTLEnableOff)
+}
+
+
+// HasRestoreForNonPrepPlanCache returns a boolean indicating whether `rf` has `RestoreForNonPrepPlanCache` flag.
+func (rf RestoreFlags) HasRestoreForNonPrepPlanCache() bool {
+	return rf.has(RestoreForNonPrepPlanCache)
 }
 
 // RestoreCtx is `Restore` context to hold flags and writer.

--- a/parser/format/format.go
+++ b/parser/format/format.go
@@ -340,7 +340,6 @@ func (rf RestoreFlags) HasRestoreWithTTLEnableOff() bool {
 	return rf.has(RestoreWithTTLEnableOff)
 }
 
-
 // HasRestoreForNonPrepPlanCache returns a boolean indicating whether `rf` has `RestoreForNonPrepPlanCache` flag.
 func (rf RestoreFlags) HasRestoreForNonPrepPlanCache() bool {
 	return rf.has(RestoreForNonPrepPlanCache)

--- a/planner/core/plan_cache_param.go
+++ b/planner/core/plan_cache_param.go
@@ -43,10 +43,7 @@ var (
 	paramCtxPool = sync.Pool{New: func() interface{} {
 		buf := new(strings.Builder)
 		buf.Reset()
-		restoreCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, buf)
-		restoreCtx.Flags ^= format.RestoreKeyWordUppercase
-		restoreCtx.Flags ^= format.RestoreNameBackQuotes
-		restoreCtx.Flags |= format.RestoreStringWithoutCharset
+		restoreCtx := format.NewRestoreCtx(format.RestoreForNonPrepPlanCache, buf)
 		return restoreCtx
 	}}
 )

--- a/planner/core/plan_cache_param_test.go
+++ b/planner/core/plan_cache_param_test.go
@@ -104,3 +104,17 @@ c_credit, c_credit_lim, c_discount, c_balance, c_since FROM customer WHERE c_w_i
 		ParameterizeAST(context.Background(), sctx, stmt)
 	}
 }
+
+func BenchmarkParameterizeInsert(b *testing.B) {
+	paymentInsertHistory := `INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES (1, 2, 3, 4, 5, 6, 7, 8)`
+	stmt, err := parser.New().ParseOneStmt(paymentInsertHistory, "", "")
+	require.Nil(b, err)
+	sctx := MockContext()
+	_, _, err = ParameterizeAST(context.Background(), sctx, stmt)
+	require.Nil(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParameterizeAST(context.Background(), sctx, stmt)
+	}
+}

--- a/planner/core/plan_cache_param_test.go
+++ b/planner/core/plan_cache_param_test.go
@@ -74,6 +74,11 @@ func TestParameterize(t *testing.T) {
 			`SELECT a + 'a b c'+"x" FROM t`, // keep the original format for select fields
 			[]interface{}{},
 		},
+		{
+			`insert into t (a, B, c) values (1, 2, 3), (4, 5, 6)`,
+			`INSERT INTO t (a,B,c) VALUES (?,?,?),(?,?,?)`,
+			[]interface{}{int64(1), int64(2), int64(3), int64(4), int64(5), int64(6)},
+		},
 		// TODO: more test cases
 	}
 

--- a/planner/core/plan_cache_param_test.go
+++ b/planner/core/plan_cache_param_test.go
@@ -16,63 +16,68 @@ package core
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/parser"
-	"github.com/pingcap/tidb/parser/format"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParameterize(t *testing.T) {
 	sctx := MockContext()
 	cases := []struct {
-		sql        string
-		paramSQL   string
-		params     []interface{}
-		restoreSQL string
+		sql      string
+		paramSQL string
+		params   []interface{}
 	}{
 		{
 			"select * from t where a<10",
 			"SELECT * FROM t WHERE a<?",
 			[]interface{}{int64(10)},
-			"SELECT * FROM `t` WHERE `a`<10",
 		},
 		{
 			"select * from t",
 			"SELECT * FROM t",
 			[]interface{}{},
-			"SELECT * FROM `t`",
 		},
 		{
 			"select * from t where a<10 and b<20 and c=30 and d>40",
 			"SELECT * FROM t WHERE a<? AND b<? AND c=? AND d>?",
 			[]interface{}{int64(10), int64(20), int64(30), int64(40)},
-			"SELECT * FROM `t` WHERE `a`<10 AND `b`<20 AND `c`=30 AND `d`>40",
 		},
 		{
 			"select * from t where a='a' and b='bbbbbbbbbbbbbbbbbbbbbbbb'",
 			"SELECT * FROM t WHERE a=? AND b=?",
 			[]interface{}{"a", "bbbbbbbbbbbbbbbbbbbbbbbb"},
-			"SELECT * FROM `t` WHERE `a`=_UTF8MB4'a' AND `b`=_UTF8MB4'bbbbbbbbbbbbbbbbbbbbbbbb'",
 		},
 		{
 			"select 1, 2, 3 from t where a<10",
 			"SELECT 1,2,3 FROM t WHERE a<?",
 			[]interface{}{int64(10)},
-			"SELECT 1,2,3 FROM `t` WHERE `a`<10",
 		},
 		{
 			"select a+1 from t where a<10",
 			"SELECT a+1 FROM t WHERE a<?",
 			[]interface{}{int64(10)},
-			"SELECT `a`+1 FROM `t` WHERE `a`<10",
 		},
 		{
 			"select a+1, sum(b) from t where a<10 group by a+1",
 			"SELECT a+1,sum(b) FROM t WHERE a<? GROUP BY a+1",
 			[]interface{}{int64(10)},
-			"SELECT `a`+1,SUM(`b`) FROM `t` WHERE `a`<10 GROUP BY `a`+1",
+		},
+		{
+			`select a+ "a b c" from t`,
+			`SELECT a+ "a b c" FROM t`,
+			[]interface{}{},
+		},
+		{
+			`select a + 'a b c'+"x" from t`,
+			`SELECT a + 'a b c'+"x" FROM t`, // keep the original format for select fields
+			[]interface{}{},
+		},
+		{
+			`insert into t (a, B, c, D) values (1, 2, 3, 4)`,
+			`INSERT INTO t (a,B,c,D) VALUES (?,?,?,?)`,
+			[]interface{}{int64(1), int64(2), int64(3), int64(4)},
 		},
 		// TODO: more test cases
 	}
@@ -87,12 +92,34 @@ func TestParameterize(t *testing.T) {
 		for i := range params {
 			require.Equal(t, c.params[i], params[i].Datum.GetValue())
 		}
+	}
+}
 
-		err = RestoreASTWithParams(context.Background(), sctx, stmt, params)
-		require.Nil(t, err)
-		var buf strings.Builder
-		rCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &buf)
-		require.Nil(t, stmt.Restore(rCtx))
-		require.Equal(t, c.restoreSQL, buf.String())
+func BenchmarkParameterizeInsert(b *testing.B) {
+	newOrderInsertOrder := `INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (1, 2, 3, 4, 5, 6, 7)`
+	stmt, err := parser.New().ParseOneStmt(newOrderInsertOrder, "", "")
+	require.Nil(b, err)
+	sctx := MockContext()
+	_, _, err = ParameterizeAST(context.Background(), sctx, stmt)
+	require.Nil(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParameterizeAST(context.Background(), sctx, stmt)
+	}
+}
+
+func BenchmarkParameterizeSelect(b *testing.B) {
+	paymentSelectCustomerForUpdate := `SELECT c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone,
+c_credit, c_credit_lim, c_discount, c_balance, c_since FROM customer WHERE c_w_id = ? AND c_d_id = ?AND c_id = ? FOR UPDATE`
+	stmt, err := parser.New().ParseOneStmt(paymentSelectCustomerForUpdate, "", "")
+	require.Nil(b, err)
+	sctx := MockContext()
+	_, _, err = ParameterizeAST(context.Background(), sctx, stmt)
+	require.Nil(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParameterizeAST(context.Background(), sctx, stmt)
 	}
 }

--- a/planner/core/plan_cache_param_test.go
+++ b/planner/core/plan_cache_param_test.go
@@ -74,11 +74,6 @@ func TestParameterize(t *testing.T) {
 			`SELECT a + 'a b c'+"x" FROM t`, // keep the original format for select fields
 			[]interface{}{},
 		},
-		{
-			`insert into t (a, B, c, D) values (1, 2, 3, 4)`,
-			`INSERT INTO t (a,B,c,D) VALUES (?,?,?,?)`,
-			[]interface{}{int64(1), int64(2), int64(3), int64(4)},
-		},
 		// TODO: more test cases
 	}
 
@@ -92,20 +87,6 @@ func TestParameterize(t *testing.T) {
 		for i := range params {
 			require.Equal(t, c.params[i], params[i].Datum.GetValue())
 		}
-	}
-}
-
-func BenchmarkParameterizeInsert(b *testing.B) {
-	newOrderInsertOrder := `INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (1, 2, 3, 4, 5, 6, 7)`
-	stmt, err := parser.New().ParseOneStmt(newOrderInsertOrder, "", "")
-	require.Nil(b, err)
-	sctx := MockContext()
-	_, _, err = ParameterizeAST(context.Background(), sctx, stmt)
-	require.Nil(b, err)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		ParameterizeAST(context.Background(), sctx, stmt)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36598

Problem Summary: planner: keep original select fields names for non-prep plan cache

### What is changed and how it works?

```
Before:
BenchmarkParameterizeSelect-8             325916              3584 ns/op
BenchmarkParameterizeInsert-8             403291              2792 ns/op

After:
BenchmarkParameterizeSelect-8             363246              3140 ns/op
BenchmarkParameterizeInsert-8             489097              2378 ns/op
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
