### PR TITLE
statistics: remove statistics.Column.Count

### DIFF
--- a/statistics/column.go
+++ b/statistics/column.go
@@ -462,3 +462,13 @@ func (s StatsLoadedStatus) StatusToString() string {
 	}
 	return "unknown"
 }
+
+// StatsCollected indicates whether the column stats are collected.
+// Note: the function merely talks about whether the stats are collected, regardless of the stats loaded status.
+// The function is used to decide StatsLoadedStatus.statsInitialized when reading the column stats from storage.
+func (c *Column) StatsCollected() bool {
+	// Typically, when the column is analyzed, StatsVer is set to Version1/Version2, so we check StatsVer != Version0.
+	// However, when we add/modify a column, its stats are generated according to the default value without setting
+	// StatsVer, so we check NDV > 0 || NullCount > 0 for the case.
+	return c.StatsVer != Version0 || c.NDV > 0 || c.NullCount > 0
+}

--- a/statistics/handle/bootstrap.go
+++ b/statistics/handle/bootstrap.go
@@ -438,7 +438,7 @@ func (h *Handle) InitStats(is infoschema.InfoSchema) (err error) {
 	// Set columns' stats status.
 	for _, table := range cache.Values() {
 		for _, col := range table.Columns {
-			if col.StatsVer != statistics.Version0 || col.Count > 0 {
+			if col.StatsCollected() {
 				if mysql.HasPriKeyFlag(col.Info.GetFlag()) {
 					col.StatsLoadedStatus = statistics.NewStatsFullLoadStatus()
 				} else {

--- a/statistics/handle/dump_test.go
+++ b/statistics/handle/dump_test.go
@@ -34,7 +34,6 @@ func requireTableEqual(t *testing.T, a *statistics.Table, b *statistics.Table) {
 	require.Equal(t, b.ModifyCount, a.ModifyCount)
 	require.Equal(t, len(b.Columns), len(a.Columns))
 	for i := range a.Columns {
-		require.Equal(t, b.Columns[i].Count, a.Columns[i].Count)
 		require.True(t, statistics.HistogramEqual(&a.Columns[i].Histogram, &b.Columns[i].Histogram, false))
 		if a.Columns[i].CMSketch == nil {
 			require.Nil(t, b.Columns[i].CMSketch)

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -1095,11 +1095,7 @@ func (h *Handle) loadNeededColumnHistograms(reader *statistics.StatsReader, col 
 		IsHandle:   c.IsHandle,
 		StatsVer:   statsVer,
 	}
-	// Column.Count is calculated by Column.TotalRowCount(). Hence we don't set Column.Count when initializing colHist.
-	colHist.Count = int64(colHist.TotalRowCount())
-	// When adding/modifying a column, we create its stats(all values are default values) without setting stats_ver.
-	// So we need add colHist.Count > 0 here.
-	if statsVer != statistics.Version0 || colHist.Count > 0 {
+	if colHist.StatsCollected() {
 		colHist.StatsLoadedStatus = statistics.NewStatsFullLoadStatus()
 	}
 	// Reload the latest stats cache, otherwise the `updateStatsCache` may fail with high probability, because functions

--- a/statistics/handle/handle_hist.go
+++ b/statistics/handle/handle_hist.go
@@ -395,11 +395,7 @@ func (h *Handle) readStatsForOneItem(item model.TableItemID, w *statsWrapper, re
 			IsHandle:   c.IsHandle,
 			StatsVer:   statsVer,
 		}
-		// Column.Count is calculated by Column.TotalRowCount(). Hence, we don't set Column.Count when initializing colHist.
-		colHist.Count = int64(colHist.TotalRowCount())
-		// When adding/modifying a column, we create its stats(all values are default values) without setting stats_ver.
-		// So we need add colHist.Count > 0 here.
-		if statsVer != statistics.Version0 || colHist.Count > 0 {
+		if colHist.StatsCollected() {
 			colHist.StatsLoadedStatus = statistics.NewStatsFullLoadStatus()
 		}
 		w.col = colHist

--- a/statistics/handle/internal/testutil.go
+++ b/statistics/handle/internal/testutil.go
@@ -27,7 +27,6 @@ func AssertTableEqual(t *testing.T, a *statistics.Table, b *statistics.Table) {
 	require.Equal(t, b.ModifyCount, a.ModifyCount)
 	require.Len(t, a.Columns, len(b.Columns))
 	for i := range a.Columns {
-		require.Equal(t, b.Columns[i].Count, a.Columns[i].Count)
 		require.True(t, statistics.HistogramEqual(&a.Columns[i].Histogram, &b.Columns[i].Histogram, false))
 		if a.Columns[i].CMSketch == nil {
 			require.Nil(t, b.Columns[i].CMSketch)

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -998,12 +998,12 @@ var AutoAnalyzeMinCnt int64 = 1000
 // TableAnalyzed checks if the table is analyzed.
 func TableAnalyzed(tbl *statistics.Table) bool {
 	for _, col := range tbl.Columns {
-		if col.StatsCollected() {
+		if col.StatsVer != statistics.Version0 {
 			return true
 		}
 	}
 	for _, idx := range tbl.Indices {
-		if idx.Histogram.Len() > 0 {
+		if idx.StatsVer != statistics.Version0 {
 			return true
 		}
 	}

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -998,7 +998,7 @@ var AutoAnalyzeMinCnt int64 = 1000
 // TableAnalyzed checks if the table is analyzed.
 func TableAnalyzed(tbl *statistics.Table) bool {
 	for _, col := range tbl.Columns {
-		if col.Count > 0 {
+		if col.StatsCollected() {
 			return true
 		}
 	}

--- a/statistics/handle/updatetest/update_test.go
+++ b/statistics/handle/updatetest/update_test.go
@@ -1373,7 +1373,7 @@ func TestFeedbackWithStatsVer2(t *testing.T) {
 
 func TestNeedAnalyzeTable(t *testing.T) {
 	columns := map[int64]*statistics.Column{}
-	columns[1] = &statistics.Column{Count: 1}
+	columns[1] = &statistics.Column{StatsVer: statistics.Version2}
 	tests := []struct {
 		tbl    *statistics.Table
 		ratio  float64

--- a/statistics/integration_test.go
+++ b/statistics/integration_test.go
@@ -770,7 +770,6 @@ func TestIndexJoinInnerRowCountUpperBound(t *testing.T) {
 	require.NoError(t, err)
 	for i := 1; i <= 2; i++ {
 		mockStatsTbl.Columns[int64(i)] = &statistics.Column{
-			Count:             500000,
 			Histogram:         *mockStatsHistogram(int64(i), colValues, 1000, types.NewFieldType(mysql.TypeLonglong)),
 			Info:              tblInfo.Columns[i-1],
 			StatsLoadedStatus: statistics.NewStatsFullLoadStatus(),
@@ -820,7 +819,6 @@ func TestOrderingIdxSelectivityThreshold(t *testing.T) {
 	pkColValues, err := generateIntDatum(1, 100000)
 	require.NoError(t, err)
 	mockStatsTbl.Columns[1] = &statistics.Column{
-		Count:             100000,
 		Histogram:         *mockStatsHistogram(1, pkColValues, 1, types.NewFieldType(mysql.TypeLonglong)),
 		Info:              tblInfo.Columns[0],
 		StatsLoadedStatus: statistics.NewStatsFullLoadStatus(),
@@ -837,7 +835,6 @@ func TestOrderingIdxSelectivityThreshold(t *testing.T) {
 
 	for i := 2; i <= 3; i++ {
 		mockStatsTbl.Columns[int64(i)] = &statistics.Column{
-			Count:             100000,
 			Histogram:         *mockStatsHistogram(int64(i), colValues, 10, types.NewFieldType(mysql.TypeLonglong)),
 			Info:              tblInfo.Columns[i-1],
 			StatsLoadedStatus: statistics.NewStatsFullLoadStatus(),

--- a/statistics/interact_with_storage.go
+++ b/statistics/interact_with_storage.go
@@ -169,40 +169,6 @@ func FMSketchFromStorage(reader *StatsReader, tblID int64, isIndex, histID int64
 	return DecodeFMSketch(rows[0].GetBytes(0))
 }
 
-// columnCountFromStorage reads column count from storage
-func columnCountFromStorage(reader *StatsReader, tableID, colID, statsVer int64) (int64, error) {
-	count := int64(0)
-	rows, _, err := reader.Read("select sum(count) from mysql.stats_buckets where table_id = %? and is_index = 0 and hist_id = %?", tableID, colID)
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-	// If there doesn't exist any buckets, the SQL will return NULL. So we only use the result if it's not NULL.
-	if !rows[0].IsNull(0) {
-		count, err = rows[0].GetMyDecimal(0).ToInt()
-		if err != nil {
-			return 0, errors.Trace(err)
-		}
-	}
-
-	if statsVer >= Version2 {
-		// Before stats ver 2, histogram represents all data in this column.
-		// In stats ver 2, histogram + TopN represent all data in this column.
-		// So we need to add TopN total count here.
-		rows, _, err = reader.Read("select sum(count) from mysql.stats_top_n where table_id = %? and is_index = 0 and hist_id = %?", tableID, colID)
-		if err != nil {
-			return 0, errors.Trace(err)
-		}
-		if !rows[0].IsNull(0) {
-			topNCount, err := rows[0].GetMyDecimal(0).ToInt()
-			if err != nil {
-				return 0, errors.Trace(err)
-			}
-			count += topNCount
-		}
-	}
-	return count, err
-}
-
 // ExtendedStatsFromStorage reads extended stats from storage.
 func ExtendedStatsFromStorage(reader *StatsReader, table *Table, physicalID int64, loadAll bool) (*Table, error) {
 	failpoint.Inject("injectExtStatsLoadErr", func() {
@@ -357,23 +323,16 @@ func columnStatsFromStorage(reader *StatsReader, row chunk.Row, table *Table, ta
 		// Here is
 		//For one column, if there is no stats for it in the storage(analyze is never)
 		if notNeedLoad {
-			count, err := columnCountFromStorage(reader, table.PhysicalID, histID, statsVer)
-			if err != nil {
-				return errors.Trace(err)
-			}
 			col = &Column{
 				PhysicalID: table.PhysicalID,
 				Histogram:  *NewHistogram(histID, distinct, nullCount, histVer, &colInfo.FieldType, 0, totColSize),
 				Info:       colInfo,
-				Count:      count + nullCount,
 				ErrorRate:  errorRate,
 				IsHandle:   tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.GetFlag()),
 				Flag:       flag,
 				StatsVer:   statsVer,
 			}
-			// When adding/modifying a column, we create its stats(all values are default values) without setting stats_ver.
-			// So we need add col.Count > 0 here.
-			if statsVer != Version0 || col.Count > 0 {
+			if col.StatsCollected() {
 				col.StatsLoadedStatus = NewStatsAllEvictedStatus()
 			}
 			lastAnalyzePos.Copy(&col.LastAnalyzePos)
@@ -410,11 +369,7 @@ func columnStatsFromStorage(reader *StatsReader, row chunk.Row, table *Table, ta
 				Flag:       flag,
 				StatsVer:   statsVer,
 			}
-			// Column.Count is calculated by Column.TotalRowCount(). Hence we don't set Column.Count when initializing col.
-			col.Count = int64(col.TotalRowCount())
-			// When adding/modifying a column, we create its stats(all values are default values) without setting stats_ver.
-			// So we need add colHist.Count > 0 here.
-			if statsVer != Version0 || col.Count > 0 {
+			if col.StatsCollected() {
 				col.StatsLoadedStatus = NewStatsFullLoadStatus()
 			}
 			lastAnalyzePos.Copy(&col.LastAnalyzePos)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42160

Problem Summary:

### What is changed and how it works?

Remove `statistics.Column.Count`. 

Before the PR, in order to maintain `statistics.Column.Count`, we need to read `mysql.stats_top_n` and `mysql.stats_buckets` for each column when init stats, which is time-consuming. On the other hand, the usage of `statistics.Column.Count` is limited. We change `(*DataSource).getColumnNDV` and add `(*Column).StatsCollected` to get rid of `statistics.Column.Count`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
