### PR TITLE
planner: add more metrics for non-prep plan cache

### DIFF
--- a/planner/core/metrics/metrics.go
+++ b/planner/core/metrics/metrics.go
@@ -27,6 +27,7 @@ var (
 	nonPreparedPlanCacheHitCounter             prometheus.Counter
 	preparedPlanCacheMissCounter               prometheus.Counter
 	nonPreparedPlanCacheMissCounter            prometheus.Counter
+	nonPreparedPlanCacheUnsupportedCounter     prometheus.Counter
 	preparedPlanCacheInstancePlanNumCounter    prometheus.Gauge
 	nonPreparedPlanCacheInstancePlanNumCounter prometheus.Gauge
 	preparedPlanCacheInstanceMemoryUsage       prometheus.Gauge
@@ -46,6 +47,7 @@ func InitMetricsVars() {
 	nonPreparedPlanCacheHitCounter = metrics.PlanCacheCounter.WithLabelValues("non-prepared")
 	preparedPlanCacheMissCounter = metrics.PlanCacheMissCounter.WithLabelValues("prepared")
 	nonPreparedPlanCacheMissCounter = metrics.PlanCacheMissCounter.WithLabelValues("non-prepared")
+	nonPreparedPlanCacheUnsupportedCounter = metrics.PlanCacheMissCounter.WithLabelValues("non-prepared-unsupported")
 	preparedPlanCacheInstancePlanNumCounter = metrics.PlanCacheInstancePlanNumCounter.WithLabelValues(" prepared")
 	nonPreparedPlanCacheInstancePlanNumCounter = metrics.PlanCacheInstancePlanNumCounter.WithLabelValues(" non-prepared")
 	preparedPlanCacheInstanceMemoryUsage = metrics.PlanCacheInstanceMemoryUsage.WithLabelValues(" prepared")
@@ -66,6 +68,11 @@ func GetPlanCacheMissCounter(isNonPrepared bool) prometheus.Counter {
 		return nonPreparedPlanCacheMissCounter
 	}
 	return preparedPlanCacheMissCounter
+}
+
+// GetNonPrepPlanCacheUnsupportedCounter get non-prepared plan cache unsupported counter.
+func GetNonPrepPlanCacheUnsupportedCounter() prometheus.Counter {
+	return nonPreparedPlanCacheUnsupportedCounter
 }
 
 // GetPlanCacheInstanceNumCounter get different plan counter of plan cache

--- a/planner/core/plan_cache_param.go
+++ b/planner/core/plan_cache_param.go
@@ -51,49 +51,26 @@ var (
 // paramReplacer is an ast.Visitor that replaces all values with `?` and collects them.
 type paramReplacer struct {
 	params []*driver.ValueExpr
-
-	// Skip all values in SelectField, e.g.
-	// `select a+1 from t where a<10 and b<23` should be parameterized to
-	// `select a+1 from t where a<? and b<?`, instead of
-	// `select a+? from t where a<? and b<?`.
-	// This is to make the output field names be corresponding to these values.
-	// Use int instead of bool to support nested SelectField.
-	selFieldsCnt int
-
-	// Skip all values in GroupByClause since them can affect the full_group_by check, e.g.
-	// `select a*2 from t group by a*?` cannot pass the full_group_by check.
-	groupByCnt int
 }
 
 func (pr *paramReplacer) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 	switch n := in.(type) {
-	case *ast.SelectField:
-		pr.selFieldsCnt++
-	case *ast.GroupByClause:
-		pr.groupByCnt++
+	case *ast.SelectField, *ast.GroupByClause, *ast.Limit:
+		return in, true
 	case *driver.ValueExpr:
-		if pr.selFieldsCnt == 0 && // not in SelectField
-			pr.groupByCnt == 0 { // not in GroupBy
-			pr.params = append(pr.params, n)
-			param := ast.NewParamMarkerExpr(len(pr.params) - 1)      // offset is used as order in non-prepared plan cache.
-			param.(*driver.ParamMarkerExpr).Datum = *n.Datum.Clone() // init the ParamMakerExpr's Datum
-			return param, true
-		}
+		pr.params = append(pr.params, n)
+		param := ast.NewParamMarkerExpr(len(pr.params) - 1)      // offset is used as order in non-prepared plan cache.
+		param.(*driver.ParamMarkerExpr).Datum = *n.Datum.Clone() // init the ParamMakerExpr's Datum
+		return param, true
 	}
 	return in, false
 }
 
 func (pr *paramReplacer) Leave(in ast.Node) (out ast.Node, ok bool) {
-	switch in.(type) {
-	case *ast.SelectField:
-		pr.selFieldsCnt--
-	case *ast.GroupByClause:
-		pr.groupByCnt--
-	}
 	return in, true
 }
 
-func (pr *paramReplacer) Reset() { pr.params, pr.selFieldsCnt, pr.groupByCnt = nil, 0, 0 }
+func (pr *paramReplacer) Reset() { pr.params = nil }
 
 // GetParamSQLFromAST returns the parameterized SQL of this AST.
 // NOTICE: this function does not modify the original AST.

--- a/planner/core/plan_cache_param_test.go
+++ b/planner/core/plan_cache_param_test.go
@@ -79,6 +79,11 @@ func TestParameterize(t *testing.T) {
 			`INSERT INTO t (a,B,c) VALUES (?,?,?),(?,?,?)`,
 			[]interface{}{int64(1), int64(2), int64(3), int64(4), int64(5), int64(6)},
 		},
+		{
+			`select a + 1 from t limit 3`,
+			`SELECT a + 1 FROM t LIMIT 3`,
+			[]interface{}{},
+		},
 		// TODO: more test cases
 	}
 

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -16,7 +16,6 @@ package core
 
 import (
 	"fmt"
-	core_metrics "github.com/pingcap/tidb/planner/core/metrics"
 	"sync"
 
 	"github.com/pingcap/tidb/expression"
@@ -25,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
+	core_metrics "github.com/pingcap/tidb/planner/core/metrics"
 	"github.com/pingcap/tidb/sessionctx"
 	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/filter"

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -383,7 +383,7 @@ func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (out ast.Node
 
 	switch node := in.(type) {
 	case *ast.SelectStmt, *ast.FieldList, *ast.SelectField, *ast.TableRefsClause, *ast.Join, *ast.BetweenExpr, *ast.OnCondition,
-		*ast.InsertStmt, *ast.DeleteStmt, *ast.UpdateStmt, *ast.Assignment, *ast.Limit, *ast.ParenthesesExpr,
+		*ast.InsertStmt, *ast.DeleteStmt, *ast.UpdateStmt, *ast.Assignment, *ast.Limit, *ast.ParenthesesExpr, *ast.RowExpr,
 		*ast.TableSource, *ast.ColumnNameExpr, *ast.PatternInExpr, *ast.BinaryOperationExpr, *ast.ByItem, *ast.AggregateFuncExpr:
 		return in, !checker.cacheable // skip child if un-cacheable
 	case *ast.ColumnName:

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -383,7 +383,7 @@ func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (out ast.Node
 
 	switch node := in.(type) {
 	case *ast.SelectStmt, *ast.FieldList, *ast.SelectField, *ast.TableRefsClause, *ast.Join, *ast.BetweenExpr, *ast.OnCondition,
-		*ast.InsertStmt, *ast.DeleteStmt, *ast.UpdateStmt, *ast.Assignment,
+		*ast.InsertStmt, *ast.DeleteStmt, *ast.UpdateStmt, *ast.Assignment, *ast.Limit,
 		*ast.TableSource, *ast.ColumnNameExpr, *ast.PatternInExpr, *ast.BinaryOperationExpr, *ast.ByItem, *ast.AggregateFuncExpr:
 		return in, !checker.cacheable // skip child if un-cacheable
 	case *ast.ColumnName:

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"fmt"
+	core_metrics "github.com/pingcap/tidb/planner/core/metrics"
 	"sync"
 
 	"github.com/pingcap/tidb/expression"
@@ -276,6 +277,12 @@ func NonPreparedPlanCacheableWithCtx(sctx sessionctx.Context, node ast.Node, is 
 
 	// put the checker back
 	nonPrepCacheCheckerPool.Put(checker)
+
+	if !cacheable {
+		// this metrics can measure the extra overhead of non-prep plan cache.
+		core_metrics.GetNonPrepPlanCacheUnsupportedCounter().Inc()
+	}
+
 	return cacheable, reason
 }
 

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -383,7 +383,7 @@ func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (out ast.Node
 
 	switch node := in.(type) {
 	case *ast.SelectStmt, *ast.FieldList, *ast.SelectField, *ast.TableRefsClause, *ast.Join, *ast.BetweenExpr, *ast.OnCondition,
-		*ast.InsertStmt, *ast.DeleteStmt, *ast.UpdateStmt, *ast.Assignment, *ast.Limit,
+		*ast.InsertStmt, *ast.DeleteStmt, *ast.UpdateStmt, *ast.Assignment, *ast.Limit, *ast.ParenthesesExpr,
 		*ast.TableSource, *ast.ColumnNameExpr, *ast.PatternInExpr, *ast.BinaryOperationExpr, *ast.ByItem, *ast.AggregateFuncExpr:
 		return in, !checker.cacheable // skip child if un-cacheable
 	case *ast.ColumnName:

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -294,7 +294,6 @@ func isSelectStmtNonPrepCacheableFastCheck(selectStmt *ast.SelectStmt) (names []
 	if len(selectStmt.TableHints) > 0 || // hints
 		selectStmt.Having != nil || // having
 		selectStmt.WindowSpecs != nil || // window function
-		selectStmt.Limit != nil || // limit
 		selectStmt.SelectIntoOpt != nil { // select-into statement
 		return nil, false, "queries that have hints, aggregation, window-function, order-by, limit and lock are not supported"
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36598

Problem Summary: planner: add more metrics for non-prep plan cache

### What is changed and how it works?

planner: add more metrics for non-prep plan cache

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
