### PR TITLE
planner: non-prep plan cache to support limit clauses

### DIFF
--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -661,14 +661,14 @@ func TestExplainFormatPlanCache(t *testing.T) {
 	tk.MustExec("select * from t limit 1")
 
 	// miss
-	tk.MustExec("explain format = 'plan_cache' select * from t limit 1")
-	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip non-prepared plan-cache: queries that have hints, aggregation, window-function, order-by, limit and lock are not supported"))
-	tk.MustExec("explain format = 'plan_cache' select * from t limit 1")
+	tk.MustExec("explain format = 'plan_cache' select * from (select * from t) t1 limit 1")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip non-prepared plan-cache: queries that have sub-queries are not supported"))
+	tk.MustExec("explain format = 'plan_cache' select * from (select * from t) t1 limit 1")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 
-	tk.MustExec("explain analyze format = 'plan_cache' select * from t limit 1")
-	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip non-prepared plan-cache: queries that have hints, aggregation, window-function, order-by, limit and lock are not supported"))
-	tk.MustExec("explain analyze format = 'plan_cache' select * from t limit 1")
+	tk.MustExec("explain analyze format = 'plan_cache' select * from (select * from t) t1 limit 1")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip non-prepared plan-cache: queries that have sub-queries are not supported"))
+	tk.MustExec("explain analyze format = 'plan_cache' select * from (select * from t) t1 limit 1")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 
 	// hit

--- a/planner/core/plan_cache_param.go
+++ b/planner/core/plan_cache_param.go
@@ -51,49 +51,30 @@ var (
 // paramReplacer is an ast.Visitor that replaces all values with `?` and collects them.
 type paramReplacer struct {
 	params []*driver.ValueExpr
-
-	// Skip all values in SelectField, e.g.
-	// `select a+1 from t where a<10 and b<23` should be parameterized to
-	// `select a+1 from t where a<? and b<?`, instead of
-	// `select a+? from t where a<? and b<?`.
-	// This is to make the output field names be corresponding to these values.
-	// Use int instead of bool to support nested SelectField.
-	selFieldsCnt int
-
-	// Skip all values in GroupByClause since them can affect the full_group_by check, e.g.
-	// `select a*2 from t group by a*?` cannot pass the full_group_by check.
-	groupByCnt int
 }
 
 func (pr *paramReplacer) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 	switch n := in.(type) {
-	case *ast.SelectField:
-		pr.selFieldsCnt++
-	case *ast.GroupByClause:
-		pr.groupByCnt++
+	case *ast.SelectField, *ast.GroupByClause, *ast.Limit:
+		// Skip replacing values in these case:
+		// 1. SelectField: to keep the output field names be corresponding to these values.
+		// 2. GroupByClause: to avoid breaking the full_group_by check.
+		// 3. Limit: to generate different plans for queries with different limit values.
+		return in, true
 	case *driver.ValueExpr:
-		if pr.selFieldsCnt == 0 && // not in SelectField
-			pr.groupByCnt == 0 { // not in GroupBy
-			pr.params = append(pr.params, n)
-			param := ast.NewParamMarkerExpr(len(pr.params) - 1)      // offset is used as order in non-prepared plan cache.
-			param.(*driver.ParamMarkerExpr).Datum = *n.Datum.Clone() // init the ParamMakerExpr's Datum
-			return param, true
-		}
+		pr.params = append(pr.params, n)
+		param := ast.NewParamMarkerExpr(len(pr.params) - 1)      // offset is used as order in non-prepared plan cache.
+		param.(*driver.ParamMarkerExpr).Datum = *n.Datum.Clone() // init the ParamMakerExpr's Datum
+		return param, true
 	}
 	return in, false
 }
 
 func (pr *paramReplacer) Leave(in ast.Node) (out ast.Node, ok bool) {
-	switch in.(type) {
-	case *ast.SelectField:
-		pr.selFieldsCnt--
-	case *ast.GroupByClause:
-		pr.groupByCnt--
-	}
 	return in, true
 }
 
-func (pr *paramReplacer) Reset() { pr.params, pr.selFieldsCnt, pr.groupByCnt = nil, 0, 0 }
+func (pr *paramReplacer) Reset() { pr.params = nil }
 
 // GetParamSQLFromAST returns the parameterized SQL of this AST.
 // NOTICE: this function does not modify the original AST.

--- a/planner/core/plan_cache_param_test.go
+++ b/planner/core/plan_cache_param_test.go
@@ -79,6 +79,18 @@ func TestParameterize(t *testing.T) {
 			`INSERT INTO t (a,B,c) VALUES (?,?,?),(?,?,?)`,
 			[]interface{}{int64(1), int64(2), int64(3), int64(4), int64(5), int64(6)},
 		},
+
+		// keep the original format for limit clauses
+		{
+			`select * from t limit 10`,
+			`SELECT * FROM t LIMIT 10`,
+			[]interface{}{},
+		},
+		{
+			`select * from t limit 10, 20`,
+			`SELECT * FROM t LIMIT 10,20`,
+			[]interface{}{},
+		},
 		// TODO: more test cases
 	}
 

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -1623,7 +1623,6 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 	unsupported := []string{
 		"select /*+ use_index(t1, idx_b) */ * from t1 where a > 1 and b < 2",               // hint
 		"select a, sum(b) as c from t1 where a > 1 and b < 2 group by a having sum(b) > 1", // having
-		"select * from t1 limit 1",                                     // limit
 		"select * from (select * from t1) t",                           // sub-query
 		"select * from t1 where a in (select a from t)",                // uncorrelated sub-query
 		"select * from t1 where a in (select a from t where a > t1.a)", // correlated sub-query
@@ -1649,9 +1648,8 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 	}
 
 	reasons := []string{
-		"skip non-prepared plan-cache: queries that have hints, aggregation, window-function, order-by, limit and lock are not supported",
-		"skip non-prepared plan-cache: queries that have hints, aggregation, window-function, order-by, limit and lock are not supported",
-		"skip non-prepared plan-cache: queries that have hints, aggregation, window-function, order-by, limit and lock are not supported",
+		"skip non-prepared plan-cache: queries that have hints, having-clause, window-function are not supported",
+		"skip non-prepared plan-cache: queries that have hints, having-clause, window-function are not supported",
 		"skip non-prepared plan-cache: queries that have sub-queries are not supported",
 		"skip non-prepared plan-cache: queries that access partitioning table are not supported",
 		"skip non-prepared plan-cache: queries that access partitioning table are not supported",

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -1623,10 +1623,10 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 	unsupported := []string{
 		"select /*+ use_index(t1, idx_b) */ * from t1 where a > 1 and b < 2",               // hint
 		"select a, sum(b) as c from t1 where a > 1 and b < 2 group by a having sum(b) > 1", // having
-		"select * from (select * from t1) t",                           // sub-query
-		"select * from t1 where a in (select a from t)",                // uncorrelated sub-query
-		"select * from t1 where a in (select a from t where a > t1.a)", // correlated sub-query
-		"select * from t where j < 1",                                  // json
+		"select * from (select * from t1) t",                                               // sub-query
+		"select * from t1 where a in (select a from t)",                                    // uncorrelated sub-query
+		"select * from t1 where a in (select a from t where a > t1.a)",                     // correlated sub-query
+		"select * from t where j < 1",                                                      // json
 		"select * from t where a > 1 and j < 1",
 		"select * from t where e < '1'", // enum
 		"select * from t where a > 1 and e < '1'",

--- a/planner/core/plan_cacheable_checker_test.go
+++ b/planner/core/plan_cacheable_checker_test.go
@@ -303,6 +303,7 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 		"select * from test.t where d>now()",     // now
 		"select a+1 from test.t where a<13",
 		"select mod(a, 10) from test.t where a<13",
+		"select * from test.t limit 1", // limit
 
 		// 2-way joins
 		"select * from test.t inner join test.t3 on test.t.a=test.t3.a",
@@ -318,7 +319,6 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 		"select distinct a from test.t1 where a > 1 and b < 2",                                  // distinct
 		"select count(*) from test.t1 where a > 1 and b < 2 group by a",                         // group by
 		"select a, sum(b) as c from test.t1 where a > 1 and b < 2 group by a having sum(b) > 1", // having
-		"select * from test.t1 limit 1",                                                         // limit
 		"select * from test.t1 order by a",                                                      // order by
 		"select * from (select * from test.t1) t",                                               // sub-query
 		"insert into test.t1 values(1, 1)",                                                      // insert
@@ -330,16 +330,19 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 		"select * from test.t1 where a in (select a from test.t where a > t1.a)",                // correlated sub-query
 	}
 
+	sctx := tk.Session()
 	for _, q := range unsupported {
 		stmt, err := p.ParseOneStmt(q, charset, collation)
 		require.NoError(t, err)
-		require.False(t, core.NonPreparedPlanCacheable(stmt, is))
+		ok, _ := core.NonPreparedPlanCacheableWithCtx(sctx, stmt, is)
+		require.False(t, ok)
 	}
 
 	for _, q := range supported {
 		stmt, err := p.ParseOneStmt(q, charset, collation)
 		require.NoError(t, err)
-		require.True(t, core.NonPreparedPlanCacheable(stmt, is))
+		ok, _ := core.NonPreparedPlanCacheableWithCtx(sctx, stmt, is)
+		require.True(t, ok)
 	}
 }
 
@@ -359,7 +362,7 @@ func BenchmarkNonPreparedPlanCacheableChecker(b *testing.B) {
 	sctx := tk.Session()
 	is := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema()
 
-	core.NonPreparedPlanCacheable(stmt, is)
+	core.NonPreparedPlanCacheableWithCtx(sctx, stmt, is)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36598

Problem Summary: planner: non-prep plan cache to support limit clauses

### What is changed and how it works?

planner: non-prep plan cache to support limit clauses

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
