### PR TITLE
sessionctx: support encoding resource group name into session states

### DIFF
--- a/sessionctx/sessionstates/session_states.go
+++ b/sessionctx/sessionstates/session_states.go
@@ -81,5 +81,6 @@ type SessionStates struct {
 	LastInsertID         uint64                       `json:"last-insert-id,omitempty"`
 	Warnings             []stmtctx.SQLWarn            `json:"warnings,omitempty"`
 	// Define it as string to avoid cycle import.
-	Bindings string `json:"bindings,omitempty"`
+	Bindings          string `json:"bindings,omitempty"`
+	ResourceGroupName string `json:"rs-group,omitempty"`
 }

--- a/sessionctx/sessionstates/session_states_test.go
+++ b/sessionctx/sessionstates/session_states_test.go
@@ -422,6 +422,19 @@ func TestSessionCtx(t *testing.T) {
 				tk.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
 			},
 		},
+		{
+			// check ResourceGroupName
+			setFunc: func(tk *testkit.TestKit) any {
+				tk.MustExec("SET GLOBAL tidb_enable_resource_control='on'")
+				tk.MustExec("CREATE RESOURCE GROUP rg1 ru_per_sec = 100")
+				tk.MustExec("SET RESOURCE GROUP `rg1`")
+				require.Equal(t, "rg1", tk.Session().GetSessionVars().ResourceGroupName)
+				return nil
+			},
+			checkFunc: func(tk *testkit.TestKit, param any) {
+				tk.MustQuery("SELECT CURRENT_RESOURCE_GROUP()").Check(testkit.Rows("rg1"))
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -2467,6 +2467,7 @@ func (s *SessionVars) EncodeSessionStates(_ context.Context, sessionStates *sess
 	sessionStates.SequenceLatestValues = s.SequenceState.GetAllStates()
 	sessionStates.FoundInPlanCache = s.PrevFoundInPlanCache
 	sessionStates.FoundInBinding = s.PrevFoundInBinding
+	sessionStates.ResourceGroupName = s.ResourceGroupName
 
 	// Encode StatementContext. We encode it here to avoid circle dependency.
 	sessionStates.LastAffectedRows = s.StmtCtx.PrevAffectedRows
@@ -2500,6 +2501,7 @@ func (s *SessionVars) DecodeSessionStates(_ context.Context, sessionStates *sess
 	s.SequenceState.SetAllStates(sessionStates.SequenceLatestValues)
 	s.FoundInPlanCache = sessionStates.FoundInPlanCache
 	s.FoundInBinding = sessionStates.FoundInBinding
+	s.ResourceGroupName = sessionStates.ResourceGroupName
 
 	// Decode StatementContext.
 	s.StmtCtx.SetAffectedRows(uint64(sessionStates.LastAffectedRows))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42884

Problem Summary:
#41722 introduced `set resource group` but session states don't encode it.

### What is changed and how it works?
Encode resource group into session states.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
