### PR TITLE
planner: add more metrics for non-prep plan cache

### DIFF
--- a/expression/function_traits.go
+++ b/expression/function_traits.go
@@ -33,9 +33,14 @@ var UnCacheableFunctions = map[string]struct{}{
 	ast.Like:                 {},
 
 	// functions below are incompatible with (non-prep) plan cache, we'll fix them one by one later.
-	ast.JSONExtract: {}, // cannot pass TestFuncJSON
-	ast.Coalesce:    {},
-	ast.Convert:     {},
+	ast.JSONExtract:      {}, // cannot pass TestFuncJSON
+	ast.JSONObject:       {},
+	ast.JSONArray:        {},
+	ast.Coalesce:         {},
+	ast.Convert:          {},
+	ast.TimeLiteral:      {},
+	ast.DateLiteral:      {},
+	ast.TimestampLiteral: {},
 }
 
 // unFoldableFunctions stores functions which can not be folded duration constant folding stage.

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -5838,7 +5838,7 @@ FieldList:
 	{
 		field := $1.(*ast.SelectField)
 		field.Offset = parser.startOffset(&yyS[yypt])
-		if field.Expr != nil && field.AsName.O == "" {
+		if field.Expr != nil {
 			endOffset := parser.yylval.offset
 			field.SetText(parser.lexer.client, strings.TrimSpace(parser.src[field.Offset:endOffset]))
 		}
@@ -5849,7 +5849,7 @@ FieldList:
 		fl := $1.([]*ast.SelectField)
 		field := $3.(*ast.SelectField)
 		field.Offset = parser.startOffset(&yyS[yypt])
-		if field.Expr != nil && field.AsName.O == "" {
+		if field.Expr != nil {
 			endOffset := parser.yylval.offset
 			field.SetText(parser.lexer.client, strings.TrimSpace(parser.src[field.Offset:endOffset]))
 		}

--- a/planner/core/metrics/metrics.go
+++ b/planner/core/metrics/metrics.go
@@ -27,6 +27,7 @@ var (
 	nonPreparedPlanCacheHitCounter             prometheus.Counter
 	preparedPlanCacheMissCounter               prometheus.Counter
 	nonPreparedPlanCacheMissCounter            prometheus.Counter
+	nonPreparedPlanCacheUnsupportedCounter     prometheus.Counter
 	preparedPlanCacheInstancePlanNumCounter    prometheus.Gauge
 	nonPreparedPlanCacheInstancePlanNumCounter prometheus.Gauge
 	preparedPlanCacheInstanceMemoryUsage       prometheus.Gauge
@@ -46,6 +47,7 @@ func InitMetricsVars() {
 	nonPreparedPlanCacheHitCounter = metrics.PlanCacheCounter.WithLabelValues("non-prepared")
 	preparedPlanCacheMissCounter = metrics.PlanCacheMissCounter.WithLabelValues("prepared")
 	nonPreparedPlanCacheMissCounter = metrics.PlanCacheMissCounter.WithLabelValues("non-prepared")
+	nonPreparedPlanCacheUnsupportedCounter = metrics.PlanCacheMissCounter.WithLabelValues("non-prepared-unsupported")
 	preparedPlanCacheInstancePlanNumCounter = metrics.PlanCacheInstancePlanNumCounter.WithLabelValues(" prepared")
 	nonPreparedPlanCacheInstancePlanNumCounter = metrics.PlanCacheInstancePlanNumCounter.WithLabelValues(" non-prepared")
 	preparedPlanCacheInstanceMemoryUsage = metrics.PlanCacheInstanceMemoryUsage.WithLabelValues(" prepared")
@@ -66,6 +68,11 @@ func GetPlanCacheMissCounter(isNonPrepared bool) prometheus.Counter {
 		return nonPreparedPlanCacheMissCounter
 	}
 	return preparedPlanCacheMissCounter
+}
+
+// GetNonPrepPlanCacheUnsupportedCounter get non-prepared plan cache unsupported counter.
+func GetNonPrepPlanCacheUnsupportedCounter() prometheus.Counter {
+	return nonPreparedPlanCacheUnsupportedCounter
 }
 
 // GetPlanCacheInstanceNumCounter get different plan counter of plan cache

--- a/planner/core/plan_cache_param_test.go
+++ b/planner/core/plan_cache_param_test.go
@@ -75,6 +75,11 @@ func TestParameterize(t *testing.T) {
 			[]interface{}{},
 		},
 		{
+			`select a + 'a b c'+"x" as 'xxx' from t`,
+			`SELECT a + 'a b c'+"x" as 'xxx' FROM t`, // keep the original format for select fields
+			[]interface{}{},
+		},
+		{
 			`insert into t (a, B, c) values (1, 2, 3), (4, 5, 6)`,
 			`INSERT INTO t (a,B,c) VALUES (?,?,?),(?,?,?)`,
 			[]interface{}{int64(1), int64(2), int64(3), int64(4), int64(5), int64(6)},

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -429,7 +429,7 @@ func TestNonPreparedPlanCacheParamInit(t *testing.T) {
 	tk.MustExec(`insert into tx values (3.0, 3)`)
 	tk.MustQuery("select json_object('k', a) = json_object('k', b) from tx").Check(testkit.Rows("1")) // no error
 	tk.MustQuery("select json_object('k', a) = json_object('k', b) from tx").Check(testkit.Rows("1"))
-	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 }
 
 func TestNonPreparedPlanCacheBinding(t *testing.T) {

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
+	core_metrics "github.com/pingcap/tidb/planner/core/metrics"
 	"github.com/pingcap/tidb/sessionctx"
 	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/filter"
@@ -267,6 +268,11 @@ func NonPreparedPlanCacheableWithCtx(sctx sessionctx.Context, node ast.Node, is 
 
 	node.Accept(checker)
 	cacheable, reason := checker.cacheable, checker.reason
+
+	if !cacheable {
+		// this metrics can measure the extra overhead of non-prep plan cache.
+		core_metrics.GetNonPrepPlanCacheUnsupportedCounter().Inc()
+	}
 
 	// put the checker back
 	nonPrepCacheCheckerPool.Put(checker)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36598

Problem Summary: planner: add more metrics for non-prep plan cache

### What is changed and how it works?

1. add a new metric to measure which can help measure the extra overhead of non-prep plan cache;
2. set the original text even if Field.As is not nil;
3. uncache some special TiDB functions;

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
