### PR TITLE
ddl: include ddl sessions in session manager's internal list

### DIFF
--- a/ddl/internal/session/BUILD.bazel
+++ b/ddl/internal/session/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "session",
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/ddl/internal/session",
     visibility = ["//ddl:__subpackages__"],
     deps = [
+        "//domain/infosync",
         "//kv",
         "//metrics",
         "//parser/mysql",
@@ -22,5 +23,18 @@ go_library(
         "@com_github_ngaut_pools//:pools",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
+    ],
+)
+
+go_test(
+    name = "session_test",
+    timeout = "short",
+    srcs = ["session_pool_test.go"],
+    flaky = True,
+    deps = [
+        ":session",
+        "//testkit",
+        "@com_github_ngaut_pools//:pools",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/ddl/internal/session/session_pool_test.go
+++ b/ddl/internal/session/session_pool_test.go
@@ -1,0 +1,68 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ngaut/pools"
+	"github.com/pingcap/tidb/ddl/internal/session"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionPool(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	resourcePool := pools.NewResourcePool(func() (pools.Resource, error) {
+		newTk := testkit.NewTestKit(t, store)
+		return newTk.Session(), nil
+	}, 4, 4, 0)
+	pool := session.NewSessionPool(resourcePool, store)
+	sessCtx, err := pool.Get()
+	require.NoError(t, err)
+	se := session.NewSession(sessCtx)
+	err = se.Begin()
+	startTS := se.GetSessionVars().TxnCtx.StartTS
+	require.NoError(t, err)
+	rows, err := se.Execute(context.Background(), "select 2;", "test")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(rows))
+	require.Equal(t, int64(2), rows[0].GetInt64(0))
+	mgr := tk.Session().GetSessionManager()
+	tsList := mgr.GetInternalSessionStartTSList()
+	var targetTS uint64
+	for _, ts := range tsList {
+		if ts == startTS {
+			targetTS = ts
+			break
+		}
+	}
+	require.NotEqual(t, uint64(0), targetTS)
+	err = se.Commit()
+	pool.Put(sessCtx)
+	require.NoError(t, err)
+	tsList = mgr.GetInternalSessionStartTSList()
+	targetTS = 0
+	for _, ts := range tsList {
+		if ts == startTS {
+			targetTS = ts
+			break
+		}
+	}
+	require.Equal(t, uint64(0), targetTS)
+}

--- a/testkit/BUILD.bazel
+++ b/testkit/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//resourcemanager",
         "//session",
         "//session/txninfo",
+        "//sessionctx",
         "//sessionctx/variable",
         "//store/driver",
         "//store/mockstore",

--- a/testkit/mocksessionmanager.go
+++ b/testkit/mocksessionmanager.go
@@ -142,7 +142,7 @@ func (msm *MockSessionManager) GetInternalSessionStartTSList() []uint64 {
 	msm.mu.Lock()
 	defer msm.mu.Unlock()
 	ret := make([]uint64, 0, len(msm.internalSessions))
-	for internalSess, _ := range msm.internalSessions {
+	for internalSess := range msm.internalSessions {
 		se := internalSess.(sessionctx.Context)
 		startTS := se.GetSessionVars().TxnCtx.StartTS
 		ret = append(ret, startTS)

--- a/testkit/mocksessionmanager.go
+++ b/testkit/mocksessionmanager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/session/txninfo"
+	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util"
 )
 
@@ -35,6 +36,8 @@ type MockSessionManager struct {
 	Dom     *domain.Domain
 	Conn    map[uint64]session.Session
 	mu      sync.Mutex
+
+	internalSessions map[interface{}]struct{}
 }
 
 // ShowTxnList is to show txn list.
@@ -104,7 +107,7 @@ func (msm *MockSessionManager) GetProcessInfo(id uint64) (*util.ProcessInfo, boo
 func (*MockSessionManager) Kill(uint64, bool) {
 }
 
-// KillAllConnections implements the SessionManager.KillAllConections interface.
+// KillAllConnections implements the SessionManager.KillAllConnections interface.
 func (*MockSessionManager) KillAllConnections() {
 }
 
@@ -118,14 +121,33 @@ func (msm *MockSessionManager) ServerID() uint64 {
 }
 
 // StoreInternalSession is to store internal session.
-func (*MockSessionManager) StoreInternalSession(interface{}) {}
+func (msm *MockSessionManager) StoreInternalSession(s interface{}) {
+	msm.mu.Lock()
+	if msm.internalSessions == nil {
+		msm.internalSessions = make(map[interface{}]struct{})
+	}
+	msm.internalSessions[s] = struct{}{}
+	msm.mu.Unlock()
+}
 
 // DeleteInternalSession is to delete the internal session pointer from the map in the SessionManager
-func (*MockSessionManager) DeleteInternalSession(interface{}) {}
+func (msm *MockSessionManager) DeleteInternalSession(s interface{}) {
+	msm.mu.Lock()
+	delete(msm.internalSessions, s)
+	msm.mu.Unlock()
+}
 
-// GetInternalSessionStartTSList is to get all startTS of every transactions running in the current internal sessions
-func (*MockSessionManager) GetInternalSessionStartTSList() []uint64 {
-	return nil
+// GetInternalSessionStartTSList is to get all startTS of every transaction running in the current internal sessions
+func (msm *MockSessionManager) GetInternalSessionStartTSList() []uint64 {
+	msm.mu.Lock()
+	defer msm.mu.Unlock()
+	ret := make([]uint64, 0, len(msm.internalSessions))
+	for internalSess, _ := range msm.internalSessions {
+		se := internalSess.(sessionctx.Context)
+		startTS := se.GetSessionVars().TxnCtx.StartTS
+		ret = append(ret, startTS)
+	}
+	return ret
 }
 
 // KillNonFlashbackClusterConn implement SessionManager interface.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42895

Problem Summary:

The session used by the internal transaction of DDL is not added to the session manager (`StoreInternalSession`), which causes the min start TS reporter to be unaware of the DDL transaction when updating the metadata on etcd, so that GC safepoint will move forward, which will further lead to the failure of the DDL transaction.

This problem will be more obvious when the DDL transaction takes a long time to execute, especially when creating index in ingest mode. If the import process takes more than 10 minutes, it will almost certainly trigger this error.

### What is changed and how it works?

Add the DDL session to the session manager.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
    ```
    [2023/04/10 16:53:58.872 +08:00] [INFO] [local.go:1394] ["put job back to jobCh to retry later"] [startKey=74800000000000005A5F6980000000000000010380000000004C83BC0380000000005B49AA] [endKey=74800000000000005A5F6980000000000000010380000000004C84ED03800000000015537A] [stage=wrote] [retryCount=4] [waitUntil=2023/04/10 16:54:14.872 +08:00]
    [2023/04/10 16:53:58.872 +08:00] [WARN] [region_job.go:377] ["meet error and handle the job later"] ["job stage"=wrote] [error="[Lightning:KV:ServerIsBusy]too many sst files are ingesting"] [region="{ID=180,startKey=7480000000000000FF5A5F698000000000FF0000010380000000FF004C1E9803800000FF000002118E000000FC,endKey=7480000000000000FF5A5F698000000000FF0000010380000000FF004C1FC503800000FF00007DD35F000000FC,epoch=\"conf_ver:1 version:66 \",peers=\"id:181 store_id:1 \"}"] [start=74800000000000005A5F6980000000000000010380000000004C1E9803800000000002118E] [end=74800000000000005A5F6980000000000000010380000000004C1FC50380000000007DD35F]
    [2023/04/10 16:53:58.872 +08:00] [INFO] [local.go:1394] ["put job back to jobCh to retry later"] [startKey=74800000000000005A5F6980000000000000010380000000004C1E9803800000000002118E] [endKey=74800000000000005A5F6980000000000000010380000000004C1FC50380000000007DD35F] [stage=wrote] [retryCount=4] [waitUntil=2023/04/10 16:54:14.872 +08:00]
    [2023/04/10 16:53:58.872 +08:00] [INFO] [local.go:1417] ["import engine pending jobs"] [count=14]
    [2023/04/10 16:53:58.872 +08:00] [INFO] [local.go:1050] ["import engine unfinished ranges"] [count=0]
    [2023/04/10 16:54:00.647 +08:00] [INFO] [info.go:813] [ReportMinStartTS] ["initial minStartTS"=440694693065392128] [StartTSLowerLimit=440672043823792128]
    [2023/04/10 16:54:00.647 +08:00] [INFO] [info.go:822] [ReportMinStartTS] ["Internal Session Transaction StartTS"=440694686144790540]
    [2023/04/10 16:54:18.878 +08:00] [INFO] [local.go:1394] ["put job back to jobCh to retry later"] [startKey=74800000000000005A5F6980000000000000010380000000005187880380000000004197FF] [endKey=74800000000000005A5F69800000000000000103800000000051F665038000000000026084] [stage=wrote] [retryCount=5] [waitUntil=2023/04/10 16:54:48.878 +08:00]
    [2023/04/10 16:54:18.878 +08:00] [WARN] [region_job.go:377] ["meet error and handle the job later"] ["job stage"=wrote] [error="[Lightning:KV:ServerIsBusy]too many sst files are ingesting"] [region="{ID=178,startKey=7480000000000000FF5A5F698000000000FF0000010380000000FF004BEBFE03800000FF00003253DD000000FC,endKey=7480000000000000FF5A5F698000000000FF0000010380000000FF004BED2E03800000FF000023488A000000FC,epoch=\"conf_ver:1 version:66 \",peers=\"id:179 store_id:1 \"}"] [start=74800000000000005A5F6980000000000000010380000000004BEBFE0380000000003253DD] [end=74800000000000005A5F6980000000000000010380000000004BED2E03800000000023488A]
    [2023/04/10 16:54:18.878 +08:00] [INFO] [local.go:1394] ["put job back to jobCh to retry later"] [startKey=74800000000000005A5F6980000000000000010380000000004BEBFE0380000000003253DD] [endKey=74800000000000005A5F6980000000000000010380000000004BED2E03800000000023488A] [stage=wrote] [retryCount=5] [waitUntil=2023/04/10 16:54:48.878 +08:00]
    
    ...
    
    [2023/04/10 16:54:28.654 +08:00] [WARN] [expensivequery.go:118] [expensive_query] [cost_time=60.000227208s] [conn=1062748356989682073] [user=root] [database=sbtest] [txn_start_ts=0] [mem_max="126976 Bytes (124 KB)"] [sql="CREATE INDEX k_1 ON sbtest1(k)"]
    [2023/04/10 16:54:30.649 +08:00] [INFO] [info.go:813] [ReportMinStartTS] ["initial minStartTS"=440694700929712128] [StartTSLowerLimit=440672051688112128]
    [2023/04/10 16:54:30.650 +08:00] [INFO] [info.go:822] [ReportMinStartTS] ["Internal Session Transaction StartTS"=440694686144790540]
    ```
    We can see the `Internal Session Transaction StartTS` is unchanged during the import. After adding the index, the minimum start TS continues to advance:
    ```
    [2023/04/10 16:54:50.456 +08:00] [INFO] [ddl.go:1164] ["[ddl] DDL job is finished"] [jobID=92]
    [2023/04/10 16:54:50.457 +08:00] [INFO] [callback.go:128] ["performing DDL change, must reload"]
    [2023/04/10 16:54:51.898 +08:00] [INFO] [update.go:1195] ["[stats] auto analyze for unanalyzed"] [sql="analyze table `sbtest`.`sbtest1` index `k_1`"]
    [2023/04/10 16:54:55.773 +08:00] [INFO] [coprocessor.go:1262] ["[TIME_COP_PROCESS] resp_time:338.637833ms txnStartTS:18446744073709551615 region_id:138 store_addr:127.0.0.1:20160 kv_process_ms:336 kv_wait_ms:0 kv_read_ms:0 processed_versions:410870 total_versions:410871 rocksdb_delete_skipped_count:0 rocksdb_key_skipped_count:410870 rocksdb_cache_hit_count:2 rocksdb_read_count:3001 rocksdb_read_byte:39644938"]
    [2023/04/10 16:54:56.106 +08:00] [INFO] [coprocessor.go:1262] ["[TIME_COP_PROCESS] resp_time:332.771333ms txnStartTS:18446744073709551615 region_id:140 store_addr:127.0.0.1:20160 kv_process_ms:331 kv_wait_ms:0 kv_read_ms:0 processed_versions:410871 total_versions:410872 rocksdb_delete_skipped_count:0 rocksdb_key_skipped_count:410871 rocksdb_cache_hit_count:2 rocksdb_read_count:3001 rocksdb_read_byte:39641119"]
    ...
    [2023/04/10 16:54:58.801 +08:00] [INFO] [coprocessor.go:1262] ["[TIME_COP_PROCESS] resp_time:326.515625ms txnStartTS:18446744073709551615 region_id:22 store_addr:127.0.0.1:20160 kv_process_ms:324 kv_wait_ms:0 kv_read_ms:0 processed_versions:549986 total_versions:549987 rocksdb_delete_skipped_count:0 rocksdb_key_skipped_count:549986 rocksdb_cache_hit_count:3 rocksdb_read_count:1353 rocksdb_read_byte:44061302"]
    [2023/04/10 16:54:59.287 +08:00] [INFO] [handle.go:1412] ["[stats] incrementally update modifyCount"] [tableID=90] [curModifyCnt=1443200] [results.BaseModifyCnt=1443200] [modifyCount=0]
    [2023/04/10 16:54:59.287 +08:00] [INFO] [handle.go:1434] ["[stats] directly update count"] [tableID=90] [results.Count=10000000] [count=10000000]
    [2023/04/10 16:54:59.464 +08:00] [INFO] [analyze.go:590] ["analyze table `sbtest`.`sbtest1` has finished"] [partition=] ["job info"="auto analyze table all columns with 256 buckets, 500 topn, 0.010449541160647636 samplerate"] ["start time"=2023/04/10 16:54:51.909 +08:00] ["end time"=2023/04/10 16:54:59.463 +08:00] [cost=7.553206458s]
    [2023/04/10 16:55:00.362 +08:00] [INFO] [domain.go:2604] ["refreshServerIDTTL succeed"] [serverID=483282] ["lease id"=2231876a59be3a5d]
    [2023/04/10 16:55:00.648 +08:00] [INFO] [info.go:813] [ReportMinStartTS] ["initial minStartTS"=440694708794294272] [StartTSLowerLimit=440672059552694272]
    [2023/04/10 16:55:30.648 +08:00] [INFO] [info.go:813] [ReportMinStartTS] ["initial minStartTS"=440694716658614272] [StartTSLowerLimit=440672067417014272]
    [2023/04/10 16:56:00.648 +08:00] [INFO] [info.go:813] [ReportMinStartTS] ["initial minStartTS"=440694724523196416] [StartTSLowerLimit=440672075281596416]
    [2023/04/10 16:56:30.649 +08:00] [INFO] [info.go:813] [ReportMinStartTS] ["initial minStartTS"=440694732387516416] [StartTSLowerLimit=440672083145916416]
    [2023/04/10 16:57:00.649 +08:00] [INFO] [info.go:813] [ReportMinStartTS] ["initial minStartTS"=440694740251836416] [StartTSLowerLimit=440672091010236416]
    ```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
