### PR TITLE
*: fix bug that table name in 'admin show ddl jobs' is missing for ongoing drop table operation

### DIFF
--- a/ddl/stat_test.go
+++ b/ddl/stat_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/ddl"
+	"github.com/pingcap/tidb/ddl/internal/callback"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
@@ -33,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessiontxn"
 	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/testkit/external"
 	"github.com/pingcap/tidb/types"
 	"github.com/stretchr/testify/require"
 )
@@ -178,4 +180,37 @@ func buildCreateIdxJob(dbInfo *model.DBInfo, tblInfo *model.TableInfo, unique bo
 			WarningsCount: make(map[errors.ErrorID]int64),
 		},
 	}
+}
+
+func TestIssue42268(t *testing.T) {
+	// issue 42268 missing table name in 'admin show ddl' result during drop table
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t_0")
+	tk.MustExec("create table t_0 (c1 int, c2 int)")
+
+	tbl := external.GetTableByName(t, tk, "test", "t_0")
+	require.NotNil(t, tbl)
+	require.Equal(t, 2, len(tbl.Cols()))
+
+	tk1 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+
+	hook := &callback.TestDDLCallback{Do: dom}
+	hook.OnJobRunBeforeExported = func(job *model.Job) {
+		if tbl.Meta().ID != job.TableID {
+			return
+		}
+		switch job.SchemaState {
+		case model.StateNone:
+		case model.StateDeleteOnly, model.StateWriteOnly, model.StateWriteReorganization:
+			rs := tk1.MustQuery("admin show ddl jobs")
+			tblName := fmt.Sprintf("%s", rs.Rows()[0][2])
+			require.Equal(t, tblName, "t_0")
+		}
+	}
+	dom.DDL().SetHook(hook)
+
+	tk.MustExec("drop table t_0")
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -551,6 +551,9 @@ func (e *DDLJobRetriever) appendJobToChunk(req *chunk.Chunk, job *model.Job, che
 			schemaName = job.BinlogInfo.DBInfo.Name.L
 		}
 	}
+	if len(tableName) == 0 {
+		tableName = job.TableName
+	}
 	// For compatibility, the old version of DDL Job wasn't store the schema name and table name.
 	if len(schemaName) == 0 {
 		schemaName = getSchemaName(e.is, job.SchemaID)


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42268

Problem Summary:

### What is changed and how it works?

During drop table, the table is removed from the infoschema
So `getTableName` found nothing.
This cause the missing of the table name in 'admin show ddl jobs' result.

On the master branch, we can get the table name by `job.TableName`.
For older tidb, there is no `TableName` field, we need some other way to fix it.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug that table name in 'admin show ddl jobs' is missing for ongoing drop table operation
```
