### PR TITLE
table: fix transaction conflict on cached table's read lock updating caused long block

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -272,7 +272,7 @@ type CachedTable interface {
 	// TryReadFromCache checks if the cache table is readable.
 	TryReadFromCache(ts uint64, leaseDuration time.Duration) (kv.MemBuffer, bool)
 
-	// UpdateLockForRead If you cannot meet the conditions of the read buffer,
+	// UpdateLockForRead if you cannot meet the conditions of the read buffer,
 	// you need to update the lock information and read the data from the original table
 	UpdateLockForRead(ctx context.Context, store kv.Storage, ts uint64, leaseDuration time.Duration)
 

--- a/table/tables/cache.go
+++ b/table/tables/cache.go
@@ -183,7 +183,7 @@ func (c *cachedTable) loadDataFromOriginalTable(store kv.Storage) (kv.MemBuffer,
 }
 
 func (c *cachedTable) UpdateLockForRead(ctx context.Context, store kv.Storage, ts uint64, leaseDuration time.Duration) {
-	if h := c.TakeStateRemoteHandle(); h != nil {
+	if h := c.TakeStateRemoteHandleNoWait(); h != nil {
 		go c.updateLockForRead(ctx, h, store, ts, leaseDuration)
 	}
 }


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42925

Problem Summary:

### What is changed and how it works?

Before this change, `UpdateLockForRead` work in a blocking way:
Read operation from all the sessions wait on this operation to continue.

It's unnecessary, and when there are many tidb instances, update lock meta information conflicts a lot, result int long waiting.
In fact, it's safe to change `UpdateLockForRead` to non-waiting, the read will just skip the cache for this time.
The session does not need to block on it.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
