### PR TITLE
testkit: lock TxnCtx before reading from sessVars

### DIFF
--- a/testkit/mocksessionmanager.go
+++ b/testkit/mocksessionmanager.go
@@ -144,7 +144,10 @@ func (msm *MockSessionManager) GetInternalSessionStartTSList() []uint64 {
 	ret := make([]uint64, 0, len(msm.internalSessions))
 	for internalSess := range msm.internalSessions {
 		se := internalSess.(sessionctx.Context)
-		startTS := se.GetSessionVars().TxnCtx.StartTS
+		sessVars := se.GetSessionVars()
+		sessVars.TxnCtxMu.Lock()
+		startTS := sessVars.TxnCtx.StartTS
+		sessVars.TxnCtxMu.Unlock()
 		ret = append(ret, startTS)
 	}
 	return ret


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42933

Problem Summary: See #42933.

### What is changed and how it works?

Lock `TxnCtx` before reading from `sessVars` in mock session manager.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
