### PR TITLE
planner: reuse parameter types from Parser for non-prep plan cache

### DIFF
--- a/expression/constant.go
+++ b/expression/constant.go
@@ -130,10 +130,9 @@ func (c *Constant) GetType() *types.FieldType {
 	if c.ParamMarker != nil {
 		// GetType() may be called in multi-threaded context, e.g, in building inner executors of IndexJoin,
 		// so it should avoid data race. We achieve this by returning different FieldType pointer for each call.
-		tp := types.NewFieldType(mysql.TypeUnspecified)
-		dt := c.ParamMarker.GetUserVar()
-		types.InferParamTypeFromDatum(&dt, tp)
-		return tp
+		svars := c.ParamMarker.ctx.GetSessionVars()
+		tp := svars.PlanCacheParams.GetParamType(c.ParamMarker.order)
+		return &tp
 	}
 	return c.RetType
 }

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -63,7 +63,13 @@ func SetParameterValuesIntoSCtx(sctx sessionctx.Context, isNonPrep bool, markers
 			param.Datum = val
 			param.InExecute = true
 		}
-		vars.PlanCacheParams.AppendParam(val, *usingParam.GetType())
+		if isNonPrep {
+			vars.PlanCacheParams.AppendParam(val, *usingParam.GetType()) // reuse the parsed type from Parser
+		} else {
+			var t types.FieldType
+			types.InferParamTypeFromDatum(&val, &t)
+			vars.PlanCacheParams.AppendParam(val, t)
+		}
 	}
 	vars.PlanCacheParams.SetForNonPrepCache(isNonPrep)
 	return nil

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -63,7 +63,7 @@ func SetParameterValuesIntoSCtx(sctx sessionctx.Context, isNonPrep bool, markers
 			param.Datum = val
 			param.InExecute = true
 		}
-		vars.PlanCacheParams.Append(val)
+		vars.PlanCacheParams.AppendParam(val, *usingParam.GetType())
 	}
 	vars.PlanCacheParams.SetForNonPrepCache(isNonPrep)
 	return nil

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -63,6 +63,8 @@ func SetParameterValuesIntoSCtx(sctx sessionctx.Context, isNonPrep bool, markers
 			param.Datum = val
 			param.InExecute = true
 		}
+		// NOTE: an implicit assumption here is that parameter types of Non-Prep are already initialized by Parser,
+		// while parameter types of Prep are not initialized yet.
 		if isNonPrep {
 			vars.PlanCacheParams.AppendParam(val, *usingParam.GetType()) // reuse the parsed type from Parser
 		} else {

--- a/planner/core/plan_cache_param.go
+++ b/planner/core/plan_cache_param.go
@@ -151,15 +151,12 @@ func RestoreASTWithParams(ctx context.Context, _ sessionctx.Context, stmt ast.St
 }
 
 // Params2Expressions converts these parameters to an expression list.
-func Params2Expressions(params []*driver.ValueExpr, needInferType bool) []expression.Expression {
+// This function assumes that ValueExpr.Type is initialized.
+func Params2Expressions(params []*driver.ValueExpr) []expression.Expression {
 	exprs := make([]expression.Expression, 0, len(params))
 	for _, p := range params {
 		tp := new(types.FieldType)
-		if needInferType {
-			types.InferParamTypeFromDatum(&p.Datum, tp)
-		} else {
-			*tp = p.Type
-		}
+		*tp = p.Type
 		exprs = append(exprs, &expression.Constant{
 			Value:   p.Datum,
 			RetType: tp,

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -182,6 +182,7 @@ func TestNonPreparedPlanCacheParamTypeInfer(t *testing.T) {
 
 	tk.MustExec(`create table t1 (s1 char(20) character set latin1)`)
 	tk.MustExec(`insert into t1 values (date_format('2004-02-02','%M'))`) // no error
+	tk.MustQuery(`select * from t1`).Check(testkit.Rows(`February`))
 }
 
 func TestNonPreparedPlanCacheNullValue(t *testing.T) {

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -173,6 +173,17 @@ func TestNonPreparedPlanCacheEnumFilter(t *testing.T) {
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 }
 
+func TestNonPreparedPlanCacheParamTypeInfer(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=1")
+
+	tk.MustExec(`create table t1 (s1 char(20) character set latin1)`)
+	tk.MustExec(`insert into t1 values (date_format('2004-02-02','%M'))`) // no error
+}
+
 func TestNonPreparedPlanCacheNullValue(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -100,7 +100,7 @@ func getPlanFromNonPreparedPlanCache(ctx context.Context, sctx sessionctx.Contex
 		return nil, nil, false, err
 	}
 	val := sctx.GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL)
-	paramExprs := core.Params2Expressions(params)
+	paramExprs := core.Params2Expressions(params, false)
 
 	if val == nil {
 		// Create a new AST upon this parameterized SQL instead of using the original AST.

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -100,7 +100,7 @@ func getPlanFromNonPreparedPlanCache(ctx context.Context, sctx sessionctx.Contex
 		return nil, nil, false, err
 	}
 	val := sctx.GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL)
-	paramExprs := core.Params2Expressions(params, false)
+	paramExprs := core.Params2Expressions(params)
 
 	if val == nil {
 		// Create a new AST upon this parameterized SQL instead of using the original AST.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1715,6 +1715,11 @@ func (p *PlanCacheParamList) GetParamValue(idx int) types.Datum {
 	return p.paramValues[idx]
 }
 
+// GetParamType returns the type of the parameter at the specified index.
+func (p *PlanCacheParamList) GetParamType(idx int) types.FieldType {
+	return p.paramTypes[idx]
+}
+
 // AllParamValues returns all parameter values.
 func (p *PlanCacheParamList) AllParamValues() []types.Datum {
 	return p.paramValues


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36598

Problem Summary: planner: reuse parameter types from Parser for non-prep plan cache

### What is changed and how it works?

planner: reuse parameter types from Parser for non-prep plan cache

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
