### PR TITLE
bindinfo: lock before reading session ctx from BindHandle

### DIFF
--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -932,7 +932,9 @@ func (h *BindHandle) CaptureBaselines() {
 		if bindSQL == "" {
 			continue
 		}
+		h.sctx.Lock()
 		charset, collation := h.sctx.GetSessionVars().GetCharsetInfo()
+		h.sctx.Unlock()
 		binding := Binding{
 			BindSQL:   bindSQL,
 			Status:    Enabled,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42333

Problem Summary:

Read access:

https://github.com/pingcap/tidb/blob/a0e6ccb4e5a7ab62f253e6143700350aa27d1997/bindinfo/handle.go#L931-L938

Write access:

https://github.com/pingcap/tidb/blob/a0e6ccb4e5a7ab62f253e6143700350aa27d1997/bindinfo/handle.go#L216-L227

We should lock for both **read** and **write** access of the field that being protected.

### What is changed and how it works?

Omitted.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
