### PR TITLE
restore: split between tables

### DIFF
--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -385,6 +385,11 @@ func (rs *RegionSplitter) ScatterRegions(ctx context.Context, newRegions []*spli
 func getSplitKeys(rewriteRules *RewriteRules, ranges []rtree.Range, regions []*split.RegionInfo, isRawKv bool) map[uint64][][]byte {
 	splitKeyMap := make(map[uint64][][]byte)
 	checkKeys := make([][]byte, 0)
+	if rewriteRules != nil && len(rewriteRules.NewKeyspace) == 0 {
+		for _, rule := range rewriteRules.Data {
+			checkKeys = append(checkKeys, rule.NewKeyPrefix)
+		}
+	}
 	for _, rg := range ranges {
 		checkKeys = append(checkKeys, rg.EndKey)
 	}

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -479,10 +479,12 @@ func initRewriteRules() *restore.RewriteRules {
 
 // expected regions after split:
 //
-//	[, aay), [aay, bba), [bba, bbf), [bbf, bbh), [bbh, bbj),
-//	[bbj, cca), [cca, xxe), [xxe, xxz), [xxz, )
+//	[aa, aay), [aay, bba), [bba, bbf), [bbf, bbh), [bbh, bbj),
+//	[bbj, cca), [cca, xx), [xx, xxe), [xxe, xxz), [xxz, )
+//
+// Please note that "aa" has been rewritten to "xx", so the "bb" rewrite rule split point won't be included.
 func validateRegions(regions map[uint64]*split.RegionInfo) bool {
-	keys := [...]string{"", "aay", "bba", "bbf", "bbh", "bbj", "cca", "xxe", "xxz", ""}
+	keys := [...]string{"", "aay", "bba", "bbf", "bbh", "bbj", "cca", "xx", "xxe", "xxz", ""}
 	return validateRegionsExt(regions, keys[:], false)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42924

Problem Summary:
When restoring tables, for optimization, we are not going to split between tables:
(Referencing #27240)
```
before：
--|-------t1 data-------|-----|---t2 data-------|
after: 
----------t1 data-------|---------t2 data-------|

Legends:
'|' the split point
'-' the key space
```
This works fine as long as we are restoring tables sequentially and restoring tables after we finish splitting. However, for now, in some scenarios:
1. t2 starts its restoration, importing file to the very left region.
2. t1 starts its restoration too, and split region from left to right -- the table may be huge and take a long time to split the regions.
3. Newly split regions will be born from the very right region of `t1`, i.e. the very left region of `t2`. Which means... this region's epoch would change frequently, which probably blocks the import of t2.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
We detected this problem in an internal cluster, where v7.0.0 BR consistently fails, and with this PR we can restore to the cluster.
- [x] (Almost) No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed a bug that may cause BR failed to restore due to "epoch not match".
```
