### PR TITLE
planner: skip caching too large plan for plan cache

### DIFF
--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -388,6 +388,64 @@ func TestNonPreparedPlanCacheSQLMode(t *testing.T) {
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 }
 
+func TestPreparedPlanCacheLargePlan(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec("create table t(a int, b int, c varchar(2048))")
+
+	baseSQL := "select * from t, t t1 where t1.c=space(2048) and t.c=space(2048) and t.a=t1.b"
+	var baseSQLs []string
+	for i := 0; i < 30; i++ {
+		baseSQLs = append(baseSQLs, baseSQL)
+	}
+
+	tk.MustExec("prepare st from '" + strings.Join(baseSQLs[:15], " union all ") + "'")
+	tk.MustExec("execute st")
+	tk.MustExec("execute st")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1")) // less than 2MB threshold
+
+	tk.MustExec("prepare st from '" + strings.Join(baseSQLs[:30], " union all ") + "'")
+	tk.MustExec("execute st")
+	tk.MustExec("execute st")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0")) // large than 2MB threshold
+}
+
+func TestPreparedPlanCacheLongInList(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec("create table t(a int, b int)")
+
+	genInList := func(l int) string {
+		var elements []string
+		for i := 0; i < l; i++ {
+			elements = append(elements, fmt.Sprintf("%v", i))
+		}
+		return "(" + strings.Join(elements, ",") + ")"
+	}
+
+	tk.MustExec(fmt.Sprintf(`prepare st_99 from 'select * from t where a in %v'`, genInList(99)))
+	tk.MustExec(`execute st_99`)
+	tk.MustExec(`execute st_99`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+	tk.MustExec(fmt.Sprintf(`prepare st_101 from 'select * from t where a in %v'`, genInList(101)))
+	tk.MustExec(`execute st_101`)
+	tk.MustExec(`execute st_101`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+
+	tk.MustExec(fmt.Sprintf(`prepare st_49_50 from 'select * from t where a in %v and b in %v'`, genInList(49), genInList(50)))
+	tk.MustExec(`execute st_49_50`)
+	tk.MustExec(`execute st_49_50`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+	tk.MustExec(fmt.Sprintf(`prepare st_49_52 from 'select * from t where a in %v and b in %v'`, genInList(49), genInList(52)))
+	tk.MustExec(`execute st_49_52`)
+	tk.MustExec(`execute st_49_52`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+}
+
 func TestPreparedPlanCacheStats(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -29,6 +29,7 @@ import (
 	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/filter"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/size"
 	"go.uber.org/zap"
 )
 
@@ -51,9 +52,10 @@ func CacheableWithCtx(sctx sessionctx.Context, node ast.Node, is infoschema.Info
 		return false, "not a SELECT/UPDATE/INSERT/DELETE/SET statement"
 	}
 	checker := cacheableChecker{
-		sctx:      sctx,
-		cacheable: true,
-		schema:    is,
+		sctx:         sctx,
+		cacheable:    true,
+		schema:       is,
+		sumInListLen: 0,
 	}
 	node.Accept(&checker)
 	return checker.cacheable, checker.reason
@@ -65,6 +67,8 @@ type cacheableChecker struct {
 	cacheable bool
 	schema    infoschema.InfoSchema
 	reason    string // reason why cannot use plan-cache
+
+	sumInListLen int // the accumulated number of elements in all in-lists
 }
 
 // Enter implements Visitor interface.
@@ -114,7 +118,13 @@ func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren 
 				return in, true
 			}
 		}
-
+	case *ast.PatternInExpr:
+		checker.sumInListLen += len(node.List)
+		if checker.sumInListLen > 100 { // to save memory
+			checker.cacheable = false
+			checker.reason = "too many values in in-list (more than 100)"
+			return in, true
+		}
 	case *ast.VariableExpr:
 		checker.cacheable = false
 		checker.reason = "query has user-defined variables is un-cacheable"
@@ -593,6 +603,9 @@ func isPlanCacheable(sctx sessionctx.Context, p Plan, paramNum, limitParamNum in
 	}
 	if hasSubQuery && !sctx.GetSessionVars().EnablePlanCacheForSubquery {
 		return false, "the switch 'tidb_enable_plan_cache_for_subquery' is off"
+	}
+	if uint64(pp.MemoryUsage()) > 2*size.MB { // to save memory
+		return false, "plan is too large(>2MB)"
 	}
 	return isPhysicalPlanCacheable(sctx, pp, paramNum, limitParamNum, false)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42975

Problem Summary: planner: skip caching too large plan for plan cache

### What is changed and how it works?

Add 2 more strategies to prevent OOM caused by plan cache:
1. if the `in-list` is too long like `where a in (1, 2, ..., 10000)`, skip caching this plan;
2. if the final plan memory usage is large than `2MB`, skip caching this plan;

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
