### PR TITLE
br: pipeline backup schemas

### DIFF
--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -534,14 +534,14 @@ func BuildBackupRangeAndSchema(
 		}
 
 		tableNum := 0
-		err = m.GetTablesDoFunc(dbInfo.ID, func(tableInfo *model.TableInfo) error {
+		err = m.IterTables(dbInfo.ID, func(tableInfo *model.TableInfo) error {
 			if !tableFilter.MatchTable(dbInfo.Name.O, tableInfo.Name.O) {
 				// Skip tables other than the given table.
 				return nil
 			}
 
 			schemasNum += 1
-
+			tableNum += 1
 			if buildRange {
 				tableRanges, err := BuildTableRanges(tableInfo)
 				if err != nil {
@@ -572,7 +572,7 @@ func BuildBackupRangeAndSchema(
 		log.Info("nothing to backup")
 		return nil, nil, nil, nil
 	}
-	return ranges, NewBackupSchemasV2(schemasNum, tableFilter, isFullBackup), policies, nil
+	return ranges, NewBackupSchemasV2(schemasNum, backupTS, tableFilter, isFullBackup), policies, nil
 }
 
 func BuildBackupSchemas(
@@ -603,7 +603,7 @@ func BuildBackupSchemas(
 		}
 
 		tableNum := 0
-		err = m.GetTablesDoFunc(dbInfo.ID, func(tableInfo *model.TableInfo) error {
+		err = m.IterTables(dbInfo.ID, func(tableInfo *model.TableInfo) error {
 			if !tableFilter.MatchTable(dbInfo.Name.O, tableInfo.Name.O) {
 				// Skip tables other than the given table.
 				return nil

--- a/br/pkg/backup/schema_test.go
+++ b/br/pkg/backup/schema_test.go
@@ -150,8 +150,8 @@ func TestBuildBackupRangeAndSchema(t *testing.T) {
 	}
 	metaWriter := metautil.NewMetaWriter(es, metautil.MetaFileSize, false, "", &cipher)
 	ctx := context.Background()
-	err = backupSchemas.BackupSchemas(
-		ctx, metaWriter, nil, m.Storage, nil, math.MaxUint64, 1, variable.DefChecksumTableConcurrency, skipChecksum, updateCh)
+	err = backup.BackupSchemas(
+		ctx, backupSchemas, metaWriter, nil, m.Storage, nil, math.MaxUint64, 1, variable.DefChecksumTableConcurrency, skipChecksum, updateCh)
 	require.Equal(t, int64(1), updateCh.get())
 	require.NoError(t, err)
 	err = metaWriter.FlushBackupMeta(ctx)
@@ -179,8 +179,8 @@ func TestBuildBackupRangeAndSchema(t *testing.T) {
 
 	es2 := GetRandomStorage(t)
 	metaWriter2 := metautil.NewMetaWriter(es2, metautil.MetaFileSize, false, "", &cipher)
-	err = backupSchemas.BackupSchemas(
-		ctx, metaWriter2, nil, m.Storage, nil, math.MaxUint64, 2, variable.DefChecksumTableConcurrency, skipChecksum, updateCh)
+	err = backup.BackupSchemas(
+		ctx, backupSchemas, metaWriter2, nil, m.Storage, nil, math.MaxUint64, 2, variable.DefChecksumTableConcurrency, skipChecksum, updateCh)
 	require.Equal(t, int64(2), updateCh.get())
 	require.NoError(t, err)
 	err = metaWriter2.FlushBackupMeta(ctx)
@@ -233,8 +233,8 @@ func TestBuildBackupRangeAndSchemaWithBrokenStats(t *testing.T) {
 	es := GetRandomStorage(t)
 	metaWriter := metautil.NewMetaWriter(es, metautil.MetaFileSize, false, "", &cipher)
 	ctx := context.Background()
-	err = backupSchemas.BackupSchemas(
-		ctx, metaWriter, nil, m.Storage, nil, math.MaxUint64, 1, variable.DefChecksumTableConcurrency, skipChecksum, updateCh)
+	err = backup.BackupSchemas(
+		ctx, backupSchemas, metaWriter, nil, m.Storage, nil, math.MaxUint64, 1, variable.DefChecksumTableConcurrency, skipChecksum, updateCh)
 	require.NoError(t, err)
 	err = metaWriter.FlushBackupMeta(ctx)
 	require.NoError(t, err)
@@ -261,8 +261,8 @@ func TestBuildBackupRangeAndSchemaWithBrokenStats(t *testing.T) {
 	statsHandle := m.Domain.StatsHandle()
 	es2 := GetRandomStorage(t)
 	metaWriter2 := metautil.NewMetaWriter(es2, metautil.MetaFileSize, false, "", &cipher)
-	err = backupSchemas.BackupSchemas(
-		ctx, metaWriter2, nil, m.Storage, statsHandle, math.MaxUint64, 1, variable.DefChecksumTableConcurrency, skipChecksum, updateCh)
+	err = backup.BackupSchemas(
+		ctx, backupSchemas, metaWriter2, nil, m.Storage, statsHandle, math.MaxUint64, 1, variable.DefChecksumTableConcurrency, skipChecksum, updateCh)
 	require.NoError(t, err)
 	err = metaWriter2.FlushBackupMeta(ctx)
 	require.NoError(t, err)
@@ -305,7 +305,7 @@ func TestBackupSchemasForSystemTable(t *testing.T) {
 	updateCh := new(simpleProgress)
 
 	metaWriter2 := metautil.NewMetaWriter(es2, metautil.MetaFileSize, false, "", &cipher)
-	err = backupSchemas.BackupSchemas(ctx, metaWriter2, nil, m.Storage, nil,
+	err = backup.BackupSchemas(ctx, backupSchemas, metaWriter2, nil, m.Storage, nil,
 		math.MaxUint64, 1, variable.DefChecksumTableConcurrency, true, updateCh)
 	require.NoError(t, err)
 	err = metaWriter2.FlushBackupMeta(ctx)

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -2729,7 +2729,7 @@ func (rc *Client) SaveSchemas(
 
 	schemas := TidyOldSchemas(sr)
 	schemasConcurrency := uint(mathutil.Min(64, schemas.Len()))
-	err := schemas.BackupSchemas(ctx, metaWriter, nil, nil, nil, rc.restoreTS, schemasConcurrency, 0, true, nil)
+	err := backup.BackupSchemas(ctx, schemas, metaWriter, nil, nil, nil, rc.restoreTS, schemasConcurrency, 0, true, nil)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -668,8 +668,8 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	updateCh = g.StartProgress(ctx, "Checksum", checksumProgress, !cfg.LogProgress)
 	schemasConcurrency := uint(mathutil.Min(backup.DefaultSchemaConcurrency, schemas.Len()))
 
-	err = schemas.BackupSchemas(
-		ctx, metawriter, client.GetCheckpointRunner(), mgr.GetStorage(), statsHandle, backupTS, schemasConcurrency, cfg.ChecksumConcurrency, skipChecksum, updateCh)
+	err = backup.BackupSchemas(
+		ctx, schemas, metawriter, client.GetCheckpointRunner(), mgr.GetStorage(), statsHandle, backupTS, schemasConcurrency, cfg.ChecksumConcurrency, skipChecksum, updateCh)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -440,7 +440,7 @@ func (s *streamMgr) backupFullSchemas(ctx context.Context, g glue.Glue) error {
 	}
 
 	schemasConcurrency := uint(mathutil.Min(backup.DefaultSchemaConcurrency, schemas.Len()))
-	err = schemas.BackupSchemas(ctx, metaWriter, nil, s.mgr.GetStorage(), nil,
+	err = backup.BackupSchemas(ctx, schemas, metaWriter, nil, s.mgr.GetStorage(), nil,
 		s.cfg.StartTS, schemasConcurrency, 0, true, nil)
 	if err != nil {
 		return errors.Trace(err)

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -872,6 +872,31 @@ func (m *Meta) UpdateTable(dbID int64, tableInfo *model.TableInfo) error {
 	return errors.Trace(err)
 }
 
+func (m *Meta) GetTablesDoFunc(dbID int64, fn func(info *model.TableInfo) error) error {
+	dbKey := m.dbKey(dbID)
+	if err := m.checkDBExists(dbKey); err != nil {
+		return errors.Trace(err)
+	}
+
+	err := m.txn.HGetOnce(dbKey, func(r structure.HashPair) error {
+		// only handle table meta
+		tableKey := string(r.Field)
+		if !strings.HasPrefix(tableKey, mTablePrefix) {
+			return nil
+		}
+
+		tbInfo := &model.TableInfo{}
+		err := json.Unmarshal(r.Value, tbInfo)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		err = fn(tbInfo)
+		return errors.Trace(err)
+	})
+	return errors.Trace(err)
+}
+
 // ListTables shows all tables in database.
 func (m *Meta) ListTables(dbID int64) ([]*model.TableInfo, error) {
 	dbKey := m.dbKey(dbID)

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -872,13 +872,14 @@ func (m *Meta) UpdateTable(dbID int64, tableInfo *model.TableInfo) error {
 	return errors.Trace(err)
 }
 
-func (m *Meta) GetTablesDoFunc(dbID int64, fn func(info *model.TableInfo) error) error {
+// IterTables iterates all the table at once, in order to avoid oom.
+func (m *Meta) IterTables(dbID int64, fn func(info *model.TableInfo) error) error {
 	dbKey := m.dbKey(dbID)
 	if err := m.checkDBExists(dbKey); err != nil {
 		return errors.Trace(err)
 	}
 
-	err := m.txn.HGetOnce(dbKey, func(r structure.HashPair) error {
+	err := m.txn.HGetIter(dbKey, func(r structure.HashPair) error {
 		// only handle table meta
 		tableKey := string(r.Field)
 		if !strings.HasPrefix(tableKey, mTablePrefix) {

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -318,6 +318,20 @@ func TestMeta(t *testing.T) {
 	tables, err := m.ListTables(1)
 	require.NoError(t, err)
 	require.Equal(t, []*model.TableInfo{tbInfo, tbInfo2}, tables)
+	{
+		idx := 0
+		err := m.IterTables(1, func(info *model.TableInfo) error {
+			require.Less(t, idx, 2)
+			if idx == 0 {
+				require.Equal(t, tbInfo, info)
+				idx += 1
+			} else {
+				require.Equal(t, tbInfo2, info)
+			}
+			return nil
+		})
+		require.NoError(t, err)
+	}
 	// Generate an auto id.
 	n, err = m.GetAutoIDAccessors(1, 2).RowID().Inc(10)
 	require.NoError(t, err)
@@ -339,7 +353,16 @@ func TestMeta(t *testing.T) {
 	tables, err = m.ListTables(1)
 	require.NoError(t, err)
 	require.Equal(t, []*model.TableInfo{tbInfo}, tables)
-
+	{
+		idx := 0
+		err := m.IterTables(1, func(info *model.TableInfo) error {
+			require.Less(t, idx, 1)
+			require.Equal(t, tbInfo, info)
+			idx += 1
+			return nil
+		})
+		require.NoError(t, err)
+	}
 	// Test case for drop a table without delete auto id key-value entry.
 	tid := int64(100)
 	tbInfo100 := &model.TableInfo{

--- a/structure/hash.go
+++ b/structure/hash.go
@@ -166,7 +166,8 @@ func (t *TxStructure) HGetAll(key []byte) ([]HashPair, error) {
 	return res, errors.Trace(err)
 }
 
-func (t *TxStructure) HGetOnce(key []byte, fn func(pair HashPair) error) error {
+// HGetIter iterates all the fields and values in hash.
+func (t *TxStructure) HGetIter(key []byte, fn func(pair HashPair) error) error {
 	return t.iterateHash(key, func(field []byte, value []byte) error {
 		pair := HashPair{
 			Field: append([]byte{}, field...),

--- a/structure/hash.go
+++ b/structure/hash.go
@@ -166,6 +166,17 @@ func (t *TxStructure) HGetAll(key []byte) ([]HashPair, error) {
 	return res, errors.Trace(err)
 }
 
+func (t *TxStructure) HGetOnce(key []byte, fn func(pair HashPair) error) error {
+	return t.iterateHash(key, func(field []byte, value []byte) error {
+		pair := HashPair{
+			Field: append([]byte{}, field...),
+			Value: append([]byte{}, value...),
+		}
+
+		return fn(pair)
+	})
+}
+
 // HGetLen gets the length of hash.
 func (t *TxStructure) HGetLen(key []byte) (uint64, error) {
 	hashLen := 0

--- a/structure/structure_test.go
+++ b/structure/structure_test.go
@@ -222,6 +222,15 @@ func TestHash(t *testing.T) {
 		{Field: []byte("1"), Value: []byte("1")},
 		{Field: []byte("2"), Value: []byte("2")}}, res)
 
+	idx := 0
+	err = tx.HGetIter(key, func(pair structure.HashPair) error {
+		require.Less(t, idx, 2)
+		require.Equal(t, res[idx], pair)
+		idx += 1
+		return nil
+	})
+	require.NoError(t, err)
+
 	res, err = tx.HGetLastN(key, 1)
 	require.NoError(t, err)
 	require.Equal(t, []structure.HashPair{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43002 

Problem Summary:
when backup a large cluster, br will loads many table info into memory, which leads to oom.
### What is changed and how it works?
pipeline backup schemas
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
