### PR TITLE
lightning: Fix build failure on FreeBSD

### DIFF
--- a/br/pkg/lightning/backend/local/local_freebsd.go
+++ b/br/pkg/lightning/backend/local/local_freebsd.go
@@ -20,8 +20,9 @@ import (
 	"go.uber.org/zap"
 )
 
-type Rlim_t = int64
+// RlimT is the type of rlimit values.
+type RlimT = int64
 
-func zapRlim_t(key string, val Rlim_t) zap.Field {
+func zapRlimT(key string, val RlimT) zap.Field {
 	return zap.Int64(key, val)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43014 

Problem Summary:

Basically `Rlim_t` was renamed to `RlimT` `local_unix.go` and `local_unix_generic.go` but not in `local_freebsd.go`.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
