### PR TITLE
planner: optimize the parameterization(parser.Restore) performance for non-prep plan cache

### DIFF
--- a/planner/core/plan_cache_param.go
+++ b/planner/core/plan_cache_param.go
@@ -15,9 +15,9 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"strings"
 	"sync"
 
 	"github.com/pingcap/tidb/expression"
@@ -41,8 +41,7 @@ var (
 		return pr
 	}}
 	paramCtxPool = sync.Pool{New: func() interface{} {
-		buf := new(strings.Builder)
-		buf.Reset()
+		buf := new(bytes.Buffer)
 		restoreCtx := format.NewRestoreCtx(format.RestoreForNonPrepPlanCache|format.RestoreStringWithoutCharset|format.RestoreStringSingleQuotes|format.RestoreNameBackQuotes, buf)
 		return restoreCtx
 	}}
@@ -106,14 +105,14 @@ func ParameterizeAST(ctx context.Context, sctx sessionctx.Context, stmt ast.Stmt
 	defer func() {
 		pr.Reset()
 		paramReplacerPool.Put(pr)
-		pCtx.In.(*strings.Builder).Reset()
+		pCtx.In.(*bytes.Buffer).Reset()
 		paramCtxPool.Put(pCtx)
 	}()
 	stmt.Accept(pr)
 	if err := stmt.Restore(pCtx); err != nil {
 		return "", nil, err
 	}
-	paramSQL, params = pCtx.In.(*strings.Builder).String(), pr.params
+	paramSQL, params = pCtx.In.(*bytes.Buffer).String(), pr.params
 	return
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36598

Problem Summary: planner: optimize the parameterization performance for non-prep plan cache

### What is changed and how it works?

4X faster and 6X less memory allocation after this optimization:
```
Before
BenchmarkParameterizeInsert-8             420446              2722 ns/op            1144 B/op         61 allocs/op

After
BenchmarkParameterizeInsert-8            1760029               678.6 ns/op           176 B/op          4 allocs/op
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
