### PR TITLE
planner: introduce a new variable to control the maximum size of plans that can be cached

### DIFF
--- a/planner/core/BUILD.bazel
+++ b/planner/core/BUILD.bazel
@@ -271,6 +271,7 @@ go_test(
         "//util/plancodec",
         "//util/ranger",
         "//util/set",
+        "//util/size",
         "//util/stmtsummary",
         "//util/tracing",
         "@com_github_golang_snappy//:snappy",

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/pingcap/tidb/util/size"
 	"math/rand"
 	"strings"
 	"sync"
@@ -36,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/size"
 	"github.com/stretchr/testify/require"
 )
 

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -1735,12 +1735,7 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"select * from t3 where a > 1 and full_name = 'a b'",
 		"select * from v",                // view
 		"select * from t where a = null", // null
-		"select * from t where a = 1 or a = 2 or a = 3 or a = 4 or a = 5 or a = 6 or a = 7 or a = 8 or a = 9 or a = 10 or " +
-			"a = 11 or a = 12 or a = 13 or a = 14 or a = 15 or a = 16 or a = 17 or a = 18 or a = 19 or a = 20 or " +
-			"a = 21 or a = 22 or a = 23 or a = 24 or a = 25 or a = 26 or a = 27 or a = 28 or a = 29 or a = 30 or " +
-			"a = 31 or a = 32 or a = 33 or a = 34 or a = 35 or a = 36 or a = 37 or a = 38 or a = 39 or a = 40 or " +
-			"a = 41 or a = 42 or a = 43 or a = 44 or a = 45 or a = 46 or a = 47 or a = 48 or a = 49 or a = 50 or a = 51", // more than 50 constants
-		"select * from t where false", // table dual
+		"select * from t where false",    // table dual
 	}
 
 	reasons := []string{
@@ -1762,7 +1757,6 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"skip non-prepared plan-cache: queries that have generated columns are not supported",
 		"skip non-prepared plan-cache: queries that access views are not supported",
 		"skip non-prepared plan-cache: query has null constants",
-		"skip non-prepared plan-cache: query has more than 50 constants",
 		"skip non-prepared plan-cache: get a TableDual plan",
 	}
 

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -239,23 +239,23 @@ func TestNonPreparedPlanCacheTooManyConsts(t *testing.T) {
 	tk.MustExec("set tidb_enable_non_prepared_plan_cache=1")
 
 	var x []string
-	for i := 0; i < 51; i++ {
+	for i := 0; i < 201; i++ {
 		x = append(x, fmt.Sprintf("%v", i))
 	}
-	list49 := strings.Join(x[:49], ", ")
-	list50 := strings.Join(x[:50], ", ")
-	list51 := strings.Join(x[:51], ", ")
+	list1 := strings.Join(x[:199], ", ")
+	list2 := strings.Join(x[:200], ", ")
+	list3 := strings.Join(x[:201], ", ")
 
-	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list49))
-	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list49))
+	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list1))
+	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list1))
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
-	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list50))
-	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list50))
+	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list2))
+	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list2))
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
 	// query has more than 50 consts cannot hit
-	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list51))
-	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list51))
+	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list3))
+	tk.MustExec(fmt.Sprintf(`select * from t where a in (%v)`, list3))
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 }
 

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/pingcap/tidb/util/size"
 	"math/rand"
 	"strings"
 	"sync"
@@ -420,6 +421,11 @@ func TestPreparedPlanCacheLargePlan(t *testing.T) {
 	tk.MustExec("execute st")
 	tk.MustExec("execute st")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0")) // large than 2MB threshold
+
+	tk.MustExec(fmt.Sprintf("set tidb_plan_cache_max_plan_size=%v", 1*size.GB))
+	tk.MustExec("execute st")
+	tk.MustExec("execute st")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1")) // less than 1GB threshold
 }
 
 func TestPreparedPlanCacheLongInList(t *testing.T) {

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -30,7 +30,6 @@ import (
 	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/filter"
 	"github.com/pingcap/tidb/util/logutil"
-	"github.com/pingcap/tidb/util/size"
 	"go.uber.org/zap"
 )
 
@@ -610,8 +609,8 @@ func isPlanCacheable(sctx sessionctx.Context, p Plan, paramNum, limitParamNum in
 	if hasSubQuery && !sctx.GetSessionVars().EnablePlanCacheForSubquery {
 		return false, "the switch 'tidb_enable_plan_cache_for_subquery' is off"
 	}
-	if uint64(pp.MemoryUsage()) > 2*size.MB { // to save memory
-		return false, "plan is too large(>2MB)"
+	if sctx.GetSessionVars().PlanCacheMaxPlanSize > 0 && uint64(pp.MemoryUsage()) > sctx.GetSessionVars().PlanCacheMaxPlanSize { // to save memory
+		return false, "plan is too large(decided by the variable @@tidb_plan_cache_max_plan_size)"
 	}
 	return isPhysicalPlanCacheable(sctx, pp, paramNum, limitParamNum, false)
 }

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -443,9 +443,9 @@ func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (out ast.Node
 			checker.reason = "query has null constants"
 		}
 		checker.constCnt++
-		if checker.constCnt > 50 { // just for safety and reduce memory cost
+		if checker.constCnt > 200 { // just for safety and reduce memory cost
 			checker.cacheable = false
-			checker.reason = "query has more than 50 constants"
+			checker.reason = "query has more than 200 constants"
 		}
 		return in, !checker.cacheable
 	case *ast.GroupByClause:

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1315,6 +1315,9 @@ type SessionVars struct {
 	// NonPreparedPlanCacheSize controls the size of non-prepared plan cache.
 	NonPreparedPlanCacheSize uint64
 
+	// PlanCacheMaxPlanSize controls the maximum size of a plan that can be cached.
+	PlanCacheMaxPlanSize uint64
+
 	// ConstraintCheckInPlacePessimistic controls whether to skip the locking of some keys in pessimistic transactions.
 	// Postpone the conflict check and constraint check to prewrite or later pessimistic locking requests.
 	ConstraintCheckInPlacePessimistic bool

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1128,6 +1128,13 @@ var defaultSysVars = []*SysVar{
 		}
 		return err
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBPlanCacheMaxPlanSize, Value: strconv.FormatUint(DefTiDBPlanCacheMaxPlanSize, 10), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxUint64, SetSession: func(s *SessionVars, val string) error {
+		uVal, err := strconv.ParseUint(val, 10, 64)
+		if err == nil {
+			s.PlanCacheMaxPlanSize = uVal
+		}
+		return err
+	}},
 	{Scope: ScopeGlobal, Name: TiDBMemOOMAction, Value: DefTiDBMemOOMAction, PossibleValues: []string{"CANCEL", "LOG"}, Type: TypeEnum,
 		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 			return OOMAction.Load(), nil

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -781,6 +781,8 @@ const (
 	TiDBEnableNonPreparedPlanCache = "tidb_enable_non_prepared_plan_cache"
 	// TiDBNonPreparedPlanCacheSize controls the size of non-prepared plan cache.
 	TiDBNonPreparedPlanCacheSize = "tidb_non_prepared_plan_cache_size"
+	// TiDBPlanCacheMaxPlanSize controls the maximum size of a plan that can be cached.
+	TiDBPlanCacheMaxPlanSize = "tidb_plan_cache_max_plan_size"
 
 	// TiDBConstraintCheckInPlacePessimistic controls whether to skip certain kinds of pessimistic locks.
 	TiDBConstraintCheckInPlacePessimistic = "tidb_constraint_check_in_place_pessimistic"
@@ -1195,6 +1197,7 @@ const (
 	DefExecutorConcurrency                         = 5
 	DefTiDBEnableNonPreparedPlanCache              = false
 	DefTiDBNonPreparedPlanCacheSize                = 100
+	DefTiDBPlanCacheMaxPlanSize                    = 2 * size.MB
 	DefTiDBEnableTiFlashReadForWriteStmt           = false
 	// MaxDDLReorgBatchSize is exported for testing.
 	MaxDDLReorgBatchSize                  int32  = 10240


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42975

Problem Summary: planner: introduce a new variable to control the maximum size of plans that can be cached

### What is changed and how it works?

planner: introduce a new variable to control the maximum size of plans that can be cached

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
