### PR TITLE
executor,util: Correct error for MAX_EXECUTION_TIME | tidb-test=pr/2115

### DIFF
--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -822,11 +822,11 @@ const (
 	ErrMustChangePasswordLogin                               = 1862
 	ErrRowInWrongPartition                                   = 1863
 	ErrErrorLast                                             = 1863
-	ErrMaxExecTimeExceeded                                   = 1907
 	ErrForeignKeyCascadeDepthExceeded                        = 3008
 	ErrInvalidFieldSize                                      = 3013
 	ErrPasswordExpireAnonymousUser                           = 3016
 	ErrInvalidArgumentForLogarithm                           = 3020
+	ErrMaxExecTimeExceeded                                   = 3024
 	ErrAggregateOrderNonAggQuery                             = 3029
 	ErrUserLockWrongName                                     = 3057
 	ErrUserLockDeadlock                                      = 3058

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -886,7 +886,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrWindowExplainJSON:                                     mysql.Message("To get information about window functions use EXPLAIN FORMAT=JSON", nil),
 	ErrWindowFunctionIgnoresFrame:                            mysql.Message("Window function '%s' ignores the frame clause of window '%s' and aggregates over the whole partition", nil),
 	ErrRoleNotGranted:                                        mysql.Message("%s is not granted to %s", nil),
-	ErrMaxExecTimeExceeded:                                   mysql.Message("Query execution was interrupted, max_execution_time exceeded.", nil),
+	ErrMaxExecTimeExceeded:                                   mysql.Message("Query execution was interrupted, maximum statement execution time exceeded", nil),
 	ErrLockAcquireFailAndNoWaitSet:                           mysql.Message("Statement aborted because lock(s) could not be acquired immediately and NOWAIT is set.", nil),
 	ErrNotHintUpdatable:                                      mysql.Message("Variable '%s' cannot be set using SET_VAR hint.", nil),
 	ErrExistsInHistoryPassword:                               mysql.Message("Cannot use these credentials for '%s@%s' because they contradict the password history policy.", nil),

--- a/errors.toml
+++ b/errors.toml
@@ -1566,6 +1566,11 @@ error = '''
 The password for anonymous user cannot be expired.
 '''
 
+["executor:3024"]
+error = '''
+Query execution was interrupted, maximum statement execution time exceeded
+'''
+
 ["executor:3523"]
 error = '''
 Unknown authorization ID %.256s

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -2550,7 +2550,7 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 	if x, ok := s.Expr.(*ast.FuncCallExpr); ok {
 		if x.FnName.L == ast.ConnectionID {
 			sm := e.ctx.GetSessionManager()
-			sm.Kill(e.ctx.GetSessionVars().ConnectionID, s.Query)
+			sm.Kill(e.ctx.GetSessionVars().ConnectionID, s.Query, false)
 			return nil
 		}
 		return errors.New("Invalid operation. Please use 'KILL TIDB [CONNECTION | QUERY] [connectionID | CONNECTION_ID()]' instead")
@@ -2562,7 +2562,7 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 			if sm == nil {
 				return nil
 			}
-			sm.Kill(s.ConnectionID, s.Query)
+			sm.Kill(s.ConnectionID, s.Query, false)
 		} else {
 			err := errors.New("Invalid operation. Please use 'KILL TIDB [CONNECTION | QUERY] [connectionID | CONNECTION_ID()]' instead")
 			e.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
@@ -2577,7 +2577,7 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 	if e.IsFromRemote {
 		logutil.BgLogger().Info("Killing connection in current instance redirected from remote TiDB", zap.Uint64("conn", s.ConnectionID), zap.Bool("query", s.Query),
 			zap.String("sourceAddr", e.ctx.GetSessionVars().SourceAddr.IP.String()))
-		sm.Kill(s.ConnectionID, s.Query)
+		sm.Kill(s.ConnectionID, s.Query, false)
 		return nil
 	}
 
@@ -2603,7 +2603,7 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 			e.ctx.GetSessionVars().StmtCtx.AppendWarning(err1)
 		}
 	} else {
-		sm.Kill(s.ConnectionID, s.Query)
+		sm.Kill(s.ConnectionID, s.Query, false)
 	}
 
 	return nil

--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -359,7 +359,13 @@ func doSleep(secs float64, sessVars *variable.SessionVars) (isKilled bool) {
 	for {
 		select {
 		case <-ticker.C:
+			// Regular kill
 			if atomic.CompareAndSwapUint32(&sessVars.Killed, 1, 0) {
+				timer.Stop()
+				return true
+			}
+			// Killed because of max execution time
+			if atomic.CompareAndSwapUint32(&sessVars.Killed, 2, 0) {
 				timer.Stop()
 				return true
 			}

--- a/parser/mysql/errcode.go
+++ b/parser/mysql/errcode.go
@@ -882,9 +882,9 @@ const (
 	ErrMustChangePasswordLogin                               = 1862
 	ErrRowInWrongPartition                                   = 1863
 	ErrErrorLast                                             = 1863
-	ErrMaxExecTimeExceeded                                   = 1907
 	ErrInvalidFieldSize                                      = 3013
 	ErrPasswordExpireAnonymousUser                           = 3016
+	ErrMaxExecTimeExceeded                                   = 3024
 	ErrIncorrectType                                         = 3064
 	ErrInvalidJSONData                                       = 3069
 	ErrGeneratedColumnFunctionIsNotAllowed                   = 3102

--- a/parser/mysql/errname.go
+++ b/parser/mysql/errname.go
@@ -935,7 +935,7 @@ var MySQLErrName = map[uint16]*ErrMessage{
 	ErrWindowExplainJson:                                     Message("To get information about window functions use EXPLAIN FORMAT=JSON", nil),
 	ErrWindowFunctionIgnoresFrame:                            Message("Window function '%s' ignores the frame clause of window '%s' and aggregates over the whole partition", nil),
 	ErrRoleNotGranted:                                        Message("%s is not granted to %s", nil),
-	ErrMaxExecTimeExceeded:                                   Message("Query execution was interrupted, max_execution_time exceeded.", nil),
+	ErrMaxExecTimeExceeded:                                   Message("Query execution was interrupted, maximum statement execution time exceeded", nil),
 	ErrLockAcquireFailAndNoWaitSet:                           Message("Statement aborted because lock(s) could not be acquired immediately and NOWAIT is set.", nil),
 	ErrDataTruncatedFunctionalIndex:                          Message("Data truncated for functional index '%s' at row %d", nil),
 	ErrDataOutOfRangeFunctionalIndex:                         Message("Value is out of range for functional index '%s' at row %d", nil),

--- a/server/server.go
+++ b/server/server.go
@@ -37,7 +37,6 @@ import (
 	"math/rand"
 	"net"
 	"net/http" //nolint:goimports
-
 	// For pprof
 	_ "net/http/pprof" // #nosec G108
 	"os"

--- a/testkit/mocksessionmanager.go
+++ b/testkit/mocksessionmanager.go
@@ -104,7 +104,7 @@ func (msm *MockSessionManager) GetProcessInfo(id uint64) (*util.ProcessInfo, boo
 }
 
 // Kill implements the SessionManager.Kill interface.
-func (*MockSessionManager) Kill(uint64, bool) {
+func (*MockSessionManager) Kill(uint64, bool, bool) {
 }
 
 // KillAllConnections implements the SessionManager.KillAllConnections interface.
@@ -159,12 +159,12 @@ func (msm *MockSessionManager) KillNonFlashbackClusterConn() {
 		processInfo := se.ShowProcess()
 		ddl, ok := processInfo.StmtCtx.GetPlan().(*core.DDL)
 		if !ok {
-			msm.Kill(se.GetSessionVars().ConnectionID, false)
+			msm.Kill(se.GetSessionVars().ConnectionID, false, false)
 			continue
 		}
 		_, ok = ddl.Statement.(*ast.FlashBackToTimestampStmt)
 		if !ok {
-			msm.Kill(se.GetSessionVars().ConnectionID, false)
+			msm.Kill(se.GetSessionVars().ConnectionID, false, false)
 			continue
 		}
 	}

--- a/util/dbterror/exeerrors/errors.go
+++ b/util/dbterror/exeerrors/errors.go
@@ -50,6 +50,7 @@ var (
 	ErrRoleNotGranted                = dbterror.ClassPrivilege.NewStd(mysql.ErrRoleNotGranted)
 	ErrDeadlock                      = dbterror.ClassExecutor.NewStd(mysql.ErrLockDeadlock)
 	ErrQueryInterrupted              = dbterror.ClassExecutor.NewStd(mysql.ErrQueryInterrupted)
+	ErrMaxExecTimeExceeded           = dbterror.ClassExecutor.NewStd(mysql.ErrMaxExecTimeExceeded)
 	ErrDynamicPrivilegeNotRegistered = dbterror.ClassExecutor.NewStd(mysql.ErrDynamicPrivilegeNotRegistered)
 	ErrIllegalPrivilegeLevel         = dbterror.ClassExecutor.NewStd(mysql.ErrIllegalPrivilegeLevel)
 	ErrInvalidSplitRegionRanges      = dbterror.ClassExecutor.NewStd(mysql.ErrInvalidSplitRegionRanges)

--- a/util/expensivequery/expensivequery.go
+++ b/util/expensivequery/expensivequery.go
@@ -69,14 +69,14 @@ func (eqh *Handle) Run() {
 				if info.MaxExecutionTime > 0 && costTime > time.Duration(info.MaxExecutionTime)*time.Millisecond {
 					logutil.BgLogger().Warn("execution timeout, kill it", zap.Duration("costTime", costTime),
 						zap.Duration("maxExecutionTime", time.Duration(info.MaxExecutionTime)*time.Millisecond), zap.String("processInfo", info.String()))
-					sm.Kill(info.ID, true)
+					sm.Kill(info.ID, true, true)
 				}
 				if info.ID == util.GetAutoAnalyzeProcID(sm.ServerID) {
 					maxAutoAnalyzeTime := variable.MaxAutoAnalyzeTime.Load()
 					if maxAutoAnalyzeTime > 0 && costTime > time.Duration(maxAutoAnalyzeTime)*time.Second {
 						logutil.BgLogger().Warn("auto analyze timeout, kill it", zap.Duration("costTime", costTime),
 							zap.Duration("maxAutoAnalyzeTime", time.Duration(maxAutoAnalyzeTime)*time.Second), zap.String("processInfo", info.String()))
-						sm.Kill(info.ID, true)
+						sm.Kill(info.ID, true, false)
 					}
 				}
 			}

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -184,7 +184,7 @@ type SessionManager interface {
 	ShowProcessList() map[uint64]*ProcessInfo
 	ShowTxnList() []*txninfo.TxnInfo
 	GetProcessInfo(id uint64) (*ProcessInfo, bool)
-	Kill(connectionID uint64, query bool)
+	Kill(connectionID uint64, query bool, maxExecutionTime bool)
 	KillAllConnections()
 	UpdateTLSConfig(cfg *tls.Config)
 	ServerID() uint64


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43031 

Problem Summary:

- The query gets killed if it hits the max execution time
- Where we return an error to the client we don't know why the query was killed, so we return a generic error

This PR changes this so that `Killed` gets set to 2 instead of  1 if the query was killed because of the max execution time and then later uses this to send the right error to the client.

1. Why is `Killed` a `uint32` instead of a bool?
2. Is using a `Killed` value other than 0 or 1 safe? Or should we change checks from `==1` to `>0` etc?
3. Is there a better way to communicate the reason something was killed to the goroutine/process that sends the error to the client?

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The error message that is returned by the server if a query hits the `MAX_EXECUTION_TIME` was made to match the error that MySQL returns.
```

### Related PRs
- https://github.com/pingcap/tidb-test/pull/2115