### PR TITLE
planner: escape the string when display `Range` to make it more clear | tidb-test=pr/2116

### DIFF
--- a/types/datum.go
+++ b/types/datum.go
@@ -457,28 +457,44 @@ func (d Datum) String() string {
 		t = "KindString"
 	case KindBytes:
 		t = "KindBytes"
+	case KindBinaryLiteral:
+		t = "KindBinaryLiteral"
 	case KindMysqlDecimal:
 		t = "KindMysqlDecimal"
 	case KindMysqlDuration:
 		t = "KindMysqlDuration"
 	case KindMysqlEnum:
 		t = "KindMysqlEnum"
-	case KindBinaryLiteral:
-		t = "KindBinaryLiteral"
 	case KindMysqlBit:
 		t = "KindMysqlBit"
 	case KindMysqlSet:
 		t = "KindMysqlSet"
-	case KindMysqlJSON:
-		t = "KindMysqlJSON"
 	case KindMysqlTime:
 		t = "KindMysqlTime"
+	case KindInterface:
+		t = "KindInterface"
+	case KindMinNotNull:
+		t = "KindMinNotNull"
+	case KindMaxValue:
+		t = "KindMaxValue"
+	case KindRaw:
+		t = "KindRaw"
+	case KindMysqlJSON:
+		t = "KindMysqlJSON"
 	default:
 		t = "Unknown"
 	}
 	v := d.GetValue()
-	if b, ok := v.([]byte); ok && d.k == KindBytes {
-		v = string(b)
+	switch v.(type) {
+	case []byte, string:
+		quote := `"`
+		// We only need the escape functionality of %q, the quoting is not needed,
+		// so we trim the \" prefix and suffix here.
+		v = strings.TrimSuffix(
+			strings.TrimPrefix(
+				fmt.Sprintf("%q", v),
+				quote),
+			quote)
 	}
 	return fmt.Sprintf("%v %v", t, v)
 }

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1432,14 +1432,14 @@ create table t(
 			exprStr:     `a LIKE "\\"`,
 			accessConds: "[like(test.t.a, \\, 92)]",
 			filterConds: "[]",
-			resultStr:   "[[\"\\\",\"\\\"]]",
+			resultStr:   "[[\"\\\\\",\"\\\\\"]]",
 		},
 		{
 			indexPos:    0,
 			exprStr:     `a LIKE "\\\\a%"`,
 			accessConds: `[like(test.t.a, \\a%, 92)]`,
 			filterConds: "[]",
-			resultStr:   "[[\"\\a\",\"\\b\")]",
+			resultStr:   "[[\"\\\\a\",\"\\\\b\")]",
 		},
 		{
 			indexPos:    0,
@@ -1663,7 +1663,7 @@ create table t(
 			exprStr:     `h LIKE 'ÿÿ%'`,
 			accessConds: `[like(test.t.h, ÿÿ%, 92)]`,
 			filterConds: "[like(test.t.h, ÿÿ%, 92)]",
-			resultStr:   "[[\"ÿÿ\",\"ÿ\xc3\xc0\")]", // The decoding error is ignored.
+			resultStr:   "[[\"ÿÿ\",\"ÿ\\xc3\\xc0\")]", // The decoding error is ignored.
 		},
 	}
 

--- a/util/ranger/types.go
+++ b/util/ranger/types.go
@@ -270,7 +270,9 @@ func formatDatum(d types.Datum, isLeftSide bool) string {
 		}
 	case types.KindBytes:
 		return fmt.Sprintf("0x%X", d.GetValue())
-	case types.KindString, types.KindMysqlEnum, types.KindMysqlSet,
+	case types.KindString:
+		return fmt.Sprintf("%q", d.GetValue())
+	case types.KindMysqlEnum, types.KindMysqlSet,
 		types.KindMysqlJSON, types.KindBinaryLiteral, types.KindMysqlBit:
 		return fmt.Sprintf("\"%v\"", d.GetValue())
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref  #43045

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Tested as in the issue.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
