### PR TITLE
backup: check the store state by last heartbeat

### DIFF
--- a/br/pkg/backup/push.go
+++ b/br/pkg/backup/push.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
@@ -20,6 +21,11 @@ import (
 	"github.com/pingcap/tidb/br/pkg/rtree"
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"go.uber.org/zap"
+)
+
+const (
+	// from PD: https://github.com/tikv/pd/blob/c40e319f50822678cda71ae62ee2fd70a9cac010/pkg/core/store.go#L523
+	storeDisconnectionDuration = 20 * time.Second
 )
 
 // pushDown wraps a backup task.
@@ -51,6 +57,20 @@ func newPushDown(mgr ClientMgr, capacity int) *pushDown {
 	}
 }
 
+func checkStoreLiveness(s *metapb.Store) error {
+	if s.State != metapb.StoreState_Up {
+		return errors.Annotatef(berrors.ErrKVStorage, "the store state isn't up, it is %s", s.State)
+	}
+	// If the field isn't present (the default value), skip this check.
+	if s.GetLastHeartbeat() > 0 {
+		lastHeartBeat := time.Unix(0, s.GetLastHeartbeat())
+		if sinceLastHB := time.Since(lastHeartBeat); sinceLastHB > storeDisconnectionDuration {
+			return errors.Annotatef(berrors.ErrKVStorage, "the store last heartbeat is too long ago, it is %s", sinceLastHB)
+		}
+	}
+	return nil
+}
+
 // FullBackup make a full backup of a tikv cluster.
 func (push *pushDown) pushBackup(
 	ctx context.Context,
@@ -77,8 +97,8 @@ func (push *pushDown) pushBackup(
 		store := s
 		storeID := s.GetId()
 		lctx := logutil.ContextWithField(ctx, zap.Uint64("store-id", storeID))
-		if s.GetState() != metapb.StoreState_Up {
-			logutil.CL(lctx).Warn("skip store", zap.Stringer("State", s.GetState()))
+		if err := checkStoreLiveness(s); err != nil {
+			logutil.CL(lctx).Warn("skip store", logutil.ShortError(err))
 			continue
 		}
 		client, err := push.mgr.GetBackupClient(lctx, storeID)
@@ -86,7 +106,7 @@ func (push *pushDown) pushBackup(
 			// BR should be able to backup even some of stores disconnected.
 			// The regions managed by this store can be retried at fine-grained backup then.
 			logutil.CL(lctx).Warn("fail to connect store, skipping", zap.Error(err))
-			return nil
+			continue
 		}
 		wg.Add(1)
 		go func() {

--- a/br/pkg/utils/misc.go
+++ b/br/pkg/utils/misc.go
@@ -19,11 +19,22 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	// storeDisconnectionDuration is the max duration of a store to be treated as living.
+	// when a store doesn't send heartbeat for 100s, it is probably offline, and most of leaders should be transformed.
+	// (How about network partition between TiKV and PD? Even that is rare.)
+	// Also note that the offline threshold in PD is 20s, see
+	// https://github.com/tikv/pd/blob/c40e319f50822678cda71ae62ee2fd70a9cac010/pkg/core/store.go#L523
+	storeDisconnectionDuration = 100 * time.Second
 )
 
 // IsTypeCompatible checks whether type target is compatible with type src
@@ -102,4 +113,21 @@ func GRPCConn(ctx context.Context, storeAddr string, tlsConf *tls.Config, opts .
 		return nil, errors.Trace(err)
 	}
 	return connection, nil
+}
+
+// CheckStoreLiveness checks whether a store is still alive.
+// Some versions of PD may not set the store state in the gRPC response.
+// We need to check it manually.
+func CheckStoreLiveness(s *metapb.Store) error {
+	if s.State != metapb.StoreState_Up {
+		return errors.Annotatef(berrors.ErrKVStorage, "the store state isn't up, it is %s", s.State)
+	}
+	// If the field isn't present (the default value), skip this check.
+	if s.GetLastHeartbeat() > 0 {
+		lastHeartBeat := time.Unix(0, s.GetLastHeartbeat())
+		if sinceLastHB := time.Since(lastHeartBeat); sinceLastHB > storeDisconnectionDuration {
+			return errors.Annotatef(berrors.ErrKVStorage, "the store last heartbeat is too far, at %s", sinceLastHB)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42973

Problem Summary:
The current implementation cannot detect whether a store is down. So it keeps retry sending request to an offline store.

### What is changed and how it works?
This PR checks the `LastHeartbeatTS` of the store and give up to request the store once the gap is greater than 20s (also defined in the PD package.)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)
Backup over a cluster with one node down, finished in reasonable time.
<img width="1918" alt="image" src="https://user-images.githubusercontent.com/36239017/232451863-c716e923-49c7-4d1b-bbd6-38c7442b0150.png">


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed a bug that caused backup get very slow when there are down TiKV nodes in the cluster.
```
