### PR TITLE
plugin: remove the limitation of decoding a plugin name

### DIFF
--- a/errno/errname.go
+++ b/errno/errname.go
@@ -945,7 +945,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrDropTableOnTemporaryTable:        mysql.Message("`drop global temporary table` can only drop global temporary table", nil),
 	ErrTxnTooLarge:                      mysql.Message("Transaction is too large, size: %d", nil),
 	ErrWriteConflictInTiDB:              mysql.Message("Write conflict, txnStartTS %d is stale", nil),
-	ErrInvalidPluginID:                  mysql.Message("Wrong plugin id: %s, valid plugin id is [name]-[version], both name and version should not contain '-'", nil),
+	ErrInvalidPluginID:                  mysql.Message("Wrong plugin id: %s, valid plugin id is [name]-[version], and version should not contain '-'", nil),
 	ErrInvalidPluginManifest:            mysql.Message("Cannot read plugin %s's manifest", nil),
 	ErrInvalidPluginName:                mysql.Message("Plugin load with %s but got wrong name %s", nil),
 	ErrInvalidPluginVersion:             mysql.Message("Plugin load with %s but got %s", nil),

--- a/plugin/helper.go
+++ b/plugin/helper.go
@@ -44,12 +44,12 @@ type ID string
 
 // Decode decodes a plugin id into name, version parts.
 func (n ID) Decode() (name string, version string, err error) {
-	splits := strings.Split(string(n), "-")
-	if len(splits) != 2 {
+	index := strings.LastIndex(string(n), "-")
+	if index == -1 {
 		err = errInvalidPluginID.GenWithStackByArgs(string(n))
 		return
 	}
-	name = splits[0]
-	version = splits[1]
+	name = string(n)[:index]
+	version = string(n)[index+1:]
 	return
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

After https://github.com/pingcap/tidb/pull/43125, the plugin name can contain `-`. But we still check the plugin name when loading it.

### What is changed and how it works?

Remove the checking.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
	- load a plugin named `tidb-audit-log-1`, where the name is `tidb-audit-log` and version is `1`
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
