### PR TITLE
ddl, executor: executor change for pause/resume on ddl jobs

### DIFF
--- a/ddl/BUILD.bazel
+++ b/ddl/BUILD.bazel
@@ -197,6 +197,7 @@ go_test(
         "mv_index_test.go",
         "options_test.go",
         "partition_test.go",
+        "pause_test.go",
         "placement_policy_ddl_test.go",
         "placement_policy_test.go",
         "placement_sql_test.go",

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1143,12 +1143,9 @@ func TestPauseJobWriteConflict(t *testing.T) {
 
 	tk1.MustExec("create table t(id int)")
 
+	var jobID int64
 	var pauseErr error
-	var resumeErr error
-	var cancelErr error
 	var pauseRS []sqlexec.RecordSet
-	var resumeRS []sqlexec.RecordSet
-	var cancelRS []sqlexec.RecordSet
 	hook := &callback.TestDDLCallback{Do: dom}
 	d := dom.DDL()
 	originalHook := d.GetHook()
@@ -1158,42 +1155,45 @@ func TestPauseJobWriteConflict(t *testing.T) {
 	// Test when pause cannot be retried and adding index succeeds.
 	hook.OnJobRunBeforeExported = func(job *model.Job) {
 		if job.Type == model.ActionAddIndex && job.State == model.JobStateRunning && job.SchemaState == model.StateWriteReorganization {
-			stmt := fmt.Sprintf("admin pause ddl jobs %d", job.ID)
 			require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/kv/mockCommitErrorInNewTxn", `return("no_retry")`))
 			defer func() { require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/kv/mockCommitErrorInNewTxn")) }()
 			require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/mockFailedCommandOnConcurencyDDL", `return(true)`))
 			defer func() {
 				require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/mockFailedCommandOnConcurencyDDL"))
 			}()
+
+			jobID = job.ID
+			stmt := fmt.Sprintf("admin pause ddl jobs %d", jobID)
 			pauseRS, pauseErr = tk2.Session().Execute(context.Background(), stmt)
 		}
 	}
 	tk1.MustExec("alter table t add index (id)")
 	require.EqualError(t, pauseErr, "mock commit error")
 
-	var jobID int64
+	var cancelRS []sqlexec.RecordSet
+	var cancelErr error
 	hook.OnJobRunBeforeExported = func(job *model.Job) {
 		if job.Type == model.ActionAddIndex && job.State == model.JobStateRunning && job.SchemaState == model.StateWriteReorganization {
+			require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/kv/mockCommitErrorInNewTxn", `return("no_retry")`))
+			defer func() { require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/kv/mockCommitErrorInNewTxn")) }()
+			require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/mockFailedCommandOnConcurencyDDL", `return(false)`))
+			defer func() {
+				require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/mockFailedCommandOnConcurencyDDL"))
+			}()
+
 			jobID = job.ID
 			stmt := fmt.Sprintf("admin pause ddl jobs %d", jobID)
-			require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/kv/mockCommitErrorInNewTxn", `return("retry_once")`))
-			defer func() { require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/kv/mockCommitErrorInNewTxn")) }()
 			pauseRS, pauseErr = tk2.Session().Execute(context.Background(), stmt)
 
-			stmt = fmt.Sprintf("admin resume ddl jobs %d", jobID)
-			resumeRS, resumeErr = tk2.Session().Execute(context.Background(), stmt)
-
+			time.Sleep(5 * time.Second)
 			stmt = fmt.Sprintf("admin cancel ddl jobs %d", jobID)
 			cancelRS, cancelErr = tk2.Session().Execute(context.Background(), stmt)
 		}
 	}
-	tk1.MustExec("alter table t add index (id)")
+	tk1.MustGetErrCode("alter table t add index (id)", errno.ErrCancelledDDLJob)
 	require.NoError(t, pauseErr)
-	require.NoError(t, resumeErr)
 	require.NoError(t, cancelErr)
 	result := tk2.ResultSetToResultWithCtx(context.Background(), pauseRS[0], "pause ddl job successfully")
-	result.Check(testkit.Rows(fmt.Sprintf("%d successful", jobID)))
-	result = tk2.ResultSetToResultWithCtx(context.Background(), resumeRS[0], "resume ddl job successfully")
 	result.Check(testkit.Rows(fmt.Sprintf("%d successful", jobID)))
 	result = tk2.ResultSetToResultWithCtx(context.Background(), cancelRS[0], "cancel ddl job successfully")
 	result.Check(testkit.Rows(fmt.Sprintf("%d successful", jobID)))

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1170,7 +1170,6 @@ func TestPauseJobWriteConflict(t *testing.T) {
 	}
 	tk1.MustExec("alter table t add index (id)")
 	require.EqualError(t, pauseErr, "mock commit error")
-	tk2.ResultSetToResultWithCtx(context.Background(), pauseRS[0], "cancel ddl job fails")
 
 	var jobID int64
 	hook.OnJobRunBeforeExported = func(job *model.Job) {
@@ -1192,7 +1191,7 @@ func TestPauseJobWriteConflict(t *testing.T) {
 	require.NoError(t, pauseErr)
 	require.NoError(t, resumeErr)
 	require.NoError(t, cancelErr)
-	var result = tk2.ResultSetToResultWithCtx(context.Background(), pauseRS[0], "pause ddl job successfully")
+	result := tk2.ResultSetToResultWithCtx(context.Background(), pauseRS[0], "pause ddl job successfully")
 	result.Check(testkit.Rows(fmt.Sprintf("%d successful", jobID)))
 	result = tk2.ResultSetToResultWithCtx(context.Background(), resumeRS[0], "resume ddl job successfully")
 	result.Check(testkit.Rows(fmt.Sprintf("%d successful", jobID)))

--- a/ddl/pause_test.go
+++ b/ddl/pause_test.go
@@ -16,8 +16,6 @@ package ddl_test
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/errno"
-	"github.com/pingcap/tidb/util/logutil"
 	"math/rand"
 	"strings"
 	"testing"
@@ -26,8 +24,10 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/ddl/internal/callback"
+	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/util/logutil"
 	"github.com/stretchr/testify/require"
 	atomicutil "go.uber.org/atomic"
 )

--- a/ddl/pause_test.go
+++ b/ddl/pause_test.go
@@ -1,0 +1,306 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl_test
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/ddl"
+	"github.com/pingcap/tidb/ddl/internal/callback"
+	"github.com/pingcap/tidb/parser/model"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/stretchr/testify/require"
+	atomicutil "go.uber.org/atomic"
+)
+
+type testPauseAndResumeJob struct {
+	sql         string
+	ok          bool
+	jobState    interface{} // model.SchemaState | []model.SchemaState
+	onJobBefore bool
+	onJobUpdate bool
+	prepareSQL  []string
+}
+
+type TestTableUser struct {
+	id          int64
+	user        string
+	name        string
+	age         int
+	province    string
+	city        string
+	phone       string
+	createdTime time.Time
+	updatedTime time.Time
+}
+
+func generateString(letterRunes []rune, length int) (string, error) {
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b), nil
+}
+
+func generateName(length int) (string, error) {
+	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ ")
+	return generateString(letterRunes, length)
+}
+
+func generatePhone(length int) (string, error) {
+	var numberRunes = []rune("0123456789")
+	return generateString(numberRunes, length)
+}
+
+func (tu *TestTableUser) generateAttributes() (err error) {
+	tu.user, err = generateName(rand.Intn(127))
+	if err != nil {
+		return err
+	}
+	tu.name, err = generateName(rand.Intn(127))
+	if err != nil {
+		return err
+	}
+
+	tu.age = rand.Intn(100)
+
+	tu.province, err = generateName(rand.Intn(32))
+	if err != nil {
+		return err
+	}
+	tu.city, err = generateName(rand.Intn(32))
+	if err != nil {
+		return err
+	}
+	tu.phone, err = generatePhone(14)
+	if err != nil {
+		return err
+	}
+	tu.createdTime = time.Now()
+	tu.updatedTime = time.Now()
+
+	return nil
+}
+
+func (tu *TestTableUser) insertStmt() string {
+	return fmt.Sprintf("INSERT INTO t_user(user, name, age, province, city, phone, created_time, updated_time) VALUES ('%s', '%s', %d, '%s', '%s', '%s', '%s', '%s')",
+		tu.user, tu.name, tu.age, tu.province, tu.city, tu.phone, tu.createdTime, tu.updatedTime)
+}
+
+var allPauseJobTestCase = []testPauseAndResumeJob{
+	// Add primary key
+	{"alter table t_user add primary key idx_id (id)", true, model.StateNone, true, false, nil},
+	{"alter table t_user add primary key idx_id (id)", true, model.StateDeleteOnly, true, true, nil},
+	{"alter table t_user add primary key idx_id (id)", true, model.StateWriteOnly, true, true, nil},
+	{"alter table t_user add primary key idx_id (id)", true, model.StateWriteReorganization, true, true, nil},
+	{"alter table t_user add primary key idx_id (id)", false, model.StatePublic, false, true, nil},
+
+	// Drop primary key
+	{"alter table t_user drop primary key", true, model.StatePublic, true, false, nil},
+	{"alter table t_user drop primary key", false, model.StateWriteOnly, true, false, nil},
+	{"alter table t_user drop primary key", false, model.StateWriteOnly, true, false, []string{"alter table t_user add primary key idx_id (id)"}},
+	{"alter table t_user drop primary key", false, model.StateDeleteOnly, true, false, []string{"alter table t_user add primary key idx_id (id)"}},
+	{"alter table t_user drop primary key", false, model.StateDeleteOnly, false, true, []string{"alter table t_user add primary key idx_id (id)"}},
+
+	// Add unique key
+	{"alter table t_user add unique index idx_name (user)", true, model.StateNone, true, false, nil},
+	{"alter table t_user add unique index idx_name (user)", true, model.StateDeleteOnly, true, true, nil},
+	{"alter table t_user add unique index idx_name (user)", true, model.StateWriteOnly, true, true, nil},
+	{"alter table t_user add unique index idx_name (user)", true, model.StateWriteReorganization, true, true, nil},
+	{"alter table t_user add unique index idx_name (user)", false, model.StatePublic, false, true, nil},
+
+	{"alter table t_user add index idx_phone (phone)", true, model.StateNone, true, false, nil},
+	{"alter table t_user add index idx_phone (phone)", true, model.StateDeleteOnly, true, true, nil},
+	{"alter table t_user add index idx_phone (phone)", true, model.StateWriteOnly, true, true, nil},
+	{"alter table t_user add index idx_phone (phone)", false, model.StatePublic, false, true, nil},
+
+	// Add column.
+	{"alter table t_user add column c4 bigint", true, model.StateNone, true, false, nil},
+	{"alter table t_user add column c4 bigint", true, model.StateDeleteOnly, true, true, nil},
+	{"alter table t_user add column c4 bigint", true, model.StateWriteOnly, true, true, nil},
+	{"alter table t_user add column c4 bigint", true, model.StateWriteReorganization, true, true, nil},
+	{"alter table t_user add column c4 bigint", false, model.StatePublic, false, true, nil},
+
+	// Create table.
+	{"create table test_create_table(a int)", true, model.StateNone, true, false, nil},
+	{"create table test_create_table(a int)", false, model.StatePublic, false, true, nil},
+
+	// Drop table.
+	{"drop table test_create_table", true, model.StatePublic, true, false, nil},
+	{"drop table test_create_table", false, model.StateWriteOnly, true, true, []string{"create table if not exists test_create_table(a int)"}},
+	{"drop table test_create_table", false, model.StateDeleteOnly, true, true, []string{"create table if not exists test_create_table(a int)"}},
+	{"drop table test_create_table", false, model.StateNone, false, true, []string{"create table if not exists test_create_table(a int)"}},
+
+	// Create schema.
+	{"create database test_create_db", true, model.StateNone, true, false, nil},
+	{"create database test_create_db", false, model.StatePublic, false, true, nil},
+
+	// Drop schema.
+	{"drop database test_create_db", true, model.StatePublic, true, false, nil},
+	{"drop database test_create_db", false, model.StateWriteOnly, true, true, []string{"create database if not exists test_create_db"}},
+	{"drop database test_create_db", false, model.StateDeleteOnly, true, true, []string{"create database if not exists test_create_db"}},
+	{"drop database test_create_db", false, model.StateNone, false, true, []string{"create database if not exists test_create_db"}},
+
+	// Drop column.
+	{"alter table t_user drop column c3", true, model.StatePublic, true, false, nil},
+	{"alter table t_user drop column c3", false, model.StateDeleteOnly, true, false, nil},
+	{"alter table t_user drop column c3", false, model.StateDeleteOnly, false, true, []string{"alter table t_user add column c3 bigint"}},
+	{"alter table t_user drop column c3", false, model.StateWriteOnly, true, true, []string{"alter table t_user add column c3 bigint"}},
+	{"alter table t_user drop column c3", false, model.StateDeleteReorganization, true, true, []string{"alter table t_user add column c3 bigint"}},
+	{"alter table t_user drop column c3", false, model.StateNone, false, true, []string{"alter table t_user add column c3 bigint"}},
+
+	// Drop column with index.
+	{"alter table t_user drop column c3", true, model.StatePublic, true, false, []string{"alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
+	{"alter table t_user drop column c3", false, model.StateDeleteOnly, true, false, nil},
+	{"alter table t_user drop column c3", false, model.StateDeleteOnly, false, true, []string{"alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
+	{"alter table t_user drop column c3", false, model.StateWriteOnly, true, true, []string{"alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
+	{"alter table t_user drop column c3", false, model.StateDeleteReorganization, true, true, []string{"alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
+	{"alter table t_user drop column c3", false, model.StateNone, false, true, []string{"alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
+
+	// Modify column, no reorg.
+	{"alter table t_user modify column c11 mediumint", true, model.StateNone, true, false, nil},
+	{"alter table t_user modify column c11 int", false, model.StatePublic, false, true, nil},
+
+	// Modify column, reorg.
+	{"alter table t_user modify column c11 char(10)", true, model.StateNone, true, false, nil},
+	{"alter table t_user modify column c11 char(10)", true, model.StateDeleteOnly, true, true, nil},
+	{"alter table t_user modify column c11 char(10)", true, model.StateWriteOnly, true, true, nil},
+	{"alter table t_user modify column c11 char(10)", true, model.StateWriteReorganization, true, true, nil},
+	{"alter table t_user modify column c11 char(10)", false, model.StatePublic, false, true, nil},
+}
+
+func isCommandSuccess(rs *testkit.Result) bool {
+	return strings.Contains(rs.Rows()[0][1].(string), "success")
+}
+
+func TestPauseAndResumeMain(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomainWithSchemaLease(t, 100*time.Millisecond)
+	tk := testkit.NewTestKit(t, store)
+	tkCommand := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE if not exists t_user (
+        id int(11) NOT NULL AUTO_INCREMENT,
+        user varchar(128) NOT NULL,
+        name varchar(128) NOT NULL,
+        age int(11) NOT NULL,
+        province varchar(32) NOT NULL DEFAULT '',
+        city varchar(32) NOT NULL DEFAULT '',
+        phone varchar(16) NOT NULL DEFAULT '',
+        created_time datetime NOT NULL,
+        updated_time datetime NOT NULL,
+        PRIMARY KEY (id)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`)
+
+	idx := 0
+	rowCount := 100000
+	tu := &TestTableUser{}
+	for idx < rowCount {
+		_ = tu.generateAttributes()
+		tk.MustExec(tu.insertStmt())
+
+		idx += 1
+	}
+
+	ddl.ReorgWaitTimeout = 10 * time.Millisecond
+	tk.MustExec("set @@global.tidb_ddl_reorg_batch_size = 2")
+	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 1")
+	tk = testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/mockBackfillSlow", "return"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/mockBackfillSlow"))
+	}()
+
+	hook := &callback.TestDDLCallback{Do: dom}
+	i := atomicutil.NewInt64(0)
+
+	isPaused := atomicutil.NewBool(false)
+	pauseWhenReorgNotStart := atomicutil.NewBool(false)
+	pauseHook := func(job *model.Job) {
+		if testMatchCancelState(t, job, allPauseJobTestCase[i.Load()].jobState, allPauseJobTestCase[i.Load()].sql) && !isPaused.Load() {
+			if !pauseWhenReorgNotStart.Load() && job.SchemaState == model.StateWriteReorganization && job.MayNeedReorg() && job.RowCount == 0 {
+				return
+			}
+			rs := tkCommand.MustQuery(fmt.Sprintf("admin pause ddl jobs %d", job.ID))
+			isPaused.Store(isCommandSuccess(rs))
+		}
+	}
+
+	isResumed := atomicutil.NewBool(false)
+	resumeHook := func(job *model.Job) {
+		rs := tkCommand.MustQuery(fmt.Sprintf("admin cancel ddl jobs %d", job.ID))
+		isResumed.Store(isCommandSuccess(rs))
+	}
+
+	isCancelled := atomicutil.NewBool(false)
+	cancelWhenReorgNotStart := atomicutil.NewBool(false)
+	cancelHook := func(job *model.Job) {
+		if testMatchCancelState(t, job, allPauseJobTestCase[i.Load()].jobState, allPauseJobTestCase[i.Load()].sql) && !isCancelled.Load() {
+			if !cancelWhenReorgNotStart.Load() && job.SchemaState == model.StateWriteReorganization && job.MayNeedReorg() && job.RowCount == 0 {
+				return
+			}
+			rs := tkCommand.MustQuery(fmt.Sprintf("admin cancel ddl jobs %d", job.ID))
+			isCancelled.Store(isCommandSuccess(rs))
+		}
+	}
+
+	dom.DDL().SetHook(hook.Clone())
+
+	restHook := func(h *callback.TestDDLCallback) {
+		h.OnJobRunBeforeExported = nil
+		h.OnJobRunAfterExported = nil
+		h.OnJobUpdatedExported.Store(nil)
+		dom.DDL().SetHook(h.Clone())
+	}
+
+	registHook := func(h *callback.TestDDLCallback) {
+		h.OnJobRunBeforeExported = pauseHook
+		h.OnJobRunAfterExported = resumeHook
+		h.OnJobUpdatedExported.Store(&cancelHook)
+		dom.DDL().SetHook(h.Clone())
+	}
+
+	for idx, tc := range allPauseJobTestCase {
+		i.Store(int64(idx))
+		msg := fmt.Sprintf("sql: %s, state: %s", tc.sql, tc.jobState)
+
+		restHook(hook)
+		for _, prepareSQL := range tc.prepareSQL {
+			tk.MustExec(prepareSQL)
+		}
+
+		isPaused.Store(false)
+		isResumed.Store(false)
+		isCancelled.Store(false)
+		pauseWhenReorgNotStart.Store(true)
+		registHook(hook)
+
+		tk.MustExec(tc.sql)
+
+		if tc.ok {
+			require.Equal(t, tc.ok, isPaused.Load(), msg)
+			require.Equal(t, tc.ok, isResumed.Load(), msg)
+			require.Equal(t, tc.ok, isCancelled.Load(), msg)
+		}
+
+		// TODO: should add some check on Job during reorganization
+	}
+}

--- a/ddl/pause_test.go
+++ b/ddl/pause_test.go
@@ -122,11 +122,11 @@ var allPauseJobTestCase = []testPauseAndResumeJob{
 	{"alter table t_user drop primary key", false, model.StateDeleteOnly, false, true, []string{"alter table t_user add primary key idx_id (id)"}},
 
 	// Add unique key
-	{"alter table t_user add unique index idx_name (user)", true, model.StateNone, true, false, nil},
-	{"alter table t_user add unique index idx_name (user)", true, model.StateDeleteOnly, true, true, nil},
-	{"alter table t_user add unique index idx_name (user)", true, model.StateWriteOnly, true, true, nil},
-	{"alter table t_user add unique index idx_name (user)", true, model.StateWriteReorganization, true, true, nil},
-	{"alter table t_user add unique index idx_name (user)", false, model.StatePublic, false, true, nil},
+	{"alter table t_user add unique index idx_name (id)", true, model.StateNone, true, false, nil},
+	{"alter table t_user add unique index idx_name (id)", true, model.StateDeleteOnly, true, true, nil},
+	{"alter table t_user add unique index idx_name (id)", true, model.StateWriteOnly, true, true, nil},
+	{"alter table t_user add unique index idx_name (id)", true, model.StateWriteReorganization, true, true, nil},
+	{"alter table t_user add unique index idx_name (id)", false, model.StatePublic, false, true, nil},
 
 	{"alter table t_user add index idx_phone (phone)", true, model.StateNone, true, false, nil},
 	{"alter table t_user add index idx_phone (phone)", true, model.StateDeleteOnly, true, true, nil},
@@ -161,31 +161,31 @@ var allPauseJobTestCase = []testPauseAndResumeJob{
 	{"drop database test_create_db", false, model.StateNone, false, true, []string{"create database if not exists test_create_db"}},
 
 	// Drop column.
-	{"alter table t_user drop column c3", true, model.StatePublic, true, false, nil},
-	{"alter table t_user drop column c3", false, model.StateDeleteOnly, true, false, nil},
-	{"alter table t_user drop column c3", false, model.StateDeleteOnly, false, true, []string{"alter table t_user add column c3 bigint"}},
-	{"alter table t_user drop column c3", false, model.StateWriteOnly, true, true, []string{"alter table t_user add column c3 bigint"}},
-	{"alter table t_user drop column c3", false, model.StateDeleteReorganization, true, true, []string{"alter table t_user add column c3 bigint"}},
-	{"alter table t_user drop column c3", false, model.StateNone, false, true, []string{"alter table t_user add column c3 bigint"}},
+	{"alter table t_user drop column c3", true, model.StatePublic, true, false, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
+	{"alter table t_user drop column c3", false, model.StateDeleteOnly, true, false, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
+	{"alter table t_user drop column c3", false, model.StateDeleteOnly, false, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
+	{"alter table t_user drop column c3", false, model.StateWriteOnly, true, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
+	{"alter table t_user drop column c3", false, model.StateDeleteReorganization, true, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
+	{"alter table t_user drop column c3", false, model.StateNone, false, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
 
 	// Drop column with index.
-	{"alter table t_user drop column c3", true, model.StatePublic, true, false, []string{"alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
-	{"alter table t_user drop column c3", false, model.StateDeleteOnly, true, false, nil},
-	{"alter table t_user drop column c3", false, model.StateDeleteOnly, false, true, []string{"alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
-	{"alter table t_user drop column c3", false, model.StateWriteOnly, true, true, []string{"alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
-	{"alter table t_user drop column c3", false, model.StateDeleteReorganization, true, true, []string{"alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
-	{"alter table t_user drop column c3", false, model.StateNone, false, true, []string{"alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
+	{"alter table t_user drop column c3", true, model.StatePublic, true, false, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
+	{"alter table t_user drop column c3", false, model.StateDeleteOnly, true, false, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
+	{"alter table t_user drop column c3", false, model.StateDeleteOnly, false, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
+	{"alter table t_user drop column c3", false, model.StateWriteOnly, true, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
+	{"alter table t_user drop column c3", false, model.StateDeleteReorganization, true, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
+	{"alter table t_user drop column c3", false, model.StateNone, false, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint", "alter table t_user add index idx_c3(c3)"}},
 
 	// Modify column, no reorg.
-	{"alter table t_user modify column c11 mediumint", true, model.StateNone, true, false, nil},
-	{"alter table t_user modify column c11 int", false, model.StatePublic, false, true, nil},
+	{"alter table t_user modify column c3 mediumint", true, model.StateNone, true, false, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
+	{"alter table t_user modify column c3 int", false, model.StatePublic, false, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
 
 	// Modify column, reorg.
-	{"alter table t_user modify column c11 char(10)", true, model.StateNone, true, false, nil},
-	{"alter table t_user modify column c11 char(10)", true, model.StateDeleteOnly, true, true, nil},
-	{"alter table t_user modify column c11 char(10)", true, model.StateWriteOnly, true, true, nil},
-	{"alter table t_user modify column c11 char(10)", true, model.StateWriteReorganization, true, true, nil},
-	{"alter table t_user modify column c11 char(10)", false, model.StatePublic, false, true, nil},
+	{"alter table t_user modify column c3 char(10)", true, model.StateNone, true, false, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
+	{"alter table t_user modify column c3 char(10)", true, model.StateDeleteOnly, true, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
+	{"alter table t_user modify column c3 char(10)", true, model.StateWriteOnly, true, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
+	{"alter table t_user modify column c3 char(10)", true, model.StateWriteReorganization, true, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
+	{"alter table t_user modify column c3 char(10)", false, model.StatePublic, false, true, []string{"alter table t_user drop column if exists c3", "alter table t_user add column c3 bigint"}},
 }
 
 func isCommandSuccess(rs *testkit.Result) bool {

--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -1113,6 +1113,11 @@ const (
 	ErrColumnInChange                     = 8245
 	ErrDDLSetting                         = 8246
 	ErrIngestFailed                       = 8247
+
+	ErrCannotPauseDDLJob  = 8260
+	ErrCannotResumeDDLJob = 8261
+	ErrPausedDDLJob       = 8262
+
 	// Resource group errors.
 	ErrResourceGroupExists            = 8248
 	ErrResourceGroupNotExists         = 8249

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -1139,4 +1139,8 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrPrometheusAddrIsNotSet:    mysql.Message("Prometheus address is not set in PD and etcd", nil),
 	ErrTiKVStaleCommand:          mysql.Message("TiKV server reports stale command", nil),
 	ErrTiKVMaxTimestampNotSynced: mysql.Message("TiKV max timestamp is not synced", nil),
+
+	ErrCannotPauseDDLJob:  mysql.Message("Job [%v] can't be paused now", nil),
+	ErrCannotResumeDDLJob: mysql.Message("Job [%v] can't be resumed", nil),
+	ErrPausedDDLJob:       mysql.Message("Job [%v] already paused", nil),
 }

--- a/errors.toml
+++ b/errors.toml
@@ -1406,6 +1406,21 @@ error = '''
 Ingest failed: %s
 '''
 
+["ddl:8260"]
+error = '''
+Job [%v] can't be paused now
+'''
+
+["ddl:8261"]
+error = '''
+Job [%v] can't be resumed
+'''
+
+["ddl:8262"]
+error = '''
+Job [%v] already paused
+'''
+
 ["domain:8027"]
 error = '''
 Information schema is out of date: schema failed to update in 1 lease, please make sure TiDB can connect to TiKV

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -206,6 +206,10 @@ func (b *executorBuilder) build(p plannercore.Plan) Executor {
 		return b.buildSelectLock(v)
 	case *plannercore.CancelDDLJobs:
 		return b.buildCancelDDLJobs(v)
+	case *plannercore.PauseDDLJobs:
+		return b.buildPauseDDLJobs(v)
+	case *plannercore.ResumeDDLJobs:
+		return b.buildResumeDDLJobs(v)
 	case *plannercore.ShowNextRowID:
 		return b.buildShowNextRowID(v)
 	case *plannercore.ShowDDL:
@@ -310,8 +314,33 @@ func (b *executorBuilder) build(p plannercore.Plan) Executor {
 
 func (b *executorBuilder) buildCancelDDLJobs(v *plannercore.CancelDDLJobs) Executor {
 	e := &CancelDDLJobsExec{
-		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ID()),
-		jobIDs:       v.JobIDs,
+		CommandDDLJobsExec: &CommandDDLJobsExec{
+			baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ID()),
+			jobIDs:       v.JobIDs,
+			execute:      ddl.CancelJobs,
+		},
+	}
+	return e
+}
+
+func (b *executorBuilder) buildPauseDDLJobs(v *plannercore.PauseDDLJobs) Executor {
+	e := &PauseDDLJobsExec{
+		CommandDDLJobsExec: &CommandDDLJobsExec{
+			baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ID()),
+			jobIDs:       v.JobIDs,
+			execute:      ddl.PauseJobs,
+		},
+	}
+	return e
+}
+
+func (b *executorBuilder) buildResumeDDLJobs(v *plannercore.ResumeDDLJobs) Executor {
+	e := &ResumeDDLJobsExec{
+		CommandDDLJobsExec: &CommandDDLJobsExec{
+			baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ID()),
+			jobIDs:       v.JobIDs,
+			execute:      ddl.ResumeJobs,
+		},
 	}
 	return e
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -335,29 +335,35 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) error {
 	return err
 }
 
-// CancelDDLJobsExec represents a cancel DDL jobs executor.
-type CancelDDLJobsExec struct {
+// CommandDDLJobsExec is the general struct for Cancel/Pause/Resume commands on
+// DDL jobs. These command currently by admin have the very similar struct and
+// operations, it should be a better idea to have them in the same struct.
+type CommandDDLJobsExec struct {
 	baseExecutor
 
 	cursor int
 	jobIDs []int64
 	errs   []error
+
+	execute func(se sessionctx.Context, ids []int64) (errs []error, err error)
 }
 
-// Open implements the Executor Open interface.
-func (e *CancelDDLJobsExec) Open(ctx context.Context) error {
+// Open implements the Executor for all Cancel/Pause/Resume command on DDL jobs
+// just with different processes. And, it should not be called directly by the
+// Executor.
+func (e *CommandDDLJobsExec) Open(ctx context.Context) error {
 	// We want to use a global transaction to execute the admin command, so we don't use e.ctx here.
 	newSess, err := e.getSysSession()
 	if err != nil {
 		return err
 	}
-	e.errs, err = ddl.CancelJobs(newSess, e.jobIDs)
+	e.errs, err = e.execute(newSess, e.jobIDs)
 	e.releaseSysSession(kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL), newSess)
 	return err
 }
 
-// Next implements the Executor Next interface.
-func (e *CancelDDLJobsExec) Next(ctx context.Context, req *chunk.Chunk) error {
+// Next implements the Executor Next interface for Cancel/Pause/Resume
+func (e *CommandDDLJobsExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.GrowAndReset(e.maxChunkSize)
 	if e.cursor >= len(e.jobIDs) {
 		return nil
@@ -373,6 +379,21 @@ func (e *CancelDDLJobsExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	}
 	e.cursor += numCurBatch
 	return nil
+}
+
+// CancelDDLJobsExec represents a cancel DDL jobs executor.
+type CancelDDLJobsExec struct {
+	*CommandDDLJobsExec
+}
+
+// PauseDDLJobsExec indicates an Executor for Pause a DDL Job.
+type PauseDDLJobsExec struct {
+	*CommandDDLJobsExec
+}
+
+// ResumeDDLJobsExec indicates an Executor for Resume a DDL Job.
+type ResumeDDLJobsExec struct {
+	*CommandDDLJobsExec
 }
 
 // ShowNextRowIDExec represents a show the next row ID executor.
@@ -640,7 +661,7 @@ func ts2Time(timestamp uint64, loc *time.Location) types.Time {
 
 // ShowDDLJobQueriesExec represents a show DDL job queries executor.
 // The jobs id that is given by 'admin show ddl job queries' statement,
-// only be searched in the latest 10 history jobs
+// only be searched in the latest 10 history jobs.
 type ShowDDLJobQueriesExec struct {
 	baseExecutor
 

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -754,7 +754,7 @@ func (job *Job) IsPausing() bool {
 
 // IsPausable checks whether we can pause the job.
 func (job *Job) IsPausable() bool {
-	return (job.NotStarted() || job.IsRunning()) && job.IsRollbackable()
+	return job.NotStarted() || (job.IsRunning() && job.IsRollbackable())
 }
 
 // IsResumable checks whether the job can be rollback.

--- a/util/dbterror/ddl_terror.go
+++ b/util/dbterror/ddl_terror.go
@@ -32,6 +32,8 @@ var (
 	ErrInvalidDDLJob = ClassDDL.NewStd(mysql.ErrInvalidDDLJob)
 	// ErrCancelledDDLJob means the DDL job is cancelled.
 	ErrCancelledDDLJob = ClassDDL.NewStd(mysql.ErrCancelledDDLJob)
+	// ErrPausedDDLJob returns when the DDL job cannot be paused.
+	ErrPausedDDLJob = ClassDDL.NewStd(mysql.ErrPausedDDLJob)
 	// ErrRunMultiSchemaChanges means we run multi schema changes.
 	ErrRunMultiSchemaChanges = ClassDDL.NewStdErr(mysql.ErrUnsupportedDDLOperation, parser_mysql.Message(fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation].Raw, "multi schema change for %s"), nil))
 	// ErrOperateSameColumn means we change the same columns multiple times in a DDL.
@@ -391,7 +393,11 @@ var (
 	ErrCancelFinishedDDLJob = ClassDDL.NewStd(mysql.ErrCancelFinishedDDLJob)
 	// ErrCannotCancelDDLJob returns when cancel a almost finished ddl job, because cancel in now may cause data inconsistency.
 	ErrCannotCancelDDLJob = ClassDDL.NewStd(mysql.ErrCannotCancelDDLJob)
-	// ErrDDLSetting returns when failing to enable/disable DDL
+	// ErrCannotPauseDDLJob returns when the State is not qualified to be paused.
+	ErrCannotPauseDDLJob = ClassDDL.NewStd(mysql.ErrCannotPauseDDLJob)
+	// ErrCannotResumeDDLJob returns  when the State is not qualified to be resumed.
+	ErrCannotResumeDDLJob = ClassDDL.NewStd(mysql.ErrCannotResumeDDLJob)
+	// ErrDDLSetting returns when failing to enable/disable DDL.
 	ErrDDLSetting = ClassDDL.NewStd(mysql.ErrDDLSetting)
 	// ErrIngestFailed returns when the DDL ingest job is failed.
 	ErrIngestFailed = ClassDDL.NewStd(mysql.ErrIngestFailed)


### PR DESCRIPTION
Add Pause/Resume admin command in parser and planner

What problem does this PR solve?
Issue Number: close https://github.com/pingcap/tidb/issues/18015 https://github.com/pingcap/tidb/issues/40041

Related issue number: https://github.com/pingcap/tidb/issues/39751 https://github.com/pingcap/tidb/pull/43061

Related PR: https://github.com/pingcap/tidb/pull/43081

Problem Summary: Add pause/resume on ddl jobs

What is changed and how it works?

`Add admin pause ddl jobs 3,5`;
a. the job should be in Running or Queueing state
b. change the state to be Pausing on command issued, in another PR
c. background work will pause the job once scheduled, in another PR

`Add admin resume ddl jobs 3,5`;
a. the job should be paused
b. change the state to be Queueing on command issued, in another PR
c. background worker will continue the job, no need to change

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
