### PR TITLE
*: format the error message when query/instance exceeds memory quota

### DIFF
--- a/ddl/BUILD.bazel
+++ b/ddl/BUILD.bazel
@@ -118,6 +118,7 @@ go_library(
         "//util/intest",
         "//util/logutil",
         "//util/mathutil",
+        "//util/memory",
         "//util/mock",
         "//util/ranger",
         "//util/resourcegrouptag",

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -64,6 +64,7 @@ import (
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mathutil"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/set"
 	"github.com/pingcap/tidb/util/sqlexec"
@@ -2859,7 +2860,7 @@ func checkPartitionByHash(ctx sessionctx.Context, tbInfo *model.TableInfo) error
 // checkPartitionByRange checks validity of a "BY RANGE" partition.
 func checkPartitionByRange(ctx sessionctx.Context, tbInfo *model.TableInfo) error {
 	failpoint.Inject("CheckPartitionByRangeErr", func() {
-		panic("Out Of Memory Quota!")
+		panic(memory.PanicMemoryExceedWarnMsg)
 	})
 	pi := tbInfo.Partition
 

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -455,7 +455,7 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 			}
 			return
 		}
-		if str, ok := r.(string); !ok || !strings.Contains(str, memory.PanicMemoryExceed) {
+		if str, ok := r.(string); !ok || !strings.Contains(str, memory.PanicMemoryExceedWarnMsg) {
 			panic(r)
 		}
 		err = errors.Errorf("%v", r)

--- a/executor/analyze_utils.go
+++ b/executor/analyze_utils.go
@@ -51,7 +51,7 @@ func getAnalyzePanicErr(r interface{}) error {
 		if msg == globalPanicAnalyzeMemoryExceed {
 			return errAnalyzeOOM
 		}
-		if strings.Contains(msg, memory.PanicMemoryExceed) {
+		if strings.Contains(msg, memory.PanicMemoryExceedWarnMsg) {
 			return errors.Errorf(msg, errAnalyzeOOM)
 		}
 	}

--- a/executor/analyzetest/BUILD.bazel
+++ b/executor/analyzetest/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "//util",
         "//util/codec",
         "//util/dbterror/exeerrors",
+        "//util/memory",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",

--- a/executor/analyzetest/analyze_test.go
+++ b/executor/analyzetest/analyze_test.go
@@ -3090,7 +3090,7 @@ func TestGlobalMemoryControlForAnalyze(t *testing.T) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/util/memory/ReadMemStats", `return(536870912)`))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/mockAnalyzeMergeWorkerSlowConsume", `return(100)`))
 	_, err := tk0.Exec(sql)
-	require.True(t, strings.Contains(err.Error(), "Out Of Memory Quota!"))
+	require.True(t, strings.Contains(err.Error(), memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForInstance))
 	runtime.GC()
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/util/memory/ReadMemStats"))
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/executor/mockAnalyzeMergeWorkerSlowConsume"))

--- a/executor/analyzetest/analyze_test.go
+++ b/executor/analyzetest/analyze_test.go
@@ -17,7 +17,6 @@ package analyzetest
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/util/memory"
 	"runtime"
 	"strconv"
 	"strings"
@@ -48,6 +47,7 @@ import (
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/dbterror/exeerrors"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/testutils"
 	"github.com/tikv/client-go/v2/tikv"

--- a/executor/analyzetest/analyze_test.go
+++ b/executor/analyzetest/analyze_test.go
@@ -17,6 +17,7 @@ package analyzetest
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tidb/util/memory"
 	"runtime"
 	"strconv"
 	"strings"
@@ -3170,7 +3171,7 @@ func TestGlobalMemoryControlForAutoAnalyze(t *testing.T) {
 	h.HandleAutoAnalyze(dom.InfoSchema())
 	rs := tk.MustQuery("select fail_reason from mysql.analyze_jobs where table_name=? and state=? limit 1", "t", "failed")
 	failReason := rs.Rows()[0][0].(string)
-	require.True(t, strings.Contains(failReason, "Out Of Memory Quota!"))
+	require.True(t, strings.Contains(failReason, memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForInstance))
 
 	childTrackers = executor.GlobalAnalyzeMemoryTracker.GetChildrenForTest()
 	require.Len(t, childTrackers, 0)

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -50,7 +50,7 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (_ *ExecS
 		if r == nil {
 			return
 		}
-		if str, ok := r.(string); !ok || !strings.Contains(str, memory.PanicMemoryExceed) {
+		if str, ok := r.(string); !ok || !strings.Contains(str, memory.PanicMemoryExceedWarnMsg) {
 			panic(r)
 		}
 		err = errors.Errorf("%v", r)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3621,27 +3621,27 @@ func TestOOMPanicAction(t *testing.T) {
 	tk.MustExec("create table t (a bigint);")
 	tk.MustExec("create table t1 (a bigint);")
 	tk.MustExec("set @@tidb_mem_quota_query=200;")
-	tk.MustMatchErrMsg("insert into t1 values (1),(2),(3),(4),(5);", "Out Of Memory Quota!.*")
-	tk.MustMatchErrMsg("replace into t1 values (1),(2),(3),(4),(5);", "Out Of Memory Quota!.*")
+	tk.MustMatchErrMsg("insert into t1 values (1),(2),(3),(4),(5);", memory.PanicMemoryExceedWarnMsg)
+	tk.MustMatchErrMsg("replace into t1 values (1),(2),(3),(4),(5);", memory.PanicMemoryExceedWarnMsg)
 	tk.MustExec("set @@tidb_mem_quota_query=10000")
 	tk.MustExec("insert into t1 values (1),(2),(3),(4),(5);")
 	tk.MustExec("set @@tidb_mem_quota_query=10;")
-	tk.MustMatchErrMsg("insert into t select a from t1 order by a desc;", "Out Of Memory Quota!.*")
-	tk.MustMatchErrMsg("replace into t select a from t1 order by a desc;", "Out Of Memory Quota!.*")
+	tk.MustMatchErrMsg("insert into t select a from t1 order by a desc;", memory.PanicMemoryExceedWarnMsg)
+	tk.MustMatchErrMsg("replace into t select a from t1 order by a desc;", memory.PanicMemoryExceedWarnMsg)
 
 	tk.MustExec("set @@tidb_mem_quota_query=10000")
 	tk.MustExec("insert into t values (1),(2),(3),(4),(5);")
 	// Set the memory quota to 244 to make this SQL panic during the DeleteExec
 	// instead of the TableReaderExec.
 	tk.MustExec("set @@tidb_mem_quota_query=244;")
-	tk.MustMatchErrMsg("delete from t", "Out Of Memory Quota!.*")
+	tk.MustMatchErrMsg("delete from t", memory.PanicMemoryExceedWarnMsg)
 
 	tk.MustExec("set @@tidb_mem_quota_query=10000;")
 	tk.MustExec("delete from t1")
 	tk.MustExec("insert into t1 values(1)")
 	tk.MustExec("insert into t values (1),(2),(3),(4),(5);")
 	tk.MustExec("set @@tidb_mem_quota_query=244;")
-	tk.MustMatchErrMsg("delete t, t1 from t join t1 on t.a = t1.a", "Out Of Memory Quota!.*")
+	tk.MustMatchErrMsg("delete t, t1 from t join t1 on t.a = t1.a", memory.PanicMemoryExceedWarnMsg)
 
 	tk.MustExec("set @@tidb_mem_quota_query=100000;")
 	tk.MustExec("truncate table t")
@@ -3649,7 +3649,7 @@ func TestOOMPanicAction(t *testing.T) {
 	// set the memory to quota to make the SQL panic during UpdateExec instead
 	// of TableReader.
 	tk.MustExec("set @@tidb_mem_quota_query=244;")
-	tk.MustMatchErrMsg("update t set a = 4", "Out Of Memory Quota!.*")
+	tk.MustMatchErrMsg("update t set a = 4", memory.PanicMemoryExceedWarnMsg)
 }
 
 func TestPointGetPreparedPlan(t *testing.T) {
@@ -6100,7 +6100,7 @@ func TestSummaryFailedUpdate(t *testing.T) {
 	tk.MustExec("SET GLOBAL tidb_mem_oom_action='CANCEL'")
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil))
 	tk.MustExec("set @@tidb_mem_quota_query=1")
-	tk.MustMatchErrMsg("update t set t.a = t.a - 1 where t.a in (select a from t where a < 4)", "Out Of Memory Quota!.*")
+	tk.MustMatchErrMsg("update t set t.a = t.a - 1 where t.a in (select a from t where a < 4)", memory.PanicMemoryExceedWarnMsg)
 	tk.MustExec("set @@tidb_mem_quota_query=1000000000")
 	tk.MustQuery("select stmt_type from information_schema.statements_summary where digest_text = 'update `t` set `t` . `a` = `t` . `a` - ? where `t` . `a` in ( select `a` from `t` where `a` < ? )'").Check(testkit.Rows("Update"))
 }
@@ -6253,7 +6253,7 @@ func TestGlobalMemoryControl2(t *testing.T) {
 		wg.Done()
 	}()
 	sql := "select * from t t1 join t t2 join t t3 on t1.a=t2.a and t1.a=t3.a order by t1.a;" // Need 500MB
-	require.True(t, strings.Contains(tk0.QueryToErr(sql).Error(), "Out Of Memory Quota!"))
+	require.True(t, strings.Contains(tk0.QueryToErr(sql).Error(), memory.PanicMemoryExceedWarnMsg))
 	require.Equal(t, tk0.Session().GetSessionVars().DiskTracker.MaxConsumed(), int64(0))
 	wg.Wait()
 	test[0] = 0
@@ -6272,7 +6272,7 @@ func TestCompileOutOfMemoryQuota(t *testing.T) {
 	tk.MustExec("create table t1(a int, c int, index idx(a))")
 	tk.MustExec("set tidb_mem_quota_query=10")
 	err := tk.ExecToErr("select t.a, t1.a from t use index(idx), t1 use index(idx) where t.a = t1.a")
-	require.Contains(t, err.Error(), "Out Of Memory Quota!")
+	require.Contains(t, err.Error(), memory.PanicMemoryExceedWarnMsg)
 }
 
 func TestSignalCheckpointForSort(t *testing.T) {
@@ -6298,7 +6298,7 @@ func TestSignalCheckpointForSort(t *testing.T) {
 	tk.Session().GetSessionVars().ConnectionID = 123456
 
 	err := tk.QueryToErr("select * from t order by a")
-	require.Contains(t, err.Error(), "Out Of Memory Quota!")
+	require.Contains(t, err.Error(), memory.PanicMemoryExceedWarnMsg)
 }
 
 func TestSessionRootTrackerDetach(t *testing.T) {
@@ -6310,7 +6310,7 @@ func TestSessionRootTrackerDetach(t *testing.T) {
 	tk.MustExec("create table t(a int, b int, index idx(a))")
 	tk.MustExec("create table t1(a int, c int, index idx(a))")
 	tk.MustExec("set tidb_mem_quota_query=10")
-	tk.MustContainErrMsg("select /*+hash_join(t1)*/ t.a, t1.a from t use index(idx), t1 use index(idx) where t.a = t1.a", "Out Of Memory Quota!")
+	tk.MustContainErrMsg("select /*+hash_join(t1)*/ t.a, t1.a from t use index(idx), t1 use index(idx) where t.a = t1.a", memory.PanicMemoryExceedWarnMsg)
 	tk.MustExec("set tidb_mem_quota_query=1000")
 	rs, err := tk.Exec("select /*+hash_join(t1)*/ t.a, t1.a from t use index(idx), t1 use index(idx) where t.a = t1.a")
 	require.NoError(t, err)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3614,7 +3614,7 @@ func TestOOMPanicAction(t *testing.T) {
 	tk.MustExec("set @@tidb_mem_quota_query=1;")
 	err := tk.QueryToErr("select sum(b) from t group by a;")
 	require.Error(t, err)
-	require.Regexp(t, "Out Of Memory Quota!.*", err.Error())
+	require.Regexp(t, memory.PanicMemoryExceedWarnMsg, err.Error())
 
 	// Test insert from select oom panic.
 	tk.MustExec("drop table if exists t,t1")

--- a/executor/fktest/BUILD.bazel
+++ b/executor/fktest/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "//tests/realtikvtest",
         "//types",
         "//util/dbterror/exeerrors",
+        "//util/memory",
         "//util/sqlexec",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//tikv",

--- a/executor/fktest/foreign_key_test.go
+++ b/executor/fktest/foreign_key_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/pingcap/tidb/util/memory"
 	"strconv"
 	"strings"
 	"sync"
@@ -2735,7 +2736,7 @@ func TestForeignKeyAndMemoryTracker(t *testing.T) {
 	// foreign key cascade behaviour will exceed memory quota.
 	err := tk.ExecToErr("update t1 set id=id+100000 where id=1")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Out Of Memory Quota!")
+	require.Contains(t, err.Error(), memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery)
 	tk.MustQuery("select id,pid from t1 where id = 1").Check(testkit.Rows("1 <nil>"))
 	tk.MustExec("set @@foreign_key_checks=0")
 	// After disable foreign_key_checks, following DML will execute successful.

--- a/executor/fktest/foreign_key_test.go
+++ b/executor/fktest/foreign_key_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/util/memory"
 	"strconv"
 	"strings"
 	"sync"
@@ -40,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/tests/realtikvtest"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/dbterror/exeerrors"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/stretchr/testify/require"
 )

--- a/executor/index_merge_reader_test.go
+++ b/executor/index_merge_reader_test.go
@@ -16,6 +16,7 @@ package executor_test
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/util/memory"
 	"math/rand"
 	"regexp"
 	"strconv"
@@ -796,7 +797,7 @@ func TestIntersectionMemQuota(t *testing.T) {
 	defer tk.MustExec("set global tidb_mem_oom_action = DEFAULT")
 	tk.MustExec("set @@tidb_mem_quota_query = 4000")
 	err := tk.QueryToErr("select /*+ use_index_merge(t1, primary, idx1, idx2) */ c1 from t1 where c1 < 1024 and c2 < 1024")
-	require.Contains(t, err.Error(), "Out Of Memory Quota!")
+	require.Contains(t, err.Error(), memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery)
 }
 
 func setupPartitionTableHelper(tk *testkit.TestKit) {

--- a/executor/index_merge_reader_test.go
+++ b/executor/index_merge_reader_test.go
@@ -16,7 +16,6 @@ package executor_test
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/util/memory"
 	"math/rand"
 	"regexp"
 	"strconv"
@@ -28,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 )

--- a/executor/issuetest/executor_issue_test.go
+++ b/executor/issuetest/executor_issue_test.go
@@ -302,9 +302,9 @@ func TestIssue28650(t *testing.T) {
 		tk.MustExec("set @@tidb_mem_quota_query = 1073741824") // 1GB
 		require.Nil(t, tk.QueryToErr(sql))
 		tk.MustExec("set @@tidb_mem_quota_query = 33554432") // 32MB, out of memory during executing
-		require.True(t, strings.Contains(tk.QueryToErr(sql).Error(), "Out Of Memory Quota!"))
+		require.True(t, strings.Contains(tk.QueryToErr(sql).Error(), memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery))
 		tk.MustExec("set @@tidb_mem_quota_query = 65536") // 64KB, out of memory during building the plan
-		require.True(t, strings.Contains(tk.ExecToErr(sql).Error(), "Out Of Memory Quota!"))
+		require.True(t, strings.Contains(tk.ExecToErr(sql).Error(), memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery))
 	}
 }
 
@@ -484,10 +484,10 @@ func TestIndexJoin31494(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		err := tk.QueryToErr("select /*+ inl_join(t1) */ * from t1 right join t2 on t1.b=t2.b;")
 		require.Error(t, err)
-		require.Regexp(t, "Out Of Memory Quota!.*", err.Error())
+		require.Regexp(t, memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery, err.Error())
 		err = tk.QueryToErr("select /*+ inl_hash_join(t1) */ * from t1 right join t2 on t1.b=t2.b;")
 		require.Error(t, err)
-		require.Regexp(t, "Out Of Memory Quota!.*", err.Error())
+		require.Regexp(t, memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery, err.Error())
 	}
 }
 

--- a/executor/jointest/BUILD.bazel
+++ b/executor/jointest/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "//testkit",
         "//util",
         "//util/dbterror/exeerrors",
+        "//util/memory",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//tikv",

--- a/executor/jointest/join_test.go
+++ b/executor/jointest/join_test.go
@@ -17,7 +17,6 @@ package jointest
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/util/memory"
 	"math/rand"
 	"strings"
 	"testing"
@@ -31,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/dbterror/exeerrors"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/stretchr/testify/require"
 )
 

--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -16,6 +16,7 @@ package executor_test
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/util/memory"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -762,7 +763,7 @@ func TestOrderByAndLimit(t *testing.T) {
 	tk.MustExec("set global tidb_mem_oom_action=CANCEL")
 	err := tk.QueryToErr("select /*+ LIMIT_TO_COP() */ a from trange use index(idx_a) where a > 1 order by a limit 2000")
 	require.Error(t, err)
-	require.Regexp(t, "Out Of Memory Quota.*", err)
+	require.Regexp(t, memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery, err)
 	tk.MustExec(fmt.Sprintf("set session tidb_mem_quota_query=%s", originMemQuota))
 	tk.MustExec(fmt.Sprintf("set global tidb_mem_oom_action=%s", originOOMAction))
 }

--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -16,7 +16,6 @@ package executor_test
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/util/memory"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -32,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/testkit/external"
 	"github.com/pingcap/tidb/testkit/testdata"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/stretchr/testify/require"
 )
 

--- a/executor/tiflashtest/BUILD.bazel
+++ b/executor/tiflashtest/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//testkit/external",
         "//util/dbterror/exeerrors",
         "//util/israce",
+        "//util/memory",
         "//util/tiflashcompute",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/executor/tiflashtest/tiflash_test.go
+++ b/executor/tiflashtest/tiflash_test.go
@@ -17,7 +17,6 @@ package tiflashtest
 import (
 	"bytes"
 	"fmt"
-	"github.com/pingcap/tidb/util/memory"
 	"math/rand"
 	"strings"
 	"sync"
@@ -39,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/testkit/external"
 	"github.com/pingcap/tidb/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/util/israce"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/tiflashcompute"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/testutils"

--- a/executor/tiflashtest/tiflash_test.go
+++ b/executor/tiflashtest/tiflash_test.go
@@ -17,6 +17,7 @@ package tiflashtest
 import (
 	"bytes"
 	"fmt"
+	"github.com/pingcap/tidb/util/memory"
 	"math/rand"
 	"strings"
 	"sync"
@@ -1454,7 +1455,7 @@ func TestMPPMemoryTracker(t *testing.T) {
 	}()
 	err = tk.QueryToErr("select * from t")
 	require.NotNil(t, err)
-	require.True(t, strings.Contains(err.Error(), "Out Of Memory Quota!"))
+	require.True(t, strings.Contains(err.Error(), memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery))
 }
 
 func TestTiFlashComputeDispatchPolicy(t *testing.T) {

--- a/executor/unstabletest/unstable_test.go
+++ b/executor/unstabletest/unstable_test.go
@@ -40,7 +40,7 @@ func TestCartesianJoinPanic(t *testing.T) {
 		tk.MustExec("insert into t select * from t")
 	}
 	err := tk.QueryToErr("desc analyze select * from t t1, t t2, t t3, t t4, t t5, t t6;")
-	require.ErrorContains(t, err, "Out Of Memory Quota!")
+	require.ErrorContains(t, err, memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery)
 }
 
 func TestGlobalMemoryControl(t *testing.T) {
@@ -86,7 +86,7 @@ func TestGlobalMemoryControl(t *testing.T) {
 		func() {
 			tracker3.Consume(1)
 		}, func(r interface{}) {
-			require.True(t, strings.Contains(r.(string), "Out Of Memory Quota!"))
+			require.True(t, strings.Contains(r.(string), memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForInstance))
 		})
 	tracker2.Consume(300 << 20) // Sum 500MB, Not Panic, Waiting t3 cancel finish.
 	time.Sleep(500 * time.Millisecond)
@@ -105,7 +105,7 @@ func TestGlobalMemoryControl(t *testing.T) {
 		func() {
 			tracker2.Consume(1)
 		}, func(r interface{}) {
-			require.True(t, strings.Contains(r.(string), "Out Of Memory Quota!"))
+			require.True(t, strings.Contains(r.(string), memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForInstance))
 		})
 	require.Equal(t, test[0], 0) // Keep 1GB HeapInUse
 }

--- a/infoschema/cluster_tables_test.go
+++ b/infoschema/cluster_tables_test.go
@@ -16,6 +16,7 @@ package infoschema_test
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/util/memory"
 	"math/rand"
 	"net"
 	"net/http/httptest"
@@ -704,7 +705,7 @@ select * from t1;
 
 		err = tk.QueryToErr("select * from `information_schema`.`slow_query` where time > '2022-04-14 00:00:00' and time < '2022-04-15 00:00:00'")
 		require.Error(t, err, quota)
-		require.Contains(t, err.Error(), "Out Of Memory Quota!", quota)
+		require.Contains(t, err.Error(), memory.PanicMemoryExceedWarnMsg, quota)
 	}
 	memQuotas := []int{128, 512, 1024, 2048, 4096}
 	for _, quota := range memQuotas {

--- a/infoschema/cluster_tables_test.go
+++ b/infoschema/cluster_tables_test.go
@@ -16,7 +16,6 @@ package infoschema_test
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/util/memory"
 	"math/rand"
 	"net"
 	"net/http/httptest"
@@ -49,6 +48,7 @@ import (
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/testkit/external"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/pdapi"
 	"github.com/pingcap/tidb/util/resourcegrouptag"
 	"github.com/pingcap/tidb/util/set"

--- a/server/conn.go
+++ b/server/conn.go
@@ -2200,7 +2200,7 @@ func (cc *clientConn) writeResultSet(ctx context.Context, rs ResultSet, binary b
 		if r == nil {
 			return
 		}
-		if str, ok := r.(string); !ok || !strings.HasPrefix(str, memory.PanicMemoryExceed) {
+		if str, ok := r.(string); !ok || !strings.HasPrefix(str, memory.PanicMemoryExceedWarnMsg) {
 			panic(r)
 		}
 		// TODO(jianzhang.zj: add metrics here)

--- a/session/sessiontest/session_test.go
+++ b/session/sessiontest/session_test.go
@@ -1233,7 +1233,7 @@ func TestCoprocessorOOMAction(t *testing.T) {
 		tk.MustExec(fmt.Sprintf("set @@tidb_mem_quota_query=%v;", quota))
 		err := tk.QueryToErr(sql)
 		require.Error(t, err)
-		require.Regexp(t, "Out Of Memory Quota.*", err)
+		require.Regexp(t, memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery, err)
 	}
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/store/copr/testRateLimitActionMockWaitMax", `return(true)`))
@@ -1280,7 +1280,7 @@ func TestCoprocessorOOMAction(t *testing.T) {
 		tk.MustExec("set @@tidb_mem_quota_query=1;")
 		err = tk.QueryToErr(testcase.sql)
 		require.Error(t, err)
-		require.Regexp(t, "Out Of Memory Quota.*", err)
+		require.Regexp(t, memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery, err)
 		se.Close()
 	}
 }

--- a/util/memory/action.go
+++ b/util/memory/action.go
@@ -44,6 +44,18 @@ type ActionOnExceed interface {
 	IsFinished() bool
 }
 
+type ActionInvoker byte
+
+const (
+	SingleQuery ActionInvoker = iota
+	Instance
+)
+
+// ActionCareInvoker is the interface for the Actions which need to be aware of the invoker.
+type ActionCareInvoker interface {
+	SetInvoker(invoker ActionInvoker)
+}
+
 // BaseOOMAction manages the fallback action for all Action.
 type BaseOOMAction struct {
 	fallbackAction ActionOnExceed
@@ -120,9 +132,10 @@ func (*LogOnExceed) GetPriority() int64 {
 type PanicOnExceed struct {
 	logHook func(uint64)
 	BaseOOMAction
-	ConnID uint64
-	mutex  sync.Mutex // For synchronization.
-	acted  bool
+	ConnID  uint64
+	mutex   sync.Mutex // For synchronization.
+	acted   bool
+	invoker ActionInvoker
 }
 
 // SetLogHook sets a hook for PanicOnExceed.
@@ -145,7 +158,10 @@ func (a *PanicOnExceed) Action(t *Tracker) {
 		}
 	}
 	a.acted = true
-	panic(PanicMemoryExceed + fmt.Sprintf("[conn=%d]", a.ConnID))
+	if a.invoker == SingleQuery {
+		panic(PanicMemoryExceedWarnMsg + WarnMsgSuffixForSingleQuery + fmt.Sprintf("[conn=%d]", a.ConnID))
+	}
+	panic(PanicMemoryExceedWarnMsg + WarnMsgSuffixForInstance + fmt.Sprintf("[conn=%d]", a.ConnID))
 }
 
 // GetPriority get the priority of the Action
@@ -153,11 +169,17 @@ func (*PanicOnExceed) GetPriority() int64 {
 	return DefPanicPriority
 }
 
+func (a *PanicOnExceed) SetInvoker(invoker ActionInvoker) {
+	a.invoker = invoker
+}
+
 var (
 	errMemExceedThreshold = dbterror.ClassUtil.NewStd(errno.ErrMemExceedThreshold)
 )
 
 const (
-	// PanicMemoryExceed represents the panic message when out of memory quota.
-	PanicMemoryExceed string = "Out Of Memory Quota!"
+	// PanicMemoryExceedWarnMsg represents the panic message when out of memory quota.
+	PanicMemoryExceedWarnMsg    string = "Your query has been cancelled due to exceeding the allowed memory limit"
+	WarnMsgSuffixForSingleQuery string = " for a single SQL query. Please try narrowing your query scope or increase the tidb_mem_quota_query limit and try again."
+	WarnMsgSuffixForInstance    string = " for the tidb-server instance and this query is currently using the most memory. Please try narrowing your query scope or increase the tidb_server_memory_limit and try again."
 )

--- a/util/memory/action.go
+++ b/util/memory/action.go
@@ -44,10 +44,13 @@ type ActionOnExceed interface {
 	IsFinished() bool
 }
 
+// ActionInvoker indicates the invoker of the Action.
 type ActionInvoker byte
 
 const (
+	// SingleQuery indicates the Action is invoked by a tidb_mem_quota_query.
 	SingleQuery ActionInvoker = iota
+	// Instance indicates the Action is invoked by a tidb_server_memory_limit.
 	Instance
 )
 
@@ -169,6 +172,7 @@ func (*PanicOnExceed) GetPriority() int64 {
 	return DefPanicPriority
 }
 
+// SetInvoker sets the invoker of the Action.
 func (a *PanicOnExceed) SetInvoker(invoker ActionInvoker) {
 	a.invoker = invoker
 }
@@ -179,7 +183,9 @@ var (
 
 const (
 	// PanicMemoryExceedWarnMsg represents the panic message when out of memory quota.
-	PanicMemoryExceedWarnMsg    string = "Your query has been cancelled due to exceeding the allowed memory limit"
+	PanicMemoryExceedWarnMsg string = "Your query has been cancelled due to exceeding the allowed memory limit"
+	// WarnMsgSuffixForSingleQuery represents the suffix of the warning message when out of memory quota for a single query.
 	WarnMsgSuffixForSingleQuery string = " for a single SQL query. Please try narrowing your query scope or increase the tidb_mem_quota_query limit and try again."
-	WarnMsgSuffixForInstance    string = " for the tidb-server instance and this query is currently using the most memory. Please try narrowing your query scope or increase the tidb_server_memory_limit and try again."
+	// WarnMsgSuffixForInstance represents the suffix of the warning message when out of memory quota for the tidb-server instance.
+	WarnMsgSuffixForInstance string = " for the tidb-server instance and this query is currently using the most memory. Please try narrowing your query scope or increase the tidb_server_memory_limit and try again."
 )

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -449,6 +449,9 @@ func (t *Tracker) Consume(bs int64) {
 				currentAction = nextAction
 				nextAction = currentAction.GetFallback()
 			}
+			if action, ok := currentAction.(ActionCareInvoker); ok {
+				action.SetInvoker(Instance)
+			}
 			currentAction.Action(tracker)
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42044

Problem Summary:

### What is changed and how it works?
As described in the issue description.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Refine the error message when a query is killed because of exceeding the memory limit. When a query is killed because of exceeding `tidb_mem_quota_query`, error message `Your query has been cancelled due to exceeding the allowed memory limit for a single SQL query. Please try narrowing your query scope or increase the tidb_mem_quota_query limit and try again.` will be returend. When a query is killed because of the instance memory exceeds `tidb_server_memory_limit`, error message `Your query has been cancelled due to exceeding the allowed memory limit for the tidb-server instance and this query is currently using the most memory. Please try narrowing your query scope or increase the tidb_server_memory_limit and try again.` will be returned.
``` 
