### PR TITLE
planner, sessionctx: add `tidb_opt_fix_control` variable

### DIFF
--- a/planner/core/casetest/integration_test.go
+++ b/planner/core/casetest/integration_test.go
@@ -3503,7 +3503,6 @@ func TestFixControl(t *testing.T) {
 			output[i].Error = errStr
 			output[i].Warnings = warning
 			output[i].Variable = rows
-
 		})
 		require.Equal(t, output[i].FixControl, s.GetSessionVars().OptimizerFixControl)
 		require.Equal(t, output[i].Error, errStr)

--- a/planner/core/casetest/testdata/integration_suite_in.json
+++ b/planner/core/casetest/testdata/integration_suite_in.json
@@ -1319,5 +1319,13 @@
       "select b from t3 where a = 1 and b is not null",
       "select b from t3 where a = 1 and b is null"
     ]
+  },
+  {
+    "name": "TestFixControl",
+    "cases": [
+      "set @@tidb_opt_fix_control = \"1000:'on', 10000:1\"",
+      "set @@tidb_opt_fix_control = \"100:'on', 100:1\"",
+      "set @@tidb_opt_fix_control = \"100, 100\""
+    ]
   }
 ]

--- a/planner/core/casetest/testdata/integration_suite_out.json
+++ b/planner/core/casetest/testdata/integration_suite_out.json
@@ -11178,5 +11178,56 @@
         "Result": null
       }
     ]
+  },
+  {
+    "Name": "TestFixControl",
+    "Cases": [
+      {
+        "SQL": "set @@tidb_opt_fix_control = \"1000:'on', 10000:1\"",
+        "FixControl": {
+          "1000": "'on'",
+          "10000": "1"
+        },
+        "Error": "",
+        "Warnings": [],
+        "Variable": [
+          "1000:'on', 10000:1"
+        ]
+      },
+      {
+        "SQL": "set @@tidb_opt_fix_control = \"100:'on', 100:1\"",
+        "FixControl": {
+          "100": "1"
+        },
+        "Error": "",
+        "Warnings": [
+          [
+            "Warning",
+            "1105",
+            "found repeated fix control: 100:'on' is overwritten with 1"
+          ]
+        ],
+        "Variable": [
+          "100:'on', 100:1"
+        ]
+      },
+      {
+        "SQL": "set @@tidb_opt_fix_control = \"100, 100\"",
+        "FixControl": {
+          "100": "1"
+        },
+        "Error": "invalid fix control: colon not found",
+        "Warnings": [
+          [
+            "Error",
+            "1105",
+            "invalid fix control: colon not found"
+          ]
+        ],
+        "Variable": [
+          "100:'on', 100:1"
+        ]
+      }
+    ]
   }
 ]

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1423,6 +1423,9 @@ type SessionVars struct {
 	// If there exists an index whose estimated selectivity is smaller than this threshold, the optimizer won't
 	// use the ExpectedCnt to adjust the estimated row count for index scan.
 	OptOrderingIdxSelThresh float64
+
+	// OptimizerFixControl control some details of the optimizer behavior through the tidb_opt_fix_control variable.
+	OptimizerFixControl map[uint64]string
 }
 
 // planReplayerSessionFinishedTaskKeyLen is used to control the max size for the finished plan replayer task key in session

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -2474,16 +2474,16 @@ var defaultSysVars = []*SysVar{
 				}
 				k := strings.TrimSpace(singleFixCtrl[0:colonIdx])
 				v := strings.TrimSpace(singleFixCtrl[colonIdx+1:])
-				kNum, err := strconv.ParseUint(k, 10, 64)
+				num, err := strconv.ParseUint(k, 10, 64)
 				if err != nil {
 					return err
 				}
-				originalV, ok := newMap[kNum]
+				originalV, ok := newMap[num]
 				if ok {
 					s.StmtCtx.AppendWarning(
 						errors.Errorf("found repeated fix control: %d:%s is overwritten with %s", kNum, originalV, v))
 				}
-				newMap[kNum] = v
+				newMap[num] = v
 			}
 			s.OptimizerFixControl = newMap
 			return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -2461,6 +2461,33 @@ var defaultSysVars = []*SysVar{
 			s.OptOrderingIdxSelThresh = tidbOptFloat64(val, DefTiDBOptOrderingIdxSelThresh)
 			return nil
 		}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBOptFixControl, Value: "", Type: TypeStr, IsHintUpdatable: true,
+		SetSession: func(s *SessionVars, val string) error {
+			newMap := make(map[uint64]string)
+			for _, singleFixCtrl := range strings.Split(val, ",") {
+				if len(singleFixCtrl) == 0 {
+					continue
+				}
+				colonIdx := strings.Index(singleFixCtrl, ":")
+				if colonIdx < 0 {
+					return errors.New("invalid fix control: colon not found")
+				}
+				k := strings.TrimSpace(singleFixCtrl[0:colonIdx])
+				v := strings.TrimSpace(singleFixCtrl[colonIdx+1:])
+				kNum, err := strconv.ParseUint(k, 10, 64)
+				if err != nil {
+					return err
+				}
+				originalV, ok := newMap[kNum]
+				if ok {
+					s.StmtCtx.AppendWarning(
+						errors.Errorf("found repeated fix control: %d:%s is overwritten with %s", kNum, originalV, v))
+				}
+				newMap[kNum] = v
+			}
+			s.OptimizerFixControl = newMap
+			return nil
+		}},
 }
 
 func setTiFlashComputeDispatchPolicy(s *SessionVars, val string) error {

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -2481,7 +2481,7 @@ var defaultSysVars = []*SysVar{
 				originalV, ok := newMap[num]
 				if ok {
 					s.StmtCtx.AppendWarning(
-						errors.Errorf("found repeated fix control: %d:%s is overwritten with %s", kNum, originalV, v))
+						errors.Errorf("found repeated fix control: %d:%s is overwritten with %s", num, originalV, v))
 				}
 				newMap[num] = v
 			}

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -855,6 +855,9 @@ const (
 
 	// TiDBOptOrderingIdxSelThresh is the threshold for optimizer to consider the ordering index.
 	TiDBOptOrderingIdxSelThresh = "tidb_opt_ordering_index_selectivity_threshold"
+
+	// TiDBOptFixControl makes the user able to control some details of the optimizer behavior.
+	TiDBOptFixControl = "tidb_opt_fix_control"
 )
 
 // TiDB vars that have only global scope


### PR DESCRIPTION
### What problem does this PR solve?


Issue Number: close #43169


### What is changed and how it works?

- Add a new system variable `tidb_opt_fix_control`
- Add the corresponding field of type `map[uint64]string` to `SessionVars` 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
