### PR TITLE
lightning: fix MakeTableRegions may panic when context is canceled

### DIFF
--- a/br/pkg/lightning/mydump/BUILD.bazel
+++ b/br/pkg/lightning/mydump/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "@com_github_xitongsys_parquet_go//reader",
         "@com_github_xitongsys_parquet_go//source",
         "@org_golang_x_exp//slices",
+        "@org_golang_x_sync//errgroup",
         "@org_golang_x_text//encoding",
         "@org_golang_x_text//encoding/charmap",
         "@org_golang_x_text//encoding/simplifiedchinese",

--- a/br/pkg/lightning/mydump/region.go
+++ b/br/pkg/lightning/mydump/region.go
@@ -277,6 +277,7 @@ func MakeTableRegions(
 		if !ok {
 			return nil, errors.Errorf("file %s not found in MakeTableRegions", dataFile.FileMeta.Path)
 		}
+		//nolint: forcetypeassert
 		fileRegionsRes := v.(fileRegionRes)
 		for _, region := range fileRegionsRes.regions {
 			region.Chunk.PrevRowIDMax += rowIDBase

--- a/br/pkg/lightning/mydump/region.go
+++ b/br/pkg/lightning/mydump/region.go
@@ -225,6 +225,7 @@ func MakeTableRegions(
 	eg.SetLimit(concurrency)
 	meta := cfg.TableMeta
 	for _, info := range meta.DataFiles {
+		info := info
 		eg.Go(func() error {
 			select {
 			case <-egCtx.Done():

--- a/br/pkg/lightning/mydump/region_test.go
+++ b/br/pkg/lightning/mydump/region_test.go
@@ -221,6 +221,13 @@ func TestMakeTableRegionsSplitLargeFile(t *testing.T) {
 	assert.Equal(t, int64(0), regions[0].Chunk.Offset)
 	assert.Equal(t, TableFileSizeINF, regions[0].Chunk.EndOffset)
 	assert.Len(t, regions[0].Chunk.Columns, 0)
+
+	// test canceled context will not panic
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	for i := 0; i < 20; i++ {
+		_, _ = MakeTableRegions(ctx, divideConfig)
+	}
 }
 
 func TestCompressedMakeSourceFileRegion(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43195

Problem Summary:

### What is changed and how it works?

use error group and sync.Map to refine the logic

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
