### PR TITLE
planner: recalculate as-of ts of staleread when plan is cached

### DIFF
--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -1379,9 +1379,9 @@ func TestStalePrepare(t *testing.T) {
 	defer tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (id int)")
 
-	stmtID, _, _, err := tk.Session().PrepareStmt("select * from t as of timestamp now(3) - interval 1000 microsecond")
+	stmtID, _, _, err := tk.Session().PrepareStmt("select * from t as of timestamp now(3) - interval 1000 microsecond order by id asc")
 	require.Nil(t, err)
-	tk.MustExec("prepare stmt from \"select * from t as of timestamp now(3) - interval 1000 microsecond\"")
+	tk.MustExec("prepare stmt from \"select * from t as of timestamp now(3) - interval 1000 microsecond order by id asc\"")
 
 	var expected [][]interface{}
 	for i := 0; i < 20; i++ {

--- a/sessiontxn/staleread/processor.go
+++ b/sessiontxn/staleread/processor.go
@@ -167,7 +167,10 @@ func (p *staleReadProcessor) OnSelectTable(tn *ast.TableName) error {
 	}
 
 	// If `stmtAsOfTS` is not 0, it means we use 'select ... from xxx as of timestamp ...'
-	stmtAsOfTS, err := parseAndValidateAsOf(p.ctx, p.sctx, tn.AsOf)
+	evaluateTS := func(sctx sessionctx.Context) (uint64, error) {
+		return parseAndValidateAsOf(context.Background(), p.sctx, tn.AsOf)
+	}
+	stmtAsOfTS, err := evaluateTS(p.sctx)
 	if err != nil {
 		return err
 	}
@@ -179,7 +182,7 @@ func (p *staleReadProcessor) OnSelectTable(tn *ast.TableName) error {
 		}
 		return nil
 	}
-	return p.evaluateFromStmtTSOrSysVariable(stmtAsOfTS)
+	return p.evaluateFromStmtTSOrSysVariable(stmtAsOfTS, evaluateTS)
 }
 
 func (p *staleReadProcessor) OnExecutePreparedStmt(preparedTSEvaluator StalenessTSEvaluator) (err error) {
@@ -201,7 +204,10 @@ func (p *staleReadProcessor) OnExecutePreparedStmt(preparedTSEvaluator Staleness
 			return err
 		}
 	}
-	return p.evaluateFromStmtTSOrSysVariable(stmtTS)
+	// When executing a prepared stmt, the stmtTS is calculated once and reused to avoid eval overhead,
+	// note it only takes PlanCacheStmt.SnapshotTSEvaluator without overwriting it.
+	// the evaluator will be re-calculated in next execution.
+	return p.evaluateFromStmtTSOrSysVariable(stmtTS, nil)
 }
 
 func (p *staleReadProcessor) evaluateFromTxn() error {
@@ -223,7 +229,7 @@ func (p *staleReadProcessor) evaluateFromTxn() error {
 	return p.setAsNonStaleRead()
 }
 
-func (p *staleReadProcessor) evaluateFromStmtTSOrSysVariable(stmtTS uint64) error {
+func (p *staleReadProcessor) evaluateFromStmtTSOrSysVariable(stmtTS uint64, evaluator StalenessTSEvaluator) error {
 	// If `txnReadTS` is not 0, it means  we meet following situation:
 	// set transaction read only as of timestamp ...
 	// select from table or execute prepared statement
@@ -235,6 +241,13 @@ func (p *staleReadProcessor) evaluateFromStmtTSOrSysVariable(stmtTS uint64) erro
 
 	if stmtTS > 0 {
 		p.stmtTS = stmtTS
+		if evaluator != nil {
+			is, err := GetSessionSnapshotInfoSchema(p.sctx, stmtTS)
+			if err != nil {
+				return err
+			}
+			return p.setEvaluatedValues(stmtTS, is, evaluator)
+		}
 		return p.setEvaluatedTS(stmtTS)
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43044

Problem Summary:

### What is changed and how it works?

Recalculate the snapshot ts for staleread when it's provided by as of statement.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the bug that prepared staleread cannot read following changes.
```
