### PR TITLE
planner: fix unsafe sync.Pool used in non-prep plan cache

### DIFF
--- a/planner/core/plan_cache_param.go
+++ b/planner/core/plan_cache_param.go
@@ -88,9 +88,7 @@ func (pr *paramReplacer) Leave(in ast.Node) (out ast.Node, ok bool) {
 }
 
 func (pr *paramReplacer) Reset() {
-	if pr.params != nil {
-		pr.params = pr.params[:0]
-	}
+	pr.params = nil
 }
 
 // GetParamSQLFromAST returns the parameterized SQL of this AST.

--- a/planner/core/plan_cache_param.go
+++ b/planner/core/plan_cache_param.go
@@ -88,7 +88,7 @@ func (pr *paramReplacer) Leave(in ast.Node) (out ast.Node, ok bool) {
 }
 
 func (pr *paramReplacer) Reset() {
-	pr.params = nil
+	pr.params = make([]*driver.ValueExpr, 0, 4)
 }
 
 // GetParamSQLFromAST returns the parameterized SQL of this AST.

--- a/planner/core/plan_cache_param_test.go
+++ b/planner/core/plan_cache_param_test.go
@@ -124,11 +124,11 @@ func TestParameterize(t *testing.T) {
 
 func TestGetParamSQLFromASTConcurrently(t *testing.T) {
 	n := 100
-	var sqls []string
+	sqls := make([]string, 0, n)
 	for i := 0; i < n; i++ {
 		sqls = append(sqls, fmt.Sprintf(`insert into t values (%d, %d, %d)`, i*3+0, i*3+1, i*3+2))
 	}
-	var stmts []ast.StmtNode
+	stmts := make([]ast.StmtNode, 0, n)
 	for _, sql := range sqls {
 		stmt, err := parser.New().ParseOneStmt(sql, "", "")
 		require.Nil(t, err)

--- a/planner/core/plan_cache_param_test.go
+++ b/planner/core/plan_cache_param_test.go
@@ -138,19 +138,18 @@ func TestGetParamSQLFromASTConcurrently(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < n; i++ {
 		wg.Add(1)
-		go func() {
+		go func(id int) {
 			for i := 0; i < 1000; i++ {
-				idx := rand.Intn(n)
-				_, vals, err := GetParamSQLFromAST(context.Background(), MockContext(), stmts[idx])
+				_, vals, err := GetParamSQLFromAST(context.Background(), MockContext(), stmts[id])
 				require.Nil(t, err)
 				require.Equal(t, len(vals), 3)
-				require.Equal(t, vals[0].GetValue(), int64(idx*3+0))
-				require.Equal(t, vals[1].GetValue(), int64(idx*3+1))
-				require.Equal(t, vals[2].GetValue(), int64(idx*3+2))
+				require.Equal(t, vals[0].GetValue(), int64(id*3+0))
+				require.Equal(t, vals[1].GetValue(), int64(id*3+1))
+				require.Equal(t, vals[2].GetValue(), int64(id*3+2))
 				time.Sleep(time.Millisecond + time.Duration(rand.Intn(int(time.Millisecond))))
 			}
 			wg.Done()
-		}()
+		}(i)
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36598

Problem Summary: planner: fix unsafe sync.Pool used in non-prep plan cache

### What is changed and how it works?

planner: fix unsafe sync.Pool used in non-prep plan cache

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
