### PR TITLE
resource_control: make metrics time point match in dynamic calibrate

### DIFF
--- a/executor/calibrate_resource.go
+++ b/executor/calibrate_resource.go
@@ -355,6 +355,8 @@ func (t *timeSeriesValues) getValue() float64 {
 
 func (t *timeSeriesValues) advance(target time.Time) bool {
 	for ; t.idx < len(t.vals); t.idx++ {
+		// `target` is maximal time in other timeSeriesValues,
+		// so we should find the time which offset is less than 10s.
 		if t.vals[t.idx].tp.Add(time.Second * 10).After(target) {
 			return t.vals[t.idx].tp.Add(-time.Second * 10).Before(target)
 		}

--- a/executor/calibrate_resource.go
+++ b/executor/calibrate_resource.go
@@ -238,7 +238,7 @@ func (e *calibrateResourceExec) dynamicCalibrate(ctx context.Context, req *chunk
 		if tidbCPUs.getTime().Before(minTime) {
 			minTime = tidbCPUs.getTime()
 		}
-		if !rus.findTime(minTime) || !tikvCPUs.findTime(minTime) || !tidbCPUs.findTime(minTime) {
+		if !rus.advance(minTime) || !tikvCPUs.advance(minTime) || !tidbCPUs.advance(minTime) {
 			break
 		}
 		tikvQuota, tidbQuota := tikvCPUs.getValue()/totalKVCPUQuota, tidbCPUs.getValue()/totalTiDBCPU
@@ -353,7 +353,7 @@ func (t *timeSeriesValues) getValue() float64 {
 	return t.vals[t.idx].val
 }
 
-func (t *timeSeriesValues) findTime(target time.Time) bool {
+func (t *timeSeriesValues) advance(target time.Time) bool {
 	for ; t.idx < len(t.vals); t.idx++ {
 		if t.vals[t.idx].tp.Add(-time.Second * 10).Before(target) {
 			return true

--- a/executor/calibrate_resource.go
+++ b/executor/calibrate_resource.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/duration"
+	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/sessiontxn/staleread"
 	"github.com/pingcap/tidb/util/chunk"
@@ -211,34 +212,48 @@ func (e *calibrateResourceExec) dynamicCalibrate(ctx context.Context, req *chunk
 	if err != nil {
 		return err
 	}
-	rus, err := getRUPerSec(ctx, exec, startTime, endTime)
+	rus, err := getRUPerSec(e.ctx, ctx, exec, startTime, endTime)
 	if err != nil {
 		return err
 	}
-	tikvCPUs, err := getComponentCPUUsagePerSec(ctx, exec, "tikv", startTime, endTime)
+	tikvCPUs, err := getComponentCPUUsagePerSec(e.ctx, ctx, exec, "tikv", startTime, endTime)
 	if err != nil {
 		return err
 	}
-	tidbCPUs, err := getComponentCPUUsagePerSec(ctx, exec, "tidb", startTime, endTime)
+	tidbCPUs, err := getComponentCPUUsagePerSec(e.ctx, ctx, exec, "tidb", startTime, endTime)
 	if err != nil {
 		return err
 	}
 	quotas := make([]float64, 0)
 	lowCount := 0
-	for idx, ru := range rus {
-		if idx >= len(tikvCPUs) || idx >= len(tidbCPUs) {
+	for {
+		if rus.isEnd() || tikvCPUs.isEnd() || tidbCPUs.isEnd() {
 			break
 		}
-		tikvQuota, tidbQuota := tikvCPUs[idx]/totalKVCPUQuota, tidbCPUs[idx]/totalTiDBCPU
+		// make time point match
+		minTime := rus.getTime()
+		if tikvCPUs.getTime().Before(minTime) {
+			minTime = tikvCPUs.getTime()
+		}
+		if tidbCPUs.getTime().Before(minTime) {
+			minTime = tidbCPUs.getTime()
+		}
+		if !rus.findTime(minTime) || !tikvCPUs.findTime(minTime) || !tidbCPUs.findTime(minTime) {
+			break
+		}
+		tikvQuota, tidbQuota := tikvCPUs.getValue()/totalKVCPUQuota, tidbCPUs.getValue()/totalTiDBCPU
 		// If one of the two cpu usage is greater than the `valuableUsageThreshold`, we can accept it.
 		// And if both are greater than the `lowUsageThreshold`, we can also accpet it.
 		if tikvQuota > valuableUsageThreshold || tidbQuota > valuableUsageThreshold {
-			quotas = append(quotas, ru/mathutil.Max(tikvQuota, tidbQuota))
+			quotas = append(quotas, rus.getValue()/mathutil.Max(tikvQuota, tidbQuota))
 		} else if tikvQuota < lowUsageThreshold || tidbQuota < lowUsageThreshold {
 			lowCount++
 		} else {
-			quotas = append(quotas, ru/mathutil.Max(tikvQuota, tidbQuota))
+			quotas = append(quotas, rus.getValue()/mathutil.Max(tikvQuota, tidbQuota))
 		}
+		rus.next()
+		tidbCPUs.next()
+		tikvCPUs.next()
 	}
 	if len(quotas) < 5 {
 		return errors.Errorf("There are too few metrics points available in selected time window")
@@ -312,14 +327,49 @@ func getTiDBTotalCPUQuota(ctx context.Context, exec sqlexec.RestrictedSQLExecuto
 	return getNumberFromMetrics(ctx, exec, query, "tidb_server_maxprocs")
 }
 
-func getRUPerSec(ctx context.Context, exec sqlexec.RestrictedSQLExecutor, startTime, endTime string) ([]float64, error) {
-	query := fmt.Sprintf("SELECT value FROM METRICS_SCHEMA.resource_manager_resource_unit where time >= '%s' and time <= '%s' ORDER BY time desc", startTime, endTime)
-	return getValuesFromMetrics(ctx, exec, query, "resource_manager_resource_unit")
+type timePointValue struct {
+	tp  time.Time
+	val float64
 }
 
-func getComponentCPUUsagePerSec(ctx context.Context, exec sqlexec.RestrictedSQLExecutor, component, startTime, endTime string) ([]float64, error) {
-	query := fmt.Sprintf("SELECT sum(value) FROM METRICS_SCHEMA.process_cpu_usage where time >= '%s' and time <= '%s' and job like '%%%s' GROUP BY time ORDER BY time desc", startTime, endTime, component)
-	return getValuesFromMetrics(ctx, exec, query, "process_cpu_usage")
+type timeSeriesValues struct {
+	idx  int
+	vals []*timePointValue
+}
+
+func (t *timeSeriesValues) isEnd() bool {
+	return t.idx >= len(t.vals)
+}
+
+func (t *timeSeriesValues) next() {
+	t.idx++
+}
+
+func (t *timeSeriesValues) getTime() time.Time {
+	return t.vals[t.idx].tp
+}
+
+func (t *timeSeriesValues) getValue() float64 {
+	return t.vals[t.idx].val
+}
+
+func (t *timeSeriesValues) findTime(target time.Time) bool {
+	for ; t.idx < len(t.vals); t.idx++ {
+		if t.vals[t.idx].tp.Add(-time.Second * 10).Before(target) {
+			return true
+		}
+	}
+	return false
+}
+
+func getRUPerSec(sctx sessionctx.Context, ctx context.Context, exec sqlexec.RestrictedSQLExecutor, startTime, endTime string) (*timeSeriesValues, error) {
+	query := fmt.Sprintf("SELECT time, value FROM METRICS_SCHEMA.resource_manager_resource_unit where time >= '%s' and time <= '%s' ORDER BY time desc", startTime, endTime)
+	return getValuesFromMetrics(sctx, ctx, exec, query, "resource_manager_resource_unit")
+}
+
+func getComponentCPUUsagePerSec(sctx sessionctx.Context, ctx context.Context, exec sqlexec.RestrictedSQLExecutor, component, startTime, endTime string) (*timeSeriesValues, error) {
+	query := fmt.Sprintf("SELECT time, sum(value) FROM METRICS_SCHEMA.process_cpu_usage where time >= '%s' and time <= '%s' and job like '%%%s' GROUP BY time ORDER BY time desc", startTime, endTime, component)
+	return getValuesFromMetrics(sctx, ctx, exec, query, "process_cpu_usage")
 }
 
 func getNumberFromMetrics(ctx context.Context, exec sqlexec.RestrictedSQLExecutor, query, metrics string) (float64, error) {
@@ -334,7 +384,7 @@ func getNumberFromMetrics(ctx context.Context, exec sqlexec.RestrictedSQLExecuto
 	return rows[0].GetFloat64(0), nil
 }
 
-func getValuesFromMetrics(ctx context.Context, exec sqlexec.RestrictedSQLExecutor, query, metrics string) ([]float64, error) {
+func getValuesFromMetrics(sctx sessionctx.Context, ctx context.Context, exec sqlexec.RestrictedSQLExecutor, query, metrics string) (*timeSeriesValues, error) {
 	rows, _, err := exec.ExecRestrictedSQL(ctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession}, query)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -342,9 +392,14 @@ func getValuesFromMetrics(ctx context.Context, exec sqlexec.RestrictedSQLExecuto
 	if len(rows) == 0 {
 		return nil, errors.Errorf("metrics '%s' is empty", metrics)
 	}
-	ret := make([]float64, 0, len(rows))
+	ret := make([]*timePointValue, 0, len(rows))
 	for _, row := range rows {
-		ret = append(ret, row.GetFloat64(0))
+		if tp, err := row.GetTime(0).AdjustedGoTime(sctx.GetSessionVars().Location()); err == nil {
+			ret = append(ret, &timePointValue{
+				tp:  tp,
+				val: row.GetFloat64(1),
+			})
+		}
 	}
-	return ret, nil
+	return &timeSeriesValues{idx: 0, vals: ret}, nil
 }

--- a/executor/calibrate_resource_test.go
+++ b/executor/calibrate_resource_test.go
@@ -321,7 +321,7 @@ func TestCalibrateResource(t *testing.T) {
 		types.MakeDatums(datetime("2020-02-12 10:49:00"), "tikv-1", "tikv", 2.234),
 		types.MakeDatums(datetime("2020-02-12 10:38:00"), "tikv-1", "tikv", 2.213),
 		types.MakeDatums(datetime("2020-02-12 10:39:00"), "tikv-1", "tikv", 2.209),
-		types.MakeDatums(datetime("2020-02-12 10:46:00"), "tikv-1", "tidb", 3.220),
+		types.MakeDatums(datetime("2020-02-12 10:46:00"), "tikv-1", "tikv", 3.220),
 		types.MakeDatums(datetime("2020-02-12 10:40:00"), "tikv-1", "tikv", 2.213),
 		types.MakeDatums(datetime("2020-02-12 10:47:00"), "tikv-1", "tikv", 2.236),
 		types.MakeDatums(datetime("2020-02-12 10:42:00"), "tikv-1", "tikv", 2.228),
@@ -350,7 +350,7 @@ func TestCalibrateResource(t *testing.T) {
 		types.MakeDatums(datetime("2020-02-12 10:43:00"), "tikv-2", "tikv", 2.119),
 		types.MakeDatums(datetime("2020-02-12 10:44:00"), "tikv-2", "tikv", 2.120),
 		types.MakeDatums(datetime("2020-02-12 10:45:00"), "tikv-2", "tikv", 2.281),
-		types.MakeDatums(datetime("2020-02-12 10:48:00"), "tikv-2", "tidb", 3.220),
+		types.MakeDatums(datetime("2020-02-12 10:48:00"), "tikv-2", "tikv", 3.220),
 	}
 	mockData["process_cpu_usage"] = cpu2Mofidy
 	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:25:00' DURATION '20m'").Check(testkit.Rows("5616"))

--- a/executor/calibrate_resource_test.go
+++ b/executor/calibrate_resource_test.go
@@ -355,6 +355,35 @@ func TestCalibrateResource(t *testing.T) {
 	mockData["process_cpu_usage"] = cpu2Mofidy
 	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:25:00' DURATION '20m'").Check(testkit.Rows("5616"))
 
+	ruModify3 := [][]types.Datum{
+		types.MakeDatums(datetime("2020-02-12 10:25:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:26:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:27:00"), 4.0),
+		types.MakeDatums(datetime("2020-02-12 10:28:00"), 6.0),
+		types.MakeDatums(datetime("2020-02-12 10:29:00"), 2200.0),
+		types.MakeDatums(datetime("2020-02-12 10:30:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:31:00"), 7.0),
+		types.MakeDatums(datetime("2020-02-12 10:32:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:33:00"), 7.0),
+		types.MakeDatums(datetime("2020-02-12 10:34:00"), 8.0),
+		types.MakeDatums(datetime("2020-02-12 10:35:00"), 29.0),
+		types.MakeDatums(datetime("2020-02-12 10:36:20"), 2100.0),
+		types.MakeDatums(datetime("2020-02-12 10:37:00"), 49.0),
+		types.MakeDatums(datetime("2020-02-12 10:38:00"), 2300.0),
+		types.MakeDatums(datetime("2020-02-12 10:39:00"), 2230.0),
+		types.MakeDatums(datetime("2020-02-12 10:40:00"), 2210.0),
+		types.MakeDatums(datetime("2020-02-12 10:41:00"), 47.0),
+		types.MakeDatums(datetime("2020-02-12 10:42:20"), 2330.0),
+		types.MakeDatums(datetime("2020-02-12 10:43:00"), 2330.0),
+		types.MakeDatums(datetime("2020-02-12 10:44:00"), 2300.0),
+		types.MakeDatums(datetime("2020-02-12 10:45:00"), 2280.0),
+		types.MakeDatums(datetime("2020-02-12 10:47:00"), 2250.0),
+		types.MakeDatums(datetime("2020-02-12 10:49:00"), 2250.0),
+	}
+	mockData["resource_manager_resource_unit"] = ruModify3
+	// because there are 20s difference in two time points, the result is changed.
+	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:25:00' DURATION '20m'").Check(testkit.Rows("4987"))
+
 	ru2 := [][]types.Datum{
 		types.MakeDatums(datetime("2020-02-12 10:25:00"), 2200.0),
 		types.MakeDatums(datetime("2020-02-12 10:26:00"), 2100.0),

--- a/executor/calibrate_resource_test.go
+++ b/executor/calibrate_resource_test.go
@@ -126,7 +126,7 @@ func TestCalibrateResource(t *testing.T) {
 	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE").Check(testkit.Rows("38094"))
 
 	// construct data for dynamic calibrate
-	mockData["resource_manager_resource_unit"] = [][]types.Datum{
+	ru1 := [][]types.Datum{
 		types.MakeDatums(datetime("2020-02-12 10:35:00"), 2200.0),
 		types.MakeDatums(datetime("2020-02-12 10:36:00"), 2100.0),
 		types.MakeDatums(datetime("2020-02-12 10:37:00"), 2250.0),
@@ -139,8 +139,9 @@ func TestCalibrateResource(t *testing.T) {
 		types.MakeDatums(datetime("2020-02-12 10:44:00"), 2300.0),
 		types.MakeDatums(datetime("2020-02-12 10:45:00"), 2280.0),
 	}
+	mockData["resource_manager_resource_unit"] = ru1
 
-	mockData["process_cpu_usage"] = [][]types.Datum{
+	cpu1 := [][]types.Datum{
 		types.MakeDatums(datetime("2020-02-12 10:35:00"), "tidb-0", "tidb", 1.212),
 		types.MakeDatums(datetime("2020-02-12 10:36:00"), "tidb-0", "tidb", 1.233),
 		types.MakeDatums(datetime("2020-02-12 10:37:00"), "tidb-0", "tidb", 1.234),
@@ -186,11 +187,12 @@ func TestCalibrateResource(t *testing.T) {
 		types.MakeDatums(datetime("2020-02-12 10:44:00"), "tikv-2", "tikv", 2.120),
 		types.MakeDatums(datetime("2020-02-12 10:45:00"), "tikv-2", "tikv", 2.281),
 	}
+	mockData["process_cpu_usage"] = cpu1
 
 	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:35:00' DURATION '10m'").Check(testkit.Rows("8161"))
 	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:35:00' END_TIME '2020-02-12 10:45:00'").Check(testkit.Rows("8161"))
 
-	mockData["process_cpu_usage"] = [][]types.Datum{
+	cpu2 := [][]types.Datum{
 		types.MakeDatums(datetime("2020-02-12 10:35:00"), "tidb-0", "tidb", 3.212),
 		types.MakeDatums(datetime("2020-02-12 10:36:00"), "tidb-0", "tidb", 3.233),
 		types.MakeDatums(datetime("2020-02-12 10:37:00"), "tidb-0", "tidb", 3.234),
@@ -236,12 +238,146 @@ func TestCalibrateResource(t *testing.T) {
 		types.MakeDatums(datetime("2020-02-12 10:44:00"), "tikv-2", "tikv", 2.120),
 		types.MakeDatums(datetime("2020-02-12 10:45:00"), "tikv-2", "tikv", 2.281),
 	}
+	mockData["process_cpu_usage"] = cpu2
 
 	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:35:00' DURATION '10m'").Check(testkit.Rows("5616"))
 	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:35:00' END_TIME '2020-02-12 10:45:00'").Check(testkit.Rows("5616"))
 	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:35:00' DURATION '10m'").Check(testkit.Rows("5616"))
 	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE END_TIME '2020-02-12 10:45:00' START_TIME '2020-02-12 10:35:00'").Check(testkit.Rows("5616"))
 	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE END_TIME '2020-02-12 10:45:00' DURATION '5m' START_TIME '2020-02-12 10:35:00' ").Check(testkit.Rows("5616"))
+
+	// Statistical time points do not correspond
+	ruModify1 := [][]types.Datum{
+		types.MakeDatums(datetime("2020-02-12 10:25:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:26:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:27:00"), 4.0),
+		types.MakeDatums(datetime("2020-02-12 10:28:00"), 6.0),
+		types.MakeDatums(datetime("2020-02-12 10:29:00"), 3.0),
+		types.MakeDatums(datetime("2020-02-12 10:30:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:31:00"), 7.0),
+		types.MakeDatums(datetime("2020-02-12 10:32:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:33:00"), 7.0),
+		types.MakeDatums(datetime("2020-02-12 10:34:00"), 8.0),
+		types.MakeDatums(datetime("2020-02-12 10:35:00"), 2200.0),
+		types.MakeDatums(datetime("2020-02-12 10:36:00"), 2100.0),
+		types.MakeDatums(datetime("2020-02-12 10:37:00"), 2250.0),
+		types.MakeDatums(datetime("2020-02-12 10:38:00"), 2300.0),
+		types.MakeDatums(datetime("2020-02-12 10:39:00"), 2230.0),
+		types.MakeDatums(datetime("2020-02-12 10:40:00"), 2210.0),
+		types.MakeDatums(datetime("2020-02-12 10:41:00"), 2250.0),
+		types.MakeDatums(datetime("2020-02-12 10:42:00"), 2330.0),
+		types.MakeDatums(datetime("2020-02-12 10:43:00"), 2330.0),
+		types.MakeDatums(datetime("2020-02-12 10:44:00"), 2300.0),
+		types.MakeDatums(datetime("2020-02-12 10:45:00"), 2280.0),
+		types.MakeDatums(datetime("2020-02-12 10:46:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:47:00"), 7.0),
+		types.MakeDatums(datetime("2020-02-12 10:48:00"), 8.0),
+	}
+	mockData["resource_manager_resource_unit"] = ruModify1
+	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:25:00' DURATION '20m'").Check(testkit.Rows("5616"))
+
+	ruModify2 := [][]types.Datum{
+		types.MakeDatums(datetime("2020-02-12 10:25:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:26:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:27:00"), 4.0),
+		types.MakeDatums(datetime("2020-02-12 10:28:00"), 6.0),
+		types.MakeDatums(datetime("2020-02-12 10:29:00"), 2200.0),
+		types.MakeDatums(datetime("2020-02-12 10:30:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:31:00"), 7.0),
+		types.MakeDatums(datetime("2020-02-12 10:32:00"), 5.0),
+		types.MakeDatums(datetime("2020-02-12 10:33:00"), 7.0),
+		types.MakeDatums(datetime("2020-02-12 10:34:00"), 8.0),
+		types.MakeDatums(datetime("2020-02-12 10:35:00"), 29.0),
+		types.MakeDatums(datetime("2020-02-12 10:36:00"), 2100.0),
+		types.MakeDatums(datetime("2020-02-12 10:37:00"), 49.0),
+		types.MakeDatums(datetime("2020-02-12 10:38:00"), 2300.0),
+		types.MakeDatums(datetime("2020-02-12 10:39:00"), 2230.0),
+		types.MakeDatums(datetime("2020-02-12 10:40:00"), 2210.0),
+		types.MakeDatums(datetime("2020-02-12 10:41:00"), 47.0),
+		types.MakeDatums(datetime("2020-02-12 10:42:00"), 2330.0),
+		types.MakeDatums(datetime("2020-02-12 10:43:00"), 2330.0),
+		types.MakeDatums(datetime("2020-02-12 10:44:00"), 2300.0),
+		types.MakeDatums(datetime("2020-02-12 10:45:00"), 2280.0),
+		types.MakeDatums(datetime("2020-02-12 10:47:00"), 2250.0),
+		types.MakeDatums(datetime("2020-02-12 10:49:00"), 2250.0),
+	}
+	mockData["resource_manager_resource_unit"] = ruModify2
+	cpu2Mofidy := [][]types.Datum{
+		types.MakeDatums(datetime("2020-02-12 10:29:00"), "tidb-0", "tidb", 3.212),
+		types.MakeDatums(datetime("2020-02-12 10:36:00"), "tidb-0", "tidb", 3.233),
+		types.MakeDatums(datetime("2020-02-12 10:38:00"), "tidb-0", "tidb", 3.213),
+		types.MakeDatums(datetime("2020-02-12 10:39:00"), "tidb-0", "tidb", 3.209),
+		types.MakeDatums(datetime("2020-02-12 10:40:00"), "tidb-0", "tidb", 3.213),
+		types.MakeDatums(datetime("2020-02-12 10:42:00"), "tidb-0", "tidb", 3.228),
+		types.MakeDatums(datetime("2020-02-12 10:43:00"), "tidb-0", "tidb", 3.219),
+		types.MakeDatums(datetime("2020-02-12 10:44:00"), "tidb-0", "tidb", 3.220),
+		types.MakeDatums(datetime("2020-02-12 10:45:00"), "tidb-0", "tidb", 3.221),
+		types.MakeDatums(datetime("2020-02-12 10:46:00"), "tidb-0", "tidb", 3.220),
+		types.MakeDatums(datetime("2020-02-12 10:47:00"), "tidb-0", "tidb", 3.236),
+		types.MakeDatums(datetime("2020-02-12 10:48:00"), "tidb-0", "tidb", 3.220),
+		types.MakeDatums(datetime("2020-02-12 10:49:00"), "tidb-0", "tidb", 3.234),
+		types.MakeDatums(datetime("2020-02-12 10:29:00"), "tikv-1", "tikv", 2.212),
+		types.MakeDatums(datetime("2020-02-12 10:36:00"), "tikv-1", "tikv", 2.233),
+		types.MakeDatums(datetime("2020-02-12 10:49:00"), "tikv-1", "tikv", 2.234),
+		types.MakeDatums(datetime("2020-02-12 10:38:00"), "tikv-1", "tikv", 2.213),
+		types.MakeDatums(datetime("2020-02-12 10:39:00"), "tikv-1", "tikv", 2.209),
+		types.MakeDatums(datetime("2020-02-12 10:46:00"), "tikv-1", "tidb", 3.220),
+		types.MakeDatums(datetime("2020-02-12 10:40:00"), "tikv-1", "tikv", 2.213),
+		types.MakeDatums(datetime("2020-02-12 10:47:00"), "tikv-1", "tikv", 2.236),
+		types.MakeDatums(datetime("2020-02-12 10:42:00"), "tikv-1", "tikv", 2.228),
+		types.MakeDatums(datetime("2020-02-12 10:43:00"), "tikv-1", "tikv", 2.219),
+		types.MakeDatums(datetime("2020-02-12 10:44:00"), "tikv-1", "tikv", 2.220),
+		types.MakeDatums(datetime("2020-02-12 10:45:00"), "tikv-1", "tikv", 2.281),
+		types.MakeDatums(datetime("2020-02-12 10:29:00"), "tikv-0", "tikv", 2.282),
+		types.MakeDatums(datetime("2020-02-12 10:36:00"), "tikv-0", "tikv", 2.283),
+		types.MakeDatums(datetime("2020-02-12 10:49:00"), "tikv-0", "tikv", 2.284),
+		types.MakeDatums(datetime("2020-02-12 10:38:00"), "tikv-0", "tikv", 2.283),
+		types.MakeDatums(datetime("2020-02-12 10:39:00"), "tikv-0", "tikv", 2.289),
+		types.MakeDatums(datetime("2020-02-12 10:40:00"), "tikv-0", "tikv", 2.283),
+		types.MakeDatums(datetime("2020-02-12 10:47:00"), "tikv-0", "tikv", 2.286),
+		types.MakeDatums(datetime("2020-02-12 10:42:00"), "tikv-0", "tikv", 2.288),
+		types.MakeDatums(datetime("2020-02-12 10:43:00"), "tikv-0", "tikv", 2.289),
+		types.MakeDatums(datetime("2020-02-12 10:44:00"), "tikv-0", "tikv", 2.280),
+		types.MakeDatums(datetime("2020-02-12 10:45:00"), "tikv-0", "tikv", 2.281),
+		types.MakeDatums(datetime("2020-02-12 10:29:00"), "tikv-2", "tikv", 2.112),
+		types.MakeDatums(datetime("2020-02-12 10:36:00"), "tikv-2", "tikv", 2.133),
+		types.MakeDatums(datetime("2020-02-12 10:49:00"), "tikv-2", "tikv", 2.134),
+		types.MakeDatums(datetime("2020-02-12 10:38:00"), "tikv-2", "tikv", 2.113),
+		types.MakeDatums(datetime("2020-02-12 10:39:00"), "tikv-2", "tikv", 2.109),
+		types.MakeDatums(datetime("2020-02-12 10:40:00"), "tikv-2", "tikv", 2.113),
+		types.MakeDatums(datetime("2020-02-12 10:47:00"), "tikv-2", "tikv", 2.136),
+		types.MakeDatums(datetime("2020-02-12 10:42:00"), "tikv-2", "tikv", 2.128),
+		types.MakeDatums(datetime("2020-02-12 10:43:00"), "tikv-2", "tikv", 2.119),
+		types.MakeDatums(datetime("2020-02-12 10:44:00"), "tikv-2", "tikv", 2.120),
+		types.MakeDatums(datetime("2020-02-12 10:45:00"), "tikv-2", "tikv", 2.281),
+		types.MakeDatums(datetime("2020-02-12 10:48:00"), "tikv-2", "tidb", 3.220),
+	}
+	mockData["process_cpu_usage"] = cpu2Mofidy
+	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:25:00' DURATION '20m'").Check(testkit.Rows("5616"))
+
+	ru2 := [][]types.Datum{
+		types.MakeDatums(datetime("2020-02-12 10:25:00"), 2200.0),
+		types.MakeDatums(datetime("2020-02-12 10:26:00"), 2100.0),
+		types.MakeDatums(datetime("2020-02-12 10:27:00"), 2250.0),
+		types.MakeDatums(datetime("2020-02-12 10:28:00"), 2300.0),
+		types.MakeDatums(datetime("2020-02-12 10:29:00"), 2230.0),
+		types.MakeDatums(datetime("2020-02-12 10:30:00"), 2210.0),
+		types.MakeDatums(datetime("2020-02-12 10:31:00"), 2250.0),
+		types.MakeDatums(datetime("2020-02-12 10:32:00"), 2330.0),
+		types.MakeDatums(datetime("2020-02-12 10:33:00"), 2330.0),
+		types.MakeDatums(datetime("2020-02-12 10:34:00"), 2300.0),
+		types.MakeDatums(datetime("2020-02-12 10:35:00"), 2280.0),
+	}
+	mockData["resource_manager_resource_unit"] = ru2
+	rs, err = tk.Exec("CALIBRATE RESOURCE START_TIME '2020-02-12 10:25:00' DURATION '20m'")
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	err = rs.Next(ctx, rs.NewChunk(nil))
+	require.ErrorContains(t, err, "There are too few metrics points available in selected time window")
+
+	// flash back to init data.
+	mockData["resource_manager_resource_unit"] = ru1
+	mockData["process_cpu_usage"] = cpu2
 
 	rs, err = tk.Exec("CALIBRATE RESOURCE START_TIME '2020-02-12 10:35:00'")
 	require.NoError(t, err)

--- a/executor/calibrate_resource_test.go
+++ b/executor/calibrate_resource_test.go
@@ -382,7 +382,7 @@ func TestCalibrateResource(t *testing.T) {
 	}
 	mockData["resource_manager_resource_unit"] = ruModify3
 	// because there are 20s difference in two time points, the result is changed.
-	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:25:00' DURATION '20m'").Check(testkit.Rows("4987"))
+	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE START_TIME '2020-02-12 10:25:00' DURATION '20m'").Check(testkit.Rows("5613"))
 
 	ru2 := [][]types.Datum{
 		types.MakeDatums(datetime("2020-02-12 10:25:00"), 2200.0),
@@ -398,6 +398,46 @@ func TestCalibrateResource(t *testing.T) {
 		types.MakeDatums(datetime("2020-02-12 10:35:00"), 2280.0),
 	}
 	mockData["resource_manager_resource_unit"] = ru2
+	rs, err = tk.Exec("CALIBRATE RESOURCE START_TIME '2020-02-12 10:25:00' DURATION '20m'")
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	err = rs.Next(ctx, rs.NewChunk(nil))
+	require.ErrorContains(t, err, "There are too few metrics points available in selected time window")
+
+	ru3 := [][]types.Datum{
+		types.MakeDatums(datetime("2020-02-12 10:25:00"), 2200.0),
+		types.MakeDatums(datetime("2020-02-12 10:27:00"), 2100.0),
+		types.MakeDatums(datetime("2020-02-12 10:28:00"), 2250.0),
+		types.MakeDatums(datetime("2020-02-12 10:30:00"), 2300.0),
+		types.MakeDatums(datetime("2020-02-12 10:31:00"), 2230.0),
+		types.MakeDatums(datetime("2020-02-12 10:33:00"), 2210.0),
+		types.MakeDatums(datetime("2020-02-12 10:34:00"), 2250.0),
+		types.MakeDatums(datetime("2020-02-12 10:36:00"), 2330.0),
+		types.MakeDatums(datetime("2020-02-12 10:37:00"), 2330.0),
+		types.MakeDatums(datetime("2020-02-12 10:39:00"), 2280.0),
+		types.MakeDatums(datetime("2020-02-12 10:40:00"), 2280.0),
+		types.MakeDatums(datetime("2020-02-12 10:42:00"), 2280.0),
+		types.MakeDatums(datetime("2020-02-12 10:43:00"), 2280.0),
+	}
+	mockData["resource_manager_resource_unit"] = ru3
+	cpu3 := [][]types.Datum{
+		types.MakeDatums(datetime("2020-02-12 10:26:00"), "tidb-0", "tidb", 3.212),
+		types.MakeDatums(datetime("2020-02-12 10:29:00"), "tidb-0", "tidb", 3.233),
+		types.MakeDatums(datetime("2020-02-12 10:32:00"), "tidb-0", "tidb", 3.213),
+		types.MakeDatums(datetime("2020-02-12 10:35:00"), "tidb-0", "tidb", 3.209),
+		types.MakeDatums(datetime("2020-02-12 10:38:00"), "tidb-0", "tidb", 3.213),
+		types.MakeDatums(datetime("2020-02-12 10:41:00"), "tidb-0", "tidb", 3.228),
+		types.MakeDatums(datetime("2020-02-12 10:44:00"), "tidb-0", "tidb", 3.219),
+
+		types.MakeDatums(datetime("2020-02-12 10:26:00"), "tikv-0", "tikv", 2.282),
+		types.MakeDatums(datetime("2020-02-12 10:29:00"), "tikv-0", "tikv", 2.283),
+		types.MakeDatums(datetime("2020-02-12 10:32:00"), "tikv-0", "tikv", 2.284),
+		types.MakeDatums(datetime("2020-02-12 10:35:00"), "tikv-0", "tikv", 2.283),
+		types.MakeDatums(datetime("2020-02-12 10:38:00"), "tikv-0", "tikv", 2.289),
+		types.MakeDatums(datetime("2020-02-12 10:41:00"), "tikv-0", "tikv", 2.283),
+		types.MakeDatums(datetime("2020-02-12 10:44:00"), "tikv-0", "tikv", 2.286),
+	}
+	mockData["process_cpu_usage"] = cpu3
 	rs, err = tk.Exec("CALIBRATE RESOURCE START_TIME '2020-02-12 10:25:00' DURATION '20m'")
 	require.NoError(t, err)
 	require.NotNil(t, rs)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #43212

Problem Summary:
When the value is 0, the corresponding metrics does not return. If `RU` metrics is empty but `CPU` metrics is not (for example, when doing backup or restore), this logic will now cause `RU` and CPU` to be misaligned

### What is changed and how it works?
Exactly match ru, tidb, and tikv metrics according to metrics timestamps

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
