### PR TITLE
domin: fix do not marshal `RuleOp` correctly

### DIFF
--- a/domain/infosync/BUILD.bazel
+++ b/domain/infosync/BUILD.bazel
@@ -61,7 +61,7 @@ go_test(
     srcs = ["info_test.go"],
     embed = [":infosync"],
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//ddl/placement",
         "//ddl/util",

--- a/domain/infosync/info_test.go
+++ b/domain/infosync/info_test.go
@@ -284,3 +284,36 @@ func TestTiFlashManager(t *testing.T) {
 
 	CloseTiFlashManager(ctx)
 }
+
+func TestRuleOp(t *testing.T) {
+	rule := MakeNewRule(1, 2, []string{"a"})
+	ruleOp := RuleOp{
+		TiFlashRule:      &rule,
+		Action:           RuleOpAdd,
+		DeleteByIDPrefix: false,
+	}
+	j, err := json.Marshal(&ruleOp)
+	require.NoError(t, err)
+	ruleOpExpect := &RuleOp{}
+	json.Unmarshal(j, ruleOpExpect)
+	require.Equal(t, ruleOp.Action, ruleOpExpect.Action)
+	require.Equal(t, *ruleOp.TiFlashRule, *ruleOpExpect.TiFlashRule)
+	require.Equal(t, ruleOp.TiFlashRule.ID, ruleOpExpect.TiFlashRule.ID)
+	ruleOps := make([]RuleOp, 0, 2)
+	for i := 0; i < 2; i++ {
+		rule := MakeNewRule(int64(i), 2, []string{"a"})
+		ruleOps = append(ruleOps, RuleOp{
+			TiFlashRule:      &rule,
+			Action:           RuleOpAdd,
+			DeleteByIDPrefix: false,
+		})
+	}
+	j, err = json.Marshal(ruleOps)
+	require.NoError(t, err)
+	var ruleOpsExpect []RuleOp
+	json.Unmarshal(j, &ruleOpsExpect)
+	require.Equal(t, ruleOps[0].Action, ruleOpsExpect[0].Action)
+	require.Equal(t, *ruleOps[0].TiFlashRule, *ruleOpsExpect[0].TiFlashRule)
+	require.Equal(t, ruleOps[1].Action, ruleOpsExpect[1].Action)
+	require.Equal(t, *ruleOps[1].TiFlashRule, *ruleOpsExpect[1].TiFlashRule)
+}

--- a/domain/infosync/info_test.go
+++ b/domain/infosync/info_test.go
@@ -298,9 +298,8 @@ func TestRuleOp(t *testing.T) {
 	json.Unmarshal(j, ruleOpExpect)
 	require.Equal(t, ruleOp.Action, ruleOpExpect.Action)
 	require.Equal(t, *ruleOp.TiFlashRule, *ruleOpExpect.TiFlashRule)
-	require.Equal(t, ruleOp.TiFlashRule.ID, ruleOpExpect.TiFlashRule.ID)
 	ruleOps := make([]RuleOp, 0, 2)
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 10; i += 2 {
 		rule := MakeNewRule(int64(i), 2, []string{"a"})
 		ruleOps = append(ruleOps, RuleOp{
 			TiFlashRule:      &rule,
@@ -308,12 +307,20 @@ func TestRuleOp(t *testing.T) {
 			DeleteByIDPrefix: false,
 		})
 	}
+	for i := 1; i < 10; i += 2 {
+		rule := MakeNewRule(int64(i), 2, []string{"b"})
+		ruleOps = append(ruleOps, RuleOp{
+			TiFlashRule:      &rule,
+			Action:           RuleOpDel,
+			DeleteByIDPrefix: false,
+		})
+	}
 	j, err = json.Marshal(ruleOps)
 	require.NoError(t, err)
 	var ruleOpsExpect []RuleOp
 	json.Unmarshal(j, &ruleOpsExpect)
-	require.Equal(t, ruleOps[0].Action, ruleOpsExpect[0].Action)
-	require.Equal(t, *ruleOps[0].TiFlashRule, *ruleOpsExpect[0].TiFlashRule)
-	require.Equal(t, ruleOps[1].Action, ruleOpsExpect[1].Action)
-	require.Equal(t, *ruleOps[1].TiFlashRule, *ruleOpsExpect[1].TiFlashRule)
+	for i := 0; i < len(ruleOps); i++ {
+		require.Equal(t, ruleOps[i].Action, ruleOpsExpect[i].Action)
+		require.Equal(t, *ruleOps[i].TiFlashRule, *ruleOpsExpect[i].TiFlashRule)
+	}
 }

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -334,7 +334,7 @@ type ruleOp struct {
 	DeleteByIDPrefix bool                   `json:"delete_by_id_prefix"`
 }
 
-// UnmarshalJSON implements json.Unmarshaler interface for RuleOp.
+// MarshalJSON implements json.Marshaler interface for RuleOp.
 func (r *RuleOp) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&ruleOp{
 		GroupID:          r.GroupID,
@@ -353,7 +353,7 @@ func (r *RuleOp) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// UnmarshalJSON implements json.Unmarshaler interface for TiFlashRule.
+// UnmarshalJSON implements json.Unmarshaler interface for RuleOp.
 func (r *RuleOp) UnmarshalJSON(bytes []byte) error {
 	var rule ruleOp
 	if err := json.Unmarshal(bytes, &rule); err != nil {

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -310,9 +310,89 @@ const (
 // RuleOp is for batching placement rule actions. The action type is
 // distinguished by the field `Action`.
 type RuleOp struct {
-	*placement.TiFlashRule            // information of the placement rule to add/delete the operation type
-	Action                 RuleOpType `json:"action"`
-	DeleteByIDPrefix       bool       `json:"delete_by_id_prefix"` // if action == delete, delete by the prefix of id
+	*placement.TiFlashRule // information of the placement rule to add/delete the operation type
+	Action                 RuleOpType
+	DeleteByIDPrefix       bool // if action == delete, delete by the prefix of id
+}
+
+var _ json.Marshaler = (*RuleOp)(nil)
+var _ json.Unmarshaler = (*RuleOp)(nil)
+
+type ruleOp struct {
+	GroupID          string                 `json:"group_id"`
+	ID               string                 `json:"id"`
+	Index            int                    `json:"index,omitempty"`
+	Override         bool                   `json:"override,omitempty"`
+	Role             placement.PeerRoleType `json:"role"`
+	Count            int                    `json:"count"`
+	Constraints      placement.Constraints  `json:"label_constraints,omitempty"`
+	LocationLabels   []string               `json:"location_labels,omitempty"`
+	IsolationLevel   string                 `json:"isolation_level,omitempty"`
+	StartKeyHex      string                 `json:"start_key"`
+	EndKeyHex        string                 `json:"end_key"`
+	Action           RuleOpType             `json:"action"`
+	DeleteByIDPrefix bool                   `json:"delete_by_id_prefix"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface for RuleOp.
+func (r *RuleOp) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&ruleOp{
+		GroupID:          r.GroupID,
+		ID:               r.ID,
+		Index:            r.Index,
+		Override:         r.Override,
+		Role:             r.Role,
+		Count:            r.Count,
+		Constraints:      r.Constraints,
+		LocationLabels:   r.LocationLabels,
+		IsolationLevel:   r.IsolationLevel,
+		StartKeyHex:      hex.EncodeToString(codec.EncodeBytes(nil, r.StartKey)),
+		EndKeyHex:        hex.EncodeToString(codec.EncodeBytes(nil, r.EndKey)),
+		Action:           r.Action,
+		DeleteByIDPrefix: r.DeleteByIDPrefix,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface for TiFlashRule.
+func (r *RuleOp) UnmarshalJSON(bytes []byte) error {
+	var rule ruleOp
+	if err := json.Unmarshal(bytes, &rule); err != nil {
+		return err
+	}
+	*r = RuleOp{
+		TiFlashRule: &placement.TiFlashRule{
+			GroupID:        rule.GroupID,
+			ID:             rule.ID,
+			Index:          rule.Index,
+			Override:       rule.Override,
+			Role:           rule.Role,
+			Count:          rule.Count,
+			Constraints:    rule.Constraints,
+			LocationLabels: rule.LocationLabels,
+			IsolationLevel: rule.IsolationLevel,
+		},
+		Action:           rule.Action,
+		DeleteByIDPrefix: rule.DeleteByIDPrefix,
+	}
+
+	startKey, err := hex.DecodeString(rule.StartKeyHex)
+	if err != nil {
+		return err
+	}
+
+	endKey, err := hex.DecodeString(rule.EndKeyHex)
+	if err != nil {
+		return err
+	}
+
+	_, r.StartKey, err = codec.DecodeBytes(startKey, nil)
+	if err != nil {
+		return err
+	}
+
+	_, r.EndKey, err = codec.DecodeBytes(endKey, nil)
+
+	return err
 }
 
 func (m *TiFlashReplicaManagerCtx) doSetPlacementRuleBatch(ctx context.Context, rules []placement.TiFlashRule) error {
@@ -333,12 +413,15 @@ func (m *TiFlashReplicaManagerCtx) doSetPlacementRuleBatch(ctx context.Context, 
 			})
 		}
 	}
+	logutil.BgLogger().Info("set placement rule batch", zap.Any("rules", ruleOps))
 	j, err := json.Marshal(ruleOps)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	logutil.BgLogger().Info("set placement rule batch", zap.String("json", string(j)))
 	buf := bytes.NewBuffer(j)
 	res, err := doRequest(ctx, "SetPlacementRuleBatch", m.etcdCli.Endpoints(), path.Join(pdapi.Config, "rules", "batch"), "POST", buf)
+	logutil.BgLogger().Info("set placement rule batch", zap.String("res", string(res)))
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -413,15 +413,12 @@ func (m *TiFlashReplicaManagerCtx) doSetPlacementRuleBatch(ctx context.Context, 
 			})
 		}
 	}
-	logutil.BgLogger().Info("set placement rule batch", zap.Any("rules", ruleOps))
 	j, err := json.Marshal(ruleOps)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	logutil.BgLogger().Info("set placement rule batch", zap.String("json", string(j)))
 	buf := bytes.NewBuffer(j)
 	res, err := doRequest(ctx, "SetPlacementRuleBatch", m.etcdCli.Endpoints(), path.Join(pdapi.Config, "rules", "batch"), "POST", buf)
-	logutil.BgLogger().Info("set placement rule batch", zap.String("res", string(res)))
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43070 

Problem Summary:

### What is changed and how it works?

`json.Marshal(ruleOps)` call `func (r *TiFlashRule) MarshalJSON() ([]byte, error)` so do not  marshal `action`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
