### PR TITLE
session: add more log for internal sql when parse failed

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -1723,21 +1723,11 @@ func (s *session) ParseWithParams(ctx context.Context, sql string, args ...inter
 	}
 	if err != nil {
 		s.rollbackOnError(ctx)
-		// Only print log message when this SQL is from the user.
-		// Mute the warning for internal SQLs.
-		if !s.sessionVars.InRestrictedSQL {
-			if s.sessionVars.EnableRedactLog {
-				logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", sql))
-			} else {
-				logutil.Logger(ctx).Warn("parse SQL failed", zap.Error(err), zap.String("SQL", sql))
-			}
+		logSQL := sql[:mathutil.Min(500, len(sql))]
+		if s.sessionVars.EnableRedactLog {
+			logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", logSQL))
 		} else {
-			logSQL := sql[:mathutil.Min(500, len(sql))]
-			if s.sessionVars.EnableRedactLog {
-				logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", logSQL))
-			} else {
-				logutil.Logger(ctx).Warn("parse SQL failed", zap.Error(err), zap.String("SQL", logSQL))
-			}
+			logutil.Logger(ctx).Warn("parse SQL failed", zap.Error(err), zap.String("SQL", logSQL))
 		}
 		return nil, util.SyntaxError(err)
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -1732,11 +1732,11 @@ func (s *session) ParseWithParams(ctx context.Context, sql string, args ...inter
 				logutil.Logger(ctx).Warn("parse SQL failed", zap.Error(err), zap.String("SQL", sql))
 			}
 		} else {
-			maxPrintLen := mathutil.Min(500, len(sql))
+			logSQL := sql[:mathutil.Min(500, len(sql))]
 			if s.sessionVars.EnableRedactLog {
-				logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", sql[:maxPrintLen]))
+				logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", logSQL))
 			} else {
-				logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", sql[:maxPrintLen]))
+				logutil.Logger(ctx).Warn("parse SQL failed", zap.Error(err), zap.String("SQL", logSQL))
 			}
 		}
 		return nil, util.SyntaxError(err)

--- a/session/session.go
+++ b/session/session.go
@@ -35,7 +35,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pingcap/tidb/util/mathutil"
 	"github.com/ngaut/pools"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -95,6 +94,7 @@ import (
 	"github.com/pingcap/tidb/util/kvcache"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/logutil/consistency"
+	"github.com/pingcap/tidb/util/mathutil"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/sem"
 	"github.com/pingcap/tidb/util/sli"

--- a/session/session.go
+++ b/session/session.go
@@ -35,6 +35,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pingcap/tidb/util/mathutil"
 	"github.com/ngaut/pools"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -1731,10 +1732,11 @@ func (s *session) ParseWithParams(ctx context.Context, sql string, args ...inter
 				logutil.Logger(ctx).Warn("parse SQL failed", zap.Error(err), zap.String("SQL", sql))
 			}
 		} else {
+			maxPrintLen := mathutil.Min(500, len(sql))
 			if s.sessionVars.EnableRedactLog {
-				logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", sql))
+				logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", sql[:maxPrintLen]))
 			} else {
-				logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", sql))
+				logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", sql[:maxPrintLen]))
 			}
 		}
 		return nil, util.SyntaxError(err)

--- a/session/session.go
+++ b/session/session.go
@@ -1730,6 +1730,12 @@ func (s *session) ParseWithParams(ctx context.Context, sql string, args ...inter
 			} else {
 				logutil.Logger(ctx).Warn("parse SQL failed", zap.Error(err), zap.String("SQL", sql))
 			}
+		} else {
+			if s.sessionVars.EnableRedactLog {
+				logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", sql))
+			} else {
+				logutil.Logger(ctx).Debug("parse SQL failed", zap.Error(err), zap.String("SQL", sql))
+			}
 		}
 		return nil, util.SyntaxError(err)
 	}

--- a/session/sessiontest/session_test.go
+++ b/session/sessiontest/session_test.go
@@ -3553,12 +3553,3 @@ func TestHandleAssertionFailureForPartitionedTable(t *testing.T) {
 	require.ErrorContains(t, err, "assertion")
 	hook.CheckLogCount(t, 0)
 }
-
-func TestInternalSQLParseFail(t *testing.T) {
-	store := testkit.CreateMockStoreWithSchemaLease(t, 1*time.Second)
-	tk1 := testkit.NewTestKit(t, store)
-
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnOthers)
-	_, err := tk1.Session().ExecuteInternal(ctx, "insert into t1 values;")
-	require.NoError(t, err)
-}

--- a/session/sessiontest/session_test.go
+++ b/session/sessiontest/session_test.go
@@ -3553,3 +3553,12 @@ func TestHandleAssertionFailureForPartitionedTable(t *testing.T) {
 	require.ErrorContains(t, err, "assertion")
 	hook.CheckLogCount(t, 0)
 }
+
+func TestInternalSQLParseFail(t *testing.T) {
+	store := testkit.CreateMockStoreWithSchemaLease(t, 1*time.Second)
+	tk1 := testkit.NewTestKit(t, store)
+
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnOthers)
+	_, err := tk1.Session().ExecuteInternal(ctx, "insert into t1 values;")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43283

Problem Summary: As issue said, add log to make life easier when debug internal sql error.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
