### PR TITLE
lightning: retry on unknown RPC error, log more info to help debug

### DIFF
--- a/br/pkg/lightning/backend/local/local_test.go
+++ b/br/pkg/lightning/backend/local/local_test.go
@@ -1568,7 +1568,7 @@ func TestDoImport(t *testing.T) {
 						{
 							write: injectedWriteBehaviour{
 								// a retryable error
-								err: errors.New("is not fully replicated"),
+								err: status.Error(codes.Unknown, "is not fully replicated"),
 							},
 						},
 					},

--- a/br/pkg/lightning/backend/local/region_job.go
+++ b/br/pkg/lightning/backend/local/region_job.go
@@ -213,19 +213,23 @@ func (local *Backend) writeToTiKV(ctx context.Context, j *regionJob) error {
 		ApiVersion: apiVersion,
 	}
 
+	annotateErr := func(in error, peer *metapb.Peer) error {
+		return errors.Annotatef(in, "peer %d, store %d, region %d, epoch %s", peer.Id, peer.StoreId, region.Id, region.RegionEpoch.String())
+	}
+
 	leaderID := j.region.Leader.GetId()
 	clients := make([]sst.ImportSST_WriteClient, 0, len(region.GetPeers()))
-	storeIDs := make([]uint64, 0, len(region.GetPeers()))
+	allPeers := make([]*metapb.Peer, 0, len(region.GetPeers()))
 	requests := make([]*sst.WriteRequest, 0, len(region.GetPeers()))
 	for _, peer := range region.GetPeers() {
 		cli, err := clientFactory.Create(ctx, peer.StoreId)
 		if err != nil {
-			return errors.Trace(err)
+			return annotateErr(err, peer)
 		}
 
 		wstream, err := cli.Write(ctx)
 		if err != nil {
-			return errors.Trace(err)
+			return annotateErr(err, peer)
 		}
 
 		// Bind uuid for this write request
@@ -235,7 +239,7 @@ func (local *Backend) writeToTiKV(ctx context.Context, j *regionJob) error {
 			},
 		}
 		if err = wstream.Send(req); err != nil {
-			return errors.Trace(err)
+			return annotateErr(err, peer)
 		}
 		req.Chunk = &sst.WriteRequest_Batch{
 			Batch: &sst.WriteBatch{
@@ -244,7 +248,7 @@ func (local *Backend) writeToTiKV(ctx context.Context, j *regionJob) error {
 		}
 		clients = append(clients, wstream)
 		requests = append(requests, req)
-		storeIDs = append(storeIDs, peer.StoreId)
+		allPeers = append(allPeers, peer)
 	}
 
 	bytesBuf := bufferPool.NewBuffer()
@@ -265,12 +269,12 @@ func (local *Backend) writeToTiKV(ctx context.Context, j *regionJob) error {
 
 	flushKVs := func() error {
 		for i := range clients {
-			if err := writeLimiter.WaitN(ctx, storeIDs[i], int(size)); err != nil {
+			if err := writeLimiter.WaitN(ctx, allPeers[i].StoreId, int(size)); err != nil {
 				return errors.Trace(err)
 			}
 			requests[i].Chunk.(*sst.WriteRequest_Batch).Batch.Pairs = pairs[:count]
 			if err := clients[i].Send(requests[i]); err != nil {
-				return errors.Trace(err)
+				return annotateErr(err, allPeers[i])
 			}
 		}
 		return nil
@@ -342,10 +346,10 @@ func (local *Backend) writeToTiKV(ctx context.Context, j *regionJob) error {
 	for i, wStream := range clients {
 		resp, closeErr := wStream.CloseAndRecv()
 		if closeErr != nil {
-			return errors.Trace(closeErr)
+			return annotateErr(closeErr, allPeers[i])
 		}
 		if resp.Error != nil {
-			return errors.New(resp.Error.Message)
+			return annotateErr(errors.New(resp.Error.Message), allPeers[i])
 		}
 		if leaderID == region.Peers[i].GetId() {
 			leaderPeerMetas = resp.Metas

--- a/br/pkg/lightning/backend/local/region_job.go
+++ b/br/pkg/lightning/backend/local/region_job.go
@@ -214,6 +214,7 @@ func (local *Backend) writeToTiKV(ctx context.Context, j *regionJob) error {
 	}
 
 	annotateErr := func(in error, peer *metapb.Peer) error {
+		// annotate the error with peer/store/region info to help debug.
 		return errors.Annotatef(in, "peer %d, store %d, region %d, epoch %s", peer.Id, peer.StoreId, region.Id, region.RegionEpoch.String())
 	}
 

--- a/br/pkg/lightning/common/retry.go
+++ b/br/pkg/lightning/common/retry.go
@@ -35,7 +35,6 @@ import (
 // so we need to check by error message,
 // such as distsql.Checksum which transforms tikv other-error into its own error
 var retryableErrorMsgList = []string{
-	"is not fully replicated",
 	// for cluster >= 4.x, lightning calls distsql.Checksum to do checksum
 	// this error happens on when distsql.Checksum calls TiKV
 	// see https://github.com/pingcap/tidb/blob/2c3d4f1ae418881a95686e8b93d4237f2e76eec6/store/copr/coprocessor.go#L941
@@ -125,12 +124,24 @@ func isSingleRetryableError(err error) bool {
 		}
 		return false
 	default:
-		switch status.Code(err) {
+		rpcStatus, ok := status.FromError(err)
+		if !ok {
+			// non RPC error
+			return isRetryableFromErrorMessage(err)
+		}
+		switch rpcStatus.Code() {
 		case codes.DeadlineExceeded, codes.NotFound, codes.AlreadyExists, codes.PermissionDenied,
 			codes.ResourceExhausted, codes.Aborted, codes.OutOfRange, codes.Unavailable, codes.DataLoss:
 			return true
+		case codes.Unknown:
+			// cases we have met during import:
+			// 1. in scatter region: rpc error: code = Unknown desc = region 31946583 is not fully replicated
+			// 2. in write TiKV: rpc error: code = Unknown desc = EngineTraits(Engine(Status { code: IoError, sub_code:
+			//    None, sev: NoError, state: \"IO error: No such file or directory: while stat a file for size:
+			//    /...../63992d9c-fbc8-4708-b963-32495b299027_32279707_325_5280_write.sst: No such file or directory\"
+			return true
 		default:
-			return isRetryableFromErrorMessage(err)
+			return false
 		}
 	}
 }

--- a/br/pkg/lightning/common/retry_test.go
+++ b/br/pkg/lightning/common/retry_test.go
@@ -84,7 +84,8 @@ func TestIsRetryableError(t *testing.T) {
 
 	// gRPC Errors
 	require.False(t, IsRetryableError(status.Error(codes.Canceled, "")))
-	require.False(t, IsRetryableError(status.Error(codes.Unknown, "")))
+	require.True(t, IsRetryableError(status.Error(codes.Unknown, "region 1234 is not fully replicated")))
+	require.True(t, IsRetryableError(status.Error(codes.Unknown, "")))
 	require.True(t, IsRetryableError(status.Error(codes.DeadlineExceeded, "")))
 	require.True(t, IsRetryableError(status.Error(codes.NotFound, "")))
 	require.True(t, IsRetryableError(status.Error(codes.AlreadyExists, "")))
@@ -109,6 +110,5 @@ func TestIsRetryableError(t *testing.T) {
 	require.True(t, IsRetryableError(multierr.Combine(&net.DNSError{IsTimeout: true}, &net.DNSError{IsTimeout: true})))
 	require.False(t, IsRetryableError(multierr.Combine(context.Canceled, &net.DNSError{IsTimeout: true})))
 
-	require.True(t, IsRetryableError(errors.Errorf("region %d is not fully replicated", 1234)))
 	require.True(t, IsRetryableError(errors.New("other error: Coprocessor task terminated due to exceeding the deadline")))
 }

--- a/br/pkg/lightning/common/retry_test.go
+++ b/br/pkg/lightning/common/retry_test.go
@@ -85,7 +85,8 @@ func TestIsRetryableError(t *testing.T) {
 	// gRPC Errors
 	require.False(t, IsRetryableError(status.Error(codes.Canceled, "")))
 	require.True(t, IsRetryableError(status.Error(codes.Unknown, "region 1234 is not fully replicated")))
-	require.True(t, IsRetryableError(status.Error(codes.Unknown, "No such file or directory: while stat a file for size: /...../63992d9c-fbc8-4708-b963-32495b299027_32279707_325_5280_write.sst: No such file or directory")))
+	require.True(t, IsRetryableError(status.Error(codes.Unknown, "No such file or directory: while stat a file "+
+		"for size: /...../63992d9c-fbc8-4708-b963-32495b299027_32279707_325_5280_write.sst: No such file or directory")))
 	require.True(t, IsRetryableError(status.Error(codes.DeadlineExceeded, "")))
 	require.True(t, IsRetryableError(status.Error(codes.NotFound, "")))
 	require.True(t, IsRetryableError(status.Error(codes.AlreadyExists, "")))

--- a/br/pkg/lightning/common/retry_test.go
+++ b/br/pkg/lightning/common/retry_test.go
@@ -85,7 +85,7 @@ func TestIsRetryableError(t *testing.T) {
 	// gRPC Errors
 	require.False(t, IsRetryableError(status.Error(codes.Canceled, "")))
 	require.True(t, IsRetryableError(status.Error(codes.Unknown, "region 1234 is not fully replicated")))
-	require.True(t, IsRetryableError(status.Error(codes.Unknown, "")))
+	require.True(t, IsRetryableError(status.Error(codes.Unknown, "No such file or directory: while stat a file for size: /...../63992d9c-fbc8-4708-b963-32495b299027_32279707_325_5280_write.sst: No such file or directory")))
 	require.True(t, IsRetryableError(status.Error(codes.DeadlineExceeded, "")))
 	require.True(t, IsRetryableError(status.Error(codes.NotFound, "")))
 	require.True(t, IsRetryableError(status.Error(codes.AlreadyExists, "")))

--- a/br/pkg/lightning/importer/import.go
+++ b/br/pkg/lightning/importer/import.go
@@ -1627,6 +1627,9 @@ func (rc *Controller) importTables(ctx context.Context) (finalErr error) {
 				web.BroadcastTableCheckpoint(task.tr.tableName, task.cp)
 
 				needPostProcess, err := task.tr.importTable(ctx, rc, task.cp)
+				if err != nil && !common.IsContextCanceledError(err) {
+					task.tr.logger.Error("failed to import table", zap.Error(err))
+				}
 
 				err = common.NormalizeOrWrapErr(common.ErrRestoreTable, err, task.tr.tableName)
 				tableLogTask.End(zap.ErrorLevel, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43291

Problem Summary:

### What is changed and how it works?
- log region/peer/store info on write tikv error
- log error when failed to import table
- retry on unknown rpc error

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - return context.Canceled or other non-retryable error, see the log print accordingly.
  - return non-retryable error during write, see if it contains region/peer/store info:
```
[2023/04/21 18:05:33.809 +08:00] [ERROR] [import.go:1631] ["failed to import table"] [table=`xxx`.`xxx`] [error="peer 173, store 1, region 172, epoch conf_ver:1 version:82 : rpc error: code = Unimplemented desc = fake error"] [errorVerbose="rpc error: code = Unimplemented desc = fake error\npeer 173, store 1, region 172, epoch conf_ver:1 version:82 \ngithub.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).writeToTiKV.func2\n\t/Users/jujiajia/code/pingcap/tidb/br/pkg/lightning/backend/local/region_job.go:220\ngithub.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).writeToTiKV.func3\n\t/Users/jujiajia/code/pingcap/tidb/br/pkg/lightning/backend/local/region_job.go:282\ngithub.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).writeToTiKV\n\t/Users/jujiajia/code/pingcap/tidb/br/pkg/lightning/backend/local/region_job.go:312\ngithub.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).executeJob\n\t/Users/jujiajia/code/pingcap/tidb/br/pkg/lightning/backend/local/local.go:1347\ngithub.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).startWorker\n\t/Users/jujiajia/code/pingcap/tidb/br/pkg/lightning/backend/local/local.go:1261\ngithub.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).doImport.func3\n\t/Users/jujiajia/code/pingcap/tidb/br/pkg/lightning/backend/local/local.go:1529\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/Users/jujiajia/go/pkg/mod/golang.org/x/sync@v0.1.0/errgroup/errgroup.go:75\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1172"]
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
