### PR TITLE
*: fix plugin build

### DIFF
--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -95,7 +95,7 @@ type Client struct {
 
 	cipher           *backuppb.CipherInfo
 	checkpointMeta   *checkpoint.CheckpointMetadataForBackup
-	checkpointRunner *checkpoint.BackupRunner
+	checkpointRunner *checkpoint.CheckpointRunner[checkpoint.BackupKeyType, checkpoint.BackupValueType]
 
 	gcTTL int64
 }
@@ -274,7 +274,7 @@ func (bc *Client) CheckCheckpoint(hash []byte) error {
 	return nil
 }
 
-func (bc *Client) GetCheckpointRunner() *checkpoint.BackupRunner {
+func (bc *Client) GetCheckpointRunner() *checkpoint.CheckpointRunner[checkpoint.BackupKeyType, checkpoint.BackupValueType] {
 	return bc.checkpointRunner
 }
 

--- a/br/pkg/backup/push.go
+++ b/br/pkg/backup/push.go
@@ -57,7 +57,7 @@ func (push *pushDown) pushBackup(
 	req backuppb.BackupRequest,
 	pr *rtree.ProgressRange,
 	stores []*metapb.Store,
-	checkpointRunner *checkpoint.BackupRunner,
+	checkpointRunner *checkpoint.CheckpointRunner[checkpoint.BackupKeyType, checkpoint.BackupValueType],
 	progressCallBack func(ProgressUnit),
 ) error {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {

--- a/br/pkg/backup/schema.go
+++ b/br/pkg/backup/schema.go
@@ -68,7 +68,7 @@ func (ss *Schemas) SetCheckpointChecksum(checkpointChecksum map[int64]*checkpoin
 func (ss *Schemas) BackupSchemas(
 	ctx context.Context,
 	metaWriter *metautil.MetaWriter,
-	checkpointRunner *checkpoint.BackupRunner,
+	checkpointRunner *checkpoint.CheckpointRunner[checkpoint.BackupKeyType, checkpoint.BackupValueType],
 	store kv.Storage,
 	statsHandle *handle.Handle,
 	backupTS uint64,

--- a/br/pkg/checkpoint/backup.go
+++ b/br/pkg/checkpoint/backup.go
@@ -26,7 +26,6 @@ import (
 
 type BackupKeyType = string
 type BackupValueType = RangeType
-type BackupRunner = CheckpointRunner[BackupKeyType, BackupValueType]
 
 const (
 	CheckpointMetaPath             = "checkpoint.meta"
@@ -50,7 +49,7 @@ func StartCheckpointBackupRunnerForTest(
 	cipher *backuppb.CipherInfo,
 	tick time.Duration,
 	timer GlobalTimer,
-) (*BackupRunner, error) {
+) (*CheckpointRunner[BackupKeyType, BackupValueType], error) {
 	runner := newCheckpointRunner[BackupKeyType, BackupValueType](ctx, storage, cipher, timer, flushPositionForBackup())
 
 	err := runner.initialLock(ctx)
@@ -66,7 +65,7 @@ func StartCheckpointRunnerForBackup(
 	storage storage.ExternalStorage,
 	cipher *backuppb.CipherInfo,
 	timer GlobalTimer,
-) (*BackupRunner, error) {
+) (*CheckpointRunner[BackupKeyType, BackupValueType], error) {
 	runner := newCheckpointRunner[BackupKeyType, BackupValueType](ctx, storage, cipher, timer, flushPositionForBackup())
 
 	err := runner.initialLock(ctx)
@@ -79,7 +78,7 @@ func StartCheckpointRunnerForBackup(
 
 func AppendForBackup(
 	ctx context.Context,
-	r *BackupRunner,
+	r *CheckpointRunner[BackupKeyType, BackupValueType],
 	groupKey BackupKeyType,
 	startKey []byte,
 	endKey []byte,

--- a/br/pkg/checkpoint/log_restore.go
+++ b/br/pkg/checkpoint/log_restore.go
@@ -38,8 +38,6 @@ func (l LogRestoreValueType) IdentKey() []byte {
 	return []byte(fmt.Sprint(l.Goff, '.', l.Foff, '.', l.TableID))
 }
 
-type LogRestoreRunner = CheckpointRunner[LogRestoreKeyType, LogRestoreValueType]
-
 // only for test
 func StartCheckpointLogRestoreRunnerForTest(
 	ctx context.Context,
@@ -47,7 +45,7 @@ func StartCheckpointLogRestoreRunnerForTest(
 	cipher *backuppb.CipherInfo,
 	tick time.Duration,
 	taskName string,
-) (*LogRestoreRunner, error) {
+) (*CheckpointRunner[LogRestoreKeyType, LogRestoreValueType], error) {
 	runner := newCheckpointRunner[LogRestoreKeyType, LogRestoreValueType](
 		ctx, storage, cipher, nil, flushPositionForRestore(taskName))
 
@@ -59,7 +57,7 @@ func StartCheckpointRunnerForLogRestore(ctx context.Context,
 	storage storage.ExternalStorage,
 	cipher *backuppb.CipherInfo,
 	taskName string,
-) (*LogRestoreRunner, error) {
+) (*CheckpointRunner[LogRestoreKeyType, LogRestoreValueType], error) {
 	runner := newCheckpointRunner[LogRestoreKeyType, LogRestoreValueType](
 		ctx, storage, cipher, nil, flushPositionForRestore(taskName))
 
@@ -70,7 +68,7 @@ func StartCheckpointRunnerForLogRestore(ctx context.Context,
 
 func AppendRangeForLogRestore(
 	ctx context.Context,
-	r *LogRestoreRunner,
+	r *CheckpointRunner[LogRestoreKeyType, LogRestoreValueType],
 	groupKey LogRestoreKeyType,
 	tableID int64,
 	goff int,

--- a/br/pkg/checkpoint/restore.go
+++ b/br/pkg/checkpoint/restore.go
@@ -28,8 +28,6 @@ import (
 type RestoreKeyType = int64
 type RestoreValueType = RangeType
 
-type RestoreRunner = CheckpointRunner[RestoreKeyType, RestoreValueType]
-
 const (
 	CheckpointDataDirForRestoreFormat     = CheckpointDir + "/restore-%s/data"
 	CheckpointChecksumDirForRestoreFormat = CheckpointDir + "/restore-%s/checksum"
@@ -62,7 +60,7 @@ func StartCheckpointRestoreRunnerForTest(
 	cipher *backuppb.CipherInfo,
 	tick time.Duration,
 	taskName string,
-) (*RestoreRunner, error) {
+) (*CheckpointRunner[RestoreKeyType, RestoreValueType], error) {
 	runner := newCheckpointRunner[RestoreKeyType, RestoreValueType](
 		ctx, storage, cipher, nil, flushPositionForRestore(taskName))
 
@@ -75,7 +73,7 @@ func StartCheckpointRunnerForRestore(
 	storage storage.ExternalStorage,
 	cipher *backuppb.CipherInfo,
 	taskName string,
-) (*RestoreRunner, error) {
+) (*CheckpointRunner[RestoreKeyType, RestoreValueType], error) {
 	runner := newCheckpointRunner[RestoreKeyType, RestoreValueType](
 		ctx, storage, cipher, nil, flushPositionForRestore(taskName))
 
@@ -86,7 +84,7 @@ func StartCheckpointRunnerForRestore(
 
 func AppendRangesForRestore(
 	ctx context.Context,
-	r *RestoreRunner,
+	r *CheckpointRunner[RestoreKeyType, RestoreValueType],
 	tableID RestoreKeyType,
 	ranges []rtree.Range,
 ) error {

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -181,7 +181,7 @@ type Client struct {
 	rewriteMode RewriteMode
 
 	// checkpoint information for snapshot restore
-	checkpointRunner   *checkpoint.RestoreRunner
+	checkpointRunner   *checkpoint.CheckpointRunner[checkpoint.RestoreKeyType, checkpoint.RestoreValueType]
 	checkpointChecksum map[int64]*checkpoint.ChecksumItem
 
 	// checkpoint information for log restore
@@ -335,11 +335,11 @@ func (rc *Client) WaitForFinishCheckpoint(ctx context.Context) {
 	}
 }
 
-func (rc *Client) GetCheckpointRunner() *checkpoint.RestoreRunner {
+func (rc *Client) GetCheckpointRunner() *checkpoint.CheckpointRunner[checkpoint.RestoreKeyType, checkpoint.RestoreValueType] {
 	return rc.checkpointRunner
 }
 
-func (rc *Client) StartCheckpointRunnerForLogRestore(ctx context.Context, taskName string) (*checkpoint.LogRestoreRunner, error) {
+func (rc *Client) StartCheckpointRunnerForLogRestore(ctx context.Context, taskName string) (*checkpoint.CheckpointRunner[checkpoint.LogRestoreKeyType, checkpoint.LogRestoreValueType], error) {
 	runner, err := checkpoint.StartCheckpointRunnerForLogRestore(ctx, rc.storage, rc.cipher, taskName)
 	return runner, errors.Trace(err)
 }
@@ -2250,7 +2250,7 @@ func (rc *Client) RestoreKVFiles(
 	rules map[int64]*RewriteRules,
 	idrules map[int64]int64,
 	logIter LogIter,
-	runner *checkpoint.LogRestoreRunner,
+	runner *checkpoint.CheckpointRunner[checkpoint.LogRestoreKeyType, checkpoint.LogRestoreValueType],
 	pitrBatchCount uint32,
 	pitrBatchSize uint32,
 	updateStats func(kvCount uint64, size uint64),

--- a/br/pkg/restore/pipeline_items.go
+++ b/br/pkg/restore/pipeline_items.go
@@ -234,7 +234,7 @@ func NewTiKVSender(
 	cli TiKVRestorer,
 	updateCh glue.Progress,
 	splitConcurrency uint,
-	runner *checkpoint.RestoreRunner,
+	runner *checkpoint.CheckpointRunner[checkpoint.RestoreKeyType, checkpoint.RestoreValueType],
 ) (BatchSender, error) {
 	inCh := make(chan DrainResult, defaultChannelSize)
 	midCh := make(chan drainResultAndDone, defaultChannelSize)
@@ -358,7 +358,7 @@ func (b *tikvSender) waitTablesDone(ts []CreatedTable) {
 	}
 }
 
-func appendRangesToCheckpoint(ctx context.Context, runner *checkpoint.RestoreRunner, result DrainResult) error {
+func appendRangesToCheckpoint(ctx context.Context, runner *checkpoint.CheckpointRunner[checkpoint.RestoreKeyType, checkpoint.RestoreValueType], result DrainResult) error {
 	if runner == nil {
 		return nil
 	}
@@ -377,7 +377,7 @@ func appendRangesToCheckpoint(ctx context.Context, runner *checkpoint.RestoreRun
 	return nil
 }
 
-func (b *tikvSender) restoreWorker(ctx context.Context, ranges <-chan drainResultAndDone, runner *checkpoint.RestoreRunner) {
+func (b *tikvSender) restoreWorker(ctx context.Context, ranges <-chan drainResultAndDone, runner *checkpoint.CheckpointRunner[checkpoint.RestoreKeyType, checkpoint.RestoreValueType]) {
 	eg, ectx := errgroup.WithContext(ctx)
 	defer func() {
 		log.Info("TiKV Sender: restore worker prepare to close.")

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1269,7 +1269,7 @@ func restoreStream(
 	}()
 
 	taskName := getStreamRestoreTaskName(client.GetClusterID(ctx), cfg.StartTS, cfg.RestoreTS)
-	var checkpointRunner *checkpoint.LogRestoreRunner
+	var checkpointRunner *checkpoint.CheckpointRunner[checkpoint.LogRestoreKeyType, checkpoint.LogRestoreValueType]
 	if cfg.UseCheckpoint {
 		oldRatioFromCheckpoint, err := client.InitCheckpointMetadataForLogRestore(ctx, taskName, oldRatio)
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43298

### What is changed and how it works?

Make the plugin can be loaded again. The load fail for plugin may be cause by the bug of the golang. When we have some generic definition like:

```
type BackupRunner = CheckpointRunner[BackupKeyType, BackupValueType]
```

The plugin cannot be loaded by tidb even they have all same dependencies and built together.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
