### PR TITLE
planner: use the correct fraction for decimal values in plan cache

### DIFF
--- a/expression/constant.go
+++ b/expression/constant.go
@@ -229,8 +229,9 @@ func (c *Constant) Eval(row chunk.Row) (types.Datum, error) {
 			sf, sfOk := c.DeferredExpr.(*ScalarFunction)
 			if sfOk {
 				if dt.Kind() == types.KindMysqlDecimal {
-					err := c.adjustDecimal(dt.GetMysqlDecimal())
-					return dt, err
+					if err := c.adjustDecimal(dt.GetMysqlDecimal()); err != nil {
+						return dt, err
+					}
 				} else {
 					val, err := dt.ConvertTo(sf.GetCtx().GetSessionVars().StmtCtx, c.RetType)
 					if err != nil {

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -228,11 +228,16 @@ func (c *Constant) Eval(row chunk.Row) (types.Datum, error) {
 		if c.DeferredExpr != nil {
 			sf, sfOk := c.DeferredExpr.(*ScalarFunction)
 			if sfOk {
-				val, err := dt.ConvertTo(sf.GetCtx().GetSessionVars().StmtCtx, c.RetType)
-				if err != nil {
+				if dt.Kind() == types.KindMysqlDecimal {
+					err := c.adjustDecimal(dt.GetMysqlDecimal())
 					return dt, err
+				} else {
+					val, err := dt.ConvertTo(sf.GetCtx().GetSessionVars().StmtCtx, c.RetType)
+					if err != nil {
+						return dt, err
+					}
+					return val, nil
 				}
-				return val, nil
 			}
 		}
 		return dt, nil
@@ -315,12 +320,19 @@ func (c *Constant) EvalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.My
 	if err != nil {
 		return nil, false, err
 	}
-	// The decimal may be modified during plan building.
-	_, frac := res.PrecisionAndFrac()
-	if frac < c.GetType().GetDecimal() {
-		err = res.Round(res, c.GetType().GetDecimal(), types.ModeHalfUp)
+	if err := c.adjustDecimal(res); err != nil {
+		return nil, false, err
 	}
-	return res, false, err
+	return res, false, nil
+}
+
+func (c *Constant) adjustDecimal(d *types.MyDecimal) error {
+	// Decimal Value's precision and frac may be modified during plan building.
+	_, frac := d.PrecisionAndFrac()
+	if frac < c.GetType().GetDecimal() {
+		return d.Round(d, c.GetType().GetDecimal(), types.ModeHalfUp)
+	}
+	return nil
 }
 
 // EvalTime returns DATE/DATETIME/TIMESTAMP representation of Constant.

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -50,6 +50,26 @@ func TestInitLRUWithSystemVar(t *testing.T) {
 	require.NotNil(t, lru)
 }
 
+func TestIssue43311(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table test.t (id int, value decimal(7,4), c1 int, c2 int)`)
+	tk.MustExec(`insert into test.t values (1,1.9285,54,28), (1,1.9286,54,28)`)
+
+	tk.MustExec(`set session tidb_enable_non_prepared_plan_cache=0`)
+	tk.MustQuery(`select * from t where value = 54 / 28`).Check(testkit.Rows()) // empty
+
+	tk.MustExec(`set session tidb_enable_non_prepared_plan_cache=1`)
+	tk.MustQuery(`select * from t where value = 54 / 28`).Check(testkit.Rows()) // empty
+	tk.MustQuery(`select * from t where value = 54 / 28`).Check(testkit.Rows()) // empty
+
+	tk.MustExec(`prepare st from 'select * from t where value = ? / ?'`)
+	tk.MustExec(`set @a=54, @b=28`)
+	tk.MustQuery(`execute st using @a, @b`).Check(testkit.Rows()) // empty
+	tk.MustQuery(`execute st using @a, @b`).Check(testkit.Rows()) // empty
+}
+
 func TestPlanCacheUnsafeRange(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43311

Problem Summary: planner: use the correct fraction for decimal values in plan cache

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
