### PR TITLE
ddl: wait schema change before rename table job is done

### DIFF
--- a/ddl/fktest/foreign_key_test.go
+++ b/ddl/fktest/foreign_key_test.go
@@ -427,7 +427,7 @@ func TestRenameTableWithForeignKeyMetaInfo(t *testing.T) {
 	// check the schema diff
 	diff = getLatestSchemaDiff(t, tk)
 	require.Equal(t, model.ActionRenameTable, diff.Type)
-	require.Equal(t, 1, len(diff.AffectedOpts))
+	require.Equal(t, 0, len(diff.AffectedOpts))
 	require.Equal(t, model.ReferredFKInfo{
 		Cols:        []model.CIStr{model.NewCIStr("id")},
 		ChildSchema: model.NewCIStr("test2"),

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -990,6 +990,9 @@ func onRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 		return ver, errors.Trace(err)
 	}
 
+	if job.SchemaState == model.StatePublic {
+		return finishJobRenameTable(t, job)
+	}
 	newSchemaID := job.SchemaID
 	err := checkTableNotExists(d, t, newSchemaID, tableName.L)
 	if err != nil {
@@ -1017,7 +1020,7 @@ func onRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
-	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
+	job.SchemaState = model.StatePublic
 	return ver, nil
 }
 
@@ -1031,6 +1034,10 @@ func onRenameTables(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error
 	if err := job.DecodeArgs(&oldSchemaIDs, &newSchemaIDs, &tableNames, &tableIDs, &oldSchemaNames, &oldTableNames); err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
+	}
+
+	if job.SchemaState == model.StatePublic {
+		return finishJobRenameTables(t, job, tableNames, tableIDs, newSchemaIDs)
 	}
 
 	var tblInfos = make([]*model.TableInfo, 0, len(tableNames))
@@ -1058,7 +1065,7 @@ func onRenameTables(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
-	job.FinishMultipleTableJob(model.JobStateDone, model.StatePublic, ver, tblInfos)
+	job.SchemaState = model.StatePublic
 	return ver, nil
 }
 
@@ -1153,6 +1160,43 @@ func adjustForeignKeyChildTableInfoAfterRenameTable(d *ddlCtx, t *meta.Meta, job
 		}
 	}
 	return nil
+}
+
+// We split the renaming table job into two steps:
+// 1. rename table and update the schema version.
+// 2. update the job state to JobStateDone.
+// This is the requirement from TiCDC because
+//   - it uses the job state to check whether the DDL is finished.
+//   - there is a gap between schema reloading and job state updating:
+//     when the job state is updated to JobStateDone, before the new schema reloaded,
+//     there may be DMLs that use the old schema.
+//   - TiCDC cannot handle the DMLs that use the old schema, because
+//     the commit TS of the DMLs are greater than the job state updating TS.
+func finishJobRenameTable(t *meta.Meta, job *model.Job) (int64, error) {
+	tblInfo, err := getTableInfo(t, job.TableID, job.SchemaID)
+	if err != nil {
+		job.State = model.JobStateCancelled
+		return 0, errors.Trace(err)
+	}
+	// Finish this job in a separate transaction.
+	job.FinishTableJob(model.JobStateDone, model.StatePublic, 0, tblInfo)
+	return 0, nil
+
+}
+
+func finishJobRenameTables(t *meta.Meta, job *model.Job,
+	tableNames []*model.CIStr, tableIDs, newSchemaIDs []int64) (int64, error) {
+	tblInfos := make([]*model.TableInfo, 0, len(tableNames))
+	for i := range newSchemaIDs {
+		tblInfo, err := getTableInfo(t, tableIDs[i], newSchemaIDs[i])
+		if err != nil {
+			job.State = model.JobStateCancelled
+			return 0, errors.Trace(err)
+		}
+		tblInfos = append(tblInfos, tblInfo)
+	}
+	job.FinishMultipleTableJob(model.JobStateDone, model.StatePublic, 0, tblInfos)
+	return 0, nil
 }
 
 func onModifyTableComment(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -1181,7 +1181,6 @@ func finishJobRenameTable(t *meta.Meta, job *model.Job) (int64, error) {
 	// Finish this job in a separate transaction.
 	job.FinishTableJob(model.JobStateDone, model.StatePublic, 0, tblInfo)
 	return 0, nil
-
 }
 
 func finishJobRenameTables(t *meta.Meta, job *model.Job,

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -1188,9 +1188,14 @@ func finishJobRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, error
 
 func finishJobRenameTables(d *ddlCtx, t *meta.Meta, job *model.Job,
 	tableNames []*model.CIStr, tableIDs, newSchemaIDs []int64) (int64, error) {
+	tblSchemaIDs := make(map[int64]int64, len(tableIDs))
+	for i := range tableIDs {
+		tblSchemaIDs[tableIDs[i]] = newSchemaIDs[i]
+	}
 	tblInfos := make([]*model.TableInfo, 0, len(tableNames))
 	for i := range newSchemaIDs {
-		tblInfo, err := getTableInfo(t, tableIDs[i], newSchemaIDs[i])
+		tblID := tableIDs[i]
+		tblInfo, err := getTableInfo(t, tblID, tblSchemaIDs[tblID])
 		if err != nil {
 			job.State = model.JobStateCancelled
 			return 0, errors.Trace(err)

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -1193,7 +1193,7 @@ func finishJobRenameTables(d *ddlCtx, t *meta.Meta, job *model.Job,
 		tblSchemaIDs[tableIDs[i]] = newSchemaIDs[i]
 	}
 	tblInfos := make([]*model.TableInfo, 0, len(tableNames))
-	for i := range newSchemaIDs {
+	for i := range tableIDs {
 		tblID := tableIDs[i]
 		tblInfo, err := getTableInfo(t, tblID, tblSchemaIDs[tblID])
 		if err != nil {

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -991,7 +991,7 @@ func onRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 	}
 
 	if job.SchemaState == model.StatePublic {
-		return finishJobRenameTable(t, job)
+		return finishJobRenameTable(d, t, job)
 	}
 	newSchemaID := job.SchemaID
 	err := checkTableNotExists(d, t, newSchemaID, tableName.L)
@@ -1037,7 +1037,7 @@ func onRenameTables(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error
 	}
 
 	if job.SchemaState == model.StatePublic {
-		return finishJobRenameTables(t, job, tableNames, tableIDs, newSchemaIDs)
+		return finishJobRenameTables(d, t, job, tableNames, tableIDs, newSchemaIDs)
 	}
 
 	var tblInfos = make([]*model.TableInfo, 0, len(tableNames))
@@ -1172,18 +1172,21 @@ func adjustForeignKeyChildTableInfoAfterRenameTable(d *ddlCtx, t *meta.Meta, job
 //     there may be DMLs that use the old schema.
 //   - TiCDC cannot handle the DMLs that use the old schema, because
 //     the commit TS of the DMLs are greater than the job state updating TS.
-func finishJobRenameTable(t *meta.Meta, job *model.Job) (int64, error) {
+func finishJobRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, error) {
 	tblInfo, err := getTableInfo(t, job.TableID, job.SchemaID)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return 0, errors.Trace(err)
 	}
-	// Finish this job in a separate transaction.
-	job.FinishTableJob(model.JobStateDone, model.StatePublic, 0, tblInfo)
-	return 0, nil
+	ver, err := updateSchemaVersion(d, t, job)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
+	return ver, nil
 }
 
-func finishJobRenameTables(t *meta.Meta, job *model.Job,
+func finishJobRenameTables(d *ddlCtx, t *meta.Meta, job *model.Job,
 	tableNames []*model.CIStr, tableIDs, newSchemaIDs []int64) (int64, error) {
 	tblInfos := make([]*model.TableInfo, 0, len(tableNames))
 	for i := range newSchemaIDs {
@@ -1194,8 +1197,12 @@ func finishJobRenameTables(t *meta.Meta, job *model.Job,
 		}
 		tblInfos = append(tblInfos, tblInfo)
 	}
-	job.FinishMultipleTableJob(model.JobStateDone, model.StatePublic, 0, tblInfos)
-	return 0, nil
+	ver, err := updateSchemaVersion(d, t, job)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+	job.FinishMultipleTableJob(model.JobStateDone, model.StatePublic, ver, tblInfos)
+	return ver, nil
 }
 
 func onModifyTableComment(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/ddl"
+	"github.com/pingcap/tidb/ddl/internal/callback"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/meta/autoid"
@@ -32,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -524,4 +526,53 @@ func TestAlterTTL(t *testing.T) {
 	historyJob, err = ddl.GetHistoryJobByID(testkit.NewTestKit(t, store).Session(), job.ID)
 	require.NoError(t, err)
 	require.Empty(t, historyJob.BinlogInfo.TableInfo.TTLInfo)
+}
+
+func TestRenameTableIntermediateState(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	originHook := dom.DDL().GetHook()
+	tk.MustExec("create database db1;")
+	tk.MustExec("create database db2;")
+	tk.MustExec("create table db1.t(a int);")
+
+	testCases := []struct {
+		renameSQL string
+		insertSQL string
+		errMsg    string
+		finalDB   string
+	}{
+		{"rename table db1.t to db1.t1;", "insert into db1.t values(1);", "[schema:1146]Table 'db1.t' doesn't exist", "db1.t1"},
+		{"rename table db1.t1 to db1.t;", "insert into db1.t values(1);", "", "db1.t"},
+		{"rename table db1.t to db2.t;", "insert into db1.t values(1);", "[schema:1146]Table 'db1.t' doesn't exist", "db2.t"},
+		{"rename table db2.t to db1.t;", "insert into db1.t values(1);", "", "db1.t"},
+	}
+
+	for _, tc := range testCases {
+		hook := &callback.TestDDLCallback{Do: dom}
+		runInsert := false
+		fn := func(job *model.Job) {
+			if job.SchemaState == model.StatePublic && !runInsert && !t.Failed() {
+				_, err := tk2.Exec(tc.insertSQL)
+				if len(tc.errMsg) > 0 {
+					assert.Equal(t, tc.errMsg, err.Error())
+				} else {
+					assert.NoError(t, err)
+				}
+				runInsert = true
+			}
+		}
+		hook.OnJobUpdatedExported.Store(&fn)
+		dom.DDL().SetHook(hook)
+		tk.MustExec(tc.renameSQL)
+		result := tk.MustQuery(fmt.Sprintf("select * from %s;", tc.finalDB))
+		if len(tc.errMsg) > 0 {
+			result.Check(testkit.Rows())
+		} else {
+			result.Check(testkit.Rows("1"))
+		}
+		tk.MustExec(fmt.Sprintf("delete from %s;", tc.finalDB))
+	}
+	dom.DDL().SetHook(originHook)
 }

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -806,7 +806,7 @@ func (job *Job) IsRollbackable() bool {
 		ActionDropForeignKey, ActionDropTablePartition:
 		return job.SchemaState == StatePublic
 	case ActionRebaseAutoID, ActionShardRowID,
-		ActionTruncateTable, ActionAddForeignKey, ActionRenameTable,
+		ActionTruncateTable, ActionAddForeignKey, ActionRenameTable, ActionRenameTables,
 		ActionModifyTableCharsetAndCollate, ActionTruncateTablePartition,
 		ActionModifySchemaCharsetAndCollate, ActionRepairTable,
 		ActionModifyTableAutoIdCache, ActionModifySchemaDefaultPlacement:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43338

Problem Summary:

### What is changed and how it works?

We split the renaming table job into two steps:
1. rename table and update the schema version.
2. update the job state to JobStateDone.

This is the requirement from TiCDC because
- it uses the job state to check whether the DDL is finished.
- there is a gap between schema reloading and job state updating:
   when the job state is updated to JobStateDone, before the new schema reloaded,
   there may be DMLs that use the old schema.
- TiCDC cannot handle the DMLs that use the old schema, because
   the commit TS of the DMLs are greater than the job state updating TS.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
