### PR TITLE
lightning: reuse worker-concurr and remove range-concurr

### DIFF
--- a/br/pkg/lightning/backend/local/local_test.go
+++ b/br/pkg/lightning/backend/local/local_test.go
@@ -1403,7 +1403,7 @@ func TestSplitRangeAgain4BigRegion(t *testing.T) {
 			panicSplitRegionClient{}, // make sure no further split region
 		),
 	}
-	local.BackendConfig.RangeConcurrency = 1
+	local.BackendConfig.WorkerConcurrency = 1
 	db, tmpPath := makePebbleDB(t, nil)
 	_, engineUUID := backend.MakeUUID("ww", 0)
 	ctx := context.Background()
@@ -1598,7 +1598,6 @@ func TestDoImport(t *testing.T) {
 	ctx := context.Background()
 	l := &Backend{
 		BackendConfig: BackendConfig{
-			RangeConcurrency:  1,
 			WorkerConcurrency: 2,
 		},
 	}

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -114,7 +114,6 @@ func NewTableImporter(param *JobImportParam, e *LoadDataController) (ti *TableIm
 		LocalStoreDir:     dir,
 		MaxConnPerStore:   config.DefaultRangeConcurrency,
 		ConnCompressType:  config.CompressionNone,
-		RangeConcurrency:  config.DefaultRangeConcurrency,
 		WorkerConcurrency: config.DefaultRangeConcurrency * 2,
 		KVWriteBatchSize:  config.KVWriteBatchSize,
 		// todo: local backend report error when the sort-dir already exists & checkpoint disabled.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42930 

Problem Summary:

### What is changed and how it works?
- reuse worker-concurr and remove range-concurr, it's not that needed to introduce another `xxx-concurr` into local backend

### Check List

Tests <!-- At least one of them must be included. -->
existing test should be enough
- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - run locally and make sure we're using worker-concurr to generate job
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
