### PR TITLE
planbuilder: Keep with clause when build recursive cte

### DIFF
--- a/planner/core/casetest/testdata/plan_suite_in.json
+++ b/planner/core/casetest/testdata/plan_suite_in.json
@@ -796,6 +796,7 @@
   {
     "name": "TestSingleConsumerCTE",
     "cases": [
+      "with base1 as (WITH RECURSIVE cte(a) AS (with tmp as (select 1 as a) SELECT a from tmp UNION SELECT a+1 FROM cte) SELECT * FROM cte) select * from base1; -- issue #43318",
       "with cte as (select 1) select * from cte; -- inline cte",
       "with cte1 as (select 1), cte2 as (select 2) select * from cte1 union select * from cte2; -- inline cte1, cte2",
       "with cte as (select 1) select * from cte union select * from cte; -- cannot be inlined",

--- a/planner/core/casetest/testdata/plan_suite_out.json
+++ b/planner/core/casetest/testdata/plan_suite_out.json
@@ -3751,6 +3751,18 @@
     "Name": "TestSingleConsumerCTE",
     "Cases": [
       {
+        "SQL": "with base1 as (WITH RECURSIVE cte(a) AS (with tmp as (select 1 as a) SELECT a from tmp UNION SELECT a+1 FROM cte) SELECT * FROM cte) select * from base1; -- issue #43318",
+        "Plan": [
+          "CTEFullScan 2.00 root CTE:cte data:CTE_3",
+          "CTE_3 2.00 root  Recursive CTE",
+          "├─Projection(Seed Part) 1.00 root  1->Column#15",
+          "│ └─TableDual 1.00 root  rows:1",
+          "└─Projection(Recursive Part) 1.00 root  cast(plus(Column#16, 1), bigint(1) BINARY)->Column#18",
+          "  └─CTETable 1.00 root  Scan on CTE_3"
+        ],
+        "Warning": null
+      },
+      {
         "SQL": "with cte as (select 1) select * from cte; -- inline cte",
         "Plan": [
           "Projection 1.00 root  1->Column#3",

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -7145,9 +7145,9 @@ func (b *PlanBuilder) buildRecursiveCTE(ctx context.Context, cte ast.ResultSetNo
 		// 1. Handle the WITH clause if exists.
 		if x.With != nil {
 			l := len(b.outerCTEs)
+			sw := x.With
 			defer func() {
 				b.outerCTEs = b.outerCTEs[:l]
-				sw := x.With
 				x.With = sw
 			}()
 			err := b.buildWith(ctx, x.With)


### PR DESCRIPTION
Fix inline cte + recursive cte + with clause could not found table name

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43318

Problem Summary:

### What is changed and how it works?

The with clause is removed incorrectly when plan builder build ```recursive cte```.
Due to the original AST is modified. When the plan builder builds again (such as inline cte), there will be a problem that the table name cannot be found.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

v6.5 and later
