### PR TITLE
*: fix warning message when to meet strconv.ErrRange

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5547,6 +5547,12 @@ func TestStrToDateBuiltinWithWarnings(t *testing.T) {
 	tk.MustQuery(`show warnings;`).Check(testkit.Rows(
 		`Warning 8034 Incorrect datetime value: '4#,8?Q'`,
 	))
+	tk.MustExec("CREATE TABLE t1 (c1 INT, c2 TEXT);")
+	tk.MustExec("INSERT INTO t1 VALUES (1833458842, '0.3503490908550797');")
+	tk.MustQuery(`SELECT  CAST(t1.c2 AS DATE) FROM t1`).Check(testkit.Rows("<nil>"))
+	tk.MustQuery(`show warnings;`).Check(testkit.Rows(
+		`Warning 1292 Incorrect datetime value: '0.3503490908550797'`,
+	))
 }
 
 func TestReadPartitionedTable(t *testing.T) {

--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -1769,7 +1769,7 @@ func (b *builtinCastStringAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chu
 		}
 		tm, err := types.ParseTime(stmtCtx, buf.GetString(i), b.tp.GetType(), fsp, nil)
 		if err != nil {
-			if errors.Is(err, strconv.ErrSyntax) {
+			if errors.Is(err, strconv.ErrSyntax) || errors.Is(err, strconv.ErrRange) {
 				err = types.ErrIncorrectDatetimeValue.GenWithStackByArgs(buf.GetString(i))
 			}
 			if err = handleInvalidTimeError(b.ctx, err); err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40582 

close #41729

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
