### PR TITLE
loaddata: make some test use 1 thread explicitly

### DIFF
--- a/executor/importer/import.go
+++ b/executor/importer/import.go
@@ -419,13 +419,8 @@ func (e *LoadDataController) initFieldParams(plan *Plan) error {
 	return nil
 }
 
-var ignoreInTest = false
-
 func (p *Plan) initDefaultOptions() {
 	threadCnt := runtime.NumCPU()
-	if intest.InTest && !ignoreInTest {
-		threadCnt = 1
-	}
 	if p.Format == LoadDataFormatParquet {
 		threadCnt = int(math.Max(1, float64(threadCnt)*0.75))
 	}

--- a/executor/importer/import_test.go
+++ b/executor/importer/import_test.go
@@ -33,11 +33,6 @@ import (
 )
 
 func TestInitDefaultOptions(t *testing.T) {
-	ignoreInTest = true
-	t.Cleanup(func() {
-		ignoreInTest = false
-	})
-
 	plan := &Plan{}
 	plan.initDefaultOptions()
 	require.Equal(t, LogicalImportMode, plan.ImportMode)

--- a/executor/loadremotetest/multi_file_test.go
+++ b/executor/loadremotetest/multi_file_test.go
@@ -89,7 +89,7 @@ func (s *mockGCSSuite) TestFilenameAsterisk() {
 	// only '*' is supported in pattern matching
 	s.tk.MustExec("TRUNCATE TABLE multi_load.t;")
 	sql = fmt.Sprintf(`LOAD DATA INFILE 'gs://test-multi-load/not.me.[1-9].tsv?endpoint=%s'
-		INTO TABLE multi_load.t;`, gcsEndpoint)
+		INTO TABLE multi_load.t with thread=1;`, gcsEndpoint)
 	s.tk.MustExec(sql)
 	s.Equal(uint64(0), s.tk.Session().GetSessionVars().StmtCtx.LastInsertID)
 	s.tk.MustQuery("SELECT * FROM multi_load.t;").Check(testkit.Rows(
@@ -160,7 +160,7 @@ func (s *mockGCSSuite) TestMultiBatchWithIgnoreLines() {
 	})
 
 	sql := fmt.Sprintf(`LOAD DATA INFILE 'gs://test-multi-load/multi-batch.*.tsv?endpoint=%s'
-		INTO TABLE multi_load.t2 IGNORE 2 LINES WITH batch_size = 3;`, gcsEndpoint)
+		INTO TABLE multi_load.t2 IGNORE 2 LINES WITH batch_size = 3, thread=1;`, gcsEndpoint)
 	s.tk.MustExec(sql)
 	s.tk.MustQuery("SELECT * FROM multi_load.t2;").Check(testkit.Rows(
 		"3", "4", "5", "6", "7", "8", "9", "10",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -375,7 +375,7 @@ func (cli *testServerClient) runTestLoadDataWithSelectIntoOutfile(t *testing.T, 
 		}()
 
 		dbt.MustExec("create table t1 (i int, r real, d decimal(10, 5), s varchar(100), dt datetime, ts timestamp, j json)")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t1", outfile))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t1 with thread=1", outfile))
 
 		fetchResults := func(table string) [][]interface{} {
 			var res [][]interface{}
@@ -432,7 +432,7 @@ func (cli *testServerClient) runTestLoadDataForSlowLog(t *testing.T, server *Ser
 		}()
 		dbt.MustExec("set tidb_slow_log_threshold=0;")
 		dbt.MustExec("set @@global.tidb_enable_stmt_summary=1")
-		query := fmt.Sprintf("load data local infile %q into table t_slow", path)
+		query := fmt.Sprintf("load data local infile %q into table t_slow with thread=1", path)
 		dbt.MustExec(query)
 		dbt.MustExec("insert ignore into t_slow values (1,1);")
 
@@ -447,7 +447,7 @@ func (cli *testServerClient) runTestLoadDataForSlowLog(t *testing.T, server *Ser
 		}
 
 		// Test for record slow log for load data statement.
-		rows := dbt.MustQuery("select plan from information_schema.slow_query where query like 'load data local infile % into table t_slow;' order by time desc limit 1")
+		rows := dbt.MustQuery("select plan from information_schema.slow_query where query like 'load data local infile % into table t_slow with thread=1;' order by time desc limit 1")
 		expectedPlan := ".*LoadData.* time.* loops.* prepare.* check_insert.* mem_insert_time:.* prefetch.* rpc.* commit_txn.*"
 		checkPlan(rows, expectedPlan)
 		require.NoError(t, rows.Close())
@@ -522,7 +522,7 @@ func (cli *testServerClient) runTestLoadDataAutoRandom(t *testing.T) {
 		// Set batch size, and check if load data got a invalid txn error.
 		dbt.MustExec("drop table if exists t")
 		dbt.MustExec("create table t(c1 bigint auto_random primary key, c2 bigint, c3 bigint)")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t (c2, c3) with batch_size = 128", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t (c2, c3) with batch_size = 128, thread=1", path))
 		rows := dbt.MustQuery("select count(*) from t")
 		cli.checkRows(t, rows, "50000")
 		require.NoError(t, rows.Close())
@@ -579,7 +579,7 @@ func (cli *testServerClient) runTestLoadDataAutoRandomWithSpecialTerm(t *testing
 		// Set batch size, and check if load data got a invalid txn error.
 		dbt.MustExec("drop table if exists t1")
 		dbt.MustExec("create table t1(c1 bigint auto_random primary key, c2 bigint, c3 bigint)")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t1 fields terminated by ',' enclosed by '\\'' lines terminated by '|' (c2, c3) with batch_size = 128", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t1 fields terminated by ',' enclosed by '\\'' lines terminated by '|' (c2, c3) with batch_size = 128, thread=1", path))
 		rows := dbt.MustQuery("select count(*) from t1")
 		cli.checkRows(t, rows, "50000")
 		rows = dbt.MustQuery("select bit_xor(c2), bit_xor(c3) from t1")
@@ -610,20 +610,20 @@ func (cli *testServerClient) runTestLoadDataForListPartition(t *testing.T) {
 	);`)
 		// Test load data into 1 partition.
 		cli.prepareLoadDataFile(t, f, "1 a", "2 b")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		rows := dbt.MustQuery("select * from t partition(p1) order by id")
 		cli.checkRows(t, rows, "1 a", "2 b")
 		// Test load data into multi-partitions.
 		dbt.MustExec("delete from t")
 		cli.prepareLoadDataFile(t, f, "1 a", "3 c", "4 e")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		require.NoError(t, rows.Close())
 		rows = dbt.MustQuery("select * from t order by id")
 		cli.checkRows(t, rows, "1 a", "3 c", "4 e")
 		require.NoError(t, rows.Close())
 		// Test load data meet duplicate error.
 		cli.prepareLoadDataFile(t, f, "1 x", "2 b", "2 x", "7 a")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		rows = dbt.MustQuery("show warnings")
 		cli.checkRows(t, rows,
 			"Warning 1062 Duplicate entry '1' for key 't.idx'",
@@ -633,7 +633,7 @@ func (cli *testServerClient) runTestLoadDataForListPartition(t *testing.T) {
 		cli.checkRows(t, rows, "1 a", "2 b", "3 c", "4 e", "7 a")
 		// Test load data meet no partition warning.
 		cli.prepareLoadDataFile(t, f, "5 a", "100 x")
-		_, err := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t", path))
+		_, err := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		require.NoError(t, err)
 		rows = dbt.MustQuery("show warnings")
 		cli.checkRows(t, rows, "Warning 1526 Table has no partition for value 100")
@@ -664,20 +664,20 @@ func (cli *testServerClient) runTestLoadDataForListPartition2(t *testing.T) {
 	);`)
 		// Test load data into 1 partition.
 		cli.prepareLoadDataFile(t, f, "1 a", "2 b")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t (id,name)", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t (id,name) with thread=1", path))
 		rows := dbt.MustQuery("select id,name from t partition(p1) order by id")
 		cli.checkRows(t, rows, "1 a", "2 b")
 		// Test load data into multi-partitions.
 		dbt.MustExec("delete from t")
 		cli.prepareLoadDataFile(t, f, "1 a", "3 c", "4 e")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t (id,name)", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t (id,name) with thread=1", path))
 		require.NoError(t, rows.Close())
 		rows = dbt.MustQuery("select id,name from t order by id")
 		cli.checkRows(t, rows, "1 a", "3 c", "4 e")
 		// Test load data meet duplicate error.
 		cli.prepareLoadDataFile(t, f, "1 x", "2 b", "2 x", "7 a")
 		require.NoError(t, rows.Close())
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t (id,name)", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t (id,name) with thread=1", path))
 		rows = dbt.MustQuery("show warnings")
 		cli.checkRows(t, rows,
 			"Warning 1062 Duplicate entry '1-2' for key 't.idx'",
@@ -688,7 +688,7 @@ func (cli *testServerClient) runTestLoadDataForListPartition2(t *testing.T) {
 		require.NoError(t, rows.Close())
 		// Test load data meet no partition warning.
 		cli.prepareLoadDataFile(t, f, "5 a", "100 x")
-		_, err := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t (id,name)", path))
+		_, err := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t (id,name) with thread=1", path))
 		require.NoError(t, err)
 		rows = dbt.MustQuery("show warnings")
 		cli.checkRows(t, rows, "Warning 1526 Table has no partition for value 100")
@@ -719,20 +719,20 @@ func (cli *testServerClient) runTestLoadDataForListColumnPartition(t *testing.T)
 	);`)
 		// Test load data into 1 partition.
 		cli.prepareLoadDataFile(t, f, "1 a", "2 b")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		rows := dbt.MustQuery("select * from t partition(p1) order by id")
 		cli.checkRows(t, rows, "1 a", "2 b")
 		// Test load data into multi-partitions.
 		dbt.MustExec("delete from t")
 		cli.prepareLoadDataFile(t, f, "1 a", "3 c", "4 e")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		require.NoError(t, rows.Close())
 		rows = dbt.MustQuery("select * from t order by id")
 		cli.checkRows(t, rows, "1 a", "3 c", "4 e")
 		require.NoError(t, rows.Close())
 		// Test load data meet duplicate error.
 		cli.prepareLoadDataFile(t, f, "1 x", "2 b", "2 x", "7 a")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		rows = dbt.MustQuery("show warnings")
 		cli.checkRows(t, rows,
 			"Warning 1062 Duplicate entry '1' for key 't.idx'",
@@ -742,7 +742,7 @@ func (cli *testServerClient) runTestLoadDataForListColumnPartition(t *testing.T)
 		cli.checkRows(t, rows, "1 a", "2 b", "3 c", "4 e", "7 a")
 		// Test load data meet no partition warning.
 		cli.prepareLoadDataFile(t, f, "5 a", "100 x")
-		_, err := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t", path))
+		_, err := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		require.NoError(t, err)
 		require.NoError(t, rows.Close())
 		rows = dbt.MustQuery("show warnings")
@@ -773,19 +773,19 @@ func (cli *testServerClient) runTestLoadDataForListColumnPartition2(t *testing.T
 	);`)
 		// Test load data into 1 partition.
 		cli.prepareLoadDataFile(t, f, "w 1 1", "w 2 2")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		rows := dbt.MustQuery("select * from t partition(p_west) order by id")
 		cli.checkRows(t, rows, "w 1 1", "w 2 2")
 		// Test load data into multi-partitions.
 		dbt.MustExec("delete from t")
 		cli.prepareLoadDataFile(t, f, "w 1 1", "e 5 5", "n 9 9")
-		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t", path))
+		dbt.MustExec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		require.NoError(t, rows.Close())
 		rows = dbt.MustQuery("select * from t order by id")
 		cli.checkRows(t, rows, "w 1 1", "e 5 5", "n 9 9")
 		// Test load data meet duplicate error.
 		cli.prepareLoadDataFile(t, f, "w 1 2", "w 2 2")
-		_, err := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t", path))
+		_, err := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		require.NoError(t, err)
 		require.NoError(t, rows.Close())
 		rows = dbt.MustQuery("show warnings")
@@ -795,13 +795,13 @@ func (cli *testServerClient) runTestLoadDataForListColumnPartition2(t *testing.T
 		cli.checkRows(t, rows, "w 1 1", "w 2 2", "e 5 5", "n 9 9")
 		// Test load data meet no partition warning.
 		cli.prepareLoadDataFile(t, f, "w 3 3", "w 5 5", "e 8 8")
-		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t", path))
+		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		require.NoError(t, err)
 		require.NoError(t, rows.Close())
 		rows = dbt.MustQuery("show warnings")
 		cli.checkRows(t, rows, "Warning 1526 Table has no partition for value from column_list")
 		cli.prepareLoadDataFile(t, f, "x 1 1", "w 1 1")
-		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t", path))
+		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table t with thread=1", path))
 		require.NoError(t, err)
 		require.NoError(t, rows.Close())
 		rows = dbt.MustQuery("show warnings")
@@ -875,7 +875,7 @@ func (cli *testServerClient) runTestLoadDataWithColumnList(t *testing.T, _ *Serv
 		db.MustExec("use test")
 		db.MustExec("drop table if exists t66")
 		db.MustExec("create table t66 (id int primary key,k int,c varchar(10),dt date,vv char(1),ts datetime)")
-		db.MustExec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t66 FIELDS TERMINATED BY ',' ENCLOSED BY '\\\"' IGNORE 1 LINES (k,id,c,dt,vv,ts)", path))
+		db.MustExec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t66 FIELDS TERMINATED BY ',' ENCLOSED BY '\\\"' IGNORE 1 LINES (k,id,c,dt,vv,ts) with thread=1", path))
 		rows := db.MustQuery("select * from t66")
 		var (
 			id sql.NullString
@@ -912,7 +912,7 @@ func (cli *testServerClient) runTestLoadDataWithColumnList(t *testing.T, _ *Serv
 		db.MustExec("use test")
 		db.MustExec("drop table if exists t66")
 		db.MustExec("create table t66 (id int primary key,k int,c varchar(10),dt date,vv char(1),ts datetime)")
-		db.MustExec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t66 FIELDS TERMINATED BY ',' ENCLOSED BY '\\\"' IGNORE 1 LINES (k,id,c)", path))
+		db.MustExec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t66 FIELDS TERMINATED BY ',' ENCLOSED BY '\\\"' IGNORE 1 LINES (k,id,c) with thread=1", path))
 		rows := db.MustQuery("select * from t66")
 		var (
 			id sql.NullString
@@ -950,7 +950,7 @@ func (cli *testServerClient) runTestLoadDataWithColumnList(t *testing.T, _ *Serv
 		db.MustExec("drop table if exists t66")
 		db.MustExec("create table t66 (id int primary key,k int,c varchar(10),dt date,vv char(1),ts datetime)")
 		// We modify the upper case and lower case in the column list to test the case-insensitivity
-		db.MustExec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t66 FIELDS TERMINATED BY ',' ENCLOSED BY '\\\"' IGNORE 1 LINES (K,Id,c,dT,Vv,Ts)", path))
+		db.MustExec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t66 FIELDS TERMINATED BY ',' ENCLOSED BY '\\\"' IGNORE 1 LINES (K,Id,c,dT,Vv,Ts) with thread=1", path))
 		rows := db.MustQuery("select * from t66")
 		var (
 			id sql.NullString
@@ -987,7 +987,7 @@ func (cli *testServerClient) runTestLoadDataWithColumnList(t *testing.T, _ *Serv
 		db.MustExec("use test")
 		db.MustExec("drop table if exists t66")
 		db.MustExec("create table t66 (id int primary key, c1 varchar(255))")
-		_, err = db.GetDB().Exec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t66 FIELDS TERMINATED BY ',' ENCLOSED BY '\\\"' IGNORE 1 LINES (c1, c2)", path))
+		_, err = db.GetDB().Exec(fmt.Sprintf("LOAD DATA LOCAL INFILE '%s' INTO TABLE t66 FIELDS TERMINATED BY ',' ENCLOSED BY '\\\"' IGNORE 1 LINES (c1, c2) with thread=1", path))
 		require.EqualError(t, err, "Error 1054 (42S22): Unknown column 'c2' in 'field list'")
 	})
 }
@@ -1034,14 +1034,14 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		dbt.MustExec("create sequence s1")
 
 		// can't insert into views (in TiDB) or sequences. issue #20880
-		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table v1", path))
+		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table v1 with thread=1", path))
 		require.Error(t, err)
 		require.Equal(t, "Error 1288 (HY000): The target table v1 of the LOAD is not updatable", err.Error())
-		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table s1", path))
+		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table s1 with thread=1", path))
 		require.Error(t, err)
 		require.Equal(t, "Error 1288 (HY000): The target table s1 of the LOAD is not updatable", err.Error())
 
-		rs, err1 := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test with batch_size = 3", path))
+		rs, err1 := dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test with batch_size = 3, thread=1", path))
 		require.NoError(t, err1)
 		lastID, err1 := rs.LastInsertId()
 		require.NoError(t, err1)
@@ -1091,7 +1091,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 
 		// specify faileds and lines
 		dbt.MustExec("delete from test")
-		rs, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test fields terminated by '\t- ' lines starting by 'xxx ' terminated by '\n' with batch_size = 3", path))
+		rs, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test fields terminated by '\t- ' lines starting by 'xxx ' terminated by '\n' with batch_size = 3, thread=1", path))
 		require.NoError(t, err)
 		lastID, err = rs.LastInsertId()
 		require.NoError(t, err)
@@ -1134,7 +1134,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 			_, err = fp.WriteString(fmt.Sprintf("xxx row%d_col1	- row%d_col2\n", i, i))
 			require.NoError(t, err)
 		}
-		rs, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test fields terminated by '\t- ' lines starting by 'xxx ' terminated by '\n' with batch_size = 3", path))
+		rs, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test fields terminated by '\t- ' lines starting by 'xxx ' terminated by '\n' with batch_size = 3, thread=1", path))
 		require.NoError(t, err)
 		lastID, err = rs.LastInsertId()
 		require.NoError(t, err)
@@ -1146,11 +1146,11 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		require.Truef(t, rows.Next(), "unexpected data")
 		require.NoError(t, rows.Close())
 		// don't support lines terminated is ""
-		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test lines terminated by ''", path))
+		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test lines terminated by '' with thread=1", path))
 		require.NotNil(t, err)
 
 		// infile doesn't exist
-		_, err = dbt.GetDB().Exec("load data local infile '/tmp/nonexistence.csv' into table test")
+		_, err = dbt.GetDB().Exec("load data local infile '/tmp/nonexistence.csv' into table test with thread=1")
 		require.NotNil(t, err)
 	})
 
@@ -1175,7 +1175,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("create table test (str varchar(10) default null, i int default null)")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' enclosed by '"' with batch_size = 3`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' enclosed by '"' with batch_size = 3, thread=1`, path))
 		require.NoError(t, err1)
 		var (
 			str string
@@ -1223,7 +1223,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("create table test (a date, b date, c date not null, d date)")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' with batch_size = 3`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' with batch_size = 3, thread=1`, path))
 		require.NoError(t, err1)
 		var (
 			a sql.NullString
@@ -1279,7 +1279,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("create table test (a varchar(20), b varchar(20))")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' enclosed by '"' with batch_size = 3`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' enclosed by '"' with batch_size = 3, thread=1`, path))
 		require.NoError(t, err1)
 		var (
 			a sql.NullString
@@ -1325,7 +1325,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		config.AllowAllFiles = true
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("create table test (id INT NOT NULL PRIMARY KEY,  b INT,  c varchar(10))")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' IGNORE 1 LINES with batch_size = 3`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table test FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' IGNORE 1 LINES with batch_size = 3, thread=1`, path))
 		require.NoError(t, err1)
 		var (
 			a int
@@ -1350,7 +1350,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		config.AllowAllFiles = true
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("create table test (a varchar(255), b varchar(255) default 'default value', c int not null auto_increment, primary key(c))")
-		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test", path))
+		_, err = dbt.GetDB().Exec(fmt.Sprintf("load data local infile %q into table test with thread=1", path))
 		require.Error(t, err)
 		checkErrorCode(t, err, errno.ErrNotAllowedCommand)
 	})
@@ -1377,7 +1377,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists pn")
 		dbt.MustExec("create table pn (c1 int, c2 int)")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ','  with batch_size = 1`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ','  with batch_size = 1, thread=1`, path))
 		require.NoError(t, err1)
 		var (
 			a int
@@ -1398,7 +1398,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 		require.NoError(t, rows.Close())
 		// fail error processing test
 		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/commitOneTaskErr", "return"))
-		_, err1 = dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ','`, path))
+		_, err1 = dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' with thread=1`, path))
 		mysqlErr, ok := err1.(*mysql.MySQLError)
 		require.True(t, ok)
 		require.Equal(t, "mock commit one task error", mysqlErr.Message)
@@ -1428,7 +1428,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists pn")
 		dbt.MustExec("create table pn (c1 int, c2 int)")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, c2) with batch_size = 1`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, c2) with batch_size = 1, thread=1`, path))
 		require.NoError(t, err1)
 		var (
 			a int
@@ -1471,7 +1471,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists pn")
 		dbt.MustExec("create table pn (c1 int, c2 int, c3 int)")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @dummy) with batch_size = 1`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @dummy) with batch_size = 1, thread=1`, path))
 		require.NoError(t, err1)
 		var (
 			a int
@@ -1517,7 +1517,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists pn")
 		dbt.MustExec("create table pn (c1 int, c2 int, c3 int)")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @val1, @val2) SET c3 = @val2 * 100, c2 = CAST(@val1 AS UNSIGNED) with batch_size = 1`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @val1, @val2) SET c3 = @val2 * 100, c2 = CAST(@val1 AS UNSIGNED) with batch_size = 1, thread=1`, path))
 		require.NoError(t, err1)
 		var (
 			a int
@@ -1549,7 +1549,7 @@ func (cli *testServerClient) runTestLoadData(t *testing.T, server *Server) {
 	}, "LoadData", func(dbt *testkit.DBTestKit) {
 		dbt.MustExec("drop table if exists pn")
 		dbt.MustExec("create table pn (c1 int, c2 int, c3 int)")
-		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @VAL1, @VAL2) SET c3 = @VAL2 * 100, c2 = CAST(@VAL1 AS UNSIGNED) with batch_size = 1`, path))
+		_, err1 := dbt.GetDB().Exec(fmt.Sprintf(`load data local infile %q into table pn FIELDS TERMINATED BY ',' (c1, @VAL1, @VAL2) SET c3 = @VAL2 * 100, c2 = CAST(@VAL1 AS UNSIGNED) with batch_size = 1, thread=1`, path))
 		require.NoError(t, err1)
 		var (
 			a int

--- a/tests/realtikvtest/loaddatatest/detach_test.go
+++ b/tests/realtikvtest/loaddatatest/detach_test.go
@@ -57,8 +57,8 @@ func (s *mockGCSSuite) TestSameBehaviourDetachedOrNot() {
 }
 
 func (s *mockGCSSuite) testSameBehaviourDetachedOrNot(importMode string) {
-	withOptions := fmt.Sprintf("WITH import_mode='%s'", importMode)
-	detachedWithOptions := fmt.Sprintf("WITH DETACHED, import_mode='%s'", importMode)
+	withOptions := fmt.Sprintf("WITH thread=1, import_mode='%s'", importMode)
+	detachedWithOptions := fmt.Sprintf("WITH DETACHED, thread=1, import_mode='%s'", importMode)
 	backup := asyncloaddata.HeartBeatInSec
 	asyncloaddata.HeartBeatInSec = 1
 	s.T().Cleanup(func() {

--- a/tests/realtikvtest/loaddatatest/load_data_test.go
+++ b/tests/realtikvtest/loaddatatest/load_data_test.go
@@ -141,7 +141,7 @@ func (s *mockGCSSuite) TestPhysicalMode() {
 	}
 
 	loadDataSQL := fmt.Sprintf(`LOAD DATA INFILE 'gs://test-multi-load/db.tbl.*.tsv?endpoint=%s'
-		INTO TABLE t %%s with import_mode='physical'`, gcsEndpoint)
+		INTO TABLE t %%s with thread=1, import_mode='physical'`, gcsEndpoint)
 	for _, c := range cases {
 		s.tk.MustExec("drop table if exists t;")
 		s.tk.MustExec(c.createTableSQL)
@@ -203,7 +203,7 @@ func (s *mockGCSSuite) TestIgnoreNLines() {
 	s.tk.MustExec("drop table if exists t;")
 	s.tk.MustExec("create table t (a bigint, b varchar(100), c int);")
 	loadDataSQL := fmt.Sprintf(`LOAD DATA INFILE 'gs://test-multi-load/skip-rows-*.csv?endpoint=%s'
-		INTO TABLE t fields terminated by ',' with import_mode='physical'`, gcsEndpoint)
+		INTO TABLE t fields terminated by ',' with thread=1, import_mode='physical'`, gcsEndpoint)
 	s.tk.MustExec(loadDataSQL)
 	s.Equal("Records: 9  Deleted: 0  Skipped: 0  Warnings: 0", s.tk.Session().GetSessionVars().StmtCtx.GetMessage())
 	s.Equal(uint64(9), s.tk.Session().GetSessionVars().StmtCtx.AffectedRows())
@@ -214,7 +214,7 @@ func (s *mockGCSSuite) TestIgnoreNLines() {
 	}...))
 	s.tk.MustExec("truncate table t")
 	loadDataSQL = fmt.Sprintf(`LOAD DATA INFILE 'gs://test-multi-load/skip-rows-*.csv?endpoint=%s'
-		INTO TABLE t fields terminated by ',' ignore 1 lines with import_mode='physical'`, gcsEndpoint)
+		INTO TABLE t fields terminated by ',' ignore 1 lines with thread=1, import_mode='physical'`, gcsEndpoint)
 	s.tk.MustExec(loadDataSQL)
 	s.Equal("Records: 7  Deleted: 0  Skipped: 0  Warnings: 0", s.tk.Session().GetSessionVars().StmtCtx.GetMessage())
 	s.Equal(uint64(7), s.tk.Session().GetSessionVars().StmtCtx.AffectedRows())
@@ -225,7 +225,7 @@ func (s *mockGCSSuite) TestIgnoreNLines() {
 	}...))
 	s.tk.MustExec("truncate table t")
 	loadDataSQL = fmt.Sprintf(`LOAD DATA INFILE 'gs://test-multi-load/skip-rows-*.csv?endpoint=%s'
-		INTO TABLE t fields terminated by ',' ignore 3 lines with import_mode='physical'`, gcsEndpoint)
+		INTO TABLE t fields terminated by ',' ignore 3 lines with thread=1, import_mode='physical'`, gcsEndpoint)
 	s.tk.MustExec(loadDataSQL)
 	s.Equal("Records: 3  Deleted: 0  Skipped: 0  Warnings: 0", s.tk.Session().GetSessionVars().StmtCtx.GetMessage())
 	s.Equal(uint64(3), s.tk.Session().GetSessionVars().StmtCtx.AffectedRows())
@@ -795,7 +795,7 @@ func (s *mockGCSSuite) TestChecksumNotMatch() {
 	s.tk.MustExec("drop table if exists t;")
 	s.tk.MustExec("create table t (a bigint primary key, b varchar(100), c int);")
 	loadDataSQL := fmt.Sprintf(`LOAD DATA INFILE 'gs://test-multi-load/duplicate-pk-*.csv?endpoint=%s'
-		INTO TABLE t fields terminated by ',' with import_mode='physical'`, gcsEndpoint)
+		INTO TABLE t fields terminated by ',' with thread=1, import_mode='physical'`, gcsEndpoint)
 	err := s.tk.ExecToErr(loadDataSQL)
 	require.ErrorIs(s.T(), err, common.ErrChecksumMismatch)
 	// for this case, we keep KV in memory and write in batch, and in each batch only first key is written.
@@ -805,7 +805,7 @@ func (s *mockGCSSuite) TestChecksumNotMatch() {
 
 	s.tk.MustExec("truncate table t;")
 	loadDataSQL = fmt.Sprintf(`LOAD DATA INFILE 'gs://test-multi-load/duplicate-pk-*.csv?endpoint=%s'
-		INTO TABLE t fields terminated by ',' with import_mode='physical', checksum_table='off'`, gcsEndpoint)
+		INTO TABLE t fields terminated by ',' with thread=1, import_mode='physical', checksum_table='off'`, gcsEndpoint)
 	s.tk.MustExec(loadDataSQL)
 	// for this case, we keep KV in memory and write in batch, and in each batch only first key is written.
 	s.tk.MustQuery("SELECT * FROM t;").Sort().Check(testkit.Rows([]string{
@@ -814,7 +814,7 @@ func (s *mockGCSSuite) TestChecksumNotMatch() {
 
 	s.tk.MustExec("truncate table t;")
 	loadDataSQL = fmt.Sprintf(`LOAD DATA INFILE 'gs://test-multi-load/duplicate-pk-*.csv?endpoint=%s'
-		INTO TABLE t fields terminated by ',' with import_mode='physical', checksum_table='optional'`, gcsEndpoint)
+		INTO TABLE t fields terminated by ',' with thread=1, import_mode='physical', checksum_table='optional'`, gcsEndpoint)
 	s.tk.MustExec(loadDataSQL)
 	// for this case, we keep KV in memory and write in batch, and in each batch only first key is written.
 	s.tk.MustQuery("SELECT * FROM t;").Sort().Check(testkit.Rows([]string{

--- a/tests/realtikvtest/loaddatatest/load_data_test.go
+++ b/tests/realtikvtest/loaddatatest/load_data_test.go
@@ -829,7 +829,7 @@ func (s *mockGCSSuite) TestColumnsAndUserVars() {
 }
 
 func (s *mockGCSSuite) testColumnsAndUserVars(importMode string, distributed bool) {
-	withOptions := fmt.Sprintf("WITH import_mode='%s'", importMode)
+	withOptions := fmt.Sprintf("WITH thread=1, import_mode='%s'", importMode)
 	withOptions = adjustOptions(withOptions, distributed)
 	s.prepareVariables(distributed)
 	s.tk.MustExec("DROP DATABASE IF EXISTS load_data;")

--- a/tests/realtikvtest/loaddatatest/show_test.go
+++ b/tests/realtikvtest/loaddatatest/show_test.go
@@ -93,9 +93,9 @@ func (s *mockGCSSuite) simpleShowLoadDataJobs(importMode string) {
 	})
 
 	resultMessage := "Records: 2  Deleted: 0  Skipped: 0  Warnings: 0"
-	withOptions := "WITH DETACHED"
+	withOptions := "WITH thread=1, DETACHED"
 	if importMode == importer.PhysicalImportMode {
-		withOptions = "WITH DETACHED, import_mode='PHYSICAL'"
+		withOptions = "WITH thread=1, DETACHED, import_mode='PHYSICAL'"
 	}
 
 	sql := fmt.Sprintf(`LOAD DATA INFILE 'gs://test-show/t.tsv?endpoint=%s'
@@ -145,7 +145,7 @@ func (s *mockGCSSuite) TestSimpleShowLoadDataJobs() {
 	require.ErrorContains(s.T(), err, "Job ID 999999999 doesn't exist")
 
 	sql := fmt.Sprintf(`LOAD DATA INFILE 'gs://test-show/t.tsv?endpoint=%s'
-		INTO TABLE test_show.t WITH DETACHED;`, gcsEndpoint)
+		INTO TABLE test_show.t WITH thread=1, DETACHED;`, gcsEndpoint)
 	// repeat LOAD DATA, will get duplicate entry error
 	rows := s.tk.MustQuery(sql).Rows()
 	require.Len(s.T(), rows, 1)
@@ -175,7 +175,7 @@ func (s *mockGCSSuite) TestSimpleShowLoadDataJobs() {
 
 	// test IGNORE
 	sql = fmt.Sprintf(`LOAD DATA INFILE 'gs://test-show/t.tsv?endpoint=%s'
-		IGNORE INTO TABLE test_show.t WITH DETACHED;`, gcsEndpoint)
+		IGNORE INTO TABLE test_show.t WITH thread=1, DETACHED;`, gcsEndpoint)
 	rows = s.tk.MustQuery(sql).Rows()
 	require.Len(s.T(), rows, 1)
 	row = rows[0]
@@ -203,7 +203,7 @@ func (s *mockGCSSuite) TestSimpleShowLoadDataJobs() {
 
 	// test REPLACE
 	sql = fmt.Sprintf(`LOAD DATA INFILE 'gs://test-show/t.tsv?endpoint=%s'
-		REPLACE INTO TABLE test_show.t WITH DETACHED;`, gcsEndpoint)
+		REPLACE INTO TABLE test_show.t WITH thread=1, DETACHED;`, gcsEndpoint)
 	rows = s.tk.MustQuery(sql).Rows()
 	require.Len(s.T(), rows, 1)
 	row = rows[0]
@@ -254,11 +254,11 @@ func (s *mockGCSSuite) testInternalStatus(importMode string) {
 	tk3.Session().GetSessionVars().User = user
 
 	resultMessage := "Records: 2  Deleted: 0  Skipped: 0  Warnings: 0"
-	withOptions := "WITH DETACHED, batch_size=1"
+	withOptions := "WITH thread=1, DETACHED, batch_size=1"
 	progressAfterFirstBatch := `{"SourceFileSize":2,"LoadedFileSize":1,"LoadedRowCnt":1}`
 	progressAfterAll := `{"SourceFileSize":2,"LoadedFileSize":2,"LoadedRowCnt":2}`
 	if importMode == importer.PhysicalImportMode {
-		withOptions = fmt.Sprintf("WITH DETACHED, import_mode='%s'", importMode)
+		withOptions = fmt.Sprintf("WITH thread=1, DETACHED, import_mode='%s'", importMode)
 		progressAfterFirstBatch = `{"SourceFileSize":2,"ReadRowCnt":1,"EncodeFileSize":1,"LoadedRowCnt":1}`
 		progressAfterAll = `{"SourceFileSize":2,"ReadRowCnt":2,"EncodeFileSize":2,"LoadedRowCnt":2}`
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42930 

Problem Summary:

### What is changed and how it works?
- previously we use `ignoreInTest` to determine how many threads to use, it's not explicit to write case. now change them to explicit use `with thread=1` if needed.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
