### PR TITLE
planner: label predicate_simplification as over-optimized for plan cache

### DIFF
--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -130,6 +130,44 @@ func TestPlanCacheUnsafeRange(t *testing.T) {
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
 }
 
+func TestIssue43405(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+
+	tk.MustExec(`create table t (a int)`)
+	tk.MustExec(`insert into t values (1), (2), (3), (4)`)
+	tk.MustExec(`prepare st from 'select * from t where a!=? and a in (?, ?, ?)'`)
+	tk.MustExec(`set @a=1, @b=2, @c=3, @d=4`)
+	tk.MustQuery(`execute st using @a, @a, @a, @a`).Sort().Check(testkit.Rows())
+	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1105 skip prepared plan-cache: NE/INList simplification is triggered"))
+	tk.MustQuery(`execute st using @a, @a, @b, @c`).Sort().Check(testkit.Rows("2", "3"))
+	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1105 skip prepared plan-cache: NE/INList simplification is triggered"))
+	tk.MustQuery(`execute st using @a, @b, @c, @d`).Sort().Check(testkit.Rows("2", "3", "4"))
+	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1105 skip prepared plan-cache: NE/INList simplification is triggered"))
+
+	tk.MustExec(`CREATE TABLE UK_SIGNED_19384 (
+    COL1 decimal(37,4) unsigned DEFAULT NULL COMMENT 'WITH DEFAULT',
+    COL2 varchar(20) COLLATE utf8mb4_bin DEFAULT NULL,
+    COL4 datetime DEFAULT NULL,
+    COL3 bigint DEFAULT NULL,
+    COL5 float DEFAULT NULL,
+    UNIQUE KEY UK_COL1 (COL1)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin`)
+	tk.MustExec(`INSERT INTO UK_SIGNED_19384 VALUES
+  (729024465529090.5423,'劗驻胭毤橰亀讁陶ĉ突錌ͳ河碡祁聓兕锻觰俆','4075-07-11 12:02:57',6021562653572886552,1.93349e38),
+  (492790234219503.0846,'硴皡箒嫹璞玚囑蚂身囈軔獰髴囥慍廂頚禌浖蕐','1193-09-27 12:13:40',1836453747944153034,-2.67982e38),
+  (471841432147994.4981,'豻貐裝濂婝蒙蘦镢県蟎髓蓼窘搴熾臐哥递泒執','1618-01-24 05:06:44',6669616052974883820,9.38232e37)`)
+	tk.MustExec(`prepare stmt from 'select/*+ tidb_inlj(t1) */ t1.col1 from UK_SIGNED_19384 t1 join UK_SIGNED_19384 t2 on t1.col1 = t2.col1 where t1. col1 != ? and t2. col1 in (?, ?, ?)'`)
+	tk.MustExec(`set @a=999999999999999999999999999999999.9999, @b=999999999999999999999999999999999.9999, @c=999999999999999999999999999999999.9999, @d=999999999999999999999999999999999.9999`)
+	tk.MustQuery(`execute stmt using @a,@b,@c,@d`).Check(testkit.Rows()) // empty result
+	tk.MustExec(`set @a=895769331208356.9029, @b=471841432147994.4981, @c=729024465529090.5423, @d=492790234219503.0846`)
+	tk.MustQuery(`execute stmt using @a,@b,@c,@d`).Sort().Check(testkit.Rows(
+		"471841432147994.4981",
+		"492790234219503.0846",
+		"729024465529090.5423"))
+}
+
 func TestIssue40296(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/planner/core/rule_predicate_simplification.go
+++ b/planner/core/rule_predicate_simplification.go
@@ -17,6 +17,7 @@ package core
 import (
 	"context"
 	"errors"
+
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/sessionctx"

--- a/planner/core/rule_predicate_simplification.go
+++ b/planner/core/rule_predicate_simplification.go
@@ -16,6 +16,8 @@ package core
 
 import (
 	"context"
+	"errors"
+	"github.com/pingcap/tidb/sessionctx"
 
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/parser/ast"
@@ -78,7 +80,7 @@ func (s *baseLogicalPlan) predicateSimplification(opt *logicalOptimizeOp) Logica
 
 // updateInPredicate applies intersection of an in list with <> value. It returns updated In list and a flag for
 // a special case if an element in the inlist is not removed to keep the list not empty.
-func updateInPredicate(inPredicate expression.Expression, notEQPredicate expression.Expression) (expression.Expression, bool) {
+func updateInPredicate(sctx sessionctx.Context, inPredicate expression.Expression, notEQPredicate expression.Expression) (expression.Expression, bool) {
 	_, inPredicateType := findPredicateType(inPredicate)
 	_, notEQPredicateType := findPredicateType(notEQPredicate)
 	if inPredicateType != inListPredicate || notEQPredicateType != notEqualPredicate {
@@ -90,8 +92,11 @@ func updateInPredicate(inPredicate expression.Expression, notEQPredicate express
 	var lastValue *expression.Constant
 	for _, element := range v.GetArgs() {
 		value, valueOK := element.(*expression.Constant)
-		redudantValue := valueOK && value.Equal(v.GetCtx(), notEQValue)
-		if !redudantValue {
+		redundantValue := valueOK && value.Equal(v.GetCtx(), notEQValue)
+		if redundantValue {
+			sctx.GetSessionVars().StmtCtx.SetSkipPlanCache(errors.New("some redundant value in IN-list is pruned"))
+		}
+		if !redundantValue {
 			newValues = append(newValues, element)
 		}
 		if valueOK {
@@ -110,7 +115,7 @@ func updateInPredicate(inPredicate expression.Expression, notEQPredicate express
 	return newPred, specialCase
 }
 
-func applyPredicateSimplification(predicates []expression.Expression) []expression.Expression {
+func applyPredicateSimplification(sctx sessionctx.Context, predicates []expression.Expression) []expression.Expression {
 	if len(predicates) <= 1 {
 		return predicates
 	}
@@ -124,12 +129,12 @@ func applyPredicateSimplification(predicates []expression.Expression) []expressi
 			jCol, jType := findPredicateType(jthPredicate)
 			if iCol == jCol {
 				if iType == notEqualPredicate && jType == inListPredicate {
-					predicates[j], specialCase = updateInPredicate(jthPredicate, ithPredicate)
+					predicates[j], specialCase = updateInPredicate(sctx, jthPredicate, ithPredicate)
 					if !specialCase {
 						removeValues = append(removeValues, i)
 					}
 				} else if iType == inListPredicate && jType == notEqualPredicate {
-					predicates[i], specialCase = updateInPredicate(ithPredicate, jthPredicate)
+					predicates[i], specialCase = updateInPredicate(sctx, ithPredicate, jthPredicate)
 					if !specialCase {
 						removeValues = append(removeValues, j)
 					}
@@ -148,8 +153,8 @@ func applyPredicateSimplification(predicates []expression.Expression) []expressi
 
 func (s *DataSource) predicateSimplification(opt *logicalOptimizeOp) LogicalPlan {
 	p := s.self.(*DataSource)
-	p.pushedDownConds = applyPredicateSimplification(p.pushedDownConds)
-	p.allConds = applyPredicateSimplification(p.allConds)
+	p.pushedDownConds = applyPredicateSimplification(p.ctx, p.pushedDownConds)
+	p.allConds = applyPredicateSimplification(p.ctx, p.allConds)
 	return p
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43405

Problem Summary: planner: label predicate_simplification as over-optimized for plan cache

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
