### PR TITLE
parser: make normalization more aggressive

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3122,7 +3122,7 @@ func TestPrevStmtDesensitization(t *testing.T) {
 	tk.MustExec("create table t (a int, unique key (a))")
 	tk.MustExec("begin")
 	tk.MustExec("insert into t values (1),(2)")
-	require.Equal(t, "insert into `t` values ( ? ) , ( ? )", tk.Session().GetSessionVars().PrevStmt.String())
+	require.Equal(t, "insert into `t` values ( ... )", tk.Session().GetSessionVars().PrevStmt.String())
 	tk.MustGetErrMsg("insert into t values (1)", `[kv:1062]Duplicate entry '?' for key 't.a'`)
 }
 

--- a/extension/event_listener_test.go
+++ b/extension/event_listener_test.go
@@ -265,7 +265,7 @@ func TestExtensionStmtEvents(t *testing.T) {
 		},
 		{
 			sql:          "insert into t1 values(1, 10), (2, 20)",
-			redactText:   "insert into `t1` values ( ... ) , ( ... )",
+			redactText:   "insert into `t1` values ( ... )",
 			affectedRows: 2,
 			tables: []stmtctx.TableEntry{
 				{DB: "test", Table: "t1"},

--- a/parser/digester_test.go
+++ b/parser/digester_test.go
@@ -64,7 +64,9 @@ func TestNormalize(t *testing.T) {
 		{"select @a=b from t", "select @a = `b` from `t`"},
 		{"select * from `table", "select * from"},
 		{"Select * from t where (i, j) in ((1,1), (2,2))", "select * from `t` where ( `i` , `j` ) in ( ( ... ) )"},
-		{"insert into t values (1,1)", "insert into `t` values ( ... )"},
+		{"insert into t values (1,1), (2,2)", "insert into `t` values ( ... )"},
+		{"insert into t values (1), (2)", "insert into `t` values ( ... )"},
+		{"insert into t values (1)", "insert into `t` values ( ? )"},
 	}
 	for _, test := range tests {
 		normalized := parser.Normalize(test.input)

--- a/parser/digester_test.go
+++ b/parser/digester_test.go
@@ -63,6 +63,8 @@ func TestNormalize(t *testing.T) {
 		{"select * from t where a > ?", "select * from `t` where `a` > ?"},
 		{"select @a=b from t", "select @a = `b` from `t`"},
 		{"select * from `table", "select * from"},
+		{"Select * from t where (i, j) in ((1,1), (2,2))", "select * from `t` where ( `i` , `j` ) in ( ( ... ) )"},
+		{"insert into t values (1,1)", "insert into `t` values ( ... )"},
 	}
 	for _, test := range tests {
 		normalized := parser.Normalize(test.input)
@@ -147,6 +149,8 @@ func TestDigestHashEqForSimpleSQL(t *testing.T) {
 		{"select * from b where id = 1", "select * from b where id = '1'", "select * from b where id =2"},
 		{"select 2 from b, c where c.id > 1", "select 4 from b, c where c.id > 23"},
 		{"Select 3", "select 1"},
+		{"Select * from t where (i, j) in ((1,1), (2,2))", "select * from t where (i, j) in ((1,1), (2,2), (3,3))"},
+		{"insert into t values (1,1)", "insert into t values (1,1), (2,2)"},
 	}
 	for _, sqlGroup := range sqlGroups {
 		var d string


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/43409

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Merge multiple placeholder lists into one to make SQL normalization more aggressive, in order to avoid meaningless distinctions that eliminate other meaningful SQLs.
```
