### PR TITLE
expression: fix the bug of Rpad function

### DIFF
--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -2269,6 +2269,10 @@ func (b *builtinRpadUTF8Sig) evalString(row chunk.Row) (string, bool, error) {
 	}
 	padLength := len([]rune(padStr))
 
+	if len(padStr)*targetLength > (1 << 32) {
+		return "", true, nil
+	}
+
 	if targetLength < 0 || targetLength*4 > b.tp.GetFlen() || (runeLength < targetLength && padLength == 0) {
 		return "", true, nil
 	}

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -1660,8 +1660,11 @@ func TestRpadSig(t *testing.T) {
 	input := chunk.NewChunkWithCapacity(colTypes, 10)
 	input.AppendString(0, "abc")
 	input.AppendString(0, "abc")
+	input.AppendString(0, "abc")
 	input.AppendInt64(1, 6)
 	input.AppendInt64(1, 10000)
+	input.AppendInt64(1, 1000000000)
+	input.AppendString(2, "123")
 	input.AppendString(2, "123")
 	input.AppendString(2, "123")
 
@@ -1670,6 +1673,12 @@ func TestRpadSig(t *testing.T) {
 	require.False(t, isNull)
 	require.NoError(t, err)
 
+	res, isNull, err = rpad.evalString(input.GetRow(1))
+	require.Equal(t, "", res)
+	require.True(t, isNull)
+	require.NoError(t, err)
+
+	rpad.maxAllowedPacket = 10000000000
 	res, isNull, err = rpad.evalString(input.GetRow(1))
 	require.Equal(t, "", res)
 	require.True(t, isNull)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42770

Problem Summary: Rpad function cause panic when length is too long!

### What is changed and how it works?
I added the logic of the length check in the method, adopted the maximum malloc memory size of intel32 bits, and added the corresponding test

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
