### PR TITLE
br: avoid too many warning logs after update schema version

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -2861,7 +2861,9 @@ func (rc *Client) UpdateSchemaVersion(ctx context.Context) error {
 		func(ctx context.Context, txn kv.Transaction) error {
 			t := meta.NewMeta(txn)
 			var e error
-			schemaVersion, e = t.GenSchemaVersions(128)
+			// To trigger full-reload instead of diff-reload, we need to increase the schema version
+			// by at least `domain.LoadSchemaDiffVersionGapThreshold`.
+			schemaVersion, e = t.GenSchemaVersions(64 + domain.LoadSchemaDiffVersionGapThreshold)
 			return e
 		},
 	); err != nil {
@@ -2881,7 +2883,9 @@ func (rc *Client) UpdateSchemaVersion(ctx context.Context) error {
 		return errors.Annotatef(err, "failed to put global schema verson %v to etcd", ver)
 	}
 
-	return nil
+	// proactively reload the domain once
+	err := rc.GetDomain().Reload()
+	return errors.Trace(err)
 }
 
 const (

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -97,7 +97,7 @@ var (
 	mdlCheckLookDuration = 50 * time.Millisecond
 
 	// The threshold for version gap to reload domain by loading schema diffs
-	LoadSchemaDiffVersionGapThreshold int64 = 100
+	LoadSchemaDiffVersionGapThreshold = int64(100)
 )
 
 func init() {
@@ -212,7 +212,7 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 	schemaTs, err := do.getTimestampForSchemaVersionWithNonEmptyDiff(m, neededSchemaVersion)
 	if err != nil {
 		// NOTICE: the log restore needs to increase schema version without `Diff:` key to full-reload the domain globally.
-		logutil.BgLogger().Debug("failed to get schema version", zap.Error(err), zap.Int64("version", neededSchemaVersion))
+		logutil.BgLogger().Warn("failed to get schema version", zap.Error(err), zap.Int64("version", neededSchemaVersion))
 		schemaTs = 0
 	}
 

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -96,8 +96,8 @@ import (
 var (
 	mdlCheckLookDuration = 50 * time.Millisecond
 
-	// The threshold for version gap to reload domain by loading schema diffs
-	LoadSchemaDiffVersionGapThreshold = int64(100)
+	// LoadSchemaDiffVersionGapThreshold is the threshold for version gap to reload domain by loading schema diffs
+	LoadSchemaDiffVersionGapThreshold int64 = 100
 )
 
 func init() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43402 

Problem Summary:
after log restore, there are many warning logs, see the issue.
### What is changed and how it works?
Add a diffKey whose `regenerateSchemaMap` is true to trigger full load schemas.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
If modify the `64 + ...` to `6` to trigger `loadSchemaDiff`, the log would print that as follows:
```
[2023/05/08 15:46:48.758 +08:00] [ERROR] [domain.go:249] ["failed to load schema diff"] [error="Meets a schema diff with RegenerateSchemaMap flag"] [errorVerbose="Meets a schema diff with RegenerateSchemaMap flag\ngithub.com/pingcap/tidb/domain.(*Domain).tryLoadSchemaDiffs\n\t/root/tidb/domain/domain.go:421\ngithub.com/pingcap/tidb/domain.(*Domain).loadInfoSchema\n\t/root/tidb/domain/domain.go:236\ngithub.com/pingcap/tidb/domain.(*Domain).Reload\n\t/root/tidb/domain/domain.go:556\ngithub.com/pingcap/tidb/domain.(*Domain).loadSchemaInLoop\n\t/root/tidb/domain/domain.go:862\ngithub.com/pingcap/tidb/domain.(*Domain).Init.func3\n\t/root/tidb/domain/domain.go:1181\ngithub.com/pingcap/tidb/util.(*WaitGroupEnhancedWrapper).Run.func1\n\t/root/tidb/util/wait_group_wrapper.go:96\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1598"] [stack="github.com/pingcap/tidb/domain.(*Domain).loadInfoSchema\n\t/root/tidb/domain/domain.go:249\ngithub.com/pingcap/tidb/domain.(*Domain).Reload\n\t/root/tidb/domain/domain.go:556\ngithub.com/pingcap/tidb/domain.(*Domain).loadSchemaInLoop\n\t/root/tidb/domain/domain.go:862\ngithub.com/pingcap/tidb/domain.(*Domain).Init.func3\n\t/root/tidb/domain/domain.go:1181\ngithub.com/pingcap/tidb/util.(*WaitGroupEnhancedWrapper).Run.func1\n\t/root/tidb/util/wait_group_wrapper.go:96"]
[2023/05/08 15:46:48.785 +08:00] [INFO] [domain.go:271] ["full load InfoSchema success"] [currentSchemaVersion=2908] [neededSchemaVersion=2914] ["start time"=29.410245ms]
[2023/05/08 15:46:48.787 +08:00] [INFO] [domain.go:586] ["full load and reset schema validator"]
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
