### PR TITLE
Optimizer: do not simplify != NULL

### DIFF
--- a/planner/core/casetest/testdata/predicate_simplification_in.json
+++ b/planner/core/casetest/testdata/predicate_simplification_in.json
@@ -27,7 +27,9 @@
       "select 1 from t A, t B where A.f <> 3 and B.f in (1,2,3) and A.f <> 1 and A.f <> 2 -- on different columns. No simplification should be done.",
       "select 1 from t A, t B where B.f <> 2 and A.f <> 3 and B.f in (1,2,3) and A.f in (3,1,4) and A.f <> 1 and A.f <> 2 -- simplification for two columns.",
       "select f from ts use index() where f <> '1' and f in ('1','2','3') -- Simple case with string type",
-      "select count(*) cnt from ts where f <> '1' and f in ('1','2','3') group by a having cnt > 100  -- aggregate  "
+      "select count(*) cnt from ts where f <> '1' and f in ('1','2','3') group by a having cnt > 100  -- aggregate  ",
+      "select f from t where f <> NULL  and f in (1,2,3) -- Special case of NULL with no simplification.",
+      "select f from t where f != NULL  and f in (NULL,2,3) -- Special case of NULL with no simplification."
     ]
   }
 ]

--- a/planner/core/casetest/testdata/predicate_simplification_out.json
+++ b/planner/core/casetest/testdata/predicate_simplification_out.json
@@ -185,6 +185,22 @@
           "      └─Selection 20.00 cop[tikv]  in(test.ts.f, \"2\", \"3\")",
           "        └─TableFullScan 10000.00 cop[tikv] table:ts keep order:false, stats:pseudo"
         ]
+      },
+      {
+        "SQL": "select f from t where f <> NULL  and f in (1,2,3) -- Special case of NULL with no simplification.",
+        "Plan": [
+          "TableReader 0.00 root  data:Selection",
+          "└─Selection 0.00 cop[tikv]  in(test.t.f, 1, 2, 3), ne(test.t.f, NULL)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select f from t where f != NULL  and f in (NULL,2,3) -- Special case of NULL with no simplification.",
+        "Plan": [
+          "TableReader 0.00 root  data:Selection",
+          "└─Selection 0.00 cop[tikv]  in(test.t.f, NULL, 2, 3), ne(test.t.f, NULL)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
       }
     ]
   }

--- a/planner/core/rule_predicate_simplification.go
+++ b/planner/core/rule_predicate_simplification.go
@@ -88,6 +88,10 @@ func updateInPredicate(inPredicate expression.Expression, notEQPredicate express
 	}
 	v := inPredicate.(*expression.ScalarFunction)
 	notEQValue := notEQPredicate.(*expression.ScalarFunction).GetArgs()[1].(*expression.Constant)
+	// do not simplify != NULL since it is always false.
+	if notEQValue.Value.IsNull() {
+		return inPredicate, true
+	}
 	newValues := make([]expression.Expression, 0, len(v.GetArgs()))
 	var lastValue *expression.Constant
 	for _, element := range v.GetArgs() {


### PR DESCRIPTION
Issue Number: Ref #43407 

### Problem Summary:
Predicate simplification merges x != constant1 with x in (list of values). Merge is not correct if constant is NULL.
TiDB follows mysql semantics where x != NULL is always false. 

**Solution**
Do not apply the merge of <> and in list for x != NULL.

### Tests
Unit tests

### Side effects
None

### Documentation
None


### Release note


```release-note
None
```
