### PR TITLE
restore: Revert "split between tables"

### DIFF
--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -385,11 +385,6 @@ func (rs *RegionSplitter) ScatterRegions(ctx context.Context, newRegions []*spli
 func getSplitKeys(rewriteRules *RewriteRules, ranges []rtree.Range, regions []*split.RegionInfo, isRawKv bool) map[uint64][][]byte {
 	splitKeyMap := make(map[uint64][][]byte)
 	checkKeys := make([][]byte, 0)
-	if rewriteRules != nil && len(rewriteRules.NewKeyspace) == 0 {
-		for _, rule := range rewriteRules.Data {
-			checkKeys = append(checkKeys, rule.NewKeyPrefix)
-		}
-	}
 	for _, rg := range ranges {
 		checkKeys = append(checkKeys, rg.EndKey)
 	}

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -479,12 +479,10 @@ func initRewriteRules() *restore.RewriteRules {
 
 // expected regions after split:
 //
-//	[aa, aay), [aay, bba), [bba, bbf), [bbf, bbh), [bbh, bbj),
-//	[bbj, cca), [cca, xx), [xx, xxe), [xxe, xxz), [xxz, )
-//
-// Please note that "aa" has been rewritten to "xx", so the "bb" rewrite rule split point won't be included.
+//	[, aay), [aay, bba), [bba, bbf), [bbf, bbh), [bbh, bbj),
+//	[bbj, cca), [cca, xxe), [xxe, xxz), [xxz, )
 func validateRegions(regions map[uint64]*split.RegionInfo) bool {
-	keys := [...]string{"", "aay", "bba", "bbf", "bbh", "bbj", "cca", "xx", "xxe", "xxz", ""}
+	keys := [...]string{"", "aay", "bba", "bbf", "bbh", "bbj", "cca", "xxe", "xxz", ""}
 	return validateRegionsExt(regions, keys[:], false)
 }
 


### PR DESCRIPTION
Reverts pingcap/tidb#42972

Issue Number: Ref https://github.com/pingcap/tidb/issues/42924, Ref https://github.com/tikv/tikv/issues/14641

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```