### PR TITLE
planner: wrong slice length check for index merge's order prop push down

### DIFF
--- a/planner/core/casetest/physical_plan_test.go
+++ b/planner/core/casetest/physical_plan_test.go
@@ -2586,24 +2586,3 @@ func TestIndexMergeOrderPushDown(t *testing.T) {
 		tk.MustQuery("explain format = 'brief' " + ts).Check(testkit.Rows(output[i].Plan...))
 	}
 }
-
-// It's a case for index merge's order prop push down.
-func TestIssue43178(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec(`CREATE TABLE aa311c3c (
-		57fd8d09 year(4) DEFAULT '1913',
-		afbdd7c3 char(220) DEFAULT 'gakkl6occ0yd2jmhi2qxog8szibtcqwxyxmga3hp4ktszjplmg3rjvu8v6lgn9q6hva2lekhw6napjejbut6svsr8q2j8w8rc551e5vq',
-		43b06e99 date NOT NULL DEFAULT '3403-10-08',
-		b80b3746 tinyint(4) NOT NULL DEFAULT '34',
-		6302d8ac timestamp DEFAULT '2004-04-01 18:21:18',
-		PRIMARY KEY (43b06e99,b80b3746) /*T![clustered_index] CLUSTERED */,
-		KEY 3080c821 (57fd8d09,43b06e99,b80b3746),
-		KEY a9af33a4 (57fd8d09,b80b3746,43b06e99),
-		KEY 464b386e (b80b3746),
-		KEY 19dc3c2d (57fd8d09)
-	      ) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='320f8401'`)
-	// Should not panic
-	tk.MustExec("explain select  /*+ use_index_merge( `aa311c3c` ) */   `aa311c3c`.`43b06e99` as r0 , `aa311c3c`.`6302d8ac` as r1 from `aa311c3c` where IsNull( `aa311c3c`.`b80b3746` ) or not( `aa311c3c`.`57fd8d09` >= '2008' )   order by r0,r1 limit 95")
-}

--- a/planner/core/casetest/physical_plan_test.go
+++ b/planner/core/casetest/physical_plan_test.go
@@ -2586,3 +2586,24 @@ func TestIndexMergeOrderPushDown(t *testing.T) {
 		tk.MustQuery("explain format = 'brief' " + ts).Check(testkit.Rows(output[i].Plan...))
 	}
 }
+
+// It's a case for index merge's order prop push down.
+func TestIssue43178(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE aa311c3c (
+		57fd8d09 year(4) DEFAULT '1913',
+		afbdd7c3 char(220) DEFAULT 'gakkl6occ0yd2jmhi2qxog8szibtcqwxyxmga3hp4ktszjplmg3rjvu8v6lgn9q6hva2lekhw6napjejbut6svsr8q2j8w8rc551e5vq',
+		43b06e99 date NOT NULL DEFAULT '3403-10-08',
+		b80b3746 tinyint(4) NOT NULL DEFAULT '34',
+		6302d8ac timestamp DEFAULT '2004-04-01 18:21:18',
+		PRIMARY KEY (43b06e99,b80b3746) /*T![clustered_index] CLUSTERED */,
+		KEY 3080c821 (57fd8d09,43b06e99,b80b3746),
+		KEY a9af33a4 (57fd8d09,b80b3746,43b06e99),
+		KEY 464b386e (b80b3746),
+		KEY 19dc3c2d (57fd8d09)
+	      ) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='320f8401'`)
+	// Should not panic
+	tk.MustExec("explain select  /*+ use_index_merge( `aa311c3c` ) */   `aa311c3c`.`43b06e99` as r0 , `aa311c3c`.`6302d8ac` as r1 from `aa311c3c` where IsNull( `aa311c3c`.`b80b3746` ) or not( `aa311c3c`.`57fd8d09` >= '2008' )   order by r0,r1 limit 95")
+}

--- a/planner/core/issuetest/BUILD.bazel
+++ b/planner/core/issuetest/BUILD.bazel
@@ -2,10 +2,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "issuetest_test",
-    timeout = "moderate",
+    timeout = "short",
     srcs = ["planner_issue_test.go"],
     flaky = True,
     race = "on",
-    shard_count = 50,
     deps = ["//testkit"],
 )

--- a/planner/core/issuetest/BUILD.bazel
+++ b/planner/core/issuetest/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "issuetest_test",
+    timeout = "moderate",
+    srcs = ["planner_issue_test.go"],
+    flaky = True,
+    race = "on",
+    shard_count = 50,
+    deps = ["//testkit"],
+)

--- a/planner/core/issuetest/planner_issue_test.go
+++ b/planner/core/issuetest/planner_issue_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issuetest
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/testkit"
+)
+
+// It's a case for index merge's order prop push down.
+func TestIssue43178(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE aa311c3c (
+		57fd8d09 year(4) DEFAULT '1913',
+		afbdd7c3 char(220) DEFAULT 'gakkl6occ0yd2jmhi2qxog8szibtcqwxyxmga3hp4ktszjplmg3rjvu8v6lgn9q6hva2lekhw6napjejbut6svsr8q2j8w8rc551e5vq',
+		43b06e99 date NOT NULL DEFAULT '3403-10-08',
+		b80b3746 tinyint(4) NOT NULL DEFAULT '34',
+		6302d8ac timestamp DEFAULT '2004-04-01 18:21:18',
+		PRIMARY KEY (43b06e99,b80b3746) /*T![clustered_index] CLUSTERED */,
+		KEY 3080c821 (57fd8d09,43b06e99,b80b3746),
+		KEY a9af33a4 (57fd8d09,b80b3746,43b06e99),
+		KEY 464b386e (b80b3746),
+		KEY 19dc3c2d (57fd8d09)
+	      ) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='320f8401'`)
+	// Should not panic
+	tk.MustExec("explain select  /*+ use_index_merge( `aa311c3c` ) */   `aa311c3c`.`43b06e99` as r0 , `aa311c3c`.`6302d8ac` as r1 from `aa311c3c` where IsNull( `aa311c3c`.`b80b3746` ) or not( `aa311c3c`.`57fd8d09` >= '2008' )   order by r0,r1 limit 95")
+}

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1248,7 +1248,7 @@ func (p *PhysicalTopN) checkOrderPropForSubIndexScan(idxCols []*expression.Colum
 				idxPos++
 				break
 			}
-			if len(constColsByCond) == 0 || idxPos >= len(constColsByCond) || !constColsByCond[idxPos] {
+			if idxPos >= len(constColsByCond) || !constColsByCond[idxPos] {
 				found = false
 				break
 			}

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1248,7 +1248,7 @@ func (p *PhysicalTopN) checkOrderPropForSubIndexScan(idxCols []*expression.Colum
 				idxPos++
 				break
 			}
-			if len(constColsByCond) == 0 || idxPos > len(constColsByCond) || !constColsByCond[idxPos] {
+			if len(constColsByCond) == 0 || idxPos >= len(constColsByCond) || !constColsByCond[idxPos] {
 				found = false
 				break
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/43178

Problem Summary:

### What is changed and how it works?

Wrong slice-bound check, so the out-of-bound panic raised.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
