### PR TITLE
load data: sync rewrite set expr for concurrent load

### DIFF
--- a/executor/importer/kv_encode.go
+++ b/executor/importer/kv_encode.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 )
 
 type kvEncoder interface {
@@ -44,7 +45,7 @@ type kvEncoder interface {
 type tableKVEncoder struct {
 	*kv.BaseKVEncoder
 	// see import.go
-	columnAssignments  []*ast.Assignment
+	columnAssignments  []expression.Expression
 	columnsAndUserVars []*ast.ColumnNameOrUserVar
 	fieldMappings      []*FieldMapping
 	insertColumns      []*table.Column
@@ -54,10 +55,7 @@ var _ kvEncoder = &tableKVEncoder{}
 
 func newTableKVEncoder(
 	config *encode.EncodingConfig,
-	columnAssignments []*ast.Assignment,
-	columnsAndUserVars []*ast.ColumnNameOrUserVar,
-	fieldMappings []*FieldMapping,
-	insertColumns []*table.Column,
+	ti *TableImporter,
 ) (*tableKVEncoder, error) {
 	baseKVEncoder, err := kv.NewBaseKVEncoder(config)
 	if err != nil {
@@ -65,13 +63,17 @@ func newTableKVEncoder(
 	}
 	// we need a non-nil TxnCtx to avoid panic when evaluating set clause
 	baseKVEncoder.SessionCtx.Vars.TxnCtx = new(variable.TransactionContext)
+	colAssignExprs, err := ti.CreateColAssignExprs(baseKVEncoder.SessionCtx)
+	if err != nil {
+		return nil, err
+	}
 
 	return &tableKVEncoder{
 		BaseKVEncoder:      baseKVEncoder,
-		columnAssignments:  columnAssignments,
-		columnsAndUserVars: columnsAndUserVars,
-		fieldMappings:      fieldMappings,
-		insertColumns:      insertColumns,
+		columnAssignments:  colAssignExprs,
+		columnsAndUserVars: ti.ColumnsAndUserVars,
+		fieldMappings:      ti.FieldMappings,
+		insertColumns:      ti.InsertColumns,
 	}, nil
 }
 
@@ -131,7 +133,7 @@ func (en *tableKVEncoder) parserData2TableData(parserData []types.Datum, rowID i
 	}
 	for i := 0; i < len(en.columnAssignments); i++ {
 		// eval expression of `SET` clause
-		d, err := expression.EvalAstExpr(en.SessionCtx, en.columnAssignments[i].Expr)
+		d, err := en.columnAssignments[i].Eval(chunk.Row{})
 		if err != nil {
 			return nil, err
 		}

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -269,7 +269,7 @@ func (ti *TableImporter) getKVEncoder(chunk *checkpoints.ChunkCheckpoint) (kvEnc
 		Table:  ti.encTable,
 		Logger: log.Logger{Logger: ti.logger.With(zap.String("path", chunk.FileMeta.Path))},
 	}
-	return newTableKVEncoder(cfg, ti.ColumnAssignments, ti.ColumnsAndUserVars, ti.FieldMappings, ti.InsertColumns)
+	return newTableKVEncoder(cfg, ti)
 }
 
 func (ti *TableImporter) importTable(ctx context.Context) (err error) {

--- a/tests/realtikvtest/loaddatatest/load_data_test.go
+++ b/tests/realtikvtest/loaddatatest/load_data_test.go
@@ -829,28 +829,34 @@ func (s *mockGCSSuite) TestColumnsAndUserVars() {
 }
 
 func (s *mockGCSSuite) testColumnsAndUserVars(importMode string, distributed bool) {
-	withOptions := fmt.Sprintf("WITH thread=1, import_mode='%s'", importMode)
+	withOptions := fmt.Sprintf("WITH thread=2, import_mode='%s'", importMode)
 	withOptions = adjustOptions(withOptions, distributed)
 	s.prepareVariables(distributed)
 	s.tk.MustExec("DROP DATABASE IF EXISTS load_data;")
 	s.tk.MustExec("CREATE DATABASE load_data;")
-	s.tk.MustExec(`CREATE TABLE load_data.cols_and_vars (a INT, b INT);`)
+	s.tk.MustExec(`CREATE TABLE load_data.cols_and_vars (a INT, b INT, c int);`)
 
 	s.server.CreateObject(fakestorage.Object{
-		ObjectAttrs: fakestorage.ObjectAttrs{
-			BucketName: "test-load",
-			Name:       "cols_and_vars.tsv",
-		},
-		Content: []byte("1\n2\n3\n4\n5\n"),
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-load", Name: "cols_and_vars-1.tsv"},
+		Content:     []byte("1,11,111\n2,22,222\n3,33,333\n4,44,444\n5,55,555\n"),
 	})
-	sql := fmt.Sprintf(`LOAD DATA INFILE 'gs://test-load/cols_and_vars.tsv?endpoint=%s'
-		INTO TABLE load_data.cols_and_vars(@V1) set a=@V1, b=@V1*100 %s`, gcsEndpoint, withOptions)
+	s.server.CreateObject(fakestorage.Object{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-load", Name: "cols_and_vars-2.tsv"},
+		Content:     []byte("6,66,666\n7,77,777\n8,88,888\n9,99,999\n"),
+	})
+	sql := fmt.Sprintf(`LOAD DATA INFILE 'gs://test-load/cols_and_vars-*.tsv?endpoint=%s'
+		INTO TABLE load_data.cols_and_vars fields terminated by ','
+		(@V1, @v2, @v3) set a=@V1, b=@V2*10, c=123 %s`, gcsEndpoint, withOptions)
 	s.tk.MustExec(sql)
-	s.tk.MustQuery("SELECT * FROM load_data.cols_and_vars;").Check(testkit.Rows(
-		"1 100",
-		"2 200",
-		"3 300",
-		"4 400",
-		"5 500",
+	s.tk.MustQuery("SELECT * FROM load_data.cols_and_vars;").Sort().Check(testkit.Rows(
+		"1 110 123",
+		"2 220 123",
+		"3 330 123",
+		"4 440 123",
+		"5 550 123",
+		"6 660 123",
+		"7 770 123",
+		"8 880 123",
+		"9 990 123",
 	))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42930 

Problem Summary:

### What is changed and how it works?
- RewriteAstExpr will write ast node in place(due to xxNode.Accept), but it doesn't change node content, so we sync it to avoid data race

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
