### PR TITLE
*: Fix issue in multi column range partition pruning

### DIFF
--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -484,13 +484,13 @@ func TestIssue43459(t *testing.T) {
 		"1 200000 2022-12-29 12:00:00"))
 	tk.MustQuery(`select * from test1 partition (2023p2)`).Check(testkit.Rows("" +
 		"2 200000 2023-01-01 00:00:00"))
-	tk.MustQuery(`select * from test1`).Check(testkit.Rows(""+
+	tk.MustQuery(`select * from test1`).Sort().Check(testkit.Rows(""+
 		"1 200000 2022-12-29 12:00:00",
 		"2 200000 2023-01-01 00:00:00"))
-	tk.MustQuery(`select * from test1 where partition_no = 200000`).Check(testkit.Rows(""+
+	tk.MustQuery(`select * from test1 where partition_no = 200000`).Sort().Check(testkit.Rows(""+
 		"1 200000 2022-12-29 12:00:00",
 		"2 200000 2023-01-01 00:00:00"))
-	tk.MustQuery(`select * from test1 where partition_no >= 200000`).Check(testkit.Rows(""+
+	tk.MustQuery(`select * from test1 where partition_no >= 200000`).Sort().Check(testkit.Rows(""+
 		"1 200000 2022-12-29 12:00:00",
 		"2 200000 2023-01-01 00:00:00"))
 	tk.MustExec(`drop table test1`)
@@ -507,13 +507,13 @@ func TestIssue43459(t *testing.T) {
 		"1 200000 2022-12-29"))
 	tk.MustQuery(`select * from test1 partition (2023p2)`).Check(testkit.Rows("" +
 		"2 200000 2023-01-01"))
-	tk.MustQuery(`select * from test1`).Check(testkit.Rows(""+
+	tk.MustQuery(`select * from test1`).Sort().Check(testkit.Rows(""+
 		"1 200000 2022-12-29",
 		"2 200000 2023-01-01"))
-	tk.MustQuery(`select * from test1 where partition_no = 200000`).Check(testkit.Rows(""+
+	tk.MustQuery(`select * from test1 where partition_no = 200000`).Sort().Check(testkit.Rows(""+
 		"1 200000 2022-12-29",
 		"2 200000 2023-01-01"))
-	tk.MustQuery(`select * from test1 where partition_no >= 200000`).Check(testkit.Rows(""+
+	tk.MustQuery(`select * from test1 where partition_no >= 200000`).Sort().Check(testkit.Rows(""+
 		"1 200000 2022-12-29",
 		"2 200000 2023-01-01"))
 }

--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -464,14 +464,56 @@ func TestIssue43459(t *testing.T) {
 	tk.MustExec(`CREATE TABLE test1 (ID varchar(50) NOT NULL,
 		PARTITION_NO int(11) NOT NULL DEFAULT '0',
 		CREATE_TIME datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		PRIMARY KEY (ID,PARTITION_NO,CREATE_TIME), 
+		PRIMARY KEY (ID,PARTITION_NO,CREATE_TIME),
 		KEY index_partition_no (PARTITION_NO)
 		) PARTITION BY RANGE COLUMNS(PARTITION_NO,CREATE_TIME)
 		(PARTITION 2023p1 VALUES LESS THAN (200000,'2023-01-01 00:00:00'),
 		PARTITION 2023p2 VALUES LESS THAN (300000,'2023-01-01 00:00:00')) `)
-	tk.MustExec(`insert into test1 values("uuid", 200000, "2022-12-29 12:00:00")`)
-	tk.MustExec(`analyze table test1`)
-	tk.MustQuery(`select * from test1`).Check(testkit.Rows("uuid 200000 2022-12-29 12:00:00"))
-	tk.MustQuery(`select * from test1 where partition_no = 200000;`).Check(testkit.Rows("uuid 200000 2022-12-29 12:00:00"))
-	tk.MustQuery(`select * from test1 where partition_no >= 200000;`).Check(testkit.Rows("uuid 200000 2022-12-29 12:00:00"))
+	checkFn := func() {
+		tk.MustExec(`insert into test1 values("1", 200000, "2022-12-29 12:00:00"), ("2",200000,"2023-01-01")`)
+		tk.MustExec(`analyze table test1`)
+		tk.MustQuery(`explain select * from test1 where partition_no > 199999`).CheckContain(`partition:all`)
+		tk.MustQuery(`explain select * from test1 where partition_no = 200000`).CheckContain("partition:all")
+		tk.MustQuery(`explain select * from test1 where partition_no >= 200000`).CheckContain("partition:all")
+		tk.MustQuery(`explain select * from test1 where partition_no < 200000`).CheckContain("partition:2023p1")
+		tk.MustQuery(`explain select * from test1 where partition_no <= 200000`).CheckContain("partition:all")
+		tk.MustQuery(`explain select * from test1 where partition_no > 200000`).CheckContain("partition:2023p2")
+	}
+	checkFn()
+	tk.MustQuery(`select * from test1 partition (2023p1)`).Check(testkit.Rows("" +
+		"1 200000 2022-12-29 12:00:00"))
+	tk.MustQuery(`select * from test1 partition (2023p2)`).Check(testkit.Rows("" +
+		"2 200000 2023-01-01 00:00:00"))
+	tk.MustQuery(`select * from test1`).Check(testkit.Rows(""+
+		"1 200000 2022-12-29 12:00:00",
+		"2 200000 2023-01-01 00:00:00"))
+	tk.MustQuery(`select * from test1 where partition_no = 200000`).Check(testkit.Rows(""+
+		"1 200000 2022-12-29 12:00:00",
+		"2 200000 2023-01-01 00:00:00"))
+	tk.MustQuery(`select * from test1 where partition_no >= 200000`).Check(testkit.Rows(""+
+		"1 200000 2022-12-29 12:00:00",
+		"2 200000 2023-01-01 00:00:00"))
+	tk.MustExec(`drop table test1`)
+	tk.MustExec(`CREATE TABLE test1 (ID varchar(50) NOT NULL,
+		PARTITION_NO int(11) NOT NULL DEFAULT '0',
+		CREATE_TIME date NOT NULL DEFAULT CURRENT_DATE,
+		PRIMARY KEY (ID,PARTITION_NO,CREATE_TIME),
+		KEY index_partition_no (PARTITION_NO)
+		) PARTITION BY RANGE COLUMNS(PARTITION_NO,CREATE_TIME)
+		(PARTITION 2023p1 VALUES LESS THAN (200000,'2023-01-01 00:00:00'),
+		PARTITION 2023p2 VALUES LESS THAN (300000,'2023-01-01 00:00:00')) `)
+	checkFn()
+	tk.MustQuery(`select * from test1 partition (2023p1)`).Check(testkit.Rows("" +
+		"1 200000 2022-12-29"))
+	tk.MustQuery(`select * from test1 partition (2023p2)`).Check(testkit.Rows("" +
+		"2 200000 2023-01-01"))
+	tk.MustQuery(`select * from test1`).Check(testkit.Rows(""+
+		"1 200000 2022-12-29",
+		"2 200000 2023-01-01"))
+	tk.MustQuery(`select * from test1 where partition_no = 200000`).Check(testkit.Rows(""+
+		"1 200000 2022-12-29",
+		"2 200000 2023-01-01"))
+	tk.MustQuery(`select * from test1 where partition_no >= 200000`).Check(testkit.Rows(""+
+		"1 200000 2022-12-29",
+		"2 200000 2023-01-01"))
 }

--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -453,3 +453,25 @@ func TestIssue33231(t *testing.T) {
 		Sort().
 		Check(testkit.Rows("6 beautiful curran 6 vigorous rhodes", "7 affectionate curie 7 sweet aryabhata", "7 epic kalam 7 sweet aryabhata"))
 }
+
+func TestIssue43459(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create database issue43459")
+	defer tk.MustExec("drop database issue43459")
+	tk.MustExec("use issue43459")
+	tk.MustExec("set @@session.tidb_partition_prune_mode = 'dynamic';")
+	tk.MustExec(`CREATE TABLE test1 (ID varchar(50) NOT NULL,
+		PARTITION_NO int(11) NOT NULL DEFAULT '0',
+		CREATE_TIME datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (ID,PARTITION_NO,CREATE_TIME), 
+		KEY index_partition_no (PARTITION_NO)
+		) PARTITION BY RANGE COLUMNS(PARTITION_NO,CREATE_TIME)
+		(PARTITION 2023p1 VALUES LESS THAN (200000,'2023-01-01 00:00:00'),
+		PARTITION 2023p2 VALUES LESS THAN (300000,'2023-01-01 00:00:00')) `)
+	tk.MustExec(`insert into test1 values("uuid", 200000, "2022-12-29 12:00:00")`)
+	tk.MustExec(`analyze table test1`)
+	tk.MustQuery(`select * from test1`).Check(testkit.Rows("uuid 200000 2022-12-29 12:00:00"))
+	tk.MustQuery(`select * from test1 where partition_no = 200000;`).Check(testkit.Rows("uuid 200000 2022-12-29 12:00:00"))
+	tk.MustQuery(`select * from test1 where partition_no >= 200000;`).Check(testkit.Rows("uuid 200000 2022-12-29 12:00:00"))
+}

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -1872,7 +1872,7 @@ func (p *rangeColumnsPruner) partitionRangeForExpr(sctx sessionctx.Context, expr
 // pruneUseBinarySearch returns the start and end of which partitions will match.
 // If no match (i.e. value > last partition) the start partition will be the number of partition, not the first partition!
 func (p *rangeColumnsPruner) pruneUseBinarySearch(sctx sessionctx.Context, op string, data *expression.Constant) (start int, end int) {
-	var err error
+	var savedError error
 	var isNull bool
 	if len(p.partCols) > 1 {
 		// Only one constant in the input, this will never be called with
@@ -1885,11 +1885,18 @@ func (p *rangeColumnsPruner) pruneUseBinarySearch(sctx sessionctx.Context, op st
 			if p.lessThan[ith][i] == nil { // MAXVALUE
 				return true
 			}
-			var expr expression.Expression
-			expr, err = expression.NewFunctionBase(sctx, op, types.NewFieldType(mysql.TypeLonglong), *p.lessThan[ith][i], v)
+			expr, err := expression.NewFunctionBase(sctx, op, types.NewFieldType(mysql.TypeLonglong), *p.lessThan[ith][i], v)
+			if err != nil {
+				savedError = err
+				return true
+			}
 			expr.SetCharsetAndCollation(charSet, collation)
 			var val int64
 			val, isNull, err = expr.EvalInt(sctx, chunk.Row{})
+			if err != nil {
+				savedError = err
+				return true
+			}
 			if val > 0 {
 				return true
 			}
@@ -1916,7 +1923,7 @@ func (p *rangeColumnsPruner) pruneUseBinarySearch(sctx sessionctx.Context, op st
 	}
 
 	// Something goes wrong, abort this pruning.
-	if err != nil || isNull {
+	if savedError != nil || isNull {
 		return 0, len(p.lessThan)
 	}
 

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -359,8 +359,13 @@ func dataForRangeColumnsPruning(ctx sessionctx.Context, defs []model.PartitionDe
 			if !ok {
 				return nil, dbterror.ErrPartitionConstDomain
 			}
-			// Will also fold constant
-			tmp = expression.BuildCastFunction(ctx, tmp, schema.Columns[colOffsets[j]].RetType)
+			// TODO: Enable this for all types!
+			// Currently it will trigger changes for collation differences
+			switch schema.Columns[colOffsets[j]].RetType.GetType() {
+			case mysql.TypeDatetime, mysql.TypeDate:
+				// Will also fold constant
+				tmp = expression.BuildCastFunction(ctx, tmp, schema.Columns[colOffsets[j]].RetType)
+			}
 			lessThanCols = append(lessThanCols, &tmp)
 		}
 		res.LessThan = append(res.LessThan, lessThanCols)

--- a/testkit/result.go
+++ b/testkit/result.go
@@ -133,14 +133,22 @@ func (res *Result) CheckAt(cols []int, expected [][]interface{}) {
 
 // CheckContain checks whether the result contains the expected string
 func (res *Result) CheckContain(expected string) {
-	for _, row := range res.rows {
-		for _, colValue := range row {
+	var result strings.Builder
+	for i, row := range res.rows {
+		if i > 0 {
+			result.WriteString("\n")
+		}
+		for j, colValue := range row {
+			if j > 0 {
+				result.WriteString(" ")
+			}
+			result.WriteString(colValue)
 			if strings.Contains(colValue, expected) {
 				return
 			}
 		}
 	}
-	comment := fmt.Sprintf("the result doesn't contain the exepected %s", expected)
+	comment := fmt.Sprintf("the result doesn't contain the exepected %s\n%s", expected, result.String())
 	res.require.Equal(true, false, comment)
 }
 


### PR DESCRIPTION
Built on top of:
https://github.com/jiyfhust/tidb/tree/fix_prune_multicolumn_datetime

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43459 

Problem Summary:

Issue is that the type of the Column List values is just from internal parsing, not from target / table.column type, so some conversions fails.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
