### PR TITLE
lightning: improve region actions for huge region number

### DIFF
--- a/br/pkg/lightning/BUILD.bazel
+++ b/br/pkg/lightning/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//br/pkg/lightning/tikv",
         "//br/pkg/lightning/web",
         "//br/pkg/redact",
+        "//br/pkg/restore/split",
         "//br/pkg/storage",
         "//br/pkg/utils",
         "//br/pkg/version/build",

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -395,9 +395,10 @@ type local struct {
 
 	localStoreDir string
 
-	workerConcurrency int
-	kvWriteBatchSize  int
-	checkpointEnabled bool
+	workerConcurrency    int
+	kvWriteBatchSize     int
+	checkpointEnabled    bool
+	splitRegionBatchSize int
 
 	dupeConcurrency int
 	maxOpenFiles    int
@@ -541,12 +542,13 @@ func NewLocalBackend(
 		g:         g,
 		tikvCodec: tikvCodec,
 
-		localStoreDir:     localFile,
-		workerConcurrency: rangeConcurrency * 2,
-		dupeConcurrency:   rangeConcurrency * 2,
-		kvWriteBatchSize:  cfg.TikvImporter.SendKVPairs,
-		checkpointEnabled: cfg.Checkpoint.Enable,
-		maxOpenFiles:      mathutil.Max(maxOpenFiles, openFilesLowerThreshold),
+		localStoreDir:        localFile,
+		workerConcurrency:    rangeConcurrency * 2,
+		dupeConcurrency:      rangeConcurrency * 2,
+		kvWriteBatchSize:     cfg.TikvImporter.SendKVPairs,
+		checkpointEnabled:    cfg.Checkpoint.Enable,
+		maxOpenFiles:         mathutil.Max(maxOpenFiles, openFilesLowerThreshold),
+		splitRegionBatchSize: cfg.TikvImporter.SplitRegionBatchSize,
 
 		engineMemCacheSize:      int(cfg.TikvImporter.EngineMemCacheSize),
 		localWriterMemCacheSize: int64(cfg.TikvImporter.LocalWriterMemCacheSize),

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -398,8 +398,8 @@ type local struct {
 	workerConcurrency      int
 	kvWriteBatchSize       int
 	checkpointEnabled      bool
-	splitRegionBatchSize   int
-	splitRegionConcurrency int
+	regionSplitBatchSize   int
+	regionSplitConcurrency int
 
 	dupeConcurrency int
 	maxOpenFiles    int
@@ -549,8 +549,8 @@ func NewLocalBackend(
 		kvWriteBatchSize:       cfg.TikvImporter.SendKVPairs,
 		checkpointEnabled:      cfg.Checkpoint.Enable,
 		maxOpenFiles:           mathutil.Max(maxOpenFiles, openFilesLowerThreshold),
-		splitRegionBatchSize:   cfg.TikvImporter.SplitRegionBatchSize,
-		splitRegionConcurrency: cfg.TikvImporter.SplitRegionConcurrency,
+		regionSplitBatchSize:   cfg.TikvImporter.RegionSplitBatchSize,
+		regionSplitConcurrency: cfg.TikvImporter.RegionSplitConcurrency,
 
 		engineMemCacheSize:      int(cfg.TikvImporter.EngineMemCacheSize),
 		localWriterMemCacheSize: int64(cfg.TikvImporter.LocalWriterMemCacheSize),

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -1089,6 +1089,7 @@ func (local *local) generateJobInRanges(
 
 		startKey := codec.EncodeBytes([]byte{}, pairStart)
 		endKey := codec.EncodeBytes([]byte{}, nextKey(pairEnd))
+		// here
 		regions, err := split.PaginateScanRegion(ctx, local.splitCli, startKey, endKey, scanRegionLimit)
 		if err != nil {
 			log.FromContext(ctx).Error("scan region failed",

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -1042,6 +1042,7 @@ func (local *local) prepareAndGenerateUnfinishedJob(
 		failpoint.Inject("failToSplit", func(_ failpoint.Value) {
 			needSplit = true
 		})
+		now := time.Now()
 		for i := 0; i < maxRetryTimes; i++ {
 			err = local.SplitAndScatterRegionInBatches(ctx, unfinishedRanges, lf.tableInfo, needSplit, regionSplitSize, maxBatchSplitRanges)
 			if err == nil || common.IsContextCanceledError(err) {
@@ -1051,6 +1052,7 @@ func (local *local) prepareAndGenerateUnfinishedJob(
 			log.FromContext(ctx).Warn("split and scatter failed in retry", zap.Stringer("uuid", engineUUID),
 				log.ShortError(err), zap.Int("retry", i))
 		}
+		log.FromContext(ctx).Info("finish to split and scatter ranges", zap.Duration("takeTime", time.Since(now)))
 		if err != nil {
 			log.FromContext(ctx).Error("split & scatter ranges failed", zap.Stringer("uuid", engineUUID), log.ShortError(err))
 			return nil, err

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -398,8 +398,7 @@ func (local *local) BatchSplitRegions(
 	var failedErr error
 	retryRegions := make([]*split.RegionInfo, 0)
 	scatterRegions := newRegions
-	backoffer := split.NewWaitRegionOnlineBackofferWithVars(
-		30, time.Second, 10*time.Second).(*split.WaitRegionOnlineBackoffer)
+	backoffer := split.NewWaitRegionOnlineBackoffer().(*split.WaitRegionOnlineBackoffer)
 	_ = utils.WithRetry(ctx, func() error {
 		retryRegions = make([]*split.RegionInfo, 0, 16)
 		for _, region := range scatterRegions {

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -132,6 +132,7 @@ func (local *local) SplitAndScatterRegionByRanges(
 			}
 		}
 		var regions []*split.RegionInfo
+		// TODO: use Check after scatter?
 		regions, err = split.PaginateScanRegion(ctx, local.splitCli, minKey, maxKey, 128)
 		log.FromContext(ctx).Info("paginate scan regions", zap.Int("count", len(regions)),
 			logutil.Key("start", minKey), logutil.Key("end", maxKey))
@@ -212,7 +213,7 @@ func (local *local) SplitAndScatterRegionByRanges(
 		}
 
 		var syncLock sync.Mutex
-		// TODO, make this size configurable
+		// TODO!!! make this size configurable
 		size := mathutil.Min(len(splitKeyMap), runtime.GOMAXPROCS(0))
 		ch := make(chan *splitInfo, size)
 		eg, splitCtx := errgroup.WithContext(ctx)

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -434,13 +434,7 @@ func (local *local) BatchSplitRegions(
 		return failedErr
 	}, backoffer)
 
-	select {
-	case <-ctx.Done():
-		return nil, nil, ctx.Err()
-	default:
-	}
-
-	return region, newRegions, nil
+	return region, newRegions, ctx.Err()
 }
 
 func (local *local) hasRegion(ctx context.Context, regionID uint64) (bool, error) {

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -209,7 +209,7 @@ func (local *local) SplitAndScatterRegionByRanges(
 		}
 
 		var syncLock sync.Mutex
-		size := mathutil.Min(len(splitKeyMap), local.splitRegionConcurrency)
+		size := mathutil.Min(len(splitKeyMap), local.regionSplitConcurrency)
 		ch := make(chan *splitInfo, size)
 		eg, splitCtx := errgroup.WithContext(ctx)
 
@@ -230,7 +230,7 @@ func (local *local) SplitAndScatterRegionByRanges(
 					for endIdx <= len(keys) {
 						if endIdx == len(keys) ||
 							batchKeySize+len(keys[endIdx]) > maxBatchSplitSize ||
-							endIdx-startIdx >= local.splitRegionBatchSize {
+							endIdx-startIdx >= local.regionSplitBatchSize {
 							splitRegionStart := codec.EncodeBytes([]byte{}, keys[startIdx])
 							splitRegionEnd := codec.EncodeBytes([]byte{}, keys[endIdx-1])
 							if bytes.Compare(splitRegionStart, splitRegion.Region.StartKey) < 0 || !beforeEnd(splitRegionEnd, splitRegion.Region.EndKey) {

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -470,6 +470,10 @@ func (local *local) waitForScatterRegions(ctx context.Context, regions []*split.
 		select {
 		case <-time.After(time.Second):
 		case <-subCtx.Done():
+			if len(regions) > 0 {
+				log.FromContext(ctx).Warn("wait for scatter region timeout, print the first region",
+					logutil.Region(regions[0].Region))
+			}
 			return
 		}
 	}

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -52,8 +52,6 @@ const (
 )
 
 var (
-	// the max keys count in a batch to split one region
-	maxBatchSplitKeys = 4096
 	// the max total key size in a split region batch.
 	// our threshold should be smaller than TiKV's raft max entry size(default is 8MB).
 	maxBatchSplitSize = 6 * units.MiB
@@ -232,7 +230,9 @@ func (local *local) SplitAndScatterRegionByRanges(
 					endIdx := 0
 					batchKeySize := 0
 					for endIdx <= len(keys) {
-						if endIdx == len(keys) || batchKeySize+len(keys[endIdx]) > maxBatchSplitSize || endIdx-startIdx >= maxBatchSplitKeys {
+						if endIdx == len(keys) ||
+							batchKeySize+len(keys[endIdx]) > maxBatchSplitSize ||
+							endIdx-startIdx >= local.splitRegionBatchSize {
 							splitRegionStart := codec.EncodeBytes([]byte{}, keys[startIdx])
 							splitRegionEnd := codec.EncodeBytes([]byte{}, keys[endIdx-1])
 							if bytes.Compare(splitRegionStart, splitRegion.Region.StartKey) < 0 || !beforeEnd(splitRegionEnd, splitRegion.Region.EndKey) {

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"database/sql"
 	"math"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -210,8 +209,7 @@ func (local *local) SplitAndScatterRegionByRanges(
 		}
 
 		var syncLock sync.Mutex
-		// TODO!!! make this size configurable
-		size := mathutil.Min(len(splitKeyMap), runtime.GOMAXPROCS(0))
+		size := mathutil.Min(len(splitKeyMap), local.splitRegionConcurrency)
 		ch := make(chan *splitInfo, size)
 		eg, splitCtx := errgroup.WithContext(ctx)
 

--- a/br/pkg/lightning/backend/local/localhelper_test.go
+++ b/br/pkg/lightning/backend/local/localhelper_test.go
@@ -455,10 +455,11 @@ func doTestBatchSplitRegionByRanges(ctx context.Context, t *testing.T, hook clie
 	keys := [][]byte{[]byte(""), []byte("aay"), []byte("bba"), []byte("bbh"), []byte("cca"), []byte("")}
 	client := initTestSplitClient(keys, hook)
 	local := &local{
-		splitCli:             client,
-		g:                    glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
-		logger:               log.L(),
-		splitRegionBatchSize: 4,
+		splitCli:               client,
+		g:                      glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
+		logger:                 log.L(),
+		splitRegionBatchSize:   4,
+		splitRegionConcurrency: 4,
 	}
 
 	// current region ranges: [, aay), [aay, bba), [bba, bbh), [bbh, cca), [cca, )
@@ -715,10 +716,11 @@ func doTestBatchSplitByRangesWithClusteredIndex(t *testing.T, hook clientHook) {
 	keys = append(keys, tableEndKey, []byte(""))
 	client := initTestSplitClient(keys, hook)
 	local := &local{
-		splitCli:             client,
-		g:                    glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
-		logger:               log.L(),
-		splitRegionBatchSize: 10,
+		splitCli:               client,
+		g:                      glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
+		logger:                 log.L(),
+		splitRegionBatchSize:   10,
+		splitRegionConcurrency: 10,
 	}
 	ctx := context.Background()
 

--- a/br/pkg/lightning/backend/local/localhelper_test.go
+++ b/br/pkg/lightning/backend/local/localhelper_test.go
@@ -631,10 +631,11 @@ func TestSplitAndScatterRegionInBatches(t *testing.T) {
 	keys := [][]byte{[]byte(""), []byte("a"), []byte("b"), []byte("")}
 	client := initTestSplitClient(keys, nil)
 	local := &local{
-		splitCli:             client,
-		g:                    glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
-		logger:               log.L(),
-		splitRegionBatchSize: 4,
+		splitCli:               client,
+		g:                      glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
+		logger:                 log.L(),
+		splitRegionBatchSize:   4,
+		splitRegionConcurrency: 4,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/br/pkg/lightning/backend/local/localhelper_test.go
+++ b/br/pkg/lightning/backend/local/localhelper_test.go
@@ -458,8 +458,8 @@ func doTestBatchSplitRegionByRanges(ctx context.Context, t *testing.T, hook clie
 		splitCli:               client,
 		g:                      glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
 		logger:                 log.L(),
-		splitRegionBatchSize:   4,
-		splitRegionConcurrency: 4,
+		regionSplitBatchSize:   4,
+		regionSplitConcurrency: 4,
 	}
 
 	// current region ranges: [, aay), [aay, bba), [bba, bbh), [bbh, cca), [cca, )
@@ -634,8 +634,8 @@ func TestSplitAndScatterRegionInBatches(t *testing.T) {
 		splitCli:               client,
 		g:                      glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
 		logger:                 log.L(),
-		splitRegionBatchSize:   4,
-		splitRegionConcurrency: 4,
+		regionSplitBatchSize:   4,
+		regionSplitConcurrency: 4,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -720,8 +720,8 @@ func doTestBatchSplitByRangesWithClusteredIndex(t *testing.T, hook clientHook) {
 		splitCli:               client,
 		g:                      glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
 		logger:                 log.L(),
-		splitRegionBatchSize:   10,
-		splitRegionConcurrency: 10,
+		regionSplitBatchSize:   10,
+		regionSplitConcurrency: 10,
 	}
 	ctx := context.Background()
 

--- a/br/pkg/lightning/backend/local/localhelper_test.go
+++ b/br/pkg/lightning/backend/local/localhelper_test.go
@@ -424,12 +424,9 @@ type batchSplitHook interface {
 type defaultHook struct{}
 
 func (d defaultHook) setup(t *testing.T) func() {
-	oldLimit := maxBatchSplitKeys
 	oldSplitBackoffTime := splitRegionBaseBackOffTime
-	maxBatchSplitKeys = 4
 	splitRegionBaseBackOffTime = time.Millisecond
 	return func() {
-		maxBatchSplitKeys = oldLimit
 		splitRegionBaseBackOffTime = oldSplitBackoffTime
 	}
 }
@@ -458,9 +455,10 @@ func doTestBatchSplitRegionByRanges(ctx context.Context, t *testing.T, hook clie
 	keys := [][]byte{[]byte(""), []byte("aay"), []byte("bba"), []byte("bbh"), []byte("cca"), []byte("")}
 	client := initTestSplitClient(keys, hook)
 	local := &local{
-		splitCli: client,
-		g:        glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
-		logger:   log.L(),
+		splitCli:             client,
+		g:                    glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
+		logger:               log.L(),
+		splitRegionBatchSize: 4,
 	}
 
 	// current region ranges: [, aay), [aay, bba), [bba, bbh), [bbh, cca), [cca, )
@@ -632,9 +630,10 @@ func TestSplitAndScatterRegionInBatches(t *testing.T) {
 	keys := [][]byte{[]byte(""), []byte("a"), []byte("b"), []byte("")}
 	client := initTestSplitClient(keys, nil)
 	local := &local{
-		splitCli: client,
-		g:        glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
-		logger:   log.L(),
+		splitCli:             client,
+		g:                    glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
+		logger:               log.L(),
+		splitRegionBatchSize: 4,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -692,12 +691,9 @@ func TestBatchSplitByRangeCtxCanceled(t *testing.T) {
 }
 
 func doTestBatchSplitByRangesWithClusteredIndex(t *testing.T, hook clientHook) {
-	oldLimit := maxBatchSplitKeys
 	oldSplitBackoffTime := splitRegionBaseBackOffTime
-	maxBatchSplitKeys = 10
 	splitRegionBaseBackOffTime = time.Millisecond
 	defer func() {
-		maxBatchSplitKeys = oldLimit
 		splitRegionBaseBackOffTime = oldSplitBackoffTime
 	}()
 
@@ -719,9 +715,10 @@ func doTestBatchSplitByRangesWithClusteredIndex(t *testing.T, hook clientHook) {
 	keys = append(keys, tableEndKey, []byte(""))
 	client := initTestSplitClient(keys, hook)
 	local := &local{
-		splitCli: client,
-		g:        glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
-		logger:   log.L(),
+		splitCli:             client,
+		g:                    glue.NewExternalTiDBGlue(nil, mysql.ModeNone),
+		logger:               log.L(),
+		splitRegionBatchSize: 10,
 	}
 	ctx := context.Background()
 

--- a/br/pkg/lightning/backend/local/localhelper_test.go
+++ b/br/pkg/lightning/backend/local/localhelper_test.go
@@ -556,10 +556,10 @@ func (h *scanRegionEmptyHook) AfterScanRegions(res []*split.RegionInfo, err erro
 }
 
 func TestBatchSplitRegionByRangesScanFailed(t *testing.T) {
-	backup := split.ScanRegionAttemptTimes
-	split.ScanRegionAttemptTimes = 3
+	backup := split.WaitRegionOnlineAttemptTimes
+	split.WaitRegionOnlineAttemptTimes = 3
 	defer func() {
-		split.ScanRegionAttemptTimes = backup
+		split.WaitRegionOnlineAttemptTimes = backup
 	}()
 	doTestBatchSplitRegionByRanges(context.Background(), t, &scanRegionEmptyHook{}, "scan region return empty result", defaultHook{})
 }

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -675,8 +675,8 @@ type TikvImporter struct {
 	CompressKVPairs        CompressionType              `toml:"compress-kv-pairs" json:"compress-kv-pairs"`
 	RegionSplitSize        ByteSize                     `toml:"region-split-size" json:"region-split-size"`
 	RegionSplitKeys        int                          `toml:"region-split-keys" json:"region-split-keys"`
-	RegionSplitBatchSize   int                          `toml:"region-split-batch-size" json:"split-region-batch-size"`
-	RegionSplitConcurrency int                          `toml:"region-split-concurrency" json:"split-region-concurrency"`
+	RegionSplitBatchSize   int                          `toml:"region-split-batch-size" json:"region-split-batch-size"`
+	RegionSplitConcurrency int                          `toml:"region-split-concurrency" json:"region-split-concurrency"`
 	SortedKVDir            string                       `toml:"sorted-kv-dir" json:"sorted-kv-dir"`
 	DiskQuota              ByteSize                     `toml:"disk-quota" json:"disk-quota"`
 	RangeConcurrency       int                          `toml:"range-concurrency" json:"range-concurrency"`

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -675,8 +675,8 @@ type TikvImporter struct {
 	CompressKVPairs        CompressionType              `toml:"compress-kv-pairs" json:"compress-kv-pairs"`
 	RegionSplitSize        ByteSize                     `toml:"region-split-size" json:"region-split-size"`
 	RegionSplitKeys        int                          `toml:"region-split-keys" json:"region-split-keys"`
-	SplitRegionBatchSize   int                          `toml:"split-region-batch-size" json:"split-region-batch-size"`
-	SplitRegionConcurrency int                          `toml:"split-region-concurrency" json:"split-region-concurrency"`
+	RegionSplitBatchSize   int                          `toml:"region-split-batch-size" json:"split-region-batch-size"`
+	RegionSplitConcurrency int                          `toml:"region-split-concurrency" json:"split-region-concurrency"`
 	SortedKVDir            string                       `toml:"sorted-kv-dir" json:"sorted-kv-dir"`
 	DiskQuota              ByteSize                     `toml:"disk-quota" json:"disk-quota"`
 	RangeConcurrency       int                          `toml:"range-concurrency" json:"range-concurrency"`
@@ -860,8 +860,8 @@ func NewConfig() *Config {
 			MaxKVPairs:             4096,
 			SendKVPairs:            32768,
 			RegionSplitSize:        0,
-			SplitRegionBatchSize:   4096,
-			SplitRegionConcurrency: runtime.GOMAXPROCS(0),
+			RegionSplitBatchSize:   4096,
+			RegionSplitConcurrency: runtime.GOMAXPROCS(0),
 			DiskQuota:              ByteSize(math.MaxInt64),
 			DuplicateResolution:    DupeResAlgNone,
 		},

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -667,21 +667,22 @@ type FileRouteRule struct {
 
 type TikvImporter struct {
 	// Deprecated: only used to keep the compatibility.
-	Addr                string                       `toml:"addr" json:"addr"`
-	Backend             string                       `toml:"backend" json:"backend"`
-	OnDuplicate         string                       `toml:"on-duplicate" json:"on-duplicate"`
-	MaxKVPairs          int                          `toml:"max-kv-pairs" json:"max-kv-pairs"`
-	SendKVPairs         int                          `toml:"send-kv-pairs" json:"send-kv-pairs"`
-	CompressKVPairs     CompressionType              `toml:"compress-kv-pairs" json:"compress-kv-pairs"`
-	RegionSplitSize     ByteSize                     `toml:"region-split-size" json:"region-split-size"`
-	RegionSplitKeys     int                          `toml:"region-split-keys" json:"region-split-keys"`
-	SortedKVDir         string                       `toml:"sorted-kv-dir" json:"sorted-kv-dir"`
-	DiskQuota           ByteSize                     `toml:"disk-quota" json:"disk-quota"`
-	RangeConcurrency    int                          `toml:"range-concurrency" json:"range-concurrency"`
-	DuplicateResolution DuplicateResolutionAlgorithm `toml:"duplicate-resolution" json:"duplicate-resolution"`
-	IncrementalImport   bool                         `toml:"incremental-import" json:"incremental-import"`
-	KeyspaceName        string                       `toml:"keyspace-name" json:"keyspace-name"`
-	AddIndexBySQL       bool                         `toml:"add-index-by-sql" json:"add-index-by-sql"`
+	Addr                 string                       `toml:"addr" json:"addr"`
+	Backend              string                       `toml:"backend" json:"backend"`
+	OnDuplicate          string                       `toml:"on-duplicate" json:"on-duplicate"`
+	MaxKVPairs           int                          `toml:"max-kv-pairs" json:"max-kv-pairs"`
+	SendKVPairs          int                          `toml:"send-kv-pairs" json:"send-kv-pairs"`
+	CompressKVPairs      CompressionType              `toml:"compress-kv-pairs" json:"compress-kv-pairs"`
+	RegionSplitSize      ByteSize                     `toml:"region-split-size" json:"region-split-size"`
+	RegionSplitKeys      int                          `toml:"region-split-keys" json:"region-split-keys"`
+	SplitRegionBatchSize int                          `toml:"split-region-batch-size" json:"split-region-batch-size"`
+	SortedKVDir          string                       `toml:"sorted-kv-dir" json:"sorted-kv-dir"`
+	DiskQuota            ByteSize                     `toml:"disk-quota" json:"disk-quota"`
+	RangeConcurrency     int                          `toml:"range-concurrency" json:"range-concurrency"`
+	DuplicateResolution  DuplicateResolutionAlgorithm `toml:"duplicate-resolution" json:"duplicate-resolution"`
+	IncrementalImport    bool                         `toml:"incremental-import" json:"incremental-import"`
+	KeyspaceName         string                       `toml:"keyspace-name" json:"keyspace-name"`
+	AddIndexBySQL        bool                         `toml:"add-index-by-sql" json:"add-index-by-sql"`
 
 	EngineMemCacheSize      ByteSize `toml:"engine-mem-cache-size" json:"engine-mem-cache-size"`
 	LocalWriterMemCacheSize ByteSize `toml:"local-writer-mem-cache-size" json:"local-writer-mem-cache-size"`
@@ -853,13 +854,14 @@ func NewConfig() *Config {
 			DataInvalidCharReplace: string(defaultCSVDataInvalidCharReplace),
 		},
 		TikvImporter: TikvImporter{
-			Backend:             "",
-			OnDuplicate:         ReplaceOnDup,
-			MaxKVPairs:          4096,
-			SendKVPairs:         32768,
-			RegionSplitSize:     0,
-			DiskQuota:           ByteSize(math.MaxInt64),
-			DuplicateResolution: DupeResAlgNone,
+			Backend:              "",
+			OnDuplicate:          ReplaceOnDup,
+			MaxKVPairs:           4096,
+			SendKVPairs:          32768,
+			RegionSplitSize:      0,
+			SplitRegionBatchSize: 4096,
+			DiskQuota:            ByteSize(math.MaxInt64),
+			DuplicateResolution:  DupeResAlgNone,
 		},
 		PostRestore: PostRestore{
 			Checksum:          OpLevelRequired,

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
-	"github.com/pingcap/tidb/br/pkg/restore/split"
 	tidbcfg "github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/util"
@@ -76,6 +75,7 @@ const (
 	defaultChecksumTableConcurrency   = 2
 	defaultTableConcurrency           = 6
 	defaultIndexConcurrency           = 2
+	DefaultRegionCheckBackoffLimit    = 1800
 
 	// defaultMetaSchemaName is the default database name used to store lightning metadata
 	defaultMetaSchemaName     = "lightning_metadata"
@@ -864,7 +864,7 @@ func NewConfig() *Config {
 			RegionSplitSize:         0,
 			RegionSplitBatchSize:    4096,
 			RegionSplitConcurrency:  runtime.GOMAXPROCS(0),
-			RegionCheckBackoffLimit: split.WaitRegionOnlineAttemptTimes,
+			RegionCheckBackoffLimit: DefaultRegionCheckBackoffLimit,
 			DiskQuota:               ByteSize(math.MaxInt64),
 			DuplicateResolution:     DupeResAlgNone,
 		},

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -667,22 +667,23 @@ type FileRouteRule struct {
 
 type TikvImporter struct {
 	// Deprecated: only used to keep the compatibility.
-	Addr                 string                       `toml:"addr" json:"addr"`
-	Backend              string                       `toml:"backend" json:"backend"`
-	OnDuplicate          string                       `toml:"on-duplicate" json:"on-duplicate"`
-	MaxKVPairs           int                          `toml:"max-kv-pairs" json:"max-kv-pairs"`
-	SendKVPairs          int                          `toml:"send-kv-pairs" json:"send-kv-pairs"`
-	CompressKVPairs      CompressionType              `toml:"compress-kv-pairs" json:"compress-kv-pairs"`
-	RegionSplitSize      ByteSize                     `toml:"region-split-size" json:"region-split-size"`
-	RegionSplitKeys      int                          `toml:"region-split-keys" json:"region-split-keys"`
-	SplitRegionBatchSize int                          `toml:"split-region-batch-size" json:"split-region-batch-size"`
-	SortedKVDir          string                       `toml:"sorted-kv-dir" json:"sorted-kv-dir"`
-	DiskQuota            ByteSize                     `toml:"disk-quota" json:"disk-quota"`
-	RangeConcurrency     int                          `toml:"range-concurrency" json:"range-concurrency"`
-	DuplicateResolution  DuplicateResolutionAlgorithm `toml:"duplicate-resolution" json:"duplicate-resolution"`
-	IncrementalImport    bool                         `toml:"incremental-import" json:"incremental-import"`
-	KeyspaceName         string                       `toml:"keyspace-name" json:"keyspace-name"`
-	AddIndexBySQL        bool                         `toml:"add-index-by-sql" json:"add-index-by-sql"`
+	Addr                   string                       `toml:"addr" json:"addr"`
+	Backend                string                       `toml:"backend" json:"backend"`
+	OnDuplicate            string                       `toml:"on-duplicate" json:"on-duplicate"`
+	MaxKVPairs             int                          `toml:"max-kv-pairs" json:"max-kv-pairs"`
+	SendKVPairs            int                          `toml:"send-kv-pairs" json:"send-kv-pairs"`
+	CompressKVPairs        CompressionType              `toml:"compress-kv-pairs" json:"compress-kv-pairs"`
+	RegionSplitSize        ByteSize                     `toml:"region-split-size" json:"region-split-size"`
+	RegionSplitKeys        int                          `toml:"region-split-keys" json:"region-split-keys"`
+	SplitRegionBatchSize   int                          `toml:"split-region-batch-size" json:"split-region-batch-size"`
+	SplitRegionConcurrency int                          `toml:"split-region-concurrency" json:"split-region-concurrency"`
+	SortedKVDir            string                       `toml:"sorted-kv-dir" json:"sorted-kv-dir"`
+	DiskQuota              ByteSize                     `toml:"disk-quota" json:"disk-quota"`
+	RangeConcurrency       int                          `toml:"range-concurrency" json:"range-concurrency"`
+	DuplicateResolution    DuplicateResolutionAlgorithm `toml:"duplicate-resolution" json:"duplicate-resolution"`
+	IncrementalImport      bool                         `toml:"incremental-import" json:"incremental-import"`
+	KeyspaceName           string                       `toml:"keyspace-name" json:"keyspace-name"`
+	AddIndexBySQL          bool                         `toml:"add-index-by-sql" json:"add-index-by-sql"`
 
 	EngineMemCacheSize      ByteSize `toml:"engine-mem-cache-size" json:"engine-mem-cache-size"`
 	LocalWriterMemCacheSize ByteSize `toml:"local-writer-mem-cache-size" json:"local-writer-mem-cache-size"`
@@ -854,14 +855,15 @@ func NewConfig() *Config {
 			DataInvalidCharReplace: string(defaultCSVDataInvalidCharReplace),
 		},
 		TikvImporter: TikvImporter{
-			Backend:              "",
-			OnDuplicate:          ReplaceOnDup,
-			MaxKVPairs:           4096,
-			SendKVPairs:          32768,
-			RegionSplitSize:      0,
-			SplitRegionBatchSize: 4096,
-			DiskQuota:            ByteSize(math.MaxInt64),
-			DuplicateResolution:  DupeResAlgNone,
+			Backend:                "",
+			OnDuplicate:            ReplaceOnDup,
+			MaxKVPairs:             4096,
+			SendKVPairs:            32768,
+			RegionSplitSize:        0,
+			SplitRegionBatchSize:   4096,
+			SplitRegionConcurrency: runtime.GOMAXPROCS(0),
+			DiskQuota:              ByteSize(math.MaxInt64),
+			DuplicateResolution:    DupeResAlgNone,
 		},
 		PostRestore: PostRestore{
 			Checksum:          OpLevelRequired,

--- a/br/pkg/lightning/lightning.go
+++ b/br/pkg/lightning/lightning.go
@@ -450,7 +450,7 @@ func (l *Lightning) run(taskCtx context.Context, taskCfg *config.Config, o *opti
 	o.logger.Info("cfg", zap.Stringer("cfg", taskCfg))
 
 	utils.LogEnvVariables()
-	
+
 	if split.WaitRegionOnlineAttemptTimes != taskCfg.TikvImporter.RegionCheckBackoffLimit {
 		// it will cause data race if lightning is used as a library, but this is a
 		// hidden config so we ignore that case

--- a/br/pkg/lightning/lightning.go
+++ b/br/pkg/lightning/lightning.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/lightning/tikv"
 	"github.com/pingcap/tidb/br/pkg/lightning/web"
 	"github.com/pingcap/tidb/br/pkg/redact"
+	"github.com/pingcap/tidb/br/pkg/restore/split"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/br/pkg/version/build"
@@ -449,6 +450,12 @@ func (l *Lightning) run(taskCtx context.Context, taskCfg *config.Config, o *opti
 	o.logger.Info("cfg", zap.Stringer("cfg", taskCfg))
 
 	utils.LogEnvVariables()
+	
+	if split.WaitRegionOnlineAttemptTimes != taskCfg.TikvImporter.RegionCheckBackoffLimit {
+		// it will cause data race if lightning is used as a library, but this is a
+		// hidden config so we ignore that case
+		split.WaitRegionOnlineAttemptTimes = taskCfg.TikvImporter.RegionCheckBackoffLimit
+	}
 
 	metrics := metric.NewMetrics(o.promFactory)
 	metrics.RegisterTo(o.promRegistry)

--- a/br/pkg/restore/split/split.go
+++ b/br/pkg/restore/split/split.go
@@ -53,14 +53,14 @@ func CheckRegionConsistency(startKey, endKey []byte, regions []*RegionInfo) erro
 
 	if bytes.Compare(regions[0].Region.StartKey, startKey) > 0 {
 		return errors.Annotatef(berrors.ErrPDBatchScanRegion,
-			"first region %d's startKey > startKey, startKey: %s, regionStartKey: %s",
+			"first region %d's startKey(%s) > startKey(%s)",
 			regions[0].Region.Id,
-			redact.Key(startKey), redact.Key(regions[0].Region.StartKey))
+			redact.Key(regions[0].Region.StartKey), redact.Key(startKey))
 	} else if len(regions[len(regions)-1].Region.EndKey) != 0 && bytes.Compare(regions[len(regions)-1].Region.EndKey, endKey) < 0 {
 		return errors.Annotatef(berrors.ErrPDBatchScanRegion,
-			"last region %d's endKey < endKey, endKey: %s, regionEndKey: %s",
+			"last region %d's endKey(%s) < endKey(%s)",
 			regions[len(regions)-1].Region.Id,
-			redact.Key(endKey), redact.Key(regions[len(regions)-1].Region.EndKey))
+			redact.Key(regions[len(regions)-1].Region.EndKey), redact.Key(endKey))
 	}
 
 	cur := regions[0]
@@ -116,9 +116,9 @@ func PaginateScanRegion(
 				break
 			}
 		}
-		// if the number of regions becomes larger, we can infer TiKV side really
+		// if the number of regions changed, we can infer TiKV side really
 		// made some progress so don't increase the retry times.
-		if len(regions) > len(lastRegions) {
+		if len(regions) != len(lastRegions) {
 			backoffer.Stat.ReduceRetry()
 		}
 		lastRegions = regions

--- a/br/pkg/restore/split/split.go
+++ b/br/pkg/restore/split/split.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	WaitRegionOnlineAttemptTimes = 150
+	WaitRegionOnlineAttemptTimes = 1800
 )
 
 // Constants for split retry machinery.
@@ -205,20 +205,6 @@ func NewWaitRegionOnlineBackoffer() utils.Backoffer {
 			WaitRegionOnlineAttemptTimes,
 			time.Millisecond*10,
 			time.Second*2,
-		),
-	}
-}
-
-// NewWaitRegionOnlineBackofferWithVars create a backoff to retry to wait region online.
-func NewWaitRegionOnlineBackofferWithVars(
-	maxAttemptTimes int,
-	initBackoff, maxBackoff time.Duration,
-) utils.Backoffer {
-	return &WaitRegionOnlineBackoffer{
-		Stat: utils.InitialRetryState(
-			maxAttemptTimes,
-			initBackoff,
-			maxBackoff,
 		),
 	}
 }

--- a/br/pkg/restore/split/split_test.go
+++ b/br/pkg/restore/split/split_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestScanRegionBackOfferWithSuccess(t *testing.T) {
 	var counter int
-	bo := split.NewScanRegionBackoffer()
+	bo := split.NewWaitRegionOnlineBackoffer()
 
 	err := utils.WithRetry(context.Background(), func() error {
 		defer func() {
@@ -37,7 +37,7 @@ func TestScanRegionBackOfferWithFail(t *testing.T) {
 	}()
 
 	var counter int
-	bo := split.NewScanRegionBackoffer()
+	bo := split.NewWaitRegionOnlineBackoffer()
 
 	err := utils.WithRetry(context.Background(), func() error {
 		defer func() {
@@ -46,7 +46,7 @@ func TestScanRegionBackOfferWithFail(t *testing.T) {
 		return berrors.ErrPDBatchScanRegion
 	}, bo)
 	require.Error(t, err)
-	require.Equal(t, counter, split.ScanRegionAttemptTimes)
+	require.Equal(t, counter, split.WaitRegionOnlineAttemptTimes)
 }
 
 func TestScanRegionBackOfferWithStopRetry(t *testing.T) {
@@ -56,7 +56,7 @@ func TestScanRegionBackOfferWithStopRetry(t *testing.T) {
 	}()
 
 	var counter int
-	bo := split.NewScanRegionBackoffer()
+	bo := split.NewWaitRegionOnlineBackoffer()
 
 	err := utils.WithRetry(context.Background(), func() error {
 		defer func() {

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -555,7 +555,7 @@ func TestRegionConsistency(t *testing.T) {
 		{
 			codec.EncodeBytes([]byte{}, []byte("a")),
 			codec.EncodeBytes([]byte{}, []byte("a")),
-			"first region 1's startKey > startKey, startKey: (.*?), regionStartKey: (.*?)",
+			"first region 1's startKey(.*?) > startKey(.*?)",
 			[]*split.RegionInfo{
 				{
 					Region: &metapb.Region{
@@ -569,7 +569,7 @@ func TestRegionConsistency(t *testing.T) {
 		{
 			codec.EncodeBytes([]byte{}, []byte("b")),
 			codec.EncodeBytes([]byte{}, []byte("e")),
-			"last region 100's endKey < endKey, endKey: (.*?), regionEndKey: (.*?)",
+			"last region 100's endKey(.*?) < endKey(.*?)",
 			[]*split.RegionInfo{
 				{
 					Region: &metapb.Region{

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -555,10 +555,11 @@ func TestRegionConsistency(t *testing.T) {
 		{
 			codec.EncodeBytes([]byte{}, []byte("a")),
 			codec.EncodeBytes([]byte{}, []byte("a")),
-			"first region's startKey > startKey, startKey: (.*?), regionStartKey: (.*?)",
+			"first region 1's startKey > startKey, startKey: (.*?), regionStartKey: (.*?)",
 			[]*split.RegionInfo{
 				{
 					Region: &metapb.Region{
+						Id:       1,
 						StartKey: codec.EncodeBytes([]byte{}, []byte("b")),
 						EndKey:   codec.EncodeBytes([]byte{}, []byte("d")),
 					},
@@ -568,10 +569,11 @@ func TestRegionConsistency(t *testing.T) {
 		{
 			codec.EncodeBytes([]byte{}, []byte("b")),
 			codec.EncodeBytes([]byte{}, []byte("e")),
-			"last region's endKey < endKey, endKey: (.*?), regionEndKey: (.*?)",
+			"last region 100's endKey < endKey, endKey: (.*?), regionEndKey: (.*?)",
 			[]*split.RegionInfo{
 				{
 					Region: &metapb.Region{
+						Id:       100,
 						StartKey: codec.EncodeBytes([]byte{}, []byte("b")),
 						EndKey:   codec.EncodeBytes([]byte{}, []byte("d")),
 					},
@@ -581,16 +583,18 @@ func TestRegionConsistency(t *testing.T) {
 		{
 			codec.EncodeBytes([]byte{}, []byte("c")),
 			codec.EncodeBytes([]byte{}, []byte("e")),
-			"region endKey not equal to next region startKey(.*?)",
+			"region 6's endKey not equal to next region 8's startKey(.*?)",
 			[]*split.RegionInfo{
 				{
 					Region: &metapb.Region{
+						Id:       6,
 						StartKey: codec.EncodeBytes([]byte{}, []byte("b")),
 						EndKey:   codec.EncodeBytes([]byte{}, []byte("d")),
 					},
 				},
 				{
 					Region: &metapb.Region{
+						Id:       8,
 						StartKey: codec.EncodeBytes([]byte{}, []byte("e")),
 						EndKey:   codec.EncodeBytes([]byte{}, []byte("f")),
 					},

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -587,9 +587,10 @@ func TestRegionConsistency(t *testing.T) {
 			[]*split.RegionInfo{
 				{
 					Region: &metapb.Region{
-						Id:       6,
-						StartKey: codec.EncodeBytes([]byte{}, []byte("b")),
-						EndKey:   codec.EncodeBytes([]byte{}, []byte("d")),
+						Id:          6,
+						StartKey:    codec.EncodeBytes([]byte{}, []byte("b")),
+						EndKey:      codec.EncodeBytes([]byte{}, []byte("d")),
+						RegionEpoch: nil,
 					},
 				},
 				{

--- a/br/pkg/restore/util_test.go
+++ b/br/pkg/restore/util_test.go
@@ -231,10 +231,10 @@ func TestPaginateScanRegion(t *testing.T) {
 	regionMap := make(map[uint64]*split.RegionInfo)
 	var regions []*split.RegionInfo
 	var batch []*split.RegionInfo
-	backup := split.ScanRegionAttemptTimes
-	split.ScanRegionAttemptTimes = 3
+	backup := split.WaitRegionOnlineAttemptTimes
+	split.WaitRegionOnlineAttemptTimes = 3
 	defer func() {
-		split.ScanRegionAttemptTimes = backup
+		split.WaitRegionOnlineAttemptTimes = backup
 	}()
 	_, err := split.PaginateScanRegion(ctx, NewTestClient(stores, regionMap, 0), []byte{}, []byte{}, 3)
 	require.Error(t, err)

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -86,6 +86,11 @@ func (rs *RetryState) RecordRetry() {
 	rs.retryTimes++
 }
 
+// ReduceRetry reduce retry times for 1.
+func (rs *RetryState) ReduceRetry() {
+	rs.retryTimes--
+}
+
 // RetryTimes returns the retry times.
 // usage: unit test.
 func (rs *RetryState) RetryTimes() int {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #43510

Problem Summary:

### What is changed and how it works?

- This PR introduce two config, `tikv-importer.region-split-batch-size` and `tikv-importer.region-split-concurrency`.
   - `tikv-importer.region-split-batch-size` controls the maximum region number in one round of region split+scatter. The default value is 4096
   - `tikv-importer.region-split-concurrency` controls the number of workers that handle the region split/scatter job., The default value is number of CPU cores.
- This PR intrudoce a hidden config `region-check-backoff-limit`. The default value is 1800 and its max backoff interval is 2s, so lightning will wait about 3600s.
- This PR changed some retry strategy. When some of retry jobs made progress, we won't increase the retry counter so won't exit retry due to reach retry counter limit.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
