### PR TITLE
ddl: flush data in local engine serially

### DIFF
--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -1222,7 +1222,6 @@ func (w *Writer) createSSTWriter() (*sstWriter, error) {
 		return nil, err
 	}
 	sw := &sstWriter{sstMeta: &sstMeta{path: path}, writer: writer, logger: w.engine.logger}
-	sw.logger.Info("create sst writer", zap.String("path", path))
 	return sw, nil
 }
 
@@ -1399,7 +1398,6 @@ func (i dbSSTIngester) mergeSSTs(metas []*sstMeta, dir string) (*sstMeta, error)
 	for _, p := range metas {
 		f, err := os.Open(p.path)
 		if err != nil {
-			i.e.logger.Error("open sst file failed", zap.String("path", p.path), zap.Error(err))
 			return nil, errors.Trace(err)
 		}
 		reader, err := sstable.NewReader(f, sstable.ReaderOptions{})
@@ -1494,8 +1492,6 @@ func (i dbSSTIngester) mergeSSTs(metas []*sstMeta, dir string) (*sstMeta, error)
 			totalSize += m.fileSize
 			if err := os.Remove(m.path); err != nil {
 				i.e.logger.Warn("async cleanup sst file failed", zap.Error(err))
-			} else {
-				i.e.logger.Warn("async cleanup sst file", zap.String("path", m.path))
 			}
 		}
 		// decrease the pending size after clean up

--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -1222,6 +1222,7 @@ func (w *Writer) createSSTWriter() (*sstWriter, error) {
 		return nil, err
 	}
 	sw := &sstWriter{sstMeta: &sstMeta{path: path}, writer: writer, logger: w.engine.logger}
+	sw.logger.Info("create sst writer", zap.String("path", path))
 	return sw, nil
 }
 
@@ -1398,6 +1399,7 @@ func (i dbSSTIngester) mergeSSTs(metas []*sstMeta, dir string) (*sstMeta, error)
 	for _, p := range metas {
 		f, err := os.Open(p.path)
 		if err != nil {
+			i.e.logger.Error("open sst file failed", zap.String("path", p.path), zap.Error(err))
 			return nil, errors.Trace(err)
 		}
 		reader, err := sstable.NewReader(f, sstable.ReaderOptions{})
@@ -1492,6 +1494,8 @@ func (i dbSSTIngester) mergeSSTs(metas []*sstMeta, dir string) (*sstMeta, error)
 			totalSize += m.fileSize
 			if err := os.Remove(m.path); err != nil {
 				i.e.logger.Warn("async cleanup sst file failed", zap.Error(err))
+			} else {
+				i.e.logger.Warn("async cleanup sst file", zap.String("path", m.path))
 			}
 		}
 		// decrease the pending size after clean up

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1654,6 +1654,8 @@ func writeChunkToLocal(writer ingest.Writer,
 	handleDataBuf := make([]types.Datum, len(copCtx.handleOutputOffsets))
 	count := 0
 	var lastHandle kv.Handle
+	unlock := writer.LockForWrite()
+	defer unlock()
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		idxDataBuf, handleDataBuf = idxDataBuf[:0], handleDataBuf[:0]
 		idxDataBuf = extractDatumByOffsets(row, copCtx.idxColOutputOffsets, copCtx.expColInfos, idxDataBuf)
@@ -1677,8 +1679,6 @@ func writeOneKVToLocal(writer ingest.Writer,
 	index table.Index, sCtx *stmtctx.StatementContext, writeBufs *variable.WriteStmtBufs,
 	idxDt, rsData []types.Datum, handle kv.Handle) error {
 	iter := index.GenIndexKVIter(sCtx, idxDt, handle, rsData)
-	unlock := writer.LockForWrite()
-	defer unlock()
 	for iter.Valid() {
 		key, idxVal, _, err := iter.Next(writeBufs.IndexKeyBuf)
 		if err != nil {

--- a/ddl/ingest/disk_root.go
+++ b/ddl/ingest/disk_root.go
@@ -76,7 +76,7 @@ func (d *diskRootImpl) ShouldImport() bool {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	if d.bcUsed > variable.DDLDiskQuota.Load() {
-		logutil.BgLogger().Info("[ddl-ingest] disk usage is over quota, start importing",
+		logutil.BgLogger().Info("[ddl-ingest] disk usage is over quota",
 			zap.Uint64("quota", variable.DDLDiskQuota.Load()),
 			zap.String("usage", d.UsageInfo()))
 		return true
@@ -85,7 +85,9 @@ func (d *diskRootImpl) ShouldImport() bool {
 		return false
 	}
 	if float64(d.used) >= float64(d.capacity)*capacityThreshold {
-		logutil.BgLogger().Warn("[ddl-ingest] available disk space is less than 10%, start importing, this may degrade the performance",
+		logutil.BgLogger().Warn("[ddl-ingest] available disk space is less than 10%, "+
+			"this may degrade the performance, "+
+			"please make sure the disk available space is larger than @@tidb_ddl_disk_quota before adding index",
 			zap.String("usage", d.UsageInfo()))
 		return true
 	}

--- a/ddl/ingest/disk_root.go
+++ b/ddl/ingest/disk_root.go
@@ -78,7 +78,7 @@ func (d *diskRootImpl) ShouldImport() bool {
 	if d.bcUsed > variable.DDLDiskQuota.Load() {
 		logutil.BgLogger().Info("[ddl-ingest] disk usage is over quota",
 			zap.Uint64("quota", variable.DDLDiskQuota.Load()),
-			zap.String("usage", d.UsageInfo()))
+			zap.String("usage", d.usageInfo()))
 		return true
 	}
 	if d.used == 0 && d.capacity == 0 {
@@ -88,7 +88,7 @@ func (d *diskRootImpl) ShouldImport() bool {
 		logutil.BgLogger().Warn("[ddl-ingest] available disk space is less than 10%, "+
 			"this may degrade the performance, "+
 			"please make sure the disk available space is larger than @@tidb_ddl_disk_quota before adding index",
-			zap.String("usage", d.UsageInfo()))
+			zap.String("usage", d.usageInfo()))
 		return true
 	}
 	return false
@@ -98,6 +98,10 @@ func (d *diskRootImpl) ShouldImport() bool {
 func (d *diskRootImpl) UsageInfo() string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
+	return d.usageInfo()
+}
+
+func (d *diskRootImpl) usageInfo() string {
 	return fmt.Sprintf("disk usage: %d/%d, backend usage: %d", d.used, d.capacity, d.bcUsed)
 }
 

--- a/ddl/ingest/engine.go
+++ b/ddl/ingest/engine.go
@@ -59,7 +59,6 @@ type engineInfo struct {
 	memRoot      MemRoot
 	diskRoot     DiskRoot
 	rowSeq       atomic.Int64
-	flushing     atomic.Bool
 	flushLock    *sync.RWMutex
 }
 
@@ -90,17 +89,6 @@ func (ei *engineInfo) Flush() error {
 		return err
 	}
 	return nil
-}
-
-// acquireFlushLock acquires the flush lock of the engine.
-func (ei *engineInfo) acquireFlushLock() (release func()) {
-	ok := ei.flushing.CompareAndSwap(false, true)
-	if !ok {
-		return nil
-	}
-	return func() {
-		ei.flushing.Store(false)
-	}
 }
 
 // Clean closes the engine and removes the local intermediate files.

--- a/ddl/ingest/engine.go
+++ b/ddl/ingest/engine.go
@@ -57,9 +57,8 @@ type engineInfo struct {
 	writerCount  int
 	writerCache  generic.SyncMap[int, backend.EngineWriter]
 	memRoot      MemRoot
-	diskRoot     DiskRoot
-	rowSeq       atomic.Int64
 	flushLock    *sync.RWMutex
+	flushing     atomic.Bool
 }
 
 // newEngineInfo create a new engineInfo struct.
@@ -75,7 +74,6 @@ func newEngineInfo(ctx context.Context, jobID, indexID int64, cfg *backend.Engin
 		writerCount:  wCnt,
 		writerCache:  generic.NewSyncMap[int, backend.EngineWriter](wCnt),
 		memRoot:      memRoot,
-		diskRoot:     diskRoot,
 		flushLock:    &sync.RWMutex{},
 	}
 }

--- a/ddl/ingest/engine.go
+++ b/ddl/ingest/engine.go
@@ -63,7 +63,7 @@ type engineInfo struct {
 
 // newEngineInfo create a new engineInfo struct.
 func newEngineInfo(ctx context.Context, jobID, indexID int64, cfg *backend.EngineConfig,
-	en *backend.OpenedEngine, uuid uuid.UUID, wCnt int, memRoot MemRoot, diskRoot DiskRoot) *engineInfo {
+	en *backend.OpenedEngine, uuid uuid.UUID, wCnt int, memRoot MemRoot) *engineInfo {
 	return &engineInfo{
 		ctx:          ctx,
 		jobID:        jobID,

--- a/ddl/ingest/engine_mgr.go
+++ b/ddl/ingest/engine_mgr.go
@@ -52,7 +52,7 @@ func (bc *litBackendCtx) Register(jobID, indexID int64, schemaName, tableName st
 			return nil, errors.Trace(err)
 		}
 		id := openedEn.GetEngineUUID()
-		en = newEngineInfo(bc.ctx, jobID, indexID, cfg, openedEn, id, 1, bc.MemRoot, bc.DiskRoot)
+		en = newEngineInfo(bc.ctx, jobID, indexID, cfg, openedEn, id, 1, bc.MemRoot)
 		bc.Store(indexID, en)
 		bc.MemRoot.Consume(StructSizeEngineInfo)
 		bc.MemRoot.ConsumeWithTag(encodeEngineTag(jobID, indexID), engineCacheSize)

--- a/ddl/ingest/mock.go
+++ b/ddl/ingest/mock.go
@@ -173,6 +173,6 @@ func (m *MockWriter) WriteRow(key, idxVal []byte, _ kv.Handle) error {
 }
 
 // LockForWrite implements Writer.LockForWrite interface.
-func (m *MockWriter) LockForWrite() func() {
+func (*MockWriter) LockForWrite() func() {
 	return func() {}
 }

--- a/ddl/ingest/mock.go
+++ b/ddl/ingest/mock.go
@@ -171,3 +171,8 @@ func (m *MockWriter) WriteRow(key, idxVal []byte, _ kv.Handle) error {
 	}
 	return txn.Set(key, idxVal)
 }
+
+// LockForWrite implements Writer.LockForWrite interface.
+func (m *MockWriter) LockForWrite() func() {
+	return func() {}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43523

Problem Summary:

We should not call `FlushEngine()` concurrently.

### What is changed and how it works?

Aquire the lock before `FlushEngine()`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
