### PR TITLE
meta/autoid: enable etcd client auto sync for autoid service

### DIFF
--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -586,8 +586,9 @@ func newSinglePointAlloc(store kv.Storage, dbID, tblID int64, isUnsigned bool) *
 	}
 	if len(addrs) > 0 {
 		etcdCli, err := clientv3.New(clientv3.Config{
-			Endpoints: addrs,
-			TLS:       ebd.TLSConfig(),
+			Endpoints:        addrs,
+			AutoSyncInterval: 30 * time.Second,
+			TLS:              ebd.TLSConfig(),
 		})
 		if err != nil {
 			logutil.BgLogger().Error("[autoid client] fail to connect etcd, fallback to default", zap.Error(err))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42643 

ref https://github.com/pingcap/tidb/pull/9575, ref #33908

Problem Summary:

When the pd server change, the corresponding etcd address should be auto-refresh on the client side.

### What is changed and how it works?

> While it is easy to just add back the option AutoSyncInterval: 30 * time.Second in, I think a bigger issue is why do we need to have 4 different etcd clients rather than sharing the same one with all the correct config 🤷

Because 1. tidb repo is too big, and it's not designed to be used as a lib. (this applies to all tidb/util/xxx), so the etcd client utility in the tidb repo is not a good place to be shared by other repos (tools / binlog ...)
2. For autoid service, it's a indenpendent component, the code is put to the tidb repo though. So this case is similiar to tools etc.
It should have shared the same etcd client instance, but it's not available when the server startup.

Maybe we can maintain a `pingcap/etcdutil` lib to solve the " 4 different etcd clients" issue

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
