### PR TITLE
txn: introduce the statement buffer of pessimistic lock cache

### DIFF
--- a/sessionctx/variable/session_test.go
+++ b/sessionctx/variable/session_test.go
@@ -352,6 +352,7 @@ func TestTransactionContextSavepoint(t *testing.T) {
 		},
 	}
 	tc.SetPessimisticLockCache([]byte{'a'}, []byte{'a'})
+	tc.FlushStmtPessimisticLockCache()
 
 	tc.AddSavepoint("S1", nil)
 	require.Equal(t, 1, len(tc.Savepoints))
@@ -371,6 +372,7 @@ func TestTransactionContextSavepoint(t *testing.T) {
 		TableID:  9,
 	}
 	tc.SetPessimisticLockCache([]byte{'b'}, []byte{'b'})
+	tc.FlushStmtPessimisticLockCache()
 
 	tc.AddSavepoint("S2", nil)
 	require.Equal(t, 2, len(tc.Savepoints))
@@ -388,6 +390,7 @@ func TestTransactionContextSavepoint(t *testing.T) {
 		TableID:  13,
 	}
 	tc.SetPessimisticLockCache([]byte{'c'}, []byte{'c'})
+	tc.FlushStmtPessimisticLockCache()
 
 	tc.AddSavepoint("s2", nil)
 	require.Equal(t, 2, len(tc.Savepoints))

--- a/sessiontxn/isolation/BUILD.bazel
+++ b/sessiontxn/isolation/BUILD.bazel
@@ -47,7 +47,7 @@ go_test(
         "serializable_test.go",
     ],
     flaky = True,
-    shard_count = 27,
+    shard_count = 29,
     deps = [
         ":isolation",
         "//config",

--- a/sessiontxn/isolation/base.go
+++ b/sessiontxn/isolation/base.go
@@ -222,6 +222,7 @@ func (p *baseTxnContextProvider) OnPessimisticStmtEnd(_ context.Context, _ bool)
 // OnStmtRetry is the hook that should be called when a statement is retried internally.
 func (p *baseTxnContextProvider) OnStmtRetry(ctx context.Context) error {
 	p.ctx = ctx
+	p.sctx.GetSessionVars().TxnCtx.CurrentStmtPessimisticLockCache = nil
 	return nil
 }
 

--- a/sessiontxn/isolation/base.go
+++ b/sessiontxn/isolation/base.go
@@ -550,6 +550,12 @@ func (p *basePessimisticTxnContextProvider) OnPessimisticStmtEnd(ctx context.Con
 			}
 		}
 	}
+
+	if isSuccessful {
+		p.sctx.GetSessionVars().TxnCtx.FlushStmtPessimisticLockCache()
+	} else {
+		p.sctx.GetSessionVars().TxnCtx.CurrentStmtPessimisticLockCache = nil
+	}
 	return nil
 }
 

--- a/sessiontxn/isolation/readcommitted_test.go
+++ b/sessiontxn/isolation/readcommitted_test.go
@@ -17,6 +17,7 @@ package isolation_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -561,4 +562,58 @@ func initializePessimisticRCProvider(t testing.TB, tk *testkit.TestKit) *isolati
 	assert := activeRCTxnAssert(t, tk.Session(), true)
 	tk.MustExec("begin pessimistic")
 	return assert.CheckAndGetProvider(t)
+}
+
+func TestFailedDMLConsistency1(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+
+	tk1 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk1.MustExec("CREATE TABLE t(id INT primary key, v int not null, index (id));")
+	tk1.MustExec("insert into t values (1, 1)")
+	tk1.MustExec("set @@tidb_txn_assertion_level = \"strict\";")
+	tk1.MustExec("set transaction isolation level read committed;")
+	tk1.MustExec("begin pessimistic")
+	tk1.MustExec("insert into t values (0, 0)")
+	tk2 := testkit.NewTestKit(t, store)
+	tk2.MustExec("use test")
+	tk2.MustExec("begin pessimistic")
+	tk1.Exec("update t set v = null where id in (1);")
+	tk2.MustExec("delete from t where id = 1;")
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(){
+		tk1.MustExec("delete from t where id in (1, 2);")
+		wg.Done()
+	}()
+	tk2.MustExec("commit")
+	wg.Wait()
+	tk1.MustExec("commit")
+}
+
+func TestFailedDMLConsistency2(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk1.MustExec("CREATE TABLE t(id INT primary key, v int not null, v2 int, index (id), unique index (v2));")
+	tk1.MustExec("INSERT INTO t VALUES (1, 1, 1);")
+	tk1.MustExec("set @@tidb_txn_assertion_level = \"off\";")
+	tk1.MustExec("set transaction isolation level read committed;")
+	tk1.MustExec("begin pessimistic")
+	tk1.MustExec("insert into t values (0, 0, 0)")
+	tk2 := testkit.NewTestKit(t, store)
+	tk2.MustExec("use test")
+	tk2.MustExec("begin pessimistic")
+	tk1.Exec("update t set v = null where id in (1);")
+	tk2.MustExec("update t set id = 10 where id = 1;")
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(){
+		tk1.MustExec("delete from t where id in (1, 2);")
+		wg.Done()
+	}()
+	tk2.MustExec("commit")
+	wg.Wait()
+	tk1.MustExec("commit")
+	tk1.MustExec("admin check table t")
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43294 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
