### PR TITLE
resource_control: update static calibrate params

### DIFF
--- a/executor/calibrate_resource.go
+++ b/executor/calibrate_resource.go
@@ -45,26 +45,26 @@ var (
 	workloadBaseRUCostMap = map[ast.CalibrateResourceType]*baseResourceCost{
 		ast.TPCC: {
 			tidbCPU:       0.6,
-			kvCPU:         0.15,
-			readBytes:     units.MiB / 2,
-			writeBytes:    units.MiB,
-			readReqCount:  300,
-			writeReqCount: 1750,
+			kvCPU:         500,
+			readBytes:     units.MiB * 4,
+			writeBytes:    units.MiB * 1.25,
+			readReqCount:  350,
+			writeReqCount: 1465,
 		},
 		ast.OLTPREADWRITE: {
-			tidbCPU:       1.25,
-			kvCPU:         0.35,
-			readBytes:     units.MiB * 4.25,
+			tidbCPU:       1.1,
+			kvCPU:         400,
+			readBytes:     units.MiB * 8.5,
 			writeBytes:    units.MiB / 3,
-			readReqCount:  1600,
-			writeReqCount: 1400,
+			readReqCount:  1365,
+			writeReqCount: 1430,
 		},
 		ast.OLTPREADONLY: {
-			tidbCPU:       2,
-			kvCPU:         0.52,
-			readBytes:     units.MiB * 28,
+			tidbCPU:       1.3,
+			kvCPU:         500,
+			readBytes:     units.MiB * 20.5,
 			writeBytes:    0,
-			readReqCount:  4500,
+			readReqCount:  3350,
 			writeReqCount: 0,
 		},
 		ast.OLTPWRITEONLY: {
@@ -243,7 +243,7 @@ func (e *calibrateResourceExec) dynamicCalibrate(ctx context.Context, req *chunk
 		}
 		tikvQuota, tidbQuota := tikvCPUs.getValue()/totalKVCPUQuota, tidbCPUs.getValue()/totalTiDBCPU
 		// If one of the two cpu usage is greater than the `valuableUsageThreshold`, we can accept it.
-		// And if both are greater than the `lowUsageThreshold`, we can also accpet it.
+		// And if both are greater than the `lowUsageThreshold`, we can also accept it.
 		if tikvQuota > valuableUsageThreshold || tidbQuota > valuableUsageThreshold {
 			quotas = append(quotas, rus.getValue()/mathutil.Max(tikvQuota, tidbQuota))
 		} else if tikvQuota < lowUsageThreshold || tidbQuota < lowUsageThreshold {
@@ -262,7 +262,7 @@ func (e *calibrateResourceExec) dynamicCalibrate(ctx context.Context, req *chunk
 		sort.Slice(quotas, func(i, j int) bool {
 			return quotas[i] > quotas[j]
 		})
-		lowerBound := int(math.Round(float64(len(quotas)) * float64(discardRate)))
+		lowerBound := int(math.Round(float64(len(quotas)) * discardRate))
 		upperBound := len(quotas) - lowerBound
 		sum := 0.
 		for i := lowerBound; i < upperBound; i++ {

--- a/executor/calibrate_resource_test.go
+++ b/executor/calibrate_resource_test.go
@@ -113,17 +113,17 @@ func TestCalibrateResource(t *testing.T) {
 	ctx = failpoint.WithHook(ctx, func(_ context.Context, fpname string) bool {
 		return fpName == fpname
 	})
-	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE").Check(testkit.Rows("68569"))
-	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE WORKLOAD TPCC").Check(testkit.Rows("68569"))
-	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE WORKLOAD OLTP_READ_WRITE").Check(testkit.Rows("53026"))
-	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE WORKLOAD OLTP_READ_ONLY").Check(testkit.Rows("31463"))
+	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE").Check(testkit.Rows("73516"))
+	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE WORKLOAD TPCC").Check(testkit.Rows("73516"))
+	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE WORKLOAD OLTP_READ_WRITE").Check(testkit.Rows("57165"))
+	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE WORKLOAD OLTP_READ_ONLY").Check(testkit.Rows("31971"))
 	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE WORKLOAD OLTP_WRITE_ONLY").Check(testkit.Rows("109776"))
 
 	// change total tidb cpu to less than tikv_cpu_quota
 	mockData["tidb_server_maxprocs"] = [][]types.Datum{
 		types.MakeDatums(datetime("2020-02-12 10:35:00"), "tidb-0", 8.0),
 	}
-	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE").Check(testkit.Rows("38094"))
+	tk.MustQueryWithContext(ctx, "CALIBRATE RESOURCE").Check(testkit.Rows("40842"))
 
 	// construct data for dynamic calibrate
 	ru1 := [][]types.Datum{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #43212

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- The previous test data due to non-exclusive hard disk, io bandwidth is not full, so the tikv is not the bottleneck, the bottleneck is tidb.
But because tidb is easy to expand, tikv is more difficult to expand, so generally tikv is easy to bottleneck
Now the test data are basically playing full tikv, may be slightly more accurate
- cpu formula is ms, the previous calculation forgot to multiply by 1000
```
