### PR TITLE
autoid_service: make test TestGRPC stable when port 10080 conflicts

### DIFF
--- a/autoid_service/autoid_test.go
+++ b/autoid_service/autoid_test.go
@@ -154,10 +154,10 @@ func TestGRPC(t *testing.T) {
 	defer cluster.Terminate(t)
 	etcdCli := cluster.RandClient()
 
-	var addr string
-	listener, err := net.Listen("tcp", addr)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer listener.Close()
+	addr := listener.Addr().String()
 
 	service := newWithCli(addr, etcdCli, store)
 	defer service.Close()
@@ -179,7 +179,7 @@ func TestGRPC(t *testing.T) {
 	}()
 	defer grpcServer.Stop()
 
-	grpcConn, err := grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	grpcConn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	cli := autoid.NewAutoIDAllocClient(grpcConn)
 	_, err = cli.AllocAutoID(context.Background(), &autoid.AutoIDRequest{

--- a/autoid_service/autoid_test.go
+++ b/autoid_service/autoid_test.go
@@ -157,7 +157,8 @@ func TestGRPC(t *testing.T) {
 
 	var addr string
 	var listener net.Listener
-	for port := 10080; ; port++ {
+	port := 10080
+	for ; ; port++ {
 		var err error
 		addr = fmt.Sprintf("127.0.0.1:%d", port)
 		listener, err = net.Listen("tcp", addr)
@@ -187,7 +188,7 @@ func TestGRPC(t *testing.T) {
 	}()
 	defer grpcServer.Stop()
 
-	grpcConn, err := grpc.Dial("127.0.0.1:10080", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	grpcConn, err := grpc.Dial(fmt.Sprintf("127.0.0.1:%d", port), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	cli := autoid.NewAutoIDAllocClient(grpcConn)
 	_, err = cli.AllocAutoID(context.Background(), &autoid.AutoIDRequest{

--- a/autoid_service/autoid_test.go
+++ b/autoid_service/autoid_test.go
@@ -16,7 +16,6 @@ package autoid
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"net"
 	"testing"
@@ -156,16 +155,8 @@ func TestGRPC(t *testing.T) {
 	etcdCli := cluster.RandClient()
 
 	var addr string
-	var listener net.Listener
-	port := 10080
-	for ; ; port++ {
-		var err error
-		addr = fmt.Sprintf("127.0.0.1:%d", port)
-		listener, err = net.Listen("tcp", addr)
-		if err == nil {
-			break
-		}
-	}
+	listener, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
 	defer listener.Close()
 
 	service := newWithCli(addr, etcdCli, store)
@@ -188,7 +179,7 @@ func TestGRPC(t *testing.T) {
 	}()
 	defer grpcServer.Stop()
 
-	grpcConn, err := grpc.Dial(fmt.Sprintf("127.0.0.1:%d", port), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	grpcConn, err := grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	cli := autoid.NewAutoIDAllocClient(grpcConn)
 	_, err = cli.AllocAutoID(context.Background(), &autoid.AutoIDRequest{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43518

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
