### PR TITLE
ddl: parse data_format for default function value

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1194,7 +1194,7 @@ func getFuncCallDefaultValue(col *table.Column, option *ast.ColumnOption, expr *
 			return nil, false, errors.Trace(err)
 		}
 		return str, true, nil
-	case ast.Rand, ast.UUID:
+	case ast.Rand, ast.UUID, ast.DateFormat:
 		if err := expression.VerifyArgsWrapper(expr.FnName.L, len(expr.Args)); err != nil {
 			return nil, false, errors.Trace(err)
 		}


### PR DESCRIPTION
Issue Number: close #43557 

Problem Summary:

### What is changed and how it works?

add `ast.DateFormat` case so that the column could set a default data_format function value.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test steps:
1. create a table: create table blog(pubdate char(8) default date_format(current_date, '%Y%m%d'));
2. If that case do not add ast.DateFormat, an error will occur with message: Default value expression of column 'pubdate' contains a disallowed function: `date_format`. When add ast.DateFormat case, there will be no error and the table could have default formatted value when insert record.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```