### PR TITLE
expression: add simple expression semantic equal check logic

### DIFF
--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -464,7 +464,9 @@ func ExpressionsSemanticEqual(ctx sessionctx.Context, expr1, expr2 Expression) b
 
 // canonicalizedHashCode is used to judge whether two expression is semantically equal.
 func simpleCanonicalizedHashCode(sf *ScalarFunction, sc *stmtctx.StatementContext) {
-	sf.canonicalhashcode = sf.canonicalhashcode[:0]
+	if sf.canonicalhashcode != nil {
+		sf.canonicalhashcode = sf.canonicalhashcode[:0]
+	}
 	sf.canonicalhashcode = append(sf.canonicalhashcode, scalarFunctionFlag)
 
 	argsHashCode := make([][]byte, 0, len(sf.GetArgs()))

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -450,11 +450,12 @@ func (sf *ScalarFunction) HashCode(sc *stmtctx.StatementContext) []byte {
 	return sf.hashcode
 }
 
+// ExpressionsSemanticEqual is used to judge whether two expression tree is semantic equivalent.
 func ExpressionsSemanticEqual(ctx sessionctx.Context, expr1, expr2 Expression) bool {
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.CanonicalHashCode.Store(true)
 	defer sc.CanonicalHashCode.Store(false)
-	return string(expr1.HashCode(sc)) == string(expr2.HashCode(sc))
+	return bytes.Equal(expr1.HashCode(sc), expr2.HashCode(sc))
 }
 
 // canonicalizedHashCode is used to judge whether two expression is semantically equal.

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -512,6 +512,8 @@ func simpleCanonicalizedHashCode(sf *ScalarFunction, sc *stmtctx.StatementContex
 	case ast.UnaryNot:
 		child, ok := sf.GetArgs()[0].(*ScalarFunction)
 		if !ok {
+			// encode original function name.
+			sf.canonicalhashcode = codec.EncodeCompactBytes(sf.canonicalhashcode, hack.Slice(sf.FuncName.L))
 			// use the origin arg hash code.
 			for _, argCode := range argsHashCode {
 				sf.canonicalhashcode = append(sf.canonicalhashcode, argCode...)

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -440,7 +440,7 @@ func (sf *ScalarFunction) EvalJSON(ctx sessionctx.Context, row chunk.Row) (types
 
 // HashCode implements Expression interface.
 func (sf *ScalarFunction) HashCode(sc *stmtctx.StatementContext) []byte {
-	if sc.CanonicalHashCode.Load() {
+	if sc.CanonicalHashCode {
 		if len(sf.canonicalhashcode) > 0 {
 			return sf.canonicalhashcode
 		}
@@ -457,8 +457,10 @@ func (sf *ScalarFunction) HashCode(sc *stmtctx.StatementContext) []byte {
 // ExpressionsSemanticEqual is used to judge whether two expression tree is semantic equivalent.
 func ExpressionsSemanticEqual(ctx sessionctx.Context, expr1, expr2 Expression) bool {
 	sc := ctx.GetSessionVars().StmtCtx
-	sc.CanonicalHashCode.Store(true)
-	defer sc.CanonicalHashCode.Store(false)
+	sc.CanonicalHashCode = true
+	defer func() {
+		sc.CanonicalHashCode = false
+	}()
 	return bytes.Equal(expr1.HashCode(sc), expr2.HashCode(sc))
 }
 

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -440,7 +440,7 @@ func (sf *ScalarFunction) EvalJSON(ctx sessionctx.Context, row chunk.Row) (types
 
 // HashCode implements Expression interface.
 func (sf *ScalarFunction) HashCode(sc *stmtctx.StatementContext) []byte {
-	if sc.CanonicalHashCode {
+	if sc != nil && sc.CanonicalHashCode {
 		if len(sf.canonicalhashcode) > 0 {
 			return sf.canonicalhashcode
 		}

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -403,6 +403,8 @@ type StatementContext struct {
 	useChunkAlloc bool
 	// Check if TiFlash read engine is removed due to strict sql mode.
 	TiFlashEngineRemovedDueToStrictSQLMode bool
+	// CanonicalHashCode try to get the canonical hash code from expression.
+	CanonicalHashCode atomic2.Bool
 }
 
 // StmtHints are SessionVars related sql hints.

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -404,7 +404,7 @@ type StatementContext struct {
 	// Check if TiFlash read engine is removed due to strict sql mode.
 	TiFlashEngineRemovedDueToStrictSQLMode bool
 	// CanonicalHashCode try to get the canonical hash code from expression.
-	CanonicalHashCode atomic2.Bool
+	CanonicalHashCode bool
 }
 
 // StmtHints are SessionVars related sql hints.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/43572

Problem Summary:

### What is changed and how it works?
In TiDB Expression tree, sometimes we may need judge whether two expression tree are semantic equal,
this PR adds the simple check logic ported from SparkSQL.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
