### PR TITLE
ddl: correct ingest row count for partition tables

### DIFF
--- a/ddl/ingest/BUILD.bazel
+++ b/ddl/ingest/BUILD.bazel
@@ -59,7 +59,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         ":ingest",
         "//config",

--- a/ddl/ingest/checkpoint_test.go
+++ b/ddl/ingest/checkpoint_test.go
@@ -154,6 +154,6 @@ type dummyFlushCtrl struct {
 	imported bool
 }
 
-func (d *dummyFlushCtrl) Flush(_ int64, _ bool) (bool, bool, error) {
+func (d *dummyFlushCtrl) Flush(_ int64, _ ingest.FlushMode) (bool, bool, error) {
 	return true, d.imported, nil
 }

--- a/ddl/ingest/engine_mgr.go
+++ b/ddl/ingest/engine_mgr.go
@@ -85,6 +85,7 @@ func (bc *litBackendCtx) Unregister(jobID, indexID int64) {
 
 	ei.Clean()
 	bc.Delete(indexID)
+	bc.checkpointMgr.Close()
 	bc.MemRoot.ReleaseWithTag(encodeEngineTag(jobID, indexID))
 	bc.MemRoot.Release(StructSizeWriterCtx * int64(ei.writerCount))
 	bc.MemRoot.Release(StructSizeEngineInfo)

--- a/ddl/ingest/integration_test.go
+++ b/ddl/ingest/integration_test.go
@@ -228,3 +228,24 @@ func (c *testCallback) OnJobRunBefore(job *model.Job) {
 		c.OnJobRunBeforeExported(job)
 	}
 }
+
+func TestIngestPartitionRowCount(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	defer injectMockBackendMgr(t, store)()
+
+	tk.MustExec(`create table t (a int, b int, c int as (b+10), d int as (b+c),
+		primary key (a) clustered) partition by range (a) (
+    		partition p0 values less than (1),
+    		partition p1 values less than (2),
+    		partition p2 values less than MAXVALUE);`)
+	tk.MustExec("insert into t (a, b) values (0, 0), (1, 1), (2, 2);")
+	tk.MustExec("alter table t add index idx(d);")
+	rows := tk.MustQuery("admin show ddl jobs 1;").Rows()
+	require.Len(t, rows, 1)
+	//nolint: forcetypeassert
+	rowCount := rows[0][7].(string)
+	require.Equal(t, "3", rowCount)
+	tk.MustExec("admin check table t;")
+}

--- a/ddl/ingest/mock.go
+++ b/ddl/ingest/mock.go
@@ -81,8 +81,9 @@ func (m *MockBackendCtxMgr) Load(jobID int64) (BackendCtx, bool) {
 
 // MockBackendCtx is a mock backend context.
 type MockBackendCtx struct {
-	sessCtx sessionctx.Context
-	mu      sync.Mutex
+	sessCtx       sessionctx.Context
+	mu            sync.Mutex
+	checkpointMgr *CheckpointManager
 }
 
 // Register implements BackendCtx.Register interface.
@@ -113,7 +114,7 @@ func (*MockBackendCtx) ResetWorkers(_, _ int64) {
 }
 
 // Flush implements BackendCtx.Flush interface.
-func (*MockBackendCtx) Flush(_ int64, _ bool) (flushed bool, imported bool, err error) {
+func (*MockBackendCtx) Flush(_ int64, _ FlushMode) (flushed bool, imported bool, err error) {
 	return false, false, nil
 }
 
@@ -124,6 +125,16 @@ func (*MockBackendCtx) Done() bool {
 
 // SetDone implements BackendCtx.SetDone interface.
 func (*MockBackendCtx) SetDone() {
+}
+
+// AttachCheckpointManager attaches a checkpoint manager to the backend context.
+func (m *MockBackendCtx) AttachCheckpointManager(mgr *CheckpointManager) {
+	m.checkpointMgr = mgr
+}
+
+// GetCheckpointManager returns the checkpoint manager attached to the backend context.
+func (m *MockBackendCtx) GetCheckpointManager() *CheckpointManager {
+	return m.checkpointMgr
 }
 
 // MockEngineInfo is a mock engine info.

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -17,6 +17,7 @@ package ddl
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -25,6 +26,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/tidb/ddl/ingest"
 	sess "github.com/pingcap/tidb/ddl/internal/session"
 	"github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/kv"
@@ -427,7 +429,7 @@ func updateDDLJob2Table(se *sess.Session, job *model.Job, updateRawArgs bool) er
 
 // getDDLReorgHandle gets DDL reorg handle.
 func getDDLReorgHandle(se *sess.Session, job *model.Job) (element *meta.Element, startKey, endKey kv.Key, physicalTableID int64, err error) {
-	sql := fmt.Sprintf("select ele_id, ele_type, start_key, end_key, physical_id from mysql.tidb_ddl_reorg where job_id = %d", job.ID)
+	sql := fmt.Sprintf("select ele_id, ele_type, start_key, end_key, physical_id, reorg_meta from mysql.tidb_ddl_reorg where job_id = %d", job.ID)
 	ctx := kv.WithInternalSourceType(context.Background(), getDDLRequestSource(job.Type))
 	rows, err := se.Execute(ctx, sql, "get_handle")
 	if err != nil {
@@ -445,6 +447,20 @@ func getDDLReorgHandle(se *sess.Session, job *model.Job) (element *meta.Element,
 	startKey = rows[0].GetBytes(2)
 	endKey = rows[0].GetBytes(3)
 	physicalTableID = rows[0].GetInt64(4)
+	if !rows[0].IsNull(5) {
+		rawReorgMeta := rows[0].GetBytes(5)
+		var reorgMeta ingest.JobReorgMeta
+		err = json.Unmarshal(rawReorgMeta, &reorgMeta)
+		if err != nil {
+			return nil, nil, nil, 0, errors.Trace(err)
+		}
+		if cp := reorgMeta.Checkpoint; cp != nil {
+			logutil.BgLogger().Info("[ddl-ingest] resume physical table ID from checkpoint",
+				zap.Int64("job ID", job.ID), zap.Int64("old physical ID", physicalTableID),
+				zap.Int64("checkpoint physical ID", cp.PhysicalID))
+			physicalTableID = cp.PhysicalID
+		}
+	}
 	return
 }
 

--- a/ddl/scheduler.go
+++ b/ddl/scheduler.go
@@ -188,7 +188,7 @@ func (b *backfillSchedulerHandle) SplitSubtask(ctx context.Context, subtask []by
 	}
 	ingestScheduler.close(false)
 
-	_, _, err = b.bc.Flush(b.index.ID, true)
+	_, _, err = b.bc.Flush(b.index.ID, ingest.FlushModeForceGlobal)
 	if err != nil {
 		if common.ErrFoundDuplicateKeys.Equal(err) {
 			err = convertToKeyExistsErr(err, b.index, b.ptbl.Meta())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43586

Problem Summary:

Previously, the checkpoint manager is created or closed in each partition. It doesn't have a way to "remember" the row count in previous partition. As a result, the row count reported by the `Status()` function from checkpoint manager is always the last partition.

### What is changed and how it works?

Create or close the checkpoint manager for each table instead of each partition.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
