### PR TITLE
lightning: fix plain error will not retry by WaitRegionOnlineBackoffer

### DIFF
--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -30,6 +30,7 @@ import (
 	sst "github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/lightning/checkpoints"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
@@ -440,6 +441,10 @@ func (local *local) BatchSplitRegions(
 		log.FromContext(ctx).Warn("scatter region failed", zap.Int("regionCount", len(newRegions)),
 			zap.Int("failedCount", len(retryRegions)), zap.Error(failedErr))
 		scatterRegions = retryRegions
+		// also it's not PDBatchScanRegion, WaitRegionOnlineBackoffer will only
+		// check this error class so we simply reuse it. Will refine WaitRegionOnlineBackoffer
+		// later
+		failedErr = errors.Annotatef(berrors.ErrPDBatchScanRegion, "scatter region failed")
 		return failedErr
 	}, backoffer)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

Wrap the error class berrors.ErrPDBatchScanRegion for the error. 
Because we use split.WaitRegionOnlineBackoffer which only backoff on berrors.ErrPDBatchScanRegion, before this pr, the "scatter" step of "split+scatter" will be skipped if any error happens, like line 421. And due to scatter step is skipped, the newly splitted regions stay in their original peers so data skew happens. And the following logic will think "scatter" step is finished rather than missing so will not discover the problem.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test included in https://github.com/pingcap/tidb/pull/43616
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

it's easy to reproduce in fact ...

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
