### PR TITLE
ddl: retry or rollback on error in ingest mode

### DIFF
--- a/ddl/ingest/integration_test.go
+++ b/ddl/ingest/integration_test.go
@@ -112,14 +112,14 @@ func TestIngestError(t *testing.T) {
 	}
 	tk.MustQuery("split table t between (0) and (50000) regions 5;").Check(testkit.Rows("4 1"))
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/mockCopSenderError", "return"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/mockCopSenderError", "1*return"))
 	tk.MustExec("alter table t add index idx(a);")
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/mockCopSenderError"))
 	tk.MustExec("admin check table t;")
 	rows := tk.MustQuery("admin show ddl jobs 1;").Rows()
 	//nolint: forcetypeassert
 	jobTp := rows[0][3].(string)
-	require.True(t, strings.Contains(jobTp, "txn-merge"), jobTp)
+	require.True(t, strings.Contains(jobTp, "ingest"), jobTp)
 
 	tk.MustExec("drop table t;")
 	tk.MustExec("create table t (a int primary key, b int);")
@@ -128,14 +128,14 @@ func TestIngestError(t *testing.T) {
 	}
 	tk.MustQuery("split table t between (0) and (50000) regions 5;").Check(testkit.Rows("4 1"))
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/mockLocalWriterError", "return"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/mockLocalWriterError", "1*return"))
 	tk.MustExec("alter table t add index idx(a);")
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/mockLocalWriterError"))
 	tk.MustExec("admin check table t;")
 	rows = tk.MustQuery("admin show ddl jobs 1;").Rows()
 	//nolint: forcetypeassert
 	jobTp = rows[0][3].(string)
-	require.True(t, strings.Contains(jobTp, "txn-merge"), jobTp)
+	require.True(t, strings.Contains(jobTp, "ingest"), jobTp)
 }
 
 func TestAddIndexIngestPanic(t *testing.T) {
@@ -148,28 +148,16 @@ func TestAddIndexIngestPanic(t *testing.T) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/mockCopSenderPanic", "return(true)"))
 	tk.MustExec("create table t (a int, b int, c int, d int, primary key (a) clustered);")
 	tk.MustExec("insert into t (a, b, c, d) values (1, 1, 1, 1), (2, 2, 2, 2), (3, 3, 3, 3);")
-	tk.MustExec("alter table t add index idx(b);")
+	tk.MustGetErrCode("alter table t add index idx(b);", errno.ErrReorgPanic)
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/mockCopSenderPanic"))
-	rows := tk.MustQuery("admin show ddl jobs 1;").Rows()
-	require.Len(t, rows, 1)
-	//nolint: forcetypeassert
-	jobTp := rows[0][3].(string)
-	// Fallback to txn-merge process.
-	require.True(t, strings.Contains(jobTp, "txn-merge"), jobTp)
 
 	// Mock panic on local engine writer.
 	tk.MustExec("drop table t;")
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/mockLocalWriterPanic", "return"))
 	tk.MustExec("create table t (a int, b int, c int, d int, primary key (a) clustered);")
 	tk.MustExec("insert into t (a, b, c, d) values (1, 1, 1, 1), (2, 2, 2, 2), (3, 3, 3, 3);")
-	tk.MustExec("alter table t add index idx(b);")
+	tk.MustGetErrCode("alter table t add index idx(b);", errno.ErrReorgPanic)
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/mockLocalWriterPanic"))
-	rows = tk.MustQuery("admin show ddl jobs 1;").Rows()
-	require.Len(t, rows, 1)
-	//nolint: forcetypeassert
-	jobTp = rows[0][3].(string)
-	// Fallback to txn-merge process.
-	require.True(t, strings.Contains(jobTp, "txn-merge"), jobTp)
 }
 
 func TestAddIndexIngestCancel(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #43523

Problem Summary:

Before this PR, if there is an error during creating index in ingest mode, TiDB will fallback to txn-merge mode automatically. However, this may not be expected by the users because the txn-merge mode is too slow in the scenario of large dataset.

### What is changed and how it works?

This PR deletes the code of falling back and divides into the following cases:
- When `BackendCtx.Register()` reports an error, roll it back directly.
- When `runReorgJob()` reports an error, try it again until the error limit is reached.
- When `FinishImport()` reports an error, try it again until the error limit is reached.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
