### PR TITLE
br: push down checkpoint record

### DIFF
--- a/br/pkg/checkpoint/BUILD.bazel
+++ b/br/pkg/checkpoint/BUILD.bazel
@@ -40,7 +40,6 @@ go_test(
     deps = [
         ":checkpoint",
         "//br/pkg/pdutil",
-        "//br/pkg/rtree",
         "//br/pkg/storage",
         "//parser/model",
         "@com_github_pingcap_kvproto//pkg/brpb",

--- a/br/pkg/checkpoint/checkpoint.go
+++ b/br/pkg/checkpoint/checkpoint.go
@@ -163,6 +163,8 @@ type CheckpointRunner[K KeyType, V ValueType] struct {
 	checksumMetaCh chan ChecksumItems
 	lockCh         chan struct{}
 	errCh          chan error
+	err            error
+	errLock        sync.RWMutex
 
 	wg sync.WaitGroup
 }
@@ -191,6 +193,7 @@ func newCheckpointRunner[K KeyType, V ValueType](
 		checksumMetaCh: make(chan ChecksumItems),
 		lockCh:         make(chan struct{}),
 		errCh:          make(chan error, 1),
+		err:            nil,
 	}
 }
 
@@ -219,7 +222,10 @@ func (r *CheckpointRunner[K, V]) FlushChecksumItem(
 		return errors.Annotatef(ctx.Err(), "failed to append checkpoint checksum item")
 	case err, ok := <-r.errCh:
 		if !ok {
-			return errors.Errorf("[checkpoint] Checksum: there is another goroutine has get the checkpoint error")
+			r.errLock.RLock()
+			err = r.err
+			r.errLock.RUnlock()
+			return errors.Errorf("[checkpoint] Checksum: failed to append checkpoint checksum item", zap.Error(err))
 		}
 		return err
 	case r.checksumCh <- checksumItem:
@@ -236,7 +242,10 @@ func (r *CheckpointRunner[K, V]) Append(
 		return errors.Annotatef(ctx.Err(), "failed to append checkpoint message")
 	case err, ok := <-r.errCh:
 		if !ok {
-			return errors.Errorf("[checkpoint] Append: there is another goroutine has get the checkpoint error")
+			r.errLock.RLock()
+			err = r.err
+			r.errLock.RUnlock()
+			return errors.Errorf("[checkpoint] Append: failed to append checkpoint message", zap.Error(err))
 		}
 		return err
 	case r.appendCh <- message:
@@ -360,6 +369,9 @@ func (r *CheckpointRunner[K, V]) sendError(err error) {
 	select {
 	case r.errCh <- err:
 		log.Error("[checkpoint] send the error", zap.Error(err))
+		r.errLock.Lock()
+		r.err = err
+		r.errLock.Unlock()
 		close(r.errCh)
 	default:
 		log.Error("errCh is blocked", logutil.ShortError(err))

--- a/br/pkg/checkpoint/checkpoint.go
+++ b/br/pkg/checkpoint/checkpoint.go
@@ -225,7 +225,7 @@ func (r *CheckpointRunner[K, V]) FlushChecksumItem(
 			r.errLock.RLock()
 			err = r.err
 			r.errLock.RUnlock()
-			return errors.Errorf("[checkpoint] Checksum: failed to append checkpoint checksum item", zap.Error(err))
+			return errors.Annotate(err, "[checkpoint] Checksum: failed to append checkpoint checksum item")
 		}
 		return err
 	case r.checksumCh <- checksumItem:
@@ -245,7 +245,7 @@ func (r *CheckpointRunner[K, V]) Append(
 			r.errLock.RLock()
 			err = r.err
 			r.errLock.RUnlock()
-			return errors.Errorf("[checkpoint] Append: failed to append checkpoint message", zap.Error(err))
+			return errors.Annotate(err, "[checkpoint] Append: failed to append checkpoint message")
 		}
 		return err
 	case r.appendCh <- message:

--- a/br/pkg/checkpoint/checkpoint_test.go
+++ b/br/pkg/checkpoint/checkpoint_test.go
@@ -280,7 +280,7 @@ func TestCheckpointRestoreRunner(t *testing.T) {
 		} else {
 			require.Equal(t, tableID, int64(1))
 		}
-		require.Equal(t, d.RangeKey, string(resp.RangeKey))
+		require.Equal(t, d.RangeKey, resp.RangeKey)
 	}
 
 	_, err = checkpoint.WalkCheckpointFileForRestore(ctx, s, cipher, taskName, checker)

--- a/br/pkg/gluetidb/glue_test.go
+++ b/br/pkg/gluetidb/glue_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/br/pkg/glue"
-	"github.com/pingcap/tidb/br/pkg/rtree"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
@@ -275,27 +274,4 @@ func TestTheSessionIsoation(t *testing.T) {
 	req.NoError(session.(glue.BatchCreateTableSession).CreateTables(ctx, map[string][]*model.TableInfo{
 		"test": infos,
 	}))
-}
-
-func TestXxx(t *testing.T) {
-	drained := []rtree.Range{
-		{
-			StartKey: []byte("1"),
-		},
-		{
-			StartKey: []byte("1"),
-		},
-		{
-			StartKey: []byte("1"),
-		},
-		{
-			StartKey: []byte("1"),
-		},
-	}
-	for _, rg := range drained {
-		rg.StartKey = []byte("3")
-	}
-
-	t.Log(drained)
-	require.True(t, false)
 }

--- a/br/pkg/gluetidb/glue_test.go
+++ b/br/pkg/gluetidb/glue_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/br/pkg/glue"
+	"github.com/pingcap/tidb/br/pkg/rtree"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
@@ -274,4 +275,27 @@ func TestTheSessionIsoation(t *testing.T) {
 	req.NoError(session.(glue.BatchCreateTableSession).CreateTables(ctx, map[string][]*model.TableInfo{
 		"test": infos,
 	}))
+}
+
+func TestXxx(t *testing.T) {
+	drained := []rtree.Range{
+		{
+			StartKey: []byte("1"),
+		},
+		{
+			StartKey: []byte("1"),
+		},
+		{
+			StartKey: []byte("1"),
+		},
+		{
+			StartKey: []byte("1"),
+		},
+	}
+	for _, rg := range drained {
+		rg.StartKey = []byte("3")
+	}
+
+	t.Log(drained)
+	require.True(t, false)
 }

--- a/br/pkg/logutil/logging.go
+++ b/br/pkg/logutil/logging.go
@@ -63,6 +63,7 @@ func (file zapFileMarshaler) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 
 type zapFilesMarshaler []*backuppb.File
 
+// MarshalLogObjectForFiles is an internal util function to zap something having `Files` field.
 func MarshalLogObjectForFiles(files []*backuppb.File, encoder zapcore.ObjectEncoder) error {
 	return zapFilesMarshaler(files).MarshalLogObject(encoder)
 }

--- a/br/pkg/logutil/logging.go
+++ b/br/pkg/logutil/logging.go
@@ -63,6 +63,10 @@ func (file zapFileMarshaler) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 
 type zapFilesMarshaler []*backuppb.File
 
+func MarshalLogObjectForFiles(files []*backuppb.File, encoder zapcore.ObjectEncoder) error {
+	return zapFilesMarshaler(files).MarshalLogObject(encoder)
+}
+
 func (fs zapFilesMarshaler) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	total := len(fs)
 	encoder.AddInt("total", total)

--- a/br/pkg/restore/BUILD.bazel
+++ b/br/pkg/restore/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "import.go",
         "import_retry.go",
         "log_client.go",
+        "logutil.go",
         "merge.go",
         "pipeline_items.go",
         "range.go",

--- a/br/pkg/restore/batcher.go
+++ b/br/pkg/restore/batcher.go
@@ -266,12 +266,12 @@ func newDrainResult() DrainResult {
 	}
 }
 
-// fileterOutRanges filter out the range from `drained-range` that is overlapped with ranges in the `range-tree`
+// fileterOutRanges filter out the files from `drained-range` that exists in the checkpoint set.
 func (b *Batcher) filterOutRanges(checkpointSet map[string]struct{}, drained []rtree.Range) []rtree.Range {
 	progress := int(0)
 	totalKVs := uint64(0)
 	totalBytes := uint64(0)
-	for _, rg := range drained {
+	for i, rg := range drained {
 		newFiles := make([]*backuppb.File, 0, len(rg.Files))
 		for _, f := range rg.Files {
 			rangeKey := getFileRangeKey(f.Name)
@@ -286,7 +286,7 @@ func (b *Batcher) filterOutRanges(checkpointSet map[string]struct{}, drained []r
 			}
 		}
 		// the newFiles may be empty
-		rg.Files = newFiles
+		drained[i].Files = newFiles
 	}
 	if progress > 0 {
 		// (split/scatter + download/ingest) / (default cf + write cf)

--- a/br/pkg/restore/batcher.go
+++ b/br/pkg/restore/batcher.go
@@ -59,7 +59,7 @@ type Batcher struct {
 	batchSizeThreshold int
 	size               int32
 
-	checkpointTrees map[int64]rtree.RangeTree
+	checkpointSetWithTableID map[int64]map[string]struct{}
 }
 
 // Len calculate the current size of this batcher.
@@ -233,12 +233,27 @@ type DrainResult struct {
 }
 
 // Files returns all files of this drain result.
-func (result DrainResult) Files() []*backuppb.File {
-	files := make([]*backuppb.File, 0, len(result.Ranges)*2)
-	for _, fs := range result.Ranges {
-		files = append(files, fs.Files...)
+func (result DrainResult) Files() []TableIDWithFiles {
+	tableIDWithFiles := make([]TableIDWithFiles, 0, len(result.TableEndOffsetInRanges))
+	var startOffset int = 0
+	for i, endOffset := range result.TableEndOffsetInRanges {
+		tableID := result.TablesToSend[i].Table.ID
+		ranges := result.Ranges[startOffset:endOffset]
+		files := make([]*backuppb.File, 0, len(result.Ranges)*2)
+		for _, rg := range ranges {
+			files = append(files, rg.Files...)
+		}
+
+		tableIDWithFiles = append(tableIDWithFiles, TableIDWithFiles{
+			TableID: tableID,
+			Files:   files,
+		})
+
+		// update start offset
+		startOffset = endOffset
 	}
-	return files
+
+	return tableIDWithFiles
 }
 
 func newDrainResult() DrainResult {
@@ -252,33 +267,36 @@ func newDrainResult() DrainResult {
 }
 
 // fileterOutRanges filter out the range from `drained-range` that is overlapped with ranges in the `range-tree`
-func (b *Batcher) filterOutRanges(tree rtree.RangeTree, drained []rtree.Range) []rtree.Range {
-	newRanges := make([]rtree.Range, 0, len(drained))
+func (b *Batcher) filterOutRanges(checkpointSet map[string]struct{}, drained []rtree.Range) []rtree.Range {
 	progress := int(0)
 	totalKVs := uint64(0)
 	totalBytes := uint64(0)
 	for _, rg := range drained {
-		if r := tree.Find(&rg); r != nil {
-			// The range is overlapped with ranges in the tree,
-			// so skip it and update the summary information.
-			progress += 1
-			for _, f := range rg.Files {
+		newFiles := make([]*backuppb.File, 0, len(rg.Files))
+		for _, f := range rg.Files {
+			rangeKey := getFileRangeKey(f.Name)
+			if _, exists := checkpointSet[rangeKey]; exists {
+				// the range has been import done, so skip it and
+				// update the summary information
+				progress += 1
 				totalKVs += f.TotalKvs
 				totalBytes += f.TotalBytes
+			} else {
+				newFiles = append(newFiles, f)
 			}
-		} else {
-			newRanges = append(newRanges, rg)
 		}
+		// the newFiles may be empty
+		rg.Files = newFiles
 	}
 	if progress > 0 {
-		// split/scatter + download/ingest
-		b.updateCh.IncBy(int64(progress) * 2)
+		// (split/scatter + download/ingest) / (default cf + write cf)
+		b.updateCh.IncBy(int64(progress) * 2 / 2)
 		summary.CollectSuccessUnit(summary.TotalKV, progress, totalKVs)
 		summary.CollectSuccessUnit(summary.SkippedKVCountByCheckpoint, progress, totalKVs)
 		summary.CollectSuccessUnit(summary.TotalBytes, progress, totalBytes)
 		summary.CollectSuccessUnit(summary.SkippedBytesByCheckpoint, progress, totalBytes)
 	}
-	return newRanges
+	return drained
 }
 
 // drainRanges 'drains' ranges from current tables.
@@ -306,7 +324,7 @@ func (b *Batcher) drainRanges() DrainResult {
 	defer b.cachedTablesMu.Unlock()
 
 	for offset, thisTable := range b.cachedTables {
-		t, exists := b.checkpointTrees[thisTable.Table.ID]
+		t, exists := b.checkpointSetWithTableID[thisTable.Table.ID]
 		thisTableLen := len(thisTable.Range)
 		collected := len(result.Ranges)
 
@@ -427,6 +445,6 @@ func (b *Batcher) SetThreshold(newThreshold int) {
 	b.batchSizeThreshold = newThreshold
 }
 
-func (b *Batcher) SetCheckpoint(trees map[int64]rtree.RangeTree) {
-	b.checkpointTrees = trees
+func (b *Batcher) SetCheckpoint(sets map[int64]map[string]struct{}) {
+	b.checkpointSetWithTableID = sets
 }

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -259,31 +259,31 @@ func (rc *Client) InitCheckpoint(
 	taskName string,
 	config *pdutil.ClusterConfig,
 	useCheckpoint bool,
-) (map[int64]rtree.RangeTree, *pdutil.ClusterConfig, error) {
+) (map[int64]map[string]struct{}, *pdutil.ClusterConfig, error) {
 	var (
-		// checkpoint ranges
-		tree = make(map[int64]rtree.RangeTree)
+		// checkpoint sets distinguished by range key
+		checkpointSetWithTableID = make(map[int64]map[string]struct{})
 
 		checkpointClusterConfig *pdutil.ClusterConfig
 	)
 
 	// if not use checkpoint, return empty checkpoint ranges and new gc-safepoint id
 	if !useCheckpoint {
-		return tree, nil, nil
+		return checkpointSetWithTableID, nil, nil
 	}
 
 	// if the checkpoint metadata exists in the external storage, the restore is not
 	// for the first time.
 	exists, err := checkpoint.ExistsRestoreCheckpoint(ctx, s, taskName)
 	if err != nil {
-		return tree, nil, errors.Trace(err)
+		return checkpointSetWithTableID, nil, errors.Trace(err)
 	}
 
 	if exists {
 		// load the checkpoint since this is not the first time to restore
 		meta, err := checkpoint.LoadCheckpointMetadataForRestore(ctx, s, taskName)
 		if err != nil {
-			return tree, nil, errors.Trace(err)
+			return checkpointSetWithTableID, nil, errors.Trace(err)
 		}
 
 		// The schedulers config is nil, so the restore-schedulers operation is just nil.
@@ -294,21 +294,21 @@ func (rc *Client) InitCheckpoint(
 		}
 
 		// t1 is the latest time the checkpoint ranges persisted to the external storage.
-		t1, err := checkpoint.WalkCheckpointFileForRestore(ctx, s, rc.cipher, taskName, func(tableID int64, rg checkpoint.RestoreValueType) {
-			t, exists := tree[tableID]
+		t1, err := checkpoint.WalkCheckpointFileForRestore(ctx, s, rc.cipher, taskName, func(tableID int64, rangeKey checkpoint.RestoreValueType) {
+			checkpointSet, exists := checkpointSetWithTableID[tableID]
 			if !exists {
-				t = rtree.NewRangeTree()
-				tree[tableID] = t
+				checkpointSet = make(map[string]struct{})
+				checkpointSetWithTableID[tableID] = checkpointSet
 			}
-			t.InsertRange(*rg.Range)
+			checkpointSet[rangeKey.RangeKey] = struct{}{}
 		})
 		if err != nil {
-			return tree, nil, errors.Trace(err)
+			return checkpointSetWithTableID, nil, errors.Trace(err)
 		}
 		// t2 is the latest time the checkpoint checksum persisted to the external storage.
 		checkpointChecksum, t2, err := checkpoint.LoadCheckpointChecksumForRestore(ctx, s, taskName)
 		if err != nil {
-			return tree, nil, errors.Trace(err)
+			return checkpointSetWithTableID, nil, errors.Trace(err)
 		}
 		rc.checkpointChecksum = checkpointChecksum
 		// use the later time to adjust the summary elapsed time.
@@ -325,12 +325,12 @@ func (rc *Client) InitCheckpoint(
 			meta.SchedulersConfig = &pdutil.ClusterConfig{Schedulers: config.Schedulers, ScheduleCfg: config.ScheduleCfg}
 		}
 		if err = checkpoint.SaveCheckpointMetadataForRestore(ctx, s, meta, taskName); err != nil {
-			return tree, nil, errors.Trace(err)
+			return checkpointSetWithTableID, nil, errors.Trace(err)
 		}
 	}
 
 	rc.checkpointRunner, err = checkpoint.StartCheckpointRunnerForRestore(ctx, s, rc.cipher, taskName)
-	return tree, checkpointClusterConfig, errors.Trace(err)
+	return checkpointSetWithTableID, checkpointClusterConfig, errors.Trace(err)
 }
 
 func (rc *Client) WaitForFinishCheckpoint(ctx context.Context) {
@@ -1258,26 +1258,35 @@ func (rc *Client) setSpeedLimit(ctx context.Context, rateLimit uint64) error {
 	return nil
 }
 
+func getFileRangeKey(f string) string {
+	idx := getFileRangeKeyIndex(f)
+	return f[:idx]
+}
+
+func getFileRangeKeyIndex(f string) int {
+	// the backup date file pattern is `{store_id}_{region_id}_{epoch_version}_{key}_{ts}_{cf}.sst`
+	// so we need to compare with out the `_{cf}.sst` suffix
+	idx := strings.LastIndex(f, "_")
+	if idx < 0 {
+		panic(fmt.Sprintf("invalid backup data file name: '%s'", f))
+	}
+
+	return idx
+}
+
 // isFilesBelongToSameRange check whether two files are belong to the same range with different cf.
 func isFilesBelongToSameRange(f1, f2 string) bool {
 	// the backup date file pattern is `{store_id}_{region_id}_{epoch_version}_{key}_{ts}_{cf}.sst`
 	// so we need to compare with out the `_{cf}.sst` suffix
-	idx1 := strings.LastIndex(f1, "_")
-	idx2 := strings.LastIndex(f2, "_")
-
-	if idx1 < 0 || idx2 < 0 {
-		panic(fmt.Sprintf("invalid backup data file name: '%s', '%s'", f1, f2))
-	}
+	idx1 := getFileRangeKeyIndex(f1)
+	idx2 := getFileRangeKeyIndex(f2)
 
 	return f1[:idx1] == f2[:idx2]
 }
 
-func drainFilesByRange(files []*backuppb.File, supportMulti bool) ([]*backuppb.File, []*backuppb.File) {
+func drainFilesByRange(files []*backuppb.File) ([]*backuppb.File, []*backuppb.File) {
 	if len(files) == 0 {
 		return nil, nil
-	}
-	if !supportMulti {
-		return files[:1], files[1:]
 	}
 	idx := 1
 	for idx < len(files) {
@@ -1288,6 +1297,20 @@ func drainFilesByRange(files []*backuppb.File, supportMulti bool) ([]*backuppb.F
 	}
 
 	return files[:idx], files[idx:]
+}
+
+func getGroupFiles(files []*backuppb.File, supportMulti bool) [][]*backuppb.File {
+	if len(files) == 0 {
+		return nil
+	}
+	if !supportMulti {
+		newFiles := make([][]*backuppb.File, 0, len(files))
+		for _, file := range files {
+			newFiles = append(newFiles, []*backuppb.File{file})
+		}
+		return newFiles
+	}
+	return [][]*backuppb.File{files}
 }
 
 // SplitRanges implements TiKVRestorer.
@@ -1352,20 +1375,21 @@ func (rc *Client) WrapLogFilesIterWithCheckpoint(
 // RestoreSSTFiles tries to restore the files.
 func (rc *Client) RestoreSSTFiles(
 	ctx context.Context,
-	files []*backuppb.File,
+	tableIDWithFiles []TableIDWithFiles,
 	rewriteRules *RewriteRules,
 	updateCh glue.Progress,
 ) (err error) {
 	start := time.Now()
+	fileCount := 0
 	defer func() {
 		elapsed := time.Since(start)
 		if err == nil {
-			log.Info("Restore files", zap.Duration("take", elapsed), logutil.Files(files))
-			summary.CollectSuccessUnit("files", len(files), elapsed)
+			log.Info("Restore files", zap.Duration("take", elapsed), zapTableIDWithFiles(tableIDWithFiles))
+			summary.CollectSuccessUnit("files", fileCount, elapsed)
 		}
 	}()
 
-	log.Debug("start to restore files", zap.Int("files", len(files)))
+	log.Debug("start to restore files", zap.Int("files", fileCount))
 
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("Client.RestoreSSTFiles", opentracing.ChildOf(span.Context()))
@@ -1379,29 +1403,54 @@ func (rc *Client) RestoreSSTFiles(
 		return errors.Trace(err)
 	}
 
+	runner := rc.GetCheckpointRunner()
+
 	var rangeFiles []*backuppb.File
 	var leftFiles []*backuppb.File
-	for rangeFiles, leftFiles = drainFilesByRange(files, rc.fileImporter.supportMultiIngest); len(rangeFiles) != 0; rangeFiles, leftFiles = drainFilesByRange(leftFiles, rc.fileImporter.supportMultiIngest) {
-		filesReplica := rangeFiles
-		if ectx.Err() != nil {
-			log.Warn("Restoring encountered error and already stopped, give up remained files.",
-				zap.Int("remained", len(leftFiles)),
-				logutil.ShortError(ectx.Err()))
-			// We will fetch the error from the errgroup then (If there were).
-			// Also note if the parent context has been canceled or something,
-			// breaking here directly is also a reasonable behavior.
-			break
-		}
-		rc.workerPool.ApplyOnErrorGroup(eg,
-			func() error {
-				fileStart := time.Now()
-				defer func() {
-					log.Info("import files done", logutil.Files(filesReplica),
-						zap.Duration("take", time.Since(fileStart)))
-					updateCh.Inc()
-				}()
-				return rc.fileImporter.ImportSSTFiles(ectx, filesReplica, rewriteRules, rc.cipher, rc.dom.Store().GetCodec().GetAPIVersion())
+	for _, tableIDWithFile := range tableIDWithFiles {
+		tableID := tableIDWithFile.TableID
+		files := tableIDWithFile.Files
+		fileCount += len(files)
+		for rangeFiles, leftFiles = drainFilesByRange(files); len(rangeFiles) != 0; rangeFiles, leftFiles = drainFilesByRange(leftFiles) {
+			filesReplica := rangeFiles
+			if ectx.Err() != nil {
+				log.Warn("Restoring encountered error and already stopped, give up remained files.",
+					zap.Int("remained", len(leftFiles)),
+					logutil.ShortError(ectx.Err()))
+				// We will fetch the error from the errgroup then (If there were).
+				// Also note if the parent context has been canceled or something,
+				// breaking here directly is also a reasonable behavior.
+				break
+			}
+			rc.workerPool.ApplyOnErrorGroup(eg, func() error {
+				filesGroups := getGroupFiles(filesReplica, rc.fileImporter.supportMultiIngest)
+				for _, filesGroup := range filesGroups {
+					if importErr := func(fs []*backuppb.File) error {
+						fileStart := time.Now()
+						defer func() {
+							log.Info("import files done", logutil.Files(filesGroup),
+								zap.Duration("take", time.Since(fileStart)))
+							updateCh.Inc()
+						}()
+						return rc.fileImporter.ImportSSTFiles(ectx, fs, rewriteRules, rc.cipher, rc.dom.Store().GetCodec().GetAPIVersion())
+					}(filesGroup); importErr != nil {
+						return errors.Trace(importErr)
+					}
+				}
+
+				// the data of this range has been import done
+				if runner != nil && len(filesReplica) > 0 {
+					rangeKeyIdx := getFileRangeKeyIndex(filesReplica[0].Name)
+					rangeKey := filesReplica[0].Name[:rangeKeyIdx]
+					// The checkpoint range shows this ranges of kvs has been restored into
+					// the table corresponding to the table-id.
+					if err := checkpoint.AppendRangesForRestore(ectx, runner, tableID, rangeKey); err != nil {
+						return errors.Trace(err)
+					}
+				}
+				return nil
 			})
+		}
 	}
 
 	if err := eg.Wait(); err != nil {

--- a/br/pkg/restore/logutil.go
+++ b/br/pkg/restore/logutil.go
@@ -1,0 +1,38 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restore
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/br/pkg/logutil"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type zapTableIDWithFilesMarshaler []TableIDWithFiles
+
+func zapTableIDWithFiles(fs []TableIDWithFiles) zap.Field {
+	return zap.Object("files", zapTableIDWithFilesMarshaler(fs))
+}
+
+func (fs zapTableIDWithFilesMarshaler) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	for _, f := range fs {
+		encoder.AddInt64("table-id", f.TableID)
+		if err := logutil.MarshalLogObjectForFiles(f.Files, encoder); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43632 

Problem Summary:
checkpoint for snapshot restore should be more accurate.
### What is changed and how it works?
records the ranges once the range has been import done.

Besides, the changed checkpoint data for snapshot restore now is :
```
<table-id, start-key>
```
instead of the original one :
```
<table-id, (start-key, end-key)>
```
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
