### PR TITLE
ddl: use session begin timestamp to read record for adding index

### DIFF
--- a/ddl/BUILD.bazel
+++ b/ddl/BUILD.bazel
@@ -223,6 +223,7 @@ go_test(
         "//config",
         "//ddl/ingest",
         "//ddl/internal/callback",
+        "//ddl/internal/session",
         "//ddl/placement",
         "//ddl/schematracker",
         "//ddl/testutil",

--- a/ddl/backfilling_scheduler.go
+++ b/ddl/backfilling_scheduler.go
@@ -434,7 +434,7 @@ func (b *ingestBackfillScheduler) createCopReqSenderPool() (*copReqSenderPool, e
 		logutil.BgLogger().Warn("[ddl-ingest] cannot init cop request sender", zap.Error(err))
 		return nil, err
 	}
-	return newCopReqSenderPool(b.ctx, copCtx, sessCtx.GetStore(), b.taskCh, b.checkpointMgr), nil
+	return newCopReqSenderPool(b.ctx, copCtx, sessCtx.GetStore(), b.taskCh, b.sessPool, b.checkpointMgr), nil
 }
 
 func (b *ingestBackfillScheduler) expectedWorkerSize() (readerSize int, writerSize int) {

--- a/ddl/export_test.go
+++ b/ddl/export_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/pingcap/tidb/ddl/internal/session"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -51,7 +52,8 @@ func FetchChunk4Test(copCtx *copContext, tbl table.PhysicalTable, startKey, endK
 	}
 	taskCh := make(chan *reorgBackfillTask, 5)
 	resultCh := make(chan idxRecResult, 5)
-	pool := newCopReqSenderPool(context.Background(), copCtx, store, taskCh, nil)
+	sessPool := session.NewSessionPool(nil, store)
+	pool := newCopReqSenderPool(context.Background(), copCtx, store, taskCh, sessPool, nil)
 	pool.chunkSender = &resultChanForTest{ch: resultCh}
 	pool.adjustSize(1)
 	pool.tasksCh <- task

--- a/ddl/index_cop.go
+++ b/ddl/index_cop.go
@@ -127,7 +127,7 @@ func (c *copReqSender) run() {
 		logutil.BgLogger().Info("[ddl-ingest] start a cop-request task",
 			zap.Int("id", task.id), zap.String("task", task.String()))
 
-		startTS, err := calculateStartTS(se)
+		startTS, err := beginAndGetStartTS(se)
 		if err != nil {
 			p.chunkSender.AddTask(idxRecResult{id: task.id, err: err})
 			return
@@ -513,7 +513,7 @@ type idxRecResult struct {
 	done  bool
 }
 
-func calculateStartTS(se *sess.Session) (uint64, error) {
+func beginAndGetStartTS(se *sess.Session) (uint64, error) {
 	se.Rollback()
 	err := se.Begin()
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #40074

Problem Summary:

Previously, we use `store.CurrentVersion` to get the latest start TS to read table records. This is problematic because it does not take the GC life time into account.

### What is changed and how it works?

Get an internal session and begin transaction explicitly. Thus, we can utilize the mechanism introduced in #42897 to block the progress of GC safe point before the reading is complete.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
