### PR TITLE
lightning: pause scheduler by removing scheduler on default

### DIFF
--- a/br/pkg/lightning/backend/local/local_test.go
+++ b/br/pkg/lightning/backend/local/local_test.go
@@ -1418,3 +1418,7 @@ func TestNotLeaderErrorNeedUpdatePeers(t *testing.T) {
 	// store 12 has a follower busy, so it will break the workflow for region (11, 12, 13)
 	require.Equal(t, []uint64{1, 2, 3, 1, 11, 12, 13, 11}, apiInvokeRecorder["MultiIngest"])
 }
+
+func TestShouldPauseSchedulerByKeyRange(t *testing.T) {
+	require.False(t, ShouldPauseSchedulerByKeyRange(true, nil))
+}

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -687,6 +687,8 @@ type TikvImporter struct {
 	KeyspaceName            string                       `toml:"keyspace-name" json:"keyspace-name"`
 	AddIndexBySQL           bool                         `toml:"add-index-by-sql" json:"add-index-by-sql"`
 
+	ForcePauseSchedulerByRemove bool `toml:"force-pause-scheduler-by-remove" json:"force-pause-scheduler-by-remove"`
+
 	EngineMemCacheSize      ByteSize `toml:"engine-mem-cache-size" json:"engine-mem-cache-size"`
 	LocalWriterMemCacheSize ByteSize `toml:"local-writer-mem-cache-size" json:"local-writer-mem-cache-size"`
 	StoreWriteBWLimit       ByteSize `toml:"store-write-bwlimit" json:"store-write-bwlimit"`
@@ -867,6 +869,8 @@ func NewConfig() *Config {
 			RegionCheckBackoffLimit: DefaultRegionCheckBackoffLimit,
 			DiskQuota:               ByteSize(math.MaxInt64),
 			DuplicateResolution:     DupeResAlgNone,
+			// default to true for this fix, so there's no need to change config files
+			ForcePauseSchedulerByRemove: true,
 		},
 		PostRestore: PostRestore{
 			Checksum:          OpLevelRequired,

--- a/br/pkg/lightning/config/config_test.go
+++ b/br/pkg/lightning/config/config_test.go
@@ -70,6 +70,7 @@ func TestAdjustPdAddrAndPort(t *testing.T) {
 	defer ts.Close()
 
 	cfg := config.NewConfig()
+	require.True(t, cfg.TikvImporter.ForcePauseSchedulerByRemove)
 	cfg.TiDB.Host = host
 	cfg.TiDB.StatusPort = port
 	cfg.Mydumper.SourceDir = "."

--- a/br/pkg/lightning/importer/import.go
+++ b/br/pkg/lightning/importer/import.go
@@ -1492,7 +1492,7 @@ func (rc *Controller) importTables(ctx context.Context) (finalErr error) {
 			err       error
 		)
 
-		if !rc.taskMgr.CanPauseSchedulerByKeyRange() {
+		if !rc.taskMgr.CanPauseSchedulerByKeyRange(rc.cfg.TikvImporter.ForcePauseSchedulerByRemove) {
 			logTask.Info("removing PD leader&region schedulers")
 
 			restoreFn, err = rc.taskMgr.CheckAndPausePdSchedulers(ctx)

--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -1025,8 +1025,7 @@ func (p *PdController) pauseSchedulerByKeyRangeWithTTL(ctx context.Context, star
 // CanPauseSchedulerByKeyRange returns whether the scheduler can be paused by key range.
 func (p *PdController) CanPauseSchedulerByKeyRange() bool {
 	// We need ttl feature to ensure scheduler can recover from pause automatically.
-	// todo: just for fast test, we can change it to config later
-	return false
+	return p.version.Compare(minVersionForRegionLabelTTL) >= 0
 }
 
 // Close close the connection to pd.

--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -1025,7 +1025,8 @@ func (p *PdController) pauseSchedulerByKeyRangeWithTTL(ctx context.Context, star
 // CanPauseSchedulerByKeyRange returns whether the scheduler can be paused by key range.
 func (p *PdController) CanPauseSchedulerByKeyRange() bool {
 	// We need ttl feature to ensure scheduler can recover from pause automatically.
-	return p.version.Compare(minVersionForRegionLabelTTL) >= 0
+	// todo: just for fast test, we can change it to config later
+	return false
 }
 
 // Close close the connection to pd.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #43657

Problem Summary:

### What is changed and how it works?
- add implicit config `tikv-importer.force-pause-scheduler-by-remove`, default is true, i.e. pause scheduler by removing scheduler on default
- 
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

run with default
```log
➜  lightning grep 'removing PD leader' tidb-lightning.log
[2023/05/09 20:02:19.006 +08:00] [INFO] [import.go:1496] ["removing PD leader&region schedulers"]
➜  lightning grep 'pause scheduler by key range' tidb-lightning.log
➜  lightning
```

set it to false and run again
```log
➜  lightning grep 'removing PD leader' tidb-lightning.log
➜  lightning grep 'pause scheduler by key range' tidb-lightning.log
[2023/05/09 20:04:12.568 +08:00] [INFO] [local.go:1298] ["pause scheduler by key range"]
[2023/05/09 20:04:13.662 +08:00] [INFO] [local.go:1298] ["pause scheduler by key range"]
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
