### PR TITLE
*: fix incorrect handling of EXECUTE stmt in plan replayer capture

### DIFF
--- a/domain/BUILD.bazel
+++ b/domain/BUILD.bazel
@@ -42,7 +42,6 @@ go_library(
         "//meta",
         "//metrics",
         "//owner",
-        "//parser",
         "//parser/ast",
         "//parser/model",
         "//parser/mysql",

--- a/domain/plan_replayer.go
+++ b/domain/plan_replayer.go
@@ -529,7 +529,7 @@ type PlanReplayerDumpTask struct {
 	replayer.PlanReplayerTaskKey
 
 	// tmp variables stored during the query
-	TblStats      map[int64]interface{}
+	TblStats map[int64]interface{}
 
 	// variables used to dump the plan
 	StartTS         uint64

--- a/domain/plan_replayer.go
+++ b/domain/plan_replayer.go
@@ -31,7 +31,6 @@ import (
 	domain_metrics "github.com/pingcap/tidb/domain/metrics"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
-	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"
@@ -437,19 +436,6 @@ func (w *planReplayerTaskDumpWorker) HandleTask(task *PlanReplayerDumpTask) (suc
 	}
 	task.Zf = file
 	task.FileName = fileName
-	if task.InExecute && len(task.NormalizedSQL) > 0 {
-		p := parser.New()
-		stmts, _, err := p.ParseSQL(task.NormalizedSQL)
-		if err != nil {
-			logutil.BgLogger().Warn("[plan-replayer-capture] parse normalized sql failed",
-				zap.String("sql", task.NormalizedSQL),
-				zap.String("sqlDigest", taskKey.SQLDigest),
-				zap.String("planDigest", taskKey.PlanDigest),
-				zap.Error(err))
-			return false
-		}
-		task.ExecStmts = stmts
-	}
 	err = DumpPlanReplayerInfo(w.ctx, w.sctx, task)
 	if err != nil {
 		logutil.BgLogger().Warn("[plan-replayer-capture] dump task result failed",
@@ -544,8 +530,6 @@ type PlanReplayerDumpTask struct {
 
 	// tmp variables stored during the query
 	TblStats      map[int64]interface{}
-	InExecute     bool
-	NormalizedSQL string
 
 	// variables used to dump the plan
 	StartTS         uint64

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/mysql"
 	core_metrics "github.com/pingcap/tidb/planner/core/metrics"
+	"github.com/pingcap/tidb/planner/util/debugtrace"
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
@@ -64,6 +65,14 @@ func SetParameterValuesIntoSCtx(sctx sessionctx.Context, isNonPrep bool, markers
 			param.InExecute = true
 		}
 		vars.PlanCacheParams.Append(val)
+	}
+	if vars.StmtCtx.EnableOptimizerDebugTrace && len(vars.PlanCacheParams.AllParamValues()) > 0 {
+		vals := vars.PlanCacheParams.AllParamValues()
+		valStrs := make([]string, len(vals))
+		for i, val := range vals {
+			valStrs[i] = val.String()
+		}
+		debugtrace.RecordAnyValuesWithNames(sctx, "Parameter datums for EXECUTE", valStrs)
 	}
 	vars.PlanCacheParams.SetForNonPrepCache(isNonPrep)
 	return nil

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -206,6 +206,7 @@ go_test(
         "//util/deadlockhistory",
         "//util/mock",
         "//util/plancodec",
+        "//util/replayer",
         "//util/resourcegrouptag",
         "//util/rowcodec",
         "//util/stmtsummary/v2:stmtsummary",

--- a/server/testdata/optimizer_suite_in.json
+++ b/server/testdata/optimizer_suite_in.json
@@ -4,7 +4,8 @@
     "cases": [
       "\u0017\u0001\u0000\u0000\u0000\u0000\u0001\u0000\u0000\u0000\u0000\u0001\u0008\u0000\u007F\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
       "\u0003create session binding for select * from t where col1 = 100 using select * from t use index () where col1 = 100",
-      "\u0003select * from t where col1 = 100"
+      "\u0003select * from t where col1 = 100",
+      "\u0003execute stmt using @a"
     ]
   }
 ]

--- a/server/testdata/optimizer_suite_out.json
+++ b/server/testdata/optimizer_suite_out.json
@@ -22,6 +22,11 @@
         {
           "github.com/pingcap/tidb/planner.Optimize": [
             {
+              "Parameter datums for EXECUTE": [
+                "KindInt64 127"
+              ]
+            },
+            {
               "github.com/pingcap/tidb/planner/core.getStatsTable": {
                 "CountIsZero": false,
                 "HandleIsNil": false,
@@ -477,6 +482,289 @@
             },
             {
               "Best Hint": "use index ()"
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "Received Command": {
+            "Command": "Query",
+            "ExecuteStmtInfo": {
+              "BinaryParamsInfo": null,
+              "PreparedSQL": "select * from t where col1 in (?, 2, 3)",
+              "UseCursor": false
+            },
+            "ExecutedASTText": "execute stmt using @a"
+          }
+        },
+        {
+          "github.com/pingcap/tidb/planner.Optimize": [
+            {
+              "Parameter datums for EXECUTE": [
+                "KindInt64 1"
+              ]
+            },
+            {
+              "github.com/pingcap/tidb/planner/core.getStatsTable": {
+                "CountIsZero": false,
+                "HandleIsNil": false,
+                "InputPhysicalID": 100,
+                "Outdated": false,
+                "StatsTblInfo": {
+                  "Columns": [
+                    {
+                      "CMSketchInfo": null,
+                      "Correlation": 0,
+                      "HistogramSize": 0,
+                      "ID": 1,
+                      "LastUpdateVersion": 440930000000000000,
+                      "LoadingStatus": "unInitialized",
+                      "NDV": 0,
+                      "Name": "col1",
+                      "NullCount": 0,
+                      "StatsVer": 0,
+                      "TopNSize": -1,
+                      "TotColSize": 0
+                    }
+                  ],
+                  "Count": 10000,
+                  "Indexes": [
+                    {
+                      "CMSketchInfo": null,
+                      "Correlation": 0,
+                      "HistogramSize": 0,
+                      "ID": 1,
+                      "LastUpdateVersion": 440930000000000000,
+                      "LoadingStatus": "unInitialized",
+                      "NDV": 0,
+                      "Name": "i",
+                      "NullCount": 0,
+                      "StatsVer": 0,
+                      "TopNSize": -1,
+                      "TotColSize": 0
+                    }
+                  ],
+                  "ModifyCount": 0,
+                  "PhysicalID": 100,
+                  "Version": 440930000000000000
+                },
+                "TableName": "t",
+                "TblInfoID": 88,
+                "Uninitialized": true,
+                "UsePartitionStats": false
+              }
+            },
+            {
+              "github.com/pingcap/tidb/planner.Optimize": [
+                {
+                  "Enable binding": true,
+                  "IsStmtNode": true,
+                  "Matched": false,
+                  "Matched bindings": null,
+                  "Scope": "",
+                  "Used binding": false
+                },
+                {
+                  "github.com/pingcap/tidb/planner.optimize": {
+                    "github.com/pingcap/tidb/planner/core.DoOptimize": [
+                      {
+                        "github.com/pingcap/tidb/planner/core.logicalOptimize": null
+                      },
+                      {
+                        "github.com/pingcap/tidb/planner/core.physicalOptimize": [
+                          {
+                            "github.com/pingcap/tidb/planner/core.getStatsTable": {
+                              "CountIsZero": false,
+                              "HandleIsNil": false,
+                              "InputPhysicalID": 100,
+                              "Outdated": false,
+                              "StatsTblInfo": {
+                                "Columns": [
+                                  {
+                                    "CMSketchInfo": null,
+                                    "Correlation": 0,
+                                    "HistogramSize": 0,
+                                    "ID": 1,
+                                    "LastUpdateVersion": 440930000000000000,
+                                    "LoadingStatus": "unInitialized",
+                                    "NDV": 0,
+                                    "Name": "col1",
+                                    "NullCount": 0,
+                                    "StatsVer": 0,
+                                    "TopNSize": -1,
+                                    "TotColSize": 0
+                                  }
+                                ],
+                                "Count": 10000,
+                                "Indexes": [
+                                  {
+                                    "CMSketchInfo": null,
+                                    "Correlation": 0,
+                                    "HistogramSize": 0,
+                                    "ID": 1,
+                                    "LastUpdateVersion": 440930000000000000,
+                                    "LoadingStatus": "unInitialized",
+                                    "NDV": 0,
+                                    "Name": "i",
+                                    "NullCount": 0,
+                                    "StatsVer": 0,
+                                    "TopNSize": -1,
+                                    "TotColSize": 0
+                                  }
+                                ],
+                                "ModifyCount": 0,
+                                "PhysicalID": 100,
+                                "Version": 440930000000000000
+                              },
+                              "TableName": "t",
+                              "TblInfoID": 88,
+                              "Uninitialized": true,
+                              "UsePartitionStats": false
+                            }
+                          },
+                          {
+                            "github.com/pingcap/tidb/planner/core.(*DataSource).DeriveStats": [
+                              {
+                                "github.com/pingcap/tidb/planner/core.(*DataSource).fillIndexPath": {
+                                  "github.com/pingcap/tidb/statistics.(*HistColl).GetRowCountByIndexRanges": [
+                                    {
+                                      "ID": 1,
+                                      "Ranges": [
+                                        "[1,1]",
+                                        "[2,2]",
+                                        "[3,3]"
+                                      ]
+                                    },
+                                    {
+                                      "github.com/pingcap/tidb/statistics.(*Index).IsInvalid": {
+                                        "CollPseudo": true,
+                                        "IsInvalid": true,
+                                        "NotAccurate": true,
+                                        "TotalCount": 0
+                                      }
+                                    },
+                                    {
+                                      "Name": "i",
+                                      "Result": 30
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "github.com/pingcap/tidb/planner/core.(*DataSource).deriveStatsByFilter": {
+                                  "github.com/pingcap/tidb/statistics.(*HistColl).Selectivity": [
+                                    {
+                                      "Input Expressions": [
+                                        "in(test.t.col1, 1, 2, 3)"
+                                      ]
+                                    },
+                                    {
+                                      "github.com/pingcap/tidb/statistics.(*HistColl).GetRowCountByColumnRanges": [
+                                        {
+                                          "ID": 1,
+                                          "Ranges": [
+                                            "[1,1]",
+                                            "[2,2]",
+                                            "[3,3]"
+                                          ]
+                                        },
+                                        {
+                                          "github.com/pingcap/tidb/statistics.(*Column).IsInvalid": {
+                                            "EssentialLoaded": false,
+                                            "InValidForCollPseudo": true,
+                                            "IsInvalid": true,
+                                            "NDV": 0,
+                                            "TotalCount": 0
+                                          }
+                                        },
+                                        {
+                                          "Name": "col1",
+                                          "Result": 30
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "github.com/pingcap/tidb/statistics.(*HistColl).GetRowCountByIndexRanges": [
+                                        {
+                                          "ID": 1,
+                                          "Ranges": [
+                                            "[1,1]",
+                                            "[2,2]",
+                                            "[3,3]"
+                                          ]
+                                        },
+                                        {
+                                          "github.com/pingcap/tidb/statistics.(*Index).IsInvalid": {
+                                            "CollPseudo": true,
+                                            "IsInvalid": true,
+                                            "NotAccurate": true,
+                                            "TotalCount": 0
+                                          }
+                                        },
+                                        {
+                                          "Name": "i",
+                                          "Result": 30
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Expressions": [
+                                        "in(test.t.col1, 1, 2, 3)"
+                                      ],
+                                      "Selectivity": 0.003,
+                                      "partial cover": false
+                                    },
+                                    {
+                                      "Result": 0.003
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "github.com/pingcap/tidb/planner/core.(*DataSource).derivePathStatsAndTryHeuristics": [
+                                  {
+                                    "github.com/pingcap/tidb/planner/core.(*DataSource).deriveTablePathStats": null
+                                  },
+                                  {
+                                    "github.com/pingcap/tidb/planner/core.(*DataSource).deriveIndexPathStats": null
+                                  }
+                                ]
+                              },
+                              {
+                                "github.com/pingcap/tidb/planner/core.(*DataSource).generateIndexMergePath": null
+                              },
+                              {
+                                "Access paths": [
+                                  {
+                                    "AccessConditions": [],
+                                    "CountAfterAccess": 10000,
+                                    "CountAfterIndex": 0,
+                                    "IndexFilters": [],
+                                    "TableFilters": [
+                                      "in(test.t.col1, 1, 2, 3)"
+                                    ]
+                                  },
+                                  {
+                                    "AccessConditions": [
+                                      "in(test.t.col1, 1, 2, 3)"
+                                    ],
+                                    "CountAfterAccess": 30,
+                                    "CountAfterIndex": 30,
+                                    "IndexFilters": [],
+                                    "IndexName": "i",
+                                    "TableFilters": []
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION

### What problem does this PR solve?


Issue Number: close #43620

Problem Summary:

Trying to parse a normalized SQL in `HandleTask()`

### What is changed and how it works?

- Fix the incorrect method to get the original prepared ast when handling the EXECUTE stmt.
- Add a debug trace point to record the parameters for both binary/non-binary EXECUTE stmt.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
