### PR TITLE
parser: polish the error message for generated column with default value

### DIFF
--- a/parser/ast/ddl.go
+++ b/parser/ast/ddl.go
@@ -1020,7 +1020,7 @@ func (n *ColumnDef) Validate() error {
 		}
 	}
 	if generatedCol && illegalOpt4gc != "" {
-		return ErrWrongUsage.GenWithStackByArgs(illegalOpt4gc , "generated column")
+		return ErrWrongUsage.GenWithStackByArgs(illegalOpt4gc, "generated column")
 	}
 	return nil
 }
@@ -3694,7 +3694,7 @@ var (
 	ErrWrongPartitionTypeExpectedSystemTime = terror.ClassDDL.NewStd(mysql.ErrWrongPartitionTypeExpectedSystemTime)
 	ErrUnknownCharacterSet                  = terror.ClassDDL.NewStd(mysql.ErrUnknownCharacterSet)
 	ErrCoalescePartitionNoPartition         = terror.ClassDDL.NewStd(mysql.ErrCoalescePartitionNoPartition)
-	ErrWrongUsage                                   = terror.ClassDDL.NewStd(mysql.ErrWrongUsage)
+	ErrWrongUsage                           = terror.ClassDDL.NewStd(mysql.ErrWrongUsage)
 )
 
 type SubPartitionDefinition struct {

--- a/parser/ast/ddl.go
+++ b/parser/ast/ddl.go
@@ -525,10 +525,10 @@ const (
 )
 
 var (
-	invalidOptionForGeneratedColumn = map[ColumnOptionType]struct{}{
-		ColumnOptionAutoIncrement: {},
-		ColumnOptionOnUpdate:      {},
-		ColumnOptionDefaultValue:  {},
+	invalidOptionForGeneratedColumn = map[ColumnOptionType]string{
+		ColumnOptionAutoIncrement: "AUTO_INCREMENT",
+		ColumnOptionOnUpdate:      "ON UPDATE",
+		ColumnOptionDefaultValue:  "DEFAULT",
 	}
 )
 
@@ -1007,17 +1007,22 @@ func (n *ColumnDef) Accept(v Visitor) (Node, bool) {
 // For example, generated column definitions that contain such
 // column options as `ON UPDATE`, `AUTO_INCREMENT`, `DEFAULT`
 // are illegal.
-func (n *ColumnDef) Validate() bool {
+func (n *ColumnDef) Validate() error {
 	generatedCol := false
-	illegalOpt4gc := false
+	var illegalOpt4gc string
 	for _, opt := range n.Options {
 		if opt.Tp == ColumnOptionGenerated {
 			generatedCol = true
 		}
-		_, found := invalidOptionForGeneratedColumn[opt.Tp]
-		illegalOpt4gc = illegalOpt4gc || found
+		msg, found := invalidOptionForGeneratedColumn[opt.Tp]
+		if found {
+			illegalOpt4gc = msg
+		}
 	}
-	return !(generatedCol && illegalOpt4gc)
+	if generatedCol && illegalOpt4gc != "" {
+		return ErrWrongUsage.GenWithStackByArgs(illegalOpt4gc , "generated column")
+	}
+	return nil
 }
 
 type TemporaryKeyword int
@@ -3689,6 +3694,7 @@ var (
 	ErrWrongPartitionTypeExpectedSystemTime = terror.ClassDDL.NewStd(mysql.ErrWrongPartitionTypeExpectedSystemTime)
 	ErrUnknownCharacterSet                  = terror.ClassDDL.NewStd(mysql.ErrUnknownCharacterSet)
 	ErrCoalescePartitionNoPartition         = terror.ClassDDL.NewStd(mysql.ErrCoalescePartitionNoPartition)
+	ErrWrongUsage                                   = terror.ClassDDL.NewStd(mysql.ErrWrongUsage)
 )
 
 type SubPartitionDefinition struct {

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -3140,8 +3140,8 @@ ColumnDef:
 	ColumnName Type ColumnOptionListOpt
 	{
 		colDef := &ast.ColumnDef{Name: $1.(*ast.ColumnName), Tp: $2.(*types.FieldType), Options: $3.([]*ast.ColumnOption)}
-		if !colDef.Validate() {
-			yylex.AppendError(yylex.Errorf("Invalid column definition"))
+	        if err := colDef.Validate(); err != nil {
+			yylex.AppendError(err)
 			return 1
 		}
 		$$ = colDef
@@ -3154,8 +3154,8 @@ ColumnDef:
 		options = append(options, $3.([]*ast.ColumnOption)...)
 		tp.AddFlag(mysql.UnsignedFlag)
 		colDef := &ast.ColumnDef{Name: $1.(*ast.ColumnName), Tp: tp, Options: options}
-		if !colDef.Validate() {
-			yylex.AppendError(yylex.Errorf("Invalid column definition"))
+	        if err := colDef.Validate(); err != nil {
+			yylex.AppendError(err)
 			return 1
 		}
 		$$ = colDef

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -5716,6 +5716,13 @@ func TestGeneratedColumn(t *testing.T) {
 			require.Error(t, err)
 		}
 	}
+
+	_, _, err := p.Parse("create table t1 (a int, b int as (a + 1) default 10);", "", "")
+	require.Equal(t, err.Error(), "[ddl:1221]Incorrect usage of DEFAULT and generated column")
+	_, _, err = p.Parse("create table t1 (a int, b int as (a + 1) on update now());", "", "")
+	require.Equal(t, err.Error(), "[ddl:1221]Incorrect usage of ON UPDATE and generated column")
+	_, _, err = p.Parse("create table t1 (a int, b int as (a + 1) auto_increment);", "", "")
+	require.Equal(t, err.Error(), "[ddl:1221]Incorrect usage of AUTO_INCREMENT and generated column")
 }
 
 func TestSetTransaction(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #22535

Problem Summary:

### What is changed and how it works?

After the change, the error code and message is the same with MySQL.

Before:
```
mysql>  create table t1 (a int, b int as (a + 1) default 10);
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 52 near ")"Invalid column definition
```

After: 
```
mysql> create table t1 (a int, b int as (a + 1) default 10);
ERROR 1221 (HY000): Incorrect usage of DEFAULT and generated column
```
### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

```
mysql> create table t1 (a int, b int as (a + 1) default 10);
ERROR 1221 (HY000): Incorrect usage of DEFAULT and generated column
mysql> create table t1 (a int, b int as (a + 1) on update now());
ERROR 1221 (HY000): Incorrect usage of ON UPDATE and generated column
mysql> create table t1 (a int, b int as (a + 1) auto_increment);
ERROR 1221 (HY000): Incorrect usage of AUTO_INCREMENT and generated column
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
