### PR TITLE
planner: skip json column which exists in mv index when collecting stats

### DIFF
--- a/executor/test/analyzetest/analyze_test.go
+++ b/executor/test/analyzetest/analyze_test.go
@@ -3176,3 +3176,34 @@ func TestGlobalMemoryControlForAutoAnalyze(t *testing.T) {
 	childTrackers = executor.GlobalAnalyzeMemoryTracker.GetChildrenForTest()
 	require.Len(t, childTrackers, 0)
 }
+
+func TestAnalyzeColumnsSkipMVIndexJsonCol(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	h := dom.StatsHandle()
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("set @@tidb_analyze_version = 2")
+	tk.MustExec("create table t (a int, b int, c json, index idx_b(b), index idx_c((cast(json_extract(c, _utf8mb4'$') as char(32) array))))")
+	tk.MustExec(`insert into t values (1, 1, '["a1", "a2"]'), (2, 2, '["b1", "b2"]'), (3, 3, '["c1", "c2"]'), (2, 2, '["c1", "c2"]')`)
+	require.NoError(t, h.DumpStatsDeltaToKV(handle.DumpAll))
+
+	tk.MustExec("analyze table t columns a")
+	tk.MustQuery("show warnings").Sort().Check(testkit.Rows(""+
+		"Note 1105 Analyze use auto adjusted sample rate 1.000000 for table test.t",
+		"Warning 1105 Columns b are missing in ANALYZE but their stats are needed for calculating stats for indexes/primary key/extended stats",
+		"Warning 1105 analyzing multi-valued indexes is not supported, skip idx_c"))
+	tk.MustQuery("select job_info from mysql.analyze_jobs where table_schema = 'test' and table_name = 't'").Check(testkit.Rows(
+		"analyze table columns a, b with 256 buckets, 500 topn, 1 samplerate"))
+
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	tblInfo := tbl.Meta()
+	stats := h.GetTableStats(tblInfo)
+	require.True(t, stats.Columns[tblInfo.Columns[0].ID].IsStatsInitialized())
+	require.True(t, stats.Columns[tblInfo.Columns[1].ID].IsStatsInitialized())
+	require.False(t, stats.Columns[tblInfo.Columns[2].ID].IsStatsInitialized())
+	require.True(t, stats.Indices[tblInfo.Indices[0].ID].IsStatsInitialized())
+	require.False(t, stats.Indices[tblInfo.Indices[1].ID].IsStatsInitialized())
+}

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -2153,7 +2153,7 @@ func (b *PlanBuilder) getMustAnalyzedColumns(tbl *ast.TableName, cols *calcOnceM
 		}
 		virtualExprs := make([]expression.Expression, 0, len(tblInfo.Columns))
 		for _, idx := range tblInfo.Indices {
-			if idx.State != model.StatePublic {
+			if idx.State != model.StatePublic || idx.MVIndex {
 				continue
 			}
 			for _, idxCol := range idx.Columns {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43705

Problem Summary:

### What is changed and how it works?

When we decide which columns must be analyzed, we skip the columns existing in multi-value indexes because we don't collect stats for multi-value indexes for now.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
