### PR TITLE
lightning: fix oom when mem/cpu ratio is low

### DIFF
--- a/br/pkg/lightning/backend/kv/base.go
+++ b/br/pkg/lightning/backend/kv/base.go
@@ -322,6 +322,11 @@ func (e *BaseKVEncoder) LogEvalGenExprFailed(row []types.Datum, colInfo *model.C
 	)
 }
 
+// TruncateWarns resets the warnings in session context.
+func (e *BaseKVEncoder) TruncateWarns() {
+	e.SessionCtx.Vars.StmtCtx.TruncateWarnings(0)
+}
+
 func evalGeneratedColumns(se *Session, record []types.Datum, cols []*table.Column,
 	genCols []GeneratedCol) (errCol *model.ColumnInfo, err error) {
 	mutRow := chunk.MutRowFromDatums(record)

--- a/br/pkg/lightning/backend/kv/sql2kv.go
+++ b/br/pkg/lightning/backend/kv/sql2kv.go
@@ -181,6 +181,11 @@ func Row2KvPairs(row encode.Row) []common.KvPair {
 // `columnPermutation` parameter.
 func (kvcodec *tableKVEncoder) Encode(row []types.Datum,
 	rowID int64, columnPermutation []int, _ int64) (encode.Row, error) {
+	// we ignore warnings when encoding rows now, but warnings uses the same memory as parser, since the input
+	// row []types.Datum share the same underlying buf, and when doing CastValue, we're using hack.String/hack.Slice.
+	// when generating error such as mysql.ErrDataOutOfRange, the data will be part of the error, causing the buf
+	// unable to release. So we truncate the warnings here.
+	defer kvcodec.SessionCtx.Vars.StmtCtx.TruncateWarnings(0)
 	var value types.Datum
 	var err error
 

--- a/br/pkg/lightning/backend/kv/sql2kv.go
+++ b/br/pkg/lightning/backend/kv/sql2kv.go
@@ -185,7 +185,7 @@ func (kvcodec *tableKVEncoder) Encode(row []types.Datum,
 	// row []types.Datum share the same underlying buf, and when doing CastValue, we're using hack.String/hack.Slice.
 	// when generating error such as mysql.ErrDataOutOfRange, the data will be part of the error, causing the buf
 	// unable to release. So we truncate the warnings here.
-	defer kvcodec.SessionCtx.Vars.StmtCtx.TruncateWarnings(0)
+	defer kvcodec.TruncateWarns()
 	var value types.Datum
 	var err error
 

--- a/executor/importer/kv_encode.go
+++ b/executor/importer/kv_encode.go
@@ -79,6 +79,11 @@ func newTableKVEncoder(
 
 // Encode implements the kvEncoder interface.
 func (en *tableKVEncoder) Encode(row []types.Datum, rowID int64) (*kv.Pairs, error) {
+	// we ignore warnings when encoding rows now, but warnings uses the same memory as parser, since the input
+	// row []types.Datum share the same underlying buf, and when doing CastValue, we're using hack.String/hack.Slice.
+	// when generating error such as mysql.ErrDataOutOfRange, the data will be part of the error, causing the buf
+	// unable to release. So we truncate the warnings here.
+	defer en.TruncateWarns()
 	record, err := en.parserData2TableData(row, rowID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43728

Problem Summary:

### What is changed and how it works?

we ignore warnings when encoding rows now, but warnings uses the same memory as parser, since the input
`row []types.Datum` share the same underlying buf, and when doing CastValue, we're using `hack.String`/`hack.Slice`.
when generating error such as `mysql.ErrDataOutOfRange`, the data will be part of the error, causing the buf
unable to release. So we truncate the warnings.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - one csv file test, about 1g, each row is about 20k. add a sleep after encode this file, then get a memory profile

before
  
![SEFXbEcoDA](https://github.com/pingcap/tidb/assets/3312245/04d9f2a9-a996-4c91-a13f-ea5862dc6f7f)

after

![JHzPzcRMCC](https://github.com/pingcap/tidb/assets/3312245/ec3e49a6-0ea6-4b4f-8946-fa1d204c9d5a)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
