### PR TITLE
lightning: improve region actions for huge region number

### DIFF
--- a/br/pkg/lightning/BUILD.bazel
+++ b/br/pkg/lightning/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//br/pkg/lightning/tikv",
         "//br/pkg/lightning/web",
         "//br/pkg/redact",
+        "//br/pkg/restore/split",
         "//br/pkg/storage",
         "//br/pkg/utils",
         "//br/pkg/version/build",

--- a/br/pkg/lightning/backend/local/BUILD.bazel
+++ b/br/pkg/lightning/backend/local/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//br/pkg/checksum",
+        "//br/pkg/errors",
         "//br/pkg/lightning/backend",
         "//br/pkg/lightning/backend/encode",
         "//br/pkg/lightning/backend/kv",

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -394,9 +394,11 @@ type BackendConfig struct {
 	// compress type when write or ingest into tikv
 	ConnCompressType config.CompressionType
 	// concurrency of generateJobForRange and import(write & ingest) workers
-	WorkerConcurrency int
-	KVWriteBatchSize  int
-	CheckpointEnabled bool
+	WorkerConcurrency      int
+	KVWriteBatchSize       int
+	RegionSplitBatchSize   int
+	RegionSplitConcurrency int
+	CheckpointEnabled      bool
 	// memory table size of pebble. since pebble can have multiple mem tables, the max memory used is
 	// MemTableSize * MemTableStopWritesThreshold, see pebble.Options for more details.
 	MemTableSize            int
@@ -427,6 +429,8 @@ func NewBackendConfig(cfg *config.Config, maxOpenFiles int, keyspaceName string)
 		ConnCompressType:        cfg.TikvImporter.CompressKVPairs,
 		WorkerConcurrency:       cfg.TikvImporter.RangeConcurrency * 2,
 		KVWriteBatchSize:        cfg.TikvImporter.SendKVPairs,
+		RegionSplitBatchSize:    cfg.TikvImporter.RegionSplitBatchSize,
+		RegionSplitConcurrency:  cfg.TikvImporter.RegionSplitConcurrency,
 		CheckpointEnabled:       cfg.Checkpoint.Enable,
 		MemTableSize:            int(cfg.TikvImporter.EngineMemCacheSize),
 		LocalWriterMemCacheSize: int64(cfg.TikvImporter.LocalWriterMemCacheSize),
@@ -1073,6 +1077,7 @@ func (local *Backend) prepareAndSendJob(
 	failpoint.Inject("failToSplit", func(_ failpoint.Value) {
 		needSplit = true
 	})
+	logger := log.FromContext(ctx).With(zap.Stringer("uuid", engine.UUID)).Begin(zap.InfoLevel, "split and scatter ranges")
 	for i := 0; i < maxRetryTimes; i++ {
 		failpoint.Inject("skipSplitAndScatter", func() {
 			failpoint.Break()
@@ -1086,8 +1091,8 @@ func (local *Backend) prepareAndSendJob(
 		log.FromContext(ctx).Warn("split and scatter failed in retry", zap.Stringer("uuid", engine.UUID),
 			log.ShortError(err), zap.Int("retry", i))
 	}
+	logger.End(zap.ErrorLevel, err)
 	if err != nil {
-		log.FromContext(ctx).Error("split & scatter ranges failed", zap.Stringer("uuid", engine.UUID), log.ShortError(err))
 		return err
 	}
 

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -455,7 +455,7 @@ func (local *Backend) BatchSplitRegions(
 		return failedErr
 	}, backoffer)
 
-	// TODO: should we return the error from WithRetry?
+	// TODO: there's still change that we may skip scatter if the retry is timeout.
 	return region, newRegions, ctx.Err()
 }
 

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -430,7 +430,6 @@ func (local *Backend) BatchSplitRegions(
 				retryRegions = append(retryRegions, region)
 				continue
 			}
-			// TODO: we must call ScatterRegion!!!
 			if err = local.splitCli.ScatterRegion(ctx, region); err != nil {
 				failedErr = err
 				retryRegions = append(retryRegions, region)
@@ -449,7 +448,7 @@ func (local *Backend) BatchSplitRegions(
 		log.FromContext(ctx).Warn("scatter region failed", zap.Int("regionCount", len(newRegions)),
 			zap.Int("failedCount", len(retryRegions)), zap.Error(failedErr))
 		scatterRegions = retryRegions
-		// although it;s not PDBatchScanRegion, WaitRegionOnlineBackoffer will only
+		// although it's not PDBatchScanRegion, WaitRegionOnlineBackoffer will only
 		// check this error class so we simply reuse it. Will refine WaitRegionOnlineBackoffer
 		// later
 		failedErr = errors.Annotatef(berrors.ErrPDBatchScanRegion, "scatter region failed")
@@ -469,13 +468,16 @@ func (local *Backend) hasRegion(ctx context.Context, regionID uint64) (bool, err
 }
 
 func (local *Backend) waitForScatterRegions(ctx context.Context, regions []*split.RegionInfo) (scatterCount int, _ error) {
-	subCtx, cancel := context.WithTimeout(ctx, split.ScatterWaitUpperInterval)
-	defer cancel()
-
-	for len(regions) > 0 {
+	var (
+		retErr    error
+		backoffer = split.NewWaitRegionOnlineBackoffer().(*split.WaitRegionOnlineBackoffer)
+	)
+	// WithRetry will return multierr which is hard to use, so we use `retErr`
+	// to save the error needed to return.
+	_ = utils.WithRetry(ctx, func() error {
 		var retryRegions []*split.RegionInfo
 		for _, region := range regions {
-			scattered, err := local.checkRegionScatteredOrReScatter(subCtx, region)
+			scattered, err := local.checkRegionScatteredOrReScatter(ctx, region)
 			if scattered {
 				scatterCount++
 				continue
@@ -483,24 +485,31 @@ func (local *Backend) waitForScatterRegions(ctx context.Context, regions []*spli
 			if err != nil {
 				if !common.IsRetryableError(err) {
 					log.FromContext(ctx).Warn("wait for scatter region encountered non-retryable error", logutil.Region(region.Region), zap.Error(err))
-					return scatterCount, err
+					retErr = err
+					// return nil to stop retry, the error is saved in `retErr`
+					return nil
 				}
 				log.FromContext(ctx).Warn("wait for scatter region encountered error, will retry again", logutil.Region(region.Region), zap.Error(err))
 			}
 			retryRegions = append(retryRegions, region)
 		}
-		regions = retryRegions
-		select {
-		case <-time.After(time.Second):
-		case <-subCtx.Done():
-			if len(regions) > 0 {
-				log.FromContext(ctx).Warn("wait for scatter region timeout, print the first region",
-					logutil.Region(regions[0].Region))
-			}
-			return
+		if len(retryRegions) == 0 {
+			regions = retryRegions
+			return nil
 		}
+		if len(retryRegions) < len(regions) {
+			backoffer.Stat.ReduceRetry()
+		}
+
+		regions = retryRegions
+		return errors.Annotatef(berrors.ErrPDBatchScanRegion, "wait for scatter region failed")
+	}, backoffer)
+
+	if len(regions) > 0 && retErr == nil {
+		retErr = errors.Errorf("wait for scatter region timeout, print the first unfinished region %v",
+			regions[0].Region.String())
 	}
-	return scatterCount, nil
+	return scatterCount, retErr
 }
 
 func (local *Backend) checkRegionScatteredOrReScatter(ctx context.Context, regionInfo *split.RegionInfo) (bool, error) {
@@ -510,6 +519,7 @@ func (local *Backend) checkRegionScatteredOrReScatter(ctx context.Context, regio
 	}
 	// Heartbeat may not be sent to PD
 	if respErr := resp.GetHeader().GetError(); respErr != nil {
+		// TODO: why this is OK?
 		if respErr.GetType() == pdpb.ErrorType_REGION_NOT_FOUND {
 			return true, nil
 		}

--- a/br/pkg/lightning/backend/local/localhelper_test.go
+++ b/br/pkg/lightning/backend/local/localhelper_test.go
@@ -945,3 +945,148 @@ func TestStoreWriteLimiter(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+type scatterRegionCli struct {
+	split.SplitClient
+
+	respM    map[uint64][]*pdpb.GetOperatorResponse
+	scatterM map[uint64]int
+}
+
+func newScatterRegionCli() *scatterRegionCli {
+	return &scatterRegionCli{
+		respM:    make(map[uint64][]*pdpb.GetOperatorResponse),
+		scatterM: make(map[uint64]int),
+	}
+}
+
+func (c *scatterRegionCli) ScatterRegion(_ context.Context, regionInfo *split.RegionInfo) error {
+	c.scatterM[regionInfo.Region.Id]++
+	return nil
+}
+
+func (c *scatterRegionCli) GetOperator(_ context.Context, regionID uint64) (*pdpb.GetOperatorResponse, error) {
+	ret := c.respM[regionID][0]
+	c.respM[regionID] = c.respM[regionID][1:]
+	return ret, nil
+}
+
+func TestWaitForScatterRegions(t *testing.T) {
+	ctx := context.Background()
+
+	regionCnt := 6
+	regions := make([]*split.RegionInfo, 0, regionCnt)
+	for i := 1; i <= regionCnt; i++ {
+		regions = append(regions, &split.RegionInfo{
+			Region: &metapb.Region{
+				Id: uint64(i),
+			},
+		})
+	}
+	checkRespDrained := func(cli *scatterRegionCli) {
+		for i := 1; i <= regionCnt; i++ {
+			require.Len(t, cli.respM[uint64(i)], 0)
+		}
+	}
+	checkNoRetry := func(cli *scatterRegionCli) {
+		for i := 1; i <= regionCnt; i++ {
+			require.Equal(t, 0, cli.scatterM[uint64(i)])
+		}
+	}
+
+	cli := newScatterRegionCli()
+	cli.respM[1] = []*pdpb.GetOperatorResponse{
+		{Header: &pdpb.ResponseHeader{Error: &pdpb.Error{Type: pdpb.ErrorType_REGION_NOT_FOUND}}},
+	}
+	cli.respM[2] = []*pdpb.GetOperatorResponse{
+		{Desc: []byte("not-scatter-region")},
+	}
+	cli.respM[3] = []*pdpb.GetOperatorResponse{
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_SUCCESS},
+	}
+	cli.respM[4] = []*pdpb.GetOperatorResponse{
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_RUNNING},
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_RUNNING},
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_SUCCESS},
+	}
+	cli.respM[5] = []*pdpb.GetOperatorResponse{
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_CANCEL},
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_CANCEL},
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_CANCEL},
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_RUNNING},
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_RUNNING},
+		{Desc: []byte("not-scatter-region")},
+	}
+	// should trigger a retry
+	cli.respM[6] = []*pdpb.GetOperatorResponse{
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_REPLACE},
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_SUCCESS},
+	}
+
+	local := &Backend{splitCli: cli}
+	cnt, err := local.waitForScatterRegions(ctx, regions)
+	require.NoError(t, err)
+	require.Equal(t, 6, cnt)
+	for i := 1; i <= 4; i++ {
+		require.Equal(t, 0, cli.scatterM[uint64(i)])
+	}
+	require.Equal(t, 3, cli.scatterM[uint64(5)])
+	require.Equal(t, 1, cli.scatterM[uint64(6)])
+	checkRespDrained(cli)
+
+	// test non-retryable error
+
+	cli = newScatterRegionCli()
+	cli.respM[1] = []*pdpb.GetOperatorResponse{
+		{Header: &pdpb.ResponseHeader{Error: &pdpb.Error{Type: pdpb.ErrorType_REGION_NOT_FOUND}}},
+	}
+	cli.respM[2] = []*pdpb.GetOperatorResponse{
+		{Desc: []byte("not-scatter-region")},
+	}
+	// mimic non-retryable error
+	cli.respM[3] = []*pdpb.GetOperatorResponse{
+		{Header: &pdpb.ResponseHeader{Error: &pdpb.Error{Type: pdpb.ErrorType_DATA_COMPACTED}}},
+	}
+	local = &Backend{splitCli: cli}
+	cnt, err = local.waitForScatterRegions(ctx, regions)
+	require.ErrorContains(t, err, "failed to get region operator, error type: DATA_COMPACTED")
+	require.Equal(t, 2, cnt)
+	checkRespDrained(cli)
+	checkNoRetry(cli)
+
+	// test backoff is timed-out
+
+	backup := split.WaitRegionOnlineAttemptTimes
+	split.WaitRegionOnlineAttemptTimes = 2
+	t.Cleanup(func() {
+		split.WaitRegionOnlineAttemptTimes = backup
+	})
+
+	cli = newScatterRegionCli()
+	cli.respM[1] = []*pdpb.GetOperatorResponse{
+		{Header: &pdpb.ResponseHeader{Error: &pdpb.Error{Type: pdpb.ErrorType_REGION_NOT_FOUND}}},
+	}
+	cli.respM[2] = []*pdpb.GetOperatorResponse{
+		{Desc: []byte("not-scatter-region")},
+	}
+	cli.respM[3] = []*pdpb.GetOperatorResponse{
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_SUCCESS},
+	}
+	cli.respM[4] = []*pdpb.GetOperatorResponse{
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_RUNNING},
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_RUNNING}, // first retry
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_RUNNING}, // second retry
+	}
+	cli.respM[5] = []*pdpb.GetOperatorResponse{
+		{Desc: []byte("not-scatter-region")},
+	}
+	cli.respM[6] = []*pdpb.GetOperatorResponse{
+		{Desc: []byte("scatter-region"), Status: pdpb.OperatorStatus_SUCCESS},
+	}
+	local = &Backend{splitCli: cli}
+	cnt, err = local.waitForScatterRegions(ctx, regions)
+	require.ErrorContains(t, err, "wait for scatter region timeout, print the first unfinished region id:4")
+	require.Equal(t, 5, cnt)
+	checkRespDrained(cli)
+	checkNoRetry(cli)
+}

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -79,6 +79,8 @@ const (
 	defaultChecksumTableConcurrency   = 2
 	DefaultTableConcurrency           = 6
 	defaultIndexConcurrency           = 2
+	DefaultRegionCheckBackoffLimit    = 1800
+	DefaultRegionSplitBatchSize       = 4096
 
 	// defaultMetaSchemaName is the default database name used to store lightning metadata
 	defaultMetaSchemaName     = "lightning_metadata"
@@ -711,21 +713,24 @@ type FileRouteRule struct {
 // TikvImporter is the config for tikv-importer.
 type TikvImporter struct {
 	// Deprecated: only used to keep the compatibility.
-	Addr                string                       `toml:"addr" json:"addr"`
-	Backend             string                       `toml:"backend" json:"backend"`
-	OnDuplicate         string                       `toml:"on-duplicate" json:"on-duplicate"`
-	MaxKVPairs          int                          `toml:"max-kv-pairs" json:"max-kv-pairs"`
-	SendKVPairs         int                          `toml:"send-kv-pairs" json:"send-kv-pairs"`
-	CompressKVPairs     CompressionType              `toml:"compress-kv-pairs" json:"compress-kv-pairs"`
-	RegionSplitSize     ByteSize                     `toml:"region-split-size" json:"region-split-size"`
-	RegionSplitKeys     int                          `toml:"region-split-keys" json:"region-split-keys"`
-	SortedKVDir         string                       `toml:"sorted-kv-dir" json:"sorted-kv-dir"`
-	DiskQuota           ByteSize                     `toml:"disk-quota" json:"disk-quota"`
-	RangeConcurrency    int                          `toml:"range-concurrency" json:"range-concurrency"`
-	DuplicateResolution DuplicateResolutionAlgorithm `toml:"duplicate-resolution" json:"duplicate-resolution"`
-	IncrementalImport   bool                         `toml:"incremental-import" json:"incremental-import"`
-	KeyspaceName        string                       `toml:"keyspace-name" json:"keyspace-name"`
-	AddIndexBySQL       bool                         `toml:"add-index-by-sql" json:"add-index-by-sql"`
+	Addr                    string                       `toml:"addr" json:"addr"`
+	Backend                 string                       `toml:"backend" json:"backend"`
+	OnDuplicate             string                       `toml:"on-duplicate" json:"on-duplicate"`
+	MaxKVPairs              int                          `toml:"max-kv-pairs" json:"max-kv-pairs"`
+	SendKVPairs             int                          `toml:"send-kv-pairs" json:"send-kv-pairs"`
+	CompressKVPairs         CompressionType              `toml:"compress-kv-pairs" json:"compress-kv-pairs"`
+	RegionSplitSize         ByteSize                     `toml:"region-split-size" json:"region-split-size"`
+	RegionSplitKeys         int                          `toml:"region-split-keys" json:"region-split-keys"`
+	RegionSplitBatchSize    int                          `toml:"region-split-batch-size" json:"region-split-batch-size"`
+	RegionSplitConcurrency  int                          `toml:"region-split-concurrency" json:"region-split-concurrency"`
+	RegionCheckBackoffLimit int                          `toml:"region-check-backoff-limit" json:"region-check-backoff-limit"`
+	SortedKVDir             string                       `toml:"sorted-kv-dir" json:"sorted-kv-dir"`
+	DiskQuota               ByteSize                     `toml:"disk-quota" json:"disk-quota"`
+	RangeConcurrency        int                          `toml:"range-concurrency" json:"range-concurrency"`
+	DuplicateResolution     DuplicateResolutionAlgorithm `toml:"duplicate-resolution" json:"duplicate-resolution"`
+	IncrementalImport       bool                         `toml:"incremental-import" json:"incremental-import"`
+	KeyspaceName            string                       `toml:"keyspace-name" json:"keyspace-name"`
+	AddIndexBySQL           bool                         `toml:"add-index-by-sql" json:"add-index-by-sql"`
 
 	EngineMemCacheSize      ByteSize `toml:"engine-mem-cache-size" json:"engine-mem-cache-size"`
 	LocalWriterMemCacheSize ByteSize `toml:"local-writer-mem-cache-size" json:"local-writer-mem-cache-size"`
@@ -915,13 +920,16 @@ func NewConfig() *Config {
 			DataInvalidCharReplace: string(defaultCSVDataInvalidCharReplace),
 		},
 		TikvImporter: TikvImporter{
-			Backend:             "",
-			OnDuplicate:         ReplaceOnDup,
-			MaxKVPairs:          4096,
-			SendKVPairs:         KVWriteBatchSize,
-			RegionSplitSize:     0,
-			DiskQuota:           ByteSize(math.MaxInt64),
-			DuplicateResolution: DupeResAlgNone,
+			Backend:                 "",
+			OnDuplicate:             ReplaceOnDup,
+			MaxKVPairs:              4096,
+			SendKVPairs:             KVWriteBatchSize,
+			RegionSplitSize:         0,
+			RegionSplitBatchSize:    DefaultRegionSplitBatchSize,
+			RegionSplitConcurrency:  runtime.GOMAXPROCS(0),
+			RegionCheckBackoffLimit: DefaultRegionCheckBackoffLimit,
+			DiskQuota:               ByteSize(math.MaxInt64),
+			DuplicateResolution:     DupeResAlgNone,
 		},
 		PostRestore: PostRestore{
 			Checksum:          OpLevelRequired,
@@ -1145,6 +1153,12 @@ func (cfg *Config) AdjustCommon() (bool, error) {
 		cfg.PostRestore.Analyze = OpLevelOff
 		cfg.PostRestore.Compact = false
 	case BackendLocal:
+		if cfg.TikvImporter.RegionSplitBatchSize <= 0 {
+			return mustHaveInternalConnections, common.ErrInvalidConfig.GenWithStack("`tikv-importer.region-split-batch-size` got %d, should be larger than 0", cfg.TikvImporter.RegionSplitBatchSize)
+		}
+		if cfg.TikvImporter.RegionSplitConcurrency <= 0 {
+			return mustHaveInternalConnections, common.ErrInvalidConfig.GenWithStack("`tikv-importer.region-split-concurrency` got %d, should be larger than 0", cfg.TikvImporter.RegionSplitConcurrency)
+		}
 		// RegionConcurrency > NumCPU is meaningless.
 		cpuCount := runtime.NumCPU()
 		if cfg.App.RegionConcurrency > cpuCount {

--- a/br/pkg/lightning/config/config_test.go
+++ b/br/pkg/lightning/config/config_test.go
@@ -806,6 +806,7 @@ func TestDefaultImporterBackendValue(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, cfg.App.IndexConcurrency)
 	require.Equal(t, 6, cfg.App.TableConcurrency)
+	require.Equal(t, 4096, cfg.TikvImporter.RegionSplitBatchSize)
 }
 
 func TestDefaultTidbBackendValue(t *testing.T) {
@@ -820,16 +821,28 @@ func TestDefaultTidbBackendValue(t *testing.T) {
 }
 
 func TestDefaultCouldBeOverwritten(t *testing.T) {
+	ctx := context.Background()
 	cfg := config.NewConfig()
 	assignMinimalLegalValue(cfg)
 	cfg.TikvImporter.Backend = "local"
 	cfg.App.IndexConcurrency = 20
 	cfg.App.TableConcurrency = 60
 	cfg.TiDB.DistSQLScanConcurrency = 1
-	err := cfg.Adjust(context.Background())
+	err := cfg.Adjust(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 20, cfg.App.IndexConcurrency)
 	require.Equal(t, 60, cfg.App.TableConcurrency)
+
+	cfg.TikvImporter.RegionSplitConcurrency = 1
+	// backoff can be 0
+	cfg.TikvImporter.RegionCheckBackoffLimit = 0
+	err = cfg.Adjust(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, cfg.TikvImporter.RegionSplitConcurrency)
+	require.Equal(t, 0, cfg.TikvImporter.RegionCheckBackoffLimit)
+	cfg.TikvImporter.RegionSplitBatchSize = 0
+	err = cfg.Adjust(ctx)
+	require.ErrorContains(t, err, "`tikv-importer.region-split-batch-size` got 0, should be larger than 0")
 }
 
 func TestLoadFromInvalidConfig(t *testing.T) {

--- a/br/pkg/lightning/lightning.go
+++ b/br/pkg/lightning/lightning.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/lightning/tikv"
 	"github.com/pingcap/tidb/br/pkg/lightning/web"
 	"github.com/pingcap/tidb/br/pkg/redact"
+	"github.com/pingcap/tidb/br/pkg/restore/split"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/br/pkg/version/build"
@@ -425,6 +426,12 @@ func (l *Lightning) run(taskCtx context.Context, taskCfg *config.Config, o *opti
 	o.logger.Info("cfg", zap.Stringer("cfg", taskCfg))
 
 	utils.LogEnvVariables()
+
+	if split.WaitRegionOnlineAttemptTimes != taskCfg.TikvImporter.RegionCheckBackoffLimit {
+		// it will cause data race if lightning is used as a library, but this is a
+		// hidden config so we ignore that case
+		split.WaitRegionOnlineAttemptTimes = taskCfg.TikvImporter.RegionCheckBackoffLimit
+	}
 
 	metrics := metric.NewMetrics(o.promFactory)
 	metrics.RegisterTo(o.promRegistry)

--- a/br/pkg/restore/split/split.go
+++ b/br/pkg/restore/split/split.go
@@ -12,13 +12,15 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
+	"github.com/pingcap/tidb/br/pkg/lightning/config"
 	"github.com/pingcap/tidb/br/pkg/logutil"
 	"github.com/pingcap/tidb/br/pkg/redact"
 	"github.com/pingcap/tidb/br/pkg/utils"
+	"go.uber.org/zap"
 )
 
 var (
-	ScanRegionAttemptTimes = 150
+	WaitRegionOnlineAttemptTimes = config.DefaultRegionCheckBackoffLimit
 )
 
 // Constants for split retry machinery.
@@ -52,21 +54,27 @@ func CheckRegionConsistency(startKey, endKey []byte, regions []*RegionInfo) erro
 
 	if bytes.Compare(regions[0].Region.StartKey, startKey) > 0 {
 		return errors.Annotatef(berrors.ErrPDBatchScanRegion,
-			"first region's startKey > startKey, startKey: %s, regionStartKey: %s",
-			redact.Key(startKey), redact.Key(regions[0].Region.StartKey))
+			"first region %d's startKey(%s) > startKey(%s), region epoch: %s",
+			regions[0].Region.Id,
+			redact.Key(regions[0].Region.StartKey), redact.Key(startKey),
+			regions[0].Region.RegionEpoch.String())
 	} else if len(regions[len(regions)-1].Region.EndKey) != 0 &&
 		bytes.Compare(regions[len(regions)-1].Region.EndKey, endKey) < 0 {
 		return errors.Annotatef(berrors.ErrPDBatchScanRegion,
-			"last region's endKey < endKey, endKey: %s, regionEndKey: %s",
-			redact.Key(endKey), redact.Key(regions[len(regions)-1].Region.EndKey))
+			"last region %d's endKey(%s) < endKey(%s), region epoch: %s",
+			regions[len(regions)-1].Region.Id,
+			redact.Key(regions[len(regions)-1].Region.EndKey), redact.Key(endKey),
+			regions[len(regions)-1].Region.RegionEpoch.String())
 	}
 
 	cur := regions[0]
 	for _, r := range regions[1:] {
 		if !bytes.Equal(cur.Region.EndKey, r.Region.StartKey) {
 			return errors.Annotatef(berrors.ErrPDBatchScanRegion,
-				"region endKey not equal to next region startKey, endKey: %s, startKey: %s",
-				redact.Key(cur.Region.EndKey), redact.Key(r.Region.StartKey))
+				"region %d's endKey not equal to next region %d's startKey, endKey: %s, startKey: %s, region epoch: %s %s",
+				cur.Region.Id, r.Region.Id,
+				redact.Key(cur.Region.EndKey), redact.Key(r.Region.StartKey),
+				cur.Region.RegionEpoch.String(), r.Region.RegionEpoch.String())
 		}
 		cur = r
 	}
@@ -85,15 +93,13 @@ func PaginateScanRegion(
 			hex.EncodeToString(startKey), hex.EncodeToString(endKey))
 	}
 
-	var regions []*RegionInfo
-	var err error
-	// we don't need to return multierr. since there only 3 times retry.
-	// in most case 3 times retry have the same error. so we just return the last error.
-	// actually we'd better remove all multierr in br/lightning.
-	// because it's not easy to check multierr equals normal error.
-	// see https://github.com/pingcap/tidb/issues/33419.
+	var (
+		lastRegions []*RegionInfo
+		err         error
+		backoffer   = NewWaitRegionOnlineBackoffer().(*WaitRegionOnlineBackoffer)
+	)
 	_ = utils.WithRetry(ctx, func() error {
-		regions = []*RegionInfo{}
+		regions := make([]*RegionInfo, 0, 16)
 		scanStartKey := startKey
 		for {
 			var batch []*RegionInfo
@@ -115,14 +121,23 @@ func PaginateScanRegion(
 				break
 			}
 		}
+		// if the number of regions changed, we can infer TiKV side really
+		// made some progress so don't increase the retry times.
+		if len(regions) != len(lastRegions) {
+			backoffer.Stat.ReduceRetry()
+		}
+		lastRegions = regions
+
 		if err = CheckRegionConsistency(startKey, endKey, regions); err != nil {
-			log.Warn("failed to scan region, retrying", logutil.ShortError(err))
+			log.Warn("failed to scan region, retrying",
+				logutil.ShortError(err),
+				zap.Int("regionLength", len(regions)))
 			return err
 		}
 		return nil
-	}, NewScanRegionBackoffer())
+	}, backoffer)
 
-	return regions, err
+	return lastRegions, err
 }
 
 // CheckPartRegionConsistency only checks the continuity of regions and the first region consistency.
@@ -182,20 +197,20 @@ func ScanRegionsWithRetry(
 		}
 
 		return nil
-	}, NewScanRegionBackoffer())
+	}, NewWaitRegionOnlineBackoffer())
 
 	return regions, err
 }
 
-type scanRegionBackoffer struct {
-	stat utils.RetryState
+type WaitRegionOnlineBackoffer struct {
+	Stat utils.RetryState
 }
 
-// NewScanRegionBackoffer create a backoff to retry to scan regions.
-func NewScanRegionBackoffer() utils.Backoffer {
-	return &scanRegionBackoffer{
-		stat: utils.InitialRetryState(
-			ScanRegionAttemptTimes,
+// NewWaitRegionOnlineBackoffer create a backoff to wait region online.
+func NewWaitRegionOnlineBackoffer() utils.Backoffer {
+	return &WaitRegionOnlineBackoffer{
+		Stat: utils.InitialRetryState(
+			WaitRegionOnlineAttemptTimes,
 			time.Millisecond*10,
 			time.Second*2,
 		),
@@ -203,11 +218,11 @@ func NewScanRegionBackoffer() utils.Backoffer {
 }
 
 // NextBackoff returns a duration to wait before retrying again
-func (b *scanRegionBackoffer) NextBackoff(err error) time.Duration {
+func (b *WaitRegionOnlineBackoffer) NextBackoff(err error) time.Duration {
 	if berrors.ErrPDBatchScanRegion.Equal(err) {
 		// it needs more time to wait splitting the regions that contains data in PITR.
 		// 2s * 150
-		delayTime := b.stat.ExponentialBackoff()
+		delayTime := b.Stat.ExponentialBackoff()
 		failpoint.Inject("hint-scan-region-backoff", func(val failpoint.Value) {
 			if val.(bool) {
 				delayTime = time.Microsecond
@@ -215,11 +230,11 @@ func (b *scanRegionBackoffer) NextBackoff(err error) time.Duration {
 		})
 		return delayTime
 	}
-	b.stat.StopRetry()
+	b.Stat.StopRetry()
 	return 0
 }
 
 // Attempt returns the remain attempt times
-func (b *scanRegionBackoffer) Attempt() int {
-	return b.stat.Attempt()
+func (b *WaitRegionOnlineBackoffer) Attempt() int {
+	return b.Stat.Attempt()
 }

--- a/br/pkg/restore/split/split_test.go
+++ b/br/pkg/restore/split/split_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestScanRegionBackOfferWithSuccess(t *testing.T) {
 	var counter int
-	bo := split.NewScanRegionBackoffer()
+	bo := split.NewWaitRegionOnlineBackoffer()
 
 	err := utils.WithRetry(context.Background(), func() error {
 		defer func() {
@@ -37,7 +37,7 @@ func TestScanRegionBackOfferWithFail(t *testing.T) {
 	}()
 
 	var counter int
-	bo := split.NewScanRegionBackoffer()
+	bo := split.NewWaitRegionOnlineBackoffer()
 
 	err := utils.WithRetry(context.Background(), func() error {
 		defer func() {
@@ -46,7 +46,7 @@ func TestScanRegionBackOfferWithFail(t *testing.T) {
 		return berrors.ErrPDBatchScanRegion
 	}, bo)
 	require.Error(t, err)
-	require.Equal(t, counter, split.ScanRegionAttemptTimes)
+	require.Equal(t, counter, split.WaitRegionOnlineAttemptTimes)
 }
 
 func TestScanRegionBackOfferWithStopRetry(t *testing.T) {
@@ -56,7 +56,7 @@ func TestScanRegionBackOfferWithStopRetry(t *testing.T) {
 	}()
 
 	var counter int
-	bo := split.NewScanRegionBackoffer()
+	bo := split.NewWaitRegionOnlineBackoffer()
 
 	err := utils.WithRetry(context.Background(), func() error {
 		defer func() {

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -556,10 +556,11 @@ func TestRegionConsistency(t *testing.T) {
 		{
 			codec.EncodeBytes([]byte{}, []byte("a")),
 			codec.EncodeBytes([]byte{}, []byte("a")),
-			"first region's startKey > startKey, startKey: (.*?), regionStartKey: (.*?)",
+			"first region 1's startKey(.*?) > startKey(.*?)",
 			[]*split.RegionInfo{
 				{
 					Region: &metapb.Region{
+						Id:       1,
 						StartKey: codec.EncodeBytes([]byte{}, []byte("b")),
 						EndKey:   codec.EncodeBytes([]byte{}, []byte("d")),
 					},
@@ -569,10 +570,11 @@ func TestRegionConsistency(t *testing.T) {
 		{
 			codec.EncodeBytes([]byte{}, []byte("b")),
 			codec.EncodeBytes([]byte{}, []byte("e")),
-			"last region's endKey < endKey, endKey: (.*?), regionEndKey: (.*?)",
+			"last region 100's endKey(.*?) < endKey(.*?)",
 			[]*split.RegionInfo{
 				{
 					Region: &metapb.Region{
+						Id:       100,
 						StartKey: codec.EncodeBytes([]byte{}, []byte("b")),
 						EndKey:   codec.EncodeBytes([]byte{}, []byte("d")),
 					},
@@ -582,16 +584,19 @@ func TestRegionConsistency(t *testing.T) {
 		{
 			codec.EncodeBytes([]byte{}, []byte("c")),
 			codec.EncodeBytes([]byte{}, []byte("e")),
-			"region endKey not equal to next region startKey(.*?)",
+			"region 6's endKey not equal to next region 8's startKey(.*?)",
 			[]*split.RegionInfo{
 				{
 					Region: &metapb.Region{
-						StartKey: codec.EncodeBytes([]byte{}, []byte("b")),
-						EndKey:   codec.EncodeBytes([]byte{}, []byte("d")),
+						Id:          6,
+						StartKey:    codec.EncodeBytes([]byte{}, []byte("b")),
+						EndKey:      codec.EncodeBytes([]byte{}, []byte("d")),
+						RegionEpoch: nil,
 					},
 				},
 				{
 					Region: &metapb.Region{
+						Id:       8,
 						StartKey: codec.EncodeBytes([]byte{}, []byte("e")),
 						EndKey:   codec.EncodeBytes([]byte{}, []byte("f")),
 					},

--- a/br/pkg/restore/util_test.go
+++ b/br/pkg/restore/util_test.go
@@ -16,6 +16,7 @@ import (
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/restore"
 	"github.com/pingcap/tidb/br/pkg/restore/split"
+	"github.com/pingcap/tidb/store/pdtypes"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/stretchr/testify/require"
@@ -232,10 +233,10 @@ func TestPaginateScanRegion(t *testing.T) {
 	regionMap := make(map[uint64]*split.RegionInfo)
 	var regions []*split.RegionInfo
 	var batch []*split.RegionInfo
-	backup := split.ScanRegionAttemptTimes
-	split.ScanRegionAttemptTimes = 3
+	backup := split.WaitRegionOnlineAttemptTimes
+	split.WaitRegionOnlineAttemptTimes = 3
 	defer func() {
-		split.ScanRegionAttemptTimes = backup
+		split.WaitRegionOnlineAttemptTimes = backup
 	}()
 	_, err := split.PaginateScanRegion(ctx, NewTestClient(stores, regionMap, 0), []byte{}, []byte{}, 3)
 	require.Error(t, err)
@@ -294,11 +295,49 @@ func TestPaginateScanRegion(t *testing.T) {
 	require.True(t, berrors.ErrPDBatchScanRegion.Equal(err))
 
 	// make the regionMap losing some region, this will cause scan region check fails
+	// region ID is key+1, so region 4 is deleted
+	missingRegion := regions[3]
 	delete(regionMap, uint64(3))
+	missingRegion2 := regions[4]
+	delete(regionMap, uint64(4))
 	_, err = split.PaginateScanRegion(ctx, NewTestClient(stores, regionMap, 0), regions[1].Region.EndKey, regions[5].Region.EndKey, 3)
 	require.Error(t, err)
 	require.True(t, berrors.ErrPDBatchScanRegion.Equal(err))
-	require.Regexp(t, ".*region endKey not equal to next region startKey.*", err.Error())
+	require.Regexp(t, ".*region 3's endKey not equal to next region 6's startKey.*", err.Error())
+
+	// test should not increase retry counter when region becomes more
+	tc = NewTestClient(stores, regionMap, 0)
+	mockClient := &regionOnlineSlowClient{
+		TestClient:     tc,
+		missingRegion:  missingRegion,
+		missingRegion2: missingRegion2,
+	}
+	_, err = split.PaginateScanRegion(ctx, mockClient, regions[1].Region.EndKey, regions[5].Region.EndKey, 3)
+	require.NoError(t, err)
+}
+
+type regionOnlineSlowClient struct {
+	*TestClient
+	scanRegionCnt  int
+	missingRegion  *split.RegionInfo
+	missingRegion2 *split.RegionInfo
+}
+
+func (c *regionOnlineSlowClient) ScanRegions(ctx context.Context, key, endKey []byte, limit int) ([]*split.RegionInfo, error) {
+	c.scanRegionCnt++
+	var toAddRegion *split.RegionInfo
+	switch c.scanRegionCnt {
+	case 2:
+		toAddRegion = c.missingRegion
+	case 4:
+		toAddRegion = c.missingRegion2
+	}
+	if toAddRegion != nil {
+		mapKey := toAddRegion.Region.Id - 1
+		c.TestClient.regions[mapKey] = toAddRegion
+		c.TestClient.regionsInfo.SetRegion(pdtypes.NewRegionInfo(toAddRegion.Region, toAddRegion.Leader))
+	}
+	return c.TestClient.ScanRegions(ctx, key, endKey, limit)
 }
 
 func TestRewriteFileKeys(t *testing.T) {

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -86,6 +86,11 @@ func (rs *RetryState) RecordRetry() {
 	rs.retryTimes++
 }
 
+// ReduceRetry reduces retry times for 1.
+func (rs *RetryState) ReduceRetry() {
+	rs.retryTimes--
+}
+
 // RetryTimes returns the retry times.
 // usage: unit test.
 func (rs *RetryState) RetryTimes() int {

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -110,12 +111,14 @@ func NewTableImporter(param *JobImportParam, e *LoadDataController) (ti *TableIm
 	}
 
 	backendConfig := local.BackendConfig{
-		PDAddr:            tidbCfg.Path,
-		LocalStoreDir:     dir,
-		MaxConnPerStore:   config.DefaultRangeConcurrency,
-		ConnCompressType:  config.CompressionNone,
-		WorkerConcurrency: config.DefaultRangeConcurrency * 2,
-		KVWriteBatchSize:  config.KVWriteBatchSize,
+		PDAddr:                 tidbCfg.Path,
+		LocalStoreDir:          dir,
+		MaxConnPerStore:        config.DefaultRangeConcurrency,
+		ConnCompressType:       config.CompressionNone,
+		WorkerConcurrency:      config.DefaultRangeConcurrency * 2,
+		KVWriteBatchSize:       config.KVWriteBatchSize,
+		RegionSplitBatchSize:   config.DefaultRegionSplitBatchSize,
+		RegionSplitConcurrency: runtime.GOMAXPROCS(0),
 		// todo: local backend report error when the sort-dir already exists & checkpoint disabled.
 		// set to false when we fix it.
 		CheckpointEnabled:       true,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43510

Problem Summary:

### What is changed and how it works?

- This PR introduce two config, `tikv-importer.region-split-batch-size` and `tikv-importer.region-split-concurrency`.
   - `tikv-importer.region-split-batch-size` controls the maximum region number in one round of region split+scatter. The default value is 4096
   - `tikv-importer.region-split-concurrency` controls the number of workers that handle the region split/scatter job., The default value is number of CPU cores.
- This PR intrudoce a hidden config `region-check-backoff-limit`. The default value is 1800 and its max backoff interval is 2s, so lightning will wait about 3600s.
- This PR changed some retry strategy. When some of retry jobs made progress, we won't increase the retry counter so won't exit retry due to reach retry counter limit.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
