### PR TITLE
br: a new checkpoint file format with smaller space used

### DIFF
--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -318,9 +318,9 @@ func (bc *Client) StartCheckpointRunner(
 	return errors.Trace(err)
 }
 
-func (bc *Client) WaitForFinishCheckpoint(ctx context.Context) {
+func (bc *Client) WaitForFinishCheckpoint(ctx context.Context, flush bool) {
 	if bc.checkpointRunner != nil {
-		bc.checkpointRunner.WaitForFinish(ctx)
+		bc.checkpointRunner.WaitForFinish(ctx, flush)
 	}
 }
 

--- a/br/pkg/checkpoint/backup.go
+++ b/br/pkg/checkpoint/backup.go
@@ -16,6 +16,7 @@ package checkpoint
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -44,6 +45,10 @@ func flushPositionForBackup() flushPosition {
 	}
 }
 
+func valueMarshalerForBackup(group *RangeGroup[BackupKeyType, BackupValueType]) ([]byte, error) {
+	return json.Marshal(group)
+}
+
 // only for test
 func StartCheckpointBackupRunnerForTest(
 	ctx context.Context,
@@ -52,7 +57,8 @@ func StartCheckpointBackupRunnerForTest(
 	tick time.Duration,
 	timer GlobalTimer,
 ) (*CheckpointRunner[BackupKeyType, BackupValueType], error) {
-	runner := newCheckpointRunner[BackupKeyType, BackupValueType](ctx, storage, cipher, timer, flushPositionForBackup())
+	runner := newCheckpointRunner[BackupKeyType, BackupValueType](
+		ctx, storage, cipher, timer, flushPositionForBackup(), valueMarshalerForBackup)
 
 	err := runner.initialLock(ctx)
 	if err != nil {
@@ -68,7 +74,8 @@ func StartCheckpointRunnerForBackup(
 	cipher *backuppb.CipherInfo,
 	timer GlobalTimer,
 ) (*CheckpointRunner[BackupKeyType, BackupValueType], error) {
-	runner := newCheckpointRunner[BackupKeyType, BackupValueType](ctx, storage, cipher, timer, flushPositionForBackup())
+	runner := newCheckpointRunner[BackupKeyType, BackupValueType](
+		ctx, storage, cipher, timer, flushPositionForBackup(), valueMarshalerForBackup)
 
 	err := runner.initialLock(ctx)
 	if err != nil {

--- a/br/pkg/checkpoint/checkpoint_test.go
+++ b/br/pkg/checkpoint/checkpoint_test.go
@@ -370,7 +370,6 @@ func TestCheckpointLogRestoreRunner(t *testing.T) {
 					return
 				}
 			}
-
 		}
 		require.FailNow(t, "not found in the original data")
 	}

--- a/br/pkg/checkpoint/log_restore.go
+++ b/br/pkg/checkpoint/log_restore.go
@@ -16,6 +16,7 @@ package checkpoint
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -41,6 +42,62 @@ func (l LogRestoreValueType) IdentKey() []byte {
 	return []byte(fmt.Sprint(l.Goff, '.', l.Foff, '.', l.TableID))
 }
 
+type LogRestoreValueMarshaled struct {
+	// group index in the metadata
+	Goff int
+	// downstream table id -> file indexes in the group
+	Foffs map[int64][]int
+}
+
+func (l LogRestoreValueMarshaled) IdentKey() []byte {
+	log.Fatal("unimplement!")
+	return nil
+}
+
+// valueMarshalerForLogRestore convert the checkpoint data‘s format to an smaller space-used format
+// input format :
+//
+//	"group-key":"...",
+//	"groups":[
+//	  ["TableId": 1, "Goff": 0, "Foff": 0],
+//	  ["TableId": 1, "Goff": 0, "Foff": 1],
+//	  ...
+//	],
+//
+// converted format :
+//
+//	"group-key":"...",
+//	"groups":[
+//	  ["Goff": 0, "Foffs":{"1", [0, 1]}],
+//	  ...
+//	],
+func valueMarshalerForLogRestore(group *RangeGroup[LogRestoreKeyType, LogRestoreValueType]) ([]byte, error) {
+	// goff -> table-id -> []foff
+	gMap := make(map[int]map[int64][]int)
+	for _, g := range group.Group {
+		fMap, exists := gMap[g.Goff]
+		if !exists {
+			fMap = make(map[int64][]int)
+			gMap[g.Goff] = fMap
+		}
+
+		fMap[g.TableID] = append(fMap[g.TableID], g.Foff)
+	}
+
+	logValues := make([]LogRestoreValueMarshaled, 0, len(gMap))
+	for goff, foffs := range gMap {
+		logValues = append(logValues, LogRestoreValueMarshaled{
+			Goff:  goff,
+			Foffs: foffs,
+		})
+	}
+
+	return json.Marshal(&RangeGroup[LogRestoreKeyType, LogRestoreValueMarshaled]{
+		GroupKey: group.GroupKey,
+		Group:    logValues,
+	})
+}
+
 // only for test
 func StartCheckpointLogRestoreRunnerForTest(
 	ctx context.Context,
@@ -50,7 +107,7 @@ func StartCheckpointLogRestoreRunnerForTest(
 	taskName string,
 ) (*CheckpointRunner[LogRestoreKeyType, LogRestoreValueType], error) {
 	runner := newCheckpointRunner[LogRestoreKeyType, LogRestoreValueType](
-		ctx, storage, cipher, nil, flushPositionForRestore(taskName))
+		ctx, storage, cipher, nil, flushPositionForRestore(taskName), valueMarshalerForLogRestore)
 
 	runner.startCheckpointMainLoop(ctx, tick, tick, 0)
 	return runner, nil
@@ -62,7 +119,7 @@ func StartCheckpointRunnerForLogRestore(ctx context.Context,
 	taskName string,
 ) (*CheckpointRunner[LogRestoreKeyType, LogRestoreValueType], error) {
 	runner := newCheckpointRunner[LogRestoreKeyType, LogRestoreValueType](
-		ctx, storage, cipher, nil, flushPositionForRestore(taskName))
+		ctx, storage, cipher, nil, flushPositionForRestore(taskName), valueMarshalerForLogRestore)
 
 	// for restore, no need to set lock
 	runner.startCheckpointMainLoop(ctx, defaultTickDurationForFlush, defaultTckDurationForChecksum, 0)

--- a/br/pkg/checkpoint/log_restore.go
+++ b/br/pkg/checkpoint/log_restore.go
@@ -44,9 +44,9 @@ func (l LogRestoreValueType) IdentKey() []byte {
 
 type LogRestoreValueMarshaled struct {
 	// group index in the metadata
-	Goff int
+	Goff int `json:"goff"`
 	// downstream table id -> file indexes in the group
-	Foffs map[int64][]int
+	Foffs map[int64][]int `json:"foffs"`
 }
 
 func (l LogRestoreValueMarshaled) IdentKey() []byte {

--- a/br/pkg/checkpoint/restore.go
+++ b/br/pkg/checkpoint/restore.go
@@ -16,6 +16,7 @@ package checkpoint
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -60,6 +61,10 @@ func flushPositionForRestore(taskName string) flushPosition {
 	}
 }
 
+func valueMarshalerForRestore(group *RangeGroup[RestoreKeyType, RestoreValueType]) ([]byte, error) {
+	return json.Marshal(group)
+}
+
 // only for test
 func StartCheckpointRestoreRunnerForTest(
 	ctx context.Context,
@@ -69,7 +74,7 @@ func StartCheckpointRestoreRunnerForTest(
 	taskName string,
 ) (*CheckpointRunner[RestoreKeyType, RestoreValueType], error) {
 	runner := newCheckpointRunner[RestoreKeyType, RestoreValueType](
-		ctx, storage, cipher, nil, flushPositionForRestore(taskName))
+		ctx, storage, cipher, nil, flushPositionForRestore(taskName), valueMarshalerForRestore)
 
 	runner.startCheckpointMainLoop(ctx, tick, tick, 0)
 	return runner, nil
@@ -82,7 +87,7 @@ func StartCheckpointRunnerForRestore(
 	taskName string,
 ) (*CheckpointRunner[RestoreKeyType, RestoreValueType], error) {
 	runner := newCheckpointRunner[RestoreKeyType, RestoreValueType](
-		ctx, storage, cipher, nil, flushPositionForRestore(taskName))
+		ctx, storage, cipher, nil, flushPositionForRestore(taskName), valueMarshalerForRestore)
 
 	// for restore, no need to set lock
 	runner.startCheckpointMainLoop(ctx, defaultTickDurationForFlush, defaultTckDurationForChecksum, 0)

--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -629,9 +629,10 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 		defer func() {
 			if !gcSafePointKeeperRemovable {
 				log.Info("wait for flush checkpoint...")
-				client.WaitForFinishCheckpoint(ctx)
+				client.WaitForFinishCheckpoint(ctx, true)
 			} else {
 				log.Info("start to remove checkpoint data for backup")
+				client.WaitForFinishCheckpoint(ctx, false)
 				if removeErr := checkpoint.RemoveCheckpointDataForBackup(ctx, client.GetStorage()); removeErr != nil {
 					log.Warn("failed to remove checkpoint data for backup", zap.Error(removeErr))
 				} else {

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -747,10 +747,8 @@ func runRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		defer func() {
 			// need to flush the whole checkpoint data so that br can quickly jump to
 			// the log kv restore step when the next retry.
-			if len(cfg.FullBackupStorage) > 0 || !schedulersRemovable {
-				log.Info("wait for flush checkpoint...")
-				client.WaitForFinishCheckpoint(ctx)
-			}
+			log.Info("wait for flush checkpoint...")
+			client.WaitForFinishCheckpoint(ctx, len(cfg.FullBackupStorage) > 0 || !schedulersRemovable)
 		}()
 	}
 

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1296,7 +1296,7 @@ func restoreStream(
 		}
 		defer func() {
 			log.Info("wait for flush checkpoint...")
-			checkpointRunner.WaitForFinish(ctx)
+			checkpointRunner.WaitForFinish(ctx, !gcDisabledRestorable)
 		}()
 	}
 

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1158,13 +1158,13 @@ func RunStreamRestore(
 			return errors.Trace(err)
 		}
 		cfg.Config.Storage = logStorage
-	} else {
+	} else if len(cfg.FullBackupStorage) > 0 {
 		skipMsg := []byte(fmt.Sprintf("%s command is skipped due to checkpoint mode for restore\n", FullRestoreCmd))
 		if _, err := glue.GetConsole(g).Out().Write(skipMsg); err != nil {
 			return errors.Trace(err)
 		}
 		if curTaskInfo != nil && curTaskInfo.TiFlashItems != nil {
-			log.Info("load tiflash records from checkpoint")
+			log.Info("load tiflash records of snapshot restore from checkpoint")
 			if err != nil {
 				return errors.Trace(err)
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43811 

Problem Summary:
The checkpoint log has much space used for log restore
### What is changed and how it works?
Use a new checkpoint file format with smaller space used
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
10.5 MB -> 2.6 MB
Before
```
[INFO] [checkpoint.go:836] ["start to remove checkpoint data"] ["checkpoint task"=/checkpoints/restore-7233306295998094311/441278585472024577.441280055261265922] [remove-count=6] [remove-size=11038833]
```
After
```
[INFO] [checkpoint.go:843] ["start to remove checkpoint data"] ["checkpoint task"=/checkpoints/restore-7233304143091542806/441278585472024577.441280055261265922] [remove-count=6] [remove-size=2753259]
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
