### PR TITLE
lightning: fix grep check in integration test

### DIFF
--- a/br/tests/_utils/check_contains
+++ b/br/tests/_utils/check_contains
@@ -16,10 +16,15 @@
 
 set -eu
 
-if ! grep -Fq "$1" "$TEST_DIR/sql_res.$TEST_NAME.txt"; then
+file_name="$TEST_DIR/sql_res.$TEST_NAME.txt"
+if [ $# -gt 1 ]; then
+	  file_name=$2
+fi
+
+if ! grep -Fq "$1" $file_name; then
     echo "TEST FAILED: OUTPUT DOES NOT CONTAIN '$1'"
     echo "____________________________________"
-    cat "$TEST_DIR/sql_res.$TEST_NAME.txt"
+    cat $file_name
     echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
     exit 1
 fi

--- a/br/tests/_utils/check_not_contains
+++ b/br/tests/_utils/check_not_contains
@@ -16,10 +16,15 @@
 
 set -eu
 
-if grep -Fq -- "$1" "$TEST_DIR/sql_res.$TEST_NAME.txt"; then
+file_name="$TEST_DIR/sql_res.$TEST_NAME.txt"
+if [ $# -gt 1 ]; then
+	  file_name=$2
+fi
+
+if grep -Fq -- "$1" $file_name; then
     echo "TEST FAILED: OUTPUT CONTAINS '$1'"
     echo "____________________________________"
-    cat "$TEST_DIR/sql_res.$TEST_NAME.txt"
+    cat $file_name
     echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
     exit 1
 fi

--- a/br/tests/lightning_csv/run.sh
+++ b/br/tests/lightning_csv/run.sh
@@ -45,19 +45,13 @@ function run_with() {
 
 rm -rf $TEST_DIR/lightning.log
 run_with "local" "tests/$TEST_NAME/config-pause-global.toml"
-grep -F 'pause pd scheduler of global scope' $TEST_DIR/lightning.log
-if grep -F 'pause pd scheduler of table scope' $TEST_DIR/lightning.log; then
-	echo "should not contain 'table scope'"
-	exit 1
-fi
+check_contains 'pause pd scheduler of global scope' $TEST_DIR/lightning.log
+check_not_contains 'pause pd scheduler of table scope' $TEST_DIR/lightning.log
 
 rm -rf $TEST_DIR/lightning.log
 run_with "local" "tests/$TEST_NAME/config.toml"
-grep -F 'pause pd scheduler of table scope' $TEST_DIR/lightning.log
-if grep -F 'pause pd scheduler of global scope' $TEST_DIR/lightning.log; then
-	echo "should not contain 'global scope'"
-	exit 1
-fi
+check_contains 'pause pd scheduler of table scope' $TEST_DIR/lightning.log
+check_not_contains 'pause pd scheduler of global scope' $TEST_DIR/lightning.log
 
 run_with "tidb" "tests/$TEST_NAME/config.toml"
 

--- a/br/tests/lightning_error_summary/run.sh
+++ b/br/tests/lightning_error_summary/run.sh
@@ -45,10 +45,10 @@ check_contains 'sum(k): 32'
 
 # Verify the log contains the expected messages at the last few lines
 tail -20 "$TEST_DIR/lightning-error-summary.log" > "$TEST_DIR/lightning-error-summary.tail"
-grep -Fq '["tables failed to be imported"] [count=2]' "$TEST_DIR/lightning-error-summary.tail"
-grep -Fq '[-] [table=`error_summary`.`a`] [status=checksum] [error="[Lighting:Restore:ErrChecksumMismatch]checksum mismatched' "$TEST_DIR/lightning-error-summary.tail"
-grep -Fq '[-] [table=`error_summary`.`c`] [status=checksum] [error="[Lighting:Restore:ErrChecksumMismatch]checksum mismatched' "$TEST_DIR/lightning-error-summary.tail"
-! grep -Fq '[-] [table=`error_summary`.`b`] [status=checksum] [error="[Lighting:Restore:ErrChecksumMismatch]checksum mismatched' "$TEST_DIR/lightning-error-summary.tail"
+check_contains '["tables failed to be imported"] [count=2]' "$TEST_DIR/lightning-error-summary.tail"
+check_contains '[-] [table=`error_summary`.`a`] [status=checksum] [error="[Lighting:Restore:ErrChecksumMismatch]checksum mismatched' "$TEST_DIR/lightning-error-summary.tail"
+check_contains '[-] [table=`error_summary`.`c`] [status=checksum] [error="[Lighting:Restore:ErrChecksumMismatch]checksum mismatched' "$TEST_DIR/lightning-error-summary.tail"
+check_not_contains '[-] [table=`error_summary`.`b`] [status=checksum] [error="[Lighting:Restore:ErrChecksumMismatch]checksum mismatched' "$TEST_DIR/lightning-error-summary.tail"
 
 # Now check the error log when the checkpoint is not cleaned.
 
@@ -61,10 +61,10 @@ set -e
 [ "$ERRORCODE" -ne 0 ]
 
 tail -100 "$TEST_DIR/lightning-error-summary.log" > "$TEST_DIR/lightning-error-summary.tail"
-grep -Fq 'TiDB Lightning has failed last time. To prevent data loss, this run will stop now' "$TEST_DIR/lightning-error-summary.tail"
-grep -Fq './tidb-lightning-ctl --checkpoint-error-destroy='"'"'`error_summary`.`a`'"'"' --config=...' "$TEST_DIR/lightning-error-summary.tail"
-grep -Fq './tidb-lightning-ctl --checkpoint-error-destroy='"'"'`error_summary`.`c`'"'"' --config=...' "$TEST_DIR/lightning-error-summary.tail"
-! grep -Fq './tidb-lightning-ctl --checkpoint-error-destroy='"'"'`error_summary`.`b`'"'"' --config=...' "$TEST_DIR/lightning-error-summary.tail"
-grep -Fq 'checkpoint-error-destroy=all --config=...` to start from scratch' "$TEST_DIR/lightning-error-summary.tail"
-grep -Fq 'For details of this failure, read the log file' "$TEST_DIR/lightning-error-summary.tail"
-grep -Fq 'PREVIOUS run' "$TEST_DIR/lightning-error-summary.tail"
+check_contains 'TiDB Lightning has failed last time. To prevent data loss, this run will stop now' "$TEST_DIR/lightning-error-summary.tail"
+check_contains './tidb-lightning-ctl --checkpoint-error-destroy='"'"'`error_summary`.`a`'"'"' --config=...' "$TEST_DIR/lightning-error-summary.tail"
+check_contains './tidb-lightning-ctl --checkpoint-error-destroy='"'"'`error_summary`.`c`'"'"' --config=...' "$TEST_DIR/lightning-error-summary.tail"
+check_not_contains './tidb-lightning-ctl --checkpoint-error-destroy='"'"'`error_summary`.`b`'"'"' --config=...' "$TEST_DIR/lightning-error-summary.tail"
+check_contains 'checkpoint-error-destroy=all --config=...` to start from scratch' "$TEST_DIR/lightning-error-summary.tail"
+check_contains 'For details of this failure, read the log file' "$TEST_DIR/lightning-error-summary.tail"
+check_contains 'PREVIOUS run' "$TEST_DIR/lightning-error-summary.tail"

--- a/br/tests/lightning_fail_fast/run.sh
+++ b/br/tests/lightning_fail_fast/run.sh
@@ -27,9 +27,7 @@ for CFG in chunk engine; do
 
   tail -n 10 $TEST_DIR/lightning-tidb.log | grep "ERROR" | tail -n 1 | grep -Fq "Error 1062 (23000): Duplicate entry '1-1' for key 'tb.uq'"
 
-  ! grep -Fq "restore file completed" $TEST_DIR/lightning-tidb.log
-  [ $? -eq 0 ]
+  check_not_contains "restore file completed" $TEST_DIR/lightning-tidb.log
 
-  ! grep -Fq "restore engine completed" $TEST_DIR/lightning-tidb.log
-  [ $? -eq 0 ]
+  check_not_contains "restore engine completed" $TEST_DIR/lightning-tidb.log
 done


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #43820

Problem Summary:

### What is changed and how it works?
```
              -e      Exit immediately if a pipeline (which may consist of a single simple command), a list, or a compound command (see SHELL GRAMMAR above), exits with a non-zero status.  The shell
                      does not exit if the command that fails is part of the command list immediately following a while or until keyword, part of the test following the if or elif reserved words, part
                      of any command executed in a && or || list except the command following the final && or ||, any command in a pipeline but the last, or if the command's return value is being
                      inverted with !.
```

> **The shell does not exit if ...... the command's return value is being inverted with !**

that means check `not contains` by `! grep` directly will not work

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
