### PR TITLE
ldap: modify variable name and initialize connection with root_dn and root_pwd

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -2572,7 +2572,7 @@ var defaultSysVars = []*SysVar{
 	}, GetGlobal: func(ctx context.Context, vars *SessionVars) (string, error) {
 		return ldap.LDAPSASLAuthImpl.GetBindRootDN(), nil
 	}},
-	{Scope: ScopeGlobal, Name: AuthenticationLDAPSASLBindRootPW, Value: "", Type: TypeStr, SetGlobal: func(ctx context.Context, vars *SessionVars, s string) error {
+	{Scope: ScopeGlobal, Name: AuthenticationLDAPSASLBindRootPWD, Value: "", Type: TypeStr, SetGlobal: func(ctx context.Context, vars *SessionVars, s string) error {
 		ldap.LDAPSASLAuthImpl.SetBindRootPW(s)
 		return nil
 	}, GetGlobal: func(ctx context.Context, vars *SessionVars) (string, error) {
@@ -2654,7 +2654,7 @@ var defaultSysVars = []*SysVar{
 	}, GetGlobal: func(ctx context.Context, vars *SessionVars) (string, error) {
 		return ldap.LDAPSimpleAuthImpl.GetBindRootDN(), nil
 	}},
-	{Scope: ScopeGlobal, Name: AuthenticationLDAPSimpleBindRootPW, Value: "", Type: TypeStr, SetGlobal: func(ctx context.Context, vars *SessionVars, s string) error {
+	{Scope: ScopeGlobal, Name: AuthenticationLDAPSimpleBindRootPWD, Value: "", Type: TypeStr, SetGlobal: func(ctx context.Context, vars *SessionVars, s string) error {
 		ldap.LDAPSimpleAuthImpl.SetBindRootPW(s)
 		return nil
 	}, GetGlobal: func(ctx context.Context, vars *SessionVars) (string, error) {

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -1007,8 +1007,8 @@ const (
 	AuthenticationLDAPSASLBindBaseDN = "authentication_ldap_sasl_bind_base_dn"
 	// AuthenticationLDAPSASLBindRootDN defines the `dn` of the user to login the LDAP server and perform search.
 	AuthenticationLDAPSASLBindRootDN = "authentication_ldap_sasl_bind_root_dn"
-	// AuthenticationLDAPSASLBindRootPW defines the password of the user to login the LDAP server and perform search.
-	AuthenticationLDAPSASLBindRootPW = "authentication_ldap_sasl_bind_root_pw"
+	// AuthenticationLDAPSASLBindRootPWD defines the password of the user to login the LDAP server and perform search.
+	AuthenticationLDAPSASLBindRootPWD = "authentication_ldap_sasl_bind_root_pwd"
 	// AuthenticationLDAPSASLInitPoolSize defines the init size of connection pool to LDAP server for SASL plugin.
 	AuthenticationLDAPSASLInitPoolSize = "authentication_ldap_sasl_init_pool_size"
 	// AuthenticationLDAPSASLMaxPoolSize defines the max size of connection pool to LDAP server for SASL plugin.
@@ -1031,8 +1031,8 @@ const (
 	AuthenticationLDAPSimpleBindBaseDN = "authentication_ldap_simple_bind_base_dn"
 	// AuthenticationLDAPSimpleBindRootDN defines the `dn` of the user to login the LDAP server and perform search.
 	AuthenticationLDAPSimpleBindRootDN = "authentication_ldap_simple_bind_root_dn"
-	// AuthenticationLDAPSimpleBindRootPW defines the password of the user to login the LDAP server and perform search.
-	AuthenticationLDAPSimpleBindRootPW = "authentication_ldap_simple_bind_root_pw"
+	// AuthenticationLDAPSimpleBindRootPWD defines the password of the user to login the LDAP server and perform search.
+	AuthenticationLDAPSimpleBindRootPWD = "authentication_ldap_simple_bind_root_pwd"
 	// AuthenticationLDAPSimpleInitPoolSize defines the init size of connection pool to LDAP server for SASL plugin.
 	AuthenticationLDAPSimpleInitPoolSize = "authentication_ldap_simple_init_pool_size"
 	// AuthenticationLDAPSimpleMaxPoolSize defines the max size of connection pool to LDAP server for SASL plugin.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #43822

Problem Summary:

1. TiDB uses variable `root_pw`, which is different from `root_pwd`.
2. TiDB doesn't support the server which doesn't allow anonymous bind.

### What is changed and how it works?

1. Rename the variables to `root_pwd`.
2. Initialize the connection with binding to the `root_dn` and `root_pwd`.

The only concern is that the the ACL configuration for anonymous user and `root` could be different.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test
- [ ] No code

I manually tested this patch with okta ldap service, which doesn't support anonymous binding.

Copied from https://github.com/pingcap/tidb/issues/43822, I also attached the "Alternatives" here:

I have checked the behavior on two different implementations:

### Alternatives

1. Percona server, as shown in its code, will also use root_dn and root_pwd to initialize the connection.
2. MySQL server doesn't detect the connection status. If a connection is killed (or lost) from the server side, the connection will pollute the connection pool, and all following login will fail. (tcpdump on the LDAP server, no request will arrive).

I think the first one is apparently better.
