### PR TITLE
planner: fix Jepsen fail caused by non-prep plan cache

### DIFF
--- a/planner/core/plan_cache_param_test.go
+++ b/planner/core/plan_cache_param_test.go
@@ -112,7 +112,7 @@ func TestParameterize(t *testing.T) {
 	for _, c := range cases {
 		stmt, err := parser.New().ParseOneStmt(c.sql, "", "")
 		require.Nil(t, err)
-		paramSQL, params, err := ParameterizeAST(context.Background(), sctx, stmt)
+		paramSQL, params, _, err := ParameterizeAST(context.Background(), sctx, stmt)
 		require.Nil(t, err)
 		require.Equal(t, c.paramSQL, paramSQL)
 		require.Equal(t, len(c.params), len(params))
@@ -160,7 +160,7 @@ c_credit, c_credit_lim, c_discount, c_balance, c_since FROM customer WHERE c_w_i
 	stmt, err := parser.New().ParseOneStmt(paymentSelectCustomerForUpdate, "", "")
 	require.Nil(b, err)
 	sctx := MockContext()
-	_, _, err = ParameterizeAST(context.Background(), sctx, stmt)
+	_, _, _, err = ParameterizeAST(context.Background(), sctx, stmt)
 	require.Nil(b, err)
 
 	b.ResetTimer()
@@ -174,7 +174,7 @@ func BenchmarkParameterizeInsert(b *testing.B) {
 	stmt, err := parser.New().ParseOneStmt(paymentInsertHistory, "", "")
 	require.Nil(b, err)
 	sctx := MockContext()
-	_, _, err = ParameterizeAST(context.Background(), sctx, stmt)
+	_, _, _, err = ParameterizeAST(context.Background(), sctx, stmt)
 	require.Nil(b, err)
 
 	b.ResetTimer()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43667

Problem Summary: planner: fix Jepsen fail caused by non-prep plan cache

### What is changed and how it works?

planner: fix Jepsen fail caused by non-prep plan cache

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
