### PR TITLE
executor: ignore non-found partitions in inner joins (#43763)

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3580,6 +3580,9 @@ func (builder *dataReaderBuilder) prunePartitionForInnerExecutor(tbl table.Table
 			locateKey[keyColOffsets[i]] = data
 		}
 		p, err := partitionTbl.GetPartitionByRow(builder.ctx, locateKey)
+		if table.ErrNoPartitionForGivenValue.Equal(err) {
+			continue
+		}
 		if err != nil {
 			return nil, false, nil, err
 		}

--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -3911,3 +3911,48 @@ from
 		`  └─Selection_18 0.80 cop[tikv]  eq(test39999.c.occur_trade_date, 2022-11-17 00:00:00.000000)`,
 		`    └─TableRangeScan_17 0.80 cop[tikv] table:c range: decided by [eq(test39999.c.txt_account_id, test39999.t.txn_account_id) eq(test39999.c.serial_id, test39999.t.serial_id) eq(test39999.c.occur_trade_date, 2022-11-17 00:00:00.000000)], keep order:false`))
 }
+
+func TestPartitionOnMissing(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create schema OnMissing")
+	tk.MustExec("use OnMissing")
+	tk.MustExec(`set global tidb_partition_prune_mode='dynamic'`)
+	tk.MustExec(`set session tidb_partition_prune_mode='dynamic'`)
+
+	tk.MustExec(`CREATE TABLE tt1 (
+		id INT NOT NULL,
+		listid INT,
+		name varchar(10)
+	)
+	PARTITION BY LIST (listid) (
+		PARTITION p1 VALUES IN (1),
+		PARTITION p2 VALUES IN (2),
+		PARTITION p3 VALUES IN (3),
+		PARTITION p4 VALUES IN (4)
+	)`)
+
+	tk.MustExec(`CREATE TABLE tt2 (
+		id INT NOT NULL,
+		listid INT
+	)`)
+
+	tk.MustExec(`create index idx_listid on tt1(id,listid)`)
+	tk.MustExec(`create index idx_listid on tt2(listid)`)
+
+	tk.MustExec(`insert into tt1 values(1,1,1)`)
+	tk.MustExec(`insert into tt1 values(2,2,2)`)
+	tk.MustExec(`insert into tt1 values(3,3,3)`)
+	tk.MustExec(`insert into tt1 values(4,4,4)`)
+	tk.MustExec(`insert into tt2 values(1,1)`)
+	tk.MustExec(`insert into tt2 values(2,2)`)
+	tk.MustExec(`insert into tt2 values(3,3)`)
+	tk.MustExec(`insert into tt2 values(4,4)`)
+	tk.MustExec(`insert into tt2 values(5,5)`)
+
+	tk.MustExec(`analyze table tt1`)
+	tk.MustExec(`analyze table tt2`)
+
+	tk.MustQuery(`select /*+ inl_join(tt1)*/ count(*) from tt2
+		left join tt1 on tt1.listid=tt2.listid and tt1.id=tt2.id`).Check(testkit.Rows("5"))
+}


### PR DESCRIPTION
This is a manual cherry-pick of #43763

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43686

Problem Summary:
When doing pruning for inner join lookup it propagated errors of not found partition instead of ignoring it (since there are no matching values).

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
