### PR TITLE
ddl: remove redundant backfill metric counting

### DIFF
--- a/ddl/backfilling_scheduler.go
+++ b/ddl/backfilling_scheduler.go
@@ -489,7 +489,6 @@ func (w *addIndexIngestWorker) HandleTask(rs idxRecResult) {
 		result.scanCount = count
 		result.nextKey = nextKey
 	}
-	w.metricCounter.Add(float64(count))
 	if ResultCounterForTest != nil && result.err == nil {
 		ResultCounterForTest.Add(1)
 	}

--- a/ddl/backfilling_scheduler.go
+++ b/ddl/backfilling_scheduler.go
@@ -483,7 +483,6 @@ func (w *addIndexIngestWorker) HandleTask(rs idxRecResult) {
 		result.totalCount = cnt
 		result.nextKey = nextKey
 		result.err = w.checkpointMgr.UpdateCurrent(rs.id, count)
-		count = cnt
 	} else {
 		result.addedCount = count
 		result.scanCount = count


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Problem Summary:

The backfill total counter has been updated in 

https://github.com/pingcap/tidb/blob/0f7bb0a1122eea2ca0fbcf9c41b5591aeba9582f/ddl/index.go#L1649

Let's remove the incorrect counting here.

### What is changed and how it works?

After this PR:

![image](https://github.com/pingcap/tidb/assets/24713065/bfa55f90-583a-4160-9239-c03695b39d37)

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
