### PR TITLE
planner: fix Jepsen fail caused by non-prep plan cache

### DIFF
--- a/planner/BUILD.bazel
+++ b/planner/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//sessiontxn",
         "//types",
         "//util/hint",
+        "//util/intest",
         "//util/logutil",
         "//util/parser",
         "//util/topsql",

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -43,6 +43,11 @@ import (
 	"github.com/pingcap/tidb/util/ranger"
 )
 
+var (
+	// PLAN_CACHE_KEY_TEST_ISSUE_43667 is for test.
+	PLAN_CACHE_KEY_TEST_ISSUE_43667 struct{}
+)
+
 // SetParameterValuesIntoSCtx sets these parameters into session context.
 func SetParameterValuesIntoSCtx(sctx sessionctx.Context, isNonPrep bool, markers []ast.ParamMarkerExpr, params []expression.Expression) error {
 	vars := sctx.GetSessionVars()

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -44,8 +44,8 @@ import (
 )
 
 var (
-	// PLAN_CACHE_KEY_TEST_ISSUE_43667 is for test.
-	PLAN_CACHE_KEY_TEST_ISSUE_43667 struct{}
+	// PlanCacheKeyTestIssue43667 is for test.
+	PlanCacheKeyTestIssue43667 struct{}
 )
 
 // SetParameterValuesIntoSCtx sets these parameters into session context.

--- a/planner/core/plan_cache_param.go
+++ b/planner/core/plan_cache_param.go
@@ -93,11 +93,18 @@ func (pr *paramReplacer) Reset() {
 
 // GetParamSQLFromAST returns the parameterized SQL of this AST.
 // NOTICE: this function does not modify the original AST.
-func GetParamSQLFromAST(ctx context.Context, sctx sessionctx.Context, stmt ast.StmtNode) (paramSQL string, params []*driver.ValueExpr, err error) {
+// paramVals are copied from this AST.
+func GetParamSQLFromAST(ctx context.Context, sctx sessionctx.Context, stmt ast.StmtNode) (paramSQL string, paramVals []types.Datum, err error) {
+	var params []*driver.ValueExpr
 	paramSQL, params, err = ParameterizeAST(ctx, sctx, stmt)
 	if err != nil {
 		return "", nil, err
 	}
+	paramVals = make([]types.Datum, len(params))
+	for i, p := range params {
+		p.Datum.Copy(&paramVals[i])
+	}
+
 	err = RestoreASTWithParams(ctx, sctx, stmt, params)
 	return
 }
@@ -167,14 +174,14 @@ func RestoreASTWithParams(ctx context.Context, _ sessionctx.Context, stmt ast.St
 }
 
 // Params2Expressions converts these parameters to an expression list.
-func Params2Expressions(params []*driver.ValueExpr) []expression.Expression {
+func Params2Expressions(params []types.Datum) []expression.Expression {
 	exprs := make([]expression.Expression, 0, len(params))
 	for _, p := range params {
 		// TODO: add a sync.Pool for type.FieldType and expression.Constant here.
 		tp := new(types.FieldType)
-		types.InferParamTypeFromDatum(&p.Datum, tp)
+		types.InferParamTypeFromDatum(&p, tp)
 		exprs = append(exprs, &expression.Constant{
-			Value:   p.Datum,
+			Value:   p,
 			RetType: tp,
 		})
 	}

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -2298,7 +2298,7 @@ func TestIssue43667(t *testing.T) {
 		v.Datum.SetInt64(7)
 	}
 
-	tctx := context.WithValue(context.Background(), plannercore.PLAN_CACHE_KEY_TEST_ISSUE_43667, updateAST)
+	tctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestIssue43667, updateAST)
 	tk.MustQueryWithContext(tctx, `select (val) from cycle where pk = 4`).Check(testkit.Rows("4"))
 }
 

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser"
+	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/planner"
 	plannercore "github.com/pingcap/tidb/planner/core"
@@ -34,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/types"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/size"
 	"github.com/stretchr/testify/require"
@@ -2276,6 +2278,28 @@ func TestNonPreparedPlanCacheAutoStmtRetry(t *testing.T) {
 	require.NoError(t, err)
 	wg.Wait()
 	require.ErrorContains(t, tk2Err, "Duplicate entry")
+}
+
+func TestIssue43667(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`set tidb_enable_non_prepared_plan_cache=1`)
+	tk.MustExec(`create table cycle (pk int not null primary key, sk int not null, val int)`)
+	tk.MustExec(`insert into cycle values (4, 4, 4)`)
+	tk.MustExec(`insert into cycle values (7, 7, 7)`)
+
+	tk.MustQuery(`select (val) from cycle where pk = 4`).Check(testkit.Rows("4"))
+	tk.MustQuery(`select (val) from cycle where pk = 7`).Check(testkit.Rows("7"))
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+	updateAST := func(stmt ast.StmtNode) {
+		v := stmt.(*ast.SelectStmt).Where.(*ast.BinaryOperationExpr).R.(*driver.ValueExpr)
+		v.Datum.SetInt64(7)
+	}
+
+	tctx := context.WithValue(context.Background(), plannercore.PLAN_CACHE_KEY_TEST_ISSUE_43667, updateAST)
+	tk.MustQueryWithContext(tctx, `select (val) from cycle where pk = 4`).Check(testkit.Rows("4"))
 }
 
 func TestNonPreparedPlanCacheBuiltinFuncs(t *testing.T) {

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -101,8 +101,8 @@ func getPlanFromNonPreparedPlanCache(ctx context.Context, sctx sessionctx.Contex
 	if err != nil {
 		return nil, nil, false, err
 	}
-	if intest.InTest && ctx.Value(core.PLAN_CACHE_KEY_TEST_ISSUE_43667) != nil { // update the AST in the middle of the process
-		ctx.Value(core.PLAN_CACHE_KEY_TEST_ISSUE_43667).(func(stmt ast.StmtNode))(stmt)
+	if intest.InTest && ctx.Value(core.PlanCacheKeyTestIssue43667) != nil { // update the AST in the middle of the process
+		ctx.Value(core.PlanCacheKeyTestIssue43667).(func(stmt ast.StmtNode))(stmt)
 	}
 	val := sctx.GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL)
 	paramExprs := core.Params2Expressions(paramsVals)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43667

Problem Summary: planner: fix Jepsen fail caused by non-prep plan cache

### What is changed and how it works?

planner: fix Jepsen fail caused by non-prep plan cache

<img width="1453" alt="image" src="https://github.com/pingcap/tidb/assets/7499936/9798a031-3dbb-4bc9-bfa4-8be9a66ba13f">


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
