### PR TITLE
ddl: roll back txn before handling ErrEntryTooLarge

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -777,7 +777,7 @@ func (w *worker) HandleDDLJobTable(d *ddlCtx, job *model.Job) (int64, error) {
 
 	if job.IsCancelled() {
 		defer d.unlockSchemaVersion(job.ID)
-		w.sess.Rollback()
+		w.sess.Reset()
 		err = w.HandleJobDone(d, job, t)
 		return 0, err
 	}
@@ -789,7 +789,7 @@ func (w *worker) HandleDDLJobTable(d *ddlCtx, job *model.Job) (int64, error) {
 		// then shouldn't discard the KV modification.
 		// And the job state is rollback done, it means the job was already finished, also shouldn't discard too.
 		// Otherwise, we should discard the KV modification when running job.
-		w.sess.Rollback()
+		w.sess.Reset()
 		// If error happens after updateSchemaVersion(), then the schemaVer is updated.
 		// Result in the retry duration is up to 2 * lease.
 		schemaVer = 0

--- a/ddl/internal/session/session.go
+++ b/ddl/internal/session/session.go
@@ -66,6 +66,11 @@ func (s *Session) Rollback() {
 	s.RollbackTxn(context.Background())
 }
 
+// Reset resets the session.
+func (s *Session) Reset() {
+	s.StmtRollback(context.Background(), false)
+}
+
 // Execute executes a query.
 func (s *Session) Execute(ctx context.Context, query string, label string) ([]chunk.Row, error) {
 	startTime := time.Now()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43725

Problem Summary:

DDL will use the same transaction to complete the update of the schema (onCreateTables) and the update of the job status (updateDDLJob). When the latter reports `ErrEntryTooLarge` error, it does not roll back the schema update, but sets the job to canceled and commits, resulting in the illusion that the DDL failed but the schema was actually updated.

```go
err = w.updateDDLJob(t, job, runJobErr != nil)
if err = w.handleUpdateJobError(t, job, err); err != nil { // ---------------- ErrEntryTooLarge is ignored
    w.sess.rollback()
    d.unlockSchemaVersion(job.ID)
    return 0, err
}
writeBinlog(d.binlogCli, txn, job)
w.sess.GetSessionVars().StmtCtx.ResetSQLDigest(job.Query)
err = w.sess.commit()                                      // ---------------- the schema is updated here
```

### What is changed and how it works?

- Roll back the transaction before handling `ErrEntryTooLarge`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
