### PR TITLE
ddl, owner: set owner op with lease

### DIFF
--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -277,10 +277,6 @@ func (d *ddl) startDispatchLoop() {
 			time.Sleep(dispatchLoopWaitingDuration)
 			continue
 		}
-		if err := d.needCheckClusterState(isOnce); err != nil {
-			continue
-		}
-		isOnce = false
 		select {
 		case <-d.ddlJobCh:
 		case <-ticker.C:
@@ -291,12 +287,11 @@ func (d *ddl) startDispatchLoop() {
 				time.Sleep(time.Second)
 				continue
 			}
-		case _, ok := <-d.stateSyncer.WatchChan():
-			if err := d.doCheckClusterState(!ok); err != nil {
-				continue
-			}
 		case <-d.ctx.Done():
 			return
+		}
+		if err := d.needCheckClusterState(isOnce); err != nil {
+			continue
 		}
 		isOnce = false
 		d.loadDDLJobAndRun(se, d.generalDDLWorkerPool, d.getGeneralJob)

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -266,22 +266,21 @@ func (d *ddl) startDispatchLoop() {
 		logutil.BgLogger().Fatal("dispatch loop get cluster state failed, it should not happen, please try restart TiDB", zap.Error(err))
 	}
 	defer ticker.Stop()
-	isFirst := true
 	isOnce := false
 	for {
 		if isChanClosed(d.ctx.Done()) {
 			return
 		}
-		if err := d.needCheckClusterState(isFirst || isOnce); err != nil {
-			continue
-		}
-		isFirst = false
 		if !d.isOwner() {
 			isOnce = true
 			d.once.Store(true)
 			time.Sleep(dispatchLoopWaitingDuration)
 			continue
 		}
+		if err := d.needCheckClusterState(isOnce); err != nil {
+			continue
+		}
+		isOnce = false
 		select {
 		case <-d.ddlJobCh:
 		case <-ticker.C:

--- a/owner/BUILD.bazel
+++ b/owner/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "@io_etcd_go_etcd_api_v3//v3rpc/rpctypes",
         "@io_etcd_go_etcd_client_v3//:client",
         "@io_etcd_go_etcd_client_v3//concurrency",
+        "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/owner/manager.go
+++ b/owner/manager.go
@@ -247,12 +247,12 @@ func (m *ownerManager) campaignLoop(etcdSession *concurrency.Session) {
 			logutil.Logger(logCtx).Info("etcd session is done, creates a new one")
 			leaseID := etcdSession.Lease()
 			etcdSession, err = util2.NewSession(campaignContext, logPrefix, m.etcdCli, util2.NewSessionRetryUnlimited, ManagerSessionTTL)
-			m.sessionLease.Store(int64(etcdSession.Lease()))
 			if err != nil {
 				logutil.Logger(logCtx).Info("break campaign loop, NewSession failed", zap.Error(err))
 				m.revokeSession(logPrefix, leaseID)
 				return
 			}
+			m.sessionLease.Store(int64(etcdSession.Lease()))
 		case <-campaignContext.Done():
 			failpoint.Inject("MockDelOwnerKey", func(v failpoint.Value) {
 				if v.(string) == "delOwnerKeyAndNotOwner" {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/43850

Problem Summary:
There a already expired additional owner,  resulting in no normal DDL owner in the cluster..
```
ETCDCTL_API=3 etcdctl --endpoints=127.0.0.1:2379 lease timetolive 2231882562b6cb5f
{"level":"warn","ts":"2023-05-17T00:40:56.476894+0800","caller":"flags/flag.go:93","msg":"unrecognized environment variable","environment-variable":"ETCDCTL_API=3"}
lease 2231882562b6cb5f already expired
```

### What is changed and how it works?
* Set the value to etcd with lease.
* Clean up the log(get global state and global state change) when the TiDB is notOwner.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

1. Using tiup start 2 TiDBs(master brach) cluster.
2. Kill a TiDB and start(before start do `update mysql.tidb set VARIABLE_VALUE = 143 WHERE VARIABLE_NAME="tidb_server_version";`) it with `--with-mock-upgrade=true` and update `var SupportUpgradeStateVer = 
version142`
3. Kill another TiDB, and start it.
Before this PR we have an owner key with already expired. After this PR, doesn't  no additional owner.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
