### PR TITLE
br: add checkpoint for repairing ingest index

### DIFF
--- a/br/pkg/checkpoint/checkpoint_test.go
+++ b/br/pkg/checkpoint/checkpoint_test.go
@@ -87,6 +87,31 @@ func TestCheckpointMeta(t *testing.T) {
 	require.Equal(t, taskInfo.RestoreTS, uint64(2))
 	require.Equal(t, taskInfo.RewriteTS, uint64(3))
 	require.Equal(t, taskInfo.TiFlashItems[1].Count, uint64(1))
+
+	exists, err = checkpoint.ExistsCheckpointIngestIndexRepairSQLs(ctx, s, "123")
+	require.NoError(t, err)
+	require.False(t, exists)
+	err = checkpoint.SaveCheckpointIngestIndexRepairSQLs(ctx, s, &checkpoint.CheckpointIngestIndexRepairSQLs{
+		SQLs: []checkpoint.CheckpointIngestIndexRepairSQL{
+			{
+				IndexID:    1,
+				SchemaName: model.NewCIStr("2"),
+				TableName:  model.NewCIStr("3"),
+				IndexName:  "4",
+				AddSQL:     "5",
+				AddArgs:    []interface{}{"6", "7", "8"},
+			},
+		},
+	}, "123")
+	require.NoError(t, err)
+	repairSQLs, err := checkpoint.LoadCheckpointIngestIndexRepairSQLs(ctx, s, "123")
+	require.NoError(t, err)
+	require.Equal(t, repairSQLs.SQLs[0].IndexID, int64(1))
+	require.Equal(t, repairSQLs.SQLs[0].SchemaName, model.NewCIStr("2"))
+	require.Equal(t, repairSQLs.SQLs[0].TableName, model.NewCIStr("3"))
+	require.Equal(t, repairSQLs.SQLs[0].IndexName, "4")
+	require.Equal(t, repairSQLs.SQLs[0].AddSQL, "5")
+	require.Equal(t, repairSQLs.SQLs[0].AddArgs, []interface{}{"6", "7", "8"})
 }
 
 type mockTimer struct {

--- a/br/pkg/checkpoint/log_restore.go
+++ b/br/pkg/checkpoint/log_restore.go
@@ -190,12 +190,12 @@ func removeCheckpointTaskInfoForLogRestore(ctx context.Context, s storage.Extern
 }
 
 type CheckpointIngestIndexRepairSQL struct {
-	IndexID    int64       `json:"index-id"`
-	SchemaName model.CIStr `json:"schema-name"`
-	TableName  model.CIStr `json:"table-name"`
-	IndexName  string      `json:"index-name"`
-	AddSQL     string      `json:"add-sql"`
-	AddArgs    []string    `json:"add-args"`
+	IndexID    int64         `json:"index-id"`
+	SchemaName model.CIStr   `json:"schema-name"`
+	TableName  model.CIStr   `json:"table-name"`
+	IndexName  string        `json:"index-name"`
+	AddSQL     string        `json:"add-sql"`
+	AddArgs    []interface{} `json:"add-args"`
 }
 
 type CheckpointIngestIndexRepairSQLs struct {

--- a/br/pkg/restore/BUILD.bazel
+++ b/br/pkg/restore/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "//util/sqlexec",
         "//util/table-filter",
         "@com_github_emirpasic_gods//maps/treemap",
+        "@com_github_fatih_color//:color",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_google_uuid//:uuid",
         "@com_github_opentracing_opentracing_go//:opentracing-go",

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -3293,6 +3293,15 @@ NEXTSQL:
 
 		w := console.StartProgressBar(progressTitle, glue.OnlyOneTask)
 
+		// TODO: When the TiDB supports the DROP and CREATE the same name index in one SQL,
+		//   the checkpoint for ingest recorder can be removed and directly use the SQL:
+		//      ALTER TABLE db.tbl DROP INDEX `i_1`, ADD IDNEX `i_1` ...
+		//
+		// This SQL is compatible with checkpoint: If one ingest index has been recreated by
+		// the SQL, the index's id would be another one. In the next retry execution, BR can
+		// not find the ingest index's dropped id so that BR regards it as a dropped index by
+		// restored metakv and then skips repairing it.
+
 		// only when first execution or old index id is not dropped
 		if !fromCheckpoint || oldIndexIDFound {
 			if err := rc.db.se.ExecuteInternal(ctx, alterTableDropIndexSQL, sql.SchemaName.O, sql.TableName.O, sql.IndexName); err != nil {
@@ -3315,7 +3324,7 @@ NEXTSQL:
 		w.Close()
 	}
 
-	return errors.Trace(err)
+	return nil
 }
 
 const (

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -3160,34 +3160,45 @@ const (
 	alterTableAddPrimaryFormat     = "ALTER TABLE %%n.%%n ADD PRIMARY KEY (%s) NONCLUSTERED"
 )
 
-// RepairIngestIndex drops the indexes from IngestRecorder and re-add them.
-func (rc *Client) RepairIngestIndex(ctx context.Context, ingestRecorder *ingestrec.IngestRecorder, g glue.Glue, storage kv.Storage) error {
-	dom, err := g.GetDomain(storage)
-	if err != nil {
-		return errors.Trace(err)
+func (rc *Client) generateRepairIngestIndexSQLs(
+	ctx context.Context,
+	ingestRecorder *ingestrec.IngestRecorder,
+	allSchema []*model.DBInfo,
+	taskName string,
+) ([]checkpoint.CheckpointIngestIndexRepairSQL, bool, error) {
+	var sqls []checkpoint.CheckpointIngestIndexRepairSQL
+	if rc.useCheckpoint {
+		exists, err := checkpoint.ExistsCheckpointIngestIndexRepairSQLs(ctx, rc.storage, taskName)
+		if err != nil {
+			return sqls, false, errors.Trace(err)
+		}
+		if exists {
+			checkpointSQLs, err := checkpoint.LoadCheckpointIngestIndexRepairSQLs(ctx, rc.storage, taskName)
+			if err != nil {
+				return sqls, false, errors.Trace(err)
+			}
+			sqls = checkpointSQLs.SQLs
+			return sqls, true, nil
+		}
 	}
-	info := dom.InfoSchema()
-	allSchema := info.AllSchemas()
+
 	ingestRecorder.UpdateIndexInfo(allSchema)
-	console := glue.GetConsole(g)
-	err = ingestRecorder.Iterate(func(_, _ int64, info *ingestrec.IngestIndexInfo) error {
+	if err := ingestRecorder.Iterate(func(_, indexID int64, info *ingestrec.IngestIndexInfo) error {
 		var (
-			addSQL        strings.Builder
-			addArgs       []interface{} = make([]interface{}, 0, 5+len(info.ColumnArgs))
-			progressTitle string        = fmt.Sprintf("repair ingest index %s for table %s.%s", info.IndexInfo.Name.O, info.SchemaName, info.TableName)
+			addSQL  strings.Builder
+			addArgs []string = make([]string, 0, 5+len(info.ColumnArgs))
 		)
-		w := console.StartProgressBar(progressTitle, glue.OnlyOneTask)
 		if info.IsPrimary {
 			addSQL.WriteString(fmt.Sprintf(alterTableAddPrimaryFormat, info.ColumnList))
-			addArgs = append(addArgs, info.SchemaName, info.TableName)
+			addArgs = append(addArgs, info.SchemaName.O, info.TableName.O)
 			addArgs = append(addArgs, info.ColumnArgs...)
 		} else if info.IndexInfo.Unique {
 			addSQL.WriteString(fmt.Sprintf(alterTableAddUniqueIndexFormat, info.ColumnList))
-			addArgs = append(addArgs, info.SchemaName, info.TableName, info.IndexInfo.Name.O)
+			addArgs = append(addArgs, info.SchemaName.O, info.TableName.O, info.IndexInfo.Name.O)
 			addArgs = append(addArgs, info.ColumnArgs...)
 		} else {
 			addSQL.WriteString(fmt.Sprintf(alterTableAddIndexFormat, info.ColumnList))
-			addArgs = append(addArgs, info.SchemaName, info.TableName, info.IndexInfo.Name.O)
+			addArgs = append(addArgs, info.SchemaName.O, info.TableName.O, info.IndexInfo.Name.O)
 			addArgs = append(addArgs, info.ColumnArgs...)
 		}
 		// USING BTREE/HASH/RTREE
@@ -3209,10 +3220,78 @@ func (rc *Client) RepairIngestIndex(ctx context.Context, ingestRecorder *ingestr
 			addSQL.WriteString(" VISIBLE")
 		}
 
-		if err := rc.db.se.ExecuteInternal(ctx, alterTableDropIndexSQL, info.SchemaName, info.TableName, info.IndexInfo.Name.O); err != nil {
+		sqls = append(sqls, checkpoint.CheckpointIngestIndexRepairSQL{
+			IndexID:    indexID,
+			SchemaName: info.SchemaName,
+			TableName:  info.TableName,
+			IndexName:  info.IndexInfo.Name.O,
+			AddSQL:     addSQL.String(),
+			AddArgs:    addArgs,
+		})
+
+		return nil
+	}); err != nil {
+		return sqls, false, errors.Trace(err)
+	}
+
+	if rc.useCheckpoint {
+		if err := checkpoint.SaveCheckpointIngestIndexRepairSQLs(ctx, rc.storage, &checkpoint.CheckpointIngestIndexRepairSQLs{
+			SQLs: sqls,
+		}, taskName); err != nil {
+			return sqls, false, errors.Trace(err)
+		}
+	}
+	return sqls, false, nil
+}
+
+// RepairIngestIndex drops the indexes from IngestRecorder and re-add them.
+func (rc *Client) RepairIngestIndex(ctx context.Context, ingestRecorder *ingestrec.IngestRecorder, g glue.Glue, storage kv.Storage, taskName string) error {
+	dom, err := g.GetDomain(storage)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	info := dom.InfoSchema()
+
+	sqls, fromCheckpoint, err := rc.generateRepairIngestIndexSQLs(ctx, ingestRecorder, info.AllSchemas(), taskName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	console := glue.GetConsole(g)
+NEXTSQL:
+	for _, sql := range sqls {
+		progressTitle := fmt.Sprintf("repair ingest index %s for table %s.%s", sql.IndexName, sql.SchemaName, sql.TableName)
+		w := console.StartProgressBar(progressTitle, glue.OnlyOneTask)
+
+		tableInfo, err := info.TableByName(sql.SchemaName, sql.TableName)
+		if err != nil {
 			return errors.Trace(err)
 		}
-		if err := rc.db.se.ExecuteInternal(ctx, addSQL.String(), addArgs...); err != nil {
+		oldIndexIDFound := false
+		if fromCheckpoint {
+		NEXTINDEX:
+			for _, idx := range tableInfo.Indices() {
+				indexInfo := idx.Meta()
+				if indexInfo.ID == sql.IndexID {
+					// the original index id is not dropped
+					oldIndexIDFound = true
+					break NEXTINDEX
+				}
+				if indexInfo.Name.O == sql.IndexName {
+					// find the same name index, but not the same index id,
+					// which means the repaired index id is created
+					continue NEXTSQL
+				}
+			}
+		}
+		// only when first execution or old index id is not dropped
+		if !fromCheckpoint || oldIndexIDFound {
+			if err := rc.db.se.ExecuteInternal(ctx, alterTableDropIndexSQL, sql.SchemaName.O, sql.TableName.O, sql.IndexName); err != nil {
+				return errors.Trace(err)
+			}
+		}
+		// create the repaired index when first execution or not found it
+		if err := rc.db.se.ExecuteInternal(ctx, sql.AddSQL, []interface{}{sql.AddArgs}...); err != nil {
 			return errors.Trace(err)
 		}
 		w.Inc()
@@ -3221,7 +3300,8 @@ func (rc *Client) RepairIngestIndex(ctx context.Context, ingestRecorder *ingestr
 		}
 		w.Close()
 		return nil
-	})
+	}
+
 	return errors.Trace(err)
 }
 

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -3281,7 +3281,11 @@ NEXTSQL:
 				if indexInfo.Name.O == sql.IndexName {
 					// find the same name index, but not the same index id,
 					// which means the repaired index id is created
-					console.Out().Write([]byte(fmt.Sprintf("%s ... %s\n", progressTitle, color.HiGreenString("SKIPPED DUE TO CHECKPOINT MODE"))))
+					if _, err := console.Out().Write(
+						[]byte(fmt.Sprintf("%s ... %s\n", progressTitle, color.HiGreenString("SKIPPED DUE TO CHECKPOINT MODE"))),
+					); err != nil {
+						return errors.Trace(err)
+					}
 					continue NEXTSQL
 				}
 			}

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -3186,7 +3186,7 @@ func (rc *Client) generateRepairIngestIndexSQLs(
 	if err := ingestRecorder.Iterate(func(_, indexID int64, info *ingestrec.IngestIndexInfo) error {
 		var (
 			addSQL  strings.Builder
-			addArgs []string = make([]string, 0, 5+len(info.ColumnArgs))
+			addArgs []interface{} = make([]interface{}, 0, 5+len(info.ColumnArgs))
 		)
 		if info.IsPrimary {
 			addSQL.WriteString(fmt.Sprintf(alterTableAddPrimaryFormat, info.ColumnList))
@@ -3291,7 +3291,7 @@ NEXTSQL:
 			}
 		}
 		// create the repaired index when first execution or not found it
-		if err := rc.db.se.ExecuteInternal(ctx, sql.AddSQL, []interface{}{sql.AddArgs}...); err != nil {
+		if err := rc.db.se.ExecuteInternal(ctx, sql.AddSQL, sql.AddArgs...); err != nil {
 			return errors.Trace(err)
 		}
 		w.Inc()

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -3179,7 +3179,7 @@ func (rc *Client) generateRepairIngestIndexSQLs(
 				return sqls, false, errors.Trace(err)
 			}
 			sqls = checkpointSQLs.SQLs
-			log.Info("[ingest] load ingest index repair sqls from checkpoint")
+			log.Info("[ingest] load ingest index repair sqls from checkpoint", zap.Reflect("sqls", sqls))
 			return sqls, true, nil
 		}
 	}
@@ -3270,14 +3270,14 @@ NEXTSQL:
 		}
 		oldIndexIDFound := false
 		if fromCheckpoint {
-		NEXTINDEX:
 			for _, idx := range tableInfo.Indices() {
 				indexInfo := idx.Meta()
 				if indexInfo.ID == sql.IndexID {
 					// the original index id is not dropped
 					oldIndexIDFound = true
-					break NEXTINDEX
+					break
 				}
+				// what if index's state is not public?
 				if indexInfo.Name.O == sql.IndexName {
 					// find the same name index, but not the same index id,
 					// which means the repaired index id is created

--- a/br/pkg/restore/ingestrec/ingest_recorder.go
+++ b/br/pkg/restore/ingestrec/ingest_recorder.go
@@ -28,7 +28,7 @@ type IngestIndexInfo struct {
 	SchemaName model.CIStr
 	TableName  model.CIStr
 	ColumnList string
-	ColumnArgs []string
+	ColumnArgs []interface{}
 	IsPrimary  bool
 	IndexInfo  *model.IndexInfo
 	Updated    bool
@@ -131,7 +131,7 @@ func (i *IngestRecorder) UpdateIndexInfo(dbInfos []*model.DBInfo) {
 					continue
 				}
 				var columnListBuilder strings.Builder
-				var columnListArgs []string = make([]string, 0, len(indexInfo.Columns))
+				var columnListArgs []interface{} = make([]interface{}, 0, len(indexInfo.Columns))
 				var isFirst bool = true
 				for _, column := range indexInfo.Columns {
 					if !isFirst {

--- a/br/pkg/restore/ingestrec/ingest_recorder.go
+++ b/br/pkg/restore/ingestrec/ingest_recorder.go
@@ -25,10 +25,10 @@ import (
 
 // IngestIndexInfo records the information used to generate index drop/re-add SQL.
 type IngestIndexInfo struct {
-	SchemaName string
-	TableName  string
+	SchemaName model.CIStr
+	TableName  model.CIStr
 	ColumnList string
-	ColumnArgs []interface{}
+	ColumnArgs []string
 	IsPrimary  bool
 	IndexInfo  *model.IndexInfo
 	Updated    bool
@@ -131,7 +131,7 @@ func (i *IngestRecorder) UpdateIndexInfo(dbInfos []*model.DBInfo) {
 					continue
 				}
 				var columnListBuilder strings.Builder
-				var columnListArgs []interface{} = make([]interface{}, 0, len(indexInfo.Columns))
+				var columnListArgs []string = make([]string, 0, len(indexInfo.Columns))
 				var isFirst bool = true
 				for _, column := range indexInfo.Columns {
 					if !isFirst {
@@ -159,8 +159,8 @@ func (i *IngestRecorder) UpdateIndexInfo(dbInfos []*model.DBInfo) {
 				index.ColumnList = columnListBuilder.String()
 				index.ColumnArgs = columnListArgs
 				index.IndexInfo = indexInfo
-				index.SchemaName = dbInfo.Name.O
-				index.TableName = tblInfo.Name.O
+				index.SchemaName = dbInfo.Name
+				index.TableName = tblInfo.Name
 				index.Updated = true
 			}
 		}

--- a/br/pkg/restore/ingestrec/ingest_recorder_test.go
+++ b/br/pkg/restore/ingestrec/ingest_recorder_test.go
@@ -312,7 +312,7 @@ func TestIndexesKind(t *testing.T) {
 	require.Equal(t, 1, count)
 	require.Equal(t, TableID, tableID)
 	require.Equal(t, int64(1), indexID)
-	require.Equal(t, SchemaName, info.SchemaName)
+	require.Equal(t, model.NewCIStr(SchemaName), info.SchemaName)
 	require.Equal(t, "%n,(`x` * 2),%n(4)", info.ColumnList)
 	require.Equal(t, []interface{}{"x", "z"}, info.ColumnArgs)
 	require.Equal(t, TableName, info.IndexInfo.Table.O)

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1412,7 +1412,7 @@ func restoreStream(
 		return errors.Annotate(err, "failed to insert rows into gc_delete_range")
 	}
 
-	if err = client.RepairIngestIndex(ctx, ingestRecorder, g, mgr.GetStorage()); err != nil {
+	if err = client.RepairIngestIndex(ctx, ingestRecorder, g, mgr.GetStorage(), taskName); err != nil {
 		return errors.Annotate(err, "failed to repair ingest index")
 	}
 

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1807,6 +1807,10 @@ func checkPiTRTaskInfo(
 			if curTaskInfo.StartTS == cfg.StartTS && curTaskInfo.RestoreTS == cfg.RestoreTS {
 				// the same task, check whether skip snapshot restore
 				doFullRestore = doFullRestore && (curTaskInfo.Progress == checkpoint.InSnapshotRestore)
+				// update the snapshot restore task name to clean up in final
+				if !doFullRestore && (len(cfg.FullBackupStorage) > 0) {
+					_ = cfg.generateSnapshotRestoreTaskName(clusterID)
+				}
 				log.Info("the same task", zap.Bool("skip-snapshot-restore", !doFullRestore))
 			} else {
 				// not the same task, so overwrite the taskInfo with a new task


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43893 

Problem Summary:
br checkpoint for log restore is not compatible with repairing ingest index
### What is changed and how it works?
add the fixed sqls into the checkpoint mode.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

the first execution
```
GO_FAILPOINTS="github.com/pingcap/tidb/br/pkg/restore/failed-before-create-ingest-index=1*return(false)->return(true)" ./br restore point -s ...
Restore Meta Files <-----------------------------------------------------------------------------------------> 100.00%
Restore KV Files <-------------------------------------------------------------------------------------------> 100.00%
repair ingest index zips2 for table test.pairs7  ... DONE
repair ingest index i2 for table test.pairs7   ABORTED
[2023/05/17 10:06:54.373 +08:00] [INFO] [collector.go:77] ["restore log failed summary"] [error="failed to repair ingest index: failed before create ingest index"] 
```
the second execution
```
GO_FAILPOINTS="github.com/pingcap/tidb/br/pkg/restore/failed-before-create-ingest-index=1*return(false)->return(true)" ./br restore point -s ...
Restore Meta Files <-----------------------------------------------------------------------------------------> 100.00%
Restore KV Files <-------------------------------------------------------------------------------------------> 100.00%
repair ingest index zips2 for table test.pairs7 ... SKIPPED DUE TO CHECKPOINT MODE
repair ingest index i2 for table test.pairs7  ... DONE
repair ingest index i1 for table test.pairs2   ABORTED
[2023/05/17 10:08:02.975 +08:00] [INFO] [collector.go:77] ["restore log failed summary"] [error="failed to repair ingest index: failed before create ingest index"]
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
