### PR TITLE
planner, expression: fix wrong fieldtype after aggregationPushDownSolver

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -2137,11 +2137,6 @@ func WrapWithCastAsInt(ctx sessionctx.Context, expr Expression) Expression {
 	tp.SetDecimal(0)
 	types.SetBinChsClnFlag(tp)
 	tp.AddFlag(expr.GetType().GetFlag() & mysql.UnsignedFlag)
-
-	if expr.GetType().GetType() == mysql.TypeNull {
-		tp.SetType(mysql.TypeLong)
-		tp.AddFlag(mysql.UnsignedFlag)
-	}
 	return BuildCastFunction(ctx, expr, tp)
 }
 

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -2137,6 +2137,11 @@ func WrapWithCastAsInt(ctx sessionctx.Context, expr Expression) Expression {
 	tp.SetDecimal(0)
 	types.SetBinChsClnFlag(tp)
 	tp.AddFlag(expr.GetType().GetFlag() & mysql.UnsignedFlag)
+
+	if expr.GetType().GetType() == mysql.TypeNull {
+		tp.SetType(mysql.TypeLong)
+		tp.AddFlag(mysql.UnsignedFlag)
+	}
 	return BuildCastFunction(ctx, expr, tp)
 }
 

--- a/expression/integration_test/integration_test.go
+++ b/expression/integration_test/integration_test.go
@@ -7933,3 +7933,16 @@ func TestAesDecryptionVecEvalWithZeroChunk(t *testing.T) {
 	tk.MustExec("insert into test values(aes_encrypt('a', 'x'), aes_encrypt('b', 'x'))")
 	tk.MustQuery("SELECT * FROM test WHERE CAST(AES_DECRYPT(name1, 'x') AS CHAR) = '00' AND CAST(AES_DECRYPT(name2, 'x') AS CHAR) = '1'").Check(testkit.Rows())
 }
+
+func TestIfFunctionWithNull(t *testing.T) {
+	// issue 43805
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists ordres;")
+	tk.MustExec("CREATE TABLE orders (id bigint(20) unsigned NOT NULL ,account_id bigint(20) unsigned NOT NULL DEFAULT '0' ,loan bigint(20) unsigned NOT NULL DEFAULT '0' ,stage_num int(20) unsigned NOT NULL DEFAULT '0' ,apply_time bigint(20) unsigned NOT NULL DEFAULT '0' ,PRIMARY KEY (id) /*T![clustered_index] CLUSTERED */,KEY idx_orders_account_id (account_id),KEY idx_orders_apply_time (apply_time));")
+	tk.MustExec("insert into orders values (20, 210802010000721168, 20000 , 2 , 1682484268727), (22, 210802010000721168, 35100 , 4 , 1650885615002);")
+	tk.MustQuery("select min(if(apply_to_now_days <= 30,loan,null)) as min, max(if(apply_to_now_days <= 720,loan,null)) as max from (select loan, datediff(from_unixtime(unix_timestamp() + 18000), from_unixtime(apply_time/1000 + 18000)) as apply_to_now_days from orders) t1;").Sort().Check(
+		testkit.Rows("20000 35100"))
+}

--- a/planner/core/rule_aggregation_push_down.go
+++ b/planner/core/rule_aggregation_push_down.go
@@ -544,6 +544,13 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan, opt *logicalOptim
 						newAggFuncsArgs = append(newAggFuncsArgs, newArgs)
 					}
 				}
+				for i, funcsArgs := range oldAggFuncsArgs {
+					for j := range funcsArgs {
+						if oldAggFuncsArgs[i][j].GetType().EvalType() != newAggFuncsArgs[i][j].GetType().EvalType() {
+							noSideEffects = false
+						}
+					}
+				}
 				if noSideEffects {
 					agg.GroupByItems = newGbyItems
 					for i, aggFunc := range agg.AggFuncs {

--- a/planner/core/rule_aggregation_push_down.go
+++ b/planner/core/rule_aggregation_push_down.go
@@ -548,7 +548,11 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan, opt *logicalOptim
 					for j := range funcsArgs {
 						if oldAggFuncsArgs[i][j].GetType().EvalType() != newAggFuncsArgs[i][j].GetType().EvalType() {
 							noSideEffects = false
+							break
 						}
+					}
+					if !noSideEffects {
+						break
 					}
 				}
 				if noSideEffects {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/43805
Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
