### PR TITLE
ddl: better approach to pause or resume ddl jobs during upgrade

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1557,8 +1557,9 @@ func processJobs(process func(*sess.Session, *model.Job, model.AdminCommandOpera
 
 			err = updateDDLJob2Table(ns, job, true)
 			if err != nil {
-				errs[i] = err
-				continue
+				// unexpected error on updating the job table, should roll it back
+				ns.Rollback()
+				return errs, err
 			}
 		}
 
@@ -1624,7 +1625,7 @@ func processAllJobs(process func(*sess.Session, *model.Job, model.AdminCommandOp
 	for {
 		var jobs []*model.Job
 		jobs, err = getJobsBySQL(ns, JobTable,
-			fmt.Sprintf("job_id >= %s order by job_id asc limit %s",
+			fmt.Sprintf("job_id >= %s and processing order by job_id asc limit %s",
 				strconv.FormatInt(jobID, 10),
 				strconv.FormatInt(int64(limit), 10)))
 		if err != nil {
@@ -1636,11 +1637,12 @@ func processAllJobs(process func(*sess.Session, *model.Job, model.AdminCommandOp
 			err = process(ns, job, byWho)
 			if err != nil {
 				jobErrs[job.ID] = err
-				ns.Rollback()
-				return jobErrs, err
+				continue
 			}
+
 			err = updateDDLJob2Table(ns, job, true)
 			if err != nil {
+				// unexpected error on updating the job table, should roll it back
 				ns.Rollback()
 				return jobErrs, err
 			}

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1520,7 +1520,7 @@ func processJobs(process func(*sess.Session, *model.Job, model.AdminCommandOpera
 	var errs []error
 	// We should process (and try) all the jobs in one Transaction.
 	for tryN := uint(0); tryN < 10; tryN += 1 {
-		errs = make([]error, 0, len(ids))
+		errs = make([]error, len(ids))
 		// Need to figure out which one could not be paused
 		jobMap := make(map[int64]int, len(ids))
 		idsStr := make([]string, 0, len(ids))

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1516,8 +1516,8 @@ func processJobs(process func(*sess.Session, *model.Job, model.AdminCommandOpera
 	}
 
 	ns := sess.NewSession(sessCtx)
-	var errs []error
 
+	var errs []error
 	// We should process (and try) all the jobs in one Transaction.
 	for tryN := uint(0); tryN < 10; tryN += 1 {
 		errs = make([]error, 0, len(ids))

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1493,7 +1493,7 @@ func resumePausedJob(se *sess.Session, job *model.Job,
 	// The Paused job should only be resumed by who paused it
 	if job.AdminOperator != byWho {
 		errMsg := fmt.Sprintf("job has been paused by [%s], should not resumed by [%s]",
-			job.AdminOperator.String(), byWho)
+			job.AdminOperator.String(), byWho.String())
 		return dbterror.ErrCannotResumeDDLJob.GenWithStackByArgs(job.ID, errMsg)
 	}
 

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1557,9 +1557,8 @@ func processJobs(process func(*sess.Session, *model.Job, model.AdminCommandOpera
 
 			err = updateDDLJob2Table(ns, job, true)
 			if err != nil {
-				// unexpected error on updating the job table, should roll it back
-				ns.Rollback()
-				return errs, err
+				errs[i] = err
+				continue
 			}
 		}
 
@@ -1642,9 +1641,8 @@ func processAllJobs(process func(*sess.Session, *model.Job, model.AdminCommandOp
 
 			err = updateDDLJob2Table(ns, job, true)
 			if err != nil {
-				// unexpected error on updating the job table, should roll it back
-				ns.Rollback()
-				return jobErrs, err
+				jobErrs[job.ID] = err
+				continue
 			}
 		}
 

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1466,7 +1466,8 @@ func pauseRunningJob(sess *sess.Session, job *model.Job,
 		return dbterror.ErrPausedDDLJob.GenWithStackByArgs(job.ID)
 	}
 	if !job.IsPausable() {
-		err = dbterror.ErrCannotPauseDDLJob.GenWithStackByArgs(job.ID, job.State.String(), job.SchemaState.String())
+		errMsg := fmt.Sprintf("state [%s] or schema state [%s]", job.State.String(), job.SchemaState.String())
+		err = dbterror.ErrCannotPauseDDLJob.GenWithStackByArgs(job.ID, errMsg)
 		if err != nil {
 			return err
 		}

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1520,7 +1520,7 @@ func processJobs(process func(*sess.Session, *model.Job, model.AdminCommandOpera
 
 	// We should process (and try) all the jobs in one Transaction.
 	for tryN := uint(0); tryN < 10; tryN += 1 {
-		errs = make([]error, len(ids))
+		errs = make([]error, 0, len(ids))
 		// Need to figure out which one could not be paused
 		jobMap := make(map[int64]int, len(ids))
 		idsStr := make([]string, 0, len(ids))
@@ -1625,7 +1625,7 @@ func processAllJobs(process func(*sess.Session, *model.Job, model.AdminCommandOp
 	for {
 		var jobs []*model.Job
 		jobs, err = getJobsBySQL(ns, JobTable,
-			fmt.Sprintf("job_id >= %s and processing order by job_id asc limit %s",
+			fmt.Sprintf("job_id >= %s order by job_id asc limit %s",
 				strconv.FormatInt(jobID, 10),
 				strconv.FormatInt(int64(limit), 10)))
 		if err != nil {

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -998,33 +998,6 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		return ver, err
 	}
 
-	// During binary upgrade, pause all running DDL jobs
-	if d.stateSyncer.IsUpgradingState() {
-		if hasSysDB(job) {
-			return ver, err
-		}
-		var errs []error
-		errs, err = PauseJobsBySystem(w.sess.Session(), []int64{job.ID})
-		if len(errs) > 0 {
-			if dbterror.ErrCannotPauseDDLJob.Equal(errs[0]) ||
-				dbterror.ErrPausedDDLJob.Equal(errs[0]) {
-				// During upgrade, there are jobs that may not be paused because of `!job.IsRunning`.
-				// Then, we would not run it and just return unless the upgrade finished.
-				return ver, nil
-			}
-			logutil.Logger(w.logCtx).Warn("[ddl] unexpected error to pause a DDL: ", zap.Error(err))
-		}
-		return ver, err
-	} else if job.IsPausedBySystem() && !hasSysDB(job) {
-		_, err = ResumeJobsBySystem(w.sess.Session(), []int64{job.ID})
-		if err != nil {
-			logutil.BgLogger().Warn(
-				"[ddl] failed to resume user DDL by system after upgrade", zap.Stringer("job", job), zap.Error(err))
-			return ver, err
-		}
-		return ver, nil
-	}
-
 	// It would be better to do the positive check, but no idea to list all valid states here now.
 	if !job.IsRollingback() {
 		job.State = model.JobStateRunning

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -957,6 +957,7 @@ func (w *worker) processJobPausingRequest(d *ddlCtx, job *model.Job) (isRunnable
 	}
 	if job.IsPausing() {
 		logutil.Logger(w.logCtx).Debug("[ddl] pausing DDL job ", zap.String("job", job.String()))
+		job.State = model.JobStatePaused
 		return false, pauseReorgWorkers(w, d, job)
 	}
 	return true, nil

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -177,7 +177,7 @@ func (d *ddl) processJobDuringUpgrade(sess *sess.Session, job *model.Job) (isRun
 		var errs []error
 		// During binary upgrade, pause all running DDL jobs
 		errs, err = PauseJobsBySystem(sess.Session(), []int64{job.ID})
-		if errs != nil && errs[0] != nil {
+		if len(errs) > 0 && errs[0] != nil {
 			err = errs[0]
 		}
 

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -173,7 +173,7 @@ func (d *ddl) processJobDuringUpgrade(sess *sess.Session, job *model.Job) (isRun
 		var errs []error
 		// During binary upgrade, pause all running DDL jobs
 		errs, err = PauseJobsBySystem(sess.Session(), []int64{job.ID})
-		if len(errs) > 0 {
+		if errs != nil && errs[0] != nil {
 			if dbterror.ErrPausedDDLJob.Equal(errs[0]) {
 				// In case of 'Pausing', we need to deliver the job to DDL
 				// worker to pause the background reorganization workers.

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -124,34 +124,6 @@ func (d *ddl) getJob(se *sess.Session, tp jobType, filter func(*model.Job) (bool
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if job.IsPaused() {
-			// If the job has been Paused, we should not process it. And the
-			// processing should have been set with 0.
-			continue
-		}
-
-		if isJobProcessing {
-			if err := d.handleUpgradingState(se, &job); err != nil {
-				return nil, errors.Trace(err)
-			}
-		}
-
-		// Receive the `admin pause ...` command on this job, turn it to be
-		// not processing; And, keep continue to pause the job and the
-		// background reorganization workers.
-		if job.IsPausing() {
-			// We want the priority of the jobs keeping the same as the time
-			// (i.e., job_id) they were issued, and lower than those are still
-			// running.
-			if err = d.markJobNotProcessing(se, &job); err != nil {
-				logutil.BgLogger().Warn("[ddl] failed to mark the job as processing=0",
-					zap.Error(err), zap.String("job", job.String()))
-				return nil, errors.Trace(err)
-			}
-			// The job may have been run for a while, we need to notify the
-			// background reorganization worker to finish in worker.runDDLJob
-			// So that we should not `continue` or `return` here
-		}
 
 		// The job has already been picked up, just return to continue it.
 		if isJobProcessing {
@@ -163,19 +135,12 @@ func (d *ddl) getJob(se *sess.Session, tp jobType, filter func(*model.Job) (bool
 			return nil, errors.Trace(err)
 		}
 		if b {
-			if err := d.handleUpgradingState(se, &job); err != nil {
+			if err = d.markJobProcessing(se, &job); err != nil {
+				logutil.BgLogger().Warn(
+					"[ddl] handle ddl job failed: mark job is processing meet error",
+					zap.Error(err),
+					zap.String("job", job.String()))
 				return nil, errors.Trace(err)
-			}
-			if !job.IsPausing() {
-				// This should be the first time that the job is picked up.
-				// Then it should not be a pausing or paused job.
-				if err = d.markJobProcessing(se, &job); err != nil {
-					logutil.BgLogger().Warn(
-						"[ddl] handle ddl job failed: mark job is processing meet error",
-						zap.Error(err),
-						zap.String("job", job.String()))
-					return nil, errors.Trace(err)
-				}
 			}
 			return &job, nil
 		}
@@ -192,30 +157,6 @@ func hasSysDB(job *model.Job) bool {
 		}
 	}
 	return false
-}
-
-func (d *ddl) handleUpgradingState(se *sess.Session, job *model.Job) error {
-	if !d.stateSyncer.IsUpgradingState() {
-		if !job.IsPausedBySystem() || hasSysDB(job) {
-			return nil
-		}
-		_, err := ResumeJobsBySystem(se.Session(), []int64{job.ID})
-		if err != nil {
-			logutil.BgLogger().Warn("[ddl] resume user DDL by system failed", zap.Stringer("job", job), zap.Error(err))
-			return err
-		}
-		logutil.BgLogger().Info("[ddl] resume user DDL by system successful", zap.Stringer("job", job))
-		return nil
-	}
-	if job.IsPausing() {
-		return nil
-	}
-	if hasSysDB(job) {
-		return nil
-	}
-	_, err := PauseJobsBySystem(se.Session(), []int64{job.ID})
-	logutil.BgLogger().Info("[ddl] pause user DDL by system successful", zap.Stringer("job", job), zap.Error(err))
-	return err
 }
 
 func (d *ddl) getGeneralJob(sess *sess.Session) (*model.Job, error) {
@@ -446,14 +387,6 @@ func (d *ddl) delivery2worker(wk *worker, pool *workerPool, job *model.Job) {
 			d.mu.RUnlock()
 		}
 	})
-}
-
-func (*ddl) markJobNotProcessing(se *sess.Session, job *model.Job) error {
-	se.SetDiskFullOpt(kvrpcpb.DiskFullOpt_AllowedOnAlmostFull)
-	_, err := se.Execute(context.Background(), fmt.Sprintf(
-		"update mysql.tidb_ddl_job set processing = 0 where job_id = %d", job.ID),
-		"mark_job_not_processing")
-	return errors.Trace(err)
 }
 
 func (*ddl) markJobProcessing(se *sess.Session, job *model.Job) error {

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -179,12 +179,6 @@ func (d *ddl) processJobDuringUpgrade(sess *sess.Session, job *model.Job) (isRun
 				// worker to pause the background reorganization workers.
 				return true, nil
 			}
-			if dbterror.ErrCannotPauseDDLJob.Equal(errs[0]) {
-				// The state could be 'cancelling' or 'rollback', as well as
-				// some corner state
-				return false, nil
-			}
-
 			// During upgrade, there are jobs that may not be paused because of
 			// some serious error. Then, we would not run it and just return
 			// unless the upgrade finished.

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -168,7 +168,7 @@ func hasSysDB(job *model.Job) bool {
 func (d *ddl) processJobDuringUpgrade(sess *sess.Session, job *model.Job) (err error, isRunnable bool) {
 	if d.stateSyncer.IsUpgradingState() {
 		if hasSysDB(job) {
-			return err, false
+			return nil, true
 		}
 		var errs []error
 		// During binary upgrade, pause all running DDL jobs

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -185,11 +185,7 @@ func (d *ddl) processJobDuringUpgrade(sess *sess.Session, job *model.Job) (isRun
 			return false, errs[0]
 		}
 
-		// The job has been issued the command 'pause', which has been turned
-		// to be 'pausing' in job table, then we need to deliver it to ddl
-		// worker to turn it to be 'paused'
-		job.State = model.JobStatePausing
-		return true, err
+		return false, err
 	}
 
 	if job.IsPausedBySystem() && !hasSysDB(job) {

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -127,8 +127,11 @@ func (d *ddl) getJob(se *sess.Session, tp jobType, filter func(*model.Job) (bool
 		}
 
 		isRunnable, err := d.processJobDuringUpgrade(se, &job)
-		if !isRunnable {
+		if err != nil {
 			return nil, errors.Trace(err)
+		}
+		if !isRunnable {
+			continue
 		}
 
 		// The job has already been picked up, just return to continue it.

--- a/ddl/multi_schema_change_test.go
+++ b/ddl/multi_schema_change_test.go
@@ -1298,7 +1298,7 @@ func (c *cancelOnceHook) OnJobUpdated(job *model.Job) {
 	}
 	c.triggered = true
 	errs, err := ddl.CancelJobs(c.s, []int64{job.ID})
-	if errs[0] != nil {
+	if errs != nil && errs[0] != nil {
 		c.cancelErr = errs[0]
 		return
 	}

--- a/ddl/multi_schema_change_test.go
+++ b/ddl/multi_schema_change_test.go
@@ -1298,7 +1298,7 @@ func (c *cancelOnceHook) OnJobUpdated(job *model.Job) {
 	}
 	c.triggered = true
 	errs, err := ddl.CancelJobs(c.s, []int64{job.ID})
-	if errs != nil && errs[0] != nil {
+	if len(errs) > 0 && errs[0] != nil {
 		c.cancelErr = errs[0]
 		return
 	}

--- a/ddl/pause_test.go
+++ b/ddl/pause_test.go
@@ -211,7 +211,7 @@ func TestPauseAndResumeMain(t *testing.T) {
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`)
 
 	idx := 0
-	rowCount := 100000
+	rowCount := 1000
 	tu := &TestTableUser{}
 	for idx < rowCount {
 		_ = tu.generateAttributes()

--- a/ddl/rollingback.go
+++ b/ddl/rollingback.go
@@ -372,8 +372,6 @@ func rollingbackReorganizePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (ve
 }
 
 func pauseReorgWorkers(w *worker, d *ddlCtx, job *model.Job) (err error) {
-	job.State = model.JobStatePaused
-
 	if needNotifyAndStopReorgWorker(job) {
 		logutil.Logger(w.logCtx).Info("[DDL] pausing the DDL job", zap.String("job", job.String()))
 		d.notifyReorgWorkerJobStateChange(job)

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -1140,7 +1140,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrTiKVStaleCommand:          mysql.Message("TiKV server reports stale command", nil),
 	ErrTiKVMaxTimestampNotSynced: mysql.Message("TiKV max timestamp is not synced", nil),
 
-	ErrCannotPauseDDLJob:  mysql.Message("Job [%v] can't be paused now", nil),
-	ErrCannotResumeDDLJob: mysql.Message("Job [%v] can't be resumed", nil),
-	ErrPausedDDLJob:       mysql.Message("Job [%v] already paused", nil),
+	ErrCannotPauseDDLJob:  mysql.Message("Job [%v] state [%s] or schema state [%s] is not qualified to be paused", nil),
+	ErrCannotResumeDDLJob: mysql.Message("Job [%v] can't be resumed, %s", nil),
+	ErrPausedDDLJob:       mysql.Message("Job [%v] has already been paused", nil),
 }

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -1140,7 +1140,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrTiKVStaleCommand:          mysql.Message("TiKV server reports stale command", nil),
 	ErrTiKVMaxTimestampNotSynced: mysql.Message("TiKV max timestamp is not synced", nil),
 
-	ErrCannotPauseDDLJob:  mysql.Message("Job [%v] state [%s] or schema state [%s] is not qualified to be paused", nil),
-	ErrCannotResumeDDLJob: mysql.Message("Job [%v] can't be resumed, %s", nil),
+	ErrCannotPauseDDLJob:  mysql.Message("Job [%v] can't be paused: %s", nil),
+	ErrCannotResumeDDLJob: mysql.Message("Job [%v] can't be resumed: %s", nil),
 	ErrPausedDDLJob:       mysql.Message("Job [%v] has already been paused", nil),
 }

--- a/errors.toml
+++ b/errors.toml
@@ -1408,17 +1408,17 @@ Ingest failed: %s
 
 ["ddl:8260"]
 error = '''
-Job [%v] can't be paused now
+Job [%v] state [%s] or schema state [%s] is not qualified to be paused
 '''
 
 ["ddl:8261"]
 error = '''
-Job [%v] can't be resumed
+Job [%v] can't be resumed, %s
 '''
 
 ["ddl:8262"]
 error = '''
-Job [%v] already paused
+Job [%v] has already been paused
 '''
 
 ["domain:8027"]

--- a/errors.toml
+++ b/errors.toml
@@ -1408,12 +1408,12 @@ Ingest failed: %s
 
 ["ddl:8260"]
 error = '''
-Job [%v] state [%s] or schema state [%s] is not qualified to be paused
+Job [%v] can't be paused: %s
 '''
 
 ["ddl:8261"]
 error = '''
-Job [%v] can't be resumed, %s
+Job [%v] can't be resumed: %s
 '''
 
 ["ddl:8262"]

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -749,7 +749,7 @@ func (job *Job) IsPaused() bool {
 
 // IsPausedBySystem returns whether the job is paused by system.
 func (job *Job) IsPausedBySystem() bool {
-	return job.State == JobStatePaused && job.AdminOperator == AdminCommandBySystem
+	return job.IsPaused() && job.AdminOperator == AdminCommandBySystem
 }
 
 // IsPausing indicates whether the job is pausing.
@@ -949,6 +949,17 @@ const (
 	// DDL job is issued by TiDB itself, such as Upgrade(bootstrap).
 	AdminCommandBySystem
 )
+
+func (a *AdminCommandOperator) String() string {
+	switch *a {
+	case AdminCommandByEndUser:
+		return "EndUser"
+	case AdminCommandBySystem:
+		return "System"
+	default:
+		return "None"
+	}
+}
 
 // SchemaDiff contains the schema modification at a particular schema version.
 // It is used to reduce schema reload cost.

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1206,11 +1206,11 @@ func syncUpgradeState(s Session) {
 func syncNormalRunning(s Session) {
 	jobErrs, err := ddl.ResumeAllJobsBySystem(s)
 	if err != nil {
-		logutil.BgLogger().Warn("[Upgrading] unexpected error to resume all paused jobs: ", zap.Error(err))
+		logutil.BgLogger().Warn("[upgrading] unexpected error to resume all paused jobs: ", zap.Error(err))
 	}
 
 	for _, e := range jobErrs {
-		logutil.BgLogger().Warn("[Upgrading] unable to resume the job, error: ", zap.Error(e))
+		logutil.BgLogger().Warn("[upgrading] unable to resume the job, error: ", zap.Error(e))
 	}
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 3*time.Second)

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1206,11 +1206,11 @@ func syncUpgradeState(s Session) {
 func syncNormalRunning(s Session) {
 	jobErrs, err := ddl.ResumeAllJobsBySystem(s)
 	if err != nil {
-		logutil.BgLogger().Fatal("[Upgrading] unexpected error to resume all paused jobs: ", zap.Error(err))
+		logutil.BgLogger().Warn("[Upgrading] unexpected error to resume all paused jobs: ", zap.Error(err))
 	}
 
-	for jobID, err := range jobErrs {
-		logutil.BgLogger().Warn("[Upgrading] unable to resume the job ["+string(jobID)+"], error: ", zap.Error(err))
+	for _, err := range jobErrs {
+		logutil.BgLogger().Warn("[Upgrading] unable to resume the job, error: ", zap.Error(err))
 	}
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 3*time.Second)

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1164,8 +1164,8 @@ func syncUpgradeState(s Session) {
 		logutil.BgLogger().Fatal("upgrade update global state failed", zap.String("state", syncer.StateUpgrading), zap.Error(err))
 	}
 
-	retryTimes := 60
-	interval := 500 * time.Millisecond
+	retryTimes := 10
+	interval := 200 * time.Millisecond
 	for i := 0; i < retryTimes; i++ {
 		op, err := owner.GetOwnerOpValue(ctx, dom.EtcdClient(), ddl.DDLOwnerKey, "upgrade bootstrap")
 		if err == nil && op.String() == owner.OpGetUpgradingState.String() {
@@ -1178,6 +1178,8 @@ func syncUpgradeState(s Session) {
 		time.Sleep(interval)
 	}
 
+	retryTimes = 60
+	interval = 500 * time.Millisecond
 	for i := 0; i < retryTimes; i++ {
 		jobErrs, err := ddl.PauseAllJobsBySystem(s)
 		if err == nil && len(jobErrs) == 0 {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1206,11 +1206,11 @@ func syncUpgradeState(s Session) {
 func syncNormalRunning(s Session) {
 	jobErrs, err := ddl.ResumeAllJobsBySystem(s)
 	if err != nil {
-		logutil.BgLogger().Fatal("upgrade pause all jobs failed", zap.Error(err))
+		logutil.BgLogger().Fatal("[Upgrading] unexpected error to resume all paused jobs: ", zap.Error(err))
 	}
 
-	for _, err = range jobErrs {
-		logutil.BgLogger().Warn("[DDL] unable to resume the job, error: ", zap.Error(err))
+	for jobID, err := range jobErrs {
+		logutil.BgLogger().Warn("[Upgrading] unable to resume the job ["+string(jobID)+"], error: ", zap.Error(err))
 	}
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 3*time.Second)

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1179,7 +1179,8 @@ func syncUpgradeState(s Session) {
 	}
 
 	for i := 0; i < retryTimes; i++ {
-		if _, err = ddl.PauseAllJobsBySystem(s); err == nil {
+		_, err = ddl.PauseAllJobsBySystem(s)
+		if err == nil || dbterror.ErrPausedDDLJob.Equal(err) {
 			break
 		}
 

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1209,8 +1209,8 @@ func syncNormalRunning(s Session) {
 		logutil.BgLogger().Warn("[Upgrading] unexpected error to resume all paused jobs: ", zap.Error(err))
 	}
 
-	for _, err := range jobErrs {
-		logutil.BgLogger().Warn("[Upgrading] unable to resume the job, error: ", zap.Error(err))
+	for _, e := range jobErrs {
+		logutil.BgLogger().Warn("[Upgrading] unable to resume the job, error: ", zap.Error(e))
 	}
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 3*time.Second)

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1164,8 +1164,8 @@ func syncUpgradeState(s Session) {
 		logutil.BgLogger().Fatal("upgrade update global state failed", zap.String("state", syncer.StateUpgrading), zap.Error(err))
 	}
 
-	retryTimes := 10
-	interval := 200 * time.Millisecond
+	retryTimes := 60
+	interval := 500 * time.Millisecond
 	for i := 0; i < retryTimes; i++ {
 		op, err := owner.GetOwnerOpValue(ctx, dom.EtcdClient(), ddl.DDLOwnerKey, "upgrade bootstrap")
 		if err == nil && op.String() == owner.OpGetUpgradingState.String() {

--- a/session/bootstraptest/BUILD.bazel
+++ b/session/bootstraptest/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     shard_count = 7,
     deps = [
         "//config",
+        "//ddl",
         "//kv",
         "//meta",
         "//parser/model",

--- a/session/bootstraptest/bootstrap_upgrade_test.go
+++ b/session/bootstraptest/bootstrap_upgrade_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/parser/model"
@@ -312,6 +313,7 @@ func execute(ctx context.Context, s sessionctx.Context, query string) ([]chunk.R
 
 func TestUpgradeWithPauseDDL(t *testing.T) {
 	session.SupportUpgradeStateVer--
+	ddl.SetWaitTimeWhenErrorOccurred(1 * time.Microsecond)
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Issue Number: close #43897

Problem Summary:
1. TiDB will try to pause jobs again if restarted during upgrade, need to omit ErrPausedDDLJob
2. Once there is error during Pause/Resume a bunch of jobs, it will fail immediately and return. Which should be continue to next job
3. There are some corner cases that jobs could not be paused during upgrade, which should not become runnable

### What is changed and how it works?

1. Would not run the jobs that could not be paused during TiDB Upgrade
2. Omit the error of `pause` during TiDB Upgrade in DDL Worker
3. Continue to pause/resume next job even error happened
4. Return `ErrPausedDDLJob` if already `paused`
5. Process the errors returned by  PauseAllJobsBySystem and ResumeAllJobsBySystem during upgrade


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Support `admin pause ddl jobs 3,5;`
- Support `admin resume ddl jobs 3,5;`
```
