### PR TITLE
extension: fix panic when use db command return error

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1450,7 +1450,7 @@ func (cc *clientConn) useDB(ctx context.Context, db string) (node ast.StmtNode, 
 	}
 	_, err = cc.ctx.ExecuteStmt(ctx, stmts[0])
 	if err != nil {
-		return nil, err
+		return stmts[0], err
 	}
 	cc.dbname = db
 	return stmts[0], err

--- a/server/extension.go
+++ b/server/extension.go
@@ -235,7 +235,7 @@ func (e *stmtEventInfo) ensureStmtContextOriginalSQL() string {
 		e.sc.InitSQLDigest(planCache.NormalizedSQL, planCache.SQLDigest)
 	}
 
-	if e.sc.OriginalSQL == "" && e.executeStmtID == 0 {
+	if e.sc.OriginalSQL == "" && e.executeStmtID == 0 && e.stmtNode != nil {
 		e.sc.OriginalSQL = e.stmtNode.Text()
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43918

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
extension: fix panic when use db command return error
```
