### PR TITLE
br : a new flag to enable ebs br cross az restore

### DIFF
--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -260,7 +260,7 @@ func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string) {
 // CreateVolumes create volumes from snapshots
 // if err happens in the middle, return half-done result
 // returned map: store id -> old volume id -> new volume id
-func (e *EC2Session) CreateVolumes(meta *config.EBSBasedBRMeta, volumeType string, iops, throughput int64) (map[string]string, error) {
+func (e *EC2Session) CreateVolumes(meta *config.EBSBasedBRMeta, volumeType string, iops, throughput int64, targetAZ string) (map[string]string, error) {
 	template := ec2.CreateVolumeInput{
 		VolumeType: &volumeType,
 		TagSpecifications: []*ec2.TagSpecification{
@@ -297,6 +297,11 @@ func (e *EC2Session) CreateVolumes(meta *config.EBSBasedBRMeta, volumeType strin
 				req := template
 				req.SetSnapshotId(oldVol.SnapshotID)
 				req.SetAvailabilityZone(oldVol.VolumeAZ)
+				if targetAZ == "" {
+					req.SetAvailabilityZone(oldVol.VolumeAZ)
+				} else {
+					req.SetAvailabilityZone(targetAZ)
+				}
 				newVol, err := e.ec2.CreateVolume(&req)
 				if err != nil {
 					return errors.Trace(err)

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -296,7 +296,6 @@ func (e *EC2Session) CreateVolumes(meta *config.EBSBasedBRMeta, volumeType strin
 				log.Debug("create volume from snapshot", zap.Any("volume", oldVol))
 				req := template
 				req.SetSnapshotId(oldVol.SnapshotID)
-				req.SetAvailabilityZone(oldVol.VolumeAZ)
 				if targetAZ == "" {
 					req.SetAvailabilityZone(oldVol.VolumeAZ)
 				} else {

--- a/br/pkg/task/backup_ebs.go
+++ b/br/pkg/task/backup_ebs.go
@@ -67,6 +67,7 @@ func DefineBackupEBSFlags(flags *pflag.FlagSet) {
 	_ = flags.MarkHidden(flagCloudAPIConcurrency)
 	_ = flags.MarkHidden(flagProgressFile)
 	_ = flags.MarkHidden(flagOperatorPausedGCAndSchedulers)
+	_ = flags.MarkHidden(flagTargetAZ)
 }
 
 // RunBackupEBS starts a backup task to backup volume vai EBS snapshot.

--- a/br/pkg/task/backup_ebs.go
+++ b/br/pkg/task/backup_ebs.go
@@ -44,6 +44,7 @@ import (
 const (
 	flagBackupVolumeFile           = "volume-file"
 	flagProgressFile               = "progress-file"
+	flagTargetAZ                   = "target-az"
 	waitAllScheduleStoppedInterval = 15 * time.Second
 )
 
@@ -58,6 +59,7 @@ func DefineBackupEBSFlags(flags *pflag.FlagSet) {
 	flags.Uint(flagCloudAPIConcurrency, defaultCloudAPIConcurrency, "concurrency of calling cloud api")
 	flags.String(flagProgressFile, "progress.txt", "the file name of progress file")
 	flags.Bool(flagOperatorPausedGCAndSchedulers, false, "if the GC and scheduler are paused by the `operator` command in another therad, set this so we can skip pausing GC and schedulers.")
+	flags.String(flagTargetAZ, "", "the target AZ for restored volumes")
 
 	_ = flags.MarkHidden(flagFullBackupType)
 	_ = flags.MarkHidden(flagBackupVolumeFile)

--- a/br/pkg/task/backup_ebs.go
+++ b/br/pkg/task/backup_ebs.go
@@ -44,7 +44,6 @@ import (
 const (
 	flagBackupVolumeFile           = "volume-file"
 	flagProgressFile               = "progress-file"
-	flagTargetAZ                   = "target-az"
 	waitAllScheduleStoppedInterval = 15 * time.Second
 )
 
@@ -59,7 +58,6 @@ func DefineBackupEBSFlags(flags *pflag.FlagSet) {
 	flags.Uint(flagCloudAPIConcurrency, defaultCloudAPIConcurrency, "concurrency of calling cloud api")
 	flags.String(flagProgressFile, "progress.txt", "the file name of progress file")
 	flags.Bool(flagOperatorPausedGCAndSchedulers, false, "if the GC and scheduler are paused by the `operator` command in another therad, set this so we can skip pausing GC and schedulers.")
-	flags.String(flagTargetAZ, "", "the target AZ for restored volumes")
 
 	_ = flags.MarkHidden(flagFullBackupType)
 	_ = flags.MarkHidden(flagBackupVolumeFile)
@@ -67,7 +65,6 @@ func DefineBackupEBSFlags(flags *pflag.FlagSet) {
 	_ = flags.MarkHidden(flagCloudAPIConcurrency)
 	_ = flags.MarkHidden(flagProgressFile)
 	_ = flags.MarkHidden(flagOperatorPausedGCAndSchedulers)
-	_ = flags.MarkHidden(flagTargetAZ)
 }
 
 // RunBackupEBS starts a backup task to backup volume vai EBS snapshot.

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -371,6 +371,10 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 		}
 
 		cfg.ProgressFile, err = flags.GetString(flagProgressFile)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
 		cfg.TargetAZ, err = flags.GetString(flagTargetAZ)
 		if err != nil {
 			return errors.Trace(err)

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -213,6 +213,7 @@ type RestoreConfig struct {
 	VolumeIOPS          int64                 `json:"volume-iops" toml:"volume-iops"`
 	VolumeThroughput    int64                 `json:"volume-throughput" toml:"volume-throughput"`
 	ProgressFile        string                `json:"progress-file" toml:"progress-file"`
+	TargetAZ            string                `json:"target-az" toml:"target-az"`
 }
 
 // DefineRestoreFlags defines common flags for the restore tidb command.
@@ -370,6 +371,7 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 		}
 
 		cfg.ProgressFile, err = flags.GetString(flagProgressFile)
+		cfg.TargetAZ, err = flags.GetString(flagTargetAZ)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/br/pkg/task/restore_ebs_meta.go
+++ b/br/pkg/task/restore_ebs_meta.go
@@ -41,6 +41,7 @@ const (
 	flagVolumeType       = "volume-type"
 	flagVolumeIOPS       = "volume-iops"
 	flagVolumeThroughput = "volume-throughput"
+	flagTargetAZ         = "target-az"
 )
 
 // DefineRestoreSnapshotFlags defines common flags for the backup command.
@@ -54,6 +55,7 @@ func DefineRestoreSnapshotFlags(command *cobra.Command) {
 	command.Flags().Int64(flagVolumeIOPS, 0, "volume iops(0 means default for that volume type)")
 	command.Flags().Int64(flagVolumeThroughput, 0, "volume throughout in MiB/s(0 means default for that volume type)")
 	command.Flags().String(flagProgressFile, "progress.txt", "the file name of progress file")
+	command.Flags().String(flagTargetAZ, "", "the target AZ for restored volumes")
 
 	_ = command.Flags().MarkHidden(flagFullBackupType)
 	_ = command.Flags().MarkHidden(flagPrepare)
@@ -64,6 +66,7 @@ func DefineRestoreSnapshotFlags(command *cobra.Command) {
 	_ = command.Flags().MarkHidden(flagVolumeIOPS)
 	_ = command.Flags().MarkHidden(flagVolumeThroughput)
 	_ = command.Flags().MarkHidden(flagProgressFile)
+	_ = command.Flags().MarkHidden(flagTargetAZ)
 }
 
 // RunRestoreEBSMeta phase 1 of EBS based restore

--- a/br/pkg/task/restore_ebs_meta.go
+++ b/br/pkg/task/restore_ebs_meta.go
@@ -235,7 +235,7 @@ func (h *restoreEBSMetaHelper) restoreVolumes(progress glue.Progress) (map[strin
 		}
 	}()
 	volumeIDMap, err = ec2Session.CreateVolumes(h.metaInfo,
-		string(h.cfg.VolumeType), h.cfg.VolumeIOPS, h.cfg.VolumeThroughput)
+		string(h.cfg.VolumeType), h.cfg.VolumeIOPS, h.cfg.VolumeThroughput, h.cfg.TargetAZ)
 	if err != nil {
 		return nil, 0, errors.Trace(err)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43963 

Problem Summary:

Currently, ebs snapshot restore command can only ebs volumes to the same az as the original.

### What is changed and how it works?

1. A new flag `target-az` is introduced to let the user specify a target Availability Zone for restoring EBS volumes.
2. The CreateVolumes method in `br/pkg/aws/ebs.go` is modified to accept a new parameter targetAZ and set the availability zone of the new volume using the targetAZ flag value.
3. The RestoreConfig struct is updated to store the TargetAZ flag value.
4. The ParseFromFlags function is updated to parse the `target-az` flag value.
5. The restore feature including cross-AZ restore capability by using the `target-az` flag is manually tested.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
EBS snapshot backup a tidb cluster in AZ az1
EBS snapshot restore with the new flag to restore the cluster to AZ az2
Verify the new cluster work properly

also verifies that if restore cr doesn't specify the target az, the volumes are restored to identical azs as the source.

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
A new flag `target-az` is introduced for `br restore` command to enable cross-AZ restore for EBS volumes.
```
