### PR TITLE
session: del NO_BACKSLASH_ESCAPES sql mode for internal sql

### DIFF
--- a/parser/mysql/const.go
+++ b/parser/mysql/const.go
@@ -412,10 +412,12 @@ func (m SQLMode) HasAllowInvalidDatesMode() bool {
 	return m&ModeAllowInvalidDates == ModeAllowInvalidDates
 }
 
+// DelSQLMode delete sql mode from ori
 func DelSQLMode(ori SQLMode, del SQLMode) SQLMode {
 	return ori & (^del)
 }
 
+// SetSQLMode add sql mode to ori
 func SetSQLMode(ori SQLMode, add SQLMode) SQLMode {
 	return ori | add
 }

--- a/parser/mysql/const.go
+++ b/parser/mysql/const.go
@@ -296,6 +296,7 @@ var Command2Str = map[byte]string{
 
 // DefaultSQLMode for GLOBAL_VARIABLES
 const DefaultSQLMode = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+const DefaultSQLModeInt SQLMode = ModeOnlyFullGroupBy|ModeStrictTransTables|ModeNoZeroInDate|ModeNoZeroDate|ModeErrorForDivisionByZero|ModeNoAutoCreateUser|ModeNoEngineSubstitution
 
 // DefaultLengthOfMysqlTypes is the map for default physical length of MySQL data types.
 // See http://dev.mysql.com/doc/refman/5.7/en/storage-requirements.html
@@ -410,6 +411,14 @@ func (m SQLMode) HasNoAutoCreateUserMode() bool {
 // HasAllowInvalidDatesMode detects if 'ALLOW_INVALID_DATES' mode is set in SQLMode
 func (m SQLMode) HasAllowInvalidDatesMode() bool {
 	return m&ModeAllowInvalidDates == ModeAllowInvalidDates
+}
+
+func DelSQLMode(ori SQLMode, del SQLMode) SQLMode {
+	return ori&(^del)
+}
+
+func SetSQLMode(ori SQLMode, add SQLMode) SQLMode {
+	return ori|add
 }
 
 // consts for sql modes.

--- a/parser/mysql/const.go
+++ b/parser/mysql/const.go
@@ -296,7 +296,6 @@ var Command2Str = map[byte]string{
 
 // DefaultSQLMode for GLOBAL_VARIABLES
 const DefaultSQLMode = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
-const DefaultSQLModeInt SQLMode = ModeOnlyFullGroupBy|ModeStrictTransTables|ModeNoZeroInDate|ModeNoZeroDate|ModeErrorForDivisionByZero|ModeNoAutoCreateUser|ModeNoEngineSubstitution
 
 // DefaultLengthOfMysqlTypes is the map for default physical length of MySQL data types.
 // See http://dev.mysql.com/doc/refman/5.7/en/storage-requirements.html
@@ -414,11 +413,11 @@ func (m SQLMode) HasAllowInvalidDatesMode() bool {
 }
 
 func DelSQLMode(ori SQLMode, del SQLMode) SQLMode {
-	return ori&(^del)
+	return ori & (^del)
 }
 
 func SetSQLMode(ori SQLMode, add SQLMode) SQLMode {
-	return ori|add
+	return ori | add
 }
 
 // consts for sql modes.

--- a/session/session.go
+++ b/session/session.go
@@ -1624,8 +1624,11 @@ func (s *session) ClearDiskFullOpt() {
 func (s *session) ExecuteInternal(ctx context.Context, sql string, args ...interface{}) (rs sqlexec.RecordSet, err error) {
 	origin := s.sessionVars.InRestrictedSQL
 	s.sessionVars.InRestrictedSQL = true
+	oriSQLMode := s.sessionVars.SQLMode
+	s.sessionVars.SQLMode = mysql.DelSQLMode(oriSQLMode, mysql.ModeNoBackslashEscapes)
 	defer func() {
 		s.sessionVars.InRestrictedSQL = origin
+		s.sessionVars.SQLMode = oriSQLMode
 		// Restore the goroutine label by using the original ctx after execution is finished.
 		pprof.SetGoroutineLabels(ctx)
 	}()

--- a/session/session.go
+++ b/session/session.go
@@ -2089,8 +2089,11 @@ func (s *session) ExecRestrictedSQL(ctx context.Context, opts []sqlexec.OptionFu
 func (s *session) ExecuteInternalStmt(ctx context.Context, stmtNode ast.StmtNode) (sqlexec.RecordSet, error) {
 	origin := s.sessionVars.InRestrictedSQL
 	s.sessionVars.InRestrictedSQL = true
+	oriSQLMode := s.sessionVars.SQLMode
+	s.sessionVars.SQLMode = mysql.DelSQLMode(oriSQLMode, mysql.ModeNoBackslashEscapes)
 	defer func() {
 		s.sessionVars.InRestrictedSQL = origin
+		s.sessionVars.SQLMode = oriSQLMode
 		// Restore the goroutine label by using the original ctx after execution is finished.
 		pprof.SetGoroutineLabels(ctx)
 	}()

--- a/session/sessiontest/session_test.go
+++ b/session/sessiontest/session_test.go
@@ -3553,3 +3553,52 @@ func TestHandleAssertionFailureForPartitionedTable(t *testing.T) {
 	require.ErrorContains(t, err, "assertion")
 	hook.CheckLogCount(t, 0)
 }
+
+func TestRandomBinary(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	allBytes := [][]byte{
+		{4, 0, 0, 0, 0, 0, 0, 4, '2'},
+		{4, 0, 0, 0, 0, 0, 0, 4, '.'},
+		{4, 0, 0, 0, 0, 0, 0, 4, '*'},
+		{4, 0, 0, 0, 0, 0, 0, 4, '('},
+		{4, 0, 0, 0, 0, 0, 0, 4, '\''},
+		{4, 0, 0, 0, 0, 0, 0, 4, '!'},
+		{4, 0, 0, 0, 0, 0, 0, 4, 29},
+		{4, 0, 0, 0, 0, 0, 0, 4, 28},
+		{4, 0, 0, 0, 0, 0, 0, 4, 23},
+		{4, 0, 0, 0, 0, 0, 0, 4, 16},
+	}
+	sql := "insert into mysql.stats_top_n (table_id, is_index, hist_id, value, count) values "
+	var val string
+	for i, bytes := range allBytes {
+		if i == 0 {
+			val += sqlexec.MustEscapeSQL("(874, 0, 1, %?, 3)", bytes)
+		} else {
+			val += sqlexec.MustEscapeSQL(",(874, 0, 1, %?, 3)", bytes)
+		}
+	}
+	sql += val
+	tk.MustExec("set sql_mode = 'NO_BACKSLASH_ESCAPES';")
+	_, err := tk.Session().ExecuteInternal(ctx, sql)
+	require.NoError(t, err)
+}
+
+func TestSQLModeOp(t *testing.T) {
+	s := mysql.ModeNoBackslashEscapes | mysql.ModeOnlyFullGroupBy
+	d := mysql.DelSQLMode(s, mysql.ModeANSIQuotes)
+	require.Equal(t, s, d)
+
+	d = mysql.DelSQLMode(s, mysql.ModeNoBackslashEscapes)
+	require.Equal(t, mysql.ModeOnlyFullGroupBy, d)
+
+	s = mysql.ModeNoBackslashEscapes | mysql.ModeOnlyFullGroupBy
+	a := mysql.SetSQLMode(s, mysql.ModeOnlyFullGroupBy)
+	require.Equal(t, s, a)
+
+	a = mysql.SetSQLMode(s, mysql.ModeAllowInvalidDates)
+	require.Equal(t, mysql.ModeNoBackslashEscapes|mysql.ModeOnlyFullGroupBy|mysql.ModeAllowInvalidDates, a)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43392

Problem Summary: As issue said, `NO_BACKSLASH_ESCAPES` may cause internal sql parse failed.

### What is changed and how it works?
Delete `NO_BACKSLASH_ESCAPES` for internal sql mode.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
