### PR TITLE
ddl: better approach to integrate with upgrade and to pause or resume ddl job (#43907)

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -818,10 +818,13 @@ func (w *worker) HandleDDLJobTable(d *ddlCtx, job *model.Job) (int64, error) {
 	w.registerSync(job)
 
 	if runJobErr != nil {
-		// wait a while to retry again. If we don't wait here, DDL will retry this job immediately,
-		// which may act like a deadlock.
-		logutil.Logger(w.logCtx).Info("[ddl] run DDL job failed, sleeps a while then retries it.",
-			zap.Duration("waitTime", GetWaitTimeWhenErrorOccurred()), zap.Error(runJobErr))
+		// Omit the ErrPausedDDLJob
+		if !dbterror.ErrPausedDDLJob.Equal(runJobErr) {
+			// wait a while to retry again. If we don't wait here, DDL will retry this job immediately,
+			// which may act like a deadlock.
+			logutil.Logger(w.logCtx).Info("[ddl] run DDL job failed, sleeps a while then retries it.",
+				zap.Duration("waitTime", GetWaitTimeWhenErrorOccurred()), zap.Error(runJobErr))
+		}
 
 		// In test and job is cancelling we can ignore the sleep
 		if !(intest.InTest && job.IsCancelling()) {
@@ -950,6 +953,19 @@ func (w *worker) countForError(err error, job *model.Job) error {
 	return err
 }
 
+func (w *worker) processJobPausingRequest(d *ddlCtx, job *model.Job) (isRunnable bool, err error) {
+	if job.IsPaused() {
+		logutil.Logger(w.logCtx).Debug("[ddl] paused DDL job ", zap.String("job", job.String()))
+		return false, err
+	}
+	if job.IsPausing() {
+		logutil.Logger(w.logCtx).Debug("[ddl] pausing DDL job ", zap.String("job", job.String()))
+		job.State = model.JobStatePaused
+		return false, pauseReorgWorkers(w, d, job)
+	}
+	return true, nil
+}
+
 // runDDLJob runs a DDL job. It returns the current schema version in this transaction and the error.
 func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, err error) {
 	defer tidbutil.Recover(metrics.LabelDDLWorker, fmt.Sprintf("%s runDDLJob", w),
@@ -961,7 +977,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 	failpoint.Inject("mockPanicInRunDDLJob", func(val failpoint.Value) {})
 
 	if job.Type != model.ActionMultiSchemaChange {
-		logutil.Logger(w.logCtx).Info("[ddl] run DDL job", zap.String("job", job.String()))
+		logutil.Logger(w.logCtx).Debug("[ddl] run DDL job", zap.String("job", job.String()))
 	}
 	timeStart := time.Now()
 	if job.RealStartTS == 0 {
@@ -975,17 +991,18 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		return ver, err
 	}
 
-	if job.IsPaused() || job.IsPausing() {
-		logutil.Logger(w.logCtx).Info("[ddl] DDL job paused", zap.String("job", job.String()))
-		return ver, pauseReorgWorkers(w, d, job)
-	}
-
 	// The cause of this job state is that the job is cancelled by client.
 	if job.IsCancelling() {
 		logutil.Logger(w.logCtx).Debug("[ddl] cancel DDL job", zap.String("job", job.String()))
 		return convertJob2RollbackJob(w, d, t, job)
 	}
 
+	isRunnable, err := w.processJobPausingRequest(d, job)
+	if !isRunnable {
+		return ver, err
+	}
+
+	// It would be better to do the positive check, but no idea to list all valid states here now.
 	if !job.IsRollingback() {
 		job.State = model.JobStateRunning
 	}
@@ -1122,7 +1139,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 	if err != nil {
 		err = w.countForError(err, job)
 	}
-	return
+	return ver, err
 }
 
 func loadDDLVars(w *worker) error {

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -123,32 +123,13 @@ func (d *ddl) getJob(se *sess.Session, tp jobType, filter func(*model.Job) (bool
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if job.IsPaused() {
-			// If the job has been Paused, we should not process it. And the
-			// processing should have been set with 0.
-			continue
-		}
-		if isJobProcessing {
-			if err := d.handleUpgradingState(se, &job); err != nil {
-				return nil, errors.Trace(err)
-			}
-		}
 
-		// Receive the `admin pause ...` command on this job, turn it to be
-		// not processing; And, keep continue to pause the job and the
-		// background reorganization workers.
-		if job.IsPausing() {
-			// We want the priority of the jobs keeping the same as the time
-			// (i.e., job_id) they were issued, and lower than those are still
-			// running.
-			if err = d.markJobNotProcessing(se, &job); err != nil {
-				logutil.BgLogger().Warn("[ddl] failed to mark the job as processing=0",
-					zap.Error(err), zap.String("job", job.String()))
-				return nil, errors.Trace(err)
-			}
-			// The job may have been run for a while, we need to notify the
-			// background reorganization worker to finish in worker.runDDLJob
-			// So that we should not `continue` or `return` here
+		isRunnable, err := d.processJobDuringUpgrade(se, &job)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if !isRunnable {
+			continue
 		}
 
 		// The job has already been picked up, just return to continue it.
@@ -161,19 +142,12 @@ func (d *ddl) getJob(se *sess.Session, tp jobType, filter func(*model.Job) (bool
 			return nil, errors.Trace(err)
 		}
 		if b {
-			if err := d.handleUpgradingState(se, &job); err != nil {
+			if err = d.markJobProcessing(se, &job); err != nil {
+				logutil.BgLogger().Warn(
+					"[ddl] handle ddl job failed: mark job is processing meet error",
+					zap.Error(err),
+					zap.String("job", job.String()))
 				return nil, errors.Trace(err)
-			}
-			if !job.IsPausing() {
-				// This should be the first time that the job is picked up.
-				// Then it should not be a pausing or paused job.
-				if err = d.markJobProcessing(se, &job); err != nil {
-					logutil.BgLogger().Warn(
-						"[ddl] handle ddl job failed: mark job is processing meet error",
-						zap.Error(err),
-						zap.String("job", job.String()))
-					return nil, errors.Trace(err)
-				}
 			}
 			return &job, nil
 		}
@@ -192,28 +166,41 @@ func hasSysDB(job *model.Job) bool {
 	return false
 }
 
-func (d *ddl) handleUpgradingState(se *sess.Session, job *model.Job) error {
-	if !d.stateSyncer.IsUpgradingState() {
-		if !job.IsPausedBySystem() || hasSysDB(job) {
-			return nil
+func (d *ddl) processJobDuringUpgrade(sess *sess.Session, job *model.Job) (isRunnable bool, err error) {
+	if d.stateSyncer.IsUpgradingState() {
+		// We need to turn the 'pausing' job to be 'paused' in ddl worker,
+		// and stop the reorganization workers
+		if job.IsPausing() || hasSysDB(job) {
+			return true, nil
 		}
-		_, err := ResumeJobsBySystem(se.Session(), []int64{job.ID})
+		var errs []error
+		// During binary upgrade, pause all running DDL jobs
+		errs, err = PauseJobsBySystem(sess.Session(), []int64{job.ID})
+		if len(errs) > 0 && errs[0] != nil {
+			err = errs[0]
+		}
+
 		if err != nil {
-			logutil.BgLogger().Warn("[ddl] resume user DDL by system failed", zap.Stringer("job", job), zap.Error(err))
-			return err
+			errMsg := fmt.Sprintf("[DDL] unable to pause [%d], error: %s",
+				job.ID, zap.Error(err).String)
+			logutil.BgLogger().Warn(errMsg)
 		}
-		logutil.BgLogger().Info("[ddl] resume user DDL by system successful", zap.Stringer("job", job))
-		return nil
+
+		return false, nil
 	}
-	if job.IsPausing() {
-		return nil
+
+	if job.IsPausedBySystem() && !hasSysDB(job) {
+		var errs []error
+		errs, err = ResumeJobsBySystem(sess.Session(), []int64{job.ID})
+		if len(errs) > 0 {
+			return false, errs[0]
+		}
+		if err != nil {
+			return false, err
+		}
 	}
-	if hasSysDB(job) {
-		return nil
-	}
-	_, err := PauseJobsBySystem(se.Session(), []int64{job.ID})
-	logutil.BgLogger().Info("[ddl] pause user DDL by system successful", zap.Stringer("job", job), zap.Error(err))
-	return err
+
+	return true, nil
 }
 
 func (d *ddl) getGeneralJob(sess *sess.Session) (*model.Job, error) {
@@ -446,15 +433,7 @@ func (d *ddl) delivery2worker(wk *worker, pool *workerPool, job *model.Job) {
 	})
 }
 
-func (d *ddl) markJobNotProcessing(se *sess.Session, job *model.Job) error {
-	se.SetDiskFullOpt(kvrpcpb.DiskFullOpt_AllowedOnAlmostFull)
-	_, err := se.Execute(context.Background(), fmt.Sprintf(
-		"update mysql.tidb_ddl_job set processing = 0 where job_id = %d", job.ID),
-		"mark_job_not_processing")
-	return errors.Trace(err)
-}
-
-func (d *ddl) markJobProcessing(se *sess.Session, job *model.Job) error {
+func (*ddl) markJobProcessing(se *sess.Session, job *model.Job) error {
 	se.SetDiskFullOpt(kvrpcpb.DiskFullOpt_AllowedOnAlmostFull)
 	_, err := se.Execute(context.Background(), fmt.Sprintf(
 		"update mysql.tidb_ddl_job set processing = 1 where job_id = %d", job.ID),

--- a/ddl/multi_schema_change_test.go
+++ b/ddl/multi_schema_change_test.go
@@ -1298,7 +1298,7 @@ func (c *cancelOnceHook) OnJobUpdated(job *model.Job) {
 	}
 	c.triggered = true
 	errs, err := ddl.CancelJobs(c.s, []int64{job.ID})
-	if errs[0] != nil {
+	if len(errs) > 0 && errs[0] != nil {
 		c.cancelErr = errs[0]
 		return
 	}

--- a/ddl/pause_test.go
+++ b/ddl/pause_test.go
@@ -211,7 +211,7 @@ func TestPauseAndResumeMain(t *testing.T) {
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`)
 
 	idx := 0
-	rowCount := 100000
+	rowCount := 1000
 	tu := &TestTableUser{}
 	for idx < rowCount {
 		_ = tu.generateAttributes()

--- a/ddl/rollingback.go
+++ b/ddl/rollingback.go
@@ -386,8 +386,6 @@ func rollingbackReorganizePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (ve
 }
 
 func pauseReorgWorkers(w *worker, d *ddlCtx, job *model.Job) (err error) {
-	job.State = model.JobStatePaused
-
 	if needNotifyAndStopReorgWorker(job) {
 		logutil.Logger(w.logCtx).Info("[DDL] pausing the DDL job", zap.String("job", job.String()))
 		d.notifyReorgWorkerJobStateChange(job)

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -1139,7 +1139,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrTiKVStaleCommand:          mysql.Message("TiKV server reports stale command", nil),
 	ErrTiKVMaxTimestampNotSynced: mysql.Message("TiKV max timestamp is not synced", nil),
 
-	ErrCannotPauseDDLJob:  mysql.Message("Job [%v] can't be paused now", nil),
-	ErrCannotResumeDDLJob: mysql.Message("Job [%v] can't be resumed", nil),
-	ErrPausedDDLJob:       mysql.Message("Job [%v] already paused", nil),
+	ErrCannotPauseDDLJob:  mysql.Message("Job [%v] can't be paused: %s", nil),
+	ErrCannotResumeDDLJob: mysql.Message("Job [%v] can't be resumed: %s", nil),
+	ErrPausedDDLJob:       mysql.Message("Job [%v] has already been paused", nil),
 }

--- a/errors.toml
+++ b/errors.toml
@@ -1408,17 +1408,17 @@ Ingest failed: %s
 
 ["ddl:8260"]
 error = '''
-Job [%v] can't be paused now
+Job [%v] can't be paused: %s
 '''
 
 ["ddl:8261"]
 error = '''
-Job [%v] can't be resumed
+Job [%v] can't be resumed: %s
 '''
 
 ["ddl:8262"]
 error = '''
-Job [%v] already paused
+Job [%v] has already been paused
 '''
 
 ["domain:8027"]

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -749,7 +749,7 @@ func (job *Job) IsPaused() bool {
 
 // IsPausedBySystem returns whether the job is paused by system.
 func (job *Job) IsPausedBySystem() bool {
-	return job.State == JobStatePaused && job.AdminOperator == AdminCommandBySystem
+	return job.IsPaused() && job.AdminOperator == AdminCommandBySystem
 }
 
 // IsPausing indicates whether the job is pausing.
@@ -949,6 +949,17 @@ const (
 	// DDL job is issued by TiDB itself, such as Upgrade(bootstrap).
 	AdminCommandBySystem
 )
+
+func (a *AdminCommandOperator) String() string {
+	switch *a {
+	case AdminCommandByEndUser:
+		return "EndUser"
+	case AdminCommandBySystem:
+		return "System"
+	default:
+		return "None"
+	}
+}
 
 // SchemaDiff contains the schema modification at a particular schema version.
 // It is used to reduce schema reload cost.

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1162,8 +1162,21 @@ func syncUpgradeState(s Session) {
 		time.Sleep(interval)
 	}
 
+	retryTimes = 60
+	interval = 500 * time.Millisecond
 	for i := 0; i < retryTimes; i++ {
-		if _, err = ddl.PauseAllJobsBySystem(s); err == nil {
+		jobErrs, err := ddl.PauseAllJobsBySystem(s)
+		if err == nil && len(jobErrs) == 0 {
+			break
+		}
+		isAllFinished := true
+		for _, jobErr := range jobErrs {
+			if dbterror.ErrPausedDDLJob.Equal(jobErr) {
+				continue
+			}
+			isAllFinished = false
+		}
+		if isAllFinished {
 			break
 		}
 
@@ -1177,9 +1190,13 @@ func syncUpgradeState(s Session) {
 }
 
 func syncNormalRunning(s Session) {
-	_, err := ddl.ResumeAllJobsBySystem(s)
+	jobErrs, err := ddl.ResumeAllJobsBySystem(s)
 	if err != nil {
-		logutil.BgLogger().Fatal("upgrade pause all jobs failed", zap.Error(err))
+		logutil.BgLogger().Warn("[upgrading] unexpected error to resume all paused jobs: ", zap.Error(err))
+	}
+
+	for _, e := range jobErrs {
+		logutil.BgLogger().Warn("[upgrading] unable to resume the job, error: ", zap.Error(e))
 	}
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 3*time.Second)

--- a/session/bootstraptest/BUILD.bazel
+++ b/session/bootstraptest/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     shard_count = 7,
     deps = [
         "//config",
+        "//ddl",
         "//kv",
         "//meta",
         "//parser/model",

--- a/session/bootstraptest/bootstrap_upgrade_test.go
+++ b/session/bootstraptest/bootstrap_upgrade_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/parser/model"
@@ -312,6 +313,7 @@ func execute(ctx context.Context, s sessionctx.Context, query string) ([]chunk.R
 
 func TestUpgradeWithPauseDDL(t *testing.T) {
 	session.SupportUpgradeStateVer--
+	ddl.SetWaitTimeWhenErrorOccurred(1 * time.Microsecond)
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #43897

Problem Summary:
1. TiDB will try to pause jobs again if restarted during upgrade, need to omit ErrPausedDDLJob
2. Once there is error during Pause/Resume a bunch of jobs, it will fail immediately and return. Which should be continue to next job
3. There are some corner cases that jobs could not be paused during upgrade, which should not become runnable

### What is changed and how it works?

1. Would not run the jobs that could not be paused during TiDB Upgrade
2. Omit the error of `pause` during TiDB Upgrade in DDL Worker
3. Continue to pause/resume next job even error happened
4. Return `ErrPausedDDLJob` if already `paused`
5. Process the errors returned by  PauseAllJobsBySystem and ResumeAllJobsBySystem during upgrade


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note


Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Support `admin pause ddl jobs 3,5;`
- Support `admin resume ddl jobs 3,5;`
```
