### PR TITLE
ddl: recover to the correct partition from checkpoint

### DIFF
--- a/ddl/ingest/checkpoint.go
+++ b/ddl/ingest/checkpoint.go
@@ -42,10 +42,6 @@ type CheckpointManager struct {
 	jobID     int64
 	indexID   int64
 
-	physicalID int64
-	startKey   kv.Key
-	endKey     kv.Key
-
 	// Derived and unchanged after the initialization.
 	instanceAddr     string
 	localDataIsValid bool
@@ -55,12 +51,20 @@ type CheckpointManager struct {
 	mu              sync.Mutex
 	minTaskIDSynced int
 	dirty           bool
+	// Local meta.
+	pidLocal   int64
+	startLocal kv.Key
+	endLocal   kv.Key
 
 	// Persisted to the storage.
 	minKeySyncLocal  kv.Key
 	minKeySyncGlobal kv.Key
 	localCnt         int
 	globalCnt        int
+	// Global meta.
+	pidGlobal   int64
+	startGlobal kv.Key
+	endGlobal   kv.Key
 
 	// For persisting the checkpoint periodically.
 	updating      bool
@@ -174,18 +178,23 @@ func (s *CheckpointManager) UpdateCurrent(taskID int, added int) error {
 	if !flushed || err != nil {
 		return err
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.progressLocalSyncMinKey()
 	if imported && s.minKeySyncGlobal.Cmp(s.minKeySyncLocal) != 0 {
 		s.minKeySyncGlobal = s.minKeySyncLocal
 		s.globalCnt = s.localCnt
 		s.dirty = true
+
+		s.pidGlobal = s.pidLocal
+		s.startGlobal = s.startLocal
+		s.endGlobal = s.endLocal
 	}
 	return nil
 }
 
 func (s *CheckpointManager) progressLocalSyncMinKey() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	for {
 		cp := s.checkpoints[s.minTaskIDSynced+1]
 		if cp == nil || !cp.lastBatchSent || cp.currentKeys < cp.totalKeys {
@@ -213,7 +222,9 @@ func (s *CheckpointManager) Sync() {
 	if err != nil {
 		logutil.BgLogger().Warn("[ddl-ingest] flush local engine failed", zap.Error(err))
 	}
+	s.mu.Lock()
 	s.progressLocalSyncMinKey()
+	s.mu.Unlock()
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	s.updaterCh <- &wg
@@ -222,22 +233,18 @@ func (s *CheckpointManager) Sync() {
 
 // Reset resets the checkpoint manager between two partitions.
 func (s *CheckpointManager) Reset(newPhysicalID int64, start, end kv.Key) {
-	reset := false
 	s.mu.Lock()
-	if s.physicalID != newPhysicalID {
+	defer s.mu.Unlock()
+	logutil.BgLogger().Info("[ddl-ingest] reset checkpoint manager",
+		zap.Int64("newPhysicalID", newPhysicalID), zap.Int64("oldPhysicalID", s.pidLocal),
+		zap.Int64("indexID", s.indexID), zap.Int64("jobID", s.jobID), zap.Int("localCnt", s.localCnt))
+	if s.pidLocal != newPhysicalID {
 		s.minKeySyncLocal = nil
 		s.minKeySyncGlobal = nil
 		s.minTaskIDSynced = 0
-		s.physicalID = newPhysicalID
-		s.startKey = start
-		s.endKey = end
-		reset = true
-	}
-	s.mu.Unlock()
-	if reset {
-		logutil.BgLogger().Info("[ddl-ingest] reset checkpoint manager",
-			zap.Int64("newPhysicalID", newPhysicalID), zap.Int64("oldPhysicalID", s.physicalID),
-			zap.Int64("indexID", s.indexID), zap.Int64("jobID", s.jobID), zap.Int("localCnt", s.localCnt))
+		s.pidLocal = newPhysicalID
+		s.startLocal = start
+		s.endLocal = end
 	}
 }
 
@@ -294,18 +301,19 @@ func (s *CheckpointManager) resumeCheckpoint() error {
 		if cp := reorgMeta.Checkpoint; cp != nil {
 			s.minKeySyncGlobal = cp.GlobalSyncKey
 			s.globalCnt = cp.GlobalKeyCount
-			if s.instanceAddr == cp.InstanceAddr {
+			if s.instanceAddr == cp.InstanceAddr || cp.InstanceAddr == "" /* initial state */ {
 				s.localDataIsValid = true
 				s.minKeySyncLocal = cp.LocalSyncKey
 				s.localCnt = cp.LocalKeyCount
-				s.physicalID = cp.PhysicalID
-				s.startKey = cp.StartKey
-				s.endKey = cp.EndKey
+				s.pidGlobal = cp.PhysicalID
+				s.startGlobal = cp.StartKey
+				s.endGlobal = cp.EndKey
 			}
 			logutil.BgLogger().Info("[ddl-ingest] resume checkpoint",
 				zap.Int64("job ID", s.jobID), zap.Int64("index ID", s.indexID),
 				zap.String("local checkpoint", hex.EncodeToString(s.minKeySyncLocal)),
 				zap.String("global checkpoint", hex.EncodeToString(s.minKeySyncGlobal)),
+				zap.Int64("physical table ID", cp.PhysicalID),
 				zap.String("previous instance", cp.InstanceAddr),
 				zap.String("current instance", s.instanceAddr))
 			return nil
@@ -322,6 +330,9 @@ func (s *CheckpointManager) updateCheckpoint() error {
 	currentGlobalKey := s.minKeySyncGlobal
 	currentLocalCnt := s.localCnt
 	currentGlobalCnt := s.globalCnt
+	currentGlobalPID := s.pidGlobal
+	currentGlobalStart := s.startGlobal
+	currentGlobalEnd := s.endGlobal
 	s.updating = true
 	s.mu.Unlock()
 	defer func() {
@@ -344,9 +355,9 @@ func (s *CheckpointManager) updateCheckpoint() error {
 			LocalKeyCount:  currentLocalCnt,
 			GlobalKeyCount: currentGlobalCnt,
 			InstanceAddr:   s.instanceAddr,
-			PhysicalID:     s.physicalID,
-			StartKey:       s.startKey,
-			EndKey:         s.endKey,
+			PhysicalID:     currentGlobalPID,
+			StartKey:       currentGlobalStart,
+			EndKey:         currentGlobalEnd,
 			Version:        JobCheckpointVersionCurrent,
 		}
 		rawReorgMeta, err := json.Marshal(JobReorgMeta{Checkpoint: cp})
@@ -368,6 +379,7 @@ func (s *CheckpointManager) updateCheckpoint() error {
 		zap.Int64("job ID", s.jobID), zap.Int64("index ID", s.indexID),
 		zap.String("local checkpoint", hex.EncodeToString(currentLocalKey)),
 		zap.String("global checkpoint", hex.EncodeToString(currentGlobalKey)),
+		zap.Int64("global physical ID", currentGlobalPID),
 		zap.Error(err))
 	return err
 }

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -17,6 +17,7 @@ package ddl
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -611,7 +612,9 @@ func getCheckpointReorgHandle(se *sess.Session, job *model.Job) (startKey, endKe
 		}
 		if cp := reorgMeta.Checkpoint; cp != nil {
 			logutil.BgLogger().Info("[ddl-ingest] resume physical table ID from checkpoint",
-				zap.Int64("job ID", job.ID), zap.Int64("old physical ID", physicalTableID),
+				zap.Int64("jobID", job.ID),
+				zap.String("start", hex.EncodeToString(cp.StartKey)),
+				zap.String("end", hex.EncodeToString(cp.EndKey)),
 				zap.Int64("checkpoint physical ID", cp.PhysicalID))
 			physicalTableID = cp.PhysicalID
 			startKey = cp.StartKey
@@ -632,9 +635,19 @@ func updateDDLReorgHandle(se *sess.Session, jobID int64, startKey kv.Key, endKey
 
 // initDDLReorgHandle initializes the handle for ddl reorg.
 func initDDLReorgHandle(s *sess.Session, jobID int64, startKey kv.Key, endKey kv.Key, physicalTableID int64, element *meta.Element) error {
+	rawReorgMeta, err := json.Marshal(ingest.JobReorgMeta{
+		Checkpoint: &ingest.ReorgCheckpoint{
+			PhysicalID: physicalTableID,
+			StartKey:   startKey,
+			EndKey:     endKey,
+			Version:    ingest.JobCheckpointVersionCurrent,
+		}})
+	if err != nil {
+		return errors.Trace(err)
+	}
 	del := fmt.Sprintf("delete from mysql.tidb_ddl_reorg where job_id = %d", jobID)
-	ins := fmt.Sprintf("insert into mysql.tidb_ddl_reorg(job_id, ele_id, ele_type, start_key, end_key, physical_id) values (%d, %d, %s, %s, %s, %d)",
-		jobID, element.ID, util.WrapKey2String(element.TypeKey), util.WrapKey2String(startKey), util.WrapKey2String(endKey), physicalTableID)
+	ins := fmt.Sprintf("insert into mysql.tidb_ddl_reorg(job_id, ele_id, ele_type, start_key, end_key, physical_id, reorg_meta) values (%d, %d, %s, %s, %s, %d, %s)",
+		jobID, element.ID, util.WrapKey2String(element.TypeKey), util.WrapKey2String(startKey), util.WrapKey2String(endKey), physicalTableID, util.WrapKey2String(rawReorgMeta))
 	return s.RunInTxn(func(se *sess.Session) error {
 		_, err := se.Execute(context.Background(), del, "init_handle")
 		if err != nil {

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -326,6 +326,10 @@ func overwriteReorgInfoFromGlobalCheckpoint(w *worker, sess *sess.Session, job *
 		// Merging the temporary index uses txn mode, so we don't need to consider the checkpoint.
 		return nil
 	}
+	if job.ReorgMeta.IsDistReorg {
+		// The global checkpoint is not used in distributed tasks.
+		return nil
+	}
 	if w.getReorgCtx(job.ID) != nil {
 		// We only overwrite from checkpoint when the job runs for the first time on this TiDB instance.
 		return nil

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -246,11 +246,6 @@ func (w *worker) runReorgJob(rh *reorgHandler, reorgInfo *reorgInfo, tblInfo *mo
 			return dbterror.ErrCancelledDDLJob
 		}
 
-		err := overwriteReorgInfoFromCheckpoint(rh.s, job, reorgInfo)
-		if err != nil {
-			return err
-		}
-
 		rc = w.newReorgCtx(reorgInfo.Job.ID, reorgInfo.Job.GetRowCount())
 		w.wg.Add(1)
 		go func() {
@@ -322,7 +317,30 @@ func (w *worker) runReorgJob(rh *reorgHandler, reorgInfo *reorgInfo, tblInfo *mo
 	return nil
 }
 
-func overwriteReorgInfoFromCheckpoint(sess *sess.Session, job *model.Job, reorgInfo *reorgInfo) error {
+func overwriteReorgInfoFromGlobalCheckpoint(w *worker, sess *sess.Session, job *model.Job, reorgInfo *reorgInfo) error {
+	if job.ReorgMeta.ReorgTp != model.ReorgTypeLitMerge {
+		// Only used for the ingest mode job.
+		return nil
+	}
+	if reorgInfo.mergingTmpIdx {
+		// Merging the temporary index uses txn mode, so we don't need to consider the checkpoint.
+		return nil
+	}
+	if w.getReorgCtx(job.ID) != nil {
+		// We only overwrite from checkpoint when the job runs for the first time on this TiDB instance.
+		return nil
+	}
+	bc, ok := ingest.LitBackCtxMgr.Load(job.ID)
+	if ok {
+		// We create the checkpoint manager here because we need to wait for the reorg meta to be initialized.
+		if bc.GetCheckpointManager() == nil {
+			mgr, err := ingest.NewCheckpointManager(w.ctx, bc, w.sessPool, job.ID, reorgInfo.currElement.ID)
+			if err != nil {
+				logutil.BgLogger().Warn("[ddl-ingest] create checkpoint manager failed", zap.Error(err))
+			}
+			bc.AttachCheckpointManager(mgr)
+		}
+	}
 	start, end, pid, err := getCheckpointReorgHandle(sess, job)
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43997

Problem Summary:

The basic idea of checkpoint is to recover the progress:

```
| add index for partition 1
|  [ local checkpoint ]
| add index for partition 2
|  [ local checkpoint ]
|  [ global checkpoint ]
| ...
| add index for partition k
|  [ local checkpoint ]
| add index for partition k+1
v  (TiDB 1) crash
  | (TiDB 2) get DDL owner
  | add index for partition 2
  | ...
```

Note that we can only begin with partition 2 because the local checkpoint is lost when TiDB 1 crashes.

In order to represent which partition we should begin with, reorg meta is used. The reorg meta contains a tuple: (partition ID or physical table ID, start key, end key). Every time TiDB restarts in the middle state of adding an index, it tries to reset the reorg meta to the state exactly before the last global checkpoint.

Previously, we store the reorg meta in the checkpoint manager. However, we did not distinguish the "local" reorg meta and the "global" reorg meta. When a partition is complete, the reorg meta is updated immediately, leading to a new TiDB reset to the wrong partition. Finally, the index data from some of the partitions is lost.

### What is changed and how it works?

- Distinguish the "local" reorg meta from the "global" one.
- When the `mysql.ddl_reorg_meta` is initialized, we also initialize the checkpoint.
- Move the creation of checkpoint manager to a proper place(which needs the info from `mysql.ddl_reorg_meta`).
- After the checkpoint manager is created, we try recover the global checkpoint and overwrite the reorg info.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  ```
  1. Create two TiDB.
  2. Prepare a table with a lot of partitions.
  3. Add index.
  4. Kill the TiDB owner. 
  5. Check if the other TiDB can reset the reorg meta to a correct partition ID. 
  ```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
