### PR TITLE
zeropool:  better Pool to improve performance

### DIFF
--- a/br/pkg/lightning/mydump/BUILD.bazel
+++ b/br/pkg/lightning/mydump/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//util/regexpr-router",
         "//util/slice",
         "//util/table-filter",
+        "//util/zeropool",
         "@com_github_pingcap_errors//:errors",
         "@com_github_spkg_bom//:bom",
         "@com_github_xitongsys_parquet_go//parquet",

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -76,6 +76,7 @@ STATICHECK_ANALYZERS = [
     "SA5012",
     "SA6000",
     "SA6001",
+    "SA6002",
     "SA6005",
     "U1000",
 ]

--- a/build/nogo_config.json
+++ b/build/nogo_config.json
@@ -1130,6 +1130,13 @@
       ".*_generated\\.go$": "ignore generated code"
     }
   },
+  "SA6002": {
+    "exclude_files": {
+      "parser/parser.go": "parser/parser.go code",
+      "external/": "no need to vet third party code",
+      ".*_generated\\.go$": "ignore generated code"
+    }
+  },
   "SA6005": {
     "exclude_files": {
       "parser/parser.go": "parser/parser.go code",

--- a/build/nogo_config.json
+++ b/build/nogo_config.json
@@ -1134,6 +1134,7 @@
     "exclude_files": {
       "parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
+      "util/zeropool/pool_test.go": "util/zeropool/pool_test.go",
       ".*_generated\\.go$": "ignore generated code"
     }
   },

--- a/expression/BUILD.bazel
+++ b/expression/BUILD.bazel
@@ -112,6 +112,7 @@ go_library(
         "//util/sqlexec",
         "//util/stringutil",
         "//util/vitess",
+        "//util/zeropool",
         "@com_github_gogo_protobuf//proto",
         "@com_github_google_uuid//:uuid",
         "@com_github_pingcap_errors//:errors",

--- a/util/checksum/BUILD.bazel
+++ b/util/checksum/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["checksum.go"],
     importpath = "github.com/pingcap/tidb/util/checksum",
     visibility = ["//visibility:public"],
+    deps = ["//util/zeropool"],
 )
 
 go_test(

--- a/util/checksum/checksum.go
+++ b/util/checksum/checksum.go
@@ -19,7 +19,8 @@ import (
 	"errors"
 	"hash/crc32"
 	"io"
-	"sync"
+
+	"github.com/pingcap/tidb/util/zeropool"
 )
 
 const (
@@ -31,9 +32,9 @@ const (
 	checksumPayloadSize = checksumBlockSize - checksumSize
 )
 
-var checksumReaderBufPool = sync.Pool{
-	New: func() interface{} { return make([]byte, checksumBlockSize) },
-}
+var checksumReaderBufPool = zeropool.New[[]byte](func() []byte {
+	return make([]byte, checksumBlockSize)
+})
 
 // Writer implements an io.WriteCloser, it calculates and stores a CRC-32 checksum for the payload before
 // writing to the underlying object.
@@ -151,7 +152,7 @@ func (r *Reader) ReadAt(p []byte, off int64) (nn int, err error) {
 	offsetInPayload := off % checksumPayloadSize
 	cursor := off / checksumPayloadSize * checksumBlockSize
 
-	buf := checksumReaderBufPool.Get().([]byte)
+	buf := checksumReaderBufPool.Get()
 	defer checksumReaderBufPool.Put(buf)
 
 	var n int

--- a/util/zeropool/BUILD.bazel
+++ b/util/zeropool/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "zeropool",
+    srcs = ["pool.go"],
+    importpath = "github.com/pingcap/tidb/util/zeropool",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "zeropool_test",
+    timeout = "short",
+    srcs = ["pool_test.go"],
+    flaky = True,
+    deps = [
+        ":zeropool",
+        "@com_github_stretchr_testify//require",
+        "@org_uber_go_atomic//:atomic",
+    ],
+)

--- a/util/zeropool/pool.go
+++ b/util/zeropool/pool.go
@@ -1,0 +1,83 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Package zeropool provides a zero-allocation type-safe alternative for sync.Pool, used to workaround staticheck SA6002.
+// The contents of this package are brought from https://github.com/colega/zeropool because "little copying is better than little dependency".
+
+package zeropool
+
+import "sync"
+
+// Pool is a type-safe pool of items that does not allocate pointers to items.
+// That is not entirely true, it does allocate sometimes, but not most of the time,
+// just like the usual sync.Pool pools items most of the time, except when they're evicted.
+// It does that by storing the allocated pointers in a secondary pool instead of letting them go,
+// so they can be used later to store the items again.
+//
+// Zero value of Pool[T] is valid, and it will return zero values of T if nothing is pooled.
+type Pool[T any] struct {
+	// items holds pointers to the pooled items, which are valid to be used.
+	items sync.Pool
+	// pointers holds just pointers to the pooled item types.
+	// The values referenced by pointers are not valid to be used (as they're used by some other caller)
+	// and it is safe to overwrite these pointers.
+	pointers sync.Pool
+}
+
+// New creates a new Pool[T] with the given function to create new items.
+// A Pool must not be copied after first use.
+func New[T any](item func() T) Pool[T] {
+	return Pool[T]{
+		items: sync.Pool{
+			New: func() interface{} {
+				val := item()
+				return &val
+			},
+		},
+	}
+}
+
+// Get returns an item from the pool, creating a new one if necessary.
+// Get may be called concurrently from multiple goroutines.
+func (p *Pool[T]) Get() T {
+	pooled := p.items.Get()
+	if pooled == nil {
+		// The only way this can happen is when someone is using the zero-value of zeropool.Pool, and items pool is empty.
+		// We don't have a pointer to store in p.pointers, so just return the empty value.
+		var zero T
+		return zero
+	}
+
+	ptr := pooled.(*T)
+	item := *ptr
+	var zero T
+	// We don't want to retain the value in p.pointers.
+	// If T holds a reference to something, we want that to be garbage-collected
+	// if for some reason caller does less Put() calls than Get() calls.
+	*ptr = zero
+	p.pointers.Put(ptr)
+	return item
+}
+
+// Put adds an item to the pool.
+func (p *Pool[T]) Put(item T) {
+	var ptr *T
+	if pooled := p.pointers.Get(); pooled != nil {
+		ptr = pooled.(*T)
+	} else {
+		ptr = new(T)
+	}
+	*ptr = item
+	p.items.Put(ptr)
+}

--- a/util/zeropool/pool_test.go
+++ b/util/zeropool/pool_test.go
@@ -1,0 +1,178 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zeropool_test
+
+import (
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/pingcap/tidb/util/zeropool"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestPool(t *testing.T) {
+	t.Run("provides correct values", func(t *testing.T) {
+		pool := zeropool.New(func() []byte { return make([]byte, 1024) })
+		item1 := pool.Get()
+		require.Equal(t, 1024, len(item1))
+
+		item2 := pool.Get()
+		require.Equal(t, 1024, len(item2))
+
+		pool.Put(item1)
+		pool.Put(item2)
+
+		item1 = pool.Get()
+		require.Equal(t, 1024, len(item1))
+
+		item2 = pool.Get()
+		require.Equal(t, 1024, len(item2))
+	})
+
+	t.Run("is not racy", func(t *testing.T) {
+		pool := zeropool.New(func() []byte { return make([]byte, 1024) })
+
+		const iterations = 1e6
+		const concurrency = math.MaxUint8
+		var counter atomic.Int64
+
+		do := make(chan struct{}, 1e6)
+		for i := 0; i < iterations; i++ {
+			do <- struct{}{}
+		}
+		close(do)
+
+		run := make(chan struct{})
+		done := sync.WaitGroup{}
+		done.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			go func(worker int) {
+				<-run
+				for range do {
+					item := pool.Get()
+					item[0] = byte(worker)
+					counter.Add(1) // Counts and also adds some delay to add raciness.
+					if item[0] != byte(worker) {
+						panic("wrong value")
+					}
+					pool.Put(item)
+				}
+				done.Done()
+			}(i)
+		}
+		close(run)
+		done.Wait()
+		t.Logf("Done %d iterations", counter.Load())
+	})
+
+	t.Run("does not allocate", func(t *testing.T) {
+		pool := zeropool.New(func() []byte { return make([]byte, 1024) })
+		// Warm up, this will alloate one slice.
+		slice := pool.Get()
+		pool.Put(slice)
+
+		allocs := testing.AllocsPerRun(1000, func() {
+			slice := pool.Get()
+			pool.Put(slice)
+		})
+		// Don't compare to 0, as when passing all the tests the GC could flush the pools during this test and we would allocate.
+		// Just check that it's less than 1 on average, which is mostly the same thing.
+		require.Less(t, allocs, 1., "Should not allocate.")
+	})
+
+	t.Run("zero value is valid", func(t *testing.T) {
+		var pool zeropool.Pool[[]byte]
+		slice := pool.Get()
+		pool.Put(slice)
+
+		allocs := testing.AllocsPerRun(1000, func() {
+			slice := pool.Get()
+			pool.Put(slice)
+		})
+		// Don't compare to 0, as when passing all the tests the GC could flush the pools during this test and we would allocate.
+		// Just check that it's less than 1 on average, which is mostly the same thing.
+		require.Less(t, allocs, 1., "Should not allocate.")
+	})
+}
+
+func BenchmarkZeropoolPool(b *testing.B) {
+	pool := zeropool.New(func() []byte { return make([]byte, 1024) })
+
+	// Warmup
+	item := pool.Get()
+	pool.Put(item)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		item := pool.Get()
+		pool.Put(item)
+	}
+}
+
+// BenchmarkSyncPoolValue uses sync.Pool to store values, which makes an allocation on each Put call.
+func BenchmarkSyncPoolValue(b *testing.B) {
+	pool := sync.Pool{New: func() any {
+		return make([]byte, 1024)
+	}}
+
+	// Warmup
+	item := pool.Get().([]byte)
+	pool.Put(item) //nolint:staticcheck // This allocates.
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		item := pool.Get().([]byte)
+		pool.Put(item) //nolint:staticcheck // This allocates.
+	}
+}
+
+// BenchmarkSyncPoolNewPointer uses sync.Pool to store pointers, but it calls Put with a new pointer every time.
+func BenchmarkSyncPoolNewPointer(b *testing.B) {
+	pool := sync.Pool{New: func() any {
+		v := make([]byte, 1024)
+		return &v
+	}}
+
+	// Warmup
+	item := pool.Get().(*[]byte)
+	pool.Put(item) //nolint:staticcheck // This allocates.
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		item := pool.Get().(*[]byte)
+		buf := *item
+		pool.Put(&buf) //nolint:staticcheck  // New pointer.
+	}
+}
+
+// BenchmarkSyncPoolPointer illustrates the optimal usage of sync.Pool, not always possible.
+func BenchmarkSyncPoolPointer(b *testing.B) {
+	pool := sync.Pool{New: func() any {
+		v := make([]byte, 1024)
+		return &v
+	}}
+
+	// Warmup
+	item := pool.Get().(*[]byte)
+	pool.Put(item)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		item := pool.Get().(*[]byte)
+		pool.Put(item)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44042

ref https://github.com/prometheus/prometheus/pull/12189

Problem Summary:

### What is changed and how it works?

```
$ go test -run=X -bench=.  -benchmem 
goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/util/zeropool
BenchmarkZeropoolPool-8                 68883153                17.39 ns/op            0 B/op          0 allocs/op
BenchmarkSyncPoolValue-8                46020945                26.25 ns/op           24 B/op          1 allocs/op
BenchmarkSyncPoolNewPointer-8           46381591                25.57 ns/op           24 B/op          1 allocs/op
```

```
                                                             │     old      │                  new                  │
                                                             │  allocs/op   │  allocs/op    vs base                 │
RowBasedFilterAndVectorizedFilter/Vec-int/-8                    4.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-int/-8                    0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-real/-8                   3.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-real/-8                   0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-decimal/-8                4.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-decimal/-8                0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-string/-8                 4.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-string/-8                 0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-datetime/-8               3.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-datetime/-8               978.0 ± ∞ ¹    967.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-timestamp/-8              4.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-timestamp/-8              982.0 ± ∞ ¹    976.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-duration/-8               3.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-duration/-8               0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-int/int/-8                5.000 ± ∞ ¹    3.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-int/int/-8                0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-real/int/-8              10.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-real/int/-8               0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-decimal/int/-8            11.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-decimal/int/-8            0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-string/int/-8             12.00 ± ∞ ¹    11.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-string/int/-8             0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-datetime/int/-8          10.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-datetime/int/-8           969.0 ± ∞ ¹    988.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-timestamp/int/-8         10.000 ± ∞ ¹    9.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-timestamp/int/-8          985.0 ± ∞ ¹    968.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-duration/int/-8          10.000 ± ∞ ¹    9.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-duration/int/-8           0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-int/real/-8               4.000 ± ∞ ¹    3.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-int/real/-8               0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-real/real/-8             10.000 ± ∞ ¹    9.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-real/real/-8              0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-decimal/real/-8           11.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-decimal/real/-8           0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-string/real/-8            12.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-string/real/-8            0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-datetime/real/-8         10.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-datetime/real/-8          970.0 ± ∞ ¹    967.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-timestamp/real/-8        10.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-timestamp/real/-8         978.0 ± ∞ ¹    970.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-duration/real/-8         10.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-duration/real/-8          0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-int/decimal/-8            5.000 ± ∞ ¹    4.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-int/decimal/-8            0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-real/decimal/-8           12.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-real/decimal/-8           0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-decimal/decimal/-8       11.000 ± ∞ ¹    9.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-decimal/decimal/-8        0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-string/decimal/-8         13.00 ± ∞ ¹    11.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-string/decimal/-8         0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-datetime/decimal/-8       12.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-datetime/decimal/-8       972.0 ± ∞ ¹    971.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-timestamp/decimal/-8      12.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-timestamp/decimal/-8      986.0 ± ∞ ¹    980.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-duration/decimal/-8       11.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-duration/decimal/-8       0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-int/string/-8             5.000 ± ∞ ¹    4.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-int/string/-8             0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-real/string/-8            14.00 ± ∞ ¹    12.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-real/string/-8            0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-decimal/string/-8         14.00 ± ∞ ¹    13.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-decimal/string/-8         0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-string/string/-8         11.000 ± ∞ ¹    9.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-string/string/-8          0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-datetime/string/-8        14.00 ± ∞ ¹    12.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-datetime/string/-8        970.0 ± ∞ ¹    970.0 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-timestamp/string/-8       13.00 ± ∞ ¹    13.00 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Row-timestamp/string/-8       984.0 ± ∞ ¹    984.0 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-duration/string/-8        14.00 ± ∞ ¹    12.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-duration/string/-8        0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-int/datetime/-8           4.000 ± ∞ ¹    3.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-int/datetime/-8           915.0 ± ∞ ¹    923.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-real/datetime/-8         10.000 ± ∞ ¹    9.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-real/datetime/-8          921.0 ± ∞ ¹    931.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-decimal/datetime/-8       11.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-decimal/datetime/-8       906.0 ± ∞ ¹    926.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-string/datetime/-8        12.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-string/datetime/-8        875.0 ± ∞ ¹    836.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-datetime/datetime/-8     10.000 ± ∞ ¹    9.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-datetime/datetime/-8     1.882k ± ∞ ¹   1.920k ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-timestamp/datetime/-8    10.000 ± ∞ ¹    9.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-timestamp/datetime/-8    1.915k ± ∞ ¹   1.914k ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-duration/datetime/-8     10.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-duration/datetime/-8      929.0 ± ∞ ¹    924.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-int/timestamp/-8          5.000 ± ∞ ¹    3.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-int/timestamp/-8          922.0 ± ∞ ¹    924.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-real/timestamp/-8        10.000 ± ∞ ¹    9.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-real/timestamp/-8         928.0 ± ∞ ¹    933.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-decimal/timestamp/-8      11.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-decimal/timestamp/-8      926.0 ± ∞ ¹    930.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-string/timestamp/-8       12.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-string/timestamp/-8       886.0 ± ∞ ¹    873.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-datetime/timestamp/-8    10.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-datetime/timestamp/-8    1.884k ± ∞ ¹   1.921k ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-timestamp/timestamp/-8   10.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-timestamp/timestamp/-8   1.905k ± ∞ ¹   1.881k ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-duration/timestamp/-8    10.000 ± ∞ ¹    9.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-duration/timestamp/-8     908.0 ± ∞ ¹    917.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-int/duration/-8           5.000 ± ∞ ¹    3.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-int/duration/-8           0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-real/duration/-8         10.000 ± ∞ ¹    9.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-real/duration/-8          0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-decimal/duration/-8       12.00 ± ∞ ¹    10.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-decimal/duration/-8       0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-string/duration/-8        12.00 ± ∞ ¹    11.00 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-string/duration/-8        0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-datetime/duration/-8     10.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-datetime/duration/-8      984.0 ± ∞ ¹    970.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-timestamp/duration/-8    10.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-timestamp/duration/-8     974.0 ± ∞ ¹    962.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Vec-duration/duration/-8     10.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-duration/duration/-8      0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
RowBasedFilterAndVectorizedFilter/Vec-special_case-8            5.000 ± ∞ ¹    3.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
RowBasedFilterAndVectorizedFilter/Row-special_case-8            0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
geomean                                                                   ⁴                 -11.19%               ⁴
```


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
