### PR TITLE
planner: fix incorrect cost when the plan has `IndexLookup->Limit/Agg/TopN`

### DIFF
--- a/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+++ b/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
@@ -2099,7 +2099,7 @@
       },
       {
         "SQL": "select * from t where t.c = 1 and t.e = 1 order by t.d limit 1",
-        "Best": "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)])->Limit, Table(t))"
+        "Best": "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t))->Limit"
       },
       {
         "SQL": "select c from t where t.c = 1 and t.e = 1 order by t.d limit 1",

--- a/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+++ b/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
@@ -2099,7 +2099,7 @@
       },
       {
         "SQL": "select * from t where t.c = 1 and t.e = 1 order by t.d limit 1",
-        "Best": "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t))->Limit"
+        "Best": "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)])->Limit, Table(t))"
       },
       {
         "SQL": "select c from t where t.c = 1 and t.e = 1 order by t.d limit 1",

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -331,7 +331,7 @@ func getTaskPlanCost(t task, op *physicalOptimizeOp) (float64, bool, error) {
 				return idxCost, false, err
 			}
 			// consider both sides
-			idxCost, err := getPlanCost(t.(*copTask).indexPlan, taskType, NewDefaultPlanCostOption().WithOptimizeTracer(op))
+			idxCost, err := getPlanCost(cop.indexPlan, taskType, NewDefaultPlanCostOption().WithOptimizeTracer(op))
 			if err != nil {
 				return 0, false, err
 			}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -329,17 +329,17 @@ func getTaskPlanCost(t task, op *physicalOptimizeOp) (float64, bool, error) {
 			if !cop.indexPlanFinished { // only consider index cost in this case
 				idxCost, err := getPlanCost(t.(*copTask).indexPlan, taskType, NewDefaultPlanCostOption().WithOptimizeTracer(op))
 				return idxCost, false, err
-			} else { // consider both sides
-				idxCost, err := getPlanCost(t.(*copTask).indexPlan, taskType, NewDefaultPlanCostOption().WithOptimizeTracer(op))
-				if err != nil {
-					return 0, false, err
-				}
-				tblCost, err := getPlanCost(t.(*copTask).tablePlan, taskType, NewDefaultPlanCostOption().WithOptimizeTracer(op))
-				if err != nil {
-					return 0, false, err
-				}
-				return idxCost + tblCost, false, nil
 			}
+			// consider both sides
+			idxCost, err := getPlanCost(t.(*copTask).indexPlan, taskType, NewDefaultPlanCostOption().WithOptimizeTracer(op))
+			if err != nil {
+				return 0, false, err
+			}
+			tblCost, err := getPlanCost(t.(*copTask).tablePlan, taskType, NewDefaultPlanCostOption().WithOptimizeTracer(op))
+			if err != nil {
+				return 0, false, err
+			}
+			return idxCost + tblCost, false, nil
 		}
 
 		taskType = property.CopSingleReadTaskType

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -327,7 +327,7 @@ func getTaskPlanCost(t task, op *physicalOptimizeOp) (float64, bool, error) {
 			taskType = property.CopMultiReadTaskType
 			// keep compatible with the old cost interface, for CopMultiReadTask, the cost is idxCost + tblCost.
 			if !cop.indexPlanFinished { // only consider index cost in this case
-				idxCost, err := getPlanCost(t.(*copTask).indexPlan, taskType, NewDefaultPlanCostOption().WithOptimizeTracer(op))
+				idxCost, err := getPlanCost(cop.indexPlan, taskType, NewDefaultPlanCostOption().WithOptimizeTracer(op))
 				return idxCost, false, err
 			}
 			// consider both sides

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -335,7 +335,7 @@ func getTaskPlanCost(t task, op *physicalOptimizeOp) (float64, bool, error) {
 			if err != nil {
 				return 0, false, err
 			}
-			tblCost, err := getPlanCost(t.(*copTask).tablePlan, taskType, NewDefaultPlanCostOption().WithOptimizeTracer(op))
+			tblCost, err := getPlanCost(cop.tablePlan, taskType, NewDefaultPlanCostOption().WithOptimizeTracer(op))
 			if err != nil {
 				return 0, false, err
 			}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -345,8 +345,8 @@ func getTaskPlanCost(t task, op *physicalOptimizeOp) (float64, bool, error) {
 		taskType = property.CopSingleReadTaskType
 
 		// TiFlash can run cop task as well, check whether this cop task will run on TiKV or TiFlash.
-		if t.(*copTask).tablePlan != nil {
-			leafNode := t.(*copTask).tablePlan
+		if cop.tablePlan != nil {
+			leafNode := cop.tablePlan
 			for len(leafNode.Children()) > 0 {
 				leafNode = leafNode.Children()[0]
 			}

--- a/planner/core/plan_cost_ver2_test.go
+++ b/planner/core/plan_cost_ver2_test.go
@@ -278,6 +278,15 @@ func TestIndexJoinPenaltyCost(t *testing.T) {
 	require.Greater(t, cost3, cost2)
 }
 
+func TestIssue44025(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t(a int, b int, c int, d int, index ia(a), index ibc(b,c))`)
+	tk.MustExec(`set @@tidb_cost_model_version=1`)
+	tk.MustUseIndex(`select * from t where a between 1 and 5 and b != 200 and c = 20 limit 100000`, `ia(a)`)
+}
+
 func BenchmarkGetPlanCost(b *testing.B) {
 	store := testkit.CreateMockStore(b)
 	tk := testkit.NewTestKit(b, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44025

Problem Summary: planner: fix incorrect cost when the plan has `IndexLookup->Limit/Agg/TopN`

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
