### PR TITLE
planner: wrong execution when CTE meet non-correlated subquery | tidb-test=pr/2135

### DIFF
--- a/cmd/explaintest/r/cte.result
+++ b/cmd/explaintest/r/cte.result
@@ -387,18 +387,18 @@ insert into tpk values(1), (2), (3);
 // Expect a Sort operator on CTE.
 explain with cte1 as (select c1 from t1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_28	8000.00	root		inner join, left key:test.t1.c1, right key:test.t1.c1
-├─Sort_26(Build)	6400.00	root		test.t1.c1
-│ └─Selection_24	6400.00	root		not(isnull(test.t1.c1))
-│   └─CTEFullScan_25	8000.00	root	CTE:dt2	data:CTE_0
+MergeJoin_28	9990.00	root		inner join, left key:test.t1.c1, right key:test.t1.c1
+├─Sort_26(Build)	7992.00	root		test.t1.c1
+│ └─Selection_24	7992.00	root		not(isnull(test.t1.c1))
+│   └─CTEFullScan_25	9990.00	root	CTE:dt2	data:CTE_0
 └─Sort_22(Probe)	9990.00	root		test.t1.c1
   └─TableReader_21	9990.00	root		data:Selection_20
     └─Selection_20	9990.00	cop[tikv]		not(isnull(test.t1.c1))
       └─TableFullScan_19	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	8000.00	root		Non-Recursive CTE
-└─Selection_11(Seed Part)	8000.00	root		not(isnull(test.t1.c1))
-  └─TableReader_14	10000.00	root		data:TableFullScan_13
-    └─TableFullScan_13	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+CTE_0	9990.00	root		Non-Recursive CTE
+└─TableReader_14(Seed Part)	9990.00	root		data:Selection_13
+  └─Selection_13	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+    └─TableFullScan_12	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 with cte1 as (select c1 from t1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
 1	1
@@ -412,16 +412,15 @@ c1	c1
 // Sort should not exist, because tpk.c1 is pk. Not the best plan for now(#25674).
 explain with cte1 as (select c1 from tpk) select /*+ MERGE_JOIN(dt1, dt2) */ * from tpk dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_26	8000.00	root		inner join, left key:test.tpk.c1, right key:test.tpk.c1
-├─Sort_24(Build)	6400.00	root		test.tpk.c1
-│ └─Selection_22	6400.00	root		not(isnull(test.tpk.c1))
-│   └─CTEFullScan_23	8000.00	root	CTE:dt2	data:CTE_0
-└─TableReader_20(Probe)	10000.00	root		data:TableFullScan_19
-  └─TableFullScan_19	10000.00	cop[tikv]	table:dt1	keep order:true, stats:pseudo
-CTE_0	8000.00	root		Non-Recursive CTE
-└─Selection_11(Seed Part)	8000.00	root		not(isnull(test.tpk.c1))
-  └─TableReader_14	10000.00	root		data:TableFullScan_13
-    └─TableFullScan_13	10000.00	cop[tikv]	table:tpk	keep order:false, stats:pseudo
+MergeJoin_25	10000.00	root		inner join, left key:test.tpk.c1, right key:test.tpk.c1
+├─Sort_23(Build)	8000.00	root		test.tpk.c1
+│ └─Selection_21	8000.00	root		not(isnull(test.tpk.c1))
+│   └─CTEFullScan_22	10000.00	root	CTE:dt2	data:CTE_0
+└─TableReader_19(Probe)	10000.00	root		data:TableFullScan_18
+  └─TableFullScan_18	10000.00	cop[tikv]	table:dt1	keep order:true, stats:pseudo
+CTE_0	10000.00	root		Non-Recursive CTE
+└─TableReader_13(Seed Part)	10000.00	root		data:TableFullScan_12
+  └─TableFullScan_12	10000.00	cop[tikv]	table:tpk	keep order:false, stats:pseudo
 with cte1 as (select c1 from tpk) select /*+ MERGE_JOIN(dt1, dt2) */ * from tpk dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
 1	1
@@ -430,19 +429,19 @@ c1	c1
 // Sort should not exist, because we have order by in CTE definition. Not the best plan for now(#25674).
 explain with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_32	8000.00	root		inner join, left key:test.t1.c1, right key:test.t1.c1
-├─Sort_30(Build)	6400.00	root		test.t1.c1
-│ └─Selection_28	6400.00	root		not(isnull(test.t1.c1))
-│   └─CTEFullScan_29	8000.00	root	CTE:dt2	data:CTE_0
+MergeJoin_32	9990.00	root		inner join, left key:test.t1.c1, right key:test.t1.c1
+├─Sort_30(Build)	7992.00	root		test.t1.c1
+│ └─Selection_28	7992.00	root		not(isnull(test.t1.c1))
+│   └─CTEFullScan_29	9990.00	root	CTE:dt2	data:CTE_0
 └─Sort_26(Probe)	9990.00	root		test.t1.c1
   └─TableReader_25	9990.00	root		data:Selection_24
     └─Selection_24	9990.00	cop[tikv]		not(isnull(test.t1.c1))
       └─TableFullScan_23	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	8000.00	root		Non-Recursive CTE
-└─Selection_12(Seed Part)	8000.00	root		not(isnull(test.t1.c1))
-  └─Sort_13	10000.00	root		test.t1.c1
-    └─TableReader_17	10000.00	root		data:TableFullScan_16
-      └─TableFullScan_16	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+CTE_0	9990.00	root		Non-Recursive CTE
+└─Sort_12(Seed Part)	9990.00	root		test.t1.c1
+  └─TableReader_17	9990.00	root		data:Selection_16
+    └─Selection_16	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+      └─TableFullScan_15	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
 1	1
@@ -503,19 +502,19 @@ c1	c1
 // Expect Sort operator in CTE definition.
 explain with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_32	8000.00	root		inner join, left key:test.t1.c1, right key:test.t1.c1
-├─Sort_30(Build)	6400.00	root		test.t1.c1
-│ └─Selection_28	6400.00	root		not(isnull(test.t1.c1))
-│   └─CTEFullScan_29	8000.00	root	CTE:dt2	data:CTE_0
+MergeJoin_32	9990.00	root		inner join, left key:test.t1.c1, right key:test.t1.c1
+├─Sort_30(Build)	7992.00	root		test.t1.c1
+│ └─Selection_28	7992.00	root		not(isnull(test.t1.c1))
+│   └─CTEFullScan_29	9990.00	root	CTE:dt2	data:CTE_0
 └─Sort_26(Probe)	9990.00	root		test.t1.c1
   └─TableReader_25	9990.00	root		data:Selection_24
     └─Selection_24	9990.00	cop[tikv]		not(isnull(test.t1.c1))
       └─TableFullScan_23	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	8000.00	root		Non-Recursive CTE
-└─Selection_12(Seed Part)	8000.00	root		not(isnull(test.t1.c1))
-  └─Sort_13	10000.00	root		test.t1.c1
-    └─TableReader_17	10000.00	root		data:TableFullScan_16
-      └─TableFullScan_16	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+CTE_0	9990.00	root		Non-Recursive CTE
+└─Sort_12(Seed Part)	9990.00	root		test.t1.c1
+  └─TableReader_17	9990.00	root		data:Selection_16
+    └─Selection_16	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+      └─TableFullScan_15	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
 1	1
@@ -529,18 +528,17 @@ c1	c1
 // Sort should not exist, because tpk is ordered. Not the best plan for now(#25674).
 explain with cte1 as (select c1 from tpk order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_34	8000.00	root		inner join, left key:test.t1.c1, right key:test.tpk.c1
-├─Sort_32(Build)	6400.00	root		test.tpk.c1
-│ └─Selection_30	6400.00	root		not(isnull(test.tpk.c1))
-│   └─CTEFullScan_31	8000.00	root	CTE:dt2	data:CTE_0
-└─Sort_28(Probe)	9990.00	root		test.t1.c1
-  └─TableReader_27	9990.00	root		data:Selection_26
-    └─Selection_26	9990.00	cop[tikv]		not(isnull(test.t1.c1))
-      └─TableFullScan_25	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	8000.00	root		Non-Recursive CTE
-└─Selection_12(Seed Part)	8000.00	root		not(isnull(test.tpk.c1))
-  └─TableReader_20	10000.00	root		data:TableFullScan_19
-    └─TableFullScan_19	10000.00	cop[tikv]	table:tpk	keep order:true, stats:pseudo
+MergeJoin_33	10000.00	root		inner join, left key:test.t1.c1, right key:test.tpk.c1
+├─Sort_31(Build)	8000.00	root		test.tpk.c1
+│ └─Selection_29	8000.00	root		not(isnull(test.tpk.c1))
+│   └─CTEFullScan_30	10000.00	root	CTE:dt2	data:CTE_0
+└─Sort_27(Probe)	9990.00	root		test.t1.c1
+  └─TableReader_26	9990.00	root		data:Selection_25
+    └─Selection_25	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+      └─TableFullScan_24	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
+CTE_0	10000.00	root		Non-Recursive CTE
+└─TableReader_19(Seed Part)	10000.00	root		data:TableFullScan_18
+  └─TableFullScan_18	10000.00	cop[tikv]	table:tpk	keep order:true, stats:pseudo
 with cte1 as (select c1 from tpk order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
 1	1
@@ -550,16 +548,16 @@ c1	c1
 // HashJoin. No need to sort
 explain with cte1 as (select c1 from t1) select /*+ HASH_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = 1 order by 1, 2;
 id	estRows	task	access object	operator info
-Sort_15	64000000.00	root		test.t1.c1, test.t1.c1
-└─HashJoin_18	64000000.00	root		CARTESIAN inner join
-  ├─Selection_22(Build)	6400.00	root		eq(test.t1.c1, 1)
-  │ └─CTEFullScan_23	8000.00	root	CTE:dt2	data:CTE_0
+Sort_15	80000.00	root		test.t1.c1, test.t1.c1
+└─HashJoin_18	80000.00	root		CARTESIAN inner join
+  ├─Selection_22(Build)	8.00	root		eq(test.t1.c1, 1)
+  │ └─CTEFullScan_23	10.00	root	CTE:dt2	data:CTE_0
   └─TableReader_21(Probe)	10000.00	root		data:TableFullScan_20
     └─TableFullScan_20	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	8000.00	root		Non-Recursive CTE
-└─Selection_11(Seed Part)	8000.00	root		eq(test.t1.c1, 1)
-  └─TableReader_14	10000.00	root		data:TableFullScan_13
-    └─TableFullScan_13	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+CTE_0	10.00	root		Non-Recursive CTE
+└─TableReader_14(Seed Part)	10.00	root		data:Selection_13
+  └─Selection_13	10.00	cop[tikv]		eq(test.t1.c1, 1)
+    └─TableFullScan_12	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 with cte1 as (select c1 from t1) select /*+ HASH_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = 1 order by 1, 2;
 c1	c1
 1	1
@@ -572,16 +570,14 @@ c1	c1
 2	1
 explain with cte1 as (select c1 from tpk) select /*+ HASH_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = 1 order by 1, 2;
 id	estRows	task	access object	operator info
-Sort_15	64000000.00	root		test.t1.c1, test.tpk.c1
-└─HashJoin_18	64000000.00	root		CARTESIAN inner join
-  ├─Selection_22(Build)	6400.00	root		eq(test.tpk.c1, 1)
-  │ └─CTEFullScan_23	8000.00	root	CTE:dt2	data:CTE_0
-  └─TableReader_21(Probe)	10000.00	root		data:TableFullScan_20
-    └─TableFullScan_20	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	8000.00	root		Non-Recursive CTE
-└─Selection_11(Seed Part)	8000.00	root		eq(test.tpk.c1, 1)
-  └─TableReader_14	10000.00	root		data:TableFullScan_13
-    └─TableFullScan_13	10000.00	cop[tikv]	table:tpk	keep order:false, stats:pseudo
+Sort_13	8000.00	root		test.t1.c1, test.tpk.c1
+└─HashJoin_16	8000.00	root		CARTESIAN inner join
+  ├─Selection_20(Build)	0.80	root		eq(test.tpk.c1, 1)
+  │ └─CTEFullScan_21	1.00	root	CTE:dt2	data:CTE_0
+  └─TableReader_19(Probe)	10000.00	root		data:TableFullScan_18
+    └─TableFullScan_18	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
+CTE_0	1.00	root		Non-Recursive CTE
+└─Point_Get_12(Seed Part)	1.00	root	table:tpk	handle:1
 with cte1 as (select c1 from tpk) select /*+ HASH_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = 1 order by 1, 2;
 c1	c1
 1	1
@@ -596,20 +592,19 @@ create table tpk1(c1 int primary key);
 insert into tpk1 values(1), (2), (3);
 explain with cte1 as (select c1 from tpk) select /*+ merge_join(dt1, dt2) */ * from tpk1 dt1 inner join cte1 dt2 inner join cte1 dt3 on dt1.c1 = dt2.c1 and dt2.c1 = dt3.c1;
 id	estRows	task	access object	operator info
-Projection_20	10000.00	root		test.tpk1.c1, test.tpk.c1, test.tpk.c1
-└─HashJoin_22	10000.00	root		inner join, equal:[eq(test.tpk.c1, test.tpk.c1)]
-  ├─Selection_23(Build)	6400.00	root		not(isnull(test.tpk.c1))
-  │ └─CTEFullScan_24	8000.00	root	CTE:dt3	data:CTE_0
-  └─MergeJoin_25(Probe)	8000.00	root		inner join, left key:test.tpk1.c1, right key:test.tpk.c1
-    ├─Sort_31(Build)	6400.00	root		test.tpk.c1
-    │ └─Selection_29	6400.00	root		not(isnull(test.tpk.c1))
-    │   └─CTEFullScan_30	8000.00	root	CTE:dt2	data:CTE_0
-    └─TableReader_27(Probe)	10000.00	root		data:TableFullScan_26
-      └─TableFullScan_26	10000.00	cop[tikv]	table:dt1	keep order:true, stats:pseudo
-CTE_0	8000.00	root		Non-Recursive CTE
-└─Selection_13(Seed Part)	8000.00	root		or(not(isnull(test.tpk.c1)), not(isnull(test.tpk.c1)))
-  └─TableReader_16	10000.00	root		data:TableFullScan_15
-    └─TableFullScan_15	10000.00	cop[tikv]	table:tpk	keep order:false, stats:pseudo
+Projection_19	12500.00	root		test.tpk1.c1, test.tpk.c1, test.tpk.c1
+└─HashJoin_21	12500.00	root		inner join, equal:[eq(test.tpk.c1, test.tpk.c1)]
+  ├─Selection_22(Build)	8000.00	root		not(isnull(test.tpk.c1))
+  │ └─CTEFullScan_23	10000.00	root	CTE:dt3	data:CTE_0
+  └─MergeJoin_24(Probe)	10000.00	root		inner join, left key:test.tpk1.c1, right key:test.tpk.c1
+    ├─Sort_30(Build)	8000.00	root		test.tpk.c1
+    │ └─Selection_28	8000.00	root		not(isnull(test.tpk.c1))
+    │   └─CTEFullScan_29	10000.00	root	CTE:dt2	data:CTE_0
+    └─TableReader_26(Probe)	10000.00	root		data:TableFullScan_25
+      └─TableFullScan_25	10000.00	cop[tikv]	table:dt1	keep order:true, stats:pseudo
+CTE_0	10000.00	root		Non-Recursive CTE
+└─TableReader_15(Seed Part)	10000.00	root		data:TableFullScan_14
+  └─TableFullScan_14	10000.00	cop[tikv]	table:tpk	keep order:false, stats:pseudo
 with cte1 as (select c1 from tpk) select /*+ merge_join(dt1, dt2) */ * from tpk1 dt1 inner join cte1 dt2 inner join cte1 dt3 on dt1.c1 = dt2.c1 and dt2.c1 = dt3.c1;
 c1	c1	c1
 1	1	1

--- a/cmd/explaintest/r/explain_cte.result
+++ b/cmd/explaintest/r/explain_cte.result
@@ -67,12 +67,11 @@ CTE_0	2.00	root		Recursive CTE
     └─CTETable_17	1.00	root		Scan on CTE_0
 explain with cte(a) as (with recursive cte1(a) as (select 1 union select a + 1 from cte1 where a < 10) select * from cte1) select * from cte t1, cte t2;
 id	estRows	task	access object	operator info
-HashJoin_26	2.56	root		CARTESIAN inner join
-├─CTEFullScan_29(Build)	1.60	root	CTE:t2	data:CTE_0
-└─CTEFullScan_28(Probe)	1.60	root	CTE:t1	data:CTE_0
-CTE_0	1.60	root		Non-Recursive CTE
-└─Selection_21(Seed Part)	1.60	root		1
-  └─CTEFullScan_23	2.00	root	CTE:cte1	data:CTE_1
+HashJoin_25	4.00	root		CARTESIAN inner join
+├─CTEFullScan_28(Build)	2.00	root	CTE:t2	data:CTE_0
+└─CTEFullScan_27(Probe)	2.00	root	CTE:t1	data:CTE_0
+CTE_0	2.00	root		Non-Recursive CTE
+└─CTEFullScan_22(Seed Part)	2.00	root	CTE:cte1	data:CTE_1
 CTE_1	2.00	root		Recursive CTE
 ├─Projection_16(Seed Part)	1.00	root		1->Column#2
 │ └─TableDual_17	1.00	root		rows:1
@@ -98,15 +97,13 @@ CTE_1	8001.00	root		Recursive CTE
     └─CTETable_33	10000.00	root		Scan on CTE_1
 explain with q(a,b) as (select * from t1) select /*+ merge(q) no_merge(q1) */ * from q, q q1 where q.a=1 and q1.a=2;
 id	estRows	task	access object	operator info
-HashJoin_19	40960000.00	root		CARTESIAN inner join
-├─Selection_23(Build)	6400.00	root		eq(test.t1.c1, 2)
-│ └─CTEFullScan_24	8000.00	root	CTE:q1	data:CTE_0
-└─Selection_21(Probe)	6400.00	root		eq(test.t1.c1, 1)
-  └─CTEFullScan_22	8000.00	root	CTE:q	data:CTE_0
-CTE_0	8000.00	root		Non-Recursive CTE
-└─Selection_11(Seed Part)	8000.00	root		or(eq(test.t1.c1, 1), eq(test.t1.c1, 2))
-  └─TableReader_14	10000.00	root		data:TableFullScan_13
-    └─TableFullScan_13	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+HashJoin_15	2.56	root		CARTESIAN inner join
+├─Selection_19(Build)	1.60	root		eq(test.t1.c1, 2)
+│ └─CTEFullScan_20	2.00	root	CTE:q1	data:CTE_0
+└─Selection_17(Probe)	1.60	root		eq(test.t1.c1, 1)
+  └─CTEFullScan_18	2.00	root	CTE:q	data:CTE_0
+CTE_0	2.00	root		Non-Recursive CTE
+└─Batch_Point_Get_12(Seed Part)	2.00	root	table:t1	handle:[1 2], keep order:false, desc:false
 explain with recursive cte(a,b) as (select 1, concat('a', 1) union select a+1, concat(b, 1) from cte where a < 5) select * from cte;
 id	estRows	task	access object	operator info
 CTEFullScan_17	2.00	root	CTE:cte	data:CTE_0

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -351,7 +351,7 @@ func TestCheckActRowsWithUnistore(t *testing.T) {
 		},
 		{
 			sql:      "with cte(a) as (select a from t_unistore_act_rows) select (select 1 from cte limit 1) from cte;",
-			expected: []string{"4", "4", "4", "4", "4"},
+			expected: []string{"4", "1", "1", "1", "4", "4", "4", "4", "4"},
 		},
 	}
 

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -1281,6 +1281,7 @@ func (p *LogicalCTE) DeriveStats(childStats []*property.StatsInfo, selfSchema *e
 	if p.cte.seedPartPhysicalPlan == nil {
 		// Build push-downed predicates.
 		if len(p.cte.pushDownPredicates) > 0 {
+			p.cte.optFlag |= flagPredicatePushDown
 			newCond := expression.ComposeDNFCondition(p.ctx, p.cte.pushDownPredicates...)
 			newSel := LogicalSelection{Conditions: []expression.Expression{newCond}}.Init(p.SCtx(), p.cte.seedPartLogicalPlan.SelectBlockOffset())
 			newSel.SetChildren(p.cte.seedPartLogicalPlan)


### PR DESCRIPTION
cherry-pick #44054
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
