### PR TITLE
config: turn on lite-init-stats and force-init-stats by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -990,7 +990,7 @@ var defaultConf = Config{
 		RunAutoAnalyze:                    true,
 		EnableLoadFMSketch:                false,
 		LiteInitStats:                     true,
-		ForceInitStats:                    false,
+		ForceInitStats:                    true,
 	},
 	ProxyProtocol: ProxyProtocol{
 		Networks:      "",

--- a/config/config.go
+++ b/config/config.go
@@ -989,7 +989,7 @@ var defaultConf = Config{
 		EnableStatsCacheMemQuota:          false,
 		RunAutoAnalyze:                    true,
 		EnableLoadFMSketch:                false,
-		LiteInitStats:                     false,
+		LiteInitStats:                     true,
 		ForceInitStats:                    false,
 	},
 	ProxyProtocol: ProxyProtocol{

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -283,7 +283,7 @@ gogc = 100
 lite-init-stats = true
 
 # Whether to wait for init stats to finish before providing service during startup
-force-init-stats = false
+force-init-stats = true
 
 [proxy-protocol]
 # PROXY protocol acceptable client networks.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -280,7 +280,7 @@ max-txn-ttl = 3600000
 gogc = 100
 
 # Whether to use the lite mode of init stats.
-lite-init-stats = false
+lite-init-stats = true
 
 # Whether to wait for init stats to finish before providing service during startup
 force-init-stats = false

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -741,7 +741,7 @@ txn-total-size-limit=2000
 tcp-no-delay = false
 enable-load-fmsketch = true
 plan-replayer-dump-worker-concurrency = 1
-lite-init-stats = true
+lite-init-stats = false
 force-init-stats = true
 [tikv-client]
 commit-timeout="41s"
@@ -834,7 +834,7 @@ max_connections = 200
 	require.Equal(t, 10240, conf.Status.GRPCInitialWindowSize)
 	require.Equal(t, 40960, conf.Status.GRPCMaxSendMsgSize)
 	require.True(t, conf.Performance.EnableLoadFMSketch)
-	require.True(t, conf.Performance.LiteInitStats)
+	require.False(t, conf.Performance.LiteInitStats)
 	require.True(t, conf.Performance.ForceInitStats)
 
 	err = f.Truncate(0)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -742,7 +742,7 @@ tcp-no-delay = false
 enable-load-fmsketch = true
 plan-replayer-dump-worker-concurrency = 1
 lite-init-stats = false
-force-init-stats = true
+force-init-stats = false
 [tikv-client]
 commit-timeout="41s"
 max-batch-size=128
@@ -835,7 +835,7 @@ max_connections = 200
 	require.Equal(t, 40960, conf.Status.GRPCMaxSendMsgSize)
 	require.True(t, conf.Performance.EnableLoadFMSketch)
 	require.False(t, conf.Performance.LiteInitStats)
-	require.True(t, conf.Performance.ForceInitStats)
+	require.False(t, conf.Performance.ForceInitStats)
 
 	err = f.Truncate(0)
 	require.NoError(t, err)

--- a/executor/test/analyzetest/analyze_test.go
+++ b/executor/test/analyzetest/analyze_test.go
@@ -1077,16 +1077,10 @@ PARTITION BY RANGE ( a ) (
 	tk.MustExec("insert into t values (1,1,1),(2,1,2),(3,1,3),(4,1,4),(5,1,5),(6,1,6),(7,7,7),(8,8,8),(9,9,9),(10,10,10),(11,11,11),(12,12,12),(13,13,13),(14,14,14)")
 
 	h := dom.StatsHandle()
-	oriLease := h.Lease()
-	h.SetLease(1)
-	defer func() {
-		h.SetLease(oriLease)
-	}()
+
 	// analyze partition only sets options of partition
 	tk.MustExec("analyze table t partition p0 with 1 topn, 3 buckets")
 	is := dom.InfoSchema()
-	tk.MustQuery("select * from t where b > 1 and c > 1")
-	require.NoError(t, h.LoadNeededHistograms())
 	table, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := table.Meta()
@@ -1106,8 +1100,6 @@ PARTITION BY RANGE ( a ) (
 
 	// merge partition & table level options
 	tk.MustExec("analyze table t columns a,b with 0 topn, 2 buckets")
-	tk.MustQuery("select * from t where b > 1 and c > 1")
-	require.NoError(t, h.LoadNeededHistograms())
 	p0 = h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
 	p1 := h.GetPartitionStats(tableInfo, pi.Definitions[1].ID)
 	require.Greater(t, p0.Version, lastVersion)
@@ -1142,8 +1134,6 @@ PARTITION BY RANGE ( a ) (
 
 	// analyze partition only updates this partition, and set different collist
 	tk.MustExec("analyze table t partition p1 columns a,c with 1 buckets")
-	tk.MustQuery("select * from t where b > 1 and c > 1")
-	require.NoError(t, h.LoadNeededHistograms())
 	p0 = h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
 	p1 = h.GetPartitionStats(tableInfo, pi.Definitions[1].ID)
 	require.Equal(t, p0.Version, lastVersion)
@@ -1282,11 +1272,6 @@ func TestSavedAnalyzeOptionsForMultipleTables(t *testing.T) {
 	tk.MustExec("insert into t2 values (1,1,1),(2,1,2),(3,1,3),(4,1,4),(5,1,5),(6,1,6),(7,7,7),(8,8,8),(9,9,9)")
 
 	h := dom.StatsHandle()
-	oriLease := h.Lease()
-	h.SetLease(1)
-	defer func() {
-		h.SetLease(oriLease)
-	}()
 
 	tk.MustExec("analyze table t1 with 1 topn, 3 buckets")
 	tk.MustExec("analyze table t2 with 0 topn, 2 buckets")

--- a/planner/core/plan_stats_test.go
+++ b/planner/core/plan_stats_test.go
@@ -288,7 +288,7 @@ func TestPlanStatsLoadTimeout(t *testing.T) {
 	switch pp := plan.(type) {
 	case *plannercore.PhysicalTableReader:
 		stats := pp.Stats().HistColl
-		require.Greater(t, countFullStats(stats, tableInfo.Columns[0].ID), 0)
+		require.Equal(t, 0, countFullStats(stats, tableInfo.Columns[0].ID))
 		require.Equal(t, 0, countFullStats(stats, tableInfo.Columns[2].ID)) // pseudo stats
 	default:
 		t.Error("unexpected plan:", pp)

--- a/statistics/handle/handle_hist_test.go
+++ b/statistics/handle/handle_hist_test.go
@@ -76,7 +76,7 @@ func TestConcurrentLoadHist(t *testing.T) {
 	stat := h.GetTableStats(tableInfo)
 	hg := stat.Columns[tableInfo.Columns[0].ID].Histogram
 	topn := stat.Columns[tableInfo.Columns[0].ID].TopN
-	require.Greater(t, hg.Len()+topn.Num(), 0)
+	require.Equal(t, 0, hg.Len()+topn.Num())
 	hg = stat.Columns[tableInfo.Columns[2].ID].Histogram
 	topn = stat.Columns[tableInfo.Columns[2].ID].TopN
 	require.Equal(t, 0, hg.Len()+topn.Num())
@@ -121,7 +121,7 @@ func TestConcurrentLoadHistTimeout(t *testing.T) {
 	stat := h.GetTableStats(tableInfo)
 	hg := stat.Columns[tableInfo.Columns[0].ID].Histogram
 	topn := stat.Columns[tableInfo.Columns[0].ID].TopN
-	require.Greater(t, hg.Len()+topn.Num(), 0)
+	require.Equal(t, 0, hg.Len()+topn.Num())
 	hg = stat.Columns[tableInfo.Columns[2].ID].Histogram
 	topn = stat.Columns[tableInfo.Columns[2].ID].TopN
 	require.Equal(t, 0, hg.Len()+topn.Num())

--- a/statistics/handle/handletest/handle_test.go
+++ b/statistics/handle/handletest/handle_test.go
@@ -428,6 +428,11 @@ func TestLoadHist(t *testing.T) {
 }
 
 func TestInitStats(t *testing.T) {
+	originValue := config.GetGlobalConfig().Performance.LiteInitStats
+	defer func() {
+		config.GetGlobalConfig().Performance.LiteInitStats = originValue
+	}()
+	config.GetGlobalConfig().Performance.LiteInitStats = false
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	testKit := testkit.NewTestKit(t, store)
 	testKit.MustExec("use test")
@@ -458,6 +463,11 @@ func TestInitStats(t *testing.T) {
 }
 
 func TestInitStatsVer2(t *testing.T) {
+	originValue := config.GetGlobalConfig().Performance.LiteInitStats
+	defer func() {
+		config.GetGlobalConfig().Performance.LiteInitStats = originValue
+	}()
+	config.GetGlobalConfig().Performance.LiteInitStats = false
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")

--- a/statistics/handle/updatetest/update_test.go
+++ b/statistics/handle/updatetest/update_test.go
@@ -446,6 +446,8 @@ func TestAutoUpdate(t *testing.T) {
 		tableInfo = tbl.Meta()
 		h.HandleAutoAnalyze(is)
 		require.NoError(t, h.Update(is))
+		testKit.MustExec("explain select * from t where a > 'a'")
+		require.NoError(t, h.LoadNeededHistograms())
 		stats = h.GetTableStats(tableInfo)
 		require.Equal(t, int64(8), stats.RealtimeCount)
 		require.Equal(t, int64(0), stats.ModifyCount)

--- a/statistics/integration_test.go
+++ b/statistics/integration_test.go
@@ -667,11 +667,7 @@ func TestShowHistogramsLoadStatus(t *testing.T) {
 	require.NoError(t, h.Update(dom.InfoSchema()))
 	rows := tk.MustQuery("show stats_histograms where db_name = 'test' and table_name = 't'").Rows()
 	for _, row := range rows {
-		if row[3] == "a" || row[3] == "idx" {
-			require.Equal(t, "allLoaded", row[10].(string))
-		} else {
-			require.Equal(t, "allEvicted", row[10].(string))
-		}
+		require.Equal(t, "allEvicted", row[10].(string))
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42160

Problem Summary:

### What is changed and how it works?

Turn on `lite-init-stats` and `force-init-stats` by default.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
