### PR TITLE
executor: disable password validation for `tidb_auth_token` users | tidb-test=pr/2136

### DIFF
--- a/errno/errname.go
+++ b/errno/errname.go
@@ -782,7 +782,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrInnodbImport:                                          mysql.Message("ALTER TABLE '%-.192s' IMPORT TABLESPACE failed with error %d : '%s'", nil),
 	ErrInnodbIndexCorrupt:                                    mysql.Message("Index corrupt: %s", nil),
 	ErrInvalidYearColumnLength:                               mysql.Message("Supports only YEAR or YEAR(4) column", nil),
-	ErrNotValidPassword:                                      mysql.Message("Your password does not satisfy the current policy requirements", nil),
+	ErrNotValidPassword:                                      mysql.Message("Your password does not satisfy the current policy requirements (%s)", nil),
 	ErrMustChangePassword:                                    mysql.Message("You must reset your password using ALTER USER statement before executing this statement", nil),
 	ErrFkNoIndexChild:                                        mysql.Message("Failed to add the foreign key constraint. Missing index for constraint '%s' in the foreign table '%s'", nil),
 	ErrForeignKeyNoIndexInParent:                             mysql.Message("Failed to add the foreign key constraint. Missing index for constraint '%s' in the referenced table '%s'", nil),

--- a/errors.toml
+++ b/errors.toml
@@ -1558,7 +1558,7 @@ SET PASSWORD has no significance for user '%-.48s'@'%-.255s' as authentication p
 
 ["executor:1819"]
 error = '''
-Your password does not satisfy the current policy requirements
+Your password does not satisfy the current policy requirements (%s)
 '''
 
 ["executor:1820"]

--- a/executor/test/passwordtest/password_management_test.go
+++ b/executor/test/passwordtest/password_management_test.go
@@ -103,9 +103,9 @@ func TestValidatePassword(t *testing.T) {
 		// "IDENTIFIED AS 'xxx'" is not affected by validation
 		tk.MustExec(fmt.Sprintf("ALTER USER testuser IDENTIFIED WITH '%s' AS ''", authPlugin))
 	}
-	tk.MustContainErrMsg("CREATE USER 'testuser1'@'localhost'", "Your password does not satisfy the current policy requirements")
-	tk.MustContainErrMsg("CREATE USER 'testuser1'@'localhost' IDENTIFIED WITH 'caching_sha2_password'", "Your password does not satisfy the current policy requirements")
-	tk.MustContainErrMsg("CREATE USER 'testuser1'@'localhost' IDENTIFIED WITH 'caching_sha2_password' AS ''", "Your password does not satisfy the current policy requirements")
+	tk.MustGetErrCode("CREATE USER 'testuser1'@'localhost'", errno.ErrNotValidPassword)
+	tk.MustGetErrCode("CREATE USER 'testuser1'@'localhost' IDENTIFIED WITH 'caching_sha2_password'", errno.ErrNotValidPassword)
+	tk.MustGetErrCode("CREATE USER 'testuser1'@'localhost' IDENTIFIED WITH 'caching_sha2_password' AS ''", errno.ErrNotValidPassword)
 
 	// if the username is '', all password can pass the check_user_name
 	subtk.MustQuery("SELECT user(), current_user()").Check(testkit.Rows("@localhost @localhost"))

--- a/executor/test/simpletest/BUILD.bazel
+++ b/executor/test/simpletest/BUILD.bazel
@@ -10,9 +10,10 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 35,
+    shard_count = 36,
     deps = [
         "//config",
+        "//errno",
         "//parser/auth",
         "//parser/model",
         "//parser/mysql",

--- a/executor/test/simpletest/simple_test.go
+++ b/executor/test/simpletest/simple_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/parser/auth"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
@@ -1133,4 +1134,20 @@ func TestAlterUserWithLDAP(t *testing.T) {
 	tk.MustExec("ALTER USER 'bob'@'localhost' IDENTIFIED WITH authentication_ldap_sasl AS 'uid=bob,ou=Manager,dc=example,dc=com'")
 	tk.MustExec("ALTER USER 'bob'@'localhost' IDENTIFIED WITH authentication_ldap_sasl AS 'uid=bob,ou=People,dc=example,dc=com'")
 	tk.MustExec("ALTER USER 'bob'@'localhost' IDENTIFIED WITH authentication_ldap_sasl AS 'uid=bob,ou=Manager,dc=example,dc=com'")
+}
+
+func TestIssue44098(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("set global validate_password.enable = 1")
+	tk.MustExec("create user u1 identified with 'tidb_auth_token'")
+	tk.MustGetErrCode("create user u2 identified with 'mysql_native_password'", errno.ErrNotValidPassword)
+	tk.MustGetErrCode("create user u2 identified with 'caching_sha2_password'", errno.ErrNotValidPassword)
+	tk.MustGetErrCode("create user u2 identified with 'tidb_sm3_password'", errno.ErrNotValidPassword)
+	tk.MustGetErrCode("create user u2 identified with 'mysql_clear_password'", errno.ErrPluginIsNotLoaded)
+	tk.MustExec("create user u2 identified with 'auth_socket'")
+	tk.MustGetErrCode("create user u3 identified with 'tidb_session_token'", errno.ErrPluginIsNotLoaded)
+	tk.MustExec("create user u3 identified with 'authentication_ldap_simple'")
+	tk.MustExec("create user u4 identified with 'authentication_ldap_sasl'")
 }

--- a/executor/test/simpletest/simple_test.go
+++ b/executor/test/simpletest/simple_test.go
@@ -1142,12 +1142,12 @@ func TestIssue44098(t *testing.T) {
 
 	tk.MustExec("set global validate_password.enable = 1")
 	tk.MustExec("create user u1 identified with 'tidb_auth_token'")
-	tk.MustGetErrCode("create user u2 identified with 'mysql_native_password'", errno.ErrNotValidPassword)
-	tk.MustGetErrCode("create user u2 identified with 'caching_sha2_password'", errno.ErrNotValidPassword)
-	tk.MustGetErrCode("create user u2 identified with 'tidb_sm3_password'", errno.ErrNotValidPassword)
-	tk.MustGetErrCode("create user u2 identified with 'mysql_clear_password'", errno.ErrPluginIsNotLoaded)
 	tk.MustExec("create user u2 identified with 'auth_socket'")
-	tk.MustGetErrCode("create user u3 identified with 'tidb_session_token'", errno.ErrPluginIsNotLoaded)
 	tk.MustExec("create user u3 identified with 'authentication_ldap_simple'")
 	tk.MustExec("create user u4 identified with 'authentication_ldap_sasl'")
+	tk.MustGetErrCode("create user u5 identified with 'mysql_native_password'", errno.ErrNotValidPassword)
+	tk.MustGetErrCode("create user u5 identified with 'caching_sha2_password'", errno.ErrNotValidPassword)
+	tk.MustGetErrCode("create user u5 identified with 'tidb_sm3_password'", errno.ErrNotValidPassword)
+	tk.MustGetErrCode("create user u5 identified with 'mysql_clear_password'", errno.ErrPluginIsNotLoaded)
+	tk.MustGetErrCode("create user u5 identified with 'tidb_session_token'", errno.ErrPluginIsNotLoaded)
 }

--- a/parser/mysql/errname.go
+++ b/parser/mysql/errname.go
@@ -845,7 +845,7 @@ var MySQLErrName = map[uint16]*ErrMessage{
 	ErrInnodbImport:                                          Message("ALTER TABLE '%-.192s' IMPORT TABLESPACE failed with error %d : '%s'", nil),
 	ErrInnodbIndexCorrupt:                                    Message("Index corrupt: %s", nil),
 	ErrInvalidYearColumnLength:                               Message("Supports only YEAR or YEAR(4) column", nil),
-	ErrNotValidPassword:                                      Message("Your password does not satisfy the current policy requirements", nil),
+	ErrNotValidPassword:                                      Message("Your password does not satisfy the current policy requirements (%s)", nil),
 	ErrMustChangePassword:                                    Message("You must SET PASSWORD before executing this statement", nil),
 	ErrFkNoIndexChild:                                        Message("Failed to add the foreign key constraint. Missing index for constraint '%s' in the foreign table '%s'", nil),
 	ErrForeignKeyNoIndexInParent:                             Message("Failed to add the foreign key constraint. Missing index for constraint '%s' in the referenced table '%s'", nil),

--- a/util/password-validation/password_validation.go
+++ b/util/password-validation/password_validation.go
@@ -143,12 +143,12 @@ func ValidatePassword(sessionVars *variable.SessionVars, pwd string) error {
 	if warn, err := ValidateUserNameInPassword(pwd, sessionVars); err != nil {
 		return err
 	} else if len(warn) > 0 {
-		return variable.ErrNotValidPassword.GenWithStack(warn)
+		return variable.ErrNotValidPassword.GenWithStackByArgs(warn)
 	}
 	if warn, err := ValidatePasswordLowPolicy(pwd, &globalVars); err != nil {
 		return err
 	} else if len(warn) > 0 {
-		return variable.ErrNotValidPassword.GenWithStack(warn)
+		return variable.ErrNotValidPassword.GenWithStackByArgs(warn)
 	}
 	// LOW
 	if validatePolicy == "LOW" {
@@ -159,7 +159,7 @@ func ValidatePassword(sessionVars *variable.SessionVars, pwd string) error {
 	if warn, err := ValidatePasswordMediumPolicy(pwd, &globalVars); err != nil {
 		return err
 	} else if len(warn) > 0 {
-		return variable.ErrNotValidPassword.GenWithStack(warn)
+		return variable.ErrNotValidPassword.GenWithStackByArgs(warn)
 	}
 	if validatePolicy == "MEDIUM" {
 		return nil
@@ -169,7 +169,7 @@ func ValidatePassword(sessionVars *variable.SessionVars, pwd string) error {
 	if ok, err := ValidateDictionaryPassword(pwd, &globalVars); err != nil {
 		return err
 	} else if !ok {
-		return variable.ErrNotValidPassword.GenWithStack("Password contains word in the dictionary")
+		return variable.ErrNotValidPassword.GenWithStackByArgs("Password contains word in the dictionary")
 	}
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #44098

Problem Summary:

Password validation should only take effect for users that authenticate with a password, like `mysql_native_password`, `caching_sha2_password` and `tidb_sm3_password`

### What is changed and how it works?

Disable password validation for users without clear text password

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a bug that validates passwords for users with `tidb_auth_token`
```
