### PR TITLE
expression: rewrite Accept() function for BinaryOperationExpr the non-recursive way

### DIFF
--- a/parser/ast/expressions.go
+++ b/parser/ast/expressions.go
@@ -241,8 +241,8 @@ type continuation interface {
 }
 
 type tailcall struct {
-	n nonRecursive
-	v Visitor
+	n  nonRecursive
+	v  Visitor
 	cc func(Node, bool)
 }
 
@@ -251,8 +251,8 @@ func (tc *tailcall) exec(t *trampoline) {
 }
 
 type continued struct {
-	cc func(Node, bool)
-	res Node
+	cc   func(Node, bool)
+	res  Node
 	succ bool
 }
 
@@ -267,7 +267,7 @@ func (t *trampoline) tailcallWith(n nonRecursive, v Visitor, cc func(Node, bool)
 	t.next = &t.tailcall
 }
 
-func (t *trampoline) continueWith(cc func(Node, bool),res Node,succ bool) {
+func (t *trampoline) continueWith(cc func(Node, bool), res Node, succ bool) {
 	t.continued.cc = cc
 	t.continued.res = res
 	t.continued.succ = succ
@@ -320,14 +320,11 @@ func (n *BinaryOperationExpr) acceptV2(t *trampoline, v Visitor, cc0 func(Node, 
 			n.R = node.(ExprNode)
 			ret, succ := v.Leave(n)
 			t.continueWith(cc0, ret, succ)
-			return
 		}
 
 		t.tailcallWith(r, v, cc2)
-		return
 	}
 	t.tailcallWith(l, v, cc1)
-	return
 }
 
 // WhenClause is the when clause in Case expression for "when condition then result".
@@ -1136,26 +1133,26 @@ func (n *ParenthesesExpr) acceptV2(t *trampoline, v Visitor, cc0 func(Node, bool
 		_, ok = n.Expr.(nonRecursive)
 	}
 	if !ok {
-		ret, succ :=  n.acceptV1(v)
+		ret, succ := n.acceptV1(v)
 		t.continueWith(cc0, ret, succ)
 		return
 	}
 
 	newNode, skipChildren := v.Enter(n)
 	if skipChildren {
-		ret, succ :=  v.Leave(newNode)
+		ret, succ := v.Leave(newNode)
 		t.continueWith(cc0, ret, succ)
 		return
 	}
 	n = newNode.(*ParenthesesExpr)
-	
+
 	cc1 := func(node Node, succ bool) {
 		if !ok {
 			t.continueWith(cc0, n, false)
 			return
 		}
 		n.Expr = node.(ExprNode)
-		ret, succ :=  v.Leave(n)
+		ret, succ := v.Leave(n)
 		t.continueWith(cc0, ret, succ)
 		return
 	}

--- a/parser/ast/expressions.go
+++ b/parser/ast/expressions.go
@@ -1147,17 +1147,15 @@ func (n *ParenthesesExpr) acceptV2(t *trampoline, v Visitor, cc0 func(Node, bool
 	n = newNode.(*ParenthesesExpr)
 
 	cc1 := func(node Node, succ bool) {
-		if !ok {
+		if !succ {
 			t.continueWith(cc0, n, false)
 			return
 		}
 		n.Expr = node.(ExprNode)
-		ret, succ := v.Leave(n)
-		t.continueWith(cc0, ret, succ)
-		return
+		ret, succ1 := v.Leave(n)
+		t.continueWith(cc0, ret, succ1)
 	}
 	t.tailcallWith(n.Expr.(nonRecursive), v, cc1)
-	return
 }
 
 // PositionExpr is the expression for order by and group by position.


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43885

Problem Summary:

### What is changed and how it works?

Rewrite to non-recursive using CPS + trampoline.

From this:

![image](https://user-images.githubusercontent.com/1420062/238697847-4d96fbcd-5eb4-4d9c-b89a-2ca85c9f41cd.png)

to this:

![image](https://github.com/pingcap/tidb/assets/1420062/f1dac9ad-4ac0-4c5a-ad37-ebfc7204ee50)

Call stack of `BinaryOperationExpr.Accept()` is eliminated.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
