### PR TITLE
ddl: roll back txn before handling ErrEntryTooLarge (#43867)

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -979,6 +979,7 @@ func TestDDLJobErrorCount(t *testing.T) {
 	require.NotNil(t, historyJob)
 	require.Equal(t, int64(1), historyJob.ErrorCount)
 	require.True(t, kv.ErrEntryTooLarge.Equal(historyJob.Error))
+	tk.MustQuery("select * from ddl_error_table;").Check(testkit.Rows())
 }
 
 func TestCommitTxnWithIndexChange(t *testing.T) {

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -476,10 +476,9 @@ func (w *worker) rollbackOrReset(txn kv.Transaction) error {
 	if w.concurrentDDL {
 		w.sess.rollback()
 		return w.sess.begin()
-	} else {
-		txn.Reset()
-		return nil
 	}
+	txn.Reset()
+	return nil
 }
 
 // updateDDLJob updates the DDL job information.

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -457,8 +457,8 @@ func (w *worker) handleUpdateJobError(t *meta.Meta, job *model.Job, err error) e
 	}
 	if kv.ErrEntryTooLarge.Equal(err) {
 		logutil.Logger(w.logCtx).Warn("[ddl] update DDL job failed", zap.String("job", job.String()), zap.Error(err))
-		w.sess.Rollback()
-		err1 := w.sess.Begin()
+		w.sess.rollback()
+		err1 := w.sess.begin()
 		if err1 != nil {
 			return errors.Trace(err1)
 		}

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -457,6 +457,11 @@ func (w *worker) handleUpdateJobError(t *meta.Meta, job *model.Job, err error) e
 	}
 	if kv.ErrEntryTooLarge.Equal(err) {
 		logutil.Logger(w.logCtx).Warn("[ddl] update DDL job failed", zap.String("job", job.String()), zap.Error(err))
+		w.sess.Rollback()
+		err1 := w.sess.Begin()
+		if err1 != nil {
+			return errors.Trace(err1)
+		}
 		// Reduce this txn entry size.
 		job.BinlogInfo.Clean()
 		job.Error = toTError(err)


### PR DESCRIPTION
Cherry-pick #43867.


### Release note

```release-note
None
```