### PR TITLE
ddl: update `run DDL job` log back to info level and SupportUpgradeStateVer 

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -977,7 +977,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 	failpoint.Inject("mockPanicInRunDDLJob", func(val failpoint.Value) {})
 
 	if job.Type != model.ActionMultiSchemaChange {
-		logutil.Logger(w.logCtx).Debug("[ddl] run DDL job", zap.String("job", job.String()))
+		logutil.Logger(w.logCtx).Info("[ddl] run DDL job", zap.String("job", job.String()))
 	}
 	timeStart := time.Now()
 	if job.RealStartTS == 0 {

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -175,6 +175,9 @@ func (d *ddl) processJobDuringUpgrade(sess *sess.Session, job *model.Job) (isRun
 		if job.IsPausing() || hasSysDB(job) {
 			return true, nil
 		}
+		if job.IsPaused() {
+			return false, nil
+		}
 		var errs []error
 		// During binary upgrade, pause all running DDL jobs
 		errs, err = PauseJobsBySystem(sess.Session(), []int64{job.ID})

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -882,13 +882,15 @@ const (
 	// version 144 turn off `tidb_plan_cache_invalidation_on_fresh_stats`, which is introduced in 7.1-rc,
 	// if it's upgraded from an existing old version cluster.
 	version144 = 144
-	// version 145 add column `step` to `mysql.tidb_background_subtask`
+	// version 145 to only add a version make we know when we support upgrade state.
 	version145 = 145
+	// version 146 add column `step` to `mysql.tidb_background_subtask`
+	version146 = 146
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version145
+var currentBootstrapVersion int64 = version146
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1021,7 +1023,8 @@ var (
 		upgradeToVer142,
 		upgradeToVer143,
 		upgradeToVer144,
-		upgradeToVer145,
+		// We will only use to differentiate versions, so it is skipped here.
+		upgradeToVer146,
 	}
 )
 
@@ -1080,7 +1083,7 @@ func getTiDBVar(s Session, name string) (sVal string, isNull bool, e error) {
 }
 
 // SupportUpgradeStateVer is exported for testing.
-var SupportUpgradeStateVer = version144
+var SupportUpgradeStateVer = version145
 
 // upgrade function  will do some upgrade works, when the system is bootstrapped by low version TiDB server
 // For example, add new system variables into mysql.global_variables table.
@@ -2627,8 +2630,8 @@ func upgradeToVer144(s Session, ver int64) {
 		mysql.SystemDB, mysql.GlobalVariablesTable, variable.TiDBPlanCacheInvalidationOnFreshStats, variable.Off)
 }
 
-func upgradeToVer145(s Session, ver int64) {
-	if ver >= version145 {
+func upgradeToVer146(s Session, ver int64) {
+	if ver >= version146 {
 		return
 	}
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_background_subtask ADD COLUMN `step` INT AFTER `id`", infoschema.ErrColumnExists)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/44120

Problem Summary:
* After https://github.com/pingcap/tidb/pull/43907 updating([line](https://github.com/pingcap/tidb/pull/43907/files#diff-dfc42c5764e7e4ff9122a1db728ff1cb0dee56e72dbccefdb211018ccd444c73R980)), the log of `[ddl] run DDL job` in ddl package the level is change from `info` to `debug`. But I think this is bad for ddl related debugging.
* The log of [line189](https://github.com/pingcap/tidb/compare/master...zimulala:zimuxia/log?expand=1#diff-91c692cc214077acc788fcaf2f92fb40d0a6c4aef3e34e3b6ed532677dac9f13R189)  always print when the jobID is small(every time do a filter). 
* Add version144 is set in v7.1.0-rc which version we doesn't support upgrade state. And version145 it is set in master. This change related to version 145 will be included in the v7.1.1 or v7.2.0 release..

### What is changed and how it works?
* update log level
* If the job is `Paused`, we return it early. 
* Add version145 to check if we support upgrading state. Make the old version145(The version number 145 is currently only present in the master branch and not in any other branches. Therefore, this modification will not have any compatibility impact. ) to version146.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
