### PR TITLE
executor, planner: fix indexLookUp with static pruning

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3880,8 +3880,8 @@ func buildIndexReq(ctx sessionctx.Context, columns []*model.IndexColumn, handleL
 		indexReq.OutputOffsets = append(indexReq.OutputOffsets, uint32(len(columns)+i))
 	}
 
-	// need add one more column for pid or physical table id or not
 	if idxScan.NeedExtraOutputCol() {
+		// need add one more column for pid or physical table id
 		indexReq.OutputOffsets = append(indexReq.OutputOffsets, uint32(len(columns)+handleLen))
 	}
 	return indexReq, err

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3890,7 +3890,7 @@ func buildNoRangeIndexLookUpReader(b *executorBuilder, v *plannercore.PhysicalIn
 	} else {
 		handleLen = 1
 	}
-	if is.Index.Global || len(is.ByItems) != 0 {
+	if is.Index.Global || (len(is.ByItems) != 0 && is.Table.Partition != nil && b.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune()) {
 		// Should output pid col.
 		handleLen++
 	}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3880,7 +3880,7 @@ func buildIndexReq(ctx sessionctx.Context, columns []*model.IndexColumn, handleL
 		indexReq.OutputOffsets = append(indexReq.OutputOffsets, uint32(len(columns)+i))
 	}
 
-	// add one more column for tid or physical table id
+	// need add one more column for pid or physical table id or not
 	if idxScan.NeedExtraOutputCol() {
 		indexReq.OutputOffsets = append(indexReq.OutputOffsets, uint32(len(columns)+handleLen))
 	}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3890,7 +3890,7 @@ func needExtraCol(is *plannercore.PhysicalIndexScan) bool {
 	if is.Index.Global {
 		return true
 	}
-	// has embeded limit, should return physical table id
+	// has embedded limit, should return physical table id
 	if len(is.ByItems) != 0 && is.SCtx().GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 		return true
 	}

--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -536,6 +536,11 @@ func TestOrderByAndLimit(t *testing.T) {
 
 	// test indexLookUp with order property pushed down.
 	for i := 0; i < 100; i++ {
+		if i%2 == 0 {
+			tk.MustExec("set tidb_partition_prune_mode = `static-only`")
+		} else {
+			tk.MustExec("set tidb_partition_prune_mode = `dynamic-only`")
+		}
 		// explain select * from t where a > {y}  use index(idx_a) order by a limit {x}; // check if IndexLookUp is used
 		// select * from t where a > {y} use index(idx_a) order by a limit {x}; // it can return the correct result
 		x := rand.Intn(1099)
@@ -553,9 +558,11 @@ func TestOrderByAndLimit(t *testing.T) {
 		require.True(t, tk.HasPlan(queryHashPartitionWithLimitHint, "IndexLookUp"))
 		require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "Limit"))
 		require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "IndexLookUp"))
-		require.False(t, tk.HasPlan(queryRangePartitionWithLimitHint, "TopN")) // fully pushed
-		require.False(t, tk.HasPlan(queryHashPartitionWithLimitHint, "TopN"))
-		require.False(t, tk.HasPlan(queryListPartitionWithLimitHint, "TopN"))
+		if i%2 != 0 {
+			require.False(t, tk.HasPlan(queryRangePartitionWithLimitHint, "TopN")) // fully pushed
+			require.False(t, tk.HasPlan(queryHashPartitionWithLimitHint, "TopN"))
+			require.False(t, tk.HasPlan(queryListPartitionWithLimitHint, "TopN"))
+		}
 		regularResult := tk.MustQuery(queryRegular).Sort().Rows()
 		tk.MustQuery(queryRangePartitionWithLimitHint).Sort().Check(regularResult)
 		tk.MustQuery(queryHashPartitionWithLimitHint).Sort().Check(regularResult)
@@ -564,6 +571,11 @@ func TestOrderByAndLimit(t *testing.T) {
 
 	// test indexLookUp with order property pushed down.
 	for i := 0; i < 100; i++ {
+		if i%2 == 0 {
+			tk.MustExec("set tidb_partition_prune_mode = `static-only`")
+		} else {
+			tk.MustExec("set tidb_partition_prune_mode = `dynamic-only`")
+		}
 		// explain select * from t where b > {y}  use index(idx_b) order by b limit {x}; // check if IndexLookUp is used
 		// select * from t where b > {y} use index(idx_b) order by b limit {x}; // it can return the correct result
 		x := rand.Intn(1999)
@@ -579,14 +591,18 @@ func TestOrderByAndLimit(t *testing.T) {
 		require.True(t, tk.HasPlan(queryHashPartitionWithLimitHint, "IndexLookUp"))
 		require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "Limit"))
 		require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "IndexLookUp"))
-		require.False(t, tk.HasPlan(queryRangePartitionWithLimitHint, "TopN")) // fully pushed
-		require.False(t, tk.HasPlan(queryHashPartitionWithLimitHint, "TopN"))
-		require.False(t, tk.HasPlan(queryListPartitionWithLimitHint, "TopN"))
+		if i%2 != 0 {
+			require.False(t, tk.HasPlan(queryRangePartitionWithLimitHint, "TopN")) // fully pushed
+			require.False(t, tk.HasPlan(queryHashPartitionWithLimitHint, "TopN"))
+			require.False(t, tk.HasPlan(queryListPartitionWithLimitHint, "TopN"))
+		}
 		regularResult := tk.MustQuery(queryRegular).Sort().Rows()
 		tk.MustQuery(queryRangePartitionWithLimitHint).Sort().Check(regularResult)
 		tk.MustQuery(queryHashPartitionWithLimitHint).Sort().Check(regularResult)
 		tk.MustQuery(queryListPartitionWithLimitHint).Sort().Check(regularResult)
 	}
+
+	tk.MustExec("set tidb_partition_prune_mode = default")
 
 	// test tableReader
 	for i := 0; i < 100; i++ {

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1541,7 +1541,7 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty,
 				})
 			}
 			cop.indexPlan.(*PhysicalIndexScan).ByItems = byItems
-			if !is.Index.Global && cop.tablePlan != nil {
+			if !is.Index.Global && cop.tablePlan != nil && ds.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 				is.Columns = append(is.Columns, model.NewExtraPhysTblIDColInfo())
 				is.schema.Append(&expression.Column{
 					RetType:  types.NewFieldType(mysql.TypeLonglong),

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1695,7 +1695,7 @@ func (is *PhysicalIndexScan) addPushedDownSelection(copTask *copTask, p *DataSou
 	}
 }
 
-func (is *PhysicalIndexScan) NeedExtraCol() bool {
+func (is *PhysicalIndexScan) NeedExtraOutputCol() bool {
 	if is.Table.Partition == nil {
 		return false
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1695,6 +1695,8 @@ func (is *PhysicalIndexScan) addPushedDownSelection(copTask *copTask, p *DataSou
 	}
 }
 
+// NeedExtraOutputCol is designed for check whether need an extra column for
+// pid or physical table id when build indexReq.
 func (is *PhysicalIndexScan) NeedExtraOutputCol() bool {
 	if is.Table.Partition == nil {
 		return false

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1695,6 +1695,21 @@ func (is *PhysicalIndexScan) addPushedDownSelection(copTask *copTask, p *DataSou
 	}
 }
 
+func (is *PhysicalIndexScan) NeedExtraCol() bool {
+	if is.Table.Partition == nil {
+		return false
+	}
+	// has global index, should return pid
+	if is.Index.Global {
+		return true
+	}
+	// has embedded limit, should return physical table id
+	if len(is.ByItems) != 0 && is.SCtx().GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
+		return true
+	}
+	return false
+}
+
 // SplitSelCondsWithVirtualColumn filter the select conditions which contain virtual column
 func SplitSelCondsWithVirtualColumn(conds []expression.Expression) (withoutVirt []expression.Expression, withVirt []expression.Expression) {
 	for i := range conds {

--- a/tests/realtikvtest/brietest/brie_test.go
+++ b/tests/realtikvtest/brietest/brie_test.go
@@ -135,5 +135,6 @@ func TestIndexLookUpWithStaticPrune(t *testing.T) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a bigint, b decimal(41,16), c set('a', 'b', 'c'), key idx_c(c)) partition by hash(a) partitions 4")
 	tk.MustExec("insert into t values (1,2.0,'c')")
-	tk.MustExec("select * from t order by b limit 5")
+	tk.HasPlan("select * from t use index(idx_c) order by c limit 5", "Limit")
+	tk.MustExec("select * from t use index(idx_c) order by c limit 5")
 }

--- a/tests/realtikvtest/brietest/brie_test.go
+++ b/tests/realtikvtest/brietest/brie_test.go
@@ -126,3 +126,14 @@ func TestCancel(t *testing.T) {
 		req.FailNow("the backup job doesn't be canceled")
 	}
 }
+
+// for https://github.com/pingcap/tidb/issues/44123
+func TestIndexLookUpWithStaticPrune(t *testing.T) {
+	tk := initTestKit(t)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a bigint, b decimal(41,16), c set('a', 'b', 'c'), key idx_c(c)) partition by hash(a) partitions 4")
+	tk.MustExec("insert into t values (1,2.0,'c')")
+	tk.MustExec("select * from t order by b limit 5")
+}

--- a/tests/realtikvtest/brietest/brie_test.go
+++ b/tests/realtikvtest/brietest/brie_test.go
@@ -126,15 +126,3 @@ func TestCancel(t *testing.T) {
 		req.FailNow("the backup job doesn't be canceled")
 	}
 }
-
-// for https://github.com/pingcap/tidb/issues/44123
-func TestIndexLookUpWithStaticPrune(t *testing.T) {
-	tk := initTestKit(t)
-
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t")
-	tk.MustExec("create table t(a bigint, b decimal(41,16), c set('a', 'b', 'c'), key idx_c(c)) partition by hash(a) partitions 4")
-	tk.MustExec("insert into t values (1,2.0,'c')")
-	tk.HasPlan("select * from t use index(idx_c) order by c limit 5", "Limit")
-	tk.MustExec("select * from t use index(idx_c) order by c limit 5")
-}

--- a/tests/realtikvtest/sessiontest/session_fail_test.go
+++ b/tests/realtikvtest/sessiontest/session_fail_test.go
@@ -224,3 +224,15 @@ func TestIssue42426(t *testing.T) {
 	tk.MustExec(`INSERT INTO sbtest1 (id, k, c, pad) VALUES (502571, 499449, "abc", "def");`)
 	tk.MustExec(`COMMIT;`)
 }
+
+// for https://github.com/pingcap/tidb/issues/44123
+func TestIndexLookUpWithStaticPrune(t *testing.T) {
+	tk := initTestKit(t)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a bigint, b decimal(41,16), c set('a', 'b', 'c'), key idx_c(c)) partition by hash(a) partitions 4")
+	tk.MustExec("insert into t values (1,2.0,'c')")
+	tk.HasPlan("select * from t use index(idx_c) order by c limit 5", "Limit")
+	tk.MustExec("select * from t use index(idx_c) order by c limit 5")
+}

--- a/tests/realtikvtest/sessiontest/session_fail_test.go
+++ b/tests/realtikvtest/sessiontest/session_fail_test.go
@@ -227,8 +227,8 @@ func TestIssue42426(t *testing.T) {
 
 // for https://github.com/pingcap/tidb/issues/44123
 func TestIndexLookUpWithStaticPrune(t *testing.T) {
-	tk := initTestKit(t)
-
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a bigint, b decimal(41,16), c set('a', 'b', 'c'), key idx_c(c)) partition by hash(a) partitions 4")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44123 

Problem Summary: The root case is we asked one more column which is `model.ExtraPhysTblID` in indexReq. When `resp.EncodeType = EncodeType_TypeDefault`, it can't handle it correctly.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
