### PR TITLE
ddl: fix cancel the rollbacking back may lead to meta data broken

### DIFF
--- a/ddl/cancel_test.go
+++ b/ddl/cancel_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/testkit/external"
 	"github.com/stretchr/testify/require"
 	atomicutil "go.uber.org/atomic"
 )
@@ -335,4 +336,41 @@ func TestCancel(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestCancelForAddUniqueIndex(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tkCancel := testkit.NewTestKit(t, store)
+
+	// Prepare schema.
+	tk.MustExec("use test")
+	tk.MustExec(`create table t (c1 int, c2 int, c3 int)`)
+	tk.MustExec("insert into t values(1, 1, 1)")
+	tk.MustExec("insert into t values(2, 2, 2)")
+	tk.MustExec("insert into t values(1, 1, 1)")
+
+	hook := &callback.TestDDLCallback{Do: dom}
+	var testCancelState model.SchemaState
+	hook.OnJobRunBeforeExported = func(job *model.Job) {
+		if job.SchemaState == testCancelState && job.State == model.JobStateRollingback {
+			tkCancel.MustExec(fmt.Sprintf("admin cancel ddl jobs %d", job.ID))
+		}
+	}
+	dom.DDL().SetHook(hook.Clone())
+
+	testCancelState = model.StateWriteOnly
+	tk.MustGetErrCode("alter table t add unique index idx1(c1)", errno.ErrDupEntry)
+	tbl := external.GetTableByName(t, tk, "test", "t")
+	require.Equal(t, 0, len(tbl.Meta().Indices))
+
+	testCancelState = model.StateDeleteOnly
+	tk.MustGetErrCode("alter table t add unique index idx1(c1)", errno.ErrDupEntry)
+	tbl = external.GetTableByName(t, tk, "test", "t")
+	require.Equal(t, 0, len(tbl.Meta().Indices))
+
+	testCancelState = model.StateDeleteReorganization
+	tk.MustGetErrCode("alter table t add unique index idx1(c1)", errno.ErrDupEntry)
+	tbl = external.GetTableByName(t, tk, "test", "t")
+	require.Equal(t, 0, len(tbl.Meta().Indices))
 }

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1472,11 +1472,6 @@ func pauseRunningJob(sess *sess.Session, job *model.Job,
 
 	job.State = model.JobStatePausing
 	job.AdminOperator = byWho
-
-	if job.RawArgs == nil {
-		return nil
-	}
-
 	return nil
 }
 

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -20,7 +20,6 @@ package ddl
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"runtime"
 	"strconv"
@@ -1454,9 +1453,7 @@ func cancelRunningJob(sess *sess.Session, job *model.Job,
 	}
 	job.State = model.JobStateCancelling
 	job.AdminOperator = byWho
-
-	// Make sure RawArgs isn't overwritten.
-	return json.Unmarshal(job.RawArgs, &job.Args)
+	return nil
 }
 
 // pauseRunningJob check and pause the running Job
@@ -1480,7 +1477,7 @@ func pauseRunningJob(sess *sess.Session, job *model.Job,
 		return nil
 	}
 
-	return json.Unmarshal(job.RawArgs, &job.Args)
+	return nil
 }
 
 // resumePausedJob check and resume the Paused Job
@@ -1500,7 +1497,7 @@ func resumePausedJob(se *sess.Session, job *model.Job,
 
 	job.State = model.JobStateQueueing
 
-	return json.Unmarshal(job.RawArgs, &job.Args)
+	return nil
 }
 
 // processJobs command on the Job according to the process
@@ -1558,7 +1555,7 @@ func processJobs(process func(*sess.Session, *model.Job, model.AdminCommandOpera
 				continue
 			}
 
-			err = updateDDLJob2Table(ns, job, true)
+			err = updateDDLJob2Table(ns, job, false)
 			if err != nil {
 				errs[i] = err
 				continue
@@ -1642,7 +1639,7 @@ func processAllJobs(process func(*sess.Session, *model.Job, model.AdminCommandOp
 				continue
 			}
 
-			err = updateDDLJob2Table(ns, job, true)
+			err = updateDDLJob2Table(ns, job, false)
 			if err != nil {
 				jobErrs[job.ID] = err
 				continue


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44143

Problem Summary:
It doesn't Unmarshal the rawArg to Arg if the job is rollbacking.

### What is changed and how it works?
Don't update the RawArg since it doesn't change during cancel/pause/resume.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix cancel the rollbacking back may lead to meta data broken
```
