### PR TITLE
br: add more information in the error when user starts another restore task but doesn't clean the cluster

### DIFF
--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1833,7 +1833,10 @@ func checkPiTRTaskInfo(
 			log.Info("check pitr requirements for the first execution")
 			if err := checkPiTRRequirements(ctx, g, cfg, mgr); err != nil {
 				if len(lastTaskMsg) > 0 {
-					err = errors.Annotatef(err, "The current restore task is regarded as a new task, %s", lastTaskMsg)
+					err = errors.Annotatef(err, "The current restore task is regarded as a new task, %s. "+
+						"If you ensure that no changes have been made to the cluster since the last execution, "+
+						"you can adjust the `start-ts` or `restored-ts` to continue with the previous execution. "+
+						"Otherwise, if you want to restore from scratch, please clean the cluster at first", lastTaskMsg)
 				}
 				return nil, false, errors.Trace(err)
 			}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1780,6 +1780,8 @@ func checkPiTRTaskInfo(
 		doFullRestore = (len(cfg.FullBackupStorage) > 0)
 
 		curTaskInfo *checkpoint.CheckpointTaskInfoForLogRestore
+
+		lastTaskMsg string
 	)
 	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config),
 		cfg.CheckRequirements, true, conn.StreamVersionChecker)
@@ -1815,6 +1817,9 @@ func checkPiTRTaskInfo(
 			} else {
 				// not the same task, so overwrite the taskInfo with a new task
 				log.Info("not the same task, start to restore from scratch")
+				lastTaskMsg = fmt.Sprintf("last task info: [start-ts=%d] [restored-ts=%d] [skip-snapshot-restore=%t]",
+					curTaskInfo.StartTS, curTaskInfo.RestoreTS, curTaskInfo.Progress == checkpoint.InLogRestoreAndIdMapPersist)
+
 				curTaskInfo = nil
 			}
 		}
@@ -1827,6 +1832,9 @@ func checkPiTRTaskInfo(
 			// skip checking requirements.
 			log.Info("check pitr requirements for the first execution")
 			if err := checkPiTRRequirements(ctx, g, cfg, mgr); err != nil {
+				if len(lastTaskMsg) > 0 {
+					err = errors.Annotatef(err, "The current restore task is regarded as a new task, %s", lastTaskMsg)
+				}
 				return nil, false, errors.Trace(err)
 			}
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44160 

Problem Summary:
when users start another restore task but don't clean the cluster, the error information make them confused.
### What is changed and how it works?
add more information in the error when user starts another restore task and doesn't clean the cluster
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

before:
```
Detail BR log in /tmp/br.log.2023-05-25T11.34.52+0800 
Error: databases ddl_test existed in restored cluster, please drop them before execute PiTR: [BR:Restore:ErrDatabasesAlreadyExisted]databases already existed in restored cluster
```
after
```
Detail BR log in /tmp/br.log.2023-05-25T11.37.13+0800 
Error: The current restore task is regarded as a new task, last task info: [start-ts=441462819686449156] [restored-ts=441485796493230080] [skip-snapshot-restore=true]. If you ensure that no changes have been made to the cluster since the last execution, you can adjust the `start-ts` or `restored-ts` to continue with the previous execution. Otherwise, if you want to restore from scratch, please clean the cluster at first: databases ddl_test existed in restored cluster, please drop them before execute PiTR: [BR:Restore:ErrDatabasesAlreadyExisted]databases already existed in restored cluster
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
