### PR TITLE
*: Fix a bug when have a lot of jobs in upgrading state(#44162)

### DIFF
--- a/ddl/BUILD.bazel
+++ b/ddl/BUILD.bazel
@@ -227,6 +227,7 @@ go_test(
         "//ddl/internal/session",
         "//ddl/placement",
         "//ddl/schematracker",
+        "//ddl/syncer",
         "//ddl/testutil",
         "//ddl/util",
         "//disttask/framework/proto",

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1652,7 +1652,6 @@ func processAllJobs(process func(*sess.Session, *model.Job, model.AdminCommandOp
 			err = updateDDLJob2Table(ns, job, true)
 			if err != nil {
 				jobErrs[job.ID] = err
-				logutil.BgLogger().Info("xxx----------------------------process all, one", zap.Stringer("job", job), zap.Error(err))
 				continue
 			}
 		}
@@ -1672,7 +1671,6 @@ func processAllJobs(process func(*sess.Session, *model.Job, model.AdminCommandOp
 
 	err = ns.Commit()
 	if err != nil {
-		logutil.BgLogger().Info("xxx----------------------------process all, commit", zap.Error(err))
 		return nil, err
 	}
 	return jobErrs, nil

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1652,6 +1652,7 @@ func processAllJobs(process func(*sess.Session, *model.Job, model.AdminCommandOp
 			err = updateDDLJob2Table(ns, job, true)
 			if err != nil {
 				jobErrs[job.ID] = err
+				logutil.BgLogger().Info("xxx----------------------------process all, one", zap.Stringer("job", job), zap.Error(err))
 				continue
 			}
 		}
@@ -1671,6 +1672,7 @@ func processAllJobs(process func(*sess.Session, *model.Job, model.AdminCommandOp
 
 	err = ns.Commit()
 	if err != nil {
+		logutil.BgLogger().Info("xxx----------------------------process all, commit", zap.Error(err))
 		return nil, err
 	}
 	return jobErrs, nil

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -188,7 +188,7 @@ func (d *ddl) processJobDuringUpgrade(sess *sess.Session, job *model.Job) (isRun
 		if err != nil {
 			isCannotPauseDDLJobErr := dbterror.ErrCannotPauseDDLJob.Equal(err)
 			logutil.BgLogger().Warn("[ddl-upgrading] pause the job failed", zap.Stringer("job", job),
-				zap.Bool("isCannotPauseDDLJobErr", isCannotPauseDDLJobErr), zap.Error(err))
+				zap.Bool("isRunnable", isCannotPauseDDLJobErr), zap.Error(err))
 			failpoint.Inject("mockPauseJobOnOneState", func(val failpoint.Value) {
 				job.State = model.JobState(val.(int))
 			})

--- a/ddl/job_table_test.go
+++ b/ddl/job_table_test.go
@@ -174,3 +174,15 @@ func check(t *testing.T, record []int64, ids ...int64) {
 		}
 	}
 }
+
+func TestPausedStateJob(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	fpReturn := fmt.Sprint("return(%d)", int(model.JobStateDone))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/ddl/mockPauseJobOnOneState", fpReturn))
+	tk.MustExec("create table pause_tbl(a int)")
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/mockPauseJobOnOneState"))
+}

--- a/ddl/mock.go
+++ b/ddl/mock.go
@@ -16,7 +16,6 @@ package ddl
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -29,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/util/logutil"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	atomicutil "go.uber.org/atomic"
 )
@@ -165,7 +163,6 @@ func (s *MockStateSyncer) Init(context.Context) error {
 func (s *MockStateSyncer) UpdateGlobalState(_ context.Context, stateInfo *syncer.StateInfo) error {
 	failpoint.Inject("mockUpgradingState", func(val failpoint.Value) {
 		if val.(bool) {
-			logutil.BgLogger().Warn(fmt.Sprintf("xxx------------------------------------------------mockUpgradingState *** job:%v", stateInfo))
 			s.clusterState.Store(stateInfo)
 			failpoint.Return(nil)
 		}

--- a/ddl/mock.go
+++ b/ddl/mock.go
@@ -179,7 +179,6 @@ func (s *MockStateSyncer) GetGlobalState(context.Context) (*syncer.StateInfo, er
 
 // IsUpgradingState implements StateSyncer.IsUpgradingState interface.
 func (s *MockStateSyncer) IsUpgradingState() bool {
-
 	return s.clusterState.Load().State == syncer.StateUpgrading
 }
 

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1172,16 +1172,14 @@ func syncUpgradeState(s Session) {
 		if err == nil && len(jobErrs) == 0 {
 			break
 		}
-		isAllFinished := true
 		jobErrStrs := make([]string, 0, len(jobErrs))
 		for _, jobErr := range jobErrs {
 			if dbterror.ErrPausedDDLJob.Equal(jobErr) {
 				continue
 			}
-			isAllFinished = false
 			jobErrStrs = append(jobErrStrs, jobErr.Error())
 		}
-		if isAllFinished {
+		if err == nil && len(jobErrs) == 0 {
 			break
 		}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/44159

Problem Summary:

### What is changed and how it works?
When we into the upgrading state we can do the `CannotPauseDDLJob` jobs.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below
As  https://github.com/pingcap/tidb/issues/44159
deploy a cluster add do large ddl in queueing
upgrade the cluster
**Before this PR**, can't upgrade successfully
**After this PR**, can upgrade successfully
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
