### PR TITLE
statistics: show stats mem usage even if stats mem quota is not set

### DIFF
--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -1010,7 +1010,6 @@ func (h *Handle) GetPartitionStats(tblInfo *model.TableInfo, pid int64, opts ...
 func (h *Handle) updateStatsCache(newCache statsCache) (updated bool) {
 	h.statsCache.Lock()
 	oldCache := h.statsCache.Load().(statsCache)
-	enableQuota := oldCache.EnableQuota()
 	newCost := newCache.Cost()
 	if oldCache.version < newCache.version || (oldCache.version == newCache.version && oldCache.minorVersion < newCache.minorVersion) {
 		h.statsCache.memTracker.Consume(newCost - oldCache.Cost())
@@ -1018,7 +1017,7 @@ func (h *Handle) updateStatsCache(newCache statsCache) (updated bool) {
 		updated = true
 	}
 	h.statsCache.Unlock()
-	if updated && enableQuota {
+	if updated {
 		handle_metrics.CostGauge.Set(float64(newCost))
 	}
 	return

--- a/statistics/handle/lru_cache.go
+++ b/statistics/handle/lru_cache.go
@@ -291,11 +291,6 @@ func (s *statsInnerCache) SetCapacity(c int64) {
 	s.lru.setCapacity(c)
 }
 
-// EnableQuota implements statsCacheInner
-func (s *statsInnerCache) EnableQuota() bool {
-	return true
-}
-
 // Front implements statsCacheInner
 func (s *statsInnerCache) Front() int64 {
 	s.RLock()

--- a/statistics/handle/statscache.go
+++ b/statistics/handle/statscache.go
@@ -35,7 +35,6 @@ type statsCacheInner interface {
 	FreshMemUsage()
 	Copy() statsCacheInner
 	SetCapacity(int64)
-	EnableQuota() bool
 	// Front returns the front element's owner tableID, only used for test
 	Front() int64
 }
@@ -236,11 +235,6 @@ func (m *mapCache) Copy() statsCacheInner {
 
 // SetCapacity implements statsCacheInner
 func (m *mapCache) SetCapacity(int64) {}
-
-// EnableQuota implements statsCacheInner
-func (m *mapCache) EnableQuota() bool {
-	return false
-}
 
 // Front implements statsCacheInner
 func (m *mapCache) Front() int64 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #34052

Problem Summary:

### What is changed and how it works?

Show stats mem usage even if stats mem quota is not set.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

![Screenshot 2023-05-25 at 16 57 44](https://github.com/pingcap/tidb/assets/30385241/bebc5542-4098-44e4-8cf7-1f607ec4fb47)


- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
