### PR TITLE
expression: modify the grouping function to receive uint64 and add more test about nullability

### DIFF
--- a/expression/builtin_grouping_test.go
+++ b/expression/builtin_grouping_test.go
@@ -39,7 +39,7 @@ func constructFieldType() types.FieldType {
 	return tp
 }
 
-func createGroupingFunc(ctx sessionctx.Context, args []Expression) (*builtinGroupingImplSig, error) {
+func createGroupingFunc(ctx sessionctx.Context, args []Expression) (*BuiltinGroupingImplSig, error) {
 	// TODO We should use the commented codes after the completion of rollup
 	// argTp := []types.EvalType{types.ETInt}
 	tp := constructFieldType()
@@ -49,7 +49,7 @@ func createGroupingFunc(ctx sessionctx.Context, args []Expression) (*builtinGrou
 		return nil, err
 	}
 	bf.tp.SetFlen(1)
-	sig := &builtinGroupingImplSig{bf, 0, map[int64]struct{}{}, false}
+	sig := &BuiltinGroupingImplSig{bf, 0, map[uint64]struct{}{}, false}
 	sig.setPbCode(tipb.ScalarFuncSig_GroupingSig)
 	return sig, nil
 }
@@ -59,33 +59,33 @@ func TestGrouping(t *testing.T) {
 	tests := []struct {
 		groupingID   uint64
 		mode         tipb.GroupingMode
-		groupingIDs  map[int64]struct{}
+		groupingIDs  map[uint64]struct{}
 		expectResult uint64
 	}{
 		// GroupingMode_ModeBitAnd
-		{1, 1, map[int64]struct{}{1: {}}, 1},
-		{1, 1, map[int64]struct{}{3: {}}, 1},
-		{1, 1, map[int64]struct{}{6: {}}, 0},
-		{2, 1, map[int64]struct{}{1: {}}, 0},
-		{2, 1, map[int64]struct{}{3: {}}, 1},
-		{2, 1, map[int64]struct{}{6: {}}, 1},
-		{4, 1, map[int64]struct{}{2: {}}, 0},
-		{4, 1, map[int64]struct{}{4: {}}, 1},
-		{4, 1, map[int64]struct{}{6: {}}, 1},
+		{1, 1, map[uint64]struct{}{1: {}}, 1},
+		{1, 1, map[uint64]struct{}{3: {}}, 1},
+		{1, 1, map[uint64]struct{}{6: {}}, 0},
+		{2, 1, map[uint64]struct{}{1: {}}, 0},
+		{2, 1, map[uint64]struct{}{3: {}}, 1},
+		{2, 1, map[uint64]struct{}{6: {}}, 1},
+		{4, 1, map[uint64]struct{}{2: {}}, 0},
+		{4, 1, map[uint64]struct{}{4: {}}, 1},
+		{4, 1, map[uint64]struct{}{6: {}}, 1},
 
 		// GroupingMode_ModeNumericCmp
-		{0, 2, map[int64]struct{}{0: {}}, 0},
-		{0, 2, map[int64]struct{}{2: {}}, 0},
-		{2, 2, map[int64]struct{}{0: {}}, 1},
-		{2, 2, map[int64]struct{}{1: {}}, 1},
-		{2, 2, map[int64]struct{}{2: {}}, 0},
-		{2, 2, map[int64]struct{}{3: {}}, 0},
+		{0, 2, map[uint64]struct{}{0: {}}, 0},
+		{0, 2, map[uint64]struct{}{2: {}}, 0},
+		{2, 2, map[uint64]struct{}{0: {}}, 1},
+		{2, 2, map[uint64]struct{}{1: {}}, 1},
+		{2, 2, map[uint64]struct{}{2: {}}, 0},
+		{2, 2, map[uint64]struct{}{3: {}}, 0},
 
 		// GroupingMode_ModeNumericSet
-		{1, 3, map[int64]struct{}{1: {}, 2: {}}, 0},
-		{1, 3, map[int64]struct{}{2: {}}, 1},
-		{2, 3, map[int64]struct{}{1: {}, 3: {}}, 1},
-		{2, 3, map[int64]struct{}{2: {}, 3: {}}, 0},
+		{1, 3, map[uint64]struct{}{1: {}, 2: {}}, 0},
+		{1, 3, map[uint64]struct{}{2: {}}, 1},
+		{2, 3, map[uint64]struct{}{1: {}, 3: {}}, 1},
+		{2, 3, map[uint64]struct{}{2: {}, 3: {}}, 0},
 	}
 
 	for _, testCase := range tests {

--- a/expression/grouping_sets.go
+++ b/expression/grouping_sets.go
@@ -35,6 +35,16 @@ type GroupingSet []GroupingExprs
 // GroupingExprs indicates one grouping-expressions inside a grouping set.
 type GroupingExprs []Expression
 
+func NewGroupingSets(groupCols []Expression) GroupingSets {
+	gss := make(GroupingSets, 0, len(groupCols))
+	for _, gCol := range groupCols {
+		ge := make(GroupingExprs, 0, 1)
+		ge = append(ge, gCol)
+		gss = append(gss, GroupingSet{ge})
+	}
+	return gss
+}
+
 // Merge function will explore the internal grouping expressions and try to find the minimum grouping sets. (prefix merging)
 func (gss GroupingSets) Merge() GroupingSets {
 	// for now, there is precondition that all grouping expressions are columns.
@@ -223,6 +233,8 @@ func (gs GroupingSet) IsEmpty() bool {
 func (gs GroupingSet) AllColIDs() *fd.FastIntSet {
 	res := fd.NewFastIntSet()
 	for _, groupingExprs := range gs {
+		// on the condition that every grouping expression is single column.
+		// eg: group by a, b, c
 		for _, one := range groupingExprs {
 			res.Insert(int(one.(*Column).UniqueID))
 		}


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?
1: change the grouping function to receive uint64, cause gid and gpos are all about uint64
2: add nullability test about the grouping sets util

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
