### PR TITLE
br: ignore restore pd and gc if SkipPauseGCAndScheduler is on

### DIFF
--- a/br/pkg/task/backup_ebs.go
+++ b/br/pkg/task/backup_ebs.go
@@ -216,12 +216,14 @@ func RunBackupEBS(c context.Context, g glue.Glue, cfg *BackupConfig) error {
 			return errors.Trace(err)
 		}
 
-		log.Info("snapshot started, restore schedule")
-		if restoreE := restoreFunc(ctx); restoreE != nil {
-			log.Warn("failed to restore removed schedulers, you may need to restore them manually", zap.Error(restoreE))
-		} else {
-			// Clear the restore func, so we won't execute it many times.
-			restoreFunc = nil
+		if !cfg.SkipPauseGCAndScheduler {
+			log.Info("snapshot started, restore schedule")
+			if restoreE := restoreFunc(ctx); restoreE != nil {
+				log.Warn("failed to restore removed schedulers, you may need to restore them manually", zap.Error(restoreE))
+			} else {
+				// Clear the restore func, so we won't execute it many times.
+				restoreFunc = nil
+			}
 		}
 
 		log.Info("wait async snapshots finish")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44182 

Problem Summary:

### What is changed and how it works?

When `operator-paused-gc-and-scheduler=true` is set for ebs snapshot full backup, PD and GC restore function is not set but is invoked erroneously, and it caused a panic as below.  We need to avoid invoke the restore function when `SkipPauseGCAndScheduler` is turned on.

`I0525 09:38:32.981380       9 backup.go:292]
I0525 09:38:32.981426       9 backup.go:299] panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4a33831]

goroutine 1 [running]:
[github.com/pingcap/tidb/br/pkg/task.RunBackupEBS](http://github.com/pingcap/tidb/br/pkg/task.RunBackupEBS)({0x6212770, 0xc000101900}, {0x62295a8?, 0x9067330?}, 0xc0001aee00)
	/home/jenkins/agent/workspace/build-common/go/src/[github.com/pingcap/br/br/pkg/task/backup_ebs.go:220](http://github.com/pingcap/br/br/pkg/task/backup_ebs.go:220) +0x10b1
main.runBackupCommand(0xc000bd8600, {0x59729f7, 0xb})
	/home/jenkins/agent/workspace/build-common/go/src/[github.com/pingcap/br/br/cmd/br/backup.go:41](http://github.com/pingcap/br/br/cmd/br/backup.go:41) +0x209
main.newFullBackupCommand.func1(0xc000bd8600?, {0xc000bd6680?, 0x8?, 0x8?})
	/home/jenkins/agent/workspace/build-common/go/src/[github.com/pingcap/br/br/cmd/br/backup.go:143](http://github.com/pingcap/br/br/cmd/br/backup.go:143) +0x25
[github.com/spf13/cobra.(*Command).execute](http://github.com/spf13/cobra.(*Command).execute)(0xc000bd8600, {0xc000126030, 0x8, 0x8})
	/go/pkg/mod/[github.com/spf13/cobra@v1.6.1/command.go:916](http://github.com/spf13/cobra@v1.6.1/command.go:916) +0x862
[github.com/spf13/cobra.(*Command).ExecuteC(0xc00078c300)](http://github.com/spf13/cobra.(*Command).ExecuteC(0xc00078c300))
	/go/pkg/mod/[github.com/spf13/cobra@v1.6.1/command.go:1044](http://github.com/spf13/cobra@v1.6.1/command.go:1044) +0x3bd
[github.com/spf13/cobra.(*Command).Execute(...)](http://github.com/spf13/cobra.(*Command).Execute(...))
	/go/pkg/mod/[github.com/spf13/cobra@v1.6.1/command.go:968](http://github.com/spf13/cobra@v1.6.1/command.go:968)
main.main()`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
Use the EBS snapshot backup operator to verify the panic is gone.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
