### PR TITLE
util/extsort: parallelize DiskSorter.Sort

### DIFF
--- a/br/pkg/lightning/backend/kv/sql2kv.go
+++ b/br/pkg/lightning/backend/kv/sql2kv.go
@@ -175,6 +175,13 @@ func Row2KvPairs(row encode.Row) []common.KvPair {
 	return row.(*Pairs).Pairs
 }
 
+// ClearRow recycles the memory used by the row.
+func ClearRow(row encode.Row) {
+	if pairs, ok := row.(*Pairs); ok {
+		pairs.Clear()
+	}
+}
+
 // Encode a row of data into KV pairs.
 //
 // See comments in `(*TableRestore).initializeColumns` for the meaning of the

--- a/br/pkg/lightning/importer/dup_detect.go
+++ b/br/pkg/lightning/importer/dup_detect.go
@@ -293,9 +293,11 @@ func (d *dupDetector) addKeysByChunk(
 		}
 		for _, kvPair := range kv.Row2KvPairs(row) {
 			if err := adder.Add(kvPair.Key, kvPair.RowID); err != nil {
+				kv.ClearRow(row)
 				return err
 			}
 		}
+		kv.ClearRow(row)
 
 		offset, _ = parser.Pos()
 		if err := parser.ReadRow(); err != nil {

--- a/util/extsort/BUILD.bazel
+++ b/util/extsort/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     embed = [":extsort"],
     flaky = True,
     deps = [
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//sstable",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//require",

--- a/util/extsort/BUILD.bazel
+++ b/util/extsort/BUILD.bazel
@@ -9,10 +9,16 @@ go_library(
     importpath = "github.com/pingcap/tidb/util/extsort",
     visibility = ["//visibility:public"],
     deps = [
+        "//util/generic",
+        "//util/syncutil",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//sstable",
+        "@com_github_cockroachdb_pebble//vfs",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_log//:log",
         "@org_golang_x_exp//slices",
+        "@org_golang_x_sync//errgroup",
+        "@org_uber_go_zap//:zap",
     ],
 )
 

--- a/util/extsort/BUILD.bazel
+++ b/util/extsort/BUILD.bazel
@@ -29,9 +29,10 @@ go_test(
         "disk_sorter_test.go",
         "external_sorter_test.go",
     ],
+    embed = [":extsort"],
     flaky = True,
     deps = [
-        ":extsort",
+        "@com_github_cockroachdb_pebble//sstable",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",

--- a/util/extsort/BUILD.bazel
+++ b/util/extsort/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     flaky = True,
     deps = [
         "@com_github_cockroachdb_pebble//sstable",
+        "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",

--- a/util/extsort/BUILD.bazel
+++ b/util/extsort/BUILD.bazel
@@ -35,8 +35,10 @@ go_test(
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//sstable",
         "@com_github_cockroachdb_pebble//vfs",
+        "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
+        "@org_uber_go_zap//:zap",
     ],
 )

--- a/util/extsort/disk_sorter.go
+++ b/util/extsort/disk_sorter.go
@@ -214,6 +214,9 @@ func (sw *sstWriter) Close() (retErr error) {
 		largest := writerMeta.Largest(pebble.DefaultComparer.Compare)
 		meta.startKey = slices.Clone(smallest.UserKey)
 		meta.lastKey = slices.Clone(largest.UserKey)
+		// Make endKey is exclusive. To avoid unnecessary overlap,
+		// we append 0 to make endKey is the smallest key which is
+		// greater than the last key.
 		meta.endKey = append(meta.lastKey, 0)
 		prop, ok := writerMeta.Properties.UserProperties[kvStatsPropKey]
 		if ok {
@@ -880,6 +883,9 @@ func (d *DiskSorter) readFileMetadata(fileNum int) (*fileMetadata, error) {
 	lastKey, _ := iter.Last()
 	if lastKey != nil {
 		meta.lastKey = slices.Clone(lastKey.UserKey)
+		// Make endKey is exclusive. To avoid unnecessary overlap,
+		// we append 0 to make endKey is the smallest key which is
+		// greater than the last key.
 		meta.endKey = append(meta.lastKey, 0)
 	} else if err := iter.Error(); err != nil {
 		return nil, errors.Trace(err)

--- a/util/extsort/disk_sorter.go
+++ b/util/extsort/disk_sorter.go
@@ -453,7 +453,7 @@ func (m *mergingIter) Seek(key []byte) bool {
 				toClose = append(toClose, oldHeap[i:]...)
 				break
 			}
-			// The iterator is not in the range of [startKey, endKey), close it.
+			// The seek key is not in the range of [startKey, endKey), close it.
 			toClose = append(toClose, item)
 		}
 	}
@@ -668,7 +668,7 @@ type DiskSorterOptions struct {
 	// file 3:       d---f
 	//
 	// The overlap depth of these files is 3, because file 0, 1, 2 overlap at
-	// the range [c, d), and file 1, 2, 3 overlap at the interval [d, e).
+	// the interval [c, d), and file 1, 2, 3 overlap at the interval [d, e).
 	//
 	// If the overlap depth is larger than CompactionThreshold, the sorter will
 	// compact files to reduce the overlap depth during sorting. The larger the

--- a/util/extsort/disk_sorter.go
+++ b/util/extsort/disk_sorter.go
@@ -915,12 +915,12 @@ func (d *DiskSorter) doSort(ctx context.Context) error {
 	slices.SortFunc(d.orderedFiles, func(a, b *fileMetadata) bool {
 		return bytes.Compare(a.startKey, b.startKey) < 0
 	})
-	files := pickCompactionFiles(d.orderedFiles, d.opts.MaxCompactionSize, d.opts.Logger)
+	files := pickCompactionFiles(d.orderedFiles, d.opts.CompactionThreshold, d.opts.Logger)
 	for len(files) > 0 {
 		if err := d.compactFiles(ctx, files); err != nil {
 			return err
 		}
-		files = pickCompactionFiles(d.orderedFiles, d.opts.MaxCompactionSize, d.opts.Logger)
+		files = pickCompactionFiles(d.orderedFiles, d.opts.CompactionThreshold, d.opts.Logger)
 	}
 	return nil
 }

--- a/util/extsort/disk_sorter.go
+++ b/util/extsort/disk_sorter.go
@@ -1059,7 +1059,7 @@ func splitCompactionFiles(files []*fileMetadata, maxCompactionDepth int) [][]*fi
 	curGroup := []*fileMetadata{files[0]}
 	maxEndKey := files[0].endKey
 	for _, file := range files[1:] {
-		if bytes.Compare(file.startKey, maxEndKey) > 0 {
+		if bytes.Compare(file.startKey, maxEndKey) >= 0 {
 			groups = append(groups, curGroup)
 			curGroup = []*fileMetadata{file}
 		} else {

--- a/util/extsort/disk_sorter.go
+++ b/util/extsort/disk_sorter.go
@@ -15,37 +15,604 @@
 package extsort
 
 import (
+	"bytes"
+	"container/heap"
 	"context"
+	"encoding/json"
 	goerrors "errors"
 	"fmt"
-	"math"
-	"path/filepath"
 	"runtime"
+	"sort"
+	"strconv"
+	"strings"
 	"sync/atomic"
 
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/util/generic"
+	"github.com/pingcap/tidb/util/syncutil"
+	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
+	sstFileSuffix            = ".sst"
+	tmpFileSuffix            = ".tmp"
+	kvStatsPropKey           = "extsort.kvstats"
+	defaultKVStatsBucketSize = 1 << 20
+
+	// If the file exists, it means the disk sorter is sorted.
+	diskSorterSortedFile   = "sorted"
 	diskSorterStateWriting = 0
 	diskSorterStateSorting = 1
 	diskSorterStateSorted  = 2
 )
 
-// DiskSorter is an external sorter that sorts data on disk.
-type DiskSorter struct {
-	db     *pebble.DB
-	dbOpts *pebble.Options
+type fileMetadata struct {
+	fileNum  int
+	startKey []byte // inclusive
+	endKey   []byte // exclusive
+	lastKey  []byte // the last key in the file
+	kvStats  kvStats
+}
 
-	opts   *DiskSorterOptions
-	dbDir  string        // directory for the pebble database
-	tmpDir string        // directory for temporary files
-	idGen  *atomic.Int64 // id generator for sst files
+type kvStats struct {
+	Histogram []kvStatsBucket `json:"histogram"`
+}
 
-	state atomic.Int32
+type kvStatsBucket struct {
+	// Size is the kv size between the upper bound of previous bucket
+	// (exclusive) and the upper bound of current bucket (inclusive).
+	Size int `json:"size"`
+	// UpperBound is the upper inclusive bound of the bucket.
+	UpperBound []byte `json:"upperBound"`
+}
+
+// kvStatsCollector implements sstable.TablePropertyCollector.
+// It collects kv stats of the sstables.
+type kvStatsCollector struct {
+	bucketSize int
+	buckets    []kvStatsBucket
+	curSize    int
+	lastKey    []byte
+}
+
+func newKVStatsCollector(bucketSize int) *kvStatsCollector {
+	return &kvStatsCollector{
+		bucketSize: bucketSize,
+	}
+}
+
+func (c *kvStatsCollector) Add(key sstable.InternalKey, value []byte) error {
+	c.curSize += len(key.UserKey) + len(value)
+	c.lastKey = append(c.lastKey[:0], key.UserKey...)
+	if c.curSize >= c.bucketSize {
+		c.addBucket()
+	}
+	return nil
+}
+
+func (c *kvStatsCollector) addBucket() {
+	c.buckets = append(c.buckets, kvStatsBucket{
+		Size:       c.curSize,
+		UpperBound: slices.Clone(c.lastKey),
+	})
+	c.curSize = 0
+}
+
+func (c *kvStatsCollector) Finish(userProps map[string]string) error {
+	if c.curSize > 0 {
+		c.addBucket()
+	}
+	stats := kvStats{Histogram: c.buckets}
+	data, err := json.Marshal(&stats)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	userProps[kvStatsPropKey] = string(data)
+	return nil
+}
+
+func (*kvStatsCollector) Name() string {
+	return kvStatsPropKey
+}
+
+func makeFilename(fs vfs.FS, dirname string, fileNum int) string {
+	return fs.PathJoin(dirname, fmt.Sprintf("%06d%s", fileNum, sstFileSuffix))
+}
+
+func parseFilename(fs vfs.FS, filename string) (fileNum int, ok bool) {
+	filename = fs.PathBase(filename)
+	if !strings.HasSuffix(filename, sstFileSuffix) {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(filename[:len(filename)-len(sstFileSuffix)], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return int(v), true
+}
+
+type sstWriter struct {
+	w         *sstable.Writer
+	fs        vfs.FS
+	fileNum   int
+	tmpPath   string
+	destPath  string
+	err       error
+	onSuccess func(meta *fileMetadata)
+}
+
+func newSSTWriter(
+	fs vfs.FS,
+	dirname string,
+	fileNum int,
+	kvStatsBucketSize int,
+	onSuccess func(meta *fileMetadata),
+) (*sstWriter, error) {
+	destPath := makeFilename(fs, dirname, fileNum)
+	tmpPath := destPath + tmpFileSuffix
+	f, err := fs.Create(tmpPath)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := sstable.NewWriter(f, sstable.WriterOptions{
+		TablePropertyCollectors: []func() sstable.TablePropertyCollector{
+			func() sstable.TablePropertyCollector {
+				return newKVStatsCollector(kvStatsBucketSize)
+			},
+		},
+	})
+
+	sw := &sstWriter{
+		w:         w,
+		fs:        fs,
+		fileNum:   fileNum,
+		tmpPath:   tmpPath,
+		destPath:  destPath,
+		onSuccess: onSuccess,
+	}
+	return sw, nil
+}
+
+func (sw *sstWriter) Set(key, value []byte) error {
+	sw.err = sw.w.Set(key, value)
+	return errors.Trace(sw.err)
+}
+
+func (sw *sstWriter) Close() (retErr error) {
+	defer func() {
+		if retErr == nil {
+			retErr = sw.fs.Rename(sw.tmpPath, sw.destPath)
+		}
+	}()
+	closeErr := sw.w.Close()
+	if err := goerrors.Join(sw.err, closeErr); err != nil {
+		return errors.Trace(err)
+	}
+
+	if sw.onSuccess != nil {
+		writerMeta, err := sw.w.Metadata()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		meta := &fileMetadata{
+			fileNum: sw.fileNum,
+		}
+		smallest := writerMeta.Smallest(pebble.DefaultComparer.Compare)
+		largest := writerMeta.Largest(pebble.DefaultComparer.Compare)
+		meta.startKey = slices.Clone(smallest.UserKey)
+		meta.lastKey = slices.Clone(largest.UserKey)
+		meta.endKey = append(meta.lastKey, 0)
+		prop, ok := writerMeta.Properties.UserProperties[kvStatsPropKey]
+		if ok {
+			if err := json.Unmarshal([]byte(prop), &meta.kvStats); err != nil {
+				return errors.Trace(err)
+			}
+		}
+		sw.onSuccess(meta)
+	}
+	return nil
+}
+
+type sstReaderPool struct {
+	fs      vfs.FS
+	dirname string
+	cache   *pebble.Cache
+	mu      struct {
+		syncutil.RWMutex
+		readers map[int]struct {
+			reader *sstable.Reader
+			refs   *atomic.Int32
+		} // fileNum -> reader and its refs
+	}
+}
+
+func newSSTReaderPool(fs vfs.FS, dirname string, cache *pebble.Cache) *sstReaderPool {
+	pool := &sstReaderPool{
+		fs:      fs,
+		dirname: dirname,
+		cache:   cache,
+	}
+	pool.mu.readers = make(map[int]struct {
+		reader *sstable.Reader
+		refs   *atomic.Int32
+	})
+	return pool
+}
+
+func (p *sstReaderPool) get(fileNum int) (*sstable.Reader, error) {
+	p.mu.RLock()
+	if v, ok := p.mu.readers[fileNum]; ok {
+		v.refs.Add(1)
+		p.mu.RUnlock()
+		return v.reader, nil
+	}
+	p.mu.RUnlock()
+
+	// Create a new reader. Note that we don't hold the lock here,
+	// since creating a reader can be expensive, and we don't want
+	// to block other readers' creation.
+	f, err := p.fs.Open(makeFilename(p.fs, p.dirname, fileNum))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	reader, err := sstable.NewReader(f, sstable.ReaderOptions{
+		Cache: p.cache,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Someone might have added the reader to the pool.
+	if v, ok := p.mu.readers[fileNum]; ok {
+		_ = reader.Close()
+		v.refs.Add(1)
+		return v.reader, nil
+	}
+	refs := new(atomic.Int32)
+	refs.Store(1)
+	p.mu.readers[fileNum] = struct {
+		reader *sstable.Reader
+		refs   *atomic.Int32
+	}{reader: reader, refs: refs}
+	return reader, nil
+}
+
+func (p *sstReaderPool) unref(fileNum int) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	v, ok := p.mu.readers[fileNum]
+	if !ok {
+		panic(fmt.Sprintf("sstReaderPool: unref a reader that does not exist: %d", fileNum))
+	}
+	if v.refs.Add(-1) == 0 {
+		delete(p.mu.readers, fileNum)
+		return errors.Trace(v.reader.Close())
+	}
+	return nil
+}
+
+type sstIter struct {
+	iter    sstable.Iterator
+	key     *sstable.InternalKey
+	value   []byte
+	onClose func() error
+}
+
+func (si *sstIter) Seek(key []byte) bool {
+	si.key, si.value = si.iter.SeekGE(key)
+	return si.key != nil
+}
+
+func (si *sstIter) First() bool {
+	si.key, si.value = si.iter.SeekGE(nil)
+	return si.key != nil
+}
+
+func (si *sstIter) Next() bool {
+	si.key, si.value = si.iter.Next()
+	return si.key != nil
+}
+
+func (si *sstIter) Last() bool {
+	si.key, si.value = si.iter.Last()
+	return si.key != nil
+}
+
+func (si *sstIter) Valid() bool {
+	return si.key != nil
+}
+
+func (si *sstIter) Error() error {
+	return errors.Trace(si.iter.Error())
+}
+
+func (si *sstIter) UnsafeKey() []byte {
+	return si.key.UserKey
+}
+
+func (si *sstIter) UnsafeValue() []byte {
+	return si.value
+}
+
+func (si *sstIter) Close() error {
+	err := si.iter.Close()
+	if si.onClose != nil {
+		err = goerrors.Join(err, si.onClose())
+	}
+	return errors.Trace(err)
+}
+
+type mergingIter struct {
+	heap          mergingIterHeap
+	orderedFiles  []*fileMetadata // ordered by start key
+	nextFileIndex int
+	openIter      openIterFunc
+	curKey        []byte // only used in Next() to avoid alloc
+	err           error
+}
+
+type mergingIterItem struct {
+	Iterator
+	index int // index in orderedFiles
+}
+
+type mergingIterHeap []mergingIterItem
+
+func (h mergingIterHeap) Len() int {
+	return len(h)
+}
+
+func (h mergingIterHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h mergingIterHeap) Less(i, j int) bool {
+	return bytes.Compare(h[i].UnsafeKey(), h[j].UnsafeKey()) < 0
+}
+
+func (h *mergingIterHeap) Push(x interface{}) {
+	*h = append(*h, x.(mergingIterItem))
+}
+
+func (h *mergingIterHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+type openIterFunc func(file *fileMetadata) (Iterator, error)
+
+// newMergingIter returns an iterator that merges the given files.
+// orderedFiles must be ordered by start key, otherwise it panics.
+func newMergingIter(orderedFiles []*fileMetadata, openIter openIterFunc) *mergingIter {
+	if !slices.IsSortedFunc(orderedFiles, func(a, b *fileMetadata) bool {
+		return bytes.Compare(a.startKey, b.startKey) < 0
+	}) {
+		panic("newMergingIter: orderedFiles are not ordered by start key")
+	}
+	return &mergingIter{
+		orderedFiles: orderedFiles,
+		openIter:     openIter,
+	}
+}
+
+func (m *mergingIter) Seek(key []byte) bool {
+	m.err = nil
+	oldHeap := m.heap
+	m.heap = nil
+
+	var toClose []mergingIterItem
+	openedIters := make(map[int]struct{})
+	for i, item := range oldHeap {
+		file := m.orderedFiles[item.index]
+		if bytes.Compare(key, file.startKey) >= 0 &&
+			bytes.Compare(key, file.endKey) < 0 &&
+			item.Seek(key) {
+			openedIters[item.index] = struct{}{}
+			heap.Push(&m.heap, item)
+		} else {
+			m.err = item.Error()
+			if m.err != nil {
+				// Iterators in m.heap should be closed by mergingIter.Close().
+				toClose = append(toClose, oldHeap[i:]...)
+				break
+			}
+			// The iterator is not in the range of [startKey, endKey), close it.
+			toClose = append(toClose, item)
+		}
+	}
+	for _, item := range toClose {
+		if err := item.Close(); err != nil && m.err == nil {
+			m.err = err
+		}
+	}
+	if m.err != nil {
+		return false
+	}
+
+	m.nextFileIndex = len(m.orderedFiles)
+	for i, file := range m.orderedFiles {
+		if bytes.Compare(file.startKey, key) > 0 {
+			m.nextFileIndex = i
+			break
+		}
+		if _, ok := openedIters[i]; ok {
+			continue
+		}
+		if bytes.Compare(file.endKey, key) <= 0 {
+			continue
+		}
+		iter, err := m.openIter(file)
+		if err != nil {
+			m.err = err
+			return false
+		}
+		if iter.Seek(key) {
+			heap.Push(&m.heap, mergingIterItem{
+				Iterator: iter,
+				index:    i,
+			})
+		} else {
+			m.err = iter.Error()
+			closeErr := iter.Close()
+			m.err = goerrors.Join(m.err, closeErr)
+			if m.err != nil {
+				return false
+			}
+		}
+	}
+	return m.maybeOpenNextFiles()
+}
+
+func (m *mergingIter) First() bool {
+	return m.Seek(nil)
+}
+
+func (m *mergingIter) Next() bool {
+	m.err = nil
+	m.curKey = append(m.curKey[:0], m.heap[0].UnsafeKey()...)
+	//revive:disable:empty-block
+	for m.next() && bytes.Equal(m.heap[0].UnsafeKey(), m.curKey) {
+	}
+	//revive:enable:empty-block
+	return m.Valid()
+}
+
+func (m *mergingIter) next() bool {
+	if len(m.heap) == 0 {
+		return false
+	}
+	if m.heap[0].Next() {
+		heap.Fix(&m.heap, 0)
+	} else {
+		m.err = m.heap[0].Error()
+		if m.err != nil {
+			return false
+		}
+		x := heap.Pop(&m.heap)
+		item := x.(mergingIterItem)
+		m.err = item.Close()
+		if m.err != nil {
+			return false
+		}
+	}
+	return m.maybeOpenNextFiles()
+}
+
+func (m *mergingIter) maybeOpenNextFiles() bool {
+	for m.nextFileIndex < len(m.orderedFiles) {
+		file := m.orderedFiles[m.nextFileIndex]
+		if len(m.heap) > 0 && bytes.Compare(m.heap[0].UnsafeKey(), file.startKey) < 0 {
+			break
+		}
+		// The next file may overlap with the min key in the heap, so we need to
+		// open it and push it into the heap.
+		iter, err := m.openIter(file)
+		if err != nil {
+			m.err = err
+			return false
+		}
+		if !iter.First() {
+			m.err = iter.Error()
+			closeErr := iter.Close()
+			m.err = goerrors.Join(m.err, closeErr)
+			if m.err != nil {
+				return false
+			}
+		}
+		heap.Push(&m.heap, mergingIterItem{
+			Iterator: iter,
+			index:    m.nextFileIndex,
+		})
+		m.nextFileIndex++
+	}
+	return len(m.heap) > 0
+}
+
+func (m *mergingIter) Last() bool {
+	m.err = nil
+	// Close all opened iterators.
+	for _, item := range m.heap {
+		if err := item.Close(); err != nil && m.err == nil {
+			m.err = err
+		}
+	}
+	m.heap = nil
+
+	// Sort files by last key in reverse order.
+	files := slices.Clone(m.orderedFiles)
+	slices.SortFunc(files, func(a, b *fileMetadata) bool {
+		return bytes.Compare(a.lastKey, b.lastKey) > 0
+	})
+
+	// Since we don't need to implement Prev() method,
+	// we can just open the file with the largest last key.
+	for _, file := range files {
+		iter, err := m.openIter(file)
+		if err != nil {
+			m.err = err
+			return false
+		}
+		if iter.Last() {
+			index := -1
+			for i := range m.orderedFiles {
+				if m.orderedFiles[i] == file {
+					index = i
+					break
+				}
+			}
+			heap.Push(&m.heap, mergingIterItem{
+				Iterator: iter,
+				index:    index,
+			})
+			break
+		}
+		m.err = iter.Error()
+		closeErr := iter.Close()
+		m.err = goerrors.Join(m.err, closeErr)
+		if m.err != nil {
+			return false
+		}
+	}
+	// Force iterating to the end.
+	m.nextFileIndex = len(m.orderedFiles)
+	return m.Valid()
+}
+
+func (m *mergingIter) Valid() bool {
+	return m.err == nil && len(m.heap) > 0
+}
+
+func (m *mergingIter) Error() error {
+	return m.err
+}
+
+func (m *mergingIter) UnsafeKey() []byte {
+	return m.heap[0].UnsafeKey()
+}
+
+func (m *mergingIter) UnsafeValue() []byte {
+	return m.heap[0].UnsafeValue()
+}
+
+func (m *mergingIter) Close() error {
+	m.err = nil
+	for _, item := range m.heap {
+		if err := item.Close(); err != nil && m.err == nil {
+			m.err = err
+		}
+	}
+	return m.err
 }
 
 // DiskSorterOptions holds the optional parameters for DiskSorter.
@@ -62,6 +629,45 @@ type DiskSorterOptions struct {
 	//
 	// The default value is 128MB.
 	WriterBufferSize int
+
+	// CompactionThreshold is maximum overlap depth necessary to trigger a
+	// compaction. The overlap depth is the number of files that overlap at
+	// same interval.
+	//
+	// For example, consider the following files:
+	//
+	// file 0: a-----d
+	// file 1:   b-----e
+	// file 2:     c-------g
+	// file 3:       d---f
+	//
+	// The overlap depth of these files is 3, because file 0, 1, 2 overlap at
+	// the range [c, d), and file 1, 2, 3 overlap at the interval [d, e).
+	//
+	// If the overlap depth is larger than CompactionThreshold, the sorter will
+	// compact files to reduce the overlap depth during sorting. The larger the
+	// overlap depth, the larger read amplification will be during iteration.
+	// This is a trade-off between read amplification and sorting cost. Setting
+	// this value to math.MaxInt32 will disable the compaction.
+	//
+	// The default value is 16.
+	CompactionThreshold int
+
+	// MaxCompactionDepth is the maximum files involved in a single compaction.
+	//
+	// The default value is 64.
+	MaxCompactionDepth int
+
+	// MaxCompactionSize is the maximum size of key-value pairs involved in a
+	// single compaction.
+	//
+	// The default value is 512MB.
+	MaxCompactionSize int
+
+	// Logger is used to write log messages.
+	//
+	// The default value is log.L().
+	Logger *zap.Logger
 }
 
 func (o *DiskSorterOptions) ensureDefaults() {
@@ -71,6 +677,37 @@ func (o *DiskSorterOptions) ensureDefaults() {
 	if o.WriterBufferSize == 0 {
 		o.WriterBufferSize = 128 << 20
 	}
+	if o.CompactionThreshold == 0 {
+		o.CompactionThreshold = 16
+	}
+	if o.MaxCompactionDepth == 0 {
+		o.MaxCompactionDepth = 64
+	}
+	if o.MaxCompactionSize == 0 {
+		o.MaxCompactionSize = 512 << 20
+	}
+	if o.Logger == nil {
+		o.Logger = log.L()
+	}
+}
+
+// DiskSorter is an external sorter that sorts data on disk.
+type DiskSorter struct {
+	opts    *DiskSorterOptions
+	fs      vfs.FS
+	dirname string
+	// cache is shared by all sst readers.
+	cache        *pebble.Cache
+	readerPool   *sstReaderPool
+	idAlloc      atomic.Int64
+	state        atomic.Int32
+	pendingFiles struct {
+		syncutil.Mutex
+		files []*fileMetadata
+	}
+	// The list of files that have been sorted.
+	// They must be ordered by its start key.
+	orderedFiles []*fileMetadata
 }
 
 // OpenDiskSorter opens a DiskSorter with the given directory.
@@ -80,37 +717,123 @@ func OpenDiskSorter(dirname string, opts *DiskSorterOptions) (*DiskSorter, error
 	}
 	opts.ensureDefaults()
 
-	dbOpts := &pebble.Options{
-		MaxConcurrentCompactions: opts.Concurrency,
-		DisableWAL:               true,
-		L0CompactionThreshold:    math.MaxInt,
-		L0StopWritesThreshold:    math.MaxInt,
+	fs := vfs.Default
+	if dirname == "" {
+		fs = vfs.NewMem()
 	}
-	dbOpts = dbOpts.EnsureDefaults()
-
-	dbDir := filepath.Join(dirname, "db")
-	tmpDir := filepath.Join(dirname, "tmp")
-
-	// Clean up the temporary directory.
-	if err := dbOpts.FS.RemoveAll(tmpDir); err != nil {
+	if err := fs.MkdirAll(dirname, 0755); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := dbOpts.FS.MkdirAll(tmpDir, 0755); err != nil {
-		return nil, errors.Trace(err)
+	cache := pebble.NewCache(8 << 20)
+	readerPool := newSSTReaderPool(fs, dirname, cache)
+	d := &DiskSorter{
+		opts:       opts,
+		fs:         fs,
+		dirname:    dirname,
+		cache:      pebble.NewCache(8 << 20),
+		readerPool: readerPool,
+	}
+	if err := d.init(); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+func (d *DiskSorter) init() error {
+	list, err := d.fs.List(d.dirname)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
-	db, err := pebble.Open(dbDir, dbOpts)
+	g, ctx := errgroup.WithContext(context.Background())
+	outputCh := make(chan *fileMetadata, len(list))
+	for _, name := range list {
+		if ctx.Err() != nil {
+			break
+		}
+		if strings.HasSuffix(name, tmpFileSuffix) {
+			_ = d.fs.Remove(d.fs.PathJoin(d.dirname, name))
+			continue
+		}
+		fileNum, ok := parseFilename(d.fs, name)
+		if !ok {
+			continue
+		}
+		if int64(fileNum) > d.idAlloc.Load() {
+			d.idAlloc.Store(int64(fileNum))
+		}
+		g.Go(func() error {
+			file, err := d.readFileMetadata(fileNum)
+			if err != nil {
+				return err
+			}
+			outputCh <- file
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	close(outputCh)
+	files := make([]*fileMetadata, 0, len(outputCh))
+	for file := range outputCh {
+		files = append(files, file)
+	}
+	if _, err := d.fs.Stat(d.fs.PathJoin(d.dirname, diskSorterSortedFile)); err == nil {
+		slices.SortFunc(files, func(a, b *fileMetadata) bool {
+			return bytes.Compare(a.startKey, b.startKey) < 0
+		})
+		d.orderedFiles = files
+		d.state.Store(diskSorterStateSorted)
+	} else {
+		d.pendingFiles.files = files
+		d.state.Store(diskSorterStateWriting)
+	}
+	return nil
+}
+
+func (d *DiskSorter) readFileMetadata(fileNum int) (*fileMetadata, error) {
+	reader, err := d.readerPool.get(fileNum)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &DiskSorter{
-		db:     db,
-		dbOpts: dbOpts,
-		opts:   opts,
-		dbDir:  dbDir,
-		tmpDir: tmpDir,
-		idGen:  new(atomic.Int64),
-	}, nil
+	defer func() {
+		_ = d.readerPool.unref(fileNum)
+	}()
+
+	meta := &fileMetadata{
+		fileNum: fileNum,
+	}
+	if prop, ok := reader.Properties.UserProperties[kvStatsPropKey]; ok {
+		if err := json.Unmarshal([]byte(prop), &meta.kvStats); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	iter, err := reader.NewIter(nil, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer func() {
+		_ = iter.Close()
+	}()
+
+	firstKey, _ := iter.First()
+	if firstKey != nil {
+		meta.startKey = slices.Clone(firstKey.UserKey)
+	} else if err := iter.Error(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	lastKey, _ := iter.Last()
+	if lastKey != nil {
+		meta.lastKey = slices.Clone(lastKey.UserKey)
+		meta.endKey = append(meta.lastKey, 0)
+	} else if err := iter.Error(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return meta, nil
 }
 
 // NewWriter implements the ExternalSorter.NewWriter.
@@ -119,8 +842,16 @@ func (d *DiskSorter) NewWriter(_ context.Context) (Writer, error) {
 		return nil, errors.Errorf("diskSorter started sorting, cannot write more data")
 	}
 	return &diskSorterWriter{
-		d:   d,
 		buf: make([]byte, d.opts.WriterBufferSize),
+		newSSTWriter: func() (*sstWriter, error) {
+			fileNum := int(d.idAlloc.Add(1))
+			return newSSTWriter(d.fs, d.dirname, fileNum, defaultKVStatsBucketSize,
+				func(meta *fileMetadata) {
+					d.pendingFiles.Lock()
+					d.pendingFiles.files = append(d.pendingFiles.files, meta)
+					d.pendingFiles.Unlock()
+				})
+		},
 	}, nil
 }
 
@@ -131,29 +862,330 @@ func (d *DiskSorter) Sort(ctx context.Context) error {
 	}
 	d.state.Store(diskSorterStateSorting)
 	if err := d.doSort(ctx); err != nil {
+		return err
+	}
+	d.state.Store(diskSorterStateSorted)
+
+	// Persist the sorted state.
+	f, err := d.fs.Create(d.fs.PathJoin(d.dirname, diskSorterSortedFile))
+	if err != nil {
 		return errors.Trace(err)
 	}
-	// TODO: Persist the state to disk.
-	d.state.Store(diskSorterStateSorted)
-	return nil
+	return errors.Trace(f.Close())
 }
 
-func (d *DiskSorter) doSort(_ context.Context) error {
-	iter := d.db.NewIter(nil)
-	if !iter.Last() {
-		// No keys or any error occurred.
-		_ = iter.Close()
-		return errors.Trace(iter.Error())
+func (d *DiskSorter) doSort(ctx context.Context) error {
+	d.pendingFiles.Lock()
+	defer d.pendingFiles.Unlock()
+	if len(d.pendingFiles.files) == 0 {
+		return nil
 	}
-	end := slices.Clone(iter.Key())
-	if err := iter.Close(); err != nil {
-		return errors.Trace(err)
+	d.orderedFiles = d.pendingFiles.files
+	d.pendingFiles.files = nil
+	slices.SortFunc(d.orderedFiles, func(a, b *fileMetadata) bool {
+		return bytes.Compare(a.startKey, b.startKey) < 0
+	})
+	return d.maybeCompact(ctx)
+}
+
+func (d *DiskSorter) maybeCompact(ctx context.Context) error {
+	files := d.pickCompactionFiles()
+	if len(files) == 0 {
+		return nil
 	}
 
-	// TODO: It seems compact doesn't run in parallel.
-	//  We can use multiple compactions to speed up.
-	err := d.db.Compact(nil, end)
-	return errors.Trace(err)
+	// Split files into multiple compaction groups.
+	// Each group will be compacted independently.
+	groups := splitCompactionFiles(files, d.opts.MaxCompactionDepth)
+	compactions := make([]*compaction, 0, len(groups))
+	for _, group := range groups {
+		compactions = append(compactions, buildCompactions(group, d.opts.MaxCompactionSize)...)
+	}
+
+	// Build file references.
+	fileRefs := make(map[int]*atomic.Int32)
+	for _, file := range files {
+		fileRefs[file.fileNum] = new(atomic.Int32)
+	}
+	for _, c := range compactions {
+		for _, file := range c.orderedFiles {
+			fileRefs[file.fileNum].Add(1)
+		}
+	}
+	d.opts.Logger.Info("total compactions", zap.Int("count", len(compactions)))
+
+	// Run all compactions.
+	removedFileNums := generic.NewSyncMap[int, struct{}](len(files))
+	outputCh := make(chan *fileMetadata, len(compactions))
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(d.opts.Concurrency)
+	for _, c := range compactions {
+		if ctx.Err() != nil {
+			break
+		}
+		c := c
+		g.Go(func() error {
+			output, err := d.runCompaction(ctx, c)
+			if err != nil {
+				return err
+			}
+			outputCh <- output
+			for _, file := range c.orderedFiles {
+				if fileRefs[file.fileNum].Add(-1) == 0 {
+					_ = d.fs.Remove(makeFilename(d.fs, d.dirname, file.fileNum))
+					removedFileNums.Store(file.fileNum, struct{}{})
+				}
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Update d.orderedFiles.
+	close(outputCh)
+	for output := range outputCh {
+		d.orderedFiles = append(d.orderedFiles, output)
+	}
+	var newOrderedFiles []*fileMetadata
+	for _, file := range d.orderedFiles {
+		if _, ok := removedFileNums.Load(file.fileNum); !ok {
+			newOrderedFiles = append(newOrderedFiles, file)
+		}
+	}
+	slices.SortFunc(newOrderedFiles, func(a, b *fileMetadata) bool {
+		return bytes.Compare(a.startKey, b.startKey) < 0
+	})
+	d.orderedFiles = newOrderedFiles
+
+	// After compaction, check if we need to compact again.
+	return d.maybeCompact(ctx)
+}
+
+func (d *DiskSorter) pickCompactionFiles() []*fileMetadata {
+	type interval struct {
+		key   []byte
+		depth int
+	}
+	// intervals is a list of intervals that perfectly overlap file boundaries.
+	// For example, if we have two files [a, c] and [b, d], the intervals will be
+	// [a, b), [b, c), [c, d).
+	intervals := make([]interval, 0, len(d.orderedFiles)*2)
+	for _, file := range d.orderedFiles {
+		intervals = append(intervals, interval{
+			key:   file.startKey,
+			depth: 1,
+		})
+		intervals = append(intervals, interval{
+			key:   file.endKey,
+			depth: -1,
+		})
+	}
+	slices.SortFunc(intervals, func(a, b interval) bool {
+		return bytes.Compare(a.key, b.key) < 0
+	})
+
+	maxDepth := 0
+	for i := 1; i < len(intervals); i++ {
+		intervals[i].depth += intervals[i-1].depth
+		if intervals[i].depth > maxDepth {
+			maxDepth = intervals[i].depth
+		}
+	}
+	if maxDepth <= d.opts.CompactionThreshold {
+		return nil
+	}
+
+	var files []*fileMetadata
+	for _, file := range d.orderedFiles {
+		minIntervalIndex := sort.Search(len(intervals), func(i int) bool {
+			return bytes.Compare(intervals[i].key, file.startKey) >= 0
+		})
+		maxIntervalIndex := sort.Search(len(intervals), func(i int) bool {
+			return bytes.Compare(intervals[i].key, file.endKey) >= 0
+		})
+		for i := minIntervalIndex; i < maxIntervalIndex; i++ {
+			if intervals[i].depth >= d.opts.CompactionThreshold {
+				files = append(files, file)
+				break
+			}
+		}
+	}
+	d.opts.Logger.Info(
+		"max overlap depth exceeds the compaction threshold, pick files to compact",
+		zap.Int("maxDepth", maxDepth),
+		zap.Int("threshold", d.opts.CompactionThreshold),
+		zap.Int("fileCount", len(files)),
+	)
+	return files
+}
+
+func splitCompactionFiles(files []*fileMetadata, maxCompactionDepth int) [][]*fileMetadata {
+	// Split files into non-overlapping groups.
+	slices.SortFunc(files, func(a, b *fileMetadata) bool {
+		return bytes.Compare(a.startKey, b.startKey) < 0
+	})
+	var groups [][]*fileMetadata
+	curGroup := []*fileMetadata{files[0]}
+	maxEndKey := files[0].endKey
+	for _, file := range files[1:] {
+		if bytes.Compare(file.startKey, maxEndKey) > 0 {
+			groups = append(groups, curGroup)
+			curGroup = []*fileMetadata{file}
+		} else {
+			curGroup = append(curGroup, file)
+		}
+		if bytes.Compare(file.endKey, maxEndKey) > 0 {
+			maxEndKey = file.endKey
+		}
+	}
+	if len(curGroup) > 0 {
+		groups = append(groups, curGroup)
+	}
+
+	var finalGroups [][]*fileMetadata
+	// Compact each group of files.
+	for _, group := range groups {
+		numSubGroups := (len(group)-1)/maxCompactionDepth + 1
+		subGroupSize := (len(group)-1)/numSubGroups + 1
+		for i := 0; i < len(group); i += subGroupSize {
+			j := i + subGroupSize
+			if j > len(group) {
+				j = len(group)
+			}
+			finalGroups = append(finalGroups, group[i:j])
+		}
+	}
+	return finalGroups
+}
+
+type compaction struct {
+	startKey     []byte
+	endKey       []byte
+	orderedFiles []*fileMetadata // ordered by start key
+}
+
+func buildCompactions(files []*fileMetadata, maxCompactionSize int) []*compaction {
+	var startKey, endKey []byte
+	buckets := make([]kvStatsBucket, 0, len(files))
+	for _, file := range files {
+		buckets = append(buckets, file.kvStats.Histogram...)
+		if startKey == nil || bytes.Compare(file.startKey, startKey) < 0 {
+			startKey = file.startKey
+		}
+		if endKey == nil || bytes.Compare(file.endKey, endKey) > 0 {
+			endKey = file.endKey
+		}
+	}
+	slices.SortFunc(buckets, func(a, b kvStatsBucket) bool {
+		return bytes.Compare(a.UpperBound, b.UpperBound) < 0
+	})
+
+	var (
+		kvSize      int
+		compactions []*compaction
+	)
+	for _, bucket := range buckets {
+		kvSize += bucket.Size
+		if kvSize >= maxCompactionSize {
+			compactions = append(compactions, &compaction{
+				startKey: startKey,
+				endKey:   bucket.UpperBound,
+			})
+			startKey = bucket.UpperBound
+			kvSize = 0
+		}
+	}
+	if bytes.Compare(startKey, endKey) < 0 {
+		compactions = append(compactions, &compaction{
+			startKey: startKey,
+			endKey:   endKey,
+		})
+	}
+
+	for _, c := range compactions {
+		for _, file := range files {
+			if !(bytes.Compare(file.endKey, c.startKey) <= 0 ||
+				bytes.Compare(file.startKey, c.endKey) >= 0) {
+				c.orderedFiles = append(c.orderedFiles, file)
+			}
+		}
+		slices.SortFunc(c.orderedFiles, func(a, b *fileMetadata) bool {
+			return bytes.Compare(a.startKey, b.startKey) < 0
+		})
+	}
+	return compactions
+}
+
+func (d *DiskSorter) runCompaction(ctx context.Context, c *compaction) (*fileMetadata, error) {
+	d.opts.Logger.Debug(
+		"run compaction",
+		zap.Binary("startKey", c.startKey),
+		zap.Binary("endKey", c.endKey),
+		zap.Int("fileCount", len(c.orderedFiles)),
+	)
+
+	var merged *fileMetadata
+	onSuccess := func(meta *fileMetadata) { merged = meta }
+
+	fileNum := int(d.idAlloc.Add(1))
+	sw, err := newSSTWriter(d.fs, d.dirname, fileNum, defaultKVStatsBucketSize, onSuccess)
+	if err != nil {
+		return nil, err
+	}
+	swClosed := false
+	defer func() {
+		if !swClosed {
+			_ = sw.Close()
+		}
+	}()
+
+	iter := newMergingIter(c.orderedFiles, d.openIter)
+	defer func() {
+		_ = iter.Close()
+	}()
+
+	iterations := 0
+	for iter.Seek(c.startKey); iter.Valid(); iter.Next() {
+		if bytes.Compare(iter.UnsafeKey(), c.endKey) >= 0 {
+			break
+		}
+		iterations++
+		if iterations%1000 == 0 && ctx.Err() != nil {
+			return nil, errors.Trace(ctx.Err())
+		}
+		if err := sw.Set(iter.UnsafeKey(), iter.UnsafeValue()); err != nil {
+			return nil, err
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return nil, err
+	}
+	err = sw.Close()
+	swClosed = true
+	if err != nil {
+		return nil, err
+	}
+	return merged, nil
+}
+
+func (d *DiskSorter) openIter(file *fileMetadata) (Iterator, error) {
+	reader, err := d.readerPool.get(file.fileNum)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	iter, err := reader.NewIter(nil, nil)
+	if err != nil {
+		_ = reader.Close()
+		return nil, errors.Trace(err)
+	}
+	return &sstIter{
+		iter: iter,
+		onClose: func() error {
+			return d.readerPool.unref(file.fileNum)
+		},
+	}, nil
 }
 
 // IsSorted implements the ExternalSorter.IsSorted.
@@ -166,37 +1198,21 @@ func (d *DiskSorter) NewIterator(_ context.Context) (Iterator, error) {
 	if d.state.Load() != diskSorterStateSorted {
 		return nil, errors.Errorf("diskSorter is not sorted")
 	}
-	return &diskSorterIterator{iter: d.db.NewIter(nil)}, nil
+	return newMergingIter(d.orderedFiles, d.openIter), nil
 }
 
 // Close implements the ExternalSorter.Close.
 func (d *DiskSorter) Close() error {
-	return errors.Trace(d.db.Close())
+	d.cache.Unref()
+	return nil
 }
 
 // CloseAndCleanup implements the ExternalSorter.CloseAndCleanup.
 func (d *DiskSorter) CloseAndCleanup() error {
-	if err := d.Close(); err != nil {
-		return errors.Trace(err)
-	}
-	fs := d.dbOpts.FS
-	err1 := fs.RemoveAll(d.dbDir)
-	err2 := fs.RemoveAll(d.tmpDir)
-	err := goerrors.Join(err1, err2)
+	d.cache.Unref()
+	err := d.fs.RemoveAll(d.dirname)
 	return errors.Trace(err)
 }
-
-type diskSorterIterator struct{ iter *pebble.Iterator }
-
-func (i *diskSorterIterator) Seek(key []byte) bool { return i.iter.SeekGE(key) }
-func (i *diskSorterIterator) First() bool          { return i.iter.First() }
-func (i *diskSorterIterator) Next() bool           { return i.iter.Next() }
-func (i *diskSorterIterator) Last() bool           { return i.iter.Last() }
-func (i *diskSorterIterator) Valid() bool          { return i.iter.Valid() }
-func (i *diskSorterIterator) Error() error         { return i.iter.Error() }
-func (i *diskSorterIterator) UnsafeKey() []byte    { return i.iter.Key() }
-func (i *diskSorterIterator) UnsafeValue() []byte  { return i.iter.Value() }
-func (i *diskSorterIterator) Close() error         { return i.iter.Close() }
 
 type keyValue struct {
 	key   []byte
@@ -204,10 +1220,10 @@ type keyValue struct {
 }
 
 type diskSorterWriter struct {
-	d   *DiskSorter
-	kvs []keyValue
-	buf []byte
-	off int
+	kvs          []keyValue
+	buf          []byte
+	off          int
+	newSSTWriter func() (*sstWriter, error)
 }
 
 func (w *diskSorterWriter) Put(key, value []byte) error {
@@ -216,8 +1232,9 @@ func (w *diskSorterWriter) Put(key, value []byte) error {
 			return errors.Trace(err)
 		}
 		// The default buffer is too small, enlarge it to fit the key and value.
-		if w.off+len(key)+len(value) > len(w.buf) {
-			w.buf = make([]byte, w.off+len(key)+len(value))
+		// w.off must be 0 after flush.
+		if len(key)+len(value) > len(w.buf) {
+			w.buf = make([]byte, len(key)+len(value))
 		}
 	}
 
@@ -242,45 +1259,23 @@ func (w *diskSorterWriter) Flush() error {
 }
 
 func (w *diskSorterWriter) flush() error {
-	db := w.d.db
-	fs := w.d.dbOpts.FS
-	comparer := w.d.dbOpts.Comparer
-
-	filename := fmt.Sprintf("%d.sst", w.d.idGen.Add(1))
-	sstPath := filepath.Join(w.d.tmpDir, filename)
-
-	defer func() {
-		if _, err := fs.Stat(sstPath); err == nil {
-			_ = fs.Remove(sstPath)
-		}
-	}()
-
-	f, err := fs.Create(sstPath)
+	sw, err := w.newSSTWriter()
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	slices.SortFunc(w.kvs, func(a, b keyValue) bool {
-		return comparer.Compare(a.key, b.key) < 0
-	})
-
-	sstWriter := sstable.NewWriter(f, sstable.WriterOptions{
-		Comparer: comparer,
+		return bytes.Compare(a.key, b.key) < 0
 	})
 	for _, kv := range w.kvs {
-		if err := sstWriter.Set(kv.key, kv.value); err != nil {
-			_ = sstWriter.Close()
-			return errors.Trace(err)
+		if err := sw.Set(kv.key, kv.value); err != nil {
+			_ = sw.Close()
+			return err
 		}
 	}
-	if err := sstWriter.Close(); err != nil {
-		return errors.Trace(err)
+	if err := sw.Close(); err != nil {
+		return err
 	}
-
-	if err := db.Ingest([]string{sstPath}); err != nil {
-		return errors.Trace(err)
-	}
-
 	w.kvs = w.kvs[:0]
 	w.off = 0
 	return nil

--- a/util/extsort/disk_sorter.go
+++ b/util/extsort/disk_sorter.go
@@ -683,6 +683,7 @@ type DiskSorterOptions struct {
 	CompactionThreshold int
 
 	// MaxCompactionDepth is the maximum files involved in a single compaction.
+	// The minimum value is 2. Any value less than 2 will be treated as not set.
 	//
 	// The default value is 64.
 	MaxCompactionDepth int
@@ -709,7 +710,7 @@ func (o *DiskSorterOptions) ensureDefaults() {
 	if o.CompactionThreshold == 0 {
 		o.CompactionThreshold = 16
 	}
-	if o.MaxCompactionDepth == 0 {
+	if o.MaxCompactionDepth < 2 {
 		o.MaxCompactionDepth = 64
 	}
 	if o.MaxCompactionSize == 0 {

--- a/util/extsort/disk_sorter.go
+++ b/util/extsort/disk_sorter.go
@@ -188,6 +188,8 @@ func (sw *sstWriter) Close() (retErr error) {
 	defer func() {
 		if retErr == nil {
 			retErr = sw.fs.Rename(sw.tmpPath, sw.destPath)
+		} else {
+			_ = sw.fs.Remove(sw.tmpPath)
 		}
 	}()
 	closeErr := sw.w.Close()

--- a/util/extsort/disk_sorter_test.go
+++ b/util/extsort/disk_sorter_test.go
@@ -31,7 +31,10 @@ import (
 
 func TestDiskSorterCommon(t *testing.T) {
 	sorter, err := OpenDiskSorter(t.TempDir(), &DiskSorterOptions{
-		WriterBufferSize: 32 * 1024,
+		WriterBufferSize:    32 * 1024,
+		CompactionThreshold: 4,
+		MaxCompactionDepth:  2,
+		MaxCompactionSize:   0,
 	})
 	require.NoError(t, err)
 	runCommonTest(t, sorter)
@@ -40,7 +43,9 @@ func TestDiskSorterCommon(t *testing.T) {
 
 func TestDiskSorterCommonParallel(t *testing.T) {
 	sorter, err := OpenDiskSorter(t.TempDir(), &DiskSorterOptions{
-		WriterBufferSize: 32 * 1024,
+		WriterBufferSize:    32 * 1024,
+		CompactionThreshold: 4,
+		MaxCompactionDepth:  2,
 	})
 	require.NoError(t, err)
 	runCommonParallelTest(t, sorter)

--- a/util/extsort/external_sorter.go
+++ b/util/extsort/external_sorter.go
@@ -48,6 +48,8 @@ type ExternalSorter interface {
 // Writer is an interface for writing key-value pairs to the external sorter.
 type Writer interface {
 	// Put adds a key-value pair to the writer.
+	//
+	// Implementations must not modify or retain slices passed to Put().
 	Put(key, value []byte) error
 	// Flush flushes all buffered key-value pairs to the external sorter.
 	// the writer can be reused after calling Flush().
@@ -65,6 +67,8 @@ type Iterator interface {
 	// First moves the iterator to the first key-value pair.
 	First() bool
 	// Next moves the iterator to the next key-value pair.
+	//
+	// Implementations must guarantee the next key is greater than the current key.
 	Next() bool
 	// Last moves the iterator to the last key-value pair.
 	Last() bool

--- a/util/extsort/external_sorter_test.go
+++ b/util/extsort/external_sorter_test.go
@@ -90,10 +90,10 @@ func runParallelTest(t *testing.T, sorter extsort.ExternalSorter) {
 
 	kvCh := make(chan keyValue, 16)
 
-	g, ctx := errgroup.WithContext(ctx)
+	g, gCtx := errgroup.WithContext(ctx)
 	for i := 0; i < numWriters; i++ {
 		g.Go(func() (retErr error) {
-			w, err := sorter.NewWriter(ctx)
+			w, err := sorter.NewWriter(gCtx)
 			if err != nil {
 				return err
 			}

--- a/util/extsort/external_sorter_test.go
+++ b/util/extsort/external_sorter_test.go
@@ -142,7 +142,7 @@ func genRandomKVs(
 		}
 		rng.Read(kv.key[:keySize-4])
 		rng.Read(kv.value)
-		kv.key = binary.BigEndian.AppendUint32(kv.key[keySize-4:], uint32(i))
+		binary.BigEndian.PutUint32(kv.key[keySize-4:], uint32(i))
 		kvs = append(kvs, kv)
 	}
 	return kvs


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/41629

Problem Summary:

### What is changed and how it works?

* Refactor `DiskSorter` to improve performance.
* Remove the dependency on `pebble.DB`.

In the test, it takes 18 minutes to sort 400G data on a 32vCPU, 64G RAM machine.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
