### PR TITLE
ddl: Fix the way to notify the reorganization worker after 'admin resume'

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -553,7 +553,8 @@ func (dc *ddlCtx) notifyReorgWorkerJobStateChange(job *model.Job) {
 		logutil.BgLogger().Error("cannot find reorgCtx", zap.Int64("jobID", job.ID))
 		return
 	}
-	logutil.BgLogger().Info("[ddl] notify reorg worker during canceling ddl job", zap.Int64("jobID", job.ID))
+	logutil.BgLogger().Info("[ddl] notify reorg worker the job's state",
+		zap.Int64("jobID", job.ID), zap.Int32("jobState", int32(job.State)), zap.Int("jobState", int(job.SchemaState)))
 	rc.notifyJobState(job.State)
 }
 

--- a/ddl/job_table.go
+++ b/ddl/job_table.go
@@ -214,6 +214,10 @@ func (d *ddl) processJobDuringUpgrade(sess *sess.Session, job *model.Job) (isRun
 		logutil.BgLogger().Warn("[ddl-upgrading] normal cluster state, resume the job successfully", zap.Stringer("job", job))
 	}
 
+	if job.IsPaused() {
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/ddl/pausetest/BUILD.bazel
+++ b/ddl/pausetest/BUILD.bazel
@@ -24,5 +24,6 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_uber_go_atomic//:atomic",
         "@org_uber_go_goleak//:goleak",
+        "@org_uber_go_zap//:zap",
     ],
 )

--- a/ddl/pausetest/pause_test.go
+++ b/ddl/pausetest/pause_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/stretchr/testify/require"
 	atomicutil "go.uber.org/atomic"
+	"go.uber.org/zap"
 )
 
 const dbTestLease = 600 * time.Millisecond
@@ -397,15 +398,42 @@ func TestPauseJobNegative(t *testing.T) {
 func TestResumeJobPositive(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomainWithSchemaLease(t, dbTestLease)
 
-	tk1 := testkit.NewTestKit(t, store)
-	tk2 := testkit.NewTestKit(t, store)
+	tk := testkit.NewTestKit(t, store)
+	tkCommand := testkit.NewTestKit(t, store)
 
-	tk1.MustExec("use test")
-	tk1.MustExec("create table t(id int)")
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE if not exists t_user (
+        id int(11) NOT NULL AUTO_INCREMENT,
+        user varchar(128) NOT NULL,
+        name varchar(128) NOT NULL,
+        age int(11) NOT NULL,
+        province varchar(32) NOT NULL DEFAULT '',
+        city varchar(32) NOT NULL DEFAULT '',
+        phone varchar(16) NOT NULL DEFAULT '',
+        created_time datetime NOT NULL,
+        updated_time datetime NOT NULL
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`)
+
+	idx := 0
+	rowCount := 1000
+	tu := &TestTableUser{}
+	for idx < rowCount {
+		_ = tu.generateAttributes()
+		tk.MustExec(tu.insertStmt())
+
+		idx += 1
+	}
+
+	logger := logutil.BgLogger()
+	ddl.ReorgWaitTimeout = 10 * time.Millisecond
+	tk.MustExec("set @@global.tidb_ddl_reorg_batch_size = 2")
+	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 1")
+	tk = testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
 
 	d := dom.DDL()
 
-	var jobID int64
+	var jobID int64 = 0
 	var pauseErr error
 
 	hook := &callback.TestDDLCallback{Do: dom}
@@ -416,31 +444,50 @@ func TestResumeJobPositive(t *testing.T) {
 	var pauseRS []sqlexec.RecordSet
 	var resumeRS []sqlexec.RecordSet
 	var resumeErr error
+	isPaused := false
 	// Test when pause cannot be retried and adding index succeeds.
 	hook.OnJobRunBeforeExported = func(job *model.Job) {
+		logger.Info("OnJobRunAfterExported, before pause,", zap.Int("Job Type:", int(job.Type)),
+			zap.Int("Job State:", int(job.State)), zap.Int("Job Schema State:", int(job.SchemaState)))
 		if job.Type == model.ActionAddIndex && job.State == model.JobStateRunning &&
 			job.SchemaState == model.StateWriteReorganization {
+			logger.Info("Paused by hook.OnGetJobAfterExported")
 			jobID = job.ID
 			stmt := fmt.Sprintf("admin pause ddl jobs %d", jobID)
-			pauseRS, pauseErr = tk2.Session().Execute(context.Background(), stmt)
-		}
-	}
-	// Test when pause cannot be retried and adding index succeeds.
-	hook.OnJobRunAfterExported = func(job *model.Job) {
-		if job.Type == model.ActionAddIndex && job.State == model.JobStatePaused {
-			time.Sleep(5 * time.Second)
-			stmt := fmt.Sprintf("admin resume ddl jobs %d", jobID)
-			resumeRS, resumeErr = tk2.Session().Execute(context.Background(), stmt)
+			pauseRS, pauseErr = tkCommand.Session().Execute(context.Background(), stmt)
+
+			isPaused = true
 		}
 	}
 
-	tk1.MustExec("alter table t add index (id)")
+	hook.OnGetJobBeforeExported = func(jobType string) {
+		if isPaused {
+			resumeFunc := func() {
+				time.Sleep(1 * time.Second)
+				// Only the 'OnGetJobBeforeExported' hook works for `resume`, but we can't get the job and its state in
+				// that hook. And it would be better to resume the job after 5s here, other than waiting in
+				// 'OnGetJobBeforeExported' since we should know that the job has been paused.
+				logger.Info("Resumed by hook.OnGetJobBeforeExported")
+				stmt := fmt.Sprintf("admin resume ddl jobs %d", jobID)
+				resumeRS, resumeErr = tkCommand.Session().Execute(context.Background(), stmt)
+			}
+
+			go resumeFunc()
+			isPaused = false
+		}
+	}
+
+	logger.Info("Main routing: create index...")
+	tk.MustExec("alter table t_user add index (name)")
+	logger.Info("Main routing: create index finished.")
 
 	require.NoError(t, pauseErr)
-	result := tk2.ResultSetToResultWithCtx(context.Background(), pauseRS[0], "pause ddl job successfully")
+	result := tkCommand.ResultSetToResultWithCtx(context.Background(), pauseRS[0], "pause ddl job successfully")
 	result.Check(testkit.Rows(fmt.Sprintf("%d successful", jobID)))
 
 	require.NoError(t, resumeErr)
-	result = tk2.ResultSetToResultWithCtx(context.Background(), resumeRS[0], "resume ddl job successfully")
+	result = tkCommand.ResultSetToResultWithCtx(context.Background(), resumeRS[0], "resume ddl job successfully")
 	result.Check(testkit.Rows(fmt.Sprintf("%d successful", jobID)))
+
+	logger.Info("TestResumeJobPositive finished.")
 }

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -284,7 +284,6 @@ func (w *worker) runReorgJob(rh *reorgHandler, reorgInfo *reorgInfo, tblInfo *mo
 		// Update a job's warnings.
 		w.mergeWarningsIntoJob(job)
 
-		// TODO: should we do this if dbterror.ErrPausedDDLJob ???
 		d.removeReorgCtx(job.ID)
 
 		updateBackfillProgress(w, reorgInfo, tblInfo, rowCount)

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -460,7 +460,7 @@ func (dc *ddlCtx) isReorgRunnable(jobID int64, isDistReorg bool) error {
 
 	if dc.isReorgPaused(jobID) {
 		logutil.BgLogger().Warn("[ddl] job paused by user", zap.String("ID", dc.uuid))
-		return dbterror.ErrPausedDDLJob
+		return dbterror.ErrPausedDDLJob.GenWithStackByArgs(jobID)
 	}
 
 	// If isDistReorg is true, we needn't check if it is owner.

--- a/ddl/rollingback.go
+++ b/ddl/rollingback.go
@@ -386,7 +386,7 @@ func pauseReorgWorkers(w *worker, d *ddlCtx, job *model.Job) (err error) {
 		d.notifyReorgWorkerJobStateChange(job)
 	}
 
-	return dbterror.ErrPausedDDLJob
+	return dbterror.ErrPausedDDLJob.GenWithStackByArgs(job.ID)
 }
 
 func convertJob2RollbackJob(w *worker, d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, err error) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #44217

Problem Summary: fail to resume the paused ddl job

### What is changed and how it works?

1. Fix bug in notify the reorganization worker after 'admin resume'
2. Better logging to reduce noise

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
