### PR TITLE
store/gcworker: reduce "full config reset" log on pd side

### DIFF
--- a/store/gcworker/gc_worker.go
+++ b/store/gcworker/gc_worker.go
@@ -2190,20 +2190,20 @@ func (w *GCWorker) doGCPlacementRules(se session.Session, safePoint uint64, dr u
 		}
 	}
 
+	// Skip table ids that's already successfully handled.
+	tmp := physicalTableIDs[:0]
+	for _, id := range physicalTableIDs {
+		if _, ok := gcPlacementRuleCache[id]; !ok {
+			tmp = append(tmp, id)
+		}
+	}
+	physicalTableIDs = tmp
+
 	if len(physicalTableIDs) == 0 {
 		return
 	}
 
-	bundles := make([]*placement.Bundle, 0, len(physicalTableIDs))
 	for _, id := range physicalTableIDs {
-		bundles = append(bundles, placement.NewBundle(id))
-	}
-
-	for _, id := range physicalTableIDs {
-		// Skip table ids that's already successfully deleted.
-		if _, ok := gcPlacementRuleCache[id]; ok {
-			continue
-		}
 		// Delete pd rule
 		failpoint.Inject("gcDeletePlacementRuleCounter", func() {})
 		logutil.BgLogger().Info("try delete TiFlash pd rule",
@@ -2212,12 +2212,22 @@ func (w *GCWorker) doGCPlacementRules(se session.Session, safePoint uint64, dr u
 		if err := infosync.DeleteTiFlashPlacementRule(context.Background(), "tiflash", ruleID); err != nil {
 			logutil.BgLogger().Error("delete TiFlash pd rule failed when gc",
 				zap.Error(err), zap.String("ruleID", ruleID), zap.Uint64("safePoint", safePoint))
-		} else {
-			// Cache the table id if its related rule are deleted successfully.
-			gcPlacementRuleCache[id] = struct{}{}
 		}
 	}
-	return infosync.PutRuleBundlesWithDefaultRetry(context.TODO(), bundles)
+	bundles := make([]*placement.Bundle, 0, len(physicalTableIDs))
+	for _, id := range physicalTableIDs {
+		bundles = append(bundles, placement.NewBundle(id))
+	}
+	err = infosync.PutRuleBundlesWithDefaultRetry(context.TODO(), bundles)
+	if err != nil {
+		return
+	}
+
+	// Cache the table id if its related rule are deleted successfully.
+	for _, id := range physicalTableIDs {
+		gcPlacementRuleCache[id] = struct{}{}
+	}
+	return nil
 }
 
 func (w *GCWorker) doGCLabelRules(dr util.DelRangeTask) (err error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33069

Problem Summary:

### What is changed and how it works?

Similiar to https://github.com/pingcap/tidb/pull/33082, reduce the duplicated request.

If there are N range to be deleted, there will be N logs like "full config reset" on the pd side.
It affects v6.1.1 and master both.

1. (*GCWorker).deleteRanges execute `doGCPlacementRules` function for each `DelRangeTask` https://github.com/pingcap/tidb/blob/b7d3c08fd6a684acea3c1c7147d0b6cea3f8cd18/store/gcworker/gc_worker.go#L924
2. `doGCPlacementRules` get the DDL history by the `DelRangeTask.JobID`
https://github.com/pingcap/tidb/blob/b7d3c08fd6a684acea3c1c7147d0b6cea3f8cd18/store/gcworker/gc_worker.go#L2165
3. Retrive all the Physical Table IDs dropped by this DDL
https://github.com/pingcap/tidb/blob/b7d3c08fd6a684acea3c1c7147d0b6cea3f8cd18/store/gcworker/gc_worker.go#L2179
4. And delete all the  Bundles for those Physical Table IDs https://github.com/pingcap/tidb/blob/b7d3c08fd6a684acea3c1c7147d0b6cea3f8cd18/store/gcworker/gc_worker.go#L2220

There are many duplicated physical IDs during step 1 and step 3


In https://github.com/pingcap/tidb/issues/33069 it add a cache to handle the Delete rule
But note line https://github.com/pingcap/tidb/blob/b7d3c08fd6a684acea3c1c7147d0b6cea3f8cd18/store/gcworker/gc_worker.go#L2220, there would still be duplicated request there, so pd print "full config reset" many times.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

```
update mysql.tidb set VARIABLE_VALUE = '3m' where VARIABLE_NAME = 'tikv_gc_run_interval';
update mysql.tidb set VARIABLE_VALUE = '3m' where VARIABLE_NAME = 'tikv_gc_life_time';

create table t (id int) partition by hash partitions 2000;
insert into t values (1),(2),(3), ....
insert into t select * from t;

drop table t;

wait 3min, check the pd log ...
```

After the fix, there would be only one line  "full config reset" in the log for the drop table operation.

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
