### PR TITLE
domain/infosync: remove `PostAccelerateSchedule` related code

### DIFF
--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -1221,16 +1221,6 @@ func GetTiFlashGroupRules(ctx context.Context, group string) ([]placement.TiFlas
 	return is.tiflashReplicaManager.GetGroupRules(ctx, group)
 }
 
-// PostTiFlashAccelerateSchedule sends `regions/accelerate-schedule` request.
-func PostTiFlashAccelerateSchedule(ctx context.Context, tableID int64) error {
-	is, err := getGlobalInfoSyncer()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	logutil.BgLogger().Info("PostTiFlashAccelerateSchedule", zap.Int64("tableID", tableID))
-	return is.tiflashReplicaManager.PostAccelerateSchedule(ctx, tableID)
-}
-
 // GetTiFlashRegionCountFromPD is a helper function calling `/stats/region`.
 func GetTiFlashRegionCountFromPD(ctx context.Context, tableID int64, regionCount *int) error {
 	is, err := getGlobalInfoSyncer()

--- a/domain/infosync/info_test.go
+++ b/domain/infosync/info_test.go
@@ -235,12 +235,6 @@ func TestTiFlashManager(t *testing.T) {
 	require.Equal(t, false, rules[0].Override, false)
 	require.Equal(t, placement.RuleIndexTiFlash, rules[0].Index)
 
-	// PostTiFlashAccelerateSchedule
-	require.Nil(t, PostTiFlashAccelerateSchedule(ctx, 1))
-	z, ok := tiflash.SyncStatus[1]
-	require.Equal(t, true, ok)
-	require.Equal(t, true, z.Accel)
-
 	// GetTiFlashStoresStat
 	stats, err := GetTiFlashStoresStat(ctx)
 	require.NoError(t, err)
@@ -275,7 +269,7 @@ func TestTiFlashManager(t *testing.T) {
 	require.NoError(t, err)
 	// Have table a and partitions p1, p2
 	require.Equal(t, 3, len(rules))
-	z, ok = tiflash.SyncStatus[2]
+	z, ok := tiflash.SyncStatus[2]
 	require.Equal(t, true, ok)
 	require.Equal(t, true, z.Accel)
 	z, ok = tiflash.SyncStatus[3]


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:
After https://github.com/pingcap/tidb/pull/43087 we use `PostAccelerateScheduleBatch` instead of `PostAccelerateSchedule`. So `PostAccelerateSchedule` is useless.


### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
