### PR TITLE
*: support mock campaign leader in owner manager

### DIFF
--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -61,14 +61,6 @@ type tidbSession struct {
 
 // GetDomain implements glue.Glue.
 func (Glue) GetDomain(store kv.Storage) (*domain.Domain, error) {
-	initStatsSe, err := session.CreateSession(store)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	se, err := session.CreateSession(store)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	dom, err := session.GetDomain(store)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -76,11 +68,6 @@ func (Glue) GetDomain(store kv.Storage) (*domain.Domain, error) {
 	err = session.InitMDLVariable(store)
 	if err != nil {
 		return nil, err
-	}
-	// create stats handler for backup and restore.
-	err = dom.UpdateTableStatsLoop(se, initStatsSe)
-	if err != nil {
-		return nil, errors.Trace(err)
 	}
 	return dom, nil
 }

--- a/br/pkg/streamhelper/daemon/owner_daemon_test.go
+++ b/br/pkg/streamhelper/daemon/owner_daemon_test.go
@@ -150,7 +150,9 @@ func TestDaemon(t *testing.T) {
 	req.False(ow.IsOwner())
 	app.AssertNotRunning(1 * time.Second)
 	ow.CampaignOwner()
-	req.True(ow.IsOwner())
+	req.Eventually(func() bool {
+		return ow.IsOwner()
+	}, 1*time.Second, 100*time.Millisecond)
 	app.AssertStart(1 * time.Second)
 	app.AssertTick(1 * time.Second)
 }

--- a/br/pkg/streamhelper/daemon/owner_daemon_test.go
+++ b/br/pkg/streamhelper/daemon/owner_daemon_test.go
@@ -136,7 +136,7 @@ func TestDaemon(t *testing.T) {
 	defer cancel()
 	req := require.New(t)
 	app := newTestApp(t)
-	ow := owner.NewMockManager(ctx, "owner_daemon_test")
+	ow := owner.NewMockManager(ctx, "owner_daemon_test", "owner_key")
 	d := daemon.New(app, ow, 100*time.Millisecond)
 
 	app.AssertService(req, false)

--- a/br/pkg/streamhelper/daemon/owner_daemon_test.go
+++ b/br/pkg/streamhelper/daemon/owner_daemon_test.go
@@ -136,7 +136,7 @@ func TestDaemon(t *testing.T) {
 	defer cancel()
 	req := require.New(t)
 	app := newTestApp(t)
-	ow := owner.NewMockManager(ctx, "owner_daemon_test", "owner_key")
+	ow := owner.NewMockManager(ctx, "owner_daemon_test", nil, "owner_key")
 	d := daemon.New(app, ow, 100*time.Millisecond)
 
 	app.AssertService(req, false)

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -628,7 +628,7 @@ func newDDL(ctx context.Context, options ...Option) *ddl {
 	if etcdCli := opt.EtcdCli; etcdCli == nil {
 		// The etcdCli is nil if the store is localstore which is only used for testing.
 		// So we use mockOwnerManager and MockSchemaSyncer.
-		manager = owner.NewMockManager(ctx, id)
+		manager = owner.NewMockManager(ctx, id, DDLOwnerKey)
 		schemaSyncer = NewMockSchemaSyncer()
 		stateSyncer = NewMockStateSyncer()
 	} else {

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -628,7 +628,7 @@ func newDDL(ctx context.Context, options ...Option) *ddl {
 	if etcdCli := opt.EtcdCli; etcdCli == nil {
 		// The etcdCli is nil if the store is localstore which is only used for testing.
 		// So we use mockOwnerManager and MockSchemaSyncer.
-		manager = owner.NewMockManager(ctx, id, DDLOwnerKey)
+		manager = owner.NewMockManager(ctx, id, opt.Store, DDLOwnerKey)
 		schemaSyncer = NewMockSchemaSyncer()
 		stateSyncer = NewMockStateSyncer()
 	} else {

--- a/ddl/util/BUILD.bazel
+++ b/ddl/util/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "dead_table_lock_checker.go",
         "event.go",
+        "mock.go",
         "util.go",
     ],
     importpath = "github.com/pingcap/tidb/ddl/util",

--- a/ddl/util/mock.go
+++ b/ddl/util/mock.go
@@ -18,23 +18,29 @@ import "sync"
 
 // MockGlobalStateEntry is a mock global state entry.
 var MockGlobalStateEntry = &MockGlobalState{
-	currentOwner: make(map[string]string),
+	currentOwner: make(map[ownerKey]string),
 }
 
 // MockGlobalState is a mock global state.
 type MockGlobalState struct {
-	currentOwner map[string]string // owner_key (ddl/stats/bindinfo) => owner_id
+	currentOwner map[ownerKey]string // store ID + owner_key (ddl/stats/bindinfo) => owner_id
 	mu           sync.Mutex
 }
 
+type ownerKey struct {
+	storeID string
+	ownerTp string
+}
+
 // OwnerKey returns a mock global state selector with corresponding owner key.
-func (m *MockGlobalState) OwnerKey(tp string) *MockGlobalStateSelector {
-	return &MockGlobalStateSelector{m: m, ownerKey: tp}
+func (m *MockGlobalState) OwnerKey(storeID, tp string) *MockGlobalStateSelector {
+	return &MockGlobalStateSelector{m: m, storeID: storeID, ownerKey: tp}
 }
 
 // MockGlobalStateSelector is used to get info from global state.
 type MockGlobalStateSelector struct {
 	m        *MockGlobalState
+	storeID  string
 	ownerKey string
 }
 
@@ -42,15 +48,17 @@ type MockGlobalStateSelector struct {
 func (t *MockGlobalStateSelector) GetOwner() string {
 	t.m.mu.Lock()
 	defer t.m.mu.Unlock()
-	return t.m.currentOwner[t.ownerKey]
+	k := ownerKey{storeID: t.storeID, ownerTp: t.ownerKey}
+	return t.m.currentOwner[k]
 }
 
 // SetOwner sets the owner if the owner is empty.
 func (t *MockGlobalStateSelector) SetOwner(owner string) bool {
 	t.m.mu.Lock()
 	defer t.m.mu.Unlock()
-	if t.m.currentOwner[t.ownerKey] == "" {
-		t.m.currentOwner[t.ownerKey] = owner
+	k := ownerKey{storeID: t.storeID, ownerTp: t.ownerKey}
+	if t.m.currentOwner[k] == "" {
+		t.m.currentOwner[k] = owner
 		return true
 	}
 	return false
@@ -60,8 +68,9 @@ func (t *MockGlobalStateSelector) SetOwner(owner string) bool {
 func (t *MockGlobalStateSelector) UnsetOwner(owner string) bool {
 	t.m.mu.Lock()
 	defer t.m.mu.Unlock()
-	if t.m.currentOwner[t.ownerKey] == owner {
-		t.m.currentOwner[t.ownerKey] = ""
+	k := ownerKey{storeID: t.storeID, ownerTp: t.ownerKey}
+	if t.m.currentOwner[k] == owner {
+		t.m.currentOwner[k] = ""
 		return true
 	}
 	return false
@@ -71,5 +80,6 @@ func (t *MockGlobalStateSelector) UnsetOwner(owner string) bool {
 func (t *MockGlobalStateSelector) IsOwner(owner string) bool {
 	t.m.mu.Lock()
 	defer t.m.mu.Unlock()
-	return t.m.currentOwner[t.ownerKey] == owner
+	k := ownerKey{storeID: t.storeID, ownerTp: t.ownerKey}
+	return t.m.currentOwner[k] == owner
 }

--- a/ddl/util/mock.go
+++ b/ddl/util/mock.go
@@ -23,8 +23,8 @@ var MockGlobalStateEntry = &MockGlobalState{
 
 // MockGlobalState is a mock global state.
 type MockGlobalState struct {
-	mu           sync.Mutex
 	currentOwner map[string]string // owner_key (ddl/stats/bindinfo) => owner_id
+	mu           sync.Mutex
 }
 
 // OwnerKey returns a mock global state selector with corresponding owner key.

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -2170,11 +2170,8 @@ func (do *Domain) UpdateTableStatsLoop(ctx, initStatsCtx sessionctx.Context) err
 }
 
 func quitStatsOwner(do *Domain, mgr owner.Manager) {
-	select {
-	case <-do.exit:
-		mgr.Cancel()
-		return
-	}
+	<-do.exit
+	mgr.Cancel()
 }
 
 // StartLoadStatsSubWorkers starts sub workers with new sessions to load stats concurrently.

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -2188,7 +2188,7 @@ func (do *Domain) newOwnerManager(prompt, ownerKey string) owner.Manager {
 	id := do.ddl.OwnerManager().ID()
 	var statsOwner owner.Manager
 	if do.etcdClient == nil {
-		statsOwner = owner.NewMockManager(context.Background(), id, ownerKey)
+		statsOwner = owner.NewMockManager(context.Background(), id, do.store, ownerKey)
 	} else {
 		statsOwner = owner.NewOwnerManager(context.Background(), do.etcdClient, prompt, id, ownerKey)
 	}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -2153,13 +2153,14 @@ func (do *Domain) UpdateTableStatsLoop(ctx, initStatsCtx sessionctx.Context) err
 		do.wg.Run(do.loadStatsWorker, "loadStatsWorker")
 	}
 	owner := do.newOwnerManager(handle.StatsPrompt, handle.StatsOwnerKey)
-	do.wg.Run(func() { quitStatsOwner(do, owner) }, "quitStatsOwner")
 	if do.indexUsageSyncLease > 0 {
 		do.wg.Run(func() {
 			do.syncIndexUsageWorker(owner)
 		}, "syncIndexUsageWorker")
 	}
 	if do.statsLease <= 0 {
+		// For statsLease > 0, `updateStatsWorker` handles the quit of stats owner.
+		do.wg.Run(func() { quitStatsOwner(do, owner) }, "quitStatsOwner")
 		return nil
 	}
 	do.SetStatsUpdating(true)

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -2182,7 +2182,7 @@ func (do *Domain) newOwnerManager(prompt, ownerKey string) owner.Manager {
 	id := do.ddl.OwnerManager().ID()
 	var statsOwner owner.Manager
 	if do.etcdClient == nil {
-		statsOwner = owner.NewMockManager(context.Background(), id)
+		statsOwner = owner.NewMockManager(context.Background(), id, ownerKey)
 	} else {
 		statsOwner = owner.NewOwnerManager(context.Background(), do.etcdClient, prompt, id, ownerKey)
 	}

--- a/owner/BUILD.bazel
+++ b/owner/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//ddl/util",
+        "//kv",
         "//metrics",
         "//parser/terror",
         "//util",

--- a/owner/mock.go
+++ b/owner/mock.go
@@ -16,11 +16,13 @@ package owner
 
 import (
 	"context"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/ddl/util"
+	"github.com/pingcap/tidb/util/logutil"
+	"go.uber.org/zap"
 )
 
 var _ Manager = &mockManager{}
@@ -29,18 +31,26 @@ var _ Manager = &mockManager{}
 // It's used for local store and testing.
 // So this worker will always be the owner.
 type mockManager struct {
-	owner       int32
-	id          string // id is the ID of manager.
-	cancel      context.CancelFunc
-	beOwnerHook func()
+	id           string // id is the ID of manager.
+	key          string
+	ctx          context.Context
+	wg           sync.WaitGroup
+	cancel       context.CancelFunc
+	beOwnerHook  func()
+	campaignDone chan struct{}
+	resignDone   chan struct{}
 }
 
 // NewMockManager creates a new mock Manager.
-func NewMockManager(ctx context.Context, id string) Manager {
-	_, cancelFunc := context.WithCancel(ctx)
+func NewMockManager(ctx context.Context, id string, ownerKey string) Manager {
+	cancelCtx, cancelFunc := context.WithCancel(ctx)
 	return &mockManager{
-		id:     id,
-		cancel: cancelFunc,
+		id:           id,
+		key:          ownerKey,
+		ctx:          cancelCtx,
+		cancel:       cancelFunc,
+		campaignDone: make(chan struct{}),
+		resignDone:   make(chan struct{}),
 	}
 }
 
@@ -51,24 +61,33 @@ func (m *mockManager) ID() string {
 
 // IsOwner implements Manager.IsOwner interface.
 func (m *mockManager) IsOwner() bool {
-	return atomic.LoadInt32(&m.owner) == 1
+	logutil.BgLogger().Debug("[ddl] owner manager checks owner",
+		zap.String("ID", m.id), zap.String("ownerKey", m.key))
+	return util.MockGlobalStateEntry.OwnerKey(m.key).IsOwner(m.id)
 }
 
 func (m *mockManager) toBeOwner() {
-	if m.beOwnerHook != nil {
-		m.beOwnerHook()
+	ok := util.MockGlobalStateEntry.OwnerKey(m.key).SetOwner(m.id)
+	if ok {
+		logutil.BgLogger().Debug("[ddl] owner manager gets owner",
+			zap.String("ID", m.id), zap.String("ownerKey", m.key))
+		if m.beOwnerHook != nil {
+			m.beOwnerHook()
+		}
 	}
-	atomic.StoreInt32(&m.owner, 1)
 }
 
 // RetireOwner implements Manager.RetireOwner interface.
 func (m *mockManager) RetireOwner() {
-	atomic.StoreInt32(&m.owner, 0)
+	util.MockGlobalStateEntry.OwnerKey(m.key).UnsetOwner(m.id)
 }
 
 // Cancel implements Manager.Cancel interface.
 func (m *mockManager) Cancel() {
 	m.cancel()
+	m.wg.Wait()
+	logutil.BgLogger().Info("[ddl] owner manager is canceled",
+		zap.String("ID", m.id), zap.String("ownerKey", m.key))
 }
 
 // GetOwnerID implements Manager.GetOwnerID interface.
@@ -88,15 +107,37 @@ func (*mockManager) SetOwnerOpValue(_ context.Context, op OpType) error {
 
 // CampaignOwner implements Manager.CampaignOwner interface.
 func (m *mockManager) CampaignOwner() error {
-	m.toBeOwner()
-	return nil
+	m.wg.Add(1)
+	go func() {
+		logutil.BgLogger().Debug("[ddl] owner manager campaign owner",
+			zap.String("ID", m.id), zap.String("ownerKey", m.key))
+		defer m.wg.Done()
+		for {
+			select {
+			case <-m.campaignDone:
+				m.RetireOwner()
+				logutil.BgLogger().Debug("[ddl] owner manager campaign done", zap.String("ID", m.id))
+				return
+			case <-m.ctx.Done():
+				m.RetireOwner()
+				logutil.BgLogger().Debug("[ddl] owner manager is cancelled", zap.String("ID", m.id))
+				return
+			case <-m.resignDone:
+				m.RetireOwner()
+				time.Sleep(1 * time.Second) // Give a chance to the other owner managers to get owner.
+			default:
+				m.toBeOwner()
+				time.Sleep(1 * time.Second)
+				logutil.BgLogger().Debug("[ddl] owner manager tick", zap.String("ID", m.id),
+					zap.String("ownerKey", m.key), zap.String("currentOwner", util.MockGlobalStateEntry.OwnerKey(m.key).GetOwner()))
+			}
+		}
+	}()
 }
 
 // ResignOwner lets the owner start a new election.
 func (m *mockManager) ResignOwner(_ context.Context) error {
-	if m.IsOwner() {
-		m.RetireOwner()
-	}
+	m.resignDone <- struct{}{}
 	return nil
 }
 
@@ -110,8 +151,8 @@ func (m *mockManager) SetBeOwnerHook(hook func()) {
 }
 
 // CampaignCancel implements Manager.CampaignCancel interface
-func (*mockManager) CampaignCancel() {
-	// do nothing
+func (m *mockManager) CampaignCancel() {
+	m.campaignDone <- struct{}{}
 }
 
 func mockDelOwnerKey(mockCal, ownerKey string, m *ownerManager) error {

--- a/owner/mock.go
+++ b/owner/mock.go
@@ -46,9 +46,13 @@ type mockManager struct {
 // NewMockManager creates a new mock Manager.
 func NewMockManager(ctx context.Context, id string, store kv.Storage, ownerKey string) Manager {
 	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	storeID := "mock_store_id"
+	if store != nil {
+		storeID = store.UUID()
+	}
 	return &mockManager{
 		id:           id,
-		storeID:      store.UUID(),
+		storeID:      storeID,
 		key:          ownerKey,
 		ctx:          cancelCtx,
 		cancel:       cancelFunc,

--- a/owner/mock.go
+++ b/owner/mock.go
@@ -133,6 +133,7 @@ func (m *mockManager) CampaignOwner() error {
 			}
 		}
 	}()
+	return nil
 }
 
 // ResignOwner lets the owner start a new election.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #41495

Problem Summary:

At present, it is not easy to mock the distributed environment in unit tests. The correctness of this feature depends heavily on the integration test in real clusters. As a result, a bugfix with little changes require a whole real cluster to verify, which is quite inefficient.

### What is changed and how it works?

This PR is the first step to mock distributed environment in unit tests. First of all, we mock the leader campaign in the owner manager used for tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
