### PR TITLE
planner: fix join reorder will append remained other condition to an outer join

### DIFF
--- a/planner/core/rule_join_reorder.go
+++ b/planner/core/rule_join_reorder.go
@@ -507,6 +507,13 @@ func (s *baseSingleGroupJoinOrderSolver) makeJoin(leftPlan, rightPlan LogicalPla
 	remainOtherConds, otherConds = expression.FilterOutInPlace(remainOtherConds, func(expr expression.Expression) bool {
 		return expression.ExprFromSchema(expr, mergedSchema)
 	})
+	if (joinType.JoinType == LeftOuterJoin || joinType.JoinType == RightOuterJoin) && len(otherConds) > 0 {
+		// the original outer join's other conditions has been bound to the outer join Edge,
+		// these remained other condition here shouldn't be appended to it because on-mismatch
+		// logic will produce more append-null rows which is banned in original semantic.
+		remainOtherConds = append(remainOtherConds, otherConds...)
+		otherConds = otherConds[:0]
+	}
 	if len(joinType.outerBindCondition) > 0 {
 		remainOBOtherConds := make([]expression.Expression, len(joinType.outerBindCondition))
 		copy(remainOBOtherConds, joinType.outerBindCondition)
@@ -549,6 +556,14 @@ func (s *baseSingleGroupJoinOrderSolver) makeBushyJoin(cartesianJoinGroup []Logi
 			resultJoinGroup = append(resultJoinGroup, newJoin)
 		}
 		cartesianJoinGroup, resultJoinGroup = resultJoinGroup, cartesianJoinGroup
+	}
+	// other conditions may be possible to exist across different cartesian join group, resolving cartesianJoin first then adding another selection.
+	if len(s.otherConds) > 0 {
+		additionSelection := LogicalSelection{
+			Conditions: s.otherConds,
+		}.Init(cartesianJoinGroup[0].SCtx(), cartesianJoinGroup[0].SelectBlockOffset())
+		additionSelection.SetChildren(cartesianJoinGroup[0])
+		cartesianJoinGroup[0] = additionSelection
 	}
 	return cartesianJoinGroup[0]
 }

--- a/planner/core/rule_join_reorder.go
+++ b/planner/core/rule_join_reorder.go
@@ -511,7 +511,7 @@ func (s *baseSingleGroupJoinOrderSolver) makeJoin(leftPlan, rightPlan LogicalPla
 		// the original outer join's other conditions has been bound to the outer join Edge,
 		// these remained other condition here shouldn't be appended to it because on-mismatch
 		// logic will produce more append-null rows which is banned in original semantic.
-		remainOtherConds = append(remainOtherConds, otherConds...)
+		remainOtherConds = append(remainOtherConds, otherConds...) // nozero
 		otherConds = otherConds[:0]
 	}
 	if len(joinType.outerBindCondition) > 0 {

--- a/planner/core/rule_join_reorder.go
+++ b/planner/core/rule_join_reorder.go
@@ -181,7 +181,7 @@ func extractJoinGroup(p LogicalPlan) *joinGroupResult {
 	tmpOtherConds = append(tmpOtherConds, join.OtherConditions...)
 	tmpOtherConds = append(tmpOtherConds, join.LeftConditions...)
 	tmpOtherConds = append(tmpOtherConds, join.RightConditions...)
-	if join.JoinType == LeftOuterJoin || join.JoinType == RightOuterJoin {
+	if join.JoinType == LeftOuterJoin || join.JoinType == RightOuterJoin || join.JoinType == LeftOuterSemiJoin || join.JoinType == AntiLeftOuterSemiJoin {
 		for range join.EqualConditions {
 			abType := &joinTypeWithExtMsg{JoinType: join.JoinType}
 			// outer join's other condition should be bound with the connecting edge.
@@ -507,7 +507,7 @@ func (s *baseSingleGroupJoinOrderSolver) makeJoin(leftPlan, rightPlan LogicalPla
 	remainOtherConds, otherConds = expression.FilterOutInPlace(remainOtherConds, func(expr expression.Expression) bool {
 		return expression.ExprFromSchema(expr, mergedSchema)
 	})
-	if (joinType.JoinType == LeftOuterJoin || joinType.JoinType == RightOuterJoin) && len(otherConds) > 0 {
+	if (joinType.JoinType == LeftOuterJoin || joinType.JoinType == RightOuterJoin || joinType.JoinType == LeftOuterSemiJoin || joinType.JoinType == AntiLeftOuterSemiJoin) && len(otherConds) > 0 {
 		// the original outer join's other conditions has been bound to the outer join Edge,
 		// these remained other condition here shouldn't be appended to it because on-mismatch
 		// logic will produce more append-null rows which is banned in original semantic.

--- a/planner/core/rule_join_reorder_greedy.go
+++ b/planner/core/rule_join_reorder_greedy.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"math"
+	"sort"
 
 	"github.com/pingcap/tidb/expression"
 )

--- a/planner/core/rule_join_reorder_greedy.go
+++ b/planner/core/rule_join_reorder_greedy.go
@@ -15,8 +15,9 @@
 package core
 
 import (
-	"github.com/pingcap/tidb/expression"
 	"math"
+
+	"github.com/pingcap/tidb/expression"
 )
 
 type joinReorderGreedySolver struct {

--- a/planner/core/rule_join_reorder_greedy.go
+++ b/planner/core/rule_join_reorder_greedy.go
@@ -15,10 +15,8 @@
 package core
 
 import (
-	"math"
-	"sort"
-
 	"github.com/pingcap/tidb/expression"
+	"math"
 )
 
 type joinReorderGreedySolver struct {

--- a/planner/core/rule_join_reorder_test.go
+++ b/planner/core/rule_join_reorder_test.go
@@ -84,6 +84,8 @@ func TestAdditionOtherConditionsRemained4OuterJoin(t *testing.T) {
 
 	tk.MustQuery("SELECT `queries_identifier`.`id`, `queries_identifier`.`name` FROM `queries_identifier` LEFT OUTER JOIN `queries_channel` ON (`queries_identifier`.`id` = `queries_channel`.`identifier_id`) INNER JOIN `queries_program` ON (`queries_identifier`.`id` = `queries_program`.`identifier_id`) WHERE ((`queries_channel`.`id` = 5 AND `queries_program`.`id` = 9) OR `queries_program`.`id` = 8) ORDER BY `queries_identifier`.`id` ASC;").Check(testkit.Rows("" +
 		"13 i1"))
+	tk.MustQuery("SELECT `queries_identifier`.`id`, `queries_identifier`.`name` FROM `queries_identifier` RIGHT OUTER JOIN `queries_channel` ON (`queries_identifier`.`id` = `queries_channel`.`identifier_id`) INNER JOIN `queries_program` ON (`queries_identifier`.`id` = `queries_program`.`identifier_id`) WHERE ((`queries_channel`.`id` = 5 AND `queries_program`.`id` = 9) OR `queries_program`.`id` = 8) ORDER BY `queries_identifier`.`id` ASC;").Check(testkit.Rows("" +
+		"13 i1"))
 	tk.MustQuery("explain format = 'brief' SELECT `queries_identifier`.`id`, `queries_identifier`.`name` FROM `queries_identifier` LEFT OUTER JOIN `queries_channel` ON (`queries_identifier`.`id` = `queries_channel`.`identifier_id`) INNER JOIN `queries_program` ON (`queries_identifier`.`id` = `queries_program`.`identifier_id`) WHERE ((`queries_channel`.`id` = 5 AND `queries_program`.`id` = 9) OR `queries_program`.`id` = 8) ORDER BY `queries_identifier`.`id` ASC;").Check(testkit.Rows(""+
 		"Sort 2.50 root  test.queries_identifier.id",
 		"└─Projection 2.50 root  test.queries_identifier.id, test.queries_identifier.name",

--- a/planner/core/rule_join_reorder_test.go
+++ b/planner/core/rule_join_reorder_test.go
@@ -69,6 +69,34 @@ func TestJoinOrderHintWithBinding(t *testing.T) {
 	tk.MustExec("drop global binding for select * from t1 join t2 on t1.a=t2.a join t3 on t2.b=t3.b")
 }
 
+func TestAdditionOtherConditionsRemained4OuterJoin(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("CREATE TABLE `queries_identifier` (\n   `id` int(11) NOT NULL AUTO_INCREMENT,\n   `name` varchar(100) COLLATE utf8mb4_general_ci NOT NULL,\n   PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */\n ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;")
+	tk.MustExec("CREATE TABLE `queries_program` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `identifier_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,\n  UNIQUE KEY `identifier_id` (`identifier_id`),\n  CONSTRAINT `queries_program_identifier_id_70ff12a6_fk_queries_identifier_id` FOREIGN KEY (`identifier_id`) REFERENCES `test`.`queries_identifier` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;")
+	tk.MustExec("CREATE TABLE `queries_channel` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `identifier_id` int(11) NOT NULL,\n  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,\n  UNIQUE KEY `identifier_id` (`identifier_id`),\n  CONSTRAINT `queries_channel_identifier_id_06ac3513_fk_queries_identifier_id` FOREIGN KEY (`identifier_id`) REFERENCES `test`.`queries_identifier` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;")
+
+	tk.MustExec("INSERT  INTO queries_identifier(`id`, `name`) values(13, 'i1'), (14, 'i2'), (15, 'i3');")
+	tk.MustExec("INSERT  INTO queries_program(`id`, `identifier_id`) values(8, 13), (9, 14);")
+	tk.MustExec("INSERT  INTO queries_channel(`id`, `identifier_id`) values(5, 13);")
+
+	tk.MustQuery("SELECT `queries_identifier`.`id`, `queries_identifier`.`name` FROM `queries_identifier` LEFT OUTER JOIN `queries_channel` ON (`queries_identifier`.`id` = `queries_channel`.`identifier_id`) INNER JOIN `queries_program` ON (`queries_identifier`.`id` = `queries_program`.`identifier_id`) WHERE ((`queries_channel`.`id` = 5 AND `queries_program`.`id` = 9) OR `queries_program`.`id` = 8) ORDER BY `queries_identifier`.`id` ASC;").Check(testkit.Rows("" +
+		"13 i1"))
+	tk.MustQuery("explain SELECT `queries_identifier`.`id`, `queries_identifier`.`name` FROM `queries_identifier` LEFT OUTER JOIN `queries_channel` ON (`queries_identifier`.`id` = `queries_channel`.`identifier_id`) INNER JOIN `queries_program` ON (`queries_identifier`.`id` = `queries_program`.`identifier_id`) WHERE ((`queries_channel`.`id` = 5 AND `queries_program`.`id` = 9) OR `queries_program`.`id` = 8) ORDER BY `queries_identifier`.`id` ASC;").Check(testkit.Rows(""+
+		"Sort_14 2.50 root  test.queries_identifier.id",
+		"└─Projection_17 2.50 root  test.queries_identifier.id, test.queries_identifier.name",
+		"  └─Selection_18 2.50 root  or(and(eq(test.queries_channel.id, 5), eq(test.queries_program.id, 9)), eq(test.queries_program.id, 8))",
+		"    └─IndexJoin_22 3.12 root  left outer join, inner:IndexReader_21, outer key:test.queries_identifier.id, inner key:test.queries_channel.identifier_id, equal cond:eq(test.queries_identifier.id, test.queries_channel.identifier_id)",
+		"      ├─IndexHashJoin_37(Build) 2.50 root  inner join, inner:TableReader_32, outer key:test.queries_program.identifier_id, inner key:test.queries_identifier.id, equal cond:eq(test.queries_program.identifier_id, test.queries_identifier.id)",
+		"      │ ├─Batch_Point_Get_42(Build) 2.00 root table:queries_program handle:[8 9], keep order:false, desc:false",
+		"      │ └─TableReader_32(Probe) 2.00 root  data:TableRangeScan_31",
+		"      │   └─TableRangeScan_31 2.00 cop[tikv] table:queries_identifier range: decided by [test.queries_program.identifier_id], keep order:false, stats:pseudo",
+		"      └─IndexReader_21(Probe) 2.50 root  index:IndexRangeScan_20",
+		"        └─IndexRangeScan_20 2.50 cop[tikv] table:queries_channel, index:identifier_id(identifier_id) range: decided by [eq(test.queries_channel.identifier_id, test.queries_identifier.id)], keep order:false, stats:pseudo"))
+}
+
 func TestOuterJoinWIthEqCondCrossInnerJoin(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 

--- a/planner/core/rule_join_reorder_test.go
+++ b/planner/core/rule_join_reorder_test.go
@@ -84,17 +84,17 @@ func TestAdditionOtherConditionsRemained4OuterJoin(t *testing.T) {
 
 	tk.MustQuery("SELECT `queries_identifier`.`id`, `queries_identifier`.`name` FROM `queries_identifier` LEFT OUTER JOIN `queries_channel` ON (`queries_identifier`.`id` = `queries_channel`.`identifier_id`) INNER JOIN `queries_program` ON (`queries_identifier`.`id` = `queries_program`.`identifier_id`) WHERE ((`queries_channel`.`id` = 5 AND `queries_program`.`id` = 9) OR `queries_program`.`id` = 8) ORDER BY `queries_identifier`.`id` ASC;").Check(testkit.Rows("" +
 		"13 i1"))
-	tk.MustQuery("explain SELECT `queries_identifier`.`id`, `queries_identifier`.`name` FROM `queries_identifier` LEFT OUTER JOIN `queries_channel` ON (`queries_identifier`.`id` = `queries_channel`.`identifier_id`) INNER JOIN `queries_program` ON (`queries_identifier`.`id` = `queries_program`.`identifier_id`) WHERE ((`queries_channel`.`id` = 5 AND `queries_program`.`id` = 9) OR `queries_program`.`id` = 8) ORDER BY `queries_identifier`.`id` ASC;").Check(testkit.Rows(""+
-		"Sort_14 2.50 root  test.queries_identifier.id",
-		"└─Projection_17 2.50 root  test.queries_identifier.id, test.queries_identifier.name",
-		"  └─Selection_18 2.50 root  or(and(eq(test.queries_channel.id, 5), eq(test.queries_program.id, 9)), eq(test.queries_program.id, 8))",
-		"    └─IndexJoin_22 3.12 root  left outer join, inner:IndexReader_21, outer key:test.queries_identifier.id, inner key:test.queries_channel.identifier_id, equal cond:eq(test.queries_identifier.id, test.queries_channel.identifier_id)",
-		"      ├─IndexHashJoin_37(Build) 2.50 root  inner join, inner:TableReader_32, outer key:test.queries_program.identifier_id, inner key:test.queries_identifier.id, equal cond:eq(test.queries_program.identifier_id, test.queries_identifier.id)",
-		"      │ ├─Batch_Point_Get_42(Build) 2.00 root table:queries_program handle:[8 9], keep order:false, desc:false",
-		"      │ └─TableReader_32(Probe) 2.00 root  data:TableRangeScan_31",
-		"      │   └─TableRangeScan_31 2.00 cop[tikv] table:queries_identifier range: decided by [test.queries_program.identifier_id], keep order:false, stats:pseudo",
-		"      └─IndexReader_21(Probe) 2.50 root  index:IndexRangeScan_20",
-		"        └─IndexRangeScan_20 2.50 cop[tikv] table:queries_channel, index:identifier_id(identifier_id) range: decided by [eq(test.queries_channel.identifier_id, test.queries_identifier.id)], keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format = 'brief' SELECT `queries_identifier`.`id`, `queries_identifier`.`name` FROM `queries_identifier` LEFT OUTER JOIN `queries_channel` ON (`queries_identifier`.`id` = `queries_channel`.`identifier_id`) INNER JOIN `queries_program` ON (`queries_identifier`.`id` = `queries_program`.`identifier_id`) WHERE ((`queries_channel`.`id` = 5 AND `queries_program`.`id` = 9) OR `queries_program`.`id` = 8) ORDER BY `queries_identifier`.`id` ASC;").Check(testkit.Rows(""+
+		"Sort 2.50 root  test.queries_identifier.id",
+		"└─Projection 2.50 root  test.queries_identifier.id, test.queries_identifier.name",
+		"  └─Selection 2.50 root  or(and(eq(test.queries_channel.id, 5), eq(test.queries_program.id, 9)), eq(test.queries_program.id, 8))",
+		"    └─IndexJoin 3.12 root  left outer join, inner:IndexReader, outer key:test.queries_identifier.id, inner key:test.queries_channel.identifier_id, equal cond:eq(test.queries_identifier.id, test.queries_channel.identifier_id)",
+		"      ├─IndexHashJoin(Build) 2.50 root  inner join, inner:TableReader, outer key:test.queries_program.identifier_id, inner key:test.queries_identifier.id, equal cond:eq(test.queries_program.identifier_id, test.queries_identifier.id)",
+		"      │ ├─Batch_Point_Get(Build) 2.00 root table:queries_program handle:[8 9], keep order:false, desc:false",
+		"      │ └─TableReader(Probe) 2.00 root  data:TableRangeScan",
+		"      │   └─TableRangeScan 2.00 cop[tikv] table:queries_identifier range: decided by [test.queries_program.identifier_id], keep order:false, stats:pseudo",
+		"      └─IndexReader(Probe) 2.50 root  index:IndexRangeScan",
+		"        └─IndexRangeScan 2.50 cop[tikv] table:queries_channel, index:identifier_id(identifier_id) range: decided by [eq(test.queries_channel.identifier_id, test.queries_identifier.id)], keep order:false, stats:pseudo"))
 }
 
 func TestOuterJoinWIthEqCondCrossInnerJoin(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/44314

Problem Summary:

### What is changed and how it works?
As mentioned in the last comment on the issue

Reason: outer join's other condition influence is quite different from inner join's other condition, the latter one functions as a simple filter, just integrated with inner join. The former functions as a simple filter but also decides whether the outer join is matched or not, consequently deciding whether appending an additional null (which means this row itself is not pruned in the final result)

So when enumerating join order when encountering inner join combined with outer join, those original other conditions bonded with an outer join, just let it be; those additional remained other conditions shouldn't be put down into it, adding additional selection above is a resolution.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix join reorder will append remained condition to an outer join
```
