### PR TITLE
partition: fix index join probe side will locate partition error when it's a table range scan

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -4276,6 +4276,9 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 					locateKey[keyColOffsets[i]] = data
 				}
 				p, err := pt.GetPartitionByRow(e.ctx, locateKey)
+				if table.ErrNoPartitionForGivenValue.Equal(err) {
+					continue
+				}
 				if err != nil {
 					return nil, err
 				}
@@ -4320,6 +4323,9 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 				locateKey[keyColOffsets[i]] = data
 			}
 			p, err := pt.GetPartitionByRow(e.ctx, locateKey)
+			if table.ErrNoPartitionForGivenValue.Equal(err) {
+				continue
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/executor/test/partitiontest/partition_test.go
+++ b/executor/test/partitiontest/partition_test.go
@@ -459,7 +459,8 @@ func TestPartitionOnMissing(t *testing.T) {
 	tk.MustExec(`CREATE TABLE tt1 (
 		id INT NOT NULL,
 		listid INT,
-		name varchar(10)
+		name varchar(10),
+		primary key (listid) clustered
 	)
 	PARTITION BY LIST (listid) (
 		PARTITION p1 VALUES IN (1),
@@ -491,4 +492,14 @@ func TestPartitionOnMissing(t *testing.T) {
 
 	tk.MustQuery(`select /*+ inl_join(tt1)*/ count(*) from tt2
 		left join tt1 on tt1.listid=tt2.listid and tt1.id=tt2.id`).Check(testkit.Rows("5"))
+	tk.MustQuery(`select /*+ inl_join(tt1)*/ count(*) from tt2
+		left join tt1 on tt1.listid=tt2.listid`).Check(testkit.Rows("5"))
+	tk.MustQuery(`explain format = 'brief' select /*+ inl_join(tt1)*/ count(*) from tt2
+		left join tt1 on tt1.listid=tt2.listid`).Check(testkit.Rows(""+
+		"StreamAgg 1.00 root  funcs:count(1)->Column#7",
+		"└─IndexJoin 5.00 root  left outer join, inner:TableReader, outer key:onmissing.tt2.listid, inner key:onmissing.tt1.listid, equal cond:eq(onmissing.tt2.listid, onmissing.tt1.listid)",
+		"  ├─IndexReader(Build) 5.00 root  index:IndexFullScan",
+		"  │ └─IndexFullScan 5.00 cop[tikv] table:tt2, index:idx_listid(listid) keep order:false",
+		"  └─TableReader(Probe) 4.00 root partition:all data:TableRangeScan",
+		"    └─TableRangeScan 4.00 cop[tikv] table:tt1 range: decided by [onmissing.tt2.listid], keep order:false"))
 }


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/43686

Problem Summary:
https://github.com/pingcap/tidb/pull/43763 This PR has missed a case where the index join has a table range scan as its probe side, the pk resolution should also consider the locate partition error.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
partition: fix index join probe side will locate partition error when it's a table range scan
```
