### PR TITLE
lightning/backend/local: fix `buildIndexDupTasks`

### DIFF
--- a/br/pkg/lightning/backend/local/duplicate.go
+++ b/br/pkg/lightning/backend/local/duplicate.go
@@ -635,8 +635,9 @@ func (m *DupeDetector) buildIndexDupTasks() ([]dupTask, error) {
 			tid := tablecodec.DecodeTableID(ranges[0].StartKey)
 			for _, r := range ranges {
 				tasks = append(tasks, dupTask{
-					KeyRange: r,
-					tableID:  tid,
+					KeyRange:  r,
+					tableID:   tid,
+					indexInfo: indexInfo,
 				})
 			}
 		})

--- a/ddl/ingest/backend.go
+++ b/ddl/ingest/backend.go
@@ -224,8 +224,11 @@ func (bc *litBackendCtx) Flush(indexID int64, mode FlushMode) (flushed, imported
 	return true, true, nil
 }
 
+// ForceSyncFlagForTest is a flag to force sync only for test.
+var ForceSyncFlagForTest = false
+
 func (bc *litBackendCtx) ShouldSync(mode FlushMode) (shouldFlush bool, shouldImport bool) {
-	if mode == FlushModeForceGlobal {
+	if mode == FlushModeForceGlobal || ForceSyncFlagForTest {
 		return true, true
 	}
 	if mode == FlushModeForceLocal {

--- a/tests/realtikvtest/addindextest/BUILD.bazel
+++ b/tests/realtikvtest/addindextest/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//ddl",
         "//ddl/ingest",
         "//ddl/testutil",
+        "//errno",
         "//sessionctx/variable",
         "//testkit",
         "//tests/realtikvtest",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44439

Problem Summary:

https://github.com/pingcap/tidb/pull/36108 refactors and adds duplicate task building support for partitions. However, one of the field has been missed.

![image](https://github.com/pingcap/tidb/assets/24713065/7d77cc28-02ca-4f54-a0ff-aa9b8bfc128f)

As a result, it takes index keys as row keys, and "invalid key" error is reported:

https://github.com/pingcap/tidb/blob/21934de769686ffcf2397e35eb4f426072756bc2/br/pkg/lightning/backend/local/duplicate.go#LL819C14-L819C14

### What is changed and how it works?

Add back the missing field `indexInfo`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
