### PR TITLE
planner, runtimefilter: resolve column index for table scan

### DIFF
--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -655,7 +655,19 @@ func (p *PhysicalApply) ResolveIndices() (err error) {
 
 // ResolveIndices implements Plan interface.
 func (p *PhysicalTableScan) ResolveIndices() (err error) {
-	return p.physicalSchemaProducer.ResolveIndices()
+	err = p.physicalSchemaProducer.ResolveIndices()
+	if err != nil {
+		return err
+	}
+	return p.ResolveIndicesItself()
+}
+
+// ResolveIndicesItself implements PhysicalTableScan interface.
+func (p *PhysicalTableScan) ResolveIndicesItself() (err error) {
+	for i, column := range p.schema.Columns {
+		column.Index = i
+	}
+	return
 }
 
 // ResolveIndices implements Plan interface.

--- a/planner/core/runtime_filter_generator.go
+++ b/planner/core/runtime_filter_generator.go
@@ -109,7 +109,6 @@ func (generator *RuntimeFilterGenerator) assignRuntimeFilter(physicalTableScan *
 	// match rf for current scan node
 	cacheBuildNodeIDToRFMode := map[int]RuntimeFilterMode{}
 	var currentRFList []*RuntimeFilter
-	physicalTableScan.ResolveIndices()
 	for _, scanOutputColumn := range physicalTableScan.schema.Columns {
 		currentColumnRFList := generator.columnUniqueIDToRF[scanOutputColumn.UniqueID]
 		for _, runtimeFilter := range currentColumnRFList {

--- a/planner/core/runtime_filter_generator.go
+++ b/planner/core/runtime_filter_generator.go
@@ -109,6 +109,7 @@ func (generator *RuntimeFilterGenerator) assignRuntimeFilter(physicalTableScan *
 	// match rf for current scan node
 	cacheBuildNodeIDToRFMode := map[int]RuntimeFilterMode{}
 	var currentRFList []*RuntimeFilter
+	physicalTableScan.ResolveIndices()
 	for _, scanOutputColumn := range physicalTableScan.schema.Columns {
 		currentColumnRFList := generator.columnUniqueIDToRF[scanOutputColumn.UniqueID]
 		for _, runtimeFilter := range currentColumnRFList {


### PR DESCRIPTION
The column of table scan needs to be resolved, otherwise its index is wrong. If the index is wrong, the target column of the runtime filter will also be wrong, and finally the runtime filter will be hung on the wrong target column. Lead to wrong results.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44450

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
