### PR TITLE
lightning: deprecate send-kv-pairs

### DIFF
--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -395,8 +395,7 @@ type BackendConfig struct {
 	ConnCompressType config.CompressionType
 	// concurrency of generateJobForRange and import(write & ingest) workers
 	WorkerConcurrency int
-	// batch kv count and size when writing to TiKV
-	KVWriteBatchCount      int
+	// batch kv size when writing to TiKV
 	KVWriteBatchSize       int64
 	RegionSplitBatchSize   int
 	RegionSplitConcurrency int
@@ -432,7 +431,6 @@ func NewBackendConfig(cfg *config.Config, maxOpenFiles int, keyspaceName string)
 		MaxConnPerStore:         cfg.TikvImporter.RangeConcurrency,
 		ConnCompressType:        cfg.TikvImporter.CompressKVPairs,
 		WorkerConcurrency:       cfg.TikvImporter.RangeConcurrency * 2,
-		KVWriteBatchCount:       cfg.TikvImporter.SendKVPairs,
 		KVWriteBatchSize:        int64(cfg.TikvImporter.SendKVSize),
 		RegionSplitBatchSize:    cfg.TikvImporter.RegionSplitBatchSize,
 		RegionSplitConcurrency:  cfg.TikvImporter.RegionSplitConcurrency,

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -71,7 +71,6 @@ const (
 	// ErrorOnDup indicates using INSERT INTO to insert data, which would violate PK or UNIQUE constraint
 	ErrorOnDup = "error"
 
-	KVWriteBatchCount = 32768
 	// KVWriteBatchSize batch size when write to TiKV.
 	// this is the default value of linux send buffer size(net.ipv4.tcp_wmem) too.
 	KVWriteBatchSize        = 16 * units.KiB
@@ -749,10 +748,11 @@ type FileRouteRule struct {
 // TikvImporter is the config for tikv-importer.
 type TikvImporter struct {
 	// Deprecated: only used to keep the compatibility.
-	Addr                    string                       `toml:"addr" json:"addr"`
-	Backend                 string                       `toml:"backend" json:"backend"`
-	OnDuplicate             string                       `toml:"on-duplicate" json:"on-duplicate"`
-	MaxKVPairs              int                          `toml:"max-kv-pairs" json:"max-kv-pairs"`
+	Addr        string `toml:"addr" json:"addr"`
+	Backend     string `toml:"backend" json:"backend"`
+	OnDuplicate string `toml:"on-duplicate" json:"on-duplicate"`
+	MaxKVPairs  int    `toml:"max-kv-pairs" json:"max-kv-pairs"`
+	// deprecated
 	SendKVPairs             int                          `toml:"send-kv-pairs" json:"send-kv-pairs"`
 	SendKVSize              ByteSize                     `toml:"send-kv-size" json:"send-kv-size"`
 	CompressKVPairs         CompressionType              `toml:"compress-kv-pairs" json:"compress-kv-pairs"`
@@ -960,7 +960,7 @@ func NewConfig() *Config {
 		TikvImporter: TikvImporter{
 			Backend:                 "",
 			MaxKVPairs:              4096,
-			SendKVPairs:             KVWriteBatchCount,
+			SendKVPairs:             32768,
 			SendKVSize:              KVWriteBatchSize,
 			RegionSplitSize:         0,
 			RegionSplitBatchSize:    DefaultRegionSplitBatchSize,

--- a/br/pkg/lightning/config/config_test.go
+++ b/br/pkg/lightning/config/config_test.go
@@ -865,7 +865,7 @@ func TestDefaultCouldBeOverwritten(t *testing.T) {
 	require.Equal(t, 20, cfg.App.IndexConcurrency)
 	require.Equal(t, 60, cfg.App.TableConcurrency)
 
-	require.Equal(t, config.KVWriteBatchCount, cfg.TikvImporter.SendKVPairs)
+	require.Equal(t, 32768, cfg.TikvImporter.SendKVPairs)
 	require.Equal(t, config.ByteSize(config.KVWriteBatchSize), cfg.TikvImporter.SendKVSize)
 
 	cfg.TikvImporter.RegionSplitConcurrency = 1

--- a/br/tests/lightning_write_batch/run.sh
+++ b/br/tests/lightning_write_batch/run.sh
@@ -37,11 +37,12 @@ for i in {1..100}; do
 done
 set -x
 
+# send-kv-pairs is deprecated, will not takes effect
 rm -rf $TEST_DIR/lightning.log
 export GO_FAILPOINTS="github.com/pingcap/tidb/br/pkg/lightning/backend/local/afterFlushKVs=return(true)"
 run_lightning --backend local -d "$TEST_DIR/data" --config "tests/$TEST_NAME/kv-count.toml"
-check_contains 'afterFlushKVs count=20,' $TEST_DIR/lightning.log
-check_not_contains 'afterFlushKVs count=1,' $TEST_DIR/lightning.log
+check_contains 'afterFlushKVs count=100,' $TEST_DIR/lightning.log
+check_not_contains 'afterFlushKVs count=20,' $TEST_DIR/lightning.log
 check_contains 'send-kv-pairs\":20,' $TEST_DIR/lightning.log
 check_contains 'send-kv-size\":16384,' $TEST_DIR/lightning.log
 

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -145,7 +145,6 @@ func NewTableImporter(param *JobImportParam, e *LoadDataController, taskID int64
 		MaxConnPerStore:        config.DefaultRangeConcurrency,
 		ConnCompressType:       config.CompressionNone,
 		WorkerConcurrency:      config.DefaultRangeConcurrency * 2,
-		KVWriteBatchCount:      config.KVWriteBatchCount,
 		KVWriteBatchSize:       config.KVWriteBatchSize,
 		RegionSplitBatchSize:   config.DefaultRegionSplitBatchSize,
 		RegionSplitConcurrency: runtime.GOMAXPROCS(0),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #43853

Problem Summary:

### What is changed and how it works?
- deprecate `send-kv-pairs`, user can still set it, but it will take no effect

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
deprecate `send-kv-pairs`, user can still set it, but it will take no effect
```
