### PR TITLE
*: simplify insert into set

### DIFF
--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -744,7 +744,7 @@ func TestDeleteOnlyForDropColumns(t *testing.T) {
 	tk.MustExec("create database test_db_state default charset utf8 default collate utf8_bin")
 	sqls := make([]sqlWithErr, 1)
 	sqls[0] = sqlWithErr{"insert t set c1 = 'c1_insert', c3 = '2018-02-12', c4 = 1",
-		errors.Errorf("[ddl:1054]Unknown column 'c1' in 'field list'")}
+		errors.Errorf("[planner:1054]Unknown column 'c1' in 'field list'")}
 	dropColumnsSQL := "alter table t drop column c1, drop column c3"
 	runTestInSchemaState(t, tk, store, dom, model.StateDeleteOnly, true, dropColumnsSQL, sqls, nil)
 }

--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -652,7 +652,7 @@ func TestDeleteOnly(t *testing.T) {
 
 	sqls := make([]sqlWithErr, 5)
 	sqls[0] = sqlWithErr{"insert t set c1 = 'c1_insert', c3 = '2018-02-12', c4 = 1",
-		errors.Errorf("[ddl:1054]Unknown column 'c1' in 'field list'")}
+		errors.Errorf("[planner:1054]Unknown column 'c1' in 'field list'")}
 	sqls[1] = sqlWithErr{"update t set c1 = 'c1_insert', c3 = '2018-02-12', c4 = 1",
 		errors.Errorf("[planner:1054]Unknown column 'c1' in 'field list'")}
 	sqls[2] = sqlWithErr{"delete from t where c1='a'",

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -934,7 +934,6 @@ func (b *executorBuilder) buildInsert(v *plannercore.Insert) Executor {
 		Table:                     v.Table,
 		Columns:                   v.Columns,
 		Lists:                     v.Lists,
-		SetList:                   v.SetList,
 		GenExprs:                  v.GenCols.Exprs,
 		allAssignmentsAreConstant: v.AllAssignmentsAreConstant,
 		hasRefCols:                v.NeedFillDefaultValue,

--- a/parser/ast/dml.go
+++ b/parser/ast/dml.go
@@ -2211,7 +2211,7 @@ type InsertStmt struct {
 	Table       *TableRefsClause
 	Columns     []*ColumnName
 	Lists       [][]ExprNode
-	Setlist     []*Assignment
+	Setlist     bool
 	Priority    mysql.PriorityEnum
 	OnDuplicate []*Assignment
 	Select      ResultSetNode
@@ -2265,38 +2265,60 @@ func (n *InsertStmt) Restore(ctx *format.RestoreCtx) error {
 		}
 		ctx.WritePlain(")")
 	}
-	if n.Columns != nil {
-		ctx.WritePlain(" (")
-		for i, v := range n.Columns {
+	if n.Setlist {
+		if len(n.Lists) != 1 {
+			return errors.Errorf("Expect len(InsertStmt.Lists)[%d] == 1 for SET x=y", len(n.Lists))
+		}
+		if len(n.Lists[0]) != len(n.Columns) {
+			return errors.Errorf("Expect len(InsertStmt.Columns)[%d] == len(InsertStmt.Lists[0])[%d] for SET x=y", len(n.Columns), len(n.Lists[0]))
+		}
+		ctx.WriteKeyWord(" SET ")
+		for i, v := range n.Lists[0] {
 			if i != 0 {
 				ctx.WritePlain(",")
 			}
-			if ctx.Flags.HasRestoreForNonPrepPlanCache() && len(v.OriginalText()) > 0 {
-				ctx.WritePlain(v.OriginalText())
-			} else {
-				if err := v.Restore(ctx); err != nil {
-					return errors.Annotatef(err, "An error occurred while restore InsertStmt.Columns[%d]", i)
-				}
+			v := &Assignment{
+				Column: n.Columns[i],
+				Expr:   v,
+			}
+			if err := v.Restore(ctx); err != nil {
+				return errors.Annotatef(err, "An error occurred while restore InsertStmt.Set (Columns = Expr)[%d]", i)
 			}
 		}
-		ctx.WritePlain(")")
-	}
-	if n.Lists != nil {
-		ctx.WriteKeyWord(" VALUES ")
-		for i, row := range n.Lists {
-			if i != 0 {
-				ctx.WritePlain(",")
-			}
-			ctx.WritePlain("(")
-			for j, v := range row {
-				if j != 0 {
+	} else {
+		if n.Columns != nil {
+			ctx.WritePlain(" (")
+			for i, v := range n.Columns {
+				if i != 0 {
 					ctx.WritePlain(",")
 				}
-				if err := v.Restore(ctx); err != nil {
-					return errors.Annotatef(err, "An error occurred while restore InsertStmt.Lists[%d][%d]", i, j)
+				if ctx.Flags.HasRestoreForNonPrepPlanCache() && len(v.OriginalText()) > 0 {
+					ctx.WritePlain(v.OriginalText())
+				} else {
+					if err := v.Restore(ctx); err != nil {
+						return errors.Annotatef(err, "An error occurred while restore InsertStmt.Columns[%d]", i)
+					}
 				}
 			}
 			ctx.WritePlain(")")
+		}
+		if n.Lists != nil {
+			ctx.WriteKeyWord(" VALUES ")
+			for i, row := range n.Lists {
+				if i != 0 {
+					ctx.WritePlain(",")
+				}
+				ctx.WritePlain("(")
+				for j, v := range row {
+					if j != 0 {
+						ctx.WritePlain(",")
+					}
+					if err := v.Restore(ctx); err != nil {
+						return errors.Annotatef(err, "An error occurred while restore InsertStmt.Lists[%d][%d]", i, j)
+					}
+				}
+				ctx.WritePlain(")")
+			}
 		}
 	}
 	if n.Select != nil {
@@ -2308,17 +2330,6 @@ func (n *InsertStmt) Restore(ctx *format.RestoreCtx) error {
 			}
 		default:
 			return errors.Errorf("Incorrect type for InsertStmt.Select: %T", v)
-		}
-	}
-	if n.Setlist != nil {
-		ctx.WriteKeyWord(" SET ")
-		for i, v := range n.Setlist {
-			if i != 0 {
-				ctx.WritePlain(",")
-			}
-			if err := v.Restore(ctx); err != nil {
-				return errors.Annotatef(err, "An error occurred while restore InsertStmt.Setlist[%d]", i)
-			}
 		}
 	}
 	if n.OnDuplicate != nil {
@@ -2373,13 +2384,6 @@ func (n *InsertStmt) Accept(v Visitor) (Node, bool) {
 			}
 			n.Lists[i][j] = node.(ExprNode)
 		}
-	}
-	for i, val := range n.Setlist {
-		node, ok := val.Accept(v)
-		if !ok {
-			return n, false
-		}
-		n.Setlist[i] = node.(*Assignment)
 	}
 	for i, val := range n.OnDuplicate {
 		node, ok := val.Accept(v)

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1096,7 +1096,6 @@ import (
 	IdentListWithParenOpt                  "column name list opt with parentheses"
 	ColumnNameOrUserVarListOpt             "column name or user vairiabe list opt"
 	ColumnNameOrUserVarListOptWithBrackets "column name or user variable list opt with brackets"
-	ColumnSetValue                         "insert statement set value by column name"
 	ColumnSetValueList                     "insert statement set value by column name list"
 	CompareOp                              "Compare opcode"
 	ColumnOption                           "column definition option"
@@ -7060,7 +7059,7 @@ InsertValues:
 	}
 |	"SET" ColumnSetValueList
 	{
-		$$ = &ast.InsertStmt{Setlist: $2.([]*ast.Assignment)}
+		$$ = $2.(*ast.InsertStmt)
 	}
 
 ValueSym:
@@ -7106,26 +7105,21 @@ ExprOrDefault:
 		$$ = &ast.DefaultExpr{}
 	}
 
-ColumnSetValue:
+ColumnSetValueList:
 	ColumnName eq ExprOrDefault
 	{
-		$$ = &ast.Assignment{
-			Column: $1.(*ast.ColumnName),
-			Expr:   $3,
+		$$ = &ast.InsertStmt{
+			Columns: []*ast.ColumnName{$1.(*ast.ColumnName)},
+			Lists:   [][]ast.ExprNode{{$3.(ast.ExprNode)}},
+			Setlist: true,
 		}
 	}
-
-ColumnSetValueList:
+|	ColumnSetValueList ',' ColumnName eq ExprOrDefault
 	{
-		$$ = []*ast.Assignment{}
-	}
-|	ColumnSetValue
-	{
-		$$ = []*ast.Assignment{$1.(*ast.Assignment)}
-	}
-|	ColumnSetValueList ',' ColumnSetValue
-	{
-		$$ = append($1.([]*ast.Assignment), $3.(*ast.Assignment))
+		ins := $1.(*ast.InsertStmt)
+		ins.Columns = append(ins.Columns, $3.(*ast.ColumnName))
+		ins.Lists[0] = append(ins.Lists[0], $5.(ast.ExprNode))
+		$$ = ins
 	}
 
 /*

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -360,7 +360,6 @@ type Insert struct {
 	tableColNames types.NameSlice
 	Columns       []*ast.ColumnName
 	Lists         [][]expression.Expression
-	SetList       []*expression.Assignment
 
 	OnDuplicate        []*expression.Assignment
 	Schema4OnDuplicate *expression.Schema
@@ -390,8 +389,8 @@ func (p *Insert) MemoryUsage() (sum int64) {
 	}
 
 	sum = p.baseSchemaProducer.MemoryUsage() + size.SizeOfInterface + size.SizeOfSlice*7 + int64(cap(p.tableColNames)+
-		cap(p.Columns)+cap(p.SetList)+cap(p.OnDuplicate)+cap(p.names4OnDuplicate)+cap(p.FKChecks))*size.SizeOfPointer +
-		p.GenCols.MemoryUsage() + size.SizeOfInterface + size.SizeOfBool*3 + size.SizeOfInt
+		cap(p.Columns)+cap(p.OnDuplicate)+cap(p.names4OnDuplicate)+cap(p.FKChecks))*size.SizeOfPointer +
+		p.GenCols.MemoryUsage() + size.SizeOfInterface + size.SizeOfBool*4 + size.SizeOfInt
 	if p.tableSchema != nil {
 		sum += p.tableSchema.MemoryUsage()
 	}
@@ -410,9 +409,6 @@ func (p *Insert) MemoryUsage() (sum int64) {
 		for _, expr := range exprs {
 			sum += expr.MemoryUsage()
 		}
-	}
-	for _, as := range p.SetList {
-		sum += as.MemoryUsage()
 	}
 	for _, as := range p.OnDuplicate {
 		sum += as.MemoryUsage()

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -3987,7 +3987,7 @@ func (*PlanBuilder) getAffectCols(insertStmt *ast.InsertStmt, insertPlan *Insert
 		// This branch is for the following scenarios:
 		// 1. `INSERT INTO tbl_name (col_name [, col_name] ...) {VALUES | VALUE} (value_list) [, (value_list)] ...`,
 		// 2. `INSERT INTO tbl_name (col_name [, col_name] ...) SELECT ...`.
-		// 2. `INSERT INTO tbl_name (col_name [, col_name] ...) SET ...`.
+		// 3. `INSERT INTO tbl_name SET col1=x1, ... colM=xM...`.
 		colName := make([]string, 0, len(insertStmt.Columns))
 		for _, col := range insertStmt.Columns {
 			colName = append(colName, col.Name.L)

--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -729,17 +729,6 @@ func (p *Insert) ResolveIndices() (err error) {
 			}
 		}
 	}
-	for _, set := range p.SetList {
-		newCol, err := set.Col.ResolveIndices(p.tableSchema)
-		if err != nil {
-			return err
-		}
-		set.Col = newCol.(*expression.Column)
-		set.Expr, err = set.Expr.ResolveIndices(p.tableSchema)
-		if err != nil {
-			return err
-		}
-	}
 	for i, expr := range p.GenCols.Exprs {
 		p.GenCols.Exprs[i], err = expr.ResolveIndices(p.tableSchema)
 		if err != nil {

--- a/util/parser/ast.go
+++ b/util/parser/ast.go
@@ -79,7 +79,7 @@ func SimpleCases(node ast.StmtNode, defaultDB, origin string) (s string, ok bool
 	if !ok {
 		return "", false
 	}
-	if insert.Select != nil || insert.Setlist != nil || insert.OnDuplicate != nil || (insert.TableHints != nil && len(insert.TableHints) != 0) {
+	if insert.Select != nil || insert.Setlist || insert.OnDuplicate != nil || (insert.TableHints != nil && len(insert.TableHints) != 0) {
 		return "", false
 	}
 	join := insert.Table.TableRefs


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44464

Problem Summary: https://github.com/mysql/mysql-server/blob/ea7087d885006918ad54458e7aad215b1650312c/sql/sql_insert.h#L241-L250

Mysql treated `INSERT .. SET x=y` and `INSERT .. (x) VALUES (y)` identically. Why do we bother two implementations for them?

### What is changed and how it works?

1. Replace `Setlist []assignment` to `Setlist bool` in ast. And remove them in plan and executor.
2. It is unified into `insert.Columns` and `insert.Lists`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
