### PR TITLE
Revert "ddl: wait schema change before rename table job is done (#43341) (#43458)"

### DIFF
--- a/ddl/foreign_key_test.go
+++ b/ddl/foreign_key_test.go
@@ -579,7 +579,7 @@ func TestRenameTableWithForeignKeyMetaInfo(t *testing.T) {
 	// check the schema diff
 	diff = getLatestSchemaDiff(t, tk)
 	require.Equal(t, model.ActionRenameTable, diff.Type)
-	require.Equal(t, 0, len(diff.AffectedOpts))
+	require.Equal(t, 1, len(diff.AffectedOpts))
 	require.Equal(t, model.ReferredFKInfo{
 		Cols:        []model.CIStr{model.NewCIStr("id")},
 		ChildSchema: model.NewCIStr("test2"),

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -978,9 +978,6 @@ func onRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 		return ver, errors.Trace(err)
 	}
 
-	if job.SchemaState == model.StatePublic {
-		return finishJobRenameTable(d, t, job)
-	}
 	newSchemaID := job.SchemaID
 	err := checkTableNotExists(d, t, newSchemaID, tableName.L)
 	if err != nil {
@@ -1008,7 +1005,7 @@ func onRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
-	job.SchemaState = model.StatePublic
+	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
 	return ver, nil
 }
 
@@ -1022,10 +1019,6 @@ func onRenameTables(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error
 	if err := job.DecodeArgs(&oldSchemaIDs, &newSchemaIDs, &tableNames, &tableIDs, &oldSchemaNames, &oldTableNames); err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
-	}
-
-	if job.SchemaState == model.StatePublic {
-		return finishJobRenameTables(d, t, job, tableNames, tableIDs, newSchemaIDs)
 	}
 
 	var tblInfos = make([]*model.TableInfo, 0, len(tableNames))
@@ -1053,7 +1046,7 @@ func onRenameTables(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
-	job.SchemaState = model.StatePublic
+	job.FinishMultipleTableJob(model.JobStateDone, model.StatePublic, ver, tblInfos)
 	return ver, nil
 }
 
@@ -1148,54 +1141,6 @@ func adjustForeignKeyChildTableInfoAfterRenameTable(d *ddlCtx, t *meta.Meta, job
 		}
 	}
 	return nil
-}
-
-// We split the renaming table job into two steps:
-// 1. rename table and update the schema version.
-// 2. update the job state to JobStateDone.
-// This is the requirement from TiCDC because
-//   - it uses the job state to check whether the DDL is finished.
-//   - there is a gap between schema reloading and job state updating:
-//     when the job state is updated to JobStateDone, before the new schema reloaded,
-//     there may be DMLs that use the old schema.
-//   - TiCDC cannot handle the DMLs that use the old schema, because
-//     the commit TS of the DMLs are greater than the job state updating TS.
-func finishJobRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, error) {
-	tblInfo, err := getTableInfo(t, job.TableID, job.SchemaID)
-	if err != nil {
-		job.State = model.JobStateCancelled
-		return 0, errors.Trace(err)
-	}
-	ver, err := updateSchemaVersion(d, t, job)
-	if err != nil {
-		return ver, errors.Trace(err)
-	}
-	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
-	return ver, nil
-}
-
-func finishJobRenameTables(d *ddlCtx, t *meta.Meta, job *model.Job,
-	tableNames []*model.CIStr, tableIDs, newSchemaIDs []int64) (int64, error) {
-	tblSchemaIDs := make(map[int64]int64, len(tableIDs))
-	for i := range tableIDs {
-		tblSchemaIDs[tableIDs[i]] = newSchemaIDs[i]
-	}
-	tblInfos := make([]*model.TableInfo, 0, len(tableNames))
-	for i := range tableIDs {
-		tblID := tableIDs[i]
-		tblInfo, err := getTableInfo(t, tblID, tblSchemaIDs[tblID])
-		if err != nil {
-			job.State = model.JobStateCancelled
-			return 0, errors.Trace(err)
-		}
-		tblInfos = append(tblInfos, tblInfo)
-	}
-	ver, err := updateSchemaVersion(d, t, job)
-	if err != nil {
-		return ver, errors.Trace(err)
-	}
-	job.FinishMultipleTableJob(model.JobStateDone, model.StatePublic, ver, tblInfos)
-	return ver, nil
 }
 
 func onModifyTableComment(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -452,55 +451,4 @@ func TestAlterTTL(t *testing.T) {
 	historyJob, err = ddl.GetHistoryJobByID(testkit.NewTestKit(t, store).Session(), job.ID)
 	require.NoError(t, err)
 	require.Empty(t, historyJob.BinlogInfo.TableInfo.TTLInfo)
-}
-
-func TestRenameTableIntermediateState(t *testing.T) {
-	store, dom := testkit.CreateMockStoreAndDomain(t)
-	tk := testkit.NewTestKit(t, store)
-	tk2 := testkit.NewTestKit(t, store)
-	originHook := dom.DDL().GetHook()
-	tk.MustExec("create database db1;")
-	tk.MustExec("create database db2;")
-	tk.MustExec("create table db1.t(a int);")
-
-	testCases := []struct {
-		renameSQL string
-		insertSQL string
-		errMsg    string
-		finalDB   string
-	}{
-		{"rename table db1.t to db1.t1;", "insert into db1.t values(1);", "[schema:1146]Table 'db1.t' doesn't exist", "db1.t1"},
-		{"rename table db1.t1 to db1.t;", "insert into db1.t values(1);", "", "db1.t"},
-		{"rename table db1.t to db2.t;", "insert into db1.t values(1);", "[schema:1146]Table 'db1.t' doesn't exist", "db2.t"},
-		{"rename table db2.t to db1.t;", "insert into db1.t values(1);", "", "db1.t"},
-	}
-
-	for _, tc := range testCases {
-		hook := &ddl.TestDDLCallback{Do: dom}
-		runInsert := false
-		fn := func(job *model.Job) {
-			if job.Type == model.ActionRenameTable &&
-				job.SchemaState == model.StatePublic && !runInsert && !t.Failed() {
-				_, err := tk2.Exec(tc.insertSQL)
-				if len(tc.errMsg) > 0 {
-					assert.NotNil(t, err)
-					assert.Equal(t, tc.errMsg, err.Error())
-				} else {
-					assert.NoError(t, err)
-				}
-				runInsert = true
-			}
-		}
-		hook.OnJobUpdatedExported.Store(&fn)
-		dom.DDL().SetHook(hook)
-		tk.MustExec(tc.renameSQL)
-		result := tk.MustQuery(fmt.Sprintf("select * from %s;", tc.finalDB))
-		if len(tc.errMsg) > 0 {
-			result.Check(testkit.Rows())
-		} else {
-			result.Check(testkit.Rows("1"))
-		}
-		tk.MustExec(fmt.Sprintf("delete from %s;", tc.finalDB))
-	}
-	dom.DDL().SetHook(originHook)
 }

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -835,7 +835,7 @@ func (job *Job) IsRollbackable() bool {
 		ActionDropForeignKey, ActionDropTablePartition:
 		return job.SchemaState == StatePublic
 	case ActionRebaseAutoID, ActionShardRowID,
-		ActionTruncateTable, ActionAddForeignKey, ActionRenameTable, ActionRenameTables,
+		ActionTruncateTable, ActionAddForeignKey, ActionRenameTable,
 		ActionModifyTableCharsetAndCollate, ActionTruncateTablePartition,
 		ActionModifySchemaCharsetAndCollate, ActionRepairTable,
 		ActionModifyTableAutoIdCache, ActionModifySchemaDefaultPlacement:


### PR DESCRIPTION
This reverts commit 135a04098f017bad633adec20a94e4229d5057a2.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
