### PR TITLE
planner: support grouping function/col/expression rewriting and physical plan exhaustion for rollup expand OP

### DIFF
--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -890,6 +890,8 @@ const (
 	ErrWindowNoGroupOrderUnused                              = 3597
 	ErrWindowExplainJSON                                     = 3598
 	ErrWindowFunctionIgnoresFrame                            = 3599
+	ErrInvalidNumberOfArgs                                   = 3601
+	ErrFieldInGroupingNotGroupBy                             = 3602
 	ErrIllegalPrivilegeLevel                                 = 3619
 	ErrCTEMaxRecursionDepth                                  = 3636
 	ErrNotHintUpdatable                                      = 3637

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -885,6 +885,8 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrWindowNoGroupOrderUnused:                              mysql.Message("ASC or DESC with GROUP BY isn't allowed with window functions; put ASC or DESC in ORDER BY", nil),
 	ErrWindowExplainJSON:                                     mysql.Message("To get information about window functions use EXPLAIN FORMAT=JSON", nil),
 	ErrWindowFunctionIgnoresFrame:                            mysql.Message("Window function '%s' ignores the frame clause of window '%s' and aggregates over the whole partition", nil),
+	ErrInvalidNumberOfArgs:                                   mysql.Message("Too many arguments for function %s; maximum allowed is %d", nil),
+	ErrFieldInGroupingNotGroupBy:                             mysql.Message("Argument %s of GROUPING function is not in GROUP BY", nil),
 	ErrRoleNotGranted:                                        mysql.Message("%s is not granted to %s", nil),
 	ErrMaxExecTimeExceeded:                                   mysql.Message("Query execution was interrupted, maximum statement execution time exceeded", nil),
 	ErrLockAcquireFailAndNoWaitSet:                           mysql.Message("Statement aborted because lock(s) could not be acquired immediately and NOWAIT is set.", nil),

--- a/errors.toml
+++ b/errors.toml
@@ -2436,6 +2436,16 @@ error = '''
 Window function '%s' ignores the frame clause of window '%s' and aggregates over the whole partition
 '''
 
+["planner:3601"]
+error = '''
+Too many arguments for function %s; maximum allowed is %d
+'''
+
+["planner:3602"]
+error = '''
+Argument %s of GROUPING function is not in GROUP BY
+'''
+
 ["planner:3637"]
 error = '''
 Variable '%s' cannot be set using SET_VAR hint.

--- a/expression/column.go
+++ b/expression/column.go
@@ -83,6 +83,11 @@ func (col *CorrelatedColumn) VecEvalJSON(ctx sessionctx.Context, input *chunk.Ch
 	return genVecFromConstExpr(ctx, col, types.ETJson, input, result)
 }
 
+// Traverse implements the TraverseDown interface.
+func (col *CorrelatedColumn) Traverse(action TraverseAction) Expression {
+	return action.Transform(col)
+}
+
 // Eval implements Expression interface.
 func (col *CorrelatedColumn) Eval(row chunk.Row) (types.Datum, error) {
 	return *col.Data, nil
@@ -396,6 +401,11 @@ func (col *Column) MarshalJSON() ([]byte, error) {
 // GetType implements Expression interface.
 func (col *Column) GetType() *types.FieldType {
 	return col.RetType
+}
+
+// Traverse implements the TraverseDown interface.
+func (col *Column) Traverse(action TraverseAction) Expression {
+	return action.Transform(col)
 }
 
 // Eval implements Expression interface.

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -231,6 +231,11 @@ func (c *Constant) getLazyDatum(row chunk.Row) (dt types.Datum, isLazy bool, err
 	return types.Datum{}, false, nil
 }
 
+// Traverse implements the TraverseDown interface.
+func (c *Constant) Traverse(action TraverseAction) Expression {
+	return action.Transform(c)
+}
+
 // Eval implements Expression interface.
 func (c *Constant) Eval(row chunk.Row) (types.Datum, error) {
 	if dt, lazy, err := c.getLazyDatum(row); lazy {

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -97,6 +97,16 @@ type ReverseExpr interface {
 	ReverseEval(sc *stmtctx.StatementContext, res types.Datum, rType types.RoundingType) (val types.Datum, err error)
 }
 
+// TraverseDown implementing a pre-order traverse for expression tree.
+type TraverseDown interface {
+	Traverse(TraverseAction) Expression
+}
+
+// TraverseAction define the interface for action when traversing down an expression.
+type TraverseAction interface {
+	Transform(Expression) Expression
+}
+
 // Expression represents all scalar expression in SQL.
 type Expression interface {
 	fmt.Stringer
@@ -104,6 +114,7 @@ type Expression interface {
 	VecExpr
 	ReverseExpr
 	CollationInfo
+	TraverseDown
 
 	// Eval evaluates an expression through a row.
 	Eval(row chunk.Row) (types.Datum, error)
@@ -1268,6 +1279,8 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 	case ast.GetFormat:
 		return true
 	case ast.IsIPv4, ast.IsIPv6:
+		return true
+	case ast.Grouping: // grouping function for grouping sets identification.
 		return true
 	}
 	return false

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -97,11 +97,6 @@ type ReverseExpr interface {
 	ReverseEval(sc *stmtctx.StatementContext, res types.Datum, rType types.RoundingType) (val types.Datum, err error)
 }
 
-// TraverseDown implementing a pre-order traverse for expression tree.
-type TraverseDown interface {
-	Traverse(TraverseAction) Expression
-}
-
 // TraverseAction define the interface for action when traversing down an expression.
 type TraverseAction interface {
 	Transform(Expression) Expression
@@ -114,7 +109,8 @@ type Expression interface {
 	VecExpr
 	ReverseExpr
 	CollationInfo
-	TraverseDown
+
+	Traverse(TraverseAction) Expression
 
 	// Eval evaluates an expression through a row.
 	Eval(row chunk.Row) (types.Datum, error)

--- a/expression/grouping_sets.go
+++ b/expression/grouping_sets.go
@@ -610,12 +610,11 @@ func (gss GroupingSets) DistinctSizeWithThreshold(N int) (int, []uint64, map[int
 			// for every original column unique, traverse the all grouping set.
 			for idx, oneOriginSetIDs := range originGroupingIDsSlice {
 				if oneOriginSetIDs.Has(i) {
-					// this column is needed in this grouping set.
-					continue
+					// this column is needed in this grouping set. maintaining the map.
+					collectionMap[gids[idx]] = struct{}{}
 				}
-				// this column is not needed in this grouping set.(this column is grouped)
-				collectionMap[gids[idx]] = struct{}{}
 			}
+			// id2GIDs maintained the needed-column's grouping sets (GIDs)
 			id2GIDs[i] = collectionMap
 		})
 		return len(distinctGroupingIDsPos), gids, id2GIDs

--- a/expression/grouping_sets_test.go
+++ b/expression/grouping_sets_test.go
@@ -414,25 +414,25 @@ func TestDistinctGroupingSets(t *testing.T) {
 	// for every col id, mapping them to a slice of gid.
 	require.Equal(t, len(id2Gids), 3)
 	// 0 -->  when grouping(column#1), the corresponding affected gids should be {0}
-	//            +--- explanation: when grouping(a), a is only grouped when grouping id = 0.
-	require.Equal(t, len(id2Gids[1]), 1)
-	_, ok := id2Gids[1][0]
+	//            +--- explanation: when grouping(a), col-a is needed when grouping id = 1,2,3.
+	require.Equal(t, len(id2Gids[1]), 3)
+	_, ok := id2Gids[1][1]
+	require.Equal(t, ok, true)
+	_, ok = id2Gids[1][2]
+	require.Equal(t, ok, true)
+	_, ok = id2Gids[1][3]
 	require.Equal(t, ok, true)
 	// 1 --> when grouping(column#2), the corresponding affected gids should be {0,1}
-	//            +--- explanation: when grouping(b), b is only grouped when grouping id = 0 or 1.
+	//            +--- explanation: when grouping(b), col-b is needed when grouping id = 2 or 3.
 	require.Equal(t, len(id2Gids[2]), 2)
-	_, ok = id2Gids[2][0]
+	_, ok = id2Gids[2][2]
 	require.Equal(t, ok, true)
-	_, ok = id2Gids[2][1]
+	_, ok = id2Gids[2][3]
 	require.Equal(t, ok, true)
 	// 2 --> when grouping(column#3), the corresponding affected gids should be {0,1,2}
-	//            +--- explanation: when grouping(c), c is only grouped when grouping id = 0 or 1 or 2.
+	//            +--- explanation: when grouping(c), col-c is needed when grouping id = 3.
 	require.Equal(t, len(id2Gids[3]), 3)
-	_, ok = id2Gids[3][0]
-	require.Equal(t, ok, true)
-	_, ok = id2Gids[3][1]
-	require.Equal(t, ok, true)
-	_, ok = id2Gids[3][2]
+	_, ok = id2Gids[3][3]
 	require.Equal(t, ok, true)
 	// column d is not in the grouping set columns, so it won't be here.
 }

--- a/expression/grouping_sets_test.go
+++ b/expression/grouping_sets_test.go
@@ -431,7 +431,7 @@ func TestDistinctGroupingSets(t *testing.T) {
 	require.Equal(t, ok, true)
 	// 2 --> when grouping(column#3), the corresponding affected gids should be {0,1,2}
 	//            +--- explanation: when grouping(c), col-c is needed when grouping id = 3.
-	require.Equal(t, len(id2Gids[3]), 3)
+	require.Equal(t, len(id2Gids[3]), 1)
 	_, ok = id2Gids[3][3]
 	require.Equal(t, ok, true)
 	// column d is not in the grouping set columns, so it won't be here.

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -352,6 +352,11 @@ func (sf *ScalarFunction) Decorrelate(schema *Schema) Expression {
 	return sf
 }
 
+// Traverse implements the TraverseDown interface.
+func (sf *ScalarFunction) Traverse(action TraverseAction) Expression {
+	return action.Transform(sf)
+}
+
 // Eval implements Expression interface.
 func (sf *ScalarFunction) Eval(row chunk.Row) (d types.Datum, err error) {
 	var (

--- a/expression/util_test.go
+++ b/expression/util_test.go
@@ -597,3 +597,6 @@ func (m *MockExpr) SetCharsetAndCollation(chs, coll string) {}
 func (m *MockExpr) MemoryUsage() (sum int64) {
 	return
 }
+func (m *MockExpr) Traverse(action TraverseAction) Expression {
+	return action.Transform(m)
+}

--- a/planner/core/casetest/testdata/enforce_mpp_suite_in.json
+++ b/planner/core/casetest/testdata/enforce_mpp_suite_in.json
@@ -198,5 +198,17 @@
       // The outer one will fail to use MPP. Since the inner one is references the outer one, the whole SQL cannot MPP.
       "explain format = 'brief' with c1 as (select /*+ read_from_storage(tikv[t]) */ * from t), c2 as (select c1.* from c1, c1 c2 where c1.b=c2.c) select * from c2 c1, c2, (with c3 as (select * from c1) select c3.* from c3, c3 c4 where c3.c=c4.b) c3 where c1.a=c2.b and c1.a=c3.a"
     ]
+  },
+  {
+    "name": "TestRollupMPP",
+    "cases": [
+      "explain format = 'brief' select count(1) from t group by a, b with rollup; -- 1. simple agg",
+      "explain format = 'brief' select sum(c), count(1) from t group by a, b with rollup; -- 2. non-grouping set col c",
+      "explain format = 'brief' select count(a) from t group by a, b with rollup; -- 3. should keep the original col a",
+      "explain format = 'brief' select grouping(a) from t group by a, b with rollup; -- 4. contain grouping function ref to grouping set column a",
+      "explain format = 'brief' select grouping(a,b) from t group by a, b with rollup; -- 5. grouping function contains grouping set column a,c",
+      "explain format = 'brief' select a, grouping(b,a) from t group by a,b with rollup; -- 6. resolve normal column a to grouping set column a'",
+      "explain format = 'brief' select a+1, grouping(b) from t group by a+1, b with rollup; -- 7. resolve field list a+1 to grouping set column a+1"
+    ]
   }
 ]

--- a/planner/core/casetest/testdata/enforce_mpp_suite_out.json
+++ b/planner/core/casetest/testdata/enforce_mpp_suite_out.json
@@ -1924,5 +1924,121 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestRollupMPP",
+    "Cases": [
+      {
+        "SQL": "explain format = 'brief' select count(1) from t group by a, b with rollup; -- 1. simple agg",
+        "Plan": [
+          "TableReader 8000.00 root  MppVersion: 1, data:ExchangeSender",
+          "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 8000.00 mpp[tiflash]  Column#8",
+          "    └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, funcs:count(1)->Column#8",
+          "      └─ExchangeReceiver 10000.00 mpp[tiflash]  ",
+          "        └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
+          "          └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column: [Column#5,Column#6,gid] Unique key: []]",
+          "            └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "explain format = 'brief' select sum(c), count(1) from t group by a, b with rollup; -- 2. non-grouping set col c",
+        "Plan": [
+          "TableReader 8000.00 root  MppVersion: 1, data:ExchangeSender",
+          "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 8000.00 mpp[tiflash]  Column#8, Column#9",
+          "    └─HashAgg 8000.00 mpp[tiflash]  group by:Column#17, Column#18, Column#19, funcs:sum(Column#16)->Column#8, funcs:count(1)->Column#9",
+          "      └─Projection 10000.00 mpp[tiflash]  cast(test.t.c, decimal(10,0) BINARY)->Column#16, Column#5, Column#6, gid",
+          "        └─ExchangeReceiver 10000.00 mpp[tiflash]  ",
+          "          └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
+          "            └─Expand 10000.00 mpp[tiflash]  level-projection:[test.t.c, <nil>->Column#5, <nil>->Column#6, 0->gid],[test.t.c, Column#5, <nil>->Column#6, 1->gid],[test.t.c, Column#5, Column#6, 3->gid]; schema: [Column: [test.t.c,Column#5,Column#6,gid] Unique key: []]",
+          "              └─Projection 10000.00 mpp[tiflash]  test.t.c, test.t.a, test.t.b",
+          "                └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "explain format = 'brief' select count(a) from t group by a, b with rollup; -- 3. should keep the original col a",
+        "Plan": [
+          "TableReader 8000.00 root  MppVersion: 1, data:ExchangeSender",
+          "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 8000.00 mpp[tiflash]  Column#8",
+          "    └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, funcs:sum(Column#11)->Column#8",
+          "      └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
+          "        └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
+          "          └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, funcs:count(test.t.a)->Column#11",
+          "            └─Expand 10000.00 mpp[tiflash]  level-projection:[test.t.a, <nil>->Column#5, <nil>->Column#6, 0->gid],[test.t.a, Column#5, <nil>->Column#6, 1->gid],[test.t.a, Column#5, Column#6, 3->gid]; schema: [Column: [test.t.a,Column#5,Column#6,gid] Unique key: []]",
+          "              └─Projection 10000.00 mpp[tiflash]  test.t.a, test.t.a, test.t.b",
+          "                └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "explain format = 'brief' select grouping(a) from t group by a, b with rollup; -- 4. contain grouping function ref to grouping set column a",
+        "Plan": [
+          "TableReader 8000.00 root  MppVersion: 1, data:ExchangeSender",
+          "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 8000.00 mpp[tiflash]  grouping(gid)->Column#8",
+          "    └─Projection 8000.00 mpp[tiflash]  gid",
+          "      └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, funcs:firstrow(gid)->gid",
+          "        └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
+          "          └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
+          "            └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, ",
+          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column: [Column#5,Column#6,gid] Unique key: []]",
+          "                └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "explain format = 'brief' select grouping(a,b) from t group by a, b with rollup; -- 5. grouping function contains grouping set column a,c",
+        "Plan": [
+          "TableReader 8000.00 root  MppVersion: 1, data:ExchangeSender",
+          "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 8000.00 mpp[tiflash]  grouping(gid)->Column#8",
+          "    └─Projection 8000.00 mpp[tiflash]  gid",
+          "      └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, funcs:firstrow(gid)->gid",
+          "        └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
+          "          └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
+          "            └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, ",
+          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column: [Column#5,Column#6,gid] Unique key: []]",
+          "                └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "explain format = 'brief' select a, grouping(b,a) from t group by a,b with rollup; -- 6. resolve normal column a to grouping set column a'",
+        "Plan": [
+          "TableReader 8000.00 root  MppVersion: 1, data:ExchangeSender",
+          "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 8000.00 mpp[tiflash]  Column#5, grouping(gid)->Column#8",
+          "    └─Projection 8000.00 mpp[tiflash]  Column#5, gid",
+          "      └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, funcs:firstrow(Column#5)->Column#5, funcs:firstrow(gid)->gid",
+          "        └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
+          "          └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
+          "            └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, ",
+          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column: [Column#5,Column#6,gid] Unique key: []]",
+          "                └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "explain format = 'brief' select a+1, grouping(b) from t group by a+1, b with rollup; -- 7. resolve field list a+1 to grouping set column a+1",
+        "Plan": [
+          "TableReader 8000.00 root  MppVersion: 1, data:ExchangeSender",
+          "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 8000.00 mpp[tiflash]  Column#5, grouping(gid)->Column#8",
+          "    └─Projection 8000.00 mpp[tiflash]  Column#5, gid",
+          "      └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, funcs:firstrow(Column#5)->Column#5, funcs:firstrow(gid)->gid",
+          "        └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
+          "          └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
+          "            └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, ",
+          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column: [Column#5,Column#6,gid] Unique key: []]",
+          "                └─Projection 10000.00 mpp[tiflash]  plus(test.t.a, 1)->Column#5, test.t.b",
+          "                  └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      }
+    ]
   }
 ]

--- a/planner/core/casetest/testdata/enforce_mpp_suite_out.json
+++ b/planner/core/casetest/testdata/enforce_mpp_suite_out.json
@@ -1937,7 +1937,7 @@
           "    └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, funcs:count(1)->Column#8",
           "      └─ExchangeReceiver 10000.00 mpp[tiflash]  ",
           "        └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
-          "          └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column: [Column#5,Column#6,gid] Unique key: []]",
+          "          └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column#5,Column#6,gid]",
           "            └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -1952,7 +1952,7 @@
           "      └─Projection 10000.00 mpp[tiflash]  cast(test.t.c, decimal(10,0) BINARY)->Column#16, Column#5, Column#6, gid",
           "        └─ExchangeReceiver 10000.00 mpp[tiflash]  ",
           "          └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
-          "            └─Expand 10000.00 mpp[tiflash]  level-projection:[test.t.c, <nil>->Column#5, <nil>->Column#6, 0->gid],[test.t.c, Column#5, <nil>->Column#6, 1->gid],[test.t.c, Column#5, Column#6, 3->gid]; schema: [Column: [test.t.c,Column#5,Column#6,gid] Unique key: []]",
+          "            └─Expand 10000.00 mpp[tiflash]  level-projection:[test.t.c, <nil>->Column#5, <nil>->Column#6, 0->gid],[test.t.c, Column#5, <nil>->Column#6, 1->gid],[test.t.c, Column#5, Column#6, 3->gid]; schema: [test.t.c,Column#5,Column#6,gid]",
           "              └─Projection 10000.00 mpp[tiflash]  test.t.c, test.t.a, test.t.b",
           "                └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
@@ -1968,7 +1968,7 @@
           "      └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
           "        └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
           "          └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, funcs:count(test.t.a)->Column#11",
-          "            └─Expand 10000.00 mpp[tiflash]  level-projection:[test.t.a, <nil>->Column#5, <nil>->Column#6, 0->gid],[test.t.a, Column#5, <nil>->Column#6, 1->gid],[test.t.a, Column#5, Column#6, 3->gid]; schema: [Column: [test.t.a,Column#5,Column#6,gid] Unique key: []]",
+          "            └─Expand 10000.00 mpp[tiflash]  level-projection:[test.t.a, <nil>->Column#5, <nil>->Column#6, 0->gid],[test.t.a, Column#5, <nil>->Column#6, 1->gid],[test.t.a, Column#5, Column#6, 3->gid]; schema: [test.t.a,Column#5,Column#6,gid]",
           "              └─Projection 10000.00 mpp[tiflash]  test.t.a, test.t.a, test.t.b",
           "                └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
@@ -1985,7 +1985,7 @@
           "        └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
           "          └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
           "            └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, ",
-          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column: [Column#5,Column#6,gid] Unique key: []]",
+          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column#5,Column#6,gid]",
           "                └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -2001,7 +2001,7 @@
           "        └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
           "          └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
           "            └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, ",
-          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column: [Column#5,Column#6,gid] Unique key: []]",
+          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column#5,Column#6,gid]",
           "                └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -2017,7 +2017,7 @@
           "        └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
           "          └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
           "            └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, ",
-          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column: [Column#5,Column#6,gid] Unique key: []]",
+          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column#5,Column#6,gid]",
           "                └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -2033,7 +2033,7 @@
           "        └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
           "          └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#5, collate: binary], [name: Column#6, collate: binary], [name: gid, collate: binary]",
           "            └─HashAgg 8000.00 mpp[tiflash]  group by:Column#5, Column#6, gid, ",
-          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column: [Column#5,Column#6,gid] Unique key: []]",
+          "              └─Expand 10000.00 mpp[tiflash]  level-projection:[<nil>->Column#5, <nil>->Column#6, 0->gid],[Column#5, <nil>->Column#6, 1->gid],[Column#5, Column#6, 3->gid]; schema: [Column#5,Column#6,gid]",
           "                └─Projection 10000.00 mpp[tiflash]  plus(test.t.a, 1)->Column#5, test.t.b",
           "                  └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],

--- a/planner/core/errors.go
+++ b/planner/core/errors.go
@@ -71,6 +71,8 @@ var (
 	ErrWindowRangeBoundNotConstant           = dbterror.ClassOptimizer.NewStd(mysql.ErrWindowRangeBoundNotConstant)
 	ErrWindowRowsIntervalUse                 = dbterror.ClassOptimizer.NewStd(mysql.ErrWindowRowsIntervalUse)
 	ErrWindowFunctionIgnoresFrame            = dbterror.ClassOptimizer.NewStd(mysql.ErrWindowFunctionIgnoresFrame)
+	ErrInvalidNumberOfArgs                   = dbterror.ClassOptimizer.NewStd(mysql.ErrInvalidNumberOfArgs)
+	ErrFieldInGroupingNotGroupBy             = dbterror.ClassOptimizer.NewStd(mysql.ErrFieldInGroupingNotGroupBy)
 	ErrUnsupportedOnGeneratedColumn          = dbterror.ClassOptimizer.NewStd(mysql.ErrUnsupportedOnGeneratedColumn)
 	ErrPrivilegeCheckFail                    = dbterror.ClassOptimizer.NewStd(mysql.ErrPrivilegeCheckFail)
 	ErrInvalidWildCard                       = dbterror.ClassOptimizer.NewStd(mysql.ErrInvalidWildCard)

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -2498,11 +2498,9 @@ func (p *LogicalExpand) exhaustPhysicalPlans(prop *property.PhysicalProperty) ([
 		return nil, true, nil
 	}
 	// for property.RootTaskType and property.MppTaskType with no partition option, we can give an MPP Expand.
-	newProps := make([]*property.PhysicalProperty, 0, 1)
 	if p.SCtx().GetSessionVars().IsMPPAllowed() || p.SCtx().GetSessionVars().IsMPPEnforced() {
 		mppProp := prop.CloneEssentialFields()
 		mppProp.TaskTp = property.MppTaskType
-		newProps = append(newProps, mppProp)
 		expand := PhysicalExpand{
 			GroupingSets:      p.rollupGroupingSets,
 			LevelExprs:        p.LevelExprs,

--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -376,7 +376,7 @@ func (p *PhysicalProjection) ExplainInfo() string {
 	return exprStr
 }
 
-func (p *PhysicalExpand) ExplainInfoV2() string {
+func (p *PhysicalExpand) explainInfoV2() string {
 	sb := strings.Builder{}
 	for i, oneL := range p.LevelExprs {
 		if i == 0 {
@@ -434,7 +434,7 @@ func (p *PhysicalLimit) ExplainInfo() string {
 // ExplainInfo implements Plan interface.
 func (p *PhysicalExpand) ExplainInfo() string {
 	if len(p.LevelExprs) > 0 {
-		return p.ExplainInfoV2()
+		return p.explainInfoV2()
 	}
 	var str strings.Builder
 	str.WriteString("group set num:")

--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -376,6 +376,26 @@ func (p *PhysicalProjection) ExplainInfo() string {
 	return exprStr
 }
 
+func (p *PhysicalExpand) ExplainInfoV2() string {
+	sb := strings.Builder{}
+	for i, oneL := range p.LevelExprs {
+		if i == 0 {
+			sb.WriteString("level-projection:")
+			sb.WriteString("[")
+			sb.WriteString(expression.ExplainExpressionList(oneL, p.schema))
+			sb.WriteString("]")
+		} else {
+			sb.WriteString(",[")
+			sb.WriteString(expression.ExplainExpressionList(oneL, p.schema))
+			sb.WriteString("]")
+		}
+	}
+	sb.WriteString("; schema: [")
+	sb.WriteString(p.schema.String())
+	sb.WriteString("]")
+	return sb.String()
+}
+
 // ExplainNormalizedInfo implements Plan interface.
 func (p *PhysicalProjection) ExplainNormalizedInfo() string {
 	return string(expression.SortedExplainNormalizedExpressionList(p.Exprs))
@@ -413,6 +433,9 @@ func (p *PhysicalLimit) ExplainInfo() string {
 
 // ExplainInfo implements Plan interface.
 func (p *PhysicalExpand) ExplainInfo() string {
+	if len(p.LevelExprs) > 0 {
+		return p.ExplainInfoV2()
+	}
 	var str strings.Builder
 	str.WriteString("group set num:")
 	str.WriteString(strconv.FormatInt(int64(len(p.GroupingSets)), 10))

--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -391,7 +391,11 @@ func (p *PhysicalExpand) explainInfoV2() string {
 		}
 	}
 	sb.WriteString("; schema: [")
-	sb.WriteString(p.schema.String())
+	colStrs := make([]string, 0, len(p.schema.Columns))
+	for _, col := range p.schema.Columns {
+		colStrs = append(colStrs, col.String())
+	}
+	sb.WriteString(strings.Join(colStrs, ","))
 	sb.WriteString("]")
 	return sb.String()
 }

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -156,7 +156,7 @@ func (b *PlanBuilder) getExpressionRewriter(ctx context.Context, p LogicalPlan) 
 	}()
 
 	if len(b.rewriterPool) < b.rewriterCounter {
-		rewriter = &expressionRewriter{p: p, b: b, sctx: b.ctx, ctx: ctx}
+		rewriter = &expressionRewriter{p: p, b: b, sctx: b.ctx, ctx: ctx, rollExpand: b.currentBlockExpand}
 		rewriter.sctx.SetValue(expression.TiDBDecodeKeyFunctionKey, decodeKeyFromString)
 		b.rewriterPool = append(b.rewriterPool, rewriter)
 		return
@@ -174,6 +174,7 @@ func (b *PlanBuilder) getExpressionRewriter(ctx context.Context, p LogicalPlan) 
 	rewriter.ctxNameStk = rewriter.ctxNameStk[:0]
 	rewriter.ctx = ctx
 	rewriter.err = nil
+	rewriter.rollExpand = b.currentBlockExpand
 	return
 }
 
@@ -244,6 +245,8 @@ type expressionRewriter struct {
 	// NOTE: This value can be changed during expression rewritten.
 	disableFoldCounter int
 	tryFoldCounter     int
+
+	rollExpand *LogicalExpand
 }
 
 func (er *expressionRewriter) ctxStackLen() int {
@@ -324,9 +327,12 @@ func (er *expressionRewriter) buildSubquery(ctx context.Context, subq *ast.Subqu
 		outerSchema := er.schema.Clone()
 		er.b.outerSchemas = append(er.b.outerSchemas, outerSchema)
 		er.b.outerNames = append(er.b.outerNames, er.names)
+		er.b.outerBlockExpand = append(er.b.outerBlockExpand, er.b.currentBlockExpand)
 		defer func() {
 			er.b.outerSchemas = er.b.outerSchemas[0 : len(er.b.outerSchemas)-1]
 			er.b.outerNames = er.b.outerNames[0 : len(er.b.outerNames)-1]
+			er.b.currentBlockExpand = er.b.outerBlockExpand[len(er.b.outerBlockExpand)-1]
+			er.b.outerBlockExpand = er.b.outerBlockExpand[0 : len(er.b.outerBlockExpand)-1]
 		}()
 	}
 	// Store the old value before we enter the subquery and reset they to default value.
@@ -1999,6 +2005,50 @@ func (er *expressionRewriter) funcCallToExpression(v *ast.FuncCallExpr) {
 			function, er.err = expression.NewFunctionBase(er.sctx, v.FnName.L, &v.Type, args...)
 			c := &expression.Constant{Value: types.NewDatum(nil), RetType: function.GetType().Clone(), DeferredExpr: function}
 			er.ctxStackAppend(c, types.EmptyName)
+		}
+	} else if v.FnName.L == ast.Grouping {
+		// grouping function should fetch the underlying grouping-sets meta and rewrite the args here.
+		// eg: grouping(a) actually is try to find in which grouping-set that the column 'a' is remained,
+		// collecting those gid as a collection and filling it into the grouping function meta. Besides,
+		// the first arg of grouping function should be rewritten as gid column defined/passed by Expand
+		// from the bottom up.
+		if er.rollExpand == nil {
+			er.err = errors.New("no rollup expand found")
+			er.ctxStackAppend(nil, types.EmptyName)
+		} else {
+			// whether there is some duplicate grouping sets, gpos is only be used in shuffle keys and group keys
+			// rather than grouping function.
+			// eg: rollup(a,a,b), the decided grouping sets are {a,a,b},{a,a,null},{a,null,null},{null,null,null}
+			// for the second and third grouping set: {a,a,null} and {a,null,null}, a here is the col ref of original
+			// column `a`. So from the static layer, this two grouping set are equivalent, we don't need to copy col
+			// `a double times at the every beginning and resort to gpos to distinguish them.
+			//  {col-a, col-b, gid, gpos}
+			//  {a, b, 0, 1}, {a, null, 1, 2}, {a, null, 1, 3}, {null, null, 2, 4}
+			// grouping function still only need to care about gid is enough, gpos what group and shuffle keys cared.
+			newArg := er.rollExpand.GID.Clone()
+			function, er.err = er.newFunction(v.FnName.L, &v.Type, newArg)
+			if er.err == nil {
+				if scalarFunc, ok := function.(*expression.ScalarFunction); ok {
+					if scalarFunc.FuncName.L == ast.Grouping {
+						if len(args) > 64 {
+							er.err = ErrInvalidNumberOfArgs.GenWithStackByArgs("GROUPING", 64)
+							er.ctxStackAppend(nil, types.EmptyName)
+						} else {
+							// resolve grouping args in group by items or not.
+							resolvedCols, err := er.rollExpand.resolveGroupingFuncArgsInGroupBy(args)
+							if err != nil {
+								er.err = err
+								er.ctxStackAppend(nil, types.EmptyName)
+							} else {
+								// rewrite the meta.
+								er.err = scalarFunc.Function.(*expression.BuiltinGroupingImplSig).
+									SetMetadata(er.rollExpand.GroupingMode, er.rollExpand.GenerateGroupingMarks(resolvedCols))
+							}
+						}
+					}
+				}
+			}
+			er.ctxStackAppend(function, types.EmptyName)
 		}
 	} else {
 		function, er.err = er.newFunction(v.FnName.L, &v.Type, args...)

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -279,7 +279,7 @@ func (b *PlanBuilder) buildExpand(p LogicalPlan, gbyItems []expression.Expressio
 	}
 	expand.GID = gid
 	expandSchema.Append(gid)
-	expand.GeneratedColNames = append(expand.GeneratedColNames, gid.OrigName)
+	expand.ExtraGroupingColNames = append(expand.ExtraGroupingColNames, gid.OrigName)
 	names = append(names, buildExpandFieldName(gid, nil, "gid_"))
 	if hasDuplicateGroupingSet {
 		// the last two col of the schema should be gid & gpos
@@ -290,7 +290,7 @@ func (b *PlanBuilder) buildExpand(p LogicalPlan, gbyItems []expression.Expressio
 		}
 		expand.GPos = gpos
 		expandSchema.Append(gpos)
-		expand.GeneratedColNames = append(expand.GeneratedColNames, gpos.OrigName)
+		expand.ExtraGroupingColNames = append(expand.ExtraGroupingColNames, gpos.OrigName)
 		names = append(names, buildExpandFieldName(gpos, nil, "gpos_"))
 	}
 	expand.SetChildren(proj)

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -254,6 +254,10 @@ func (b *PlanBuilder) buildExpand(p LogicalPlan, gbyItems []expression.Expressio
 	expand := LogicalExpand{
 		rollupGroupingSets: rollupGroupingSets,
 		distinctGroupByCol: distinctGbyCols,
+		// for resolving grouping function args.
+		distinctGbyExprs: distinctGbyExprs,
+		gbyExprsRefPos:   gbyExprsRefPos,
+
 		// fill the gen col names when building level projections.
 	}.Init(b.ctx, b.getSelectOffset())
 
@@ -1543,6 +1547,54 @@ func findColFromNaturalUsingJoin(p LogicalPlan, col *expression.Column) (name *t
 	return nil
 }
 
+type resolveGroupingTraverseAction struct {
+	CurrentBlockExpand *LogicalExpand
+}
+
+func (r resolveGroupingTraverseAction) Transform(expr expression.Expression) (res expression.Expression) {
+	switch x := expr.(type) {
+	case *expression.Column:
+		// when meeting a column, judge whether it's a relate grouping set col.
+		// eg: select a, b from t group by a, c with rollup, here a is, while b is not.
+		// in underlying Expand schema (a,b,c,a',c'), a select list should be resolved to a'.
+		res, _ = r.CurrentBlockExpand.trySubstituteExprWithGroupingSetCol(x)
+	case *expression.CorrelatedColumn:
+		// select 1 in (select t2.a from t group by t2.a, b with rollup) from t2;
+		// in this case: group by item has correlated column t2.a, and it's select list contains t2.a as well.
+		res, _ = r.CurrentBlockExpand.trySubstituteExprWithGroupingSetCol(x)
+	case *expression.Constant:
+		// constant just keep it real: select 1 from t group by a, b with rollup.
+		res = x
+	case *expression.ScalarFunction:
+		// scalar function just try to resolve itself first, then if not changed, trying resolve its children.
+		var substituted bool
+		res, substituted = r.CurrentBlockExpand.trySubstituteExprWithGroupingSetCol(x)
+		if !substituted {
+			// if not changed, try to resolve it children.
+			// select a+1, grouping(b) from t group by a+1 (projected as c), b with rollup: in this case, a+1 is resolved as c as a whole.
+			// select a+1, grouping(b) from t group by a(projected as a'), b with rollup  : in this case, a+1 is resolved as a'+ 1.
+			newArgs := x.GetArgs()
+			for i, arg := range newArgs {
+				newArgs[i] = r.Transform(arg)
+			}
+			res = x
+		}
+	default:
+		res = expr
+	}
+	return res
+}
+
+func (b *PlanBuilder) replaceGroupingFunc(expr expression.Expression) expression.Expression {
+	// current block doesn't have an expand OP, just return it.
+	if b.currentBlockExpand == nil {
+		return expr
+	}
+	// curExpand can supply the distinctGbyExprs and gid col.
+	traverseAction := resolveGroupingTraverseAction{CurrentBlockExpand: b.currentBlockExpand}
+	return expr.Traverse(traverseAction)
+}
+
 // buildProjection returns a Projection plan and non-aux columns length.
 func (b *PlanBuilder) buildProjection(ctx context.Context, p LogicalPlan, fields []*ast.SelectField, mapper map[*ast.AggregateFuncExpr]int,
 	windowMapper map[*ast.WindowFuncExpr]int, considerWindow bool, expandGenerateColumn bool) (LogicalPlan, []expression.Expression, int, error) {
@@ -1588,6 +1640,11 @@ func (b *PlanBuilder) buildProjection(ctx context.Context, p LogicalPlan, fields
 		if err != nil {
 			return nil, nil, 0, err
 		}
+
+		// for case: select a+1, b, sum(b), grouping(a) from t group by a, b with rollup.
+		// the column inside aggregate (only sum(b) here) should be resolved to original source column,
+		// while for others, just use expanded columns if exists: a'+ 1, b', group(gid)
+		newExpr = b.replaceGroupingFunc(newExpr)
 
 		// For window functions in the order by clause, we will append an field for it.
 		// We need rewrite the window mapper here so order by clause could find the added field.
@@ -3514,6 +3571,9 @@ func (*PlanBuilder) checkOnlyFullGroupByWithGroupClause(p LogicalPlan, sel *ast.
 		}
 		switch errExprLoc.Loc {
 		case ErrExprInSelect:
+			if sel.GroupBy.Rollup {
+				return ErrFieldInGroupingNotGroupBy.GenWithStackByArgs(strconv.Itoa(errExprLoc.Offset + 1))
+			}
 			return ErrFieldNotInGroupBy.GenWithStackByArgs(errExprLoc.Offset+1, errExprLoc.Loc, name.DBName.O+"."+name.TblName.O+"."+name.OrigColName.O)
 		case ErrExprInOrderBy:
 			return ErrFieldNotInGroupBy.GenWithStackByArgs(errExprLoc.Offset+1, errExprLoc.Loc, sel.OrderBy.Items[errExprLoc.Offset].Expr.Text())

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -576,7 +576,7 @@ type LogicalExpand struct {
 	LevelExprs [][]expression.Expression
 
 	// The generated column names. Eg: "grouping_id" and so on.
-	GeneratedColNames []string
+	ExtraGroupingColNames []string
 
 	// GroupingMode records the grouping id allocation mode.
 	GroupingMode tipb.GroupingMode
@@ -669,7 +669,7 @@ func (p *LogicalExpand) GenLevelProjections() {
 
 // GenerateGroupingMarks generate the groupingMark for the source column specified in grouping function.
 func (p *LogicalExpand) GenerateGroupingMarks(sourceCols []*expression.Column) []map[uint64]struct{} {
-	// since grouping function may have multi args like grouping(a,b), so the source columns may greater than 1.
+	// Since grouping function may have multi args like grouping(a,b), so the source columns may greater than 1.
 	// reference: https://dev.mysql.com/blog-archive/mysql-8-0-grouping-function/
 	// Let's say GROUPING(b,a) group by a,b with rollup. (Note the b,a sequence is reversed from gby item)
 	// if GROUPING (b,a) returns 3, it means that NULL in column “b” and NULL in column “a” for that row is

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -15,6 +15,8 @@
 package core
 
 import (
+	"bytes"
+	"fmt"
 	"math"
 	"unsafe"
 
@@ -559,6 +561,10 @@ type LogicalExpand struct {
 
 	// distinct group by columns. (maybe projected below if it's a non-col)
 	distinctGroupByCol []*expression.Column
+	// keep the old gbyExprs for resolve cases like grouping(a+b), the args:
+	// a+b should be resolved to new projected gby col according to ref pos.
+	distinctGbyExprs []expression.Expression
+	gbyExprsRefPos   []int
 
 	// rollup grouping sets.
 	distinctSize       int
@@ -662,23 +668,102 @@ func (p *LogicalExpand) GenLevelProjections() {
 }
 
 // GenerateGroupingMarks generate the groupingMark for the source column specified in grouping function.
-func (p *LogicalExpand) GenerateGroupingMarks(sourceCol *expression.Column) (resMap map[uint64]struct{}) {
+func (p *LogicalExpand) GenerateGroupingMarks(sourceCols []*expression.Column) []map[uint64]struct{} {
+	// since grouping function may have multi args like grouping(a,b), so the source columns may greater than 1.
+	// reference: https://dev.mysql.com/blog-archive/mysql-8-0-grouping-function/
+	// Let's say GROUPING(b,a) group by a,b with rollup. (Note the b,a sequence is reversed from gby item)
+	// if GROUPING (b,a) returns 3, it means that NULL in column “b” and NULL in column “a” for that row is
+	// produce by a ROLLUP operation. If result is 2, NULL in column “a” alone is a result of ROLLUP operation.
+	//
+	// Formula: GROUPING(x,y,z) = GROUPING(x) << 2 + GROUPING(y) << 1 + GROUPING(z)
+	//
+	// so for the multi args GROUPING FUNCTION, we should return all the simple col grouping marks. When evaluating,
+	// after all grouping marks are & with gid in sequence, the final res is derived as the formula said. This also
+	// means that the grouping function accepts a maximum of 64 parameters.
+	resSliceMap := make([]map[uint64]struct{}, 0, len(sourceCols))
 	if p.GroupingMode == tipb.GroupingMode_ModeBitAnd {
-		resMap = make(map[uint64]struct{}, 1)
-		res := uint64(0)
-		// from high pos to low pos.
-		for i := len(p.distinctGroupByCol) - 1; i >= 0; i-- {
-			if p.distinctGroupByCol[i].UniqueID == sourceCol.UniqueID {
-				// col is needed, fill the corresponding pos as 1.
-				res = res | 1
+		for _, oneCol := range sourceCols {
+			resMap := make(map[uint64]struct{}, 1)
+			res := uint64(0)
+			// from high pos to low pos.
+			for i := len(p.distinctGroupByCol) - 1; i >= 0; i-- {
+				// left shift.
+				res = res << 1
+				if p.distinctGroupByCol[i].UniqueID == oneCol.UniqueID {
+					// fill the corresponding col pos as 1 as bitMark.
+					// eg: say distinctGBY [x,y,z] and GROUPING(x) with '100'.
+					// When any groupingID & 100 > 0 means the source column x
+					// is needed in this grouping set and is not grouped, so res = 0.
+					res = res | 1
+				}
 			}
-			// left shift.
-			res = res << 1
+			resMap[res] = struct{}{}
+			resSliceMap = append(resSliceMap, resMap)
 		}
-		return resMap
+		return resSliceMap
 	}
-	// for tipb.GroupingMode_ModeNumericSet.
-	return p.rollupID2GIDS[int(sourceCol.UniqueID)]
+	// For GroupingMode_ModeNumericSet mode, for every simple col, its grouping marks is an id slice rather than a bit map.
+	// For example, GROUPING(x,y,z) returns 6 it means: GROUPING(x) is 1, GROUPING(y) is 1 and GROUPING(z) is 0, in which
+	// we should also return all these three single column grouping marks as function meta to GROUPING FUNCTION.
+	for _, oneCol := range sourceCols {
+		resSliceMap = append(resSliceMap, p.rollupID2GIDS[int(oneCol.UniqueID)])
+	}
+	return resSliceMap
+}
+
+func (p *LogicalExpand) trySubstituteExprWithGroupingSetCol(expr expression.Expression) (expression.Expression, bool) {
+	sc := p.SCtx().GetSessionVars().StmtCtx
+	sc.CanonicalHashCode = true
+	defer func() {
+		sc.CanonicalHashCode = false
+	}()
+
+	// since all the original group items has been projected even single col,
+	// let's check the origin gby expression here, and map it to new gby col.
+	for i, oneExpr := range p.distinctGbyExprs {
+		if bytes.Equal(expr.HashCode(sc), oneExpr.HashCode(sc)) {
+			// found
+			for originIdx, ref := range p.gbyExprsRefPos {
+				if ref == i {
+					return p.distinctGroupByCol[originIdx], true
+				}
+			}
+		}
+	}
+	// not found.
+	return expr, false
+}
+
+// CheckGroupingFuncArgsInGroupBy checks whether grouping function args is in grouping items.
+func (p *LogicalExpand) resolveGroupingFuncArgsInGroupBy(groupingFuncArgs []expression.Expression) ([]*expression.Column, error) {
+	sc := p.SCtx().GetSessionVars().StmtCtx
+	sc.CanonicalHashCode = true
+	defer func() {
+		sc.CanonicalHashCode = false
+	}()
+	var refPos int
+	rewrittenArgCols := make([]*expression.Column, 0, len(groupingFuncArgs))
+	for argIdx, oneArg := range groupingFuncArgs {
+		refPos = -1
+		// since all the original group items has been projected even single col,
+		// let's check the origin gby expression here, and map it to new gby col.
+		for i, oneExpr := range p.distinctGbyExprs {
+			if bytes.Equal(oneArg.HashCode(sc), oneExpr.HashCode(sc)) {
+				refPos = i
+				break
+			}
+		}
+		if refPos == -1 {
+			return nil, ErrFieldInGroupingNotGroupBy.GenWithStackByArgs(fmt.Sprintf("#%d", argIdx))
+		}
+		for originIdx, ref := range p.gbyExprsRefPos {
+			if ref == refPos {
+				rewrittenArgCols = append(rewrittenArgCols, p.distinctGroupByCol[originIdx])
+				break
+			}
+		}
+	}
+	return rewrittenArgCols, nil
 }
 
 // GenerateGroupingIDModeBitAnd is used to generate convenient groupingID for quick computation of grouping function.
@@ -695,12 +780,12 @@ func (p *LogicalExpand) GenerateGroupingIDModeBitAnd(oneSet expression.GroupingS
 	res := uint64(0)
 	// from high pos to low pos.
 	for i := len(p.distinctGroupByCol) - 1; i >= 0; i-- {
+		// left shift.
+		res = res << 1
 		if idsNeeded.Has(int(p.distinctGroupByCol[i].UniqueID)) {
 			// col is needed, fill the corresponding pos as 1.
 			res = res | 1
 		}
-		// left shift.
-		res = res << 1
 	}
 	// how to use it, eg: when encountering a grouping function like: grouping(a), we can know the column a's pos index in distinctGbyCols
 	// is about 0, then we can get the mask as 001 which will be returned back as this grouping function's meta when rewriting it, then we

--- a/planner/core/logical_plans_test.go
+++ b/planner/core/logical_plans_test.go
@@ -2195,7 +2195,7 @@ func TestRollupExpand(t *testing.T) {
 	require.Equal(t, builder.currentBlockExpand.rollupID2GIDS == nil, true)
 	require.Equal(t, builder.currentBlockExpand.rollupGroupingIDs == nil, true)
 	require.Equal(t, builder.currentBlockExpand.GroupingMode == tipb.GroupingMode_ModeBitAnd, true)
-	require.Equal(t, builder.currentBlockExpand.GeneratedColNames[0], "gid")
+	require.Equal(t, builder.currentBlockExpand.ExtraGroupingColNames[0], "gid")
 	require.Equal(t, builder.currentBlockExpand.distinctSize, 3)
 	require.Equal(t, len(builder.currentBlockExpand.distinctGroupByCol), 2)
 

--- a/planner/core/logical_plans_test.go
+++ b/planner/core/logical_plans_test.go
@@ -2207,8 +2207,8 @@ func TestRollupExpand(t *testing.T) {
 	require.Equal(t, builder.currentBlockExpand.LevelExprs != nil, true)
 	require.Equal(t, len(builder.currentBlockExpand.LevelExprs), 3)
 	require.Equal(t, expression.ExplainExpressionList(expand.LevelExprs[0], expand.schema), "test.t.a, <nil>->Column#13, <nil>->Column#14, 0->gid")
-	require.Equal(t, expression.ExplainExpressionList(expand.LevelExprs[1], expand.schema), "test.t.a, Column#13, <nil>->Column#14, 2->gid")
-	require.Equal(t, expression.ExplainExpressionList(expand.LevelExprs[2], expand.schema), "test.t.a, Column#13, Column#14, 6->gid")
+	require.Equal(t, expression.ExplainExpressionList(expand.LevelExprs[1], expand.schema), "test.t.a, Column#13, <nil>->Column#14, 1->gid")
+	require.Equal(t, expression.ExplainExpressionList(expand.LevelExprs[2], expand.schema), "test.t.a, Column#13, Column#14, 3->gid")
 
 	require.Equal(t, expand.Schema().Len(), 4)
 	// source column a should be kept as real.

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1584,7 +1584,7 @@ type PhysicalExpand struct {
 	LevelExprs [][]expression.Expression
 
 	// The generated column names. Eg: "grouping_id" and so on.
-	GeneratedColNames []string
+	ExtraGroupingColNames []string
 }
 
 // Init only assigns type and context.

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1579,11 +1579,18 @@ type PhysicalExpand struct {
 	// GroupingSets is used to define what kind of group layout should the underlying data follow.
 	// For simple case: select count(distinct a), count(distinct b) from t; the grouping expressions are [a] and [b].
 	GroupingSets expression.GroupingSets
+
+	// The level projections is generated from grouping sets，make execution more clearly.
+	LevelExprs [][]expression.Expression
+
+	// The generated column names. Eg: "grouping_id" and so on.
+	GeneratedColNames []string
 }
 
 // Init only assigns type and context.
-func (p PhysicalExpand) Init(ctx sessionctx.Context, stats *property.StatsInfo, offset int) *PhysicalExpand {
+func (p PhysicalExpand) Init(ctx sessionctx.Context, stats *property.StatsInfo, offset int, props ...*property.PhysicalProperty) *PhysicalExpand {
 	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeExpand, &p, offset)
+	p.childrenReqProps = props
 	p.stats = stats
 	return &p
 }

--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -412,7 +412,8 @@ func (p *PhysicalExchangeSender) ResolveIndices() (err error) {
 }
 
 // ResolveIndicesItself resolve indices for PhysicalPlan itself
-func (p *PhysicalExpand) ResolveIndicesItself() error {
+func (p *PhysicalExpand) ResolveIndicesItself() (err error) {
+	// for version 1
 	for _, gs := range p.GroupingSets {
 		for _, groupingExprs := range gs {
 			for k, groupingExpr := range groupingExprs {
@@ -421,6 +422,16 @@ func (p *PhysicalExpand) ResolveIndicesItself() error {
 					return err
 				}
 				groupingExprs[k] = gExpr
+			}
+		}
+	}
+	// for version 2
+	for i, oneLevel := range p.LevelExprs {
+		for j, expr := range oneLevel {
+			// expr in expand level-projections only contains column ref and literal constant projection.
+			p.LevelExprs[i][j], err = expr.ResolveIndices(p.children[0].Schema())
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1354,13 +1354,7 @@ func (p *PhysicalExpand) attach2Task(tasks ...task) task {
 		mpp.p = p
 		return mpp
 	}
-	// future code for TiDB self Expand implementation.
-	t = t.convertToRootTask(p.ctx)
-	t = attachPlan2Task(p, t)
-	if root, ok := tasks[0].(*rootTask); ok && root.isEmpty {
-		t.(*rootTask).isEmpty = true
-	}
-	return t
+	return invalidTask
 }
 
 func (p *PhysicalProjection) attach2Task(tasks ...task) task {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/44487

Problem Summary:

https://github.com/pingcap/tidb/pull/44216  logical expand support
https://github.com/pingcap/tidb/pull/44436  grouping function refactor

Now, after the above two PR is merged, now we can support transforming a ast rollup syntax to a Expand logical plan.
There is something important that needs to be done before we step into the next physical plan generation --- that's rewriting.

* grouping function needs to be rewritten. what the user typed in the SQL layer is the raw definition of the grouping function which receives multi-raw columns ref as its parameters with a maximum number of up to 64. While in its runtime, what she only considered is the gid(uint64) column, getting the gid uint64 value from every row and comparing it with the meta filled in the rewriting time according to some rule regulated with the grouping mode.

```
case: select grouping(a), grouping(b,a) from t group by a, b with rollup.
                      |             |
                      |             +>.  grouping(gid) with [meta1, meta2]
                      +>    grouping(gid) with meta
```

* except for the grouping function, normal columns or expressions should be considered to be rewritten as grouping set columns or expressions. As we talked about in the previous pull request, the gby expressions will be projected out in one another projection under expand even if it's simple columns already. We do this because gby item will be filled with a null value when we replicate the source rows to distinguish data for different grouping layouts, so it's not a real column ref yet! (column ref doesn't change anything from the source column, including the field type). So is there any chance we should use the source column rather than the copied-changed grouping column? Yes, any column args in an aggregation should use the source column ref, otherwise, use the copied-changed grouping column instead!

```
eg： select   sum(a),  a,  a+1,  grouping(b,a) from t group by a, b with rollup.
                |      |     |             +>   absolutely resolve the grouping set col a and b.
                |      |     +>  resolve to the grouping set col a'#3. (it can show NULL anyway)
                |     +> resolve to the grouping set col a'#3. (it can show NULL anyway)
                +> resolve to the base column a.

logical plan:   
                projection: col#9, a'#3, a'#3+1, grouping(gid#5, metas)
                     aggregation: sum(a) -> col#9
                         expand:   [a, b, a'#3, b'#4, gid#5]
                             + projection:  [a, b, a -> a'#3, b -> b'#4]
```
* After comparison between spark and MySQL, the former has a more analyzing ability, cases like below can even be resolved.
```
eg： select   sum(a),  a+1,  grouping(1+a,b) from t group by 1+a, b with rollup.
                |      |                 +>   absolutely resolve the grouping set col a+1 (A#3) and b'#4.
                |      |     
                |      +> resolve to the grouping set ** Expression ** a+1, here we should substitute it with A#3. 
                +> resolve to the base column a.

logical plan:   
                projection: col#9, A#3,  grouping(gid#5, metas)
                     aggregation: sum(a) -> col#9
                         expand:   [a, b, A#3, b'#4, gid#5]
                             + projection:  [a, b, a+1 -> A#3, b -> b'#4]
```
* grouping function rewriting and grouping column/expression-related rewriting can exist in select-list fields/having/order clause. Given the complexity of rewriting them in having/order clause, this PR currently focus on the rewriting of them in the select-list fields.
1. we rewrite the grouping function in place when we first meet/rewrite it in the expressionWriter.
2. we rewrite the grouping expressions/columns after select Expr is built, then traverse down the expression tree to find the shallow-most scope for substitution.  (how to understand shallow-most, let's say we have a field like a+1, then we got two group by item (a(a#3), a+1 (A#4)) with a rollup, the a+1 should be resolved to ** bigger** one a+1 rather than single expression a)
```
          
   +     find gby item using scalar plus function hashcode (shadow layer in tree),  final substitution as  A#4         
  /  \                                                                                                                                 
a     1                                                                                                                    
                                                                                                 
   +       
  /  \                                                                                                                                 
a     1  find gby item using a hashcode (deep layer in tree), final substitution as a'#3 + 1
  

both cases is reasonable, but actually, we need case1: substitute a+1 completely as gby item as A#4
```

* After rewriting is done, then, we put the logical plan tree through the logical optimization rules, at the final rule `resolveExpand` we generate the level projections for this logical Expand. Then, enumerate the possible physical plan for logical Expand, we should keep in mind that currently we only have the MPP Expand Execution mode, so only MPP task type can be generated by now.


### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: support grouping function/col rewriting and physical plan exhausion for rollup expand OP
```
