### PR TITLE
statistics/handle: try to avoid copy-on-write on the whole statscache to get better statistics updating performance

### DIFF
--- a/statistics/handle/lru_cache_test.go
+++ b/statistics/handle/lru_cache_test.go
@@ -346,23 +346,22 @@ func BenchmarkStatsCacheUpdate(b *testing.B) {
 	pseudo := func(id int64) *statistics.Table {
 		ti := &model.TableInfo{}
 		colInfo := &model.ColumnInfo{
-			ID:        int64(i),
+			ID:        id,
 			FieldType: *types.NewFieldType(mysql.TypeLonglong),
 			State:     model.StatePublic,
 		}
 		ti.Columns = append(ti.Columns, colInfo)
-		tbl := statistics.PseudoTable(ti)
+		return statistics.PseudoTable(ti)
 	}
 
 	sc := newStatsCache()
 	for i := 0; i < 10000; i++ {
-		tbl := pseudo(i)
+		tbl := pseudo(int64(i))
 		sc = sc.update([]*statistics.Table{tbl}, nil, sc.version)
 	}
 
 	tbl := pseudo(0)
 	b.ResetTimer()
-	tbl := statistics.PseudoTable(ti)
 	for i := 0; i < b.N; i++ {
 		tbl.PhysicalID = int64(rand.Intn(20000))
 		sc = sc.update([]*statistics.Table{tbl}, nil, sc.version)

--- a/statistics/handle/statscache.go
+++ b/statistics/handle/statscache.go
@@ -267,6 +267,8 @@ func (m *mapCache) Copy() statsCacheInner {
 		tables:   make(map[int64]cacheItem, len(m.tables)),
 		memUsage: m.memUsage,
 	}
+	m.RLock()
+	defer m.RUnlock()
 	for k, v := range m.tables {
 		newM.tables[k] = v.copy()
 	}

--- a/statistics/handle/statscache.go
+++ b/statistics/handle/statscache.go
@@ -144,9 +144,9 @@ func (c cacheItem) copy() cacheItem {
 }
 
 type mapCache struct {
-	sync.RWMutex
 	tables   map[int64]cacheItem
 	memUsage int64
+	sync.RWMutex
 }
 
 // GetByQuery implements statsCacheInner

--- a/statistics/handle/statscache.go
+++ b/statistics/handle/statscache.go
@@ -205,12 +205,16 @@ func (m *mapCache) Del(k int64) {
 
 // Cost implements statsCacheInner
 func (m *mapCache) Cost() int64 {
+	m.RLock()
+	defer m.RUnlock()
 	return m.memUsage
 }
 
 // Keys implements statsCacheInner
 func (m *mapCache) Keys() []int64 {
 	ks := make([]int64, 0, len(m.tables))
+	m.RLock()
+	defer m.RUnlock()
 	for k := range m.tables {
 		ks = append(ks, k)
 	}
@@ -220,6 +224,8 @@ func (m *mapCache) Keys() []int64 {
 // Values implements statsCacheInner
 func (m *mapCache) Values() []*statistics.Table {
 	vs := make([]*statistics.Table, 0, len(m.tables))
+	m.RLock()
+	defer m.RUnlock()
 	for _, v := range m.tables {
 		vs = append(vs, v.value)
 	}
@@ -239,11 +245,15 @@ func (m *mapCache) Map() map[int64]*statistics.Table {
 
 // Len implements statsCacheInner
 func (m *mapCache) Len() int {
+	m.RLock()
+	defer m.RUnlock()
 	return len(m.tables)
 }
 
 // FreshMemUsage implements statsCacheInner
 func (m *mapCache) FreshMemUsage() {
+	m.RLock()
+	defer m.RUnlock()
 	for _, v := range m.tables {
 		oldCost := v.cost
 		newCost := v.value.MemoryUsage().TotalMemUsage


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44492

Problem Summary:

For statistics updating, we use copy-on-write to make it thread-safe, but the granularity is coarse.

The stats cache is basically a `map[tblID]statistics.Table`, and when we update one table, we deep copy the whole map data struct, update that table in the new map, and atomitically update the stats cache handle to point to the new map.

When there are a lot of tables, the deep copy of stats cache is infeasible.
As you can see the flamegraph from the issue:

![image](https://github.com/pingcap/tidb/assets/1420062/09bbd890-06d5-47c8-9c15-c29dcedf74ef)

### What is changed and how it works?

Indeed, to make the statscache safe for concurreny, we can make the modification of `mapCache` thread-safe, and we can still used the copy-on-write, but use a fine-grained granularity: on the statistics.Table.

This commit make the `mapCache` modification thread-safe, then change the deep-copy to a shallow copy.


```
cd statistics/handle;

Before:
go test -test.run XXX -test.bench BenchmarkStatsCacheUpdate
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/statistics/handle
cpu: AMD Ryzen 7 PRO 4750G with Radeon Graphics
BenchmarkStatsCacheUpdate-16               10000            205387 ns/op

After:
go test -test.run XXX -test.bench BenchmarkStatsCacheUpdate
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/statistics/handle
cpu: AMD Ryzen 7 PRO 4750G with Radeon Graphics
BenchmarkStatsCacheUpdate-16             2950261               406.0 ns/op
```

P.S.  I try to refact on the lru_cache code at first, but find it is so damn complex and almost inpossible to be concurrent-safe and high performance. So I give up and just modify the basic mapCache implementation.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
