### PR TITLE
session,expression: Support IS_USED_LOCK function

### DIFF
--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -969,7 +969,7 @@ func (b *builtinUsedLockSig) Clone() builtinFunc {
 }
 
 // evalInt evals a builtinLockSig.
-// See https://dev.mysql.com/doc/refman/ ...
+// See https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html#function_is-used-lock
 func (b *builtinUsedLockSig) evalInt(row chunk.Row) (int64, bool, error) {
 	lockName, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil {

--- a/expression/integration_test/integration_test.go
+++ b/expression/integration_test/integration_test.go
@@ -451,7 +451,7 @@ func TestMiscellaneousBuiltin(t *testing.T) {
 	result = tk.MustQuery(`SELECT GET_LOCK('test_lock2', 10);`)
 	result.Check(testkit.Rows("1"))
 
-	result = tk.MustQuery(`SELECT IS_USED_LOCK('test_lock1') > 0;`)
+	result = tk.MustQuery(`SELECT IS_USED_LOCK('test_lock1') = CONNECTION_ID();`)
 	result.Check(testkit.Rows("1"))
 	result = tk.MustQuery(`SELECT IS_USED_LOCK('foobar');`)
 	result.Check(testkit.Rows("<nil>"))

--- a/expression/integration_test/integration_test.go
+++ b/expression/integration_test/integration_test.go
@@ -451,6 +451,16 @@ func TestMiscellaneousBuiltin(t *testing.T) {
 	result = tk.MustQuery(`SELECT GET_LOCK('test_lock2', 10);`)
 	result.Check(testkit.Rows("1"))
 
+	result = tk.MustQuery(`SELECT IS_USED_LOCK('test_lock1') > 0;`)
+	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery(`SELECT IS_USED_LOCK('foobar');`)
+	result.Check(testkit.Rows("<nil>"))
+
+	result = tk.MustQuery(`SELECT IS_FREE_LOCK('test_lock1');`)
+	result.Check(testkit.Rows("0"))
+	result = tk.MustQuery(`SELECT IS_FREE_LOCK('foobar');`)
+	result.Check(testkit.Rows("1"))
+
 	result = tk.MustQuery(`SELECT RELEASE_LOCK('test_lock2');`)
 	result.Check(testkit.Rows("1"))
 	result = tk.MustQuery(`SELECT RELEASE_LOCK('test_lock1');`)

--- a/session/advisory_locks.go
+++ b/session/advisory_locks.go
@@ -90,6 +90,7 @@ func (a *advisoryLock) GetLock(lockName string, timeout int64) error {
 	return nil
 }
 
+// IsUsedLock checks if a lockName is already in use
 func (a *advisoryLock) IsUsedLock(lockName string) error {
 	a.ctx = kv.WithInternalSourceType(a.ctx, kv.InternalTxnOthers)
 	_, err := a.session.ExecuteInternal(a.ctx, "SET innodb_lock_wait_timeout = 1")
@@ -102,9 +103,6 @@ func (a *advisoryLock) IsUsedLock(lockName string) error {
 	}
 	_, err = a.session.ExecuteInternal(a.ctx, "INSERT INTO mysql.advisory_locks (lock_name) VALUES (%?)", lockName)
 	if err != nil {
-		// We couldn't acquire the LOCK so we close the session cleanly
-		// and return the error to the caller. The caller will need to interpret
-		// this differently if it is lock wait timeout or a deadlock.
 		a.Close()
 		return err
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -1807,6 +1807,7 @@ func (s *session) GetAdvisoryLock(lockName string, timeout int64) error {
 	return nil
 }
 
+// IsUsedAdvisoryLock checks if a lockName is already in use
 func (s *session) IsUsedAdvisoryLock(lockName string) uint64 {
 	// Same session
 	if lock, ok := s.advisoryLocks[lockName]; ok {

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -176,6 +176,8 @@ type Context interface {
 	ShowProcess() *util.ProcessInfo
 	// GetAdvisoryLock acquires an advisory lock (aka GET_LOCK()).
 	GetAdvisoryLock(string, int64) error
+	// IsUsedAdvisoryLock checks for existing locks (aka IS_USED_LOCK()).
+	IsUsedAdvisoryLock(string) uint64
 	// ReleaseAdvisoryLock releases an advisory lock (aka RELEASE_LOCK()).
 	ReleaseAdvisoryLock(string) bool
 	// ReleaseAllAdvisoryLocks releases all advisory locks that this session holds.

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -413,6 +413,11 @@ func (*Context) GetAdvisoryLock(_ string, _ int64) error {
 	return nil
 }
 
+// IsUsedAdvisoryLock check if a lock name is in use
+func (*Context) IsUsedAdvisoryLock(_ string) uint64 {
+	return 0
+}
+
 // ReleaseAdvisoryLock releases an advisory lock
 func (*Context) ReleaseAdvisoryLock(_ string) bool {
 	return true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44493 

Problem Summary:

### What is changed and how it works?

TiDB, Session 1
```
sql> select is_used_lock('foo');
+---------------------+
| is_used_lock('foo') |
+---------------------+
|                NULL |
+---------------------+
1 row in set (0.0037 sec)

sql> select get_lock('foo', 10);
+---------------------+
| get_lock('foo', 10) |
+---------------------+
|                   1 |
+---------------------+
1 row in set (0.0032 sec)

sql> select is_used_lock('foo');
+---------------------+
| is_used_lock('foo') |
+---------------------+
|       2199023255557 |
+---------------------+
1 row in set (0.0005 sec)

sql> select connection_id();
+-----------------+
| connection_id() |
+-----------------+
|   2199023255557 |
+-----------------+
1 row in set (0.0004 sec)
```

TiDB, Session 2
```
sql> select is_used_lock('foo');
+---------------------+
| is_used_lock('foo') |
+---------------------+
|                   1 |
+---------------------+
1 row in set (1.0120 sec)

sql> select is_used_lock('bar');
+---------------------+
| is_used_lock('bar') |
+---------------------+
|                NULL |
+---------------------+
1 row in set (0.0033 sec)
```

MySQL
```
sql> select is_used_lock('foo');
+---------------------+
| is_used_lock('foo') |
+---------------------+
|                NULL |
+---------------------+
1 row in set (0.0007 sec)

sql> select get_lock('foo',10);
+--------------------+
| get_lock('foo',10) |
+--------------------+
|                  1 |
+--------------------+
1 row in set (0.0007 sec)

sql> select is_used_lock('foo');
+---------------------+
| is_used_lock('foo') |
+---------------------+
|                  36 |
+---------------------+
1 row in set (0.0007 sec)

sql> select connection_id();
+-----------------+
| connection_id() |
+-----------------+
|              36 |
+-----------------+
1 row in set (0.0006 sec)

sql> select version();
+-----------+
| version() |
+-----------+
| 8.0.33    |
+-----------+
1 row in set (0.0007 sec)
```
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support for the `IS_USED_LOCK()` and `IS_FREE_LOCK()` functions was added
```
