### PR TITLE
*: fix cte miss cleaning spilled-disk file

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -178,8 +178,11 @@ func (a *recordSet) NewChunk(alloc chunk.Allocator) *chunk.Chunk {
 
 func (a *recordSet) Close() error {
 	err := a.executor.Close()
-	err = a.stmt.CloseRecordSet(a.txnStartTS, a.lastErr)
-	return err
+	err1 := a.stmt.CloseRecordSet(a.txnStartTS, a.lastErr)
+	if err != nil {
+		return err
+	}
+	return err1
 }
 
 // OnFetchReturned implements commandLifeCycle#OnFetchReturned
@@ -743,9 +746,6 @@ func (a *ExecStmt) handleNoDelay(ctx context.Context, e Executor, isPessimistic 
 		if handled && sc != nil && rs == nil {
 			sc.DetachMemDiskTracker()
 			cteErr := resetCTEStorageMap(a.Ctx)
-			if cteErr != nil {
-				logutil.BgLogger().Error("got error when reset cte storage", zap.Error(cteErr))
-			}
 			if err == nil {
 				// Only overwrite err when it's nil.
 				err = cteErr
@@ -1431,7 +1431,7 @@ func (a *ExecStmt) CloseRecordSet(txnStartTS uint64, lastErr error) error {
 	a.FinishExecuteStmt(txnStartTS, lastErr, false)
 	a.logAudit()
 	a.Ctx.GetSessionVars().StmtCtx.DetachMemDiskTracker()
-	return lastErr
+	return cteErr
 }
 
 // Clean CTE storage shared by different CTEFullScan executor within a SQL stmt.

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -1422,7 +1422,7 @@ func (a *ExecStmt) checkPlanReplayerCapture(txnTS uint64) {
 func (a *ExecStmt) CloseRecordSet(txnStartTS uint64, lastErr error) error {
 	cteErr := resetCTEStorageMap(a.Ctx)
 	if cteErr != nil {
-		logutil.BgLogger().Error("got error when reset cte storage", zap.Error(cteErr))
+		logutil.BgLogger().Error("got error when reset cte storage, should check if the spill disk file deleted or not", zap.Error(cteErr))
 	}
 	if lastErr == nil {
 		// Only overwrite err when it's nil.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3533,8 +3533,8 @@ func TestUnreasonablyClose(t *testing.T) {
 
 		if hasCTE {
 			// Normally CTEStorages will be setup in ResetContextOfStmt.
-			// But the following case call e.Close() directly, it doesn't use session.ExecStmt(), which calls ResetContextOfStmt.
-			// So we need to setup CTEStorages manually.
+			// But the following case call e.Close() directly, instead of calling session.ExecStmt(), which calls ResetContextOfStmt.
+			// So need to setup CTEStorages manually.
 			tk.Session().GetSessionVars().StmtCtx.CTEStorageMap = map[int]*executor.CTEStorages{}
 		}
 		e := executorBuilder.Build(p)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3502,6 +3502,7 @@ func TestUnreasonablyClose(t *testing.T) {
 		require.NotNil(t, p)
 
 		// This for loop level traverses the plan tree to get which operators are covered.
+		var hasCTE bool
 		for child := []plannercore.PhysicalPlan{p.(plannercore.PhysicalPlan)}; len(child) != 0; {
 			newChild := make([]plannercore.PhysicalPlan, 0, len(child))
 			for _, ch := range child {
@@ -3518,6 +3519,7 @@ func TestUnreasonablyClose(t *testing.T) {
 				case *plannercore.PhysicalCTE:
 					newChild = append(newChild, x.RecurPlan)
 					newChild = append(newChild, x.SeedPlan)
+					hasCTE = true
 					continue
 				case *plannercore.PhysicalShuffle:
 					newChild = append(newChild, x.DataSources...)
@@ -3529,6 +3531,12 @@ func TestUnreasonablyClose(t *testing.T) {
 			child = newChild
 		}
 
+		if hasCTE {
+			// Normally CTEStorages will be setup in ResetContextOfStmt.
+			// But the following case call e.Close() directly, it doesn't use session.ExecStmt(), which calls ResetContextOfStmt.
+			// So we need to setup CTEStorages manually.
+			tk.Session().GetSessionVars().StmtCtx.CTEStorageMap = map[int]*executor.CTEStorages{}
+		}
 		e := executorBuilder.Build(p)
 
 		func() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44477

Problem Summary: 
Close record set for select stmt and insert/update stmt is in different code path.
Miss calling `resetCTEStorage` for insert/update stmt, whose recordSet is nil.

### What is changed and how it works?
1. call `resetCTEStorage()` in handleNoDelay(), this will cover insert/update.. DML stmt.
2. call `resetCTEStorage() in `(a *ExecStmt) CloseRecordSet`, this will cover select stmt. Also for prepare/execute/plan cache/select for update.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
