### PR TITLE
disttask: unify wg and add recovery for long running loop

### DIFF
--- a/disttask/framework/dispatcher/BUILD.bazel
+++ b/disttask/framework/dispatcher/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//disttask/framework/proto",
         "//disttask/framework/storage",
         "//domain/infosync",
+        "//metrics",
         "//resourcemanager/pool/spool",
         "//resourcemanager/util",
         "//sessionctx/variable",

--- a/disttask/framework/scheduler/BUILD.bazel
+++ b/disttask/framework/scheduler/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//disttask/framework/proto",
         "//resourcemanager/pool/spool",
         "//resourcemanager/util",
+        "//util",
         "//util/logutil",
         "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//mock",

--- a/disttask/framework/scheduler/BUILD.bazel
+++ b/disttask/framework/scheduler/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//disttask/framework/proto",
+        "//metrics",
         "//resourcemanager/pool/spool",
         "//resourcemanager/util",
         "//util",

--- a/util/wait_group_wrapper.go
+++ b/util/wait_group_wrapper.go
@@ -110,7 +110,7 @@ func (w *WaitGroupEnhancedWrapper) RunWithRecover(exec func(), recoverFn func(r 
 		defer func() {
 			r := recover()
 			if r != nil && recoverFn != nil {
-				logutil.BgLogger().Info("WaitGroupEnhancedWrapper exec panic recovered", zap.String("process", label))
+				logutil.BgLogger().Info("WaitGroupEnhancedWrapper exec panic recovered", zap.String("process", label), zap.Stack(string(debug.Stack())))
 				recoverFn(r)
 			}
 			w.onExit(label)
@@ -167,7 +167,7 @@ func (w *WaitGroupWrapper) RunWithRecover(exec func(), recoverFn func(r interfac
 			r := recover()
 			if recoverFn != nil {
 				if r != nil {
-					debug.PrintStack()
+					logutil.BgLogger().Info("WaitGroupWrapper exec panic recovered", zap.Stack(string(debug.Stack())))
 				}
 				recoverFn(r)
 			}

--- a/util/wait_group_wrapper.go
+++ b/util/wait_group_wrapper.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -165,6 +166,9 @@ func (w *WaitGroupWrapper) RunWithRecover(exec func(), recoverFn func(r interfac
 		defer func() {
 			r := recover()
 			if recoverFn != nil {
+				if r != nil {
+					debug.PrintStack()
+				}
 				recoverFn(r)
 			}
 			w.Done()

--- a/util/wait_group_wrapper.go
+++ b/util/wait_group_wrapper.go
@@ -15,7 +15,6 @@
 package util
 
 import (
-	"runtime/debug"
 	"sync"
 	"time"
 
@@ -110,7 +109,7 @@ func (w *WaitGroupEnhancedWrapper) RunWithRecover(exec func(), recoverFn func(r 
 		defer func() {
 			r := recover()
 			if r != nil && recoverFn != nil {
-				logutil.BgLogger().Info("WaitGroupEnhancedWrapper exec panic recovered", zap.String("process", label), zap.Stack(string(debug.Stack())))
+				logutil.BgLogger().Info("WaitGroupEnhancedWrapper exec panic recovered", zap.String("process", label))
 				recoverFn(r)
 			}
 			w.onExit(label)
@@ -166,9 +165,6 @@ func (w *WaitGroupWrapper) RunWithRecover(exec func(), recoverFn func(r interfac
 		defer func() {
 			r := recover()
 			if recoverFn != nil {
-				if r != nil {
-					logutil.BgLogger().Info("WaitGroupWrapper exec panic recovered", zap.Stack(string(debug.Stack())))
-				}
 				recoverFn(r)
 			}
 			w.Done()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44504 

Problem Summary:
Use RunWithRecover to make the disttask framework run forever
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
