### PR TITLE
br: run `UpdateTableStatsLoop` when domain is not bootstrapped

### DIFF
--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -61,13 +61,25 @@ type tidbSession struct {
 
 // GetDomain implements glue.Glue.
 func (Glue) GetDomain(store kv.Storage) (*domain.Domain, error) {
+	existDom, _ := session.GetDomain(nil)
+	initStatsSe, err := session.CreateSession(store)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	se, err := session.CreateSession(store)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	dom, err := session.GetDomain(store)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	err = session.InitMDLVariable(store)
-	if err != nil {
-		return nil, err
+	if existDom == nil {
+		// create stats handler for backup and restore.
+		err = dom.UpdateTableStatsLoop(se, initStatsSe)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	return dom, nil
 }

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -75,6 +75,10 @@ func (Glue) GetDomain(store kv.Storage) (*domain.Domain, error) {
 		return nil, errors.Trace(err)
 	}
 	if existDom == nil {
+		err = session.InitMDLVariable(store)
+		if err != nil {
+			return nil, err
+		}
 		// create stats handler for backup and restore.
 		err = dom.UpdateTableStatsLoop(se, initStatsSe)
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44496, close #44490

Problem Summary:

https://github.com/pingcap/tidb/pull/44338 add a goroutine to detect exit signal for `UpdateTableStatsLoop`. It breaks the test `TestIsOnline` because it runs `UpdateTableStatsLoop` twice. #44338 removes the loop from glue, resulting in failures of BR's integration tests.

### What is changed and how it works?

Check if the domain exists and run `UpdateTableStatsLoop` only if necessary.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
