### PR TITLE
executor: set handle changed when col gets auto-updated

### DIFF
--- a/executor/test/writetest/write_test.go
+++ b/executor/test/writetest/write_test.go
@@ -3557,7 +3557,7 @@ func TestHandleColumnWithOnUpdateCurrentTimestamp(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	tk.MustExec("create table t (a timestamp on update current_timestamp(0), b int, primary key (a), key idx (a))")
+	tk.MustExec("create table t (a timestamp on update current_timestamp(0), b int, primary key (a) clustered, key idx (a))")
 	tk.MustExec("insert into t values ('2023-06-11 10:00:00', 1)")
 	tk.MustExec("update t force index(primary) set b = 10 where a = '2023-06-11 10:00:00'")
 	tk.MustExec("admin check table t")

--- a/executor/test/writetest/write_test.go
+++ b/executor/test/writetest/write_test.go
@@ -3551,3 +3551,14 @@ func TestMutipleReplaceAndInsertInOneSession(t *testing.T) {
 
 	tk2.MustQuery("select * from t_securities").Sort().Check(testkit.Rows("1 1 2 7", "2 7 1 7", "3 8 1 7", "8 9 1 7"))
 }
+
+func TestHandleColumnWithOnUpdateCurrentTimestamp(t *testing.T) {
+	// Test https://github.com/pingcap/tidb/issues/44565
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a timestamp on update current_timestamp(0), b int, primary key (a), key idx (a))")
+	tk.MustExec("insert into t values ('2023-06-11 10:00:00', 1)")
+	tk.MustExec("update t force index(primary) set b = 10 where a = '2023-06-11 10:00:00'")
+	tk.MustExec("admin check table t")
+}

--- a/executor/write.go
+++ b/executor/write.go
@@ -147,6 +147,11 @@ func updateRecord(ctx context.Context, sctx sessionctx.Context, h kv.Handle, old
 			if v, err := expression.GetTimeValue(sctx, strings.ToUpper(ast.CurrentTimestamp), col.GetType(), col.GetDecimal(), nil); err == nil {
 				newData[i] = v
 				modified[i] = true
+				// Only a TIMESTAMP and DATETIME column can be automatically updated, so it cannot be PKIsHandle.
+				// Ref: https://dev.mysql.com/doc/refman/8.0/en/timestamp-initialization.html
+				if col.IsCommonHandleColumn(t.Meta()) {
+					handleChanged = true
+				}
 			} else {
 				return false, err
 			}

--- a/executor/write.go
+++ b/executor/write.go
@@ -147,8 +147,11 @@ func updateRecord(ctx context.Context, sctx sessionctx.Context, h kv.Handle, old
 			if v, err := expression.GetTimeValue(sctx, strings.ToUpper(ast.CurrentTimestamp), col.GetType(), col.GetDecimal(), nil); err == nil {
 				newData[i] = v
 				modified[i] = true
-				// Only a TIMESTAMP and DATETIME column can be automatically updated, so it cannot be PKIsHandle.
+				// Only TIMESTAMP and DATETIME columns can be automatically updated, so it cannot be PKIsHandle.
 				// Ref: https://dev.mysql.com/doc/refman/8.0/en/timestamp-initialization.html
+				if col.IsPKHandleColumn(t.Meta()) {
+					panic("on-update-now col should never be pk-is-handle")
+				}
 				if col.IsCommonHandleColumn(t.Meta()) {
 					handleChanged = true
 				}

--- a/executor/write.go
+++ b/executor/write.go
@@ -150,7 +150,7 @@ func updateRecord(ctx context.Context, sctx sessionctx.Context, h kv.Handle, old
 				// Only TIMESTAMP and DATETIME columns can be automatically updated, so it cannot be PKIsHandle.
 				// Ref: https://dev.mysql.com/doc/refman/8.0/en/timestamp-initialization.html
 				if col.IsPKHandleColumn(t.Meta()) {
-					panic("on-update-now col should never be pk-is-handle")
+					return false, errors.Errorf("on-update-now column should never be pk-is-handle")
 				}
 				if col.IsCommonHandleColumn(t.Meta()) {
 					handleChanged = true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44565

Problem Summary: We didn't set `handleChanged` properly when a on-update-now column gets updated automatically and it's also a pk column, which leads to #44565 .

### What is changed and how it works?

Set `handleChanged` properly in that case.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
