### PR TITLE
sessionctx: make session_vars' type closer to MySQL

### DIFF
--- a/disttask/framework/storage/task_table.go
+++ b/disttask/framework/storage/task_table.go
@@ -168,10 +168,7 @@ func (stm *TaskManager) AddNewGlobalTask(key, tp string, concurrency int, meta [
 			return err
 		}
 
-		taskID, err = strconv.ParseInt(rs[0].GetString(0), 10, 64)
-		if err != nil {
-			return err
-		}
+		taskID = int64(rs[0].GetUint64(0))
 		failpoint.Inject("testSetLastTaskID", func() { TestLastTaskID.Store(taskID) })
 
 		return nil

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1437,7 +1437,7 @@ func (er *expressionRewriter) rewriteVariable(v *ast.VariableExpr) {
 		e.GetType().SetCharset(charset.CharsetBin)
 		e.GetType().SetCollate(charset.CollationBin)
 	default:
-		er.err = errors.Errorf("Not support type(%x) in sysVar", nativeType)
+		er.err = errors.Errorf("Not supported type(%x) in GetNativeValType() function", nativeType)
 		return
 	}
 	er.ctxStackAppend(e, types.EmptyName)

--- a/sessionctx/variable/BUILD.bazel
+++ b/sessionctx/variable/BUILD.bazel
@@ -96,6 +96,7 @@ go_test(
         "//kv",
         "//parser",
         "//parser/auth",
+        "//parser/charset",
         "//parser/mysql",
         "//parser/terror",
         "//planner/core",

--- a/sessionctx/variable/BUILD.bazel
+++ b/sessionctx/variable/BUILD.bazel
@@ -96,7 +96,6 @@ go_test(
         "//kv",
         "//parser",
         "//parser/auth",
-        "//parser/charset",
         "//parser/mysql",
         "//parser/terror",
         "//planner/core",

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -108,25 +108,11 @@ var defaultSysVars = []*SysVar{
 		return strconv.FormatUint(s.StmtCtx.PrevLastInsertID, 10), nil
 	}, GetStateValue: func(s *SessionVars) (string, bool, error) {
 		return "", false, nil
-	}, SetSession: func(sv *SessionVars, s string) error {
-		lastInsertID, err := strconv.ParseUint(s, 10, 64)
-		if err != nil {
-			return err
-		}
-		sv.StmtCtx.PrevLastInsertID = lastInsertID
-		return nil
 	}},
 	{Scope: ScopeSession, Name: Identity, Value: "0", Type: TypeUnsigned, AllowEmpty: true, MinValue: 0, MaxValue: math.MaxUint64, GetSession: func(s *SessionVars) (string, error) {
 		return strconv.FormatUint(s.StmtCtx.PrevLastInsertID, 10), nil
 	}, GetStateValue: func(s *SessionVars) (string, bool, error) {
 		return "", false, nil
-	}, SetSession: func(sv *SessionVars, s string) error {
-		lastInsertID, err := strconv.ParseUint(s, 10, 64)
-		if err != nil {
-			return err
-		}
-		sv.StmtCtx.PrevLastInsertID = lastInsertID
-		return nil
 	}},
 	/* TiDB specific variables */
 	// TODO: TiDBTxnScope is hidden because local txn feature is not done.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -116,10 +116,17 @@ var defaultSysVars = []*SysVar{
 		sv.StmtCtx.PrevLastInsertID = lastInsertID
 		return nil
 	}},
-	{Scope: ScopeSession, Name: Identity, Value: "0", Type: TypeInt, AllowEmpty: true, MinValue: 0, MaxValue: math.MaxInt64, GetSession: func(s *SessionVars) (string, error) {
+	{Scope: ScopeSession, Name: Identity, Value: "0", Type: TypeUnsigned, AllowEmpty: true, MinValue: 0, MaxValue: math.MaxUint64, GetSession: func(s *SessionVars) (string, error) {
 		return strconv.FormatUint(s.StmtCtx.PrevLastInsertID, 10), nil
 	}, GetStateValue: func(s *SessionVars) (string, bool, error) {
 		return "", false, nil
+	}, SetSession: func(sv *SessionVars, s string) error {
+		lastInsertID, err := strconv.ParseUint(s, 10, 64)
+		if err != nil {
+			return err
+		}
+		sv.StmtCtx.PrevLastInsertID = lastInsertID
+		return nil
 	}},
 	/* TiDB specific variables */
 	// TODO: TiDBTxnScope is hidden because local txn feature is not done.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -104,10 +104,17 @@ var defaultSysVars = []*SysVar{
 	{Scope: ScopeSession, Name: ErrorCount, Value: "0", ReadOnly: true, GetSession: func(s *SessionVars) (string, error) {
 		return strconv.Itoa(int(s.SysErrorCount)), nil
 	}},
-	{Scope: ScopeSession, Name: LastInsertID, Value: "0", Type: TypeInt, AllowEmpty: true, MinValue: 0, MaxValue: math.MaxInt64, GetSession: func(s *SessionVars) (string, error) {
+	{Scope: ScopeSession, Name: LastInsertID, Value: "0", Type: TypeUnsigned, AllowEmpty: true, MinValue: 0, MaxValue: math.MaxUint64, GetSession: func(s *SessionVars) (string, error) {
 		return strconv.FormatUint(s.StmtCtx.PrevLastInsertID, 10), nil
 	}, GetStateValue: func(s *SessionVars) (string, bool, error) {
 		return "", false, nil
+	}, SetSession: func(sv *SessionVars, s string) error {
+		lastInsertID, err := strconv.ParseUint(s, 10, 64)
+		if err != nil {
+			return err
+		}
+		sv.StmtCtx.PrevLastInsertID = lastInsertID
+		return nil
 	}},
 	{Scope: ScopeSession, Name: Identity, Value: "0", Type: TypeInt, AllowEmpty: true, MinValue: 0, MaxValue: math.MaxInt64, GetSession: func(s *SessionVars) (string, error) {
 		return strconv.FormatUint(s.StmtCtx.PrevLastInsertID, 10), nil

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -454,6 +454,17 @@ func TestLastInsertID(t *testing.T) {
 	val, err = vars.GetSessionOrGlobalSystemVar(context.Background(), LastInsertID)
 	require.NoError(t, err)
 	require.Equal(t, val, "21")
+
+	vars.StmtCtx.PrevLastInsertID = 9223372036854775809
+	val, err = vars.GetSessionOrGlobalSystemVar(context.Background(), LastInsertID)
+	require.NoError(t, err)
+	require.Equal(t, val, "9223372036854775809")
+
+	f := GetSysVar("last_insert_id")
+	d, valType, flag := f.GetNativeValType(val)
+	require.Equal(t, valType, mysql.TypeLonglong)
+	require.True(t, mysql.HasUnsignedFlag(flag))
+	require.Equal(t, d.GetUint64(), uint64(9223372036854775809))
 }
 
 func TestTimestamp(t *testing.T) {

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/config"
-	"github.com/pingcap/tidb/parser/charset"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/util/gctuner"
@@ -466,7 +465,6 @@ func TestLastInsertID(t *testing.T) {
 	require.Equal(t, valType, mysql.TypeLonglong)
 	require.Equal(t, flag, mysql.BinaryFlag|mysql.UnsignedFlag)
 	require.Equal(t, d.GetUint64(), uint64(9223372036854775809))
-	require.Equal(t, d.Collation(), charset.CollationBin)
 }
 
 func TestTimestamp(t *testing.T) {

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/parser/charset"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/util/gctuner"
@@ -463,8 +464,9 @@ func TestLastInsertID(t *testing.T) {
 	f := GetSysVar("last_insert_id")
 	d, valType, flag := f.GetNativeValType(val)
 	require.Equal(t, valType, mysql.TypeLonglong)
-	require.True(t, mysql.HasUnsignedFlag(flag))
+	require.Equal(t, flag, mysql.BinaryFlag|mysql.UnsignedFlag)
 	require.Equal(t, d.GetUint64(), uint64(9223372036854775809))
+	require.Equal(t, d.Collation(), charset.CollationBin)
 }
 
 func TestTimestamp(t *testing.T) {

--- a/sessionctx/variable/variable.go
+++ b/sessionctx/variable/variable.go
@@ -518,6 +518,7 @@ func (sv *SysVar) checkBoolSystemVar(value string, vars *SessionVars) (string, e
 }
 
 // GetNativeValType attempts to convert the val to the approx MySQL non-string type
+// TODO: only return 3 types now, support others like DOUBLE, TIME later
 func (sv *SysVar) GetNativeValType(val string) (types.Datum, byte, uint) {
 	switch sv.Type {
 	case TypeUnsigned:
@@ -525,13 +526,13 @@ func (sv *SysVar) GetNativeValType(val string) (types.Datum, byte, uint) {
 		if err != nil {
 			u = 0
 		}
-		return types.NewUintDatum(u), mysql.TypeLonglong, mysql.UnsignedFlag
+		return types.NewUintDatum(u), mysql.TypeLonglong, mysql.UnsignedFlag | mysql.BinaryFlag
 	case TypeBool:
 		optVal := int64(0) // OFF
 		if TiDBOptOn(val) {
 			optVal = 1
 		}
-		return types.NewIntDatum(optVal), mysql.TypeLong, 0
+		return types.NewIntDatum(optVal), mysql.TypeLonglong, mysql.BinaryFlag
 	}
 	return types.NewStringDatum(val), mysql.TypeVarString, 0
 }

--- a/sessionctx/variable/variable_test.go
+++ b/sessionctx/variable/variable_test.go
@@ -292,35 +292,35 @@ func TestTimeValidation(t *testing.T) {
 func TestGetNativeValType(t *testing.T) {
 	sv := SysVar{Scope: ScopeGlobal | ScopeSession, Name: "mynewsysvar", Value: Off, Type: TypeBool}
 
-	nativeVal, nativeType, unsignedFlag := sv.GetNativeValType("ON")
-	require.Equal(t, mysql.TypeLong, nativeType)
-	require.Equal(t, uint(0), unsignedFlag)
+	nativeVal, nativeType, flag := sv.GetNativeValType("ON")
+	require.Equal(t, mysql.TypeLonglong, nativeType)
+	require.Equal(t, mysql.BinaryFlag, flag)
 	require.Equal(t, types.NewIntDatum(1), nativeVal)
 
-	nativeVal, nativeType, unsignedFlag = sv.GetNativeValType("OFF")
-	require.Equal(t, mysql.TypeLong, nativeType)
-	require.Equal(t, uint(0), unsignedFlag)
+	nativeVal, nativeType, flag = sv.GetNativeValType("OFF")
+	require.Equal(t, mysql.TypeLonglong, nativeType)
+	require.Equal(t, mysql.BinaryFlag, flag)
 	require.Equal(t, types.NewIntDatum(0), nativeVal)
 
-	nativeVal, nativeType, unsignedFlag = sv.GetNativeValType("bogus")
-	require.Equal(t, mysql.TypeLong, nativeType)
-	require.Equal(t, uint(0), unsignedFlag)
+	nativeVal, nativeType, flag = sv.GetNativeValType("bogus")
+	require.Equal(t, mysql.TypeLonglong, nativeType)
+	require.Equal(t, mysql.BinaryFlag, flag)
 	require.Equal(t, types.NewIntDatum(0), nativeVal)
 
 	sv = SysVar{Scope: ScopeGlobal | ScopeSession, Name: "mynewsysvar", Value: Off, Type: TypeUnsigned}
-	nativeVal, nativeType, unsignedFlag = sv.GetNativeValType("1234")
+	nativeVal, nativeType, flag = sv.GetNativeValType("1234")
 	require.Equal(t, mysql.TypeLonglong, nativeType)
-	require.Equal(t, mysql.UnsignedFlag, unsignedFlag)
+	require.Equal(t, mysql.UnsignedFlag|mysql.BinaryFlag, flag)
 	require.Equal(t, types.NewUintDatum(1234), nativeVal)
-	nativeVal, nativeType, unsignedFlag = sv.GetNativeValType("bogus")
+	nativeVal, nativeType, flag = sv.GetNativeValType("bogus")
 	require.Equal(t, mysql.TypeLonglong, nativeType)
-	require.Equal(t, mysql.UnsignedFlag, unsignedFlag)
+	require.Equal(t, mysql.UnsignedFlag|mysql.BinaryFlag, flag)
 	require.Equal(t, types.NewUintDatum(0), nativeVal) // converts to zero
 
 	sv = SysVar{Scope: ScopeGlobal | ScopeSession, Name: "mynewsysvar", Value: "abc"}
-	nativeVal, nativeType, unsignedFlag = sv.GetNativeValType("1234")
+	nativeVal, nativeType, flag = sv.GetNativeValType("1234")
 	require.Equal(t, mysql.TypeVarString, nativeType)
-	require.Equal(t, uint(0), unsignedFlag)
+	require.Equal(t, uint(0), flag)
 	require.Equal(t, types.NewStringDatum("1234"), nativeVal)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44574

Problem Summary: For mysql, the return type of `last_insert_id` is `LONGLONG` with `UNSIGNED`, `BINARY` and `NUM` three flags. Also the return type of bool session value is `LONGLONG` with `BINARY` and `NUM` flasgs. Just change the behavior closer to MySQL.

```
mysql> select @@last_insert_id;
Field   1:  `@@last_insert_id`
Catalog:    `def`
Database:   ``
Table:      ``
Org_table:  ``
Type:       LONGLONG
Collation:  binary (63)
Length:     21
Max_length: 1
Decimals:   0
Flags:      UNSIGNED BINARY NUM


+------------------+
| @@last_insert_id |
+------------------+
|                0 |
+------------------+
1 row in set (0.01 sec)


mysql> select @@super_read_only;
Field   1:  `@@super_read_only`
Catalog:    `def`
Database:   ``
Table:      ``
Org_table:  ``
Type:       LONGLONG
Collation:  binary (63)
Length:     1
Max_length: 1
Decimals:   0
Flags:      BINARY NUM


+-------------------+
| @@super_read_only |
+-------------------+
|                 0 |
+-------------------+
1 row in set (0.00 sec)
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
