### PR TITLE
infoschema: update raw args to make it drop correct table in `RENAME TABLE`

### DIFF
--- a/ddl/table.go
+++ b/ddl/table.go
@@ -1178,6 +1178,9 @@ func finishJobRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, error
 		job.State = model.JobStateCancelled
 		return 0, errors.Trace(err)
 	}
+	// Before updating the schema version, we need to reset the old schema ID to new schema ID, so that
+	// the table info can be dropped normally in `ApplyDiff`. This is because renaming table requires two
+	// schema versions to complete.
 	oldRawArgs := job.RawArgs
 	job.Args[0] = job.SchemaID
 	job.RawArgs, err = json.Marshal(job.Args)
@@ -1209,6 +1212,9 @@ func finishJobRenameTables(d *ddlCtx, t *meta.Meta, job *model.Job,
 		}
 		tblInfos = append(tblInfos, tblInfo)
 	}
+	// Before updating the schema version, we need to reset the old schema ID to new schema ID, so that
+	// the table info can be dropped normally in `ApplyDiff`. This is because renaming table requires two
+	// schema versions to complete.
 	var err error
 	oldRawArgs := job.RawArgs
 	job.Args[0] = newSchemaIDs

--- a/infoschema/BUILD.bazel
+++ b/infoschema/BUILD.bazel
@@ -73,7 +73,7 @@ go_test(
     ],
     embed = [":infoschema"],
     flaky = True,
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//ddl/placement",
         "//domain",

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -716,6 +716,12 @@ func (b *Builder) applyCreateTable(m *meta.Meta, dbInfo *model.DBInfo, tableID i
 	}
 
 	switch tp {
+	case model.ActionRenameTable, model.ActionRenameTables:
+		if tableNames, ok := b.is.schemaMap[dbInfo.Name.L]; ok {
+			if _, ok = tableNames.tables[tblInfo.Name.L]; ok {
+				return affected, nil
+			}
+		}
 	case model.ActionDropTablePartition:
 	case model.ActionTruncateTablePartition:
 	// ReorganizePartition handle the bundles in applyReorganizePartition

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -716,12 +716,6 @@ func (b *Builder) applyCreateTable(m *meta.Meta, dbInfo *model.DBInfo, tableID i
 	}
 
 	switch tp {
-	case model.ActionRenameTable, model.ActionRenameTables:
-		if tableNames, ok := b.is.schemaMap[dbInfo.Name.L]; ok {
-			if _, ok = tableNames.tables[tblInfo.Name.L]; ok {
-				return affected, nil
-			}
-		}
 	case model.ActionDropTablePartition:
 	case model.ActionTruncateTablePartition:
 	// ReorganizePartition handle the bundles in applyReorganizePartition

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -828,9 +828,17 @@ func TestInfoSchemaRenameTable(t *testing.T) {
 
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	tk.MustExec("create table test.t1 (id int primary key,a text);")
+	tk.MustExec("create table test.t1 (id int primary key, a text);")
 	tk.MustExec("insert test.t1 values(1,'334'),(4,'3443435'),(5,'fdf43t536653');")
 	tk.MustExec("rename table test.t1 to mysql.t1;")
 	tk.MustQuery("SELECT count(*) FROM information_schema.TABLES WHERE (TABLE_SCHEMA = 'mysql') AND (TABLE_NAME = 't1');").
+		Check(testkit.Rows("1"))
+
+	tk.MustExec("create table test.t2 (id int primary key, a text);")
+	tk.MustExec("insert test.t2 values(1,'334'),(4,'3443435'),(5,'fdf43t536653');")
+	tk.MustExec("create table test.t3 (id int primary key, a text);")
+	tk.MustExec("insert test.t3 values(1,'334'),(4,'3443435'),(5,'fdf43t536653');")
+	tk.MustExec("rename table test.t2 to mysql.t2, test.t3 to mysql.t3;")
+	tk.MustQuery("SELECT count(*) FROM information_schema.TABLES WHERE (TABLE_SCHEMA = 'mysql') AND (TABLE_NAME = 't3');").
 		Check(testkit.Rows("1"))
 }

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -822,3 +822,15 @@ func TestIssue42400(t *testing.T) {
 	tk.MustQuery("show create table information_schema.ddl_jobs").CheckContain("`QUERY` text")
 	tk.MustQuery("select length(query) from information_schema.ddl_jobs;") // No error
 }
+
+func TestInfoSchemaRenameTable(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table test.t1 (id int primary key,a text);")
+	tk.MustExec("insert test.t1 values(1,'334'),(4,'3443435'),(5,'fdf43t536653');")
+	tk.MustExec("rename table test.t1 to mysql.t1;")
+	tk.MustQuery("SELECT count(*) FROM information_schema.TABLES WHERE (TABLE_SCHEMA = 'mysql') AND (TABLE_NAME = 't1');").
+		Check(testkit.Rows("1"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43714

Problem Summary:

Reproducible step:

```sql
create table test.t1 (id int primary key,a text);
insert test.t1 values(1,'334'),(4,'3443435'),(5,'fdf43t536653');
rename table test.t1 to mysql.t1;
SELECT * FROM information_schema.TABLES WHERE (TABLE_SCHEMA = 'mysql') AND (TABLE_NAME = 't1');
```

#43341 changes the behavior of `RENAME TABLE`: it takes two schema versions to complete. However, `applyDiff()` doesn't handle two `SchemaDiff`s properly. The same table is created twice in `infoschema`, causing the phantom described in #43714.

### What is changed and how it works?

During applying schema diff, we check if the table already exists before creating a new table. Thus, we can skip the second creation.

Other alternative fixes include

- Drop the table first and then create a new table(like what `CREATE TABLE` with foreign key does).
    - Change `job.Args` at second step, so that it contains the new schema ID.
    - There are risks if we change `job.Args`, it is hard to guarantee all the components that relying on this work correctly.
- Check if the old table is dropped. If it is not found, skip creating the second table.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
