### PR TITLE
planner: avoid have two `ExtraPhysTblID` row in same schema

### DIFF
--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1660,23 +1660,9 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty,
 					})
 				}
 				// global index for tableScan with keepOrder also need PhysicalTblID
-				find := false
 				ts := cop.tablePlan.(*PhysicalTableScan)
-				for _, col := range ts.Columns {
-					if col.ID == model.ExtraPhysTblID {
-						find = true
-						break
-					}
-				}
-				if !find {
-					ts.Columns = append(ts.Columns, model.NewExtraPhysTblIDColInfo())
-					ts.schema.Append(&expression.Column{
-						RetType:  types.NewFieldType(mysql.TypeLonglong),
-						UniqueID: ds.ctx.GetSessionVars().AllocPlanColumnID(),
-						ID:       model.ExtraPhysTblID,
-					})
-					cop.needExtraProj = true
-				}
+				succ := ts.AddExtraPhysTblIDColumn()
+				cop.needExtraProj = cop.needExtraProj || succ
 			}
 		}
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1652,11 +1652,12 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty,
 			cop.indexPlan.(*PhysicalIndexScan).ByItems = byItems
 			if cop.tablePlan != nil && ds.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 				if !is.Index.Global {
-					is.AddExtraPhysTblIDColumn()
+					is.Columns, is.schema, _ = AddExtraPhysTblIDColumn(is.ctx, is.Columns, is.Schema())
 				}
+				var succ bool
 				// global index for tableScan with keepOrder also need PhysicalTblID
 				ts := cop.tablePlan.(*PhysicalTableScan)
-				succ := ts.AddExtraPhysTblIDColumn()
+				ts.Columns, ts.schema, succ = AddExtraPhysTblIDColumn(ts.ctx, ts.Columns, ts.Schema())
 				cop.needExtraProj = cop.needExtraProj || succ
 			}
 		}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1652,12 +1652,7 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty,
 			cop.indexPlan.(*PhysicalIndexScan).ByItems = byItems
 			if cop.tablePlan != nil && ds.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
 				if !is.Index.Global {
-					is.Columns = append(is.Columns, model.NewExtraPhysTblIDColInfo())
-					is.schema.Append(&expression.Column{
-						RetType:  types.NewFieldType(mysql.TypeLonglong),
-						UniqueID: ds.ctx.GetSessionVars().AllocPlanColumnID(),
-						ID:       model.ExtraPhysTblID,
-					})
+					is.AddExtraPhysTblIDColumn()
 				}
 				// global index for tableScan with keepOrder also need PhysicalTblID
 				ts := cop.tablePlan.(*PhysicalTableScan)

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1660,14 +1660,23 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty,
 					})
 				}
 				// global index for tableScan with keepOrder also need PhysicalTblID
+				find := false
 				ts := cop.tablePlan.(*PhysicalTableScan)
-				ts.Columns = append(ts.Columns, model.NewExtraPhysTblIDColInfo())
-				ts.schema.Append(&expression.Column{
-					RetType:  types.NewFieldType(mysql.TypeLonglong),
-					UniqueID: ds.ctx.GetSessionVars().AllocPlanColumnID(),
-					ID:       model.ExtraPhysTblID,
-				})
-				cop.needExtraProj = true
+				for _, col := range ts.Columns {
+					if col.ID == model.ExtraPhysTblID {
+						find = true
+						break
+					}
+				}
+				if !find {
+					ts.Columns = append(ts.Columns, model.NewExtraPhysTblIDColInfo())
+					ts.schema.Append(&expression.Column{
+						RetType:  types.NewFieldType(mysql.TypeLonglong),
+						UniqueID: ds.ctx.GetSessionVars().AllocPlanColumnID(),
+						ID:       model.ExtraPhysTblID,
+					})
+					cop.needExtraProj = true
+				}
 			}
 		}
 	}

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -785,15 +785,15 @@ func (p *PhysicalIndexScan) MemoryUsage() (sum int64) {
 // For keepOrder with partition table,
 // we need use partitionHandle to distinct two handles,
 // the `_tidb_rowid` in differenct partition will same in some scenario.
-func (is *PhysicalIndexScan) AddExtraPhysTblIDColumn() bool {
+func (p *PhysicalIndexScan) AddExtraPhysTblIDColumn() bool {
 	// The first column will return 0 when has more than two ExtraPhysTblID columns.
-	if FindColumnInfoByID(is.Columns, model.ExtraPhysTblID) == nil {
+	if FindColumnInfoByID(p.Columns, model.ExtraPhysTblID) == nil {
 		return false
 	}
-	is.Columns = append(is.Columns, model.NewExtraPhysTblIDColInfo())
-	is.schema.Append(&expression.Column{
+	p.Columns = append(p.Columns, model.NewExtraPhysTblIDColInfo())
+	p.schema.Append(&expression.Column{
 		RetType:  types.NewFieldType(mysql.TypeLonglong),
-		UniqueID: is.ctx.GetSessionVars().AllocPlanColumnID(),
+		UniqueID: p.ctx.GetSessionVars().AllocPlanColumnID(),
 		ID:       model.ExtraPhysTblID,
 	})
 	return true

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -787,7 +787,7 @@ func (p *PhysicalIndexScan) MemoryUsage() (sum int64) {
 // the `_tidb_rowid` in differenct partition will same in some scenario.
 func (p *PhysicalIndexScan) AddExtraPhysTblIDColumn() bool {
 	// The first column will return 0 when has more than two ExtraPhysTblID columns.
-	if FindColumnInfoByID(p.Columns, model.ExtraPhysTblID) == nil {
+	if FindColumnInfoByID(p.Columns, model.ExtraPhysTblID) != nil {
 		return false
 	}
 	p.Columns = append(p.Columns, model.NewExtraPhysTblIDColInfo())
@@ -1016,7 +1016,7 @@ func (ts *PhysicalTableScan) SetIsChildOfIndexLookUp(isIsChildOfIndexLookUp bool
 // the `_tidb_rowid` in differenct partition will same in some scenario.
 func (ts *PhysicalTableScan) AddExtraPhysTblIDColumn() bool {
 	// The first column will return 0 when has more than two ExtraPhysTblID columns.
-	if FindColumnInfoByID(ts.Columns, model.ExtraPhysTblID) == nil {
+	if FindColumnInfoByID(ts.Columns, model.ExtraPhysTblID) != nil {
 		return false
 	}
 	ts.Columns = append(ts.Columns, model.NewExtraPhysTblIDColInfo())

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -786,7 +786,7 @@ func (p *PhysicalIndexScan) MemoryUsage() (sum int64) {
 // we need use partitionHandle to distinct two handles,
 // the `_tidb_rowid` in differenct partition will same in some scenario.
 func (is *PhysicalIndexScan) AddExtraPhysTblIDColumn() bool {
-	// The first column will return 0 when it happend.
+	// The first column will return 0 when has more than two ExtraPhysTblID columns.
 	if FindColumnInfoByID(is.Columns, model.ExtraPhysTblID) == nil {
 		return false
 	}
@@ -1015,7 +1015,7 @@ func (ts *PhysicalTableScan) SetIsChildOfIndexLookUp(isIsChildOfIndexLookUp bool
 // we need use partitionHandle to distinct two handles,
 // the `_tidb_rowid` in differenct partition will same in some scenario.
 func (ts *PhysicalTableScan) AddExtraPhysTblIDColumn() bool {
-	// The first column will return 0 when it happend.
+	// The first column will return 0 when has more than two ExtraPhysTblID columns.
 	if FindColumnInfoByID(ts.Columns, model.ExtraPhysTblID) == nil {
 		return false
 	}

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1146,13 +1146,13 @@ func (p *PhysicalTopN) pushPartialTopNDownToCop(copTsk *copTask) (task, bool) {
 			if plan, ok := finalScan.(*PhysicalTableScan); ok {
 				plan.ByItems = p.ByItems
 				if plan.Table.GetPartitionInfo() != nil && p.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
-					plan.AddExtraPhysTblIDColumn()
+					plan.Columns, plan.schema, _ = AddExtraPhysTblIDColumn(plan.ctx, plan.Columns, plan.Schema())
 				}
 			}
 			if plan, ok := finalScan.(*PhysicalIndexScan); ok {
 				plan.ByItems = p.ByItems
 				if plan.Table.GetPartitionInfo() != nil && p.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() && !plan.Index.Global {
-					plan.AddExtraPhysTblIDColumn()
+					plan.Columns, plan.schema, _ = AddExtraPhysTblIDColumn(plan.ctx, plan.Columns, plan.Schema())
 				}
 			}
 			partialScans = append(partialScans, finalScan)
@@ -1206,7 +1206,8 @@ func (p *PhysicalTopN) pushPartialTopNDownToCop(copTsk *copTask) (task, bool) {
 		}
 		// global index for tableScan with keepOrder also need PhysicalTblID
 		if clonedTblScan.Table.GetPartitionInfo() != nil && p.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
-			succ := clonedTblScan.AddExtraPhysTblIDColumn()
+			var succ bool
+			clonedTblScan.Columns, clonedTblScan.schema, succ = AddExtraPhysTblIDColumn(clonedTblScan.ctx, clonedTblScan.Columns, clonedTblScan.Schema())
 			copTsk.needExtraProj = copTsk.needExtraProj || succ
 		}
 		clonedTblScan.HandleCols, err = clonedTblScan.HandleCols.ResolveIndices(clonedTblScan.Schema())

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1216,22 +1216,8 @@ func (p *PhysicalTopN) pushPartialTopNDownToCop(copTsk *copTask) (task, bool) {
 		}
 		// global index for tableScan with keepOrder also need PhysicalTblID
 		if clonedTblScan.Table.GetPartitionInfo() != nil && p.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
-			find := false
-			for _, col := range clonedTblScan.Columns {
-				if col.ID == model.ExtraPhysTblID {
-					find = true
-					break
-				}
-			}
-			if !find {
-				clonedTblScan.Columns = append(clonedTblScan.Columns, model.NewExtraPhysTblIDColInfo())
-				clonedTblScan.Schema().Append(&expression.Column{
-					RetType:  types.NewFieldType(mysql.TypeLonglong),
-					UniqueID: p.ctx.GetSessionVars().AllocPlanColumnID(),
-					ID:       model.ExtraPhysTblID,
-				})
-				copTsk.needExtraProj = true
-			}
+			succ := clonedTblScan.AddExtraPhysTblIDColumn()
+			copTsk.needExtraProj = copTsk.needExtraProj || succ
 		}
 		clonedTblScan.HandleCols, err = clonedTblScan.HandleCols.ResolveIndices(clonedTblScan.Schema())
 		if err != nil {

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1146,23 +1146,13 @@ func (p *PhysicalTopN) pushPartialTopNDownToCop(copTsk *copTask) (task, bool) {
 			if plan, ok := finalScan.(*PhysicalTableScan); ok {
 				plan.ByItems = p.ByItems
 				if plan.Table.GetPartitionInfo() != nil && p.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() {
-					plan.Columns = append(plan.Columns, model.NewExtraPhysTblIDColInfo())
-					plan.schema.Append(&expression.Column{
-						RetType:  types.NewFieldType(mysql.TypeLonglong),
-						UniqueID: p.ctx.GetSessionVars().AllocPlanColumnID(),
-						ID:       model.ExtraPhysTblID,
-					})
+					plan.AddExtraPhysTblIDColumn()
 				}
 			}
 			if plan, ok := finalScan.(*PhysicalIndexScan); ok {
 				plan.ByItems = p.ByItems
 				if plan.Table.GetPartitionInfo() != nil && p.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune() && !plan.Index.Global {
-					plan.Columns = append(plan.Columns, model.NewExtraPhysTblIDColInfo())
-					plan.schema.Append(&expression.Column{
-						RetType:  types.NewFieldType(mysql.TypeLonglong),
-						UniqueID: p.ctx.GetSessionVars().AllocPlanColumnID(),
-						ID:       model.ExtraPhysTblID,
-					})
+					plan.AddExtraPhysTblIDColumn()
 				}
 			}
 			partialScans = append(partialScans, finalScan)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44615

Problem Summary: When a schema has two `ExtraPhysTblID` rows, the first one will return 0 in TiKV side which caused `SelectLock` failed. And in some reasons, the `SelectLock` will ignore this problem, see https://github.com/pingcap/tidb/blob/bd278a05dae96861c94cc9dc69203c26b77fe15b/executor/executor.go#L1281-L1288
So we should avoid it in planner part.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
