### PR TITLE
*: fix fileperm on bazel RBE

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -18,6 +18,20 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+bool_flag(
+    name = "with_rbe_flag",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "without_rbe",
+    flag_values = {
+        ":with_rbe_flag": "false",
+    },
+    visibility = ["//visibility:public"],
+)
+
 STATICHECK_ANALYZERS = [
     "S1000",
     "S1001",
@@ -152,9 +166,14 @@ nogo(
                "//build:with_nogo": [
                    "//build/linter/allrevive",
                    "//build/linter/errcheck",
-                   "//build/linter/filepermission",
                    "//build/linter/lll",
                    "//build/linter/revive",
+               ],
+               "//conditions:default": [],
+           }) +
+           select({
+               "//build:without_rbe": [
+                   "//build/linter/filepermission",
                ],
                "//conditions:default": [],
            }),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: fileperm linters are not working on bazel RBE environemnt, where all files are `555`. Add a flag to disable this linter.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
