### PR TITLE
test: refine func signature of distributed execution test context

### DIFF
--- a/disttask/framework/framework_test.go
+++ b/disttask/framework/framework_test.go
@@ -178,12 +178,10 @@ func TestFrameworkBasic(t *testing.T) {
 	defer scheduler.ClearSchedulers()
 	var v atomic.Int64
 	RegisterTaskMeta(&v)
-	testContext, err := testkit.NewDistExecutionTestContext(t, 2)
-	require.NoError(t, err)
+	testContext := testkit.NewDistExecutionTestContext(t, 2)
 	DispatchTask("key1", t, &v)
 	DispatchTask("key2", t, &v)
-	err = testContext.SetOwner(0)
-	require.NoError(t, err)
+	testContext.SetOwner(0)
 	time.Sleep(2 * time.Second) // make sure owner changed
 	DispatchTask("key3", t, &v)
 	DispatchTask("key4", t, &v)
@@ -195,12 +193,10 @@ func TestFramework3Server(t *testing.T) {
 	defer scheduler.ClearSchedulers()
 	var v atomic.Int64
 	RegisterTaskMeta(&v)
-	testContext, err := testkit.NewDistExecutionTestContext(t, 3)
-	require.NoError(t, err)
+	testContext := testkit.NewDistExecutionTestContext(t, 3)
 	DispatchTask("key1", t, &v)
 	DispatchTask("key2", t, &v)
-	err = testContext.SetOwner(0)
-	require.NoError(t, err)
+	testContext.SetOwner(0)
 	time.Sleep(2 * time.Second) // make sure owner changed
 	DispatchTask("key3", t, &v)
 	DispatchTask("key4", t, &v)
@@ -212,13 +208,11 @@ func TestFrameworkAddServer(t *testing.T) {
 	defer scheduler.ClearSchedulers()
 	var v atomic.Int64
 	RegisterTaskMeta(&v)
-	testContext, err := testkit.NewDistExecutionTestContext(t, 2)
-	require.NoError(t, err)
+	testContext := testkit.NewDistExecutionTestContext(t, 2)
 	DispatchTask("key1", t, &v)
 	testContext.AddServer()
 	DispatchTask("key2", t, &v)
-	err = testContext.SetOwner(1)
-	require.NoError(t, err)
+	testContext.SetOwner(1)
 	time.Sleep(2 * time.Second) // make sure owner changed
 	DispatchTask("key3", t, &v)
 	testContext.Close()
@@ -231,11 +225,9 @@ func TestFrameworkDeleteServer(t *testing.T) {
 	defer scheduler.ClearSchedulers()
 	var v atomic.Int64
 	RegisterTaskMeta(&v)
-	testContext, err := testkit.NewDistExecutionTestContext(t, 2)
-	require.NoError(t, err)
+	testContext := testkit.NewDistExecutionTestContext(t, 2)
 	DispatchTask("key1", t, &v)
-	err = testContext.DeleteServer(1)
-	require.NoError(t, err)
+	testContext.DeleteServer(1)
 	time.Sleep(2 * time.Second) // make sure the owner changed
 	DispatchTask("key2", t, &v)
 	testContext.Close()
@@ -246,8 +238,7 @@ func TestFrameworkWithQuery(t *testing.T) {
 	defer scheduler.ClearSchedulers()
 	var v atomic.Int64
 	RegisterTaskMeta(&v)
-	testContext, err := testkit.NewDistExecutionTestContext(t, 2)
-	require.NoError(t, err)
+	testContext := testkit.NewDistExecutionTestContext(t, 2)
 	DispatchTask("key1", t, &v)
 
 	tk := testkit.NewTestKit(t, testContext.Store)
@@ -269,8 +260,7 @@ func TestFrameworkCancelGTask(t *testing.T) {
 	defer scheduler.ClearSchedulers()
 	var v atomic.Int64
 	RegisterTaskMeta(&v)
-	testContext, err := testkit.NewDistExecutionTestContext(t, 2)
-	require.NoError(t, err)
+	testContext := testkit.NewDistExecutionTestContext(t, 2)
 	DispatchAndCancelTask("key1", t, &v)
 	testContext.Close()
 }

--- a/testkit/mockstore.go
+++ b/testkit/mockstore.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/ddl/schematracker"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/domain/infosync"
@@ -90,7 +91,7 @@ func (d *DistExecutionTestContext) SetOwner(idx int) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if idx >= len(d.domains) || idx < 0 {
-		d.t.Fatal("server idx out of bound")
+		require.NoError(d.t, errors.New("server idx out of bound"))
 		return
 	}
 	for _, dom := range d.domains {
@@ -115,11 +116,11 @@ func (d *DistExecutionTestContext) DeleteServer(idx int) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if idx >= len(d.domains) || idx < 0 {
-		d.t.Fatal("server idx out of bound")
+		require.NoError(d.t, errors.New("server idx out of bound"))
 		return
 	}
 	if len(d.domains) == 1 {
-		d.t.Fatal("can't delete server, since server num = 1")
+		require.NoError(d.t, errors.New("can't delete server, since server num = 1"))
 		return
 	}
 	if d.domains[idx].DDL().OwnerManager().IsOwner() {

--- a/testkit/mockstore.go
+++ b/testkit/mockstore.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/ddl/schematracker"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/domain/infosync"
@@ -76,26 +75,29 @@ type DistExecutionTestContext struct {
 }
 
 // InitOwner select the last domain as DDL owner.
-func (d *DistExecutionTestContext) InitOwner() error {
+func (d *DistExecutionTestContext) InitOwner() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	for _, dom := range d.domains {
 		dom.DDL().OwnerManager().RetireOwner()
 	}
-	return d.domains[len(d.domains)-1].DDL().OwnerManager().CampaignOwner()
+	err := d.domains[len(d.domains)-1].DDL().OwnerManager().CampaignOwner()
+	require.NoError(d.t, err)
 }
 
 // SetOwner set one mock domain to DDL Owner by idx.
-func (d *DistExecutionTestContext) SetOwner(idx int) error {
+func (d *DistExecutionTestContext) SetOwner(idx int) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if idx >= len(d.domains) || idx < 0 {
-		return errors.New("server idx out of bound")
+		d.t.Fatal("server idx out of bound")
+		return
 	}
 	for _, dom := range d.domains {
 		dom.DDL().OwnerManager().RetireOwner()
 	}
-	return d.domains[idx].DDL().OwnerManager().CampaignOwner()
+	err := d.domains[idx].DDL().OwnerManager().CampaignOwner()
+	require.NoError(d.t, err)
 }
 
 // AddServer add 1 server which is not ddl owner.
@@ -109,25 +111,25 @@ func (d *DistExecutionTestContext) AddServer() {
 }
 
 // DeleteServer delete 1 server by idx, set server0 as ddl owner if the deleted owner is ddl owner.
-func (d *DistExecutionTestContext) DeleteServer(idx int) error {
+func (d *DistExecutionTestContext) DeleteServer(idx int) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if idx >= len(d.domains) || idx < 0 {
-		return errors.New("server idx out of bound")
+		d.t.Fatal("server idx out of bound")
+		return
 	}
 	if len(d.domains) == 1 {
-		return errors.New("can't delete server, since server num = 1")
+		d.t.Fatal("can't delete server, since server num = 1")
+		return
 	}
 	if d.domains[idx].DDL().OwnerManager().IsOwner() {
 		d.mu.Unlock()
-		err := d.SetOwner(0)
+		d.SetOwner(0)
 		d.mu.Lock()
-		if err != nil {
-			return err
-		}
 	}
 	d.domains = append(d.domains[:idx], d.domains[idx+1:]...)
-	return infosync.MockGlobalServerInfoManagerEntry.Delete(idx)
+	err := infosync.MockGlobalServerInfoManagerEntry.Delete(idx)
+	require.NoError(d.t, err)
 }
 
 // Close cleanup running goroutines, release resources used.
@@ -136,16 +138,21 @@ func (d *DistExecutionTestContext) Close() {
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		gctuner.GlobalMemoryLimitTuner.Stop()
-		for _, domain := range d.domains {
-			domain.Close()
+		for _, dom := range d.domains {
+			dom.Close()
 		}
 		err := d.Store.Close()
 		require.NoError(d.t, err)
 	})
 }
 
+// GetDomain get domain by index.
+func (d *DistExecutionTestContext) GetDomain(idx int) *domain.Domain {
+	return d.domains[idx]
+}
+
 // NewDistExecutionTestContext create DistExecutionTestContext for testing.
-func NewDistExecutionTestContext(t testing.TB, serverNum int) (*DistExecutionTestContext, error) {
+func NewDistExecutionTestContext(t testing.TB, serverNum int) *DistExecutionTestContext {
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	gctuner.GlobalMemoryLimitTuner.Stop()
@@ -159,11 +166,8 @@ func NewDistExecutionTestContext(t testing.TB, serverNum int) (*DistExecutionTes
 
 	res := DistExecutionTestContext{
 		schematracker.UnwrapStorage(store), domains, t, sync.Mutex{}}
-	err = res.InitOwner()
-	if err != nil {
-		return nil, err
-	}
-	return &res, nil
+	res.InitOwner()
+	return &res
 }
 
 // CreateMockStoreAndDomain return a new mock kv.Storage and *domain.Domain.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Problem Summary:

Since `NewDistExecutionTestContext` takes the argument `testing.TB`, we can assert the error is not null instead of returning it to the caller.

### What is changed and how it works?

- Refine the function signature of `DistExecutionTestContext`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
