### PR TITLE
*: Show required changes by git diff when CI check bazel files failed

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -4230,7 +4230,7 @@ def go_deps():
         name = "com_github_tikv_client_go_v2",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sum = "h1:7JvBwc+e1x4AXHtwXp9IK1X04Iokol+HgrWdukU5iqM=",
+        sum = "h1:7JvBwc+e1x4AXHtwXp9IK1X04Iokol+HgrWdukU5iqN=",
         version = "v2.0.8-0.20230605085112-28247160f497",
     )
     go_repository(

--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -4230,7 +4230,7 @@ def go_deps():
         name = "com_github_tikv_client_go_v2",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sum = "h1:7JvBwc+e1x4AXHtwXp9IK1X04Iokol+HgrWdukU5iqN=",
+        sum = "h1:7JvBwc+e1x4AXHtwXp9IK1X04Iokol+HgrWdukU5iqM=",
         version = "v2.0.8-0.20230605085112-28247160f497",
     )
     go_repository(

--- a/tools/check/check-bazel-prepare.sh
+++ b/tools/check/check-bazel-prepare.sh
@@ -25,11 +25,9 @@ make bazel_ci_prepare
 after_checksum=`find . -type f \( -name *.bazel -o -name *.bzl \) -exec md5sum {} \;| sort -k 2`
 if [ "$before_checksum" != "$after_checksum" ]
 then
-  echo "Please run \`make bazel_prepare\` to update \`.bazel\` files, or just apply the following git diff:"
-  echo --------------------
+  echo "Please run \`make bazel_prepare\` to update \`.bazel\` files, or just apply the following git diff (run \`git apply -\` and paste following contents):"
   git diff
-  echo --------------------
-  echo -e "\nChecksum diff:"
+  echo -e "\n\nChecksum diff:"
   diff <(echo "$before_checksum") <(echo "$after_checksum") || true
   exit 1
 fi

--- a/tools/check/check-bazel-prepare.sh
+++ b/tools/check/check-bazel-prepare.sh
@@ -25,7 +25,11 @@ make bazel_ci_prepare
 after_checksum=`find . -type f \( -name *.bazel -o -name *.bzl \) -exec md5sum {} \;| sort -k 2`
 if [ "$before_checksum" != "$after_checksum" ]
 then
-  echo "Please run \`make bazel_prepare\` to update \`.bazel\` files"
-  diff <(echo "$before_checksum") <(echo "$after_checksum")
+  echo "Please run \`make bazel_prepare\` to update \`.bazel\` files, or just apply the following git diff:"
+  echo --------------------
+  git diff
+  echo --------------------
+  echo -e "\nChecksum diff:"
+  diff <(echo "$before_checksum") <(echo "$after_checksum") || true
   exit 1
 fi


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44661

Problem Summary:

### What is changed and how it works?

This PR adds some more simple commands to check-bazel-prepare.sh to output the expected changes to be made after CI check bazel failed.

Not sure if the checksum diff makes any sense. I kept them anyway. Btw the previous `diff` command exits immediately if there are any diff (since there's a `set -e` before). I added `|| true` to avoid this behavior, though it doesn't make anything different for now.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
