### PR TITLE
import into: redact task meta after import & cancel on kill

### DIFF
--- a/ddl/scheduler.go
+++ b/ddl/scheduler.go
@@ -71,14 +71,6 @@ type BackfillSubTaskMeta struct {
 	EndKey          []byte `json:"end_key"`
 }
 
-// BackfillMinimalTask is the minimal-task for backfilling index.
-type BackfillMinimalTask struct {
-}
-
-// IsMinimalTask implements the MinimalTask interface.
-func (*BackfillMinimalTask) IsMinimalTask() {
-}
-
 // NewBackfillSchedulerHandle creates a new backfill scheduler.
 func NewBackfillSchedulerHandle(taskMeta []byte, d *ddl, stepForImport bool) (scheduler.Scheduler, error) {
 	bh := &backfillSchedulerHandle{d: d}

--- a/disttask/example/proto.go
+++ b/disttask/example/proto.go
@@ -31,3 +31,8 @@ type MinimalTaskExample struct{}
 
 // IsMinimalTask is used to implement the proto.MinimalTask interface.
 func (MinimalTaskExample) IsMinimalTask() {}
+
+// String is used to implement the fmt.Stringer interface.
+func (MinimalTaskExample) String() string {
+	return "minimal task example"
+}

--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -279,20 +279,20 @@ func (d *dispatcher) detectTask(gTask *proto.Task) {
 			if !stepIsFinished && len(errStr) == 0 {
 				GetTaskFlowHandle(gTask.Type).OnTicker(d.ctx, gTask)
 				logutil.BgLogger().Debug("detect task, this task keeps current state",
-					zap.Int64("taskID", gTask.ID), zap.String("state", gTask.State))
+					zap.Int64("task-id", gTask.ID), zap.String("state", gTask.State))
 				break
 			}
 
 			err := d.processFlow(gTask, errStr)
 			if err == nil && gTask.IsFinished() {
 				logutil.BgLogger().Info("detect task, task is finished",
-					zap.Int64("taskID", gTask.ID), zap.String("state", gTask.State))
+					zap.Int64("task-id", gTask.ID), zap.String("state", gTask.State))
 				d.delRunningGTask(gTask.ID)
 				return
 			}
 			if !d.isRunningGTask(gTask.ID) {
 				logutil.BgLogger().Info("detect task, this task can't run",
-					zap.Int64("taskID", gTask.ID), zap.String("state", gTask.State))
+					zap.Int64("task-id", gTask.ID), zap.String("state", gTask.State))
 			}
 		}
 	}
@@ -301,17 +301,17 @@ func (d *dispatcher) detectTask(gTask *proto.Task) {
 func (d *dispatcher) processFlow(gTask *proto.Task, errStr [][]byte) error {
 	if len(errStr) > 0 {
 		// Found an error when task is running.
-		logutil.BgLogger().Info("process flow, handle an error", zap.Int64("taskID", gTask.ID), zap.Any("err msg", errStr))
+		logutil.BgLogger().Info("process flow, handle an error", zap.Int64("task-id", gTask.ID), zap.Any("err msg", errStr))
 		return d.processErrFlow(gTask, errStr)
 	}
 	// previous step is finished.
 	if gTask.State == proto.TaskStateReverting {
 		// Finish the rollback step.
-		logutil.BgLogger().Info("process flow, update the task to reverted", zap.Int64("taskID", gTask.ID))
+		logutil.BgLogger().Info("process flow, update the task to reverted", zap.Int64("task-id", gTask.ID))
 		return d.updateTask(gTask, proto.TaskStateReverted, nil, retrySQLTimes)
 	}
 	// Finish the normal step.
-	logutil.BgLogger().Info("process flow, process normal", zap.Int64("taskID", gTask.ID))
+	logutil.BgLogger().Info("process flow, process normal", zap.Int64("task-id", gTask.ID))
 	return d.processNormalFlow(gTask)
 }
 
@@ -324,14 +324,14 @@ func (d *dispatcher) updateTask(gTask *proto.Task, gTaskState string, newSubTask
 			break
 		}
 		if i%10 == 0 {
-			logutil.BgLogger().Warn("updateTask first failed", zap.Int64("taskID", gTask.ID),
+			logutil.BgLogger().Warn("updateTask first failed", zap.Int64("task-id", gTask.ID),
 				zap.String("previous state", prevState), zap.String("curr state", gTask.State),
 				zap.Int("retry times", retryTimes), zap.Error(err))
 		}
 		time.Sleep(retrySQLInterval)
 	}
 	if err != nil && retryTimes != nonRetrySQLTime {
-		logutil.BgLogger().Warn("updateTask failed and delete running task info", zap.Int64("taskID", gTask.ID),
+		logutil.BgLogger().Warn("updateTask failed and delete running task info", zap.Int64("task-id", gTask.ID),
 			zap.String("previous state", prevState), zap.String("curr state", gTask.State), zap.Int("retry times", retryTimes), zap.Error(err))
 		d.delRunningGTask(gTask.ID)
 	}

--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -301,7 +301,7 @@ func (d *dispatcher) detectTask(gTask *proto.Task) {
 func (d *dispatcher) processFlow(gTask *proto.Task, errStr [][]byte) error {
 	if len(errStr) > 0 {
 		// Found an error when task is running.
-		logutil.BgLogger().Info("process flow, handle an error", zap.Int64("task-id", gTask.ID), zap.Any("err msg", errStr))
+		logutil.BgLogger().Info("process flow, handle an error", zap.Int64("task-id", gTask.ID), zap.ByteStrings("err msg", errStr))
 		return d.processErrFlow(gTask, errStr)
 	}
 	// previous step is finished.

--- a/disttask/framework/framework_test.go
+++ b/disttask/framework/framework_test.go
@@ -78,6 +78,10 @@ type testMiniTask struct{}
 
 func (testMiniTask) IsMinimalTask() {}
 
+func (testMiniTask) String() string {
+	return ""
+}
+
 type testScheduler struct{}
 
 func (*testScheduler) InitSubtaskExecEnv(_ context.Context) error { return nil }

--- a/disttask/framework/handle/handle.go
+++ b/disttask/framework/handle/handle.go
@@ -85,7 +85,7 @@ func WaitGlobalTask(ctx context.Context, globalTask *proto.Task) error {
 			case proto.TaskStateSucceed:
 				return nil
 			case proto.TaskStateReverted:
-				logutil.BgLogger().Error("global task reverted", zap.Int64("taskID", globalTask.ID), zap.String("error", string(found.Error)))
+				logutil.BgLogger().Error("global task reverted", zap.Int64("task-id", globalTask.ID), zap.String("error", string(found.Error)))
 				return errors.New(string(found.Error))
 			case proto.TaskStateFailed, proto.TaskStateCanceled:
 				return errors.Errorf("task stopped with state %s, err %s", found.State, found.Error)

--- a/disttask/framework/proto/task.go
+++ b/disttask/framework/proto/task.go
@@ -15,6 +15,7 @@
 package proto
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -104,6 +105,7 @@ func NewSubtask(taskID int64, tp, schedulerID string, meta []byte) *Subtask {
 type MinimalTask interface {
 	// IsMinimalTask is a marker to check if it is a minimal task for compiler.
 	IsMinimalTask()
+	fmt.Stringer
 }
 
 const (

--- a/disttask/framework/scheduler/interface_mock.go
+++ b/disttask/framework/scheduler/interface_mock.go
@@ -202,3 +202,8 @@ type MockMinimalTask struct{}
 
 // IsMinimalTask implements MinimalTask.IsMinimalTask.
 func (MockMinimalTask) IsMinimalTask() {}
+
+// String is used to implement the fmt.Stringer interface.
+func (MockMinimalTask) String() string {
+	return "mock minimal task"
+}

--- a/disttask/framework/scheduler/scheduler.go
+++ b/disttask/framework/scheduler/scheduler.go
@@ -174,7 +174,7 @@ func (s *InternalSchedulerImpl) runSubtask(ctx context.Context, scheduler Schedu
 		s.subtaskWg.Done()
 		return
 	}
-	logutil.Logger(s.logCtx).Info("split subTask", zap.Int("cnt", len(minimalTasks)), zap.Int64("subtask_id", subtask.ID))
+	logutil.Logger(s.logCtx).Info("split subTask", zap.Int("cnt", len(minimalTasks)), zap.Int64("subtask-id", subtask.ID))
 
 	// fast path for ADD INDEX.
 	// ADD INDEX is a special case now, no minimal tasks will be generated.
@@ -229,7 +229,7 @@ func (s *InternalSchedulerImpl) onSubtaskFinished(ctx context.Context, scheduler
 }
 
 func (s *InternalSchedulerImpl) runMinimalTask(minimalTaskCtx context.Context, minimalTask proto.MinimalTask, tp string, step int64) {
-	logutil.Logger(s.logCtx).Info("scheduler run a minimalTask", zap.Any("step", step), zap.Any("minimal_task", minimalTask))
+	logutil.Logger(s.logCtx).Info("scheduler run a minimalTask", zap.Any("step", step), zap.Stringer("minimal-task", minimalTask))
 	select {
 	case <-minimalTaskCtx.Done():
 		s.onError(minimalTaskCtx.Err())

--- a/disttask/importinto/BUILD.bazel
+++ b/disttask/importinto/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//errno",
         "//executor/asyncloaddata",
         "//executor/importer",
+        "//parser/ast",
         "//parser/mysql",
         "//sessionctx",
         "//table/tables",

--- a/disttask/importinto/dispatcher.go
+++ b/disttask/importinto/dispatcher.go
@@ -260,7 +260,7 @@ func (h *flowHandle) ProcessErrFlow(ctx context.Context, handle dispatcher.TaskH
 		zap.Int64("task-id", gTask.ID),
 		zap.String("step", stepStr(gTask.Step)),
 	)
-	logger.Info("process error flow", zap.ByteStrings("error message", receiveErr))
+	logger.Info("process error flow", zap.ByteStrings("error-message", receiveErr))
 	taskMeta := &TaskMeta{}
 	err := json.Unmarshal(gTask.Meta, taskMeta)
 	if err != nil {
@@ -326,7 +326,7 @@ func (h *flowHandle) switchTiKV2NormalMode(ctx context.Context, logger *zap.Logg
 
 // preProcess does the pre-processing for the task.
 func preProcess(_ context.Context, _ dispatcher.TaskHandle, gTask *proto.Task, taskMeta *TaskMeta, logger *zap.Logger) error {
-	logger.Info("pre process", zap.Any("table_info", taskMeta.Plan.TableInfo))
+	logger.Info("pre process")
 	// TODO: drop table indexes depends on the option.
 	// if err := dropTableIndexes(ctx, handle, taskMeta, logger); err != nil {
 	// 	return err

--- a/disttask/importinto/job.go
+++ b/disttask/importinto/job.go
@@ -57,7 +57,7 @@ func NewDistImporter(param *importer.JobImportParam, plan *importer.Plan, stmt s
 		JobImportParam: param,
 		plan:           plan,
 		stmt:           stmt,
-		logger:         logutil.BgLogger().With(zap.String("component", "importer")),
+		logger:         logutil.BgLogger(),
 		sourceFileSize: sourceFileSize,
 	}, nil
 }
@@ -72,7 +72,7 @@ func NewDistImporterCurrNode(param *importer.JobImportParam, plan *importer.Plan
 		JobImportParam: param,
 		plan:           plan,
 		stmt:           stmt,
-		logger:         logutil.BgLogger().With(zap.String("component", "importer")),
+		logger:         logutil.BgLogger(),
 		instance:       serverInfo,
 		sourceFileSize: sourceFileSize,
 	}, nil
@@ -119,7 +119,7 @@ func (ti *DistImporter) Result() importer.JobImportResult {
 		return result
 	}
 
-	ti.logger.Info("finish distribute IMPORT INTO", zap.Any("task meta", taskMeta))
+	ti.logger.Info("finish distribute IMPORT INTO")
 	var (
 		numWarnings uint64
 		numRecords  uint64

--- a/disttask/importinto/job.go
+++ b/disttask/importinto/job.go
@@ -119,7 +119,6 @@ func (ti *DistImporter) Result() importer.JobImportResult {
 		return result
 	}
 
-	ti.logger.Info("finish distribute IMPORT INTO")
 	var (
 		numWarnings uint64
 		numRecords  uint64
@@ -217,6 +216,11 @@ func (ti *DistImporter) SubmitTask(ctx context.Context) (int64, *proto.Task, err
 func (*DistImporter) taskKey() string {
 	// task key is meaningless to IMPORT INTO, so we use a random uuid.
 	return fmt.Sprintf("%s/%s", proto.ImportInto, uuid.New().String())
+}
+
+// JobID returns the job id.
+func (ti *DistImporter) JobID() int64 {
+	return ti.jobID
 }
 
 func getTaskMeta(jobID int64) (*TaskMeta, error) {

--- a/disttask/importinto/proto.go
+++ b/disttask/importinto/proto.go
@@ -61,7 +61,6 @@ type TaskMeta struct {
 // Dispatcher will split the task into subtasks(FileInfos -> Chunks)
 // All the field should be serializable.
 type ImportStepMeta struct {
-	Plan importer.Plan
 	// this is the engine ID, not the id in tidb_background_subtask table.
 	ID       int32
 	Chunks   []Chunk

--- a/disttask/importinto/proto.go
+++ b/disttask/importinto/proto.go
@@ -15,6 +15,7 @@
 package importinto
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/pingcap/tidb/br/pkg/lightning/backend"
@@ -98,6 +99,10 @@ type importStepMinimalTask struct {
 // IsMinimalTask implements the MinimalTask interface.
 func (*importStepMinimalTask) IsMinimalTask() {}
 
+func (t *importStepMinimalTask) String() string {
+	return fmt.Sprintf("chunk:%s:%d", t.Chunk.Path, t.Chunk.Offset)
+}
+
 // postProcessStepMinimalTask is the minimal task of post process step.
 type postProcessStepMinimalTask struct {
 	meta     PostProcessStepMeta
@@ -106,6 +111,10 @@ type postProcessStepMinimalTask struct {
 }
 
 func (*postProcessStepMinimalTask) IsMinimalTask() {}
+
+func (*postProcessStepMinimalTask) String() string {
+	return "post process"
+}
 
 // Chunk records the chunk information.
 type Chunk struct {

--- a/disttask/importinto/subtask_executor.go
+++ b/disttask/importinto/subtask_executor.go
@@ -37,8 +37,8 @@ type ImportMinimalTaskExecutor struct {
 
 // Run implements the SubtaskExecutor.Run interface.
 func (e *ImportMinimalTaskExecutor) Run(ctx context.Context) error {
-	logger := logutil.BgLogger().With(zap.String("component", "minimal task executor"), zap.String("type", proto.ImportInto), zap.Int64("table_id", e.mTtask.Plan.TableInfo.ID))
-	logger.Info("subtask executor run", zap.Any("task", e.mTtask))
+	logger := logutil.BgLogger().With(zap.String("type", proto.ImportInto), zap.Int64("table-id", e.mTtask.Plan.TableInfo.ID))
+	logger.Info("run minimal task")
 	failpoint.Inject("waitBeforeSortChunk", func() {
 		time.Sleep(3 * time.Second)
 	})

--- a/disttask/importinto/wrapper.go
+++ b/disttask/importinto/wrapper.go
@@ -21,6 +21,10 @@ import (
 
 func toChunkCheckpoint(chunk Chunk) checkpoints.ChunkCheckpoint {
 	return checkpoints.ChunkCheckpoint{
+		Key: checkpoints.ChunkCheckpointKey{
+			Path:   chunk.Path,
+			Offset: chunk.Offset,
+		},
 		FileMeta: mydump.SourceFileMeta{
 			Path:        chunk.Path,
 			Type:        chunk.Type,

--- a/executor/import_into.go
+++ b/executor/import_into.go
@@ -219,9 +219,7 @@ func (e *ImportIntoExec) doImport(ctx context.Context, se sessionctx.Context, di
 			return err2
 		}
 		// use background, since ctx is canceled already.
-		if err2 = cancelImportJob(context.Background(), globalTaskManager, distImporter.JobID()); err2 != nil {
-			return err2
-		}
+		return cancelImportJob(context.Background(), globalTaskManager, distImporter.JobID())
 	}
 	if err2 := flushStats(ctx, se, e.importPlan.TableInfo.ID, distImporter.Result()); err2 != nil {
 		logutil.Logger(ctx).Error("flush stats failed", zap.Error(err2))

--- a/executor/import_into_test.go
+++ b/executor/import_into_test.go
@@ -162,4 +162,17 @@ func TestImportIntoOptionsNegativeCase(t *testing.T) {
 			require.ErrorIs(t, err, c.Err, sql)
 		}
 	}
+
+	parameterCheck := []struct {
+		sql string
+		Err error
+	}{
+		{sql: "import into t from ''", Err: exeerrors.ErrLoadDataEmptyPath},
+		{sql: "import into t from '/a.csv' format 'xx'", Err: exeerrors.ErrLoadDataUnsupportedFormat},
+	}
+
+	for _, c := range parameterCheck {
+		err := tk.ExecToErr(c.sql)
+		require.ErrorIs(t, err, c.Err, c.sql)
+	}
 }

--- a/executor/importer/import.go
+++ b/executor/importer/import.go
@@ -26,6 +26,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
 	"github.com/pingcap/tidb/br/pkg/lightning/config"
@@ -457,9 +458,10 @@ func (e *LoadDataController) checkFieldParams() error {
 
 func (p *Plan) initDefaultOptions() {
 	threadCnt := runtime.NumCPU()
-	if p.Format == DataFormatParquet {
-		threadCnt = int(math.Max(1, float64(threadCnt)*0.75))
-	}
+	failpoint.Inject("mockNumCpu", func(val failpoint.Value) {
+		threadCnt = val.(int)
+	})
+	threadCnt = int(math.Max(1, float64(threadCnt)*0.5))
 
 	p.Checksum = config.OpLevelRequired
 	p.ThreadCnt = int64(threadCnt)

--- a/executor/importer/import_test.go
+++ b/executor/importer/import_test.go
@@ -16,7 +16,6 @@ package importer
 
 import (
 	"fmt"
-	"math"
 	"runtime"
 	"testing"
 
@@ -35,20 +34,20 @@ import (
 
 func TestInitDefaultOptions(t *testing.T) {
 	plan := &Plan{}
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/importer/mockNumCpu", "return(1)"))
 	plan.initDefaultOptions()
 	require.Equal(t, config.ByteSize(0), plan.DiskQuota)
 	require.Equal(t, config.OpLevelRequired, plan.Checksum)
-	require.Equal(t, int64(runtime.NumCPU()), plan.ThreadCnt)
+	require.Equal(t, int64(1), plan.ThreadCnt)
 	require.Equal(t, unlimitedWriteSpeed, plan.MaxWriteSpeed)
 	require.Equal(t, false, plan.SplitFile)
 	require.Equal(t, int64(100), plan.MaxRecordedErrors)
 	require.Equal(t, false, plan.Detached)
 	require.Equal(t, "utf8mb4", *plan.Charset)
 
-	plan = &Plan{Format: DataFormatParquet}
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/importer/mockNumCpu", "return(10)"))
 	plan.initDefaultOptions()
-	require.Greater(t, plan.ThreadCnt, int64(0))
-	require.Equal(t, int64(math.Max(1, float64(runtime.NumCPU())*0.75)), plan.ThreadCnt)
+	require.Equal(t, int64(5), plan.ThreadCnt)
 }
 
 // for negative case see TestImportIntoOptionsNegativeCase

--- a/executor/importer/job.go
+++ b/executor/importer/job.go
@@ -17,6 +17,7 @@ package importer
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync/atomic"
 
 	"github.com/pingcap/errors"
@@ -79,6 +80,14 @@ type ImportParameters struct {
 	Format       string `json:"format"`
 	// only include what user specified, not include default value.
 	Options map[string]interface{} `json:"options,omitempty"`
+}
+
+var _ fmt.Stringer = &ImportParameters{}
+
+// String implements fmt.Stringer interface.
+func (ip *ImportParameters) String() string {
+	b, _ := json.Marshal(ip)
+	return string(b)
 }
 
 // JobSummary is the summary info of import into job.

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/br/pkg/lightning/backend"
@@ -601,10 +602,12 @@ func adjustDiskQuota(diskQuota int64, sortDir string, logger *zap.Logger) int64 
 	maxDiskQuota := int64(float64(sz.Capacity) * 0.8)
 	switch {
 	case diskQuota == 0:
-		logger.Info("use 0.8 of the storage size as default disk quota", zap.Int64("quota", maxDiskQuota))
+		logger.Info("use 0.8 of the storage size as default disk quota",
+			zap.String("quota", units.HumanSize(float64(maxDiskQuota))))
 		return maxDiskQuota
 	case diskQuota > maxDiskQuota:
-		logger.Warn("disk quota is larger than 0.8 of the storage size, use 0.8 of the storage size instead", zap.Int64("quota", maxDiskQuota))
+		logger.Warn("disk quota is larger than 0.8 of the storage size, use 0.8 of the storage size instead",
+			zap.String("quota", units.HumanSize(float64(maxDiskQuota))))
 		return maxDiskQuota
 	default:
 		return diskQuota

--- a/tests/realtikvtest/importintotest/BUILD.bazel
+++ b/tests/realtikvtest/importintotest/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "@com_github_fsouza_fake_gcs_server//fakestorage",
         "@com_github_golang_mock//gomock",
         "@com_github_ngaut_pools//:pools",
+        "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/brpb",
         "@com_github_pingcap_log//:log",

--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -834,6 +834,19 @@ func (s *mockGCSSuite) TestColumnsAndUserVars() {
 	}
 }
 
+func (s *mockGCSSuite) checkTaskMetaRedacted(jobID int64) {
+	globalTaskManager, err := storage.GetTaskManager()
+	s.NoError(err)
+	taskKey := importinto.TaskKey(jobID)
+	s.NoError(err)
+	globalTask, err2 := globalTaskManager.GetGlobalTaskByKey(taskKey)
+	s.NoError(err2)
+	s.Regexp(`[?&]access-key=xxxxxx`, string(globalTask.Meta))
+	s.Contains(string(globalTask.Meta), "secret-access-key=xxxxxx")
+	s.NotContains(string(globalTask.Meta), "aaaaaa")
+	s.NotContains(string(globalTask.Meta), "bbbbbb")
+}
+
 func (s *mockGCSSuite) TestImportMode() {
 	var intoImportTime, intoNormalTime time.Time
 	controller := gomock.NewController(s.T())
@@ -866,10 +879,15 @@ func (s *mockGCSSuite) TestImportMode() {
 
 	// NOTE: this case only runs when current instance is TiDB owner, if you run it locally,
 	// better start a cluster without TiDB instance.
-	sql := fmt.Sprintf(`IMPORT INTO load_data.import_mode FROM 'gs://test-load/import_mode-*.tsv?endpoint=%s'`, gcsEndpoint)
-	s.tk.MustQuery(sql)
+	s.enableFailpoint("github.com/pingcap/tidb/parser/ast/forceRedactURL", "return(true)")
+	sql := fmt.Sprintf(`IMPORT INTO load_data.import_mode FROM 'gs://test-load/import_mode-*.tsv?access-key=aaaaaa&secret-access-key=bbbbbb&endpoint=%s'`, gcsEndpoint)
+	rows := s.tk.MustQuery(sql).Rows()
+	s.Len(rows, 1)
+	jobID, err := strconv.Atoi(rows[0][0].(string))
+	s.NoError(err)
 	s.tk.MustQuery("SELECT * FROM load_data.import_mode;").Sort().Check(testkit.Rows("1 11 111"))
 	s.Greater(intoNormalTime, intoImportTime)
+	s.checkTaskMetaRedacted(int64(jobID))
 
 	intoNormalTime, intoImportTime = time.Time{}, time.Time{}
 	switcher.EXPECT().ToImportMode(gomock.Any()).DoAndReturn(func(ctx context.Context) error {
@@ -886,10 +904,12 @@ func (s *mockGCSSuite) TestImportMode() {
 	// wait ToImportMode called
 	s.enableFailpoint("github.com/pingcap/tidb/disttask/importinto/waitBeforeSortChunk", "return(true)")
 	s.enableFailpoint("github.com/pingcap/tidb/disttask/importinto/errorWhenSortChunk", "return(true)")
-	sql = fmt.Sprintf(`IMPORT INTO load_data.import_mode FROM 'gs://test-load/import_mode-*.tsv?endpoint=%s'`, gcsEndpoint)
-	err := s.tk.QueryToErr(sql)
+	s.enableFailpoint("github.com/pingcap/tidb/executor/importer/setLastImportJobID", `return(true)`)
+	sql = fmt.Sprintf(`IMPORT INTO load_data.import_mode FROM 'gs://test-load/import_mode-*.tsv?access-key=aaaaaa&secret-access-key=bbbbbb&endpoint=%s'`, gcsEndpoint)
+	err = s.tk.QueryToErr(sql)
 	s.Error(err)
 	s.Greater(intoNormalTime, intoImportTime)
+	s.checkTaskMetaRedacted(importer.TestLastImportJobID.Load())
 }
 
 func (s *mockGCSSuite) TestRegisterTask() {

--- a/tests/realtikvtest/importintotest/util_test.go
+++ b/tests/realtikvtest/importintotest/util_test.go
@@ -73,3 +73,9 @@ func (s *mockGCSSuite) enableFailpoint(path, term string) {
 		_ = failpoint.Disable(path)
 	})
 }
+
+func (s *mockGCSSuite) cleanupSysTables() {
+	s.tk.MustExec("delete from mysql.tidb_import_jobs")
+	s.tk.MustExec("delete from mysql.tidb_global_task")
+	s.tk.MustExec("delete from mysql.tidb_background_subtask")
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42930 

Problem Summary:

### What is changed and how it works?
- unify and fix log, avoid exposing meta info in log
- redact meta after task end(success or err)
- cancel job on kill event
- change default `thread` param to `0.5*cpuCount`
- add some missed ut

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - add some wait before start sorting, start import, kill it in another terminal, the job should be cancelled, check task status too, should be reverted
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
