### PR TITLE
planner: support pushing down predicates to memory tables in prepared mode (#40262) | tidb-test=pr/2145

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -1565,6 +1565,8 @@ func Args2Expressions4Test(args ...interface{}) []Expression {
 			ft = types.NewFieldType(mysql.TypeDouble)
 		case types.KindString:
 			ft = types.NewFieldType(mysql.TypeVarString)
+		case types.KindMysqlTime:
+			ft = types.NewFieldType(mysql.TypeTimestamp)
 		default:
 			exprs[i] = nil
 			continue

--- a/planner/core/memtable_predicate_extractor_test.go
+++ b/planner/core/memtable_predicate_extractor_test.go
@@ -25,10 +25,14 @@ import (
 
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/errno"
+	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/parser"
+	"github.com/pingcap/tidb/parser/ast"
+	"github.com/pingcap/tidb/planner"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/hint"
 	"github.com/pingcap/tidb/util/set"
 	"github.com/stretchr/testify/require"
@@ -1747,5 +1751,114 @@ PARTITION BY RANGE COLUMNS ( id ) (
 		tableids := rse.GetTablesID()
 		slices.Sort(tableids)
 		require.Equal(t, ca.tableIDs, tableids)
+	}
+}
+
+func TestExtractorInPreparedStmt(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	var cases = []struct {
+		prepared string
+		userVars []interface{}
+		params   []interface{}
+		checker  func(extractor plannercore.MemTablePredicateExtractor)
+	}{
+		{
+			prepared: "select * from information_schema.TIKV_REGION_STATUS where table_id = ?",
+			userVars: []interface{}{1},
+			params:   []interface{}{1},
+			checker: func(extractor plannercore.MemTablePredicateExtractor) {
+				rse := extractor.(*plannercore.TiKVRegionStatusExtractor)
+				tableids := rse.GetTablesID()
+				slices.Sort(tableids)
+				require.Equal(t, []int64{1}, tableids)
+			},
+		},
+		{
+			prepared: "select * from information_schema.TIKV_REGION_STATUS where table_id = ? or table_id = ?",
+			userVars: []interface{}{1, 2},
+			params:   []interface{}{1, 2},
+			checker: func(extractor plannercore.MemTablePredicateExtractor) {
+				rse := extractor.(*plannercore.TiKVRegionStatusExtractor)
+				tableids := rse.GetTablesID()
+				slices.Sort(tableids)
+				require.Equal(t, []int64{1, 2}, tableids)
+			},
+		},
+		{
+			prepared: "select * from information_schema.TIKV_REGION_STATUS where table_id in (?,?)",
+			userVars: []interface{}{1, 2},
+			params:   []interface{}{1, 2},
+			checker: func(extractor plannercore.MemTablePredicateExtractor) {
+				rse := extractor.(*plannercore.TiKVRegionStatusExtractor)
+				tableids := rse.GetTablesID()
+				slices.Sort(tableids)
+				require.Equal(t, []int64{1, 2}, tableids)
+			},
+		},
+		{
+			prepared: "select * from information_schema.COLUMNS where table_name like ?",
+			userVars: []interface{}{`"a%"`},
+			params:   []interface{}{"a%"},
+			checker: func(extractor plannercore.MemTablePredicateExtractor) {
+				rse := extractor.(*plannercore.ColumnsTableExtractor)
+				require.EqualValues(t, []string{"a%"}, rse.TableNamePatterns)
+			},
+		},
+		{
+			prepared: "select * from information_schema.tidb_hot_regions_history where update_time>=?",
+			userVars: []interface{}{"cast('2019-10-10 10:10:10' as datetime)"},
+			params: []interface{}{func() types.Time {
+				tt, err := types.ParseTimestamp(tk.Session().GetSessionVars().StmtCtx, "2019-10-10 10:10:10")
+				require.NoError(t, err)
+				return tt
+			}()},
+			checker: func(extractor plannercore.MemTablePredicateExtractor) {
+				rse := extractor.(*plannercore.HotRegionsHistoryTableExtractor)
+				require.Equal(t, timestamp(t, "2019-10-10 10:10:10"), rse.StartTime)
+			},
+		},
+	}
+
+	// text protocol
+	parser := parser.New()
+	for _, ca := range cases {
+		tk.MustExec(fmt.Sprintf("prepare stmt from '%s'", ca.prepared))
+		setStmt := "set "
+		exec := "execute stmt using "
+		for i, uv := range ca.userVars {
+			name := fmt.Sprintf("@a%d", i)
+			setStmt += fmt.Sprintf("%s=%v", name, uv)
+			exec += name
+			if i != len(ca.userVars)-1 {
+				setStmt += ","
+				exec += ","
+			}
+		}
+		tk.MustExec(setStmt)
+		stmt, err := parser.ParseOneStmt(exec, "", "")
+		require.NoError(t, err)
+		plan, _, err := planner.OptimizeExecStmt(context.Background(), tk.Session(), stmt.(*ast.ExecuteStmt), dom.InfoSchema())
+		require.NoError(t, err)
+		extractor := plan.(*plannercore.Execute).Plan.(*plannercore.PhysicalMemTable).Extractor
+		ca.checker(extractor)
+	}
+
+	// binary protocol
+	for _, ca := range cases {
+		id, _, _, err := tk.Session().PrepareStmt(ca.prepared)
+		require.NoError(t, err)
+		prepStmt, err := tk.Session().GetSessionVars().GetPreparedStmtByID(id)
+		require.NoError(t, err)
+		params := expression.Args2Expressions4Test(ca.params...)
+		execStmt := &ast.ExecuteStmt{
+			BinaryArgs: params,
+			PrepStmt:   prepStmt,
+		}
+		plan, _, err := planner.OptimizeExecStmt(context.Background(), tk.Session(), execStmt, dom.InfoSchema())
+		require.NoError(t, err)
+		extractor := plan.(*plannercore.Execute).Plan.(*plannercore.PhysicalMemTable).Extractor
+		ca.checker(extractor)
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/39605, cherry-pick from https://github.com/pingcap/tidb/pull/40262

Problem Summary:
Predicates are not pushed down to memory tables in the prepared mode because the author avoids doing that intentionally. I'm not sure why but it should work.

### What is changed and how it works?
Get the value from constant when it uses prepared mode. Note that it still skips evaluating when DeferredExpr is not nil.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
