### PR TITLE
server: implement spill disk for cursorFetch result

### DIFF
--- a/parser/mysql/errname.go
+++ b/parser/mysql/errname.go
@@ -269,7 +269,7 @@ var MySQLErrName = map[uint16]*ErrMessage{
 	ErrKeyRefDoNotMatchTableRef:                 Message("Key reference and table reference don't match", nil),
 	ErrOperandColumns:                           Message("Operand should contain %d column(s)", nil),
 	ErrSubqueryNo1Row:                           Message("Subquery returns more than 1 row", nil),
-	ErrUnknownStmtHandler:                       Message("Unknown prepared statement handler (%.*s) given to %s", nil),
+	ErrUnknownStmtHandler:                       Message("Unknown prepared statement handler %s given to %s", nil),
 	ErrCorruptHelpDB:                            Message("Help database is corrupt or does not exist", nil),
 	ErrCyclicReference:                          Message("Cyclic reference on subqueries", nil),
 	ErrAutoConvert:                              Message("Converting column '%s' from %s to %s", nil),

--- a/server/conn.go
+++ b/server/conn.go
@@ -2410,10 +2410,10 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs ResultSet, binary bool
 // serverStatus, a flag bit represents server information.
 // fetchSize, the desired number of rows to be fetched each time when client uses cursor.
 func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs cursorResultSet, serverStatus uint16, fetchSize int) error {
-	iter := rs.GetRowIterator()
-
 	// construct the rows sent to the client according to fetchSize.
 	var curRows []chunk.Row
+	iter := rs.GetRowContainerReader()
+	// send the rows to the client according to fetchSize.
 	for i := 0; i < fetchSize && iter.Current() != iter.End(); i++ {
 		curRows = append(curRows, iter.Current())
 		iter.Next()

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -369,6 +369,12 @@ func (cc *clientConn) handleStmtFetch(ctx context.Context, data []byte) (err err
 	cc.ctx.GetSessionVars().ClearAlloc(nil, false)
 	cc.ctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, true)
 	defer cc.ctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, false)
+	// Reset the warn count. TODO: consider whether it's better to reset the whole session context/statement context.
+	if cc.ctx.GetSessionVars().StmtCtx != nil {
+		cc.ctx.GetSessionVars().StmtCtx.SetWarnings(nil)
+	}
+	cc.ctx.GetSessionVars().SysErrorCount = 0
+	cc.ctx.GetSessionVars().SysWarningCount = 0
 
 	stmtID, fetchSize, err := parse.StmtFetchCmd(data)
 	if err != nil {

--- a/server/conn_stmt_test.go
+++ b/server/conn_stmt_test.go
@@ -17,11 +17,19 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/testkit"
 	"github.com/stretchr/testify/require"
@@ -235,6 +243,12 @@ func TestMemoryTrackForPrepareBinaryProtocol(t *testing.T) {
 }
 
 func TestCursorFetchShouldSpill(t *testing.T) {
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.TempStoragePath = t.TempDir()
+	})
+
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	srv := CreateMockServer(t, store)
 	srv.SetDomain(dom)
@@ -269,4 +283,72 @@ func TestCursorFetchShouldSpill(t *testing.T) {
 		appendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt.ID())),
 		mysql.CursorTypeReadOnly, 0x1, 0x0, 0x0, 0x0,
 	)))
+}
+
+func TestCursorFetchErrorInFetch(t *testing.T) {
+	tmpStoragePath := t.TempDir()
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.TempStoragePath = tmpStoragePath
+	})
+
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	srv := CreateMockServer(t, store)
+	srv.SetDomain(dom)
+	defer srv.Close()
+
+	appendUint32 := binary.LittleEndian.AppendUint32
+	ctx := context.Background()
+	c := CreateMockConn(t, srv).(*mockConn)
+
+	tk := testkit.NewTestKitWithSession(t, store, c.Context().Session)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id int, payload BLOB)")
+	payload := make([]byte, 512)
+	for i := 0; i < 2048; i++ {
+		rand.Read(payload)
+		tk.MustExec("insert into t values (?, ?)", i, payload)
+	}
+
+	tk.MustExec("set global tidb_enable_tmp_storage_on_oom = ON")
+	tk.MustExec("set global tidb_mem_oom_action = 'CANCEL'")
+	defer tk.MustExec("set global tidb_mem_oom_action= DEFAULT")
+	require.Len(t, tk.Session().GetSessionVars().MemTracker.GetChildrenForTest(), 1)
+
+	// execute a normal statement, it'll spill to disk
+	stmt, _, _, err := c.Context().Prepare("select * from t")
+	require.NoError(t, err)
+
+	tk.MustExec(fmt.Sprintf("set tidb_mem_quota_query=%d", 1))
+
+	require.NoError(t, c.Dispatch(ctx, append(
+		appendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt.ID())),
+		mysql.CursorTypeReadOnly, 0x1, 0x0, 0x0, 0x0,
+	)))
+
+	// close these disk files to produce error
+	filepath.Walk("/proc/self/fd", func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		target, err := os.Readlink(path)
+		if err != nil {
+			return nil
+		}
+		if strings.HasPrefix(target, tmpStoragePath) {
+			fd, err := strconv.Atoi(filepath.Base(path))
+			require.NoError(t, err)
+			require.NoError(t, syscall.Close(fd))
+		}
+		return nil
+	})
+
+	// it'll get "bad file descriptor", as it has been closed in the test.
+	require.Error(t, c.Dispatch(ctx, appendUint32(appendUint32([]byte{mysql.ComStmtFetch}, uint32(stmt.ID())), 1024)))
+	// after getting a failed FETCH, the cursor should have been reseted
+	require.False(t, stmt.GetCursorActive())
+	require.Len(t, tk.Session().GetSessionVars().MemTracker.GetChildrenForTest(), 0)
+	require.Len(t, tk.Session().GetSessionVars().DiskTracker.GetChildrenForTest(), 0)
 }

--- a/server/conn_stmt_test.go
+++ b/server/conn_stmt_test.go
@@ -112,8 +112,8 @@ func TestCursorWithParams(t *testing.T) {
 	)))
 	rows := c.Context().stmts[stmt1.ID()].GetResultSet().GetRowIterator()
 	require.Len(t, rows, 1)
-	require.Equal(t, int64(1), rows[0].GetInt64(0))
-	require.Equal(t, int64(2), rows[0].GetInt64(1))
+	require.Equal(t, int64(1), rows.Current().GetInt64(0))
+	require.Equal(t, int64(2), rows.Current().GetInt64(1))
 
 	// `execute stmt2 using 1` with cursor
 	require.NoError(t, c.Dispatch(ctx, append(
@@ -124,10 +124,10 @@ func TestCursorWithParams(t *testing.T) {
 	)))
 	rows = c.Context().stmts[stmt2.ID()].GetResultSet().GetRowIterator()
 	require.Len(t, rows, 2)
-	require.Equal(t, int64(1), rows[0].GetInt64(0))
-	require.Equal(t, int64(1), rows[0].GetInt64(1))
-	require.Equal(t, int64(1), rows[1].GetInt64(0))
-	require.Equal(t, int64(2), rows[1].GetInt64(1))
+	require.Equal(t, int64(1), rows.Current().GetInt64(0))
+	require.Equal(t, int64(1), rows.Current().GetInt64(1))
+	require.Equal(t, int64(1), rows.Next().GetInt64(0))
+	require.Equal(t, int64(2), rows.Current().GetInt64(1))
 
 	// fetch stmt2 with fetch size 256
 	require.NoError(t, c.Dispatch(ctx, append(

--- a/server/conn_stmt_test.go
+++ b/server/conn_stmt_test.go
@@ -124,7 +124,7 @@ func TestCursorWithParams(t *testing.T) {
 		0x0, 0x1, 0x3, 0x0, 0x3, 0x0,
 		0x1, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0,
 	)))
-	rows := c.Context().stmts[stmt1.ID()].GetResultSet().GetRowIterator()
+	rows := c.Context().stmts[stmt1.ID()].GetResultSet().GetRowContainerReader()
 	require.Equal(t, int64(1), rows.Current().GetInt64(0))
 	require.Equal(t, int64(2), rows.Current().GetInt64(1))
 	rows.Next()
@@ -137,7 +137,7 @@ func TestCursorWithParams(t *testing.T) {
 		0x0, 0x1, 0x3, 0x0,
 		0x1, 0x0, 0x0, 0x0,
 	)))
-	rows = c.Context().stmts[stmt2.ID()].GetResultSet().GetRowIterator()
+	rows = c.Context().stmts[stmt2.ID()].GetResultSet().GetRowContainerReader()
 	require.Equal(t, int64(1), rows.Current().GetInt64(0))
 	require.Equal(t, int64(1), rows.Current().GetInt64(1))
 	require.Equal(t, int64(1), rows.Next().GetInt64(0))

--- a/server/conn_stmt_test.go
+++ b/server/conn_stmt_test.go
@@ -111,9 +111,10 @@ func TestCursorWithParams(t *testing.T) {
 		0x1, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0,
 	)))
 	rows := c.Context().stmts[stmt1.ID()].GetResultSet().GetRowIterator()
-	require.Len(t, rows, 1)
 	require.Equal(t, int64(1), rows.Current().GetInt64(0))
 	require.Equal(t, int64(2), rows.Current().GetInt64(1))
+	rows.Next()
+	require.Equal(t, rows.End(), rows.Current())
 
 	// `execute stmt2 using 1` with cursor
 	require.NoError(t, c.Dispatch(ctx, append(
@@ -123,11 +124,12 @@ func TestCursorWithParams(t *testing.T) {
 		0x1, 0x0, 0x0, 0x0,
 	)))
 	rows = c.Context().stmts[stmt2.ID()].GetResultSet().GetRowIterator()
-	require.Len(t, rows, 2)
 	require.Equal(t, int64(1), rows.Current().GetInt64(0))
 	require.Equal(t, int64(1), rows.Current().GetInt64(1))
 	require.Equal(t, int64(1), rows.Next().GetInt64(0))
 	require.Equal(t, int64(2), rows.Current().GetInt64(1))
+	rows.Next()
+	require.Equal(t, rows.End(), rows.Current())
 
 	// fetch stmt2 with fetch size 256
 	require.NoError(t, c.Dispatch(ctx, append(

--- a/server/conn_stmt_test.go
+++ b/server/conn_stmt_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"github.com/pingcap/failpoint"
 	"testing"
 
 	"github.com/pingcap/tidb/parser/mysql"
@@ -178,7 +179,9 @@ func TestCursorDetachMemTracker(t *testing.T) {
 	// testkit also uses `PREPARE` related calls to run statement with arguments.
 	// format the SQL to avoid the interference from testkit.
 	tk.MustExec(fmt.Sprintf("set tidb_mem_quota_query=%d", maxConsumed/2))
-	require.Len(t, tk.Session().GetSessionVars().MemTracker.GetChildrenForTest(), 0)
+	// there is one memTracker for the resultSet spill-disk
+	require.Len(t, tk.Session().GetSessionVars().MemTracker.GetChildrenForTest(), 1)
+
 	// This query should exceed the memory limitation during `openExecutor`
 	require.Error(t, c.Dispatch(ctx, append(
 		appendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt.ID())),
@@ -194,7 +197,8 @@ func TestCursorDetachMemTracker(t *testing.T) {
 		appendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt.ID())),
 		mysql.CursorTypeReadOnly, 0x1, 0x0, 0x0, 0x0,
 	)))
-	require.Len(t, tk.Session().GetSessionVars().MemTracker.GetChildrenForTest(), 0)
+	// there is one memTracker for the resultSet spill-disk
+	require.Len(t, tk.Session().GetSessionVars().MemTracker.GetChildrenForTest(), 1)
 }
 
 func TestMemoryTrackForPrepareBinaryProtocol(t *testing.T) {
@@ -215,4 +219,42 @@ func TestMemoryTrackForPrepareBinaryProtocol(t *testing.T) {
 		require.NoError(t, stmt.Close())
 	}
 	require.Len(t, tk.Session().GetSessionVars().MemTracker.GetChildrenForTest(), 0)
+}
+
+func TestCursorFetchShouldSpill(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	srv := CreateMockServer(t, store)
+	srv.SetDomain(dom)
+	defer srv.Close()
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/server/testCursorFetchSpill", "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/server/testCursorFetchSpill"))
+	}()
+
+	appendUint32 := binary.LittleEndian.AppendUint32
+	ctx := context.Background()
+	c := CreateMockConn(t, srv).(*mockConn)
+
+	tk := testkit.NewTestKitWithSession(t, store, c.Context().Session)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id_1 int, id_2 int)")
+	tk.MustExec("insert into t values (1, 1), (1, 2)")
+	tk.MustExec("set global tidb_enable_tmp_storage_on_oom = ON")
+	tk.MustExec("set global tidb_mem_oom_action = 'CANCEL'")
+	defer tk.MustExec("set global tidb_mem_oom_action= DEFAULT")
+	// TODO: find whether it's expected to have one child at the beginning
+	require.Len(t, tk.Session().GetSessionVars().MemTracker.GetChildrenForTest(), 1)
+
+	// execute a normal statement, it'll spill to disk
+	stmt, _, _, err := c.Context().Prepare("select * from t")
+	require.NoError(t, err)
+
+	tk.MustExec(fmt.Sprintf("set tidb_mem_quota_query=%d", 1))
+
+	require.NoError(t, c.Dispatch(ctx, append(
+		appendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt.ID())),
+		mysql.CursorTypeReadOnly, 0x1, 0x0, 0x0, 0x0,
+	)))
 }

--- a/server/conn_stmt_test.go
+++ b/server/conn_stmt_test.go
@@ -110,7 +110,7 @@ func TestCursorWithParams(t *testing.T) {
 		0x0, 0x1, 0x3, 0x0, 0x3, 0x0,
 		0x1, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0,
 	)))
-	rows := c.Context().stmts[stmt1.ID()].GetResultSet().GetFetchedRows()
+	rows := c.Context().stmts[stmt1.ID()].GetResultSet().GetRowIterator()
 	require.Len(t, rows, 1)
 	require.Equal(t, int64(1), rows[0].GetInt64(0))
 	require.Equal(t, int64(2), rows[0].GetInt64(1))
@@ -122,7 +122,7 @@ func TestCursorWithParams(t *testing.T) {
 		0x0, 0x1, 0x3, 0x0,
 		0x1, 0x0, 0x0, 0x0,
 	)))
-	rows = c.Context().stmts[stmt2.ID()].GetResultSet().GetFetchedRows()
+	rows = c.Context().stmts[stmt2.ID()].GetResultSet().GetRowIterator()
 	require.Len(t, rows, 2)
 	require.Equal(t, int64(1), rows[0].GetInt64(0))
 	require.Equal(t, int64(1), rows[0].GetInt64(1))

--- a/server/conn_stmt_test.go
+++ b/server/conn_stmt_test.go
@@ -19,9 +19,9 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/pingcap/failpoint"
 	"testing"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/testkit"
 	"github.com/stretchr/testify/require"

--- a/server/driver.go
+++ b/server/driver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/extension"
 	"github.com/pingcap/tidb/server/internal/column"
+	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 )
 
@@ -54,10 +55,10 @@ type PreparedStatement interface {
 	GetParamsType() []byte
 
 	// StoreResultSet stores ResultSet for subsequent stmt fetching
-	StoreResultSet(rs ResultSet)
+	StoreResultSet(rs cursorResultSet)
 
 	// GetResultSet gets ResultSet associated this statement
-	GetResultSet() ResultSet
+	GetResultSet() cursorResultSet
 
 	// Reset removes all bound parameters.
 	Reset()
@@ -70,6 +71,13 @@ type PreparedStatement interface {
 
 	// SetCursorActive sets whether the statement has active cursor
 	SetCursorActive(active bool)
+
+	// StoreRowContainer stores a row container into the prepared statement. The `rowContainer` is used to be closed at
+	// appropriate time. It's actually not used to read, because an iterator of it has been stored in the result set.
+	StoreRowContainer(container *chunk.RowContainer)
+
+	// GetRowContainer returns the row container of the statement
+	GetRowContainer() *chunk.RowContainer
 }
 
 // ResultSet is the result set of an query.
@@ -77,11 +85,18 @@ type ResultSet interface {
 	Columns() []*column.Info
 	NewChunk(chunk.Allocator) *chunk.Chunk
 	Next(context.Context, *chunk.Chunk) error
-	StoreFetchedRows(rows []chunk.Row)
-	GetFetchedRows() []chunk.Row
 	Close() error
 	// IsClosed checks whether the result set is closed.
 	IsClosed() bool
+	FieldTypes() []*types.FieldType
+}
+
+// cursorResultSet extends the `ResultSet` to provide the ability to store an iterator
+type cursorResultSet interface {
+	ResultSet
+
+	StoreRowIterator(chunk.Iterator)
+	GetRowIterator() chunk.Iterator
 }
 
 // fetchNotifier represents notifier will be called in COM_FETCH.
@@ -89,4 +104,10 @@ type fetchNotifier interface {
 	// OnFetchReturned be called when COM_FETCH returns.
 	// it will be used in server-side cursor.
 	OnFetchReturned()
+}
+
+func wrapWithCursor(rs ResultSet) cursorResultSet {
+	return &tidbCursorResultSet{
+		rs, nil,
+	}
 }

--- a/server/driver.go
+++ b/server/driver.go
@@ -95,8 +95,8 @@ type ResultSet interface {
 type cursorResultSet interface {
 	ResultSet
 
-	StoreRowIterator(chunk.Iterator)
-	GetRowIterator() chunk.Iterator
+	StoreRowContainerReader(reader chunk.RowContainerReader)
+	GetRowContainerReader() chunk.RowContainerReader
 }
 
 // fetchNotifier represents notifier will be called in COM_FETCH.

--- a/server/driver.go
+++ b/server/driver.go
@@ -60,8 +60,8 @@ type PreparedStatement interface {
 	// GetResultSet gets ResultSet associated this statement
 	GetResultSet() cursorResultSet
 
-	// Reset removes all bound parameters.
-	Reset()
+	// Reset removes all bound parameters and opened resultSet/rowContainer.
+	Reset() error
 
 	// Close closes the statement.
 	Close() error

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -152,6 +152,7 @@ func (ts *TiDBStatement) Reset() error {
 		ts.boundParams[i] = nil
 	}
 	ts.hasActiveCursor = false
+	ts.rs = nil
 
 	if ts.rowContainer != nil {
 		ts.rowContainer.GetMemTracker().Detach()
@@ -161,9 +162,9 @@ func (ts *TiDBStatement) Reset() error {
 		if err != nil {
 			return err
 		}
-	}
 
-	ts.rs = nil
+		ts.rowContainer = nil
+	}
 
 	return nil
 }

--- a/sessionctx/sessionstates/session_states_test.go
+++ b/sessionctx/sessionstates/session_states_test.go
@@ -1000,9 +1000,9 @@ func TestPreparedStatements(t *testing.T) {
 				require.NoError(t, conn.Dispatch(context.Background(), cmd))
 				cmd = getFetchBytes(1, 10)
 				require.NoError(t, conn.Dispatch(context.Background(), cmd))
-				// This COM_STMT_FETCH returns EOF.
+				// This COM_STMT_FETCH returns error, because the cursor has been automatically closed.
 				cmd = getFetchBytes(1, 10)
-				require.NoError(t, conn.Dispatch(context.Background(), cmd))
+				require.Error(t, conn.Dispatch(context.Background(), cmd))
 				return uint32(1)
 			},
 			checkFunc: func(tk *testkit.TestKit, conn server.MockConn, param any) {
@@ -1373,7 +1373,7 @@ func TestShowStateFail(t *testing.T) {
 			},
 		},
 		{
-			// fetched all the data but the EOF packet is not sent
+			// fetched all the data and `ServerStatusLastRowSend` is set, then the cursor should have been closed
 			setFunc: func(tk *testkit.TestKit, conn server.MockConn) {
 				tk.MustExec("create table test.t1(id int)")
 				tk.MustExec("insert test.t1 value(1), (2), (3)")
@@ -1383,26 +1383,8 @@ func TestShowStateFail(t *testing.T) {
 				require.NoError(t, conn.Dispatch(context.Background(), cmd))
 				cmd = getFetchBytes(1, 10)
 				require.NoError(t, conn.Dispatch(context.Background(), cmd))
-			},
-			showErr: errno.ErrCannotMigrateSession,
-			cleanFunc: func(tk *testkit.TestKit) {
-				tk.MustExec("drop table test.t1")
-			},
-		},
-		{
-			// EOF is sent
-			setFunc: func(tk *testkit.TestKit, conn server.MockConn) {
-				tk.MustExec("create table test.t1(id int)")
-				tk.MustExec("insert test.t1 value(1), (2), (3)")
-				cmd := append([]byte{mysql.ComStmtPrepare}, []byte("select * from test.t1")...)
-				require.NoError(t, conn.Dispatch(context.Background(), cmd))
-				cmd = getExecuteBytes(1, true, false)
-				require.NoError(t, conn.Dispatch(context.Background(), cmd))
-				cmd = getFetchBytes(1, 10)
-				require.NoError(t, conn.Dispatch(context.Background(), cmd))
-				// This COM_STMT_FETCH returns EOF.
-				cmd = getFetchBytes(1, 10)
-				require.NoError(t, conn.Dispatch(context.Background(), cmd))
+				// following FETCH command should fail because the cursor has been closed
+				require.Error(t, conn.Dispatch(context.Background(), getFetchBytes(1, 10)))
 			},
 			cleanFunc: func(tk *testkit.TestKit) {
 				tk.MustExec("drop table test.t1")

--- a/util/chunk/BUILD.bazel
+++ b/util/chunk/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "pool.go",
         "row.go",
         "row_container.go",
+        "row_container_reader.go",
     ],
     importpath = "github.com/pingcap/tidb/util/chunk",
     visibility = ["//visibility:public"],

--- a/util/chunk/row_container_reader.go
+++ b/util/chunk/row_container_reader.go
@@ -1,0 +1,236 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunk
+
+import (
+	"bufio"
+	"context"
+	"runtime"
+	"sync"
+
+	"github.com/pingcap/tidb/util/logutil"
+)
+
+// RowContainerReader is a forward-only iterator for the row container.
+// It's recommended to use the following pattern to use it:
+//
+//	for iter := NewRowContainerReader(rc); iter.Current() != iter.End(); iter.Next() {
+//	}
+//	if iter.Error() != nil {
+//	}
+type RowContainerReader interface {
+	// Next returns the next Row.
+	Next() Row
+
+	// Current returns the current Row.
+	Current() Row
+
+	// End returns the invalid end Row.
+	End() Row
+
+	// Error returns none-nil error if anything wrong happens during the iteration.
+	Error() error
+
+	// Close closes the dumper
+	Close()
+}
+
+var _ RowContainerReader = &rowContainerReader{}
+
+// rowContainerReader is a forward-only iterator for the row container
+// This implementation is much faster than the `iterator4RowContainer`, but provide less methods. Be careful, unlike the
+// `iterator4RowContainer`, the `rowContainerReader` needs to be closed manually, to avoid goroutine leak.
+type rowContainerReader struct {
+	// context, cancel and waitgroup are used to stop and wait until all goroutine stops.
+	ctx    context.Context
+	cancel func()
+	wg     sync.WaitGroup
+
+	rc *RowContainer
+
+	currentRow Row
+	rowCh      chan Row
+
+	// this error will only be set by worker
+	err error
+}
+
+// Next implements RowContainerReader
+func (reader *rowContainerReader) Next() Row {
+	for row := range reader.rowCh {
+		reader.currentRow = row
+		return row
+	}
+	reader.currentRow = reader.End()
+	return reader.End()
+}
+
+// Current implements RowContainerReader
+func (reader *rowContainerReader) Current() Row {
+	return reader.currentRow
+}
+
+// End implements RowContainerReader
+func (*rowContainerReader) End() Row {
+	return Row{}
+}
+
+// Error implements RowContainerReader
+func (reader *rowContainerReader) Error() error {
+	return reader.err
+}
+
+func (reader *rowContainerReader) initializeChannel() {
+	reader.rc.m.RLock()
+	defer reader.rc.m.RUnlock()
+
+	if !reader.rc.alreadySpilled() {
+		// just any long enough channel should be fine. But in case the row container is spilled in the future,
+		// set the length to be the default maxChunks size.
+		reader.rowCh = make(chan Row, 1024)
+	} else if reader.rc.NumChunks() == 0 {
+		reader.rowCh = make(chan Row, 1024)
+	} else {
+		// TODO: give a more reasonable assumption of chunksize
+		assumeChunkSize := reader.rc.m.records.inDisk.numRowsOfEachChunk[0]
+		// To avoid blocking in sending to `rowCh` and  don't start reading the next chunk, it'd be better to give it
+		// a buffer with double size of chunk.
+		reader.rowCh = make(chan Row, 2*assumeChunkSize)
+	}
+}
+
+func (reader *rowContainerReader) dumpChunk(chkIdx int) {
+	reader.rc.m.RLock()
+	defer reader.rc.m.RUnlock()
+
+	if !reader.rc.alreadySpilled() {
+		for rowIdx := 0; rowIdx < reader.rc.NumRowsOfChunk(chkIdx); rowIdx++ {
+			row, err := reader.rc.GetRow(RowPtr{uint32(chkIdx), uint32(rowIdx)})
+			if err != nil {
+				reader.err = err
+				break
+			}
+
+			sendToChanWithoutLock(reader, reader.rowCh, row)
+		}
+	} else {
+		reader.dumpDiskChunk(chkIdx)
+	}
+}
+
+// sendToChanWithoutLock sends the `item` to `ch`, and around it with the `reader.rc.m.R(Unl|L)ock`.
+// it returns true when the item is sent to the channel successfully. It returns false when the context is canceled while
+// sending the item.
+// The `reader.rc.m` should has been `RLocked` when calling this function
+func sendToChanWithoutLock[T any](reader *rowContainerReader, ch chan<- T, item T) bool {
+	reader.rc.m.RUnlock()
+	defer reader.rc.m.RLock()
+	select {
+	case ch <- item:
+		return true
+	case <-reader.ctx.Done():
+		return false
+	}
+}
+
+func (reader *rowContainerReader) dumpDiskChunk(chkIdx int) {
+	l := reader.rc.m.records.inDisk
+
+	// This implementation assumes that all rows in a chunk is stored together tightly.
+	chk := NewChunkWithCapacity(l.fieldTypes, l.NumRowsOfChunk(chkIdx))
+	chkSize := l.numRowsOfEachChunk[chkIdx]
+
+	firstRowOffset, err := l.getOffset(uint32(chkIdx), 0)
+	if err != nil {
+		reader.err = err
+		return
+	}
+
+	formatCh := make(chan rowInDisk, chkSize)
+	reader.wg.Add(1)
+	go func() {
+		defer close(formatCh)
+		defer reader.wg.Done()
+
+		reader.rc.m.RLock()
+		defer reader.rc.m.RUnlock()
+
+		// If the row is small, a bufio can significantly improve the performance. As benchmark shows, it's still not bad
+		// for longer rows.
+		r := bufio.NewReader(l.dataFile.getSectionReader(firstRowOffset))
+		format := rowInDisk{numCol: len(l.fieldTypes)}
+		for rowIdx := 0; rowIdx < chkSize; rowIdx++ {
+			_, err = format.ReadFrom(r)
+			if err != nil {
+				// it's safe to set error here. Nothing else will modify the error concurrently.
+				// once this loop breaks, the outer one will also stop after draining the channel
+				reader.err = err
+				break
+			}
+
+			sendToChanWithoutLock(reader, formatCh, format)
+		}
+	}()
+
+	rows := make([]Row, 0, chkSize)
+	for format := range formatCh {
+		var row Row
+		row, chk = format.toRow(l.fieldTypes, chk)
+		rows = append(rows, row)
+	}
+
+	for _, row := range rows {
+		sendToChanWithoutLock(reader, reader.rowCh, row)
+	}
+}
+
+func (reader *rowContainerReader) Close() {
+	reader.cancel()
+	reader.wg.Wait()
+}
+
+func (reader *rowContainerReader) startWorker() {
+	reader.wg.Add(1)
+	go func() {
+		defer reader.wg.Done()
+		for chkIdx := 0; chkIdx < reader.rc.NumChunks(); chkIdx++ {
+			reader.dumpChunk(chkIdx)
+		}
+
+		close(reader.rowCh)
+	}()
+}
+
+// NewRowContainerReader creates a forward only iterator for row container
+func NewRowContainerReader(rc *RowContainer) *rowContainerReader {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	reader := &rowContainerReader{
+		ctx:    ctx,
+		cancel: cancel,
+		wg:     sync.WaitGroup{},
+
+		rc: rc,
+	}
+	reader.initializeChannel()
+	reader.startWorker()
+	reader.Next()
+	runtime.SetFinalizer(reader, func(reader *rowContainerReader) {
+		logutil.BgLogger().Warn("rowContainerReader is closed by finalizer")
+		reader.Close()
+	})
+
+	return reader
+}

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -857,6 +857,8 @@ const (
 	LabelForSession int = -27
 	// LabelForMemDB represents the label of the MemDB
 	LabelForMemDB int = -28
+	// LabelForCursorFetch represents the label of the execution of cursor fetch
+	LabelForCursorFetch int = -29
 )
 
 // MetricsTypes is used to get label for metrics


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #43233

### What is changed and how it works?

1. Use the `rowContainer` to store the rows after execution.
2. Reset the memory/disk tracker when the statement is closed.

TODO:

- [x] Add tests
- [x] Consider the behavior of `Reset`.
- [x] Consider carefully about the server status. https://github.com/pingcap/tidb/issues/44672 seems to have shown some bugs about server status.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test (TODO)
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

I used the following codes to do some basic tests. The preloaded data is 5M rows `sysbench ./oltp_insert.lua` :

```java
public static void tidbBigSelectTest() throws SQLException, InterruptedException {
    // the following are test codes for MySQL
    ConnectionImpl conn = (ConnectionImpl) DriverManager.getConnection("jdbc:mysql://127.0.0.1:4000/test?useCursorFetch=true&defaultFetchSize=1000", "root", "");
    conn.prepareStatement("set @@tidb_mem_quota_query = 8 << 20\n").execute();
    conn.prepareStatement("begin").execute();

    String sql = "SELECT * FROM test.sbtest1";
    PreparedStatement stmt = conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
    stmt.setFetchSize(1000);
    Instant beforeExecuteTime = Clock.systemUTC().instant();
    ResultSet rs = stmt.executeQuery();
    Instant afterExecuteTime = Clock.systemUTC().instant();
    System.out.println("It takes " + (Duration.between(beforeExecuteTime, afterExecuteTime).toString()) + " to EXECUTE QUERY");

    ResultSetMetaData metaData = rs.getMetaData();
    int columnCount = metaData.getColumnCount();
    int batchSize = stmt.getFetchSize();
    int rowCount = 0;
    int totalCount = 0;
    while (rs.next()) {
        rowCount++;
        totalCount++;
        Object[] columns = new Object[columnCount];
        for (int i = 1; i <= columnCount; i++) {
            columns[i - 1] = rs.getObject(i);
        }
        Row row = new Row(columns);
        if (rowCount == batchSize) {
            System.out.println("Fetched " + batchSize + " rows");
            System.out.println("allocated memory is " + (Runtime.getRuntime().totalMemory()-Runtime.getRuntime().freeMemory()));
            System.out.println("TotalCount " + totalCount);
            rowCount = 0;
        }
        if (totalCount == 4999999) {
            System.out.println("here");
        }
    }
    if (rowCount > 0) {
        System.out.println("allocated memory is " + (Runtime.getRuntime().totalMemory()-Runtime.getRuntime().freeMemory()));
        System.out.println("Fetched " + rowCount + " rows");
        System.out.println("TotalCount " + totalCount);
    }

    conn.prepareStatement("commit").execute();
}
```

### Release note

```release-note
Automatically spill the memory exceeding `tidb_mem_quota_query` into the disk
```
