### PR TITLE
sessionctx: encode hypo indexes and tiflash replicas into session states

### DIFF
--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -336,7 +336,7 @@ func (tc *TiDBContext) EncodeSessionStates(ctx context.Context, sctx sessionctx.
 	for preparedID, preparedObj := range sessionVars.PreparedStmts {
 		preparedStmt, ok := preparedObj.(*core.PlanCacheStmt)
 		if !ok {
-			return errors.Errorf("invalid CachedPreparedStmt type")
+			return errors.Errorf("invalid PlanCacheStmt type")
 		}
 		sessionStates.PreparedStmts[preparedID] = &sessionstates.PreparedStmtInfo{
 			StmtText: preparedStmt.StmtText,

--- a/sessionctx/sessionstates/BUILD.bazel
+++ b/sessionctx/sessionstates/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//errno",
+        "//parser/model"
         "//parser/types",
         "//sessionctx/stmtctx",
         "//types",

--- a/sessionctx/sessionstates/BUILD.bazel
+++ b/sessionctx/sessionstates/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//errno",
-        "//parser/model"
+        "//parser/model",
         "//parser/types",
         "//sessionctx/stmtctx",
         "//types",

--- a/sessionctx/sessionstates/session_states.go
+++ b/sessionctx/sessionstates/session_states.go
@@ -16,6 +16,7 @@ package sessionstates
 
 import (
 	"github.com/pingcap/tidb/errno"
+	"github.com/pingcap/tidb/parser/model"
 	ptypes "github.com/pingcap/tidb/parser/types"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
@@ -81,6 +82,8 @@ type SessionStates struct {
 	LastInsertID         uint64                       `json:"last-insert-id,omitempty"`
 	Warnings             []stmtctx.SQLWarn            `json:"warnings,omitempty"`
 	// Define it as string to avoid cycle import.
-	Bindings          string `json:"bindings,omitempty"`
-	ResourceGroupName string `json:"rs-group,omitempty"`
+	Bindings            string                                            `json:"bindings,omitempty"`
+	ResourceGroupName   string                                            `json:"rs-group,omitempty"`
+	HypoIndexes         map[string]map[string]map[string]*model.IndexInfo `json:"hypo-indexes,omitempty"`
+	HypoTiFlashReplicas map[string]map[string]struct{}                    `json:"hypo-tiflash-replicas,omitempty"`
 }

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -2584,6 +2584,8 @@ func (s *SessionVars) EncodeSessionStates(_ context.Context, sessionStates *sess
 	sessionStates.FoundInPlanCache = s.PrevFoundInPlanCache
 	sessionStates.FoundInBinding = s.PrevFoundInBinding
 	sessionStates.ResourceGroupName = s.ResourceGroupName
+	sessionStates.HypoIndexes = s.HypoIndexes
+	sessionStates.HypoTiFlashReplicas = s.HypoTiFlashReplicas
 
 	// Encode StatementContext. We encode it here to avoid circle dependency.
 	sessionStates.LastAffectedRows = s.StmtCtx.PrevAffectedRows
@@ -2618,6 +2620,8 @@ func (s *SessionVars) DecodeSessionStates(_ context.Context, sessionStates *sess
 	s.FoundInPlanCache = sessionStates.FoundInPlanCache
 	s.FoundInBinding = sessionStates.FoundInBinding
 	s.ResourceGroupName = sessionStates.ResourceGroupName
+	s.HypoIndexes = sessionStates.HypoIndexes
+	s.HypoTiFlashReplicas = sessionStates.HypoTiFlashReplicas
 
 	// Decode StatementContext.
 	s.StmtCtx.SetAffectedRows(uint64(sessionStates.LastAffectedRows))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44738

Problem Summary:
Hypo indexes and hypo tiflash replicas are added in #43607 and #44575 but are not encoded into session states, so they won't be migrated when the session is migrated.

### What is changed and how it works?
Encode `HypoIndexes` and `HypoTiFlashReplicas` into `SessionStates`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
