### PR TITLE
import into: change max pool size to num-cpu

### DIFF
--- a/disttask/importinto/scheduler.go
+++ b/disttask/importinto/scheduler.go
@@ -224,7 +224,7 @@ func init() {
 		logger.Info("create step scheduler")
 		return &taskMeta, logger, nil
 	}
-	scheduler.RegisterTaskType(proto.ImportInto, scheduler.WithPoolSize(int32(runtime.NumCPU())))
+	scheduler.RegisterTaskType(proto.ImportInto, scheduler.WithPoolSize(int32(runtime.GOMAXPROCS(0))))
 	scheduler.RegisterSchedulerConstructor(proto.ImportInto, StepImport,
 		func(taskID int64, bs []byte, step int64) (scheduler.Scheduler, error) {
 			taskMeta, logger, err := prepareFn(taskID, bs, step)

--- a/disttask/importinto/scheduler.go
+++ b/disttask/importinto/scheduler.go
@@ -17,6 +17,7 @@ package importinto
 import (
 	"context"
 	"encoding/json"
+	"runtime"
 	"sync"
 
 	"github.com/pingcap/errors"
@@ -223,7 +224,7 @@ func init() {
 		logger.Info("create step scheduler")
 		return &taskMeta, logger, nil
 	}
-	scheduler.RegisterTaskType(proto.ImportInto)
+	scheduler.RegisterTaskType(proto.ImportInto, scheduler.WithPoolSize(int32(runtime.NumCPU())))
 	scheduler.RegisterSchedulerConstructor(proto.ImportInto, StepImport,
 		func(taskID int64, bs []byte, step int64) (scheduler.Scheduler, error) {
 			taskMeta, logger, err := prepareFn(taskID, bs, step)

--- a/executor/importer/import.go
+++ b/executor/importer/import.go
@@ -460,7 +460,7 @@ func (e *LoadDataController) checkFieldParams() error {
 }
 
 func (p *Plan) initDefaultOptions() {
-	threadCnt := runtime.NumCPU()
+	threadCnt := runtime.GOMAXPROCS(0)
 	failpoint.Inject("mockNumCpu", func(val failpoint.Value) {
 		threadCnt = val.(int)
 	})
@@ -637,7 +637,7 @@ func (p *Plan) initOptions(seCtx sessionctx.Context, options []*plannercore.Load
 
 func (p *Plan) adjustOptions() {
 	// max value is cpu-count
-	numCPU := int64(runtime.NumCPU())
+	numCPU := int64(runtime.GOMAXPROCS(0))
 	if p.ThreadCnt > numCPU {
 		log.L().Info("IMPORT INTO thread count is larger than cpu-count, set to cpu-count")
 		p.ThreadCnt = numCPU

--- a/executor/importer/import_test.go
+++ b/executor/importer/import_test.go
@@ -102,7 +102,7 @@ func TestInitOptionsPositiveCase(t *testing.T) {
 	require.Equal(t, uint64(3), plan.IgnoreLines, sql)
 	require.Equal(t, config.ByteSize(100<<30), plan.DiskQuota, sql)
 	require.Equal(t, config.OpLevelOptional, plan.Checksum, sql)
-	require.Equal(t, int64(runtime.NumCPU()), plan.ThreadCnt, sql) // it's adjusted to the number of CPUs
+	require.Equal(t, int64(runtime.GOMAXPROCS(0)), plan.ThreadCnt, sql) // it's adjusted to the number of CPUs
 	require.Equal(t, config.ByteSize(200<<20), plan.MaxWriteSpeed, sql)
 	require.True(t, plan.SplitFile, sql)
 	require.Equal(t, int64(123), plan.MaxRecordedErrors, sql)
@@ -117,7 +117,7 @@ func TestAdjustOptions(t *testing.T) {
 		MaxWriteSpeed: 10,
 	}
 	plan.adjustOptions()
-	require.Equal(t, int64(runtime.NumCPU()), plan.ThreadCnt)
+	require.Equal(t, int64(runtime.GOMAXPROCS(0)), plan.ThreadCnt)
 	require.Equal(t, config.ByteSize(10), plan.MaxWriteSpeed) // not adjusted
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42930 

Problem Summary:

### What is changed and how it works?
- change max pool size to num-cpu, so import be able to use all cpu resource, previously it's 10 independently on TiDB cpu count

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - after change cfg, import is 8(8c on local mac)
![nTF41gZrQL](https://github.com/pingcap/tidb/assets/3312245/0e5d2772-85b7-4e78-bec5-af96d7a0ad42)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
