### PR TITLE
import into: exit ImportMode after import step

### DIFF
--- a/br/pkg/checksum/executor.go
+++ b/br/pkg/checksum/executor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/distsql"
+	"github.com/pingcap/tidb/domain/resourcegroup"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -213,6 +214,7 @@ func buildTableRequest(
 		SetStartTS(startTS).
 		SetChecksumRequest(checksum).
 		SetConcurrency(int(concurrency)).
+		SetResourceGroupName(resourcegroup.DefaultResourceGroupName).
 		Build()
 }
 

--- a/br/pkg/checksum/executor.go
+++ b/br/pkg/checksum/executor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/distsql"
-	"github.com/pingcap/tidb/domain/resourcegroup"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -214,7 +213,6 @@ func buildTableRequest(
 		SetStartTS(startTS).
 		SetChecksumRequest(checksum).
 		SetConcurrency(int(concurrency)).
-		SetResourceGroupName(resourcegroup.DefaultResourceGroupName).
 		Build()
 }
 

--- a/disttask/importinto/dispatcher.go
+++ b/disttask/importinto/dispatcher.go
@@ -243,6 +243,9 @@ func (h *flowHandle) ProcessNormalFlow(ctx context.Context, handle dispatcher.Ta
 		return metaBytes, nil
 	case StepImport:
 		h.switchTiKV2NormalMode(ctx, gTask, logger)
+		failpoint.Inject("clearLastSwitchTime", func() {
+			h.lastSwitchTime.Store(time.Time{})
+		})
 		stepMeta, err2 := toPostProcessStep(handle, gTask, taskMeta)
 		if err2 != nil {
 			return nil, err2

--- a/disttask/importinto/dispatcher.go
+++ b/disttask/importinto/dispatcher.go
@@ -148,7 +148,9 @@ func (h *flowHandle) OnTicker(ctx context.Context, task *proto.Task) {
 
 func (h *flowHandle) switchTiKVMode(ctx context.Context, task *proto.Task) {
 	h.updateCurrentTask(task)
-	if h.disableTiKVImportMode.Load() {
+	// only import step need to switch to IMPORT mode,
+	// If TiKV is in IMPORT mode during checksum, coprocessor will time out.
+	if h.disableTiKVImportMode.Load() || task.Step != StepImport {
 		return
 	}
 
@@ -204,7 +206,7 @@ func (h *flowHandle) ProcessNormalFlow(ctx context.Context, handle dispatcher.Ta
 		taskFinished := err == nil && len(resSubtaskMeta) == 0
 		if taskFinished {
 			// todo: we're not running in a transaction with task update
-			if err2 := h.finishJob(ctx, handle, gTask, taskMeta, logger); err2 != nil {
+			if err2 := h.finishJob(ctx, handle, gTask, taskMeta); err2 != nil {
 				err = err2
 			}
 		} else if err != nil && !h.IsRetryableErr(err) {
@@ -240,6 +242,7 @@ func (h *flowHandle) ProcessNormalFlow(ctx context.Context, handle dispatcher.Ta
 		gTask.Step = StepImport
 		return metaBytes, nil
 	case StepImport:
+		h.switchTiKV2NormalMode(ctx, gTask, logger)
 		stepMeta, err2 := toPostProcessStep(handle, gTask, taskMeta)
 		if err2 != nil {
 			return nil, err2
@@ -603,9 +606,7 @@ func job2Step(ctx context.Context, taskMeta *TaskMeta, step string) error {
 	})
 }
 
-func (h *flowHandle) finishJob(ctx context.Context, handle dispatcher.TaskHandle, gTask *proto.Task,
-	taskMeta *TaskMeta, logger *zap.Logger) error {
-	h.switchTiKV2NormalMode(ctx, gTask, logger)
+func (h *flowHandle) finishJob(ctx context.Context, handle dispatcher.TaskHandle, gTask *proto.Task, taskMeta *TaskMeta) error {
 	h.unregisterTask(ctx, gTask)
 	redactSensitiveInfo(gTask, taskMeta)
 	summary := &importer.JobSummary{ImportedRows: taskMeta.Result.LoadedRowCnt}

--- a/disttask/importinto/subtask_executor.go
+++ b/disttask/importinto/subtask_executor.go
@@ -67,6 +67,9 @@ type postProcessMinimalTaskExecutor struct {
 
 func (e *postProcessMinimalTaskExecutor) Run(ctx context.Context) error {
 	mTask := e.mTask
+	failpoint.Inject("waitBeforePostProcess", func() {
+		time.Sleep(5 * time.Second)
+	})
 	return postProcess(ctx, mTask.taskMeta, &mTask.meta, mTask.logger)
 }
 

--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -891,7 +891,7 @@ func (s *mockGCSSuite) TestImportMode() {
 	s.Greater(intoNormalTime, intoImportTime)
 	s.checkTaskMetaRedacted(int64(jobID))
 
-	// after import step, we should not enter normal mode, i.e. we only call ToImportMode once
+	// after import step, we should enter normal mode, i.e. we only call ToImportMode once
 	intoNormalTime, intoImportTime = time.Time{}, time.Time{}
 	switcher.EXPECT().ToImportMode(gomock.Any()).DoAndReturn(toImportModeFn).Times(1)
 	switcher.EXPECT().ToNormalMode(gomock.Any()).DoAndReturn(toNormalModeFn).Times(1)

--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -851,16 +851,18 @@ func (s *mockGCSSuite) TestImportMode() {
 	var intoImportTime, intoNormalTime time.Time
 	controller := gomock.NewController(s.T())
 	switcher := mocklocal.NewMockTiKVModeSwitcher(controller)
-	switcher.EXPECT().ToImportMode(gomock.Any()).DoAndReturn(func(ctx context.Context) error {
+	toImportModeFn := func(ctx context.Context) error {
 		log.L().Info("ToImportMode")
 		intoImportTime = time.Now()
 		return nil
-	}).Times(1)
-	switcher.EXPECT().ToNormalMode(gomock.Any()).DoAndReturn(func(ctx context.Context) error {
+	}
+	toNormalModeFn := func(ctx context.Context) error {
 		log.L().Info("ToNormalMode")
 		intoNormalTime = time.Now()
 		return nil
-	}).Times(1)
+	}
+	switcher.EXPECT().ToImportMode(gomock.Any()).DoAndReturn(toImportModeFn).Times(1)
+	switcher.EXPECT().ToNormalMode(gomock.Any()).DoAndReturn(toNormalModeFn).Times(1)
 	backup := importer.NewTiKVModeSwitcher
 	importer.NewTiKVModeSwitcher = func(tls *common.TLS, pdAddr string, logger *zap.Logger) local.TiKVModeSwitcher {
 		return switcher
@@ -889,25 +891,32 @@ func (s *mockGCSSuite) TestImportMode() {
 	s.Greater(intoNormalTime, intoImportTime)
 	s.checkTaskMetaRedacted(int64(jobID))
 
+	// after import step, we should not enter normal mode, i.e. we only call ToImportMode once
 	intoNormalTime, intoImportTime = time.Time{}, time.Time{}
-	switcher.EXPECT().ToImportMode(gomock.Any()).DoAndReturn(func(ctx context.Context) error {
-		log.L().Info("ToImportMode")
-		intoImportTime = time.Now()
-		return nil
-	}).Times(1)
-	switcher.EXPECT().ToNormalMode(gomock.Any()).DoAndReturn(func(ctx context.Context) error {
-		log.L().Info("ToNormalMode")
-		intoNormalTime = time.Now()
-		return nil
-	}).Times(1)
+	switcher.EXPECT().ToImportMode(gomock.Any()).DoAndReturn(toImportModeFn).Times(1)
+	switcher.EXPECT().ToNormalMode(gomock.Any()).DoAndReturn(toNormalModeFn).Times(1)
+	s.enableFailpoint("github.com/pingcap/tidb/disttask/importinto/clearLastSwitchTime", "return(true)")
+	s.enableFailpoint("github.com/pingcap/tidb/disttask/importinto/waitBeforePostProcess", "return(true)")
 	s.tk.MustExec("truncate table load_data.import_mode;")
+	sql = fmt.Sprintf(`IMPORT INTO load_data.import_mode FROM 'gs://test-load/import_mode-*.tsv?endpoint=%s'`, gcsEndpoint)
+	s.tk.MustQuery(sql)
+	s.tk.MustQuery("SELECT * FROM load_data.import_mode;").Sort().Check(testkit.Rows("1 11 111"))
+	s.tk.MustExec("truncate table load_data.import_mode;")
+	s.Greater(intoNormalTime, intoImportTime)
+	s.NoError(failpoint.Disable("github.com/pingcap/tidb/disttask/importinto/clearLastSwitchTime"))
+	s.NoError(failpoint.Disable("github.com/pingcap/tidb/disttask/importinto/waitBeforePostProcess"))
 
+	// test disable_tikv_import_mode, should not call ToImportMode and ToNormalMode
+	s.tk.MustExec("truncate table load_data.import_mode;")
 	sql = fmt.Sprintf(`IMPORT INTO load_data.import_mode FROM 'gs://test-load/import_mode-*.tsv?endpoint=%s' WITH disable_tikv_import_mode`, gcsEndpoint)
 	s.tk.MustQuery(sql)
 	s.tk.MustQuery("SELECT * FROM load_data.import_mode;").Sort().Check(testkit.Rows("1 11 111"))
 	s.tk.MustExec("truncate table load_data.import_mode;")
 
-	// wait ToImportMode called
+	// to normal mode should be called on error
+	intoNormalTime, intoImportTime = time.Time{}, time.Time{}
+	switcher.EXPECT().ToImportMode(gomock.Any()).DoAndReturn(toImportModeFn).Times(1)
+	switcher.EXPECT().ToNormalMode(gomock.Any()).DoAndReturn(toNormalModeFn).Times(1)
 	s.enableFailpoint("github.com/pingcap/tidb/disttask/importinto/waitBeforeSortChunk", "return(true)")
 	s.enableFailpoint("github.com/pingcap/tidb/disttask/importinto/errorWhenSortChunk", "return(true)")
 	s.enableFailpoint("github.com/pingcap/tidb/executor/importer/setLastImportJobID", `return(true)`)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44755

Problem Summary:

### What is changed and how it works?
- exit importMode after import step, coprocessor is extremely slow if in importMode
- change default `regionSplitSize` to 192MiB which is the value we set when importing 50T data.
- change the value of `regionSplitSize` to be the same as lightning when doing `unsafeImport`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
