### PR TITLE
util: fix index out of range error when using the copStat twice

### DIFF
--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -489,13 +489,11 @@ func (p *Percentile[valueType]) MergePercentile(p2 *Percentile[valueType]) {
 	p.sumVal += p2.sumVal
 	p.size += p2.size
 	if p.dt == nil {
-		p.dt = p2.dt
-		p2.dt = nil
+		p.dt = tdigest.New()
 		for _, v := range p.values {
 			p.dt.Add(v.GetFloat64(), 1)
 		}
 		p.values = nil
-		return
 	}
 	p.dt.AddCentroidList(p2.dt.Centroids())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/44753

Problem Summary:

### What is changed and how it works?

MergePercentile will set `p2.dt = nil`, so the next time using the copStats will get an empty result.
It will getting different results(or panic) when calling `CopRuntimeStats.String()`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
