### PR TITLE
test: fix data race in resouce control interceptor initialization

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1382,6 +1382,7 @@ func (do *Domain) initResourceGroupsController(ctx context.Context, pdClient pd.
 	serverAddr := net.JoinHostPort(serverInfo.IP, strconv.Itoa(int(serverInfo.Port)))
 	do.runawayManager = resourcegroup.NewRunawayManager(control, serverAddr)
 	do.resourceGroupsController = control
+	tikv.SetResourceControlInterceptor(control)
 	return nil
 }
 

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -238,7 +238,6 @@ func main() {
 	resourcemanager.InstanceResourceManager.Start()
 	storage, dom := createStoreAndDomain(keyspaceName)
 	svr := createServer(storage, dom)
-	tikv.SetResourceControlInterceptor(dom.ResourceGroupsController())
 
 	// Register error API is not thread-safe, the caller MUST NOT register errors after initialization.
 	// To prevent misuse, set a flag to indicate that register new error will panic immediately.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44776

Problem Summary:

### What is changed and how it works?
The change move the ResourceControlInterceptor from main into domain to avoid data race. In the previous implementation, `SetResourceControlInterceptor` is run after dom is inited, so it's possible that session variable(`tidb_enable_resource_control`) initialization runs at the same time with `SetResourceControlInterceptor`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
