### PR TITLE
test: fix data race at init resource controller

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1379,11 +1379,9 @@ func (do *Domain) initResourceGroupsController(ctx context.Context, pdClient pd.
 		return err
 	}
 	control.Start(ctx)
-	serverInfo, err := infosync.GetServerInfo()
-	if err != nil {
-		return err
-	}
-	serverAddr := net.JoinHostPort(serverInfo.IP, strconv.Itoa(int(serverInfo.Port)))
+	// don't use infosync.GetServerInfo here, because infosync is still not inited.
+	cfg := config.GetGlobalConfig()
+	serverAddr := net.JoinHostPort(cfg.AdvertiseAddress, strconv.Itoa(int(cfg.Port)))
 	do.runawayManager = resourcegroup.NewRunawayManager(control, serverAddr)
 	do.resourceGroupsController = control
 	tikv.SetResourceControlInterceptor(control)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44818

Problem Summary:

### What is changed and how it works?
PR #44789 tried to fix the data race, but it was still not early enough. Resource controller's init can race with other sessions because it will update the RPCInterceptor. Because after the previous, resource controller is inited after ddl, so the internal session used by ddl can race with the resource controller's init.

This PR change to init resource controller first in domain.Init, so we can ensure no other session will start working before resource controller is inited.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
