### PR TITLE
planner: ignore index_merge when partial path has global index

### DIFF
--- a/executor/test/writetest/write_test.go
+++ b/executor/test/writetest/write_test.go
@@ -3423,9 +3423,8 @@ func TestListColumnsPartitionWithGlobalIndex(t *testing.T) {
 		tk.MustExec("update t set a='bbb' where a = 'aaa'")
 		tk.MustExec("admin check table t")
 		tk.MustQuery("select a from t order by a").Check(testkit.Rows("abc", "acd", "bbb"))
-		// TODO: fix below test.
-		//tk.MustQuery("select a from t partition (p0) order by a").Check(testkit.Rows("abc", "acd"))
-		//tk.MustQuery("select a from t partition (p1) order by a").Check(testkit.Rows("bbb"))
+		tk.MustQuery("select a from t partition (p0) order by a").Check(testkit.Rows("abc", "acd"))
+		tk.MustQuery("select a from t partition (p1) order by a").Check(testkit.Rows("bbb"))
 		tk.MustQuery("select * from t where a = 'bbb' order by a").Check(testkit.Rows("bbb b"))
 		// Test insert meet duplicate error.
 		err := tk.ExecToErr("insert into t (a) values  ('abc')")
@@ -3434,9 +3433,8 @@ func TestListColumnsPartitionWithGlobalIndex(t *testing.T) {
 		tk.MustExec("insert into t (a) values ('abc') on duplicate key update a='bbc'")
 		tk.MustQuery("select a from t order by a").Check(testkit.Rows("acd", "bbb", "bbc"))
 		tk.MustQuery("select * from t where a = 'bbc'").Check(testkit.Rows("bbc b"))
-		// TODO: fix below test.
-		//tk.MustQuery("select a from t partition (p0) order by a").Check(testkit.Rows("acd"))
-		//tk.MustQuery("select a from t partition (p1) order by a").Check(testkit.Rows("bbb", "bbc"))
+		tk.MustQuery("select a from t partition (p0) order by a").Check(testkit.Rows("acd"))
+		tk.MustQuery("select a from t partition (p1) order by a").Check(testkit.Rows("bbb", "bbc"))
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--
ignore index merge when partial path is global index.

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #43013 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
