### PR TITLE
executor, infoschema: add tiproxy into table `cluster_info`

### DIFF
--- a/pkg/domain/infosync/info.go
+++ b/pkg/domain/infosync/info.go
@@ -1342,8 +1342,9 @@ func GetTiProxyServerInfo(ctx context.Context) (map[string]*TiProxyServerInfo, e
 }
 
 func (is *InfoSyncer) getTiProxyServerInfo(ctx context.Context) (map[string]*TiProxyServerInfo, error) {
+	// In test.
 	if is.etcdCli == nil {
-		return nil, errors.Errorf("pd unavailable")
+		return nil, nil
 	}
 
 	var err error

--- a/pkg/domain/infosync/info.go
+++ b/pkg/domain/infosync/info.go
@@ -83,6 +83,10 @@ const (
 	TopologyTimeToRefresh = 30 * time.Second
 	// TopologyPrometheus means address of prometheus.
 	TopologyPrometheus = "/topology/prometheus"
+	// TopologyTiProxy means address of TiProxy.
+	TopologyTiProxy = "/topology/tiproxy"
+	// infoSuffix is the suffix of TiDB/TiProxy topology info.
+	infoSuffix = "/info"
 	// TablePrometheusCacheExpiry is the expiry time for prometheus address cache.
 	TablePrometheusCacheExpiry = 10 * time.Second
 	// RequestRetryInterval is the sleep time before next retry for http request
@@ -1311,4 +1315,68 @@ func SetPDScheduleConfig(ctx context.Context, config map[string]interface{}) err
 		return errors.Trace(err)
 	}
 	return is.scheduleManager.SetPDScheduleConfig(ctx, config)
+}
+
+// TiProxyServerInfo is the server info for TiProxy.
+type TiProxyServerInfo struct {
+	Version        string `json:"version"`
+	GitHash        string `json:"git_hash"`
+	IP             string `json:"ip"`
+	Port           string `json:"port"`
+	StatusPort     string `json:"status_port"`
+	StartTimestamp int64  `json:"start_timestamp"`
+}
+
+// GetTiProxyServerInfo gets all TiProxy servers information from etcd.
+func GetTiProxyServerInfo(ctx context.Context) (map[string]*TiProxyServerInfo, error) {
+	failpoint.Inject("mockGetTiProxyServerInfo", func(val failpoint.Value) {
+		res := make(map[string]*TiProxyServerInfo)
+		err := json.Unmarshal([]byte(val.(string)), &res)
+		failpoint.Return(res, err)
+	})
+	is, err := getGlobalInfoSyncer()
+	if err != nil {
+		return nil, err
+	}
+	return is.getTiProxyServerInfo(ctx)
+}
+
+func (is *InfoSyncer) getTiProxyServerInfo(ctx context.Context) (map[string]*TiProxyServerInfo, error) {
+	if is.etcdCli == nil {
+		return nil, errors.Errorf("pd unavailable")
+	}
+
+	var err error
+	var resp *clientv3.GetResponse
+	allInfo := make(map[string]*TiProxyServerInfo)
+	for i := 0; i < keyOpDefaultRetryCnt; i++ {
+		if ctx.Err() != nil {
+			return nil, errors.Trace(ctx.Err())
+		}
+		childCtx, cancel := context.WithTimeout(ctx, keyOpDefaultTimeout)
+		resp, err = is.etcdCli.Get(childCtx, TopologyTiProxy, clientv3.WithPrefix())
+		cancel()
+		if err != nil {
+			logutil.BgLogger().Info("get key failed", zap.String("key", TopologyTiProxy), zap.Error(err))
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		for _, kv := range resp.Kvs {
+			key := string(kv.Key)
+			if !strings.HasSuffix(key, infoSuffix) {
+				continue
+			}
+			addr := key[len(TopologyTiProxy)+1 : len(key)-len(infoSuffix)]
+			var info TiProxyServerInfo
+			err = json.Unmarshal(kv.Value, &info)
+			if err != nil {
+				logutil.BgLogger().Info("unmarshal key failed", zap.String("key", key), zap.ByteString("value", kv.Value),
+					zap.Error(err))
+				return nil, errors.Trace(err)
+			}
+			allInfo[addr] = &info
+		}
+		return allInfo, nil
+	}
+	return nil, errors.Trace(err)
 }

--- a/pkg/executor/infoschema_cluster_table_test.go
+++ b/pkg/executor/infoschema_cluster_table_test.go
@@ -233,6 +233,7 @@ func TestTiDBClusterInfo(t *testing.T) {
 		"pd,127.0.0.1:11080," + mockAddr + ",mock-version,mock-githash,0",
 		"tidb,127.0.0.1:11080," + mockAddr + ",mock-version,mock-githash,1001",
 		"tikv,127.0.0.1:11080," + mockAddr + ",mock-version,mock-githash,0",
+		"tiproxy,127.0.0.1:6000," + mockAddr + ",mock-version,mock-githash,0",
 	}
 	fpExpr := `return("` + strings.Join(instances, ";") + `")`
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/infoschema/mockClusterInfo", fpExpr))
@@ -243,6 +244,7 @@ func TestTiDBClusterInfo(t *testing.T) {
 		row("pd", "127.0.0.1:11080", mockAddr, "mock-version", "mock-githash", "0"),
 		row("tidb", "127.0.0.1:11080", mockAddr, "mock-version", "mock-githash", "1001"),
 		row("tikv", "127.0.0.1:11080", mockAddr, "mock-version", "mock-githash", "0"),
+		row("tiproxy", "127.0.0.1:6000", mockAddr, "mock-version", "mock-githash", "0"),
 	))
 	tk.MustQuery("select * from information_schema.cluster_config").Check(testkit.Rows(
 		"pd 127.0.0.1:11080 key1 value1",

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -68,7 +68,7 @@ func TestInspectionTables(t *testing.T) {
 		"tiproxy 127.0.0.1:6000 127.0.0.1:3380 mock-version mock-githash 0",
 	))
 	require.NoError(t, inspectionTableCache["cluster_info"].Err)
-	require.Len(t, inspectionTableCache["cluster_info"].Rows, 3)
+	require.Len(t, inspectionTableCache["cluster_info"].Rows, 4)
 
 	// check whether is obtain data from cache at the next time
 	inspectionTableCache["cluster_info"].Rows[0][0].SetString("modified-pd", mysql.DefaultCollationName)

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -44,6 +44,7 @@ func TestInspectionTables(t *testing.T) {
 		"pd,127.0.0.1:11080,127.0.0.1:10080,mock-version,mock-githash,0",
 		"tidb,127.0.0.1:11080,127.0.0.1:10080,mock-version,mock-githash,1001",
 		"tikv,127.0.0.1:11080,127.0.0.1:10080,mock-version,mock-githash,0",
+		"tiproxy,127.0.0.1:6000,127.0.0.1:3380,mock-version,mock-githash,0",
 	}
 	fpName := "github.com/pingcap/tidb/pkg/infoschema/mockClusterInfo"
 	fpExpr := `return("` + strings.Join(instances, ";") + `")`
@@ -54,6 +55,7 @@ func TestInspectionTables(t *testing.T) {
 		"pd 127.0.0.1:11080 127.0.0.1:10080 mock-version mock-githash 0",
 		"tidb 127.0.0.1:11080 127.0.0.1:10080 mock-version mock-githash 1001",
 		"tikv 127.0.0.1:11080 127.0.0.1:10080 mock-version mock-githash 0",
+		"tiproxy 127.0.0.1:6000 127.0.0.1:3380 mock-version mock-githash 0",
 	))
 
 	// enable inspection mode
@@ -63,6 +65,7 @@ func TestInspectionTables(t *testing.T) {
 		"pd 127.0.0.1:11080 127.0.0.1:10080 mock-version mock-githash 0",
 		"tidb 127.0.0.1:11080 127.0.0.1:10080 mock-version mock-githash 1001",
 		"tikv 127.0.0.1:11080 127.0.0.1:10080 mock-version mock-githash 0",
+		"tiproxy 127.0.0.1:6000 127.0.0.1:3380 mock-version mock-githash 0",
 	))
 	require.NoError(t, inspectionTableCache["cluster_info"].Err)
 	require.Len(t, inspectionTableCache["cluster_info"].Rows, 3)
@@ -73,6 +76,7 @@ func TestInspectionTables(t *testing.T) {
 		"modified-pd 127.0.0.1:11080 127.0.0.1:10080 mock-version mock-githash 0",
 		"tidb 127.0.0.1:11080 127.0.0.1:10080 mock-version mock-githash 1001",
 		"tikv 127.0.0.1:11080 127.0.0.1:10080 mock-version mock-githash 0",
+		"tiproxy 127.0.0.1:6000 127.0.0.1:3380 mock-version mock-githash 0",
 	))
 	tk.Session().GetSessionVars().InspectionTableCache = nil
 }

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -1752,7 +1752,7 @@ func GetClusterServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 	type retriever func(ctx sessionctx.Context) ([]ServerInfo, error)
 	//nolint: prealloc
 	var servers []ServerInfo
-	for _, r := range []retriever{GetTiDBServerInfo, GetPDServerInfo, GetStoreServerInfo} {
+	for _, r := range []retriever{GetTiDBServerInfo, GetPDServerInfo, GetStoreServerInfo, GetTiProxyServerInfo} {
 		nodes, err := r(ctx)
 		if err != nil {
 			return nil, err
@@ -2007,6 +2007,25 @@ func GetTiFlashStoreCount(ctx sessionctx.Context) (cnt uint64, err error) {
 		}
 	}
 	return cnt, nil
+}
+
+func GetTiProxyServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
+	tiproxyNodes, err := infosync.GetTiProxyServerInfo(context.Background())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var servers = make([]ServerInfo, 0, len(tiproxyNodes))
+	for _, node := range tiproxyNodes {
+		servers = append(servers, ServerInfo{
+			ServerType:     "tiproxy",
+			Address:        net.JoinHostPort(node.IP, node.Port),
+			StatusAddr:     net.JoinHostPort(node.IP, node.StatusPort),
+			Version:        node.Version,
+			GitHash:        node.GitHash,
+			StartTimestamp: node.StartTimestamp,
+		})
+	}
+	return servers, nil
 }
 
 // SysVarHiddenForSem checks if a given sysvar is hidden according to SEM and privileges.

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -2009,6 +2009,7 @@ func GetTiFlashStoreCount(ctx sessionctx.Context) (cnt uint64, err error) {
 	return cnt, nil
 }
 
+// GetTiProxyServerInfo gets server info of TiProxy from PD.
 func GetTiProxyServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 	tiproxyNodes, err := infosync.GetTiProxyServerInfo(context.Background())
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #44827 

Problem Summary:
Add TiProxy to table `information_schema.cluster_info`.

### What is changed and how it works?
- Read TiProxy server info from `/topology/tiproxy/xxx/info`. The path for TiDB server info is `/tidb/server/info` but it's duplicated with `/topology/tidb/xxx/info`. I'll just use `/topology/tiproxy/xxx/info` for TiProxy.
- Add TiProxy to table `information_schema.cluster_info`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Before starting TiProxy:
```
mysql> select * from information_schema.cluster_info;
+------+-----------------+-----------------+---------+------------------------------------------+---------------------------+--------------+-----------+
| TYPE | INSTANCE        | STATUS_ADDRESS  | VERSION | GIT_HASH                                 | START_TIME                | UPTIME       | SERVER_ID |
+------+-----------------+-----------------+---------+------------------------------------------+---------------------------+--------------+-----------+
| tidb | 127.0.0.1:4000  | 127.0.0.1:10080 | 7.0.0   | 7376954cd868dbc44fc3015c9ef89c53749339a7 | 2023-06-20T15:43:14+08:00 | 2m5.673827s  |   2928446 |
| tidb | 127.0.0.1:4001  | 127.0.0.1:10081 | None    | None                                     | 2023-06-20T15:44:43+08:00 | 36.67383s    |   2921643 |
| pd   | 127.0.0.1:2379  | 127.0.0.1:2379  | 7.0.0   | da5a4e95ca0a739fc91e4dfd0f281e5413f5ff15 | 2023-06-20T15:40:59+08:00 | 4m20.673832s |         0 |
| tikv | 127.0.0.1:20160 | 127.0.0.1:20180 | 7.0.0   | 85e27ae5015694958a9bc123988775b2138ea58e | 2023-06-20T15:41:02+08:00 | 4m17.673835s |         0 |
+------+-----------------+-----------------+---------+------------------------------------------+---------------------------+--------------+-----------+
4 rows in set (0.00 sec)
```

After starting TiProxy:
```
mysql> select * from information_schema.cluster_info;
+---------+--------------------+--------------------+-------------------+------------------------------------------+---------------------------+------------------+-----------+
| TYPE    | INSTANCE           | STATUS_ADDRESS     | VERSION           | GIT_HASH                                 | START_TIME                | UPTIME           | SERVER_ID |
+---------+--------------------+--------------------+-------------------+------------------------------------------+---------------------------+------------------+-----------+
| tidb    | 127.0.0.1:4000     | 127.0.0.1:10080    | 7.0.0             | 7376954cd868dbc44fc3015c9ef89c53749339a7 | 2023-06-19T16:52:49+08:00 | 22h34m30.3175s   |   2221717 |
| tidb    | 127.0.0.1:4001     | 127.0.0.1:10081    | None              | None                                     | 2023-06-20T15:26:31+08:00 | 48.317505s       |   2786754 |
| pd      | 127.0.0.1:2379     | 127.0.0.1:2379     | 7.0.0             | da5a4e95ca0a739fc91e4dfd0f281e5413f5ff15 | 2023-06-19T16:52:30+08:00 | 22h34m49.317507s |         0 |
| tikv    | 127.0.0.1:20160    | 127.0.0.1:20180    | 7.0.0             | 85e27ae5015694958a9bc123988775b2138ea58e | 2023-06-19T16:52:34+08:00 | 22h34m45.317508s |         0 |
| tiproxy | 192.168.0.101:6000 | 192.168.0.101:3080 | refactor_infosync | 9ca256a0b53bfa45acba674025ffab73807a639e | 2023-06-20T15:25:09+08:00 | 2m10.317511s     |         0 |
+---------+--------------------+--------------------+-------------------+------------------------------------------+---------------------------+------------------+-----------+
5 rows in set (0.00 sec)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

Since TiProxy won't be released recently, it's invisible to users, so I won't add a release note here.

```release-note
None
```
