### PR TITLE
sql: fix error when use true in check constraint expression

### DIFF
--- a/ddl/constraint_test.go
+++ b/ddl/constraint_test.go
@@ -1128,11 +1128,13 @@ func TestIssue44689(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("USE test")
-	tk.MustExec("DROP TABLE IF EXISTS t0")
-	tk.MustExec("CREATE TABLE t0(c1 NUMERIC CHECK(true))")
+	for _, expr := range []string{"true", "false"} {
+		tk.MustExec("DROP TABLE IF EXISTS t0, t1, t2")
+		tk.MustExec(fmt.Sprintf("CREATE TABLE t0(c1 NUMERIC CHECK(%s))", expr))
 
-	tk.MustExec("CREATE TABLE t1(c1 NUMERIC, CHECK(true))")
+		tk.MustExec(fmt.Sprintf("CREATE TABLE t1(c1 NUMERIC, CHECK(%s))", expr))
 
-	tk.MustExec("CREATE TABLE t2(c1 NUMERIC)")
-	tk.MustExec("ALTER TABLE t2 ADD CONSTRAINT CHECK (true)")
+		tk.MustExec("CREATE TABLE t2(c1 NUMERIC)")
+		tk.MustExec(fmt.Sprintf("ALTER TABLE t2 ADD CONSTRAINT CHECK(%s)", expr))
+	}
 }

--- a/ddl/constraint_test.go
+++ b/ddl/constraint_test.go
@@ -1123,3 +1123,16 @@ func TestAlterEnforcedConstraintStateChange(t *testing.T) {
 	tk.MustExec("alter table t alter constraint c1 enforced")
 	tk.MustQuery("select * from t").Check(testkit.Rows("12"))
 }
+
+func TestIssue44689(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("USE test")
+	tk.MustExec("DROP TABLE IF EXISTS t0")
+	tk.MustExec("CREATE TABLE t0(c1 NUMERIC CHECK(true))")
+
+	tk.MustExec("CREATE TABLE t1(c1 NUMERIC, CHECK(true))")
+
+	tk.MustExec("CREATE TABLE t2(c1 NUMERIC)")
+	tk.MustExec("ALTER TABLE t2 ADD CONSTRAINT CHECK (true)")
+}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1997,13 +1997,21 @@ func BuildTableInfo(
 				}
 			} else {
 				// Check the column-type constraint dependency.
-				if len(dependedColsMap) != 1 {
+				if len(dependedColsMap) > 1 {
 					return nil, dbterror.ErrColumnCheckConstraintReferOther.GenWithStackByArgs(constr.Name)
 				}
-				if _, ok := dependedColsMap[constr.InColumnName]; !ok {
-					return nil, dbterror.ErrColumnCheckConstraintReferOther.GenWithStackByArgs(constr.Name)
+				if len(dependedColsMap) == 0 {
+					// If dependedCols is empty, the expression must be true/false.
+					valExpr, ok := constr.Expr.(*driver.ValueExpr)
+					if !ok || !mysql.HasIsBooleanFlag(valExpr.GetType().GetFlag()) {
+						return nil, errors.Trace(errors.New("unsupported expression in check constraint"))
+					}
+				} else {
+					if _, ok := dependedColsMap[constr.InColumnName]; !ok {
+						return nil, dbterror.ErrColumnCheckConstraintReferOther.GenWithStackByArgs(constr.Name)
+					}
+					dependedCols = []model.CIStr{model.NewCIStr(constr.InColumnName)}
 				}
-				dependedCols = []model.CIStr{model.NewCIStr(constr.InColumnName)}
 			}
 			// check auto-increment column
 			if table.ContainsAutoIncrementCol(dependedCols, tbInfo) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1999,8 +1999,7 @@ func BuildTableInfo(
 				// Check the column-type constraint dependency.
 				if len(dependedColsMap) > 1 {
 					return nil, dbterror.ErrColumnCheckConstraintReferOther.GenWithStackByArgs(constr.Name)
-				}
-				if len(dependedColsMap) == 0 {
+				} else if len(dependedColsMap) == 0 {
 					// If dependedCols is empty, the expression must be true/false.
 					valExpr, ok := constr.Expr.(*driver.ValueExpr)
 					if !ok || !mysql.HasIsBooleanFlag(valExpr.GetType().GetFlag()) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44689 

Problem Summary:
As issue describe, when use `check(true)` in column check constraint, we receive unexpected error. The reason is when validate the column if exists, we don't consider this situation.

### What is changed and how it works?
Involve this situation.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
