### PR TITLE
lightning: Adding Base 64 encoding support to lightning

### DIFF
--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -31,7 +31,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/BurntSushi/toml"
-        "github.com/docker/go-units"
+	"github.com/docker/go-units"
 	gomysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -31,7 +31,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/BurntSushi/toml"
-	"github.com/docker/go-units"
 	gomysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
@@ -639,7 +638,8 @@ type CSVConfig struct {
 	// deprecated, use `escaped-by` instead.
 	BackslashEscape bool `toml:"backslash-escape" json:"backslash-escape"`
 	// EscapedBy has higher priority than BackslashEscape, currently it must be a single character if set.
-	EscapedBy string `toml:"escaped-by" json:"escaped-by"`
+	Base64Encoded bool   `toml:"base64-encoded" json:"base64-encoded"`
+	EscapedBy     string `toml:"escaped-by" json:"escaped-by"`
 
 	// hide these options for lightning configuration file, they can only be used by LOAD DATA
 	// https://dev.mysql.com/doc/refman/8.0/en/load-data.html#load-data-field-line-handling

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -31,6 +31,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/BurntSushi/toml"
+        "github.com/docker/go-units"
 	gomysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"

--- a/br/pkg/lightning/importer/import.go
+++ b/br/pkg/lightning/importer/import.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-semver/semver"
+        "github.com/docker/go-units"
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"

--- a/br/pkg/lightning/importer/import.go
+++ b/br/pkg/lightning/importer/import.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/coreos/go-semver/semver"
-	"github.com/docker/go-units"
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -2125,10 +2124,11 @@ func (rc *Controller) DataCheck(ctx context.Context) error {
 	if err := rc.checkTableEmpty(ctx); err != nil {
 		return common.ErrCheckTableEmpty.Wrap(err).GenWithStackByArgs()
 	}
-	if err := rc.checkCSVHeader(ctx); err != nil {
-		return common.ErrCheckCSVHeader.Wrap(err).GenWithStackByArgs()
+	if rc.cfg.Mydumper.CSV.Base64Encoded == false {
+		if err := rc.checkCSVHeader(ctx); err != nil {
+			return common.ErrCheckCSVHeader.Wrap(err).GenWithStackByArgs()
+		}
 	}
-
 	return nil
 }
 

--- a/br/pkg/lightning/importer/import.go
+++ b/br/pkg/lightning/importer/import.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-semver/semver"
-        "github.com/docker/go-units"
+	"github.com/docker/go-units"
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"

--- a/br/pkg/lightning/importer/import.go
+++ b/br/pkg/lightning/importer/import.go
@@ -2125,7 +2125,7 @@ func (rc *Controller) DataCheck(ctx context.Context) error {
 	if err := rc.checkTableEmpty(ctx); err != nil {
 		return common.ErrCheckTableEmpty.Wrap(err).GenWithStackByArgs()
 	}
-	if rc.cfg.Mydumper.CSV.Base64Encoded == false {
+	if !rc.cfg.Mydumper.CSV.Base64Encoded {
 		if err := rc.checkCSVHeader(ctx); err != nil {
 			return common.ErrCheckCSVHeader.Wrap(err).GenWithStackByArgs()
 		}

--- a/br/pkg/lightning/mydump/csv_parser.go
+++ b/br/pkg/lightning/mydump/csv_parser.go
@@ -17,10 +17,6 @@ package mydump
 import (
 	"bytes"
 	"context"
-	"io"
-	"regexp"
-	"strings"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/lightning/config"
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
@@ -30,6 +26,9 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mathutil"
 	"golang.org/x/exp/slices"
+	"io"
+	"regexp"
+	"strings"
 )
 
 var (
@@ -669,6 +668,12 @@ func (parser *CSVParser) ReadRow() error {
 		}
 		if isNull {
 			row.Row[i].SetNull()
+		} else if parser.cfg.Base64Encoded {
+			decoded, err := base64.StdEncoding.WithPadding(base64.StdPadding).DecodeString(strings.TrimSpace(unescaped))
+			if err != nil {
+				return errors.Trace(err)
+			}
+			row.Row[i].SetString(string(decoded), "utf8mb4_bin")
 		} else {
 			row.Row[i].SetString(unescaped, "utf8mb4_bin")
 		}

--- a/br/pkg/lightning/mydump/csv_parser.go
+++ b/br/pkg/lightning/mydump/csv_parser.go
@@ -17,6 +17,7 @@ package mydump
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/lightning/config"
 	"github.com/pingcap/tidb/br/pkg/lightning/log"

--- a/br/pkg/lightning/mydump/csv_parser.go
+++ b/br/pkg/lightning/mydump/csv_parser.go
@@ -18,6 +18,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"io"
+	"regexp"
+	"strings"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/lightning/config"
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
@@ -27,9 +31,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mathutil"
 	"golang.org/x/exp/slices"
-	"io"
-	"regexp"
-	"strings"
 )
 
 var (


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44893 

Problem Summary:

### What is changed and how it works?
In lightning.toml, a config param can be added as follows
[mydumper.csv]
base64-encoded = true

This means all columns in csv files are base64 encoded. So lightning will decode it before storing it in the database.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
