### PR TITLE
*: support MPPGather for UnionScan

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1375,15 +1375,13 @@ func (b *executorBuilder) buildUnionScanFromReader(reader Executor, v *plannerco
 	}
 
 	switch x := reader.(type) {
-	// todo: when we full banned cop tiflash, we should think about combination of MPPGather and UnionScan
 	case *MPPGather:
 		us.desc = false
 		us.conditions, us.conditionsWithVirCol = plannercore.SplitSelCondsWithVirtualColumn(v.Conditions)
 		us.columns = x.columns
 		us.table = x.table
 		us.virtualColumnIndex = x.virtualColumnIndex
-		// gjt todo: check, add case
-		// us.handleCachedTable(b, x, sessionVars, startTS)
+		us.handleCachedTable(b, x, sessionVars, startTS)
 	case *TableReaderExecutor:
 		us.desc = x.desc
 		us.conditions, us.conditionsWithVirCol = plannercore.SplitSelCondsWithVirtualColumn(v.Conditions)

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3514,6 +3514,7 @@ func (b *executorBuilder) buildMPPGather(v *plannercore.PhysicalTableReader) Exe
 	tbl, _ := b.is.TableByID(ts.Table.ID)
 	isPartition, physicalTableID := ts.IsPartition()
 	if isPartition {
+		// Only for static pruning partition table.
 		pt := tbl.(table.PartitionedTable)
 		tbl = pt.GetPartition(physicalTableID)
 	}

--- a/executor/internal/mpp/local_mpp_coordinator.go
+++ b/executor/internal/mpp/local_mpp_coordinator.go
@@ -538,19 +538,19 @@ func (c *localMppCoordinator) Next(ctx context.Context) (kv.ResultSubset, error)
 }
 
 // Execute executes physical plan and returns a response.
-func (c *localMppCoordinator) Execute(ctx context.Context) (kv.Response, error) {
+func (c *localMppCoordinator) Execute(ctx context.Context) (kv.Response, []kv.KeyRange, error) {
 	// TODO: Move the construct tasks logic to planner, so we can see the explain results.
 	sender := c.originalPlan.(*plannercore.PhysicalExchangeSender)
 	sctx := c.sessionCtx
-	frags, err := plannercore.GenerateRootMPPTasks(sctx, c.startTS, c.mppQueryID, sender, c.is)
+	frags, kvRanges, err := plannercore.GenerateRootMPPTasks(sctx, c.startTS, c.mppQueryID, sender, c.is)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 
 	for _, frag := range frags {
 		err = c.appendMPPDispatchReq(frag)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, nil, errors.Trace(err)
 		}
 	}
 	failpoint.Inject("checkTotalMPPTasks", func(val failpoint.Value) {
@@ -569,5 +569,5 @@ func (c *localMppCoordinator) Execute(ctx context.Context) (kv.Response, error) 
 	ctxChild, c.cancelFunc = context.WithCancel(ctx)
 	go c.dispatchAll(ctxChild)
 
-	return c, nil
+	return c, kvRanges, nil
 }

--- a/executor/internal/mpp/local_mpp_coordinator.go
+++ b/executor/internal/mpp/local_mpp_coordinator.go
@@ -555,7 +555,7 @@ func (c *localMppCoordinator) Execute(ctx context.Context) (kv.Response, []kv.Ke
 	}
 	failpoint.Inject("checkTotalMPPTasks", func(val failpoint.Value) {
 		if val.(int) != len(c.mppReqs) {
-			failpoint.Return(nil, errors.Errorf("The number of tasks is not right, expect %d tasks but actually there are %d tasks", val.(int), len(c.mppReqs)))
+			failpoint.Return(nil, nil, errors.Errorf("The number of tasks is not right, expect %d tasks but actually there are %d tasks", val.(int), len(c.mppReqs)))
 		}
 	})
 

--- a/executor/mem_reader.go
+++ b/executor/mem_reader.go
@@ -181,7 +181,7 @@ type allocBuf struct {
 	rd          *rowcodec.BytesDecoder
 }
 
-func buildMemTableReader(ctx context.Context, us *UnionScanExec, tblReader *TableReaderExecutor) *memTableReader {
+func buildMemTableReader(ctx context.Context, us *UnionScanExec, kvRanges []kv.KeyRange) *memTableReader {
 	defer tracing.StartRegion(ctx, "buildMemTableReader").End()
 	colIDs := make(map[int64]int, len(us.columns))
 	for i, col := range us.columns {
@@ -215,7 +215,7 @@ func buildMemTableReader(ctx context.Context, us *UnionScanExec, tblReader *Tabl
 		ctx:           us.ctx,
 		table:         us.table.Meta(),
 		columns:       us.columns,
-		kvRanges:      tblReader.kvRanges,
+		kvRanges:      kvRanges,
 		desc:          us.desc,
 		conditions:    us.conditions,
 		retFieldTypes: retTypes(us),

--- a/executor/mpp_gather.go
+++ b/executor/mpp_gather.go
@@ -64,18 +64,15 @@ type MPPGather struct {
 
 	memTracker *memory.Tracker
 
-	// For virtual column and UnionScan.
-	table table.Table
-
 	// For virtual column.
 	columns                    []*model.ColumnInfo
 	virtualColumnIndex         []int
 	virtualColumnRetFieldTypes []*types.FieldType
 
 	// For UnionScan.
+	table    table.Table
 	kvRanges []kv.KeyRange
-
-	dummy bool
+	dummy    bool
 }
 
 func collectPlanIDS(plan plannercore.PhysicalPlan, ids []int) []int {

--- a/executor/mpp_gather.go
+++ b/executor/mpp_gather.go
@@ -64,7 +64,10 @@ type MPPGather struct {
 
 	memTracker *memory.Tracker
 
-	table                      table.Table
+	// For virtual column and UnionScan.
+	table table.Table
+
+	// For virtual column.
 	columns                    []*model.ColumnInfo
 	virtualColumnIndex         []int
 	virtualColumnRetFieldTypes []*types.FieldType

--- a/executor/mpp_gather.go
+++ b/executor/mpp_gather.go
@@ -90,7 +90,7 @@ func (e *MPPGather) Open(ctx context.Context) (err error) {
 	if e.dummy {
 		sender, ok := e.originalPlan.(*plannercore.PhysicalExchangeSender)
 		if !ok {
-			return errors.Errorf("unexpected plan type", zap.Any("expect", "PhysicalExchangeSender"), zap.Any("got", e.originalPlan.TP()))
+			return errors.Errorf("unexpected plan type, expect: PhysicalExchangeSender, got: %s", e.originalPlan.TP())
 		}
 		_, e.kvRanges, err = plannercore.GenerateRootMPPTasks(e.ctx, e.startTS, e.mppQueryID, sender, e.is)
 		return err

--- a/executor/mpp_gather.go
+++ b/executor/mpp_gather.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/memory"
-	"go.uber.org/zap"
 )
 
 func useMPPExecution(ctx sessionctx.Context, tr *plannercore.PhysicalTableReader) bool {

--- a/executor/mpp_gather.go
+++ b/executor/mpp_gather.go
@@ -132,4 +132,3 @@ func (e *MPPGather) Table() table.Table {
 func (e *MPPGather) setDummy() {
 	e.dummy = true
 }
-

--- a/executor/mpp_gather.go
+++ b/executor/mpp_gather.go
@@ -71,6 +71,8 @@ type MPPGather struct {
 
 	// For UnionScan.
 	kvRanges []kv.KeyRange
+
+	dummy bool
 }
 
 func collectPlanIDS(plan plannercore.PhysicalPlan, ids []int) []int {
@@ -121,3 +123,13 @@ func (e *MPPGather) Close() error {
 	}
 	return nil
 }
+
+// Table implements the dataSourceExecutor interface.
+func (e *MPPGather) Table() table.Table {
+	return e.table
+}
+
+func (e *MPPGather) setDummy() {
+	e.dummy = true
+}
+

--- a/executor/test/tiflashtest/BUILD.bazel
+++ b/executor/test/tiflashtest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 37,
+    shard_count = 38,
     deps = [
         "//config",
         "//domain",

--- a/executor/test/tiflashtest/tiflash_test.go
+++ b/executor/test/tiflashtest/tiflash_test.go
@@ -1711,3 +1711,104 @@ func TestMppStoreCntWithErrors(t *testing.T) {
 	require.Nil(t, failpoint.Disable(mppStoreCountSetLastUpdateTimeP2))
 	require.Nil(t, failpoint.Disable(mppStoreCountPDError))
 }
+
+func TestUnionScan(t *testing.T) {
+	store := testkit.CreateMockStore(t, withMockTiFlash(2))
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@session.tidb_allow_mpp=1")
+	tk.MustExec("set @@session.tidb_enforce_mpp=1")
+	tk.MustExec("set @@session.tidb_allow_tiflash_cop=off")
+
+	for x := 0; x < 2; x++ {
+		tk.MustExec("drop table if exists t")
+		if x == 0 {
+			// Test cache table.
+			tk.MustExec("create table t(a int not null primary key, b int not null)")
+			tk.MustExec("alter table t set tiflash replica 1")
+			tb := external.GetTableByName(t, tk, "test", "t")
+			err := domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
+			require.NoError(t, err)
+			tk.MustExec("alter table t cache")
+		} else {
+			// Test dirty transaction.
+			tk.MustExec("create table t(a int not null primary key, b int not null) partition by hash(a) partitions 2")
+			tk.MustExec("alter table t set tiflash replica 1")
+			tb := external.GetTableByName(t, tk, "test", "t")
+			err := domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
+			require.NoError(t, err)
+		}
+
+		insertStr := "insert into t values(0, 0)"
+		for i := 1; i < 10; i++ {
+			insertStr += fmt.Sprintf(",(%d, %d)", i, i)
+		}
+		tk.MustExec(insertStr)
+
+		if x != 0 {
+			// Test dirty transaction.
+			tk.MustExec("begin")
+		}
+
+		// Test Basic.
+		sql := "select /*+ READ_FROM_STORAGE(tiflash[t]) */ count(1) from t"
+		checkMPPInExplain(t, tk, "explain "+sql)
+		tk.MustQuery(sql).Check(testkit.Rows("10"))
+
+		// Test Delete.
+		tk.MustExec("delete from t where a = 0")
+
+		sql = "select  /*+ READ_FROM_STORAGE(tiflash[t]) */ count(1) from t"
+		checkMPPInExplain(t, tk, "explain "+sql)
+		tk.MustQuery(sql).Check(testkit.Rows("9"))
+
+		sql = "select  /*+ READ_FROM_STORAGE(tiflash[t]) */ a, b from t order by 1"
+		checkMPPInExplain(t, tk, "explain "+sql)
+		tk.MustQuery(sql).Check(testkit.Rows("1 1", "2 2", "3 3", "4 4", "5 5", "6 6", "7 7", "8 8", "9 9"))
+
+		// Test Insert.
+		tk.MustExec("insert into t values(100, 100)")
+
+		sql = "select  /*+ READ_FROM_STORAGE(tiflash[t]) */ count(1) from t"
+		checkMPPInExplain(t, tk, "explain "+sql)
+		tk.MustQuery(sql).Check(testkit.Rows("10"))
+
+		sql = "select  /*+ READ_FROM_STORAGE(tiflash[t]) */ a, b from t order by 1, 2"
+		checkMPPInExplain(t, tk, "explain "+sql)
+		tk.MustQuery(sql).Check(testkit.Rows("1 1", "2 2", "3 3", "4 4", "5 5", "6 6", "7 7", "8 8", "9 9", "100 100"))
+
+		// Test Update
+		tk.MustExec("update t set b = 200 where a = 100")
+
+		sql = "select  /*+ READ_FROM_STORAGE(tiflash[t]) */ count(1) from t"
+		checkMPPInExplain(t, tk, "explain "+sql)
+		tk.MustQuery(sql).Check(testkit.Rows("10"))
+
+		sql = "select  /*+ READ_FROM_STORAGE(tiflash[t]) */ a, b from t order by 1, 2"
+		checkMPPInExplain(t, tk, "explain "+sql)
+		tk.MustQuery(sql).Check(testkit.Rows("1 1", "2 2", "3 3", "4 4", "5 5", "6 6", "7 7", "8 8", "9 9", "100 200"))
+
+		if x != 0 {
+			// Test dirty transaction.
+			tk.MustExec("commit")
+		}
+
+		sql = "select  /*+ READ_FROM_STORAGE(tiflash[t]) */ count(1) from t"
+		checkMPPInExplain(t, tk, "explain "+sql)
+		tk.MustQuery(sql).Check(testkit.Rows("10"))
+
+		if x == 0 {
+			tk.MustExec("alter table t nocache")
+		}
+	}
+}
+
+func checkMPPInExplain(t *testing.T, tk *testkit.TestKit, sql string) {
+	rows := tk.MustQuery(sql).Rows()
+	resBuff := bytes.NewBufferString("")
+	for _, row := range rows {
+		fmt.Fprintf(resBuff, "%s\n", row)
+	}
+	res := resBuff.String()
+	require.Contains(t, res, "mpp[tiflash]")
+}

--- a/executor/test/tiflashtest/tiflash_test.go
+++ b/executor/test/tiflashtest/tiflash_test.go
@@ -93,7 +93,6 @@ func TestReadPartitionTable(t *testing.T) {
 	tk.MustExec("insert into t values(2,0)")
 	tk.MustExec("insert into t values(3,0)")
 	tk.MustExec("set @@session.tidb_isolation_read_engines=\"tiflash\"")
-	tk.MustExec("set @@session.tidb_allow_tiflash_cop=ON")
 	// mock executor does not support use outer table as build side for outer join, so need to
 	// force the inner table as build side
 	tk.MustExec("set tidb_opt_mpp_outer_join_fixed_build_side=1")

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -114,13 +114,15 @@ func (us *UnionScanExec) open(ctx context.Context) error {
 	// 2. build virtual columns and select with virtual columns
 	switch x := reader.(type) {
 	case *TableReaderExecutor:
-		us.addedRows, err = buildMemTableReader(ctx, us, x).getMemRows(ctx)
+		us.addedRows, err = buildMemTableReader(ctx, us, x.kvRanges).getMemRows(ctx)
 	case *IndexReaderExecutor:
 		us.addedRows, err = buildMemIndexReader(ctx, us, x).getMemRows(ctx)
 	case *IndexLookUpExecutor:
 		us.addedRows, err = buildMemIndexLookUpReader(ctx, us, x).getMemRows(ctx)
 	case *IndexMergeReaderExecutor:
 		us.addedRows, err = buildMemIndexMergeReader(ctx, us, x).getMemRows(ctx)
+	case *MPPGather:
+		us.addedRows, err = buildMemTableReader(ctx, us, x.kvRanges).getMemRows(ctx)
 	default:
 		err = fmt.Errorf("unexpected union scan children:%T", reader)
 	}

--- a/kv/mpp.go
+++ b/kv/mpp.go
@@ -194,7 +194,7 @@ type MPPClient interface {
 // MppCoordinator describes the basic api for executing mpp physical plan.
 type MppCoordinator interface {
 	// Execute generates and executes mpp tasks for mpp physical plan.
-	Execute(ctx context.Context) (Response, error)
+	Execute(ctx context.Context) (Response, []KeyRange, error)
 	// Next returns next data
 	Next(ctx context.Context) (ResultSubset, error)
 	// Close and release the used resources.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44705

Problem Summary: 
UnionScan doesn't support MPPGather, so when you force use tiflash in dirty transaction, will give err msg like "union scan integrated with MPPGather is not supported now"

### What is changed and how it works?
1. support scan mem buf for MPPGather, basically just use `memTableReader` is ok.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
