### PR TITLE
tests: fix unstable test in resource group

### DIFF
--- a/testkit/result.go
+++ b/testkit/result.go
@@ -49,6 +49,21 @@ func (res *Result) Check(expected [][]interface{}) {
 	res.require.Equal(needBuff.String(), resBuff.String(), res.comment)
 }
 
+// Equal check whether the result equals the expected results.
+func (res *Result) Equal(expected [][]interface{}) bool {
+	resBuff := bytes.NewBufferString("")
+	for _, row := range res.rows {
+		_, _ = fmt.Fprintf(resBuff, "%s\n", row)
+	}
+
+	needBuff := bytes.NewBufferString("")
+	for _, row := range expected {
+		_, _ = fmt.Fprintf(needBuff, "%s\n", row)
+	}
+
+	return bytes.Equal(needBuff.Bytes(), resBuff.Bytes())
+}
+
 // AddComment adds the extra comment for the Result's output.
 func (res *Result) AddComment(c string) {
 	res.comment += "\n" + c

--- a/testkit/testkit.go
+++ b/testkit/testkit.go
@@ -149,6 +149,22 @@ func (tk *TestKit) MustQuery(sql string, args ...interface{}) *Result {
 	return tk.MustQueryWithContext(context.Background(), sql, args...)
 }
 
+// EventuallyMustQueryAndCheck query the statements and assert that
+// result rows.lt will equal the expected results in waitFor time, periodically checking equality each tick.
+// Note: retry can't ignore error of the statements. If statements returns error, it will break out.
+func (tk *TestKit) EventuallyMustQueryAndCheck(sql string, args []interface{},
+	expected [][]interface{}, waitFor time.Duration, tick time.Duration) {
+	defer func() {
+		if tk.alloc != nil {
+			tk.alloc.Reset()
+		}
+	}()
+	tk.require.Eventually(func() bool {
+		res := tk.MustQueryWithContext(context.Background(), sql, args...)
+		return res.Equal(expected)
+	}, waitFor, tick)
+}
+
 // MustQueryWithContext query the statements and returns result rows.
 func (tk *TestKit) MustQueryWithContext(ctx context.Context, sql string, args ...interface{}) *Result {
 	comment := fmt.Sprintf("sql:%s, args:%v", sql, args)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44883

Problem Summary:

### What is changed and how it works?
introduce EventuallyMustQueryAndCheck into `TestKit` to assert query eventually

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
