### PR TITLE
planner: update the syntax of `drop hypo index`

### DIFF
--- a/parser/ast/ddl.go
+++ b/parser/ast/ddl.go
@@ -1830,6 +1830,7 @@ type DropIndexStmt struct {
 	IndexName string
 	Table     *TableName
 	LockAlg   *IndexLockAndAlgorithm
+	IsHypo    bool // whether this operation is for a hypothetical index.
 }
 
 // Restore implements Node interface.

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -5023,6 +5023,10 @@ DropIndexStmt:
 		}
 		$$ = &ast.DropIndexStmt{IfExists: $3.(bool), IndexName: $4, Table: $6.(*ast.TableName), LockAlg: indexLockAndAlgorithm}
 	}
+|	"DROP" "HYPO" "INDEX" IfExists Identifier "ON" TableName
+	{
+		$$ = &ast.DropIndexStmt{IfExists: $4.(bool), IndexName: $5, Table: $7.(*ast.TableName), IsHypo: true}
+	}
 
 DropTableStmt:
 	"DROP" OptTemporary TableOrTables IfExists TableNameList RestrictOrCascadeOpt

--- a/planner/core/plan_test.go
+++ b/planner/core/plan_test.go
@@ -977,8 +977,8 @@ func TestHypoIndexDDL(t *testing.T) {
 		"  KEY `hypo_bc` (`b`,`c`) /* HYPO INDEX */\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 
-	tk.MustExec(`drop index hypo_a on t`)
-	tk.MustExec(`drop index hypo_bc on t`)
+	tk.MustExec(`drop hypo index hypo_a on t`)
+	tk.MustExec(`drop hypo index hypo_bc on t`)
 	tk.MustQuery(`show create table t`).Check(testkit.Rows("t CREATE TABLE `t` (\n" +
 		"  `a` int(11) DEFAULT NULL,\n" +
 		"  `b` int(11) DEFAULT NULL,\n" +
@@ -1005,7 +1005,7 @@ func TestHypoIndexPlan(t *testing.T) {
 		`IndexReader_6 10.00 root  index:IndexRangeScan_5`,
 		`└─IndexRangeScan_5 10.00 cop[tikv] table:t, index:hypo_a(a) range:[1,1], keep order:false, stats:pseudo`))
 
-	tk.MustExec(`drop index hypo_a on t`)
+	tk.MustExec(`drop hypo index hypo_a on t`)
 	tk.MustExec(`create unique index hypo_a type hypo on t (a)`)
 
 	tk.MustQuery(`explain select a from t where a = 1`).Check(testkit.Rows(

--- a/session/session.go
+++ b/session/session.go
@@ -3879,11 +3879,26 @@ func GetStartTSFromSession(se interface{}) (startTS, processInfoID uint64) {
 // if variable.ProcessGeneralLog is set.
 func logStmt(execStmt *executor.ExecStmt, s *session) {
 	vars := s.GetSessionVars()
+	isCrucial := false
 	switch stmt := execStmt.StmtNode.(type) {
+	case *ast.DropIndexStmt:
+		isCrucial = true
+		if stmt.IsHypo {
+			isCrucial = false
+		}
+	case *ast.CreateIndexStmt:
+		isCrucial = true
+		if stmt.IndexOption != nil && stmt.IndexOption.Tp == model.IndexTypeHypo {
+			isCrucial = false
+		}
 	case *ast.CreateUserStmt, *ast.DropUserStmt, *ast.AlterUserStmt, *ast.SetPwdStmt, *ast.GrantStmt,
-		*ast.RevokeStmt, *ast.AlterTableStmt, *ast.CreateDatabaseStmt, *ast.CreateIndexStmt, *ast.CreateTableStmt,
-		*ast.DropDatabaseStmt, *ast.DropIndexStmt, *ast.DropTableStmt, *ast.RenameTableStmt, *ast.TruncateTableStmt,
+		*ast.RevokeStmt, *ast.AlterTableStmt, *ast.CreateDatabaseStmt, *ast.CreateTableStmt,
+		*ast.DropDatabaseStmt, *ast.DropTableStmt, *ast.RenameTableStmt, *ast.TruncateTableStmt,
 		*ast.RenameUserStmt:
+		isCrucial = true
+	}
+
+	if isCrucial {
 		user := vars.User
 		schemaVersion := s.GetInfoSchema().SchemaMetaVersion()
 		if ss, ok := execStmt.StmtNode.(ast.SensitiveStmtNode); ok {
@@ -3897,10 +3912,10 @@ func logStmt(execStmt *executor.ExecStmt, s *session) {
 				zap.Uint64("conn", vars.ConnectionID),
 				zap.Int64("schemaVersion", schemaVersion),
 				zap.String("cur_db", vars.CurrentDB),
-				zap.String("sql", stmt.Text()),
+				zap.String("sql", execStmt.StmtNode.Text()),
 				zap.Stringer("user", user))
 		}
-	default:
+	} else {
 		logGeneralQuery(execStmt, s, false)
 	}
 }

--- a/sessionctx/sessionstates/session_states_test.go
+++ b/sessionctx/sessionstates/session_states_test.go
@@ -483,7 +483,7 @@ func TestSessionCtx(t *testing.T) {
 			// check empty HypoIndexes
 			setFunc: func(tk *testkit.TestKit) any {
 				tk.MustExec(`create index hypo_id type hypo on test.t1(id)`)
-				tk.MustExec(`drop index hypo_id on test.t1`)
+				tk.MustExec(`drop hypo index hypo_id on test.t1`)
 				require.Empty(t, tk.Session().GetSessionVars().HypoIndexes["test"]["t1"])
 				return nil
 			},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43817

Problem Summary: planner: update the syntax of `drop hypo index`

### What is changed and how it works?

`drop index {index-name} on {table-name}` --> `drop hypo index {index-name} on {table-name}`

Add the keyword `hypo` into this syntax to make it clearer and safer.

And also, let the optimizer not output `crucial operation log records` for operations on hypo-indexes.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
