### PR TITLE
disttask: use the correct session pool for dist tasks

### DIFF
--- a/disttask/framework/storage/task_table.go
+++ b/disttask/framework/storage/task_table.go
@@ -47,7 +47,12 @@ type SessionExecutor interface {
 // TaskManager is the manager of global/sub task.
 type TaskManager struct {
 	ctx    context.Context
-	sePool *pools.ResourcePool
+	sePool sessionPool
+}
+
+type sessionPool interface {
+	Get() (pools.Resource, error)
+	Put(resource pools.Resource)
 }
 
 var _ SessionExecutor = &TaskManager{}
@@ -60,7 +65,7 @@ var (
 )
 
 // NewTaskManager creates a new task manager.
-func NewTaskManager(ctx context.Context, sePool *pools.ResourcePool) *TaskManager {
+func NewTaskManager(ctx context.Context, sePool sessionPool) *TaskManager {
 	ctx = util.WithInternalSourceType(ctx, kv.InternalDistTask)
 	return &TaskManager{
 		ctx:    ctx,

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -186,7 +186,6 @@ type Domain struct {
 
 	mdlCheckCh      chan struct{}
 	stopAutoAnalyze atomicutil.Bool
-	resourcePool    *pools.ResourcePool
 }
 
 type mdlCheckTableInfo struct {
@@ -1129,7 +1128,6 @@ func (do *Domain) Init(
 		return sysExecutorFactory(do)
 	}
 	sysCtxPool := pools.NewResourcePool(sysFac, 128, 128, resourceIdleTimeout)
-	do.resourcePool = sysCtxPool
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	do.cancel = cancelFunc
 	var callback ddl.Callback
@@ -1655,7 +1653,7 @@ func (do *Domain) InitDistTaskLoop(ctx context.Context) error {
 		}
 	})
 
-	taskManager := storage.NewTaskManager(ctx, do.resourcePool)
+	taskManager := storage.NewTaskManager(ctx, do.sysSessionPool)
 	var serverID string
 	if intest.InTest {
 		do.InitInfo4Test()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44983

Problem Summary:

The distributed task framework should not use `*pools.ResourcePool` directly, otherwise we may encounter issues like #42895.

### What is changed and how it works?

Use wrapped `*sessionPool` instead.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
