### PR TITLE
planner: add `model.ExtraPhysTblID` into indexScan.Schema()

### DIFF
--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1758,6 +1758,14 @@ func (is *PhysicalIndexScan) initSchema(idxExprCols []*expression.Column, isDoub
 		}
 	}
 
+	if FindColumnInfoByID(is.Columns, model.ExtraPhysTblID) != nil {
+		indexCols = append(indexCols, &expression.Column{
+			RetType:  types.NewFieldType(mysql.TypeLonglong),
+			ID:       model.ExtraPhysTblID,
+			UniqueID: is.ctx.GetSessionVars().AllocPlanColumnID(),
+		})
+	}
+
 	is.SetSchema(expression.NewSchema(indexCols...))
 }
 

--- a/tests/realtikvtest/txntest/txn_test.go
+++ b/tests/realtikvtest/txntest/txn_test.go
@@ -260,18 +260,18 @@ func TestSelectLockForPartitionTable(t *testing.T) {
 
 	tk1.MustExec("use test")
 	tk1.MustExec("create table t(a int, b int, c int, key idx(a, b, c)) PARTITION BY HASH (c) PARTITIONS 10")
-	tk1.MustExec("insert into t values (1, 1, 1)")
+	tk1.MustExec("insert into t values (1, 1, 1), (2, 2, 2), (3, 3, 3)")
 	tk1.MustExec("analyze table t")
 	tk1.MustExec("begin")
-	tk1.HasPlan("select * from t use index(idx) where a = 1 and b = 1 for update", "IndexLookUp_9")
-	tk1.MustExec("select * from t use index(idx) where a = 1 and b = 1 for update")
+	tk1.HasPlan("select * from t use index(idx) where a = 1 and b = 1 order by a limit 1 for update", "IndexLookUp_9")
+	tk1.MustExec("select * from t use index(idx) where a = 1 and b = 1 order by a limit 1 for update")
 	ch := make(chan bool, 1)
 	go func() {
 		tk2.MustExec("use test")
 		tk2.MustExec("begin")
 		ch <- false
 		// block here, until tk1 finish
-		tk2.MustExec("select * from t use index(idx) where a = 1 and b = 1 for update")
+		tk2.MustExec("select * from t use index(idx) where a = 1 and b = 1 order by a limit 1 for update")
 		ch <- true
 	}()
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44984

Problem Summary: If we add `model.ExtraPhysTblID` in DataSource via `SelectLock`, we will not add it again in `AddExtraPhysTblIDColumn`, which will be missing this column in indexScan.Schema()

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
