### PR TITLE
planner: add `model.ExtraPhysTblID` into indexScan.Schema()

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -643,7 +643,7 @@ func (e *IndexLookUpExecutor) needPartitionHandle(tp getHandleType) (bool, error
 
 	// TODO: fix global index related bugs later
 	// For `SelectLock`, the `ExtraPhysTblID` will contained in schema,
-	// but it needn't partition handle to keep order anymore.
+	// but it needn't partition handle to keep order.
 	if needPartitionHandle && !ret && !e.index.Global {
 		return ret, errors.Errorf("Internal error, needPartitionHandle != ret, tp(%d)", tp)
 	}

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -625,27 +625,27 @@ func (e *IndexLookUpExecutor) startWorkers(ctx context.Context, initBatchSize in
 
 func (e *IndexLookUpExecutor) needPartitionHandle(tp getHandleType) (bool, error) {
 	var col *expression.Column
-	var needPartitionHandle, ret bool
+	var needPartitionHandle, hasExtraCol bool
 	needPartitionHandle = e.index.Global || (e.partitionTableMode && e.keepOrder)
 	if tp == getHandleFromIndex {
 		cols := e.idxPlans[0].Schema().Columns
 		outputOffsets := e.dagPB.OutputOffsets
 		col = cols[outputOffsets[len(outputOffsets)-1]]
-		ret = col.ID == model.ExtraPhysTblID || col.ID == model.ExtraPidColID
+		hasExtraCol = col.ID == model.ExtraPhysTblID || col.ID == model.ExtraPidColID
 	} else {
 		cols := e.tblPlans[0].Schema().Columns
 		outputOffsets := e.tableRequest.OutputOffsets
 		col = cols[outputOffsets[len(outputOffsets)-1]]
 
 		// no ExtraPidColID here, because TableScan shouldn't contain them.
-		ret = col.ID == model.ExtraPhysTblID
+		hasExtraCol = col.ID == model.ExtraPhysTblID
 	}
 
 	// TODO: fix global index related bugs later
 	// For `SelectLock`, the `ExtraPhysTblID` will contained in schema,
 	// but it needn't partition handle to keep order.
-	if needPartitionHandle && !ret && !e.index.Global {
-		return ret, errors.Errorf("Internal error, needPartitionHandle != ret, tp(%d)", tp)
+	if needPartitionHandle && !hasExtraCol && !e.index.Global {
+		return needPartitionHandle, errors.Errorf("Internal error, needPartitionHandle != ret, tp(%d)", tp)
 	}
 	return needPartitionHandle, nil
 }

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -638,16 +638,16 @@ func (e *IndexLookUpExecutor) needPartitionHandle(tp getHandleType) (bool, error
 		outputOffsets := e.tableRequest.OutputOffsets
 		col = cols[outputOffsets[len(outputOffsets)-1]]
 
-		// For tableScan, only need partitionHandle when e.keepOrder == true
-		// and get parition handle from indexScan.task
+		// For TableScan, need partitionHandle in `indexOrder` when e.keepOrder == true
 		needPartitionHandle = (e.index.Global || e.partitionTableMode) && e.keepOrder
 		// no ExtraPidColID here, because TableScan shouldn't contain them.
 		hasExtraCol = col.ID == model.ExtraPhysTblID
 	}
 
 	// TODO: fix global index related bugs later
-	// For `SelectLock`, the `ExtraPhysTblID` will contained in schema,
-	// but it needn't partition handle to keep order.
+	// There will be two needPartitionHandle != hasExtraCol situations.
+	// Only `needPartitionHandle` == true and `hasExtraCol` == false are not allowed.
+	// `ExtraPhysTblID` will be used in `SelectLock` when `needPartitionHandle` == false and `hasExtraCol` == true.
 	if needPartitionHandle && !hasExtraCol && !e.index.Global {
 		return needPartitionHandle, errors.Errorf("Internal error, needPartitionHandle != ret, tp(%d)", tp)
 	}

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -643,8 +643,8 @@ func (e *IndexLookUpExecutor) needPartitionHandle(tp getHandleType) (bool, error
 	}
 
 	// TODO: fix global index related bugs later
-	if needPartitionHandle != ret && !e.index.Global {
-		return ret, errors.Errorf("Internal error, needPartitionHandle(%t) != ret(%t), tp(%d)", needPartitionHandle, ret, tp)
+	if needPartitionHandle && !ret && !e.index.Global {
+		return ret, errors.Errorf("Internal error, needPartitionHandle != ret, tp(%d)", tp)
 	}
 	return ret, nil
 }

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -699,3 +699,16 @@ func TestCoprocessorBatchByStore(t *testing.T) {
 		}
 	}
 }
+
+func TestIndexLookUpWithSelectForUpdateOnPartitionTable(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int, index k(b)) PARTITION BY HASH(a) partitions 4")
+	tk.MustExec("insert into t(a, b) values (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8)")
+	tk.MustQuery("select b from t use index(k) where b > 2 order by b limit 1 for update").Check(testkit.Rows("3"))
+
+	tk.MustExec("analyze table t")
+	tk.MustQuery("select b from t use index(k) where b > 2 order by b limit 1 for update").Check(testkit.Rows("3"))
+}

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -707,8 +707,11 @@ func TestIndexLookUpWithSelectForUpdateOnPartitionTable(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t(a int, b int, index k(b)) PARTITION BY HASH(a) partitions 4")
 	tk.MustExec("insert into t(a, b) values (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8)")
+	tk.HasPlan("select b from t use index(k) where b > 2 order by b limit 1 for update", "UnionScan")
+	tk.HasPlan("select b from t use index(k) where b > 2 order by b limit 1 for update", "IndexLookUp")
 	tk.MustQuery("select b from t use index(k) where b > 2 order by b limit 1 for update").Check(testkit.Rows("3"))
 
 	tk.MustExec("analyze table t")
+	tk.HasPlan("select b from t use index(k) where b > 2 order by b limit 1 for update", "IndexLookUp")
 	tk.MustQuery("select b from t use index(k) where b > 2 order by b limit 1 for update").Check(testkit.Rows("3"))
 }

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -608,12 +608,12 @@ func (w *partialTableWorker) needPartitionHandle() (bool, error) {
 
 	needPartitionHandle := w.partitionTableMode && len(w.byItems) > 0
 	// no ExtraPidColID here, because a clustered index couldn't be a global index.
-	ret := col.ID == model.ExtraPhysTblID
+	hasExtraCol := col.ID == model.ExtraPhysTblID
 
 	// For `SelectLock`, the `ExtraPhysTblID` will contained in schema,
 	// but it needn't partition handle to keep order.
-	if needPartitionHandle && !ret {
-		return ret, errors.Errorf("Internal error, needPartitionHandle != ret")
+	if needPartitionHandle && !hasExtraCol {
+		return needPartitionHandle, errors.Errorf("Internal error, needPartitionHandle != ret")
 	}
 	return needPartitionHandle, nil
 }
@@ -1468,12 +1468,12 @@ func (w *partialIndexWorker) needPartitionHandle() (bool, error) {
 	col := cols[outputOffsets[len(outputOffsets)-1]]
 
 	needPartitionHandle := w.partitionTableMode && len(w.byItems) > 0
-	ret := col.ID == model.ExtraPidColID || col.ID == model.ExtraPhysTblID
+	hasExtraCol := col.ID == model.ExtraPidColID || col.ID == model.ExtraPhysTblID
 
 	// For `SelectLock`, the `ExtraPhysTblID` will contained in schema,
 	// but it needn't partition handle to keep order.
-	if needPartitionHandle && !ret {
-		return ret, errors.Errorf("Internal error, needPartitionHandle != ret")
+	if needPartitionHandle && !hasExtraCol {
+		return needPartitionHandle, errors.Errorf("Internal error, needPartitionHandle != ret")
 	}
 	return needPartitionHandle, nil
 }

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -610,10 +610,12 @@ func (w *partialTableWorker) needPartitionHandle() (bool, error) {
 	// no ExtraPidColID here, because a clustered index couldn't be a global index.
 	ret := col.ID == model.ExtraPhysTblID
 
+	// For `SelectLock`, the `ExtraPhysTblID` will contained in schema,
+	// but it needn't partition handle to keep order anymore.
 	if needPartitionHandle && !ret {
 		return ret, errors.Errorf("Internal error, needPartitionHandle != ret")
 	}
-	return ret, nil
+	return needPartitionHandle, nil
 }
 
 func (w *partialTableWorker) fetchHandles(ctx context.Context, exitCh <-chan struct{}, fetchCh chan<- *indexMergeTableTask,
@@ -1468,10 +1470,12 @@ func (w *partialIndexWorker) needPartitionHandle() (bool, error) {
 	needPartitionHandle := w.partitionTableMode && len(w.byItems) > 0
 	ret := col.ID == model.ExtraPidColID || col.ID == model.ExtraPhysTblID
 
+	// For `SelectLock`, the `ExtraPhysTblID` will contained in schema,
+	// but it needn't partition handle to keep order anymore.
 	if needPartitionHandle && !ret {
 		return ret, errors.Errorf("Internal error, needPartitionHandle != ret")
 	}
-	return ret, nil
+	return needPartitionHandle, nil
 }
 
 func (w *partialIndexWorker) fetchHandles(

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -610,8 +610,9 @@ func (w *partialTableWorker) needPartitionHandle() (bool, error) {
 	// no ExtraPidColID here, because a clustered index couldn't be a global index.
 	hasExtraCol := col.ID == model.ExtraPhysTblID
 
-	// For `SelectLock`, the `ExtraPhysTblID` will contained in schema,
-	// but it needn't partition handle to keep order.
+	// There will be two needPartitionHandle != hasExtraCol situations.
+	// Only `needPartitionHandle` == true and `hasExtraCol` == false are not allowed.
+	// `ExtraPhysTblID` will be used in `SelectLock` when `needPartitionHandle` == false and `hasExtraCol` == true.
 	if needPartitionHandle && !hasExtraCol {
 		return needPartitionHandle, errors.Errorf("Internal error, needPartitionHandle != ret")
 	}
@@ -1470,8 +1471,9 @@ func (w *partialIndexWorker) needPartitionHandle() (bool, error) {
 	needPartitionHandle := w.partitionTableMode && len(w.byItems) > 0
 	hasExtraCol := col.ID == model.ExtraPidColID || col.ID == model.ExtraPhysTblID
 
-	// For `SelectLock`, the `ExtraPhysTblID` will contained in schema,
-	// but it needn't partition handle to keep order.
+	// There will be two needPartitionHandle != hasExtraCol situations.
+	// Only `needPartitionHandle` == true and `hasExtraCol` == false are not allowed.
+	// `ExtraPhysTblID` will be used in `SelectLock` when `needPartitionHandle` == false and `hasExtraCol` == true.
 	if needPartitionHandle && !hasExtraCol {
 		return needPartitionHandle, errors.Errorf("Internal error, needPartitionHandle != ret")
 	}

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -610,8 +610,8 @@ func (w *partialTableWorker) needPartitionHandle() (bool, error) {
 	// no ExtraPidColID here, because a clustered index couldn't be a global index.
 	ret := col.ID == model.ExtraPhysTblID
 
-	if needPartitionHandle != ret {
-		return ret, errors.Errorf("Internal error, needPartitionHandle(%t) != ret(%t)", needPartitionHandle, ret)
+	if needPartitionHandle && !ret {
+		return ret, errors.Errorf("Internal error, needPartitionHandle != ret")
 	}
 	return ret, nil
 }
@@ -1468,8 +1468,8 @@ func (w *partialIndexWorker) needPartitionHandle() (bool, error) {
 	needPartitionHandle := w.partitionTableMode && len(w.byItems) > 0
 	ret := col.ID == model.ExtraPidColID || col.ID == model.ExtraPhysTblID
 
-	if needPartitionHandle != ret {
-		return ret, errors.Errorf("Internal error, needPartitionHandle(%t) != ret(%t)", needPartitionHandle, ret)
+	if needPartitionHandle && !ret {
+		return ret, errors.Errorf("Internal error, needPartitionHandle != ret")
 	}
 	return ret, nil
 }

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -611,7 +611,7 @@ func (w *partialTableWorker) needPartitionHandle() (bool, error) {
 	ret := col.ID == model.ExtraPhysTblID
 
 	// For `SelectLock`, the `ExtraPhysTblID` will contained in schema,
-	// but it needn't partition handle to keep order anymore.
+	// but it needn't partition handle to keep order.
 	if needPartitionHandle && !ret {
 		return ret, errors.Errorf("Internal error, needPartitionHandle != ret")
 	}
@@ -1471,7 +1471,7 @@ func (w *partialIndexWorker) needPartitionHandle() (bool, error) {
 	ret := col.ID == model.ExtraPidColID || col.ID == model.ExtraPhysTblID
 
 	// For `SelectLock`, the `ExtraPhysTblID` will contained in schema,
-	// but it needn't partition handle to keep order anymore.
+	// but it needn't partition handle to keep order.
 	if needPartitionHandle && !ret {
 		return ret, errors.Errorf("Internal error, needPartitionHandle != ret")
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1771,6 +1771,15 @@ func (is *PhysicalIndexScan) initSchema(idxExprCols []*expression.Column, isDoub
 		}
 	}
 
+	// global index not tested, could delete '!is.Index.Global' after test
+	if !is.Index.Global && FindColumnInfoByID(is.Columns, model.ExtraPhysTblID) != nil {
+		indexCols = append(indexCols, &expression.Column{
+			RetType:  types.NewFieldType(mysql.TypeLonglong),
+			ID:       model.ExtraPhysTblID,
+			UniqueID: is.ctx.GetSessionVars().AllocPlanColumnID(),
+		})
+	}
+
 	is.SetSchema(expression.NewSchema(indexCols...))
 }
 

--- a/tests/realtikvtest/txntest/txn_test.go
+++ b/tests/realtikvtest/txntest/txn_test.go
@@ -260,18 +260,18 @@ func TestSelectLockForPartitionTable(t *testing.T) {
 
 	tk1.MustExec("use test")
 	tk1.MustExec("create table t(a int, b int, c int, key idx(a, b, c)) PARTITION BY HASH (c) PARTITIONS 10")
-	tk1.MustExec("insert into t values (1, 1, 1)")
+	tk1.MustExec("insert into t values (1, 1, 1), (2, 2, 2), (3, 3, 3)")
 	tk1.MustExec("analyze table t")
 	tk1.MustExec("begin")
-	tk1.HasPlan("select * from t use index(idx) where a = 1 and b = 1 for update", "IndexLookUp_9")
-	tk1.MustExec("select * from t use index(idx) where a = 1 and b = 1 for update")
+	tk1.HasPlan("select * from t use index(idx) where a = 1 and b = 1 order by a limit 1 for update", "IndexLookUp_9")
+	tk1.MustExec("select * from t use index(idx) where a = 1 and b = 1 order by a limit 1 for update")
 	ch := make(chan bool, 1)
 	go func() {
 		tk2.MustExec("use test")
 		tk2.MustExec("begin")
 		ch <- false
 		// block here, until tk1 finish
-		tk2.MustExec("select * from t use index(idx) where a = 1 and b = 1 for update")
+		tk2.MustExec("select * from t use index(idx) where a = 1 and b = 1 order by a limit 1 for update")
 		ch <- true
 	}()
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44984

Problem Summary: 
Sloved two problems, 
1. If we add `model.ExtraPhysTblID` in DataSource via `SelectLock`, we will not add it again in `AddExtraPhysTblIDColumn`, which will be missing this column in indexScan.Schema()
2. For `SelectLock`, `needPartitionHandle = flase` and `hasExtraCol = true` is exsits, we should allow it.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
