### PR TITLE
ttl: fix a bug that a TTL task will not be taken by other tidb after failover sometimes

### DIFF
--- a/ttl/ttlworker/task_manager_integration_test.go
+++ b/ttl/ttlworker/task_manager_integration_test.go
@@ -325,16 +325,19 @@ func TestMeetTTLRunningTasks(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 
 	// -1, the default value, means the count of TiKV
-	require.True(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(2))
-	require.False(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(3))
+	require.True(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(2, cache.TaskStatusWaiting))
+	require.False(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(3, cache.TaskStatusWaiting))
+	require.True(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(2, cache.TaskStatusRunning))
 
 	// positive number means the limitation
 	tk.MustExec("set global tidb_ttl_running_tasks = 32")
-	require.False(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(32))
-	require.True(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(31))
+	require.False(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(32, cache.TaskStatusWaiting))
+	require.True(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(31, cache.TaskStatusWaiting))
+	require.True(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(32, cache.TaskStatusRunning))
 
 	// set it back to auto value
 	tk.MustExec("set global tidb_ttl_running_tasks = -1")
-	require.True(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(2))
-	require.False(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(3))
+	require.True(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(2, cache.TaskStatusWaiting))
+	require.False(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(3, cache.TaskStatusWaiting))
+	require.True(t, dom.TTLJobManager().TaskManager().MeetTTLRunningTasks(3, cache.TaskStatusRunning))
 }

--- a/ttl/ttlworker/task_manager_test.go
+++ b/ttl/ttlworker/task_manager_test.go
@@ -65,8 +65,8 @@ func (m *taskManager) GetRunningTasks() []*runningScanTask {
 }
 
 // MeetTTLRunningTasks is an exported version of meetTTLRunningTask
-func (m *taskManager) MeetTTLRunningTasks(count int) bool {
-	return m.meetTTLRunningTask(count)
+func (m *taskManager) MeetTTLRunningTasks(count int, taskStatus cache.TaskStatus) bool {
+	return m.meetTTLRunningTask(count, taskStatus)
 }
 
 // ReportTaskFinished is an exported version of reportTaskFinished


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45022

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
ttl: fix a bug that a TTL task will not be taken by other tidb after failover sometimes
```
