### PR TITLE
table/tables: fix locate partition error info for unsigned | tidb-test=pr/2162

### DIFF
--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -964,9 +964,12 @@ func (lp *ForListPruning) locateListPartitionByRow(ctx sessionctx.Context, r []t
 	if isNull {
 		return -1, table.ErrNoPartitionForGivenValue.GenWithStackByArgs("NULL")
 	}
-	valueMsg := fmt.Sprintf("%d", value)
+	var valueMsg string
 	if mysql.HasUnsignedFlag(lp.LocateExpr.GetType().GetFlag()) {
+		// Handle unsigned value
 		valueMsg = fmt.Sprintf("%d", uint64(value))
+	} else {
+		valueMsg = fmt.Sprintf("%d", value)
 	}
 	return -1, table.ErrNoPartitionForGivenValue.GenWithStackByArgs(valueMsg)
 }
@@ -1369,9 +1372,10 @@ func (t *partitionedTable) locateRangePartition(ctx sessionctx.Context, partitio
 			if err == nil {
 				val, _, err := e.EvalInt(ctx, chunk.MutRowFromDatums(r).ToRow())
 				if err == nil {
-					valueMsg = fmt.Sprintf("%d", val)
 					if unsigned {
 						valueMsg = fmt.Sprintf("%d", uint64(val))
+					} else {
+						valueMsg = fmt.Sprintf("%d", val)
 					}
 				}
 			}

--- a/table/tables/partition_test.go
+++ b/table/tables/partition_test.go
@@ -2422,6 +2422,19 @@ func TestKeyPartitionTableDDL(t *testing.T) {
 	result.CheckContain("Unsupported partition type KEY, treat as normal table")
 }
 
+func TestLocatePartitionErrorInfo(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop tables if exists t_44966")
+	tk.MustExec("create table t_44966 (a bigint unsigned) partition by range (a) (partition p0 values less than (10))")
+	err := tk.ExecToErr("insert into t_44966 values (0xffffffffffffffff)")
+	require.Regexp(t, "Table has no partition for value 18446744073709551615", err)
+	tk.MustExec("drop tables if exists t_44966")
+	tk.MustExec("create table t_44966 (a bigint unsigned) partition by list (a) (partition p0 values in (1,2))")
+	require.Regexp(t, "Table has no partition for value 18446744073709551615", err)
+}
+
 func TestPruneModeWarningInfo(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/44966

Problem Summary:
If the value is  unsigned type and exceeds max(int64) when locating partition is out of partition range, an error message will be displayed with incorrect values. This issue exist in the scenarios of range and list partition.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
