### PR TITLE
*: ignore the semicolon at the end of the SQL when generating the SQL digest

### DIFF
--- a/executor/cluster_table_test.go
+++ b/executor/cluster_table_test.go
@@ -416,6 +416,10 @@ func TestFunctionEncodeSQLDigest(t *testing.T) {
 
 	tk.MustQuery("select tidb_encode_sql_digest(null)").Check(testkit.Rows("<nil>"))
 	tk.MustGetErrCode("select tidb_encode_sql_digest()", 1582)
+
+	tk.MustQuery("select (select tidb_encode_sql_digest('select 1')) = tidb_encode_sql_digest('select 1;')").Check(testkit.Rows("1"))
+	tk.MustQuery("select (select tidb_encode_sql_digest('select 1')) = tidb_encode_sql_digest('select 1 ;')").Check(testkit.Rows("1"))
+	tk.MustQuery("select (select tidb_encode_sql_digest('select 1')) = tidb_encode_sql_digest('select 2 ;')").Check(testkit.Rows("1"))
 }
 
 func prepareLogs(t *testing.T, logData []string, fileNames []string) {

--- a/extension/event_listener_test.go
+++ b/extension/event_listener_test.go
@@ -286,7 +286,7 @@ func TestExtensionStmtEvents(t *testing.T) {
 			multiQueryCases: []stmtEventCase{
 				{
 					originalText: "select 1;",
-					redactText:   "select ? ;",
+					redactText:   "select ?",
 				},
 				{
 					originalText: "select * from t1 where a > 1",

--- a/infoschema/test/clustertablestest/tables_test.go
+++ b/infoschema/test/clustertablestest/tables_test.go
@@ -1366,7 +1366,7 @@ func TestStmtSummaryTableOther(t *testing.T) {
 		Check(testkit.Rows(
 			// digest in cache
 			// "show databases ;"
-			"show databases ; dcd020298c5f79e8dc9d63b3098083601614a04a52db458738347d15ea5712a1",
+			"show databases 0e247706bf6e791fbf4af8c8e7658af5ffc45c63179871202d8f91551ee03161",
 			// digest evicted
 			" <nil>",
 		))
@@ -1402,7 +1402,7 @@ func TestStmtSummaryHistoryTableOther(t *testing.T) {
 		Check(testkit.Rows(
 			// digest in cache
 			// "show databases ;"
-			"show databases ; dcd020298c5f79e8dc9d63b3098083601614a04a52db458738347d15ea5712a1",
+			"show databases 0e247706bf6e791fbf4af8c8e7658af5ffc45c63179871202d8f91551ee03161",
 			// digest evicted
 			" <nil>",
 		))

--- a/parser/digester.go
+++ b/parser/digester.go
@@ -183,7 +183,7 @@ func (d *sqlDigester) normalize(sql string, keepHint bool) {
 		if tok == invalid {
 			break
 		}
-		if pos.Offset == len(sql) {
+		if pos.Offset == len(sql) || (pos.Offset == len(sql) - 1 && sql[pos.Offset] == ';') {
 			break
 		}
 		currTok := token{tok, strings.ToLower(lit)}

--- a/parser/digester.go
+++ b/parser/digester.go
@@ -183,7 +183,7 @@ func (d *sqlDigester) normalize(sql string, keepHint bool) {
 		if tok == invalid {
 			break
 		}
-		if pos.Offset == len(sql) || (pos.Offset == len(sql) - 1 && sql[pos.Offset] == ';') {
+		if pos.Offset == len(sql) || (pos.Offset == len(sql)-1 && sql[pos.Offset] == ';') {
 			break
 		}
 		currTok := token{tok, strings.ToLower(lit)}

--- a/sessionctx/variable/session_test.go
+++ b/sessionctx/variable/session_test.go
@@ -234,7 +234,7 @@ func TestSlowLogFormat(t *testing.T) {
 # DB: test
 # Index_names: [t1:a,t2:b]
 # Is_internal: true
-# Digest: 01d00e6e93b28184beae487ac05841145d2a2f6a7b16de32a763bed27967e83d
+# Digest: e5796985ccafe2f71126ed6c0ac939ffa015a8c0744a24b7aee6d587103fd2f7
 # Stats: t1:123[1000;0][ID 1:allLoaded,ID 2:allLoaded][ID 2:allEvicted,ID 3:onlyCmsEvicted],t2:pseudo[10000;0]
 # Num_cop_tasks: 10
 # Cop_proc_avg: 1 Cop_proc_p90: 2 Cop_proc_max: 3 Cop_proc_addr: 10.6.131.78

--- a/util/stmtsummary/v2/tests/table_test.go
+++ b/util/stmtsummary/v2/tests/table_test.go
@@ -410,7 +410,7 @@ func TestStmtSummaryTableOther(t *testing.T) {
 		Check(testkit.Rows(
 			// digest in cache
 			// "show databases ;"
-			"show databases ; dcd020298c5f79e8dc9d63b3098083601614a04a52db458738347d15ea5712a1",
+			"show databases 0e247706bf6e791fbf4af8c8e7658af5ffc45c63179871202d8f91551ee03161",
 			// digest evicted
 			" <nil>",
 		))
@@ -445,7 +445,7 @@ func TestStmtSummaryHistoryTableOther(t *testing.T) {
 		Check(testkit.Rows(
 			// digest in cache
 			// "show databases ;"
-			"show databases ; dcd020298c5f79e8dc9d63b3098083601614a04a52db458738347d15ea5712a1",
+			"show databases 0e247706bf6e791fbf4af8c8e7658af5ffc45c63179871202d8f91551ee03161",
 			// digest evicted
 			" <nil>",
 		))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45104

Problem Summary:

Ignore the ending semicolon of the SQL when generating the digest.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
When generating SQL digests, the semicolon at the end of the SQL statement will not affect the generated digest. In other words, whether there is a semicolon or not, the same digest will be generated for an SQL statement.
```
