### PR TITLE
util/chunk: optimize `(*ListInDisk).GetChunk` and add a fast row container reader

### DIFF
--- a/util/chunk/BUILD.bazel
+++ b/util/chunk/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "pool.go",
         "row.go",
         "row_container.go",
+        "row_container_reader.go",
     ],
     importpath = "github.com/pingcap/tidb/util/chunk",
     visibility = ["//visibility:public"],

--- a/util/chunk/disk_test.go
+++ b/util/chunk/disk_test.go
@@ -262,6 +262,7 @@ func testListInDisk(t *testing.T, concurrency int) {
 }
 
 func BenchmarkListInDisk_GetChunk(b *testing.B) {
+	b.StopTimer()
 	numChk, numRow := 10, 1000
 	chks, fields := initChunks(numChk, numRow)
 	l := NewListInDisk(fields)
@@ -270,6 +271,7 @@ func BenchmarkListInDisk_GetChunk(b *testing.B) {
 		_ = l.Add(chk)
 	}
 
+	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		v := i % numChk
 		_, _ = l.GetChunk(v)

--- a/util/chunk/row_container_reader.go
+++ b/util/chunk/row_container_reader.go
@@ -1,0 +1,166 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunk
+
+import (
+	"context"
+	"runtime"
+	"sync"
+
+	"github.com/pingcap/tidb/util/logutil"
+)
+
+// RowContainerReader is a forward-only iterator for the row container. It provides an interface similar to other
+// iterators, but it doesn't provide `ReachEnd` function and requires manually closing to release goroutine.
+//
+// It's recommended to use the following pattern to use it:
+//
+//	for iter := NewRowContainerReader(rc); iter.Current() != iter.End(); iter.Next() {
+//		...
+//	}
+//	iter.Close()
+//	if iter.Error() != nil {
+//	}
+type RowContainerReader interface {
+	// Next returns the next Row.
+	Next() Row
+
+	// Current returns the current Row.
+	Current() Row
+
+	// End returns the invalid end Row.
+	End() Row
+
+	// Error returns none-nil error if anything wrong happens during the iteration.
+	Error() error
+
+	// Close closes the dumper
+	Close()
+}
+
+var _ RowContainerReader = &rowContainerReader{}
+
+// rowContainerReader is a forward-only iterator for the row container
+// It will spawn two goroutines for reading chunks from disk, and converting the chunk to rows. The row will only be sent
+// to `rowCh` inside only after when the full chunk has been read, to avoid concurrently read/write to the chunk.
+//
+// TODO: record the memory allocated for the channel and chunks.
+type rowContainerReader struct {
+	// context, cancel and waitgroup are used to stop and wait until all goroutine stops.
+	ctx    context.Context
+	cancel func()
+	wg     sync.WaitGroup
+
+	rc *RowContainer
+
+	currentRow Row
+	rowCh      chan Row
+
+	// this error will only be set by worker
+	err error
+}
+
+// Next implements RowContainerReader
+func (reader *rowContainerReader) Next() Row {
+	for row := range reader.rowCh {
+		reader.currentRow = row
+		return row
+	}
+	reader.currentRow = reader.End()
+	return reader.End()
+}
+
+// Current implements RowContainerReader
+func (reader *rowContainerReader) Current() Row {
+	return reader.currentRow
+}
+
+// End implements RowContainerReader
+func (*rowContainerReader) End() Row {
+	return Row{}
+}
+
+// Error implements RowContainerReader
+func (reader *rowContainerReader) Error() error {
+	return reader.err
+}
+
+func (reader *rowContainerReader) initializeChannel() {
+	reader.rc.m.RLock()
+	defer reader.rc.m.RUnlock()
+
+	if reader.rc.NumChunks() == 0 {
+		reader.rowCh = make(chan Row, 1024)
+	} else {
+		assumeChunkSize := reader.rc.NumRowsOfChunk(0)
+		// To avoid blocking in sending to `rowCh` and  don't start reading the next chunk, it'd be better to give it
+		// a buffer at least larger than a single chunk. Here it's allocated twice the chunk size to leave some margin.
+		reader.rowCh = make(chan Row, 2*assumeChunkSize)
+	}
+}
+
+// Close implements RowContainerReader
+func (reader *rowContainerReader) Close() {
+	reader.cancel()
+	reader.wg.Wait()
+}
+
+func (reader *rowContainerReader) startWorker() {
+	reader.wg.Add(1)
+	go func() {
+		defer close(reader.rowCh)
+		defer reader.wg.Done()
+
+		for chkIdx := 0; chkIdx < reader.rc.NumChunks(); chkIdx++ {
+			chk, err := reader.rc.GetChunk(chkIdx)
+			if err != nil {
+				reader.err = err
+				return
+			}
+
+			for i := 0; i < chk.NumRows(); i++ {
+				select {
+				case reader.rowCh <- chk.GetRow(i):
+				case <-reader.ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+}
+
+// NewRowContainerReader creates a forward only iterator for row container
+func NewRowContainerReader(rc *RowContainer) *rowContainerReader {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	reader := &rowContainerReader{
+		ctx:    ctx,
+		cancel: cancel,
+		wg:     sync.WaitGroup{},
+
+		rc: rc,
+	}
+	reader.initializeChannel()
+	reader.startWorker()
+	reader.Next()
+	runtime.SetFinalizer(reader, func(reader *rowContainerReader) {
+		if reader.ctx.Err() == nil {
+			logutil.BgLogger().Warn("rowContainerReader is closed by finalizer")
+			reader.Close()
+		}
+	})
+
+	return reader
+}

--- a/util/chunk/row_container_reader.go
+++ b/util/chunk/row_container_reader.go
@@ -98,9 +98,6 @@ func (reader *rowContainerReader) Error() error {
 }
 
 func (reader *rowContainerReader) initializeChannel() {
-	reader.rc.m.RLock()
-	defer reader.rc.m.RUnlock()
-
 	if reader.rc.NumChunks() == 0 {
 		reader.rowCh = make(chan Row, 1024)
 	} else {

--- a/util/chunk/row_container_test.go
+++ b/util/chunk/row_container_test.go
@@ -15,10 +15,14 @@
 package chunk
 
 import (
+	"crypto/rand"
+	rand2 "math/rand"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/memory"
@@ -302,4 +306,244 @@ func TestActionBlocked(t *testing.T) {
 	}()
 	ac.Action(tracker)
 	require.GreaterOrEqual(t, time.Since(starttime), 200*time.Millisecond)
+}
+
+func TestRowContainerReaderInDisk(t *testing.T) {
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.TempStoragePath = t.TempDir()
+	})
+
+	longVarCharTyp := types.NewFieldTypeBuilder().SetType(mysql.TypeVarchar).SetFlen(4096).Build()
+	fields := []*types.FieldType{&longVarCharTyp}
+
+	// create a row container which stores the data in disk
+	rc := NewRowContainer(fields, 1<<10)
+	rc.SpillToDisk()
+
+	allRows := [][]byte{}
+	// insert 16 chunks
+	for i := 0; i < 16; i++ {
+		chk := NewChunkWithCapacity(fields, 1<<10)
+		// insert 16 rows for each chunk
+		for j := 0; j < 16; j++ {
+			length := rand2.Uint32()
+			randomBytes := make([]byte, length%4096)
+			_, err := rand.Read(randomBytes)
+			require.NoError(t, err)
+
+			chk.AppendBytes(0, randomBytes)
+			allRows = append(allRows, randomBytes)
+		}
+		rc.Add(chk)
+	}
+
+	reader := NewRowContainerReader(rc)
+	defer reader.Close()
+	for i := 0; i < 16; i++ {
+		for j := 0; j < 16; j++ {
+			row := reader.Current()
+			require.Equal(t, allRows[i*16+j], row.GetBytes(0))
+			reader.Next()
+		}
+	}
+}
+
+func TestCloseRowContainerReader(t *testing.T) {
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.TempStoragePath = t.TempDir()
+	})
+
+	longVarCharTyp := types.NewFieldTypeBuilder().SetType(mysql.TypeVarchar).SetFlen(4096).Build()
+	fields := []*types.FieldType{&longVarCharTyp}
+
+	// create a row container which stores the data in disk
+	rc := NewRowContainer(fields, 1<<10)
+	rc.SpillToDisk()
+
+	allRows := [][]byte{}
+	// insert 16 chunks
+	for i := 0; i < 16; i++ {
+		chk := NewChunkWithCapacity(fields, 1<<10)
+		// insert 16 rows for each chunk
+		for j := 0; j < 16; j++ {
+			length := rand2.Uint32()
+			randomBytes := make([]byte, length%4096)
+			_, err := rand.Read(randomBytes)
+			require.NoError(t, err)
+
+			chk.AppendBytes(0, randomBytes)
+			allRows = append(allRows, randomBytes)
+		}
+		rc.Add(chk)
+	}
+
+	// read 8.5 of these chunks
+	reader := NewRowContainerReader(rc)
+	defer reader.Close()
+	for i := 0; i < 8; i++ {
+		for j := 0; j < 16; j++ {
+			row := reader.Current()
+			require.Equal(t, allRows[i*16+j], row.GetBytes(0))
+			reader.Next()
+		}
+	}
+	for j := 0; j < 8; j++ {
+		row := reader.Current()
+		require.Equal(t, allRows[8*16+j], row.GetBytes(0))
+		reader.Next()
+	}
+}
+
+func TestConcurrentSpillWithRowContainerReader(t *testing.T) {
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.TempStoragePath = t.TempDir()
+	})
+
+	longVarCharTyp := types.NewFieldTypeBuilder().SetType(mysql.TypeVarchar).SetFlen(4096).Build()
+	fields := []*types.FieldType{&longVarCharTyp}
+
+	// create a row container which stores the data in disk
+	rc := NewRowContainer(fields, 1<<10)
+	allRows := [][]byte{}
+	// insert 16 chunks
+	for i := 0; i < 16; i++ {
+		chk := NewChunkWithCapacity(fields, 1<<10)
+		// insert 1024 rows for each chunk
+		for j := 0; j < 1024; j++ {
+			length := rand2.Uint32()
+			randomBytes := make([]byte, length%4096)
+			_, err := rand.Read(randomBytes)
+			require.NoError(t, err)
+
+			chk.AppendBytes(0, randomBytes)
+			allRows = append(allRows, randomBytes)
+		}
+		rc.Add(chk)
+	}
+
+	var wg sync.WaitGroup
+	// concurrently read and spill to disk
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		reader := NewRowContainerReader(rc)
+		defer reader.Close()
+
+		for i := 0; i < 16; i++ {
+			for j := 0; j < 1024; j++ {
+				row := reader.Current()
+				require.Equal(t, allRows[i*1024+j], row.GetBytes(0))
+				reader.Next()
+			}
+		}
+	}()
+	rc.SpillToDisk()
+	wg.Wait()
+}
+
+func TestReadAfterSpillWithRowContainerReader(t *testing.T) {
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.TempStoragePath = t.TempDir()
+	})
+
+	longVarCharTyp := types.NewFieldTypeBuilder().SetType(mysql.TypeVarchar).SetFlen(4096).Build()
+	fields := []*types.FieldType{&longVarCharTyp}
+
+	// create a row container which stores the data in disk
+	rc := NewRowContainer(fields, 1<<10)
+	allRows := [][]byte{}
+	// insert 16 chunks
+	for i := 0; i < 16; i++ {
+		chk := NewChunkWithCapacity(fields, 1<<10)
+		// insert 2048 rows for each chunk
+		for j := 0; j < 2048; j++ {
+			length := rand2.Uint32()
+			randomBytes := make([]byte, length%4096)
+			_, err := rand.Read(randomBytes)
+			require.NoError(t, err)
+
+			chk.AppendBytes(0, randomBytes)
+			allRows = append(allRows, randomBytes)
+		}
+		rc.Add(chk)
+	}
+
+	reader := NewRowContainerReader(rc)
+	defer reader.Close()
+	for i := 0; i < 8; i++ {
+		for j := 0; j < 1024; j++ {
+			row := reader.Current()
+			require.Equal(t, allRows[i*1024+j], row.GetBytes(0))
+			reader.Next()
+		}
+	}
+	rc.SpillToDisk()
+	for i := 8; i < 16; i++ {
+		for j := 0; j < 1024; j++ {
+			row := reader.Current()
+			require.Equal(t, allRows[i*1024+j], row.GetBytes(0))
+			reader.Next()
+		}
+	}
+}
+
+func BenchmarkRowContainerReaderInDiskWithRowSize512(b *testing.B) {
+	benchmarkRowContainerReaderInDiskWithRowLength(b, 512)
+}
+
+func BenchmarkRowContainerReaderInDiskWithRowSize1024(b *testing.B) {
+	benchmarkRowContainerReaderInDiskWithRowLength(b, 1024)
+}
+
+func BenchmarkRowContainerReaderInDiskWithRowSize4096(b *testing.B) {
+	benchmarkRowContainerReaderInDiskWithRowLength(b, 4096)
+}
+
+func benchmarkRowContainerReaderInDiskWithRowLength(b *testing.B, rowLength int) {
+	b.StopTimer()
+
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.TempStoragePath = b.TempDir()
+	})
+
+	longVarCharTyp := types.NewFieldTypeBuilder().SetType(mysql.TypeVarchar).SetFlen(rowLength).Build()
+	fields := []*types.FieldType{&longVarCharTyp}
+
+	randomBytes := make([]byte, rowLength)
+	_, err := rand.Read(randomBytes)
+	require.NoError(b, err)
+
+	// create a row container which stores the data in disk
+	rc := NewRowContainer(fields, 1<<10)
+	rc.SpillToDisk()
+
+	// insert `b.N * 1<<10` rows (`b.N` chunks) into the rc
+	for i := 0; i < b.N; i++ {
+		chk := NewChunkWithCapacity(fields, 1<<10)
+		for j := 0; j < 1<<10; j++ {
+			chk.AppendBytes(0, randomBytes)
+		}
+
+		rc.Add(chk)
+	}
+
+	reader := NewRowContainerReader(rc)
+	defer reader.Close()
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		for i := 0; i < 1<<10; i++ {
+			reader.Next()
+		}
+	}
+	require.NoError(b, reader.Error())
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #45125

Problem Summary:

The existing reading method of `RowContainer` (`GetChunk(...)`) is not fast enough for dumping a lot of rows from disk (for the `cursorFetch` use case). 

The existing `Iterator4RowContainer` is even slower, as it allocates a new chunk for each row :facepalm:.

This PR is extracted from https://github.com/pingcap/tidb/pull/44730 (with a some refractor).

### What is changed and how it works?

This PR pipelines the IO and CPU calculation, to make full use of the IO bandwidth. It should also help other features using `rowContainer`, as `GetChunk` is now much faster.

The performance of existing benchmark `BenchmarkListInDisk_GetChunk` increases from `2877471ns/op` to `462864ns/op`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
