### PR TITLE
import/add-index: fix race and performance regression

### DIFF
--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -1159,8 +1159,8 @@ func (w *Writer) flush(ctx context.Context) error {
 
 // EstimatedSize returns the estimated size of the SST file.
 func (w *Writer) EstimatedSize() uint64 {
-	if w.writer.Load() != nil {
-		return w.writerSize.Load()
+	if size := w.writerSize.Load(); size > 0 {
+		return size
 	}
 	// if kvs are still in memory, only calculate half of the total size
 	// in our tests, SST file size is about 50% of the raw kv size

--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -1155,10 +1155,13 @@ func (w *Writer) flush(ctx context.Context) error {
 	return nil
 }
 
+// EstimatedSize returns the estimated size of the SST file.
 func (w *Writer) EstimatedSize() uint64 {
 	if w.writer != nil {
 		return w.writerSize.Load()
 	}
+	// if kvs are still in memory, only calculate half of the total size
+	// in our tests, SST file size is about 50% of the raw kv size
 	return uint64(w.batchSize) / 2
 }
 

--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -1145,6 +1145,7 @@ func (w *Writer) flush(ctx context.Context) error {
 			return errors.Trace(err)
 		}
 		w.writer = nil
+		w.writerSize.Store(0)
 		w.batchCount = 0
 		if meta != nil && meta.totalSize > 0 {
 			return w.addSST(ctx, meta)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44584 

Problem Summary:
```
WARNING: DATA RACE
Write at 0x00c006882480 by goroutine 304253:
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Writer).appendRowsSorted()
      br/pkg/lightning/backend/local/engine.go:1028 +0xa5
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Writer).AppendRows()
      br/pkg/lightning/backend/local/engine.go:1124 +0x3e9
  github.com/pingcap/tidb/executor/importer.(*chunkProcessor).deliverLoop.func1()
      executor/importer/chunk_process.go:253 +0x1cd
  github.com/pingcap/tidb/executor/importer.(*chunkProcessor).deliverLoop()
      executor/importer/chunk_process.go:266 +0x578
  github.com/pingcap/tidb/executor/importer.(*chunkProcessor).process.func2()
      executor/importer/chunk_process.go:131 +0x4c
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      external/org_golang_x_sync/errgroup/errgroup.go:75 +0x82

Previous read at 0x00c006882480 by goroutine 304138:
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Writer).EstimatedSize()
      br/pkg/lightning/backend/local/engine.go:1160 +0x64
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Engine).getEngineFileSize.func1()
      br/pkg/lightning/backend/local/engine.go:489 +0x7b
  sync.(*Map).Range()
      GOROOT/src/sync/map.go:476 +0x1db
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Engine).getEngineFileSize()
      br/pkg/lightning/backend/local/engine.go:487 +0x165
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).EngineFileSizes.func1()
      br/pkg/lightning/backend/local/local.go:1744 +0x75
  sync.(*Map).Range()
      GOROOT/src/sync/map.go:476 +0x1db
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).EngineFileSizes()
      br/pkg/lightning/backend/local/local.go:1742 +0x64
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.CheckDiskQuota()
      br/pkg/lightning/backend/local/disk_quota.go:40 +0x61
  github.com/pingcap/tidb/executor/importer.(*TableImporter).CheckDiskQuota()
      executor/importer/table_import.go:492 +0x1f6
  github.com/pingcap/tidb/disttask/importinto.(*importStepScheduler).InitSubtaskExecEnv.func1()
      disttask/importinto/scheduler.go:87 +0xbb

Goroutine 304253 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      external/org_golang_x_sync/errgroup/errgroup.go:72 +0x12e
  github.com/pingcap/tidb/executor/importer.(*chunkProcessor).process()
      executor/importer/chunk_process.go:130 +0x1f9
  github.com/pingcap/tidb/executor/importer.ProcessChunk()
      executor/importer/engine_process.go:100 +0xc69
  github.com/pingcap/tidb/disttask/importinto.(*ImportMinimalTaskExecutor).Run()
      disttask/importinto/subtask_executor.go:65 +0x70e
  github.com/pingcap/tidb/disttask/framework/scheduler.(*InternalSchedulerImpl).runMinimalTask()
      disttask/framework/scheduler/scheduler.go:292 +0xac7
  github.com/pingcap/tidb/disttask/framework/scheduler.(*InternalSchedulerImpl).runSubtask.func1()
      disttask/framework/scheduler/scheduler.go:219 +0x21a
  github.com/pingcap/tidb/resourcemanager/pool/spool.runTask()
      resourcemanager/pool/spool/spool.go:229 +0xfe
  github.com/pingcap/tidb/resourcemanager/pool/spool.(*Pool).RunWithConcurrency.func1()
      resourcemanager/pool/spool/spool.go:166 +0x30
  github.com/pingcap/tidb/resourcemanager/pool/spool.(*Pool).run.func1()
      resourcemanager/pool/spool/spool.go:145 +0x72

Goroutine 304138 (running) created at:
  github.com/pingcap/tidb/disttask/importinto.(*importStepScheduler).InitSubtaskExecEnv()
      disttask/importinto/scheduler.go:85 +0xa19
  github.com/pingcap/tidb/disttask/framework/scheduler.(*InternalSchedulerImpl).run()
      disttask/framework/scheduler/scheduler.go:127 +0x473
  github.com/pingcap/tidb/disttask/framework/scheduler.(*InternalSchedulerImpl).Run()
      disttask/framework/scheduler/scheduler.go:104 +0x4e
  github.com/pingcap/tidb/disttask/framework/scheduler.(*Manager).onRunnableTask()
      disttask/framework/scheduler/manager.go:293 +0xd8f
  github.com/pingcap/tidb/disttask/framework/scheduler.(*Manager).onRunnableTasks.func1()
      disttask/framework/scheduler/manager.go:204 +0x90
  github.com/pingcap/tidb/resourcemanager/pool/spool.(*Pool).run.func1()
      resourcemanager/pool/spool/spool.go:145 +0x72
==================
==================
WARNING: DATA RACE
Write at 0x00c0068824d8 by goroutine 304253:
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Writer).appendRowsSorted()
      br/pkg/lightning/backend/local/engine.go:1035 +0x2c4
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Writer).AppendRows()
      br/pkg/lightning/backend/local/engine.go:1124 +0x3e9
  github.com/pingcap/tidb/executor/importer.(*chunkProcessor).deliverLoop.func1()
      executor/importer/chunk_process.go:253 +0x1cd
  github.com/pingcap/tidb/executor/importer.(*chunkProcessor).deliverLoop()
      executor/importer/chunk_process.go:266 +0x578
  github.com/pingcap/tidb/executor/importer.(*chunkProcessor).process.func2()
      executor/importer/chunk_process.go:131 +0x4c
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      external/org_golang_x_sync/errgroup/errgroup.go:75 +0x82

Previous read at 0x00c0068824d8 by goroutine 304138:
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Writer).EstimatedSize()
      br/pkg/lightning/backend/local/engine.go:1165 +0x88
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Engine).getEngineFileSize.func1()
      br/pkg/lightning/backend/local/engine.go:489 +0x7b
  sync.(*Map).Range()
      GOROOT/src/sync/map.go:476 +0x1db
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Engine).getEngineFileSize()
      br/pkg/lightning/backend/local/engine.go:487 +0x165
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).EngineFileSizes.func1()
      br/pkg/lightning/backend/local/local.go:1744 +0x75
  sync.(*Map).Range()
      GOROOT/src/sync/map.go:476 +0x1db
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).EngineFileSizes()
      br/pkg/lightning/backend/local/local.go:1742 +0x64
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.CheckDiskQuota()
      br/pkg/lightning/backend/local/disk_quota.go:40 +0x61
  github.com/pingcap/tidb/executor/importer.(*TableImporter).CheckDiskQuota()
      executor/importer/table_import.go:492 +0x1f6
  github.com/pingcap/tidb/disttask/importinto.(*importStepScheduler).InitSubtaskExecEnv.func1()
      disttask/importinto/scheduler.go:87 +0xbb

Goroutine 304253 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      external/org_golang_x_sync/errgroup/errgroup.go:72 +0x12e
  github.com/pingcap/tidb/executor/importer.(*chunkProcessor).process()
      executor/importer/chunk_process.go:130 +0x1f9
  github.com/pingcap/tidb/executor/importer.ProcessChunk()
      executor/importer/engine_process.go:100 +0xc69
  github.com/pingcap/tidb/disttask/importinto.(*ImportMinimalTaskExecutor).Run()
      disttask/importinto/subtask_executor.go:65 +0x70e
  github.com/pingcap/tidb/disttask/framework/scheduler.(*InternalSchedulerImpl).runMinimalTask()
      disttask/framework/scheduler/scheduler.go:292 +0xac7
  github.com/pingcap/tidb/disttask/framework/scheduler.(*InternalSchedulerImpl).runSubtask.func1()
      disttask/framework/scheduler/scheduler.go:219 +0x21a
  github.com/pingcap/tidb/resourcemanager/pool/spool.runTask()
      resourcemanager/pool/spool/spool.go:229 +0xfe
  github.com/pingcap/tidb/resourcemanager/pool/spool.(*Pool).RunWithConcurrency.func1()
      resourcemanager/pool/spool/spool.go:166 +0x30
  github.com/pingcap/tidb/resourcemanager/pool/spool.(*Pool).run.func1()
      resourcemanager/pool/spool/spool.go:145 +0x72

Goroutine 304138 (running) created at:
  github.com/pingcap/tidb/disttask/importinto.(*importStepScheduler).InitSubtaskExecEnv()
      disttask/importinto/scheduler.go:85 +0xa19
  github.com/pingcap/tidb/disttask/framework/scheduler.(*InternalSchedulerImpl).run()
      disttask/framework/scheduler/scheduler.go:127 +0x473
  github.com/pingcap/tidb/disttask/framework/scheduler.(*InternalSchedulerImpl).Run()
      disttask/framework/scheduler/scheduler.go:104 +0x4e
  github.com/pingcap/tidb/disttask/framework/scheduler.(*Manager).onRunnableTask()
      disttask/framework/scheduler/manager.go:293 +0xd8f
  github.com/pingcap/tidb/disttask/framework/scheduler.(*Manager).onRunnableTasks.func1()
      disttask/framework/scheduler/manager.go:204 +0x90
  github.com/pingcap/tidb/resourcemanager/pool/spool.(*Pool).run.func1()
      resourcemanager/pool/spool/spool.go:145 +0x72
```
### What is changed and how it works?
- remove lock when get engine size
- add writerSize to fix data race
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
