### PR TITLE
server: support timestamp with timezone info in parameter

### DIFF
--- a/server/internal/parse/parse_test.go
+++ b/server/internal/parse/parse_test.go
@@ -124,6 +124,28 @@ func TestParseExecArgs(t *testing.T) {
 				[][]byte{nil},
 				[]byte{0x0},
 				[]byte{7, 0},
+				[]byte{0x0d, 0xdb, 0x07, 0x02, 0x03, 0x04, 0x05, 0x06, 0x40, 0xe2, 0x01, 0x00, 0xf2, 0x02},
+			},
+			nil,
+			"2011-02-03 04:05:06.123456+12:34",
+		},
+		{
+			args{
+				expression.Args2Expressions4Test(1),
+				[][]byte{nil},
+				[]byte{0x0},
+				[]byte{7, 0},
+				[]byte{0x0d, 0xdb, 0x07, 0x02, 0x03, 0x04, 0x05, 0x06, 0x40, 0xe2, 0x01, 0x00, 0x0e, 0xfd},
+			},
+			nil,
+			"2011-02-03 04:05:06.123456-12:34",
+		},
+		{
+			args{
+				expression.Args2Expressions4Test(1),
+				[][]byte{nil},
+				[]byte{0x0},
+				[]byte{7, 0},
 				[]byte{0x00},
 			},
 			nil,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #45144 

### What is changed and how it works?

Add support for time_zone information in the parameters.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Add support for timezone information in the executing parameter.
```
