### PR TITLE
executor: void create IntHandle when table is commonHandle

### DIFF
--- a/executor/union_scan_test.go
+++ b/executor/union_scan_test.go
@@ -575,6 +575,19 @@ func TestIssue36903(t *testing.T) {
 	tk.MustQuery("select pkey from t_vwvgdc where 0 <> 0 union select pkey from t_vwvgdc;").Sort().Check(testkit.Rows("15000", "228000"))
 }
 
+func TestIssue41827(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a year(4), b enum('2','k','4','nsy','wmlgy','alkr7'), primary key (a), key idx(b))")
+
+	tk.MustExec("insert into t values (2033, 'alkr7')")
+	tk.MustExec("begin")
+	tk.MustExec("insert into t set a = '2011', b = '4'")
+	tk.MustExec("select /*+ USE_INDEX_MERGE(t, primary, idx) */b from t where not( b in ( 'alkr7' ) ) or not( a in ( '1989' ,'1970' ) )")
+}
+
 func BenchmarkUnionScanRead(b *testing.B) {
 	store := testkit.CreateMockStore(b)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41827

Problem Summary: `tablecodec.DecodeIndexHandle` will create a `IntHandle` when handle only contained a column which type is year. We could check `IsCommonHanle` when create handle in `IndexMerge` and `IndexLookUp` to avoid this problem.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
