### PR TITLE
planner: fix column pruner will clear handleCols and lead filling _tidb_rowid when datasource's schema length is 0 for a pkIsHandled table

### DIFF
--- a/planner/core/handle_cols.go
+++ b/planner/core/handle_cols.go
@@ -46,7 +46,7 @@ type HandleCols interface {
 	BuildPartitionHandleFromIndexRow(row chunk.Row) (kv.PartitionHandle, error)
 	// ResolveIndices resolves handle column indices.
 	ResolveIndices(schema *expression.Schema) (HandleCols, error)
-	// IsInt returns if the HandleCols is a single tnt column.
+	// IsInt returns if the HandleCols is a single int column.
 	IsInt() bool
 	// String implements the fmt.Stringer interface.
 	String() string

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -5032,6 +5032,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 		}
 	}
 	ds.handleCols = handleCols
+	ds.unMutableHandleCols = handleCols
 	handleMap := make(map[int64][]HandleCols)
 	handleMap[tableInfo.ID] = []HandleCols{handleCols}
 	b.handleHelper.pushMap(handleMap)

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -1472,7 +1472,8 @@ type DataSource struct {
 	// handleCol represents the handle column for the datasource, either the
 	// int primary key column or extra handle column.
 	// handleCol *expression.Column
-	handleCols HandleCols
+	handleCols          HandleCols
+	unMutableHandleCols HandleCols
 	// TblCols contains the original columns of table before being pruned, and it
 	// is used for estimating table scan cost.
 	TblCols []*expression.Column


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/44579

Problem Summary:

### What is changed and how it works?
step1: when column pruner #1 steps into datasource, it will keep column ‘a’ and clear handleCols in the case below
step2: ppd logical optimization will clear invalid condition count(a) = null, which is always false

step3: as is known to all, the last column pruner finds there is nothing required by datasource parent, it will clear all the schema columns existed now, and try to add a handle col (which cleared in step 1), therefore it adds a _tidb_rowid instead for a clustered table.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
tiup playground v7.2.0 --tiflash=1 --db.binpath="/Users/arenatlx/go/src/github.com/pingcap/tidb/bin/tidb-server"
create table if not exists test.t1(a int(11) DEFAULT NULL, id int(11) NOT NULL, PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */);
alter table test.t1 set tiflash replica 1;
use test; set tidb_enforce_mpp=on; set tidb_isolation_read_engines='tiflash';
explain select sum(1) as c from test.t1 having count(*)>1 or count(a)= null;
select sum(1) as c from test.t1 having count(*)>1 or count(a)= null;
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix column pruner will clear handleCols and leading filling _tidb_rowid for a pkIsHanle table
```
