### PR TITLE
infoschema: Don't truncate versions

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1770,7 +1770,7 @@ func FormatTiDBVersion(TiDBVersion string, isDefaultVersion bool) string {
 		if len(nodeVersion) > 0 && nodeVersion[0] == 'v' {
 			nodeVersion = nodeVersion[1:]
 		}
-		nodeVersions := strings.Split(nodeVersion, "-")
+		nodeVersions := strings.SplitN(nodeVersion, "-", 2)
 		if len(nodeVersions) == 1 {
 			version = nodeVersions[0]
 		} else if len(nodeVersions) >= 2 {

--- a/infoschema/test/clustertablestest/tables_test.go
+++ b/infoschema/test/clustertablestest/tables_test.go
@@ -775,28 +775,31 @@ func TestSelectHiddenColumn(t *testing.T) {
 
 func TestFormatVersion(t *testing.T) {
 	// Test for defaultVersions.
-	defaultVersions := []string{
-		"5.7.25-TiDB-None",
-		"5.7.25-TiDB-8.0.18",
-		"5.7.25-TiDB-8.0.18-beta.1",
-		"5.7.25-TiDB-v4.0.0-beta-446-g5268094af",
-		"5.7.25-TiDB-",
-		"5.7.25-TiDB-v4.0.0-TiDB-446"}
-	defaultRes := []string{"None", "8.0.18", "8.0.18-beta.1", "4.0.0-beta-446-g5268094af", "", "4.0.0-TiDB-446"}
-	for i, v := range defaultVersions {
-		version := infoschema.FormatTiDBVersion(v, true)
-		require.Equal(t, defaultRes[i], version)
+	versions := []struct {
+		version  string
+		expected string
+		userset  bool
+	}{
+		// default versions
+		{"5.7.25-TiDB-None", "None", true},
+		{"5.7.25-TiDB-8.0.18", "8.0.18", true},
+		{"5.7.25-TiDB-8.0.18-beta.1", "8.0.18-beta.1", true},
+		{"5.7.25-TiDB-v4.0.0-beta-446-g5268094af", "4.0.0-beta-446-g5268094af", true},
+		{"5.7.25-TiDB-", "", true},
+		{"5.7.25-TiDB-v4.0.0-TiDB-446", "4.0.0-TiDB-446", true},
+		// userset
+		{"8.0.18", "8.0.18", false},
+		{"5.7.25-TiDB", "5.7.25-TiDB", false},
+		{"8.0.18-TiDB-4.0.0-beta.1", "8.0.18-TiDB-4.0.0-beta.1", false},
 	}
-
-	// Test for versions user set.
-	versions := []string{"8.0.18", "5.7.25-TiDB", "8.0.18-TiDB-4.0.0-beta.1"}
-	res := []string{"8.0.18", "5.7.25-TiDB", "8.0.18-TiDB-4.0.0-beta.1"}
-	for i, v := range versions {
-		version := infoschema.FormatTiDBVersion(v, false)
-		require.Equal(t, res[i], version)
+	for _, tt := range versions {
+		version := infoschema.FormatTiDBVersion(tt.version, tt.userset)
+		require.Equal(t, tt.expected, version)
 	}
+}
 
-	versions = []string{"v4.0.12", "4.0.12", "v5.0.1"}
+func TestFormatStoreServerVersion(t *testing.T) {
+	versions := []string{"v4.0.12", "4.0.12", "v5.0.1"}
 	resultVersion := []string{"4.0.12", "4.0.12", "5.0.1"}
 
 	for i, versionString := range versions {

--- a/infoschema/test/clustertablestest/tables_test.go
+++ b/infoschema/test/clustertablestest/tables_test.go
@@ -782,7 +782,7 @@ func TestFormatVersion(t *testing.T) {
 		"5.7.25-TiDB-v4.0.0-beta-446-g5268094af",
 		"5.7.25-TiDB-",
 		"5.7.25-TiDB-v4.0.0-TiDB-446"}
-	defaultRes := []string{"None", "8.0.18", "8.0.18-beta.1", "4.0.0-beta", "", "4.0.0-TiDB"}
+	defaultRes := []string{"None", "8.0.18", "8.0.18-beta.1", "4.0.0-beta-446-g5268094af", "", "4.0.0-TiDB-446"}
 	for i, v := range defaultVersions {
 		version := infoschema.FormatTiDBVersion(v, true)
 		require.Equal(t, defaultRes[i], version)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #16302 

Problem Summary:

Before (`7.3.0-alpha`):
```
mysql> TABLE information_schema.CLUSTER_INFO;
+------+-----------------+-----------------+-------------+------------------------------------------+---------------------+---------------+-----------+
| TYPE | INSTANCE        | STATUS_ADDRESS  | VERSION     | GIT_HASH                                 | START_TIME          | UPTIME        | SERVER_ID |
+------+-----------------+-----------------+-------------+------------------------------------------+---------------------+---------------+-----------+
| tidb | 127.0.0.1:4000  | 127.0.0.1:10080 | 7.3.0-alpha | 8c71149116f9439713604d3bf737156a2735b963 | 2023-07-06 15:14:07 | 12.962112656s |   1561139 |
| pd   | 127.0.0.1:2379  | 127.0.0.1:2379  | 7.2.0       | 0934e641129d8bac3c5975372b2ce492b81fd9db | 2023-07-06 15:13:54 | 25.962125837s |         0 |
| tikv | 127.0.0.1:20160 | 127.0.0.1:20180 | 7.2.0       | 12ce5540f9e8f781f14d3b3a58fb9442f03b6b29 | 2023-07-06 15:13:57 | 22.962131038s |         0 |
+------+-----------------+-----------------+-------------+------------------------------------------+---------------------+---------------+-----------+
3 rows in set (0.00 sec)
```

After (`7.3.0-alpha-128-g967699a509-dirty`):
```
mysql> TABLE information_schema.CLUSTER_INFO;
+------+-------------------+--------------------+-----------------------------------+------------------------------------------+---------------------------+--------------+-----------+
| TYPE | INSTANCE          | STATUS_ADDRESS     | VERSION                           | GIT_HASH                                 | START_TIME                | UPTIME       | SERVER_ID |
+------+-------------------+--------------------+-----------------------------------+------------------------------------------+---------------------------+--------------+-----------+
| tidb | 192.168.1.54:4000 | 192.168.1.54:10080 | 7.3.0-alpha-128-g967699a509-dirty | 967699a50938848bcd3504a43856d5487af2d0b3 | 2023-07-06T15:24:54+02:00 | 552.343537ms |         1 |
| tikv | store1            |                    |                                   |                                          |                           |              |         0 |
+------+-------------------+--------------------+-----------------------------------+------------------------------------------+---------------------------+--------------+-----------+
2 rows in set (0.00 sec)
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The versions in `information_schema.cluster_info` are no longer truncated on the first `-`.
```
