### PR TITLE
server: add more integration/unit tests for cursor fetch

### DIFF
--- a/server/mock_conn.go
+++ b/server/mock_conn.go
@@ -45,6 +45,8 @@ type MockConn interface {
 	Close()
 	// ID returns the connection ID.
 	ID() uint64
+	// GetOutbound replaces the internal outbound endpoint with a empty buffer, and return it
+	GetOutput() *bytes.Buffer
 }
 
 type mockConn struct {
@@ -75,6 +77,14 @@ func (mc *mockConn) Close() {
 // ID implements MockConn.ID
 func (mc *mockConn) ID() uint64 {
 	return mc.clientConn.connectionID
+}
+
+// GetOutput implements MockConn.GetOutbound
+func (mc *mockConn) GetOutput() *bytes.Buffer {
+	buf := bytes.NewBuffer([]byte{})
+	mc.clientConn.pkt.bufWriter = bufio.NewWriter(buf)
+
+	return buf
 }
 
 // CreateMockServer creates a mock server.


### PR DESCRIPTION
Add more tests to cover the following situations:

1. Execute returns error in the early check
2. Execute / Fetch can return the expected data
3. Execute multiple times will not return an error, and the original cursor will be closed automatically
4. Reset will close the opened cursor automatically
5. Command send long data works well
6. Reset will removes the stored "long data"