### PR TITLE
br: fix forget to set partition info when debug validate backupmeta

### DIFF
--- a/br/cmd/br/debug.go
+++ b/br/cmd/br/debug.go
@@ -238,6 +238,21 @@ func newBackupMetaValidateCommand() *cobra.Command {
 						Name: indexInfo.Name,
 					}
 				}
+				if table.Info.Partition != nil {
+					if table.Info.Partition != nil {
+						newTable.Partition = &model.PartitionInfo{
+							Definitions: make([]model.PartitionDefinition, len(table.Info.Partition.Definitions)),
+						}
+					}
+					for _, old := range table.Info.Partition.Definitions {
+						partitionID, _ := tableIDAllocator.Alloc()
+						newTable.Partition.Definitions = append(newTable.Partition.Definitions, model.PartitionDefinition{
+							ID:   int64(partitionID),
+							Name: old.Name,
+						})
+					}
+				}
+
 				rules := restore.GetRewriteRules(newTable, table.Info, 0, true)
 				rewriteRules.Data = append(rewriteRules.Data, rules.Data...)
 				tableIDMap[table.Info.ID] = int64(tableID)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44690

Problem Summary:
in debug mode to validate backupmeta, br forgets to set partition info before get rewrite rules.
### What is changed and how it works?
set partition info
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
