### PR TITLE
lightning: fix lightning failed to log encoding error

### DIFF
--- a/br/pkg/lightning/backend/kv/BUILD.bazel
+++ b/br/pkg/lightning/backend/kv/BUILD.bazel
@@ -48,7 +48,7 @@ go_test(
     name = "kv_test",
     timeout = "short",
     srcs = [
-        "base_test"
+        "base_test",
         "kv2sql_test.go",
         "session_internal_test.go",
         "session_test.go",

--- a/br/pkg/lightning/backend/kv/BUILD.bazel
+++ b/br/pkg/lightning/backend/kv/BUILD.bazel
@@ -57,7 +57,7 @@ go_test(
     embed = [":kv"],
     flaky = True,
     race = "on",
-    shard_count = 18,
+    shard_count = 19,
     deps = [
         "//br/pkg/lightning/backend/encode",
         "//br/pkg/lightning/common",

--- a/br/pkg/lightning/backend/kv/BUILD.bazel
+++ b/br/pkg/lightning/backend/kv/BUILD.bazel
@@ -48,7 +48,7 @@ go_test(
     name = "kv_test",
     timeout = "short",
     srcs = [
-        "base_test",
+        "base_test.go",
         "kv2sql_test.go",
         "session_internal_test.go",
         "session_test.go",

--- a/br/pkg/lightning/backend/kv/BUILD.bazel
+++ b/br/pkg/lightning/backend/kv/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     name = "kv_test",
     timeout = "short",
     srcs = [
+        "base_test"
         "kv2sql_test.go",
         "session_internal_test.go",
         "session_test.go",

--- a/br/pkg/lightning/backend/kv/base.go
+++ b/br/pkg/lightning/backend/kv/base.go
@@ -100,6 +100,7 @@ func (row RowArrayMarshaller) MarshalLogArray(encoder zapcore.ArrayEncoder) erro
 		}
 		totalLength += len(str)
 		if totalLength >= 512*1024 {
+			encoder.AppendString("The row has been truncated, and the log has exited early.")
 			return nil
 		}
 		if err := encoder.AppendObject(zapcore.ObjectMarshalerFunc(func(enc zapcore.ObjectEncoder) error {
@@ -316,7 +317,7 @@ func (e *BaseKVEncoder) LogKVConvertFailed(row []types.Datum, j int, colInfo *mo
 	)
 
 	if len(original.GetString()) >= 512*1024 {
-		originalPrefix := original.GetString()[0:1024]
+		originalPrefix := original.GetString()[0:1024] + " (truncated)"
 		e.logger.Error("failed to convert kv value", logutil.RedactAny("origVal", originalPrefix),
 			zap.Stringer("fieldType", &colInfo.FieldType), zap.String("column", colInfo.Name.O),
 			zap.Int("columnID", j+1))

--- a/br/pkg/lightning/backend/kv/base.go
+++ b/br/pkg/lightning/backend/kv/base.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	maxFileSize = 512 * 1024
+	maxLogLength = 512 * 1024
 )
 
 // ExtraHandleColumnInfo is the column info of extra handle column.
@@ -99,11 +99,11 @@ func (row RowArrayMarshaller) MarshalLogArray(encoder zapcore.ArrayEncoder) erro
 				return err
 			}
 		}
-		if len(str) > maxFileSize {
+		if len(str) > maxLogLength {
 			str = str[0:1024] + " (truncated)"
 		}
 		totalLength += len(str)
-		if totalLength >= maxFileSize {
+		if totalLength >= maxLogLength {
 			encoder.AppendString("The row has been truncated, and the log has exited early.")
 			return nil
 		}
@@ -320,7 +320,7 @@ func (e *BaseKVEncoder) LogKVConvertFailed(row []types.Datum, j int, colInfo *mo
 		log.ShortError(err),
 	)
 
-	if len(original.GetString()) >= maxFileSize {
+	if len(original.GetString()) >= maxLogLength {
 		originalPrefix := original.GetString()[0:1024] + " (truncated)"
 		e.logger.Error("failed to convert kv value", logutil.RedactAny("origVal", originalPrefix),
 			zap.Stringer("fieldType", &colInfo.FieldType), zap.String("column", colInfo.Name.O),

--- a/br/pkg/lightning/backend/kv/base.go
+++ b/br/pkg/lightning/backend/kv/base.go
@@ -316,9 +316,17 @@ func (e *BaseKVEncoder) LogKVConvertFailed(row []types.Datum, j int, colInfo *mo
 		log.ShortError(err),
 	)
 
-	e.logger.Error("failed to convert kv value", logutil.RedactAny("origVal", original.GetValue()),
-		zap.Stringer("fieldType", &colInfo.FieldType), zap.String("column", colInfo.Name.O),
-		zap.Int("columnID", j+1))
+	var originalPrefix string
+	if len(row[0].GetString()) >= 512*1024 {
+		originalPrefix = original.GetString()[0:1024]
+		e.logger.Error("failed to convert kv value", logutil.RedactAny("origVal", originalPrefix),
+			zap.Stringer("fieldType", &colInfo.FieldType), zap.String("column", colInfo.Name.O),
+			zap.Int("columnID", j+1))
+	} else {
+		e.logger.Error("failed to convert kv value", logutil.RedactAny("origVal", original.GetValue()),
+			zap.Stringer("fieldType", &colInfo.FieldType), zap.String("column", colInfo.Name.O),
+			zap.Int("columnID", j+1))
+	}
 	return errors.Annotatef(
 		err,
 		"failed to cast value as %s for column `%s` (#%d)", &colInfo.FieldType, colInfo.Name.O, j+1,

--- a/br/pkg/lightning/backend/kv/base.go
+++ b/br/pkg/lightning/backend/kv/base.go
@@ -99,16 +99,15 @@ func (row RowArrayMarshaller) MarshalLogArray(encoder zapcore.ArrayEncoder) erro
 			}
 			totalLength += len(str)
 		}
-		if totalLength < 512*1024 {
-			if err := encoder.AppendObject(zapcore.ObjectMarshalerFunc(func(enc zapcore.ObjectEncoder) error {
-				enc.AddString("kind", kindStr[kind])
-				enc.AddString("val", redact.String(str))
-				return nil
-			})); err != nil {
-				return err
-			}
-		} else {
+		if totalLength >= 512*1024 {
 			return nil
+		}
+		if err := encoder.AppendObject(zapcore.ObjectMarshalerFunc(func(enc zapcore.ObjectEncoder) error {
+			enc.AddString("kind", kindStr[kind])
+			enc.AddString("val", redact.String(str))
+			return nil
+		})); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/br/pkg/lightning/backend/kv/base.go
+++ b/br/pkg/lightning/backend/kv/base.go
@@ -37,6 +37,10 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+const (
+	maxFileSize = 512 * 1024
+)
+
 // ExtraHandleColumnInfo is the column info of extra handle column.
 var ExtraHandleColumnInfo = model.NewExtraHandleColInfo()
 
@@ -95,11 +99,11 @@ func (row RowArrayMarshaller) MarshalLogArray(encoder zapcore.ArrayEncoder) erro
 				return err
 			}
 		}
-		if len(str) > 512*1024 {
+		if len(str) > maxFileSize {
 			str = str[0:1024] + " (truncated)"
 		}
 		totalLength += len(str)
-		if totalLength >= 512*1024 {
+		if totalLength >= maxFileSize {
 			encoder.AppendString("The row has been truncated, and the log has exited early.")
 			return nil
 		}
@@ -316,7 +320,7 @@ func (e *BaseKVEncoder) LogKVConvertFailed(row []types.Datum, j int, colInfo *mo
 		log.ShortError(err),
 	)
 
-	if len(original.GetString()) >= 512*1024 {
+	if len(original.GetString()) >= maxFileSize {
 		originalPrefix := original.GetString()[0:1024] + " (truncated)"
 		e.logger.Error("failed to convert kv value", logutil.RedactAny("origVal", originalPrefix),
 			zap.Stringer("fieldType", &colInfo.FieldType), zap.String("column", colInfo.Name.O),

--- a/br/pkg/lightning/backend/kv/base.go
+++ b/br/pkg/lightning/backend/kv/base.go
@@ -316,8 +316,7 @@ func (e *BaseKVEncoder) LogKVConvertFailed(row []types.Datum, j int, colInfo *mo
 	)
 
 	if len(original.GetString()) >= 512*1024 {
-		var originalPrefix string
-		originalPrefix = original.GetString()[0:1024]
+		originalPrefix := original.GetString()[0:1024]
 		e.logger.Error("failed to convert kv value", logutil.RedactAny("origVal", originalPrefix),
 			zap.Stringer("fieldType", &colInfo.FieldType), zap.String("column", colInfo.Name.O),
 			zap.Int("columnID", j+1))

--- a/br/pkg/lightning/backend/kv/base.go
+++ b/br/pkg/lightning/backend/kv/base.go
@@ -94,11 +94,11 @@ func (row RowArrayMarshaller) MarshalLogArray(encoder zapcore.ArrayEncoder) erro
 			if err != nil {
 				return err
 			}
-			if len(str) > 512*1024 {
-				str = str[0:1024]
-			}
-			totalLength += len(str)
 		}
+		if len(str) > 512*1024 {
+			str = str[0:1024] + " (truncated)"
+		}
+		totalLength += len(str)
 		if totalLength >= 512*1024 {
 			return nil
 		}
@@ -315,8 +315,8 @@ func (e *BaseKVEncoder) LogKVConvertFailed(row []types.Datum, j int, colInfo *mo
 		log.ShortError(err),
 	)
 
-	var originalPrefix string
-	if len(row[0].GetString()) >= 512*1024 {
+	if len(original.GetString()) >= 512*1024 {
+		var originalPrefix string
 		originalPrefix = original.GetString()[0:1024]
 		e.logger.Error("failed to convert kv value", logutil.RedactAny("origVal", originalPrefix),
 			zap.Stringer("fieldType", &colInfo.FieldType), zap.String("column", colInfo.Name.O),

--- a/br/pkg/lightning/backend/kv/base_test.go
+++ b/br/pkg/lightning/backend/kv/base_test.go
@@ -40,7 +40,10 @@ func TestLogKVConvertFailed(t *testing.T) {
 	msg := "logger is initialized"
 	log.L().Info(msg)
 
-	c1 := &model.ColumnInfo{ID: 1, Name: model.NewCIStr("c1"), State: model.StatePublic, Offset: 0, FieldType: *types.NewFieldType(mysql.TypeTiny)}
+	modelName := model.NewCIStr("c1")
+	modelState := model.StatePublic
+	modelFieldType := *types.NewFieldType(mysql.TypeTiny)
+	c1 := &model.ColumnInfo{ID: 1, Name: modelName, State: modelState, Offset: 0, FieldType: modelFieldType}
 	cols := []*model.ColumnInfo{c1}
 	tblInfo := &model.TableInfo{ID: 1, Columns: cols, PKIsHandle: false, State: model.StatePublic}
 	var tbl table.Table

--- a/br/pkg/lightning/backend/kv/base_test.go
+++ b/br/pkg/lightning/backend/kv/base_test.go
@@ -16,6 +16,10 @@ package kv_test
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/pingcap/tidb/br/pkg/lightning/backend/encode"
 	"github.com/pingcap/tidb/br/pkg/lightning/backend/kv"
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
@@ -25,8 +29,6 @@ import (
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
 	"github.com/stretchr/testify/require"
-	"os"
-	"testing"
 )
 
 func TestLogKVConvertFailed(t *testing.T) {
@@ -54,11 +56,11 @@ func TestLogKVConvertFailed(t *testing.T) {
 		},
 		Logger: log.L(),
 	})
-	newString := "test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test"
-	for i := 0; i < 10000; i++ {
-		newString = newString + "_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test"
+	var newString strings.Builder
+	for i := 0; i < 100000; i++ {
+		newString.WriteString("test_test_test_test_")
 	}
-	newDatum := types.NewStringDatum(newString)
+	newDatum := types.NewStringDatum(newString.String())
 	rows := []types.Datum{}
 	for i := 0; i <= 10; i++ {
 		rows = append(rows, newDatum)

--- a/br/pkg/lightning/backend/kv/base_test.go
+++ b/br/pkg/lightning/backend/kv/base_test.go
@@ -1,0 +1,73 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv_test
+
+import (
+	"fmt"
+	"github.com/pingcap/tidb/br/pkg/lightning/backend/encode"
+	"github.com/pingcap/tidb/br/pkg/lightning/backend/kv"
+	"github.com/pingcap/tidb/br/pkg/lightning/log"
+	"github.com/pingcap/tidb/parser/model"
+	"github.com/pingcap/tidb/parser/mysql"
+	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/table/tables"
+	"github.com/pingcap/tidb/types"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestLogKVConvertFailed(t *testing.T) {
+	dir := "/temp.txt"
+	dir = fmt.Sprintf("%s%s", t.TempDir(), dir)
+	logCfg := &log.Config{File: dir, FileMaxSize: 1}
+	err := log.InitLogger(logCfg, "info")
+	require.NoError(t, err)
+	msg := "logger is initialized"
+	log.L().Info(msg)
+
+	c1 := &model.ColumnInfo{ID: 1, Name: model.NewCIStr("c1"), State: model.StatePublic, Offset: 0, FieldType: *types.NewFieldType(mysql.TypeTiny)}
+	cols := []*model.ColumnInfo{c1}
+	tblInfo := &model.TableInfo{ID: 1, Columns: cols, PKIsHandle: false, State: model.StatePublic}
+	var tbl table.Table
+	tbl, err = tables.TableFromMeta(kv.NewPanickingAllocators(0), tblInfo)
+	require.NoError(t, err)
+
+	var baseKVEncoder *kv.BaseKVEncoder
+	baseKVEncoder, err = kv.NewBaseKVEncoder(&encode.EncodingConfig{
+		Table: tbl,
+		SessionOptions: encode.SessionOptions{
+			SQLMode:   mysql.ModeStrictAllTables,
+			Timestamp: 1234567890,
+		},
+		Logger: log.L(),
+	})
+	newString := "test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test"
+	for i := 0; i < 10000; i++ {
+		newString = newString + "_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test"
+	}
+	newDatum := types.NewStringDatum(newString)
+	rows := []types.Datum{}
+	for i := 0; i <= 10; i++ {
+		rows = append(rows, newDatum)
+	}
+	err = baseKVEncoder.LogKVConvertFailed(rows, 6, c1, err)
+	require.NoError(t, err)
+
+	var content []byte
+	content, err = os.ReadFile(dir)
+	require.NoError(t, err)
+	require.LessOrEqual(t, 500, len(string(content)))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44321 

Problem Summary:

When the source file has ill-formated row, the row is very large so it can't be logged. We can't locate the bad row;

```
2023-06-01 10:55:27.887067902 +0800 CST m=+35.508861459 write error: write length 20297970322 exceeds maximum file size 536870912
```

### What is changed and how it works?

When we encounter ill-formatted row, we take out the ill-formatted row and only log the first 1024 characters of the row, so that it would not report error that write length exceeds maximum file size.

Before fixing the issue, the log looks like this when encountering ill-formatted row:

```
[2023/07/06 22:23:38.812 +08:00] [INFO] [base_test.go:40] ["logger is initialized"]
2023-07-06 22:23:39.344279 +0800 CST m=+0.575101501 write error: write length 1050272 exceeds maximum file size 1048576
2023-07-06 22:23:39.353842 +0800 CST m=+0.584668709 write error: write length 1050249 exceeds maximum file size 1048576
```
The length of the row is 324.

After fixing the issue, the log looks like this when encountering ill-formatted row:
```
[2023/07/07 21:08:03.211 +08:00] [INFO] [base_test.go:41] ["logger is initialized"]
[2023/07/07 21:08:03.737 +08:00] [ERROR] [base.go:308] ["kv convert failed"] [original=test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test] [originalCol=6] [colName=c1] [colType=tinyint(4)] []
[2023/07/07 21:08:03.737 +08:00] [ERROR] [base.go:315] ["failed to convert kv value"] [origVal=test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test_test] [fieldType=tinyint(4)] [column=c1] [columnID=7]
```
The length of the row is 2419.

So to check whether the "exceeds maximum file size" issue has been fixed, we could check whether the length of the row is larger than 500, which can make sure the log shows the first 1024 characters of the ill-formatted row instead of saying "write error: write length xxx exceeds maximum file size xxx".

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
When lightning encounters ill-formatted row, it can log the encoding error within which shows the first 1024 characters of the row content, instead of logging the write error that write length exceeds maximum file size.
```
