### PR TITLE
cgroup: fixed cpu,cpuacct controller order incompatibility.

### DIFF
--- a/util/cgroup/cgroup_cpu.go
+++ b/util/cgroup/cgroup_cpu.go
@@ -32,7 +32,7 @@ func getCgroupCPU(root string) (CPUUsage, error) {
 
 	// No CPU controller detected
 	if path == "" {
-		return CPUUsage{}, errNoCPUControllerDetected
+		return CPUUsage{}, errors.New("no cpu controller detected")
 	}
 
 	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "cpu,cpuacct")
@@ -81,7 +81,7 @@ func getCgroupCPU(root string) (CPUUsage, error) {
 				return res, err
 			}
 		default:
-			return CPUUsage{}, fmt.Errorf("detected unknown cgroup version index: %d", ver)
+			return CPUUsage{}, fmt.Errorf("detected unknown cgroup version index: %d", ver[0])
 		}
 	}
 

--- a/util/cgroup/cgroup_mock_test.go
+++ b/util/cgroup/cgroup_mock_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -369,6 +370,27 @@ const (
 )
 
 func TestCgroupsGetCPU(t *testing.T) {
+	for i := 0; i < 2; i++ {
+		if i == 1 {
+			// The field in /proc/self/cgroup and /proc/self/meminfo may appear as "cpuacct,cpu" or "rw,cpuacct,cpu"
+			// while the input controller is "cpu,cpuacct"
+			v1CgroupWithCPUController = strings.ReplaceAll(v1CgroupWithCPUController, "cpu,cpuacct", "cpuacct,cpu")
+			v1CgroupWithCPUControllerNS = strings.ReplaceAll(v1CgroupWithCPUControllerNS, "cpu,cpuacct", "cpuacct,cpu")
+			v1CgroupWithCPUControllerNSMountRel = strings.ReplaceAll(v1CgroupWithCPUControllerNSMountRel, "cpu,cpuacct", "cpuacct,cpu")
+			v1CgroupWithCPUControllerNSMountRelRemount = strings.ReplaceAll(v1CgroupWithCPUControllerNSMountRelRemount, "cpu,cpuacct", "cpuacct,cpu")
+			v1CgroupWithCPUControllerNS2 = strings.ReplaceAll(v1CgroupWithCPUControllerNS2, "cpu,cpuacct", "cpuacct,cpu")
+
+			v1MountsWithCPUController = strings.ReplaceAll(v1MountsWithCPUController, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
+			v1MountsWithCPUControllerNS = strings.ReplaceAll(v1MountsWithCPUControllerNS, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
+			v1MountsWithCPUControllerNSMountRel = strings.ReplaceAll(v1MountsWithCPUControllerNSMountRel, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
+			v1MountsWithCPUControllerNSMountRelRemount = strings.ReplaceAll(v1MountsWithCPUControllerNSMountRelRemount, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
+			v1MountsWithCPUControllerNS2 = strings.ReplaceAll(v1MountsWithCPUControllerNS2, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
+		}
+		testCgroupsGetCPU(t)
+	}
+}
+
+func testCgroupsGetCPU(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		paths  map[string]string
@@ -562,7 +584,7 @@ func createFiles(t *testing.T, paths map[string]string) (dir string) {
 	return dir
 }
 
-const (
+var (
 	v1CgroupWithMemoryController = `11:blkio:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
 10:devices:/kubepods/besteffort/podcbfx2j5d-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
 9:perf_event:/kubepods/besteffort/podcbfx2j5d-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44790

Problem Summary:

### What is changed and how it works?
Fixed the issue that getCgroupCPU() v1 logic doesn't work with CPU controller that appears like 'cpuacct,cpu' in /proc/self/cgroup and /proc/self/mountinfo. Added controllerMatch() to split the controllers and do the matching one by one instead of simply comparing them as a whole.

### Check List

Tests <!-- At least one of them must be included. -->

- Unit test: the modified cgroup_mock_test

Side effects

None

Documentation

None

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that getCgroupCPU() v1 logic doesn't work with CPU controller that appears like 'cpuacct,cpu' in /proc/self/cgroup and /proc/self/mountinfo.
```
