### PR TITLE
placement: supports survival preferences (#40613) (#44701)

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3022,6 +3022,8 @@ func SetDirectPlacementOpt(placementSettings *model.PlacementSettings, placement
 		placementSettings.FollowerConstraints = stringVal
 	case ast.PlacementOptionVoterConstraints:
 		placementSettings.VoterConstraints = stringVal
+	case ast.PlacementOptionSurvivalPreferences:
+		placementSettings.SurvivalPreferences = stringVal
 	default:
 		return errors.Trace(errors.New("unknown placement policy option"))
 	}

--- a/ddl/placement/bundle_test.go
+++ b/ddl/placement/bundle_test.go
@@ -887,6 +887,9 @@ func TestTidy(t *testing.T) {
 	bundle.Rules = append(bundle.Rules, rules3...)
 	bundle.Rules = append(bundle.Rules, rules4...)
 
+	for _, r := range bundle.Rules {
+		r.LocationLabels = []string{"zone", "host"}
+	}
 	chkfunc := func() {
 		require.NoError(t, err)
 		require.Len(t, bundle.Rules, 3)
@@ -901,6 +904,7 @@ func TestTidy(t *testing.T) {
 				Values: []string{EngineLabelTiFlash},
 			},
 		}, bundle.Rules[2].Constraints)
+		require.Equal(t, []string{"zone", "host"}, bundle.Rules[2].LocationLabels)
 	}
 	err = bundle.Tidy()
 	chkfunc()

--- a/ddl/placement/errors.go
+++ b/ddl/placement/errors.go
@@ -29,6 +29,8 @@ var (
 	ErrInvalidConstraintsMapcnt = errors.New("label constraints in map syntax have invalid replicas")
 	// ErrInvalidConstraintsFormat is from rule.go.
 	ErrInvalidConstraintsFormat = errors.New("invalid label constraints format")
+	// ErrInvalidSurvivalPreferenceFormat is from rule.go.
+	ErrInvalidSurvivalPreferenceFormat = errors.New("survival preference format should be in format [xxx=yyy, ...]")
 	// ErrInvalidConstraintsRelicas is from rule.go.
 	ErrInvalidConstraintsRelicas = errors.New("label constraints with invalid REPLICAS")
 	// ErrInvalidBundleID is from bundle.go.

--- a/ddl/placement/rule.go
+++ b/ddl/placement/rule.go
@@ -45,15 +45,16 @@ type RuleGroupConfig struct {
 
 // Rule is the core placement rule struct. Check https://github.com/tikv/pd/blob/master/server/schedule/placement/rule.go.
 type Rule struct {
-	GroupID     string       `json:"group_id"`
-	ID          string       `json:"id"`
-	Index       int          `json:"index,omitempty"`
-	Override    bool         `json:"override,omitempty"`
-	StartKeyHex string       `json:"start_key"`
-	EndKeyHex   string       `json:"end_key"`
-	Role        PeerRoleType `json:"role"`
-	Count       int          `json:"count"`
-	Constraints Constraints  `json:"label_constraints,omitempty"`
+	GroupID        string       `json:"group_id"`
+	ID             string       `json:"id"`
+	Index          int          `json:"index,omitempty"`
+	Override       bool         `json:"override,omitempty"`
+	StartKeyHex    string       `json:"start_key"`
+	EndKeyHex      string       `json:"end_key"`
+	Role           PeerRoleType `json:"role"`
+	Count          int          `json:"count"`
+	Constraints    Constraints  `json:"label_constraints,omitempty"`
+	LocationLabels []string     `json:"location_labels,omitempty"`
 }
 
 // TiFlashRule extends Rule with other necessary fields.

--- a/ddl/placement_policy_test.go
+++ b/ddl/placement_policy_test.go
@@ -193,7 +193,8 @@ func TestPlacementPolicy(t *testing.T) {
 		"LEARNERS=1 " +
 		"LEARNER_CONSTRAINTS=\"[+region=cn-west-1]\" " +
 		"FOLLOWERS=3 " +
-		"FOLLOWER_CONSTRAINTS=\"[+disk=ssd]\"")
+		"FOLLOWER_CONSTRAINTS=\"[+disk=ssd]\"" +
+		"SURVIVAL_PREFERENCES=\"[region, zone]\"")
 
 	checkFunc := func(policyInfo *model.PolicyInfo) {
 		require.Equal(t, true, policyInfo.ID != 0)
@@ -206,6 +207,7 @@ func TestPlacementPolicy(t *testing.T) {
 		require.Equal(t, "[+region=cn-west-1]", policyInfo.LearnerConstraints)
 		require.Equal(t, model.StatePublic, policyInfo.State)
 		require.Equal(t, "", policyInfo.Schedule)
+		require.Equal(t, "[region, zone]", policyInfo.SurvivalPreferences)
 	}
 
 	// Check the policy is correctly reloaded in the information schema.
@@ -628,11 +630,16 @@ func TestCreateTableWithPlacementPolicy(t *testing.T) {
 	tk.MustExec("create placement policy x " +
 		"FOLLOWERS=2 " +
 		"CONSTRAINTS=\"[+disk=ssd]\" ")
+	tk.MustExec("create placement policy z " +
+		"FOLLOWERS=1 " +
+		"SURVIVAL_PREFERENCES=\"[region, zone]\"")
 	tk.MustExec("create placement policy y " +
 		"FOLLOWERS=3 " +
 		"CONSTRAINTS=\"[+region=bj]\" ")
 	tk.MustExec("create table t(a int)" +
 		"PLACEMENT POLICY=\"x\"")
+	tk.MustExec("create table tt(a int)" +
+		"PLACEMENT POLICY=\"z\"")
 	tk.MustQuery("SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TIDB_PLACEMENT_POLICY_NAME FROM information_schema.Tables WHERE TABLE_SCHEMA='test' AND TABLE_NAME = 't'").Check(testkit.Rows(`def test t x`))
 	tk.MustExec("create table t_range_p(id int) placement policy x partition by range(id) (" +
 		"PARTITION p0 VALUES LESS THAN (100)," +
@@ -655,7 +662,18 @@ func TestCreateTableWithPlacementPolicy(t *testing.T) {
 	require.Equal(t, "y", policyY.Name.L)
 	require.Equal(t, true, policyY.ID != 0)
 
-	tbl := external.GetTableByName(t, tk, "test", "t")
+	policyZ := testGetPolicyByName(t, tk.Session(), "z", true)
+	require.Equal(t, "z", policyZ.Name.L)
+	require.Equal(t, true, policyZ.ID != 0)
+	require.Equal(t, "[region, zone]", policyZ.SurvivalPreferences)
+
+	tbl := external.GetTableByName(t, tk, "test", "tt")
+	require.NotNil(t, tbl)
+	require.NotNil(t, tbl.Meta().PlacementPolicyRef)
+	require.Equal(t, "z", tbl.Meta().PlacementPolicyRef.Name.L)
+	require.Equal(t, policyZ.ID, tbl.Meta().PlacementPolicyRef.ID)
+
+	tbl = external.GetTableByName(t, tk, "test", "t")
 	require.NotNil(t, tbl)
 	require.NotNil(t, tbl.Meta().PlacementPolicyRef)
 	require.Equal(t, "x", tbl.Meta().PlacementPolicyRef.Name.L)

--- a/docs/design/2020-06-24-placement-rules-in-sql.md
+++ b/docs/design/2020-06-24-placement-rules-in-sql.md
@@ -413,6 +413,26 @@ If a table is imported when `tidb_placement_mode='IGNORE'`, and the placement po
 
 The default value for `tidb_placement_mode` is `STRICT`. The option is an enum, and in future we may add support for a `WARN` mode.
 
+
+#### Survival preference
+
+Some important data may need to store multiple copies across availability zones, so as to have high disaster recovery survivability, such as region-level survivability, `SURVIVAL_PREFERENCES` can provide survivability preference settings.
+
+The following example sets a constraint that the data try to satisfy the Survival Preferences setting:
+
+``` sql
+CREATE PLACEMENT POLICY multiregion
+    follower=4
+    PRIMARY_REGION="region1"
+    SURVIVAL_PREFERENCES="[region, zone]";
+```
+
+For tables with this policy set, the data will first meet the survival goal of cross-region data isolation, and then ensure the survival goal of cross-zone data isolation.
+
+> **Note:**
+>
+> `SURVIVAL_PREFERENCES` is equivalent to `LOCATION_LABELS` in PD. For more information, please refer to [Replica scheduling by topology label](https://docs.pingcap.com/tidb/dev/schedule-replicas-by-topology-labels#schedule-replicas-by-topology-labels).
+
 #### Ambiguous and edge cases
 
 The following two policies are not identical:
@@ -491,6 +511,7 @@ In this case the default rules will apply to placement, and the output from `SHO
 - `FOLLOWER_CONSTRAINTS`
 - `LEARNER_CONSTRAINTS`
 - `PLACEMENT POLICY`
+- `SURVIVAL_PREFERENCE`
 
 For a more complex rule using partitions, consider the following example:
 

--- a/domain/infosync/BUILD.bazel
+++ b/domain/infosync/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/metapb",
+        "@com_github_pingcap_log//:log",
         "@com_github_tikv_client_go_v2//oracle",
         "@com_github_tikv_pd_client//:client",
         "@io_etcd_go_etcd_client_v3//:client",

--- a/domain/infosync/placement_manager.go
+++ b/domain/infosync/placement_manager.go
@@ -21,9 +21,11 @@ import (
 	"path"
 	"sync"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/util/pdapi"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
 )
 
 // PlacementManager manages placement settings
@@ -72,6 +74,7 @@ func (m *PDPlacementManager) PutRuleBundles(ctx context.Context, bundles []*plac
 		return err
 	}
 
+	log.Debug("Put placement rule bundles", zap.String("rules", string(b)))
 	_, err = doRequest(ctx, "PutPlacementRules", m.etcdCli.Endpoints(), path.Join(pdapi.Config, "placement-rule")+"?partial=true", "POST", bytes.NewReader(b))
 	return err
 }

--- a/parser/ast/ddl.go
+++ b/parser/ast/ddl.go
@@ -1958,6 +1958,7 @@ const (
 	PlacementOptionLearnerConstraints
 	PlacementOptionFollowerConstraints
 	PlacementOptionVoterConstraints
+	PlacementOptionSurvivalPreferences
 	PlacementOptionPolicy
 )
 
@@ -2022,6 +2023,10 @@ func (n *PlacementOption) Restore(ctx *format.RestoreCtx) error {
 			ctx.WriteKeyWord("PLACEMENT POLICY ")
 			ctx.WritePlain("= ")
 			ctx.WriteName(n.StrValue)
+		case PlacementOptionSurvivalPreferences:
+			ctx.WriteKeyWord("SURVIVAL_PREFERENCES ")
+			ctx.WritePlain("= ")
+			ctx.WriteString(n.StrValue)
 		default:
 			return errors.Errorf("invalid PlacementOption: %d", n.Tp)
 		}

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -707,6 +707,7 @@ var tokenMap = map[string]int{
 	"SUBSTRING":                substring,
 	"SUM":                      sum,
 	"SUPER":                    super,
+	"SURVIVAL_PREFERENCES":     survivalPreferences,
 	"SWAPS":                    swaps,
 	"SWITCHES":                 switchesSym,
 	"SYSTEM":                   system,

--- a/parser/model/model.go
+++ b/parser/model/model.go
@@ -1735,6 +1735,7 @@ type PlacementSettings struct {
 	LearnerConstraints  string `json:"learner_constraints"`
 	FollowerConstraints string `json:"follower_constraints"`
 	VoterConstraints    string `json:"voter_constraints"`
+	SurvivalPreferences string `json:"survival_preferences"`
 }
 
 // PolicyInfo is the struct to store the placement policy.

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -701,6 +701,7 @@ import (
 	subDate               "SUBDATE"
 	sum                   "SUM"
 	substring             "SUBSTRING"
+	survivalPreferences   "SURVIVAL_PREFERENCES"
 	target                "TARGET"
 	tidbJson              "TIDB_JSON"
 	timestampAdd          "TIMESTAMPADD"
@@ -1634,6 +1635,10 @@ DirectPlacementOption:
 |	"LEARNER_CONSTRAINTS" EqOpt stringLit
 	{
 		$$ = &ast.PlacementOption{Tp: ast.PlacementOptionLearnerConstraints, StrValue: $3}
+	}
+|	"SURVIVAL_PREFERENCES" EqOpt stringLit
+	{
+		$$ = &ast.PlacementOption{Tp: ast.PlacementOptionSurvivalPreferences, StrValue: $3}
 	}
 
 PlacementPolicyOption:
@@ -6539,6 +6544,7 @@ NotKeywordToken:
 |	"CONSTRAINTS"
 |	"PRIMARY_REGION"
 |	"SCHEDULE"
+|	"SURVIVAL_PREFERENCES"
 |	"LEADER_CONSTRAINTS"
 |	"FOLLOWER_CONSTRAINTS"
 |	"LEARNER_CONSTRAINTS"

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2497,6 +2497,7 @@ func TestDDL(t *testing.T) {
 		{`create table t (c int) follower_constraints="ww";`, false, ""},
 		{`create table t (c int) voter_constraints="ww";`, false, ""},
 		{`create table t (c int) learner_constraints="ww";`, false, ""},
+		{`create table t (c int) survival_preference="ww";`, false, ""},
 		{`create table t (c int) /*T![placement] primary_region="us" */;`, false, ""},
 		{`create table t (c int) /*T![placement] regions="us,3" */;`, false, ""},
 		{`create table t (c int) /*T![placement] followers="us,3 */";`, false, ""},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/38605
pick: https://github.com/pingcap/tidb/pull/40613
Problem Summary:

**Is your feature request related to a problem? Please describe:**
 users hoped that the scale of high availability is controllable, not for the entire database.  they want to distribute data across regions with specified tables. Such as:
 
![image](https://user-images.githubusercontent.com/6428910/197327433-78ed0fd8-aab5-4a11-a9ee-a90e479e6729.png)





**Describe the feature you'd like:**

Supports SQL Placement Policy Like :
```
ALTER PLACEMENT POLICY myplacementpolicy FOLLOWERS=5 SURVIVAL_PREFERENCES=["region", "zone", "host"]; 
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
placement: supports survival preferences
```
