### PR TITLE
ttl: refactor TTL to seperate creating new job and take timeout job codes

### DIFF
--- a/ttl/ttlworker/job_manager.go
+++ b/ttl/ttlworker/job_manager.go
@@ -315,20 +315,15 @@ func (m *JobManager) triggerTTLJob(requestID string, cmd *client.TriggerNewTTLJo
 		}
 
 		jobID := uuid.NewString()
-		job, err := m.lockJob(m.ctx, se, ttlTbl, now, jobID, false)
-		if err != nil {
+		if _, err = m.lockNewJob(m.ctx, se, ttlTbl, now, jobID, false); err != nil {
 			firstError = err
 			tblResult.ErrorMessage = err.Error()
 			tableResults = append(tableResults, tblResult)
 			continue
 		}
-
 		allError = false
-		if job != nil {
-			m.appendJob(job)
-			tblResult.JobID = job.id
-			tableResults = append(tableResults, tblResult)
-		}
+		tblResult.JobID = jobID
+		tableResults = append(tableResults, tblResult)
 	}
 
 	if allError {
@@ -457,15 +452,13 @@ func (m *JobManager) rescheduleJobs(se session.Session, now time.Time) {
 	// when the heart beat is not sent
 	for i, table := range jobTables {
 		logutil.Logger(m.ctx).Info("try lock new job", zap.Int64("tableID", table.ID))
-		jobID := ""
+		var err error
 		if isCreate[i] {
-			jobID = uuid.NewString()
+			_, err = m.lockNewJob(m.ctx, se, table, now, uuid.NewString(), true)
+		} else {
+			_, err = m.lockHBTimeoutJob(m.ctx, se, table, now)
 		}
-		job, err := m.lockJob(m.ctx, se, table, now, jobID, isCreate[i])
-		if job != nil {
-			logutil.Logger(m.ctx).Info("append new running job", zap.String("jobID", job.id), zap.Int64("tableID", job.tbl.ID))
-			m.appendJob(job)
-		}
+
 		if err != nil {
 			logutil.Logger(m.ctx).Warn("fail to create new job", zap.Error(err))
 		}
@@ -546,7 +539,7 @@ func (m *JobManager) couldLockJob(tableStatus *cache.TableStatus, table *cache.P
 	}
 
 	// if isCreate is false, it means to take over an exist job
-	if tableStatus.CurrentJobID == "" {
+	if tableStatus == nil || tableStatus.CurrentJobID == "" {
 		return false
 	}
 
@@ -564,47 +557,47 @@ func (m *JobManager) couldLockJob(tableStatus *cache.TableStatus, table *cache.P
 	return true
 }
 
-// lockJob tries to occupy a new job in the ttl_table_status table. If it locks successfully, it will create a new
-// localJob and return it.
-func (m *JobManager) lockJob(ctx context.Context, se session.Session, table *cache.PhysicalTable, now time.Time, createJobID string, checkScheduleInterval bool) (*ttlJob, error) {
+func (m *JobManager) lockHBTimeoutJob(ctx context.Context, se session.Session, table *cache.PhysicalTable, now time.Time) (*ttlJob, error) {
+	var jobID string
+	var jobStart time.Time
 	var expireTime time.Time
-	jobID := createJobID
-	isCreate := jobID != ""
-
 	err := se.RunInTxn(ctx, func() error {
-		sql, args := cache.SelectFromTTLTableStatusWithID(table.ID)
-		// use ` FOR UPDATE NOWAIT`, then if the new job has been locked by other nodes, it will return:
-		// [tikv:3572]Statement aborted because lock(s) could not be acquired immediately and NOWAIT is set.
-		// Then this tidb node will not waste resource in calculating the ranges.
-		rows, err := se.ExecuteSQL(ctx, sql+" FOR UPDATE NOWAIT", args...)
-		if err != nil {
-			return errors.Wrapf(err, "execute sql: %s", sql)
-		}
-		if len(rows) == 0 {
-			if !isCreate {
-				return errors.New("couldn't schedule ttl job")
-			}
-
-			// cannot find the row, insert the status row
-			sql, args := insertNewTableIntoStatusSQL(table.ID, table.TableInfo.ID)
-			_, err = se.ExecuteSQL(ctx, sql, args...)
-			if err != nil {
-				return errors.Wrapf(err, "execute sql: %s", sql)
-			}
-			sql, args = cache.SelectFromTTLTableStatusWithID(table.ID)
-			rows, err = se.ExecuteSQL(ctx, sql+" FOR UPDATE NOWAIT", args...)
-			if err != nil {
-				return errors.Wrapf(err, "execute sql: %s", sql)
-			}
-			if len(rows) == 0 {
-				return errors.New("table status row still doesn't exist after insertion")
-			}
-		}
-		tableStatus, err := cache.RowToTableStatus(se, rows[0])
+		tableStatus, err := m.getTableStatusForUpdateNotWait(ctx, se, table.ID, table.TableInfo.ID, false)
 		if err != nil {
 			return err
 		}
-		if !m.couldLockJob(tableStatus, m.infoSchemaCache.Tables[tableStatus.TableID], now, isCreate, checkScheduleInterval) {
+
+		if tableStatus == nil || !m.couldLockJob(tableStatus, m.infoSchemaCache.Tables[tableStatus.TableID], now, false, false) {
+			return errors.Errorf("couldn't lock timeout TTL job for table id '%d'", table.ID)
+		}
+
+		jobID = tableStatus.CurrentJobID
+		jobStart = tableStatus.CurrentJobStartTime
+		expireTime = tableStatus.CurrentJobTTLExpire
+		sql, args := setTableStatusOwnerSQL(tableStatus.CurrentJobID, table.ID, jobStart, now, expireTime, m.id)
+		if _, err = se.ExecuteSQL(ctx, sql, args...); err != nil {
+			return errors.Wrapf(err, "execute sql: %s", sql)
+		}
+		return nil
+	}, session.TxnModePessimistic)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return m.appendLockedJob(jobID, se, jobStart, expireTime, table)
+}
+
+// lockNewJob locks a new job
+func (m *JobManager) lockNewJob(ctx context.Context, se session.Session, table *cache.PhysicalTable, now time.Time, jobID string, checkScheduleInterval bool) (*ttlJob, error) {
+	var expireTime time.Time
+	err := se.RunInTxn(ctx, func() error {
+		tableStatus, err := m.getTableStatusForUpdateNotWait(ctx, se, table.ID, table.TableInfo.ID, true)
+		if err != nil {
+			return err
+		}
+
+		if !m.couldLockJob(tableStatus, m.infoSchemaCache.Tables[tableStatus.TableID], now, true, checkScheduleInterval) {
 			return errors.New("couldn't schedule ttl job")
 		}
 
@@ -613,26 +606,10 @@ func (m *JobManager) lockJob(ctx context.Context, se session.Session, table *cac
 			return err
 		}
 
-		jobStart := now
-		jobExist := false
-		if len(tableStatus.CurrentJobID) > 0 {
-			// don't create new job if there is already one running
-			// so the running tasks don't need to be cancelled
-			jobID = tableStatus.CurrentJobID
-			expireTime = tableStatus.CurrentJobTTLExpire
-			jobStart = tableStatus.CurrentJobStartTime
-			jobExist = true
-		}
-
-		sql, args = setTableStatusOwnerSQL(jobID, table.ID, jobStart, now, expireTime, m.id)
+		sql, args := setTableStatusOwnerSQL(jobID, table.ID, now, now, expireTime, m.id)
 		_, err = se.ExecuteSQL(ctx, sql, args...)
 		if err != nil {
 			return errors.Wrapf(err, "execute sql: %s", sql)
-		}
-
-		// if the job already exist, don't need to submit scan tasks
-		if jobExist {
-			return nil
 		}
 
 		sql, args = createJobHistorySQL(jobID, table, expireTime, now)
@@ -662,8 +639,48 @@ func (m *JobManager) lockJob(ctx context.Context, se session.Session, table *cac
 		return nil, err
 	}
 
+	return m.appendLockedJob(jobID, se, now, expireTime, table)
+}
+
+func (m *JobManager) getTableStatusForUpdateNotWait(ctx context.Context, se session.Session, physicalID int64, parentTableID int64, createIfNotExist bool) (*cache.TableStatus, error) {
+	sql, args := cache.SelectFromTTLTableStatusWithID(physicalID)
+	// use ` FOR UPDATE NOWAIT`, then if the new job has been locked by other nodes, it will return:
+	// [tikv:3572]Statement aborted because lock(s) could not be acquired immediately and NOWAIT is set.
+	// Then this tidb node will not waste resource in calculating the ranges.
+	rows, err := se.ExecuteSQL(ctx, sql+" FOR UPDATE NOWAIT", args...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "execute sql: %s", sql)
+	}
+
+	if len(rows) == 0 && !createIfNotExist {
+		return nil, nil
+	}
+
+	if len(rows) == 0 {
+		// cannot find the row, insert the status row
+		sql, args = insertNewTableIntoStatusSQL(physicalID, parentTableID)
+		_, err = se.ExecuteSQL(ctx, sql, args...)
+		if err != nil {
+			return nil, errors.Wrapf(err, "execute sql: %s", sql)
+		}
+
+		sql, args = cache.SelectFromTTLTableStatusWithID(physicalID)
+		rows, err = se.ExecuteSQL(ctx, sql+" FOR UPDATE NOWAIT", args...)
+		if err != nil {
+			return nil, errors.Wrapf(err, "execute sql: %s", sql)
+		}
+
+		if len(rows) == 0 {
+			return nil, errors.New("table status row still doesn't exist after insertion")
+		}
+	}
+
+	return cache.RowToTableStatus(se, rows[0])
+}
+
+func (m *JobManager) appendLockedJob(id string, se session.Session, createTime time.Time, expireTime time.Time, table *cache.PhysicalTable) (*ttlJob, error) {
 	// successfully update the table status, will need to refresh the cache.
-	err = m.updateInfoSchemaCache(se)
+	err := m.updateInfoSchemaCache(se)
 	if err != nil {
 		return nil, err
 	}
@@ -672,22 +689,17 @@ func (m *JobManager) lockJob(ctx context.Context, se session.Session, table *cac
 		return nil, err
 	}
 
-	job := m.createNewJob(jobID, expireTime, now, table)
-
 	// job is created, notify every scan managers to fetch new tasks
-	err = m.notificationCli.Notify(m.ctx, scanTaskNotificationType, job.id)
+	err = m.notificationCli.Notify(m.ctx, scanTaskNotificationType, id)
 	if err != nil {
 		logutil.Logger(m.ctx).Warn("fail to trigger scan tasks", zap.Error(err))
 	}
-	return job, nil
-}
 
-func (m *JobManager) createNewJob(id string, expireTime time.Time, now time.Time, table *cache.PhysicalTable) *ttlJob {
-	return &ttlJob{
+	job := &ttlJob{
 		id:      id,
 		ownerID: m.id,
 
-		createTime:    now,
+		createTime:    createTime,
 		ttlExpireTime: expireTime,
 		// at least, the info schema cache and table status cache are consistent in table id, so it's safe to get table
 		// information from schema cache directly
@@ -695,6 +707,11 @@ func (m *JobManager) createNewJob(id string, expireTime time.Time, now time.Time
 
 		status: cache.JobStatusRunning,
 	}
+
+	logutil.Logger(m.ctx).Info("append new running job", zap.String("jobID", job.id), zap.Int64("tableID", job.tbl.ID))
+	m.appendJob(job)
+
+	return job, nil
 }
 
 // updateHeartBeat updates the heartbeat for all task with current instance as owner

--- a/ttl/ttlworker/job_manager_integration_test.go
+++ b/ttl/ttlworker/job_manager_integration_test.go
@@ -72,7 +72,7 @@ func TestParallelLockNewJob(t *testing.T) {
 	m.InfoSchemaCache().Tables[testTable.ID] = testTable
 
 	se := sessionFactory()
-	job, err := m.LockJob(context.Background(), se, testTable, time.Now(), true, false)
+	job, err := m.LockJob(context.Background(), se, testTable, time.Now(), uuid.NewString(), false)
 	require.NoError(t, err)
 	job.Finish(se, time.Now(), &ttlworker.TTLSummary{})
 
@@ -95,7 +95,7 @@ func TestParallelLockNewJob(t *testing.T) {
 				m.InfoSchemaCache().Tables[testTable.ID] = testTable
 
 				se := sessionFactory()
-				job, err := m.LockJob(context.Background(), se, testTable, now, true, false)
+				job, err := m.LockJob(context.Background(), se, testTable, now, uuid.NewString(), false)
 				if err == nil {
 					successCounter.Add(1)
 					successJob = job
@@ -129,7 +129,7 @@ func TestFinishJob(t *testing.T) {
 	m.InfoSchemaCache().Tables[testTable.ID] = testTable
 	se := sessionFactory()
 	startTime := time.Now()
-	job, err := m.LockJob(context.Background(), se, testTable, startTime, true, false)
+	job, err := m.LockJob(context.Background(), se, testTable, startTime, uuid.NewString(), false)
 	require.NoError(t, err)
 
 	expireTime, err := testTable.EvalExpireTime(context.Background(), se, startTime)

--- a/ttl/ttlworker/job_manager_integration_test.go
+++ b/ttl/ttlworker/job_manager_integration_test.go
@@ -72,7 +72,7 @@ func TestParallelLockNewJob(t *testing.T) {
 	m.InfoSchemaCache().Tables[testTable.ID] = testTable
 
 	se := sessionFactory()
-	job, err := m.LockNewJob(context.Background(), se, testTable, time.Now(), false)
+	job, err := m.LockJob(context.Background(), se, testTable, time.Now(), true, false)
 	require.NoError(t, err)
 	job.Finish(se, time.Now(), &ttlworker.TTLSummary{})
 
@@ -95,7 +95,7 @@ func TestParallelLockNewJob(t *testing.T) {
 				m.InfoSchemaCache().Tables[testTable.ID] = testTable
 
 				se := sessionFactory()
-				job, err := m.LockNewJob(context.Background(), se, testTable, now, false)
+				job, err := m.LockJob(context.Background(), se, testTable, now, true, false)
 				if err == nil {
 					successCounter.Add(1)
 					successJob = job
@@ -129,7 +129,7 @@ func TestFinishJob(t *testing.T) {
 	m.InfoSchemaCache().Tables[testTable.ID] = testTable
 	se := sessionFactory()
 	startTime := time.Now()
-	job, err := m.LockNewJob(context.Background(), se, testTable, startTime, false)
+	job, err := m.LockJob(context.Background(), se, testTable, startTime, true, false)
 	require.NoError(t, err)
 
 	expireTime, err := testTable.EvalExpireTime(context.Background(), se, startTime)
@@ -405,6 +405,7 @@ func TestRescheduleJobs(t *testing.T) {
 	m := ttlworker.NewJobManager("manager-1", nil, store, nil)
 	m.TaskManager().ResizeWorkersWithSysVar()
 	require.NoError(t, m.InfoSchemaCache().Update(se))
+	require.NoError(t, m.TableStatusCache().Update(context.Background(), se))
 	// schedule jobs
 	m.RescheduleJobs(se, now)
 	sql, args := cache.SelectFromTTLTableStatusWithID(table.Meta().ID)
@@ -423,6 +424,7 @@ func TestRescheduleJobs(t *testing.T) {
 	anotherManager := ttlworker.NewJobManager("manager-2", nil, store, nil)
 	anotherManager.TaskManager().ResizeWorkersWithSysVar()
 	require.NoError(t, anotherManager.InfoSchemaCache().Update(se))
+	require.NoError(t, anotherManager.TableStatusCache().Update(context.Background(), se))
 	anotherManager.RescheduleJobs(se, now.Add(time.Hour))
 	sql, args = cache.SelectFromTTLTableStatusWithID(table.Meta().ID)
 	rows, err = se.ExecuteSQL(ctx, sql, args...)
@@ -459,6 +461,7 @@ func TestJobTimeout(t *testing.T) {
 	m := ttlworker.NewJobManager("manager-1", nil, store, nil)
 	m.TaskManager().ResizeWorkersWithSysVar()
 	require.NoError(t, m.InfoSchemaCache().Update(se))
+	require.NoError(t, m.TableStatusCache().Update(context.Background(), se))
 	// schedule jobs
 	m.RescheduleJobs(se, now)
 	// set the worker to be empty, so none of the tasks will be scheduled
@@ -478,6 +481,7 @@ func TestJobTimeout(t *testing.T) {
 	m2 := ttlworker.NewJobManager("manager-2", nil, store, nil)
 	m2.TaskManager().ResizeWorkersWithSysVar()
 	require.NoError(t, m2.InfoSchemaCache().Update(se))
+	require.NoError(t, m2.TableStatusCache().Update(context.Background(), se))
 	// schedule jobs
 	now = now.Add(10 * time.Minute)
 	m2.RescheduleJobs(se, now)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45285

There are two scenes for a tidb instance to lock and execute a job:

1. A table is time to execute, a new job should be created.
2. A exist job's heartbeat is timeout, the tidb should take over it.

In the previous implement this two scenes and processed in one method and not separated. However, in the future we want to move the trigger codes to timer so it's better to separate the above code from two scenes apart.

### What is changed and how it works?

Refactor method `lockNewJob` to `lockJob` and it can pass the extra argument `isCreate`, if `isCreate` is true, it only creates a new job and if `isCreate` is false, it only takes over the timeout job.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
