### PR TITLE
planner: remove unnecessary method `StatsCache.FreshMemUsage `

### DIFF
--- a/statistics/handle/bootstrap.go
+++ b/statistics/handle/bootstrap.go
@@ -58,7 +58,7 @@ func (h *Handle) initStatsMeta4Chunk(is infoschema.InfoSchema, cache *cache.Stat
 			Version:  row.GetUint64(0),
 			Name:     getFullTableName(is, tableInfo),
 		}
-		cache.Put(physicalID, tbl)
+		cache.Put(physicalID, tbl) // put this table again since it is updated
 	}
 }
 
@@ -153,7 +153,7 @@ func (h *Handle) initStatsHistograms4ChunkLite(is infoschema.InfoSchema, cache *
 			}
 			table.Columns[hist.ID] = col
 		}
-		cache.Put(tblID, table)
+		cache.Put(tblID, table) // put this table again since it is updated
 	}
 }
 
@@ -222,7 +222,7 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache *cach
 			lastAnalyzePos.Copy(&col.LastAnalyzePos)
 			table.Columns[hist.ID] = col
 		}
-		cache.Put(tblID, table)
+		cache.Put(tblID, table) // put this table again since it is updated
 	}
 }
 
@@ -290,7 +290,7 @@ func (*Handle) initStatsTopN4Chunk(cache *cache.StatsCache, iter *chunk.Iterator
 		data := make([]byte, len(row.GetBytes(2)))
 		copy(data, row.GetBytes(2))
 		idx.TopN.AppendTopN(data, row.GetUint64(3))
-		cache.Put(table.PhysicalID, table)
+		cache.Put(table.PhysicalID, table) // put this table again since it is updated
 	}
 	for idx := range affectedIndexes {
 		idx.TopN.Sort()
@@ -343,7 +343,7 @@ func (*Handle) initStatsFMSketch4Chunk(cache *cache.StatsCache, iter *chunk.Iter
 				colStats.FMSketch = fms
 			}
 		}
-		cache.Put(table.PhysicalID, table)
+		cache.Put(table.PhysicalID, table) // put this table again since it is updated
 	}
 }
 
@@ -415,7 +415,7 @@ func (*Handle) initStatsBuckets4Chunk(cache *cache.StatsCache, iter *chunk.Itera
 			}
 		}
 		hist.AppendBucketWithNDV(&lower, &upper, row.GetInt64(3), row.GetInt64(4), row.GetInt64(7))
-		cache.Put(tableID, table)
+		cache.Put(tableID, table) // put this table again since it is updated
 	}
 }
 
@@ -453,7 +453,7 @@ func (h *Handle) initStatsBuckets(cache *cache.StatsCache) error {
 			}
 			col.PreCalculateScalar()
 		}
-		cache.Put(table.PhysicalID, table)
+		cache.Put(table.PhysicalID, table) // put this table again since it is updated
 	}
 	return nil
 }

--- a/statistics/handle/cache/statscacheinner.go
+++ b/statistics/handle/cache/statscacheinner.go
@@ -113,16 +113,6 @@ func (sc *StatsCache) Values() []*statistics.Table {
 	return sc.c.Values()
 }
 
-// FreshMemUsage refreshes the memory usage of the cache.
-// Values in StatsCache should be read-only, but when initializing the cache, some values can be modified.
-// To make the memory cost more accurate, we need to refresh the memory usage of the cache after finishing the initialization.
-func (sc *StatsCache) FreshMemUsage() {
-	values := sc.c.Values()
-	for _, v := range values {
-		sc.c.Put(v.PhysicalID, v)
-	}
-}
-
 // Cost returns the memory usage of the cache.
 func (sc *StatsCache) Cost() int64 {
 	return sc.c.Cost()

--- a/statistics/handle/handletest/statstest/BUILD.bazel
+++ b/statistics/handle/handletest/statstest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//config",
         "//parser/model",

--- a/statistics/handle/handletest/statstest/stats_test.go
+++ b/statistics/handle/handletest/statstest/stats_test.go
@@ -15,6 +15,7 @@
 package statstest
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -155,6 +156,34 @@ func TestStatsStoreAndLoad(t *testing.T) {
 	require.False(t, statsTbl2.Pseudo)
 	require.Equal(t, int64(recordCount), statsTbl2.RealtimeCount)
 	internal.AssertTableEqual(t, statsTbl1, statsTbl2)
+}
+
+func TestInitStatsMemTrace(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (a int, b int, c int, primary key(a), key idx(b))")
+	tk.MustExec("insert into t1 values (1,1,1),(2,2,2),(3,3,3),(4,4,4),(5,5,5),(6,7,8)")
+	tk.MustExec("analyze table t1")
+	for i := 2; i < 10; i++ {
+		tk.MustExec(fmt.Sprintf("create table t%v (a int, b int, c int, primary key(a), key idx(b))", i))
+		tk.MustExec(fmt.Sprintf("insert into t%v select * from t1", i))
+		tk.MustExec(fmt.Sprintf("analyze table t%v", i))
+	}
+	h := dom.StatsHandle()
+	is := dom.InfoSchema()
+	h.Clear()
+	require.NoError(t, h.InitStats(is))
+
+	var memCostTot int64
+	for i := 1; i <10; i++ {
+		tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr(fmt.Sprintf("t%v", i)))
+		require.NoError(t, err)
+		tStats := h.GetTableStats(tbl.Meta())
+		memCostTot += tStats.MemoryUsage().TotalMemUsage
+	}
+
+	require.Equal(t, h.GetMemConsumed(), memCostTot)
 }
 
 func TestInitStats(t *testing.T) {

--- a/statistics/handle/handletest/statstest/stats_test.go
+++ b/statistics/handle/handletest/statstest/stats_test.go
@@ -158,7 +158,7 @@ func TestStatsStoreAndLoad(t *testing.T) {
 	internal.AssertTableEqual(t, statsTbl1, statsTbl2)
 }
 
-func TestInitStatsMemTrace(t *testing.T) {
+func testInitStatsMemTrace(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -176,7 +176,7 @@ func TestInitStatsMemTrace(t *testing.T) {
 	require.NoError(t, h.InitStats(is))
 
 	var memCostTot int64
-	for i := 1; i <10; i++ {
+	for i := 1; i < 10; i++ {
 		tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr(fmt.Sprintf("t%v", i)))
 		require.NoError(t, err)
 		tStats := h.GetTableStats(tbl.Meta())
@@ -184,6 +184,17 @@ func TestInitStatsMemTrace(t *testing.T) {
 	}
 
 	require.Equal(t, h.GetMemConsumed(), memCostTot)
+}
+
+func TestInitStatsMemTrace(t *testing.T) {
+	originValue := config.GetGlobalConfig().Performance.LiteInitStats
+	defer func() {
+		config.GetGlobalConfig().Performance.LiteInitStats = originValue
+	}()
+	for _, v := range []bool{false, true} {
+		config.GetGlobalConfig().Performance.LiteInitStats = v
+		testInitStatsMemTrace(t)
+	}
 }
 
 func TestInitStats(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #44461

Problem Summary: planner: remove unnecessary method `StatsCache.FreshMemUsage `

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
