### PR TITLE
statcache: faster LFU

### DIFF
--- a/statistics/handle/cache/internal/BUILD.bazel
+++ b/statistics/handle/cache/internal/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     flaky = True,
     deps = [
         ":internal",
+        "//statistics/handle/cache/internal/lfu",
         "//statistics/handle/cache/internal/lru",
         "//statistics/handle/cache/internal/mapcache",
         "//statistics/handle/cache/internal/testutil",

--- a/statistics/handle/cache/internal/bench_test.go
+++ b/statistics/handle/cache/internal/bench_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/statistics/handle/cache/internal"
+	"github.com/pingcap/tidb/statistics/handle/cache/internal/lfu"
 	"github.com/pingcap/tidb/statistics/handle/cache/internal/lru"
 	"github.com/pingcap/tidb/statistics/handle/cache/internal/mapcache"
 	"github.com/pingcap/tidb/statistics/handle/cache/internal/testutil"
@@ -41,6 +42,13 @@ var cases = []struct {
 		name: "mapcache",
 		newFunc: func() internal.StatsCacheInner {
 			return mapcache.NewMapCache()
+		},
+	},
+	{
+		name: "LFU",
+		newFunc: func() internal.StatsCacheInner {
+			result, _ := lfu.NewLFU(defaultSize)
+			return result
 		},
 	},
 }

--- a/statistics/handle/cache/internal/lfu/BUILD.bazel
+++ b/statistics/handle/cache/internal/lfu/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "lfu",
+    srcs = [
+        "key_set.go",
+        "key_set_shard.go",
+        "lfu_cache.go",
+    ],
+    importpath = "github.com/pingcap/tidb/statistics/handle/cache/internal/lfu",
+    visibility = ["//statistics/handle/cache:__subpackages__"],
+    deps = [
+        "//statistics",
+        "//statistics/handle/cache/internal",
+        "//util/intest",
+        "@com_github_dgraph_io_ristretto//:ristretto",
+        "@org_golang_x_exp//maps",
+    ],
+)
+
+go_test(
+    name = "lfu_test",
+    timeout = "short",
+    srcs = ["lfu_cache_test.go"],
+    embed = [":lfu"],
+    flaky = True,
+    race = "on",
+    shard_count = 6,
+    deps = [
+        "//statistics/handle/cache/internal/testutil",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/statistics/handle/cache/internal/lfu/key_set.go
+++ b/statistics/handle/cache/internal/lfu/key_set.go
@@ -1,0 +1,52 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lfu
+
+import (
+	"sync"
+
+	"golang.org/x/exp/maps"
+)
+
+type keySet struct {
+	set map[int64]struct{}
+	mu  sync.RWMutex
+}
+
+func (ks *keySet) Add(key int64) {
+	ks.mu.Lock()
+	ks.set[key] = struct{}{}
+	ks.mu.Unlock()
+}
+
+func (ks *keySet) Remove(key int64) {
+	ks.mu.Lock()
+	delete(ks.set, key)
+	ks.mu.Unlock()
+}
+
+func (ks *keySet) Keys() []int64 {
+	ks.mu.RLock()
+	result := maps.Keys(ks.set)
+	ks.mu.RUnlock()
+	return result
+}
+
+func (ks *keySet) Len() int {
+	ks.mu.RLock()
+	result := len(ks.set)
+	ks.mu.RUnlock()
+	return result
+}

--- a/statistics/handle/cache/internal/lfu/key_set_shard.go
+++ b/statistics/handle/cache/internal/lfu/key_set_shard.go
@@ -1,0 +1,55 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lfu
+
+const keySetCnt = 128
+
+type keySetShard struct {
+	resultKeySet [keySetCnt]keySet
+}
+
+func newKeySetShard() *keySetShard {
+	result := keySetShard{}
+	for i := 0; i < keySetCnt; i++ {
+		result.resultKeySet[i] = keySet{
+			set: make(map[int64]struct{}),
+		}
+	}
+	return &result
+}
+
+func (kss *keySetShard) Add(key int64) {
+	kss.resultKeySet[key%keySetCnt].Add(key)
+}
+
+func (kss *keySetShard) Remove(key int64) {
+	kss.resultKeySet[key%keySetCnt].Remove(key)
+}
+
+func (kss *keySetShard) Keys() []int64 {
+	result := make([]int64, 0, len(kss.resultKeySet))
+	for idx := range kss.resultKeySet {
+		result = append(result, kss.resultKeySet[idx].Keys()...)
+	}
+	return result
+}
+
+func (kss *keySetShard) Len() int {
+	result := 0
+	for idx := range kss.resultKeySet {
+		result += kss.resultKeySet[idx].Len()
+	}
+	return result
+}

--- a/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -1,0 +1,132 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lfu
+
+import (
+	"sync/atomic"
+
+	"github.com/dgraph-io/ristretto"
+	"github.com/pingcap/tidb/statistics"
+	"github.com/pingcap/tidb/statistics/handle/cache/internal"
+	"github.com/pingcap/tidb/util/intest"
+)
+
+// LFU is a LFU based on the ristretto.Cache
+type LFU struct {
+	cache        *ristretto.Cache
+	resultKeySet *keySetShard
+	cost         atomic.Int64
+}
+
+// NewLFU creates a new LFU cache.
+func NewLFU(totalMemCost int64) (*LFU, error) {
+	result := &LFU{}
+	bufferItems := int64(64)
+	if intest.InTest {
+		bufferItems = 1
+	}
+	cache, err := ristretto.NewCache(&ristretto.Config{
+		NumCounters:        1024 * 1024 * 1024, // TODO(hawkingrei): make it configurable for NumCounters and MaxCost
+		MaxCost:            totalMemCost,
+		BufferItems:        bufferItems,
+		OnEvict:            result.onEvict,
+		OnExit:             result.onExit,
+		IgnoreInternalCost: intest.InTest,
+		Metrics:            intest.InTest,
+	})
+	result.cache = cache
+	result.resultKeySet = newKeySetShard()
+	return result, err
+}
+
+// Get implements statsCacheInner
+func (s *LFU) Get(tid int64, _ bool) (*statistics.Table, bool) {
+	result, ok := s.cache.Get(tid)
+	if !ok {
+		return nil, ok
+	}
+	return result.(*statistics.Table), ok
+}
+
+// Put implements statsCacheInner
+func (s *LFU) Put(tblID int64, tbl *statistics.Table, _ bool) {
+	ok := s.cache.Set(tblID, tbl, tbl.MemoryUsage().TotalTrackingMemUsage())
+	if ok { // NOTE: `s.cache` and `s.resultKeySet` may be inconsistent since the update operation is not atomic, but it's acceptable for our scenario
+		s.resultKeySet.Add(tblID)
+		s.cost.Add(tbl.MemoryUsage().TotalTrackingMemUsage())
+	}
+}
+
+// Del implements statsCacheInner
+func (s *LFU) Del(tblID int64) {
+	s.cache.Del(tblID)
+	s.resultKeySet.Remove(tblID)
+}
+
+// Cost implements statsCacheInner
+func (s *LFU) Cost() int64 {
+	return s.cost.Load()
+}
+
+// Values implements statsCacheInner
+func (s *LFU) Values() []*statistics.Table {
+	result := make([]*statistics.Table, 0, 512)
+	for _, k := range s.resultKeySet.Keys() {
+		if value, ok := s.cache.Get(k); ok {
+			result = append(result, value.(*statistics.Table))
+		}
+	}
+	return nil
+}
+
+func (s *LFU) onEvict(item *ristretto.Item) {
+	// We do not need to calculate the cost during onEvict, because the onexit function
+	// is also called when the evict event occurs.
+	s.resultKeySet.Remove(int64(item.Key))
+}
+
+func (s *LFU) onExit(val interface{}) {
+	s.cost.Add(-1 * val.(*statistics.Table).MemoryUsage().TotalTrackingMemUsage())
+}
+
+// Len implements statsCacheInner
+func (s *LFU) Len() int {
+	return s.resultKeySet.Len()
+}
+
+// Front implements statsCacheInner
+func (*LFU) Front() int64 {
+	return 0
+}
+
+// Copy implements statsCacheInner
+func (s *LFU) Copy() internal.StatsCacheInner {
+	return s
+}
+
+// SetCapacity implements statsCacheInner
+func (s *LFU) SetCapacity(maxCost int64) {
+	s.cache.UpdateMaxCost(maxCost)
+}
+
+// wait blocks until all buffered writes have been applied. This ensures a call to Set()
+// will be visible to future calls to Get(). it is only used for test.
+func (s *LFU) wait() {
+	s.cache.Wait()
+}
+
+func (s *LFU) metrics() *ristretto.Metrics {
+	return s.cache.Metrics
+}

--- a/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -88,7 +88,7 @@ func (s *LFU) Values() []*statistics.Table {
 			result = append(result, value.(*statistics.Table))
 		}
 	}
-	return nil
+	return result
 }
 
 func (s *LFU) onEvict(item *ristretto.Item) {

--- a/statistics/handle/cache/internal/lfu/lfu_cache_test.go
+++ b/statistics/handle/cache/internal/lfu/lfu_cache_test.go
@@ -42,6 +42,7 @@ func TestLFUPutGetDel(t *testing.T) {
 	require.Nil(t, v)
 	lfu.wait()
 	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
+	require.Equal(t, 0, len(lfu.Values()))
 }
 
 func TestLFUFreshMemUsage(t *testing.T) {
@@ -158,4 +159,5 @@ func TestLFUCachePutGetWithManyConcurrency2(t *testing.T) {
 	wg.Wait()
 	lfu.wait()
 	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
+	require.Equal(t, 1000, len(lfu.Values()))
 }

--- a/statistics/handle/cache/internal/lfu/lfu_cache_test.go
+++ b/statistics/handle/cache/internal/lfu/lfu_cache_test.go
@@ -1,0 +1,161 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lfu
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pingcap/tidb/statistics/handle/cache/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	mockCMSMemoryUsage  = int64(4)
+	mockTopNMemoryUsage = int64(64)
+	mockHistMemoryUsage = int64(289)
+)
+
+func TestLFUPutGetDel(t *testing.T) {
+	capacity := int64(100)
+	lfu, err := NewLFU(capacity)
+	require.NoError(t, err)
+	mockTable := testutil.NewMockStatisticsTable(1, 1, true, false, false)
+	mockTableID := int64(1)
+	lfu.Put(mockTableID, mockTable, false)
+	lfu.wait()
+	lfu.Del(mockTableID)
+	v, ok := lfu.Get(mockTableID, false)
+	require.False(t, ok)
+	require.Nil(t, v)
+	lfu.wait()
+	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
+}
+
+func TestLFUFreshMemUsage(t *testing.T) {
+	lfu, err := NewLFU(1000)
+	require.NoError(t, err)
+	t1 := testutil.NewMockStatisticsTable(1, 1, true, false, false)
+	t2 := testutil.NewMockStatisticsTable(2, 2, true, false, false)
+	t3 := testutil.NewMockStatisticsTable(3, 3, true, false, false)
+	lfu.Put(int64(1), t1, false)
+	lfu.Put(int64(2), t2, false)
+	lfu.Put(int64(3), t3, false)
+	require.Equal(t, lfu.Cost(), 6*mockCMSMemoryUsage+6*mockCMSMemoryUsage)
+	t4 := testutil.NewMockStatisticsTable(2, 1, true, false, false)
+	lfu.Put(int64(1), t4, false)
+	require.Equal(t, lfu.Cost(), 6*mockCMSMemoryUsage+7*mockCMSMemoryUsage)
+	t5 := testutil.NewMockStatisticsTable(2, 2, true, false, false)
+	lfu.Put(int64(1), t5, false)
+	require.Equal(t, lfu.Cost(), 7*mockCMSMemoryUsage+7*mockCMSMemoryUsage)
+
+	t6 := testutil.NewMockStatisticsTable(1, 2, true, false, false)
+	lfu.Put(int64(1), t6, false)
+	require.Equal(t, lfu.Cost(), 7*mockCMSMemoryUsage+6*mockCMSMemoryUsage)
+
+	t7 := testutil.NewMockStatisticsTable(1, 1, true, false, false)
+	lfu.Put(int64(1), t7, false)
+	require.Equal(t, lfu.Cost(), 6*mockCMSMemoryUsage+6*mockCMSMemoryUsage)
+	lfu.wait()
+	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
+}
+
+func TestLFUPutTooBig(t *testing.T) {
+	lfu, err := NewLFU(1)
+	require.NoError(t, err)
+	mockTable := testutil.NewMockStatisticsTable(1, 1, true, false, false)
+	// put mockTable, the index should be evicted
+	lfu.Put(int64(1), mockTable, false)
+	_, ok := lfu.Get(int64(1), false)
+	require.False(t, ok)
+	lfu.wait()
+	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
+}
+
+func TestCacheLen(t *testing.T) {
+	capacity := int64(12)
+	lfu, err := NewLFU(capacity)
+	require.NoError(t, err)
+	t1 := testutil.NewMockStatisticsTable(2, 1, true, false, false)
+	require.Equal(t, int64(12), t1.MemoryUsage().TotalTrackingMemUsage())
+	lfu.Put(int64(1), t1, false)
+	t2 := testutil.NewMockStatisticsTable(1, 1, true, false, false)
+	// put t2, t1 should be evicted 2 items and still exists in the list
+	lfu.Put(int64(2), t2, false)
+	lfu.wait()
+	require.Equal(t, lfu.Len(), 1)
+	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
+
+	// put t3, t1/t2 should be evicted all items and disappeared from the list
+	t3 := testutil.NewMockStatisticsTable(2, 1, true, false, false)
+	lfu.Put(int64(3), t3, false)
+	lfu.wait()
+	require.Equal(t, lfu.Len(), 1)
+	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
+}
+
+func TestLFUCachePutGetWithManyConcurrency(t *testing.T) {
+	// to test DATA RACE
+	capacity := int64(12)
+	lfu, err := NewLFU(capacity)
+	require.NoError(t, err)
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			t1 := testutil.NewMockStatisticsTable(1, 1, true, false, false)
+			lfu.Put(int64(i), t1, true)
+		}(i)
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			lfu.Get(int64(i), true)
+		}(i)
+	}
+	wg.Wait()
+	lfu.wait()
+	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
+}
+
+func TestLFUCachePutGetWithManyConcurrency2(t *testing.T) {
+	// to test DATA RACE
+	capacity := int64(12)
+	lfu, err := NewLFU(capacity)
+	require.NoError(t, err)
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				t1 := testutil.NewMockStatisticsTable(1, 1, true, false, false)
+				lfu.Put(int64(i), t1, true)
+			}
+		}()
+	}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				lfu.Get(int64(i), true)
+			}
+		}()
+	}
+	wg.Wait()
+	lfu.wait()
+	require.Equal(t, uint64(lfu.Cost()), lfu.metrics().CostAdded()-lfu.metrics().CostEvicted())
+}

--- a/statistics/handle/cache/internal/lru/BUILD.bazel
+++ b/statistics/handle/cache/internal/lru/BUILD.bazel
@@ -4,7 +4,7 @@ go_library(
     name = "lru",
     srcs = ["lru_cache.go"],
     importpath = "github.com/pingcap/tidb/statistics/handle/cache/internal/lru",
-    visibility = ["//statistics/handle:__subpackages__"],
+    visibility = ["//statistics/handle/cache:__subpackages__"],
     deps = [
         "//statistics",
         "//statistics/handle/cache/internal",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #45367

Problem Summary:

### What is changed and how it works?

```
BenchmarkCachePut
BenchmarkCachePut/LRU
BenchmarkCachePut/LRU-8         	   35224	     65941 ns/op
BenchmarkCachePut/LFU
BenchmarkCachePut/LFU-8         	  143685	     10771 ns/op

BenchmarkCachePutGet/LRU
BenchmarkCachePutGet/LRU-8         	   30358	     40205 ns/op
BenchmarkCachePutGet/LFU
BenchmarkCachePutGet/LFU-8         	   85431	     14172 ns/op
```
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

add benchmark

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
