### PR TITLE
coprocessor: fix the evict metrics for copr cache

### DIFF
--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -1125,9 +1125,6 @@ func (worker *copIteratorWorker) handleTask(ctx context.Context, task *copTask, 
 			remainTasks = remainTasks[1:]
 		}
 	}
-	if worker.store.coprCache != nil && worker.store.coprCache.cache.Metrics != nil {
-		copr_metrics.CoprCacheCounterEvict.Add(float64(worker.store.coprCache.cache.Metrics.KeysEvicted()))
-	}
 }
 
 // handleTaskOnce handles single copTask, successful results are send to channel.

--- a/store/copr/coprocessor_cache.go
+++ b/store/copr/coprocessor_cache.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
+	copr_metrics "github.com/pingcap/tidb/store/copr/metrics"
 	"github.com/tikv/client-go/v2/config"
 )
 
@@ -81,6 +82,9 @@ func newCoprCache(config *config.CoprocessorCache) (*coprCache, error) {
 		NumCounters: estimatedEntities * 10,
 		MaxCost:     capacityInBytes,
 		BufferItems: 64,
+		OnEvict: func(_ *ristretto.Item) {
+			copr_metrics.CoprCacheCounterEvict.Add(1)
+		},
 	})
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45398

Problem Summary:

### What is changed and how it works?

https://pkg.go.dev/github.com/dgraph-io/ristretto?utm_source=godoc#Config

we know from the document of ristretto. ristretto's metric is disabled at default. so we are never able to read value from it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
coprocessor: fix the evict metrics for copr cache
```
