### PR TITLE
import into: enlarge subtask size to reduce range overlap

### DIFF
--- a/executor/importer/BUILD.bazel
+++ b/executor/importer/BUILD.bazel
@@ -82,7 +82,7 @@ go_test(
     embed = [":importer"],
     flaky = True,
     race = "on",
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//br/pkg/errors",
         "//br/pkg/lightning/config",

--- a/executor/importer/import.go
+++ b/executor/importer/import.go
@@ -91,7 +91,8 @@ const (
 	recordErrorsOption          = "record_errors"
 	detachedOption              = "detached"
 	disableTiKVImportModeOption = "disable_tikv_import_mode"
-	maxEngineSizeOption         = "__max_engine_size"
+	// used for test
+	maxEngineSizeOption = "__max_engine_size"
 )
 
 var (

--- a/executor/importer/import.go
+++ b/executor/importer/import.go
@@ -91,6 +91,7 @@ const (
 	recordErrorsOption          = "record_errors"
 	detachedOption              = "detached"
 	disableTiKVImportModeOption = "disable_tikv_import_mode"
+	maxEngineSizeOption         = "__max_engine_size"
 )
 
 var (
@@ -111,6 +112,7 @@ var (
 		recordErrorsOption:          true,
 		detachedOption:              false,
 		disableTiKVImportModeOption: false,
+		maxEngineSizeOption:         true,
 	}
 
 	csvOnlyOptions = map[string]struct{}{
@@ -183,6 +185,7 @@ type Plan struct {
 	MaxRecordedErrors     int64
 	Detached              bool
 	DisableTiKVImportMode bool
+	MaxEngineSize         config.ByteSize
 
 	// used for checksum in physical mode
 	DistSQLScanConcurrency int
@@ -473,6 +476,7 @@ func (p *Plan) initDefaultOptions() {
 	p.MaxRecordedErrors = 100
 	p.Detached = false
 	p.DisableTiKVImportMode = false
+	p.MaxEngineSize = config.ByteSize(defaultMaxEngineSize)
 
 	v := "utf8mb4"
 	p.Charset = &v
@@ -629,6 +633,15 @@ func (p *Plan) initOptions(seCtx sessionctx.Context, options []*plannercore.Load
 	}
 	if _, ok := specifiedOptions[disableTiKVImportModeOption]; ok {
 		p.DisableTiKVImportMode = true
+	}
+	if opt, ok := specifiedOptions[maxEngineSizeOption]; ok {
+		v, err := optAsString(opt)
+		if err != nil {
+			return exeerrors.ErrInvalidOptionVal.FastGenByArgs(opt.Name)
+		}
+		if err = p.MaxEngineSize.UnmarshalText([]byte(v)); err != nil || p.MaxEngineSize < 0 {
+			return exeerrors.ErrInvalidOptionVal.FastGenByArgs(opt.Name)
+		}
 	}
 
 	p.adjustOptions()

--- a/executor/importer/import_test.go
+++ b/executor/importer/import_test.go
@@ -45,6 +45,7 @@ func TestInitDefaultOptions(t *testing.T) {
 	require.Equal(t, false, plan.Detached)
 	require.Equal(t, "utf8mb4", *plan.Charset)
 	require.Equal(t, false, plan.DisableTiKVImportMode)
+	require.Equal(t, config.ByteSize(defaultMaxEngineSize), plan.MaxEngineSize)
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/importer/mockNumCpu", "return(10)"))
 	plan.initDefaultOptions()
@@ -87,7 +88,8 @@ func TestInitOptionsPositiveCase(t *testing.T) {
 		splitFileOption+", "+
 		recordErrorsOption+"=123, "+
 		detachedOption+", "+
-		disableTiKVImportModeOption,
+		disableTiKVImportModeOption+", "+
+		maxEngineSizeOption+"='100gib'",
 	)
 	stmt, err := p.ParseOneStmt(sql, "", "")
 	require.NoError(t, err, sql)
@@ -108,6 +110,7 @@ func TestInitOptionsPositiveCase(t *testing.T) {
 	require.Equal(t, int64(123), plan.MaxRecordedErrors, sql)
 	require.True(t, plan.Detached, sql)
 	require.True(t, plan.DisableTiKVImportMode, sql)
+	require.Equal(t, config.ByteSize(100<<30), plan.MaxEngineSize, sql)
 }
 
 func TestAdjustOptions(t *testing.T) {

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -290,14 +290,13 @@ func (e *LoadDataController) PopulateChunks(ctx context.Context) (ecp map[int32]
 		DataFiles: e.toMyDumpFiles(),
 	}
 	dataDivideCfg := &mydump.DataDivideConfig{
-		ColumnCnt:         len(e.Table.Meta().Columns),
-		EngineDataSize:    int64(e.MaxEngineSize),
-		MaxChunkSize:      int64(config.MaxRegionSize),
-		Concurrency:       int(e.ThreadCnt),
-		EngineConcurrency: config.DefaultTableConcurrency,
-		IOWorkers:         nil,
-		Store:             e.dataStore,
-		TableMeta:         tableMeta,
+		ColumnCnt:      len(e.Table.Meta().Columns),
+		EngineDataSize: int64(e.MaxEngineSize),
+		MaxChunkSize:   int64(config.MaxRegionSize),
+		Concurrency:    int(e.ThreadCnt),
+		IOWorkers:      nil,
+		Store:          e.dataStore,
+		TableMeta:      tableMeta,
 	}
 	tableRegions, err2 := mydump.MakeTableRegions(ctx, dataDivideCfg)
 

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -55,6 +55,12 @@ var (
 	// CheckDiskQuotaInterval is the default time interval to check disk quota.
 	// TODO: make it dynamically adjusting according to the speed of import and the disk size.
 	CheckDiskQuotaInterval = 10 * time.Second
+
+	// defaultMaxRegionSize is the default max region size in bytes.
+	// we make it 5 times larger than lightning default engine size to reduce region overlap, especially for index,
+	// since we have an index engine per distributed subtask.
+	// TODO: might not be the best value.
+	defaultMaxRegionSize = int64(5 * config.MaxRegionSize)
 )
 
 // prepareSortDir creates a new directory for import, remove previous sort directory if exists.
@@ -285,7 +291,7 @@ func (e *LoadDataController) PopulateChunks(ctx context.Context) (ecp map[int32]
 	}
 	dataDivideCfg := &mydump.DataDivideConfig{
 		ColumnCnt:         len(e.Table.Meta().Columns),
-		EngineDataSize:    int64(config.DefaultBatchSize),
+		EngineDataSize:    defaultMaxRegionSize,
 		MaxChunkSize:      int64(config.MaxRegionSize),
 		Concurrency:       int(e.ThreadCnt),
 		EngineConcurrency: config.DefaultTableConcurrency,

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -60,7 +60,12 @@ var (
 	// defaultMaxEngineSize is the default max engine size in bytes.
 	// we make it 5 times larger than lightning default engine size to reduce range overlap, especially for index,
 	// since we have an index engine per distributed subtask.
-	// TODO: might not be the best value.
+	// for 1TiB data, we can divide it into 2 engines that runs on 2 TiDB. it can have a good balance between
+	// range overlap and sort speed in one of our test of:
+	// 	- 10 columns, PK + 6 secondary index 2 of which is mv index
+	//	- 1.05 KiB per row, 527 MiB per file, 1024000000 rows, 1 TiB total
+	//
+	// it might not be the optimal value for other cases.
 	defaultMaxEngineSize = int64(5 * config.DefaultBatchSize)
 )
 

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -56,8 +57,8 @@ var (
 	// TODO: make it dynamically adjusting according to the speed of import and the disk size.
 	CheckDiskQuotaInterval = 10 * time.Second
 
-	// defaultMaxEngineSize is the default max region size in bytes.
-	// we make it 5 times larger than lightning default engine size to reduce region overlap, especially for index,
+	// defaultMaxEngineSize is the default max engine size in bytes.
+	// we make it 5 times larger than lightning default engine size to reduce range overlap, especially for index,
 	// since we have an index engine per distributed subtask.
 	// TODO: might not be the best value.
 	defaultMaxEngineSize = int64(5 * config.DefaultBatchSize)
@@ -275,6 +276,31 @@ func (ti *TableImporter) getKVEncoder(chunk *checkpoints.ChunkCheckpoint) (kvEnc
 	return newTableKVEncoder(cfg, ti)
 }
 
+func (e *LoadDataController) getAdjustedMaxEngineSize() int64 {
+	// we want to split data files into subtask of size close to MaxEngineSize to reduce range overlap,
+	// and evenly distribute them to subtasks.
+	// so we adjust MaxEngineSize to make sure each subtask has a similar amount of data to import.
+	// we calculate subtask count first by round(TotalFileSize) / maxEngineSize), then adjust maxEngineSize
+	//
+	// AllocateEngineIDs is using ceil() to calculate subtask count, engine size might be too small in some case,
+	// such as 501G data, maxEngineSize will be about 250G, so we don't relay on it.
+	// see https://github.com/pingcap/tidb/blob/b4183e1dc9bb01fb81d3aa79ca4b5b74387c6c2a/br/pkg/lightning/mydump/region.go#L109
+	//
+	// for default e.MaxEngineSize = 500GiB, we have:
+	// data size range(G)   cnt    adjusted-engine-size range(G)
+	// [0, 750)               1    [0, 750)
+	// [750, 1250)            2    [375, 625)
+	// [1250, 1750)           3    [416, 583)
+	// [1750, 2250)           4    [437, 562)
+	maxEngineSize := int64(e.MaxEngineSize)
+	if e.TotalFileSize <= maxEngineSize {
+		return e.TotalFileSize
+	}
+	subtaskCount := math.Round(float64(e.TotalFileSize) / float64(maxEngineSize))
+	adjusted := math.Ceil(float64(e.TotalFileSize) / subtaskCount)
+	return int64(adjusted)
+}
+
 // PopulateChunks populates chunks from table regions.
 // in dist framework, this should be done in the tidb node which is responsible for splitting job into subtasks
 // then table-importer handles data belongs to the subtask.
@@ -289,9 +315,12 @@ func (e *LoadDataController) PopulateChunks(ctx context.Context) (ecp map[int32]
 		Name:      e.Table.Meta().Name.O,
 		DataFiles: e.toMyDumpFiles(),
 	}
+	adjustedMaxEngineSize := e.getAdjustedMaxEngineSize()
+	e.logger.Info("adjust max engine size", zap.Int64("before", int64(e.MaxEngineSize)),
+		zap.Int64("after", adjustedMaxEngineSize))
 	dataDivideCfg := &mydump.DataDivideConfig{
 		ColumnCnt:      len(e.Table.Meta().Columns),
-		EngineDataSize: int64(e.MaxEngineSize),
+		EngineDataSize: adjustedMaxEngineSize,
 		MaxChunkSize:   int64(config.MaxRegionSize),
 		Concurrency:    int(e.ThreadCnt),
 		IOWorkers:      nil,

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -285,7 +285,7 @@ func (e *LoadDataController) getAdjustedMaxEngineSize() int64 {
 	// we want to split data files into subtask of size close to MaxEngineSize to reduce range overlap,
 	// and evenly distribute them to subtasks.
 	// so we adjust MaxEngineSize to make sure each subtask has a similar amount of data to import.
-	// we calculate subtask count first by round(TotalFileSize) / maxEngineSize), then adjust maxEngineSize
+	// we calculate subtask count first by round(TotalFileSize / maxEngineSize), then adjust maxEngineSize
 	//
 	// AllocateEngineIDs is using ceil() to calculate subtask count, engine size might be too small in some case,
 	// such as 501G data, maxEngineSize will be about 250G, so we don't relay on it.

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -291,7 +291,7 @@ func (e *LoadDataController) PopulateChunks(ctx context.Context) (ecp map[int32]
 	}
 	dataDivideCfg := &mydump.DataDivideConfig{
 		ColumnCnt:         len(e.Table.Meta().Columns),
-		EngineDataSize:    defaultMaxEngineSize,
+		EngineDataSize:    int64(e.MaxEngineSize),
 		MaxChunkSize:      int64(config.MaxRegionSize),
 		Concurrency:       int(e.ThreadCnt),
 		EngineConcurrency: config.DefaultTableConcurrency,

--- a/executor/importer/table_import.go
+++ b/executor/importer/table_import.go
@@ -56,11 +56,11 @@ var (
 	// TODO: make it dynamically adjusting according to the speed of import and the disk size.
 	CheckDiskQuotaInterval = 10 * time.Second
 
-	// defaultMaxRegionSize is the default max region size in bytes.
+	// defaultMaxEngineSize is the default max region size in bytes.
 	// we make it 5 times larger than lightning default engine size to reduce region overlap, especially for index,
 	// since we have an index engine per distributed subtask.
 	// TODO: might not be the best value.
-	defaultMaxRegionSize = int64(5 * config.MaxRegionSize)
+	defaultMaxEngineSize = int64(5 * config.DefaultBatchSize)
 )
 
 // prepareSortDir creates a new directory for import, remove previous sort directory if exists.
@@ -291,7 +291,7 @@ func (e *LoadDataController) PopulateChunks(ctx context.Context) (ecp map[int32]
 	}
 	dataDivideCfg := &mydump.DataDivideConfig{
 		ColumnCnt:         len(e.Table.Meta().Columns),
-		EngineDataSize:    defaultMaxRegionSize,
+		EngineDataSize:    defaultMaxEngineSize,
 		MaxChunkSize:      int64(config.MaxRegionSize),
 		Concurrency:       int(e.ThreadCnt),
 		EngineConcurrency: config.DefaultTableConcurrency,

--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/lightning/backend/local"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
-	"github.com/pingcap/tidb/br/pkg/lightning/config"
 	"github.com/pingcap/tidb/br/pkg/mock"
 	"github.com/pingcap/tidb/br/pkg/mock/mocklocal"
 	"github.com/pingcap/tidb/br/pkg/utils"
@@ -749,18 +748,11 @@ func (s *mockGCSSuite) TestChecksumNotMatch() {
 6,test6,66`),
 	})
 
-	// populate into 2 engines
-	backup := config.DefaultBatchSize
-	config.DefaultBatchSize = 1
-	s.T().Cleanup(func() {
-		config.DefaultBatchSize = backup
-	})
-
 	s.prepareAndUseDB("load_data")
 	s.tk.MustExec("drop table if exists t;")
 	s.tk.MustExec("create table t (a bigint primary key, b varchar(100), c int);")
 	loadDataSQL := fmt.Sprintf(`IMPORT INTO t FROM 'gs://test-multi-load/duplicate-pk-*.csv?endpoint=%s'
-		with thread=1`, gcsEndpoint)
+		with thread=1, __max_engine_size=1`, gcsEndpoint)
 	err := s.tk.QueryToErr(loadDataSQL)
 	require.ErrorContains(s.T(), err, "ErrChecksumMismatch")
 	s.tk.MustQuery("SELECT * FROM t;").Sort().Check(testkit.Rows([]string{
@@ -769,7 +761,7 @@ func (s *mockGCSSuite) TestChecksumNotMatch() {
 
 	s.tk.MustExec("truncate table t;")
 	loadDataSQL = fmt.Sprintf(`IMPORT INTO t FROM 'gs://test-multi-load/duplicate-pk-*.csv?endpoint=%s'
-		with thread=1, checksum_table='off'`, gcsEndpoint)
+		with thread=1, checksum_table='off', __max_engine_size=1`, gcsEndpoint)
 	s.tk.MustQuery(loadDataSQL)
 	s.tk.MustQuery("SELECT * FROM t;").Sort().Check(testkit.Rows([]string{
 		"1 test1 11", "2 test2 22", "4 test4 44", "6 test6 66",
@@ -777,7 +769,7 @@ func (s *mockGCSSuite) TestChecksumNotMatch() {
 
 	s.tk.MustExec("truncate table t;")
 	loadDataSQL = fmt.Sprintf(`IMPORT INTO t FROM 'gs://test-multi-load/duplicate-pk-*.csv?endpoint=%s'
-		with thread=1, checksum_table='optional'`, gcsEndpoint)
+		with thread=1, checksum_table='optional', __max_engine_size=1`, gcsEndpoint)
 	s.tk.MustQuery(loadDataSQL)
 	s.tk.MustQuery("SELECT * FROM t;").Sort().Check(testkit.Rows([]string{
 		"1 test1 11", "2 test2 22", "4 test4 44", "6 test6 66",
@@ -1058,17 +1050,12 @@ func (s *mockGCSSuite) TestAddIndexBySQL() {
 	))
 
 	// encode error, rollback
-	backup := config.DefaultBatchSize
-	config.DefaultBatchSize = 1
-	s.T().Cleanup(func() {
-		config.DefaultBatchSize = backup
-	})
 	s.tk.MustExec("truncate table load_data.add_index")
 	s.server.CreateObject(fakestorage.Object{
 		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-load", Name: "add_index-3.tsv"},
 		Content:     []byte("8,8|8,888\n"),
 	})
-	err := s.tk.QueryToErr(sql)
+	err := s.tk.QueryToErr(sql + " WITH __max_engine_size=1")
 	require.ErrorContains(s.T(), err, "Truncated incorrect DOUBLE value")
 	s.tk.MustQuery("SHOW CREATE TABLE load_data.add_index;").Check(testkit.Rows(
 		"add_index CREATE TABLE `add_index` (\n" +
@@ -1083,7 +1070,6 @@ func (s *mockGCSSuite) TestAddIndexBySQL() {
 	s.tk.MustQuery("SELECT COUNT(1) FROM load_data.add_index;").Sort().Check(testkit.Rows(
 		"0",
 	))
-	config.DefaultBatchSize = backup
 
 	// checksum error
 	s.server.CreateObject(fakestorage.Object{

--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -752,7 +752,7 @@ func (s *mockGCSSuite) TestChecksumNotMatch() {
 	s.tk.MustExec("drop table if exists t;")
 	s.tk.MustExec("create table t (a bigint primary key, b varchar(100), c int);")
 	loadDataSQL := fmt.Sprintf(`IMPORT INTO t FROM 'gs://test-multi-load/duplicate-pk-*.csv?endpoint=%s'
-		with thread=1, __max_engine_size=1`, gcsEndpoint)
+		with thread=1, __max_engine_size='1'`, gcsEndpoint)
 	err := s.tk.QueryToErr(loadDataSQL)
 	require.ErrorContains(s.T(), err, "ErrChecksumMismatch")
 	s.tk.MustQuery("SELECT * FROM t;").Sort().Check(testkit.Rows([]string{
@@ -761,7 +761,7 @@ func (s *mockGCSSuite) TestChecksumNotMatch() {
 
 	s.tk.MustExec("truncate table t;")
 	loadDataSQL = fmt.Sprintf(`IMPORT INTO t FROM 'gs://test-multi-load/duplicate-pk-*.csv?endpoint=%s'
-		with thread=1, checksum_table='off', __max_engine_size=1`, gcsEndpoint)
+		with thread=1, checksum_table='off', __max_engine_size='1'`, gcsEndpoint)
 	s.tk.MustQuery(loadDataSQL)
 	s.tk.MustQuery("SELECT * FROM t;").Sort().Check(testkit.Rows([]string{
 		"1 test1 11", "2 test2 22", "4 test4 44", "6 test6 66",
@@ -769,7 +769,7 @@ func (s *mockGCSSuite) TestChecksumNotMatch() {
 
 	s.tk.MustExec("truncate table t;")
 	loadDataSQL = fmt.Sprintf(`IMPORT INTO t FROM 'gs://test-multi-load/duplicate-pk-*.csv?endpoint=%s'
-		with thread=1, checksum_table='optional', __max_engine_size=1`, gcsEndpoint)
+		with thread=1, checksum_table='optional', __max_engine_size='1'`, gcsEndpoint)
 	s.tk.MustQuery(loadDataSQL)
 	s.tk.MustQuery("SELECT * FROM t;").Sort().Check(testkit.Rows([]string{
 		"1 test1 11", "2 test2 22", "4 test4 44", "6 test6 66",
@@ -1055,7 +1055,7 @@ func (s *mockGCSSuite) TestAddIndexBySQL() {
 		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-load", Name: "add_index-3.tsv"},
 		Content:     []byte("8,8|8,888\n"),
 	})
-	err := s.tk.QueryToErr(sql + " WITH __max_engine_size=1")
+	err := s.tk.QueryToErr(sql + " WITH __max_engine_size='1'")
 	require.ErrorContains(s.T(), err, "Truncated incorrect DOUBLE value")
 	s.tk.MustQuery("SHOW CREATE TABLE load_data.add_index;").Check(testkit.Rows(
 		"add_index CREATE TABLE `add_index` (\n" +

--- a/tests/realtikvtest/importintotest/job_test.go
+++ b/tests/realtikvtest/importintotest/job_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
-	"github.com/pingcap/tidb/br/pkg/lightning/config"
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/disttask/framework/proto"
 	"github.com/pingcap/tidb/disttask/framework/scheduler"
@@ -189,11 +188,6 @@ func (s *mockGCSSuite) TestShowJob() {
 		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-show-job", Name: "t2.csv"},
 		Content:     []byte("3\n4"),
 	})
-	backup4 := config.DefaultBatchSize
-	config.DefaultBatchSize = 1
-	s.T().Cleanup(func() {
-		config.DefaultBatchSize = backup4
-	})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -252,7 +246,7 @@ func (s *mockGCSSuite) TestShowJob() {
 		s.NoError(failpoint.Disable("github.com/pingcap/tidb/disttask/framework/scheduler/syncAfterSubtaskFinish"))
 		scheduler.TestSyncChan <- struct{}{}
 	}()
-	s.tk.MustQuery(fmt.Sprintf(`import into t3 FROM 'gs://test-show-job/t*.csv?access-key=aaaaaa&secret-access-key=bbbbbb&endpoint=%s' with thread=1`, gcsEndpoint))
+	s.tk.MustQuery(fmt.Sprintf(`import into t3 FROM 'gs://test-show-job/t*.csv?access-key=aaaaaa&secret-access-key=bbbbbb&endpoint=%s' with thread=1, __max_engine_size=1`, gcsEndpoint))
 	wg.Wait()
 	s.tk.MustQuery("select * from t3").Sort().Check(testkit.Rows("1", "2", "3", "4"))
 }

--- a/tests/realtikvtest/importintotest/job_test.go
+++ b/tests/realtikvtest/importintotest/job_test.go
@@ -246,7 +246,7 @@ func (s *mockGCSSuite) TestShowJob() {
 		s.NoError(failpoint.Disable("github.com/pingcap/tidb/disttask/framework/scheduler/syncAfterSubtaskFinish"))
 		scheduler.TestSyncChan <- struct{}{}
 	}()
-	s.tk.MustQuery(fmt.Sprintf(`import into t3 FROM 'gs://test-show-job/t*.csv?access-key=aaaaaa&secret-access-key=bbbbbb&endpoint=%s' with thread=1, __max_engine_size=1`, gcsEndpoint))
+	s.tk.MustQuery(fmt.Sprintf(`import into t3 FROM 'gs://test-show-job/t*.csv?access-key=aaaaaa&secret-access-key=bbbbbb&endpoint=%s' with thread=1, __max_engine_size='1'`, gcsEndpoint))
 	wg.Wait()
 	s.tk.MustQuery("select * from t3").Sort().Check(testkit.Rows("1", "2", "3", "4"))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44975, ref #45005

Problem Summary:

### What is changed and how it works?
- change default engine size to 500g, it's adjusted by total data size to avoid generate engine that is too small
- add logs about read/encode/deliver duration

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

for a 1T data set, before this change, we split into 11 subtasks, takes more than 241m
![image](https://github.com/pingcap/tidb/assets/3312245/a5657de5-74c2-4352-9435-a4d1b371ea82)
after, 2 subtasks, takes about 164m
![image](https://github.com/pingcap/tidb/assets/3312245/1ebcddbf-a925-4cfa-9882-99c449678707)

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
