### PR TITLE
lightning: add parameter to output logs of all packages and enable grpc log

### DIFF
--- a/br/pkg/lightning/log/BUILD.bazel
+++ b/br/pkg/lightning/log/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//util/logutil",
-        "@com_github_daixiang0_gci//pkg/log",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_log//:log",
         "@org_golang_google_grpc//codes",

--- a/br/pkg/lightning/log/BUILD.bazel
+++ b/br/pkg/lightning/log/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//util/logutil",
+        "@com_github_daixiang0_gci//pkg/log",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_log//:log",
         "@org_golang_google_grpc//codes",
@@ -33,6 +34,8 @@ go_test(
     shard_count = 4,
     deps = [
         ":log",
+        "//util/logutil",
+        "@com_github_pingcap_log//:log",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_zap//:zap",
         "@org_uber_go_zap//zapcore",

--- a/br/pkg/lightning/log/log.go
+++ b/br/pkg/lightning/log/log.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -84,7 +85,7 @@ func InitLogger(cfg *Config, _ string) error {
 	if cfg.EnableDiagnoseLogs {
 		// the value doesn't matter, logutil.InitLogger only checks whether it's empty.
 		if err := os.Setenv(logutil.GRPCDebugEnvName, "true"); err != nil {
-			L().Warn("failed to enable GRPC debug log", zap.Error(err))
+			fmt.Println("Failed to set environment variable to enable GRPC debug log", err)
 		}
 	} else {
 		// Only output logs of br package and main package.

--- a/br/pkg/lightning/log/log.go
+++ b/br/pkg/lightning/log/log.go
@@ -82,6 +82,7 @@ var (
 func InitLogger(cfg *Config, _ string) error {
 	loggerOptions := []zap.Option{}
 	if cfg.EnableDiagnoseLogs {
+		// the value doesn't matter, logutil.InitLogger only checks whether it's empty.
 		if err := os.Setenv(logutil.GRPCDebugEnvName, "true"); err != nil {
 			L().Warn("failed to enable GRPC debug log", zap.Error(err))
 		}

--- a/br/pkg/lightning/log/log.go
+++ b/br/pkg/lightning/log/log.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -45,6 +46,8 @@ type Config struct {
 	FileMaxDays int `toml:"max-days" json:"max-days"`
 	// Maximum number of old log files to retain.
 	FileMaxBackups int `toml:"max-backups" json:"max-backups"`
+	// EnableDiagnoseLogs, when enabled, we will output logs from all packages and enable GRPC debug log.
+	EnableDiagnoseLogs bool `toml:"enable-diagnose-logs" json:"enable-diagnose-logs"`
 }
 
 // Adjust adjusts some fields in the config to a proper value.
@@ -77,10 +80,23 @@ var (
 
 // InitLogger initializes Lightning's and also the TiDB library's loggers.
 func InitLogger(cfg *Config, _ string) error {
+	loggerOptions := []zap.Option{}
+	if cfg.EnableDiagnoseLogs {
+		if err := os.Setenv(logutil.GRPCDebugEnvName, "true"); err != nil {
+			L().Warn("failed to enable GRPC debug log", zap.Error(err))
+		}
+	} else {
+		// Only output logs of br package and main package.
+		loggerOptions = append(loggerOptions, zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return NewFilterCore(core, "github.com/pingcap/tidb/br/", "main.main")
+		}))
+	}
 	tidbLogCfg := logutil.LogConfig{}
 	// Disable annoying TiDB Log.
 	// TODO: some error logs outputs randomly, we need to fix them in TiDB.
+	// this LEVEL only affects SlowQueryLogger, later ReplaceGlobals will overwrite it.
 	tidbLogCfg.Level = "fatal"
+	// this also init GRPCLogger, controlled by GRPC_DEBUG env.
 	err := logutil.InitLogger(&tidbLogCfg)
 	if err != nil {
 		return errors.Trace(err)
@@ -90,10 +106,6 @@ func InitLogger(cfg *Config, _ string) error {
 		Level:         cfg.Level,
 		DisableCaller: false, // FilterCore requires zap.AddCaller.
 	}
-	filterTiDBLog := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-		// Filter logs from TiDB and PD.
-		return NewFilterCore(core, "github.com/pingcap/tidb/br/", "main.main")
-	})
 	// "-" is a special config for log to stdout.
 	if len(cfg.File) > 0 && cfg.File != "-" {
 		logCfg.File = pclog.FileLogConfig{
@@ -103,7 +115,7 @@ func InitLogger(cfg *Config, _ string) error {
 			MaxBackups: cfg.FileMaxBackups,
 		}
 	}
-	logger, props, err := pclog.InitLogger(logCfg, filterTiDBLog)
+	logger, props, err := pclog.InitLogger(logCfg, loggerOptions...)
 	if err != nil {
 		return err
 	}

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -94,6 +94,9 @@ const (
 	SlowLogTimeFormat = time.RFC3339Nano
 	// OldSlowLogTimeFormat is the first version of the the time format for slow log, This is use for compatibility.
 	OldSlowLogTimeFormat = "2006-01-02-15:04:05.999999999 -0700"
+
+	// GRPCDebugEnvName is the environment variable name for GRPC_DEBUG.
+	GRPCDebugEnvName = "GRPC_DEBUG"
 )
 
 // SlowQueryLogger is used to log slow query, InitLogger will modify it according to config file.
@@ -121,7 +124,7 @@ func InitLogger(cfg *LogConfig, opts ...zap.Option) error {
 func initGRPCLogger(gl *zap.Logger) {
 	level := zapcore.ErrorLevel
 	verbosity := 0
-	if len(os.Getenv("GRPC_DEBUG")) > 0 {
+	if len(os.Getenv(GRPCDebugEnvName)) > 0 {
 		verbosity = 999
 		level = zapcore.DebugLevel
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45497

Problem Summary:

### What is changed and how it works?
- add parameter `enable-diagnose-logs` to output logs of all packages and enable grpc log when enabled, default is false
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - enable the parameter, we can see logs: `coprocessor.go` of tidb, and `client_batch.go` of client-go
```log
[2023/07/21 14:48:09.126 +08:00] [INFO] [grpclogger.go:92] ["[core][Channel #1] Channel created"] [system=grpc] [grpc_log=true]
[2023/07/21 14:48:09.126 +08:00] [INFO] [grpclogger.go:92] ["[core][Channel #1] original dial target is: \"127.0.0.1:2379\""] [system=grpc] [grpc_log=true]


[2023/07/21 14:16:56.613 +08:00] [INFO] [coprocessor.go:1290] ["[TIME_COP_PROCESS] resp_time:380.626041ms txnStartTS:443002375548698627 region_id:128 store_addr:192.168.192.77:20160 kv_process_ms:194 kv_w
ait_ms:5 kv_read_ms:0 processed_versions:5072 total_versions:5073 rocksdb_delete_skipped_count:0 rocksdb_key_skipped_count:10143 rocksdb_cache_hit_count:2 rocksdb_read_count:2542 rocksdb_read_byte:2460442
7"]

[2023/07/21 14:20:27.622 +08:00] [INFO] [import.go:1336] [progress] [total=100.0%] [tables="2/2 (100.0%)"] [chunks="2/2 (100.0%)"] [engines="4/4 (100.0%)"] [restore-bytes=489.6MiB/489.6MiB] [restore-rows=
25004/25004(estimated)] [import-bytes=552.1MiB/552.1MiB(estimated)] ["encode speed(MiB/s)"=0.6799745656866469] [state=post-processing] []
[2023/07/21 14:20:27.623 +08:00] [DEBUG] [client_batch.go:615] ["batchRecvLoop fails when receiving, needs to reconnect"] [target=192.168.192.77:20160] [forwardedHost=] [error="rpc error: code = Unavailab
le desc = keepalive watchdog timeout"]
[2023/07/21 14:20:43.450 +08:00] [DEBUG] [client_batch.go:615] ["batchRecvLoop fails when receiving, needs to reconnect"] [target=192.168.192.77:20160] [forwardedHost=] [error="rpc error: code = Unavailab
le desc = keepalive watchdog timeout"]
[2023/07/21 14:20:43.453 +08:00] [DEBUG] [pd.go:100] ["store min resolved ts"] [resp="{\n  \"is_real_time\": true,\n  \"min_resolved_ts\": 443002498349793281,\n  \"persist_interval\": \"1s\"\n}\n"]
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
