### PR TITLE
executor: make `TestOrderByAndLimit` stable

### DIFF
--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -548,22 +548,25 @@ func TestOrderByAndLimit(t *testing.T) {
 		// Since we only use order by a not order by a, b, the result is not stable when we read both a and b.
 		// We cut the max element so that the result can be stable.
 		maxEle := tk.MustQuery(fmt.Sprintf("select ifnull(max(a), 1100) from (select * from tregular use index(idx_a) where a > %v order by a limit %v) t", x, y)).Rows()[0][0]
-		queryRangePartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from trange use index(idx_a) where a > %v and a < greatest(%v+1, %v) order by a limit %v", x, x+1, maxEle, y)
-		queryHashPartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from thash use index(idx_a) where a > %v and a < greatest(%v+1, %v) order by a limit %v", x, x+1, maxEle, y)
-		queryListPartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from tlist use index(idx_a) where a > %v and a < greatest(%v+1, %v) order by a limit %v", x, x+1, maxEle, y)
-		queryRegular := fmt.Sprintf("select * from tregular use index(idx_a) where a > %v and a < greatest(%v+1, %v) order by a limit %v;", x, x+1, maxEle, y)
-		require.True(t, tk.HasPlan(queryRangePartitionWithLimitHint, "Limit"))
-		require.True(t, tk.HasPlan(queryRangePartitionWithLimitHint, "IndexLookUp"))
-		require.True(t, tk.HasPlan(queryHashPartitionWithLimitHint, "Limit"))
-		require.True(t, tk.HasPlan(queryHashPartitionWithLimitHint, "IndexLookUp"))
-		require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "Limit"))
-		require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "IndexLookUp"))
+		queryRangePartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from trange use index(idx_a) where a > %v and a < %v order by a limit %v", x, maxEle, y)
+		queryHashPartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from thash use index(idx_a) where a > %v and a < %v order by a limit %v", x, maxEle, y)
+		queryListPartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from tlist use index(idx_a) where a > %v and a < %v order by a limit %v", x, maxEle, y)
+		queryRegular := fmt.Sprintf("select * from tregular use index(idx_a) where a > %v and a < %v order by a limit %v;", x, maxEle, y)
+
+		regularResult := tk.MustQuery(queryRegular).Sort().Rows()
+		if len(regularResult) > 0 {
+			require.True(t, tk.HasPlan(queryRangePartitionWithLimitHint, "Limit"))
+			require.True(t, tk.HasPlan(queryRangePartitionWithLimitHint, "IndexLookUp"))
+			require.True(t, tk.HasPlan(queryHashPartitionWithLimitHint, "Limit"))
+			require.True(t, tk.HasPlan(queryHashPartitionWithLimitHint, "IndexLookUp"))
+			require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "Limit"))
+			require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "IndexLookUp"))
+		}
 		if i%2 != 0 {
 			require.False(t, tk.HasPlan(queryRangePartitionWithLimitHint, "TopN")) // fully pushed
 			require.False(t, tk.HasPlan(queryHashPartitionWithLimitHint, "TopN"))
 			require.False(t, tk.HasPlan(queryListPartitionWithLimitHint, "TopN"))
 		}
-		regularResult := tk.MustQuery(queryRegular).Sort().Rows()
 		tk.MustQuery(queryRangePartitionWithLimitHint).Sort().Check(regularResult)
 		tk.MustQuery(queryHashPartitionWithLimitHint).Sort().Check(regularResult)
 		tk.MustQuery(queryListPartitionWithLimitHint).Sort().Check(regularResult)
@@ -581,22 +584,25 @@ func TestOrderByAndLimit(t *testing.T) {
 		x := rand.Intn(1999)
 		y := rand.Intn(2000) + 1
 		maxEle := tk.MustQuery(fmt.Sprintf("select ifnull(max(b), 2000) from (select * from tregular use index(idx_b) where b > %v order by b limit %v) t", x, y)).Rows()[0][0]
-		queryRangePartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from trange use index(idx_b) where b > %v and b < greatest(%v+1, %v) order by b limit %v", x, x+1, maxEle, y)
-		queryHashPartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from thash use index(idx_b) where b > %v and b < greatest(%v+1, %v) order by b limit %v", x, x+1, maxEle, y)
-		queryListPartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from tlist use index(idx_b) where b > %v and b < greatest(%v+1, %v) order by b limit %v", x, x+1, maxEle, y)
-		queryRegular := fmt.Sprintf("select * from tregular use index(idx_b) where b > %v and b < greatest(%v+1, %v) order by b limit %v;", x, x+1, maxEle, y)
-		require.True(t, tk.HasPlan(queryRangePartitionWithLimitHint, "Limit"))
-		require.True(t, tk.HasPlan(queryRangePartitionWithLimitHint, "IndexLookUp"))
-		require.True(t, tk.HasPlan(queryHashPartitionWithLimitHint, "Limit"))
-		require.True(t, tk.HasPlan(queryHashPartitionWithLimitHint, "IndexLookUp"))
-		require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "Limit"))
-		require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "IndexLookUp"))
+		queryRangePartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from trange use index(idx_b) where b > %v and b < %v order by b limit %v", x, maxEle, y)
+		queryHashPartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from thash use index(idx_b) where b > %v and b < %v order by b limit %v", x, maxEle, y)
+		queryListPartitionWithLimitHint := fmt.Sprintf("select /*+ LIMIT_TO_COP() */ * from tlist use index(idx_b) where b > %v and b < %v order by b limit %v", x, maxEle, y)
+		queryRegular := fmt.Sprintf("select * from tregular use index(idx_b) where b > %v and b < %v order by b limit %v;", x, maxEle, y)
+
+		regularResult := tk.MustQuery(queryRegular).Sort().Rows()
+		if len(regularResult) > 0 {
+			require.True(t, tk.HasPlan(queryRangePartitionWithLimitHint, "Limit"))
+			require.True(t, tk.HasPlan(queryRangePartitionWithLimitHint, "IndexLookUp"))
+			require.True(t, tk.HasPlan(queryHashPartitionWithLimitHint, "Limit"))
+			require.True(t, tk.HasPlan(queryHashPartitionWithLimitHint, "IndexLookUp"))
+			require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "Limit"))
+			require.True(t, tk.HasPlan(queryListPartitionWithLimitHint, "IndexLookUp"))
+		}
 		if i%2 != 0 {
 			require.False(t, tk.HasPlan(queryRangePartitionWithLimitHint, "TopN")) // fully pushed
 			require.False(t, tk.HasPlan(queryHashPartitionWithLimitHint, "TopN"))
 			require.False(t, tk.HasPlan(queryListPartitionWithLimitHint, "TopN"))
 		}
-		regularResult := tk.MustQuery(queryRegular).Sort().Rows()
 		tk.MustQuery(queryRangePartitionWithLimitHint).Sort().Check(regularResult)
 		tk.MustQuery(queryHashPartitionWithLimitHint).Sort().Check(regularResult)
 		tk.MustQuery(queryListPartitionWithLimitHint).Sort().Check(regularResult)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45496

Problem Summary:

```
The test easy failed when `limit = 1`.

Like `select /*+ LIMIT_TO_COP() */ * from tlist use index(idx_b) where b > 1126 and b < greatest(1127+1, 1127) order by b limit 1`.

It will change to `b = 1127`. Sometimes we have more than 1 line equal to 1127, so the result is unstable.
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
Modify y=1 to run the test without error.
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
