### PR TITLE
Lightning: Update Parameter Name from `tikv-importer.incremental-import` to `tikv-importer.parallel-import`

### DIFF
--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -1068,12 +1068,9 @@ func (t *TikvImporter) adjust() error {
 		return common.ErrInvalidConfig.GenWithStack("tikv-importer.backend must not be empty!")
 	}
 	t.Backend = strings.ToLower(t.Backend)
+	// only need to assign t.IncrementalImport to t.ParallelImport when t.ParallelImport is false and t.IncrementalImport is true
 	if !t.ParallelImport && t.IncrementalImport {
-		// need to assign t.IncrementalImport to t.ParallelImport when t.ParallelImport is false and t.IncrementalImport is true
 		t.ParallelImport = t.IncrementalImport
-	} else if t.ParallelImport && !t.IncrementalImport {
-		// need to assign t.ParallelImport to t.IncrementalImport when t.IncrementalImport is false and t.ParallelImport is true, to keep compatibility
-		t.IncrementalImport = t.ParallelImport
 	}
 	switch t.Backend {
 	case BackendTiDB:

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -1068,9 +1068,12 @@ func (t *TikvImporter) adjust() error {
 		return common.ErrInvalidConfig.GenWithStack("tikv-importer.backend must not be empty!")
 	}
 	t.Backend = strings.ToLower(t.Backend)
-	// only need to assign t.IncrementalImport to t.ParallelImport when t.ParallelImport is false and t.IncrementalImport is true
 	if !t.ParallelImport && t.IncrementalImport {
+		// need to assign t.IncrementalImport to t.ParallelImport when t.ParallelImport is false and t.IncrementalImport is true
 		t.ParallelImport = t.IncrementalImport
+	} else if t.ParallelImport && !t.IncrementalImport {
+		// need to assign t.ParallelImport to t.IncrementalImport when t.IncrementalImport is false and t.ParallelImport is true, to keep compatibility
+		t.IncrementalImport = t.ParallelImport
 	}
 	switch t.Backend {
 	case BackendTiDB:

--- a/br/pkg/lightning/config/config_test.go
+++ b/br/pkg/lightning/config/config_test.go
@@ -982,12 +982,12 @@ func TestAdjustConflictStrategy(t *testing.T) {
 
 	cfg.TikvImporter.Backend = BackendLocal
 	cfg.Conflict.Strategy = ReplaceOnDup
-	cfg.TikvImporter.IncrementalImport = true
-	require.ErrorContains(t, cfg.Adjust(ctx), "conflict.strategy cannot be used with tikv-importer.incremental-import")
+	cfg.TikvImporter.ParallelImport = true
+	require.ErrorContains(t, cfg.Adjust(ctx), "conflict.strategy cannot be used with tikv-importer.parallel-import")
 
 	cfg.TikvImporter.Backend = BackendLocal
 	cfg.Conflict.Strategy = ReplaceOnDup
-	cfg.TikvImporter.IncrementalImport = false
+	cfg.TikvImporter.ParallelImport = false
 	cfg.TikvImporter.DuplicateResolution = DupeResAlgRemove
 	require.ErrorContains(t, cfg.Adjust(ctx), "conflict.strategy cannot be used with tikv-importer.duplicate-resolution")
 
@@ -1203,7 +1203,7 @@ func TestAdjustTikvImporter(t *testing.T) {
 
 	cfg.TikvImporter.IncrementalImport = true
 	cfg.TikvImporter.AddIndexBySQL = true
-	require.ErrorContains(t, cfg.TikvImporter.adjust(), "tikv-importer.add-index-using-ddl cannot be used with tikv-importer.incremental-import")
+	require.ErrorContains(t, cfg.TikvImporter.adjust(), "tikv-importer.add-index-using-ddl cannot be used with tikv-importer.parallel-import")
 }
 
 func TestCreateSeveralConfigsWithDifferentFilters(t *testing.T) {

--- a/br/pkg/lightning/config/config_test.go
+++ b/br/pkg/lightning/config/config_test.go
@@ -994,7 +994,7 @@ func TestAdjustConflictStrategy(t *testing.T) {
 	cfg.TikvImporter.Backend = BackendLocal
 	cfg.Conflict.Strategy = ""
 	cfg.TikvImporter.OnDuplicate = ReplaceOnDup
-	cfg.TikvImporter.IncrementalImport = false
+	cfg.TikvImporter.ParallelImport = false
 	cfg.TikvImporter.DuplicateResolution = DupeResAlgRemove
 	require.ErrorContains(t, cfg.Adjust(ctx), "tikv-importer.on-duplicate cannot be used with tikv-importer.duplicate-resolution")
 }
@@ -1201,7 +1201,7 @@ func TestAdjustTikvImporter(t *testing.T) {
 	cfg.TikvImporter.SortedKVDir = base
 	require.NoError(t, cfg.TikvImporter.adjust())
 
-	cfg.TikvImporter.IncrementalImport = true
+	cfg.TikvImporter.ParallelImport = true
 	cfg.TikvImporter.AddIndexBySQL = true
 	require.ErrorContains(t, cfg.TikvImporter.adjust(), "tikv-importer.add-index-using-ddl cannot be used with tikv-importer.parallel-import")
 }

--- a/br/pkg/lightning/importer/check_info.go
+++ b/br/pkg/lightning/importer/check_info.go
@@ -137,7 +137,7 @@ func (rc *Controller) checkCSVHeader(ctx context.Context) error {
 }
 
 func (rc *Controller) checkTableEmpty(ctx context.Context) error {
-	if rc.cfg.TikvImporter.Backend == config.BackendTiDB || rc.cfg.TikvImporter.IncrementalImport {
+	if rc.cfg.TikvImporter.Backend == config.BackendTiDB || rc.cfg.TikvImporter.ParallelImport {
 		return nil
 	}
 	return rc.doPreCheckOnItem(ctx, precheck.CheckTargetTableEmpty)

--- a/br/pkg/lightning/importer/check_info_test.go
+++ b/br/pkg/lightning/importer/check_info_test.go
@@ -482,13 +482,13 @@ func TestCheckTableEmpty(t *testing.T) {
 	err := rc.checkTableEmpty(ctx)
 	require.NoError(t, err)
 
-	// test incremental mode
+	// test parallel mode
 	rc.cfg.TikvImporter.Backend = config.BackendLocal
 	rc.cfg.TikvImporter.ParallelImport = true
 	err = rc.checkTableEmpty(ctx)
 	require.NoError(t, err)
 
-	rc.cfg.TikvImporter.IncrementalImport = false
+	rc.cfg.TikvImporter.ParallelImport = false
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	mock.MatchExpectationsInOrder(false)

--- a/br/pkg/lightning/importer/check_info_test.go
+++ b/br/pkg/lightning/importer/check_info_test.go
@@ -484,7 +484,7 @@ func TestCheckTableEmpty(t *testing.T) {
 
 	// test incremental mode
 	rc.cfg.TikvImporter.Backend = config.BackendLocal
-	rc.cfg.TikvImporter.IncrementalImport = true
+	rc.cfg.TikvImporter.ParallelImport = true
 	err = rc.checkTableEmpty(ctx)
 	require.NoError(t, err)
 

--- a/br/pkg/lightning/importer/import.go
+++ b/br/pkg/lightning/importer/import.go
@@ -378,7 +378,7 @@ func NewImportControllerWithPauser(
 	var metaBuilder metaMgrBuilder
 	isSSTImport := cfg.TikvImporter.Backend == config.BackendLocal
 	switch {
-	case isSSTImport && cfg.TikvImporter.IncrementalImport:
+	case isSSTImport && cfg.TikvImporter.ParallelImport:
 		metaBuilder = &dbMetaMgrBuilder{
 			db:           db,
 			taskID:       cfg.TaskID,

--- a/br/tests/lightning_incremental/config.toml
+++ b/br/tests/lightning_incremental/config.toml
@@ -1,2 +1,2 @@
 [tikv-importer]
-incremental-import = true
+parallel-import = true


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45501 

Problem Summary:

The actual meaning of `tikv-importer.incremental-import` is to use the physical import mode for parallel import, which requires the target table to be empty. However, the current name may mislead users into thinking it is for incremental import, leading to misuse.
When the user misuses it and sets the `duplicate-resolution` to `remove`, conflicts between data in the source file and the existing data in the target table can lead to the mistaken deletion of the conflicting records in the target table.

### What is changed and how it works?

1. Starting from version 7.3, the parameter name has been changed from `tikv-importer.incremental-import` to `tikv-importer.parallel-import`.
2. If users pass the parameter name as `tikv-importer.incremental-import`, it will be converted to `tikv-importer.parallel-import` for compatibility.

Since there exist multiple unit tests and integration tests that have covered test cases of `tikv-importer.incremental-import`, I changed some of them to `tikv-importer.parallel-import`, and let others remain as `tikv-importer.incremental-import`. If all of the related unit tests and integration tests can pass, that means the functionality of both `tikv-importer.parallel-import` and `tikv-importer.incremental-import` work well.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Parameter name `tikv-importer.incremental-import` has been updated to `tikv-importer.parallel-import`. The meaning of this parameter is to use the physical import mode for parallel import, which requires the target table to be empty.
```
