### PR TITLE
executor, util: make tmp-storage-quota take affect

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2014,6 +2014,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	vars.MemTracker.UnbindActions()
 	vars.MemTracker.SetBytesLimit(vars.MemQuotaQuery)
 	vars.MemTracker.ResetMaxConsumed()
+	vars.DiskTracker.Detach()
 	vars.DiskTracker.ResetMaxConsumed()
 	vars.MemTracker.SessionID.Store(vars.ConnectionID)
 	vars.StmtCtx.TableStats = make(map[int64]interface{})
@@ -2054,6 +2055,9 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	globalConfig := config.GetGlobalConfig()
 	if variable.EnableTmpStorageOnOOM.Load() && sc.DiskTracker != nil {
 		sc.DiskTracker.AttachTo(vars.DiskTracker)
+		if GlobalDiskUsageTracker != nil {
+			vars.DiskTracker.AttachTo(GlobalDiskUsageTracker)
+		}
 	}
 	if execStmt, ok := s.(*ast.ExecuteStmt); ok {
 		prepareStmt, err := plannercore.GetPreparedStmt(execStmt, vars)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -138,7 +138,7 @@ type dataSourceExecutor interface {
 
 const (
 	// globalPanicStorageExceed represents the panic message when out of storage quota.
-	globalPanicStorageExceed string = "Out Of Global Storage Quota!"
+	globalPanicStorageExceed string = "Out Of Quota For Local Temporary Space!"
 	// globalPanicMemoryExceed represents the panic message when out of memory limit.
 	globalPanicMemoryExceed string = "Out Of Global Memory Limit!"
 	// globalPanicAnalyzeMemoryExceed represents the panic message when out of analyze memory limit.

--- a/util/chunk/row_container.go
+++ b/util/chunk/row_container.go
@@ -16,6 +16,7 @@ package chunk
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -140,6 +141,18 @@ func (c *RowContainer) SpillToDisk() {
 	n := c.m.records.inMemory.NumChunks()
 	c.m.records.inDisk = NewListInDisk(c.m.records.inMemory.FieldTypes())
 	c.m.records.inDisk.diskTracker.AttachTo(c.diskTracker)
+	defer func() {
+		if r := recover(); r != nil {
+			err := fmt.Errorf("%v", r)
+			c.m.records.spillError = err
+			logutil.BgLogger().Error("SpillToDisk panicked", zap.Stack("stack"), zap.Error(err))
+		}
+	}()
+	failpoint.Inject("spillToDiskOutOfDiskQuota", func(val failpoint.Value) {
+		if val.(bool) {
+			panic("out of disk quota when spilling")
+		}
+	})
 	for i := 0; i < n; i++ {
 		chk := c.m.records.inMemory.GetChunk(i)
 		err = c.m.records.inDisk.Add(chk)

--- a/util/chunk/row_container.go
+++ b/util/chunk/row_container.go
@@ -145,7 +145,7 @@ func (c *RowContainer) SpillToDisk() {
 		if r := recover(); r != nil {
 			err := fmt.Errorf("%v", r)
 			c.m.records.spillError = err
-			logutil.BgLogger().Error("SpillToDisk panicked", zap.Stack("stack"), zap.Error(err))
+			logutil.BgLogger().Error("spill to disk failed", zap.Stack("stack"), zap.Error(err))
 		}
 	}()
 	failpoint.Inject("spillToDiskOutOfDiskQuota", func(val failpoint.Value) {

--- a/util/chunk/row_container_test.go
+++ b/util/chunk/row_container_test.go
@@ -439,6 +439,37 @@ func TestReadAfterSpillWithRowContainerReader(t *testing.T) {
 	}
 }
 
+func TestPanicWhenSpillToDisk(t *testing.T) {
+	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
+	sz := 20
+	chk := NewChunkWithCapacity(fields, sz)
+	for i := 0; i < sz; i++ {
+		chk.AppendInt64(0, int64(i))
+	}
+
+	rc := NewRowContainer(fields, sz)
+	tracker := rc.GetMemTracker()
+	tracker.SetBytesLimit(chk.MemoryUsage() + 1)
+	tracker.FallbackOldAndSetNewAction(rc.ActionSpillForTest())
+	require.False(t, rc.AlreadySpilledSafeForTest())
+
+	require.NoError(t, rc.Add(chk))
+	rc.actionSpill.WaitForTest()
+	require.False(t, rc.AlreadySpilledSafeForTest())
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/util/chunk/spillToDiskOutOfDiskQuota", "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/util/chunk/spillToDiskOutOfDiskQuota"))
+	}()
+	require.NoError(t, rc.Add(chk))
+	rc.actionSpill.WaitForTest()
+	require.True(t, rc.AlreadySpilledSafeForTest())
+
+	_, err := rc.GetRow(RowPtr{})
+	require.EqualError(t, err, "out of disk quota when spilling")
+	require.EqualError(t, rc.Add(chk), "out of disk quota when spilling")
+}
+
 func BenchmarkRowContainerReaderInDiskWithRowSize512(b *testing.B) {
 	benchmarkRowContainerReaderInDiskWithRowLength(b, 512)
 }
@@ -490,71 +521,4 @@ func benchmarkRowContainerReaderInDiskWithRowLength(b *testing.B, rowLength int)
 		}
 	}
 	require.NoError(b, reader.Error())
-}
-
-func TestPanicWhenSort(t *testing.T) {
-	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
-	sz := 20
-	chk := NewChunkWithCapacity(fields, sz)
-	for i := 0; i < sz; i++ {
-		chk.AppendInt64(0, int64(i))
-	}
-
-	byItemsDesc := []bool{false}
-	keyColumns := []int{0}
-	keyCmpFuncs := []CompareFunc{cmpInt64}
-	rc := NewSortedRowContainer(fields, sz, byItemsDesc, keyColumns, keyCmpFuncs)
-
-	tracker := rc.GetMemTracker()
-	tracker.SetBytesLimit(chk.MemoryUsage() + 1)
-	tracker.FallbackOldAndSetNewAction(rc.ActionSpillForTest())
-	require.False(t, rc.AlreadySpilledSafeForTest())
-
-	require.NoError(t, rc.Add(chk))
-	rc.actionSpill.WaitForTest()
-	require.False(t, rc.AlreadySpilledSafeForTest())
-
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/util/chunk/sortOOM", "return(true)"))
-	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/util/chunk/sortOOM"))
-	}()
-	// sortAndSpillToDisk should be called
-	require.NoError(t, rc.Add(chk))
-	rc.actionSpill.WaitForTest()
-	_, err := rc.GetSortedRow(0)
-	require.EqualError(t, err, "out of memory quota when sorting")
-	require.False(t, rc.AlreadySpilledSafeForTest())
-
-	require.EqualError(t, rc.Add(chk), "out of memory quota when sorting")
-}
-
-func TestPanicWhenSpillToDisk(t *testing.T) {
-	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
-	sz := 20
-	chk := NewChunkWithCapacity(fields, sz)
-	for i := 0; i < sz; i++ {
-		chk.AppendInt64(0, int64(i))
-	}
-
-	rc := NewRowContainer(fields, sz)
-	tracker := rc.GetMemTracker()
-	tracker.SetBytesLimit(chk.MemoryUsage() + 1)
-	tracker.FallbackOldAndSetNewAction(rc.ActionSpillForTest())
-	require.False(t, rc.AlreadySpilledSafeForTest())
-
-	require.NoError(t, rc.Add(chk))
-	rc.actionSpill.WaitForTest()
-	require.False(t, rc.AlreadySpilledSafeForTest())
-
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/util/chunk/spillToDiskOutOfDiskQuota", "return(true)"))
-	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/util/chunk/spillToDiskOutOfDiskQuota"))
-	}()
-	require.NoError(t, rc.Add(chk))
-	rc.actionSpill.WaitForTest()
-	require.True(t, rc.AlreadySpilledSafeForTest())
-
-	_, err := rc.GetRow(RowPtr{})
-	require.EqualError(t, err, "out of disk quota when spilling")
-	require.EqualError(t, rc.Add(chk), "out of disk quota when spilling")
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/45161
close https://github.com/pingcap/tidb/issues/26806

Problem Summary:

Tmp-storage-quota can't take affect.

### What is changed and how it works?

Use global disk tracker to track the disk usage.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Pass the test case in issue45161 and issue26806.

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
