### PR TITLE
store: Don't set limit for GetRegionsInfoByRange function

### DIFF
--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -808,7 +808,7 @@ func (h *Helper) GetRegionInfoByID(regionID uint64) (*RegionInfo, error) {
 // GetRegionsInfoByRange scans region by key range
 func (h *Helper) GetRegionsInfoByRange(sk, ek []byte) (*RegionsInfo, error) {
 	var regionsInfo RegionsInfo
-	err := h.requestPD("GetRegionByRange", "GET", fmt.Sprintf("%v?key=%s&end_key=%s", pdapi.ScanRegions,
+	err := h.requestPD("GetRegionByRange", "GET", fmt.Sprintf("%v?key=%s&end_key=%s&limit=-1", pdapi.ScanRegions,
 		url.QueryEscape(string(sk)), url.QueryEscape(string(ek))), nil, &regionsInfo)
 	return &regionsInfo, err
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45531

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
mysql> select tidb_table_id from information_schema.tables where table_schema='test' and table_name='t1';
+---------------+
| tidb_table_id |
+---------------+
|            96 |
+---------------+
1 row in set (0.01 sec)

mysql> select region_id, is_index, start_key from information_schema.tikv_region_status where table_id = 96;
+-----------+----------+--------------------------------------------------------+
| region_id | is_index | start_key                                              |
+-----------+----------+--------------------------------------------------------+
|       154 |        0 | 7480000000000000FF605F720173000000FF0000000000000000FB |
|       160 |        0 | 7480000000000000FF605F720176000000FF0000000000000000FB |
|       162 |        0 | 7480000000000000FF605F720177000000FF0000000000000000FB |
|       118 |        1 | 7480000000000000FF6000000000000000F8                   |
|       118 |        0 | 7480000000000000FF6000000000000000F8                   |
|       124 |        0 | 7480000000000000FF605F720164000000FF0000000000000000FB |
|       140 |        0 | 7480000000000000FF605F72016C000000FF0000000000000000FB |
|       142 |        0 | 7480000000000000FF605F72016D000000FF0000000000000000FB |
|       156 |        0 | 7480000000000000FF605F720174000000FF0000000000000000FB |
|       130 |        0 | 7480000000000000FF605F720167000000FF0000000000000000FB |
|       134 |        0 | 7480000000000000FF605F720169000000FF0000000000000000FB |
|       138 |        0 | 7480000000000000FF605F72016B000000FF0000000000000000FB |
|       144 |        0 | 7480000000000000FF605F72016E000000FF0000000000000000FB |
|       136 |        0 | 7480000000000000FF605F72016A000000FF0000000000000000FB |
|       146 |        0 | 7480000000000000FF605F72016F000000FF0000000000000000FB |
|       150 |        0 | 7480000000000000FF605F720171000000FF0000000000000000FB |
|        22 |        0 | 7480000000000000FF605F720179000000FF0000000000000000FB |
|       132 |        0 | 7480000000000000FF605F720168000000FF0000000000000000FB |
|       148 |        0 | 7480000000000000FF605F720170000000FF0000000000000000FB |
|       152 |        0 | 7480000000000000FF605F720172000000FF0000000000000000FB |
|       158 |        0 | 7480000000000000FF605F720175000000FF0000000000000000FB |
|       120 |        0 | 7480000000000000FF605F720162000000FF0000000000000000FB |
|       122 |        0 | 7480000000000000FF605F720163000000FF0000000000000000FB |
|       126 |        0 | 7480000000000000FF605F720165000000FF0000000000000000FB |
|       128 |        0 | 7480000000000000FF605F720166000000FF0000000000000000FB |
|       164 |        0 | 7480000000000000FF605F720178000000FF0000000000000000FB |
+-----------+----------+--------------------------------------------------------+
26 rows in set (0.01 sec)

mysql> select region_id, is_index, start_key from information_schema.tikv_region_status where db_name = 'test' and table_name = 't1';
+-----------+----------+--------------------------------------------------------+
| region_id | is_index | start_key                                              |
+-----------+----------+--------------------------------------------------------+
|       140 |        0 | 7480000000000000FF605F72016C000000FF0000000000000000FB |
|        22 |        0 | 7480000000000000FF605F720179000000FF0000000000000000FB |
|       120 |        0 | 7480000000000000FF605F720162000000FF0000000000000000FB |
|       122 |        0 | 7480000000000000FF605F720163000000FF0000000000000000FB |
|       130 |        0 | 7480000000000000FF605F720167000000FF0000000000000000FB |
|       158 |        0 | 7480000000000000FF605F720175000000FF0000000000000000FB |
|       162 |        0 | 7480000000000000FF605F720177000000FF0000000000000000FB |
|       134 |        0 | 7480000000000000FF605F720169000000FF0000000000000000FB |
|       146 |        0 | 7480000000000000FF605F72016F000000FF0000000000000000FB |
|       156 |        0 | 7480000000000000FF605F720174000000FF0000000000000000FB |
|       164 |        0 | 7480000000000000FF605F720178000000FF0000000000000000FB |
|       132 |        0 | 7480000000000000FF605F720168000000FF0000000000000000FB |
|       150 |        0 | 7480000000000000FF605F720171000000FF0000000000000000FB |
|       124 |        0 | 7480000000000000FF605F720164000000FF0000000000000000FB |
|       144 |        0 | 7480000000000000FF605F72016E000000FF0000000000000000FB |
|       126 |        0 | 7480000000000000FF605F720165000000FF0000000000000000FB |
|       152 |        0 | 7480000000000000FF605F720172000000FF0000000000000000FB |
|       160 |        0 | 7480000000000000FF605F720176000000FF0000000000000000FB |
|       136 |        0 | 7480000000000000FF605F72016A000000FF0000000000000000FB |
|       148 |        0 | 7480000000000000FF605F720170000000FF0000000000000000FB |
|       118 |        1 | 7480000000000000FF6000000000000000F8                   |
|       118 |        0 | 7480000000000000FF6000000000000000F8                   |
|       142 |        0 | 7480000000000000FF605F72016D000000FF0000000000000000FB |
|       154 |        0 | 7480000000000000FF605F720173000000FF0000000000000000FB |
|       128 |        0 | 7480000000000000FF605F720166000000FF0000000000000000FB |
|       138 |        0 | 7480000000000000FF605F72016B000000FF0000000000000000FB |
+-----------+----------+--------------------------------------------------------+
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
