### PR TITLE
CI: make `codecov/project` failed when coverage decreased in pull request

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,15 +6,17 @@ codecov:
 coverage:
   precision: 4
   round: down
-  range: "65...90"
+  range: "70...100"
 
   status:
-    project: 
+    project:
       default:
-        threshold: 0.2 #Allow the coverage to drop by threshold%, and posting a success status.
+        target: auto
+        threshold: 0% # decline in denial coverage.
     patch: 
       default:
-        target: 0% # trial operation
+        target: auto
+        threshold: 0%
     changes: no
 
 parsers:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45560

Problem Summary:

### What is changed and how it works?

- update green range value, current the coverage of trunk branch is greater than 70%.
- update `.coverage.status.project` to make `codecov/project` github status failed when coverage decreased in pull request.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
