### PR TITLE
*: fix parallel execution "alter index" (cherry-pick #45582 and fixed "alter index" issue)

### DIFF
--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -946,6 +946,16 @@ func (s *stateChangeSuite) TestShowIndex() {
 	tk.MustQuery("select key_name, clustered from information_schema.tidb_indexes where table_name = 'tr' order by key_name").Check(testkit.Rows("PRIMARY NO", "vv NO"))
 }
 
+func (s *stateChangeSuite) TestParallelAlterIndex() {
+	sql := "alter table t alter index idx1 invisible;"
+	f := func(err1, err2 error) {
+		s.Require().NoError(err1)
+		s.Require().NoError(err2)
+		s.tk.MustExec("select * from t")
+	}
+	s.testControlParallelExecSQL("", sql, sql, f)
+}
+
 func (s *stateChangeSuite) TestParallelAlterModifyColumn() {
 	sql := "ALTER TABLE t MODIFY COLUMN b int FIRST;"
 	f := func(err1, err2 error) {

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1002,6 +1002,7 @@ func checkAlterIndexVisibility(t *meta.Meta, job *model.Job) (*model.TableInfo, 
 		return nil, indexName, invisible, errors.Trace(err)
 	}
 	if skip {
+		job.State = model.JobStateDone
 		return nil, indexName, invisible, nil
 	}
 	return tblInfo, indexName, invisible, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/45575

Problem Summary:

### What is changed and how it works?
cherry-pick #45582 and fixed "alter index" issue)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
