### PR TITLE
planner: fix having clause item that ref-ed to grouping set expression shouldn't be pushed down through Expand OP

### DIFF
--- a/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_in.json
+++ b/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_in.json
@@ -209,8 +209,9 @@
       "explain format = 'brief' select grouping(a,b) from t group by a, b with rollup; -- 5. grouping function contains grouping set column a,c",
       "explain format = 'brief' select a, grouping(b,a) from t group by a,b with rollup; -- 6. resolve normal column a to grouping set column a'",
       "explain format = 'brief' select a+1, grouping(b) from t group by a+1, b with rollup; -- 7. resolve field list a+1 to grouping set column a+1",
-      "explain format = 'brief' SELECT SUM(profit) AS profit FROM sales GROUP BY year+2, year+profit WITH ROLLUP order by year+2",
-      "explain format = 'brief' SELECT year+2, SUM(profit) AS profit FROM sales GROUP BY year+2, year+profit WITH ROLLUP order by year+2"
+      "explain format = 'brief' SELECT SUM(profit) AS profit FROM sales GROUP BY year+2, year+profit WITH ROLLUP order by year+2; -- 8. order by item year+2 resolve to gby grouping expression",
+      "explain format = 'brief' SELECT year+2, SUM(profit) AS profit FROM sales GROUP BY year+2, year+profit WITH ROLLUP order by year+2; -- 9. order by item year+2 resolve to select field",
+      "explain format = 'brief' SELECT year+2 as y, SUM(profit) as profit FROM sales GROUP BY year+2, year+profit WITH ROLLUP having y > 2002 order by year+2, profit; -- 10. having (year+2) shouldn't be pushed down"
     ]
   }
 ]

--- a/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_out.json
+++ b/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_out.json
@@ -2049,7 +2049,7 @@
         "Warn": null
       },
       {
-        "SQL": "explain format = 'brief' SELECT SUM(profit) AS profit FROM sales GROUP BY year+2, year+profit WITH ROLLUP order by year+2",
+        "SQL": "explain format = 'brief' SELECT SUM(profit) AS profit FROM sales GROUP BY year+2, year+profit WITH ROLLUP order by year+2; -- 8. order by item year+2 resolve to gby grouping expression",
         "Plan": [
           "Projection 8000.00 root  Column#9",
           "└─Sort 8000.00 root  Column#6",
@@ -2067,7 +2067,7 @@
         "Warn": null
       },
       {
-        "SQL": "explain format = 'brief' SELECT year+2, SUM(profit) AS profit FROM sales GROUP BY year+2, year+profit WITH ROLLUP order by year+2",
+        "SQL": "explain format = 'brief' SELECT year+2, SUM(profit) AS profit FROM sales GROUP BY year+2, year+profit WITH ROLLUP order by year+2; -- 9. order by item year+2 resolve to select field",
         "Plan": [
           "Projection 8000.00 root  Column#6->Column#10, Column#9",
           "└─Sort 8000.00 root  Column#6",
@@ -2081,6 +2081,25 @@
           "                └─Expand 10000.00 mpp[tiflash]  level-projection:[test.sales.profit, <nil>->Column#6, <nil>->Column#7, 0->gid],[test.sales.profit, Column#6, <nil>->Column#7, 1->gid],[test.sales.profit, Column#6, Column#7, 3->gid]; schema: [test.sales.profit,Column#6,Column#7,gid]",
           "                  └─Projection 10000.00 mpp[tiflash]  test.sales.profit, plus(test.sales.year, 2)->Column#6, plus(test.sales.year, test.sales.profit)->Column#7",
           "                    └─TableFullScan 10000.00 mpp[tiflash] table:sales keep order:false, stats:pseudo"
+        ],
+        "Warn": null
+      },
+      {
+        "SQL": "explain format = 'brief' SELECT year+2 as y, SUM(profit) as profit FROM sales GROUP BY year+2, year+profit WITH ROLLUP having y > 2002 order by year+2, profit; -- 10. having (year+2) shouldn't be pushed down",
+        "Plan": [
+          "Projection 6400.00 root  Column#6, Column#9",
+          "└─Sort 6400.00 root  Column#6, Column#9",
+          "  └─TableReader 6400.00 root  MppVersion: 2, data:ExchangeSender",
+          "    └─ExchangeSender 6400.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "      └─Projection 6400.00 mpp[tiflash]  Column#9, Column#6",
+          "        └─HashAgg 6400.00 mpp[tiflash]  group by:Column#20, Column#21, Column#22, funcs:sum(Column#18)->Column#9, funcs:firstrow(Column#19)->Column#6",
+          "          └─Projection 8000.00 mpp[tiflash]  cast(test.sales.profit, decimal(10,0) BINARY)->Column#18, Column#6->Column#19, Column#6->Column#20, Column#7->Column#21, gid->Column#22",
+          "            └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
+          "              └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#6, collate: binary], [name: Column#7, collate: binary], [name: gid, collate: binary]",
+          "                └─Selection 8000.00 mpp[tiflash]  gt(Column#6, 2002)",
+          "                  └─Expand 10000.00 mpp[tiflash]  level-projection:[test.sales.profit, <nil>->Column#6, <nil>->Column#7, 0->gid],[test.sales.profit, Column#6, <nil>->Column#7, 1->gid],[test.sales.profit, Column#6, Column#7, 3->gid]; schema: [test.sales.profit,Column#6,Column#7,gid]",
+          "                    └─Projection 10000.00 mpp[tiflash]  test.sales.profit, plus(test.sales.year, 2)->Column#6, plus(test.sales.year, test.sales.profit)->Column#7",
+          "                      └─TableFullScan 10000.00 mpp[tiflash] table:sales keep order:false, stats:pseudo"
         ],
         "Warn": null
       }

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -455,27 +455,14 @@ func isNullRejected(ctx sessionctx.Context, schema *expression.Schema, expr expr
 
 // PredicatePushDown implements LogicalPlan PredicatePushDown interface.
 func (p *LogicalExpand) PredicatePushDown(predicates []expression.Expression, opt *logicalOptimizeOp) (ret []expression.Expression, retPlan LogicalPlan) {
-	canBePushed := make([]expression.Expression, 0, len(predicates))
-	canNotBePushed := make([]expression.Expression, 0, len(predicates))
 	// Note that, grouping column related predicates can't be pushed down, since grouping column has nullability change after Expand OP itself.
 	// condition related with grouping column shouldn't be pushed down through it.
-	m := make(map[int64]struct{}, len(p.distinctGroupByCol))
-	for _, gCol := range p.distinctGroupByCol {
-		m[gCol.UniqueID] = struct{}{}
-	}
-	for _, predicate := range predicates {
-		cols := expression.ExtractColumns(predicate)
-		for _, anyCol := range cols {
-			if _, ok := m[anyCol.UniqueID]; ok {
-				// this predicate is related to grouping col after Expand action, it can't be pushed down.
-				canNotBePushed = append(canNotBePushed, predicate)
-			} else {
-				canBePushed = append(canBePushed, predicate)
-			}
-		}
-	}
-	remained, child := p.baseLogicalPlan.PredicatePushDown(canBePushed, opt)
-	return append(remained, canNotBePushed...), child
+	// currently, since expand is adjacent to aggregate, any filter above aggregate wanted to be push down through expand only have two cases:
+	// 		1. agg function related filters. (these condition is always above aggregate)
+	// 		2. group-by item related filters. (there condition is always related with grouping sets columns, which can't be pushed down)
+	// As a whole, we banned all the predicates pushing-down logic here that remained in Expand OP, and constructing a new selection above it if any.
+	remained, child := p.baseLogicalPlan.PredicatePushDown(nil, opt)
+	return append(remained, predicates...), child
 }
 
 // PredicatePushDown implements LogicalPlan PredicatePushDown interface.


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/45647

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix having clause item that ref-ed to grouping set expression shouldn't pushed down through Expand OP
```
