### PR TITLE
importintotest: fail fast to avoid data race

### DIFF
--- a/tests/realtikvtest/importintotest/job_test.go
+++ b/tests/realtikvtest/importintotest/job_test.go
@@ -292,10 +292,10 @@ func (s *mockGCSSuite) TestShowDetachedJob() {
 	jobInfo.ID = int64(jobID1)
 	s.compareJobInfoWithoutTime(jobInfo, result1[0])
 
-	s.Eventually(func() bool {
+	s.Require().Eventually(func() bool {
 		rows := s.tk.MustQuery(fmt.Sprintf("show import job %d", jobID1)).Rows()
 		return rows[0][5] == "finished"
-	}, 10*time.Second, 500*time.Millisecond)
+	}, 20*time.Second, 500*time.Millisecond)
 	rows := s.tk.MustQuery(fmt.Sprintf("show import job %d", jobID1)).Rows()
 	s.Len(rows, 1)
 	jobInfo.Status = "finished"
@@ -326,7 +326,7 @@ func (s *mockGCSSuite) TestShowDetachedJob() {
 		Step:           "",
 	}
 	s.compareJobInfoWithoutTime(jobInfo, result2[0])
-	s.Eventually(func() bool {
+	s.Require().Eventually(func() bool {
 		rows = s.tk.MustQuery(fmt.Sprintf("show import job %d", jobID2)).Rows()
 		return rows[0][5] == "failed"
 	}, 10*time.Second, 500*time.Millisecond)
@@ -359,7 +359,7 @@ func (s *mockGCSSuite) TestShowDetachedJob() {
 		Step:           "",
 	}
 	s.compareJobInfoWithoutTime(jobInfo, result3[0])
-	s.Eventually(func() bool {
+	s.Require().Eventually(func() bool {
 		rows = s.tk.MustQuery(fmt.Sprintf("show import job %d", jobID3)).Rows()
 		return rows[0][5] == "failed"
 	}, 10*time.Second, 500*time.Millisecond)
@@ -439,7 +439,7 @@ func (s *mockGCSSuite) TestCancelJob() {
 		ErrorMessage:   "cancelled by user",
 	}
 	s.compareJobInfoWithoutTime(jobInfo, rows[0])
-	s.Eventually(func() bool {
+	s.Require().Eventually(func() bool {
 		task := getTask(int64(jobID1))
 		return task.State == proto.TaskStateReverted
 	}, 10*time.Second, 500*time.Millisecond)
@@ -492,7 +492,7 @@ func (s *mockGCSSuite) TestCancelJob() {
 	s.NoError(err)
 	taskKey := importinto.TaskKey(int64(jobID2))
 	s.NoError(err)
-	s.Eventually(func() bool {
+	s.Require().Eventually(func() bool {
 		globalTask, err2 := globalTaskManager.GetGlobalTaskByKey(taskKey)
 		s.NoError(err2)
 		subtasks, err2 := globalTaskManager.GetSubtasksByStep(globalTask.ID, importinto.StepPostProcess)
@@ -541,7 +541,7 @@ func (s *mockGCSSuite) TestCancelJob() {
 	//	ErrorMessage:   "cancelled by user",
 	//}
 	//s.compareJobInfoWithoutTime(jobInfo, rows[0])
-	//s.Eventually(func() bool {
+	//s.Require().Eventually(func() bool {
 	//	task := getTask(int64(jobID2))
 	//	return task.State == proto.TaskStateReverted
 	//}, 10*time.Second, 500*time.Millisecond)
@@ -621,7 +621,7 @@ func (s *mockGCSSuite) TestKillBeforeFinish() {
 	s.NoError(err)
 	taskKey := importinto.TaskKey(jobID)
 	s.NoError(err)
-	s.Eventually(func() bool {
+	s.Require().Eventually(func() bool {
 		globalTask, err2 := globalTaskManager.GetGlobalTaskByKey(taskKey)
 		s.NoError(err2)
 		return globalTask.State == proto.TaskStateReverted


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45655

Problem Summary:

If we meet

```
    job_test.go:295: 
        	Error Trace:	tests/realtikvtest/importintotest/job_test.go:295
        	Error:      	Condition never satisfied
        	Test:       	TestLoadRemote/TestShowDetachedJob
```

we don't continue the test, because the slow closure may race with following test logic on `s.tk`

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
