### PR TITLE
server: make call to `ReleaseConnID` idempotent.

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -335,9 +335,14 @@ func (cc *clientConn) Close() error {
 	return closeConn(cc, connections)
 }
 
+// closeConn should be idempotent.
+// It will be called on the same `clientConn` more than once to avoid connection leak.
 func closeConn(cc *clientConn, connections int) error {
 	metrics.ConnGauge.Set(float64(connections))
-	cc.server.dom.ReleaseConnID(cc.connectionID)
+	if cc.connectionID > 0 {
+		cc.server.dom.ReleaseConnID(cc.connectionID)
+		cc.connectionID = 0
+	}
 	if cc.bufReadConn != nil {
 		err := cc.bufReadConn.Close()
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45675

Problem Summary: Failed to release 32bits connection ID

There are two calls to release for every connection ID. So the pool is unexpected full.

```
(dlv) bt
0  0x00000000041129aa in github.com/pingcap/tidb/util/globalconn.(*LockFreeCircularPool).Put
   at ./util/globalconn/pool.go:219
1  0x0000000004111d31 in github.com/pingcap/tidb/util/globalconn.(*GlobalAllocator).Release
   at ./util/globalconn/globalconn.go:307
2  0x0000000004c36e18 in github.com/pingcap/tidb/domain.(*Domain).ReleaseConnID
   at ./domain/domain.go:2859
3  0x0000000004c36e18 in github.com/pingcap/tidb/server.closeConn
   at ./server/conn.go:340
4  0x0000000004c36d69 in github.com/pingcap/tidb/server.(*clientConn).Close
   at ./server/conn.go:335
5  0x0000000004c3d58f in github.com/pingcap/tidb/server.(*clientConn).Run.func1
   at ./server/conn.go:967
6  0x0000000004c3cf7c in github.com/pingcap/tidb/server.(*clientConn).Run
   at ./server/conn.go:1030
7  0x0000000004c74867 in github.com/pingcap/tidb/server.(*Server).onConn
   at ./server/server.go:662
8  0x0000000004c7324a in github.com/pingcap/tidb/server.(*Server).startNetworkListener.func1
   at ./server/server.go:478
9  0x0000000001ad5d21 in runtime.goexit
   at /data/nvme0n1/home/pingyu/opt/go1.20.4/src/runtime/asm_amd64.s:1598
```

```
(dlv) bt
0  0x00000000041129aa in github.com/pingcap/tidb/util/globalconn.(*LockFreeCircularPool).Put
   at ./util/globalconn/pool.go:219
1  0x0000000004111d31 in github.com/pingcap/tidb/util/globalconn.(*GlobalAllocator).Release
   at ./util/globalconn/globalconn.go:307
2  0x0000000004c36e18 in github.com/pingcap/tidb/domain.(*Domain).ReleaseConnID
   at ./domain/domain.go:2859
3  0x0000000004c36e18 in github.com/pingcap/tidb/server.closeConn
   at ./server/conn.go:340
4  0x0000000004c36d69 in github.com/pingcap/tidb/server.(*clientConn).Close
   at ./server/conn.go:335
5  0x0000000004c75caf in github.com/pingcap/tidb/server.(*Server).onConn.func3
   at ./server/server.go:639
6  0x0000000004c74950 in github.com/pingcap/tidb/server.(*Server).onConn
   at ./server/server.go:678
7  0x0000000004c7324a in github.com/pingcap/tidb/server.(*Server).startNetworkListener.func1
   at ./server/server.go:478
8  0x0000000001ad5d21 in runtime.goexit
   at /data/nvme0n1/home/pingyu/opt/go1.20.4/src/runtime/asm_amd64.s:1598
```

### What is changed and how it works?

Make release connection ID idempotent by set `clientClient.connectionID` to `0` after connection ID is released.

*The duplicated close connection may need to be fixed later.*
*But as there are even more calls to [`clientConn.Close`](https://github.com/pingcap/tidb/blob/f4f78a1db3018f6026263ffa6190ac133c483da8/server/conn.go#L330) and [`closeConn`](https://github.com/pingcap/tidb/blob/f4f78a1db3018f6026263ffa6190ac133c483da8/server/conn.go#L338), especially on handling errors, this PR prefer to make `closeConn` idempotent to ensue correctness.*


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
