### PR TITLE
lightning: extract region job's accessing data to an interface

### DIFF
--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -947,9 +947,11 @@ func (e *Engine) newKVIter(ctx context.Context, opts *pebble.IterOptions) Iter {
 	return newDupDetectIter(e.getDB(), e.keyAdapter, opts, e.duplicateDB, logger, e.dupDetectOpt)
 }
 
-// getFirstAndLastKey reads the first and last key in range [lowerBound, upperBound)
+var _ ingestData = (*Engine)(nil)
+
+// GetFirstAndLastKey reads the first and last key in range [lowerBound, upperBound)
 // in the engine. Empty upperBound means unbounded.
-func (e *Engine) getFirstAndLastKey(lowerBound, upperBound []byte) ([]byte, []byte, error) {
+func (e *Engine) GetFirstAndLastKey(lowerBound, upperBound []byte) ([]byte, []byte, error) {
 	if len(upperBound) == 0 {
 		// we use empty slice for unbounded upper bound, but it means max value in pebble
 		// so reset to nil
@@ -978,6 +980,19 @@ func (e *Engine) getFirstAndLastKey(lowerBound, upperBound []byte) ([]byte, []by
 	}
 	lastKey := append([]byte{}, iter.Key()...)
 	return firstKey, lastKey, nil
+}
+
+func (e *Engine) NewIter(ctx context.Context, lowerBound, upperBound []byte) ForwardIter {
+	return e.newKVIter(ctx, &pebble.IterOptions{LowerBound: lowerBound, UpperBound: upperBound})
+}
+
+func (e *Engine) GetTS() uint64 {
+	return e.TS
+}
+
+func (e *Engine) Finish(totalBytes, totalCount int64) {
+	e.importedKVSize.Add(totalBytes)
+	e.importedKVCount.Add(totalCount)
 }
 
 type sstMeta struct {

--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -982,14 +982,17 @@ func (e *Engine) GetFirstAndLastKey(lowerBound, upperBound []byte) ([]byte, []by
 	return firstKey, lastKey, nil
 }
 
+// NewIter implements ingestData interface.
 func (e *Engine) NewIter(ctx context.Context, lowerBound, upperBound []byte) ForwardIter {
 	return e.newKVIter(ctx, &pebble.IterOptions{LowerBound: lowerBound, UpperBound: upperBound})
 }
 
+// GetTS implements ingestData interface.
 func (e *Engine) GetTS() uint64 {
 	return e.TS
 }
 
+// Finish implements ingestData interface.
 func (e *Engine) Finish(totalBytes, totalCount int64) {
 	e.importedKVSize.Add(totalBytes)
 	e.importedKVCount.Add(totalCount)

--- a/br/pkg/lightning/backend/local/engine_test.go
+++ b/br/pkg/lightning/backend/local/engine_test.go
@@ -142,27 +142,27 @@ func TestGetFirstAndLastKey(t *testing.T) {
 	err = db.Set([]byte("e"), []byte("e"), nil)
 	require.NoError(t, err)
 
-	first, last, err := f.getFirstAndLastKey(nil, nil)
+	first, last, err := f.GetFirstAndLastKey(nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, []byte("a"), first)
 	require.Equal(t, []byte("e"), last)
 
-	first, last, err = f.getFirstAndLastKey([]byte("b"), []byte("d"))
+	first, last, err = f.GetFirstAndLastKey([]byte("b"), []byte("d"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("c"), first)
 	require.Equal(t, []byte("c"), last)
 
-	first, last, err = f.getFirstAndLastKey([]byte("b"), []byte("f"))
+	first, last, err = f.GetFirstAndLastKey([]byte("b"), []byte("f"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("c"), first)
 	require.Equal(t, []byte("e"), last)
 
-	first, last, err = f.getFirstAndLastKey([]byte("y"), []byte("z"))
+	first, last, err = f.GetFirstAndLastKey([]byte("y"), []byte("z"))
 	require.NoError(t, err)
 	require.Nil(t, first)
 	require.Nil(t, last)
 
-	first, last, err = f.getFirstAndLastKey([]byte("e"), []byte(""))
+	first, last, err = f.GetFirstAndLastKey([]byte("e"), []byte(""))
 	require.NoError(t, err)
 	require.Equal(t, []byte("e"), first)
 	require.Equal(t, []byte("e"), last)

--- a/br/pkg/lightning/backend/local/iterator.go
+++ b/br/pkg/lightning/backend/local/iterator.go
@@ -28,25 +28,12 @@ import (
 
 // Iter abstract iterator method for Ingester.
 type Iter interface {
+	ForwardIter
 	// Seek seek to specify position.
 	// if key not found, seeks next key position in iter.
 	Seek(key []byte) bool
-	// Error return current error on this iter.
-	Error() error
-	// First moves this iter to the first key.
-	First() bool
 	// Last moves this iter to the last key.
 	Last() bool
-	// Valid check this iter reach the end.
-	Valid() bool
-	// Next moves this iter forward.
-	Next() bool
-	// Key represents current position pair's key.
-	Key() []byte
-	// Value represents current position pair's Value.
-	Value() []byte
-	// Close close this iter.
-	Close() error
 	// OpType represents operations of pair. currently we have two types.
 	// 1. Put
 	// 2. Delete

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -1024,7 +1024,7 @@ func (local *Backend) readAndSplitIntoRange(
 	sizeLimit int64,
 	keysLimit int64,
 ) ([]Range, error) {
-	firstKey, lastKey, err := engine.getFirstAndLastKey(nil, nil)
+	firstKey, lastKey, err := engine.GetFirstAndLastKey(nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1191,7 +1191,7 @@ var fakeRegionJobs map[[2]string]struct {
 // It will retry internally when scan region meet error.
 func (local *Backend) generateJobForRange(
 	ctx context.Context,
-	engine *Engine,
+	engine ingestData,
 	keyRange Range,
 	regionSplitSize, regionSplitKeys int64,
 ) ([]*regionJob, error) {
@@ -1210,7 +1210,7 @@ func (local *Backend) generateJobForRange(
 	})
 
 	start, end := keyRange.start, keyRange.end
-	pairStart, pairEnd, err := engine.getFirstAndLastKey(start, end)
+	pairStart, pairEnd, err := engine.GetFirstAndLastKey(start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -1247,7 +1247,7 @@ func (local *Backend) generateJobForRange(
 			keyRange:        intersectRange(region.Region, Range{start: start, end: end}),
 			region:          region,
 			stage:           regionScanned,
-			engine:          engine,
+			ingestData:      engine,
 			regionSplitSize: regionSplitSize,
 			regionSplitKeys: regionSplitKeys,
 			metrics:         local.metrics,
@@ -1283,7 +1283,7 @@ func (local *Backend) startWorker(
 			case needRescan:
 				jobs, err2 := local.generateJobForRange(
 					ctx,
-					job.engine,
+					job.ingestData,
 					job.keyRange,
 					job.regionSplitSize,
 					job.regionSplitKeys,

--- a/br/pkg/lightning/backend/local/region_job.go
+++ b/br/pkg/lightning/backend/local/region_job.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/pebble"
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -103,7 +102,7 @@ type regionJob struct {
 	// writeResult is available only in wrote and ingested stage
 	writeResult *tikvWriteResult
 
-	engine          *Engine
+	ingestData      ingestData
 	regionSplitSize int64
 	regionSplitKeys int64
 	metrics         *metric.Metrics
@@ -121,6 +120,39 @@ type tikvWriteResult struct {
 	count             int64
 	totalBytes        int64
 	remainingStartKey []byte
+}
+
+// ingestData describes a common interface that is needed by TiKV write +
+// ingest RPC.
+// TODO(lance6716): make it public to remote backend can use it.
+type ingestData interface {
+	// GetFirstAndLastKey returns the first and last key of the data reader in the
+	// range [lowerBound, upperBound). Empty or nil bounds means unbounded.
+	// lowerBound must be less than upperBound.
+	// when there is no data in the range, it should return nil, nil, nil
+	GetFirstAndLastKey(lowerBound, upperBound []byte) ([]byte, []byte, error)
+	NewIter(ctx context.Context, lowerBound, upperBound []byte) ForwardIter
+	// GetTS will be used as the start/commit TS of the data.
+	GetTS() uint64
+	// Finish will be called when the data is ingested successfully.
+	Finish(totalBytes, totalCount int64)
+}
+
+type ForwardIter interface {
+	// First moves this iter to the first key.
+	First() bool
+	// Valid check this iter reach the end.
+	Valid() bool
+	// Next moves this iter forward.
+	Next() bool
+	// Key represents current position pair's key.
+	Key() []byte
+	// Value represents current position pair's Value.
+	Value() []byte
+	// Close close this iter.
+	Close() error
+	// Error return current error on this iter.
+	Error() error
 }
 
 type injectedBehaviour struct {
@@ -149,8 +181,7 @@ func (j *regionJob) convertStageTo(stage jobStageTp) {
 			return
 		}
 
-		j.engine.importedKVSize.Add(j.writeResult.totalBytes)
-		j.engine.importedKVCount.Add(j.writeResult.count)
+		j.ingestData.Finish(j.writeResult.totalBytes, j.writeResult.count)
 		if j.metrics != nil {
 			j.metrics.BytesCounter.WithLabelValues(metric.StateImported).
 				Add(float64(j.writeResult.totalBytes))
@@ -191,7 +222,7 @@ func (local *Backend) writeToTiKV(ctx context.Context, j *regionJob) error {
 	begin := time.Now()
 	region := j.region.Region
 
-	firstKey, lastKey, err := j.engine.getFirstAndLastKey(j.keyRange.start, j.keyRange.end)
+	firstKey, lastKey, err := j.ingestData.GetFirstAndLastKey(j.keyRange.start, j.keyRange.end)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -259,7 +290,7 @@ func (local *Backend) writeToTiKV(ctx context.Context, j *regionJob) error {
 	}
 	req.Chunk = &sst.WriteRequest_Batch{
 		Batch: &sst.WriteBatch{
-			CommitTs: j.engine.TS,
+			CommitTs: j.ingestData.GetTS(),
 		},
 	}
 
@@ -300,8 +331,7 @@ func (local *Backend) writeToTiKV(ctx context.Context, j *regionJob) error {
 		return nil
 	}
 
-	opt := &pebble.IterOptions{LowerBound: j.keyRange.start, UpperBound: j.keyRange.end}
-	iter := j.engine.newKVIter(ctx, opt)
+	iter := j.ingestData.NewIter(ctx, j.keyRange.start, j.keyRange.end)
 	//nolint: errcheck
 	defer iter.Close()
 

--- a/br/pkg/lightning/backend/local/region_job.go
+++ b/br/pkg/lightning/backend/local/region_job.go
@@ -138,6 +138,7 @@ type ingestData interface {
 	Finish(totalBytes, totalCount int64)
 }
 
+// ForwardIter describes a iterator that can only move forward.
 type ForwardIter interface {
 	// First moves this iter to the first key.
 	First() bool


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #45719

Problem Summary:

### What is changed and how it works?

part of #45356

before this PR, region job holds an `Engine` structure which is the concept of local backend. In this PR an interface `ingestData` replaces `Engine` so we can introduce a new implementation. Compared with `Engine` which stores data in the disk, we can use a pure memory sorted slice of KV pairs to accomplish region job.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
