### PR TITLE
statistics: reduce memory usage when to MergePartTopN2GlobalTopN

### DIFF
--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -306,6 +306,7 @@ func (hg *Histogram) BinarySearchRemoveVal(valCntPairs TopNMeta) {
 		if hg.Buckets[midIdx].Count < 0 {
 			hg.Buckets[midIdx].Count = 0
 		}
+		break
 	}
 }
 

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -281,6 +281,35 @@ func (hg *Histogram) BucketToString(bktID, idxCols int) string {
 	return fmt.Sprintf("num: %d lower_bound: %s upper_bound: %s repeats: %d ndv: %d", hg.bucketCount(bktID), lowerVal, upperVal, hg.Buckets[bktID].Repeat, hg.Buckets[bktID].NDV)
 }
 
+// BinarySearchRemoveVal removes the value from the TopN using binary search.
+func (hg *Histogram) BinarySearchRemoveVal(valCntPairs TopNMeta) {
+	lowIdx, highIdx := 0, hg.Len()-1
+	for lowIdx <= highIdx {
+		midIdx := (lowIdx + highIdx) / 2
+		cmpResult := bytes.Compare(hg.Bounds.Column(0).GetRaw(midIdx*2), valCntPairs.Encoded)
+		if cmpResult > 0 {
+			lowIdx = midIdx + 1
+			continue
+		}
+		cmpResult = bytes.Compare(hg.Bounds.Column(0).GetRaw(midIdx*2+1), valCntPairs.Encoded)
+		if cmpResult < 0 {
+			highIdx = midIdx - 1
+			continue
+		}
+		if hg.Buckets[midIdx].NDV > 0 {
+			hg.Buckets[midIdx].NDV--
+		}
+		if cmpResult == 0 {
+			hg.Buckets[midIdx].Repeat = 0
+
+		}
+		hg.Buckets[midIdx].Count -= int64(valCntPairs.Count)
+		if hg.Buckets[midIdx].Count < 0 {
+			hg.Buckets[midIdx].Count = 0
+		}
+	}
+}
+
 // RemoveVals remove the given values from the histogram.
 // This function contains an **ASSUMPTION**: valCntPairs is sorted in ascending order.
 func (hg *Histogram) RemoveVals(valCntPairs []TopNMeta) {

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -301,7 +301,6 @@ func (hg *Histogram) BinarySearchRemoveVal(valCntPairs TopNMeta) {
 		}
 		if cmpResult == 0 {
 			hg.Buckets[midIdx].Repeat = 0
-
 		}
 		hg.Buckets[midIdx].Count -= int64(valCntPairs.Count)
 		if hg.Buckets[midIdx].Count < 0 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45727

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

add some gobench for it.

Before:

| Benchmark                                  | Iterations | Time per Operation | Memory Allocated | Allocations per Operation |
|--------------------------------------------|------------|-------------------|------------------|---------------------------|
| BenchmarkMergePartTopN2GlobalTopNWithHists100-8    | 85184      | 13737 ns/op       | 4408 B/op        | 53 allocs/op             |
| BenchmarkMergePartTopN2GlobalTopNWithHists1000-8   | 8985       | 136583 ns/op      | 40696 B/op       | 503 allocs/op            |
| BenchmarkMergePartTopN2GlobalTopNWithHists10000-8  | 702        | 1637701 ns/op     | 405880 B/op      | 5003 allocs/op           |
| BenchmarkMergePartTopN2GlobalTopNWithHists100000-8 | 48         | 23604707 ns/op    | 4000376 B/op     | 50003 allocs/op          |
| BenchmarkMergePartTopN2GlobalTopNWithHists1000000-8| 5          | 235231317 ns/op   | 40002699 B/op    | 500003 allocs/op         |
| BenchmarkMergePartTopN2GlobalTopNWithHists10000000-8| 1         | 17470526833 ns/op | 400001144 B/op   | 5000003 allocs/op        |


After: https://github.com/pingcap/tidb/pull/45718

| Benchmark                                  | Iterations | Time per Operation | Memory Allocated | Allocations per Operation |
|--------------------------------------------|------------|-------------------|------------------|---------------------------|
| BenchmarkMergePartTopN2GlobalTopNWithHists100-8    | 103918     | 11497 ns/op       | 120 B/op         | 2 allocs/op              |
| BenchmarkMergePartTopN2GlobalTopNWithHists1000-8   | 10000      | 113324 ns/op      | 120 B/op         | 2 allocs/op              |
| BenchmarkMergePartTopN2GlobalTopNWithHists10000-8  | 909        | 1308099 ns/op     | 120 B/op         | 2 allocs/op              |
| BenchmarkMergePartTopN2GlobalTopNWithHists100000-8 | 63         | 17689263 ns/op    | 120 B/op         | 2 allocs/op              |
| BenchmarkMergePartTopN2GlobalTopNWithHists1000000-8| 6          | 180973042 ns/op   | 120 B/op         | 2 allocs/op              |
| BenchmarkMergePartTopN2GlobalTopNWithHists10000000-8| 1         | 8101635583 ns/op | 120 B/op         | 2 allocs/op              |



- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
