### PR TITLE
expression: WEIGHT_STRING() collation

### DIFF
--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -3959,6 +3959,7 @@ func (c *weightStringFunctionClass) getFunction(ctx sessionctx.Context, args []E
 	if err != nil {
 		return nil, err
 	}
+	types.SetBinChsClnFlag(bf.tp)
 	var sig builtinFunc
 	if padding == weightStringPaddingNull {
 		sig = &builtinWeightStringNullSig{bf}

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -2604,6 +2604,10 @@ func TestWeightString(t *testing.T) {
 			f, err = fc.getFunction(ctx, datumsToConstants([]types.Datum{str, padding, length}))
 		}
 		require.NoError(t, err)
+
+		retType := f.getRetTp()
+		require.Equal(t, charset.CollationBin, retType.GetCollate())
+
 		// Reset warnings.
 		ctx.GetSessionVars().StmtCtx.ResetForRetry()
 		result, err := evalBuiltinFunc(f, chunk.Row{})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45725 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
MySQL Compatibility of `WEIGHT_STRING()` was improved by matching the collation.
```


TiDB with this PR:
```
sql> SET NAMES utf8mb4 COLLATE utf8mb4_general_ci;
Query OK, 0 rows affected (0.0011 sec)

sql> SELECT WEIGHT_STRING('aéè€☺');
Field 1
Name:      `WEIGHT_STRING('aéè€☺')`
Org_name:  ``
Catalog:   `def`
Database:  ``
Table:     ``
Org_table: ``
Type:      Bytes
DbType:    VAR_STRING
Collation: binary (63)
Length:    0
Decimals:  31
Flags:     NOT_NULL BINARY 

+------------------------+
| WEIGHT_STRING('aéè€☺') |
+------------------------+
| 0x00410045004520AC263A |
+------------------------+
1 row in set (0.0011 sec)
```

MySQL 8.1.0:
```
sql> SET NAMES utf8mb4 COLLATE utf8mb4_general_ci;
Query OK, 0 rows affected (0.0355 sec)

sql> SELECT WEIGHT_STRING('aéè€☺');
Field 1
Name:      `WEIGHT_STRING('aéè€☺')`
Org_name:  ``
Catalog:   `def`
Database:  ``
Table:     ``
Org_table: ``
Type:      Bytes
DbType:    VAR_STRING
Collation: binary (63)
Length:    40
Decimals:  31
Flags:     BINARY 

+------------------------+
| WEIGHT_STRING('aéè€☺') |
+------------------------+
| 0x00410045004520AC263A |
+------------------------+
1 row in set (0.0009 sec)
```

Here `Type` is now `Bytes` for both. There are still differences in `Length` and `Flags`.