### PR TITLE
planner, executor: fix batch_point_get with specific table partitions

### DIFF
--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -51,7 +51,6 @@ type BatchPointGetExec struct {
 	partExpr    *tables.PartitionExpr
 	partPos     int
 	planPhysIDs []int64
-	singlePart  bool
 	partTblID   []int64
 	idxVals     [][]types.Datum
 	txn         kv.Transaction
@@ -235,11 +234,8 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 				}
 			}
 
-			// If this BatchPointGetExec is built only for the specific table partition, skip those filters not matching this partition.
+			// If this BatchPointGetExec is built only for the specific table partitions, skip those filters not matching those partitions.
 			if len(e.partTblID) >= 1 {
-				if e.singlePart && e.partTblID[0] != physID {
-					continue
-				}
 				if _, found := slices.BinarySearch(e.partTblID, physID); !found {
 					continue
 				}
@@ -384,11 +380,8 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 				}
 			}
 		}
-		// If this BatchPointGetExec is built only for the specific table partition, skip those handles not matching this partition.
+		// If this BatchPointGetExec is built only for the specific table partitions, skip those handles not matching those partitions.
 		if len(e.partTblID) >= 1 {
-			if e.singlePart && e.partTblID[0] != tID {
-				continue
-			}
 			if _, found := slices.BinarySearch(e.partTblID, tID); !found {
 				continue
 			}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -5217,7 +5217,6 @@ func (b *executorBuilder) buildBatchPointGet(plan *plannercore.BatchPointGetPlan
 		partExpr:     plan.PartitionExpr,
 		partPos:      plan.PartitionColPos,
 		planPhysIDs:  plan.PartitionIDs,
-		singlePart:   plan.SinglePart,
 		partTblID:    plan.PartTblID,
 		columns:      plan.Columns,
 	}

--- a/planner/core/casetest/partition/testdata/integration_partition_suite_in.json
+++ b/planner/core/casetest/partition/testdata/integration_partition_suite_in.json
@@ -247,14 +247,23 @@
       "select * from thash3 where a in (1,3) and 1 = 1",
       "select * from thash3 where a in (1,3) and 1 = 1 order by a",
       "select * from thash3 where a in (1,3) and 1 = 1 order by a desc",
+      "select * from thash3 partition(p0) where a in (1,4)",
+      "select * from thash3 partition(p1) where a in (2,4)",
+      "select * from thash3 partition(p0,p1) where a in (2,4)",
       "select * from trange3 where a in (1,2) and 1 = 1",
       "select * from trange3 where a in (1,3) and 1 = 1",
       "select * from trange3 where a in (1,3) and 1 = 1 order by a",
       "select * from trange3 where a in (1,3) and 1 = 1 order by a desc",
+      "select * from trange3 partition(p0) where a in (1,4)",
+      "select * from trange3 partition(p1) where a in (1,2)",
+      "select * from trange3 partition(p0,p1) where a in (1,2)",
       "select * from tlist3 where a in (1,2) and 1 = 1",
       "select * from tlist3 where a in (1,3) and 1 = 1",
       "select * from tlist3 where a in (1,2) and 1 = 1 order by a",
-      "select * from tlist3 where a in (1,2) and 1 = 1 order by a desc"
+      "select * from tlist3 where a in (1,2) and 1 = 1 order by a desc",
+      "select * from tlist3 partition(p0) where a in (1,4)",
+      "select * from tlist3 partition(p1) where a in (1,2)",
+      "select * from tlist3 partition(p0,p1) where a in (1,2)"
     ]
   },
   {

--- a/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
+++ b/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
@@ -2268,6 +2268,42 @@
         ]
       },
       {
+        "SQL": "select * from thash3 partition(p0) where a in (1,4)",
+        "DynamicPlan": [
+          "Batch_Point_Get 2.00 root table:thash3 handle:[1 4], keep order:false, desc:false"
+        ],
+        "StaticPlan": [
+          "Batch_Point_Get 2.00 root table:thash3 handle:[1 4], keep order:false, desc:false"
+        ],
+        "Result": [
+          "4 0"
+        ]
+      },
+      {
+        "SQL": "select * from thash3 partition(p1) where a in (2,4)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:dual data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:thash3 range:[2,2], [4,4], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from thash3 partition(p0,p1) where a in (2,4)",
+        "DynamicPlan": [
+          "Batch_Point_Get 2.00 root table:thash3 handle:[2 4], keep order:false, desc:false"
+        ],
+        "StaticPlan": [
+          "Batch_Point_Get 2.00 root table:thash3 handle:[2 4], keep order:false, desc:false"
+        ],
+        "Result": [
+          "2 0",
+          "4 0"
+        ]
+      },
+      {
         "SQL": "select * from trange3 where a in (1,2) and 1 = 1",
         "DynamicPlan": [
           "Batch_Point_Get 2.00 root table:trange3 handle:[1 2], keep order:false, desc:false"
@@ -2330,6 +2366,42 @@
         ]
       },
       {
+        "SQL": "select * from trange3 partition(p0) where a in (1,4)",
+        "DynamicPlan": [
+          "Batch_Point_Get 2.00 root table:trange3 handle:[1 4], keep order:false, desc:false"
+        ],
+        "StaticPlan": [
+          "Batch_Point_Get 2.00 root table:trange3 handle:[1 4], keep order:false, desc:false"
+        ],
+        "Result": [
+          "1 0"
+        ]
+      },
+      {
+        "SQL": "select * from trange3 partition(p1) where a in (1,2)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:dual data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange3 range:[1,1], [2,2], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from trange3 partition(p0,p1) where a in (1,2)",
+        "DynamicPlan": [
+          "Batch_Point_Get 2.00 root table:trange3 handle:[1 2], keep order:false, desc:false"
+        ],
+        "StaticPlan": [
+          "Batch_Point_Get 2.00 root table:trange3 handle:[1 2], keep order:false, desc:false"
+        ],
+        "Result": [
+          "1 0",
+          "2 0"
+        ]
+      },
+      {
         "SQL": "select * from tlist3 where a in (1,2) and 1 = 1",
         "DynamicPlan": [
           "Batch_Point_Get 2.00 root table:tlist3 handle:[1 2], keep order:false, desc:false"
@@ -2383,6 +2455,42 @@
         "Result": [
           "2 0",
           "1 0"
+        ]
+      },
+      {
+        "SQL": "select * from tlist3 partition(p0) where a in (1,4)",
+        "DynamicPlan": [
+          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 4], keep order:false, desc:false"
+        ],
+        "StaticPlan": [
+          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 4], keep order:false, desc:false"
+        ],
+        "Result": [
+          "1 0"
+        ]
+      },
+      {
+        "SQL": "select * from tlist3 partition(p1) where a in (1,2)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:dual data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist3 range:[1,1], [2,2], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from tlist3 partition(p0,p1) where a in (1,2)",
+        "DynamicPlan": [
+          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 2], keep order:false, desc:false"
+        ],
+        "StaticPlan": [
+          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 2], keep order:false, desc:false"
+        ],
+        "Result": [
+          "1 0",
+          "2 0"
         ]
       }
     ]

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -2547,7 +2547,6 @@ func (ds *DataSource) convertToBatchPointGet(prop *property.PhysicalProperty, ca
 	}
 	if ds.isPartition {
 		// static prune
-		batchPointGetPlan.SinglePart = true
 		batchPointGetPlan.PartTblID = make([]int64, 1)
 		batchPointGetPlan.PartTblID[0] = ds.physicalTableID
 	} else if ds.tableInfo.GetPartitionInfo() != nil {

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -2543,9 +2543,26 @@ func (ds *DataSource) convertToBatchPointGet(prop *property.PhysicalProperty, ca
 		TblInfo:          ds.TableInfo(),
 		KeepOrder:        !prop.IsSortItemEmpty(),
 		Columns:          ds.Columns,
-		SinglePart:       ds.isPartition,
-		PartTblID:        ds.physicalTableID,
 		PartitionExpr:    getPartitionExpr(ds.SCtx(), ds.TableInfo()),
+	}
+	if ds.isPartition {
+		// static prune
+		batchPointGetPlan.SinglePart = true
+		batchPointGetPlan.PartTblID = make([]int64, 1)
+		batchPointGetPlan.PartTblID[0] = ds.physicalTableID
+	} else if ds.tableInfo.GetPartitionInfo() != nil {
+		// dynamic prune
+		idxs, err := PartitionPruning(ds.SCtx(), ds.table.GetPartitionedTable(), ds.allConds, ds.partitionNames, ds.TblCols, ds.names)
+		if err != nil || len(idxs) == 0 {
+			return invalidTask
+		}
+		if idxs[0] != FullRange {
+			batchPointGetPlan.PartTblID = make([]int64, len(idxs))
+			for i, idx := range idxs {
+				batchPointGetPlan.PartTblID[i] = ds.tableInfo.GetPartitionInfo().Definitions[idx].ID
+			}
+			slices.Sort(batchPointGetPlan.PartTblID)
+		}
 	}
 	if batchPointGetPlan.KeepOrder {
 		// TODO: support keepOrder for partition table with dynamic pruning

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -329,11 +329,6 @@ type BatchPointGetPlan struct {
 	Columns          []*model.ColumnInfo
 	cost             float64
 
-	// SinglePart indicates whether this BatchPointGetPlan is just for a single partition, instead of the whole partition table.
-	// If the BatchPointGetPlan is built in fast path, this value is false; if the plan is generated in physical optimization for a partition,
-	// this value would be true. This value would decide the behavior of BatchPointGetExec, i.e, whether to compute the table ID of the partition
-	// on the fly.
-	SinglePart bool
 	// PartTblID is the table IDs for the specific table partitions.
 	PartTblID []int64
 

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -334,8 +334,8 @@ type BatchPointGetPlan struct {
 	// this value would be true. This value would decide the behavior of BatchPointGetExec, i.e, whether to compute the table ID of the partition
 	// on the fly.
 	SinglePart bool
-	// PartTblID is the table ID for the specific table partition.
-	PartTblID int64
+	// PartTblID is the table IDs for the specific table partitions.
+	PartTblID []int64
 
 	// required by cost model
 	planCostInit bool


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45720

Problem Summary: I didn't check specific table partitions in `batch_point_get` before, support it and add tests to cover it.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
