### PR TITLE
lightning: fix lightning TLS.WithHost to access the correct host

### DIFF
--- a/br/pkg/lightning/common/BUILD.bazel
+++ b/br/pkg/lightning/common/BUILD.bazel
@@ -104,7 +104,7 @@ go_test(
     ],
     embed = [":common"],
     flaky = True,
-    shard_count = 19,
+    shard_count = 20,
     deps = [
         "//br/pkg/errors",
         "//br/pkg/lightning/log",

--- a/br/pkg/lightning/common/security.go
+++ b/br/pkg/lightning/common/security.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/httputil"
@@ -88,8 +89,15 @@ func NewTLSFromMockServer(server *httptest.Server) *TLS {
 	}
 }
 
+// GetMockTLSUrl returns tls's host for mock test
+func GetMockTLSUrl(tls *TLS) string {
+	return tls.url
+}
+
 // WithHost creates a new TLS instance with the host replaced.
 func (tc *TLS) WithHost(host string) *TLS {
+	host = strings.TrimPrefix(host, "http://")
+	host = strings.TrimPrefix(host, "https://")
 	var url string
 	if tc.inner != nil {
 		url = "https://" + host

--- a/br/tests/lightning_partitioned-table/run.sh
+++ b/br/tests/lightning_partitioned-table/run.sh
@@ -25,8 +25,6 @@ for BACKEND in tidb local; do
 
     run_sql 'DROP DATABASE IF EXISTS partitioned;'
 
-    # DEFAULT List partitioning needs to be enabled for defaultlist table
-    run_sql 'set @@global.tidb_enable_default_list_partition=1;'
     run_lightning --backend $BACKEND
 
     run_sql 'SELECT count(1), sum(a) FROM partitioned.a;'


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/45747

Problem Summary:

### What is changed and how it works?
TrimPrefix before WithHost

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Side effects

- None

Documentation

- None

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
