### PR TITLE
*: support rollback from higher version to 6.5

### DIFF
--- a/meta/meta.go
+++ b/meta/meta.go
@@ -619,7 +619,11 @@ func (m *Meta) CheckMDLTableExists() (bool, error) {
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	return bytes.Equal(v, []byte("2")), nil
+	iv, err := strconv.Atoi(string(v))
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return iv >= 2, nil
 }
 
 // SetConcurrentDDL set the concurrent DDL flag.

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -1543,3 +1543,26 @@ func TestTiDBStatsLoadPseudoTimeoutUpgradeFrom610To650(t *testing.T) {
 	require.Equal(t, 2, row.Len())
 	require.Equal(t, "1", row.GetString(1))
 }
+
+func TestTiDBDowngradeTo65(t *testing.T) {
+	ctx := context.Background()
+	store, _ := createStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMeta(txn)
+	err = m.FinishBootstrap(currentBootstrapVersion)
+	require.NoError(t, err)
+	err = txn.Commit(context.Background())
+	txn, err = store.Begin()
+	require.NoError(t, err)
+	err = txn.Set([]byte("DDLTableVersion"), []byte("3"))
+	require.NoError(t, err)
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+	require.NoError(t, err)
+	dom, err := BootstrapSession(store)
+	require.NoError(t, err)
+	dom.Close()
+}

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -1555,6 +1555,7 @@ func TestTiDBDowngradeTo65(t *testing.T) {
 	err = m.FinishBootstrap(currentBootstrapVersion)
 	require.NoError(t, err)
 	err = txn.Commit(context.Background())
+	require.NoError(t, err)
 	txn, err = store.Begin()
 	require.NoError(t, err)
 	err = txn.Set([]byte("DDLTableVersion"), []byte("3"))

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -1561,7 +1561,6 @@ func TestTiDBDowngradeTo65(t *testing.T) {
 	require.NoError(t, err)
 	err = txn.Commit(ctx)
 	require.NoError(t, err)
-	require.NoError(t, err)
 	dom, err := BootstrapSession(store)
 	require.NoError(t, err)
 	dom.Close()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45570

Problem Summary:
We checked DDLTableVersion == 2 in 6.5, but it may be set to a higher value in a higher version TiDB.

### What is changed and how it works?
check DDLTableVersion >= 2, which is the same as the fixed in the higher version.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
Start a master cluster, then use this PR to start a TiDB server. It can start normally.

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
 support rollback from higher version to 6.5
```
