### PR TITLE
infoschema: fix the value of `MaxColumnID` in memDB

### DIFF
--- a/infoschema/BUILD.bazel
+++ b/infoschema/BUILD.bazel
@@ -73,7 +73,7 @@ go_test(
     ],
     embed = [":infoschema"],
     flaky = True,
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         "//ddl/placement",
         "//domain",

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -378,6 +378,8 @@ func init() {
 		for i, c := range tableInfo.Columns {
 			c.ID = int64(i) + 1
 		}
+		tableInfo.MaxColumnID = int64(len(tableInfo.Columns))
+		tableInfo.MaxIndexID = int64(len(tableInfo.Indices))
 	}
 	infoSchemaDB := &model.DBInfo{
 		ID:      dbID,

--- a/infoschema/metrics_schema.go
+++ b/infoschema/metrics_schema.go
@@ -49,6 +49,8 @@ func init() {
 		tableInfo.Comment = def.Comment
 		tableID++
 		metricTables = append(metricTables, tableInfo)
+		tableInfo.MaxColumnID = int64(len(tableInfo.Columns))
+		tableInfo.MaxIndexID = int64(len(tableInfo.Indices))
 	}
 	dbInfo := &model.DBInfo{
 		ID:      dbID,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/45744

Problem Summary:
At present, it is the `MaxColumnID` of the table in the `information_schema` database, which affects `modify column`, `add column`(this action has no problem in behavior, but can cause problems with column ids that are not unique)
. 
The table under `metrics_schema` has a similar problem, and the table under `performance_schema` does not.

### What is changed and how it works?
* Set tables' `MaxColumnID` in the `information_schema` and `metrics_schema` databases.
* Set tables' `MaxIndexD`, although this field is not currently used.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
