### PR TITLE
statistics: enable fieldalignment 

### DIFF
--- a/build/nogo_config.json
+++ b/build/nogo_config.json
@@ -175,7 +175,7 @@
       ".*_test\\.go$": "ignore test code"
     },
     "only_files": {
-      "statistics/handle": "statistics/handle code",
+      "statistics/": "statistics/ code",
       "util/checksum": "util/checksum code",
       "util/processinfo.go": "util/processinfo.go code",
       "util/cpuprofile/": "util/cpuprofile/ code",

--- a/statistics/analyze.go
+++ b/statistics/analyze.go
@@ -68,12 +68,12 @@ type AnalyzeResult struct {
 
 // AnalyzeResults represents the analyze results of a task.
 type AnalyzeResults struct {
-	TableID  AnalyzeTableID
-	Ars      []*AnalyzeResult
-	Count    int64
-	ExtStats *ExtendedStatsColl
 	Err      error
+	ExtStats *ExtendedStatsColl
 	Job      *AnalyzeJob
+	Ars      []*AnalyzeResult
+	TableID  AnalyzeTableID
+	Count    int64
 	StatsVer int
 	Snapshot uint64
 	// BaseCount is the original count in mysql.stats_meta at the beginning of analyze.

--- a/statistics/analyze_jobs.go
+++ b/statistics/analyze_jobs.go
@@ -21,23 +21,23 @@ import (
 
 // AnalyzeJob is used to represent the status of one analyze job.
 type AnalyzeJob struct {
+	Progress      AnalyzeProgress
+	StartTime     time.Time
+	EndTime       time.Time
 	ID            *uint64
 	DBName        string
 	TableName     string
 	PartitionName string
 	JobInfo       string
-	StartTime     time.Time
-	EndTime       time.Time
-	Progress      AnalyzeProgress
 }
 
 // AnalyzeProgress represents the process of one analyze job.
 type AnalyzeProgress struct {
-	sync.Mutex
-	// deltaCount is the newly processed rows after the last time mysql.analyze_jobs.processed_rows is updated.
-	deltaCount int64
 	// lastDumpTime is the last time mysql.analyze_jobs.processed_rows is updated.
 	lastDumpTime time.Time
+	// deltaCount is the newly processed rows after the last time mysql.analyze_jobs.processed_rows is updated.
+	deltaCount int64
+	sync.Mutex
 }
 
 // Update adds rowCount to the delta count. If the updated delta count reaches threshold, it returns the delta count for

--- a/statistics/analyze_jobs.go
+++ b/statistics/analyze_jobs.go
@@ -21,7 +21,6 @@ import (
 
 // AnalyzeJob is used to represent the status of one analyze job.
 type AnalyzeJob struct {
-	Progress      AnalyzeProgress
 	StartTime     time.Time
 	EndTime       time.Time
 	ID            *uint64
@@ -29,6 +28,7 @@ type AnalyzeJob struct {
 	TableName     string
 	PartitionName string
 	JobInfo       string
+	Progress      AnalyzeProgress
 }
 
 // AnalyzeProgress represents the process of one analyze job.

--- a/statistics/builder.go
+++ b/statistics/builder.go
@@ -30,12 +30,12 @@ import (
 // SortedBuilder is used to build histograms for PK and index.
 type SortedBuilder struct {
 	sc              *stmtctx.StatementContext
+	hist            *Histogram
 	numBuckets      int64
 	valuesPerBucket int64
 	lastNumber      int64
 	bucketIdx       int64
 	Count           int64
-	hist            *Histogram
 	needBucketNDV   bool
 }
 

--- a/statistics/cmsketch.go
+++ b/statistics/cmsketch.go
@@ -133,7 +133,7 @@ func newTopNHelper(sample [][]byte, numTop uint32) *topNHelper {
 		sumTopN += sorted[actualNumTop].cnt
 	}
 
-	return &topNHelper{uint64(len(sample)), sorted, onlyOnceItems, sumTopN, actualNumTop}
+	return &topNHelper{sorted, uint64(len(sample)), onlyOnceItems, sumTopN, actualNumTop}
 }
 
 // NewCMSketchAndTopN returns a new CM sketch with TopN elements, the estimate NDV and the scale ratio.

--- a/statistics/cmsketch.go
+++ b/statistics/cmsketch.go
@@ -53,11 +53,11 @@ var (
 // CMSketch is used to estimate point queries.
 // Refer: https://en.wikipedia.org/wiki/Count-min_sketch
 type CMSketch struct {
-	depth        int32
-	width        int32
+	table        [][]uint32
 	count        uint64 // TopN is not counted in count
 	defaultValue uint64 // In sampled data, if cmsketch returns a small value (less than avg value / 2), then this will returned.
-	table        [][]uint32
+	depth        int32
+	width        int32
 }
 
 // NewCMSketch returns a new CM sketch.
@@ -80,8 +80,8 @@ func NewCMSketch(d, w int32) *CMSketch {
 
 // topNHelper wraps some variables used when building cmsketch with top n.
 type topNHelper struct {
-	sampleSize    uint64
 	sorted        []dataCnt
+	sampleSize    uint64
 	onlyOnceItems uint64
 	sumTopN       uint64
 	actualNumTop  uint32

--- a/statistics/column.go
+++ b/statistics/column.go
@@ -35,20 +35,21 @@ import (
 
 // Column represents a column histogram.
 type Column struct {
-	Histogram
-	CMSketch   *CMSketch
-	TopN       *TopN
-	FMSketch   *FMSketch
-	PhysicalID int64
-	Info       *model.ColumnInfo
-	IsHandle   bool
-	ErrorRate
-	Flag           int64
 	LastAnalyzePos types.Datum
-	StatsVer       int64 // StatsVer is the version of the current stats, used to maintain compatibility
+	CMSketch       *CMSketch
+	TopN           *TopN
+	FMSketch       *FMSketch
+	Info           *model.ColumnInfo
+	Histogram
+	ErrorRate
 
 	// StatsLoadedStatus indicates the status of column statistics
 	StatsLoadedStatus
+	PhysicalID int64
+	Flag       int64
+	StatsVer   int64 // StatsVer is the version of the current stats, used to maintain compatibility
+
+	IsHandle bool
 }
 
 func (c *Column) String() string {

--- a/statistics/debugtrace.go
+++ b/statistics/debugtrace.go
@@ -31,28 +31,29 @@ import (
 
 // StatsTblTraceInfo is simplified from Table and used for debug trace.
 type StatsTblTraceInfo struct {
+	Columns     []*statsTblColOrIdxInfo
+	Indexes     []*statsTblColOrIdxInfo
 	PhysicalID  int64
 	Version     uint64
 	Count       int64
 	ModifyCount int64
-	Columns     []*statsTblColOrIdxInfo
-	Indexes     []*statsTblColOrIdxInfo
 }
 
 type statsTblColOrIdxInfo struct {
+	CMSketchInfo  *cmSketchInfo
+	Name          string
+	LoadingStatus string
+
 	ID                int64
-	Name              string
 	NDV               int64
 	NullCount         int64
 	LastUpdateVersion uint64
 	TotColSize        int64
 	Correlation       float64
 	StatsVer          int64
-	LoadingStatus     string
 
 	HistogramSize int
 	TopNSize      int
-	CMSketchInfo  *cmSketchInfo
 }
 
 type cmSketchInfo struct {
@@ -176,8 +177,8 @@ func TraceStatsTbl(statsTbl *Table) *StatsTblTraceInfo {
 */
 
 type getRowCountInput struct {
-	ID     int64
 	Ranges []string
+	ID     int64
 }
 
 func debugTraceGetRowCountInput(
@@ -201,10 +202,10 @@ func debugTraceGetRowCountInput(
 */
 
 type startEstimateRangeInfo struct {
-	CurrentRowCount  float64
 	Range            string
 	LowValueEncoded  []byte
 	HighValueEncoded []byte
+	CurrentRowCount  float64
 }
 
 func debugTraceStartEstimateRange(
@@ -271,8 +272,8 @@ func debugTraceEndEstimateRange(
 
 type locateBucketInfo struct {
 	Value          string
-	Exceed         bool
 	BucketIdx      int
+	Exceed         bool
 	InBucket       bool
 	MatchLastValue bool
 }
@@ -329,11 +330,11 @@ func debugTraceBuckets(s sessionctx.Context, hg *Histogram, bucketIdxs []int) {
 */
 
 type topNRangeInfo struct {
-	FirstIdx     int
 	FirstEncoded []byte
-	LastIdx      int
 	LastEncoded  []byte
 	Count        []uint64
+	FirstIdx     int
+	LastIdx      int
 }
 
 func debugTraceTopNRange(s sessionctx.Context, t *TopN, startIdx, endIdx int) {

--- a/statistics/feedback.go
+++ b/statistics/feedback.go
@@ -95,8 +95,8 @@ type QueryFeedbackKey struct {
 
 // QueryFeedbackMap is the collection of feedbacks.
 type QueryFeedbackMap struct {
-	Size      int
 	Feedbacks map[QueryFeedbackKey][]*QueryFeedback
+	Size      int
 }
 
 // NewQueryFeedbackMap builds a feedback collection.
@@ -387,9 +387,9 @@ func NonOverlappedFeedbacks(sc *stmtctx.StatementContext, fbs []Feedback) ([]Fee
 
 // BucketFeedback stands for all the feedback for a bucket.
 type BucketFeedback struct {
-	feedback []Feedback   // All the feedback info in the same bucket.
 	lower    *types.Datum // The lower bound of the new bucket.
 	upper    *types.Datum // The upper bound of the new bucket.
+	feedback []Feedback   // All the feedback info in the same bucket.
 }
 
 // outOfRange checks if the `val` is between `min` and `max`.

--- a/statistics/fmsketch.go
+++ b/statistics/fmsketch.go
@@ -27,10 +27,10 @@ import (
 
 // FMSketch is used to count the number of distinct elements in a set.
 type FMSketch struct {
+	hashFunc hash.Hash64
 	hashset  map[uint64]bool
 	mask     uint64
 	maxSize  int
-	hashFunc hash.Hash64
 }
 
 // NewFMSketch returns a new FM sketch.

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -47,12 +47,6 @@ import (
 
 // Histogram represents statistics for a column or index.
 type Histogram struct {
-	ID        int64 // Column ID.
-	NDV       int64 // Number of distinct values.
-	NullCount int64 // Number of null values.
-	// LastUpdateVersion is the version that this histogram updated last time.
-	LastUpdateVersion uint64
-
 	Tp *types.FieldType
 
 	// Histogram elements.
@@ -69,7 +63,13 @@ type Histogram struct {
 
 	// Used for estimating fraction of the interval [lower, upper] that lies within the [lower, value].
 	// For some types like `Int`, we do not build it because we can get them directly from `Bounds`.
-	scalars []scalar
+	scalars   []scalar
+	ID        int64 // Column ID.
+	NDV       int64 // Number of distinct values.
+	NullCount int64 // Number of null values.
+	// LastUpdateVersion is the version that this histogram updated last time.
+	LastUpdateVersion uint64
+
 	// TotColSize is the total column size for the histogram.
 	// For unfixed-len types, it includes LEN and BYTE.
 	TotColSize int64

--- a/statistics/index.go
+++ b/statistics/index.go
@@ -38,17 +38,17 @@ import (
 
 // Index represents an index histogram.
 type Index struct {
-	Histogram
-	CMSketch *CMSketch
-	TopN     *TopN
-	FMSketch *FMSketch
-	ErrorRate
-	StatsVer       int64 // StatsVer is the version of the current stats, used to maintain compatibility
-	Info           *model.IndexInfo
-	Flag           int64
 	LastAnalyzePos types.Datum
-	PhysicalID     int64
+	CMSketch       *CMSketch
+	TopN           *TopN
+	FMSketch       *FMSketch
+	Info           *model.IndexInfo
+	Histogram
+	ErrorRate
 	StatsLoadedStatus
+	StatsVer   int64 // StatsVer is the version of the current stats, used to maintain compatibility
+	Flag       int64
+	PhysicalID int64
 }
 
 // ItemID implements TableCacheItem

--- a/statistics/merge_worker.go
+++ b/statistics/merge_worker.go
@@ -77,10 +77,10 @@ func NewTopnStatsMergeTask(start, end int) *TopnStatsMergeTask {
 
 // TopnStatsMergeResponse indicates topn merge worker response
 type TopnStatsMergeResponse struct {
+	Err        error
 	TopN       *TopN
 	PopedTopn  []TopNMeta
 	RemoveVals [][]TopNMeta
-	Err        error
 }
 
 // Run runs topn merge like statistics.MergePartTopN2GlobalTopN

--- a/statistics/row_sampler.go
+++ b/statistics/row_sampler.go
@@ -65,9 +65,9 @@ type ReservoirRowSampleCollector struct {
 
 // ReservoirRowSampleItem is the item for the ReservoirRowSampleCollector. The weight is needed for the sampling algorithm.
 type ReservoirRowSampleItem struct {
+	Handle  kv.Handle
 	Columns []types.Datum
 	Weight  int64
-	Handle  kv.Handle
 }
 
 // EmptyReservoirSampleItemSize = (24 + 16 + 8) now.
@@ -119,15 +119,15 @@ func (h *WeightedRowSampleHeap) Pop() interface{} {
 
 // RowSampleBuilder is used to construct the ReservoirRowSampleCollector to get the samples.
 type RowSampleBuilder struct {
-	Sc              *stmtctx.StatementContext
 	RecordSet       sqlexec.RecordSet
+	Sc              *stmtctx.StatementContext
+	Rng             *rand.Rand
 	ColsFieldType   []*types.FieldType
 	Collators       []collate.Collator
 	ColGroups       [][]int64
 	MaxSampleSize   int
 	SampleRate      float64
 	MaxFMSketchSize int
-	Rng             *rand.Rand
 }
 
 // NewRowSampleCollector creates a collector from the given inputs.

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -40,12 +40,12 @@ import (
 type SampleItem struct {
 	// Value is the sampled column value.
 	Value types.Datum
-	// Ordinal is original position of this item in SampleCollector before sorting. This
-	// is used for computing correlation.
-	Ordinal int
 	// Handle is the handle of the sample in its key.
 	// This property is used to calculate Ordinal in fast analyze.
 	Handle kv.Handle
+	// Ordinal is original position of this item in SampleCollector before sorting. This
+	// is used for computing correlation.
+	Ordinal int
 }
 
 // EmptySampleItemSize is the size of empty SampleItem, 96 = 72 (datum) + 8 (int) + 16.
@@ -71,9 +71,9 @@ func SortSampleItems(sc *stmtctx.StatementContext, items []*SampleItem) ([]*Samp
 }
 
 type sampleItemSorter struct {
-	items []*SampleItem
-	sc    *stmtctx.StatementContext
 	err   error
+	sc    *stmtctx.StatementContext
+	items []*SampleItem
 }
 
 func (s *sampleItemSorter) Len() int {
@@ -95,17 +95,17 @@ func (s *sampleItemSorter) Swap(i, j int) {
 
 // SampleCollector will collect Samples and calculate the count and ndv of an attribute.
 type SampleCollector struct {
-	Samples       []*SampleItem
-	seenValues    int64 // seenValues is the current seen values.
-	IsMerger      bool
-	NullCount     int64
-	Count         int64 // Count is the number of non-null rows.
-	MaxSampleSize int64
 	FMSketch      *FMSketch
 	CMSketch      *CMSketch
 	TopN          *TopN
+	Samples       []*SampleItem
+	seenValues    int64 // seenValues is the current seen values.
+	NullCount     int64
+	Count         int64 // Count is the number of non-null rows.
+	MaxSampleSize int64
 	TotalSize     int64 // TotalSize is the total size of column.
 	MemSize       int64 // major memory size of this sample collector.
+	IsMerger      bool
 }
 
 // MergeSampleCollector merges two sample collectors.
@@ -214,17 +214,17 @@ func (c *SampleCollector) CalcTotalSize() {
 // SampleBuilder is used to build samples for columns.
 // Also, if primary key is handle, it will directly build histogram for it.
 type SampleBuilder struct {
-	Sc              *stmtctx.StatementContext
 	RecordSet       sqlexec.RecordSet
-	ColLen          int // ColLen is the number of columns need to be sampled.
+	Sc              *stmtctx.StatementContext
 	PkBuilder       *SortedBuilder
+	Collators       []collate.Collator
+	ColsFieldType   []*types.FieldType
+	ColLen          int // ColLen is the number of columns need to be sampled.
 	MaxBucketSize   int64
 	MaxSampleSize   int64
 	MaxFMSketchSize int64
 	CMSketchDepth   int32
 	CMSketchWidth   int32
-	Collators       []collate.Collator
-	ColsFieldType   []*types.FieldType
 }
 
 // CollectColumnStats collects sample from the result set using Reservoir Sampling algorithm,

--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -43,12 +43,12 @@ const selectionFactor = 0.8
 
 // StatsNode is used for calculating selectivity.
 type StatsNode struct {
-	Tp int
-	ID int64
-	// mask is a bit pattern whose ith bit will indicate whether the ith expression is covered by this index/column.
-	mask int64
 	// Ranges contains all the Ranges we got.
 	Ranges []*ranger.Range
+	Tp     int
+	ID     int64
+	// mask is a bit pattern whose ith bit will indicate whether the ith expression is covered by this index/column.
+	mask int64
 	// Selectivity indicates the Selectivity of this column/index.
 	Selectivity float64
 	// numCols is the number of columns contained in the index or column(which is always 1).

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -64,10 +64,10 @@ const (
 
 // Table represents statistics for a table.
 type Table struct {
-	HistColl
-	Version       uint64
-	Name          string
 	ExtendedStats *ExtendedStatsColl
+	Name          string
+	HistColl
+	Version uint64
 	// TblInfoUpdateTS is the UpdateTS of the TableInfo used when filling this struct.
 	// It is the schema version of the corresponding table. It is used to skip redundant
 	// loading of stats, i.e, if the cached stats is already update-to-date with mysql.stats_xxx tables,
@@ -78,10 +78,10 @@ type Table struct {
 
 // ExtendedStatsItem is the cached item of a mysql.stats_extended record.
 type ExtendedStatsItem struct {
-	ColIDs     []int64
-	Tp         uint8
-	ScalarVals float64
 	StringVals string
+	ColIDs     []int64
+	ScalarVals float64
+	Tp         uint8
 }
 
 // ExtendedStatsColl is a collection of cached items for mysql.stats_extended records.
@@ -106,13 +106,13 @@ const (
 
 // HistColl is a collection of histogram. It collects enough information for plan to calculate the selectivity.
 type HistColl struct {
-	PhysicalID int64
-	Columns    map[int64]*Column
-	Indices    map[int64]*Index
+	Columns map[int64]*Column
+	Indices map[int64]*Index
 	// Idx2ColumnIDs maps the index id to its column ids. It's used to calculate the selectivity in planner.
 	Idx2ColumnIDs map[int64][]int64
 	// ColID2IdxIDs maps the column id to a list index ids whose first column is it. It's used to calculate the selectivity in planner.
 	ColID2IdxIDs map[int64][]int64
+	PhysicalID   int64
 	// TODO: add AnalyzeCount here
 	RealtimeCount int64 // RealtimeCount is the current table row count, maintained by applying stats delta based on AnalyzeCount.
 	ModifyCount   int64 // Total modify count in a table.
@@ -125,10 +125,10 @@ type HistColl struct {
 
 // TableMemoryUsage records tbl memory usage
 type TableMemoryUsage struct {
-	TableID         int64
-	TotalMemUsage   int64
 	ColumnsMemUsage map[int64]CacheItemMemoryUsage
 	IndicesMemUsage map[int64]CacheItemMemoryUsage
+	TableID         int64
+	TotalMemUsage   int64
 }
 
 // TotalIdxTrackingMemUsage returns total indices' tracking memory usage
@@ -442,8 +442,8 @@ func (t *Table) GetStatsHealthy() (int64, bool) {
 }
 
 type neededStatsMap struct {
-	m     sync.RWMutex
 	items map[model.TableItemID]struct{}
+	m     sync.RWMutex
 }
 
 func (n *neededStatsMap) AllItems() []model.TableItemID {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40786

Problem Summary:

### What is changed and how it works?

```
/Users/weizhenwang/devel/opensource/tidb/statistics/analyze.go:70:21: struct with 80 pointer bytes could be 40
/Users/weizhenwang/devel/opensource/tidb/statistics/analyze_jobs.go:23:17: struct with 160 pointer bytes could be 152
/Users/weizhenwang/devel/opensource/tidb/statistics/analyze_jobs.go:35:22: struct with 40 pointer bytes could be 24
/Users/weizhenwang/devel/opensource/tidb/statistics/builder.go:31:20: struct with 56 pointer bytes could be 16
/Users/weizhenwang/devel/opensource/tidb/statistics/cmsketch.go:55:15: struct with 32 pointer bytes could be 8
/Users/weizhenwang/devel/opensource/tidb/statistics/cmsketch.go:82:17: struct with 16 pointer bytes could be 8
/Users/weizhenwang/devel/opensource/tidb/statistics/column.go:37:13: struct with 256 pointer bytes could be 184
/Users/weizhenwang/devel/opensource/tidb/statistics/debugtrace.go:33:24: struct with 64 pointer bytes could be 32
/Users/weizhenwang/devel/opensource/tidb/statistics/debugtrace.go:42:27: struct with 112 pointer bytes could be 32
/Users/weizhenwang/devel/opensource/tidb/statistics/debugtrace.go:178:23: struct with 16 pointer bytes could be 8
/Users/weizhenwang/devel/opensource/tidb/statistics/debugtrace.go:203:29: struct with 56 pointer bytes could be 48
/Users/weizhenwang/devel/opensource/tidb/statistics/debugtrace.go:272:23: struct of size 40 could be 32
/Users/weizhenwang/devel/opensource/tidb/statistics/debugtrace.go:331:20: struct with 72 pointer bytes could be 56
/Users/weizhenwang/devel/opensource/tidb/statistics/feedback.go:97:23: struct with 16 pointer bytes could be 8
/Users/weizhenwang/devel/opensource/tidb/statistics/feedback.go:389:21: struct with 40 pointer bytes could be 24
/Users/weizhenwang/devel/opensource/tidb/statistics/fmsketch.go:29:15: struct with 40 pointer bytes could be 24
/Users/weizhenwang/devel/opensource/tidb/statistics/histogram.go:49:16: struct with 80 pointer bytes could be 48
/Users/weizhenwang/devel/opensource/tidb/statistics/index.go:40:12: struct with 248 pointer bytes could be 184
/Users/weizhenwang/devel/opensource/tidb/statistics/merge_worker.go:79:29: struct with 72 pointer bytes could be 56
/Users/weizhenwang/devel/opensource/tidb/statistics/row_sampler.go:67:29: struct with 48 pointer bytes could be 24
/Users/weizhenwang/devel/opensource/tidb/statistics/row_sampler.go:121:23: struct with 128 pointer bytes could be 88
/Users/weizhenwang/devel/opensource/tidb/statistics/sample.go:40:17: struct with 96 pointer bytes could be 88
/Users/weizhenwang/devel/opensource/tidb/statistics/sample.go:73:23: struct with 48 pointer bytes could be 32
/Users/weizhenwang/devel/opensource/tidb/statistics/sample.go:97:22: struct with 88 pointer bytes could be 32
/Users/weizhenwang/devel/opensource/tidb/statistics/sample.go:216:20: struct with 104 pointer bytes could be 64
/Users/weizhenwang/devel/opensource/tidb/statistics/selectivity.go:45:16: struct with 32 pointer bytes could be 8
/Users/weizhenwang/devel/opensource/tidb/statistics/table.go:66:12: struct with 96 pointer bytes could be 64
/Users/weizhenwang/devel/opensource/tidb/statistics/table.go:80:24: struct with 48 pointer bytes could be 24
/Users/weizhenwang/devel/opensource/tidb/statistics/table.go:108:15: struct with 40 pointer bytes could be 32
/Users/weizhenwang/devel/opensource/tidb/statistics/table.go:127:23: struct with 32 pointer bytes could be 16
/Users/weizhenwang/devel/opensource/tidb/statistics/table.go:444:21: struct with 32 pointer bytes could be 8

```


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
