### PR TITLE
planner: allow the optimizer to cache query plans accessing generated columns (test only)

### DIFF
--- a/executor/explainfor_test.go
+++ b/executor/explainfor_test.go
@@ -874,8 +874,7 @@ func TestIndexMerge4PlanCache(t *testing.T) {
 	tk.MustExec("prepare stmt from 'SELECT /*+ USE_INDEX_MERGE(t0, i0, PRIMARY)*/ t0.c0 FROM t0 WHERE t0.c1 OR t0.c0;';")
 	tk.MustQuery("execute stmt;").Check(testkit.Rows("1"))
 	tk.MustQuery("execute stmt;").Check(testkit.Rows("1"))
-	// The plan contains the generated column, so it can not be cached.
-	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("0"))
+	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("1"))
 
 	tk.MustExec("drop table if exists t1, t2")
 	tk.MustExec("create table t1(id int primary key, a int, b int, c int, d int)")

--- a/planner/core/indexmerge_path_test.go
+++ b/planner/core/indexmerge_path_test.go
@@ -187,10 +187,10 @@ func TestMVIndexIndexMergePlanCache(t *testing.T) {
 	tk.MustExec(`create table t(j json, index kj((cast(j as signed array))))`)
 
 	tk.MustExec("prepare st from 'select /*+ use_index_merge(t, kj) */ * from t where (1 member of (j))'")
-	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip prepared plan-cache: query accesses generated columns is un-cacheable"))
+	//tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 skip prepared plan-cache: query accesses generated columns is un-cacheable"))
 	tk.MustExec("execute st")
 	tk.MustExec("execute st")
-	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 }
 
 func TestMVIndexPointGet(t *testing.T) {

--- a/planner/core/plan_cache_test.go
+++ b/planner/core/plan_cache_test.go
@@ -1142,6 +1142,56 @@ func TestPlanCacheGeneratedCols(t *testing.T) {
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows(`1`)) // hit cache
 }
 
+func TestPlanCacheGeneratedCols2(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE t1 (
+  ipk varbinary(255) NOT NULL,
+  i_id varchar(45) DEFAULT NULL,
+  i_set_id varchar(45) DEFAULT NULL,
+  p_id varchar(45) DEFAULT NULL,
+  p_set_id varchar(45) DEFAULT NULL,
+  m_id bigint(20) DEFAULT NULL,
+  m_i_id varchar(127) DEFAULT NULL,
+  m_i_set_id varchar(127) DEFAULT NULL,
+  d json DEFAULT NULL,
+  p_sources json DEFAULT NULL,
+  nslc json DEFAULT NULL,
+  cl json DEFAULT NULL,
+  fii json DEFAULT NULL,
+  fpi json DEFAULT NULL,
+  PRIMARY KEY (ipk) /*T![clustered_index] CLUSTERED */,
+  UNIQUE KEY i_id (i_id),
+  KEY d ((cast(d as char(253) array))),
+  KEY m_i_id (m_i_id),
+  KEY m_i_set_id (m_i_set_id),
+  KEY fpi ((cast(fpi as unsigned array))),
+  KEY nslc ((cast(nslc as char(1000) array))),
+  KEY cl ((cast(cl as char(3000) array))),
+  KEY fii ((cast(fii as unsigned array))),
+  KEY m_id (m_id),
+  KEY i_set_id (i_set_id),
+  KEY m_i_and_m_id (m_i_id,m_id))`)
+
+	tk.MustExec(`CREATE TABLE t2 (
+  ipk varbinary(255) NOT NULL,
+  created_time bigint(20) DEFAULT NULL,
+  arrival_time bigint(20) DEFAULT NULL,
+  updated_time bigint(20) DEFAULT NULL,
+  timestamp_data json DEFAULT NULL,
+  PRIMARY KEY (ipk) /*T![clustered_index] CLUSTERED */)`)
+
+	tk.MustExec(`prepare stmt from 'select *
+    from ( t1 left outer join t2 on ( t1 . ipk = t2 . ipk ) )
+    where ( t1 . i_id = ? )'`)
+	tk.MustQuery(`show warnings`).Check(testkit.Rows()) // no warning
+	tk.MustExec(`set @a='a', @b='b'`)
+	tk.MustQuery(`execute stmt using @a`).Check(testkit.Rows())
+	tk.MustQuery(`execute stmt using @b`).Check(testkit.Rows())
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows(`1`)) // hit cache
+}
+
 func TestInvalidRange(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -656,9 +656,9 @@ func isPhysicalPlanCacheable(sctx sessionctx.Context, p PhysicalPlan, paramNum, 
 	case *PhysicalMemTable:
 		return false, "PhysicalMemTable plan is un-cacheable"
 	case *PhysicalIndexMergeReader:
-		if x.AccessMVIndex {
-			return false, "the plan with IndexMerge accessing Multi-Valued Index is un-cacheable"
-		}
+		//if x.AccessMVIndex {
+		//	return false, "the plan with IndexMerge accessing Multi-Valued Index is un-cacheable"
+		//}
 		underIndexMerge = true
 		subPlans = append(subPlans, x.partialPlans...)
 	case *PhysicalIndexScan:

--- a/planner/core/plan_cacheable_checker.go
+++ b/planner/core/plan_cacheable_checker.go
@@ -198,11 +198,11 @@ func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren 
 				checker.reason = "query accesses partitioned tables is un-cacheable"
 				return in, true
 			}
-			if hasGeneratedCol(checker.schema, node) {
-				checker.cacheable = false
-				checker.reason = "query accesses generated columns is un-cacheable"
-				return in, true
-			}
+			//if hasGeneratedCol(checker.schema, node) {
+			//	checker.cacheable = false
+			//	checker.reason = "query accesses generated columns is un-cacheable"
+			//	return in, true
+			//}
 			if isTempTable(checker.schema, node) {
 				checker.cacheable = false
 				checker.reason = "query accesses temporary tables is un-cacheable"

--- a/store/driver/tikv_driver.go
+++ b/store/driver/tikv_driver.go
@@ -235,7 +235,7 @@ func (d TiKVDriver) OpenWithOptions(path string, options ...Option) (resStore kv
 		tikv.WithCodec(codec),
 	)
 
-	s, err = tikv.NewKVStore(uuid, pdClient, spkv, rpcClient, tikv.WithPDHTTPClient(tlsConfig, etcdAddrs))
+	s, err = tikv.NewKVStore(uuid, pdClient, spkv, rpcClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #45798

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
