### PR TITLE
ddl: Advance iterator when skip handling TiFlash tables

### DIFF
--- a/ddl/ddl_tiflash_api.go
+++ b/ddl/ddl_tiflash_api.go
@@ -406,6 +406,8 @@ func pollAvailableTableProgress(schemas infoschema.InfoSchema, _ sessionctx.Cont
 				// https://github.com/pingcap/tidb/issues/39949
 				panic(err)
 			}
+			pollTiFlashContext.UpdatingProgressTables.Remove(element)
+			element = element.Next()
 			continue
 		}
 		err = infosync.UpdateTiFlashProgressCache(availableTableID.ID, progress)
@@ -416,6 +418,8 @@ func pollAvailableTableProgress(schemas infoschema.InfoSchema, _ sessionctx.Cont
 				zap.Bool("IsPartition", availableTableID.IsPartition),
 				zap.Float64("progress", progress),
 			)
+			pollTiFlashContext.UpdatingProgressTables.Remove(element)
+			element = element.Next()
 			continue
 		}
 		next := element.Next()

--- a/ddl/ddl_tiflash_api.go
+++ b/ddl/ddl_tiflash_api.go
@@ -351,6 +351,7 @@ func updateTiFlashStores(pollTiFlashContext *TiFlashManagementContext) error {
 	return nil
 }
 
+// PollAvailableTableProgress will poll and check availability of available tables.
 func PollAvailableTableProgress(schemas infoschema.InfoSchema, _ sessionctx.Context, pollTiFlashContext *TiFlashManagementContext) {
 	pollMaxCount := RefreshProgressMaxTableCount
 	failpoint.Inject("PollAvailableTableProgressMaxCount", func(val failpoint.Value) {

--- a/ddl/tests/tiflash/BUILD.bazel
+++ b/ddl/tests/tiflash/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 33,
+    shard_count = 34,
     deps = [
         "//config",
         "//ddl",
@@ -19,6 +19,7 @@ go_test(
         "//kv",
         "//parser/model",
         "//session",
+        "//sessionctx",
         "//store/gcworker",
         "//store/mockstore",
         "//store/mockstore/unistore",

--- a/ddl/tests/tiflash/ddl_tiflash_test.go
+++ b/ddl/tests/tiflash/ddl_tiflash_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/gcworker"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/mockstore/unistore"
@@ -1086,6 +1087,57 @@ func TestTiFlashGroupIndexWhenStartup(t *testing.T) {
 	require.Equal(t, placement.RuleIndexTiFlash, tiflash.GetRuleGroupIndex(), errMsg)
 	require.Greater(t, tiflash.GetRuleGroupIndex(), placement.RuleIndexTable)
 	require.Greater(t, tiflash.GetRuleGroupIndex(), placement.RuleIndexPartition)
+}
+
+func TestTiFlashFailureProgressAfterAvailable(t *testing.T) {
+	s, teardown := createTiFlashContext(t)
+	defer teardown()
+	tk := testkit.NewTestKit(t, s.store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists ddltiflash")
+	tk.MustExec("create table ddltiflash(z int)")
+	tk.MustExec("alter table ddltiflash set tiflash replica 1")
+	time.Sleep(ddl.PollTiFlashInterval * RoundToBeAvailable * 3)
+	CheckTableAvailable(s.dom, t, 1, []string{})
+
+	tb, err := s.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("ddltiflash"))
+	require.NoError(t, err)
+	require.NotNil(t, tb)
+	// after available, progress should can be updated.
+	// s.tiflash.ResetSyncStatus(int(tb.Meta().ID), false)
+
+	s.tiflash.SetNetworkError(true)
+	pool := s.dom.SysSessionPool()
+	se, err := pool.Get()
+	sctx := se.(sessionctx.Context)
+	defer pool.Put(se)
+	pollTiflashContext, err := ddl.NewTiFlashManagementContext()
+	pollTiflashContext.UpdatingProgressTables.PushBack(ddl.AvailableTableID{
+		ID:          tb.Meta().ID,
+		IsPartition: false,
+	})
+	require.NoError(t, err)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ddl.PollAvailableTableProgress(s.dom.InfoSchema(), sctx, pollTiflashContext)
+	}()
+	time.Sleep(ddl.PollTiFlashInterval)
+	s.tiflash.SetNetworkError(false)
+
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return
+	case <-time.After(time.Second):
+		panic("DDL can't finish")
+	}
 }
 
 func TestTiFlashProgressAfterAvailable(t *testing.T) {

--- a/ddl/tests/tiflash/ddl_tiflash_test.go
+++ b/ddl/tests/tiflash/ddl_tiflash_test.go
@@ -1110,6 +1110,7 @@ func TestTiFlashFailureProgressAfterAvailable(t *testing.T) {
 	s.tiflash.SetNetworkError(true)
 	pool := s.dom.SysSessionPool()
 	se, err := pool.Get()
+	require.NoError(t, err)
 	sctx := se.(sessionctx.Context)
 	defer pool.Put(se)
 	pollTiflashContext, err := ddl.NewTiFlashManagementContext()

--- a/ddl/tests/tiflash/ddl_tiflash_test.go
+++ b/ddl/tests/tiflash/ddl_tiflash_test.go
@@ -1126,7 +1126,6 @@ func TestTiFlashFailureProgressAfterAvailable(t *testing.T) {
 		ddl.PollAvailableTableProgress(s.dom.InfoSchema(), sctx, pollTiflashContext)
 	}()
 	time.Sleep(ddl.PollTiFlashInterval)
-	s.tiflash.SetNetworkError(false)
 
 	c := make(chan struct{})
 	go func() {

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -960,7 +960,7 @@ func (tiflash *MockTiFlash) PdSwitch(enabled bool) {
 	tiflash.PdEnabled = enabled
 }
 
-// Set network error state.
+// SetNetworkError sets network error state.
 func (tiflash *MockTiFlash) SetNetworkError(e bool) {
 	tiflash.Lock()
 	defer tiflash.Unlock()

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -960,6 +960,13 @@ func (tiflash *MockTiFlash) PdSwitch(enabled bool) {
 	tiflash.PdEnabled = enabled
 }
 
+// Set network error state.
+func (tiflash *MockTiFlash) SetNetworkError(e bool) {
+	tiflash.Lock()
+	defer tiflash.Unlock()
+	tiflash.NetworkError = e
+}
+
 // CalculateTiFlashProgress return truncated string to avoid float64 comparison.
 func (m *mockTiFlashReplicaManagerCtx) CalculateTiFlashProgress(tableID int64, replicaCount uint64, tiFlashStores map[int64]helper.StoreStat) (float64, error) {
 	return calculateTiFlashProgress(tikv.NullspaceID, tableID, replicaCount, tiFlashStores)
@@ -1103,13 +1110,6 @@ func (m *mockTiFlashReplicaManagerCtx) Close(ctx context.Context) {
 	if m.tiflash.StatusServer != nil {
 		m.tiflash.StatusServer.Close()
 	}
-}
-
-// Set network error state.
-func (m *MockTiFlash) SetNetworkError(e bool) {
-	m.Lock()
-	defer m.Unlock()
-	m.NetworkError = e
 }
 
 // MockTiFlashError represents MockTiFlash error


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45859

Problem Summary:

In `pollAvailableTableProgress`, iterator of `UpdatingProgressTables` may not be advanced under several errors.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
