### PR TITLE
partition: Revert support batch_point_get for partition table in dynamic mode

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -5217,6 +5217,7 @@ func (b *executorBuilder) buildBatchPointGet(plan *plannercore.BatchPointGetPlan
 		partExpr:     plan.PartitionExpr,
 		partPos:      plan.PartitionColPos,
 		planPhysIDs:  plan.PartitionIDs,
+		singlePart:   plan.SinglePart,
 		partTblID:    plan.PartTblID,
 		columns:      plan.Columns,
 	}

--- a/planner/core/casetest/partition/integration_partition_test.go
+++ b/planner/core/casetest/partition/integration_partition_test.go
@@ -292,6 +292,9 @@ func TestBatchPointGetTablePartition(t *testing.T) {
 	tk.MustExec("create table tlist3(a int, b int, primary key(a)) partition by list(a) (partition p0 values in (0, 1, 2), partition p1 values in (3, 4, 5))")
 	tk.MustExec("insert into tlist3 values(1,0),(2,0),(3,0),(4,0)")
 
+	tk.MustExec("create table issue45889(a int) partition by list(a) (partition p0 values in (0, 1), partition p1 values in (2, 3))")
+	tk.MustExec("insert into issue45889 values (0),(0),(1),(1),(2),(2),(3),(3)")
+
 	var input []string
 	var output []struct {
 		SQL         string

--- a/planner/core/casetest/partition/testdata/integration_partition_suite_in.json
+++ b/planner/core/casetest/partition/testdata/integration_partition_suite_in.json
@@ -247,14 +247,24 @@
       "select * from thash3 where a in (1,3) and 1 = 1",
       "select * from thash3 where a in (1,3) and 1 = 1 order by a",
       "select * from thash3 where a in (1,3) and 1 = 1 order by a desc",
+      "select * from thash3 partition(p0) where a in (1,4)",
+      "select * from thash3 partition(p1) where a in (2,4)",
+      "select * from thash3 partition(p0,p1) where a in (2,4)",
       "select * from trange3 where a in (1,2) and 1 = 1",
       "select * from trange3 where a in (1,3) and 1 = 1",
       "select * from trange3 where a in (1,3) and 1 = 1 order by a",
       "select * from trange3 where a in (1,3) and 1 = 1 order by a desc",
+      "select * from trange3 partition(p0) where a in (1,4)",
+      "select * from trange3 partition(p1) where a in (1,2)",
+      "select * from trange3 partition(p0,p1) where a in (1,2)",
       "select * from tlist3 where a in (1,2) and 1 = 1",
       "select * from tlist3 where a in (1,3) and 1 = 1",
       "select * from tlist3 where a in (1,2) and 1 = 1 order by a",
-      "select * from tlist3 where a in (1,2) and 1 = 1 order by a desc"
+      "select * from tlist3 where a in (1,2) and 1 = 1 order by a desc",
+      "select * from tlist3 partition(p0) where a in (1,4)",
+      "select * from tlist3 partition(p1) where a in (1,2)",
+      "select * from tlist3 partition(p0,p1) where a in (1,2)",
+      "select _tidb_rowid, a from issue45889 where _tidb_rowid in (7, 8)"
     ]
   },
   {

--- a/planner/core/casetest/partition/testdata/integration_partition_suite_in.json
+++ b/planner/core/casetest/partition/testdata/integration_partition_suite_in.json
@@ -247,23 +247,14 @@
       "select * from thash3 where a in (1,3) and 1 = 1",
       "select * from thash3 where a in (1,3) and 1 = 1 order by a",
       "select * from thash3 where a in (1,3) and 1 = 1 order by a desc",
-      "select * from thash3 partition(p0) where a in (1,4)",
-      "select * from thash3 partition(p1) where a in (2,4)",
-      "select * from thash3 partition(p0,p1) where a in (2,4)",
       "select * from trange3 where a in (1,2) and 1 = 1",
       "select * from trange3 where a in (1,3) and 1 = 1",
       "select * from trange3 where a in (1,3) and 1 = 1 order by a",
       "select * from trange3 where a in (1,3) and 1 = 1 order by a desc",
-      "select * from trange3 partition(p0) where a in (1,4)",
-      "select * from trange3 partition(p1) where a in (1,2)",
-      "select * from trange3 partition(p0,p1) where a in (1,2)",
       "select * from tlist3 where a in (1,2) and 1 = 1",
       "select * from tlist3 where a in (1,3) and 1 = 1",
       "select * from tlist3 where a in (1,2) and 1 = 1 order by a",
-      "select * from tlist3 where a in (1,2) and 1 = 1 order by a desc",
-      "select * from tlist3 partition(p0) where a in (1,4)",
-      "select * from tlist3 partition(p1) where a in (1,2)",
-      "select * from tlist3 partition(p0,p1) where a in (1,2)"
+      "select * from tlist3 where a in (1,2) and 1 = 1 order by a desc"
     ]
   },
   {

--- a/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
+++ b/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
@@ -1764,10 +1764,12 @@
       {
         "SQL": "select * from trange1 where a in (1,2) and b = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:trange1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "IndexReader 2.00 root partition:p0 index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:trange1, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:trange1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "IndexReader 2.00 root  index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:trange1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -1781,7 +1783,8 @@
           "└─IndexRangeScan 2.00 cop[tikv] table:trange1, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:true, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:trange1, index:PRIMARY(a, b) keep order:true, desc:false"
+          "IndexReader 2.00 root  index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:trange1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:true, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -1795,7 +1798,8 @@
           "└─IndexRangeScan 2.00 cop[tikv] table:trange1, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:true, desc, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:trange1, index:PRIMARY(a, b) keep order:true, desc:true"
+          "IndexReader 2.00 root  index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:trange1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:true, desc, stats:pseudo"
         ],
         "Result": [
           "2 1",
@@ -1805,12 +1809,15 @@
       {
         "SQL": "select * from trange1 where a = 1 and b in (1,2)",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:trange1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "IndexReader 2.00 root partition:all index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:trange1, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "PartitionUnion 4.00 root  ",
-          "├─Batch_Point_Get 2.00 root table:trange1, index:PRIMARY(a, b) keep order:false, desc:false",
-          "└─Batch_Point_Get 2.00 root table:trange1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "├─IndexReader 2.00 root  index:IndexRangeScan",
+          "│ └─IndexRangeScan 2.00 cop[tikv] table:trange1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "└─IndexReader 2.00 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 2.00 cop[tikv] table:trange1, partition:p1, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -1826,8 +1833,10 @@
         "StaticPlan": [
           "Sort 4.00 root  test.trange1.b",
           "└─PartitionUnion 4.00 root  ",
-          "  ├─Batch_Point_Get 2.00 root table:trange1, index:PRIMARY(a, b) keep order:false, desc:false",
-          "  └─Batch_Point_Get 2.00 root table:trange1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "  ├─IndexReader 2.00 root  index:IndexRangeScan",
+          "  │ └─IndexRangeScan 2.00 cop[tikv] table:trange1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "  └─IndexReader 2.00 root  index:IndexRangeScan",
+          "    └─IndexRangeScan 2.00 cop[tikv] table:trange1, partition:p1, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -1843,8 +1852,10 @@
         "StaticPlan": [
           "Sort 4.00 root  test.trange1.b:desc",
           "└─PartitionUnion 4.00 root  ",
-          "  ├─Batch_Point_Get 2.00 root table:trange1, index:PRIMARY(a, b) keep order:false, desc:false",
-          "  └─Batch_Point_Get 2.00 root table:trange1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "  ├─IndexReader 2.00 root  index:IndexRangeScan",
+          "  │ └─IndexRangeScan 2.00 cop[tikv] table:trange1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "  └─IndexReader 2.00 root  index:IndexRangeScan",
+          "    └─IndexRangeScan 2.00 cop[tikv] table:trange1, partition:p1, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 2",
@@ -1854,10 +1865,12 @@
       {
         "SQL": "select * from tlist1 where a in (1,2) and b = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:tlist1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "IndexReader 2.00 root partition:p0 index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:tlist1, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:tlist1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "IndexReader 2.00 root  index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:tlist1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -1871,7 +1884,8 @@
           "└─IndexRangeScan 2.00 cop[tikv] table:tlist1, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:true, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:tlist1, index:PRIMARY(a, b) keep order:true, desc:false"
+          "IndexReader 2.00 root  index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:tlist1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:true, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -1885,7 +1899,8 @@
           "└─IndexRangeScan 2.00 cop[tikv] table:tlist1, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:true, desc, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:tlist1, index:PRIMARY(a, b) keep order:true, desc:true"
+          "IndexReader 2.00 root  index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:tlist1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:true, desc, stats:pseudo"
         ],
         "Result": [
           "2 1",
@@ -1895,12 +1910,15 @@
       {
         "SQL": "select * from tlist1 where a = 1 and b in (1,2)",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:tlist1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "IndexReader 2.00 root partition:p0,p1 index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:tlist1, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "PartitionUnion 4.00 root  ",
-          "├─Batch_Point_Get 2.00 root table:tlist1, index:PRIMARY(a, b) keep order:false, desc:false",
-          "└─Batch_Point_Get 2.00 root table:tlist1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "├─IndexReader 2.00 root  index:IndexRangeScan",
+          "│ └─IndexRangeScan 2.00 cop[tikv] table:tlist1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "└─IndexReader 2.00 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 2.00 cop[tikv] table:tlist1, partition:p1, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -1916,8 +1934,10 @@
         "StaticPlan": [
           "Sort 4.00 root  test.tlist1.b",
           "└─PartitionUnion 4.00 root  ",
-          "  ├─Batch_Point_Get 2.00 root table:tlist1, index:PRIMARY(a, b) keep order:false, desc:false",
-          "  └─Batch_Point_Get 2.00 root table:tlist1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "  ├─IndexReader 2.00 root  index:IndexRangeScan",
+          "  │ └─IndexRangeScan 2.00 cop[tikv] table:tlist1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "  └─IndexReader 2.00 root  index:IndexRangeScan",
+          "    └─IndexRangeScan 2.00 cop[tikv] table:tlist1, partition:p1, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -1933,8 +1953,10 @@
         "StaticPlan": [
           "Sort 4.00 root  test.tlist1.b:desc",
           "└─PartitionUnion 4.00 root  ",
-          "  ├─Batch_Point_Get 2.00 root table:tlist1, index:PRIMARY(a, b) keep order:false, desc:false",
-          "  └─Batch_Point_Get 2.00 root table:tlist1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "  ├─IndexReader 2.00 root  index:IndexRangeScan",
+          "  │ └─IndexRangeScan 2.00 cop[tikv] table:tlist1, partition:p0, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "  └─IndexReader 2.00 root  index:IndexRangeScan",
+          "    └─IndexRangeScan 2.00 cop[tikv] table:tlist1, partition:p1, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 2",
@@ -2034,10 +2056,12 @@
       {
         "SQL": "select * from trange2 where a in (1,2) and b = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:trange2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange2 range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:trange2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange2, partition:p0 range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -2051,7 +2075,8 @@
           "└─TableRangeScan 2.00 cop[tikv] table:trange2 range:[1 1,1 1], [2 1,2 1], keep order:true, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:trange2, clustered index:PRIMARY(a, b) keep order:true, desc:false"
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange2, partition:p0 range:[1 1,1 1], [2 1,2 1], keep order:true, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -2061,11 +2086,14 @@
       {
         "SQL": "select * from trange2 where a in (1,2) and b = 1 order by a desc",
         "DynamicPlan": [
-          "TableReader 2.00 root partition:p0 data:TableRangeScan",
-          "└─TableRangeScan 2.00 cop[tikv] table:trange2 range:[1 1,1 1], [2 1,2 1], keep order:true, desc, stats:pseudo"
+          "Sort 0.02 root  test.trange2.a:desc",
+          "└─TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:trange2 range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:trange2, clustered index:PRIMARY(a, b) keep order:true, desc:true"
+          "Sort 0.02 root  test.trange2.a:desc",
+          "└─TableReader 2.00 root  data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:trange2, partition:p0 range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "Result": [
           "2 1",
@@ -2075,12 +2103,15 @@
       {
         "SQL": "select * from trange2 where a = 1 and b in (1,2)",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:trange2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "TableReader 2.00 root partition:all data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange2 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "PartitionUnion 0.04 root  ",
-          "├─Batch_Point_Get 2.00 root table:trange2, clustered index:PRIMARY(a, b) keep order:false, desc:false",
-          "└─Batch_Point_Get 2.00 root table:trange2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "├─TableReader 2.00 root  data:TableRangeScan",
+          "│ └─TableRangeScan 2.00 cop[tikv] table:trange2, partition:p0 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "└─TableReader 2.00 root  data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:trange2, partition:p1 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -2096,8 +2127,10 @@
         "StaticPlan": [
           "Sort 0.04 root  test.trange2.b",
           "└─PartitionUnion 0.04 root  ",
-          "  ├─Batch_Point_Get 2.00 root table:trange2, clustered index:PRIMARY(a, b) keep order:false, desc:false",
-          "  └─Batch_Point_Get 2.00 root table:trange2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "  ├─TableReader 2.00 root  data:TableRangeScan",
+          "  │ └─TableRangeScan 2.00 cop[tikv] table:trange2, partition:p0 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "  └─TableReader 2.00 root  data:TableRangeScan",
+          "    └─TableRangeScan 2.00 cop[tikv] table:trange2, partition:p1 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -2107,14 +2140,17 @@
       {
         "SQL": "select * from trange2 where a = 1 and b in (1,2) order by b desc",
         "DynamicPlan": [
-          "TableReader 2.00 root partition:all data:TableRangeScan",
-          "└─TableRangeScan 2.00 cop[tikv] table:trange2 range:[1 1,1 1], [1 2,1 2], keep order:true, desc, stats:pseudo"
+          "Sort 0.02 root  test.trange2.b:desc",
+          "└─TableReader 2.00 root partition:all data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:trange2 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "Sort 0.04 root  test.trange2.b:desc",
           "└─PartitionUnion 0.04 root  ",
-          "  ├─Batch_Point_Get 2.00 root table:trange2, clustered index:PRIMARY(a, b) keep order:false, desc:false",
-          "  └─Batch_Point_Get 2.00 root table:trange2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "  ├─TableReader 2.00 root  data:TableRangeScan",
+          "  │ └─TableRangeScan 2.00 cop[tikv] table:trange2, partition:p0 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "  └─TableReader 2.00 root  data:TableRangeScan",
+          "    └─TableRangeScan 2.00 cop[tikv] table:trange2, partition:p1 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 2",
@@ -2124,10 +2160,12 @@
       {
         "SQL": "select * from tlist2 where a in (1,2) and b = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:tlist2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist2 range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:tlist2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist2, partition:p0 range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -2141,7 +2179,8 @@
           "└─TableRangeScan 2.00 cop[tikv] table:tlist2 range:[1 1,1 1], [2 1,2 1], keep order:true, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:tlist2, clustered index:PRIMARY(a, b) keep order:true, desc:false"
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist2, partition:p0 range:[1 1,1 1], [2 1,2 1], keep order:true, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -2151,11 +2190,14 @@
       {
         "SQL": "select * from tlist2 where a in (1,2) and b = 1 order by a desc",
         "DynamicPlan": [
-          "TableReader 2.00 root partition:p0 data:TableRangeScan",
-          "└─TableRangeScan 2.00 cop[tikv] table:tlist2 range:[1 1,1 1], [2 1,2 1], keep order:true, desc, stats:pseudo"
+          "Sort 0.02 root  test.tlist2.a:desc",
+          "└─TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:tlist2 range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:tlist2, clustered index:PRIMARY(a, b) keep order:true, desc:true"
+          "Sort 0.02 root  test.tlist2.a:desc",
+          "└─TableReader 2.00 root  data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:tlist2, partition:p0 range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "Result": [
           "2 1",
@@ -2165,12 +2207,15 @@
       {
         "SQL": "select * from tlist2 where a = 1 and b in (1,2)",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:tlist2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "TableReader 2.00 root partition:p0,p1 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist2 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "PartitionUnion 0.04 root  ",
-          "├─Batch_Point_Get 2.00 root table:tlist2, clustered index:PRIMARY(a, b) keep order:false, desc:false",
-          "└─Batch_Point_Get 2.00 root table:tlist2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "├─TableReader 2.00 root  data:TableRangeScan",
+          "│ └─TableRangeScan 2.00 cop[tikv] table:tlist2, partition:p0 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "└─TableReader 2.00 root  data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:tlist2, partition:p1 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -2186,8 +2231,10 @@
         "StaticPlan": [
           "Sort 0.04 root  test.tlist2.b",
           "└─PartitionUnion 0.04 root  ",
-          "  ├─Batch_Point_Get 2.00 root table:tlist2, clustered index:PRIMARY(a, b) keep order:false, desc:false",
-          "  └─Batch_Point_Get 2.00 root table:tlist2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "  ├─TableReader 2.00 root  data:TableRangeScan",
+          "  │ └─TableRangeScan 2.00 cop[tikv] table:tlist2, partition:p0 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "  └─TableReader 2.00 root  data:TableRangeScan",
+          "    └─TableRangeScan 2.00 cop[tikv] table:tlist2, partition:p1 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",
@@ -2197,14 +2244,17 @@
       {
         "SQL": "select * from tlist2 where a = 1 and b in (1,2) order by b desc",
         "DynamicPlan": [
-          "TableReader 2.00 root partition:p0,p1 data:TableRangeScan",
-          "└─TableRangeScan 2.00 cop[tikv] table:tlist2 range:[1 1,1 1], [1 2,1 2], keep order:true, desc, stats:pseudo"
+          "Sort 0.02 root  test.tlist2.b:desc",
+          "└─TableReader 2.00 root partition:p0,p1 data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:tlist2 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "Sort 0.04 root  test.tlist2.b:desc",
           "└─PartitionUnion 0.04 root  ",
-          "  ├─Batch_Point_Get 2.00 root table:tlist2, clustered index:PRIMARY(a, b) keep order:false, desc:false",
-          "  └─Batch_Point_Get 2.00 root table:tlist2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "  ├─TableReader 2.00 root  data:TableRangeScan",
+          "  │ └─TableRangeScan 2.00 cop[tikv] table:tlist2, partition:p0 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo",
+          "  └─TableReader 2.00 root  data:TableRangeScan",
+          "    └─TableRangeScan 2.00 cop[tikv] table:tlist2, partition:p1 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 2",
@@ -2270,10 +2320,12 @@
       {
         "SQL": "select * from trange3 where a in (1,2) and 1 = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:trange3 handle:[1 2], keep order:false, desc:false"
+          "TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange3 range:[1,1], [2,2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:trange3 handle:[1 2], keep order:false, desc:false"
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange3, partition:p0 range:[1,1], [2,2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 0",
@@ -2283,12 +2335,15 @@
       {
         "SQL": "select * from trange3 where a in (1,3) and 1 = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:trange3 handle:[1 3], keep order:false, desc:false"
+          "TableReader 2.00 root partition:all data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange3 range:[1,1], [3,3], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "PartitionUnion 4.00 root  ",
-          "├─Batch_Point_Get 2.00 root table:trange3 handle:[1 3], keep order:false, desc:false",
-          "└─Batch_Point_Get 2.00 root table:trange3 handle:[1 3], keep order:false, desc:false"
+          "├─TableReader 2.00 root  data:TableRangeScan",
+          "│ └─TableRangeScan 2.00 cop[tikv] table:trange3, partition:p0 range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "└─TableReader 2.00 root  data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:trange3, partition:p1 range:[1,1], [3,3], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 0",
@@ -2304,8 +2359,10 @@
         "StaticPlan": [
           "Sort 4.00 root  test.trange3.a",
           "└─PartitionUnion 4.00 root  ",
-          "  ├─Batch_Point_Get 2.00 root table:trange3 handle:[1 3], keep order:false, desc:false",
-          "  └─Batch_Point_Get 2.00 root table:trange3 handle:[1 3], keep order:false, desc:false"
+          "  ├─TableReader 2.00 root  data:TableRangeScan",
+          "  │ └─TableRangeScan 2.00 cop[tikv] table:trange3, partition:p0 range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "  └─TableReader 2.00 root  data:TableRangeScan",
+          "    └─TableRangeScan 2.00 cop[tikv] table:trange3, partition:p1 range:[1,1], [3,3], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 0",
@@ -2321,8 +2378,10 @@
         "StaticPlan": [
           "Sort 4.00 root  test.trange3.a:desc",
           "└─PartitionUnion 4.00 root  ",
-          "  ├─Batch_Point_Get 2.00 root table:trange3 handle:[1 3], keep order:false, desc:false",
-          "  └─Batch_Point_Get 2.00 root table:trange3 handle:[1 3], keep order:false, desc:false"
+          "  ├─TableReader 2.00 root  data:TableRangeScan",
+          "  │ └─TableRangeScan 2.00 cop[tikv] table:trange3, partition:p0 range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "  └─TableReader 2.00 root  data:TableRangeScan",
+          "    └─TableRangeScan 2.00 cop[tikv] table:trange3, partition:p1 range:[1,1], [3,3], keep order:false, stats:pseudo"
         ],
         "Result": [
           "3 0",
@@ -2332,10 +2391,12 @@
       {
         "SQL": "select * from tlist3 where a in (1,2) and 1 = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 2], keep order:false, desc:false"
+          "TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist3 range:[1,1], [2,2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 2], keep order:false, desc:false"
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist3, partition:p0 range:[1,1], [2,2], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 0",
@@ -2345,12 +2406,15 @@
       {
         "SQL": "select * from tlist3 where a in (1,3) and 1 = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 3], keep order:false, desc:false"
+          "TableReader 2.00 root partition:p0,p1 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist3 range:[1,1], [3,3], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "PartitionUnion 4.00 root  ",
-          "├─Batch_Point_Get 2.00 root table:tlist3 handle:[1 3], keep order:false, desc:false",
-          "└─Batch_Point_Get 2.00 root table:tlist3 handle:[1 3], keep order:false, desc:false"
+          "├─TableReader 2.00 root  data:TableRangeScan",
+          "│ └─TableRangeScan 2.00 cop[tikv] table:tlist3, partition:p0 range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "└─TableReader 2.00 root  data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:tlist3, partition:p1 range:[1,1], [3,3], keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 0",
@@ -2364,7 +2428,8 @@
           "└─TableRangeScan 2.00 cop[tikv] table:tlist3 range:[1,1], [2,2], keep order:true, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 2], keep order:true, desc:false"
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist3, partition:p0 range:[1,1], [2,2], keep order:true, stats:pseudo"
         ],
         "Result": [
           "1 0",
@@ -2378,7 +2443,8 @@
           "└─TableRangeScan 2.00 cop[tikv] table:tlist3 range:[1,1], [2,2], keep order:true, desc, stats:pseudo"
         ],
         "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 2], keep order:true, desc:true"
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist3, partition:p0 range:[1,1], [2,2], keep order:true, desc, stats:pseudo"
         ],
         "Result": [
           "2 0",

--- a/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
+++ b/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
@@ -1467,7 +1467,8 @@
       {
         "SQL": "explain format = 'brief' select * from t where a = 1 OR a = 2",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:t handle:[1 2], keep order:false, desc:false"
+          "TableReader 2.00 root partition:p1,P2 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:t range:[1,1], [2,2], keep order:false"
         ],
         "StaticPlan": [
           "PartitionUnion 2.00 root  ",

--- a/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
+++ b/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
@@ -1674,7 +1674,8 @@
       {
         "SQL": "select * from thash1 where a in (1,2) and b = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:thash1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "IndexReader 2.00 root partition:p1 index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:thash1, index:PRIMARY(a, b) range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "Batch_Point_Get 2.00 root table:thash1, index:PRIMARY(a, b) keep order:false, desc:false"
@@ -1715,7 +1716,8 @@
       {
         "SQL": "select * from thash1 where a = 1 and b in (1,2)",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:thash1, index:PRIMARY(a, b) keep order:false, desc:false"
+          "IndexReader 2.00 root partition:p0,p1 index:IndexRangeScan",
+          "└─IndexRangeScan 2.00 cop[tikv] table:thash1, index:PRIMARY(a, b) range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "PartitionUnion 4.00 root  ",
@@ -1966,7 +1968,8 @@
       {
         "SQL": "select * from thash2 where a in (1,2) and b = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:thash2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "TableReader 2.00 root partition:p1 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:thash2 range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "Batch_Point_Get 2.00 root table:thash2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
@@ -1993,8 +1996,9 @@
       {
         "SQL": "select * from thash2 where a in (1,2) and b = 1 order by a desc",
         "DynamicPlan": [
-          "TableReader 2.00 root partition:p1 data:TableRangeScan",
-          "└─TableRangeScan 2.00 cop[tikv] table:thash2 range:[1 1,1 1], [2 1,2 1], keep order:true, desc, stats:pseudo"
+          "Sort 0.02 root  test.thash2.a:desc",
+          "└─TableReader 2.00 root partition:p1 data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:thash2 range:[1 1,1 1], [2 1,2 1], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "Batch_Point_Get 2.00 root table:thash2, clustered index:PRIMARY(a, b) keep order:true, desc:true"
@@ -2007,7 +2011,8 @@
       {
         "SQL": "select * from thash2 where a = 1 and b in (1,2)",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:thash2, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+          "TableReader 2.00 root partition:p0,p1 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:thash2 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "PartitionUnion 0.04 root  ",
@@ -2039,8 +2044,9 @@
       {
         "SQL": "select * from thash2 where a = 1 and b in (1,2) order by b desc",
         "DynamicPlan": [
-          "TableReader 2.00 root partition:p0,p1 data:TableRangeScan",
-          "└─TableRangeScan 2.00 cop[tikv] table:thash2 range:[1 1,1 1], [1 2,1 2], keep order:true, desc, stats:pseudo"
+          "Sort 0.02 root  test.thash2.b:desc",
+          "└─TableReader 2.00 root partition:p0,p1 data:TableRangeScan",
+          "  └─TableRangeScan 2.00 cop[tikv] table:thash2 range:[1 1,1 1], [1 2,1 2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "Sort 0.04 root  test.thash2.b:desc",
@@ -2264,7 +2270,8 @@
       {
         "SQL": "select * from thash3 where a in (1,2) and 1 = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:thash3 handle:[1 2], keep order:false, desc:false"
+          "TableReader 2.00 root partition:p0,p1 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:thash3 range:[1,1], [2,2], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "PartitionUnion 4.00 root  ",
@@ -2279,7 +2286,8 @@
       {
         "SQL": "select * from thash3 where a in (1,3) and 1 = 1",
         "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:thash3 handle:[1 3], keep order:false, desc:false"
+          "TableReader 2.00 root partition:p1 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:thash3 range:[1,1], [3,3], keep order:false, stats:pseudo"
         ],
         "StaticPlan": [
           "Batch_Point_Get 2.00 root table:thash3 handle:[1 3], keep order:false, desc:false"
@@ -2315,6 +2323,44 @@
         "Result": [
           "3 0",
           "1 0"
+        ]
+      },
+      {
+        "SQL": "select * from thash3 partition(p0) where a in (1,4)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:thash3 range:[1,1], [4,4], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "Batch_Point_Get 2.00 root table:thash3 handle:[1 4], keep order:false, desc:false"
+        ],
+        "Result": [
+          "4 0"
+        ]
+      },
+      {
+        "SQL": "select * from thash3 partition(p1) where a in (2,4)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:dual data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:thash3 range:[2,2], [4,4], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from thash3 partition(p0,p1) where a in (2,4)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:thash3 range:[2,2], [4,4], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "Batch_Point_Get 2.00 root table:thash3 handle:[2 4], keep order:false, desc:false"
+        ],
+        "Result": [
+          "2 0",
+          "4 0"
         ]
       },
       {
@@ -2389,6 +2435,46 @@
         ]
       },
       {
+        "SQL": "select * from trange3 partition(p0) where a in (1,4)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange3 range:[1,1], [4,4], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange3, partition:p0 range:[1,1], [4,4], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 0"
+        ]
+      },
+      {
+        "SQL": "select * from trange3 partition(p1) where a in (1,2)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:dual data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange3 range:[1,1], [2,2], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from trange3 partition(p0,p1) where a in (1,2)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange3 range:[1,1], [2,2], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:trange3, partition:p0 range:[1,1], [2,2], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 0",
+          "2 0"
+        ]
+      },
+      {
         "SQL": "select * from tlist3 where a in (1,2) and 1 = 1",
         "DynamicPlan": [
           "TableReader 2.00 root partition:p0 data:TableRangeScan",
@@ -2449,6 +2535,66 @@
         "Result": [
           "2 0",
           "1 0"
+        ]
+      },
+      {
+        "SQL": "select * from tlist3 partition(p0) where a in (1,4)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist3 range:[1,1], [4,4], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist3, partition:p0 range:[1,1], [4,4], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 0"
+        ]
+      },
+      {
+        "SQL": "select * from tlist3 partition(p1) where a in (1,2)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:dual data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist3 range:[1,1], [2,2], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from tlist3 partition(p0,p1) where a in (1,2)",
+        "DynamicPlan": [
+          "TableReader 2.00 root partition:p0 data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist3 range:[1,1], [2,2], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "TableReader 2.00 root  data:TableRangeScan",
+          "└─TableRangeScan 2.00 cop[tikv] table:tlist3, partition:p0 range:[1,1], [2,2], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 0",
+          "2 0"
+        ]
+      },
+      {
+        "SQL": "select _tidb_rowid, a from issue45889 where _tidb_rowid in (7, 8)",
+        "DynamicPlan": [
+          "Projection 8000.00 root  test.issue45889._tidb_rowid, test.issue45889.a",
+          "└─TableReader 10000.00 root partition:all data:TableRangeScan",
+          "  └─TableRangeScan 10000.00 cop[tikv] table:issue45889 range:[7,7], [8,8], keep order:false, stats:pseudo"
+        ],
+        "StaticPlan": [
+          "Projection 16000.00 root  test.issue45889._tidb_rowid, test.issue45889.a",
+          "└─PartitionUnion 16000.00 root  ",
+          "  ├─TableReader 10000.00 root  data:TableRangeScan",
+          "  │ └─TableRangeScan 10000.00 cop[tikv] table:issue45889, partition:p0 range:[7,7], [8,8], keep order:false, stats:pseudo",
+          "  └─TableReader 10000.00 root  data:TableRangeScan",
+          "    └─TableRangeScan 10000.00 cop[tikv] table:issue45889, partition:p1 range:[7,7], [8,8], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "7 3",
+          "8 3"
         ]
       }
     ]

--- a/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
+++ b/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
@@ -2268,42 +2268,6 @@
         ]
       },
       {
-        "SQL": "select * from thash3 partition(p0) where a in (1,4)",
-        "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:thash3 handle:[1 4], keep order:false, desc:false"
-        ],
-        "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:thash3 handle:[1 4], keep order:false, desc:false"
-        ],
-        "Result": [
-          "4 0"
-        ]
-      },
-      {
-        "SQL": "select * from thash3 partition(p1) where a in (2,4)",
-        "DynamicPlan": [
-          "TableReader 2.00 root partition:dual data:TableRangeScan",
-          "└─TableRangeScan 2.00 cop[tikv] table:thash3 range:[2,2], [4,4], keep order:false, stats:pseudo"
-        ],
-        "StaticPlan": [
-          "TableDual 0.00 root  rows:0"
-        ],
-        "Result": null
-      },
-      {
-        "SQL": "select * from thash3 partition(p0,p1) where a in (2,4)",
-        "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:thash3 handle:[2 4], keep order:false, desc:false"
-        ],
-        "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:thash3 handle:[2 4], keep order:false, desc:false"
-        ],
-        "Result": [
-          "2 0",
-          "4 0"
-        ]
-      },
-      {
         "SQL": "select * from trange3 where a in (1,2) and 1 = 1",
         "DynamicPlan": [
           "Batch_Point_Get 2.00 root table:trange3 handle:[1 2], keep order:false, desc:false"
@@ -2366,42 +2330,6 @@
         ]
       },
       {
-        "SQL": "select * from trange3 partition(p0) where a in (1,4)",
-        "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:trange3 handle:[1 4], keep order:false, desc:false"
-        ],
-        "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:trange3 handle:[1 4], keep order:false, desc:false"
-        ],
-        "Result": [
-          "1 0"
-        ]
-      },
-      {
-        "SQL": "select * from trange3 partition(p1) where a in (1,2)",
-        "DynamicPlan": [
-          "TableReader 2.00 root partition:dual data:TableRangeScan",
-          "└─TableRangeScan 2.00 cop[tikv] table:trange3 range:[1,1], [2,2], keep order:false, stats:pseudo"
-        ],
-        "StaticPlan": [
-          "TableDual 0.00 root  rows:0"
-        ],
-        "Result": null
-      },
-      {
-        "SQL": "select * from trange3 partition(p0,p1) where a in (1,2)",
-        "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:trange3 handle:[1 2], keep order:false, desc:false"
-        ],
-        "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:trange3 handle:[1 2], keep order:false, desc:false"
-        ],
-        "Result": [
-          "1 0",
-          "2 0"
-        ]
-      },
-      {
         "SQL": "select * from tlist3 where a in (1,2) and 1 = 1",
         "DynamicPlan": [
           "Batch_Point_Get 2.00 root table:tlist3 handle:[1 2], keep order:false, desc:false"
@@ -2455,42 +2383,6 @@
         "Result": [
           "2 0",
           "1 0"
-        ]
-      },
-      {
-        "SQL": "select * from tlist3 partition(p0) where a in (1,4)",
-        "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 4], keep order:false, desc:false"
-        ],
-        "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 4], keep order:false, desc:false"
-        ],
-        "Result": [
-          "1 0"
-        ]
-      },
-      {
-        "SQL": "select * from tlist3 partition(p1) where a in (1,2)",
-        "DynamicPlan": [
-          "TableReader 2.00 root partition:dual data:TableRangeScan",
-          "└─TableRangeScan 2.00 cop[tikv] table:tlist3 range:[1,1], [2,2], keep order:false, stats:pseudo"
-        ],
-        "StaticPlan": [
-          "TableDual 0.00 root  rows:0"
-        ],
-        "Result": null
-      },
-      {
-        "SQL": "select * from tlist3 partition(p0,p1) where a in (1,2)",
-        "DynamicPlan": [
-          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 2], keep order:false, desc:false"
-        ],
-        "StaticPlan": [
-          "Batch_Point_Get 2.00 root table:tlist3 handle:[1 2], keep order:false, desc:false"
-        ],
-        "Result": [
-          "1 0",
-          "2 0"
         ]
       }
     ]

--- a/planner/core/casetest/partition/testdata/partition_pruner_out.json
+++ b/planner/core/casetest/partition/testdata/partition_pruner_out.json
@@ -754,11 +754,13 @@
           "1 1 1 1 1 1"
         ],
         "Plan": [
-          "HashJoin 2.00 root  inner join, equal:[eq(test_partition.t4.id, test_partition.t4.id)]",
-          "├─Selection(Build) 2.00 root  not(isnull(test_partition.t4.id))",
-          "│ └─Batch_Point_Get 2.00 root table:t4 handle:[1 4], keep order:false, desc:false",
-          "└─Selection(Probe) 4.00 root  not(isnull(test_partition.t4.id))",
-          "  └─Batch_Point_Get 4.00 root table:t4 handle:[1 3 9 100], keep order:false, desc:false"
+          "HashJoin 2.50 root  inner join, equal:[eq(test_partition.t4.id, test_partition.t4.id)]",
+          "├─TableReader(Build) 2.00 root partition:p0 data:Selection",
+          "│ └─Selection 2.00 cop[tikv]  not(isnull(test_partition.t4.id))",
+          "│   └─TableRangeScan 2.00 cop[tikv] table:t1 range:[1,1], [4,4], keep order:false, stats:pseudo",
+          "└─TableReader(Probe) 4.00 root partition:p0,p1 data:Selection",
+          "  └─Selection 4.00 cop[tikv]  not(isnull(test_partition.t4.id))",
+          "    └─TableRangeScan 4.00 cop[tikv] table:t2 range:[1,1], [3,3], [9,9], [100,100], keep order:false, stats:pseudo"
         ]
       },
       {

--- a/planner/core/casetest/partition/testdata/partition_pruner_out.json
+++ b/planner/core/casetest/partition/testdata/partition_pruner_out.json
@@ -740,8 +740,9 @@
         ],
         "Plan": [
           "HashJoin 2.20 root  inner join, equal:[eq(test_partition.t4.id, test_partition.t5.id)]",
-          "├─Selection(Build) 2.00 root  not(isnull(test_partition.t4.id))",
-          "│ └─Batch_Point_Get 2.00 root table:t4 handle:[1 3], keep order:false, desc:false",
+          "├─TableReader(Build) 2.00 root partition:p0 data:Selection",
+          "│ └─Selection 2.00 cop[tikv]  not(isnull(test_partition.t4.id))",
+          "│   └─TableRangeScan 2.00 cop[tikv] table:t4 range:[1,1], [3,3], keep order:false",
           "└─IndexLookUp(Probe) 3.64 root partition:p0,p1 ",
           "  ├─IndexRangeScan(Build) 4.00 cop[tikv] table:t5, index:a(a, b) range:[1 1,1 1], [1 6,1 6], [6 1,6 1], [6 6,6 6], keep order:false",
           "  └─Selection(Probe) 3.64 cop[tikv]  not(isnull(test_partition.t5.id))",
@@ -754,13 +755,13 @@
           "1 1 1 1 1 1"
         ],
         "Plan": [
-          "HashJoin 2.50 root  inner join, equal:[eq(test_partition.t4.id, test_partition.t4.id)]",
+          "HashJoin 2.00 root  inner join, equal:[eq(test_partition.t4.id, test_partition.t4.id)]",
           "├─TableReader(Build) 2.00 root partition:p0 data:Selection",
           "│ └─Selection 2.00 cop[tikv]  not(isnull(test_partition.t4.id))",
-          "│   └─TableRangeScan 2.00 cop[tikv] table:t1 range:[1,1], [4,4], keep order:false, stats:pseudo",
+          "│   └─TableRangeScan 2.00 cop[tikv] table:t1 range:[1,1], [4,4], keep order:false",
           "└─TableReader(Probe) 4.00 root partition:p0,p1 data:Selection",
           "  └─Selection 4.00 cop[tikv]  not(isnull(test_partition.t4.id))",
-          "    └─TableRangeScan 4.00 cop[tikv] table:t2 range:[1,1], [3,3], [9,9], [100,100], keep order:false, stats:pseudo"
+          "    └─TableRangeScan 4.00 cop[tikv] table:t2 range:[1,1], [3,3], [9,9], [100,100], keep order:false"
         ]
       },
       {

--- a/planner/core/casetest/partition/testdata/partition_pruner_out.json
+++ b/planner/core/casetest/partition/testdata/partition_pruner_out.json
@@ -1375,8 +1375,9 @@
         ],
         "Plan": [
           "HashJoin 2.17 root  inner join, equal:[eq(default_partition.t4.id, default_partition.t5.id)]",
-          "├─Selection(Build) 2.00 root  not(isnull(default_partition.t4.id))",
-          "│ └─Batch_Point_Get 2.00 root table:t4 handle:[1 3], keep order:false, desc:false",
+          "├─TableReader(Build) 2.00 root partition:p0 data:Selection",
+          "│ └─Selection 2.00 cop[tikv]  not(isnull(default_partition.t4.id))",
+          "│   └─TableRangeScan 2.00 cop[tikv] table:t4 range:[1,1], [3,3], keep order:false",
           "└─IndexLookUp(Probe) 3.69 root partition:p0,p1 ",
           "  ├─IndexRangeScan(Build) 4.00 cop[tikv] table:t5, index:a(a, b) range:[1 1,1 1], [1 6,1 6], [6 1,6 1], [6 6,6 6], keep order:false",
           "  └─Selection(Probe) 3.69 cop[tikv]  not(isnull(default_partition.t5.id))",
@@ -1390,10 +1391,12 @@
         ],
         "Plan": [
           "HashJoin 2.00 root  inner join, equal:[eq(default_partition.t4.id, default_partition.t4.id)]",
-          "├─Selection(Build) 2.00 root  not(isnull(default_partition.t4.id))",
-          "│ └─Batch_Point_Get 2.00 root table:t4 handle:[1 4], keep order:false, desc:false",
-          "└─Selection(Probe) 4.00 root  not(isnull(default_partition.t4.id))",
-          "  └─Batch_Point_Get 4.00 root table:t4 handle:[1 3 9 100], keep order:false, desc:false"
+          "├─TableReader(Build) 2.00 root partition:p0 data:Selection",
+          "│ └─Selection 2.00 cop[tikv]  not(isnull(default_partition.t4.id))",
+          "│   └─TableRangeScan 2.00 cop[tikv] table:t1 range:[1,1], [4,4], keep order:false",
+          "└─TableReader(Probe) 4.00 root partition:p0,p1 data:Selection",
+          "  └─Selection 4.00 cop[tikv]  not(isnull(default_partition.t4.id))",
+          "    └─TableRangeScan 4.00 cop[tikv] table:t2 range:[1,1], [3,3], [9,9], [100,100], keep order:false"
         ]
       },
       {

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -2543,25 +2543,9 @@ func (ds *DataSource) convertToBatchPointGet(prop *property.PhysicalProperty, ca
 		TblInfo:          ds.TableInfo(),
 		KeepOrder:        !prop.IsSortItemEmpty(),
 		Columns:          ds.Columns,
+		SinglePart:       ds.isPartition,
+		PartTblID:        ds.physicalTableID,
 		PartitionExpr:    getPartitionExpr(ds.SCtx(), ds.TableInfo()),
-	}
-	if ds.isPartition {
-		// static prune
-		batchPointGetPlan.PartTblID = make([]int64, 1)
-		batchPointGetPlan.PartTblID[0] = ds.physicalTableID
-	} else if ds.tableInfo.GetPartitionInfo() != nil {
-		// dynamic prune
-		idxs, err := PartitionPruning(ds.SCtx(), ds.table.GetPartitionedTable(), ds.allConds, ds.partitionNames, ds.TblCols, ds.names)
-		if err != nil || len(idxs) == 0 {
-			return invalidTask
-		}
-		if idxs[0] != FullRange {
-			batchPointGetPlan.PartTblID = make([]int64, len(idxs))
-			for i, idx := range idxs {
-				batchPointGetPlan.PartTblID[i] = ds.tableInfo.GetPartitionInfo().Definitions[idx].ID
-			}
-			slices.Sort(batchPointGetPlan.PartTblID)
-		}
 	}
 	if batchPointGetPlan.KeepOrder {
 		// TODO: support keepOrder for partition table with dynamic pruning

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -329,8 +329,13 @@ type BatchPointGetPlan struct {
 	Columns          []*model.ColumnInfo
 	cost             float64
 
-	// PartTblID is the table IDs for the specific table partitions.
-	PartTblID []int64
+	// SinglePart indicates whether this BatchPointGetPlan is just for a single partition, instead of the whole partition table.
+	// If the BatchPointGetPlan is built in fast path, this value is false; if the plan is generated in physical optimization for a partition,
+	// this value would be true. This value would decide the behavior of BatchPointGetExec, i.e, whether to compute the table ID of the partition
+	// on the fly.
+	SinglePart bool
+	// PartTblID is the table ID for the specific table partition.
+	PartTblID int64
 
 	// required by cost model
 	planCostInit bool

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -1892,31 +1892,17 @@ func getPartitionColumnPos(idx *model.IndexInfo, partitionExpr *tables.Partition
 		return 0, nil
 	}
 
-	partitionColName := getPartitionColumnName(partitionExpr, tbl)
-	if partitionColName == nil {
-		return 0, errors.Errorf("unsupported partition type in BatchGet")
-	}
-
-	return getColumnPosInIndex(idx, partitionColName), nil
-}
-
-func getPartitionColumnName(partitionExpr *tables.PartitionExpr, tbl *model.TableInfo) *model.CIStr {
-	if partitionExpr == nil {
-		return nil
-	}
-
-	pi := tbl.GetPartitionInfo()
 	var partitionColName model.CIStr
 	switch pi.Type {
 	case model.PartitionTypeHash:
 		col, ok := partitionExpr.OrigExpr.(*ast.ColumnNameExpr)
 		if !ok {
-			return nil
+			return 0, errors.Errorf("unsupported partition type in BatchGet")
 		}
 		partitionColName = col.Name.Name
 	case model.PartitionTypeKey:
 		if len(partitionExpr.KeyPartCols) != 1 {
-			return nil
+			return 0, errors.Errorf("unsupported partition type in BatchGet")
 		}
 		colInfo := findColNameByColID(tbl.Columns, partitionExpr.KeyPartCols[0])
 		partitionColName = colInfo.Name
@@ -1924,7 +1910,7 @@ func getPartitionColumnName(partitionExpr *tables.PartitionExpr, tbl *model.Tabl
 		// left range columns partition for future development
 		col, ok := partitionExpr.Expr.(*expression.Column)
 		if !(ok && len(pi.Columns) == 0) {
-			return nil
+			return 0, errors.Errorf("unsupported partition type in BatchGet")
 		}
 		colInfo := findColNameByColID(tbl.Columns, col)
 		partitionColName = colInfo.Name
@@ -1932,13 +1918,13 @@ func getPartitionColumnName(partitionExpr *tables.PartitionExpr, tbl *model.Tabl
 		// left list columns partition for future development
 		locateExpr, ok := partitionExpr.ForListPruning.LocateExpr.(*expression.Column)
 		if !(ok && partitionExpr.ForListPruning.ColPrunes == nil) {
-			return nil
+			return 0, errors.Errorf("unsupported partition type in BatchGet")
 		}
 		colInfo := findColNameByColID(tbl.Columns, locateExpr)
 		partitionColName = colInfo.Name
 	}
 
-	return &partitionColName
+	return getColumnPosInIndex(idx, &partitionColName), nil
 }
 
 // getColumnPosInIndex gets the column's position in the index.
@@ -1969,6 +1955,36 @@ func getPartitionExpr(ctx sessionctx.Context, tbl *model.TableInfo) *tables.Part
 
 	// PartitionExpr don't need columns and names for hash partition.
 	return partTable.PartitionExpr()
+}
+
+func getHashOrKeyPartitionColumnName(ctx sessionctx.Context, tbl *model.TableInfo) *model.CIStr {
+	pi := tbl.GetPartitionInfo()
+	if pi == nil {
+		return nil
+	}
+	if pi.Type != model.PartitionTypeHash && pi.Type != model.PartitionTypeKey {
+		return nil
+	}
+	is := ctx.GetInfoSchema().(infoschema.InfoSchema)
+	table, ok := is.TableByID(tbl.ID)
+	if !ok {
+		return nil
+	}
+	// PartitionExpr don't need columns and names for hash partition.
+	partitionExpr := table.(partitionTable).PartitionExpr()
+	if pi.Type == model.PartitionTypeKey {
+		// used to judge whether the key partition contains only one field
+		if len(pi.Columns) != 1 {
+			return nil
+		}
+		return &pi.Columns[0]
+	}
+	expr := partitionExpr.OrigExpr
+	col, ok := expr.(*ast.ColumnNameExpr)
+	if !ok {
+		return nil
+	}
+	return &col.Name.Name
 }
 
 func findColNameByColID(cols []*model.ColumnInfo, col *expression.Column) *model.ColumnInfo {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45889

Problem Summary: Revert https://github.com/pingcap/tidb/pull/45748 and #45646. `Batch_point_get` for partition table in dynamic mode has many potential problems (see it in https://github.com/pingcap/tidb/issues/45532), let's ban it now.


### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
