### PR TITLE
*: demo for add session indentifiers across nodes

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1031,6 +1031,7 @@ func setDDLJobQuery(ctx sessionctx.Context, job *model.Job) {
 // - context.Cancel: job has been sent to worker, but not found in history DDL job before cancel
 // - other: found in history DDL job and return that job error
 func (d *ddl) DoDDLJob(ctx sessionctx.Context, job *model.Job) error {
+	job.TraceInfo = ctx.GetSessionVars().GetTraceInfo()
 	if mci := ctx.GetSessionVars().StmtCtx.MultiSchemaInfo; mci != nil {
 		// In multiple schema change, we don't run the job.
 		// Instead, we merge all the jobs into one pending job.

--- a/ddl/rollingback.go
+++ b/ddl/rollingback.go
@@ -382,7 +382,7 @@ func rollingbackReorganizePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (ve
 
 func pauseReorgWorkers(w *worker, d *ddlCtx, job *model.Job) (err error) {
 	if needNotifyAndStopReorgWorker(job) {
-		logutil.Logger(w.logCtx).Info("pausing the DDL job", zap.String("category", "ddl"), zap.String("job", job.String()))
+		w.jobLogger(job).Info("pausing the DDL job", zap.String("category", "ddl"), zap.String("job", job.String()))
 		d.notifyReorgWorkerJobStateChange(job)
 	}
 
@@ -457,22 +457,22 @@ func convertJob2RollbackJob(w *worker, d *ddlCtx, t *meta.Meta, job *model.Job) 
 			// job state and args may not be correctly overwritten. The job will be fetched to run with the cancelling
 			// state again. So we should check the error count here.
 			if err1 := loadDDLVars(w); err1 != nil {
-				logutil.Logger(w.logCtx).Error("load DDL global variable failed", zap.String("category", "ddl"), zap.Error(err1))
+				w.jobLogger(job).Error("load DDL global variable failed", zap.String("category", "ddl"), zap.Error(err1))
 			}
 			errorCount := variable.GetDDLErrorCountLimit()
 			if job.ErrorCount > errorCount {
-				logutil.Logger(w.logCtx).Warn("rollback DDL job error count exceed the limit, cancelled it now", zap.String("category", "ddl"), zap.Int64("jobID", job.ID), zap.Int64("errorCountLimit", errorCount))
+				w.jobLogger(job).Warn("rollback DDL job error count exceed the limit, cancelled it now", zap.String("category", "ddl"), zap.Int64("jobID", job.ID), zap.Int64("errorCountLimit", errorCount))
 				job.Error = toTError(errors.Errorf("rollback DDL job error count exceed the limit %d, cancelled it now", errorCount))
 				job.State = model.JobStateCancelled
 			}
 		}
 
 		if !(job.State != model.JobStateRollingback && job.State != model.JobStateCancelled) {
-			logutil.Logger(w.logCtx).Info("the DDL job is cancelled normally", zap.String("category", "ddl"), zap.String("job", job.String()), zap.Error(err))
+			w.jobLogger(job).Info("the DDL job is cancelled normally", zap.String("category", "ddl"), zap.String("job", job.String()), zap.Error(err))
 			// If job is cancelled, we shouldn't return an error.
 			return ver, nil
 		}
-		logutil.Logger(w.logCtx).Error("run DDL job failed", zap.String("category", "ddl"), zap.String("job", job.String()), zap.Error(err))
+		w.jobLogger(job).Error("run DDL job failed", zap.String("category", "ddl"), zap.String("job", job.String()), zap.Error(err))
 	}
 
 	return

--- a/disttask/framework/scheduler/manager.go
+++ b/disttask/framework/scheduler/manager.go
@@ -88,7 +88,7 @@ func (b *ManagerBuilder) BuildManager(ctx context.Context, id string, taskTable 
 		id:                   id,
 		taskTable:            taskTable,
 		subtaskExecutorPools: make(map[string]Pool),
-		logCtx:               logutil.WithKeyValue(context.Background(), "dist_task_manager", id),
+		logCtx:               logutil.WithFields(context.Background(), zap.String("dist_task_manager", id)),
 		newPool:              b.newPool,
 		newScheduler:         b.newScheduler,
 	}

--- a/disttask/framework/scheduler/scheduler.go
+++ b/disttask/framework/scheduler/scheduler.go
@@ -60,7 +60,7 @@ func NewInternalScheduler(ctx context.Context, id string, taskID int64, taskTabl
 		taskID:    taskID,
 		taskTable: taskTable,
 		pool:      pool,
-		logCtx:    logutil.WithKeyValue(context.Background(), "scheduler", logPrefix),
+		logCtx:    logutil.WithFields(context.Background(), zap.String("scheduler", logPrefix)),
 	}
 	schedulerImpl.ctx, schedulerImpl.cancel = context.WithCancel(ctx)
 

--- a/domain/topn_slow_query.go
+++ b/domain/topn_slow_query.go
@@ -207,17 +207,18 @@ func (q *topNSlowQueries) Close() {
 
 // SlowQueryInfo is a struct to record slow query info.
 type SlowQueryInfo struct {
-	SQL        string
-	Start      time.Time
-	Duration   time.Duration
-	Detail     execdetails.ExecDetails
-	ConnID     uint64
-	TxnTS      uint64
-	User       string
-	DB         string
-	TableIDs   string
-	IndexNames string
-	Digest     string
-	Internal   bool
-	Succ       bool
+	SQL          string
+	Start        time.Time
+	Duration     time.Duration
+	Detail       execdetails.ExecDetails
+	ConnID       uint64
+	SessionAlias string
+	TxnTS        uint64
+	User         string
+	DB           string
+	TableIDs     string
+	IndexNames   string
+	Digest       string
+	Internal     bool
+	Succ         bool
 }

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -1640,19 +1640,20 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 			tableIDs = strings.ReplaceAll(fmt.Sprintf("%v", stmtCtx.TableIDs), " ", ",")
 		}
 		domain.GetDomain(a.Ctx).LogSlowQuery(&domain.SlowQueryInfo{
-			SQL:        sql.String(),
-			Digest:     digest.String(),
-			Start:      sessVars.StartTime,
-			Duration:   costTime,
-			Detail:     stmtCtx.GetExecDetails(),
-			Succ:       succ,
-			ConnID:     sessVars.ConnectionID,
-			TxnTS:      txnTS,
-			User:       userString,
-			DB:         sessVars.CurrentDB,
-			TableIDs:   tableIDs,
-			IndexNames: indexNames,
-			Internal:   sessVars.InRestrictedSQL,
+			SQL:          sql.String(),
+			Digest:       digest.String(),
+			Start:        sessVars.StartTime,
+			Duration:     costTime,
+			Detail:       stmtCtx.GetExecDetails(),
+			Succ:         succ,
+			ConnID:       sessVars.ConnectionID,
+			SessionAlias: sessVars.SessionAlias,
+			TxnTS:        txnTS,
+			User:         userString,
+			DB:           sessVars.CurrentDB,
+			TableIDs:     tableIDs,
+			IndexNames:   indexNames,
+			Internal:     sessVars.InRestrictedSQL,
 		})
 	}
 }

--- a/executor/coprocessor.go
+++ b/executor/coprocessor.go
@@ -31,7 +31,9 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/timeutil"
+	"github.com/pingcap/tidb/util/tracing"
 	"github.com/pingcap/tipb/go-tipb"
 )
 
@@ -50,6 +52,10 @@ func NewCoprocessorDAGHandler(sctx sessionctx.Context) *CoprocessorDAGHandler {
 
 // HandleRequest handles the coprocessor request.
 func (h *CoprocessorDAGHandler) HandleRequest(ctx context.Context, req *coprocessor.Request) *coprocessor.Response {
+	traceInfo := tracing.TraceInfoFromPbTraceContext(req.Context.TraceContext)
+	ctx = tracing.ContextWithTraceInfo(ctx, traceInfo)
+	ctx = logutil.WithTraceInfo(ctx, traceInfo)
+
 	e, err := h.buildDAGExecutor(req)
 	if err != nil {
 		return h.buildErrorResponse(err)
@@ -90,6 +96,10 @@ func (h *CoprocessorDAGHandler) HandleRequest(ctx context.Context, req *coproces
 
 // HandleStreamRequest handles the coprocessor stream request.
 func (h *CoprocessorDAGHandler) HandleStreamRequest(ctx context.Context, req *coprocessor.Request, stream tikvpb.Tikv_CoprocessorStreamServer) error {
+	traceInfo := tracing.TraceInfoFromPbTraceContext(req.Context.TraceContext)
+	ctx = tracing.ContextWithTraceInfo(ctx, traceInfo)
+	ctx = logutil.WithTraceInfo(ctx, traceInfo)
+
 	e, err := h.buildDAGExecutor(req)
 	if err != nil {
 		return stream.Send(h.buildErrorResponse(err))

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1117,6 +1117,7 @@ func (e *ShowSlowExec) Next(_ context.Context, req *chunk.Chunk) error {
 			req.AppendInt64(11, 0)
 		}
 		req.AppendString(12, slow.Digest)
+		req.AppendString(13, slow.SessionAlias)
 		e.cursor++
 	}
 	return nil

--- a/executor/slow_query.go
+++ b/executor/slow_query.go
@@ -760,7 +760,7 @@ func getColumnValueFactoryByName(colName string, columnIdx int) (slowQueryColumn
 		}, nil
 	case variable.SlowLogUserStr, variable.SlowLogHostStr, execdetails.BackoffTypesStr, variable.SlowLogDBStr, variable.SlowLogIndexNamesStr, variable.SlowLogDigestStr,
 		variable.SlowLogStatsInfoStr, variable.SlowLogCopProcAddr, variable.SlowLogCopWaitAddr, variable.SlowLogPlanDigest,
-		variable.SlowLogPrevStmt, variable.SlowLogQuerySQLStr, variable.SlowLogWarnings:
+		variable.SlowLogPrevStmt, variable.SlowLogQuerySQLStr, variable.SlowLogWarnings, variable.SlowLogSessionAliasStr:
 		return func(row []types.Datum, value string, tz *time.Location, checker *slowLogChecker) (valid bool, err error) {
 			row[columnIdx] = types.NewStringDatum(value)
 			return true, nil

--- a/go.mod
+++ b/go.mod
@@ -303,5 +303,6 @@ replace (
 	// fix potential security issue(CVE-2020-26160) introduced by indirect dependency.
 	github.com/dgrijalva/jwt-go => github.com/form3tech-oss/jwt-go v3.2.6-0.20210809144907-32ab6a8243d7+incompatible
 	github.com/go-ldap/ldap/v3 => github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117
+	github.com/pingcap/kvproto => github.com/lcwangchao/kvproto v0.0.0-20230803053554-bf0445fa0c59
 	github.com/pingcap/tidb/parser => ./parser
 )

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,10 @@ github.com/cloudfoundry/gosigar v1.3.6 h1:gIc08FbB3QPb+nAQhINIK/qhf5REKkY0FTGgRG
 github.com/cloudfoundry/gosigar v1.3.6/go.mod h1:lNWstu5g5gw59O09Y+wsMNFzBSnU8a0u+Sfx4dq360E=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
+github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292/go.mod h1:qRiX68mZX1lGBkTWyp3CLcenw9I94W2dLeRvMzcn9N4=
 github.com/cockroachdb/cockroach v0.0.0-20170608034007-84bc9597164f/go.mod h1:xeT/CQ0qZHangbYbWShlCGAx31aV4AjGswDUjhKS6HQ=
@@ -274,6 +278,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/etcd-io/gofail v0.0.0-20190801230047-ad7f989257ca/go.mod h1:49H/RkXP8pKaZy4h0d+NW16rSLhyVBt4o6VLJbmOqDE=
@@ -354,7 +359,6 @@ github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MG
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -386,7 +390,6 @@ github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
-github.com/golang/protobuf v0.0.0-20180814211427-aa810b61a9c7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -658,6 +661,8 @@ github.com/kyoh86/exportloopref v0.1.11 h1:1Z0bcmTypkL3Q4k+IDHMWTcnCliEZcaPiIe0/
 github.com/kyoh86/exportloopref v0.1.11/go.mod h1:qkV4UF1zGl6EkF1ox8L5t9SwyeBAZ3qLMd6up458uqA=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
+github.com/lcwangchao/kvproto v0.0.0-20230803053554-bf0445fa0c59 h1:RDCvtAQ6AoYr3rZU9IwKRpW6HHAsQPhSorLcAAWFFQc=
+github.com/lcwangchao/kvproto v0.0.0-20230803053554-bf0445fa0c59/go.mod h1:r0q/CFcwvyeRhKtoqzmWMBebrtpIziQQ9vR+JKh1knc=
 github.com/lestrrat-go/blackmagic v1.0.1 h1:lS5Zts+5HIC/8og6cGHb0uCcNCa3OUt1ygh3Qz2Fe80=
 github.com/lestrrat-go/blackmagic v1.0.1/go.mod h1:UrEqBzIR2U6CnzVyUtfM6oZNMt/7O7Vohk2J0OGSAtU=
 github.com/lestrrat-go/httpcc v1.0.1 h1:ydWCStUeJLkpYyjLDHihupbn2tYmZ7m22BGkcvZZrIE=
@@ -807,9 +812,6 @@ github.com/pingcap/fn v1.0.0 h1:CyA6AxcOZkQh52wIqYlAmaVmF6EvrcqFywP463pjA8g=
 github.com/pingcap/fn v1.0.0/go.mod h1:u9WZ1ZiOD1RpNhcI42RucFh/lBuzTu6rw88a+oF2Z24=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20230724163613-ee4a4ff68ac3 h1:6Ri5yW/xst0i+zPDJPzXpfRb6movVRRzDINCTctt7D4=
-github.com/pingcap/kvproto v0.0.0-20230724163613-ee4a4ff68ac3/go.mod h1:r0q/CFcwvyeRhKtoqzmWMBebrtpIziQQ9vR+JKh1knc=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20230317032135-a0d097d16e22 h1:2SOzvGvE8beiC1Y4g9Onkvu6UmuBBOeWRGQEjJaT/JY=
@@ -1209,7 +1211,6 @@ golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20181005035420-146acd28ed58/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1338,6 +1339,7 @@ golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1507,7 +1509,6 @@ google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180518175338-11a468237815/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
-google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -1541,7 +1542,6 @@ google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 h1:KpwkzHKEF7B9Zxg18WzOa7djJ+Ha5DzthMyZYQfEn2A=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1/go.mod h1:nKE/iIaLqn2bQwXBg8f1g2Ylh6r5MN5CmZvuzZCgsCU=
-google.golang.org/grpc v0.0.0-20180607172857-7a6a684ca69e/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -1563,6 +1563,7 @@ google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
 google.golang.org/grpc v1.54.0 h1:EhTqbhiYeixwWQtAEZAxmV9MGqcjEU2mFx52xCzNyag=
 google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
@@ -1577,6 +1578,7 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -919,6 +919,7 @@ var slowQueryCols = []columnInfo{
 	{name: variable.SlowLogBinaryPlan, tp: mysql.TypeLongBlob, size: types.UnspecifiedLength},
 	{name: variable.SlowLogPrevStmt, tp: mysql.TypeLongBlob, size: types.UnspecifiedLength},
 	{name: variable.SlowLogQuerySQLStr, tp: mysql.TypeLongBlob, size: types.UnspecifiedLength},
+	{name: variable.SlowLogSessionAliasStr, tp: mysql.TypeVarchar, size: 64},
 }
 
 // TableTiDBHotRegionsCols is TiDB hot region mem table columns.

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -589,6 +589,9 @@ type Request struct {
 
 	// ConnID stores the session connection id.
 	ConnID uint64
+
+	// TraceInfo indicates the trace info
+	TraceInfo *model.TraceInfo
 }
 
 // CoprRequestAdjuster is used to check and adjust a copr request according to specific rules.

--- a/owner/manager.go
+++ b/owner/manager.go
@@ -125,7 +125,7 @@ func NewOwnerManager(ctx context.Context, etcdCli *clientv3.Client, prompt, id, 
 		prompt:       prompt,
 		cancel:       cancelFunc,
 		logPrefix:    logPrefix,
-		logCtx:       logutil.WithKeyValue(context.Background(), "owner info", logPrefix),
+		logCtx:       logutil.WithFields(context.Background(), zap.String("owner info", logPrefix)),
 		sessionLease: atomicutil.NewInt64(0),
 	}
 }
@@ -418,14 +418,14 @@ func GetOwnerOpValue(ctx context.Context, etcdCli *clientv3.Client, ownerPath, l
 		return *mockOwnerOpValue.Load(), nil
 	}
 
-	logCtx := logutil.WithKeyValue(context.Background(), "owner info", logPrefix)
+	logCtx := logutil.WithFields(context.Background(), zap.String("owner info", logPrefix))
 	_, _, op, _, err := getOwnerInfo(ctx, logCtx, etcdCli, ownerPath)
 	return op, errors.Trace(err)
 }
 
 func (m *ownerManager) watchOwner(ctx context.Context, etcdSession *concurrency.Session, key string) {
 	logPrefix := fmt.Sprintf("[%s] ownerManager %s watch owner key %v", m.prompt, m.id, key)
-	logCtx := logutil.WithKeyValue(context.Background(), "owner info", logPrefix)
+	logCtx := logutil.WithFields(context.Background(), zap.String("owner info", logPrefix))
 	logutil.BgLogger().Debug(logPrefix)
 	watchCh := m.etcdCli.Watch(ctx, key)
 	for {

--- a/owner/manager_test.go
+++ b/owner/manager_test.go
@@ -35,6 +35,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.etcd.io/etcd/tests/v3/integration"
+	"go.uber.org/zap"
 )
 
 const testLease = 5 * time.Millisecond
@@ -271,7 +272,7 @@ func TestCluster(t *testing.T) {
 	d1.OwnerManager().Cancel()
 
 	logPrefix := fmt.Sprintf("[ddl] %s ownerManager %s", DDLOwnerKey, "useless id")
-	logCtx := logutil.WithKeyValue(context.Background(), "owner info", logPrefix)
+	logCtx := logutil.WithFields(context.Background(), zap.String("owner info", logPrefix))
 	_, err = owner.GetOwnerKey(context.Background(), logCtx, cliRW, DDLOwnerKey, "useless id")
 	require.Truef(t, terror.ErrorEqual(err, concurrency.ErrElectionNoLeader), "get owner info result don't match, err %v", err)
 	op, err := owner.GetOwnerOpValue(context.Background(), cliRW, DDLOwnerKey, logPrefix)

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -437,6 +437,9 @@ type Job struct {
 	// AdminOperator indicates where the Admin command comes, by the TiDB
 	// itself (AdminCommandBySystem) or by user (AdminCommandByEndUser).
 	AdminOperator AdminCommandOperator `json:"admin_operator"`
+
+	// TraceInfo is the info for trace
+	TraceInfo *TraceInfo
 }
 
 // FinishTableJob is called when a job is finished.

--- a/parser/model/model.go
+++ b/parser/model/model.go
@@ -2152,3 +2152,11 @@ func (s WindowRepeatType) String() string {
 		return ""
 	}
 }
+
+// TraceInfo is the information for trace
+type TraceInfo struct {
+	// ConnectionID is the id of the connection
+	ConnectionID uint64 `json:"connection_id"`
+	// SessionAlias is the alias of session
+	SessionAlias string `json:"connection_alias"`
+}

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -3221,6 +3221,7 @@ func buildShowSlowSchema() (*expression.Schema, types.NameSlice) {
 	schema.Append(buildColumnWithName("", "INDEX_IDS", mysql.TypeVarchar, 256))
 	schema.Append(buildColumnWithName("", "INTERNAL", mysql.TypeTiny, tinySize))
 	schema.Append(buildColumnWithName("", "DIGEST", mysql.TypeVarchar, 64))
+	schema.Append(buildColumnWithName("", "SESSION_ALIAS", mysql.TypeVarchar, 64))
 	return schema.col2Schema(), schema.names
 }
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1530,6 +1530,9 @@ type SessionVars struct {
 	// When set to true, skip missing partition stats and continue to merge other partition stats to global stats.
 	// When set to false, give up merging partition stats to global stats.
 	SkipMissingPartitionStats bool
+
+	// SessionAlias is the identifier of the session
+	SessionAlias string
 }
 
 // GetOptimizerFixControlMap returns the specified value of the optimizer fix control.
@@ -2948,6 +2951,8 @@ const (
 	SlowLogHostStr = "Host"
 	// SlowLogConnIDStr is slow log field name.
 	SlowLogConnIDStr = "Conn_ID"
+	// SlowLogSessionAliasStr is the session alias set by user.
+	SlowLogSessionAliasStr = "Session_alias"
 	// SlowLogQueryTimeStr is slow log field name.
 	SlowLogQueryTimeStr = "Query_time"
 	// SlowLogParseTimeStr is the parse sql time.
@@ -3149,6 +3154,9 @@ func (s *SessionVars) SlowLogFormat(logItems *SlowQueryLogItems) string {
 	}
 	if s.ConnectionID != 0 {
 		writeSlowLogItem(&buf, SlowLogConnIDStr, strconv.FormatUint(s.ConnectionID, 10))
+	}
+	if s.SessionAlias != "" {
+		writeSlowLogItem(&buf, SlowLogSessionAliasStr, s.SessionAlias)
 	}
 	if logItems.ExecRetryCount > 0 {
 		buf.WriteString(SlowLogRowPrefixStr)
@@ -3498,6 +3506,14 @@ func (s *SessionVars) GetRuntimeFilterTypes() []RuntimeFilterType {
 // GetRuntimeFilterMode return the session variable runtimeFilterMode
 func (s *SessionVars) GetRuntimeFilterMode() RuntimeFilterMode {
 	return s.runtimeFilterMode
+}
+
+// GetTraceInfo returns the trace info of a session
+func (s *SessionVars) GetTraceInfo() *model.TraceInfo {
+	return &model.TraceInfo{
+		ConnectionID: s.ConnectionID,
+		SessionAlias: s.SessionAlias,
+	}
 }
 
 // RuntimeFilterType type of runtime filter "IN"

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -2781,6 +2781,12 @@ var defaultSysVars = []*SysVar{
 	}, GetGlobal: func(ctx context.Context, vars *SessionVars) (string, error) {
 		return BoolToOnOff(EnableCheckConstraint.Load()), nil
 	}},
+	{Scope: ScopeSession, Name: TiDBSessionAlias, Value: "", Type: TypeStr, SetSession: func(vars *SessionVars, s string) error {
+		vars.SessionAlias = s
+		return nil
+	}, GetSession: func(vars *SessionVars) (string, error) {
+		return vars.SessionAlias, nil
+	}},
 }
 
 func setTiFlashComputeDispatchPolicy(s *SessionVars, val string) error {

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -904,6 +904,9 @@ const (
 
 	// TiDBEnableCheckConstraint indicates whether to enable check constraint feature.
 	TiDBEnableCheckConstraint = "tidb_enable_check_constraint"
+
+	// TiDBSessionAlias indicates the alias of a session
+	TiDBSessionAlias = "tidb_session_alias"
 )
 
 // TiDB vars that have only global scope

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/tiflash"
 	"github.com/pingcap/tidb/util/tiflashcompute"
+	"github.com/pingcap/tidb/util/tracing"
 	"github.com/tikv/client-go/v2/metrics"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
@@ -1275,6 +1276,7 @@ func (b *batchCopIterator) handleTaskOnce(ctx context.Context, bo *backoff.Backo
 		RecordTimeStat: true,
 		RecordScanStat: true,
 		TaskId:         b.req.TaskID,
+		TraceContext:   tracing.ToPbTraceContext(b.req.TraceInfo),
 	})
 	if b.req.ResourceGroupTagger != nil {
 		b.req.ResourceGroupTagger(req)

--- a/ttl/ttlworker/job_manager.go
+++ b/ttl/ttlworker/job_manager.go
@@ -118,7 +118,7 @@ func NewJobManager(id string, sessPool sessionPool, store kv.Storage, etcdCli *c
 	manager.sessPool = sessPool
 
 	manager.init(manager.jobLoop)
-	manager.ctx = logutil.WithKeyValue(manager.ctx, "ttl-worker", "job-manager")
+	manager.ctx = logutil.WithFields(manager.ctx, zap.String("ttl-worker", "job-manager"))
 
 	manager.infoSchemaCache = cache.NewInfoSchemaCache(getUpdateInfoSchemaCacheInterval())
 	manager.tableStatusCache = cache.NewTableStatusCache(getUpdateTTLTableStatusCacheInterval())

--- a/ttl/ttlworker/task_manager.go
+++ b/ttl/ttlworker/task_manager.go
@@ -97,7 +97,7 @@ type taskManager struct {
 
 func newTaskManager(ctx context.Context, sessPool sessionPool, infoSchemaCache *cache.InfoSchemaCache, id string, store kv.Storage) *taskManager {
 	return &taskManager{
-		ctx:      logutil.WithKeyValue(ctx, "ttl-worker", "task-manager"),
+		ctx:      logutil.WithFields(ctx, zap.String("ttl-worker", "task-manager")),
 		sessPool: sessPool,
 
 		id: id,

--- a/ttl/ttlworker/task_manager_integration_test.go
+++ b/ttl/ttlworker/task_manager_integration_test.go
@@ -314,7 +314,7 @@ func TestTTLRunningTasksLimitation(t *testing.T) {
 			workers = append(workers, scanWorker)
 		}
 
-		ctx := logutil.WithKeyValue(context.Background(), "ttl-worker-test", fmt.Sprintf("task-manager-%d", i))
+		ctx := logutil.WithFields(context.Background(), zap.String("ttl-worker-test", fmt.Sprintf("task-manager-%d", i)))
 		m := ttlworker.NewTaskManager(ctx, nil, isc, fmt.Sprintf("task-manager-%d", i), store)
 		m.SetScanWorkers4Test(workers)
 		scheduleWg.Add(1)

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -27,6 +27,7 @@ import (
 	tlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/parser/model"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -199,43 +200,75 @@ func BgLogger() *zap.Logger {
 
 // WithConnID attaches connId to context.
 func WithConnID(ctx context.Context, connID uint64) context.Context {
-	var logger *zap.Logger
-	if ctxLogger, ok := ctx.Value(CtxLogKey).(*zap.Logger); ok {
-		logger = ctxLogger
-	} else {
-		logger = log.L()
-	}
-	return context.WithValue(ctx, CtxLogKey, logger.With(zap.Uint64("conn", connID)))
+	return WithFields(ctx, zap.Uint64("conn", connID))
+}
+
+// WithSessionAlias attaches session_alias to context
+func WithSessionAlias(ctx context.Context, alias string) context.Context {
+	return WithFields(ctx, zap.String("session_alias", alias))
 }
 
 // WithCategory attaches category to context.
 func WithCategory(ctx context.Context, category string) context.Context {
-	var logger *zap.Logger
-	if ctxLogger, ok := ctx.Value(CtxLogKey).(*zap.Logger); ok {
-		logger = ctxLogger
-	} else {
+	return WithFields(ctx, zap.String("category", category))
+}
+
+// WithTraceInfo attaches fields from trace info to logger in context
+func WithTraceInfo(ctx context.Context, info *model.TraceInfo) context.Context {
+	fields := fieldsFromTraceInfo(info)
+	return WithFields(ctx, fields...)
+}
+
+// LoggerWithTraceInfo attaches fields from trace info to logger
+func LoggerWithTraceInfo(logger *zap.Logger, info *model.TraceInfo) *zap.Logger {
+	if logger == nil {
 		logger = log.L()
 	}
-	return context.WithValue(ctx, CtxLogKey, logger.With(zap.String("category", category)))
+
+	if fields := fieldsFromTraceInfo(info); len(fields) > 0 {
+		logger = logger.With(fields...)
+	}
+
+	return logger
+}
+
+func fieldsFromTraceInfo(info *model.TraceInfo) []zap.Field {
+	if info == nil {
+		return nil
+	}
+
+	fields := make([]zap.Field, 0, 2)
+	if info.ConnectionID != 0 {
+		fields = append(fields, zap.Uint64("conn", info.ConnectionID))
+	}
+
+	if info.SessionAlias != "" {
+		fields = append(fields, zap.String("session_alias", info.SessionAlias))
+	}
+
+	return fields
 }
 
 // WithTraceLogger attaches trace identifier to context
-func WithTraceLogger(ctx context.Context, connID uint64) context.Context {
+func WithTraceLogger(ctx context.Context, info *model.TraceInfo) context.Context {
 	var logger *zap.Logger
 	if ctxLogger, ok := ctx.Value(CtxLogKey).(*zap.Logger); ok {
 		logger = ctxLogger
 	} else {
 		logger = log.L()
 	}
-	return context.WithValue(ctx, CtxLogKey, wrapTraceLogger(ctx, connID, logger))
+	return context.WithValue(ctx, CtxLogKey, wrapTraceLogger(ctx, info, logger))
 }
 
-func wrapTraceLogger(ctx context.Context, connID uint64, logger *zap.Logger) *zap.Logger {
+func wrapTraceLogger(ctx context.Context, info *model.TraceInfo, logger *zap.Logger) *zap.Logger {
 	return logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 		tl := &traceLog{ctx: ctx}
 		// cfg.Format == "", never return error
 		enc, _ := log.NewTextEncoder(&log.Config{})
-		traceCore := log.NewTextCore(enc, tl, tl).With([]zapcore.Field{zap.Uint64("conn", connID)})
+		traceCore := log.NewTextCore(enc, tl, tl)
+		if fields := fieldsFromTraceInfo(info); len(fields) > 0 {
+			traceCore = traceCore.With(fields)
+		}
 		return zapcore.NewTee(traceCore, core)
 	}))
 }
@@ -257,15 +290,20 @@ func (*traceLog) Sync() error {
 	return nil
 }
 
-// WithKeyValue attaches key/value to context.
-func WithKeyValue(ctx context.Context, key, value string) context.Context {
+// WithFields attaches key/value to context.
+func WithFields(ctx context.Context, fields ...zap.Field) context.Context {
 	var logger *zap.Logger
 	if ctxLogger, ok := ctx.Value(CtxLogKey).(*zap.Logger); ok {
 		logger = ctxLogger
 	} else {
 		logger = log.L()
 	}
-	return context.WithValue(ctx, CtxLogKey, logger.With(zap.String(key, value)))
+
+	if len(fields) > 0 {
+		logger = logger.With(fields...)
+	}
+
+	return context.WithValue(ctx, CtxLogKey, logger)
 }
 
 // TraceEventKey presents the TraceEventKey in span log.

--- a/util/logutil/log_test.go
+++ b/util/logutil/log_test.go
@@ -50,7 +50,7 @@ func TestZapLoggerWithKeys(t *testing.T) {
 	require.NoError(t, err)
 	key := "ctxKey"
 	val := "ctxValue"
-	ctx1 := WithKeyValue(context.Background(), key, val)
+	ctx1 := WithFields(context.Background(), zap.String(key, val))
 	testZapLogger(ctx1, t, fileCfg.Filename, zapLogWithKeyValPatternByCtx)
 	err = os.Remove(fileCfg.Filename)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Tracing some operations in some distributed components.

1. The PR depends on the kvproto in a custom branch: https://github.com/lcwangchao/kvproto/tree/sql_trace
2. You can see the pull request: https://github.com/tikv/tikv/pull/15285 to enable slow log trace in tikv

### What is changed and how it works?

An new object `TraceInfo` is introduced to collection tracing information in a query.

```
type TraceInfo struct {
	// ConnectionID is the id of the connection
	ConnectionID uint64 `json:"connection_id"`
	// SessionAlias is the alias of session
	SessionAlias string `json:"connection_alias"`
}
```

After `set @@tidb_session_alias='alias123456'` some logs will contain session alias info in tidb, for example:

```
[2023/08/08 14:15:16.304 +08:00] [INFO] [ddl_worker.go:989] ["run DDL job"] [worker="worker 1, tp general"] [conn=3596615686] [session_alias=alias123456] [category=ddl] [job="ID:244, Type:create table, State:queueing, SchemaState:none, SchemaID:136, TableID:243, RowCount:0, ArgLen:0, start time: 2023-08-08 14:15:16.278 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:0"]
.....
[2023/08/08 14:15:16.389 +08:00] [INFO] [ddl_worker.go:610] ["finish DDL job"] [worker="worker 1, tp general"] [conn=3596615686] [session_alias=alias123456] [category=ddl] [job="ID:244, Type:create table, State:synced, SchemaState:public, SchemaID:136, TableID:243, RowCount:0, ArgLen:0, start time: 2023-08-08 14:15:16.278 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:0"]
```

slow log:

```
# Time: 2023-08-08T14:16:41.319342+08:00
# Txn_start_ts: 0
# User@Host: root[root] @ 127.0.0.1 [127.0.0.1]
# Conn_ID: 3596615686
# Session_alias: alias123456
# Query_time: 1.001107666
# Parse_time: 0.00006575
# Compile_time: 0.000716916
# Rewrite_time: 0.000654875
# Optimize_time: 0.000020667
# Wait_TS: 0
# DB: test
# Is_internal: false
# Digest: a0adeeb79b71315ac13a77f3f11162106b5ec7b48212cf17c20c754263ab9228
# Num_cop_tasks: 0
# Prepared: false
# Plan_from_cache: false
# Plan_from_binding: false
# Has_more_results: false
# KV_total: 0
# PD_total: 0.000004708
# Backoff_total: 0
# Write_sql_response_total: 0.000020374
# Result_rows: 1
# Succ: true
# IsExplicitTxn: false
# IsSyncStatsFailed: false
# Plan: tidb_decode_plan('ffBhMAkzXzMJMAkxCXNsZWVwKDEpLT5Db2x1bW4jMQkxCXRpbWU6MXMsIGxvb3BzOjIsIENvbmN1cnJlbmN5Ok9GRgkwIEJ5dGVzCU4vQQoxCTI1XzQJMAkxCXJvd3M6MQkxCXQBQgw5MTduGUUgCU4vQQlOL0EK')
# Plan_digest: a55eaee1d30304ad05500afbbfff1409ce22376e0f062c0d06ff34b8ed9c2b47
# Binary_plan: tidb_decode_binary_plan('vgGICrkBCgxQcm9qZWN0aW9uXzMSTwoLVGFibGVEdWFsXzQpAAABAqDwPzABOAFAAVIGcm93czoxWhN0aW1lOjkxN25zLCBsb29wczoycP///wkCBAF4CQgw////ASH2KFyPwvUjQD5LAFASc2xlZXAoMSktPkNvbHVtbiMxWhAFVwAxGVR0Yg9Db25jdXJyZW5jeTpPRkZ4////////////ARgB')
```

```
TiDB root@127.0.0.1:test> select * from information_schema.slow_query order by time desc limit 1\G
***************************[ 1. row ]***************************
Time                          | 2023-08-08 14:16:41.319342
Txn_start_ts                  | 0
User                          | root
Host                          | 127.0.0.1
Conn_ID                       | 3596615686
Exec_retry_count              | 0
Exec_retry_time               | 0.0
Query_time                    | 1.001107666
Parse_time                    | 6.575e-05
Compile_time                  | 0.000716916
Rewrite_time                  | 0.000654875
Preproc_subqueries            | 0
Preproc_subqueries_time       | 0.0
Optimize_time                 | 2.0667e-05
Wait_TS                       | 0.0
Prewrite_time                 | 0.0
Wait_prewrite_binlog_time     | 0.0
Commit_time                   | 0.0
Get_commit_ts_time            | 0.0
Commit_backoff_time           | 0.0
Backoff_types                 |
Resolve_lock_time             | 0.0
Local_latch_wait_time         | 0.0
Write_keys                    | 0
Write_size                    | 0
Prewrite_region               | 0
Txn_retry                     | 0
Cop_time                      | 0.0
Process_time                  | 0.0
Wait_time                     | 0.0
Backoff_time                  | 0.0
LockKeys_time                 | 0.0
Request_count                 | 0
Total_keys                    | 0
Process_keys                  | 0
Rocksdb_delete_skipped_count  | 0
Rocksdb_key_skipped_count     | 0
Rocksdb_block_cache_hit_count | 0
Rocksdb_block_read_count      | 0
Rocksdb_block_read_byte       | 0
DB                            | test
Index_names                   |
Is_internal                   | 0
Digest                        | a0adeeb79b71315ac13a77f3f11162106b5ec7b48212cf17c20c754263ab9228
Stats                         |
Cop_proc_avg                  | 0.0
Cop_proc_p90                  | 0.0
Cop_proc_max                  | 0.0
Cop_proc_addr                 |
Cop_wait_avg                  | 0.0
Cop_wait_p90                  | 0.0
Cop_wait_max                  | 0.0
Cop_wait_addr                 |
Mem_max                       | 0
Disk_max                      | 0
KV_total                      | 0.0
PD_total                      | 4.708e-06
Backoff_total                 | 0.0
Write_sql_response_total      | 2.0374e-05
Result_rows                   | 1
Warnings                      |
Backoff_Detail                |
Prepared                      | 0
Succ                          | 1
IsExplicitTxn                 | 0
IsWriteCacheTable             | 0
Plan_from_cache               | 0
Plan_from_binding             | 0
Has_more_results              | 0
Plan                          | 	id           	task	estRows	operator info     	actRows	execution info                   	memory 	disk
	Projection_3 	root	1      	sleep(1)->Column#1	1      	time:1s, loops:2, Concurrency:OFF	0 Bytes	N/A
	└─TableDual_4	root	1      	rows:1            	1      	time:917ns, loops:2              	N/A    	N/A
Plan_digest                   | a55eaee1d30304ad05500afbbfff1409ce22376e0f062c0d06ff34b8ed9c2b47
Binary_plan                   | vgGICrkBCgxQcm9qZWN0aW9uXzMSTwoLVGFibGVEdWFsXzQpAAABAqDwPzABOAFAAVIGcm93czoxWhN0aW1lOjkxN25zLCBsb29wczoycP///wkCBAF4CQgw////ASH2KFyPwvUjQD5LAFASc2xlZXAoMSktPkNvbHVtbiMxWhAFVwAxGVR0Yg9Db25jdXJyZW5jeTpPRkZ4////////////ARgB
Prev_stmt                     |
Query                         | select sleep(1);
Session_alias                 | alias123456
```

In tikv slow log:

```
[2023/08/08 14:32:49.952 +08:00] [INFO] [tracker.rs:270] [slow-query] [perf_stats.internal_delete_skipped_count=0] [perf_stats.internal_key_skipped_count=0] [perf_stats.block_read_byte=0] [perf_stats.block_read_count=0] [perf_stats.block_cache_hit_count=0] [scan.range.first="Some(start: 7480000000000000F35F720000000000000000 end: 7480000000000000F35F7280000000000C4979)"] [scan.ranges=1] [scan.total=0] [scan.processed_size=0] [scan.processed=0] [scan.is_desc=false] [session_alias=se12345] [connection_id=3596615700] [tag=select] [table_id=243] [txn_start_ts=443410381515522049] [total_suspend_time=0ns] [total_process_time=2.834µs] [handler_build_time=42.834µs] [wait_time.snapshot=67.333µs] [wait_time.schedule=51.083µs] [wait_time=118.416µs] [total_lifetime=180.458µs] [remote_host=ipv4:127.0.0.1:55601] [region_id=18007]
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
