### PR TITLE
statistics: Add tests for MergePartTopN2GlobalTopN

### DIFF
--- a/statistics/cmsketch.go
+++ b/statistics/cmsketch.go
@@ -42,7 +42,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// topNThreshold is the minimum ratio of the number of topn elements in CMSketch, 10 means 1 / 10 = 10%.
+// topNThreshold is the minimum ratio of the number of topN elements in CMSketch, 10 means 1 / 10 = 10%.
 const topNThreshold = uint64(10)
 
 var (
@@ -786,9 +786,11 @@ func NewTopN(n int) *TopN {
 
 // MergePartTopN2GlobalTopN is used to merge the partition-level topN to global-level topN.
 // The input parameters:
-//  1. `topNs` are the partition-level topNs to be merged.
-//  2. `n` is the size of the global-level topN. Notice: This value can be 0 and has no default value, we must explicitly specify this value.
-//  3. `hists` are the partition-level histograms. Some values not in topN may be placed in the histogram. We need it here to make the value in the global-level TopN more accurate.
+//  1. `loc` is the time zone. We need it to decode the date time value.
+//  2. `version` indicates how TiDB collect and use analyzed statistics.
+//  3. `topNs` are the partition-level topNs to be merged.
+//  4. `n` is the size of the global-level topN. Notice: This value can be 0 and has no default value, we must explicitly specify this value.
+//  5. `hists` are the partition-level histograms. Some values not in topN may be placed in the histogram. We need it here to make the value in the global-level TopN more accurate.
 //
 // The output parameters:
 //  1. `*TopN` is the final global-level topN.
@@ -845,7 +847,7 @@ func MergePartTopN2GlobalTopN(loc *time.Location, version int, topNs []*TopN, n 
 					} else {
 						var err error
 						if types.IsTypeTime(hists[0].Tp.GetType()) {
-							// handle datetime values specially since they are encoded to int and we'll get int values if using DecodeOne.
+							// Handle date time values specially since they are encoded to int and we'll get int values if using DecodeOne.
 							_, d, err = codec.DecodeAsDateTime(val.Encoded, hists[0].Tp.GetType(), loc)
 						} else if types.IsTypeFloat(hists[0].Tp.GetType()) {
 							_, d, err = codec.DecodeAsFloat32(val.Encoded, hists[0].Tp.GetType())

--- a/statistics/cmsketch.go
+++ b/statistics/cmsketch.go
@@ -786,11 +786,9 @@ func NewTopN(n int) *TopN {
 
 // MergePartTopN2GlobalTopN is used to merge the partition-level topN to global-level topN.
 // The input parameters:
-//  1. `loc` is the time zone. We need it to decode the date time value.
-//  2. `version` indicates how TiDB collect and use analyzed statistics.
-//  3. `topNs` are the partition-level topNs to be merged.
-//  4. `n` is the size of the global-level topN. Notice: This value can be 0 and has no default value, we must explicitly specify this value.
-//  5. `hists` are the partition-level histograms. Some values not in topN may be placed in the histogram. We need it here to make the value in the global-level TopN more accurate.
+//  1. `topNs` are the partition-level topNs to be merged.
+//  2. `n` is the size of the global-level topN. Notice: This value can be 0 and has no default value, we must explicitly specify this value.
+//  3. `hists` are the partition-level histograms. Some values not in topN may be placed in the histogram. We need it here to make the value in the global-level TopN more accurate.
 //
 // The output parameters:
 //  1. `*TopN` is the final global-level topN.

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -383,10 +383,11 @@ func TestMergePartTopN2GlobalTopNWithHists(t *testing.T) {
 	}
 
 	// Test merge 2 topN.
-	globalTopN, _, _, err := MergePartTopN2GlobalTopN(loc, version, topNs, 2, hists, false, &isKilled)
+	globalTopN, leftTopN, _, err := MergePartTopN2GlobalTopN(loc, version, topNs, 2, hists, false, &isKilled)
 	require.NoError(t, err)
 	require.Len(t, globalTopN.TopN, 2, "should only have 2 topN")
 	require.Equal(t, uint64(55), globalTopN.TotalCount(), "should have 55")
+	require.Len(t, leftTopN, 1, "should have 1 left topN")
 }
 
 // cmd: go test -run=^$ -bench=BenchmarkMergePartTopN2GlobalTopNWithHists -benchmem github.com/pingcap/tidb/statistics

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -335,6 +335,6 @@ func TestMergePartTopN2GlobalTopNWithoutHists(t *testing.T) {
 	globalTopN, leftTopN, _, err := MergePartTopN2GlobalTopN(loc, version, topNs, 2, nil, true, &isKilled)
 	require.NoError(t, err)
 	require.Len(t, globalTopN.TopN, 2, "should only have 2 topN")
-	require.Equal(t, uint64(40), globalTopN.TotalCount(), "should have 40 rows")
+	require.Equal(t, uint64(50), globalTopN.TotalCount(), "should have 50 rows")
 	require.Len(t, leftTopN, 1, "should have 1 left topN")
 }

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -418,7 +418,7 @@ func benchmarkMergePartTopN2GlobalTopNWithHists(partitions int, b *testing.B) {
 
 	// Prepare Hists.
 	hists := make([]*Histogram, 0, partitions)
-	for i := 0; i < 110000; i++ {
+	for i := 0; i < partitions; i++ {
 		// Construct Hist
 		h := NewHistogram(1, 10, 0, 0, types.NewFieldType(mysql.TypeTiny), chunk.InitialCapacity, 0)
 		h.Bounds.AppendInt64(0, 1)

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -315,7 +315,7 @@ func TestMergePartTopN2GlobalTopNWithoutHists(t *testing.T) {
 	// Prepare TopNs.
 	topNs := make([]*TopN, 0, 10)
 	for i := 0; i < 10; i++ {
-		// Construct TopN, should be (1, 1) -> 2, (1, 2) -> 2, (1, 3) -> 3.
+		// Construct TopN, should be key(1, 1) -> 2, key(1, 2) -> 2, key(1, 3) -> 3.
 		topN := NewTopN(3)
 		{
 			key1, err := codec.EncodeKey(sc, nil, types.NewIntDatum(1), types.NewIntDatum(1))
@@ -331,7 +331,7 @@ func TestMergePartTopN2GlobalTopNWithoutHists(t *testing.T) {
 		topNs = append(topNs, topN)
 	}
 
-	// Test merge 2 topN.
+	// Test merge 2 topN with nil hists.
 	globalTopN, leftTopN, _, err := MergePartTopN2GlobalTopN(loc, version, topNs, 2, nil, false, &isKilled)
 	require.NoError(t, err)
 	require.Len(t, globalTopN.TopN, 2, "should only have 2 topN")
@@ -348,7 +348,7 @@ func TestMergePartTopN2GlobalTopNWithHists(t *testing.T) {
 	// Prepare TopNs.
 	topNs := make([]*TopN, 0, 10)
 	for i := 0; i < 10; i++ {
-		// Construct TopN, should be 1 -> 2, 2 -> 2, 3 -> 3.
+		// Construct TopN, should be key1 -> 2, key2 -> 2, key3 -> 3.
 		topN := NewTopN(3)
 		{
 			key1, err := codec.EncodeKey(sc, nil, types.NewIntDatum(1))

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -19,9 +19,11 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/parser/mysql"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
@@ -302,4 +304,37 @@ func TestCMSketchCodingTopN(t *testing.T) {
 	// do not panic
 	_, _, err = DecodeCMSketchAndTopN([]byte{}, rows)
 	require.NoError(t, err)
+}
+
+func TestMergePartTopN2GlobalTopNWithoutHists(t *testing.T) {
+	loc := time.UTC
+	sc := &stmtctx.StatementContext{TimeZone: loc}
+	version := 1
+	isKilled := uint32(0)
+
+	// Prepare TopNs.
+	topNs := make([]*TopN, 0, 10)
+	for i := 0; i < 10; i++ {
+		// Construct TopN, should be (1, 1) -> 2, (1, 2) -> 2, (1, 3) -> 3.
+		topN := NewTopN(3)
+		{
+			key1, err := codec.EncodeKey(sc, nil, types.NewIntDatum(1), types.NewIntDatum(1))
+			require.NoError(t, err)
+			topN.AppendTopN(key1, 2)
+			key2, err := codec.EncodeKey(sc, nil, types.NewIntDatum(1), types.NewIntDatum(2))
+			require.NoError(t, err)
+			topN.AppendTopN(key2, 2)
+			key3, err := codec.EncodeKey(sc, nil, types.NewIntDatum(1), types.NewIntDatum(3))
+			require.NoError(t, err)
+			topN.AppendTopN(key3, 3)
+		}
+		topNs = append(topNs, topN)
+	}
+
+	// Test merge 2 topN.
+	globalTopN, leftTopN, _, err := MergePartTopN2GlobalTopN(loc, version, topNs, 2, nil, true, &isKilled)
+	require.NoError(t, err)
+	require.Len(t, globalTopN.TopN, 2, "should only have 2 topN")
+	require.Equal(t, uint64(40), globalTopN.TotalCount(), "should have 40 rows")
+	require.Len(t, leftTopN, 1, "should have 1 left topN")
 }

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -389,6 +389,7 @@ func TestMergePartTopN2GlobalTopNWithHists(t *testing.T) {
 	require.Equal(t, uint64(55), globalTopN.TotalCount(), "should have 55")
 }
 
+// cmd: go test -run=^$ -bench=BenchmarkMergePartTopN2GlobalTopNWithHists -benchmem github.com/pingcap/tidb/statistics
 func benchmarkMergePartTopN2GlobalTopNWithHists(partitions int, b *testing.B) {
 	loc := time.UTC
 	sc := &stmtctx.StatementContext{TimeZone: loc}

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -454,3 +454,11 @@ func BenchmarkMergePartTopN2GlobalTopNWithHists10000(b *testing.B) {
 func BenchmarkMergePartTopN2GlobalTopNWithHists100000(b *testing.B) {
 	benchmarkMergePartTopN2GlobalTopNWithHists(100000, b)
 }
+
+func BenchmarkMergePartTopN2GlobalTopNWithHists1000000(b *testing.B) {
+	benchmarkMergePartTopN2GlobalTopNWithHists(1000000, b)
+}
+
+func BenchmarkMergePartTopN2GlobalTopNWithHists10000000(b *testing.B) {
+	benchmarkMergePartTopN2GlobalTopNWithHists(10000000, b)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/45899

Problem Summary:

### What is changed and how it works?

- Add normal tests for MergePartTopN2GlobalTopN
- Update outdated comment.
- Add benchmark tests

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```
