### PR TITLE
parser: reset `lexer.identifierDot` correctly when reusing parsers

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -101,7 +101,7 @@ func (s *Scanner) reset(sql string) {
 	s.stmtStartPos = 0
 	s.inBangComment = false
 	s.lastKeyword = 0
-	s.identifierDot = true
+	s.identifierDot = false
 }
 
 func (s *Scanner) stmtText() string {

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -101,6 +101,7 @@ func (s *Scanner) reset(sql string) {
 	s.stmtStartPos = 0
 	s.inBangComment = false
 	s.lastKeyword = 0
+	s.identifierDot = true
 }
 
 func (s *Scanner) stmtText() string {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -7389,6 +7389,18 @@ func TestTTLTableOption(t *testing.T) {
 	RunTest(t, table, false)
 }
 
+func TestIssue45898(t *testing.T) {
+	p := parser.New()
+	p.ParseSQL("a.")
+	stmts, _, err := p.ParseSQL("select count(1) from t")
+	require.NoError(t, err)
+	var sb strings.Builder
+	restoreCtx := NewRestoreCtx(DefaultRestoreFlags, &sb)
+	sb.Reset()
+	stmts[0].Restore(restoreCtx)
+	require.Equal(t, sb.String(), "SELECT COUNT(1) FROM `t`")
+}
+
 func TestMultiStmt(t *testing.T) {
 	p := parser.New()
 	stmts, _, err := p.Parse("SELECT 'foo'; SELECT 'foo;bar','baz'; select 'foo' , 'bar' , 'baz' ;select 1", "", "")

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -7398,7 +7398,7 @@ func TestIssue45898(t *testing.T) {
 	restoreCtx := NewRestoreCtx(DefaultRestoreFlags, &sb)
 	sb.Reset()
 	stmts[0].Restore(restoreCtx)
-	require.Equal(t, sb.String(), "SELECT COUNT(1) FROM `t`")
+	require.Equal(t, "SELECT COUNT(1) FROM `t`", sb.String())
 }
 
 func TestMultiStmt(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45898

Problem Summary: parser: reset `lexer.identifierDot` correctly when reusing parsers

### What is changed and how it works?

parser: reset `lexer.identifierDot` correctly when reusing parsers

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
