### PR TITLE
lightning/external: port merge iterators 

### DIFF
--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -31,10 +31,11 @@ go_test(
     ],
     embed = [":external"],
     flaky = True,
-    shard_count = 5,
+    shard_count = 7,
     deps = [
         "//br/pkg/storage",
         "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//rand",
     ],
 )

--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -37,7 +37,6 @@ go_test(
     shard_count = 13,
     deps = [
         "//br/pkg/storage",
-        "//util/logutil",
         "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//rand",

--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "byte_reader.go",
         "codec.go",
         "file.go",
+        "iter.go",
         "kv_reader.go",
         "sharedisk.go",
         "stat_reader.go",
@@ -14,9 +15,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//br/pkg/storage",
+        "//kv",
         "//util/logutil",
         "//util/mathutil",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_kvproto//pkg/import_sstpb",
+        "@org_golang_x_sync//errgroup",
         "@org_uber_go_zap//:zap",
     ],
 )
@@ -28,10 +32,11 @@ go_test(
         "byte_reader_test.go",
         "codec_test.go",
         "file_test.go",
+        "iter_test.go",
     ],
     embed = [":external"],
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//br/pkg/storage",
         "@com_github_pingcap_errors//:errors",

--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
     shard_count = 13,
     deps = [
         "//br/pkg/storage",
+        "//util/logutil",
         "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//rand",

--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//util/logutil",
         "//util/mathutil",
         "@com_github_pingcap_errors//:errors",
-        "@com_github_pingcap_kvproto//pkg/import_sstpb",
         "@org_golang_x_sync//errgroup",
         "@org_uber_go_zap//:zap",
     ],

--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//br/pkg/storage",
-        "//kv",
         "//util/logutil",
         "//util/mathutil",
         "@com_github_pingcap_errors//:errors",
@@ -35,7 +34,7 @@ go_test(
     ],
     embed = [":external"],
     flaky = True,
-    shard_count = 8,
+    shard_count = 13,
     deps = [
         "//br/pkg/storage",
         "@com_github_pingcap_errors//:errors",

--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -42,5 +42,6 @@ go_test(
         "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//rand",
+        "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/br/pkg/lightning/backend/external/byte_reader.go
+++ b/br/pkg/lightning/backend/external/byte_reader.go
@@ -86,7 +86,7 @@ func (r *byteReader) readNBytes(n int) (*[]byte, error) {
 		switch err {
 		case nil:
 		case io.EOF:
-			if readLen > 0 && readLen < n {
+			if readLen > 0 {
 				return nil, io.ErrUnexpectedEOF
 			}
 			return nil, err

--- a/br/pkg/lightning/backend/external/byte_reader.go
+++ b/br/pkg/lightning/backend/external/byte_reader.go
@@ -52,6 +52,8 @@ func openStoreReaderAndSeek(
 	return storageReader, nil
 }
 
+// newByteReader wraps readNBytes functionality to storageReader. It will not
+// close storageReader when meet error.
 func newByteReader(ctx context.Context, storageReader storage.ReadSeekCloser, bufSize int) (*byteReader, error) {
 	r := &byteReader{
 		ctx:           ctx,
@@ -81,7 +83,14 @@ func (r *byteReader) readNBytes(n int) (*[]byte, error) {
 	for readLen < n {
 		r.cloneSlices()
 		err := r.reload()
-		if err != nil {
+		switch err {
+		case nil:
+		case io.EOF:
+			if readLen > 0 && readLen < n {
+				return nil, io.ErrUnexpectedEOF
+			}
+			return nil, err
+		default:
 			return nil, err
 		}
 		b = r.next(n - readLen)

--- a/br/pkg/lightning/backend/external/byte_reader_test.go
+++ b/br/pkg/lightning/backend/external/byte_reader_test.go
@@ -221,3 +221,17 @@ func TestReset(t *testing.T) {
 	_, err = br.readNBytes(1)
 	require.Equal(t, io.EOF, err)
 }
+
+func TestUnexpectedEOF(t *testing.T) {
+	ms := &mockExtStore{src: []byte("0123456789")}
+	br, err := newByteReader(context.Background(), ms, 3)
+	require.NoError(t, err)
+	_, err = br.readNBytes(100)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestEmptyContent(t *testing.T) {
+	ms := &mockExtStore{src: []byte{}}
+	_, err := newByteReader(context.Background(), ms, 100)
+	require.Equal(t, io.EOF, err)
+}

--- a/br/pkg/lightning/backend/external/byte_reader_test.go
+++ b/br/pkg/lightning/backend/external/byte_reader_test.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
 )
 
 // mockExtStore is only used for test.
@@ -177,4 +179,45 @@ func TestByteReaderAuxBuf(t *testing.T) {
 	require.Equal(t, []byte("45"), *y4)
 	require.Equal(t, []byte("0"), *y1)
 	require.Equal(t, []byte("12"), *y2)
+}
+
+func TestReset(t *testing.T) {
+	seed := time.Now().Unix()
+	rand.Seed(uint64(seed))
+	t.Logf("seed: %d", seed)
+	src := make([]byte, 256)
+	for i := range src {
+		src[i] = byte(i)
+	}
+	ms := &mockExtStore{src: src}
+	bufSize := rand.Intn(256)
+	br, err := newByteReader(context.Background(), ms, bufSize)
+	require.NoError(t, err)
+	end := 0
+	toCheck := make([]*[]byte, 0, 10)
+	for end < len(src) {
+		n := rand.Intn(len(src) - end)
+		if n == 0 {
+			n = 1
+		}
+		y, err := br.readNBytes(n)
+		require.NoError(t, err)
+		toCheck = append(toCheck, y)
+		end += n
+
+		l := end
+		r := end
+		for i := len(toCheck) - 1; i >= 0; i-- {
+			l -= len(*toCheck[i])
+			require.Equal(t, src[l:r], *toCheck[i])
+			r = l
+		}
+
+		if rand.Intn(2) == 0 {
+			br.reset()
+			toCheck = toCheck[:0]
+		}
+	}
+	_, err = br.readNBytes(1)
+	require.Equal(t, io.EOF, err)
 }

--- a/br/pkg/lightning/backend/external/file.go
+++ b/br/pkg/lightning/backend/external/file.go
@@ -65,7 +65,7 @@ func (s *KeyValueStore) AddKeyValue(key, value []byte) error {
 	// data layout: keyLen + key + valueLen + value
 	_, err := s.dataWriter.Write(
 		s.ctx,
-		binary.BigEndian.AppendUint64(b[:], uint64(len(key))),
+		binary.BigEndian.AppendUint64(b[:0], uint64(len(key))),
 	)
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func (s *KeyValueStore) AddKeyValue(key, value []byte) error {
 	}
 	_, err = s.dataWriter.Write(
 		s.ctx,
-		binary.BigEndian.AppendUint64(b[:], uint64(len(value))),
+		binary.BigEndian.AppendUint64(b[:0], uint64(len(value))),
 	)
 	if err != nil {
 		return err

--- a/br/pkg/lightning/backend/external/file.go
+++ b/br/pkg/lightning/backend/external/file.go
@@ -58,6 +58,7 @@ func NewKeyValueStore(
 // AddKeyValue saves a key-value pair to the KeyValueStore. If the accumulated
 // size or key count exceeds the given distance, a new range property will be
 // appended to the rangePropertiesCollector with current status.
+// `key` must be in strictly ascending order for invocations of a KeyValueStore.
 func (s *KeyValueStore) AddKeyValue(key, value []byte) error {
 	kvLen := len(key) + len(value) + 16
 	var b [8]byte

--- a/br/pkg/lightning/backend/external/iter.go
+++ b/br/pkg/lightning/backend/external/iter.go
@@ -1,0 +1,368 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external
+
+import (
+	"bytes"
+	"container/heap"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	sst "github.com/pingcap/kvproto/pkg/import_sstpb"
+	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/util/logutil"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+type kvPair struct {
+	key       []byte
+	value     []byte
+	fileIndex int
+}
+
+type kvPairHeap []*kvPair
+
+func (h kvPairHeap) Len() int {
+	return len(h)
+}
+
+func (h kvPairHeap) Less(i, j int) bool {
+	return bytes.Compare(h[i].key, h[j].key) < 0
+}
+
+func (h kvPairHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *kvPairHeap) Push(x interface{}) {
+	*h = append(*h, x.(*kvPair))
+}
+
+func (h *kvPairHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+// MergeIter is an iterator that merges multiple sorted KV pairs from different files.
+type MergeIter struct {
+	startKey       []byte
+	endKey         []byte
+	dataFilePaths  []string
+	dataFileReader []*kvReader
+	exStorage      storage.ExternalStorage
+	kvHeap         kvPairHeap
+	currKV         *kvPair
+	lastFileIndex  int
+
+	firstKey []byte
+
+	err error
+}
+
+// NewMergeIter creates a new MergeIter.
+// readBufferSize is the buffer size for each file reader, which means the total memory usage is
+// readBufferSize * len(paths).
+func NewMergeIter(
+	ctx context.Context,
+	paths []string,
+	pathsStartOffset []uint64,
+	exStorage storage.ExternalStorage,
+	readBufferSize int,
+) (*MergeIter, error) {
+	it := &MergeIter{
+		dataFilePaths: paths,
+		lastFileIndex: -1,
+	}
+	it.dataFileReader = make([]*kvReader, len(paths))
+	it.kvHeap = make([]*kvPair, 0, len(paths))
+
+	// Open all data files concurrently.
+	wg, wgCtx := errgroup.WithContext(ctx)
+	for i := range paths {
+		i := i
+		wg.Go(func() error {
+			rd, err := newKVReader(wgCtx, paths[i], exStorage, pathsStartOffset[i], readBufferSize)
+			if err != nil {
+				return err
+			}
+			it.dataFileReader[i] = rd
+			return nil
+		})
+	}
+	if err := wg.Wait(); err != nil {
+		return nil, err
+	}
+
+	for i, rd := range it.dataFileReader {
+		k, v, err := rd.nextKV()
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		if len(k) == 0 {
+			rd.Close()
+			continue
+		}
+		pair := kvPair{key: k, value: v, fileIndex: i}
+		it.kvHeap.Push(&pair)
+	}
+	heap.Init(&it.kvHeap)
+	return it, nil
+}
+
+func (i *MergeIter) Error() error {
+	return i.err
+}
+
+func (i *MergeIter) Valid() bool {
+	return i.err == nil && i.kvHeap.Len() > 0
+}
+
+func (i *MergeIter) Next() bool {
+	i.currKV = nil
+	// Populate the heap.
+	if i.lastFileIndex >= 0 {
+		k, v, err := i.dataFileReader[i.lastFileIndex].nextKV()
+		// TODO(lance6716): EOF
+		if err != nil {
+			i.err = err
+			return false
+		}
+		if len(k) > 0 {
+			heap.Push(&i.kvHeap, &kvPair{k, v, i.lastFileIndex})
+		} else {
+			i.dataFileReader[i.lastFileIndex].Close()
+		}
+	}
+	i.lastFileIndex = -1
+
+	if i.kvHeap.Len() == 0 {
+		return false
+	}
+	i.currKV = heap.Pop(&i.kvHeap).(*kvPair)
+	i.lastFileIndex = i.currKV.fileIndex
+	return true
+}
+
+func (i *MergeIter) Key() []byte {
+	return i.currKV.key
+}
+
+func (i *MergeIter) Value() []byte {
+	return i.currKV.value
+}
+
+func (i *MergeIter) Close() error {
+	var firstErr error
+	if i.lastFileIndex >= 0 {
+		firstErr = i.dataFileReader[i.lastFileIndex].Close()
+	}
+	for _, p := range i.kvHeap {
+		err := i.dataFileReader[p.fileIndex].Close()
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}
+
+func (i *MergeIter) OpType() sst.Pair_OP {
+	return sst.Pair_Put
+}
+
+type prop struct {
+	p         rangeProperty
+	fileIndex int
+}
+
+type propHeap []*prop
+
+func (h propHeap) Len() int {
+	return len(h)
+}
+
+func (h propHeap) Less(i, j int) bool {
+	return bytes.Compare(h[i].p.key, h[j].p.key) < 0
+}
+
+func (h propHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *propHeap) Push(x interface{}) {
+	*h = append(*h, x.(*prop))
+}
+
+func (h *propHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+func (h *propHeap) Print() string {
+	var buf bytes.Buffer
+	for _, p := range *h {
+		fmt.Fprintf(&buf, "%s ", hex.EncodeToString(p.p.key))
+	}
+	return buf.String()
+}
+
+// MergePropIter is an iterator that merges multiple range properties from different files.
+type MergePropIter struct {
+	startKey       []byte
+	endKey         []byte
+	statFilePaths  []string
+	statFileReader []*statsReader
+	propHeap       propHeap
+	currProp       *prop
+
+	firstKey      []byte
+	lastFileIndex int
+
+	err error
+}
+
+func NewMergePropIter(
+	ctx context.Context,
+	paths []string,
+	exStorage storage.ExternalStorage,
+) (*MergePropIter, error) {
+	it := &MergePropIter{
+		statFilePaths: paths,
+		lastFileIndex: -1,
+	}
+	it.propHeap = make([]*prop, 0, len(paths))
+	it.statFileReader = make([]*statsReader, len(paths))
+
+	// Open all stat files concurrently.
+	wg, wgCtx := errgroup.WithContext(ctx)
+	for i := range paths {
+		i := i
+		wg.Go(func() error {
+			rd, err := newStatsReader(wgCtx, exStorage, paths[i], 4096)
+			if err != nil {
+				return err
+			}
+			it.statFileReader[i] = rd
+			return nil
+		})
+	}
+
+	if err := wg.Wait(); err != nil {
+		return nil, err
+	}
+
+	for i, rd := range it.statFileReader {
+		p, err := rd.nextProp()
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		if p == nil {
+			rd.Close()
+			continue
+		}
+		pair := prop{p: *p, fileIndex: i}
+		it.propHeap.Push(&pair)
+	}
+	heap.Init(&it.propHeap)
+	return it, nil
+}
+
+// TODO(lance6716): This is the only use of MergePropIter?
+func SeekPropsOffsets(ctx context.Context, start kv.Key, paths []string, exStorage storage.ExternalStorage) ([]uint64, error) {
+	iter, err := NewMergePropIter(ctx, paths, exStorage)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := iter.Close(); err != nil {
+			logutil.BgLogger().Warn("failed to close merge prop iterator", zap.Error(err))
+		}
+	}()
+	offsets := make([]uint64, len(paths))
+	for iter.Next() {
+		if iter.Error() != nil {
+			return nil, iter.Error()
+		}
+		p := iter.prop()
+		propKey := kv.Key(p.key)
+		if propKey.Cmp(start) > 0 {
+			return offsets, nil
+		} else {
+			offsets[iter.currProp.fileIndex] = iter.currProp.p.offset
+		}
+	}
+	return offsets, nil
+}
+
+func (i *MergePropIter) Error() error {
+	return i.err
+}
+
+func (i *MergePropIter) Valid() bool {
+	return i.err == nil && i.propHeap.Len() > 0
+}
+
+func (i *MergePropIter) Next() bool {
+	i.currProp = nil
+	if i.lastFileIndex >= 0 {
+		p, err := i.statFileReader[i.lastFileIndex].nextProp()
+		// TODO(lance6716): EOF
+		if err != nil {
+			i.err = err
+			return false
+		}
+		if p != nil {
+			heap.Push(&i.propHeap, &prop{*p, i.lastFileIndex})
+		} else {
+			i.statFileReader[i.lastFileIndex].Close()
+		}
+	}
+	i.lastFileIndex = -1
+
+	if i.propHeap.Len() == 0 {
+		return false
+	}
+	i.currProp = heap.Pop(&i.propHeap).(*prop)
+	i.lastFileIndex = i.currProp.fileIndex
+	return true
+}
+
+func (i *MergePropIter) prop() *rangeProperty {
+	return &i.currProp.p
+}
+
+func (i *MergePropIter) Close() error {
+	var firstErr error
+	if i.lastFileIndex >= 0 {
+		firstErr = i.statFileReader[i.lastFileIndex].Close()
+	}
+	for _, p := range i.propHeap {
+		err := i.statFileReader[p.fileIndex].Close()
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/br/pkg/lightning/backend/external/iter.go
+++ b/br/pkg/lightning/backend/external/iter.go
@@ -318,7 +318,6 @@ func NewMergePropIter(
 }
 
 // SeekPropsOffsets seeks the offsets of the range properties that are greater than the start key.
-// TODO(lance6716): check this function
 func SeekPropsOffsets(
 	ctx context.Context,
 	start kv.Key,

--- a/br/pkg/lightning/backend/external/iter.go
+++ b/br/pkg/lightning/backend/external/iter.go
@@ -80,11 +80,8 @@ type mergeIter[T heapElem, R sortedReader[T]] struct {
 // readerOpenerFn is a function that opens a sorted reader.
 type readerOpenerFn[T heapElem, R sortedReader[T]] func(ctx context.Context) (*R, error)
 
-// newMergeIter creates a merge iterator for multiple sorted readers. the
-// ownership of readers is transferred to the mergeIter. When newMergeIter
-// returns error, the reader will be closed.
-// To reduce duplication, we tolerate caller passing nil readers which means
-// reader's source file is empty.
+// newMergeIter creates a merge iterator for multiple sorted reader opener
+// functions.
 func newMergeIter[
 	T heapElem,
 	R sortedReader[T],
@@ -116,7 +113,7 @@ func newMergeIter[
 			switch err {
 			case nil:
 			case io.EOF:
-				// will leave a nil reader in `readers`
+				// will leave a nil reader in `readers` when reader is empty
 				return nil
 			default:
 				return err
@@ -291,7 +288,6 @@ func NewMergeKVIter(
 	}
 
 	it, err := newMergeIter[kvPair, kvReaderProxy](ctx, readerOpeners)
-	// if error happens in newMergeIter, newMergeIter itself will close readers
 	return &MergeKVIter{iter: it}, err
 }
 
@@ -365,7 +361,6 @@ func NewMergePropIter(
 	}
 
 	it, err := newMergeIter[*rangeProperty, statReaderProxy](ctx, readerOpeners)
-	// if error happens in newMergeIter, newMergeIter itself will close readers
 	return &MergePropIter{iter: it}, err
 }
 

--- a/br/pkg/lightning/backend/external/iter.go
+++ b/br/pkg/lightning/backend/external/iter.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 
-	sst "github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/util/logutil"
@@ -138,14 +137,17 @@ func NewMergeIter(
 	return it, nil
 }
 
+// Error returns the error of the iterator.
 func (i *MergeIter) Error() error {
 	return i.err
 }
 
+// Valid returns whether the iterator is valid to be iterated.
 func (i *MergeIter) Valid() bool {
 	return i.err == nil && i.kvHeap.Len() > 0
 }
 
+// Next moves the iterator to the next position.
 func (i *MergeIter) Next() bool {
 	i.currKV = nil
 	// Populate the heap.
@@ -178,14 +180,17 @@ func (i *MergeIter) Next() bool {
 	return true
 }
 
+// Key returns the current key.
 func (i *MergeIter) Key() []byte {
 	return i.currKV.key
 }
 
+// Value returns the current value.
 func (i *MergeIter) Value() []byte {
 	return i.currKV.value
 }
 
+// Close closes the iterator.
 func (i *MergeIter) Close() error {
 	var firstErr error
 	if i.lastFileIndex >= 0 {
@@ -199,10 +204,6 @@ func (i *MergeIter) Close() error {
 	}
 
 	return firstErr
-}
-
-func (i *MergeIter) OpType() sst.Pair_OP {
-	return sst.Pair_Put
 }
 
 type prop struct {
@@ -260,6 +261,7 @@ type MergePropIter struct {
 	logger *zap.Logger
 }
 
+// NewMergePropIter creates a new MergePropIter.
 func NewMergePropIter(
 	ctx context.Context,
 	paths []string,
@@ -315,6 +317,8 @@ func NewMergePropIter(
 	return it, nil
 }
 
+// SeekPropsOffsets seeks the offsets of the range properties that are greater than the start key.
+// TODO(lance6716): check this function
 func SeekPropsOffsets(
 	ctx context.Context,
 	start kv.Key,
@@ -339,21 +343,23 @@ func SeekPropsOffsets(
 		propKey := kv.Key(p.key)
 		if propKey.Cmp(start) > 0 {
 			return offsets, nil
-		} else {
-			offsets[iter.currProp.fileIndex] = iter.currProp.p.offset
 		}
+		offsets[iter.currProp.fileIndex] = iter.currProp.p.offset
 	}
 	return offsets, nil
 }
 
+// Error returns the error of the iterator.
 func (i *MergePropIter) Error() error {
 	return i.err
 }
 
+// Valid returns whether the iterator is valid to be iterated.
 func (i *MergePropIter) Valid() bool {
 	return i.err == nil && i.propHeap.Len() > 0
 }
 
+// Next moves the iterator to the next position.
 func (i *MergePropIter) Next() bool {
 	i.currProp = nil
 	if i.lastFileIndex >= 0 {
@@ -389,6 +395,7 @@ func (i *MergePropIter) prop() *rangeProperty {
 	return &i.currProp.p
 }
 
+// Close closes the iterator.
 func (i *MergePropIter) Close() error {
 	var firstErr error
 	if i.lastFileIndex >= 0 {

--- a/br/pkg/lightning/backend/external/iter.go
+++ b/br/pkg/lightning/backend/external/iter.go
@@ -173,19 +173,20 @@ func newMergeIter[
 func (i *mergeIter[T, R]) close() error {
 	var firstErr error
 	for idx, rdp := range i.readers {
-		if rdp != nil {
-			rd := *rdp
-			err := rd.close()
-			if err != nil {
-				i.logger.Warn("failed to close reader",
-					zap.String("path", rd.path()),
-					zap.Error(err))
-				if firstErr == nil {
-					firstErr = err
-				}
-			}
-			i.readers[idx] = nil
+		if rdp == nil {
+			continue
 		}
+		rd := *rdp
+		err := rd.close()
+		if err != nil {
+			i.logger.Warn("failed to close reader",
+				zap.String("path", rd.path()),
+				zap.Error(err))
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+		i.readers[idx] = nil
 	}
 	return firstErr
 }

--- a/br/pkg/lightning/backend/external/iter_test.go
+++ b/br/pkg/lightning/backend/external/iter_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeIter(t *testing.T) {
+	ctx := context.Background()
+	memStore := storage.NewMemStorage()
+	filenames := []string{"/test1", "/test2", "/test3"}
+	data := [][][2]string{
+		{},
+		{{"key1", "value1"}, {"key3", "value3"}},
+		{{"key2", "value2"}},
+	}
+	for i, filename := range filenames {
+		writer, err := memStore.Create(ctx, filename, nil)
+		require.NoError(t, err)
+		rc := &rangePropertiesCollector{
+			propSizeIdxDistance: 100,
+			propKeysIdxDistance: 2,
+		}
+		rc.reset()
+		kvStore, err := NewKeyValueStore(ctx, writer, rc, 1, 1)
+		require.NoError(t, err)
+		for _, kv := range data[i] {
+			err = kvStore.AddKeyValue([]byte(kv[0]), []byte(kv[1]))
+			require.NoError(t, err)
+		}
+		err = writer.Close(ctx)
+		require.NoError(t, err)
+	}
+
+	mergeIter, err := NewMergeIter(ctx, filenames, []uint64{0, 0, 0}, memStore, 5)
+	require.NoError(t, err)
+	got := make([][2]string, 0)
+	for mergeIter.Valid() {
+		mergeIter.Next()
+		got = append(got, [2]string{string(mergeIter.Key()), string(mergeIter.Value())})
+	}
+	expected := [][2]string{
+		{"key1", "value1"},
+		{"key2", "value2"},
+		{"key3", "value3"},
+	}
+	require.Equal(t, expected, got)
+}

--- a/br/pkg/lightning/backend/external/iter_test.go
+++ b/br/pkg/lightning/backend/external/iter_test.go
@@ -85,10 +85,17 @@ func TestMergeIter(t *testing.T) {
 	require.EqualValues(t, 2, trackStore.opened.Load())
 
 	got := make([][2]string, 0)
-	for mergeIter.Valid() {
-		mergeIter.Next()
-		got = append(got, [2]string{string(mergeIter.Key()), string(mergeIter.Value())})
-	}
+	require.True(t, mergeIter.Valid())
+	require.True(t, mergeIter.Next())
+	got = append(got, [2]string{string(mergeIter.Key()), string(mergeIter.Value())})
+	require.True(t, mergeIter.Valid())
+	require.True(t, mergeIter.Next())
+	got = append(got, [2]string{string(mergeIter.Key()), string(mergeIter.Value())})
+	require.True(t, mergeIter.Valid())
+	require.True(t, mergeIter.Next())
+	got = append(got, [2]string{string(mergeIter.Key()), string(mergeIter.Value())})
+	require.False(t, mergeIter.Valid())
+
 	expected := [][2]string{
 		{"key1", "value1"},
 		{"key2", "value2"},

--- a/br/pkg/lightning/backend/external/kv_reader.go
+++ b/br/pkg/lightning/backend/external/kv_reader.go
@@ -29,12 +29,22 @@ type kvReader struct {
 	byteReader *byteReader
 }
 
-func newKVReader(ctx context.Context, name string, store storage.ExternalStorage, initFileOffset uint64, bufSize int) (*kvReader, error) {
+func newKVReader(
+	ctx context.Context,
+	name string,
+	store storage.ExternalStorage,
+	initFileOffset uint64,
+	bufSize int,
+) (*kvReader, error) {
 	sr, err := openStoreReaderAndSeek(ctx, store, name, initFileOffset)
 	if err != nil {
 		return nil, err
 	}
 	br, err := newByteReader(ctx, sr, bufSize)
+	if err != nil {
+		br.Close()
+		return nil, err
+	}
 	return &kvReader{
 		byteReader: br,
 	}, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #45719

Problem Summary:

### What is changed and how it works?

Add two merge iterators, which are implemented on min-heap.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
