### PR TITLE
executor: Updated ADMIN SHOW DDL JOBS to show same table for EXCHANGE PARTITION

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -2474,6 +2474,7 @@ func TestGlobalIndexUpdateInDropPartition(t *testing.T) {
 }
 
 func waitForDDLJobState(t *testing.T, tk *testkit.TestKit, errChan chan error, dbName, tableName, jobType, s string, pos int) {
+	count := 0
 	for {
 		select {
 		case alterErr := <-errChan:
@@ -2495,7 +2496,12 @@ func waitForDDLJobState(t *testing.T, tk *testkit.TestKit, errChan chan error, d
 				logutil.BgLogger().Info("admin show ddl jobs", zap.Strings("job", fields))
 			}
 		}
-		time.Sleep(50 * time.Millisecond)
+		if count > 100 {
+			// 10s wait
+			require.Fail(t, "time out while waiting for DDL JOB state")
+		}
+		time.Sleep(100 * time.Millisecond)
+		count++
 	}
 }
 

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -2473,6 +2473,32 @@ func TestGlobalIndexUpdateInDropPartition(t *testing.T) {
 	tk.MustQuery("select * from test_global use index(idx_b) order by a").Check(testkit.Rows("2 11 11", "12 12 12"))
 }
 
+func waitForDDLJobState(t *testing.T, tk *testkit.TestKit, errChan chan error, dbName, tableName, jobType, s string, pos int) {
+	for {
+		select {
+		case alterErr := <-errChan:
+			require.Fail(t, "unexpected error", "With error %v", alterErr)
+		default:
+			// Alter still running
+		}
+		res := tk.MustQuery(`admin show ddl jobs where db_name = '` + strings.ToLower(dbName) + `' and table_name = '` + tableName + `' and job_type = '` + jobType + `'`).Rows()
+		if len(res) == 1 && res[0][pos] == s {
+			break
+		}
+		res = tk.MustQuery(`admin show ddl jobs where db_name = '` + strings.ToLower(dbName) + `'`).Rows()
+		if len(res) > 0 {
+			for i := range res {
+				fields := make([]string, len(res[i]))
+				for j := range res[i] {
+					fields[j] = res[i][j].(string)
+				}
+				logutil.BgLogger().Info("admin show ddl jobs", zap.Strings("job", fields))
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
 func TestTruncatePartitionWithGlobalIndex(t *testing.T) {
 	defer config.RestoreFunc()()
 	config.UpdateGlobal(func(conf *config.Config) {
@@ -2499,23 +2525,13 @@ func TestTruncatePartitionWithGlobalIndex(t *testing.T) {
 	tk2.MustExec(`use test`)
 	tk2.MustExec(`begin`)
 	tk2.MustExec(`insert into test_global values (5,5,5)`)
-	syncChan := make(chan bool)
+	syncChan := make(chan error)
 	go func() {
-		tk.MustExec("alter table test_global truncate partition p2;")
-		syncChan <- true
+		syncChan <- tk.ExecToErr("alter table test_global truncate partition p2;")
 	}()
-	waitFor := func(i int, s string) {
-		for {
-			tk4 := testkit.NewTestKit(t, store)
-			tk4.MustExec(`use test`)
-			res := tk4.MustQuery(`admin show ddl jobs where db_name = 'test' and table_name = 'test_global' and job_type = 'truncate partition'`).Rows()
-			if len(res) == 1 && res[0][i] == s {
-				break
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
-	waitFor(4, "delete only")
+	tk4 := testkit.NewTestKit(t, store)
+	tk4.MustExec(`use test`)
+	waitForDDLJobState(t, tk4, syncChan, "test", "test_global", "truncate partition", "delete only", 4)
 	tk3 := testkit.NewTestKit(t, store)
 	tk3.MustExec(`begin`)
 	tk3.MustExec(`use test`)
@@ -2527,7 +2543,7 @@ func TestTruncatePartitionWithGlobalIndex(t *testing.T) {
 	assert.NotNil(t, err)
 	tk2.MustExec(`commit`)
 	tk3.MustExec(`commit`)
-	<-syncChan
+	require.NoError(t, <-syncChan)
 	result := tk.MustQuery("select * from test_global;")
 	result.Sort().Check(testkit.Rows(`1 1 1`, `2 2 2`, `5 5 5`))
 
@@ -3377,6 +3393,41 @@ func TestTiDBEnableExchangePartition(t *testing.T) {
 	tk.MustExec("alter table pt exchange partition p0 with table nt")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 after the exchange, please analyze related table of the exchange to update statistics"))
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 after the exchange, please analyze related table of the exchange to update statistics"))
+}
+
+func TestExchangePartitionAdminShowDDLJobs(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk2 := testkit.NewTestKit(t, store)
+	tk2.MustExec("use test")
+	tk3 := testkit.NewTestKit(t, store)
+	tk3.MustExec("use test")
+	tk4 := testkit.NewTestKit(t, store)
+	tk4.MustExec("use test")
+
+	tk1.MustExec(`create table t (a int, b varchar(255))`)
+	tk1.MustExec(`create table tp (a int, b varchar(255)) partition by range (a) (partition p0 values less than (1000000), partition p1 values less than (2000000))`)
+
+	tk2.MustExec(`BEGIN`)
+	tk2.MustExec(`insert into t values (1,1)`)
+
+	alterChan := make(chan error)
+	go func() {
+		alterChan <- tk1.ExecToErr(`alter table tp exchange partition p0 with table t`)
+	}()
+
+	waitForDDLJobState(t, tk3, alterChan, "test", "t", "exchange partition", "none", 4)
+
+	tk4.MustExec(`BEGIN`)
+	tk4.MustExec(`insert into t values (2,2)`)
+	tk2.MustExec(`COMMIT`)
+	waitForDDLJobState(t, tk3, alterChan, "test", "t", "exchange partition", "none", 4)
+	waitForDDLJobState(t, tk3, alterChan, "test", "t", "exchange partition", "running", 11)
+	tk4.MustExec(`COMMIT`)
+	require.NoError(t, <-alterChan)
+	waitForDDLJobState(t, tk3, alterChan, "test", "t", "exchange partition", "none", 4)
+	waitForDDLJobState(t, tk3, alterChan, "test", "t", "exchange partition", "synced", 11)
 }
 
 func TestExchangePartitionExpressIndex(t *testing.T) {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -486,7 +486,9 @@ func (e *DDLJobRetriever) appendJobToChunk(req *chunk.Chunk, job *model.Job, che
 	if job.BinlogInfo != nil {
 		finishTS = job.BinlogInfo.FinishedTS
 		if job.BinlogInfo.TableInfo != nil {
-			tableName = job.BinlogInfo.TableInfo.Name.L
+			if job.Type != model.ActionExchangeTablePartition {
+				tableName = job.BinlogInfo.TableInfo.Name.L
+			}
 		}
 		if job.BinlogInfo.MultipleTableInfos != nil {
 			tablenames := new(strings.Builder)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45823, close #43819

Problem Summary:
When `BinlogInfo` was set on the job, it used that table name, which might be different from previously showed names.
Simple fix was to avoid doing this for EXCHANGE PARTITION.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
