### PR TITLE
expression: Fix different behaviors with MySQL when comparing datetime column with numeric constant | tidb-test=pr/2196

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -133,29 +133,35 @@ func TestCompareIssue38361(t *testing.T) {
 	tk.MustExec("drop database if exists TEST1")
 	tk.MustExec("create database TEST1")
 	tk.MustExec("use TEST1")
-	tk.MustExec("create table t(a datetime, b bigint)")
-	tk.MustExec("insert into t values(cast('2023-08-09 00:00:00' as datetime), 20230809)")
+	tk.MustExec("create table t(a datetime, b bigint, c bigint)")
+	tk.MustExec("insert into t values(cast('2023-08-09 00:00:00' as datetime), 20230809, 20231310)")
 
 	tk.MustQuery("select a > 20230809 from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select a = 20230809 from t").Check(testkit.Rows("1"))
 	tk.MustQuery("select a < 20230810 from t").Check(testkit.Rows("1"))
+	tk.MustQuery("select a < 20231310 from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select 20230809 < a from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select 20230809 = a from t").Check(testkit.Rows("1"))
 	tk.MustQuery("select 20230810 > a from t").Check(testkit.Rows("1"))
+	tk.MustQuery("select 20231310 > a from t").Check(testkit.Rows("0"))
 
 	// constant datetime cmp numeric constant should be compared as real data type
 	tk.MustQuery("select cast('2023-08-09 00:00:00' as datetime) > 20230809 from t").Check(testkit.Rows("1"))
 	tk.MustQuery("select cast('2023-08-09 00:00:00' as datetime) = 20230809 from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select cast('2023-08-09 00:00:00' as datetime) < 20230810 from t").Check(testkit.Rows("0"))
+	tk.MustQuery("select cast('2023-08-09 00:00:00' as datetime) < 20231310 from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select 20230809 < cast('2023-08-09 00:00:00' as datetime) from t").Check(testkit.Rows("1"))
 	tk.MustQuery("select 20230809 = cast('2023-08-09 00:00:00' as datetime) from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select 20230810 > cast('2023-08-09 00:00:00' as datetime) from t").Check(testkit.Rows("0"))
+	tk.MustQuery("select 20231310 > cast('2023-08-09 00:00:00' as datetime) from t").Check(testkit.Rows("0"))
 
 	// datetime column cmp numeric column should be compared as real data type
 	tk.MustQuery("select a > b from t").Check(testkit.Rows("1"))
 	tk.MustQuery("select a = b from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select a < b + 1 from t").Check(testkit.Rows("0"))
+	tk.MustQuery("select a < c from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select b < a from t").Check(testkit.Rows("1"))
 	tk.MustQuery("select b = a from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select b > a from t").Check(testkit.Rows("0"))
+	tk.MustQuery("select c > a from t").Check(testkit.Rows("0"))
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -139,6 +139,8 @@ func TestCompareIssue38361(t *testing.T) {
 	tk.MustQuery("select a > 20230809 from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select a = 20230809 from t").Check(testkit.Rows("1"))
 	tk.MustQuery("select a < 20230810 from t").Check(testkit.Rows("1"))
+	// 20231310 can't be converted to valid datetime, thus should be compared using real date type,and datetime will be
+	// converted to something like 'YYYYMMDDHHMMSS', bigger than 20231310
 	tk.MustQuery("select a < 20231310 from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select 20230809 < a from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select 20230809 = a from t").Check(testkit.Rows("1"))

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1730,7 +1730,7 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 // see https://github.com/pingcap/tidb/issues/38361 for more details
 func (c *compareFunctionClass) refineNumericConstantCmpDatetime(ctx sessionctx.Context, args []Expression, constArg *Constant, constArgIdx int) []Expression {
 	dt, err := constArg.Eval(chunk.Row{})
-	if err != nil {
+	if err != nil || dt.IsNull() {
 		return args
 	}
 	sc := ctx.GetSessionVars().StmtCtx

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1734,14 +1734,14 @@ func (c *compareFunctionClass) refineNumericConstantCmpDatetime(ctx sessionctx.C
 		return args
 	}
 	sc := ctx.GetSessionVars().StmtCtx
-	var timestampDatum types.Datum
-	targetFieldType := types.NewFieldType(mysql.TypeTimestamp)
-	timestampDatum, err = dt.ConvertTo(sc, targetFieldType)
-	if err != nil || timestampDatum.IsNull() {
+	var datetimeDatum types.Datum
+	targetFieldType := types.NewFieldType(mysql.TypeDatetime)
+	datetimeDatum, err = dt.ConvertTo(sc, targetFieldType)
+	if err != nil || datetimeDatum.IsNull() {
 		return args
 	}
 	finalArg := Constant{
-		Value:        timestampDatum,
+		Value:        datetimeDatum,
 		RetType:      targetFieldType,
 		DeferredExpr: nil,
 		ParamMarker:  nil,

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1612,7 +1612,7 @@ func allowCmpArgsRefining4PlanCache(ctx sessionctx.Context, args []Expression) (
 // refineArgs will rewrite the arguments if the compare expression is
 // 1. `int column <cmp> non-int constant` or `non-int constant <cmp> int column`. E.g., `a < 1.1` will be rewritten to `a < 2`.
 // 2. It also handles comparing year type with int constant if the int constant falls into a sensible year representation.
-// 3. It also handles comparing datetime/timestamp column with numeric constant falls into a sensible datetime representation
+// 3. It also handles comparing datetime/timestamp column with numeric constant, try to cast numeric constant as timestamp type, do nothing if failed.
 // This refining operation depends on the values of these args, but these values can change when using plan-cache.
 // So we have to skip this operation or mark the plan as over-optimized when using plan-cache.
 func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Expression) []Expression {

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1737,7 +1737,7 @@ func (c *compareFunctionClass) refineNumericConstantCmpDatetime(ctx sessionctx.C
 	var timestampDatum types.Datum
 	targetFieldType := types.NewFieldType(mysql.TypeTimestamp)
 	timestampDatum, err = dt.ConvertTo(sc, targetFieldType)
-	if err != nil {
+	if err != nil || timestampDatum.IsNull() {
 		return args
 	}
 	finalArg := Constant{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #38361

Problem Summary: When compare datetime/timestamp column with numeric constant, try convert numeric constant to timestamp datetime, do nothing if conversion failed.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
