### PR TITLE
planner: increase the maximum number limit of TopN when analyzing tables

### DIFF
--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -2945,7 +2945,7 @@ var CMSketchSizeLimit = kv.TxnEntrySizeLimit / binary.MaxVarintLen32
 
 var analyzeOptionLimit = map[ast.AnalyzeOptionType]uint64{
 	ast.AnalyzeOptNumBuckets:    1024,
-	ast.AnalyzeOptNumTopN:       1024,
+	ast.AnalyzeOptNumTopN:       16384,
 	ast.AnalyzeOptCMSketchWidth: CMSketchSizeLimit,
 	ast.AnalyzeOptCMSketchDepth: CMSketchSizeLimit,
 	ast.AnalyzeOptNumSamples:    500000,

--- a/statistics/handle/handletest/analyze/analyze_test.go
+++ b/statistics/handle/handletest/analyze/analyze_test.go
@@ -154,7 +154,7 @@ func TestAnalyzeGlobalStatsWithOpts1(t *testing.T) {
 		{77, 219, false},
 		{-31, 222, true},
 		{10, -77, true},
-		{10000, 47, true},
+		{100000, 47, true},
 		{77, 47000, true},
 	}
 	for _, ca := range cases {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #45919

Problem Summary: planner: increase the maximum number limit of TopN when analyzing tables

### What is changed and how it works?

planner: increase the maximum number limit of TopN when analyzing tables

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
