### PR TITLE
statistics: improve memory for mergeGlobalStatsTopNByConcurrency

### DIFF
--- a/statistics/cmsketch_bench_test.go
+++ b/statistics/cmsketch_bench_test.go
@@ -123,10 +123,7 @@ func benchmarkMergeGlobalStatsTopNByConcurrencyWithHists(partitions int, b *test
 		h.Buckets = append(h.Buckets, statistics.Bucket{Repeat: 10, Count: 40})
 		hists = append(hists, h)
 	}
-	wrapper := &statistics.StatsWrapper{
-		AllTopN: topNs,
-		AllHg:   hists,
-	}
+	wrapper := statistics.NewStatsWrapper(hists, topNs)
 	const mergeConcurrency = 4
 	batchSize := len(wrapper.AllTopN) / mergeConcurrency
 	if batchSize < 1 {

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -956,19 +956,15 @@ func MergeGlobalStatsTopNByConcurrency(mergeConcurrency, mergeBatchSize int, wra
 
 	// handle Error
 	hasErr := false
+	errMsg := make([]string, 0)
 	for resp := range respCh {
 		if resp.Err != nil {
 			hasErr = true
+			errMsg = append(errMsg, resp.Err.Error())
 		}
 		resps = append(resps, resp)
 	}
 	if hasErr {
-		errMsg := make([]string, 0)
-		for _, resp := range resps {
-			if resp.Err != nil {
-				errMsg = append(errMsg, resp.Err.Error())
-			}
-		}
 		return nil, nil, nil, errors.New(strings.Join(errMsg, ","))
 	}
 

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -951,7 +951,7 @@ func MergeGlobalStatsTopNByConcurrency(mergeConcurrency, mergeBatchSize int, wra
 	wg.Wait()
 	close(respCh)
 	close(removeCh)
-	wg.Wait()
+	removeWg.Wait()
 	resps := make([]*statistics.TopnStatsMergeResponse, 0)
 
 	// handle Error

--- a/statistics/merge_worker.go
+++ b/statistics/merge_worker.go
@@ -30,11 +30,13 @@ type StatsWrapper struct {
 	AllTopN []*TopN
 }
 
+// RemoveTopNTask indicates a task for remove topn
 type RemoveTopNTask struct {
-	partition int
 	topn      TopNMeta
+	partition int
 }
 
+// NewRemoveTopNTask returns task
 func NewRemoveTopNTask(partition int, topn TopNMeta) *RemoveTopNTask {
 	return &RemoveTopNTask{
 		partition: partition,
@@ -42,10 +44,12 @@ func NewRemoveTopNTask(partition int, topn TopNMeta) *RemoveTopNTask {
 	}
 }
 
+// GetPartition returns partition
 func (t *RemoveTopNTask) GetPartition() int {
 	return t.partition
 }
 
+// GetTopN returns topN
 func (t *RemoveTopNTask) GetTopN() TopNMeta {
 	return t.topn
 }

--- a/statistics/merge_worker.go
+++ b/statistics/merge_worker.go
@@ -34,7 +34,7 @@ type StatsWrapper struct {
 
 // NewStatsWrapper returns wrapper
 func NewStatsWrapper(hg []*Histogram, topN []*TopN) *StatsWrapper {
-	allHgMutex := make([]sync.Mutex, 0, len(hg))
+	allHgMutex := make([]sync.Mutex, len(hg), len(hg))
 	for i := range allHgMutex {
 		allHgMutex[i] = sync.Mutex{}
 	}

--- a/statistics/merge_worker.go
+++ b/statistics/merge_worker.go
@@ -45,7 +45,8 @@ type topnStatsMergeWorker struct {
 	respCh chan<- *TopnStatsMergeResponse
 	// the stats in the wrapper should only be read during the worker
 	statsWrapper *StatsWrapper
-	shardMutex   []sync.Mutex
+	// shardMutex is used to protect `statsWrapper.AllHg`
+	shardMutex []sync.Mutex
 }
 
 // NewTopnStatsMergeWorker returns topn merge worker


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/45727

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/statistics
cpu: AMD Ryzen 7 7735HS with Radeon Graphics
BenchmarkMergeGlobalStatsTopNByConcurrencyWithHists/Size100-16         	   16852	     82494 ns/op	   19801 B/op	     248 allocs/op
BenchmarkMergeGlobalStatsTopNByConcurrencyWithHists/Size1000-16        	    2394	    528919 ns/op	  164952 B/op	    2048 allocs/op
BenchmarkMergeGlobalStatsTopNByConcurrencyWithHists/Size10000-16       	      46	  27104549 ns/op	16254536 B/op	  200239 allocs/op
BenchmarkMergeGlobalStatsTopNByConcurrencyWithHists/Size100000-16      	       1	3820741278 ns/op	1564350080 B/op	19552007 allocs/op
```

after

```
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/statistics
cpu: AMD Ryzen 7 7735HS with Radeon Graphics
BenchmarkMergeGlobalStatsTopNByConcurrencyWithHists/Size100-16         	   25230	     54848 ns/op	    6234 B/op	      48 allocs/op
BenchmarkMergeGlobalStatsTopNByConcurrencyWithHists/Size1000-16        	    5294	    209518 ns/op	   35425 B/op	      48 allocs/op
BenchmarkMergeGlobalStatsTopNByConcurrencyWithHists/Size10000-16       	     128	   9095930 ns/op	  350648 B/op	     203 allocs/op
BenchmarkMergeGlobalStatsTopNByConcurrencyWithHists/Size100000-16      	       1	1199193921 ns/op	 3448576 B/op	    1617 allocs/op
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
