### PR TITLE
statistics: using standard lib slices instead of exp slices

### DIFF
--- a/statistics/BUILD.bazel
+++ b/statistics/BUILD.bazel
@@ -120,7 +120,6 @@ go_test(
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_log//:log",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//slices",
         "@org_uber_go_goleak//:goleak",
         "@org_uber_go_zap//:zap",
     ],

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -339,6 +339,18 @@ func TestMergePartTopN2GlobalTopNWithoutHists(t *testing.T) {
 	require.Len(t, leftTopN, 1, "should have 1 left topN")
 }
 
+func TestSortTopnMeta(t *testing.T) {
+	data := []TopNMeta{{
+		Encoded: []byte("a"),
+		Count:   1,
+	}, {
+		Encoded: []byte("b"),
+		Count:   2,
+	}}
+	sortedData := SortTopnMeta(data)
+	require.Equal(t, uint64(2), sortedData[0].Count)
+}
+
 func TestMergePartTopN2GlobalTopNWithHists(t *testing.T) {
 	loc := time.UTC
 	sc := &stmtctx.StatementContext{TimeZone: loc}

--- a/statistics/handle/BUILD.bazel
+++ b/statistics/handle/BUILD.bazel
@@ -49,7 +49,6 @@ go_library(
         "@com_github_pingcap_log//:log",
         "@com_github_pingcap_tipb//go-tipb",
         "@com_github_tikv_client_go_v2//oracle",
-        "@org_golang_x_exp//slices",
         "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",
     ],

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -50,7 +51,6 @@ import (
 	"github.com/tikv/client-go/v2/oracle"
 	atomic2 "go.uber.org/atomic"
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 )
 
 const (
@@ -976,9 +976,8 @@ func (*Handle) mergeGlobalStatsTopNByConcurrency(mergeConcurrency, mergeBatchSiz
 			// Remove the value from the Hists.
 			if len(removeTopn) > 0 {
 				tmp := removeTopn
-				slices.SortFunc(tmp, func(i, j statistics.TopNMeta) bool {
-					cmpResult := bytes.Compare(i.Encoded, j.Encoded)
-					return cmpResult < 0
+				slices.SortFunc(tmp, func(i, j statistics.TopNMeta) int {
+					return bytes.Compare(i.Encoded, j.Encoded)
 				})
 				wrapper.AllHg[i].RemoveVals(tmp)
 			}

--- a/statistics/index.go
+++ b/statistics/index.go
@@ -17,6 +17,7 @@ package statistics
 import (
 	"bytes"
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/pingcap/failpoint"
@@ -33,7 +34,6 @@ import (
 	"github.com/pingcap/tidb/util/mathutil"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/twmb/murmur3"
-	"golang.org/x/exp/slices"
 )
 
 // Index represents an index histogram.

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"regexp"
 	"runtime/pprof"
+	"slices"
 	"testing"
 	"time"
 
@@ -44,7 +45,6 @@ import (
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestCollationColumnEstimate(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

using builtin slices lib instead of exp slices 

Issue Number: ref #45933

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

