### PR TITLE
*: revert packet IO metrics to histograms

### DIFF
--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -3558,14 +3558,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tidb_server_packet_io_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+              "expr": "sum(rate(tidb_server_packet_io_bytes_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{type}}-rate",
               "refId": "A"
             },
             {
-              "expr": "sum(tidb_server_packet_io_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (type)",
+              "expr": "sum(tidb_server_packet_io_bytes_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (type)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{type}}-total",

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -170,7 +170,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(PlanCacheInstanceMemoryUsage)
 	prometheus.MustRegister(PlanCacheInstancePlanNumCounter)
 	prometheus.MustRegister(PseudoEstimation)
-	prometheus.MustRegister(PacketIOCounter)
+	prometheus.MustRegister(PacketIOHistogram)
 	prometheus.MustRegister(QueryDurationHistogram)
 	prometheus.MustRegister(QueryTotalCounter)
 	prometheus.MustRegister(AffectedRowsCounter)

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -27,7 +27,7 @@ var (
 
 // Metrics
 var (
-	PacketIOCounter        *prometheus.CounterVec
+	PacketIOHistogram      *prometheus.HistogramVec
 	QueryDurationHistogram *prometheus.HistogramVec
 	QueryTotalCounter      *prometheus.CounterVec
 	AffectedRowsCounter    *prometheus.CounterVec
@@ -74,12 +74,13 @@ var (
 
 // InitServerMetrics initializes server metrics.
 func InitServerMetrics() {
-	PacketIOCounter = NewCounterVec(
-		prometheus.CounterOpts{
+	PacketIOHistogram = NewHistogramVec(
+		prometheus.HistogramOpts{
 			Namespace: "tidb",
 			Subsystem: "server",
 			Name:      "packet_io_bytes",
-			Help:      "Counters of packet IO bytes.",
+			Help:      "Bucketed histogram of packet IO bytes.",
+			Buckets:   prometheus.ExponentialBuckets(4, 4, 21), // 4Bytes ~ 4TB
 		}, []string{LblType})
 
 	QueryDurationHistogram = NewHistogramVec(

--- a/server/internal/packetio.go
+++ b/server/internal/packetio.go
@@ -230,7 +230,7 @@ func (p *PacketIO) ReadPacket() ([]byte, error) {
 	}
 
 	if len(data) < mysql.MaxPayloadLen {
-		server_metrics.ReadPacketBytes.Add(float64(len(data)))
+		server_metrics.ReadPacketBytes.Observe(float64(len(data)))
 		return data, nil
 	}
 
@@ -248,14 +248,14 @@ func (p *PacketIO) ReadPacket() ([]byte, error) {
 		}
 	}
 
-	server_metrics.ReadPacketBytes.Add(float64(len(data)))
+	server_metrics.ReadPacketBytes.Observe(float64(len(data)))
 	return data, nil
 }
 
 // WritePacket writes data that already have header
 func (p *PacketIO) WritePacket(data []byte) error {
 	length := len(data) - 4
-	server_metrics.WritePacketBytes.Add(float64(len(data)))
+	server_metrics.WritePacketBytes.Observe(float64(len(data)))
 
 	maxPayloadLen := mysql.MaxPayloadLen
 	if p.compressionAlgorithm != mysql.CompressionNone {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -37,8 +37,8 @@ var (
 	AffectedRowsCounterDelete  prometheus.Counter
 	AffectedRowsCounterReplace prometheus.Counter
 
-	ReadPacketBytes  prometheus.Counter
-	WritePacketBytes prometheus.Counter
+	ReadPacketBytes  prometheus.Observer
+	WritePacketBytes prometheus.Observer
 )
 
 func init() {
@@ -90,6 +90,6 @@ func InitMetricsVars() {
 	AffectedRowsCounterDelete = metrics.AffectedRowsCounter.WithLabelValues("Delete")
 	AffectedRowsCounterReplace = metrics.AffectedRowsCounter.WithLabelValues("Replace")
 
-	ReadPacketBytes = metrics.PacketIOCounter.WithLabelValues("read")
-	WritePacketBytes = metrics.PacketIOCounter.WithLabelValues("write")
+	ReadPacketBytes = metrics.PacketIOHistogram.WithLabelValues("read")
+	WritePacketBytes = metrics.PacketIOHistogram.WithLabelValues("write")
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46012

Problem Summary: Change packet IO metrics to histograms

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
