### PR TITLE
executor: Fix coroutine leak after kill remote connection

### DIFF
--- a/executor/simple.go
+++ b/executor/simple.go
@@ -2617,6 +2617,7 @@ func killRemoteConn(ctx context.Context, sctx sessionctx.Context, gcid *globalco
 		err := errors.New("client returns nil response")
 		return err
 	}
+	resp.Close()
 
 	logutil.BgLogger().Info("Killed remote connection", zap.Uint64("serverID", gcid.ServerID),
 		zap.Uint64("conn", gcid.ToConnID()), zap.Bool("query", query))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46034 

Problem Summary: Coroutine leak after kill remote connection.

### What is changed and how it works?

Close `resp` of coprocessor request. Otherwise the coprocessor will be blocked on the `respChan`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


Run the same test in issue, the coroutine count was stable, and no OOM occurred.
<img width="1236" alt="image" src="https://github.com/pingcap/tidb/assets/1907938/539dd1a4-9b3c-4f5b-9cbd-5e7d43c74cdf">
<img width="1225" alt="image" src="https://github.com/pingcap/tidb/assets/1907938/6e3c05e1-3d76-467d-bd0b-bcd1aac37800">
<img width="1239" alt="image" src="https://github.com/pingcap/tidb/assets/1907938/71dacb8d-2912-498a-971d-9243b51b0c3a">


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
