### PR TITLE
br: configure the httpclient for external storage

### DIFF
--- a/br/pkg/lightning/importer/precheck_impl.go
+++ b/br/pkg/lightning/importer/precheck_impl.go
@@ -17,7 +17,6 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"net/http"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -433,7 +432,6 @@ func (ci *storagePermissionCheckItem) Check(ctx context.Context) (*precheck.Chec
 			storage.ListObjects,
 			storage.GetObject,
 		},
-		HTTPClient: &http.Client{},
 	})
 	if err != nil {
 		theResult.Passed = false

--- a/br/pkg/lightning/importer/precheck_impl.go
+++ b/br/pkg/lightning/importer/precheck_impl.go
@@ -17,6 +17,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -432,6 +433,7 @@ func (ci *storagePermissionCheckItem) Check(ctx context.Context) (*precheck.Chec
 			storage.ListObjects,
 			storage.GetObject,
 		},
+		HTTPClient: &http.Client{},
 	})
 	if err != nil {
 		theResult.Passed = false

--- a/br/pkg/storage/BUILD.bazel
+++ b/br/pkg/storage/BUILD.bazel
@@ -72,11 +72,12 @@ go_test(
         "memstore_test.go",
         "parse_test.go",
         "s3_test.go",
+        "storage_test.go",
         "writer_test.go",
     ],
     embed = [":storage"],
     flaky = True,
-    shard_count = 45,
+    shard_count = 47,
     deps = [
         "//br/pkg/mock",
         "@com_github_aws_aws_sdk_go//aws",

--- a/br/pkg/storage/azblob.go
+++ b/br/pkg/storage/azblob.go
@@ -216,7 +216,7 @@ func getAzureServiceClientBuilder(options *backuppb.AzureBlobStorage, opts *Exte
 	}
 
 	clientOptions := getDefaultClientOptions()
-	if opts.HTTPClient != nil {
+	if opts != nil && opts.HTTPClient != nil {
 		clientOptions.Transport = opts.HTTPClient
 	}
 

--- a/br/pkg/storage/azblob.go
+++ b/br/pkg/storage/azblob.go
@@ -157,10 +157,12 @@ type sharedKeyClientBuilder struct {
 	cred        *azblob.SharedKeyCredential
 	accountName string
 	serviceURL  string
+
+	clientOptions *azblob.ClientOptions
 }
 
 func (b *sharedKeyClientBuilder) GetServiceClient() (*azblob.Client, error) {
-	return azblob.NewClientWithSharedKeyCredential(b.serviceURL, b.cred, getDefaultClientOptions())
+	return azblob.NewClientWithSharedKeyCredential(b.serviceURL, b.cred, b.clientOptions)
 }
 
 func (b *sharedKeyClientBuilder) GetAccountName() string {
@@ -172,10 +174,12 @@ type sasClientBuilder struct {
 	accountName string
 	// Example of serviceURL: https://<account>.blob.core.windows.net/?<sas token>
 	serviceURL string
+
+	clientOptions *azblob.ClientOptions
 }
 
 func (b *sasClientBuilder) GetServiceClient() (*azblob.Client, error) {
-	return azblob.NewClientWithNoCredential(b.serviceURL, getDefaultClientOptions())
+	return azblob.NewClientWithNoCredential(b.serviceURL, b.clientOptions)
 }
 
 func (b *sasClientBuilder) GetAccountName() string {
@@ -187,10 +191,12 @@ type tokenClientBuilder struct {
 	cred        *azidentity.ClientSecretCredential
 	accountName string
 	serviceURL  string
+
+	clientOptions *azblob.ClientOptions
 }
 
 func (b *tokenClientBuilder) GetServiceClient() (*azblob.Client, error) {
-	return azblob.NewClient(b.serviceURL, b.cred, getDefaultClientOptions())
+	return azblob.NewClient(b.serviceURL, b.cred, b.clientOptions)
 }
 
 func (b *tokenClientBuilder) GetAccountName() string {
@@ -209,6 +215,11 @@ func getAzureServiceClientBuilder(options *backuppb.AzureBlobStorage, opts *Exte
 		return nil, errors.New("bucket(container) cannot be empty to access azure blob storage")
 	}
 
+	clientOptions := getDefaultClientOptions()
+	if opts.HTTPClient != nil {
+		clientOptions.Transport = opts.HTTPClient
+	}
+
 	if len(options.AccountName) > 0 && len(options.AccessSig) > 0 {
 		serviceURL := options.Endpoint
 		if len(serviceURL) == 0 {
@@ -221,6 +232,8 @@ func getAzureServiceClientBuilder(options *backuppb.AzureBlobStorage, opts *Exte
 		return &sasClientBuilder{
 			options.AccountName,
 			serviceURL,
+
+			clientOptions,
 		}, nil
 	}
 
@@ -237,6 +250,8 @@ func getAzureServiceClientBuilder(options *backuppb.AzureBlobStorage, opts *Exte
 			cred,
 			options.AccountName,
 			serviceURL,
+
+			clientOptions,
 		}, nil
 	}
 
@@ -265,6 +280,8 @@ func getAzureServiceClientBuilder(options *backuppb.AzureBlobStorage, opts *Exte
 				cred,
 				accountName,
 				serviceURL,
+
+				clientOptions,
 			}, nil
 		}
 		log.Warn("Failed to get azure token credential but environment variables exist, try to use shared key.", zap.String("tenantId", tenantID), zap.String("clientId", clientID), zap.String("clientSecret", "?"))
@@ -292,6 +309,8 @@ func getAzureServiceClientBuilder(options *backuppb.AzureBlobStorage, opts *Exte
 		cred,
 		accountName,
 		serviceURL,
+
+		clientOptions,
 	}, nil
 }
 

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -171,9 +171,6 @@ func New(ctx context.Context, backend *backuppb.StorageBackend, opts *ExternalSt
 	if opts == nil {
 		opts = &ExternalStorageOptions{}
 	}
-	if opts.HTTPClient == nil {
-		opts.HTTPClient = GetDefaultHttpClient(DefaultRequestConcurrency)
-	}
 	switch backend := backend.Backend.(type) {
 	case *backuppb.StorageBackend_Local:
 		if backend.Local == nil {

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -172,7 +172,7 @@ func New(ctx context.Context, backend *backuppb.StorageBackend, opts *ExternalSt
 		opts = &ExternalStorageOptions{}
 	}
 	if opts.HTTPClient == nil {
-		opts.HTTPClient = GetDefaultHttpClient(DefaultRequestConcurrency)
+		//opts.HTTPClient = GetDefaultHttpClient(DefaultRequestConcurrency)
 	}
 	switch backend := backend.Backend.(type) {
 	case *backuppb.StorageBackend_Local:

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -172,7 +172,7 @@ func New(ctx context.Context, backend *backuppb.StorageBackend, opts *ExternalSt
 		opts = &ExternalStorageOptions{}
 	}
 	if opts.HTTPClient == nil {
-		//opts.HTTPClient = GetDefaultHttpClient(DefaultRequestConcurrency)
+		opts.HTTPClient = GetDefaultHttpClient(DefaultRequestConcurrency)
 	}
 	switch backend := backend.Backend.(type) {
 	case *backuppb.StorageBackend_Local:

--- a/br/pkg/storage/storage_test.go
+++ b/br/pkg/storage/storage_test.go
@@ -21,6 +21,6 @@ func TestDefaultHttpClient(t *testing.T) {
 	var concurrency uint = 128
 	transport, ok := storage.GetDefaultHttpClient(concurrency).Transport.(*http.Transport)
 	require.True(t, ok)
-	require.Equal(t, transport.MaxIdleConnsPerHost, int(concurrency))
-	require.Equal(t, transport.MaxIdleConns, int(concurrency))
+	require.Equal(t, int(concurrency), transport.MaxIdleConnsPerHost)
+	require.Equal(t, int(concurrency), transport.MaxIdleConns)
 }

--- a/br/pkg/storage/storage_test.go
+++ b/br/pkg/storage/storage_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package storage_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultHttpTransport(t *testing.T) {
+	transport, ok := storage.CloneDefaultHttpTransport()
+	require.True(t, ok)
+	require.True(t, transport.MaxConnsPerHost == 0)
+	require.True(t, transport.MaxIdleConns > 0)
+}
+
+func TestDefaultHttpClient(t *testing.T) {
+	var concurrency uint = 128
+	transport, ok := storage.GetDefaultHttpClient(concurrency).Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Equal(t, transport.MaxIdleConnsPerHost, int(concurrency))
+	require.Equal(t, transport.MaxIdleConns, int(concurrency))
+}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -135,6 +135,7 @@ func (cfg *StreamConfig) makeStorage(ctx context.Context) (storage.ExternalStora
 	opts := storage.ExternalStorageOptions{
 		NoCredentials:   cfg.NoCreds,
 		SendCredentials: cfg.SendCreds,
+		HTTPClient:      storage.GetDefaultHttpClient(cfg.MetadataDownloadBatchSize),
 	}
 	storage, err := storage.New(ctx, u, &opts)
 	if err != nil {
@@ -1471,6 +1472,7 @@ func createRestoreClient(ctx context.Context, g glue.Glue, cfg *RestoreConfig, m
 	opts := storage.ExternalStorageOptions{
 		NoCredentials:   cfg.NoCreds,
 		SendCredentials: cfg.SendCreds,
+		HTTPClient:      storage.GetDefaultHttpClient(cfg.MetadataDownloadBatchSize),
 	}
 	if err = client.SetStorage(ctx, u, &opts); err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46011 

Problem Summary:
br use the default http client to connect the external storage, which doesn't have enough reuse-connection-pool for each host(the default value is 2). This leads to slow batch files processing and TCP connections exceeding the system configuration limit.

### What is changed and how it works?
set the `MaxIdleConnsPerHost` as the same as `MaxIdleConns`.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

before configuration
![img_v2_6f0edf8a-a936-4ed6-aa18-77f5e663fa7g](https://github.com/pingcap/tidb/assets/36503113/a7f07545-bad0-4f9d-9ba8-e3cba14dc614)

after configuration
![fd011f9c-050a-4c66-9a2a-57bfab0ab882](https://github.com/pingcap/tidb/assets/36503113/7952b557-6211-4f7b-81a7-b03709800c28)


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
