### PR TITLE
br: add force_use_start_ts to check start-ts when doing PITR

### DIFF
--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -62,6 +62,7 @@ const (
 	// FlagWaitTiFlashReady represents whether wait tiflash replica ready after table restored and checksumed.
 	FlagWaitTiFlashReady = "wait-tiflash-ready"
 
+	FlagForceUseStartTS = "force-use-start-ts"
 	// FlagStreamStartTS and FlagStreamRestoreTS is used for log restore timestamp range.
 	FlagStreamStartTS   = "start-ts"
 	FlagStreamRestoreTS = "restored-ts"
@@ -193,6 +194,7 @@ type RestoreConfig struct {
 	// if it is empty, directly take restoring log justly.
 	FullBackupStorage string `json:"full-backup-storage" toml:"full-backup-storage"`
 
+	ForceUseStartTS bool `json:"force-use-start-ts" toml:"force-use-start-ts"`
 	// [startTs, RestoreTS] is used to `restore log` from StartTS to RestoreTS.
 	StartTS         uint64                      `json:"start-ts" toml:"start-ts"`
 	RestoreTS       uint64                      `json:"restore-ts" toml:"restore-ts"`
@@ -238,6 +240,8 @@ func DefineRestoreFlags(flags *pflag.FlagSet) {
 
 // DefineStreamRestoreFlags defines for the restore log command.
 func DefineStreamRestoreFlags(command *cobra.Command) {
+	command.Flags().Bool(FlagForceUseStartTS, false, "force to use start-ts in log restore.\n"+
+		"It only can be used in a non table-id-rewritten cluster")
 	command.Flags().String(FlagStreamStartTS, "", "the start timestamp which log restore from.\n"+
 		"support TSO or datetime, e.g. '400036290571534337' or '2018-05-11 01:42:23+0800'")
 	command.Flags().String(FlagStreamRestoreTS, "", "the point of restore, used for log restore.\n"+
@@ -270,9 +274,20 @@ func (cfg *RestoreConfig) ParseStreamRestoreFlags(flags *pflag.FlagSet) error {
 		return errors.Trace(err)
 	}
 
-	if cfg.StartTS > 0 && len(cfg.FullBackupStorage) > 0 {
-		return errors.Annotatef(berrors.ErrInvalidArgument, "%v and %v are mutually exclusive",
-			FlagStreamStartTS, FlagStreamFullBackupStorage)
+	if cfg.ForceUseStartTS, err = flags.GetBool(FlagForceUseStartTS); err != nil {
+		return errors.Trace(err)
+	}
+
+	if cfg.StartTS > 0 {
+		if !cfg.ForceUseStartTS {
+			return errors.Annotatef(berrors.ErrInvalidArgument, "[Waring] Don't use `--start-ts` in a table id rewritten cluster.\n"+
+				"you should use `--full-backup-storage` at first, if you know what's going on and still want use it,\n"+
+				"you can add `--force-use-start-ts` to skip this check.")
+		}
+		if len(cfg.FullBackupStorage) > 0 {
+			return errors.Annotatef(berrors.ErrInvalidArgument, "%v and %v are mutually exclusive",
+				FlagStreamStartTS, FlagStreamFullBackupStorage)
+		}
 	}
 
 	if cfg.PitrBatchCount, err = flags.GetUint32(FlagPiTRBatchCount); err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:
Don't use start-ts in frist PITR command. because it may cause data loss cluster.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
