### PR TITLE
disttask: fix owner change flaky test

### DIFF
--- a/disttask/framework/framework_rollback_test.go
+++ b/disttask/framework/framework_rollback_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/disttask/framework/framework_rollback_test.go
+++ b/disttask/framework/framework_rollback_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,7 @@ package framework_test
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -69,7 +70,7 @@ func (testRollbackMiniTask) String() string {
 }
 
 type rollbackScheduler struct {
-	v *atomic.Int64
+	m *sync.Map
 }
 
 func (*rollbackScheduler) InitSubtaskExecEnv(_ context.Context) error { return nil }
@@ -77,7 +78,7 @@ func (*rollbackScheduler) InitSubtaskExecEnv(_ context.Context) error { return n
 func (t *rollbackScheduler) CleanupSubtaskExecEnv(_ context.Context) error { return nil }
 
 func (t *rollbackScheduler) Rollback(_ context.Context) error {
-	t.v.Store(0)
+	t.m = &sync.Map{}
 	rollbackCnt.Add(1)
 	return nil
 }
@@ -95,24 +96,24 @@ func (t *rollbackScheduler) OnSubtaskFinished(_ context.Context, meta []byte) ([
 }
 
 type rollbackSubtaskExecutor struct {
-	v *atomic.Int64
+	m *sync.Map
 }
 
 func (e *rollbackSubtaskExecutor) Run(_ context.Context) error {
-	e.v.Add(1)
+	e.m.Store("1", "1")
 	return nil
 }
 
-func RegisterRollbackTaskMeta(v *atomic.Int64) {
+func RegisterRollbackTaskMeta(m *sync.Map) {
 	dispatcher.ClearTaskFlowHandle()
 	dispatcher.RegisterTaskFlowHandle(proto.TaskTypeExample, &rollbackFlowHandle{})
 	scheduler.ClearSchedulers()
 	scheduler.RegisterTaskType(proto.TaskTypeExample)
 	scheduler.RegisterSchedulerConstructor(proto.TaskTypeExample, proto.StepOne, func(_ context.Context, _ int64, _ []byte, _ int64) (scheduler.Scheduler, error) {
-		return &rollbackScheduler{v: v}, nil
+		return &rollbackScheduler{m: m}, nil
 	})
 	scheduler.RegisterSubtaskExectorConstructor(proto.TaskTypeExample, proto.StepOne, func(_ proto.MinimalTask, _ int64) (scheduler.SubtaskExecutor, error) {
-		return &rollbackSubtaskExecutor{v: v}, nil
+		return &rollbackSubtaskExecutor{m: m}, nil
 	})
 	rollbackCnt.Store(0)
 }
@@ -120,15 +121,16 @@ func RegisterRollbackTaskMeta(v *atomic.Int64) {
 func TestFrameworkRollback(t *testing.T) {
 	defer dispatcher.ClearTaskFlowHandle()
 	defer scheduler.ClearSchedulers()
-	var v atomic.Int64
-	RegisterRollbackTaskMeta(&v)
+	m := sync.Map{}
+
+	RegisterRollbackTaskMeta(&m)
 	distContext := testkit.NewDistExecutionContext(t, 2)
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/disttask/framework/dispatcher/cancelTaskAfterRefreshTask", "2*return(true)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/disttask/framework/dispatcher/cancelTaskAfterRefreshTask"))
 	}()
 
-	DispatchTaskAndCheckFail("key2", t, &v)
+	DispatchTaskAndCheckFail("key2", t, &m)
 	require.Equal(t, int32(2), rollbackCnt.Load())
 	rollbackCnt.Store(0)
 	distContext.Close()

--- a/disttask/framework/framework_test.go
+++ b/disttask/framework/framework_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/disttask/framework/framework_test.go
+++ b/disttask/framework/framework_test.go
@@ -191,13 +191,19 @@ func DispatchAndCancelTask(taskKey string, t *testing.T, m *sync.Map) {
 	}()
 	task := DispatchTask(taskKey, t)
 	require.Equal(t, proto.TaskStateReverted, task.State)
-	m = &sync.Map{}
+	m.Range(func(key, value interface{}) bool {
+		m.Delete(key)
+		return true
+	})
 }
 
 func DispatchTaskAndCheckFail(taskKey string, t *testing.T, m *sync.Map) {
 	task := DispatchTask(taskKey, t)
 	require.Equal(t, proto.TaskStateReverted, task.State)
-	m = &sync.Map{}
+	m.Range(func(key, value interface{}) bool {
+		m.Delete(key)
+		return true
+	})
 }
 
 func TestFrameworkBasic(t *testing.T) {

--- a/disttask/framework/framework_test.go
+++ b/disttask/framework/framework_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,7 @@ package framework_test
 import (
 	"context"
 	"errors"
-	"sync/atomic"
+	"sync"
 	"testing"
 	"time"
 
@@ -109,16 +109,26 @@ func (t *testScheduler) OnSubtaskFinished(_ context.Context, meta []byte) ([]byt
 	return meta, nil
 }
 
+// Note: the subtask must be Reentrant.
 type testSubtaskExecutor struct {
-	v *atomic.Int64
+	m *sync.Map
 }
 
 func (e *testSubtaskExecutor) Run(_ context.Context) error {
-	e.v.Add(1)
+	e.m.Store("0", "0")
 	return nil
 }
 
-func RegisterTaskMeta(v *atomic.Int64) {
+type testSubtaskExecutor1 struct {
+	m *sync.Map
+}
+
+func (e *testSubtaskExecutor1) Run(_ context.Context) error {
+	e.m.Store("1", "1")
+	return nil
+}
+
+func RegisterTaskMeta(m *sync.Map) {
 	dispatcher.ClearTaskFlowHandle()
 	dispatcher.RegisterTaskFlowHandle(proto.TaskTypeExample, &testFlowHandle{})
 	scheduler.ClearSchedulers()
@@ -130,10 +140,10 @@ func RegisterTaskMeta(v *atomic.Int64) {
 		return &testScheduler{}, nil
 	})
 	scheduler.RegisterSubtaskExectorConstructor(proto.TaskTypeExample, proto.StepOne, func(_ proto.MinimalTask, _ int64) (scheduler.SubtaskExecutor, error) {
-		return &testSubtaskExecutor{v: v}, nil
+		return &testSubtaskExecutor{m: m}, nil
 	})
 	scheduler.RegisterSubtaskExectorConstructor(proto.TaskTypeExample, proto.StepTwo, func(_ proto.MinimalTask, _ int64) (scheduler.SubtaskExecutor, error) {
-		return &testSubtaskExecutor{v: v}, nil
+		return &testSubtaskExecutor1{m: m}, nil
 	})
 }
 
@@ -162,100 +172,104 @@ func DispatchTask(taskKey string, t *testing.T) *proto.Task {
 	return task
 }
 
-func DispatchTaskAndCheckSuccess(taskKey string, t *testing.T, v *atomic.Int64) {
+func DispatchTaskAndCheckSuccess(taskKey string, t *testing.T, m *sync.Map) {
 	task := DispatchTask(taskKey, t)
-
 	require.Equal(t, proto.TaskStateSucceed, task.State)
-	require.Equal(t, int64(12), v.Load())
-	v.Store(0)
+	v, ok := m.Load("1")
+	require.Equal(t, true, ok)
+	require.Equal(t, "1", v)
+	v, ok = m.Load("0")
+	require.Equal(t, true, ok)
+	require.Equal(t, "0", v)
+	m = &sync.Map{}
 }
 
-func DispatchAndCancelTask(taskKey string, t *testing.T, v *atomic.Int64) {
+func DispatchAndCancelTask(taskKey string, t *testing.T, m *sync.Map) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/disttask/framework/scheduler/MockExecutorRunCancel", "1*return(1)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/disttask/framework/scheduler/MockExecutorRunCancel"))
 	}()
 	task := DispatchTask(taskKey, t)
 	require.Equal(t, proto.TaskStateReverted, task.State)
-	v.Store(0)
+	m = &sync.Map{}
 }
 
-func DispatchTaskAndCheckFail(taskKey string, t *testing.T, v *atomic.Int64) {
+func DispatchTaskAndCheckFail(taskKey string, t *testing.T, m *sync.Map) {
 	task := DispatchTask(taskKey, t)
 	require.Equal(t, proto.TaskStateReverted, task.State)
-	v.Store(0)
+	m = &sync.Map{}
 }
 
 func TestFrameworkBasic(t *testing.T) {
 	defer dispatcher.ClearTaskFlowHandle()
 	defer scheduler.ClearSchedulers()
-	var v atomic.Int64
-	RegisterTaskMeta(&v)
+	var m sync.Map
+	RegisterTaskMeta(&m)
 	distContext := testkit.NewDistExecutionContext(t, 2)
-	DispatchTaskAndCheckSuccess("key1", t, &v)
-	DispatchTaskAndCheckSuccess("key2", t, &v)
+	DispatchTaskAndCheckSuccess("key1", t, &m)
+	DispatchTaskAndCheckSuccess("key2", t, &m)
 	distContext.SetOwner(0)
 	time.Sleep(2 * time.Second) // make sure owner changed
-	DispatchTaskAndCheckSuccess("key3", t, &v)
-	DispatchTaskAndCheckSuccess("key4", t, &v)
+	DispatchTaskAndCheckSuccess("key3", t, &m)
+	DispatchTaskAndCheckSuccess("key4", t, &m)
 	distContext.SetOwner(1)
 	time.Sleep(2 * time.Second) // make sure owner changed
-	DispatchTaskAndCheckSuccess("key5", t, &v)
+	DispatchTaskAndCheckSuccess("key5", t, &m)
 	distContext.Close()
 }
 
 func TestFramework3Server(t *testing.T) {
 	defer dispatcher.ClearTaskFlowHandle()
 	defer scheduler.ClearSchedulers()
-	var v atomic.Int64
-	RegisterTaskMeta(&v)
+	var m sync.Map
+	RegisterTaskMeta(&m)
 	distContext := testkit.NewDistExecutionContext(t, 3)
-	DispatchTaskAndCheckSuccess("key1", t, &v)
-	DispatchTaskAndCheckSuccess("key2", t, &v)
+	DispatchTaskAndCheckSuccess("key1", t, &m)
+	DispatchTaskAndCheckSuccess("key2", t, &m)
 	distContext.SetOwner(0)
 	time.Sleep(2 * time.Second) // make sure owner changed
-	DispatchTaskAndCheckSuccess("key3", t, &v)
-	DispatchTaskAndCheckSuccess("key4", t, &v)
+	DispatchTaskAndCheckSuccess("key3", t, &m)
+	DispatchTaskAndCheckSuccess("key4", t, &m)
 	distContext.Close()
 }
 
 func TestFrameworkAddDomain(t *testing.T) {
 	defer dispatcher.ClearTaskFlowHandle()
 	defer scheduler.ClearSchedulers()
-	var v atomic.Int64
-	RegisterTaskMeta(&v)
+	var m sync.Map
+	RegisterTaskMeta(&m)
 	distContext := testkit.NewDistExecutionContext(t, 2)
-	DispatchTaskAndCheckSuccess("key1", t, &v)
+	DispatchTaskAndCheckSuccess("key1", t, &m)
 	distContext.AddDomain()
-	DispatchTaskAndCheckSuccess("key2", t, &v)
+	DispatchTaskAndCheckSuccess("key2", t, &m)
 	distContext.SetOwner(1)
 	time.Sleep(2 * time.Second) // make sure owner changed
-	DispatchTaskAndCheckSuccess("key3", t, &v)
+	DispatchTaskAndCheckSuccess("key3", t, &m)
 	distContext.Close()
 	distContext.AddDomain()
-	DispatchTaskAndCheckSuccess("key4", t, &v)
+	DispatchTaskAndCheckSuccess("key4", t, &m)
 }
 
 func TestFrameworkDeleteDomain(t *testing.T) {
 	defer dispatcher.ClearTaskFlowHandle()
 	defer scheduler.ClearSchedulers()
-	var v atomic.Int64
-	RegisterTaskMeta(&v)
+	var m sync.Map
+	RegisterTaskMeta(&m)
 	distContext := testkit.NewDistExecutionContext(t, 2)
-	DispatchTaskAndCheckSuccess("key1", t, &v)
+	DispatchTaskAndCheckSuccess("key1", t, &m)
 	distContext.DeleteDomain(1)
 	time.Sleep(2 * time.Second) // make sure the owner changed
-	DispatchTaskAndCheckSuccess("key2", t, &v)
+	DispatchTaskAndCheckSuccess("key2", t, &m)
 	distContext.Close()
 }
 
 func TestFrameworkWithQuery(t *testing.T) {
 	defer dispatcher.ClearTaskFlowHandle()
 	defer scheduler.ClearSchedulers()
-	var v atomic.Int64
-	RegisterTaskMeta(&v)
+	var m sync.Map
+	RegisterTaskMeta(&m)
 	distContext := testkit.NewDistExecutionContext(t, 2)
-	DispatchTaskAndCheckSuccess("key1", t, &v)
+	DispatchTaskAndCheckSuccess("key1", t, &m)
 
 	tk := testkit.NewTestKit(t, distContext.Store)
 
@@ -274,10 +288,10 @@ func TestFrameworkWithQuery(t *testing.T) {
 func TestFrameworkCancelGTask(t *testing.T) {
 	defer dispatcher.ClearTaskFlowHandle()
 	defer scheduler.ClearSchedulers()
-	var v atomic.Int64
-	RegisterTaskMeta(&v)
+	var m sync.Map
+	RegisterTaskMeta(&m)
 	distContext := testkit.NewDistExecutionContext(t, 2)
-	DispatchAndCancelTask("key1", t, &v)
+	DispatchAndCancelTask("key1", t, &m)
 	distContext.Close()
 }
 
@@ -285,14 +299,14 @@ func TestFrameworkSubTaskFailed(t *testing.T) {
 	defer dispatcher.ClearTaskFlowHandle()
 	defer scheduler.ClearSchedulers()
 
-	var v atomic.Int64
-	RegisterTaskMeta(&v)
+	var m sync.Map
+	RegisterTaskMeta(&m)
 	distContext := testkit.NewDistExecutionContext(t, 1)
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/disttask/framework/scheduler/MockExecutorRunErr", "1*return(true)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/disttask/framework/scheduler/MockExecutorRunErr"))
 	}()
-	DispatchTaskAndCheckFail("key1", t, &v)
+	DispatchTaskAndCheckFail("key1", t, &m)
 	distContext.Close()
 }
 
@@ -300,29 +314,29 @@ func TestFrameworkSubTaskInitEnvFailed(t *testing.T) {
 	defer dispatcher.ClearTaskFlowHandle()
 	defer scheduler.ClearSchedulers()
 
-	var v atomic.Int64
-	RegisterTaskMeta(&v)
+	var m sync.Map
+	RegisterTaskMeta(&m)
 	distContext := testkit.NewDistExecutionContext(t, 1)
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/disttask/framework/scheduler/mockExecSubtaskInitEnvErr", "return()"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/disttask/framework/scheduler/mockExecSubtaskInitEnvErr"))
 	}()
-	DispatchTaskAndCheckFail("key1", t, &v)
+	DispatchTaskAndCheckFail("key1", t, &m)
 	distContext.Close()
 }
 
 func TestOwnerChange(t *testing.T) {
 	defer dispatcher.ClearTaskFlowHandle()
 	defer scheduler.ClearSchedulers()
-	var v atomic.Int64
-	RegisterTaskMeta(&v)
+	var m sync.Map
+	RegisterTaskMeta(&m)
 
 	distContext := testkit.NewDistExecutionContext(t, 3)
 	dispatcher.MockOwnerChange = func() {
 		distContext.SetOwner(0)
 	}
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/disttask/framework/dispatcher/mockOwnerChange", "1*return(true)"))
-	DispatchTaskAndCheckSuccess("😊", t, &v)
+	DispatchTaskAndCheckSuccess("😊", t, &m)
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/disttask/framework/dispatcher/mockOwnerChange"))
 	distContext.Close()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46014 

Problem Summary:
Subtask in tests are not reentrant.

### What is changed and how it works?
Use map instead of atomic.Int64
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
