### PR TITLE
br: avoid possible infinite loop checking tikv gc and scheduling status

### DIFF
--- a/br/pkg/task/backup_ebs.go
+++ b/br/pkg/task/backup_ebs.go
@@ -295,13 +295,13 @@ func waitAllScheduleStoppedAndNoRegionHole(ctx context.Context, cfg Config, mgr 
 			} else {
 				log.Warn("failed to wait schedule, will retry later", zap.Error(err2))
 			}
-			continue
-		}
+		} else {
+			log.Info("all leader regions got, start checking hole", zap.Int("len", len(allRegions)))
 
-		log.Info("all leader regions got, start checking hole", zap.Int("len", len(allRegions)))
-
-		if !isRegionsHasHole(allRegions) {
-			return nil
+			if !isRegionsHasHole(allRegions) {
+				return nil
+			}
+			log.Info("Regions has hole, needs sleep and retry")
 		}
 		time.Sleep(backoffer.ExponentialBackoff())
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46073 

Problem Summary:

### What is changed and how it works?

To make sure TiKV gc and schedule status check can exit in 10 mins.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
Repro the tikv shutdown at backup execution time, and make sure ebs br backup will fail with timeout.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
