### PR TITLE
snap_restore: added retry for recovery

### DIFF
--- a/br/pkg/restore/data.go
+++ b/br/pkg/restore/data.go
@@ -73,7 +73,7 @@ type recoveryBackoffer struct {
 
 func newRecoveryBackoffer() *recoveryBackoffer {
 	return &recoveryBackoffer{
-		state: utils.InitialRetryState(16, 0, 0),
+		state: utils.InitialRetryState(16, 30*time.Second, 4*time.Minute),
 	}
 }
 

--- a/br/pkg/restore/data.go
+++ b/br/pkg/restore/data.go
@@ -27,6 +27,75 @@ import (
 	"google.golang.org/grpc/backoff"
 )
 
+type RecoveryStage int
+
+const (
+	StageUnknown RecoveryStage = iota
+	StageCollectingMeta
+	StageMakingRecoveryPlan
+	StageResetPDAllocateID
+	StageRecovering
+	StageFlashback
+)
+
+func (s RecoveryStage) String() string {
+	switch s {
+	case StageCollectingMeta:
+		return "collecting meta"
+	case StageMakingRecoveryPlan:
+		return "making recovery plan"
+	case StageResetPDAllocateID:
+		return "resetting PD allocate ID"
+	case StageRecovering:
+		return "recovering"
+	case StageFlashback:
+		return "flashback"
+	default:
+		return "unknown"
+	}
+}
+
+type recoveryError struct {
+	error
+	atStage RecoveryStage
+}
+
+func FailedAt(err error) RecoveryStage {
+	if rerr, ok := err.(recoveryError); ok {
+		return rerr.atStage
+	}
+	return StageUnknown
+}
+
+type recoveryBackoffer struct {
+	state utils.RetryState
+}
+
+func newRecoveryBackoffer() *recoveryBackoffer {
+	return &recoveryBackoffer{
+		state: utils.InitialRetryState(16, 0, 0),
+	}
+}
+
+func (bo *recoveryBackoffer) NextBackoff(err error) time.Duration {
+	s := FailedAt(err)
+	switch s {
+	case StageCollectingMeta, StageMakingRecoveryPlan, StageResetPDAllocateID, StageRecovering:
+		log.Info("Recovery data retrying.", zap.Error(err), zap.Stringer("stage", s))
+		return bo.state.ExponentialBackoff()
+	case StageFlashback:
+		log.Info("Giving up retry for flashback stage.", zap.Error(err), zap.Stringer("stage", s))
+		bo.state.GiveUp()
+		return 0
+	}
+	log.Warn("unknown stage of backing off.", zap.Int("val", int(s)))
+	return bo.state.ExponentialBackoff()
+}
+
+func (bo *recoveryBackoffer) Attempt() int {
+	return bo.state.Attempt()
+}
+
 // RecoverData recover the tikv cluster
 // 1. read all meta data from tikvs
 // 2. make recovery plan and then recovery max allocate ID firstly
@@ -35,39 +104,50 @@ import (
 // 5. prepare the flashback
 // 6. flashback to resolveTS
 func RecoverData(ctx context.Context, resolveTS uint64, allStores []*metapb.Store, mgr *conn.Mgr, progress glue.Progress, restoreTS uint64, concurrency uint32) (int, error) {
+	return utils.WithRetryV2(ctx, newRecoveryBackoffer(), func(ctx context.Context) (int, error) {
+		return doRecoveryData(ctx, resolveTS, allStores, mgr, progress, restoreTS, concurrency)
+	})
+}
+
+func doRecoveryData(ctx context.Context, resolveTS uint64, allStores []*metapb.Store, mgr *conn.Mgr, progress glue.Progress, restoreTS uint64, concurrency uint32) (int, error) {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	defer cancel()
+
 	var recovery = NewRecovery(allStores, mgr, progress, concurrency)
 	if err := recovery.ReadRegionMeta(ctx); err != nil {
-		return 0, errors.Trace(err)
+		return 0, recoveryError{error: err, atStage: StageCollectingMeta}
 	}
 
 	totalRegions := recovery.GetTotalRegions()
 
-	if err := recovery.MakeRecoveryPlan(); err != nil {
-		return totalRegions, errors.Trace(err)
+	err := recovery.MakeRecoveryPlan()
+	if err != nil {
+		return totalRegions, recoveryError{error: err, atStage: StageMakingRecoveryPlan}
 	}
 
 	log.Info("recover the alloc id to pd", zap.Uint64("max alloc id", recovery.MaxAllocID))
 	if err := recovery.mgr.RecoverBaseAllocID(ctx, recovery.MaxAllocID); err != nil {
-		return totalRegions, errors.Trace(err)
+		return totalRegions, recoveryError{error: err, atStage: StageResetPDAllocateID}
 	}
 
 	// Once TiKV shuts down and reboot then, it may be left with no leader because of the recovery mode.
 	// This wathcher will retrigger `RecoveryRegions` for those stores.
 	recovery.SpawnTiKVShutDownWatchers(ctx)
 	if err := recovery.RecoverRegions(ctx); err != nil {
-		return totalRegions, errors.Trace(err)
+		return totalRegions, recoveryError{error: err, atStage: StageRecovering}
 	}
 
 	if err := recovery.WaitApply(ctx); err != nil {
-		return totalRegions, errors.Trace(err)
+		return totalRegions, recoveryError{error: err, atStage: StageRecovering}
 	}
-
-	if err := recovery.PrepareFlashbackToVersion(ctx, resolveTS, restoreTS-1); err != nil {
-		return totalRegions, errors.Trace(err)
+	err = recovery.PrepareFlashbackToVersion(ctx, resolveTS, restoreTS-1)
+	if err != nil {
+		return totalRegions, recoveryError{error: err, atStage: StageFlashback}
 	}
 
 	if err := recovery.FlashbackToVersion(ctx, resolveTS, restoreTS); err != nil {
-		return totalRegions, errors.Trace(err)
+		return totalRegions, recoveryError{error: err, atStage: StageFlashback}
 	}
 
 	return totalRegions, nil

--- a/br/pkg/task/restore_data.go
+++ b/br/pkg/task/restore_data.go
@@ -146,8 +146,6 @@ func RunResolveKvData(c context.Context, g glue.Glue, cmdName string, cfg *Resto
 	// restore tikv data from a snapshot volume
 	var totalRegions int
 
-	// Roughly handle the case that some TiKVs are rebooted during making plan.
-	// Generally,
 	totalRegions, err = restore.RecoverData(ctx, resolveTS, allStores, mgr, progress, restoreTS, cfg.Concurrency)
 	if err != nil {
 		return errors.Trace(err)

--- a/br/pkg/task/restore_data.go
+++ b/br/pkg/task/restore_data.go
@@ -146,6 +146,8 @@ func RunResolveKvData(c context.Context, g glue.Glue, cmdName string, cfg *Resto
 	// restore tikv data from a snapshot volume
 	var totalRegions int
 
+	// Roughly handle the case that some TiKVs are rebooted during making plan.
+	// Generally,
 	totalRegions, err = restore.RecoverData(ctx, resolveTS, allStores, mgr, progress, restoreTS, cfg.Concurrency)
 	if err != nil {
 		return errors.Trace(err)

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -72,6 +72,10 @@ func (rs *RetryState) ExponentialBackoff() time.Duration {
 	return backoff
 }
 
+func (rs *RetryState) GiveUp() {
+	rs.retryTimes = rs.maxRetry
+}
+
 // InitialRetryState make the initial state for retrying.
 func InitialRetryState(maxRetryTimes int, initialBackoff, maxBackoff time.Duration) RetryState {
 	return RetryState{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46181

Problem Summary:
Now, when TiKV reboots, it is possible to abort the whole restore procedure.

This PR has also introduced a new interface for retrying, `WithRetryV2`, which supports returned value and move the closure to be retried last of the arguments. (So the code will probably be more readable, comparing `WithRetry(ctx, backoffer, func() { /* multi lines */ })` and `WithRetry(ctx, func() { /* multi lines */ }, backoffer)`.

### What is changed and how it works?
This PR added retry to the `RecoverData` call.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Make snapshot restoration more robust.
```
