### PR TITLE
disttask: add server info for dispatcher log

### DIFF
--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -60,22 +60,24 @@ type TaskHandle interface {
 // Manage the lifetime of a task
 // including submitting subtasks and updating the status of a task.
 type dispatcher struct {
-	ctx     context.Context
-	taskMgr *storage.TaskManager
-	task    *proto.Task
-	logCtx  context.Context
+	ctx      context.Context
+	taskMgr  *storage.TaskManager
+	task     *proto.Task
+	logCtx   context.Context
+	serverID string
 }
 
 // MockOwnerChange mock owner change in tests.
 var MockOwnerChange func()
 
-func newDispatcher(ctx context.Context, taskMgr *storage.TaskManager, task *proto.Task) *dispatcher {
-	logPrefix := fmt.Sprintf("task_id: %d, task_type: %s, server_id: %s", task.ID, task.Type, ctx.Value("serverID"))
+func newDispatcher(ctx context.Context, taskMgr *storage.TaskManager, serverID string, task *proto.Task) *dispatcher {
+	logPrefix := fmt.Sprintf("task_id: %d, task_type: %s, server_id: %s", task.ID, task.Type, serverID)
 	return &dispatcher{
 		ctx,
 		taskMgr,
 		task,
 		logutil.WithKeyValue(context.Background(), "dispatcher", logPrefix),
+		serverID,
 	}
 }
 

--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -70,7 +70,7 @@ type dispatcher struct {
 var MockOwnerChange func()
 
 func newDispatcher(ctx context.Context, taskMgr *storage.TaskManager, task *proto.Task) *dispatcher {
-	logPrefix := fmt.Sprintf("task_id: %d, task_type: %s", task.ID, task.Type)
+	logPrefix := fmt.Sprintf("task_id: %d, task_type: %s, server_id: %s", task.ID, task.Type, ctx.Value("serverID"))
 	return &dispatcher{
 		ctx,
 		taskMgr,

--- a/disttask/framework/dispatcher/dispatcher_manager.go
+++ b/disttask/framework/dispatcher/dispatcher_manager.go
@@ -70,12 +70,13 @@ func (dm *Manager) clearRunningTasks() {
 // Dispatcher schedule and monitor tasks.
 // The scheduling task number is limited by size of gPool.
 type Manager struct {
-	ctx     context.Context
-	cancel  context.CancelFunc
-	taskMgr *storage.TaskManager
-	wg      tidbutil.WaitGroupWrapper
-	gPool   *spool.Pool
-	inited  bool
+	ctx      context.Context
+	cancel   context.CancelFunc
+	taskMgr  *storage.TaskManager
+	wg       tidbutil.WaitGroupWrapper
+	gPool    *spool.Pool
+	inited   bool
+	serverID string
 
 	runningTasks struct {
 		syncutil.RWMutex
@@ -86,10 +87,11 @@ type Manager struct {
 }
 
 // NewManager creates a dispatcher struct.
-func NewManager(ctx context.Context, taskTable *storage.TaskManager) (*Manager, error) {
+func NewManager(ctx context.Context, taskTable *storage.TaskManager, serverID string) (*Manager, error) {
 	dispatcherManager := &Manager{
 		taskMgr:        taskTable,
 		finishedTaskCh: make(chan *proto.Task, DefaultDispatchConcurrency),
+		serverID:       serverID,
 	}
 	gPool, err := spool.NewPool("dispatch_pool", int32(DefaultDispatchConcurrency), util.DistTask, spool.WithBlocking(true))
 	if err != nil {
@@ -184,7 +186,7 @@ func (*Manager) checkConcurrencyOverflow(cnt int) bool {
 func (dm *Manager) startDispatcher(task *proto.Task) {
 	// Using the pool with block, so it wouldn't return an error.
 	_ = dm.gPool.Run(func() {
-		dispatcher := newDispatcher(dm.ctx, dm.taskMgr, task)
+		dispatcher := newDispatcher(dm.ctx, dm.taskMgr, dm.serverID, task)
 		dm.setRunningTask(task, dispatcher)
 		dispatcher.executeTask()
 		dm.delRunningTask(task.ID)
@@ -193,5 +195,5 @@ func (dm *Manager) startDispatcher(task *proto.Task) {
 
 // MockDispatcher mock one dispatcher for one task, only used for tests.
 func (dm *Manager) MockDispatcher(task *proto.Task) *dispatcher {
-	return newDispatcher(dm.ctx, dm.taskMgr, task)
+	return newDispatcher(dm.ctx, dm.taskMgr, dm.serverID, task)
 }

--- a/disttask/framework/dispatcher/dispatcher_test.go
+++ b/disttask/framework/dispatcher/dispatcher_test.go
@@ -61,7 +61,7 @@ func MockDispatcherManager(t *testing.T, pool *pools.ResourcePool) (*dispatcher.
 	ctx := context.Background()
 	mgr := storage.NewTaskManager(util.WithInternalSourceType(ctx, "taskManager"), pool)
 	storage.SetTaskManager(mgr)
-	dsp, err := dispatcher.NewManager(util.WithInternalSourceType(ctx, "dispatcher"), mgr)
+	dsp, err := dispatcher.NewManager(util.WithInternalSourceType(ctx, "dispatcher"), mgr, "host:port")
 	require.NoError(t, err)
 	dispatcher.RegisterTaskFlowHandle(proto.TaskTypeExample, &testFlowHandle{})
 	return dsp, mgr

--- a/disttask/framework/scheduler/manager.go
+++ b/disttask/framework/scheduler/manager.go
@@ -330,3 +330,7 @@ func (m *Manager) onError(err error) {
 
 	logutil.Logger(m.logCtx).Error("task manager error", zap.Error(err))
 }
+
+func (m *Manager) GetID() string {
+	return m.id
+}

--- a/disttask/framework/scheduler/manager.go
+++ b/disttask/framework/scheduler/manager.go
@@ -330,7 +330,3 @@ func (m *Manager) onError(err error) {
 
 	logutil.Logger(m.logCtx).Error("task manager error", zap.Error(err))
 }
-
-func (m *Manager) GetID() string {
-	return m.id
-}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1437,7 +1437,6 @@ func (do *Domain) InitDistTaskLoop(ctx context.Context) error {
 	} else {
 		serverID = disttaskutil.GenerateSubtaskExecID(ctx, do.ddl.GetID())
 	}
-	ctx = context.WithValue(ctx, "serverID", serverID)
 
 	if serverID == "" {
 		errMsg := fmt.Sprintf("TiDB node ID( = %s ) not found in available TiDB nodes list", do.ddl.GetID())
@@ -1473,7 +1472,7 @@ func (do *Domain) distTaskFrameworkLoop(ctx context.Context, taskManager *storag
 			return
 		}
 		var err error
-		dispatcherManager, err = dispatcher.NewManager(ctx, taskManager)
+		dispatcherManager, err = dispatcher.NewManager(ctx, taskManager, schedulerManager.GetID())
 		if err != nil {
 			logutil.BgLogger().Error("failed to create a disttask dispatcher", zap.Error(err))
 			return

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1452,12 +1452,12 @@ func (do *Domain) InitDistTaskLoop(ctx context.Context) error {
 		defer func() {
 			storage.SetTaskManager(nil)
 		}()
-		do.distTaskFrameworkLoop(ctx, taskManager, schedulerManager)
+		do.distTaskFrameworkLoop(ctx, taskManager, schedulerManager, serverID)
 	}, "distTaskFrameworkLoop")
 	return nil
 }
 
-func (do *Domain) distTaskFrameworkLoop(ctx context.Context, taskManager *storage.TaskManager, schedulerManager *scheduler.Manager) {
+func (do *Domain) distTaskFrameworkLoop(ctx context.Context, taskManager *storage.TaskManager, schedulerManager *scheduler.Manager, serverID string) {
 	schedulerManager.Start()
 	logutil.BgLogger().Info("dist task scheduler started")
 	defer func() {
@@ -1472,7 +1472,7 @@ func (do *Domain) distTaskFrameworkLoop(ctx context.Context, taskManager *storag
 			return
 		}
 		var err error
-		dispatcherManager, err = dispatcher.NewManager(ctx, taskManager, schedulerManager.GetID())
+		dispatcherManager, err = dispatcher.NewManager(ctx, taskManager, serverID)
 		if err != nil {
 			logutil.BgLogger().Error("failed to create a disttask dispatcher", zap.Error(err))
 			return

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1437,6 +1437,7 @@ func (do *Domain) InitDistTaskLoop(ctx context.Context) error {
 	} else {
 		serverID = disttaskutil.GenerateSubtaskExecID(ctx, do.ddl.GetID())
 	}
+	ctx = context.WithValue(ctx, "serverID", serverID)
 
 	if serverID == "" {
 		errMsg := fmt.Sprintf("TiDB node ID( = %s ) not found in available TiDB nodes list", do.ddl.GetID())


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #46122

Problem Summary:
the log of the dispatcher in disttask does not contain any server information

### What is changed and how it works?
add server info(host+port) for dispatcher log

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
