### PR TITLE
ddl: Exchange part schema load fix

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -1394,13 +1394,14 @@ func updateSchemaVersion(d *ddlCtx, t *meta.Meta, job *model.Job, multiInfos ...
 		// TODO: Update TiFlash, to handle StateWriteOnly
 		diff.AffectedOpts = []*model.AffectedOption{{
 			TableID: ptTableID,
-			// Keep this as Schema ID of non-partitioned table
-			// to avoid trigger early rename in TiFlash
-			SchemaID: job.SchemaID,
 		}}
 		if job.SchemaState != model.StatePublic {
-			// No change, just to a refresh of the non-partitioned table
+			// No change, just to refresh the non-partitioned table
+			// with its new ExchangePartitionInfo.
 			diff.TableID = job.TableID
+			// Keep this as Schema ID of non-partitioned table
+			// to avoid trigger early rename in TiFlash
+			diff.AffectedOpts[0].SchemaID = job.SchemaID
 		} else {
 			// Swap
 			diff.TableID = ptDefID

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -1373,27 +1373,39 @@ func updateSchemaVersion(d *ddlCtx, t *meta.Meta, job *model.Job, multiInfos ...
 		diff.OldSchemaID = oldSchemaIDs[0]
 		diff.AffectedOpts = affects
 	case model.ActionExchangeTablePartition:
+		// From start of function: diff.SchemaID = job.SchemaID
+		// Old is original non partitioned table
 		diff.OldTableID = job.TableID
 		diff.OldSchemaID = job.SchemaID
+		// Update the partitioned table (it is only done in the last state)
+		var (
+			ptSchemaID     int64
+			ptTableID      int64
+			ptDefID        int64
+			partName       string // Not used
+			withValidation bool   // Not used
+		)
+		// See ddl.ExchangeTablePartition
+		err = job.DecodeArgs(&ptDefID, &ptSchemaID, &ptTableID, &partName, &withValidation)
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
+		// This is needed for not crashing TiFlash!
+		// TODO: Update TiFlash, to handle StateWriteOnly
+		diff.AffectedOpts = []*model.AffectedOption{{
+			TableID: ptTableID,
+			// Keep this as Schema ID of non-partitioned table
+			// to avoid trigger early rename in TiFlash
+			SchemaID: job.SchemaID,
+		}}
 		if job.SchemaState != model.StatePublic {
+			// No change, just to a refresh of the non-partitioned table
 			diff.TableID = job.TableID
-			diff.SchemaID = job.SchemaID
 		} else {
-			// Update the partitioned table (it is only done in the last state)
-			var (
-				ptSchemaID     int64
-				ptTableID      int64
-				ptDefID        int64  // Not needed, will reload the whole table
-				partName       string // Not used
-				withValidation bool   // Not used
-			)
-			// See ddl.ExchangeTablePartition
-			err = job.DecodeArgs(&ptDefID, &ptSchemaID, &ptTableID, &partName, &withValidation)
-			if err != nil {
-				return 0, errors.Trace(err)
-			}
-			diff.SchemaID = ptSchemaID
-			diff.TableID = ptTableID
+			// Swap
+			diff.TableID = ptDefID
+			// Also add correct SchemaID in case different schemas
+			diff.AffectedOpts[0].SchemaID = ptSchemaID
 		}
 	case model.ActionTruncateTablePartition:
 		diff.TableID = job.TableID

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -2569,6 +2569,7 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 	ntr := rules[ntrID]
 	ptr := rules[ptrID]
 
+	// This must be a bug, nt cannot be partitioned!
 	partIDs := getPartitionIDs(nt)
 
 	var setRules []*label.Rule

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -325,7 +325,6 @@ func (b *Builder) applyExchangeTablePartition(m *meta.Meta, diff *model.SchemaDi
 	if len(diff.AffectedOpts) > 0 {
 		ptID = diff.AffectedOpts[0].TableID
 		if diff.AffectedOpts[0].SchemaID != 0 {
-			// Old version!
 			ptSchemaID = diff.AffectedOpts[0].SchemaID
 		}
 	}

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -348,7 +348,8 @@ func (b *Builder) applyExchangeTablePartition(m *meta.Meta, diff *model.SchemaDi
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	b.markPartitionBundleShouldUpdate(ntID)
+	// partID is the new id for the non-partitioned table!
+	b.markTableBundleShouldUpdate(partID)
 	// Then the partitioned table, will re-read the whole table, including all partitions!
 	currDiff.TableID = ptID
 	currDiff.SchemaID = ptSchemaID
@@ -358,7 +359,8 @@ func (b *Builder) applyExchangeTablePartition(m *meta.Meta, diff *model.SchemaDi
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	b.markTableBundleShouldUpdate(ptID)
+	// ntID is the new id for the partition!
+	b.markPartitionBundleShouldUpdate(ntID)
 	err = updateAutoIDForExchangePartition(b.store, ptSchemaID, ptID, ntSchemaID, ntID)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -321,26 +321,40 @@ func (b *Builder) applyExchangeTablePartition(m *meta.Meta, diff *model.SchemaDi
 	ntID := diff.OldTableID
 	ptSchemaID := diff.SchemaID
 	ptID := diff.TableID
+	partID := diff.TableID
 	if len(diff.AffectedOpts) > 0 {
-		// From old version
 		ptID = diff.AffectedOpts[0].TableID
-		ptSchemaID = diff.AffectedOpts[0].SchemaID
+		if diff.AffectedOpts[0].SchemaID != 0 {
+			// Old version!
+			ptSchemaID = diff.AffectedOpts[0].SchemaID
+		}
 	}
 	// The normal table needs to be updated first:
 	// Just update the tables separately
 	currDiff := &model.SchemaDiff{
+		// This is only for the case since https://github.com/pingcap/tidb/pull/45877
+		// Fixed now, by adding back the AffectedOpts
+		// to carry the partitioned Table ID.
+		Type:     diff.Type,
 		Version:  diff.Version,
 		TableID:  ntID,
 		SchemaID: ntSchemaID,
+	}
+	if ptID != partID {
+		currDiff.TableID = partID
+		currDiff.OldTableID = ntID
+		currDiff.OldSchemaID = ntSchemaID
 	}
 	ntIDs, err := b.applyTableUpdate(m, currDiff)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	b.markPartitionBundleShouldUpdate(ntID)
-	// Then the partitioned table
+	// Then the partitioned table, will re-read the whole table, including all partitions!
 	currDiff.TableID = ptID
 	currDiff.SchemaID = ptSchemaID
+	currDiff.OldTableID = ptID
+	currDiff.OldSchemaID = ptSchemaID
 	ptIDs, err := b.applyTableUpdate(m, currDiff)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -451,7 +465,8 @@ func (b *Builder) applyTableUpdate(m *meta.Meta, diff *model.SchemaDiff) ([]int6
 		newTableID = diff.TableID
 	case model.ActionDropTable, model.ActionDropView, model.ActionDropSequence:
 		oldTableID = diff.TableID
-	case model.ActionTruncateTable, model.ActionCreateView:
+	case model.ActionTruncateTable, model.ActionCreateView,
+		model.ActionExchangeTablePartition:
 		oldTableID = diff.OldTableID
 		newTableID = diff.TableID
 	default:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46125 close #45791

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:
Build this PR and use it for starting a cluster `tiup playground --db.binpath ./bin/tidb-server`
and then run tiflash test `sh run-test.sh fullstack-test2/ddl/alter_exchange_partition.test` which no longer fails
Also check the tidb.log that there are no failures loading new schema diffs, so no full schema reloads are needed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
(Unless 7.4 get released without this fix).