### PR TITLE
ddl, session: using table ID instead of partition ID when calling `SplitRegions`

### DIFF
--- a/ddl/split_region.go
+++ b/ddl/split_region.go
@@ -42,7 +42,7 @@ func splitPartitionTableRegion(ctx sessionctx.Context, store kv.SplittableStore,
 		}
 	} else {
 		for _, def := range parts {
-			regionIDs = append(regionIDs, SplitRecordRegion(ctxWithTimeout, store, def.ID, scatter))
+			regionIDs = append(regionIDs, SplitRecordRegion(ctxWithTimeout, store, def.ID, tbInfo.ID, scatter))
 		}
 	}
 	if scatter {
@@ -58,7 +58,7 @@ func splitTableRegion(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *
 	if shardingBits(tbInfo) > 0 && tbInfo.PreSplitRegions > 0 {
 		regionIDs = preSplitPhysicalTableByShardRowID(ctxWithTimeout, store, tbInfo, tbInfo.ID, scatter)
 	} else {
-		regionIDs = append(regionIDs, SplitRecordRegion(ctxWithTimeout, store, tbInfo.ID, scatter))
+		regionIDs = append(regionIDs, SplitRecordRegion(ctxWithTimeout, store, tbInfo.ID, tbInfo.ID, scatter))
 	}
 	if scatter {
 		WaitScatterRegionFinish(ctxWithTimeout, store, regionIDs...)
@@ -118,8 +118,8 @@ func preSplitPhysicalTableByShardRowID(ctx context.Context, store kv.SplittableS
 }
 
 // SplitRecordRegion is to split region in store by table prefix.
-func SplitRecordRegion(ctx context.Context, store kv.SplittableStore, tableID int64, scatter bool) uint64 {
-	tableStartKey := tablecodec.GenTablePrefix(tableID)
+func SplitRecordRegion(ctx context.Context, store kv.SplittableStore, physicalTableID, tableID int64, scatter bool) uint64 {
+	tableStartKey := tablecodec.GenTablePrefix(physicalTableID)
 	regionIDs, err := store.SplitRegions(ctx, [][]byte{tableStartKey}, scatter, &tableID)
 	if err != nil {
 		// It will be automatically split by TiKV later.

--- a/session/session.go
+++ b/session/session.go
@@ -3148,7 +3148,7 @@ func splitAndScatterTable(store kv.Storage, tableIDs []int64) {
 		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), variable.DefWaitSplitRegionTimeout*time.Second)
 		var regionIDs []uint64
 		for _, id := range tableIDs {
-			regionIDs = append(regionIDs, ddl.SplitRecordRegion(ctxWithTimeout, s, id, variable.DefTiDBScatterRegion))
+			regionIDs = append(regionIDs, ddl.SplitRecordRegion(ctxWithTimeout, s, id, id, variable.DefTiDBScatterRegion))
 		}
 		if variable.DefTiDBScatterRegion {
 			ddl.WaitScatterRegionFinish(ctxWithTimeout, s, regionIDs...)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46135

Problem Summary:
https://github.com/pingcap/tidb/blob/95b4dcce80d3ad4af89bc9813911af94be7f7a82/ddl/split_region.go#L44-L46

https://github.com/pingcap/tidb/blob/95b4dcce80d3ad4af89bc9813911af94be7f7a82/ddl/split_region.go#L121-L123

https://github.com/tikv/pd/blob/346e7716e2598dfba2db6afa73c3731e15449f49/client/client.go#L1403-L1409
```
	req := &pdpb.ScatterRegionRequest{
		Header:         c.requestHeader(),
		Group:          options.group,
		RegionsId:      regionsID,
		RetryLimit:     options.retryLimit,
		SkipStoreLimit: options.skipStoreLimit,
	}
```

As you can see from the above code, the tableID passed to `SplitRegions` is the ID of the partitioned table. And we use tableID as `Group` pass to PD. So different partition ID uses different group ID in a table which makes the split region is uneven.

### What is changed and how it works?
In the partition table, we use table ID as a group ID to pass PD.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
tidb> select @@global.tidb_scatter_region;
+------------------------------+
| @@global.tidb_scatter_region |
+------------------------------+
|                            1 |
+------------------------------+
1 row in set (0.00 sec)
create table test.t1(id int,b int) shard_row_id_bits=4 partition by hash(id) partitions 2000; 
```

Before this PR:
<img width="914" alt="1" src="https://github.com/pingcap/tidb/assets/4242506/de3a4df4-4db0-43ea-89bd-7ca309290432">


After this PR:
<img width="926" alt="2" src="https://github.com/pingcap/tidb/assets/4242506/70df0cc2-72fc-44b4-9816-e01cd3c06d0e">

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
