### PR TITLE
expression: Replace `initialzied` with `initialized`

### DIFF
--- a/expression/builtin_grouping.go
+++ b/expression/builtin_grouping.go
@@ -229,7 +229,7 @@ func (b *BuiltinGroupingImplSig) grouping(groupingID uint64) int64 {
 // evalInt evals a builtinGroupingSig.
 func (b *BuiltinGroupingImplSig) evalInt(row chunk.Row) (int64, bool, error) {
 	if !b.isMetaInited {
-		return 0, false, errors.Errorf("Meta data is not initialzied")
+		return 0, false, errors.Errorf("Meta data is not initialized")
 	}
 	// grouping function should be rewritten from raw column ref to built gid column and groupingMarks meta.
 	groupingID, isNull, err := b.args[0].EvalInt(b.ctx, row)
@@ -261,7 +261,7 @@ func (b *BuiltinGroupingImplSig) groupingVec(groupingIds *chunk.Column, rowNum i
 
 func (b *BuiltinGroupingImplSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
 	if !b.isMetaInited {
-		return errors.Errorf("Meta data is not initialzied")
+		return errors.Errorf("Meta data is not initialized")
 	}
 	rowNum := input.NumRows()
 


### PR DESCRIPTION
This typo has been introduced via https://github.com/pingcap/tidb/pull/42464

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: None

Problem Summary: Fix typo ref #42464

### What is changed and how it works?
expression: Replace `initialzied` with `initialized`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
