### PR TITLE
*: fix the duplicate entry error when using BR to restore a NONCLUSTERED AUTO_ID_CACHE=1 table (#46127)

### DIFF
--- a/br/tests/br_autoid/run.sh
+++ b/br/tests/br_autoid/run.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+#
+# Copyright 2023 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+DB="$TEST_NAME"
+
+run_sql "create database if not exists ${DB}"
+run_sql "create table $DB.issue46093 (a int primary key nonclustered auto_increment, b int) auto_id_cache = 1;"
+run_sql "insert into $DB.issue46093 (b) values (1), (2), (3);"
+run_sql "show table $DB.issue46093 next_row_id;"
+check_contains "NEXT_GLOBAL_ROW_ID: 30001"
+check_contains "NEXT_GLOBAL_ROW_ID: 4"
+
+run_sql "backup table $DB.issue46093 to 'local://$TEST_DIR/$DB'";
+run_sql "drop table $DB.issue46093;"
+run_sql "restore table $DB.issue46093 from 'local://$TEST_DIR/$DB';"
+
+run_sql "show table $DB.issue46093 next_row_id;"
+check_contains "NEXT_GLOBAL_ROW_ID: 30001"
+check_contains "NEXT_GLOBAL_ROW_ID: 4001"
+run_sql "insert into $DB.issue46093 (b) values (4), (5), (6);"
+run_sql "insert into $DB.issue46093 (b) values (7), (8), (9);"
+run_sql "select * from $DB.issue46093;"
+check_contains "a: 1"
+check_contains "a: 2"
+check_contains "a: 3"
+check_contains "a: 4001"
+check_contains "a: 4002"
+check_contains "a: 4003"
+check_contains "a: 4004"
+check_contains "a: 4005"
+check_contains "a: 4006"
+check_contains "b: 4"
+check_contains "b: 5"
+check_contains "b: 6"
+check_contains "b: 7"
+check_contains "b: 8"
+check_contains "b: 9"

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2514,6 +2514,12 @@ func (d *ddl) createTableWithInfoPost(
 			return errors.Trace(err)
 		}
 	}
+	// For issue https://github.com/pingcap/tidb/issues/46093
+	if tbInfo.AutoIncIDExtra != 0 {
+		if err = d.handleAutoIncID(tbInfo, schemaID, tbInfo.AutoIncIDExtra-1, autoid.RowIDAllocType); err != nil {
+			return errors.Trace(err)
+		}
+	}
 	if tbInfo.AutoRandID > 1 {
 		// Default tableAutoRandID base is 0.
 		// If the first ID is expected to greater than 1, we need to do rebase.

--- a/parser/model/model.go
+++ b/parser/model/model.go
@@ -458,14 +458,29 @@ type TableInfo struct {
 	// 1 for the clustered index created > 5.0.0 RC.
 	CommonHandleVersion uint16 `json:"common_handle_version"`
 
-	Comment         string `json:"comment"`
-	AutoIncID       int64  `json:"auto_inc_id"`
-	AutoIdCache     int64  `json:"auto_id_cache"` //nolint:revive
-	AutoRandID      int64  `json:"auto_rand_id"`
-	MaxColumnID     int64  `json:"max_col_id"`
-	MaxIndexID      int64  `json:"max_idx_id"`
-	MaxForeignKeyID int64  `json:"max_fk_id"`
-	MaxConstraintID int64  `json:"max_cst_id"`
+	Comment   string `json:"comment"`
+	AutoIncID int64  `json:"auto_inc_id"`
+
+	// Only used by BR when:
+	// 1. SepAutoInc() is true
+	// 2. The table is nonclustered and has auto_increment column.
+	// In that case, both auto_increment_id and tidb_rowid need to be backup & recover.
+	// See also https://github.com/pingcap/tidb/issues/46093
+	//
+	// It should have been named TiDBRowID, but for historial reasons, we do not use separate meta key for _tidb_rowid and auto_increment_id,
+	// and field `AutoIncID` is used to serve both _tidb_rowid and auto_increment_id.
+	// If we introduce a TiDBRowID here, it could make furthur misunderstanding:
+	//	in most cases, AutoIncID is _tidb_rowid and TiDBRowID is null
+	//      but in some cases, AutoIncID is auto_increment_id and TiDBRowID is _tidb_rowid
+	// So let's just use another name AutoIncIDExtra to avoid misconception.
+	AutoIncIDExtra int64 `json:"auto_inc_id_extra,omitempty"`
+
+	AutoIdCache     int64 `json:"auto_id_cache"` //nolint:revive
+	AutoRandID      int64 `json:"auto_rand_id"`
+	MaxColumnID     int64 `json:"max_col_id"`
+	MaxIndexID      int64 `json:"max_idx_id"`
+	MaxForeignKeyID int64 `json:"max_fk_id"`
+	MaxConstraintID int64 `json:"max_cst_id"`
 	// UpdateTS is used to record the timestamp of updating the table's schema information.
 	// These changing schema operations don't include 'truncate table' and 'rename table'.
 	UpdateTS uint64 `json:"update_timestamp"`


### PR DESCRIPTION

close pingcap/tidb#46093

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
