### PR TITLE
planner: use fixed TblInfoID in `stabilizeGetStatsTblInfo`

### DIFF
--- a/planner/core/debugtrace.go
+++ b/planner/core/debugtrace.go
@@ -202,6 +202,7 @@ func debugTraceGetStatsTbl(
 	root.AppendStepToCurrentContext(traceInfo)
 }
 
+// Only for test.
 func stabilizeGetStatsTblInfo(info *getStatsTblInfo) {
 	info.TblInfoID = 100
 	info.InputPhysicalID = 100

--- a/planner/core/debugtrace.go
+++ b/planner/core/debugtrace.go
@@ -203,6 +203,7 @@ func debugTraceGetStatsTbl(
 }
 
 func stabilizeGetStatsTblInfo(info *getStatsTblInfo) {
+	info.TblInfoID = 100
 	info.InputPhysicalID = 100
 	tbl := info.StatsTblInfo
 	if tbl == nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -34,6 +34,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// cmd: go test -run=^TestOptimizerDebugTrace$ --tags=intest github.com/pingcap/tidb/server
+// If you want to update the test result, please run the following command:
+// cmd: go test -run=^TestOptimizerDebugTrace$ --tags=intest github.com/pingcap/tidb/server --record
 func TestOptimizerDebugTrace(t *testing.T) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/planner/SetBindingTimeToZero", `return(true)`))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/planner/core/DebugTraceStableStatsTbl", `return(true)`))

--- a/server/testdata/optimizer_suite_out.json
+++ b/server/testdata/optimizer_suite_out.json
@@ -71,7 +71,7 @@
                   "Version": 440930000000000000
                 },
                 "TableName": "t",
-                "TblInfoID": 98,
+                "TblInfoID": 100,
                 "Uninitialized": true,
                 "UsePartitionStats": false
               }
@@ -139,7 +139,7 @@
                                 "Version": 440930000000000000
                               },
                               "TableName": "t",
-                              "TblInfoID": 98,
+                              "TblInfoID": 100,
                               "Uninitialized": true,
                               "UsePartitionStats": false
                             }
@@ -379,7 +379,7 @@
                             "Version": 440930000000000000
                           },
                           "TableName": "t",
-                          "TblInfoID": 98,
+                          "TblInfoID": 100,
                           "Uninitialized": true,
                           "UsePartitionStats": false
                         }
@@ -550,7 +550,7 @@
                   "Version": 440930000000000000
                 },
                 "TableName": "t",
-                "TblInfoID": 98,
+                "TblInfoID": 100,
                 "Uninitialized": true,
                 "UsePartitionStats": false
               }
@@ -618,7 +618,7 @@
                                 "Version": 440930000000000000
                               },
                               "TableName": "t",
-                              "TblInfoID": 98,
+                              "TblInfoID": 100,
                               "Uninitialized": true,
                               "UsePartitionStats": false
                             }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46229

Problem Summary:

### What is changed and how it works?

Used fixed TblInfoID in `stabilizeGetStatsTblInfo`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
