### PR TITLE
planner: refactor `Next` function of `AnalyzeExec`

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -179,7 +179,7 @@ func filterAndCollectTasks(tasks []*analyzeTask, statsHandle *handle.Handle, inf
 	for _, task := range tasks {
 		tableID := getTableIDFromTask(task)
 		isLocked := statsHandle.IsTableLocked(tableID)
-		if isLocked {
+		if !isLocked {
 			filteredTasks = append(filteredTasks, task)
 		}
 		if _, ok := tids[tableID]; !ok {

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -99,7 +99,7 @@ func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 		return nil
 	}
 
-	// Get the max number of goroutines for parallel execution.
+	// Get the min number of goroutines for parallel execution.
 	concurrency, err := getBuildStatsConcurrency(e.Ctx())
 	if err != nil {
 		return err

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -183,6 +183,7 @@ func filterAndCollectTasks(tasks []*analyzeTask, statsHandle *handle.Handle, inf
 			if statsHandle.IsTableLocked(tableID) {
 				tbl, ok := infoSchema.TableByID(tableID)
 				if !ok {
+					logutil.BgLogger().Warn("Unknown table ID in analyze task", zap.Int64("tid", tableID))
 					continue
 				}
 				skippedTables = append(skippedTables, tbl.Meta().Name.L)

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -171,10 +171,12 @@ func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 
 // filterAndCollectTasks filters the tasks that are not locked and collects the table IDs.
 func filterAndCollectTasks(tasks []*analyzeTask, statsHandle *handle.Handle, infoSchema infoschema.InfoSchema) ([]*analyzeTask, uint, []string) {
-	var filteredTasks []*analyzeTask
-	tids := make(map[int64]struct{})
-	var skippedTables []string
-	needAnalyzeTableCnt := uint(0)
+	var (
+		filteredTasks       []*analyzeTask
+		skippedTables       []string
+		needAnalyzeTableCnt uint
+		tids                = make(map[int64]struct{})
+	)
 
 	for _, task := range tasks {
 		tableID := getTableIDFromTask(task)

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -198,13 +198,13 @@ func filterAndCollectTasks(tasks []*analyzeTask, statsHandle *handle.Handle, inf
 func warnLockedTableMsg(sessionVars *variable.SessionVars, tids map[int64]struct{}, skippedTables []string) {
 	if len(skippedTables) > 0 {
 		tables := strings.Join(skippedTables, ", ")
-		msg := "skip analyze locked table"
+		msg := "skip analyze locked table: %s"
 		if len(tids) > 1 {
 			if len(tids) > len(skippedTables) {
-				msg = "skip analyze locked tables"
+				msg = "skip analyze locked tables: %s, other tables will be analyzed"
 			}
 		}
-		sessionVars.StmtCtx.AppendWarning(errors.New(msg + ": " + tables))
+		sessionVars.StmtCtx.AppendWarning(errors.Errorf(msg, tables))
 	}
 }
 

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -201,9 +201,14 @@ func filterAndCollectTasks(tasks []*analyzeTask, statsHandle *handle.Handle, inf
 func warnLockedTableMsg(sessionVars *variable.SessionVars, tids map[int64]struct{}, skippedTables []string) {
 	if len(skippedTables) > 0 {
 		tables := strings.Join(skippedTables, ", ")
-		msg := "skip analyze locked table: %s"
-		if len(skippedTables) > 1 && len(tids) > len(skippedTables) {
-			msg = "skip analyze locked tables: %s, other tables will be analyzed"
+		var msg string
+		if len(skippedTables) > 1 {
+			msg = "skip analyze locked tables: %s"
+			if len(tids) > 0 {
+				msg = "skip analyze locked tables: %s, other tables will be analyzed"
+			}
+		} else {
+			msg = "skip analyze locked table: %s"
 		}
 		sessionVars.StmtCtx.AppendWarning(errors.Errorf(msg, tables))
 	}

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -109,7 +109,7 @@ func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 
 	// Start workers with channel to collect results.
 	taskCh := make(chan *analyzeTask, concurrency)
-	resultsCh := make(chan *statistics.AnalyzeResults, concurrency)
+	resultsCh := make(chan *statistics.AnalyzeResults, len(tasks))
 	for i := 0; i < concurrency; i++ {
 		e.wg.Run(func() { e.analyzeWorker(taskCh, resultsCh) })
 	}

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -88,79 +88,31 @@ const (
 // It will collect all the sample task and run them concurrently.
 func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	statsHandle := domain.GetDomain(e.Ctx()).StatsHandle()
-	var tasks []*analyzeTask
-	tids := make(map[int64]struct{}) // use a set for tid
-	skippedTables := make([]string, 0)
-	is := e.Ctx().GetInfoSchema().(infoschema.InfoSchema)
-	for _, task := range e.tasks {
-		var tableID statistics.AnalyzeTableID
-		switch task.taskType {
-		case colTask:
-			tableID = task.colExec.tableID
-		case idxTask:
-			tableID = task.idxExec.tableID
-		case fastTask:
-			tableID = task.fastExec.tableID
-		case pkIncrementalTask:
-			tableID = task.colIncrementalExec.tableID
-		case idxIncrementalTask:
-			tableID = task.idxIncrementalExec.tableID
-		}
-		// skip locked tables
-		if !statsHandle.IsTableLocked(tableID.TableID) {
-			tasks = append(tasks, task)
-		}
-		// generate warning message
-		if _, ok := tids[tableID.TableID]; !ok {
-			if statsHandle.IsTableLocked(tableID.TableID) {
-				tbl, ok := is.TableByID(tableID.TableID)
-				if !ok {
-					return nil
-				}
-				skippedTables = append(skippedTables, tbl.Meta().Name.L)
-			}
-			tids[tableID.TableID] = struct{}{}
-		}
-	}
+	infoSchema := e.Ctx().GetInfoSchema().(infoschema.InfoSchema)
+	sessionVars := e.Ctx().GetSessionVars()
 
-	if len(skippedTables) > 0 {
-		tables := skippedTables[0]
-		for i, table := range skippedTables {
-			if i == 0 {
-				continue
-			}
-			tables += ", " + table
-		}
-		var msg string
-		if len(tids) > 1 {
-			if len(tids) > len(skippedTables) {
-				msg = "skip analyze locked tables: " + tables + ", other tables will be analyzed"
-			} else {
-				msg = "skip analyze locked tables: " + tables
-			}
-		} else {
-			msg = "skip analyze locked table: " + tables
-		}
-
-		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.New(msg))
-	}
+	// Filter the locked tables.
+	tasks, tids, skippedTables := filterAndCollectTasks(e.tasks, statsHandle, infoSchema)
+	warnLockedTableMsg(sessionVars, tids, skippedTables)
 
 	if len(tasks) == 0 {
 		return nil
 	}
 
+	// Get the max number of goroutines for parallel execution.
 	concurrency, err := getBuildStatsConcurrency(e.Ctx())
 	if err != nil {
 		return err
 	}
-	taskCh := make(chan *analyzeTask, len(tasks))
-	resultsCh := make(chan *statistics.AnalyzeResults, len(tasks))
-	if len(tasks) < concurrency {
-		concurrency = len(tasks)
-	}
+	concurrency = min(len(tasks), concurrency)
+
+	// Start workers with channel to collect results.
+	taskCh := make(chan *analyzeTask, concurrency)
+	resultsCh := make(chan *statistics.AnalyzeResults, concurrency)
 	for i := 0; i < concurrency; i++ {
 		e.wg.Run(func() { e.analyzeWorker(taskCh, resultsCh) })
 	}
+
 	for _, task := range tasks {
 		prepareV2AnalyzeJobInfo(task.colExec, false)
 		AddNewAnalyzeJob(e.Ctx(), task.job)
@@ -169,13 +121,17 @@ func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 		dom := domain.GetDomain(e.Ctx())
 		dom.SysProcTracker().KillSysProcess(dom.GetAutoAnalyzeProcID())
 	})
+
 	for _, task := range tasks {
 		taskCh <- task
 	}
 	close(taskCh)
+
+	// Wait all workers done and close the results channel.
 	e.wg.Wait()
 	close(resultsCh)
-	pruneMode := variable.PartitionPruneMode(e.Ctx().GetSessionVars().PartitionPruneMode.Load())
+
+	pruneMode := variable.PartitionPruneMode(sessionVars.PartitionPruneMode.Load())
 	// needGlobalStats used to indicate whether we should merge the partition-level stats to global-level stats.
 	needGlobalStats := pruneMode == variable.Dynamic
 	globalStatsMap := make(map[globalStatsKey]globalStatsInfo)
@@ -198,14 +154,77 @@ func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	if err != nil {
 		return err
 	}
+
+	// Update analyze options to mysql.analyze_options for auto analyze.
 	err = e.saveV2AnalyzeOpts()
 	if err != nil {
-		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(err)
+		sessionVars.StmtCtx.AppendWarning(err)
 	}
-	if e.Ctx().GetSessionVars().InRestrictedSQL {
-		return statsHandle.Update(e.Ctx().GetInfoSchema().(infoschema.InfoSchema))
+
+	if sessionVars.InRestrictedSQL {
+		return statsHandle.Update(infoSchema)
 	}
-	return statsHandle.Update(e.Ctx().GetInfoSchema().(infoschema.InfoSchema), cache.WithTableStatsByQuery())
+
+	return statsHandle.Update(infoSchema, cache.WithTableStatsByQuery())
+}
+
+// filterAndCollectTasks filters the tasks that are not locked and collects the table IDs.
+func filterAndCollectTasks(tasks []*analyzeTask, statsHandle *handle.Handle, infoSchema infoschema.InfoSchema) ([]*analyzeTask, map[int64]struct{}, []string) {
+	var filteredTasks []*analyzeTask
+	tids := make(map[int64]struct{})
+	var skippedTables []string
+
+	for _, task := range tasks {
+		tableID := getTableIDFromTask(task)
+		if !statsHandle.IsTableLocked(tableID) {
+			filteredTasks = append(filteredTasks, task)
+		}
+		if _, ok := tids[tableID]; !ok {
+			if statsHandle.IsTableLocked(tableID) {
+				tbl, ok := infoSchema.TableByID(tableID)
+				if !ok {
+					continue
+				}
+				skippedTables = append(skippedTables, tbl.Meta().Name.L)
+			}
+			tids[tableID] = struct{}{}
+		}
+	}
+
+	return filteredTasks, tids, skippedTables
+}
+
+// warnLockedTableMsg warns the locked table IDs.
+func warnLockedTableMsg(sessionVars *variable.SessionVars, tids map[int64]struct{}, skippedTables []string) {
+	if len(skippedTables) > 0 {
+		tables := strings.Join(skippedTables, ", ")
+		msg := "skip analyze locked table"
+		if len(tids) > 1 {
+			if len(tids) > len(skippedTables) {
+				msg = "skip analyze locked tables"
+			}
+		}
+		sessionVars.StmtCtx.AppendWarning(errors.New(msg + ": " + tables))
+	}
+}
+
+func getTableIDFromTask(task *analyzeTask) int64 {
+	var tableID statistics.AnalyzeTableID
+
+	switch task.taskType {
+	case colTask:
+		tableID = task.colExec.tableID
+	case idxTask:
+		tableID = task.idxExec.tableID
+	case fastTask:
+		tableID = task.fastExec.tableID
+	case pkIncrementalTask:
+		tableID = task.colIncrementalExec.tableID
+	case idxIncrementalTask:
+		tableID = task.idxIncrementalExec.tableID
+	}
+
+	return tableID.TableID
 }
 
 func (e *AnalyzeExec) saveV2AnalyzeOpts() error {

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -184,7 +184,7 @@ func filterAndCollectTasks(tasks []*analyzeTask, statsHandle *handle.Handle, inf
 			if statsHandle.IsTableLocked(tableID) {
 				tbl, ok := infoSchema.TableByID(tableID)
 				if !ok {
-					logutil.BgLogger().Debug("Unknown table ID in analyze task", zap.Int64("tid", tableID))
+					logutil.BgLogger().Warn("Unknown table ID in analyze task", zap.Int64("tid", tableID))
 					// Ignore this table because it may have been dropped.
 					continue
 				}
@@ -202,10 +202,8 @@ func warnLockedTableMsg(sessionVars *variable.SessionVars, tids map[int64]struct
 	if len(skippedTables) > 0 {
 		tables := strings.Join(skippedTables, ", ")
 		msg := "skip analyze locked table: %s"
-		if len(tids) > 1 {
-			if len(tids) > len(skippedTables) {
-				msg = "skip analyze locked tables: %s, other tables will be analyzed"
-			}
+		if len(skippedTables) > 1 && len(tids) > len(skippedTables) {
+			msg = "skip analyze locked tables: %s, other tables will be analyzed"
 		}
 		sessionVars.StmtCtx.AppendWarning(errors.Errorf(msg, tables))
 	}

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -194,7 +194,7 @@ func filterAndCollectTasks(tasks []*analyzeTask, statsHandle *handle.Handle, inf
 				}
 				skippedTables = append(skippedTables, tbl.Meta().Name.L)
 			} else {
-				needAnalyzeTableCnt += 1
+				needAnalyzeTableCnt++
 			}
 			tids[tableID] = struct{}{}
 		}

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -184,7 +184,8 @@ func filterAndCollectTasks(tasks []*analyzeTask, statsHandle *handle.Handle, inf
 			if statsHandle.IsTableLocked(tableID) {
 				tbl, ok := infoSchema.TableByID(tableID)
 				if !ok {
-					logutil.BgLogger().Warn("Unknown table ID in analyze task", zap.Int64("tid", tableID))
+					logutil.BgLogger().Debug("Unknown table ID in analyze task", zap.Int64("tid", tableID))
+					// Ignore this table because it may have been dropped.
 					continue
 				}
 				skippedTables = append(skippedTables, tbl.Meta().Name.L)

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -188,11 +188,11 @@ func filterAndCollectTasks(tasks []*analyzeTask, statsHandle *handle.Handle, inf
 			if isLocked {
 				tbl, ok := infoSchema.TableByID(tableID)
 				if !ok {
-					logutil.BgLogger().Warn("Unknown table ID in analyze task", zap.Int64("tid", tableID))
 					// Ignore this table because it may have been dropped.
-					continue
+					logutil.BgLogger().Warn("Unknown table ID in analyze task", zap.Int64("tid", tableID))
+				} else {
+					skippedTables = append(skippedTables, tbl.Meta().Name.L)
 				}
-				skippedTables = append(skippedTables, tbl.Meta().Name.L)
 			} else {
 				needAnalyzeTableCnt++
 			}

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessiontxn"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/statistics/handle"
 	"github.com/pingcap/tidb/statistics/handle/cache"
@@ -88,7 +89,7 @@ const (
 // It will collect all the sample task and run them concurrently.
 func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	statsHandle := domain.GetDomain(e.Ctx()).StatsHandle()
-	infoSchema := e.Ctx().GetInfoSchema().(infoschema.InfoSchema)
+	infoSchema := sessiontxn.GetTxnManager(e.Ctx()).GetTxnInfoSchema()
 	sessionVars := e.Ctx().GetSessionVars()
 
 	// Filter the locked tables.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: None

Problem Summary:

### What is changed and how it works?

- Split the `Next` function into small functions
- Used minimal channel size: `concurrency = min(len(tasks), concurrency)`
- Called `e.Ctx().GetSessionVars()` only once
- Used `strings.Join` to generate the warning message

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
