### PR TITLE
pkg/lightning: retry individual scatter region

### DIFF
--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -399,7 +399,7 @@ func (local *Backend) SplitAndScatterRegionByRanges(
 	return nil
 }
 
-// it scatter region and retry if it fails. It retuns error if can not scatter after max_retry
+// it scatter region and retry if it fails. It returns error if can not scatter after max_retry
 func (local *Backend) ScatterRegion(ctx context.Context, regionInfo *split.RegionInfo) error {
 	backoffer := split.NewWaitRegionOnlineBackoffer().(*split.WaitRegionOnlineBackoffer)
 	_ = utils.WithRetry(ctx, func() error {

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -471,7 +471,7 @@ func (local *Backend) BatchSplitRegions(
 	scatterRegions := newRegions
 	for _, region := range scatterRegions {
 		err = local.ScatterRegion(ctx, region)
-		if failedErr == nil {
+		if err != nil && failedErr == nil {
 			failedErr = errors.Annotatef(berrors.ErrPDBatchScanRegion, "scatter region failed")
 		}
 	}

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -468,6 +468,7 @@ func (local *Backend) BatchSplitRegions(
 	}
 
 	// scatter regions
+	failedErr = nil
 	scatterRegions := newRegions
 	for _, region := range scatterRegions {
 		err = local.ScatterRegion(ctx, region)

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -482,7 +482,7 @@ func (local *Backend) BatchSplitRegions(
 	for _, region := range scatterRegions {
 		err = local.ScatterRegion(ctx, region)
 		if err != nil && failedErr == nil {
-			failedErr = errors.Annotatef(berrors.ErrPDBatchScanRegion, "scatter region failed")
+			failedErr = err
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46203

Problem Summary:
Lightning try to scatter all the regions and at the end it backoff and retry it again. It causes few issues
1. If we are hiting a store limit, than further scatter regions cause unnecessarily load on PD. 
2. Regions can be skewed as stores are allocated based on number of scatter operation scheduled. It doesn't take into number of scatter operations cancelled because of store limit.
 
### What is changed and how it works?
I am proposing the change similar to tikv go client which doesn't retry and back off after scattering all the regions. 

https://github.com/tikv/client-go/blob/a0ac170698524cbf20a869cb3471e969608d599a/tikv/split_region.go#L198

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)

I tested the similar logic in 6.5 and 6.6 by using the below steps
1. Set store limit to 16
2. Parallel import and verify that regions are not skewed


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
