### PR TITLE
planner: remove outer join on unique keys when there is no column referenced

### DIFF
--- a/executor/test/partitiontest/partition_test.go
+++ b/executor/test/partitiontest/partition_test.go
@@ -496,10 +496,8 @@ func TestPartitionOnMissing(t *testing.T) {
 		left join tt1 on tt1.listid=tt2.listid`).Check(testkit.Rows("5"))
 	tk.MustQuery(`explain format = 'brief' select /*+ inl_join(tt1)*/ count(*) from tt2
 		left join tt1 on tt1.listid=tt2.listid`).Check(testkit.Rows(""+
-		"StreamAgg 1.00 root  funcs:count(1)->Column#7",
-		"└─IndexJoin 5.00 root  left outer join, inner:TableReader, outer key:onmissing.tt2.listid, inner key:onmissing.tt1.listid, equal cond:eq(onmissing.tt2.listid, onmissing.tt1.listid)",
-		"  ├─IndexReader(Build) 5.00 root  index:IndexFullScan",
-		"  │ └─IndexFullScan 5.00 cop[tikv] table:tt2, index:idx_listid(listid) keep order:false",
-		"  └─TableReader(Probe) 4.00 root partition:all data:TableRangeScan",
-		"    └─TableRangeScan 4.00 cop[tikv] table:tt1 range: decided by [onmissing.tt2.listid], keep order:false"))
+		"StreamAgg 1.00 root  funcs:count(Column#13)->Column#7",
+		"└─IndexReader 1.00 root  index:StreamAgg",
+		"  └─StreamAgg 1.00 cop[tikv]  funcs:count(1)->Column#13",
+		"    └─IndexFullScan 5.00 cop[tikv] table:tt2, index:idx_listid(listid) keep order:false"))
 }

--- a/planner/core/testdata/plan_suite_unexported_in.json
+++ b/planner/core/testdata/plan_suite_unexported_in.json
@@ -546,6 +546,12 @@
   {
     "name": "TestOuterJoinEliminator",
     "cases": [
+      // Test no column reference from left outer join
+      "select count(*) from t t1 left outer join t t2 on t1.a = t2.a",
+      "select 1 from t t1 left outer join t t2 on t1.a = t2.a",
+      // Test no column reference from right outer join
+      "select count(*) from t t1 right outer join t t2 on t1.a = t2.a",
+      "select 2 from t t1 right outer join t t2 on t1.a = t2.a",
       // Test left outer join + distinct
       "select distinct t1.a, t1.b from t t1 left outer join t t2 on t1.b = t2.b",
       // Test right outer join + distinct

--- a/planner/core/testdata/plan_suite_unexported_out.json
+++ b/planner/core/testdata/plan_suite_unexported_out.json
@@ -971,6 +971,10 @@
   {
     "Name": "TestOuterJoinEliminator",
     "Cases": [
+      "DataScan(t1)->Aggr(count(1))->Projection",
+      "DataScan(t1)->Projection",
+      "DataScan(t2)->Aggr(count(1))->Projection",
+      "DataScan(t2)->Projection",
       "DataScan(t1)->Projection",
       "DataScan(t2)->Projection",
       "DataScan(t1)->Aggr(max(test.t.a),min(test.t.b))->Projection",

--- a/tests/integrationtest/r/explain_easy.result
+++ b/tests/integrationtest/r/explain_easy.result
@@ -378,28 +378,22 @@ Projection	5.00	root		Column#17
 └─Apply	5.00	root		CARTESIAN left outer semi join, other cond:eq(explain_easy.t.c, Column#16)
   ├─TableReader(Build)	5.00	root		data:TableFullScan
   │ └─TableFullScan	5.00	cop[tikv]	table:t	keep order:false
-  └─StreamAgg(Probe)	5.00	root		funcs:count(1)->Column#16
-    └─MergeJoin	12.00	root		left outer join, left key:explain_easy.t.a, right key:explain_easy.t.a
-      ├─TableReader(Build)	20.00	root		data:Selection
-      │ └─Selection	20.00	cop[tikv]		eq(3, explain_easy.t.a)
-      │   └─TableFullScan	25.00	cop[tikv]	table:t1	keep order:true
-      └─IndexReader(Probe)	12.00	root		index:Selection
+  └─StreamAgg(Probe)	5.00	root		funcs:count(Column#19)->Column#16
+    └─IndexReader	5.00	root		index:StreamAgg
+      └─StreamAgg	5.00	cop[tikv]		funcs:count(1)->Column#19
         └─Selection	12.00	cop[tikv]		eq(3, explain_easy.t.a)
-          └─IndexRangeScan	15.00	cop[tikv]	table:s, index:idx(b)	range:[3,3], keep order:true
+          └─IndexRangeScan	15.00	cop[tikv]	table:s, index:idx(b)	range:[3,3], keep order:false
 explain format = 'brief' select t.c in (select count(*) from t s right join t t1 on s.a = t1.a where 3 = t.a and t1.b = 3) from t;
 id	estRows	task	access object	operator info
 Projection	5.00	root		Column#17
 └─Apply	5.00	root		CARTESIAN left outer semi join, other cond:eq(explain_easy.t.c, Column#16)
   ├─TableReader(Build)	5.00	root		data:TableFullScan
   │ └─TableFullScan	5.00	cop[tikv]	table:t	keep order:false
-  └─StreamAgg(Probe)	5.00	root		funcs:count(1)->Column#16
-    └─MergeJoin	12.00	root		right outer join, left key:explain_easy.t.a, right key:explain_easy.t.a
-      ├─TableReader(Build)	20.00	root		data:Selection
-      │ └─Selection	20.00	cop[tikv]		eq(3, explain_easy.t.a)
-      │   └─TableFullScan	25.00	cop[tikv]	table:s	keep order:true
-      └─IndexReader(Probe)	12.00	root		index:Selection
+  └─StreamAgg(Probe)	5.00	root		funcs:count(Column#19)->Column#16
+    └─IndexReader	5.00	root		index:StreamAgg
+      └─StreamAgg	5.00	cop[tikv]		funcs:count(1)->Column#19
         └─Selection	12.00	cop[tikv]		eq(3, explain_easy.t.a)
-          └─IndexRangeScan	15.00	cop[tikv]	table:t1, index:idx(b)	range:[3,3], keep order:true
+          └─IndexRangeScan	15.00	cop[tikv]	table:t1, index:idx(b)	range:[3,3], keep order:false
 drop table if exists t;
 create table t(a int unsigned not null);
 explain format = 'brief' select t.a = '123455' from t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #46248 

Problem Summary:
Previously we check all the referenced columns come from outer table or not, if yes, then we proceed to check whether we can eliminate outer join or not. However, when there is no column referenced from outer table and inner table, e.g. SELECT 1 FROM R LOJ S ON x=y, there is no column matching with outer table columns, we decided that we can't eliminate outer join, which is incorrect.

### What is changed and how it works?
This patch fixes above issue by checking as long as there is no column referenced from inner table, we should continue to next step to see whether we can remove outer join or not, instead of bailing out quickly.

### Check List

Tests 

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
