### PR TITLE
pkg/backup: fix test case br_autoid for the previous cherry-pick

### DIFF
--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -577,7 +577,8 @@ func BuildBackupRangeAndSchema(
 				// no auto ID for views or table without either rowID nor auto_increment ID.
 			default:
 				if tableInfo.SepAutoInc() {
-					globalAutoID, err = autoIDAccess.IncrementID(tableInfo.Version).Get()
+					// NextXXXID = XXXID + 1
+					globalAutoID, err = autoIDAccess.IncrementID(tableInfo.Version).Get() + 1
 					// For a nonclustered table with auto_increment column, both auto_increment_id and _tidb_rowid are required.
 					// See also https://github.com/pingcap/tidb/issues/46093
 					if rowID, err1 := autoIDAccess.RowID().Get(); err1 == nil {

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -577,8 +577,7 @@ func BuildBackupRangeAndSchema(
 				// no auto ID for views or table without either rowID nor auto_increment ID.
 			default:
 				if tableInfo.SepAutoInc() {
-					// NextXXXID = XXXID + 1
-					globalAutoID, err = autoIDAccess.IncrementID(tableInfo.Version).Get() + 1
+					globalAutoID, err = autoIDAccess.IncrementID(tableInfo.Version).Get()
 					// For a nonclustered table with auto_increment column, both auto_increment_id and _tidb_rowid are required.
 					// See also https://github.com/pingcap/tidb/issues/46093
 					if rowID, err1 := autoIDAccess.RowID().Get(); err1 == nil {
@@ -593,6 +592,8 @@ func BuildBackupRangeAndSchema(
 						// Print a warning in other scenes, should it be a INFO log?
 						log.Warn("get rowid error", zap.Error(err1))
 					}
+					// NextGlobalAutoID = globalAutoID  + 1
+					globalAutoID = globalAutoID + 1
 				} else {
 					globalAutoID, err = idAlloc.NextGlobalAutoID()
 				}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46093

Problem Summary:

### What is changed and how it works?

In the previous cherry-pick https://github.com/pingcap/tidb/pull/46217
I didn't notice the subtle difference between master and v6.5 branch.

Before this PR:
https://github.com/pingcap/tidb/commit/91f675247d5a763aeac7e2f8232b8fd8986a5917#diff-e611f02c279107dbfa433418c809e99569c0b24c2ea92cc7aef9f7f41fbcc3b9L581 

old version use 

```
idAlloc.NextGlobalAutoID()
```

and master use

```
rowID + 1
```

The semantic is the same, but the tiny code struct change make the previous cherry-pick introduce a bug and break CI.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
