### PR TITLE
disttask: fix wrongly add subtask when state transform fail

### DIFF
--- a/disttask/framework/BUILD.bazel
+++ b/disttask/framework/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         "//disttask/framework/dispatcher",
         "//disttask/framework/proto",

--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -219,12 +219,10 @@ func (d *dispatcher) updateTask(taskState string, newSubTasks []*proto.Subtask, 
 		return errors.Errorf("invalid task state transform, from %s to %s", prevState, taskState)
 	}
 
-	failpoint.Inject("cancelBeforeUpdate", func(val failpoint.Value) {
-		if val.(bool) {
-			err := d.taskMgr.CancelGlobalTask(d.task.ID)
-			if err != nil {
-				logutil.Logger(d.logCtx).Error("cancel task failed", zap.Error(err))
-			}
+	failpoint.Inject("cancelBeforeUpdate", func() {
+		err := d.taskMgr.CancelGlobalTask(d.task.ID)
+		if err != nil {
+			logutil.Logger(d.logCtx).Error("cancel task failed", zap.Error(err))
 		}
 	})
 	var retryable bool
@@ -269,10 +267,6 @@ func (d *dispatcher) dispatchSubTask4Revert(task *proto.Task, handle TaskFlowHan
 	if err != nil {
 		logutil.Logger(d.logCtx).Warn("get task's all instances failed", zap.Error(err))
 		return err
-	}
-
-	if len(instanceIDs) == 0 {
-		return d.updateTask(proto.TaskStateReverted, nil, retrySQLTimes)
 	}
 
 	subTasks := make([]*proto.Subtask, 0, len(instanceIDs))
@@ -420,7 +414,7 @@ func (d *dispatcher) WithNewTxn(ctx context.Context, fn func(se sessionctx.Conte
 }
 
 // VerifyTaskStateTransform verifies whether the task state transform is valid.
-func VerifyTaskStateTransform(oldState, newState string) bool {
+func VerifyTaskStateTransform(from, to string) bool {
 	rules := map[string][]string{
 		proto.TaskStatePending: {
 			proto.TaskStateRunning,
@@ -446,7 +440,6 @@ func VerifyTaskStateTransform(oldState, newState string) bool {
 		proto.TaskStateRevertFailed: {},
 		proto.TaskStateCancelling: {
 			proto.TaskStateReverting,
-			proto.TaskStateReverted,
 			// no canceled now
 			// proto.TaskStateCanceled,
 		},
@@ -463,14 +456,14 @@ func VerifyTaskStateTransform(oldState, newState string) bool {
 		proto.TaskStateRevertPending: {},
 		proto.TaskStateReverted:      {},
 	}
-	logutil.BgLogger().Info("task state transform", zap.String("oldState", oldState), zap.String("newState", newState))
+	logutil.BgLogger().Info("task state transform", zap.String("from", from), zap.String("to", to))
 
-	if oldState == newState {
+	if from == to {
 		return true
 	}
 
-	for _, state := range rules[oldState] {
-		if state == newState {
+	for _, state := range rules[from] {
+		if state == to {
 			return true
 		}
 	}

--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -219,9 +219,17 @@ func (d *dispatcher) updateTask(taskState string, newSubTasks []*proto.Subtask, 
 		return errors.Errorf("invalid task state transform, from %s to %s", prevState, taskState)
 	}
 
+	failpoint.Inject("cancelBeforeUpdate", func(val failpoint.Value) {
+		if val.(bool) {
+			err := d.taskMgr.CancelGlobalTask(d.task.ID)
+			if err != nil {
+				logutil.Logger(d.logCtx).Error("cancel task failed", zap.Error(err))
+			}
+		}
+	})
 	for i := 0; i < retryTimes; i++ {
-		err = d.taskMgr.UpdateGlobalTaskAndAddSubTasks(d.task, newSubTasks, prevState)
-		if err == nil {
+		retryable, err := d.taskMgr.UpdateGlobalTaskAndAddSubTasks(d.task, newSubTasks, prevState)
+		if err == nil || !retryable {
 			break
 		}
 		if i%10 == 0 {
@@ -343,7 +351,6 @@ func (d *dispatcher) dispatchSubTask(task *proto.Task, handle TaskFlowHandle, me
 		logutil.Logger(d.logCtx).Debug("create subtasks", zap.String("instanceID", instanceID))
 		subTasks = append(subTasks, proto.NewSubtask(task.ID, task.Type, instanceID, meta))
 	}
-
 	return d.updateTask(proto.TaskStateRunning, subTasks, retrySQLTimes)
 }
 
@@ -438,6 +445,7 @@ func VerifyTaskStateTransform(oldState, newState string) bool {
 		proto.TaskStateRevertFailed: {},
 		proto.TaskStateCancelling: {
 			proto.TaskStateReverting,
+			proto.TaskStateReverted,
 			// no canceled now
 			// proto.TaskStateCanceled,
 		},
@@ -454,6 +462,7 @@ func VerifyTaskStateTransform(oldState, newState string) bool {
 		proto.TaskStateRevertPending: {},
 		proto.TaskStateReverted:      {},
 	}
+	logutil.BgLogger().Info(fmt.Sprintf("task state transform, from %s to %s", oldState, newState))
 
 	if oldState == newState {
 		return true

--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -227,8 +227,9 @@ func (d *dispatcher) updateTask(taskState string, newSubTasks []*proto.Subtask, 
 			}
 		}
 	})
+	retryable := true
 	for i := 0; i < retryTimes; i++ {
-		retryable, err := d.taskMgr.UpdateGlobalTaskAndAddSubTasks(d.task, newSubTasks, prevState)
+		retryable, err = d.taskMgr.UpdateGlobalTaskAndAddSubTasks(d.task, newSubTasks, prevState)
 		if err == nil || !retryable {
 			break
 		}
@@ -462,7 +463,7 @@ func VerifyTaskStateTransform(oldState, newState string) bool {
 		proto.TaskStateRevertPending: {},
 		proto.TaskStateReverted:      {},
 	}
-	logutil.BgLogger().Info(fmt.Sprintf("task state transform, from %s to %s", oldState, newState))
+	logutil.BgLogger().Info("task state transform", zap.String("oldState", oldState), zap.String("newState", newState))
 
 	if oldState == newState {
 		return true

--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -227,7 +227,7 @@ func (d *dispatcher) updateTask(taskState string, newSubTasks []*proto.Subtask, 
 			}
 		}
 	})
-	retryable := true
+	var retryable bool
 	for i := 0; i < retryTimes; i++ {
 		retryable, err = d.taskMgr.UpdateGlobalTaskAndAddSubTasks(d.task, newSubTasks, prevState)
 		if err == nil || !retryable {

--- a/disttask/framework/framework_test.go
+++ b/disttask/framework/framework_test.go
@@ -346,3 +346,15 @@ func TestOwnerChange(t *testing.T) {
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/disttask/framework/dispatcher/mockOwnerChange"))
 	distContext.Close()
 }
+
+func TestFrameworkCancelThenSubmitSubTask(t *testing.T) {
+	defer dispatcher.ClearTaskFlowHandle()
+	defer scheduler.ClearSchedulers()
+	var m sync.Map
+	RegisterTaskMeta(&m)
+	distContext := testkit.NewDistExecutionContext(t, 3)
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/disttask/framework/dispatcher/cancelBeforeUpdate", "1*return(true)"))
+	DispatchTaskAndCheckFail("😊", t, &m)
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/disttask/framework/dispatcher/cancelBeforeUpdate"))
+	distContext.Close()
+}

--- a/disttask/framework/framework_test.go
+++ b/disttask/framework/framework_test.go
@@ -353,7 +353,7 @@ func TestFrameworkCancelThenSubmitSubTask(t *testing.T) {
 	var m sync.Map
 	RegisterTaskMeta(&m)
 	distContext := testkit.NewDistExecutionContext(t, 3)
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/disttask/framework/dispatcher/cancelBeforeUpdate", "1*return(true)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/disttask/framework/dispatcher/cancelBeforeUpdate", "return()"))
 	DispatchTaskAndCheckFail("😊", t, &m)
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/disttask/framework/dispatcher/cancelBeforeUpdate"))
 	distContext.Close()

--- a/disttask/framework/storage/table_test.go
+++ b/disttask/framework/storage/table_test.go
@@ -82,8 +82,9 @@ func TestGlobalTaskTable(t *testing.T) {
 
 	prevState := task.State
 	task.State = proto.TaskStateRunning
-	err = gm.UpdateGlobalTaskAndAddSubTasks(task, nil, prevState)
+	retryable, err := gm.UpdateGlobalTaskAndAddSubTasks(task, nil, prevState)
 	require.NoError(t, err)
+	require.Equal(t, true, retryable)
 
 	task5, err := gm.GetGlobalTasksInStates(proto.TaskStateRunning)
 	require.NoError(t, err)
@@ -253,8 +254,9 @@ func TestBothGlobalAndSubTaskTable(t *testing.T) {
 			Meta:        []byte("m2"),
 		},
 	}
-	err = sm.UpdateGlobalTaskAndAddSubTasks(task, subTasks, prevState)
+	retryable, err := sm.UpdateGlobalTaskAndAddSubTasks(task, subTasks, prevState)
 	require.NoError(t, err)
+	require.Equal(t, true, retryable)
 
 	task, err = sm.GetGlobalTaskByID(1)
 	require.NoError(t, err)
@@ -291,8 +293,9 @@ func TestBothGlobalAndSubTaskTable(t *testing.T) {
 			Meta:        []byte("m4"),
 		},
 	}
-	err = sm.UpdateGlobalTaskAndAddSubTasks(task, subTasks, prevState)
+	retryable, err = sm.UpdateGlobalTaskAndAddSubTasks(task, subTasks, prevState)
 	require.NoError(t, err)
+	require.Equal(t, true, retryable)
 
 	task, err = sm.GetGlobalTaskByID(1)
 	require.NoError(t, err)
@@ -322,8 +325,9 @@ func TestBothGlobalAndSubTaskTable(t *testing.T) {
 	}()
 	prevState = task.State
 	task.State = proto.TaskStateFailed
-	err = sm.UpdateGlobalTaskAndAddSubTasks(task, subTasks, prevState)
+	retryable, err = sm.UpdateGlobalTaskAndAddSubTasks(task, subTasks, prevState)
 	require.EqualError(t, err, "updateTaskErr")
+	require.Equal(t, true, retryable)
 
 	task, err = sm.GetGlobalTaskByID(1)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46261 ref #46258 

Problem Summary:
see #46261
1. When state transform fails, framework still adds subtasks.
2. can't transform state from cancelling to reverted.(If there are no subtasks for task submitted, this state transform is legal.)
### What is changed and how it works?
1. When state transform fails, check the affected row cnt to skip adding subtask. This error should not be retryable.
2. When there are no subtasks submitted and the task is canceled, the state transform will be canceling--->reverting--->reverted. Remove the old fast path: canceling--->reverted.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
