### PR TITLE
planner: fix the issue that TIDB_INLJ hint cannot take effect when left joining two sub-queries

### DIFF
--- a/planner/core/casetest/hint/hint_test.go
+++ b/planner/core/casetest/hint/hint_test.go
@@ -647,16 +647,3 @@ func TestInvalidHint(t *testing.T) {
 		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
 	}
 }
-
-func TestIssue46160(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-
-	tk.MustExec("use test")
-	tk.MustExec(`create table t1 (a int, key(a))`)
-	tk.MustExec(`create table t2 (a int, key(a))`)
-
-	query := `select /*+ tidb_inlj(bb) */ aa.* from (select * from t1) as aa left join
-    (select t2.a, t2.a*2 as a2 from t2) as bb on aa.a=bb.a;`
-	tk.HasPlan(query, "IndexJoin")
-}

--- a/planner/core/casetest/hint/hint_test.go
+++ b/planner/core/casetest/hint/hint_test.go
@@ -647,3 +647,16 @@ func TestInvalidHint(t *testing.T) {
 		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
 	}
 }
+
+func TestIssue46160(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec(`create table t1 (a int, key(a))`)
+	tk.MustExec(`create table t2 (a int, key(a))`)
+
+	query := `select /*+ tidb_inlj(bb) */ aa.* from (select * from t1) as aa left join
+    (select t2.a, t2.a*2 as a2 from t2) as bb on aa.a=bb.a;`
+	tk.HasPlan(query, "IndexJoin")
+}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -714,7 +714,8 @@ func extractTableAlias(p Plan, parentOffset int) *hintTableInfo {
 	if len(p.OutputNames()) > 0 && p.OutputNames()[0].TblName.L != "" {
 		firstName := p.OutputNames()[0]
 		for _, name := range p.OutputNames() {
-			if name.TblName.L != firstName.TblName.L || name.DBName.L != firstName.DBName.L {
+			if name.TblName.L != firstName.TblName.L ||
+				(name.DBName.L != "" && firstName.DBName.L != "" && name.DBName.L != firstName.DBName.L) { // DBName can be nil, see #46160
 				return nil
 			}
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46160

Problem Summary: planner: fix the issue that TIDB_INLJ hint cannot take effect when left joining two sub-queries

### What is changed and how it works?

planner: fix the issue that TIDB_INLJ hint cannot take effect when left joining two sub-queries

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
