### PR TITLE
*: compatible upgrade with previous versions

### DIFF
--- a/ddl/mock.go
+++ b/ddl/mock.go
@@ -148,11 +148,14 @@ func NewMockStateSyncer() syncer.StateSyncer {
 	return &MockStateSyncer{}
 }
 
+// clusterState mocks cluster state.
+// We move it from MockStateSyncer to here. Because we want to make it unaffected by ddl close.
+var clusterState *atomicutil.Pointer[syncer.StateInfo]
+
 // MockStateSyncer is a mock state syncer, it is exported for testing.
 type MockStateSyncer struct {
-	clusterState *atomicutil.Pointer[syncer.StateInfo]
-	globalVerCh  chan clientv3.WatchResponse
-	mockSession  chan struct{}
+	globalVerCh chan clientv3.WatchResponse
+	mockSession chan struct{}
 }
 
 // Init implements StateSyncer.Init interface.
@@ -160,7 +163,9 @@ func (s *MockStateSyncer) Init(context.Context) error {
 	s.globalVerCh = make(chan clientv3.WatchResponse, 1)
 	s.mockSession = make(chan struct{}, 1)
 	state := syncer.NewStateInfo(syncer.StateNormalRunning)
-	s.clusterState = atomicutil.NewPointer(state)
+	if clusterState == nil {
+		clusterState = atomicutil.NewPointer(state)
+	}
 	return nil
 }
 
@@ -168,23 +173,23 @@ func (s *MockStateSyncer) Init(context.Context) error {
 func (s *MockStateSyncer) UpdateGlobalState(_ context.Context, stateInfo *syncer.StateInfo) error {
 	failpoint.Inject("mockUpgradingState", func(val failpoint.Value) {
 		if val.(bool) {
-			s.clusterState.Store(stateInfo)
+			clusterState.Store(stateInfo)
 			failpoint.Return(nil)
 		}
 	})
 	s.globalVerCh <- clientv3.WatchResponse{}
-	s.clusterState.Store(stateInfo)
+	clusterState.Store(stateInfo)
 	return nil
 }
 
 // GetGlobalState implements StateSyncer.GetGlobalState interface.
-func (s *MockStateSyncer) GetGlobalState(context.Context) (*syncer.StateInfo, error) {
-	return s.clusterState.Load(), nil
+func (*MockStateSyncer) GetGlobalState(context.Context) (*syncer.StateInfo, error) {
+	return clusterState.Load(), nil
 }
 
 // IsUpgradingState implements StateSyncer.IsUpgradingState interface.
-func (s *MockStateSyncer) IsUpgradingState() bool {
-	return s.clusterState.Load().State == syncer.StateUpgrading
+func (*MockStateSyncer) IsUpgradingState() bool {
+	return clusterState.Load().State == syncer.StateUpgrading
 }
 
 // WatchChan implements StateSyncer.WatchChan interface.

--- a/server/handler/upgrade_handler.go
+++ b/server/handler/upgrade_handler.go
@@ -46,9 +46,9 @@ func (h ClusterUpgradeHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	op := req.FormValue("op")
 	switch op {
 	case "start":
-		hasDone, err = h.startUpgrade()
+		hasDone, err = h.StartUpgrade()
 	case "finish":
-		hasDone, err = h.finishUpgrade()
+		hasDone, err = h.FinishUpgrade()
 	default:
 		WriteError(w, errors.Errorf("wrong operation:%s", op))
 		return
@@ -71,7 +71,8 @@ func (h ClusterUpgradeHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 		zap.String("category", "upgrading"), zap.String("op", req.FormValue("op")), zap.Bool("hasDone", hasDone))
 }
 
-func (h ClusterUpgradeHandler) startUpgrade() (hasDone bool, err error) {
+// StartUpgrade is used to start the upgrade.
+func (h ClusterUpgradeHandler) StartUpgrade() (hasDone bool, err error) {
 	se, err := session.CreateSession(h.store)
 	if err != nil {
 		return false, err
@@ -90,7 +91,8 @@ func (h ClusterUpgradeHandler) startUpgrade() (hasDone bool, err error) {
 	return false, err
 }
 
-func (h ClusterUpgradeHandler) finishUpgrade() (hasDone bool, err error) {
+// FinishUpgrade is used to finish the upgrade.
+func (h ClusterUpgradeHandler) FinishUpgrade() (hasDone bool, err error) {
 	se, err := session.CreateSession(h.store)
 	if err != nil {
 		return false, err

--- a/session/bootstraptest/BUILD.bazel
+++ b/session/bootstraptest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         "//config",
         "//ddl",
@@ -17,6 +17,7 @@ go_test(
         "//meta",
         "//parser/model",
         "//parser/terror",
+        "//server/handler",
         "//session",  #keep
         "//sessionctx",
         "//testkit",  #keep

--- a/session/bootstraptest/bootstrap_upgrade_test.go
+++ b/session/bootstraptest/bootstrap_upgrade_test.go
@@ -565,6 +565,7 @@ func TestUpgradeVersionForResumeJob(t *testing.T) {
 	require.NoError(t, err)
 	defer domLatestV.Close()
 	domLatestV.DDL().SetHook(hook)
+	finishUpgrade(store)
 	seLatestV := session.CreateSessionAndSetID(t, store)
 	// Add a new DDL (an "add index" job uses a different table than the previous DDL job) to the DDL table.
 	session.MustExec(t, seLatestV, "alter table test.upgrade_tbl1 add index idx2(a)")
@@ -573,7 +574,6 @@ func TestUpgradeVersionForResumeJob(t *testing.T) {
 	require.Equal(t, session.CurrentBootstrapVersion, ver)
 
 	wg.Wait()
-	finishUpgrade(store)
 	require.Equal(t, 3, times)
 	// Make sure the second add index operation is successful.
 	sql := fmt.Sprintf("select job_meta from mysql.tidb_ddl_history where job_id=%d or job_id=%d order by job_id", jobID, jobID+1)

--- a/session/session.go
+++ b/session/session.go
@@ -3726,7 +3726,8 @@ func getStoreBootstrapVersion(store kv.Storage) int64 {
 		storeBootstrapped[store.UUID()] = true
 	}
 
-	return modifyBootstrapVersionForTest(store, ver)
+	modifyBootstrapVersionForTest(ver)
+	return ver
 }
 
 func finishBootstrap(store kv.Storage) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46275

Problem Summary:
* `version < v7.1.0`, we don't support upgrading TiDB without manually Canceling DDL
* `v7.4.0 > version >= v7.1.0`, we support upgrading TiDB without manually Canceling DDL, but we don't support `/upgrade/start` and `upgrade/finish` APIs.
* `version >= v7.4.0`, we support `/upgrade/start` and `upgrade/finish` APIs.

### What is changed and how it works?
* For compatibility:
    * When upgrading from the version in the `v7.4.0 > version >= v7.1.0` range, we do not need to execute `/upgrade/start` before upgrading.
    * When upgrading from the `version >= v7.4.0` version, we need to execute `/upgrade/start` before upgrading.
   
* ddl/mock.go : We move `clusterState` out of `MockStateSyncer`. Because we want to make it unaffected by ddl close.
* Update `modifyBootstrapVersionForTest`
    * Remove `modifyBootstrapVersionForTest` code, because IT removes this logic.
    * Now we want to test `SupportUpgradeHTTPOpVer` upgrade `SupportUpgradeHTTPOpVer++`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
When upgrading from a version greater than or equal to v7.4.0, an explicit `/upgrade/start` HTTP request is required to start the cluster upgrade
```
