### PR TITLE
import into: split real-tikv test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -564,6 +564,27 @@ bazel_importintotest: failpoint-enable bazel_ci_simple_prepare
 		-- //tests/realtikvtest/importintotest/...
 	./build/jenkins_collect_coverage.sh
 
+# on timeout, bazel won't print log sometimes, so we use --test_output=all to print log always
+bazel_importintotest2: failpoint-enable bazel_ci_simple_prepare
+	bazel $(BAZEL_GLOBAL_CONFIG) coverage $(BAZEL_CMD_CONFIG) --test_output=all --test_arg=-with-real-tikv --define gotags=deadlock,intest \
+	--@io_bazel_rules_go//go/config:cover_format=go_cover \
+		-- //tests/realtikvtest/importintotest2/...
+	./build/jenkins_collect_coverage.sh
+
+# on timeout, bazel won't print log sometimes, so we use --test_output=all to print log always
+bazel_importintotest3: failpoint-enable bazel_ci_simple_prepare
+	bazel $(BAZEL_GLOBAL_CONFIG) coverage $(BAZEL_CMD_CONFIG) --test_output=all --test_arg=-with-real-tikv --define gotags=deadlock,intest \
+	--@io_bazel_rules_go//go/config:cover_format=go_cover \
+		-- //tests/realtikvtest/importintotest3/...
+	./build/jenkins_collect_coverage.sh
+
+# on timeout, bazel won't print log sometimes, so we use --test_output=all to print log always
+bazel_importintotest4: failpoint-enable bazel_ci_simple_prepare
+	bazel $(BAZEL_GLOBAL_CONFIG) coverage $(BAZEL_CMD_CONFIG) --test_output=all --test_arg=-with-real-tikv --define gotags=deadlock,intest \
+	--@io_bazel_rules_go//go/config:cover_format=go_cover \
+		-- //tests/realtikvtest/importintotest4/...
+	./build/jenkins_collect_coverage.sh
+
 bazel_lint: bazel_prepare
 	bazel build //... --//build:with_nogo_flag=true
 

--- a/tests/realtikvtest/importintotest2/BUILD.bazel
+++ b/tests/realtikvtest/importintotest2/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "importintotest2_test",
+    timeout = "moderate",
+    srcs = [
+        "dummy_test.go",
+        "main_test.go",
+    ],
+    flaky = True,
+    race = "on",
+    deps = [
+        "//config",
+        "//kv",
+        "//testkit",
+        "//tests/realtikvtest",
+        "@com_github_fsouza_fake_gcs_server//fakestorage",
+        "@com_github_pingcap_failpoint//:failpoint",
+        "@com_github_stretchr_testify//require",
+        "@com_github_stretchr_testify//suite",
+    ],
+)

--- a/tests/realtikvtest/importintotest2/dummy_test.go
+++ b/tests/realtikvtest/importintotest2/dummy_test.go
@@ -1,0 +1,19 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importintotest
+
+func (s *mockGCSSuite) TestDummy() {
+	s.True(true, gcsEndpoint)
+}

--- a/tests/realtikvtest/importintotest2/main_test.go
+++ b/tests/realtikvtest/importintotest2/main_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importintotest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/tests/realtikvtest"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type mockGCSSuite struct {
+	suite.Suite
+
+	server *fakestorage.Server
+	store  kv.Storage
+	tk     *testkit.TestKit
+}
+
+var (
+	gcsHost = "127.0.0.1"
+	gcsPort = uint16(4443)
+	// for fake gcs server, we must use this endpoint format
+	// NOTE: must end with '/'
+	gcsEndpointFormat = "http://%s:%d/storage/v1/"
+	gcsEndpoint       = fmt.Sprintf(gcsEndpointFormat, gcsHost, gcsPort)
+)
+
+func TestLoadRemote(t *testing.T) {
+	suite.Run(t, &mockGCSSuite{})
+}
+
+func (s *mockGCSSuite) SetupSuite() {
+	s.Require().True(*realtikvtest.WithRealTiKV)
+	var err error
+	opt := fakestorage.Options{
+		Scheme:     "http",
+		Host:       gcsHost,
+		Port:       gcsPort,
+		PublicHost: gcsHost,
+	}
+	s.server, err = fakestorage.NewServerWithOptions(opt)
+	s.Require().NoError(err)
+	s.store = realtikvtest.CreateMockStoreAndSetup(s.T())
+	s.tk = testkit.NewTestKit(s.T(), s.store)
+}
+
+func (s *mockGCSSuite) TearDownSuite() {
+	s.server.Stop()
+}
+
+func (s *mockGCSSuite) enableFailpoint(path, term string) {
+	require.NoError(s.T(), failpoint.Enable(path, term))
+	s.T().Cleanup(func() {
+		_ = failpoint.Disable(path)
+	})
+}
+
+func (s *mockGCSSuite) cleanupSysTables() {
+	s.tk.MustExec("delete from mysql.tidb_import_jobs")
+	s.tk.MustExec("delete from mysql.tidb_global_task")
+	s.tk.MustExec("delete from mysql.tidb_background_subtask")
+}
+
+func init() {
+	// need a real PD
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Path = "127.0.0.1:2379"
+	})
+}
+
+func TestMain(m *testing.M) {
+	realtikvtest.RunTestMain(m)
+}

--- a/tests/realtikvtest/importintotest3/BUILD.bazel
+++ b/tests/realtikvtest/importintotest3/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "importintotest3_test",
+    timeout = "moderate",
+    srcs = [
+        "dummy_test.go",
+        "main_test.go",
+    ],
+    flaky = True,
+    race = "on",
+    deps = [
+        "//config",
+        "//kv",
+        "//testkit",
+        "//tests/realtikvtest",
+        "@com_github_fsouza_fake_gcs_server//fakestorage",
+        "@com_github_pingcap_failpoint//:failpoint",
+        "@com_github_stretchr_testify//require",
+        "@com_github_stretchr_testify//suite",
+    ],
+)

--- a/tests/realtikvtest/importintotest3/dummy_test.go
+++ b/tests/realtikvtest/importintotest3/dummy_test.go
@@ -1,0 +1,19 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importintotest
+
+func (s *mockGCSSuite) TestDummy() {
+	s.True(true, gcsEndpoint)
+}

--- a/tests/realtikvtest/importintotest3/main_test.go
+++ b/tests/realtikvtest/importintotest3/main_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importintotest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/tests/realtikvtest"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type mockGCSSuite struct {
+	suite.Suite
+
+	server *fakestorage.Server
+	store  kv.Storage
+	tk     *testkit.TestKit
+}
+
+var (
+	gcsHost = "127.0.0.1"
+	gcsPort = uint16(4443)
+	// for fake gcs server, we must use this endpoint format
+	// NOTE: must end with '/'
+	gcsEndpointFormat = "http://%s:%d/storage/v1/"
+	gcsEndpoint       = fmt.Sprintf(gcsEndpointFormat, gcsHost, gcsPort)
+)
+
+func TestLoadRemote(t *testing.T) {
+	suite.Run(t, &mockGCSSuite{})
+}
+
+func (s *mockGCSSuite) SetupSuite() {
+	s.Require().True(*realtikvtest.WithRealTiKV)
+	var err error
+	opt := fakestorage.Options{
+		Scheme:     "http",
+		Host:       gcsHost,
+		Port:       gcsPort,
+		PublicHost: gcsHost,
+	}
+	s.server, err = fakestorage.NewServerWithOptions(opt)
+	s.Require().NoError(err)
+	s.store = realtikvtest.CreateMockStoreAndSetup(s.T())
+	s.tk = testkit.NewTestKit(s.T(), s.store)
+}
+
+func (s *mockGCSSuite) TearDownSuite() {
+	s.server.Stop()
+}
+
+func (s *mockGCSSuite) enableFailpoint(path, term string) {
+	require.NoError(s.T(), failpoint.Enable(path, term))
+	s.T().Cleanup(func() {
+		_ = failpoint.Disable(path)
+	})
+}
+
+func (s *mockGCSSuite) cleanupSysTables() {
+	s.tk.MustExec("delete from mysql.tidb_import_jobs")
+	s.tk.MustExec("delete from mysql.tidb_global_task")
+	s.tk.MustExec("delete from mysql.tidb_background_subtask")
+}
+
+func init() {
+	// need a real PD
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Path = "127.0.0.1:2379"
+	})
+}
+
+func TestMain(m *testing.M) {
+	realtikvtest.RunTestMain(m)
+}

--- a/tests/realtikvtest/importintotest4/BUILD.bazel
+++ b/tests/realtikvtest/importintotest4/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "importintotest4_test",
+    timeout = "moderate",
+    srcs = [
+        "dummy_test.go",
+        "main_test.go",
+    ],
+    flaky = True,
+    race = "on",
+    deps = [
+        "//config",
+        "//kv",
+        "//testkit",
+        "//tests/realtikvtest",
+        "@com_github_fsouza_fake_gcs_server//fakestorage",
+        "@com_github_pingcap_failpoint//:failpoint",
+        "@com_github_stretchr_testify//require",
+        "@com_github_stretchr_testify//suite",
+    ],
+)

--- a/tests/realtikvtest/importintotest4/dummy_test.go
+++ b/tests/realtikvtest/importintotest4/dummy_test.go
@@ -1,0 +1,19 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importintotest
+
+func (s *mockGCSSuite) TestDummy() {
+	s.True(true, gcsEndpoint)
+}

--- a/tests/realtikvtest/importintotest4/main_test.go
+++ b/tests/realtikvtest/importintotest4/main_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importintotest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/tests/realtikvtest"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type mockGCSSuite struct {
+	suite.Suite
+
+	server *fakestorage.Server
+	store  kv.Storage
+	tk     *testkit.TestKit
+}
+
+var (
+	gcsHost = "127.0.0.1"
+	gcsPort = uint16(4443)
+	// for fake gcs server, we must use this endpoint format
+	// NOTE: must end with '/'
+	gcsEndpointFormat = "http://%s:%d/storage/v1/"
+	gcsEndpoint       = fmt.Sprintf(gcsEndpointFormat, gcsHost, gcsPort)
+)
+
+func TestLoadRemote(t *testing.T) {
+	suite.Run(t, &mockGCSSuite{})
+}
+
+func (s *mockGCSSuite) SetupSuite() {
+	s.Require().True(*realtikvtest.WithRealTiKV)
+	var err error
+	opt := fakestorage.Options{
+		Scheme:     "http",
+		Host:       gcsHost,
+		Port:       gcsPort,
+		PublicHost: gcsHost,
+	}
+	s.server, err = fakestorage.NewServerWithOptions(opt)
+	s.Require().NoError(err)
+	s.store = realtikvtest.CreateMockStoreAndSetup(s.T())
+	s.tk = testkit.NewTestKit(s.T(), s.store)
+}
+
+func (s *mockGCSSuite) TearDownSuite() {
+	s.server.Stop()
+}
+
+func (s *mockGCSSuite) enableFailpoint(path, term string) {
+	require.NoError(s.T(), failpoint.Enable(path, term))
+	s.T().Cleanup(func() {
+		_ = failpoint.Disable(path)
+	})
+}
+
+func (s *mockGCSSuite) cleanupSysTables() {
+	s.tk.MustExec("delete from mysql.tidb_import_jobs")
+	s.tk.MustExec("delete from mysql.tidb_global_task")
+	s.tk.MustExec("delete from mysql.tidb_background_subtask")
+}
+
+func init() {
+	// need a real PD
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Path = "127.0.0.1:2379"
+	})
+}
+
+func TestMain(m *testing.M) {
+	realtikvtest.RunTestMain(m)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42930

Problem Summary:

### What is changed and how it works?
currently, test in real-tikv-test is run in serial, if there're too many test in one directory, test will run slow and delay pr merge, or even timeout

so we add 3 importintotestX into real tikv test, we will split the test later, to avoid test timeout as we will add more test later.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
