### PR TITLE
br: wait tiflash replicas ready && fix unstable test

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1812,6 +1812,7 @@ func (rc *Client) GoWaitTiFlashReady(ctx context.Context, inCh <-chan *CreatedTa
 		}
 	}
 	go concurrentHandleTablesCh(ctx, inCh, outCh, errCh, workers, func(c context.Context, tbl *CreatedTable) error {
+		tiFlashStoresMap := tiFlashStores
 		if tbl.Table != nil && tbl.Table.TiFlashReplica == nil {
 			log.Info("table has no tiflash replica",
 				zap.Stringer("table", tbl.OldTable.Info.Name),
@@ -1824,11 +1825,28 @@ func (rc *Client) GoWaitTiFlashReady(ctx context.Context, inCh <-chan *CreatedTa
 				zap.Stringer("table", tbl.OldTable.Info.Name),
 				zap.Stringer("db", tbl.OldTable.DB.Name))
 			for {
-				progress, err := infosync.CalculateTiFlashProgress(tbl.Table.ID, tbl.Table.TiFlashReplica.Count, tiFlashStores)
-				if err != nil {
-					log.Warn("failed to get tiflash replica progress, wait for next retry", zap.Error(err))
-					time.Sleep(time.Second)
-					continue
+				var progress float64
+				if pi := tbl.Table.GetPartitionInfo(); pi != nil && len(pi.Definitions) > 0 {
+					for _, p := range pi.Definitions {
+						progressOfPartition, err := infosync.MustGetTiFlashProgress(p.ID, tbl.Table.TiFlashReplica.Count, &tiFlashStoresMap)
+						if err != nil {
+							log.Warn("failed to get progress for tiflash partition replica, retry it",
+								zap.Int64("tableID", tbl.Table.ID), zap.Int64("partitionID", p.ID), zap.Error(err))
+							time.Sleep(time.Second)
+							continue
+						}
+						progress += progressOfPartition
+					}
+					progress = progress / float64(len(pi.Definitions))
+				} else {
+					var err error
+					progress, err = infosync.MustGetTiFlashProgress(tbl.Table.ID, tbl.Table.TiFlashReplica.Count, &tiFlashStoresMap)
+					if err != nil {
+						log.Warn("failed to get progress for tiflash replica, retry it",
+							zap.Int64("tableID", tbl.Table.ID), zap.Error(err))
+						time.Sleep(time.Second)
+						continue
+					}
 				}
 				// check until progress is 1
 				if progress == 1 {

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1812,7 +1812,6 @@ func (rc *Client) GoWaitTiFlashReady(ctx context.Context, inCh <-chan *CreatedTa
 		}
 	}
 	go concurrentHandleTablesCh(ctx, inCh, outCh, errCh, workers, func(c context.Context, tbl *CreatedTable) error {
-		tiFlashStoresMap := tiFlashStores
 		if tbl.Table != nil && tbl.Table.TiFlashReplica == nil {
 			log.Info("table has no tiflash replica",
 				zap.Stringer("table", tbl.OldTable.Info.Name),
@@ -1828,7 +1827,7 @@ func (rc *Client) GoWaitTiFlashReady(ctx context.Context, inCh <-chan *CreatedTa
 				var progress float64
 				if pi := tbl.Table.GetPartitionInfo(); pi != nil && len(pi.Definitions) > 0 {
 					for _, p := range pi.Definitions {
-						progressOfPartition, err := infosync.MustGetTiFlashProgress(p.ID, tbl.Table.TiFlashReplica.Count, &tiFlashStoresMap)
+						progressOfPartition, err := infosync.MustGetTiFlashProgress(p.ID, tbl.Table.TiFlashReplica.Count, &tiFlashStores)
 						if err != nil {
 							log.Warn("failed to get progress for tiflash partition replica, retry it",
 								zap.Int64("tableID", tbl.Table.ID), zap.Int64("partitionID", p.ID), zap.Error(err))
@@ -1840,7 +1839,7 @@ func (rc *Client) GoWaitTiFlashReady(ctx context.Context, inCh <-chan *CreatedTa
 					progress = progress / float64(len(pi.Definitions))
 				} else {
 					var err error
-					progress, err = infosync.MustGetTiFlashProgress(tbl.Table.ID, tbl.Table.TiFlashReplica.Count, &tiFlashStoresMap)
+					progress, err = infosync.MustGetTiFlashProgress(tbl.Table.ID, tbl.Table.TiFlashReplica.Count, &tiFlashStores)
 					if err != nil {
 						log.Warn("failed to get progress for tiflash replica, retry it",
 							zap.Int64("tableID", tbl.Table.ID), zap.Error(err))

--- a/br/tests/br_tiflash/run.sh
+++ b/br/tests/br_tiflash/run.sh
@@ -24,10 +24,10 @@ run_sql "CREATE DATABASE $DB"
 run_sql "CREATE TABLE $DB.kv(k varchar(256) primary key, v int)"
 
 run_sql "CREATE TABLE $DB.partition_kv(
-    id BIGINT,
-    data INT,
-    PRIMARY KEY(id) CLUSTERED
-) PARTITION BY RANGE(id) (
+    k BIGINT,
+    v INT,
+    PRIMARY KEY(k) CLUSTERED
+) PARTITION BY RANGE(k) (
     PARTITION p0 VALUES LESS THAN (200),
     PARTITION p1 VALUES LESS THAN (400),
     PARTITION p2 VALUES LESS THAN (600)

--- a/br/tests/br_tiflash/run.sh
+++ b/br/tests/br_tiflash/run.sh
@@ -54,6 +54,8 @@ run_sql "DROP DATABASE $DB"
 run_br restore full -s "local://$TEST_DIR/$DB" --pd $PD_ADDR --wait-tiflash-ready=true
 
 # check TiFlash sync
+echo "wait 3 seconds for tiflash tick puller triggered"
+sleep 3
 if ! [ $(run_sql "select * from information_schema.tiflash_replica" | grep "PROGRESS" | sed "s/[^0-9]//g") -eq 1 ]; then
     echo "restore didn't wait tiflash synced after set --wait-tiflash-ready=true."
     exit 1

--- a/br/tests/br_tiflash/run.sh
+++ b/br/tests/br_tiflash/run.sh
@@ -23,14 +23,14 @@ run_sql "CREATE DATABASE $DB"
 
 run_sql "CREATE TABLE $DB.kv(k varchar(256) primary key, v int)"
 
-run_sql "CREATE TABLE $DB.partition_kv(
-    k BIGINT,
-    v INT,
-    PRIMARY KEY(k) CLUSTERED
-) PARTITION BY RANGE(k) (
-    PARTITION p0 VALUES LESS THAN (200),
-    PARTITION p1 VALUES LESS THAN (400),
-    PARTITION p2 VALUES LESS THAN (600)
+run_sql "CREATE TABLE $DB.partition_kv( \
+    k BIGINT, \
+    v INT, \
+    PRIMARY KEY(k) CLUSTERED \
+) PARTITION BY RANGE(k) ( \
+    PARTITION p0 VALUES LESS THAN (200), \
+    PARTITION p1 VALUES LESS THAN (400), \
+    PARTITION p2 VALUES LESS THAN (600) \
 );"
 
 stmt="INSERT INTO $DB.kv(k, v) VALUES ('1-record', 1)"

--- a/br/tests/br_tiflash/run.sh
+++ b/br/tests/br_tiflash/run.sh
@@ -30,8 +30,7 @@ run_sql "CREATE TABLE $DB.partition_kv( \
 ) PARTITION BY RANGE(k) ( \
     PARTITION p0 VALUES LESS THAN (200), \
     PARTITION p1 VALUES LESS THAN (400), \
-    PARTITION p2 VALUES LESS THAN (600) \
-);"
+    PARTITION p2 VALUES LESS THAN (600))"
 
 stmt="INSERT INTO $DB.kv(k, v) VALUES ('1-record', 1)"
 parition_stmt="INSERT INTO $DB.partition_kv(k, v) VALUES (1, 1)"

--- a/br/tests/br_tiflash/run.sh
+++ b/br/tests/br_tiflash/run.sh
@@ -23,16 +23,30 @@ run_sql "CREATE DATABASE $DB"
 
 run_sql "CREATE TABLE $DB.kv(k varchar(256) primary key, v int)"
 
+CREATE TABLE $DB.partition_kv(
+    id BIGINT,
+    data INT,
+    PRIMARY KEY(id) CLUSTERED
+) PARTITION BY RANGE(id) (
+    PARTITION p0 VALUES LESS THAN (200),
+    PARTITION p1 VALUES LESS THAN (400),
+    PARTITION p2 VALUES LESS THAN (600)
+);
+
 stmt="INSERT INTO $DB.kv(k, v) VALUES ('1-record', 1)"
+parition_stmt="INSERT INTO $DB.partition_kv(k, v) VALUES (1, 1)"
 for i in $(seq 2 $RECORD_COUNT); do
     stmt="$stmt,('$i-record', $i)"
+    parition_stmt="$parition_stmt,($i, $i)"
 done
 run_sql "$stmt"
+run_sql "$parition_stmt"
 
 if ! run_sql "ALTER TABLE $DB.kv SET TIFLASH REPLICA 1"; then
   # 10s should be enough for tiflash-proxy get started
   sleep 10
   run_sql "ALTER TABLE $DB.kv SET TIFLASH REPLICA 1"
+  run_sql "ALTER TABLE $DB.partition_kv SET TIFLASH REPLICA 1"
 fi
 
 

--- a/br/tests/br_tiflash/run.sh
+++ b/br/tests/br_tiflash/run.sh
@@ -23,7 +23,7 @@ run_sql "CREATE DATABASE $DB"
 
 run_sql "CREATE TABLE $DB.kv(k varchar(256) primary key, v int)"
 
-CREATE TABLE $DB.partition_kv(
+run_sql "CREATE TABLE $DB.partition_kv(
     id BIGINT,
     data INT,
     PRIMARY KEY(id) CLUSTERED
@@ -31,7 +31,7 @@ CREATE TABLE $DB.partition_kv(
     PARTITION p0 VALUES LESS THAN (200),
     PARTITION p1 VALUES LESS THAN (400),
     PARTITION p2 VALUES LESS THAN (600)
-);
+);"
 
 stmt="INSERT INTO $DB.kv(k, v) VALUES ('1-record', 1)"
 parition_stmt="INSERT INTO $DB.partition_kv(k, v) VALUES (1, 1)"

--- a/br/tests/br_tiflash/run.sh
+++ b/br/tests/br_tiflash/run.sh
@@ -23,14 +23,14 @@ run_sql "CREATE DATABASE $DB"
 
 run_sql "CREATE TABLE $DB.kv(k varchar(256) primary key, v int)"
 
-run_sql "CREATE TABLE $DB.partition_kv( \
-    k BIGINT, \
-    v INT, \
-    PRIMARY KEY(k) CLUSTERED \
-) PARTITION BY RANGE(k) ( \
-    PARTITION p0 VALUES LESS THAN (200), \
-    PARTITION p1 VALUES LESS THAN (400), \
-    PARTITION p2 VALUES LESS THAN (600))"
+run_sql "CREATE TABLE $DB.partition_kv(\
+ k INT, \
+ v INT, \
+ PRIMARY KEY(k) CLUSTERED \
+) PARTITION BY RANGE(k) (\
+  PARTITION p0 VALUES LESS THAN (200), \
+  PARTITION p1 VALUES LESS THAN (400), \
+  PARTITION p2 VALUES LESS THAN MAXVALUE)"
 
 stmt="INSERT INTO $DB.kv(k, v) VALUES ('1-record', 1)"
 parition_stmt="INSERT INTO $DB.partition_kv(k, v) VALUES (1, 1)"

--- a/br/tests/run.sh
+++ b/br/tests/run.sh
@@ -21,6 +21,11 @@ export TEST_DIR=/tmp/backup_restore_test
 export COV_DIR="/tmp/group_cover"
 source $CUR/_utils/run_services
 
+# Create COV_DIR if not exists
+if [ -d "$COV_DIR" ]; then
+   mkdir -p $COV_DIR
+fi
+
 # Reset TEST_DIR
 rm -rf $TEST_DIR && mkdir -p $TEST_DIR
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46302

Problem Summary:
1. restore wait tiflash ready need handle partition tables
2. tiflash refresh ticker need 2 seconds to trigger. so make the test sleep 3 seconds.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
