### PR TITLE
schema cache: fix wrong timestamp in schema cache

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -230,10 +230,9 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 	}
 
 	if is := do.infoCache.GetByVersion(neededSchemaVersion); is != nil {
-		if schemaTs > 0 {
-			// try to insert here as well to correct the schemaTs if previous is wrong
-			do.infoCache.Insert(is, uint64(schemaTs))
-		}
+		// try to insert here as well to correct the schemaTs if previous is wrong
+        // the insert method check if schemaTs is zero
+		do.infoCache.Insert(is, uint64(schemaTs))
 		return is, true, 0, nil, nil
 	}
 

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -230,6 +230,10 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 	}
 
 	if is := do.infoCache.GetByVersion(neededSchemaVersion); is != nil {
+		if schemaTs > 0 {
+			// try to insert here as well to correct the schemaTs if previous is wrong
+			do.infoCache.Insert(is, uint64(schemaTs))
+		}
 		return is, true, 0, nil, nil
 	}
 

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -231,7 +231,7 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 
 	if is := do.infoCache.GetByVersion(neededSchemaVersion); is != nil {
 		// try to insert here as well to correct the schemaTs if previous is wrong
-        // the insert method check if schemaTs is zero
+		// the insert method check if schemaTs is zero
 		do.infoCache.Insert(is, uint64(schemaTs))
 		return is, true, 0, nil, nil
 	}

--- a/infoschema/cache.go
+++ b/infoschema/cache.go
@@ -63,6 +63,11 @@ func (h *InfoCache) GetLatest() InfoSchema {
 	return nil
 }
 
+// Len returns the size of the cache
+func (h *InfoCache) Len() int {
+	return len(h.cache)
+}
+
 func (h *InfoCache) getSchemaByTimestampNoLock(ts uint64) (InfoSchema, bool) {
 	logutil.BgLogger().Debug("SCHEMA CACHE get schema", zap.Uint64("timestamp", ts))
 	// search one by one instead of binary search, because the timestamp of a schema could be 0

--- a/infoschema/test/cachetest/cache_test.go
+++ b/infoschema/test/cachetest/cache_test.go
@@ -176,5 +176,4 @@ func TestGetByTimestamp(t *testing.T) {
 	require.Equal(t, is2, ic.GetBySnapshotTS(2))
 	require.Equal(t, is3, ic.GetBySnapshotTS(3))
 	require.Equal(t, 3, ic.Len())
-
 }

--- a/infoschema/test/cachetest/cache_test.go
+++ b/infoschema/test/cachetest/cache_test.go
@@ -137,12 +137,14 @@ func TestGetByTimestamp(t *testing.T) {
 	ic := infoschema.NewCache(16)
 	require.NotNil(t, ic)
 	require.Nil(t, ic.GetLatest())
+	require.Equal(t, 0, ic.Len())
 
 	is1 := infoschema.MockInfoSchemaWithSchemaVer(nil, 1)
 	ic.Insert(is1, 1)
 	require.Nil(t, ic.GetBySnapshotTS(0))
 	require.Equal(t, is1, ic.GetBySnapshotTS(1))
 	require.Equal(t, is1, ic.GetBySnapshotTS(2))
+	require.Equal(t, 1, ic.Len())
 
 	is3 := infoschema.MockInfoSchemaWithSchemaVer(nil, 3)
 	ic.Insert(is3, 3)
@@ -152,6 +154,7 @@ func TestGetByTimestamp(t *testing.T) {
 	require.Nil(t, ic.GetBySnapshotTS(2))
 	require.Equal(t, is3, ic.GetBySnapshotTS(3))
 	require.Equal(t, is3, ic.GetBySnapshotTS(4))
+	require.Equal(t, 2, ic.Len())
 
 	is2 := infoschema.MockInfoSchemaWithSchemaVer(nil, 2)
 	// schema version 2 doesn't have timestamp set
@@ -164,4 +167,14 @@ func TestGetByTimestamp(t *testing.T) {
 	require.Nil(t, ic.GetBySnapshotTS(2))
 	require.Equal(t, is3, ic.GetBySnapshotTS(3))
 	require.Equal(t, is3, ic.GetBySnapshotTS(4))
+	require.Equal(t, 3, ic.Len())
+
+	// insert is2 again with correct timestamp, to correct previous wrong timestamp
+	ic.Insert(is2, 2)
+	require.Equal(t, is3, ic.GetLatest())
+	require.Equal(t, is1, ic.GetBySnapshotTS(1))
+	require.Equal(t, is2, ic.GetBySnapshotTS(2))
+	require.Equal(t, is3, ic.GetBySnapshotTS(3))
+	require.Equal(t, 3, ic.Len())
+
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
correct the wrong timestamp in schema cache to make it useful

Issue Number: close #46325 

Problem Summary: 

### What is changed and how it works?
try to update the timestamp of the existing schema cache when the timestamp is fetched

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
