### PR TITLE
planner: adjust N used in TopN cost formula based on the total number of rows

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -3205,31 +3205,40 @@ func TestLimitPushDown(t *testing.T) {
 
 	tk.MustExec(`create table t (a int)`)
 	tk.MustExec(`insert into t values (1)`)
+	tk.MustExec(`insert into t values (1)`)
+	tk.MustExec(`insert into t values (1)`)
+	tk.MustExec(`insert into t values (1)`)
+	tk.MustExec(`insert into t values (1)`)
+	tk.MustExec(`insert into t values (1)`)
+	tk.MustExec(`insert into t values (1)`)
+	tk.MustExec(`insert into t values (1)`)
+	tk.MustExec(`insert into t values (1)`)
+	tk.MustExec(`insert into t values (1)`)
 	tk.MustExec(`analyze table t`)
 
 	tk.MustExec(`set tidb_opt_limit_push_down_threshold=0`)
 	tk.MustQuery(`explain format=brief select a from t order by a desc limit 10`).Check(testkit.Rows(
-		`TopN 1.00 root  test.t.a:desc, offset:0, count:10`,
-		`└─TableReader 1.00 root  data:TableFullScan`,
-		`  └─TableFullScan 1.00 cop[tikv] table:t keep order:false`))
+		`TopN 10.00 root  test.t.a:desc, offset:0, count:10`,
+		`└─TableReader 10.00 root  data:TableFullScan`,
+		`  └─TableFullScan 10.00 cop[tikv] table:t keep order:false`))
 
 	tk.MustExec(`set tidb_opt_limit_push_down_threshold=10`)
 	tk.MustQuery(`explain format=brief select a from t order by a desc limit 10`).Check(testkit.Rows(
-		`TopN 1.00 root  test.t.a:desc, offset:0, count:10`,
-		`└─TableReader 1.00 root  data:TopN`,
-		`  └─TopN 1.00 cop[tikv]  test.t.a:desc, offset:0, count:10`,
-		`    └─TableFullScan 1.00 cop[tikv] table:t keep order:false`))
+		`TopN 10.00 root  test.t.a:desc, offset:0, count:10`,
+		`└─TableReader 10.00 root  data:TopN`,
+		`  └─TopN 10.00 cop[tikv]  test.t.a:desc, offset:0, count:10`,
+		`    └─TableFullScan 10.00 cop[tikv] table:t keep order:false`))
 
 	tk.MustQuery(`explain format=brief select a from t order by a desc limit 11`).Check(testkit.Rows(
-		`TopN 1.00 root  test.t.a:desc, offset:0, count:11`,
-		`└─TableReader 1.00 root  data:TableFullScan`,
-		`  └─TableFullScan 1.00 cop[tikv] table:t keep order:false`))
+		`TopN 10.00 root  test.t.a:desc, offset:0, count:11`,
+		`└─TableReader 10.00 root  data:TableFullScan`,
+		`  └─TableFullScan 10.00 cop[tikv] table:t keep order:false`))
 
 	tk.MustQuery(`explain format=brief select /*+ limit_to_cop() */ a from t order by a desc limit 11`).Check(testkit.Rows(
-		`TopN 1.00 root  test.t.a:desc, offset:0, count:11`,
-		`└─TableReader 1.00 root  data:TopN`,
-		`  └─TopN 1.00 cop[tikv]  test.t.a:desc, offset:0, count:11`,
-		`    └─TableFullScan 1.00 cop[tikv] table:t keep order:false`))
+		`TopN 10.00 root  test.t.a:desc, offset:0, count:11`,
+		`└─TableReader 10.00 root  data:TopN`,
+		`  └─TopN 10.00 cop[tikv]  test.t.a:desc, offset:0, count:11`,
+		`    └─TableFullScan 10.00 cop[tikv] table:t keep order:false`))
 }
 
 func TestIssue26559(t *testing.T) {

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -3204,16 +3204,7 @@ func TestLimitPushDown(t *testing.T) {
 	tk.MustExec("drop table if exists t")
 
 	tk.MustExec(`create table t (a int)`)
-	tk.MustExec(`insert into t values (1)`)
-	tk.MustExec(`insert into t values (1)`)
-	tk.MustExec(`insert into t values (1)`)
-	tk.MustExec(`insert into t values (1)`)
-	tk.MustExec(`insert into t values (1)`)
-	tk.MustExec(`insert into t values (1)`)
-	tk.MustExec(`insert into t values (1)`)
-	tk.MustExec(`insert into t values (1)`)
-	tk.MustExec(`insert into t values (1)`)
-	tk.MustExec(`insert into t values (1)`)
+	tk.MustExec(`insert into t values (1), (1), (1), (1), (1), (1), (1), (1), (1), (1)`)
 	tk.MustExec(`analyze table t`)
 
 	tk.MustExec(`set tidb_opt_limit_push_down_threshold=0`)

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -3204,32 +3204,32 @@ func TestLimitPushDown(t *testing.T) {
 	tk.MustExec("drop table if exists t")
 
 	tk.MustExec(`create table t (a int)`)
-	tk.MustExec(`insert into t values (1), (1), (1), (1), (1), (1), (1), (1), (1), (1)`)
+	tk.MustExec(`insert into t values (1)`)
 	tk.MustExec(`analyze table t`)
 
 	tk.MustExec(`set tidb_opt_limit_push_down_threshold=0`)
 	tk.MustQuery(`explain format=brief select a from t order by a desc limit 10`).Check(testkit.Rows(
-		`TopN 10.00 root  test.t.a:desc, offset:0, count:10`,
-		`└─TableReader 10.00 root  data:TableFullScan`,
-		`  └─TableFullScan 10.00 cop[tikv] table:t keep order:false`))
+		`TopN 1.00 root  test.t.a:desc, offset:0, count:10`,
+		`└─TableReader 1.00 root  data:TableFullScan`,
+		`  └─TableFullScan 1.00 cop[tikv] table:t keep order:false`))
 
 	tk.MustExec(`set tidb_opt_limit_push_down_threshold=10`)
 	tk.MustQuery(`explain format=brief select a from t order by a desc limit 10`).Check(testkit.Rows(
-		`TopN 10.00 root  test.t.a:desc, offset:0, count:10`,
-		`└─TableReader 10.00 root  data:TopN`,
-		`  └─TopN 10.00 cop[tikv]  test.t.a:desc, offset:0, count:10`,
-		`    └─TableFullScan 10.00 cop[tikv] table:t keep order:false`))
+		`TopN 1.00 root  test.t.a:desc, offset:0, count:10`,
+		`└─TableReader 1.00 root  data:TopN`,
+		`  └─TopN 1.00 cop[tikv]  test.t.a:desc, offset:0, count:10`,
+		`    └─TableFullScan 1.00 cop[tikv] table:t keep order:false`))
 
 	tk.MustQuery(`explain format=brief select a from t order by a desc limit 11`).Check(testkit.Rows(
-		`TopN 10.00 root  test.t.a:desc, offset:0, count:11`,
-		`└─TableReader 10.00 root  data:TableFullScan`,
-		`  └─TableFullScan 10.00 cop[tikv] table:t keep order:false`))
+		`TopN 1.00 root  test.t.a:desc, offset:0, count:11`,
+		`└─TableReader 1.00 root  data:TableFullScan`,
+		`  └─TableFullScan 1.00 cop[tikv] table:t keep order:false`))
 
 	tk.MustQuery(`explain format=brief select /*+ limit_to_cop() */ a from t order by a desc limit 11`).Check(testkit.Rows(
-		`TopN 10.00 root  test.t.a:desc, offset:0, count:11`,
-		`└─TableReader 10.00 root  data:TopN`,
-		`  └─TopN 10.00 cop[tikv]  test.t.a:desc, offset:0, count:11`,
-		`    └─TableFullScan 10.00 cop[tikv] table:t keep order:false`))
+		`TopN 1.00 root  test.t.a:desc, offset:0, count:11`,
+		`└─TableReader 1.00 root  data:TopN`,
+		`  └─TopN 1.00 cop[tikv]  test.t.a:desc, offset:0, count:11`,
+		`    └─TableFullScan 1.00 cop[tikv] table:t keep order:false`))
 }
 
 func TestIssue26559(t *testing.T) {

--- a/planner/core/plan_cost_ver2.go
+++ b/planner/core/plan_cost_ver2.go
@@ -396,6 +396,7 @@ func (p *PhysicalTopN) getPlanCostVer2(taskType property.TaskType, option *PlanC
 
 	rows := getCardinality(p.children[0], option.CostFlag)
 	n := math.Max(1, float64(p.Count+p.Offset))
+	n = math.Min(n, rows)
 	rowSize := getAvgRowSize(p.StatsInfo(), p.Schema().Columns)
 	cpuFactor := getTaskCPUFactorVer2(p, taskType)
 	memFactor := getTaskMemFactorVer2(p, taskType)

--- a/planner/core/plan_cost_ver2.go
+++ b/planner/core/plan_cost_ver2.go
@@ -396,7 +396,11 @@ func (p *PhysicalTopN) getPlanCostVer2(taskType property.TaskType, option *PlanC
 
 	rows := getCardinality(p.children[0], option.CostFlag)
 	n := max(1, float64(p.Count+p.Offset))
-	n = min(n, rows)
+	if n > 10000 {
+		// It's only used to prevent some extreme cases, e.g. `select * from t order by a limit 18446744073709551615`.
+		// For normal cases, considering that `rows` may be under-estimated, better to keep `n` unchanged.
+		n = min(n, rows)
+	}
 	rowSize := getAvgRowSize(p.StatsInfo(), p.Schema().Columns)
 	cpuFactor := getTaskCPUFactorVer2(p, taskType)
 	memFactor := getTaskMemFactorVer2(p, taskType)

--- a/planner/core/plan_cost_ver2.go
+++ b/planner/core/plan_cost_ver2.go
@@ -395,8 +395,8 @@ func (p *PhysicalTopN) getPlanCostVer2(taskType property.TaskType, option *PlanC
 	}
 
 	rows := getCardinality(p.children[0], option.CostFlag)
-	n := math.Max(1, float64(p.Count+p.Offset))
-	n = math.Min(n, rows)
+	n := max(1, float64(p.Count+p.Offset))
+	n = min(n, rows)
 	rowSize := getAvgRowSize(p.StatsInfo(), p.Schema().Columns)
 	cpuFactor := getTaskCPUFactorVer2(p, taskType)
 	memFactor := getTaskMemFactorVer2(p, taskType)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43285

Problem Summary: planner: adjust N used in TopN cost formula based on the total number of rows

### What is changed and how it works?

planner: adjust N used in TopN cost formula based on the total number of rows

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
