### PR TITLE
planner: Add eliminateFalseOrs in buildSelection to eliminate OR condition always False

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -575,28 +575,28 @@ explain format = 'brief' select * from t ta left outer join t tb on ta.nb = tb.n
 id	estRows	task	access object	operator info
 HashJoin	10000.00	root		left outer join, equal:[eq(test.t.nb, test.t.nb)], left cond:[gt(test.t.a, 1)]
 ├─TableReader(Build)	8000.00	root		data:Selection
-│ └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
+│ └─Selection	8000.00	cop[tikv]		cast(test.t.nb, bigint(11) BINARY), 0
 │   └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 └─TableReader(Probe)	8000.00	root		data:Selection
-  └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
+  └─Selection	8000.00	cop[tikv]		cast(test.t.nb, bigint(11) BINARY), 0
     └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 explain format = 'brief' select * from t ta right outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
 id	estRows	task	access object	operator info
 HashJoin	8000.00	root		right outer join, equal:[eq(test.t.nb, test.t.nb)]
 ├─TableReader(Build)	2666.67	root		data:Selection
-│ └─Selection	2666.67	cop[tikv]		gt(test.t.a, 1), or(cast(test.t.nb, bigint(11) BINARY), 0)
+│ └─Selection	2666.67	cop[tikv]		gt(test.t.a, 1), or(cast(test.t.nb, bigint(11) BINARY))
 │   └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 └─TableReader(Probe)	8000.00	root		data:Selection
-  └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
+  └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY))
     └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 explain format = 'brief' select * from t ta inner join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
 id	estRows	task	access object	operator info
 HashJoin	3333.33	root		inner join, equal:[eq(test.t.nb, test.t.nb)]
 ├─TableReader(Build)	2666.67	root		data:Selection
-│ └─Selection	2666.67	cop[tikv]		gt(test.t.a, 1), or(cast(test.t.nb, bigint(11) BINARY), 0)
+│ └─Selection	2666.67	cop[tikv]		gt(test.t.a, 1), or(cast(test.t.nb, bigint(11) BINARY))
 │   └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 └─TableReader(Probe)	8000.00	root		data:Selection
-  └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
+  └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY))
     └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(t.nc, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 id	estRows	task	access object	operator info

--- a/planner/core/casetest/partition/testdata/partition_pruner_out.json
+++ b/planner/core/casetest/partition/testdata/partition_pruner_out.json
@@ -3926,7 +3926,7 @@
         ],
         "Plan": [
           "TableReader 1.00 root partition:p0,pDef data:Selection",
-          "└─Selection 1.00 cop[tikv]  or(eq(test_partition.t1.a, 1), 0)",
+          "└─Selection 1.00 cop[tikv]  eq(test_partition.t1.a, 1)",
           "  └─TableFullScan 11.00 cop[tikv] table:t1 keep order:false"
         ],
         "IndexPlan": [

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -3649,19 +3649,19 @@ func TestDNFCondSelectivityWithConst(t *testing.T) {
 		"  └─TableFullScan 129.00 cop[tikv] table:t1 keep order:false"))
 	testKit.MustQuery("explain format = 'brief' select * from t1 where 0=1 or a=1 or b=1;").Check(testkit.Rows(
 		"TableReader 1.99 root  data:Selection",
-		"└─Selection 1.99 cop[tikv]  or(0, or(eq(test.t1.a, 1), eq(test.t1.b, 1)))",
+		"└─Selection 1.99 cop[tikv]  or(eq(test.t1.a, 1), eq(test.t1.b, 1))",
 		"  └─TableFullScan 129.00 cop[tikv] table:t1 keep order:false"))
 	testKit.MustQuery("explain format = 'brief' select * from t1 where null or a=1 or b=1;").Check(testkit.Rows(
 		"TableReader 1.99 root  data:Selection",
-		"└─Selection 1.99 cop[tikv]  or(0, or(eq(test.t1.a, 1), eq(test.t1.b, 1)))",
+		"└─Selection 1.99 cop[tikv]  or(eq(test.t1.a, 1), eq(test.t1.b, 1))",
 		"  └─TableFullScan 129.00 cop[tikv] table:t1 keep order:false"))
 	testKit.MustQuery("explain format = 'brief' select * from t1 where a=1 or false or b=1;").Check(testkit.Rows(
 		"TableReader 1.99 root  data:Selection",
-		"└─Selection 1.99 cop[tikv]  or(eq(test.t1.a, 1), or(0, eq(test.t1.b, 1)))",
+		"└─Selection 1.99 cop[tikv]  or(eq(test.t1.a, 1), eq(test.t1.b, 1))",
 		"  └─TableFullScan 129.00 cop[tikv] table:t1 keep order:false"))
 	testKit.MustQuery("explain format = 'brief' select * from t1 where a=1 or b=1 or \"false\";").Check(testkit.Rows(
 		"TableReader 1.99 root  data:Selection",
-		"└─Selection 1.99 cop[tikv]  or(eq(test.t1.a, 1), or(eq(test.t1.b, 1), 0))",
+		"└─Selection 1.99 cop[tikv]  or(eq(test.t1.a, 1), eq(test.t1.b, 1))",
 		"  └─TableFullScan 129.00 cop[tikv] table:t1 keep order:false"))
 	testKit.MustQuery("explain format = 'brief' select * from t1 where 1=1 or a=1 or b=1;").Check(testkit.Rows(
 		"TableReader 129.00 root  data:Selection",

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1450,7 +1450,6 @@ func eliminateFalseOrs(ctx sessionctx.Context, cnfExpressions []expression.Expre
 		default:
 			// For non-scalar function expressions, add them to the final CNF expressions.
 			finalCNFExprs = append(finalCNFExprs, expr)
-
 		}
 	}
 


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45785

Problem Summary:

TiDB doesn't have logical to eliminate always false condition in DNFs,like PostgreSQL(find_duplicate_ors/process_duplicate_ors) or OB etc.

### What is changed and how it works?

I've add a recursive function named `eliminateFalseOrs`  to deal with and eliminate this scenario.
More info : https://pingcap.feishu.cn/docx/Mlgjdl4aHomqmwxeOB7ckMD0nVi 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
