### PR TITLE
test: remove useless code

### DIFF
--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -167,7 +167,6 @@ func TestBootstrapWithError(t *testing.T) {
 
 	dom, err := domap.Get(store)
 	require.NoError(t, err)
-	domap.Delete(store)
 	dom.Close()
 
 	dom1, err := BootstrapSession(store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46385

Problem Summary:

### What is changed and how it works?
This issue arose after #45465,  and #28555 caused it.
After #45465, `runawayWatchSyncLoop` will do `ExecRestrictedSQL` which will get the domain from the session, so `domainMap` will get or create it. #28555 deletes the store before closing the domain, which causes runawayWatchSyncLoop create a new Domain. So the domain created in `TestBootstrapWithError` can not become DDL owner and finish `bootstrap`.
We don't need to delete the store from `domainMap` because we will do it in `Domain.Close`. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
