### PR TITLE
infoschema,executor: Add CHECK_CONSTRAINTS I_S table

### DIFF
--- a/executor/BUILD.bazel
+++ b/executor/BUILD.bazel
@@ -317,6 +317,7 @@ go_test(
         "index_lookup_join_test.go",
         "index_lookup_merge_join_test.go",
         "infoschema_cluster_table_test.go",
+        "infoschema_reader_internal_test.go",
         "infoschema_reader_test.go",
         "insert_test.go",
         "inspection_common_test.go",

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2115,7 +2115,8 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) exec.Ex
 			strings.ToLower(infoschema.ClusterTableMemoryUsage),
 			strings.ToLower(infoschema.ClusterTableMemoryUsageOpsHistory),
 			strings.ToLower(infoschema.TableResourceGroups),
-			strings.ToLower(infoschema.TableRunawayWatches):
+			strings.ToLower(infoschema.TableRunawayWatches),
+			strings.ToLower(infoschema.TableCheckConstraints):
 			return &MemTableReaderExec{
 				BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID()),
 				table:        v.Table,

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -194,6 +194,8 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 			err = e.setDataFromResourceGroups()
 		case infoschema.TableRunawayWatches:
 			err = e.setDataFromRunawayWatches(sctx)
+		case infoschema.TableCheckConstraints:
+			err = e.setDataFromCheckConstraints(ctx, sctx, dbs)
 		}
 		if err != nil {
 			return nil, err
@@ -620,6 +622,31 @@ func (e *memtableRetriever) setDataFromTables(ctx context.Context, sctx sessionc
 					nil,                   // TIDB_PLACEMENT_POLICY_NAME
 				)
 				rows = append(rows, record)
+			}
+		}
+	}
+	e.rows = rows
+	return nil
+}
+
+func (e *memtableRetriever) setDataFromCheckConstraints(ctx context.Context, sctx sessionctx.Context, schemas []*model.DBInfo) error {
+	var rows [][]types.Datum
+	checker := privilege.GetPrivilegeManager(sctx)
+	for _, schema := range schemas {
+		for _, table := range schema.Tables {
+			if len(table.Constraints) > 0 {
+				if checker != nil && !checker.RequestVerification(sctx.GetSessionVars().ActiveRoles, schema.Name.L, table.Name.L, "", mysql.SelectPriv) {
+					continue
+				}
+				for _, constraint := range table.Constraints {
+					record := types.MakeDatums(
+						infoschema.CatalogVal, // CONSTRAINT_CATALOG
+						schema.Name.O,         // CONSTRAINT_SCHEMA
+						constraint.Name.O,     // CONSTRAINT_NAME
+						fmt.Sprintf("(%s)", constraint.ExprString), // CHECK_CLAUSE
+					)
+					rows = append(rows, record)
+				}
 			}
 		}
 	}

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -195,7 +195,7 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 		case infoschema.TableRunawayWatches:
 			err = e.setDataFromRunawayWatches(sctx)
 		case infoschema.TableCheckConstraints:
-			err = e.setDataFromCheckConstraints(ctx, sctx, dbs)
+			err = e.setDataFromCheckConstraints(sctx, dbs)
 		}
 		if err != nil {
 			return nil, err
@@ -629,7 +629,7 @@ func (e *memtableRetriever) setDataFromTables(ctx context.Context, sctx sessionc
 	return nil
 }
 
-func (e *memtableRetriever) setDataFromCheckConstraints(ctx context.Context, sctx sessionctx.Context, schemas []*model.DBInfo) error {
+func (e *memtableRetriever) setDataFromCheckConstraints(sctx sessionctx.Context, schemas []*model.DBInfo) error {
 	var rows [][]types.Datum
 	checker := privilege.GetPrivilegeManager(sctx)
 	for _, schema := range schemas {

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -639,6 +639,9 @@ func (e *memtableRetriever) setDataFromCheckConstraints(sctx sessionctx.Context,
 					continue
 				}
 				for _, constraint := range table.Constraints {
+					if constraint.State != model.StatePublic {
+						continue
+					}
 					record := types.MakeDatums(
 						infoschema.CatalogVal, // CONSTRAINT_CATALOG
 						schema.Name.O,         // CONSTRAINT_SCHEMA

--- a/executor/infoschema_reader_internal_test.go
+++ b/executor/infoschema_reader_internal_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package executor
 
 import (

--- a/executor/infoschema_reader_internal_test.go
+++ b/executor/infoschema_reader_internal_test.go
@@ -50,8 +50,8 @@ func TestSetDataFromCheckConstraints(t *testing.T) {
 	err := mt.setDataFromCheckConstraints(sctx, dbs)
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(mt.rows))
-	require.Equal(t, 4, len(mt.rows[0]))
+	require.Equal(t, 1, len(mt.rows))    // 1 row
+	require.Equal(t, 4, len(mt.rows[0])) // 4 columns
 	require.Equal(t, types.NewStringDatum("def"), mt.rows[0][0])
 	require.Equal(t, types.NewStringDatum("test"), mt.rows[0][1])
 	require.Equal(t, types.NewStringDatum("t2_c1"), mt.rows[0][2])

--- a/executor/infoschema_reader_internal_test.go
+++ b/executor/infoschema_reader_internal_test.go
@@ -1,0 +1,59 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/parser/model"
+	"github.com/pingcap/tidb/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetDataFromCheckConstraints(t *testing.T) {
+	mt := memtableRetriever{}
+	sctx := defaultCtx()
+	dbs := []*model.DBInfo{
+		{
+			ID:   1,
+			Name: model.NewCIStr("test"),
+			Tables: []*model.TableInfo{
+				{
+					ID:   1,
+					Name: model.NewCIStr("t1"),
+				},
+				{
+					ID:   2,
+					Name: model.NewCIStr("t2"),
+					Constraints: []*model.ConstraintInfo{
+						{
+							Name:       model.NewCIStr("t2_c1"),
+							Table:      model.NewCIStr("t2"),
+							ExprString: "id<10",
+							State:      model.StatePublic,
+						},
+					},
+				},
+				{
+					ID:   3,
+					Name: model.NewCIStr("t3"),
+					Constraints: []*model.ConstraintInfo{
+						{
+							Name:       model.NewCIStr("t3_c1"),
+							Table:      model.NewCIStr("t3"),
+							ExprString: "id<10",
+							State:      model.StateDeleteOnly,
+						},
+					},
+				},
+			},
+		},
+	}
+	err := mt.setDataFromCheckConstraints(sctx, dbs)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(mt.rows))
+	require.Equal(t, 4, len(mt.rows[0]))
+	require.Equal(t, types.NewStringDatum("def"), mt.rows[0][0])
+	require.Equal(t, types.NewStringDatum("test"), mt.rows[0][1])
+	require.Equal(t, types.NewStringDatum("t2_c1"), mt.rows[0][2])
+	require.Equal(t, types.NewStringDatum("(id<10)"), mt.rows[0][3])
+}

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -206,6 +206,8 @@ const (
 	TableResourceGroups = "RESOURCE_GROUPS"
 	// TableRunawayWatches is the query list of runaway watch.
 	TableRunawayWatches = "RUNAWAY_WATCHES"
+	// TableCheckConstraints is the list of CHECK constraints.
+	TableCheckConstraints = "CHECK_CONSTRAINTS"
 )
 
 const (
@@ -314,6 +316,7 @@ var tableIDMap = map[string]int64{
 	ClusterTableMemoryUsageOpsHistory:    autoid.InformationSchemaDBID + 87,
 	TableResourceGroups:                  autoid.InformationSchemaDBID + 88,
 	TableRunawayWatches:                  autoid.InformationSchemaDBID + 89,
+	TableCheckConstraints:                autoid.InformationSchemaDBID + 90,
 }
 
 // columnInfo represents the basic column information of all kinds of INFORMATION_SCHEMA tables
@@ -1625,6 +1628,13 @@ var tableRunawayWatchListCols = []columnInfo{
 	{name: "ACTION", tp: mysql.TypeVarchar, size: 12, flag: mysql.NotNullFlag},
 }
 
+var tableCheckConstraintsCols = []columnInfo{
+	{name: "CONSTRAINT_CATALOG", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag},
+	{name: "CONSTRAINT_SCHEMA", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag},
+	{name: "CONSTRAINT_NAME", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag},
+	{name: "CHECK_CLAUSE", tp: mysql.TypeLongBlob, size: types.UnspecifiedLength, flag: mysql.NotNullFlag},
+}
+
 // GetShardingInfo returns a nil or description string for the sharding information of given TableInfo.
 // The returned description string may be:
 //   - "NOT_SHARDED": for tables that SHARD_ROW_ID_BITS is not specified.
@@ -2138,6 +2148,7 @@ var tableNameToColumns = map[string][]columnInfo{
 	TableMemoryUsageOpsHistory:              tableMemoryUsageOpsHistoryCols,
 	TableResourceGroups:                     tableResourceGroupsCols,
 	TableRunawayWatches:                     tableRunawayWatchListCols,
+	TableCheckConstraints:                   tableCheckConstraintsCols,
 }
 
 func createInfoSchemaTable(_ autoid.Allocators, meta *model.TableInfo) (table.Table, error) {

--- a/infoschema/test/clustertablestest/tables_test.go
+++ b/infoschema/test/clustertablestest/tables_test.go
@@ -1814,13 +1814,30 @@ func TestAddFieldsForBinding(t *testing.T) {
 
 func TestCheckConstraints(t *testing.T) {
 	store := testkit.CreateMockStore(t)
-
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("SET GLOBAL tidb_enable_check_constraint = ON")
+
 	tk.MustExec("CREATE TABLE test.t1 (id INT PRIMARY KEY, CHECK (id<10))")
 	rows := tk.MustQuery("SELECT * FROM information_schema.CHECK_CONSTRAINTS").Rows()
+	require.Equal(t, len(rows), 1)
 	require.Equal(t, rows[0][0], "def")
 	require.Equal(t, rows[0][1], "test")
 	require.Equal(t, rows[0][2], "t1_chk_1")
 	require.Equal(t, rows[0][3], "(`id` < 10)")
+
+	tk.MustExec("ALTER TABLE test.t1 DROP CONSTRAINT t1_chk_1")
+	rows = tk.MustQuery("SELECT * FROM information_schema.CHECK_CONSTRAINTS").Rows()
+	require.Equal(t, len(rows), 0)
+
+	tk.MustExec("CREATE TABLE test.t2 (id INT PRIMARY KEY, CHECK (id<20))")
+	rows = tk.MustQuery("SELECT * FROM information_schema.CHECK_CONSTRAINTS").Rows()
+	require.Equal(t, len(rows), 1)
+	require.Equal(t, rows[0][0], "def")
+	require.Equal(t, rows[0][1], "test")
+	require.Equal(t, rows[0][2], "t2_chk_1")
+	require.Equal(t, rows[0][3], "(`id` < 20)")
+
+	tk.MustExec("DROP TABLE test.t2")
+	rows = tk.MustQuery("SELECT * FROM information_schema.CHECK_CONSTRAINTS").Rows()
+	require.Equal(t, len(rows), 0)
 }

--- a/infoschema/test/clustertablestest/tables_test.go
+++ b/infoschema/test/clustertablestest/tables_test.go
@@ -1811,3 +1811,16 @@ func TestAddFieldsForBinding(t *testing.T) {
 	require.Equal(t, rows[0][7], "use_index(@`sel_1` `test`.`t` ), ignore_index(`t` `a`)")
 	require.Equal(t, rows[0][8], "select * from `t` where `a` = ?")
 }
+
+func TestCheckConstraints(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("SET GLOBAL tidb_enable_check_constraint = ON")
+	tk.MustExec("CREATE TABLE test.t1 (id INT PRIMARY KEY, CHECK (id<10))")
+	rows := tk.MustQuery("SELECT * FROM information_schema.CHECK_CONSTRAINTS").Rows()
+	require.Equal(t, rows[0][0], "def")
+	require.Equal(t, rows[0][1], "test")
+	require.Equal(t, rows[0][2], "t1_chk_1")
+	require.Equal(t, rows[0][3], "(`id` < 10)")
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

- This adds the [`information_schema.CHECK_CONSTRAINTS`  table](https://dev.mysql.com/doc/mysql-infoschema-excerpt/8.1/en/information-schema-check-constraints-table.html) similar to what MySQL 8.0 does.

Note that other databases implement this as well:
```

postgres=# \d information_schema.CHECK_CONSTRAINTS
                       View "information_schema.check_constraints"
       Column       |               Type                | Collation | Nullable | Default 
--------------------+-----------------------------------+-----------+----------+---------
 constraint_catalog | information_schema.sql_identifier |           |          | 
 constraint_schema  | information_schema.sql_identifier |           |          | 
 constraint_name    | information_schema.sql_identifier |           |          | 
 check_clause       | information_schema.character_data |           |          | 

postgres=# SELECT VERSION();
                                                      version                                                      
-------------------------------------------------------------------------------------------------------------------
 PostgreSQL 15.3 (Debian 15.3-0+deb12u1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
(1 row)
```
Issue Number: close #46427 

Problem Summary:



### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The `information_schema.CHECK_CONSTRAINTS` table was added for improved compatibility with MySQL 8.0
```
