### PR TITLE
fix(partition_test.go): reduced number of rows

### DIFF
--- a/table/tables/partition_test.go
+++ b/table/tables/partition_test.go
@@ -2829,7 +2829,7 @@ func TestPartitionByExtensivePart(t *testing.T) {
 	t2Str := `create table t2 ` + tBase
 	tStr := `create table t ` + tBase
 
-	rows := 1000
+	rows := 100
 	pkInserts := 20
 	pkUpdates := 20
 	pkDeletes := 10 // Enough to delete half of what is inserted?


### PR DESCRIPTION
pkg tidb\table\tables\partition_test.go

Issue Number: ref #46263

### What problem does this PR solve?
Reduces time of big test TestPartitionByExtensivePart (2819 line) execution from 10+ minutes to 15-20 seconds

Problem Summary: TestPartitionByExtensivePart  executes too long time

### What is changed and how it works?
Time of test execution reduced to 15-20 seconds

### Check List
Tests

- [ ]  Unit test
- [ ]  Integration test
- [ ]  Manual test (add detailed scripts or steps below)
- [ ]  No code

### Side effects
- [ ]  Performance regression: Consumes more CPU
- [ ]  Performance regression: Consumes more Memory
- [ ]  Breaking backward compatibility


### Documentation
- [ ]  Affects user behaviors
- [ ]  Contains syntax changes
- [ ]  Contains variable changes
- [ ]  Contains experimental features
- [ ]  Changes MySQL compatibility


### Release note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

None