### PR TITLE
planner: Move some NDV and join estimation functions from the physical-optimization package into cardinality package

### DIFF
--- a/planner/cardinality/BUILD.bazel
+++ b/planner/cardinality/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "cardinality",
     srcs = [
         "histogram.go",
+        "ndv.go",
         "pseudo.go",
         "row_count_column.go",
         "row_count_index.go",
@@ -19,6 +20,7 @@ go_library(
         "//parser/format",
         "//parser/model",
         "//parser/mysql",
+        "//planner/property",
         "//planner/util",
         "//planner/util/debugtrace",
         "//sessionctx",

--- a/planner/cardinality/BUILD.bazel
+++ b/planner/cardinality/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "cardinality",
     srcs = [
         "histogram.go",
+        "join.go",
         "ndv.go",
         "pseudo.go",
         "row_count_column.go",

--- a/planner/cardinality/cross_estimation.go
+++ b/planner/cardinality/cross_estimation.go
@@ -1,0 +1,1 @@
+package cardinality

--- a/planner/cardinality/cross_estimation.go
+++ b/planner/cardinality/cross_estimation.go
@@ -1,1 +1,0 @@
-package cardinality

--- a/planner/cardinality/join.go
+++ b/planner/cardinality/join.go
@@ -1,3 +1,17 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cardinality
 
 import (

--- a/planner/cardinality/join.go
+++ b/planner/cardinality/join.go
@@ -1,0 +1,37 @@
+package cardinality
+
+import (
+	"math"
+
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/planner/property"
+	"github.com/pingcap/tidb/sessionctx"
+)
+
+// EstimateFullJoinRowCount estimates the row count of a full join.
+func EstimateFullJoinRowCount(sctx sessionctx.Context,
+	isCartesian bool,
+	leftProfile, rightProfile *property.StatsInfo,
+	leftJoinKeys, rightJoinKeys []*expression.Column,
+	leftSchema, rightSchema *expression.Schema,
+	leftNAJoinKeys, rightNAJoinKeys []*expression.Column) float64 {
+	if isCartesian {
+		return leftProfile.RowCount * rightProfile.RowCount
+	}
+	var leftKeyNDV, rightKeyNDV float64
+	var leftColCnt, rightColCnt int
+	if len(leftJoinKeys) > 0 || len(rightJoinKeys) > 0 {
+		leftKeyNDV, leftColCnt = EstimateColsNDVWithMatchedLen(leftJoinKeys, leftSchema, leftProfile)
+		rightKeyNDV, rightColCnt = EstimateColsNDVWithMatchedLen(rightJoinKeys, rightSchema, rightProfile)
+	} else {
+		leftKeyNDV, leftColCnt = EstimateColsNDVWithMatchedLen(leftNAJoinKeys, leftSchema, leftProfile)
+		rightKeyNDV, rightColCnt = EstimateColsNDVWithMatchedLen(rightNAJoinKeys, rightSchema, rightProfile)
+	}
+	count := leftProfile.RowCount * rightProfile.RowCount / max(leftKeyNDV, rightKeyNDV)
+	if sctx.GetSessionVars().TiDBOptJoinReorderThreshold <= 0 {
+		return count
+	}
+	// If we enable the DP choice, we multiple the 0.9 for each remained join key supposing that 0.9 is the correlation factor between them.
+	// This estimation logic is referred to Presto.
+	return count * math.Pow(0.9, float64(len(leftJoinKeys)-max(leftColCnt, rightColCnt)))
+}

--- a/planner/cardinality/ndv.go
+++ b/planner/cardinality/ndv.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var distinctFactor = 0.8
+const distinctFactor = 0.8
 
 // EstimateColumnNDV computes estimated NDV of specified column using the original
 // histogram of `DataSource` which is retrieved from storage(not the derived one).

--- a/planner/cardinality/ndv.go
+++ b/planner/cardinality/ndv.go
@@ -1,0 +1,96 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cardinality
+
+import (
+	"math"
+
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/planner/property"
+	"github.com/pingcap/tidb/statistics"
+	"github.com/pingcap/tidb/util/logutil"
+	"go.uber.org/zap"
+)
+
+var distinctFactor = 0.8
+
+// EstimateColumnNDV computes estimated NDV of specified column using the original
+// histogram of `DataSource` which is retrieved from storage(not the derived one).
+func EstimateColumnNDV(tbl *statistics.Table, colID int64) (ndv float64) {
+	hist, ok := tbl.Columns[colID]
+	if ok && hist.IsStatsInitialized() {
+		ndv = float64(hist.Histogram.NDV)
+		// TODO: a better way to get the total row count derived from the last analyze.
+		analyzeCount := getTotalRowCount(tbl, hist)
+		if analyzeCount > 0 {
+			factor := float64(tbl.RealtimeCount) / float64(analyzeCount)
+			ndv *= factor
+		}
+	} else {
+		ndv = float64(tbl.RealtimeCount) * distinctFactor
+	}
+	return ndv
+}
+
+// getTotalRowCount returns the total row count, which is obtained when collecting colHist.
+func getTotalRowCount(statsTbl *statistics.Table, colHist *statistics.Column) int64 {
+	if colHist.IsFullLoad() {
+		return int64(colHist.TotalRowCount())
+	}
+	// If colHist is not fully loaded, we may still get its total row count from other index/column stats.
+	for _, idx := range statsTbl.Indices {
+		if idx.IsFullLoad() && idx.LastUpdateVersion == colHist.LastUpdateVersion {
+			return int64(idx.TotalRowCount())
+		}
+	}
+	for _, col := range statsTbl.Columns {
+		if col.IsFullLoad() && col.LastUpdateVersion == colHist.LastUpdateVersion {
+			return int64(col.TotalRowCount())
+		}
+	}
+	return 0
+}
+
+// EstimateColsNDVWithMatchedLen returns the NDV of a couple of columns.
+// If the columns match any GroupNDV maintained by child operator, we can get an accurate NDV.
+// Otherwise, we simply return the max NDV among the columns, which is a lower bound.
+func EstimateColsNDVWithMatchedLen(cols []*expression.Column, schema *expression.Schema, profile *property.StatsInfo) (float64, int) {
+	ndv := 1.0
+	if groupNDV := profile.GetGroupNDV4Cols(cols); groupNDV != nil {
+		return math.Max(groupNDV.NDV, ndv), len(groupNDV.Cols)
+	}
+	indices := schema.ColumnsIndices(cols)
+	if indices == nil {
+		logutil.BgLogger().Error("column not found in schema", zap.Any("columns", cols), zap.String("schema", schema.String()))
+		return ndv, 1
+	}
+	for _, idx := range indices {
+		// It is a very naive estimation.
+		col := schema.Columns[idx]
+		ndv = math.Max(ndv, profile.ColNDVs[col.UniqueID])
+	}
+	return ndv, 1
+}
+
+// EstimateColsDNVWithMatchedLenFromUniqueIDs is similar to EstimateColsDNVWithMatchedLen, but it receives UniqueIDs instead of Columns.
+func EstimateColsDNVWithMatchedLenFromUniqueIDs(ids []int64, schema *expression.Schema, profile *property.StatsInfo) (float64, int) {
+	cols := make([]*expression.Column, 0, len(ids))
+	for _, id := range ids {
+		cols = append(cols, &expression.Column{
+			UniqueID: id,
+		})
+	}
+	return EstimateColsNDVWithMatchedLen(cols, schema, profile)
+}

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -1826,7 +1826,7 @@ func (ijHelper *indexJoinBuildHelper) updateBestChoice(ranges ranger.MutableRang
 	}
 	var innerNDV float64
 	if stats := ijHelper.innerPlan.StatsInfo(); stats != nil && stats.StatsVersion != statistics.PseudoVersion {
-		innerNDV, _ = getColsNDVWithMatchedLen(path.IdxCols[:usedColsLen], ijHelper.innerPlan.Schema(), stats)
+		innerNDV, _ = cardinality.EstimateColsNDVWithMatchedLen(path.IdxCols[:usedColsLen], ijHelper.innerPlan.Schema(), stats)
 	}
 	// We choose the index by the NDV of the used columns, the larger the better.
 	// If NDVs are same, we choose index which uses more columns.
@@ -2774,7 +2774,7 @@ func (la *LogicalApply) exhaustPhysicalPlans(prop *property.PhysicalProperty) ([
 	}
 	cacheHitRatio := 0.0
 	if la.StatsInfo().RowCount != 0 {
-		ndv, _ := getColsNDVWithMatchedLen(columns, la.schema, la.StatsInfo())
+		ndv, _ := cardinality.EstimateColsNDVWithMatchedLen(columns, la.schema, la.StatsInfo())
 		// for example, if there are 100 rows and the number of distinct values of these correlated columns
 		// are 70, then we can assume 30 rows can hit the cache so the cache hit ratio is 1 - (70/100) = 0.3
 		cacheHitRatio = 1 - (ndv / la.StatsInfo().RowCount)

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -1703,7 +1703,7 @@ func (ds *DataSource) deriveCommonHandleTablePathStats(path *util.AccessPath, co
 			selectivity := path.CountAfterAccess / float64(ds.statisticTable.RealtimeCount)
 			for i := range accesses {
 				col := path.IdxCols[path.EqOrInCondCount+i]
-				ndv := ds.getColumnNDV(col.ID)
+				ndv := cardinality.EstimateColumnNDV(ds.statisticTable, col.ID)
 				ndv *= selectivity
 				if ndv < 1 {
 					ndv = 1.0
@@ -1854,7 +1854,7 @@ func (ds *DataSource) deriveIndexPathStats(path *util.AccessPath, _ []expression
 			selectivity := path.CountAfterAccess / float64(ds.statisticTable.RealtimeCount)
 			for i := range accesses {
 				col := path.IdxCols[path.EqOrInCondCount+i]
-				ndv := ds.getColumnNDV(col.ID)
+				ndv := cardinality.EstimateColumnNDV(ds.statisticTable, col.ID)
 				ndv *= selectivity
 				if ndv < 1 {
 					ndv = 1.0

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/planner/cardinality"
 	"github.com/pingcap/tidb/planner/core/internal/base"
 	fd "github.com/pingcap/tidb/planner/funcdep"
 	"github.com/pingcap/tidb/planner/property"
@@ -142,7 +143,7 @@ func optimizeByShuffle4Window(pp *PhysicalWindow, ctx sessionctx.Context) *Physi
 	for _, item := range pp.PartitionBy {
 		partitionBy = append(partitionBy, item.Col)
 	}
-	ndv, _ := getColsNDVWithMatchedLen(partitionBy, dataSource.Schema(), dataSource.StatsInfo())
+	ndv, _ := cardinality.EstimateColsNDVWithMatchedLen(partitionBy, dataSource.Schema(), dataSource.StatsInfo())
 	if ndv <= 1 {
 		return nil
 	}
@@ -183,7 +184,7 @@ func optimizeByShuffle4StreamAgg(pp *PhysicalStreamAgg, ctx sessionctx.Context) 
 			partitionBy = append(partitionBy, col)
 		}
 	}
-	ndv, _ := getColsNDVWithMatchedLen(partitionBy, dataSource.Schema(), dataSource.StatsInfo())
+	ndv, _ := cardinality.EstimateColsNDVWithMatchedLen(partitionBy, dataSource.Schema(), dataSource.StatsInfo())
 	if ndv <= 1 {
 		return nil
 	}

--- a/planner/core/plan_cost_ver1.go
+++ b/planner/core/plan_cost_ver1.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/planner/cardinality"
 	"github.com/pingcap/tidb/planner/property"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
@@ -817,7 +818,7 @@ func (p *PhysicalMergeJoin) GetCost(lCnt, rCnt float64, costFlag uint64) float64
 	cpuCost += probeCost
 	// For merge join, only one group of rows with same join key(not null) are cached,
 	// we compute average memory cost using estimated group size.
-	ndv, _ := getColsNDVWithMatchedLen(innerKeys, innerSchema, innerStats)
+	ndv, _ := cardinality.EstimateColsNDVWithMatchedLen(innerKeys, innerSchema, innerStats)
 	memoryCost := (innerCnt / ndv) * sessVars.GetMemoryFactor()
 	return cpuCost + memoryCost
 }

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -167,43 +167,6 @@ func (p *baseLogicalPlan) DeriveStats(childStats []*property.StatsInfo, selfSche
 	return profile, nil
 }
 
-// getTotalRowCount returns the total row count, which is obtained when collecting colHist.
-func getTotalRowCount(statsTbl *statistics.Table, colHist *statistics.Column) int64 {
-	if colHist.IsFullLoad() {
-		return int64(colHist.TotalRowCount())
-	}
-	// If colHist is not fully loaded, we may still get its total row count from other index/column stats.
-	for _, idx := range statsTbl.Indices {
-		if idx.IsFullLoad() && idx.LastUpdateVersion == colHist.LastUpdateVersion {
-			return int64(idx.TotalRowCount())
-		}
-	}
-	for _, col := range statsTbl.Columns {
-		if col.IsFullLoad() && col.LastUpdateVersion == colHist.LastUpdateVersion {
-			return int64(col.TotalRowCount())
-		}
-	}
-	return 0
-}
-
-// getColumnNDV computes estimated NDV of specified column using the original
-// histogram of `DataSource` which is retrieved from storage(not the derived one).
-func (ds *DataSource) getColumnNDV(colID int64) (ndv float64) {
-	hist, ok := ds.statisticTable.Columns[colID]
-	if ok && hist.IsStatsInitialized() {
-		ndv = float64(hist.Histogram.NDV)
-		// TODO: a better way to get the total row count derived from the last analyze.
-		analyzeCount := getTotalRowCount(ds.statisticTable, hist)
-		if analyzeCount > 0 {
-			factor := float64(ds.statisticTable.RealtimeCount) / float64(analyzeCount)
-			ndv *= factor
-		}
-	} else {
-		ndv = float64(ds.statisticTable.RealtimeCount) * distinctFactor
-	}
-	return ndv
-}
-
 func (ds *DataSource) getGroupNDVs(colGroups [][]*expression.Column) []property.GroupNDV {
 	if colGroups == nil {
 		return nil
@@ -309,7 +272,7 @@ func (ds *DataSource) initStats(colGroups [][]*expression.Column) {
 	}
 
 	for _, col := range ds.schema.Columns {
-		tableStats.ColNDVs[col.UniqueID] = ds.getColumnNDV(col.ID)
+		tableStats.ColNDVs[col.UniqueID] = cardinality.EstimateColumnNDV(ds.statisticTable, col.ID)
 	}
 	ds.tableStats = tableStats
 	ds.tableStats.GroupNDVs = ds.getGroupNDVs(colGroups)
@@ -637,60 +600,6 @@ func (lt *LogicalTopN) DeriveStats(childStats []*property.StatsInfo, _ *expressi
 	return lt.StatsInfo(), nil
 }
 
-func getGroupNDV4Cols(cols []*expression.Column, stats *property.StatsInfo) *property.GroupNDV {
-	if len(cols) == 0 || len(stats.GroupNDVs) == 0 {
-		return nil
-	}
-	cols = expression.SortColumns(cols)
-	for _, groupNDV := range stats.GroupNDVs {
-		if len(cols) != len(groupNDV.Cols) {
-			continue
-		}
-		match := true
-		for i, col := range groupNDV.Cols {
-			if col != cols[i].UniqueID {
-				match = false
-				break
-			}
-		}
-		if match {
-			return &groupNDV
-		}
-	}
-	return nil
-}
-
-// getColsNDVWithMatchedLen returns the NDV of a couple of columns.
-// If the columns match any GroupNDV maintained by child operator, we can get an accurate NDV.
-// Otherwise, we simply return the max NDV among the columns, which is a lower bound.
-func getColsNDVWithMatchedLen(cols []*expression.Column, schema *expression.Schema, profile *property.StatsInfo) (float64, int) {
-	ndv := 1.0
-	if groupNDV := getGroupNDV4Cols(cols, profile); groupNDV != nil {
-		return math.Max(groupNDV.NDV, ndv), len(groupNDV.Cols)
-	}
-	indices := schema.ColumnsIndices(cols)
-	if indices == nil {
-		logutil.BgLogger().Error("column not found in schema", zap.Any("columns", cols), zap.String("schema", schema.String()))
-		return ndv, 1
-	}
-	for _, idx := range indices {
-		// It is a very naive estimation.
-		col := schema.Columns[idx]
-		ndv = math.Max(ndv, profile.ColNDVs[col.UniqueID])
-	}
-	return ndv, 1
-}
-
-func getColsDNVWithMatchedLenFromUniqueIDs(ids []int64, schema *expression.Schema, profile *property.StatsInfo) (float64, int) {
-	cols := make([]*expression.Column, 0, len(ids))
-	for _, id := range ids {
-		cols = append(cols, &expression.Column{
-			UniqueID: id,
-		})
-	}
-	return getColsNDVWithMatchedLen(cols, schema, profile)
-}
-
 func (p *LogicalProjection) getGroupNDVs(colGroups [][]*expression.Column, childProfile *property.StatsInfo, selfSchema *expression.Schema) []property.GroupNDV {
 	if len(colGroups) == 0 || len(childProfile.GroupNDVs) == 0 {
 		return nil
@@ -741,7 +650,7 @@ func (p *LogicalProjection) DeriveStats(childStats []*property.StatsInfo, selfSc
 	})
 	for i, expr := range p.Exprs {
 		cols := expression.ExtractColumns(expr)
-		p.StatsInfo().ColNDVs[selfSchema.Columns[i].UniqueID], _ = getColsNDVWithMatchedLen(cols, childSchema[0], childProfile)
+		p.StatsInfo().ColNDVs[selfSchema.Columns[i].UniqueID], _ = cardinality.EstimateColsNDVWithMatchedLen(cols, childSchema[0], childProfile)
 	}
 	p.StatsInfo().GroupNDVs = p.getGroupNDVs(colGroups, childProfile, selfSchema)
 	return p.StatsInfo(), nil
@@ -784,7 +693,7 @@ func (*LogicalAggregation) getGroupNDVs(colGroups [][]*expression.Column, childP
 	// Note that gbyCols may not be the exact GROUP BY columns, e.g, GROUP BY a+b,
 	// but we have no other approaches for the NDV estimation of these cases
 	// except for using the independent assumption, unless we can use stats of expression index.
-	groupNDV := getGroupNDV4Cols(gbyCols, childProfile)
+	groupNDV := childProfile.GetGroupNDV4Cols(gbyCols)
 	if groupNDV == nil {
 		return nil
 	}
@@ -804,7 +713,7 @@ func (la *LogicalAggregation) DeriveStats(childStats []*property.StatsInfo, self
 		la.StatsInfo().GroupNDVs = la.getGroupNDVs(colGroups, childProfile, gbyCols)
 		return la.StatsInfo(), nil
 	}
-	ndv, _ := getColsNDVWithMatchedLen(gbyCols, childSchema[0], childProfile)
+	ndv, _ := cardinality.EstimateColsNDVWithMatchedLen(gbyCols, childSchema[0], childProfile)
 	la.SetStats(&property.StatsInfo{
 		RowCount: ndv,
 		ColNDVs:  make(map[int64]float64, selfSchema.Len()),
@@ -965,11 +874,11 @@ func (h *fullJoinRowCountHelper) estimate() float64 {
 	var leftKeyNDV, rightKeyNDV float64
 	var leftColCnt, rightColCnt int
 	if len(h.leftJoinKeys) > 0 || len(h.rightJoinKeys) > 0 {
-		leftKeyNDV, leftColCnt = getColsNDVWithMatchedLen(h.leftJoinKeys, h.leftSchema, h.leftProfile)
-		rightKeyNDV, rightColCnt = getColsNDVWithMatchedLen(h.rightJoinKeys, h.rightSchema, h.rightProfile)
+		leftKeyNDV, leftColCnt = cardinality.EstimateColsNDVWithMatchedLen(h.leftJoinKeys, h.leftSchema, h.leftProfile)
+		rightKeyNDV, rightColCnt = cardinality.EstimateColsNDVWithMatchedLen(h.rightJoinKeys, h.rightSchema, h.rightProfile)
 	} else {
-		leftKeyNDV, leftColCnt = getColsNDVWithMatchedLen(h.leftNAJoinKeys, h.leftSchema, h.leftProfile)
-		rightKeyNDV, rightColCnt = getColsNDVWithMatchedLen(h.rightNAJoinKeys, h.rightSchema, h.rightProfile)
+		leftKeyNDV, leftColCnt = cardinality.EstimateColsNDVWithMatchedLen(h.leftNAJoinKeys, h.leftSchema, h.leftProfile)
+		rightKeyNDV, rightColCnt = cardinality.EstimateColsNDVWithMatchedLen(h.rightNAJoinKeys, h.rightSchema, h.rightProfile)
 	}
 	count := h.leftProfile.RowCount * h.rightProfile.RowCount / math.Max(leftKeyNDV, rightKeyNDV)
 	if h.sctx.GetSessionVars().TiDBOptJoinReorderThreshold <= 0 {
@@ -1149,7 +1058,7 @@ func (p *LogicalCTE) DeriveStats(_ []*property.StatsInfo, selfSchema *expression
 			p.StatsInfo().ColNDVs[col.UniqueID] += recurStat.ColNDVs[p.cte.recursivePartLogicalPlan.Schema().Columns[i].UniqueID]
 		}
 		if p.cte.IsDistinct {
-			p.StatsInfo().RowCount, _ = getColsNDVWithMatchedLen(p.schema.Columns, p.schema, p.StatsInfo())
+			p.StatsInfo().RowCount, _ = cardinality.EstimateColsNDVWithMatchedLen(p.schema.Columns, p.schema, p.StatsInfo())
 		} else {
 			p.StatsInfo().RowCount += recurStat.RowCount
 		}

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1985,7 +1985,7 @@ func (p *PhysicalHashAgg) scaleStats4GroupingSets(groupingSets expression.Groupi
 		// for every grouping set, pick its cols out, and combine with normal group cols to get the ndv.
 		groupingSetCols := groupingSet.ExtractCols()
 		groupingSetCols = append(groupingSetCols, normalGbyCols...)
-		ndv, _ := getColsNDVWithMatchedLen(groupingSetCols, childSchema, childStats)
+		ndv, _ := cardinality.EstimateColsNDVWithMatchedLen(groupingSetCols, childSchema, childStats)
 		sumNDV += ndv
 	}
 	// After group operator, all same rows are grouped into one row, that means all
@@ -2012,7 +2012,7 @@ func (p *PhysicalHashAgg) scaleStats4GroupingSets(groupingSets expression.Groupi
 					// when meet an id in grouping sets, skip it (cause its null) and append the rest ids to count the incrementNDV.
 					beforeLen := len(intersectionIDs)
 					intersectionIDs = append(intersectionIDs, oneGNDV.Cols[i:]...)
-					incrementNDV, _ := getColsDNVWithMatchedLenFromUniqueIDs(intersectionIDs, childSchema, childStats)
+					incrementNDV, _ := cardinality.EstimateColsDNVWithMatchedLenFromUniqueIDs(intersectionIDs, childSchema, childStats)
 					newGNDV += incrementNDV
 					// restore the before intersectionIDs slice.
 					intersectionIDs = intersectionIDs[:beforeLen]

--- a/planner/property/stats_info.go
+++ b/planner/property/stats_info.go
@@ -17,6 +17,7 @@ package property
 import (
 	"fmt"
 
+	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/statistics"
 )
 
@@ -88,4 +89,28 @@ func (s *StatsInfo) ScaleByExpectCnt(expectCnt float64) *StatsInfo {
 		return s.Scale(expectCnt / s.RowCount)
 	}
 	return s
+}
+
+// GetGroupNDV4Cols gets the GroupNDV for the given columns.
+func (s *StatsInfo) GetGroupNDV4Cols(cols []*expression.Column) *GroupNDV {
+	if s == nil || len(cols) == 0 || len(s.GroupNDVs) == 0 {
+		return nil
+	}
+	cols = expression.SortColumns(cols)
+	for _, groupNDV := range s.GroupNDVs {
+		if len(cols) != len(groupNDV.Cols) {
+			continue
+		}
+		match := true
+		for i, col := range groupNDV.Cols {
+			if col != cols[i].UniqueID {
+				match = false
+				break
+			}
+		}
+		if match {
+			return &groupNDV
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46358

Problem Summary: Move the Selectivity function from the stats package into cardinality package

### What is changed and how it works?

**No logical change, just some code movement.**

Follow with https://github.com/pingcap/tidb/pull/46359

Move the Selectivity function from the stats package.

<img width="421" alt="image" src="https://github.com/pingcap/tidb/assets/7499936/2792f67a-460e-4df8-a5b6-b1321afec51d">

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
