### PR TITLE
explaintest: don't use `test` database in explaintest

### DIFF
--- a/cmd/explaintest/r/black_list.result
+++ b/cmd/explaintest/r/black_list.result
@@ -1,18 +1,17 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t;
 create table t (a int);
 explain format = 'brief' select * from t where a < 1;
 id	estRows	task	access object	operator info
 TableReader	3323.33	root		data:Selection
-└─Selection	3323.33	cop[tikv]		lt(test.t.a, 1)
+└─Selection	3323.33	cop[tikv]		lt(black_list.t.a, 1)
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 insert into mysql.opt_rule_blacklist values('predicate_push_down');
 admin reload opt_rule_blacklist;
 
 explain format = 'brief' select * from t where a < 1;
 id	estRows	task	access object	operator info
-Selection	8000.00	root		lt(test.t.a, 1)
+Selection	8000.00	root		lt(black_list.t.a, 1)
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 delete from mysql.opt_rule_blacklist where name='predicate_push_down';
@@ -21,14 +20,14 @@ admin reload opt_rule_blacklist;
 explain format = 'brief' select * from t where a < 1;
 id	estRows	task	access object	operator info
 TableReader	3323.33	root		data:Selection
-└─Selection	3323.33	cop[tikv]		lt(test.t.a, 1)
+└─Selection	3323.33	cop[tikv]		lt(black_list.t.a, 1)
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 insert into mysql.expr_pushdown_blacklist values('<', 'tikv,tiflash,tidb', 'for test');
 admin reload expr_pushdown_blacklist;
 
 explain format = 'brief' select * from t where a < 1;
 id	estRows	task	access object	operator info
-Selection	8000.00	root		lt(test.t.a, 1)
+Selection	8000.00	root		lt(black_list.t.a, 1)
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 delete from mysql.expr_pushdown_blacklist where name='<' and store_type = 'tikv,tiflash,tidb' and reason = 'for test';
@@ -37,14 +36,14 @@ admin reload expr_pushdown_blacklist;
 explain format = 'brief' select * from t where a < 1;
 id	estRows	task	access object	operator info
 TableReader	3323.33	root		data:Selection
-└─Selection	3323.33	cop[tikv]		lt(test.t.a, 1)
+└─Selection	3323.33	cop[tikv]		lt(black_list.t.a, 1)
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 insert into mysql.expr_pushdown_blacklist values('lt', 'tikv,tiflash,tidb', 'for test');
 admin reload expr_pushdown_blacklist;
 
 explain format = 'brief' select * from t where a < 1;
 id	estRows	task	access object	operator info
-Selection	8000.00	root		lt(test.t.a, 1)
+Selection	8000.00	root		lt(black_list.t.a, 1)
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 delete from mysql.expr_pushdown_blacklist where name='lt' and store_type = 'tikv,tiflash,tidb' and reason = 'for test';
@@ -53,5 +52,5 @@ admin reload expr_pushdown_blacklist;
 explain format = 'brief' select * from t where a < 1;
 id	estRows	task	access object	operator info
 TableReader	3323.33	root		data:Selection
-└─Selection	3323.33	cop[tikv]		lt(test.t.a, 1)
+└─Selection	3323.33	cop[tikv]		lt(black_list.t.a, 1)
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/cmd/explaintest/r/collation_agg_func_disabled.result
+++ b/cmd/explaintest/r/collation_agg_func_disabled.result
@@ -298,5 +298,3 @@ StreamAgg	1.00	root		funcs:max(Column#8)->Column#6
 select max(d collate utf8mb4_bin) from tt;
 max(d collate utf8mb4_bin)
 {"c": "c"}
-drop database collation_agg_func;
-use test

--- a/cmd/explaintest/r/collation_agg_func_enabled.result
+++ b/cmd/explaintest/r/collation_agg_func_enabled.result
@@ -295,5 +295,3 @@ StreamAgg	1.00	root		funcs:max(Column#8)->Column#6
 select max(d collate utf8mb4_bin) from tt;
 max(d collate utf8mb4_bin)
 {"c": "c"}
-drop database collation_agg_func;
-use test

--- a/cmd/explaintest/r/collation_check_use_collation_disabled.result
+++ b/cmd/explaintest/r/collation_check_use_collation_disabled.result
@@ -176,4 +176,3 @@ Projection	80000000.00	root		is_ipv4(cast(collation_check_use_collation.t0.c1, v
   │   └─TableFullScan	10000.00	cop[tikv]	table:t0	keep order:false, stats:pseudo
   └─TableReader(Probe)	10000.00	root		data:TableFullScan
     └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-use test

--- a/cmd/explaintest/r/collation_check_use_collation_enabled.result
+++ b/cmd/explaintest/r/collation_check_use_collation_enabled.result
@@ -195,4 +195,3 @@ Projection	80000000.00	root		is_ipv4(cast(collation_check_use_collation.t0.c1, v
   │   └─TableFullScan	10000.00	cop[tikv]	table:t0	keep order:false, stats:pseudo
   └─TableReader(Probe)	10000.00	root		data:TableFullScan
     └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-use test

--- a/cmd/explaintest/r/collation_misc_disabled.result
+++ b/cmd/explaintest/r/collation_misc_disabled.result
@@ -118,4 +118,3 @@ binary	binary	63	Yes	Yes	1
 ascii_bin	ascii	65	Yes	Yes	1
 utf8_bin	utf8	83	Yes	Yes	1
 gbk_bin	gbk	87	Yes	Yes	1
-use test;

--- a/cmd/explaintest/r/collation_misc_enabled.result
+++ b/cmd/explaintest/r/collation_misc_enabled.result
@@ -135,4 +135,3 @@ utf8mb4_0900_bin	utf8mb4	309		Yes	1
 utf8mb4_bin	utf8mb4	46	Yes	Yes	1
 utf8mb4_general_ci	utf8mb4	45		Yes	1
 utf8mb4_unicode_ci	utf8mb4	224		Yes	1
-use test;

--- a/cmd/explaintest/r/cte.result
+++ b/cmd/explaintest/r/cte.result
@@ -1,5 +1,6 @@
 set tidb_cost_model_version=1;
-use test;
+drop database if exists cte1;
+create database cte1;
 drop table if exists tbl_0;
 create table tbl_0(a int);
 with recursive cte_0 (col_10,col_11,col_12) AS ( select 1, 2,3 from tbl_0 UNION select col_10 + 1,col_11 + 1,col_12 + 1 from cte_0 where col_10 < 10 ) select * from cte_0;
@@ -356,7 +357,7 @@ drop table if exists t1;
 create table t1(c1 bigint unsigned);
 insert into t1 values(0);
 with recursive cte1 as (select c1 - 1 c1 from t1 union all select c1 - 1 c1 from cte1 where c1 != 0) select * from cte1 dt1, cte1 dt2;
-Error 1690: BIGINT UNSIGNED value is out of range in '(test.t1.c1 - 1)'
+Error 1690: BIGINT UNSIGNED value is out of range in '(cte.t1.c1 - 1)'
 drop table if exists t;
 create table t(a int, b int, key (b));
 desc with cte as (select * from t) select * from cte;
@@ -382,14 +383,14 @@ insert into tpk values(1), (2), (3);
 // Expect a Sort operator on CTE.
 explain with cte1 as (select c1 from t1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_25	12487.50	root		inner join, left key:test.t1.c1, right key:test.t1.c1
-├─Sort_23(Build)	9990.00	root		test.t1.c1
+MergeJoin_25	12487.50	root		inner join, left key:cte.t1.c1, right key:cte.t1.c1
+├─Sort_23(Build)	9990.00	root		cte.t1.c1
 │ └─TableReader_22	9990.00	root		data:Selection_21
-│   └─Selection_21	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+│   └─Selection_21	9990.00	cop[tikv]		not(isnull(cte.t1.c1))
 │     └─TableFullScan_20	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Sort_19(Probe)	9990.00	root		test.t1.c1
+└─Sort_19(Probe)	9990.00	root		cte.t1.c1
   └─TableReader_18	9990.00	root		data:Selection_17
-    └─Selection_17	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+    └─Selection_17	9990.00	cop[tikv]		not(isnull(cte.t1.c1))
       └─TableFullScan_16	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 with cte1 as (select c1 from t1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
@@ -404,7 +405,7 @@ c1	c1
 // Sort should not exist, because tpk.c1 is pk. Not the best plan for now(#25674).
 explain with cte1 as (select c1 from tpk) select /*+ MERGE_JOIN(dt1, dt2) */ * from tpk dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_27	12500.00	root		inner join, left key:test.tpk.c1, right key:test.tpk.c1
+MergeJoin_27	12500.00	root		inner join, left key:cte.tpk.c1, right key:cte.tpk.c1
 ├─TableReader_24(Build)	10000.00	root		data:TableFullScan_23
 │ └─TableFullScan_23	10000.00	cop[tikv]	table:tpk	keep order:true, stats:pseudo
 └─TableReader_22(Probe)	10000.00	root		data:TableFullScan_21
@@ -417,14 +418,14 @@ c1	c1
 // Sort should not exist, because we have order by in CTE definition. Not the best plan for now(#25674).
 explain with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_25	12487.50	root		inner join, left key:test.t1.c1, right key:test.t1.c1
-├─Sort_23(Build)	9990.00	root		test.t1.c1
+MergeJoin_25	12487.50	root		inner join, left key:cte.t1.c1, right key:cte.t1.c1
+├─Sort_23(Build)	9990.00	root		cte.t1.c1
 │ └─TableReader_22	9990.00	root		data:Selection_21
-│   └─Selection_21	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+│   └─Selection_21	9990.00	cop[tikv]		not(isnull(cte.t1.c1))
 │     └─TableFullScan_20	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Sort_19(Probe)	9990.00	root		test.t1.c1
+└─Sort_19(Probe)	9990.00	root		cte.t1.c1
   └─TableReader_18	9990.00	root		data:Selection_17
-    └─Selection_17	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+    └─Selection_17	9990.00	cop[tikv]		not(isnull(cte.t1.c1))
       └─TableFullScan_16	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
@@ -439,19 +440,19 @@ c1	c1
 // Expect a Sort operator on CTE. Because it's recursive.
 explain with recursive cte1 as (select c1 from t1 union select c1 +1 c1 from cte1 where c1 < 3) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_36	8001.00	root		inner join, left key:test.t1.c1, right key:test.t1.c1
-├─Sort_34(Build)	6400.80	root		test.t1.c1
-│ └─Selection_32	6400.80	root		not(isnull(test.t1.c1))
+MergeJoin_36	8001.00	root		inner join, left key:cte.t1.c1, right key:cte.t1.c1
+├─Sort_34(Build)	6400.80	root		cte.t1.c1
+│ └─Selection_32	6400.80	root		not(isnull(cte.t1.c1))
 │   └─CTEFullScan_33	8001.00	root	CTE:cte1 AS dt2	data:CTE_0
-└─Sort_30(Probe)	9990.00	root		test.t1.c1
+└─Sort_30(Probe)	9990.00	root		cte.t1.c1
   └─TableReader_29	9990.00	root		data:Selection_28
-    └─Selection_28	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+    └─Selection_28	9990.00	cop[tikv]		not(isnull(cte.t1.c1))
       └─TableFullScan_27	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 CTE_0	8001.00	root		Recursive CTE
 ├─TableReader_18(Seed Part)	10000.00	root		data:TableFullScan_17
 │ └─TableFullScan_17	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Projection_19(Recursive Part)	8000.00	root		cast(plus(test.t1.c1, 1), int(11))->test.t1.c1
-  └─Selection_20	8000.00	root		lt(test.t1.c1, 3)
+└─Projection_19(Recursive Part)	8000.00	root		cast(plus(cte.t1.c1, 1), int(11))->cte.t1.c1
+  └─Selection_20	8000.00	root		lt(cte.t1.c1, 3)
     └─CTETable_21	10000.00	root		Scan on CTE_0
 with recursive cte1 as (select c1 from t1 union select c1 +1 c1 from cte1 where c1 < 3) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
@@ -462,19 +463,19 @@ c1	c1
 // Expect a Sort operator on CTE. Because it's recursive.
 explain with recursive cte1 as (select c1 from tpk union select c1 +1 c1 from cte1 where c1 < 3) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_36	8001.00	root		inner join, left key:test.t1.c1, right key:test.tpk.c1
-├─Sort_34(Build)	6400.80	root		test.tpk.c1
-│ └─Selection_32	6400.80	root		not(isnull(test.tpk.c1))
+MergeJoin_36	8001.00	root		inner join, left key:cte.t1.c1, right key:cte.tpk.c1
+├─Sort_34(Build)	6400.80	root		cte.tpk.c1
+│ └─Selection_32	6400.80	root		not(isnull(cte.tpk.c1))
 │   └─CTEFullScan_33	8001.00	root	CTE:cte1 AS dt2	data:CTE_0
-└─Sort_30(Probe)	9990.00	root		test.t1.c1
+└─Sort_30(Probe)	9990.00	root		cte.t1.c1
   └─TableReader_29	9990.00	root		data:Selection_28
-    └─Selection_28	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+    └─Selection_28	9990.00	cop[tikv]		not(isnull(cte.t1.c1))
       └─TableFullScan_27	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 CTE_0	8001.00	root		Recursive CTE
 ├─TableReader_18(Seed Part)	10000.00	root		data:TableFullScan_17
 │ └─TableFullScan_17	10000.00	cop[tikv]	table:tpk	keep order:false, stats:pseudo
-└─Projection_19(Recursive Part)	8000.00	root		cast(plus(test.tpk.c1, 1), int(11))->test.tpk.c1
-  └─Selection_20	8000.00	root		lt(test.tpk.c1, 3)
+└─Projection_19(Recursive Part)	8000.00	root		cast(plus(cte.tpk.c1, 1), int(11))->cte.tpk.c1
+  └─Selection_20	8000.00	root		lt(cte.tpk.c1, 3)
     └─CTETable_21	10000.00	root		Scan on CTE_0
 with recursive cte1 as (select c1 from tpk union select c1 +1 c1 from cte1 where c1 < 3) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
@@ -486,14 +487,14 @@ c1	c1
 // Expect Sort operator in CTE definition.
 explain with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_25	12487.50	root		inner join, left key:test.t1.c1, right key:test.t1.c1
-├─Sort_23(Build)	9990.00	root		test.t1.c1
+MergeJoin_25	12487.50	root		inner join, left key:cte.t1.c1, right key:cte.t1.c1
+├─Sort_23(Build)	9990.00	root		cte.t1.c1
 │ └─TableReader_22	9990.00	root		data:Selection_21
-│   └─Selection_21	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+│   └─Selection_21	9990.00	cop[tikv]		not(isnull(cte.t1.c1))
 │     └─TableFullScan_20	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Sort_19(Probe)	9990.00	root		test.t1.c1
+└─Sort_19(Probe)	9990.00	root		cte.t1.c1
   └─TableReader_18	9990.00	root		data:Selection_17
-    └─Selection_17	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+    └─Selection_17	9990.00	cop[tikv]		not(isnull(cte.t1.c1))
       └─TableFullScan_16	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
@@ -508,12 +509,12 @@ c1	c1
 // Sort should not exist, because tpk is ordered. Not the best plan for now(#25674).
 explain with cte1 as (select c1 from tpk order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_23	12487.50	root		inner join, left key:test.t1.c1, right key:test.tpk.c1
+MergeJoin_23	12487.50	root		inner join, left key:cte.t1.c1, right key:cte.tpk.c1
 ├─TableReader_21(Build)	10000.00	root		data:TableFullScan_20
 │ └─TableFullScan_20	10000.00	cop[tikv]	table:tpk	keep order:true, stats:pseudo
-└─Sort_19(Probe)	9990.00	root		test.t1.c1
+└─Sort_19(Probe)	9990.00	root		cte.t1.c1
   └─TableReader_18	9990.00	root		data:Selection_17
-    └─Selection_17	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+    └─Selection_17	9990.00	cop[tikv]		not(isnull(cte.t1.c1))
       └─TableFullScan_16	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 with cte1 as (select c1 from tpk order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
@@ -524,11 +525,11 @@ c1	c1
 // HashJoin. No need to sort
 explain with cte1 as (select c1 from t1) select /*+ HASH_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = 1 order by 1, 2;
 id	estRows	task	access object	operator info
-Sort_13	100000.00	root		test.t1.c1, test.t1.c1
-└─Projection_16	100000.00	root		test.t1.c1, test.t1.c1
+Sort_13	100000.00	root		cte.t1.c1, cte.t1.c1
+└─Projection_16	100000.00	root		cte.t1.c1, cte.t1.c1
   └─HashJoin_18	100000.00	root		CARTESIAN inner join
     ├─TableReader_21(Build)	10.00	root		data:Selection_20
-    │ └─Selection_20	10.00	cop[tikv]		eq(test.t1.c1, 1)
+    │ └─Selection_20	10.00	cop[tikv]		eq(cte.t1.c1, 1)
     │   └─TableFullScan_19	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
     └─TableReader_23(Probe)	10000.00	root		data:TableFullScan_22
       └─TableFullScan_22	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
@@ -544,8 +545,8 @@ c1	c1
 2	1
 explain with cte1 as (select c1 from tpk) select /*+ HASH_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = 1 order by 1, 2;
 id	estRows	task	access object	operator info
-Sort_13	10000.00	root		test.t1.c1, test.tpk.c1
-└─Projection_16	10000.00	root		test.t1.c1, test.tpk.c1
+Sort_13	10000.00	root		cte.t1.c1, cte.tpk.c1
+└─Projection_16	10000.00	root		cte.t1.c1, cte.tpk.c1
   └─HashJoin_18	10000.00	root		CARTESIAN inner join
     ├─Point_Get_19(Build)	1.00	root	table:tpk	handle:1
     └─TableReader_21(Probe)	10000.00	root		data:TableFullScan_20
@@ -564,12 +565,12 @@ create table tpk1(c1 int primary key);
 insert into tpk1 values(1), (2), (3);
 explain with cte1 as (select c1 from tpk) select /*+ merge_join(dt1, dt2) */ * from tpk1 dt1 inner join cte1 dt2 inner join cte1 dt3 on dt1.c1 = dt2.c1 and dt2.c1 = dt3.c1;
 id	estRows	task	access object	operator info
-HashJoin_19	12500.00	root		inner join, equal:[eq(test.tpk.c1, test.tpk.c1)]
-├─Selection_28(Build)	8000.00	root		not(isnull(test.tpk.c1))
+HashJoin_19	12500.00	root		inner join, equal:[eq(cte.tpk.c1, cte.tpk.c1)]
+├─Selection_28(Build)	8000.00	root		not(isnull(cte.tpk.c1))
 │ └─CTEFullScan_29	10000.00	root	CTE:cte1 AS dt3	data:CTE_0
-└─MergeJoin_21(Probe)	10000.00	root		inner join, left key:test.tpk1.c1, right key:test.tpk.c1
-  ├─Sort_27(Build)	8000.00	root		test.tpk.c1
-  │ └─Selection_25	8000.00	root		not(isnull(test.tpk.c1))
+└─MergeJoin_21(Probe)	10000.00	root		inner join, left key:cte.tpk1.c1, right key:cte.tpk.c1
+  ├─Sort_27(Build)	8000.00	root		cte.tpk.c1
+  │ └─Selection_25	8000.00	root		not(isnull(cte.tpk.c1))
   │   └─CTEFullScan_26	10000.00	root	CTE:cte1 AS dt2	data:CTE_0
   └─TableReader_23(Probe)	10000.00	root		data:TableFullScan_22
     └─TableFullScan_22	10000.00	cop[tikv]	table:dt1	keep order:true, stats:pseudo
@@ -591,14 +592,14 @@ insert into t2 values(1, 1);
 insert into t2 values(3, 2);
 explain select * from t1 where c1 > all(with cte1 as (select c1 from t2 where t2.c2 = t1.c2) select c1 from cte1);
 id	estRows	task	access object	operator info
-Projection_16	10000.00	root		test.t1.c1, test.t1.c2
-└─Apply_18	10000.00	root		CARTESIAN inner join, other cond:or(and(gt(test.t1.c1, Column#11), if(ne(Column#12, 0), NULL, 1)), or(eq(Column#13, 0), if(isnull(test.t1.c1), NULL, 0)))
+Projection_16	10000.00	root		cte.t1.c1, cte.t1.c2
+└─Apply_18	10000.00	root		CARTESIAN inner join, other cond:or(and(gt(cte.t1.c1, Column#11), if(ne(Column#12, 0), NULL, 1)), or(eq(Column#13, 0), if(isnull(cte.t1.c1), NULL, 0)))
   ├─TableReader_20(Build)	10000.00	root		data:TableFullScan_19
   │ └─TableFullScan_19	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
   └─StreamAgg_35(Probe)	10000.00	root		funcs:max(Column#19)->Column#11, funcs:sum(Column#20)->Column#12, funcs:count(Column#21)->Column#13
     └─TableReader_36	10000.00	root		data:StreamAgg_24
-      └─StreamAgg_24	10000.00	cop[tikv]		funcs:max(test.t2.c1)->Column#19, funcs:sum(isnull(test.t2.c1))->Column#20, funcs:count(1)->Column#21
-        └─Selection_34	100000.00	cop[tikv]		eq(test.t2.c2, test.t1.c2)
+      └─StreamAgg_24	10000.00	cop[tikv]		funcs:max(cte.t2.c1)->Column#19, funcs:sum(isnull(cte.t2.c1))->Column#20, funcs:count(1)->Column#21
+        └─Selection_34	100000.00	cop[tikv]		eq(cte.t2.c2, cte.t1.c2)
           └─TableFullScan_33	100000000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 select * from t1 where c1 > all(with cte1 as (select c1 from t2 where t2.c2 = t1.c2) select c1 from cte1);
 c1	c2
@@ -607,12 +608,12 @@ c1	c2
 insert into t1 values(2, 3);
 explain select * from t1 where exists(with cte1 as (select c1 from t2 where t2.c2 = t1.c2) select c1 from cte1);
 id	estRows	task	access object	operator info
-HashJoin_14	7992.00	root		semi join, equal:[eq(test.t1.c2, test.t2.c2)]
+HashJoin_14	7992.00	root		semi join, equal:[eq(cte.t1.c2, cte.t2.c2)]
 ├─TableReader_20(Build)	9990.00	root		data:Selection_19
-│ └─Selection_19	9990.00	cop[tikv]		not(isnull(test.t2.c2))
+│ └─Selection_19	9990.00	cop[tikv]		not(isnull(cte.t2.c2))
 │   └─TableFullScan_18	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 └─TableReader_17(Probe)	9990.00	root		data:Selection_16
-  └─Selection_16	9990.00	cop[tikv]		not(isnull(test.t1.c2))
+  └─Selection_16	9990.00	cop[tikv]		not(isnull(cte.t1.c2))
     └─TableFullScan_15	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 select * from t1 where exists(with cte1 as (select c1 from t2 where t2.c2 = t1.c2) select c1 from cte1);
 c1	c2
@@ -621,19 +622,19 @@ c1	c2
 // Same as above, but test recursive cte.
 explain select * from t1 where c1 > all(with recursive cte1 as (select c1 from t2 where t2.c2 = t1.c2 union all select c1+1 as c1 from cte1 limit 1) select c1 from cte1);
 id	estRows	task	access object	operator info
-Projection_26	10000.00	root		test.t1.c1, test.t1.c2
-└─Apply_28	10000.00	root		CARTESIAN inner join, other cond:or(and(gt(test.t1.c1, Column#14), if(ne(Column#15, 0), NULL, 1)), or(eq(Column#16, 0), if(isnull(test.t1.c1), NULL, 0)))
+Projection_26	10000.00	root		cte.t1.c1, cte.t1.c2
+└─Apply_28	10000.00	root		CARTESIAN inner join, other cond:or(and(gt(cte.t1.c1, Column#14), if(ne(Column#15, 0), NULL, 1)), or(eq(Column#16, 0), if(isnull(cte.t1.c1), NULL, 0)))
   ├─TableReader_30(Build)	10000.00	root		data:TableFullScan_29
   │ └─TableFullScan_29	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
   └─HashAgg_31(Probe)	10000.00	root		funcs:max(Column#19)->Column#14, funcs:sum(Column#20)->Column#15, funcs:count(1)->Column#16
-    └─Projection_35	200000.00	root		test.t2.c1->Column#19, cast(isnull(test.t2.c1), decimal(20,0) BINARY)->Column#20
+    └─Projection_35	200000.00	root		cte.t2.c1->Column#19, cast(isnull(cte.t2.c1), decimal(20,0) BINARY)->Column#20
       └─CTEFullScan_33	200000.00	root	CTE:cte1	data:CTE_0
 CTE_0	20.00	root		Recursive CTE, limit(offset:0, count:1)
-├─Projection_19(Seed Part)	10.00	root		test.t2.c1
+├─Projection_19(Seed Part)	10.00	root		cte.t2.c1
 │ └─TableReader_22	10.00	root		data:Selection_21
-│   └─Selection_21	10.00	cop[tikv]		eq(test.t2.c2, test.t1.c2)
+│   └─Selection_21	10.00	cop[tikv]		eq(cte.t2.c2, cte.t1.c2)
 │     └─TableFullScan_20	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
-└─Projection_23(Recursive Part)	10.00	root		cast(plus(test.t2.c1, 1), int(11))->test.t2.c1
+└─Projection_23(Recursive Part)	10.00	root		cast(plus(cte.t2.c1, 1), int(11))->cte.t2.c1
   └─CTETable_24	10.00	root		Scan on CTE_0
 select * from t1 where c1 > all(with recursive cte1 as (select c1 from t2 where t2.c2 = t1.c2 union all select c1+1 as c1 from cte1 limit 1) select c1 from cte1);
 c1	c2
@@ -646,11 +647,11 @@ Apply_25	10000.00	root		CARTESIAN semi join
 │ └─TableFullScan_26	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 └─CTEFullScan_28(Probe)	200000.00	root	CTE:cte1	data:CTE_0
 CTE_0	20.00	root		Recursive CTE, limit(offset:0, count:10)
-├─Projection_17(Seed Part)	10.00	root		test.t2.c1
+├─Projection_17(Seed Part)	10.00	root		cte.t2.c1
 │ └─TableReader_20	10.00	root		data:Selection_19
-│   └─Selection_19	10.00	cop[tikv]		eq(test.t2.c2, test.t1.c2)
+│   └─Selection_19	10.00	cop[tikv]		eq(cte.t2.c2, cte.t1.c2)
 │     └─TableFullScan_18	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
-└─Projection_21(Recursive Part)	10.00	root		cast(plus(test.t2.c1, 1), int(11))->test.t2.c1
+└─Projection_21(Recursive Part)	10.00	root		cast(plus(cte.t2.c1, 1), int(11))->cte.t2.c1
   └─CTETable_22	10.00	root		Scan on CTE_0
 select * from t1 where exists(with recursive cte1 as (select c1 from t2 where t2.c2 = t1.c2 union all select c1+1 as c1 from cte1 limit 10) select c1 from cte1);
 c1	c2
@@ -659,18 +660,18 @@ c1	c2
 // Test correlated col is in recursive part.
 explain select * from t1 where c1 > all(with recursive cte1 as (select c1, c2 from t2 union all select c1+1 as c1, c2+1 as c2 from cte1 where cte1.c2=t1.c2) select c1 from cte1);
 id	estRows	task	access object	operator info
-Projection_24	10000.00	root		test.t1.c1, test.t1.c2
-└─Apply_26	10000.00	root		CARTESIAN inner join, other cond:or(and(gt(test.t1.c1, Column#18), if(ne(Column#19, 0), NULL, 1)), or(eq(Column#20, 0), if(isnull(test.t1.c1), NULL, 0)))
+Projection_24	10000.00	root		cte.t1.c1, cte.t1.c2
+└─Apply_26	10000.00	root		CARTESIAN inner join, other cond:or(and(gt(cte.t1.c1, Column#18), if(ne(Column#19, 0), NULL, 1)), or(eq(Column#20, 0), if(isnull(cte.t1.c1), NULL, 0)))
   ├─TableReader_28(Build)	10000.00	root		data:TableFullScan_27
   │ └─TableFullScan_27	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
   └─HashAgg_29(Probe)	10000.00	root		funcs:max(Column#23)->Column#18, funcs:sum(Column#24)->Column#19, funcs:count(1)->Column#20
-    └─Projection_33	180000000.00	root		test.t2.c1->Column#23, cast(isnull(test.t2.c1), decimal(20,0) BINARY)->Column#24
+    └─Projection_33	180000000.00	root		cte.t2.c1->Column#23, cast(isnull(cte.t2.c1), decimal(20,0) BINARY)->Column#24
       └─CTEFullScan_31	180000000.00	root	CTE:cte1	data:CTE_0
 CTE_0	18000.00	root		Recursive CTE
 ├─TableReader_19(Seed Part)	10000.00	root		data:TableFullScan_18
 │ └─TableFullScan_18	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
-└─Projection_20(Recursive Part)	8000.00	root		cast(plus(test.t2.c1, 1), int(11))->test.t2.c1, cast(plus(test.t2.c2, 1), int(11))->test.t2.c2
-  └─Selection_21	8000.00	root		eq(test.t2.c2, test.t1.c2)
+└─Projection_20(Recursive Part)	8000.00	root		cast(plus(cte.t2.c1, 1), int(11))->cte.t2.c1, cast(plus(cte.t2.c2, 1), int(11))->cte.t2.c2
+  └─Selection_21	8000.00	root		eq(cte.t2.c2, cte.t1.c2)
     └─CTETable_22	10000.00	root		Scan on CTE_0
 select * from t1 where c1 > all(with recursive cte1 as (select c1, c2 from t2 union all select c1+1 as c1, c2+1 as c2 from cte1 where cte1.c2=t1.c2) select c1 from cte1);
 c1	c2
@@ -683,15 +684,15 @@ Apply_23	10000.00	root		CARTESIAN semi join
 CTE_0	18000.00	root		Recursive CTE
 ├─TableReader_17(Seed Part)	10000.00	root		data:TableFullScan_16
 │ └─TableFullScan_16	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
-└─Projection_18(Recursive Part)	8000.00	root		cast(plus(test.t2.c1, 1), int(11))->test.t2.c1, cast(plus(test.t2.c2, 1), int(11))->test.t2.c2
-  └─Selection_19	8000.00	root		eq(test.t2.c2, test.t1.c2)
+└─Projection_18(Recursive Part)	8000.00	root		cast(plus(cte.t2.c1, 1), int(11))->cte.t2.c1, cast(plus(cte.t2.c2, 1), int(11))->cte.t2.c2
+  └─Selection_19	8000.00	root		eq(cte.t2.c2, cte.t1.c2)
     └─CTETable_20	10000.00	root		Scan on CTE_0
 select * from t1 where exists(with recursive cte1 as (select c1, c2 from t2 union all select c1+1 as c1, c2+1 as c2 from cte1 where cte1.c2=t1.c2) select c1 from cte1);
 c1	c2
 2	1
 2	2
 2	3
-use test;
+use cte;
 drop table if exists t1, t2;
 drop view if exists v1;
 create table t1 (a int);
@@ -701,21 +702,20 @@ insert into t2 values (1), (2), (3), (4), (5);
 drop view if exists v1,v2;
 create view v1 as with t1 as (select a from t2 where t2.a=3 union select t2.a+1 from t1,t2 where t1.a=t2.a) select * from t1 order by a desc limit 5;
 create view v2 as with recursive t1 as ( select a from t2 where t2.a=3 union select t2.a+1 from t1,t2 where t1.a=t2.a) select * from t1 order by a desc limit 5;
-create database if not exists test1;
-use test1;
-select * from test.v1;
+use cte1;
+select * from cte.v1;
 a
 5
 4
 3
 2
-select * from test.v2;
+select * from cte.v2;
 a
 6
 5
 4
 3
-use test;
+use cte;
 drop table if exists t ,t1, t2;
 create table t(a int);
 insert into t values (0);
@@ -725,33 +725,33 @@ create table t2 (c int);
 insert into t2 values (0);
 drop view if exists v1;
 create view v1 as with t1 as (with t11 as (select * from t) select * from t1, t2) select * from t1;
-use test1;
-select * from test.v1;
+use cte1;
+select * from cte.v1;
 b	c
 0	0
-use test;
+use cte;
 drop table if exists t11111;
 create table t11111 (d int);
 insert into t11111 values (123), (223), (323);
 drop view if exists v1;
 create view v1 as WITH t123 AS (WITH t11111 AS ( SELECT * FROM t1 ) SELECT ( WITH t2 AS ( SELECT ( WITH t23 AS ( SELECT * FROM t11111 ) SELECT * FROM t23 LIMIT 1 ) FROM t11111 ) SELECT *  FROM t2  LIMIT 1  )  FROM t11111, t2 ) SELECT * FROM t11111;
-use test1;
-select * from test.v1;
+use cte1;
+select * from cte.v1;
 d
 123
 223
 323
-use test;
+use cte;
 drop table if exists t1;
 create table t1 (a int);
 insert into t1 values (1);
 drop view if exists v1;
 create view v1 as SELECT (WITH qn AS (SELECT 10*a as a FROM t1),qn2 AS (SELECT 3*a AS b FROM qn) SELECT * from qn2 LIMIT 1) FROM t1;
-use test1;
-select * from test.v1;
+use cte1;
+select * from cte.v1;
 name_exp_1
 30
-use test;
+use cte;
 drop table if exists t1,t2;
 create table t1 (a int);
 insert into t1 values (0), (1);
@@ -759,8 +759,8 @@ create table t2 (b int);
 insert into t2 values  (4), (5);
 drop view if exists v1;
 create view v1 as with t1 as (with t11 as (select * from t1) select * from t1, t2) select * from t1;
-use test1;
-select * from test.v1;
+use cte1;
+select * from cte.v1;
 a	b
 0	5
 0	4

--- a/cmd/explaintest/r/explain-non-select-stmt.result
+++ b/cmd/explaintest/r/explain-non-select-stmt.result
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t;
 create table t(a bigint, b bigint);
 explain format = 'brief' insert into t values(1, 1);
@@ -15,18 +14,18 @@ id	estRows	task	access object	operator info
 Delete	N/A	root		N/A
 └─SelectLock	3333.33	root		for update 0
   └─TableReader	3333.33	root		data:Selection
-    └─Selection	3333.33	cop[tikv]		gt(test.t.a, 100)
+    └─Selection	3333.33	cop[tikv]		gt(explain-non-select-stmt.t.a, 100)
       └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' update t set b = 100 where a = 200;
 id	estRows	task	access object	operator info
 Update	N/A	root		N/A
 └─SelectLock	10.00	root		for update 0
   └─TableReader	10.00	root		data:Selection
-    └─Selection	10.00	cop[tikv]		eq(test.t.a, 200)
+    └─Selection	10.00	cop[tikv]		eq(explain-non-select-stmt.t.a, 200)
       └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' replace into t select a, 100 from t;
 id	estRows	task	access object	operator info
 Insert	N/A	root		N/A
-└─Projection	10000.00	root		test.t.a, 100->Column#6
+└─Projection	10000.00	root		explain-non-select-stmt.t.a, 100->Column#6
   └─TableReader	10000.00	root		data:TableFullScan
     └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/cmd/explaintest/r/explain_cte.result
+++ b/cmd/explaintest/r/explain_cte.result
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t1, t2;
 create table t1 (c1 int primary key, c2 int, index c2 (c2));
 create table t2 (c1 int unique, c2 int);
@@ -35,8 +34,8 @@ CTEFullScan_20	8001.00	root	CTE:cte	data:CTE_0
 CTE_0	8001.00	root		Recursive CTE
 ├─TableReader_13(Seed Part)	10000.00	root		data:TableFullScan_12
 │ └─TableFullScan_12	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Projection_16(Recursive Part)	8000.00	root		cast(plus(test.t1.c2, 1), int(11))->test.t1.c2
-  └─Selection_17	8000.00	root		lt(test.t1.c2, 10)
+└─Projection_16(Recursive Part)	8000.00	root		cast(plus(explain_cte.t1.c2, 1), int(11))->explain_cte.t1.c2
+  └─Selection_17	8000.00	root		lt(explain_cte.t1.c2, 10)
     └─CTETable_18	10000.00	root		Scan on CTE_0
 explain with cte(a) as (with recursive cte1(a) as (select 1 union select a + 1 from cte1 where a < 10) select * from cte1) select * from cte;
 id	estRows	task	access object	operator info
@@ -85,15 +84,15 @@ CTE_0	2.00	root		Recursive CTE
 CTE_1	8001.00	root		Recursive CTE
 ├─TableReader_28(Seed Part)	10000.00	root		data:TableFullScan_27
 │ └─TableFullScan_27	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Projection_31(Recursive Part)	8000.00	root		cast(plus(test.t1.c2, 1), int(11))->test.t1.c2
-  └─Selection_32	8000.00	root		lt(test.t1.c2, 10)
+└─Projection_31(Recursive Part)	8000.00	root		cast(plus(explain_cte.t1.c2, 1), int(11))->explain_cte.t1.c2
+  └─Selection_32	8000.00	root		lt(explain_cte.t1.c2, 10)
     └─CTETable_33	10000.00	root		Scan on CTE_1
 explain with q(a,b) as (select * from t1) select /*+ merge(q) no_merge(q1) */ * from q, q q1 where q.a=1 and q1.a=2;
 id	estRows	task	access object	operator info
 HashJoin_15	2.56	root		CARTESIAN inner join
-├─Selection_19(Build)	1.60	root		eq(test.t1.c1, 2)
+├─Selection_19(Build)	1.60	root		eq(explain_cte.t1.c1, 2)
 │ └─CTEFullScan_20	2.00	root	CTE:q AS q1	data:CTE_0
-└─Selection_17(Probe)	1.60	root		eq(test.t1.c1, 1)
+└─Selection_17(Probe)	1.60	root		eq(explain_cte.t1.c1, 1)
   └─CTEFullScan_18	2.00	root	CTE:q	data:CTE_0
 CTE_0	2.00	root		Non-Recursive CTE
 └─Batch_Point_Get_12(Seed Part)	2.00	root	table:t1	handle:[1 2], keep order:false, desc:false
@@ -114,7 +113,7 @@ Apply_24	10000.00	root		CARTESIAN semi join
 └─Selection_29(Probe)	14400.00	root		eq(Column#8, 1)
   └─CTEFullScan_30	18000.00	root	CTE:qn	data:CTE_0
 CTE_0	1.80	root		Recursive CTE
-├─Projection_17(Seed Part)	1.00	root		plus(mul(test.t1.c1, 0), 1)->Column#4
+├─Projection_17(Seed Part)	1.00	root		plus(mul(explain_cte.t1.c1, 0), 1)->Column#4
 │ └─TableDual_18	1.00	root		rows:1
 └─Projection_19(Recursive Part)	0.80	root		plus(Column#5, 1)->Column#7
   └─Selection_20	0.80	root		eq(Column#5, 0)
@@ -125,7 +124,7 @@ CTEFullScan_19	8001.00	root	CTE:cte1	data:CTE_0
 CTE_0	8001.00	root		Recursive CTE, limit(offset:0, count:1)
 ├─TableReader_13(Seed Part)	10000.00	root		data:TableFullScan_12
 │ └─TableFullScan_12	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Projection_16(Recursive Part)	10000.00	root		cast(plus(test.t1.c1, 1), int(11))->test.t1.c1
+└─Projection_16(Recursive Part)	10000.00	root		cast(plus(explain_cte.t1.c1, 1), int(11))->explain_cte.t1.c1
   └─CTETable_17	10000.00	root		Scan on CTE_0
 explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 100 offset 100) select * from cte1;
 id	estRows	task	access object	operator info
@@ -133,7 +132,7 @@ CTEFullScan_19	8001.00	root	CTE:cte1	data:CTE_0
 CTE_0	8001.00	root		Recursive CTE, limit(offset:100, count:100)
 ├─TableReader_13(Seed Part)	10000.00	root		data:TableFullScan_12
 │ └─TableFullScan_12	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Projection_16(Recursive Part)	10000.00	root		cast(plus(test.t1.c1, 1), int(11))->test.t1.c1
+└─Projection_16(Recursive Part)	10000.00	root		cast(plus(explain_cte.t1.c1, 1), int(11))->explain_cte.t1.c1
   └─CTETable_17	10000.00	root		Scan on CTE_0
 explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 0 offset 0) select * from cte1;
 id	estRows	task	access object	operator info
@@ -141,31 +140,31 @@ CTEFullScan_19	8001.00	root	CTE:cte1	data:CTE_0
 CTE_0	8001.00	root		Recursive CTE, limit(offset:0, count:0)
 ├─TableReader_13(Seed Part)	10000.00	root		data:TableFullScan_12
 │ └─TableFullScan_12	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Projection_16(Recursive Part)	10000.00	root		cast(plus(test.t1.c1, 1), int(11))->test.t1.c1
+└─Projection_16(Recursive Part)	10000.00	root		cast(plus(explain_cte.t1.c1, 1), int(11))->explain_cte.t1.c1
   └─CTETable_17	10000.00	root		Scan on CTE_0
 explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 1) select * from cte1 dt1 join cte1 dt2 on dt1.c1 = dt2.c1;
 id	estRows	task	access object	operator info
-HashJoin_25	6400.80	root		inner join, equal:[eq(test.t1.c1, test.t1.c1)]
-├─Selection_29(Build)	6400.80	root		not(isnull(test.t1.c1))
+HashJoin_25	6400.80	root		inner join, equal:[eq(explain_cte.t1.c1, explain_cte.t1.c1)]
+├─Selection_29(Build)	6400.80	root		not(isnull(explain_cte.t1.c1))
 │ └─CTEFullScan_30	8001.00	root	CTE:cte1 AS dt2	data:CTE_0
-└─Selection_27(Probe)	6400.80	root		not(isnull(test.t1.c1))
+└─Selection_27(Probe)	6400.80	root		not(isnull(explain_cte.t1.c1))
   └─CTEFullScan_28	8001.00	root	CTE:cte1 AS dt1	data:CTE_0
 CTE_0	8001.00	root		Recursive CTE, limit(offset:0, count:1)
 ├─TableReader_18(Seed Part)	10000.00	root		data:TableFullScan_17
 │ └─TableFullScan_17	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Projection_21(Recursive Part)	10000.00	root		cast(plus(test.t1.c1, 1), int(11))->test.t1.c1
+└─Projection_21(Recursive Part)	10000.00	root		cast(plus(explain_cte.t1.c1, 1), int(11))->explain_cte.t1.c1
   └─CTETable_22	10000.00	root		Scan on CTE_0
 explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 0 offset 0) select * from cte1 dt1 join cte1 dt2 on dt1.c1 = dt2.c1;
 id	estRows	task	access object	operator info
-HashJoin_25	6400.80	root		inner join, equal:[eq(test.t1.c1, test.t1.c1)]
-├─Selection_29(Build)	6400.80	root		not(isnull(test.t1.c1))
+HashJoin_25	6400.80	root		inner join, equal:[eq(explain_cte.t1.c1, explain_cte.t1.c1)]
+├─Selection_29(Build)	6400.80	root		not(isnull(explain_cte.t1.c1))
 │ └─CTEFullScan_30	8001.00	root	CTE:cte1 AS dt2	data:CTE_0
-└─Selection_27(Probe)	6400.80	root		not(isnull(test.t1.c1))
+└─Selection_27(Probe)	6400.80	root		not(isnull(explain_cte.t1.c1))
   └─CTEFullScan_28	8001.00	root	CTE:cte1 AS dt1	data:CTE_0
 CTE_0	8001.00	root		Recursive CTE, limit(offset:0, count:0)
 ├─TableReader_18(Seed Part)	10000.00	root		data:TableFullScan_17
 │ └─TableFullScan_17	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Projection_21(Recursive Part)	10000.00	root		cast(plus(test.t1.c1, 1), int(11))->test.t1.c1
+└─Projection_21(Recursive Part)	10000.00	root		cast(plus(explain_cte.t1.c1, 1), int(11))->explain_cte.t1.c1
   └─CTETable_22	10000.00	root		Scan on CTE_0
 explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 1) select * from cte1;
 id	estRows	task	access object	operator info
@@ -402,37 +401,37 @@ TopN	40.00	root		Column#180, Column#181, Column#182, Column#186, offset:0, count
         └─CTEFullScan	50.00	root	CTE:year_total AS t_s_firstyear	data:CTE_0
 CTE_0	50.00	root		Non-Recursive CTE
 └─Union(Seed Part)	50.00	root		
-  ├─Projection	25.00	root		test.customer.c_customer_id->Column#160, test.customer.c_first_name->Column#161, test.customer.c_last_name->Column#162, test.customer.c_preferred_cust_flag->Column#163, test.customer.c_birth_country->Column#164, test.customer.c_login->Column#165, test.customer.c_email_address->Column#166, test.date_dim.d_year->Column#167, Column#73->Column#168, s->Column#169
-  │ └─Selection	25.00	root		or(or(and(1, and(eq(test.date_dim.d_year, 2001), gt(Column#73, 0))), and(1, eq(test.date_dim.d_year, 2002))), 0)
-  │   └─HashAgg	31.25	root		group by:Column#233, Column#234, Column#235, Column#236, Column#237, Column#238, Column#239, Column#240, funcs:sum(Column#224)->Column#73, funcs:firstrow(Column#225)->test.customer.c_customer_id, funcs:firstrow(Column#226)->test.customer.c_first_name, funcs:firstrow(Column#227)->test.customer.c_last_name, funcs:firstrow(Column#228)->test.customer.c_preferred_cust_flag, funcs:firstrow(Column#229)->test.customer.c_birth_country, funcs:firstrow(Column#230)->test.customer.c_login, funcs:firstrow(Column#231)->test.customer.c_email_address, funcs:firstrow(Column#232)->test.date_dim.d_year
-  │     └─Projection	31.25	root		minus(test.store_sales.ss_ext_list_price, test.store_sales.ss_ext_discount_amt)->Column#224, test.customer.c_customer_id->Column#225, test.customer.c_first_name->Column#226, test.customer.c_last_name->Column#227, test.customer.c_preferred_cust_flag->Column#228, test.customer.c_birth_country->Column#229, test.customer.c_login->Column#230, test.customer.c_email_address->Column#231, test.date_dim.d_year->Column#232, test.customer.c_customer_id->Column#233, test.customer.c_first_name->Column#234, test.customer.c_last_name->Column#235, test.customer.c_preferred_cust_flag->Column#236, test.customer.c_birth_country->Column#237, test.customer.c_login->Column#238, test.customer.c_email_address->Column#239, test.date_dim.d_year->Column#240
-  │       └─Projection	31.25	root		test.customer.c_customer_id, test.customer.c_first_name, test.customer.c_last_name, test.customer.c_preferred_cust_flag, test.customer.c_birth_country, test.customer.c_login, test.customer.c_email_address, test.store_sales.ss_ext_discount_amt, test.store_sales.ss_ext_list_price, test.date_dim.d_year
-  │         └─IndexJoin	31.25	root		inner join, inner:IndexLookUp, outer key:test.store_sales.ss_customer_sk, inner key:test.customer.c_customer_sk, equal cond:eq(test.store_sales.ss_customer_sk, test.customer.c_customer_sk)
-  │           ├─HashJoin(Build)	25.00	root		inner join, equal:[eq(test.date_dim.d_date_sk, test.store_sales.ss_sold_date_sk)]
+  ├─Projection	25.00	root		explain_cte.customer.c_customer_id->Column#160, explain_cte.customer.c_first_name->Column#161, explain_cte.customer.c_last_name->Column#162, explain_cte.customer.c_preferred_cust_flag->Column#163, explain_cte.customer.c_birth_country->Column#164, explain_cte.customer.c_login->Column#165, explain_cte.customer.c_email_address->Column#166, explain_cte.date_dim.d_year->Column#167, Column#73->Column#168, s->Column#169
+  │ └─Selection	25.00	root		or(or(and(1, and(eq(explain_cte.date_dim.d_year, 2001), gt(Column#73, 0))), and(1, eq(explain_cte.date_dim.d_year, 2002))), 0)
+  │   └─HashAgg	31.25	root		group by:Column#233, Column#234, Column#235, Column#236, Column#237, Column#238, Column#239, Column#240, funcs:sum(Column#224)->Column#73, funcs:firstrow(Column#225)->explain_cte.customer.c_customer_id, funcs:firstrow(Column#226)->explain_cte.customer.c_first_name, funcs:firstrow(Column#227)->explain_cte.customer.c_last_name, funcs:firstrow(Column#228)->explain_cte.customer.c_preferred_cust_flag, funcs:firstrow(Column#229)->explain_cte.customer.c_birth_country, funcs:firstrow(Column#230)->explain_cte.customer.c_login, funcs:firstrow(Column#231)->explain_cte.customer.c_email_address, funcs:firstrow(Column#232)->explain_cte.date_dim.d_year
+  │     └─Projection	31.25	root		minus(explain_cte.store_sales.ss_ext_list_price, explain_cte.store_sales.ss_ext_discount_amt)->Column#224, explain_cte.customer.c_customer_id->Column#225, explain_cte.customer.c_first_name->Column#226, explain_cte.customer.c_last_name->Column#227, explain_cte.customer.c_preferred_cust_flag->Column#228, explain_cte.customer.c_birth_country->Column#229, explain_cte.customer.c_login->Column#230, explain_cte.customer.c_email_address->Column#231, explain_cte.date_dim.d_year->Column#232, explain_cte.customer.c_customer_id->Column#233, explain_cte.customer.c_first_name->Column#234, explain_cte.customer.c_last_name->Column#235, explain_cte.customer.c_preferred_cust_flag->Column#236, explain_cte.customer.c_birth_country->Column#237, explain_cte.customer.c_login->Column#238, explain_cte.customer.c_email_address->Column#239, explain_cte.date_dim.d_year->Column#240
+  │       └─Projection	31.25	root		explain_cte.customer.c_customer_id, explain_cte.customer.c_first_name, explain_cte.customer.c_last_name, explain_cte.customer.c_preferred_cust_flag, explain_cte.customer.c_birth_country, explain_cte.customer.c_login, explain_cte.customer.c_email_address, explain_cte.store_sales.ss_ext_discount_amt, explain_cte.store_sales.ss_ext_list_price, explain_cte.date_dim.d_year
+  │         └─IndexJoin	31.25	root		inner join, inner:IndexLookUp, outer key:explain_cte.store_sales.ss_customer_sk, inner key:explain_cte.customer.c_customer_sk, equal cond:eq(explain_cte.store_sales.ss_customer_sk, explain_cte.customer.c_customer_sk)
+  │           ├─HashJoin(Build)	25.00	root		inner join, equal:[eq(explain_cte.date_dim.d_date_sk, explain_cte.store_sales.ss_sold_date_sk)]
   │           │ ├─TableReader(Build)	20.00	root		data:Selection
-  │           │ │ └─Selection	20.00	cop[tikv]		or(and(1, eq(test.date_dim.d_year, 2001)), or(and(1, eq(test.date_dim.d_year, 2002)), 0))
+  │           │ │ └─Selection	20.00	cop[tikv]		or(and(1, eq(explain_cte.date_dim.d_year, 2001)), or(and(1, eq(explain_cte.date_dim.d_year, 2002)), 0))
   │           │ │   └─TableFullScan	10000.00	cop[tikv]	table:date_dim	keep order:false, stats:pseudo
   │           │ └─TableReader(Probe)	9980.01	root		data:Selection
-  │           │   └─Selection	9980.01	cop[tikv]		not(isnull(test.store_sales.ss_customer_sk)), not(isnull(test.store_sales.ss_sold_date_sk))
+  │           │   └─Selection	9980.01	cop[tikv]		not(isnull(explain_cte.store_sales.ss_customer_sk)), not(isnull(explain_cte.store_sales.ss_sold_date_sk))
   │           │     └─TableFullScan	10000.00	cop[tikv]	table:store_sales	keep order:false, stats:pseudo
   │           └─IndexLookUp(Probe)	25.00	root		
-  │             ├─IndexRangeScan(Build)	25.00	cop[tikv]	table:customer, index:PRIMARY(c_customer_sk)	range: decided by [eq(test.customer.c_customer_sk, test.store_sales.ss_customer_sk)], keep order:false, stats:pseudo
+  │             ├─IndexRangeScan(Build)	25.00	cop[tikv]	table:customer, index:PRIMARY(c_customer_sk)	range: decided by [eq(explain_cte.customer.c_customer_sk, explain_cte.store_sales.ss_customer_sk)], keep order:false, stats:pseudo
   │             └─TableRowIDScan(Probe)	25.00	cop[tikv]	table:customer	keep order:false, stats:pseudo
-  └─Projection	25.00	root		test.customer.c_customer_id->Column#160, test.customer.c_first_name->Column#161, test.customer.c_last_name->Column#162, test.customer.c_preferred_cust_flag->Column#163, test.customer.c_birth_country->Column#164, test.customer.c_login->Column#165, test.customer.c_email_address->Column#166, test.date_dim.d_year->Column#167, Column#158->Column#168, w->Column#169
-    └─Selection	25.00	root		or(0, or(and(1, and(eq(test.date_dim.d_year, 2001), gt(Column#158, 0))), and(1, eq(test.date_dim.d_year, 2002))))
-      └─HashAgg	31.25	root		group by:Column#250, Column#251, Column#252, Column#253, Column#254, Column#255, Column#256, Column#257, funcs:sum(Column#241)->Column#158, funcs:firstrow(Column#242)->test.customer.c_customer_id, funcs:firstrow(Column#243)->test.customer.c_first_name, funcs:firstrow(Column#244)->test.customer.c_last_name, funcs:firstrow(Column#245)->test.customer.c_preferred_cust_flag, funcs:firstrow(Column#246)->test.customer.c_birth_country, funcs:firstrow(Column#247)->test.customer.c_login, funcs:firstrow(Column#248)->test.customer.c_email_address, funcs:firstrow(Column#249)->test.date_dim.d_year
-        └─Projection	31.25	root		minus(test.web_sales.ws_ext_list_price, test.web_sales.ws_ext_discount_amt)->Column#241, test.customer.c_customer_id->Column#242, test.customer.c_first_name->Column#243, test.customer.c_last_name->Column#244, test.customer.c_preferred_cust_flag->Column#245, test.customer.c_birth_country->Column#246, test.customer.c_login->Column#247, test.customer.c_email_address->Column#248, test.date_dim.d_year->Column#249, test.customer.c_customer_id->Column#250, test.customer.c_first_name->Column#251, test.customer.c_last_name->Column#252, test.customer.c_preferred_cust_flag->Column#253, test.customer.c_birth_country->Column#254, test.customer.c_login->Column#255, test.customer.c_email_address->Column#256, test.date_dim.d_year->Column#257
-          └─Projection	31.25	root		test.customer.c_customer_id, test.customer.c_first_name, test.customer.c_last_name, test.customer.c_preferred_cust_flag, test.customer.c_birth_country, test.customer.c_login, test.customer.c_email_address, test.web_sales.ws_ext_discount_amt, test.web_sales.ws_ext_list_price, test.date_dim.d_year
-            └─IndexJoin	31.25	root		inner join, inner:IndexLookUp, outer key:test.web_sales.ws_bill_customer_sk, inner key:test.customer.c_customer_sk, equal cond:eq(test.web_sales.ws_bill_customer_sk, test.customer.c_customer_sk)
-              ├─HashJoin(Build)	25.00	root		inner join, equal:[eq(test.date_dim.d_date_sk, test.web_sales.ws_sold_date_sk)]
+  └─Projection	25.00	root		explain_cte.customer.c_customer_id->Column#160, explain_cte.customer.c_first_name->Column#161, explain_cte.customer.c_last_name->Column#162, explain_cte.customer.c_preferred_cust_flag->Column#163, explain_cte.customer.c_birth_country->Column#164, explain_cte.customer.c_login->Column#165, explain_cte.customer.c_email_address->Column#166, explain_cte.date_dim.d_year->Column#167, Column#158->Column#168, w->Column#169
+    └─Selection	25.00	root		or(0, or(and(1, and(eq(explain_cte.date_dim.d_year, 2001), gt(Column#158, 0))), and(1, eq(explain_cte.date_dim.d_year, 2002))))
+      └─HashAgg	31.25	root		group by:Column#250, Column#251, Column#252, Column#253, Column#254, Column#255, Column#256, Column#257, funcs:sum(Column#241)->Column#158, funcs:firstrow(Column#242)->explain_cte.customer.c_customer_id, funcs:firstrow(Column#243)->explain_cte.customer.c_first_name, funcs:firstrow(Column#244)->explain_cte.customer.c_last_name, funcs:firstrow(Column#245)->explain_cte.customer.c_preferred_cust_flag, funcs:firstrow(Column#246)->explain_cte.customer.c_birth_country, funcs:firstrow(Column#247)->explain_cte.customer.c_login, funcs:firstrow(Column#248)->explain_cte.customer.c_email_address, funcs:firstrow(Column#249)->explain_cte.date_dim.d_year
+        └─Projection	31.25	root		minus(explain_cte.web_sales.ws_ext_list_price, explain_cte.web_sales.ws_ext_discount_amt)->Column#241, explain_cte.customer.c_customer_id->Column#242, explain_cte.customer.c_first_name->Column#243, explain_cte.customer.c_last_name->Column#244, explain_cte.customer.c_preferred_cust_flag->Column#245, explain_cte.customer.c_birth_country->Column#246, explain_cte.customer.c_login->Column#247, explain_cte.customer.c_email_address->Column#248, explain_cte.date_dim.d_year->Column#249, explain_cte.customer.c_customer_id->Column#250, explain_cte.customer.c_first_name->Column#251, explain_cte.customer.c_last_name->Column#252, explain_cte.customer.c_preferred_cust_flag->Column#253, explain_cte.customer.c_birth_country->Column#254, explain_cte.customer.c_login->Column#255, explain_cte.customer.c_email_address->Column#256, explain_cte.date_dim.d_year->Column#257
+          └─Projection	31.25	root		explain_cte.customer.c_customer_id, explain_cte.customer.c_first_name, explain_cte.customer.c_last_name, explain_cte.customer.c_preferred_cust_flag, explain_cte.customer.c_birth_country, explain_cte.customer.c_login, explain_cte.customer.c_email_address, explain_cte.web_sales.ws_ext_discount_amt, explain_cte.web_sales.ws_ext_list_price, explain_cte.date_dim.d_year
+            └─IndexJoin	31.25	root		inner join, inner:IndexLookUp, outer key:explain_cte.web_sales.ws_bill_customer_sk, inner key:explain_cte.customer.c_customer_sk, equal cond:eq(explain_cte.web_sales.ws_bill_customer_sk, explain_cte.customer.c_customer_sk)
+              ├─HashJoin(Build)	25.00	root		inner join, equal:[eq(explain_cte.date_dim.d_date_sk, explain_cte.web_sales.ws_sold_date_sk)]
               │ ├─TableReader(Build)	20.00	root		data:Selection
-              │ │ └─Selection	20.00	cop[tikv]		or(0, or(and(1, eq(test.date_dim.d_year, 2001)), and(1, eq(test.date_dim.d_year, 2002))))
+              │ │ └─Selection	20.00	cop[tikv]		or(0, or(and(1, eq(explain_cte.date_dim.d_year, 2001)), and(1, eq(explain_cte.date_dim.d_year, 2002))))
               │ │   └─TableFullScan	10000.00	cop[tikv]	table:date_dim	keep order:false, stats:pseudo
               │ └─TableReader(Probe)	9980.01	root		data:Selection
-              │   └─Selection	9980.01	cop[tikv]		not(isnull(test.web_sales.ws_bill_customer_sk)), not(isnull(test.web_sales.ws_sold_date_sk))
+              │   └─Selection	9980.01	cop[tikv]		not(isnull(explain_cte.web_sales.ws_bill_customer_sk)), not(isnull(explain_cte.web_sales.ws_sold_date_sk))
               │     └─TableFullScan	10000.00	cop[tikv]	table:web_sales	keep order:false, stats:pseudo
               └─IndexLookUp(Probe)	25.00	root		
-                ├─IndexRangeScan(Build)	25.00	cop[tikv]	table:customer, index:PRIMARY(c_customer_sk)	range: decided by [eq(test.customer.c_customer_sk, test.web_sales.ws_bill_customer_sk)], keep order:false, stats:pseudo
+                ├─IndexRangeScan(Build)	25.00	cop[tikv]	table:customer, index:PRIMARY(c_customer_sk)	range: decided by [eq(explain_cte.customer.c_customer_sk, explain_cte.web_sales.ws_bill_customer_sk)], keep order:false, stats:pseudo
                 └─TableRowIDScan(Probe)	25.00	cop[tikv]	table:customer	keep order:false, stats:pseudo
 drop table if exists t1;
 create table t1 (id int, bench_type varchar(10),version varchar(10),tps int(20));
@@ -455,30 +454,30 @@ select v1.tps v1_tps,v2.tps v2_tps
 from version1 v1, version2 v2
 where v1.bench_type =v2.bench_type;
 id	estRows	task	access object	operator info
-HashJoin	19.97	root		inner join, equal:[eq(test.t1.bench_type, test.t1.bench_type)]
-├─Selection(Build)	15.98	root		eq(test.t1.version, "6.0.0"), not(isnull(test.t1.bench_type))
+HashJoin	19.97	root		inner join, equal:[eq(explain_cte.t1.bench_type, explain_cte.t1.bench_type)]
+├─Selection(Build)	15.98	root		eq(explain_cte.t1.version, "6.0.0"), not(isnull(explain_cte.t1.bench_type))
 │ └─CTEFullScan	19.97	root	CTE:all_data	data:CTE_0
-└─Selection(Probe)	15.98	root		eq(test.t1.version, "5.4.0"), not(isnull(test.t1.bench_type))
+└─Selection(Probe)	15.98	root		eq(explain_cte.t1.version, "5.4.0"), not(isnull(explain_cte.t1.bench_type))
   └─CTEFullScan	19.97	root	CTE:all_data	data:CTE_0
 CTE_0	19.97	root		Non-Recursive CTE
 └─TableReader(Seed Part)	19.97	root		data:Selection
-  └─Selection	19.97	cop[tikv]		or(and(eq(test.t1.version, "5.4.0"), not(isnull(test.t1.bench_type))), and(eq(test.t1.version, "6.0.0"), not(isnull(test.t1.bench_type))))
+  └─Selection	19.97	cop[tikv]		or(and(eq(explain_cte.t1.version, "5.4.0"), not(isnull(explain_cte.t1.bench_type))), and(eq(explain_cte.t1.version, "6.0.0"), not(isnull(explain_cte.t1.bench_type))))
     └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 drop table if exists tbl;
 create table tbl (id int);
 explain with t1 as (select id from tbl), t2 as (select a.id from t1 a join t1 b on a.id = b.id) select * from t2 where id in (select id from t2);
 id	estRows	task	access object	operator info
-HashJoin_33	8000.00	root		inner join, equal:[eq(test.tbl.id, test.tbl.id)]
-├─HashAgg_37(Build)	5120.00	root		group by:test.tbl.id, funcs:firstrow(test.tbl.id)->test.tbl.id
-│ └─Selection_38	8000.00	root		not(isnull(test.tbl.id))
+HashJoin_33	8000.00	root		inner join, equal:[eq(explain_cte.tbl.id, explain_cte.tbl.id)]
+├─HashAgg_37(Build)	5120.00	root		group by:explain_cte.tbl.id, funcs:firstrow(explain_cte.tbl.id)->explain_cte.tbl.id
+│ └─Selection_38	8000.00	root		not(isnull(explain_cte.tbl.id))
 │   └─CTEFullScan_39	10000.00	root	CTE:t2	data:CTE_1
-└─Selection_35(Probe)	8000.00	root		not(isnull(test.tbl.id))
+└─Selection_35(Probe)	8000.00	root		not(isnull(explain_cte.tbl.id))
   └─CTEFullScan_36	10000.00	root	CTE:t2	data:CTE_1
 CTE_1	10000.00	root		Non-Recursive CTE
-└─HashJoin_25(Seed Part)	10000.00	root		inner join, equal:[eq(test.tbl.id, test.tbl.id)]
-  ├─Selection_29(Build)	8000.00	root		not(isnull(test.tbl.id))
+└─HashJoin_25(Seed Part)	10000.00	root		inner join, equal:[eq(explain_cte.tbl.id, explain_cte.tbl.id)]
+  ├─Selection_29(Build)	8000.00	root		not(isnull(explain_cte.tbl.id))
   │ └─CTEFullScan_30	10000.00	root	CTE:t1 AS b	data:CTE_0
-  └─Selection_27(Probe)	8000.00	root		not(isnull(test.tbl.id))
+  └─Selection_27(Probe)	8000.00	root		not(isnull(explain_cte.tbl.id))
     └─CTEFullScan_28	10000.00	root	CTE:t1 AS a	data:CTE_0
 CTE_0	10000.00	root		Non-Recursive CTE
 └─TableReader_22(Seed Part)	10000.00	root		data:TableFullScan_21
@@ -493,17 +492,17 @@ insert into t3 values(1,1234);
 explain update t1 inner join (select t2.c from t2 inner join (with temp as (select e from t3 where t3.f = 1234) select e from temp) tt on t2.d = tt.e) t on t1.a = t.c set t1.b = 4321;
 id	estRows	task	access object	operator info
 Update_17	N/A	root		N/A
-└─HashJoin_22	15.61	root		inner join, equal:[eq(test.t1.a, test.t2.c)]
-  ├─HashJoin_30(Build)	12.49	root		inner join, equal:[eq(test.t3.e, test.t2.d)]
-  │ ├─Projection_32(Build)	9.99	root		test.t3.e
+└─HashJoin_22	15.61	root		inner join, equal:[eq(explain_cte.t1.a, explain_cte.t2.c)]
+  ├─HashJoin_30(Build)	12.49	root		inner join, equal:[eq(explain_cte.t3.e, explain_cte.t2.d)]
+  │ ├─Projection_32(Build)	9.99	root		explain_cte.t3.e
   │ │ └─TableReader_35	9.99	root		data:Selection_34
-  │ │   └─Selection_34	9.99	cop[tikv]		eq(test.t3.f, 1234), not(isnull(test.t3.e))
+  │ │   └─Selection_34	9.99	cop[tikv]		eq(explain_cte.t3.f, 1234), not(isnull(explain_cte.t3.e))
   │ │     └─TableFullScan_33	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
   │ └─TableReader_38(Probe)	9980.01	root		data:Selection_37
-  │   └─Selection_37	9980.01	cop[tikv]		not(isnull(test.t2.c)), not(isnull(test.t2.d))
+  │   └─Selection_37	9980.01	cop[tikv]		not(isnull(explain_cte.t2.c)), not(isnull(explain_cte.t2.d))
   │     └─TableFullScan_36	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
   └─TableReader_26(Probe)	9990.00	root		data:Selection_25
-    └─Selection_25	9990.00	cop[tikv]		not(isnull(test.t1.a))
+    └─Selection_25	9990.00	cop[tikv]		not(isnull(explain_cte.t1.a))
       └─TableFullScan_24	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 update t1 inner join (select t2.c from t2 inner join (with temp as (select e from t3 where t3.f = 1234) select e from temp) tt on t2.d = tt.e) t on t1.a = t.c set t1.b = 4321;
 select * from t1;
@@ -512,16 +511,16 @@ a	b
 explain insert into t1  select t1.a, t1.b  from  t1 inner join (select t2.c from t2 inner join (with temp as (select e from t3 where t3.f = 1234) select e from temp) tt on t2.d = tt.e) t on t1.a = t.c;
 id	estRows	task	access object	operator info
 Insert_1	N/A	root		N/A
-└─HashJoin_25	15.61	root		inner join, equal:[eq(test.t2.c, test.t1.a)]
-  ├─HashJoin_27(Build)	12.49	root		inner join, equal:[eq(test.t3.e, test.t2.d)]
+└─HashJoin_25	15.61	root		inner join, equal:[eq(explain_cte.t2.c, explain_cte.t1.a)]
+  ├─HashJoin_27(Build)	12.49	root		inner join, equal:[eq(explain_cte.t3.e, explain_cte.t2.d)]
   │ ├─TableReader_30(Build)	9.99	root		data:Selection_29
-  │ │ └─Selection_29	9.99	cop[tikv]		eq(test.t3.f, 1234), not(isnull(test.t3.e))
+  │ │ └─Selection_29	9.99	cop[tikv]		eq(explain_cte.t3.f, 1234), not(isnull(explain_cte.t3.e))
   │ │   └─TableFullScan_28	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
   │ └─TableReader_33(Probe)	9980.01	root		data:Selection_32
-  │   └─Selection_32	9980.01	cop[tikv]		not(isnull(test.t2.c)), not(isnull(test.t2.d))
+  │   └─Selection_32	9980.01	cop[tikv]		not(isnull(explain_cte.t2.c)), not(isnull(explain_cte.t2.d))
   │     └─TableFullScan_31	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
   └─TableReader_36(Probe)	9990.00	root		data:Selection_35
-    └─Selection_35	9990.00	cop[tikv]		not(isnull(test.t1.a))
+    └─Selection_35	9990.00	cop[tikv]		not(isnull(explain_cte.t1.a))
       └─TableFullScan_34	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 insert into t1  select t1.a, t1.b  from  t1 inner join (select t2.c from t2 inner join (with temp as (select e from t3 where t3.f = 1234) select e from temp) tt on t2.d = tt.e) t on t1.a = t.c;
 select * from t1;
@@ -531,17 +530,17 @@ a	b
 explain delete from  t1 using t1 inner join (select t2.c from t2 inner join (with temp as (select e from t3 where t3.f = 1234) select e from temp) tt on t2.d = tt.e) t on t1.a = t.c;
 id	estRows	task	access object	operator info
 Delete_17	N/A	root		N/A
-└─Projection_22	15.61	root		test.t1.a, test.t1.b, test.t1._tidb_rowid, test.t2.c
-  └─HashJoin_24	15.61	root		inner join, equal:[eq(test.t2.c, test.t1.a)]
-    ├─HashJoin_26(Build)	12.49	root		inner join, equal:[eq(test.t3.e, test.t2.d)]
+└─Projection_22	15.61	root		explain_cte.t1.a, explain_cte.t1.b, explain_cte.t1._tidb_rowid, explain_cte.t2.c
+  └─HashJoin_24	15.61	root		inner join, equal:[eq(explain_cte.t2.c, explain_cte.t1.a)]
+    ├─HashJoin_26(Build)	12.49	root		inner join, equal:[eq(explain_cte.t3.e, explain_cte.t2.d)]
     │ ├─TableReader_29(Build)	9.99	root		data:Selection_28
-    │ │ └─Selection_28	9.99	cop[tikv]		eq(test.t3.f, 1234), not(isnull(test.t3.e))
+    │ │ └─Selection_28	9.99	cop[tikv]		eq(explain_cte.t3.f, 1234), not(isnull(explain_cte.t3.e))
     │ │   └─TableFullScan_27	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
     │ └─TableReader_32(Probe)	9980.01	root		data:Selection_31
-    │   └─Selection_31	9980.01	cop[tikv]		not(isnull(test.t2.c)), not(isnull(test.t2.d))
+    │   └─Selection_31	9980.01	cop[tikv]		not(isnull(explain_cte.t2.c)), not(isnull(explain_cte.t2.d))
     │     └─TableFullScan_30	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader_35(Probe)	9990.00	root		data:Selection_34
-      └─Selection_34	9990.00	cop[tikv]		not(isnull(test.t1.a))
+      └─Selection_34	9990.00	cop[tikv]		not(isnull(explain_cte.t1.a))
         └─TableFullScan_33	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 delete from  t1 using t1 inner join (select t2.c from t2 inner join (with temp as (select e from t3 where t3.f = 1234) select e from temp) tt on t2.d = tt.e) t on t1.a = t.c;
 select * from t1;

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -1,6 +1,5 @@
 set tidb_cost_model_version=1;
 set @@sql_mode = 'strict_trans_tables';
-use test;
 drop table if exists t1, t2, t3, t4;
 create table t1 (c1 int primary key, c2 int, c3 int, index c2 (c2));
 create table t2 (c1 int unique, c2 int);
@@ -18,9 +17,9 @@ id	estRows	task	access object	operator info
 HashJoin	8000.00	root		semi join, equal:[eq(Column#13, Column#11)]
 ├─StreamAgg(Build)	1.00	root		funcs:sum(Column#16)->Column#11
 │ └─TableReader	1.00	root		data:StreamAgg
-│   └─StreamAgg	1.00	cop[tikv]		funcs:sum(test.t3.a)->Column#16
+│   └─StreamAgg	1.00	cop[tikv]		funcs:sum(explain_easy.t3.a)->Column#16
 │     └─TableFullScan	10000.00	cop[tikv]	table:s	keep order:false, stats:pseudo
-└─Projection(Probe)	10000.00	root		test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a, decimal(20,0) BINARY)->Column#13
+└─Projection(Probe)	10000.00	root		explain_easy.t3.a, explain_easy.t3.b, explain_easy.t3.c, explain_easy.t3.d, cast(explain_easy.t3.a, decimal(20,0) BINARY)->Column#13
   └─TableReader	10000.00	root		data:TableFullScan
     └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
 explain format = 'brief' select * from t1;
@@ -34,7 +33,7 @@ IndexLookUp	10000.00	root
 └─TableRowIDScan(Probe)	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select * from t2 order by c2;
 id	estRows	task	access object	operator info
-Sort	10000.00	root		test.t2.c2
+Sort	10000.00	root		explain_easy.t2.c2
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format = 'brief' select * from t1 where t1.c1 > 0;
@@ -47,11 +46,11 @@ IndexReader	10.00	root		index:IndexRangeScan
 └─IndexRangeScan	10.00	cop[tikv]	table:t1, index:c2(c2)	range:[1,1], keep order:false, stats:pseudo
 explain format = 'brief' select * from t1 left join t2 on t1.c2 = t2.c1 where t1.c1 > 1;
 id	estRows	task	access object	operator info
-HashJoin	4166.67	root		left outer join, equal:[eq(test.t1.c2, test.t2.c1)]
+HashJoin	4166.67	root		left outer join, equal:[eq(explain_easy.t1.c2, explain_easy.t2.c1)]
 ├─TableReader(Build)	3333.33	root		data:TableRangeScan
 │ └─TableRangeScan	3333.33	cop[tikv]	table:t1	range:(1,+inf], keep order:false, stats:pseudo
 └─TableReader(Probe)	9990.00	root		data:Selection
-  └─Selection	9990.00	cop[tikv]		not(isnull(test.t2.c1))
+  └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t2.c1))
     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format = 'brief' update t1 set t1.c2 = 2 where t1.c1 = 1;
 id	estRows	task	access object	operator info
@@ -67,53 +66,53 @@ Delete	N/A	root		N/A
 explain format = 'brief' select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	estRows	task	access object	operator info
 Projection	9990.00	root		Column#7
-└─HashJoin	9990.00	root		inner join, equal:[eq(test.t1.c1, test.t2.c2)]
-  ├─HashAgg(Build)	7992.00	root		group by:test.t2.c2, funcs:count(Column#9)->Column#8, funcs:firstrow(test.t2.c2)->test.t2.c2
+└─HashJoin	9990.00	root		inner join, equal:[eq(explain_easy.t1.c1, explain_easy.t2.c2)]
+  ├─HashAgg(Build)	7992.00	root		group by:explain_easy.t2.c2, funcs:count(Column#9)->Column#8, funcs:firstrow(explain_easy.t2.c2)->explain_easy.t2.c2
   │ └─TableReader	7992.00	root		data:HashAgg
-  │   └─HashAgg	7992.00	cop[tikv]		group by:test.t2.c2, funcs:count(test.t2.c2)->Column#9
-  │     └─Selection	9990.00	cop[tikv]		not(isnull(test.t2.c2))
+  │   └─HashAgg	7992.00	cop[tikv]		group by:explain_easy.t2.c2, funcs:count(explain_easy.t2.c2)->Column#9
+  │     └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t2.c2))
   │       └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo
   └─TableReader(Probe)	10000.00	root		data:TableFullScan
     └─TableFullScan	10000.00	cop[tikv]	table:a	keep order:false, stats:pseudo
 explain format = 'brief' select * from t2 order by t2.c2 limit 0, 1;
 id	estRows	task	access object	operator info
-TopN	1.00	root		test.t2.c2, offset:0, count:1
+TopN	1.00	root		explain_easy.t2.c2, offset:0, count:1
 └─TableReader	1.00	root		data:TopN
-  └─TopN	1.00	cop[tikv]		test.t2.c2, offset:0, count:1
+  └─TopN	1.00	cop[tikv]		explain_easy.t2.c2, offset:0, count:1
     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format = 'brief' select * from t1 where c1 > 1 and c2 = 1 and c3 < 1;
 id	estRows	task	access object	operator info
 IndexLookUp	11.08	root		
 ├─IndexRangeScan(Build)	33.33	cop[tikv]	table:t1, index:c2(c2)	range:(1 1,1 +inf], keep order:false, stats:pseudo
-└─Selection(Probe)	11.08	cop[tikv]		lt(test.t1.c3, 1)
+└─Selection(Probe)	11.08	cop[tikv]		lt(explain_easy.t1.c3, 1)
   └─TableRowIDScan	33.33	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select * from t1 where c1 = 1 and c2 > 1;
 id	estRows	task	access object	operator info
-Selection	0.33	root		gt(test.t1.c2, 1)
+Selection	0.33	root		gt(explain_easy.t1.c2, 1)
 └─Point_Get	1.00	root	table:t1	handle:1
 explain format = 'brief' select sum(t1.c1 in (select c1 from t2)) from t1;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:sum(Column#13)->Column#11
 └─Projection	10000.00	root		cast(Column#10, decimal(3,0) BINARY)->Column#13
-  └─HashJoin	10000.00	root		CARTESIAN left outer semi join, other cond:eq(test.t1.c1, test.t2.c1)
+  └─HashJoin	10000.00	root		CARTESIAN left outer semi join, other cond:eq(explain_easy.t1.c1, explain_easy.t2.c1)
     ├─IndexReader(Build)	10000.00	root		index:IndexFullScan
     │ └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:c1(c1)	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
       └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select c1 from t1 where c1 in (select c2 from t2);
 id	estRows	task	access object	operator info
-HashJoin	9990.00	root		inner join, equal:[eq(test.t1.c1, test.t2.c2)]
-├─HashAgg(Build)	7992.00	root		group by:test.t2.c2, funcs:firstrow(test.t2.c2)->test.t2.c2
+HashJoin	9990.00	root		inner join, equal:[eq(explain_easy.t1.c1, explain_easy.t2.c2)]
+├─HashAgg(Build)	7992.00	root		group by:explain_easy.t2.c2, funcs:firstrow(explain_easy.t2.c2)->explain_easy.t2.c2
 │ └─TableReader	9990.00	root		data:Selection
-│   └─Selection	9990.00	cop[tikv]		not(isnull(test.t2.c2))
+│   └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t2.c2))
 │     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select (select count(1) k from t1 s where s.c1 = t1.c1 having k != 0) from t1;
 id	estRows	task	access object	operator info
 Projection	12500.00	root		ifnull(Column#10, 0)->Column#10
-└─MergeJoin	12500.00	root		left outer join, left key:test.t1.c1, right key:test.t1.c1
-  ├─Projection(Build)	10000.00	root		1->Column#10, test.t1.c1
+└─MergeJoin	12500.00	root		left outer join, left key:explain_easy.t1.c1, right key:explain_easy.t1.c1
+  ├─Projection(Build)	10000.00	root		1->Column#10, explain_easy.t1.c1
   │ └─TableReader	10000.00	root		data:TableFullScan
   │   └─TableFullScan	10000.00	cop[tikv]	table:s	keep order:true, stats:pseudo
   └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -129,14 +128,14 @@ id	estRows	task	access object	operator info
 MemTableScan	10000.00	root	table:COLUMNS	table_schema:["test"], table_name:["t1"], column_name:["c1"]
 explain format = 'brief' select c2 = (select c2 from t2 where t1.c1 = t2.c1 order by c1 limit 1) from t1;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		eq(test.t1.c2, test.t2.c2)->Column#11
+Projection	10000.00	root		eq(explain_easy.t1.c2, explain_easy.t2.c2)->Column#11
 └─Apply	10000.00	root		CARTESIAN left outer join
   ├─TableReader(Build)	10000.00	root		data:TableFullScan
   │ └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-  └─Projection(Probe)	10000.00	root		test.t2.c1, test.t2.c2
+  └─Projection(Probe)	10000.00	root		explain_easy.t2.c1, explain_easy.t2.c2
     └─IndexLookUp	10000.00	root		limit embedded(offset:0, count:1)
       ├─Limit(Build)	10000.00	cop[tikv]		offset:0, count:1
-      │ └─IndexRangeScan	10000.00	cop[tikv]	table:t2, index:c1(c1)	range: decided by [eq(test.t1.c1, test.t2.c1)], keep order:true, stats:pseudo
+      │ └─IndexRangeScan	10000.00	cop[tikv]	table:t2, index:c1(c1)	range: decided by [eq(explain_easy.t1.c1, explain_easy.t2.c1)], keep order:true, stats:pseudo
       └─TableRowIDScan(Probe)	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format = 'brief' select * from t1 order by c1 desc limit 1;
 id	estRows	task	access object	operator info
@@ -148,17 +147,17 @@ explain format = 'brief' select * from t4 use index(idx) where a > 1 and b > 1 a
 id	estRows	task	access object	operator info
 Limit	1.00	root		offset:0, count:1
 └─IndexLookUp	1.00	root		
-  ├─Selection(Build)	3.00	cop[tikv]		gt(test.t4.b, 1)
+  ├─Selection(Build)	3.00	cop[tikv]		gt(explain_easy.t4.b, 1)
   │ └─IndexRangeScan	9.00	cop[tikv]	table:t4, index:idx(a, b)	range:(1,+inf], keep order:false, stats:pseudo
   └─Limit(Probe)	1.00	cop[tikv]		offset:0, count:1
-    └─Selection	1.00	cop[tikv]		gt(test.t4.c, 1)
+    └─Selection	1.00	cop[tikv]		gt(explain_easy.t4.c, 1)
       └─TableRowIDScan	3.00	cop[tikv]	table:t4	keep order:false, stats:pseudo
 explain format = 'brief' select * from t4 where a > 1 and c > 1 limit 1;
 id	estRows	task	access object	operator info
 Limit	1.00	root		offset:0, count:1
 └─TableReader	1.00	root		data:Limit
   └─Limit	1.00	cop[tikv]		offset:0, count:1
-    └─Selection	1.00	cop[tikv]		gt(test.t4.c, 1)
+    └─Selection	1.00	cop[tikv]		gt(explain_easy.t4.c, 1)
       └─TableRangeScan	3.00	cop[tikv]	table:t4	range:(1,+inf], keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(null, t1.c1) from t1;
 id	estRows	task	access object	operator info
@@ -173,13 +172,13 @@ id	estRows	task	access object	operator info
 Union	26000.00	root		
 ├─HashAgg	16000.00	root		group by:Column#10, funcs:firstrow(Column#12)->Column#10
 │ └─Union	16000.00	root		
-│   ├─StreamAgg	8000.00	root		group by:test.t2.c1, funcs:firstrow(test.t2.c1)->Column#12, funcs:firstrow(test.t2.c1)->Column#10
+│   ├─StreamAgg	8000.00	root		group by:explain_easy.t2.c1, funcs:firstrow(explain_easy.t2.c1)->Column#12, funcs:firstrow(explain_easy.t2.c1)->Column#10
 │   │ └─IndexReader	8000.00	root		index:StreamAgg
-│   │   └─StreamAgg	8000.00	cop[tikv]		group by:test.t2.c1, 
+│   │   └─StreamAgg	8000.00	cop[tikv]		group by:explain_easy.t2.c1, 
 │   │     └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:c1(c1)	keep order:true, stats:pseudo
-│   └─StreamAgg	8000.00	root		group by:test.t2.c1, funcs:firstrow(test.t2.c1)->Column#12, funcs:firstrow(test.t2.c1)->Column#10
+│   └─StreamAgg	8000.00	root		group by:explain_easy.t2.c1, funcs:firstrow(explain_easy.t2.c1)->Column#12, funcs:firstrow(explain_easy.t2.c1)->Column#10
 │     └─IndexReader	8000.00	root		index:StreamAgg
-│       └─StreamAgg	8000.00	cop[tikv]		group by:test.t2.c1, 
+│       └─StreamAgg	8000.00	cop[tikv]		group by:explain_easy.t2.c1, 
 │         └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:c1(c1)	keep order:true, stats:pseudo
 └─IndexReader	10000.00	root		index:IndexFullScan
   └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:c1(c1)	keep order:false, stats:pseudo
@@ -187,31 +186,31 @@ explain format = 'brief' select c1 from t2 union all select c1 from t2 union sel
 id	estRows	task	access object	operator info
 HashAgg	24000.00	root		group by:Column#10, funcs:firstrow(Column#11)->Column#10
 └─Union	24000.00	root		
-  ├─StreamAgg	8000.00	root		group by:test.t2.c1, funcs:firstrow(test.t2.c1)->Column#11, funcs:firstrow(test.t2.c1)->Column#10
+  ├─StreamAgg	8000.00	root		group by:explain_easy.t2.c1, funcs:firstrow(explain_easy.t2.c1)->Column#11, funcs:firstrow(explain_easy.t2.c1)->Column#10
   │ └─IndexReader	8000.00	root		index:StreamAgg
-  │   └─StreamAgg	8000.00	cop[tikv]		group by:test.t2.c1, 
+  │   └─StreamAgg	8000.00	cop[tikv]		group by:explain_easy.t2.c1, 
   │     └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:c1(c1)	keep order:true, stats:pseudo
-  ├─StreamAgg	8000.00	root		group by:test.t2.c1, funcs:firstrow(test.t2.c1)->Column#11, funcs:firstrow(test.t2.c1)->Column#10
+  ├─StreamAgg	8000.00	root		group by:explain_easy.t2.c1, funcs:firstrow(explain_easy.t2.c1)->Column#11, funcs:firstrow(explain_easy.t2.c1)->Column#10
   │ └─IndexReader	8000.00	root		index:StreamAgg
-  │   └─StreamAgg	8000.00	cop[tikv]		group by:test.t2.c1, 
+  │   └─StreamAgg	8000.00	cop[tikv]		group by:explain_easy.t2.c1, 
   │     └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:c1(c1)	keep order:true, stats:pseudo
-  └─StreamAgg	8000.00	root		group by:test.t2.c1, funcs:firstrow(test.t2.c1)->Column#11, funcs:firstrow(test.t2.c1)->Column#10
+  └─StreamAgg	8000.00	root		group by:explain_easy.t2.c1, funcs:firstrow(explain_easy.t2.c1)->Column#11, funcs:firstrow(explain_easy.t2.c1)->Column#10
     └─IndexReader	8000.00	root		index:StreamAgg
-      └─StreamAgg	8000.00	cop[tikv]		group by:test.t2.c1, 
+      └─StreamAgg	8000.00	cop[tikv]		group by:explain_easy.t2.c1, 
         └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:c1(c1)	keep order:true, stats:pseudo
 select * from information_schema.tidb_indexes where table_name='t4';
 TABLE_SCHEMA	TABLE_NAME	NON_UNIQUE	KEY_NAME	SEQ_IN_INDEX	COLUMN_NAME	SUB_PART	INDEX_COMMENT	Expression	INDEX_ID	IS_VISIBLE	CLUSTERED
-test	t4	0	PRIMARY	1	a	NULL		NULL	0	YES	YES
-test	t4	1	idx	1	a	NULL		NULL	1	YES	NO
-test	t4	1	idx	2	b	NULL		NULL	1	YES	NO
-test	t4	1	expr_idx	1	NULL	NULL		`a` + `b` + 1	2	YES	NO
+explain_easy	t4	0	PRIMARY	1	a	NULL		NULL	0	YES	YES
+explain_easy	t4	1	idx	1	a	NULL		NULL	1	YES	NO
+explain_easy	t4	1	idx	2	b	NULL		NULL	1	YES	NO
+explain_easy	t4	1	expr_idx	1	NULL	NULL		`a` + `b` + 1	2	YES	NO
 explain format = 'brief' select count(1) from (select count(1) from (select * from t1 where c3 = 100) k) k2;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:count(1)->Column#5
 └─StreamAgg	1.00	root		funcs:count(Column#9)->Column#7
   └─TableReader	1.00	root		data:StreamAgg
     └─StreamAgg	1.00	cop[tikv]		funcs:count(1)->Column#9
-      └─Selection	10.00	cop[tikv]		eq(test.t1.c3, 100)
+      └─Selection	10.00	cop[tikv]		eq(explain_easy.t1.c3, 100)
         └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select 1 from (select count(c2), count(c3) from t1) k;
 id	estRows	task	access object	operator info
@@ -230,23 +229,23 @@ StreamAgg	1.00	root		funcs:count(1)->Column#6
 explain format = 'brief' select count(1) from (select count(c2) from t1 group by c3) k;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:count(1)->Column#5
-└─HashAgg	8000.00	root		group by:test.t1.c3, funcs:count(Column#9)->Column#7
+└─HashAgg	8000.00	root		group by:explain_easy.t1.c3, funcs:count(Column#9)->Column#7
   └─TableReader	8000.00	root		data:HashAgg
-    └─HashAgg	8000.00	cop[tikv]		group by:test.t1.c3, funcs:count(1)->Column#9
+    └─HashAgg	8000.00	cop[tikv]		group by:explain_easy.t1.c3, funcs:count(1)->Column#9
       └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 set @@session.tidb_opt_insubq_to_join_and_agg=0;
 explain format = 'brief' select sum(t1.c1 in (select c1 from t2)) from t1;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:sum(Column#13)->Column#11
 └─Projection	10000.00	root		cast(Column#10, decimal(3,0) BINARY)->Column#13
-  └─HashJoin	10000.00	root		CARTESIAN left outer semi join, other cond:eq(test.t1.c1, test.t2.c1)
+  └─HashJoin	10000.00	root		CARTESIAN left outer semi join, other cond:eq(explain_easy.t1.c1, explain_easy.t2.c1)
     ├─IndexReader(Build)	10000.00	root		index:IndexFullScan
     │ └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:c1(c1)	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
       └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select 1 in (select c2 from t2) from t1;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		CARTESIAN left outer semi join, other cond:eq(1, test.t2.c2)
+HashJoin	10000.00	root		CARTESIAN left outer semi join, other cond:eq(1, explain_easy.t2.c2)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -255,7 +254,7 @@ explain format = 'brief' select sum(6 in (select c2 from t2)) from t1;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:sum(Column#13)->Column#11
 └─Projection	10000.00	root		cast(Column#10, decimal(3,0) BINARY)->Column#13
-  └─HashJoin	10000.00	root		CARTESIAN left outer semi join, other cond:eq(6, test.t2.c2)
+  └─HashJoin	10000.00	root		CARTESIAN left outer semi join, other cond:eq(6, explain_easy.t2.c2)
     ├─TableReader(Build)	10000.00	root		data:TableFullScan
     │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -322,100 +321,100 @@ create table t(a int primary key, b int, c int, index idx(b));
 explain format = 'brief' select t.c in (select count(*) from t s ignore index(idx), t t1 where s.a = t.a and s.a = t1.a) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#17
-└─Apply	10000.00	root		CARTESIAN left outer semi join, other cond:eq(test.t.c, Column#16)
+└─Apply	10000.00	root		CARTESIAN left outer semi join, other cond:eq(explain_easy.t.c, Column#16)
   ├─TableReader(Build)	10000.00	root		data:TableFullScan
   │ └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
   └─StreamAgg(Probe)	10000.00	root		funcs:count(1)->Column#16
-    └─MergeJoin	125000.00	root		inner join, left key:test.t.a, right key:test.t.a
+    └─MergeJoin	125000.00	root		inner join, left key:explain_easy.t.a, right key:explain_easy.t.a
       ├─TableReader(Build)	10000.00	root		data:TableRangeScan
-      │ └─TableRangeScan	10000.00	cop[tikv]	table:t1	range: decided by [eq(test.t.a, test.t.a)], keep order:true, stats:pseudo
+      │ └─TableRangeScan	10000.00	cop[tikv]	table:t1	range: decided by [eq(explain_easy.t.a, explain_easy.t.a)], keep order:true, stats:pseudo
       └─TableReader(Probe)	10000.00	root		data:TableRangeScan
-        └─TableRangeScan	10000.00	cop[tikv]	table:s	range: decided by [eq(test.t.a, test.t.a)], keep order:true, stats:pseudo
+        └─TableRangeScan	10000.00	cop[tikv]	table:s	range: decided by [eq(explain_easy.t.a, explain_easy.t.a)], keep order:true, stats:pseudo
 explain format = 'brief' select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.a = t1.a) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#17
-└─Apply	10000.00	root		CARTESIAN left outer semi join, other cond:eq(test.t.c, Column#16)
+└─Apply	10000.00	root		CARTESIAN left outer semi join, other cond:eq(explain_easy.t.c, Column#16)
   ├─TableReader(Build)	10000.00	root		data:TableFullScan
   │ └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
   └─StreamAgg(Probe)	10000.00	root		funcs:count(1)->Column#16
-    └─IndexJoin	125000.00	root		inner join, inner:TableReader, outer key:test.t.a, inner key:test.t.a, equal cond:eq(test.t.a, test.t.a)
+    └─IndexJoin	125000.00	root		inner join, inner:TableReader, outer key:explain_easy.t.a, inner key:explain_easy.t.a, equal cond:eq(explain_easy.t.a, explain_easy.t.a)
       ├─IndexReader(Build)	100000.00	root		index:IndexRangeScan
-      │ └─IndexRangeScan	100000.00	cop[tikv]	table:s, index:idx(b)	range: decided by [eq(test.t.b, test.t.a)], keep order:false, stats:pseudo
+      │ └─IndexRangeScan	100000.00	cop[tikv]	table:s, index:idx(b)	range: decided by [eq(explain_easy.t.b, explain_easy.t.a)], keep order:false, stats:pseudo
       └─TableReader(Probe)	100000.00	root		data:TableRangeScan
-        └─TableRangeScan	100000.00	cop[tikv]	table:t1	range: decided by [test.t.a], keep order:false, stats:pseudo
+        └─TableRangeScan	100000.00	cop[tikv]	table:t1	range: decided by [explain_easy.t.a], keep order:false, stats:pseudo
 explain format = 'brief' select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.c = t1.a) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#17
-└─Apply	10000.00	root		CARTESIAN left outer semi join, other cond:eq(test.t.c, Column#16)
+└─Apply	10000.00	root		CARTESIAN left outer semi join, other cond:eq(explain_easy.t.c, Column#16)
   ├─TableReader(Build)	10000.00	root		data:TableFullScan
   │ └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
   └─StreamAgg(Probe)	10000.00	root		funcs:count(1)->Column#16
-    └─IndexJoin	124875.00	root		inner join, inner:TableReader, outer key:test.t.c, inner key:test.t.a, equal cond:eq(test.t.c, test.t.a)
+    └─IndexJoin	124875.00	root		inner join, inner:TableReader, outer key:explain_easy.t.c, inner key:explain_easy.t.a, equal cond:eq(explain_easy.t.c, explain_easy.t.a)
       ├─IndexLookUp(Build)	99900.00	root		
-      │ ├─IndexRangeScan(Build)	100000.00	cop[tikv]	table:s, index:idx(b)	range: decided by [eq(test.t.b, test.t.a)], keep order:false, stats:pseudo
-      │ └─Selection(Probe)	99900.00	cop[tikv]		not(isnull(test.t.c))
+      │ ├─IndexRangeScan(Build)	100000.00	cop[tikv]	table:s, index:idx(b)	range: decided by [eq(explain_easy.t.b, explain_easy.t.a)], keep order:false, stats:pseudo
+      │ └─Selection(Probe)	99900.00	cop[tikv]		not(isnull(explain_easy.t.c))
       │   └─TableRowIDScan	100000.00	cop[tikv]	table:s	keep order:false, stats:pseudo
       └─TableReader(Probe)	99900.00	root		data:TableRangeScan
-        └─TableRangeScan	99900.00	cop[tikv]	table:t1	range: decided by [test.t.c], keep order:false, stats:pseudo
+        └─TableRangeScan	99900.00	cop[tikv]	table:t1	range: decided by [explain_easy.t.c], keep order:false, stats:pseudo
 insert into t values(1, 1, 1), (2, 2 ,2), (3, 3, 3), (4, 3, 4),(5,3,5);
 analyze table t;
 explain format = 'brief' select t.c in (select count(*) from t s, t t1 where s.b = t.a and s.b = 3 and s.a = t1.a) from t;
 id	estRows	task	access object	operator info
 Projection	5.00	root		Column#17
-└─Apply	5.00	root		CARTESIAN left outer semi join, other cond:eq(test.t.c, Column#16)
+└─Apply	5.00	root		CARTESIAN left outer semi join, other cond:eq(explain_easy.t.c, Column#16)
   ├─TableReader(Build)	5.00	root		data:TableFullScan
   │ └─TableFullScan	5.00	cop[tikv]	table:t	keep order:false
   └─StreamAgg(Probe)	5.00	root		funcs:count(1)->Column#16
-    └─MergeJoin	12.00	root		inner join, left key:test.t.a, right key:test.t.a
+    └─MergeJoin	12.00	root		inner join, left key:explain_easy.t.a, right key:explain_easy.t.a
       ├─TableReader(Build)	20.00	root		data:Selection
-      │ └─Selection	20.00	cop[tikv]		eq(3, test.t.a)
+      │ └─Selection	20.00	cop[tikv]		eq(3, explain_easy.t.a)
       │   └─TableFullScan	25.00	cop[tikv]	table:t1	keep order:true
       └─IndexReader(Probe)	12.00	root		index:Selection
-        └─Selection	12.00	cop[tikv]		eq(3, test.t.a)
+        └─Selection	12.00	cop[tikv]		eq(3, explain_easy.t.a)
           └─IndexRangeScan	15.00	cop[tikv]	table:s, index:idx(b)	range:[3,3], keep order:true
 explain format = 'brief' select t.c in (select count(*) from t s left join t t1 on s.a = t1.a where 3 = t.a and s.b = 3) from t;
 id	estRows	task	access object	operator info
 Projection	5.00	root		Column#17
-└─Apply	5.00	root		CARTESIAN left outer semi join, other cond:eq(test.t.c, Column#16)
+└─Apply	5.00	root		CARTESIAN left outer semi join, other cond:eq(explain_easy.t.c, Column#16)
   ├─TableReader(Build)	5.00	root		data:TableFullScan
   │ └─TableFullScan	5.00	cop[tikv]	table:t	keep order:false
   └─StreamAgg(Probe)	5.00	root		funcs:count(1)->Column#16
-    └─MergeJoin	12.00	root		left outer join, left key:test.t.a, right key:test.t.a
+    └─MergeJoin	12.00	root		left outer join, left key:explain_easy.t.a, right key:explain_easy.t.a
       ├─TableReader(Build)	20.00	root		data:Selection
-      │ └─Selection	20.00	cop[tikv]		eq(3, test.t.a)
+      │ └─Selection	20.00	cop[tikv]		eq(3, explain_easy.t.a)
       │   └─TableFullScan	25.00	cop[tikv]	table:t1	keep order:true
       └─IndexReader(Probe)	12.00	root		index:Selection
-        └─Selection	12.00	cop[tikv]		eq(3, test.t.a)
+        └─Selection	12.00	cop[tikv]		eq(3, explain_easy.t.a)
           └─IndexRangeScan	15.00	cop[tikv]	table:s, index:idx(b)	range:[3,3], keep order:true
 explain format = 'brief' select t.c in (select count(*) from t s right join t t1 on s.a = t1.a where 3 = t.a and t1.b = 3) from t;
 id	estRows	task	access object	operator info
 Projection	5.00	root		Column#17
-└─Apply	5.00	root		CARTESIAN left outer semi join, other cond:eq(test.t.c, Column#16)
+└─Apply	5.00	root		CARTESIAN left outer semi join, other cond:eq(explain_easy.t.c, Column#16)
   ├─TableReader(Build)	5.00	root		data:TableFullScan
   │ └─TableFullScan	5.00	cop[tikv]	table:t	keep order:false
   └─StreamAgg(Probe)	5.00	root		funcs:count(1)->Column#16
-    └─MergeJoin	12.00	root		right outer join, left key:test.t.a, right key:test.t.a
+    └─MergeJoin	12.00	root		right outer join, left key:explain_easy.t.a, right key:explain_easy.t.a
       ├─TableReader(Build)	20.00	root		data:Selection
-      │ └─Selection	20.00	cop[tikv]		eq(3, test.t.a)
+      │ └─Selection	20.00	cop[tikv]		eq(3, explain_easy.t.a)
       │   └─TableFullScan	25.00	cop[tikv]	table:s	keep order:true
       └─IndexReader(Probe)	12.00	root		index:Selection
-        └─Selection	12.00	cop[tikv]		eq(3, test.t.a)
+        └─Selection	12.00	cop[tikv]		eq(3, explain_easy.t.a)
           └─IndexRangeScan	15.00	cop[tikv]	table:t1, index:idx(b)	range:[3,3], keep order:true
 drop table if exists t;
 create table t(a int unsigned not null);
 explain format = 'brief' select t.a = '123455' from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		eq(test.t.a, 123455)->Column#3
+Projection	10000.00	root		eq(explain_easy.t.a, 123455)->Column#3
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select t.a > '123455' from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		gt(test.t.a, 123455)->Column#3
+Projection	10000.00	root		gt(explain_easy.t.a, 123455)->Column#3
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select t.a != '123455' from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		ne(test.t.a, 123455)->Column#3
+Projection	10000.00	root		ne(explain_easy.t.a, 123455)->Column#3
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select t.a = 12345678912345678998789678687678.111 from t;
@@ -432,7 +431,7 @@ IndexReader	10.00	root		index:IndexRangeScan
 explain format = 'brief' select * from t where b in (1, 2) and b in (1, 3);
 id	estRows	task	access object	operator info
 TableReader	10.00	root		data:Selection
-└─Selection	10.00	cop[tikv]		in(test.t.b, 1, 2), in(test.t.b, 1, 3)
+└─Selection	10.00	cop[tikv]		in(explain_easy.t.b, 1, 2), in(explain_easy.t.b, 1, 3)
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select * from t where a = 1 and a = 1;
 id	estRows	task	access object	operator info
@@ -446,17 +445,17 @@ id	estRows	task	access object	operator info
 TableDual	0.00	root		rows:0
 explain format = 'brief' select * from t t1 join t t2 where t1.b = t2.b and t2.b is null;
 id	estRows	task	access object	operator info
-Projection	0.00	root		test.t.a, test.t.b, test.t.a, test.t.b
-└─HashJoin	0.00	root		inner join, equal:[eq(test.t.b, test.t.b)]
+Projection	0.00	root		explain_easy.t.a, explain_easy.t.b, explain_easy.t.a, explain_easy.t.b
+└─HashJoin	0.00	root		inner join, equal:[eq(explain_easy.t.b, explain_easy.t.b)]
   ├─TableReader(Build)	0.00	root		data:Selection
-  │ └─Selection	0.00	cop[tikv]		isnull(test.t.b), not(isnull(test.t.b))
+  │ └─Selection	0.00	cop[tikv]		isnull(explain_easy.t.b), not(isnull(explain_easy.t.b))
   │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
   └─TableReader(Probe)	9990.00	root		data:Selection
-    └─Selection	9990.00	cop[tikv]		not(isnull(test.t.b))
+    └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.b))
       └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select * from t t1 where not exists (select * from t t2 where t1.b = t2.b);
 id	estRows	task	access object	operator info
-HashJoin	8000.00	root		anti semi join, equal:[eq(test.t.b, test.t.b)]
+HashJoin	8000.00	root		anti semi join, equal:[eq(explain_easy.t.b, explain_easy.t.b)]
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -468,7 +467,7 @@ id	estRows	task	access object	operator info
 TableDual	0.00	root		rows:0
 explain format = 'brief' select null or a > 1 from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		or(<nil>, gt(test.t.a, 1))->Column#2
+Projection	10000.00	root		or(<nil>, gt(explain_easy.t.a, 1))->Column#2
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select * from t where a = 1 for update;
@@ -482,7 +481,7 @@ insert tb values ('1');
 explain format = 'brief' select * from ta where a = 1;
 id	estRows	task	access object	operator info
 TableReader	8000.00	root		data:Selection
-└─Selection	8000.00	cop[tikv]		eq(cast(test.ta.a, double BINARY), 1)
+└─Selection	8000.00	cop[tikv]		eq(cast(explain_easy.ta.a, double BINARY), 1)
   └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 rollback;
 drop table if exists t1, t2;
@@ -514,17 +513,17 @@ explain format = 'brief' SELECT COUNT(1) FROM (SELECT COALESCE(b.region_name, '�
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:count(1)->Column#22
 └─HashAgg	2.50	root		group by:Column#47, Column#48, Column#49, funcs:count(1)->Column#36
-  └─Projection	2.50	root		Column#14->Column#47, Column#15->Column#48, coalesce(test.test02.region_name, 不详)->Column#49
-    └─IndexJoin	2.50	root		left outer join, inner:TableReader, outer key:Column#16, inner key:test.test02.id, equal cond:eq(Column#16, test.test02.id)
+  └─Projection	2.50	root		Column#14->Column#47, Column#15->Column#48, coalesce(explain_easy.test02.region_name, 不详)->Column#49
+    └─IndexJoin	2.50	root		left outer join, inner:TableReader, outer key:Column#16, inner key:explain_easy.test02.id, equal cond:eq(Column#16, explain_easy.test02.id)
       ├─HashAgg(Build)	2.00	root		group by:Column#14, Column#15, Column#16, funcs:firstrow(Column#33)->Column#14, funcs:firstrow(Column#34)->Column#15, funcs:firstrow(Column#35)->Column#16, funcs:count(1)->Column#37
       │ └─Union	2.00	root		
       │   ├─Projection	1.00	root		Column#33, Column#34, Column#35, Column#14, Column#15, Column#16
-      │   │ └─HashAgg	1.00	root		group by:test.test01.region_id, test.test01.show_date, test.test01.stat_date, funcs:firstrow(test.test01.stat_date)->Column#33, funcs:firstrow(test.test01.show_date)->Column#34, funcs:firstrow(test.test01.region_id)->Column#35, funcs:firstrow(test.test01.stat_date)->Column#14, funcs:firstrow(test.test01.show_date)->Column#15, funcs:firstrow(test.test01.region_id)->Column#16, funcs:count(1)->Column#38
+      │   │ └─HashAgg	1.00	root		group by:explain_easy.test01.region_id, explain_easy.test01.show_date, explain_easy.test01.stat_date, funcs:firstrow(explain_easy.test01.stat_date)->Column#33, funcs:firstrow(explain_easy.test01.show_date)->Column#34, funcs:firstrow(explain_easy.test01.region_id)->Column#35, funcs:firstrow(explain_easy.test01.stat_date)->Column#14, funcs:firstrow(explain_easy.test01.show_date)->Column#15, funcs:firstrow(explain_easy.test01.region_id)->Column#16, funcs:count(1)->Column#38
       │   │   └─TableDual	0.00	root		rows:0
       │   └─Projection	1.00	root		Column#33, Column#34, Column#35, Column#14, Column#15, Column#16
-      │     └─HashAgg	1.00	root		group by:test.test01.region_id, test.test01.show_date, test.test01.stat_date, funcs:firstrow(test.test01.stat_date)->Column#33, funcs:firstrow(test.test01.show_date)->Column#34, funcs:firstrow(test.test01.region_id)->Column#35, funcs:firstrow(test.test01.stat_date)->Column#14, funcs:firstrow(test.test01.show_date)->Column#15, funcs:firstrow(test.test01.region_id)->Column#16, funcs:count(1)->Column#39
+      │     └─HashAgg	1.00	root		group by:explain_easy.test01.region_id, explain_easy.test01.show_date, explain_easy.test01.stat_date, funcs:firstrow(explain_easy.test01.stat_date)->Column#33, funcs:firstrow(explain_easy.test01.show_date)->Column#34, funcs:firstrow(explain_easy.test01.region_id)->Column#35, funcs:firstrow(explain_easy.test01.stat_date)->Column#14, funcs:firstrow(explain_easy.test01.show_date)->Column#15, funcs:firstrow(explain_easy.test01.region_id)->Column#16, funcs:count(1)->Column#39
       │       └─TableReader	0.01	root		data:Selection
-      │         └─Selection	0.01	cop[tikv]		eq(test.test01.period, 1), ge(test.test01.stat_date, 20191202), gt(cast(test.test01.registration_num, bigint(20) BINARY), 0), le(test.test01.stat_date, 20191202)
+      │         └─Selection	0.01	cop[tikv]		eq(explain_easy.test01.period, 1), ge(explain_easy.test01.stat_date, 20191202), gt(cast(explain_easy.test01.registration_num, bigint(20) BINARY), 0), le(explain_easy.test01.stat_date, 20191202)
       │           └─TableFullScan	10000.00	cop[tikv]	table:test01	keep order:false, stats:pseudo
       └─TableReader(Probe)	2.00	root		data:TableRangeScan
         └─TableRangeScan	2.00	cop[tikv]	table:b	range: decided by [Column#16], keep order:false, stats:pseudo
@@ -532,122 +531,122 @@ drop table if exists t;
 create table t(a int, nb int not null, nc int not null);
 explain format = 'brief' select ifnull(a, 0) from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		ifnull(test.t.a, 0)->Column#5
+Projection	10000.00	root		ifnull(explain_easy.t.a, 0)->Column#5
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(nb, 0) from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		cast(test.t.nb, bigint(11) BINARY)->Column#5
+Projection	10000.00	root		cast(explain_easy.t.nb, bigint(11) BINARY)->Column#5
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(nb, 0), ifnull(nc, 0) from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		cast(test.t.nb, bigint(11) BINARY)->Column#5, cast(test.t.nc, bigint(11) BINARY)->Column#6
+Projection	10000.00	root		cast(explain_easy.t.nb, bigint(11) BINARY)->Column#5, cast(explain_easy.t.nc, bigint(11) BINARY)->Column#6
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(a, 0), ifnull(nb, 0) from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		ifnull(test.t.a, 0)->Column#5, cast(test.t.nb, bigint(11) BINARY)->Column#6
+Projection	10000.00	root		ifnull(explain_easy.t.a, 0)->Column#5, cast(explain_easy.t.nb, bigint(11) BINARY)->Column#6
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(nb, 0), ifnull(nb, 0) from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		cast(test.t.nb, bigint(11) BINARY)->Column#5, cast(test.t.nb, bigint(11) BINARY)->Column#6
+Projection	10000.00	root		cast(explain_easy.t.nb, bigint(11) BINARY)->Column#5, cast(explain_easy.t.nb, bigint(11) BINARY)->Column#6
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select 1+ifnull(nb, 0) from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		plus(1, cast(test.t.nb, bigint(11) BINARY))->Column#5
+Projection	10000.00	root		plus(1, cast(explain_easy.t.nb, bigint(11) BINARY))->Column#5
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select 1+ifnull(a, 0) from t;
 id	estRows	task	access object	operator info
-Projection	10000.00	root		plus(1, ifnull(test.t.a, 0))->Column#5
+Projection	10000.00	root		plus(1, ifnull(explain_easy.t.a, 0))->Column#5
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select 1+ifnull(nb, 0) from t where nb=1;
 id	estRows	task	access object	operator info
-Projection	10.00	root		plus(1, cast(test.t.nb, bigint(11) BINARY))->Column#5
+Projection	10.00	root		plus(1, cast(explain_easy.t.nb, bigint(11) BINARY))->Column#5
 └─TableReader	10.00	root		data:Selection
-  └─Selection	10.00	cop[tikv]		eq(test.t.nb, 1)
+  └─Selection	10.00	cop[tikv]		eq(explain_easy.t.nb, 1)
     └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select * from t ta left outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(ta.nb, 1) or ta.nb is null;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		left outer join, equal:[eq(test.t.nb, test.t.nb)], left cond:[gt(test.t.a, 1)]
+HashJoin	10000.00	root		left outer join, equal:[eq(explain_easy.t.nb, explain_easy.t.nb)], left cond:[gt(explain_easy.t.a, 1)]
 ├─TableReader(Build)	8000.00	root		data:Selection
-│ └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
+│ └─Selection	8000.00	cop[tikv]		or(cast(explain_easy.t.nb, bigint(11) BINARY), 0)
 │   └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 └─TableReader(Probe)	8000.00	root		data:Selection
-  └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
+  └─Selection	8000.00	cop[tikv]		or(cast(explain_easy.t.nb, bigint(11) BINARY), 0)
     └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 explain format = 'brief' select * from t ta right outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
 id	estRows	task	access object	operator info
-HashJoin	8000.00	root		right outer join, equal:[eq(test.t.nb, test.t.nb)]
+HashJoin	8000.00	root		right outer join, equal:[eq(explain_easy.t.nb, explain_easy.t.nb)]
 ├─TableReader(Build)	2666.67	root		data:Selection
-│ └─Selection	2666.67	cop[tikv]		gt(test.t.a, 1), or(cast(test.t.nb, bigint(11) BINARY), 0)
+│ └─Selection	2666.67	cop[tikv]		gt(explain_easy.t.a, 1), or(cast(explain_easy.t.nb, bigint(11) BINARY), 0)
 │   └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 └─TableReader(Probe)	8000.00	root		data:Selection
-  └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
+  └─Selection	8000.00	cop[tikv]		or(cast(explain_easy.t.nb, bigint(11) BINARY), 0)
     └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 explain format = 'brief' select * from t ta inner join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
 id	estRows	task	access object	operator info
-HashJoin	3333.33	root		inner join, equal:[eq(test.t.nb, test.t.nb)]
+HashJoin	3333.33	root		inner join, equal:[eq(explain_easy.t.nb, explain_easy.t.nb)]
 ├─TableReader(Build)	2666.67	root		data:Selection
-│ └─Selection	2666.67	cop[tikv]		gt(test.t.a, 1), or(cast(test.t.nb, bigint(11) BINARY), 0)
+│ └─Selection	2666.67	cop[tikv]		gt(explain_easy.t.a, 1), or(cast(explain_easy.t.nb, bigint(11) BINARY), 0)
 │   └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 └─TableReader(Probe)	8000.00	root		data:Selection
-  └─Selection	8000.00	cop[tikv]		or(cast(test.t.nb, bigint(11) BINARY), 0)
+  └─Selection	8000.00	cop[tikv]		or(cast(explain_easy.t.nb, bigint(11) BINARY), 0)
     └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(t.nc, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#22
 └─Apply	10000.00	root		left outer semi join, equal:[eq(Column#23, Column#21)]
-  ├─Projection(Build)	10000.00	root		test.t.a, cast(test.t.nc, bigint(11) BINARY)->Column#23
+  ├─Projection(Build)	10000.00	root		explain_easy.t.a, cast(explain_easy.t.nc, bigint(11) BINARY)->Column#23
   │ └─TableReader	10000.00	root		data:TableFullScan
   │   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
   └─HashAgg(Probe)	10000.00	root		funcs:count(Column#25)->Column#21
-    └─HashJoin	99900.00	root		inner join, equal:[eq(test.t.a, test.t.a)]
-      ├─HashAgg(Build)	79920.00	root		group by:test.t.a, funcs:count(Column#26)->Column#25, funcs:firstrow(test.t.a)->test.t.a
+    └─HashJoin	99900.00	root		inner join, equal:[eq(explain_easy.t.a, explain_easy.t.a)]
+      ├─HashAgg(Build)	79920.00	root		group by:explain_easy.t.a, funcs:count(Column#26)->Column#25, funcs:firstrow(explain_easy.t.a)->explain_easy.t.a
       │ └─TableReader	79920.00	root		data:HashAgg
-      │   └─HashAgg	79920.00	cop[tikv]		group by:test.t.a, funcs:count(1)->Column#26
-      │     └─Selection	99900.00	cop[tikv]		eq(test.t.a, test.t.a), not(isnull(test.t.a))
+      │   └─HashAgg	79920.00	cop[tikv]		group by:explain_easy.t.a, funcs:count(1)->Column#26
+      │     └─Selection	99900.00	cop[tikv]		eq(explain_easy.t.a, explain_easy.t.a), not(isnull(explain_easy.t.a))
       │       └─TableFullScan	100000000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
       └─TableReader(Probe)	99900.00	root		data:Selection
-        └─Selection	99900.00	cop[tikv]		eq(test.t.a, test.t.a), not(isnull(test.t.a))
+        └─Selection	99900.00	cop[tikv]		eq(explain_easy.t.a, explain_easy.t.a), not(isnull(explain_easy.t.a))
           └─TableFullScan	100000000.00	cop[tikv]	table:s	keep order:false, stats:pseudo
 explain format = 'brief' select * from t ta left outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.a, 1) or tb.a is null;
 id	estRows	task	access object	operator info
-Selection	10000.00	root		or(ifnull(test.t.a, 1), isnull(test.t.a))
-└─HashJoin	12500.00	root		left outer join, equal:[eq(test.t.nb, test.t.nb)], left cond:[gt(test.t.a, 1)]
+Selection	10000.00	root		or(ifnull(explain_easy.t.a, 1), isnull(explain_easy.t.a))
+└─HashJoin	12500.00	root		left outer join, equal:[eq(explain_easy.t.nb, explain_easy.t.nb)], left cond:[gt(explain_easy.t.a, 1)]
   ├─TableReader(Build)	10000.00	root		data:TableFullScan
   │ └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
   └─TableReader(Probe)	10000.00	root		data:TableFullScan
     └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 explain format = 'brief' select * from t ta right outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.a, 1) or tb.a is null;
 id	estRows	task	access object	operator info
-HashJoin	8002.00	root		right outer join, equal:[eq(test.t.nb, test.t.nb)]
+HashJoin	8002.00	root		right outer join, equal:[eq(explain_easy.t.nb, explain_easy.t.nb)]
 ├─TableReader(Build)	3333.33	root		data:Selection
-│ └─Selection	3333.33	cop[tikv]		gt(test.t.a, 1)
+│ └─Selection	3333.33	cop[tikv]		gt(explain_easy.t.a, 1)
 │   └─TableFullScan	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 └─TableReader(Probe)	8002.00	root		data:Selection
-  └─Selection	8002.00	cop[tikv]		or(ifnull(test.t.a, 1), isnull(test.t.a))
+  └─Selection	8002.00	cop[tikv]		or(ifnull(explain_easy.t.a, 1), isnull(explain_easy.t.a))
     └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 explain format = 'brief' select ifnull(t.a, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#22
 └─Apply	10000.00	root		left outer semi join, equal:[eq(Column#23, Column#21)]
-  ├─Projection(Build)	10000.00	root		test.t.a, ifnull(test.t.a, 1)->Column#23
+  ├─Projection(Build)	10000.00	root		explain_easy.t.a, ifnull(explain_easy.t.a, 1)->Column#23
   │ └─TableReader	10000.00	root		data:TableFullScan
   │   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
   └─HashAgg(Probe)	10000.00	root		funcs:count(Column#25)->Column#21
-    └─HashJoin	99900.00	root		inner join, equal:[eq(test.t.a, test.t.a)]
-      ├─HashAgg(Build)	79920.00	root		group by:test.t.a, funcs:count(Column#26)->Column#25, funcs:firstrow(test.t.a)->test.t.a
+    └─HashJoin	99900.00	root		inner join, equal:[eq(explain_easy.t.a, explain_easy.t.a)]
+      ├─HashAgg(Build)	79920.00	root		group by:explain_easy.t.a, funcs:count(Column#26)->Column#25, funcs:firstrow(explain_easy.t.a)->explain_easy.t.a
       │ └─TableReader	79920.00	root		data:HashAgg
-      │   └─HashAgg	79920.00	cop[tikv]		group by:test.t.a, funcs:count(1)->Column#26
-      │     └─Selection	99900.00	cop[tikv]		eq(test.t.a, test.t.a), not(isnull(test.t.a))
+      │   └─HashAgg	79920.00	cop[tikv]		group by:explain_easy.t.a, funcs:count(1)->Column#26
+      │     └─Selection	99900.00	cop[tikv]		eq(explain_easy.t.a, explain_easy.t.a), not(isnull(explain_easy.t.a))
       │       └─TableFullScan	100000000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
       └─TableReader(Probe)	99900.00	root		data:Selection
-        └─Selection	99900.00	cop[tikv]		eq(test.t.a, test.t.a), not(isnull(test.t.a))
+        └─Selection	99900.00	cop[tikv]		eq(explain_easy.t.a, explain_easy.t.a), not(isnull(explain_easy.t.a))
           └─TableFullScan	100000000.00	cop[tikv]	table:s	keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int);
@@ -656,30 +655,30 @@ id	estRows	task	access object	operator info
 Point_Get	1.00	root	table:t	handle:0
 explain format = 'brief' select * from t where _tidb_rowid > 0;
 id	estRows	task	access object	operator info
-Projection	8000.00	root		test.t.a
+Projection	8000.00	root		explain_easy.t.a
 └─TableReader	10000.00	root		data:TableRangeScan
   └─TableRangeScan	10000.00	cop[tikv]	table:t	range:(0,+inf], keep order:false, stats:pseudo
 explain format = 'brief' select a, _tidb_rowid from t where a > 0;
 id	estRows	task	access object	operator info
 TableReader	3333.33	root		data:Selection
-└─Selection	3333.33	cop[tikv]		gt(test.t.a, 0)
+└─Selection	3333.33	cop[tikv]		gt(explain_easy.t.a, 0)
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select * from t where _tidb_rowid > 0 and a > 0;
 id	estRows	task	access object	operator info
-Projection	2666.67	root		test.t.a
+Projection	2666.67	root		explain_easy.t.a
 └─TableReader	2666.67	root		data:Selection
-  └─Selection	2666.67	cop[tikv]		gt(test.t.a, 0)
+  └─Selection	2666.67	cop[tikv]		gt(explain_easy.t.a, 0)
     └─TableRangeScan	3333.33	cop[tikv]	table:t	range:(0,+inf], keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int, b int, c int);
 explain format = 'brief' select * from (select * from t order by (select 2)) t order by a, b;
 id	estRows	task	access object	operator info
-Sort	10000.00	root		test.t.a, test.t.b
+Sort	10000.00	root		explain_easy.t.a, explain_easy.t.b
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select * from (select * from t order by c) t order by a, b;
 id	estRows	task	access object	operator info
-Sort	10000.00	root		test.t.a, test.t.b
+Sort	10000.00	root		explain_easy.t.a, explain_easy.t.b
 └─TableReader	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t;
@@ -708,7 +707,7 @@ insert into t values (1, 1);
 explain format = 'brief' update t set j = -j where i = 1 and j = 1;
 id	estRows	task	access object	operator info
 Update	N/A	root		N/A
-└─Selection	1.00	root		eq(test.t.j, 1)
+└─Selection	1.00	root		eq(explain_easy.t.j, 1)
   └─Point_Get	1.00	root	table:t	handle:1, lock
 rollback;
 drop table if exists t;
@@ -717,14 +716,14 @@ begin;
 insert into t values (1);
 explain format = 'brief' select * from t left outer join t t1 on t.a = t1.a where t.a not between 1 and 2;
 id	estRows	task	access object	operator info
-HashJoin	8320.83	root		left outer join, equal:[eq(test.t.a, test.t.a)]
-├─UnionScan(Build)	6656.67	root		not(and(ge(test.t.a, 1), le(test.t.a, 2))), not(isnull(test.t.a))
+HashJoin	8320.83	root		left outer join, equal:[eq(explain_easy.t.a, explain_easy.t.a)]
+├─UnionScan(Build)	6656.67	root		not(and(ge(explain_easy.t.a, 1), le(explain_easy.t.a, 2))), not(isnull(explain_easy.t.a))
 │ └─TableReader	6656.67	root		data:Selection
-│   └─Selection	6656.67	cop[tikv]		not(isnull(test.t.a)), or(lt(test.t.a, 1), gt(test.t.a, 2))
+│   └─Selection	6656.67	cop[tikv]		not(isnull(explain_easy.t.a)), or(lt(explain_easy.t.a, 1), gt(explain_easy.t.a, 2))
 │     └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─UnionScan(Probe)	6656.67	root		not(and(ge(test.t.a, 1), le(test.t.a, 2)))
+└─UnionScan(Probe)	6656.67	root		not(and(ge(explain_easy.t.a, 1), le(explain_easy.t.a, 2)))
   └─TableReader	6656.67	root		data:Selection
-    └─Selection	6656.67	cop[tikv]		or(lt(test.t.a, 1), gt(test.t.a, 2))
+    └─Selection	6656.67	cop[tikv]		or(lt(explain_easy.t.a, 1), gt(explain_easy.t.a, 2))
       └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 rollback;
 drop table if exists t;
@@ -734,12 +733,12 @@ analyze table t;
 explain format = 'brief' select * from t where a = 1;
 id	estRows	task	access object	operator info
 TableReader	1.00	root		data:Selection
-└─Selection	1.00	cop[tikv]		eq(test.t.a, 00:00:01.000000)
+└─Selection	1.00	cop[tikv]		eq(explain_easy.t.a, 00:00:01.000000)
   └─TableFullScan	3.00	cop[tikv]	table:t	keep order:false
 explain format = 'brief' select * from t where b = "1000-01-01";
 id	estRows	task	access object	operator info
 TableReader	1.00	root		data:Selection
-└─Selection	1.00	cop[tikv]		eq(test.t.b, 1000-01-01 00:00:00.000000)
+└─Selection	1.00	cop[tikv]		eq(explain_easy.t.b, 1000-01-01 00:00:00.000000)
   └─TableFullScan	3.00	cop[tikv]	table:t	keep order:false
 drop table t;
 create table t(a int);
@@ -748,7 +747,7 @@ analyze table t with 1 buckets;
 explain format = 'brief' select * from t where a >= 3 and a <= 8;
 id	estRows	task	access object	operator info
 TableReader	0.00	root		data:Selection
-└─Selection	0.00	cop[tikv]		ge(test.t.a, 3), le(test.t.a, 8)
+└─Selection	0.00	cop[tikv]		ge(explain_easy.t.a, 3), le(explain_easy.t.a, 8)
   └─TableFullScan	8.00	cop[tikv]	table:t	keep order:false
 drop table t;
 create table t(a int, b int, index idx_ab(a, b));
@@ -764,12 +763,12 @@ drop table if exists t;
 create table t(a int, b int);
 explain format = 'brief' select a, b from (select a, b, avg(b) over (partition by a)as avg_b from t) as tt where a > 10 and b < 10 and a > avg_b;
 id	estRows	task	access object	operator info
-Projection	2666.67	root		test.t.a, test.t.b
-└─Selection	2666.67	root		gt(cast(test.t.a, decimal(10,0) BINARY), Column#5), lt(test.t.b, 10)
-  └─Window	3333.33	root		avg(cast(test.t.b, decimal(10,0) BINARY))->Column#5 over(partition by test.t.a)
-    └─Sort	3333.33	root		test.t.a
+Projection	2666.67	root		explain_easy.t.a, explain_easy.t.b
+└─Selection	2666.67	root		gt(cast(explain_easy.t.a, decimal(10,0) BINARY), Column#5), lt(explain_easy.t.b, 10)
+  └─Window	3333.33	root		avg(cast(explain_easy.t.b, decimal(10,0) BINARY))->Column#5 over(partition by explain_easy.t.a)
+    └─Sort	3333.33	root		explain_easy.t.a
       └─TableReader	3333.33	root		data:Selection
-        └─Selection	3333.33	cop[tikv]		gt(test.t.a, 10)
+        └─Selection	3333.33	cop[tikv]		gt(explain_easy.t.a, 10)
           └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int, b int);
@@ -812,7 +811,7 @@ explain format = 'brief' select (select count(n.a) from t) from t n;
 id	estRows	task	access object	operator info
 Projection	1.00	root		Column#11->Column#12
 └─Apply	1.00	root		CARTESIAN left outer join
-  ├─StreamAgg(Build)	1.00	root		funcs:count(test.t.a)->Column#7
+  ├─StreamAgg(Build)	1.00	root		funcs:count(explain_easy.t.a)->Column#7
   │ └─TableReader	10000.00	root		data:TableFullScan
   │   └─TableFullScan	10000.00	cop[tikv]	table:n	keep order:false, stats:pseudo
   └─MaxOneRow(Probe)	1.00	root		
@@ -823,7 +822,7 @@ explain format = 'brief' select (select sum((select count(a)))) from t;
 id	estRows	task	access object	operator info
 Projection	1.00	root		Column#7->Column#8
 └─Apply	1.00	root		CARTESIAN left outer join
-  ├─StreamAgg(Build)	1.00	root		funcs:count(test.t.a)->Column#5
+  ├─StreamAgg(Build)	1.00	root		funcs:count(explain_easy.t.a)->Column#5
   │ └─TableReader	10000.00	root		data:TableFullScan
   │   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
   └─HashAgg(Probe)	1.00	root		funcs:sum(Column#12)->Column#7
@@ -839,15 +838,15 @@ id	estRows	task	access object	operator info
 Sort	8000.00	root		Column#5
 └─HashJoin	8000.00	root		CARTESIAN left outer join
   ├─TableDual(Build)	1.00	root		rows:1
-  └─HashAgg(Probe)	8000.00	root		group by:test.t.b, funcs:count(Column#9)->Column#5
+  └─HashAgg(Probe)	8000.00	root		group by:explain_easy.t.b, funcs:count(Column#9)->Column#5
     └─TableReader	8000.00	root		data:HashAgg
-      └─HashAgg	8000.00	cop[tikv]		group by:test.t.b, funcs:count(test.t.a)->Column#9
+      └─HashAgg	8000.00	cop[tikv]		group by:explain_easy.t.b, funcs:count(explain_easy.t.a)->Column#9
         └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select (select sum(count(a))) from t;
 id	estRows	task	access object	operator info
 Projection	1.00	root		Column#5->Column#6
 └─Apply	1.00	root		CARTESIAN left outer join
-  ├─StreamAgg(Build)	1.00	root		funcs:count(test.t.a)->Column#4
+  ├─StreamAgg(Build)	1.00	root		funcs:count(explain_easy.t.a)->Column#4
   │ └─TableReader	10000.00	root		data:TableFullScan
   │   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
   └─StreamAgg(Probe)	1.00	root		funcs:sum(Column#7)->Column#5
@@ -861,9 +860,9 @@ Projection	8000.00	root		Column#5->Column#9, Column#5->Column#10, Column#6->Colu
     ├─TableDual(Build)	1.00	root		rows:1
     └─HashJoin(Probe)	8000.00	root		CARTESIAN left outer join
       ├─TableDual(Build)	1.00	root		rows:1
-      └─HashAgg(Probe)	8000.00	root		group by:test.t.b, funcs:sum(Column#14)->Column#5, funcs:count(Column#15)->Column#6
+      └─HashAgg(Probe)	8000.00	root		group by:explain_easy.t.b, funcs:sum(Column#14)->Column#5, funcs:count(Column#15)->Column#6
         └─TableReader	8000.00	root		data:HashAgg
-          └─HashAgg	8000.00	cop[tikv]		group by:test.t.b, funcs:sum(test.t.a)->Column#14, funcs:count(test.t.a)->Column#15
+          └─HashAgg	8000.00	cop[tikv]		group by:explain_easy.t.b, funcs:sum(explain_easy.t.a)->Column#14, funcs:count(explain_easy.t.a)->Column#15
             └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a tinyint, b smallint, c mediumint, d int, e bigint);
@@ -873,112 +872,112 @@ admin reload opt_rule_blacklist;
 explain format = 'brief' select sum(t1.a) from t t1 join t t2 on t1.a=t2.a;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:sum(Column#14)->Column#13
-└─Projection	12487.50	root		cast(test.t.a, decimal(3,0) BINARY)->Column#14
-  └─HashJoin	12487.50	root		inner join, equal:[eq(test.t.a, test.t.a)]
+└─Projection	12487.50	root		cast(explain_easy.t.a, decimal(3,0) BINARY)->Column#14
+  └─HashJoin	12487.50	root		inner join, equal:[eq(explain_easy.t.a, explain_easy.t.a)]
     ├─TableReader(Build)	9990.00	root		data:Selection
-    │ └─Selection	9990.00	cop[tikv]		not(isnull(test.t.a))
+    │ └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.a))
     │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	9990.00	root		data:Selection
-      └─Selection	9990.00	cop[tikv]		not(isnull(test.t.a))
+      └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.a))
         └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select sum(t1.b) from t t1 join t t2 on t1.b=t2.b;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:sum(Column#14)->Column#13
-└─Projection	12487.50	root		cast(test.t.b, decimal(5,0) BINARY)->Column#14
-  └─HashJoin	12487.50	root		inner join, equal:[eq(test.t.b, test.t.b)]
+└─Projection	12487.50	root		cast(explain_easy.t.b, decimal(5,0) BINARY)->Column#14
+  └─HashJoin	12487.50	root		inner join, equal:[eq(explain_easy.t.b, explain_easy.t.b)]
     ├─TableReader(Build)	9990.00	root		data:Selection
-    │ └─Selection	9990.00	cop[tikv]		not(isnull(test.t.b))
+    │ └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.b))
     │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	9990.00	root		data:Selection
-      └─Selection	9990.00	cop[tikv]		not(isnull(test.t.b))
+      └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.b))
         └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select sum(t1.c) from t t1 join t t2 on t1.c=t2.c;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:sum(Column#14)->Column#13
-└─Projection	12487.50	root		cast(test.t.c, decimal(8,0) BINARY)->Column#14
-  └─HashJoin	12487.50	root		inner join, equal:[eq(test.t.c, test.t.c)]
+└─Projection	12487.50	root		cast(explain_easy.t.c, decimal(8,0) BINARY)->Column#14
+  └─HashJoin	12487.50	root		inner join, equal:[eq(explain_easy.t.c, explain_easy.t.c)]
     ├─TableReader(Build)	9990.00	root		data:Selection
-    │ └─Selection	9990.00	cop[tikv]		not(isnull(test.t.c))
+    │ └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.c))
     │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	9990.00	root		data:Selection
-      └─Selection	9990.00	cop[tikv]		not(isnull(test.t.c))
+      └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.c))
         └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select sum(t1.d) from t t1 join t t2 on t1.d=t2.d;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:sum(Column#14)->Column#13
-└─Projection	12487.50	root		cast(test.t.d, decimal(10,0) BINARY)->Column#14
-  └─HashJoin	12487.50	root		inner join, equal:[eq(test.t.d, test.t.d)]
+└─Projection	12487.50	root		cast(explain_easy.t.d, decimal(10,0) BINARY)->Column#14
+  └─HashJoin	12487.50	root		inner join, equal:[eq(explain_easy.t.d, explain_easy.t.d)]
     ├─TableReader(Build)	9990.00	root		data:Selection
-    │ └─Selection	9990.00	cop[tikv]		not(isnull(test.t.d))
+    │ └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.d))
     │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	9990.00	root		data:Selection
-      └─Selection	9990.00	cop[tikv]		not(isnull(test.t.d))
+      └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.d))
         └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select sum(t1.e) from t t1 join t t2 on t1.e=t2.e;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:sum(Column#14)->Column#13
-└─Projection	12487.50	root		cast(test.t.e, decimal(20,0) BINARY)->Column#14
-  └─HashJoin	12487.50	root		inner join, equal:[eq(test.t.e, test.t.e)]
+└─Projection	12487.50	root		cast(explain_easy.t.e, decimal(20,0) BINARY)->Column#14
+  └─HashJoin	12487.50	root		inner join, equal:[eq(explain_easy.t.e, explain_easy.t.e)]
     ├─TableReader(Build)	9990.00	root		data:Selection
-    │ └─Selection	9990.00	cop[tikv]		not(isnull(test.t.e))
+    │ └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.e))
     │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	9990.00	root		data:Selection
-      └─Selection	9990.00	cop[tikv]		not(isnull(test.t.e))
+      └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.e))
         └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select avg(t1.a) from t t1 join t t2 on t1.a=t2.a;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:avg(Column#14)->Column#13
-└─Projection	12487.50	root		cast(test.t.a, decimal(3,0) BINARY)->Column#14
-  └─HashJoin	12487.50	root		inner join, equal:[eq(test.t.a, test.t.a)]
+└─Projection	12487.50	root		cast(explain_easy.t.a, decimal(3,0) BINARY)->Column#14
+  └─HashJoin	12487.50	root		inner join, equal:[eq(explain_easy.t.a, explain_easy.t.a)]
     ├─TableReader(Build)	9990.00	root		data:Selection
-    │ └─Selection	9990.00	cop[tikv]		not(isnull(test.t.a))
+    │ └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.a))
     │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	9990.00	root		data:Selection
-      └─Selection	9990.00	cop[tikv]		not(isnull(test.t.a))
+      └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.a))
         └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select avg(t1.b) from t t1 join t t2 on t1.b=t2.b;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:avg(Column#14)->Column#13
-└─Projection	12487.50	root		cast(test.t.b, decimal(5,0) BINARY)->Column#14
-  └─HashJoin	12487.50	root		inner join, equal:[eq(test.t.b, test.t.b)]
+└─Projection	12487.50	root		cast(explain_easy.t.b, decimal(5,0) BINARY)->Column#14
+  └─HashJoin	12487.50	root		inner join, equal:[eq(explain_easy.t.b, explain_easy.t.b)]
     ├─TableReader(Build)	9990.00	root		data:Selection
-    │ └─Selection	9990.00	cop[tikv]		not(isnull(test.t.b))
+    │ └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.b))
     │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	9990.00	root		data:Selection
-      └─Selection	9990.00	cop[tikv]		not(isnull(test.t.b))
+      └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.b))
         └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select avg(t1.c) from t t1 join t t2 on t1.c=t2.c;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:avg(Column#14)->Column#13
-└─Projection	12487.50	root		cast(test.t.c, decimal(8,0) BINARY)->Column#14
-  └─HashJoin	12487.50	root		inner join, equal:[eq(test.t.c, test.t.c)]
+└─Projection	12487.50	root		cast(explain_easy.t.c, decimal(8,0) BINARY)->Column#14
+  └─HashJoin	12487.50	root		inner join, equal:[eq(explain_easy.t.c, explain_easy.t.c)]
     ├─TableReader(Build)	9990.00	root		data:Selection
-    │ └─Selection	9990.00	cop[tikv]		not(isnull(test.t.c))
+    │ └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.c))
     │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	9990.00	root		data:Selection
-      └─Selection	9990.00	cop[tikv]		not(isnull(test.t.c))
+      └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.c))
         └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select avg(t1.d) from t t1 join t t2 on t1.d=t2.d;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:avg(Column#14)->Column#13
-└─Projection	12487.50	root		cast(test.t.d, decimal(10,0) BINARY)->Column#14
-  └─HashJoin	12487.50	root		inner join, equal:[eq(test.t.d, test.t.d)]
+└─Projection	12487.50	root		cast(explain_easy.t.d, decimal(10,0) BINARY)->Column#14
+  └─HashJoin	12487.50	root		inner join, equal:[eq(explain_easy.t.d, explain_easy.t.d)]
     ├─TableReader(Build)	9990.00	root		data:Selection
-    │ └─Selection	9990.00	cop[tikv]		not(isnull(test.t.d))
+    │ └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.d))
     │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	9990.00	root		data:Selection
-      └─Selection	9990.00	cop[tikv]		not(isnull(test.t.d))
+      └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.d))
         └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select avg(t1.e) from t t1 join t t2 on t1.e=t2.e;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:avg(Column#14)->Column#13
-└─Projection	12487.50	root		cast(test.t.e, decimal(20,0) BINARY)->Column#14
-  └─HashJoin	12487.50	root		inner join, equal:[eq(test.t.e, test.t.e)]
+└─Projection	12487.50	root		cast(explain_easy.t.e, decimal(20,0) BINARY)->Column#14
+  └─HashJoin	12487.50	root		inner join, equal:[eq(explain_easy.t.e, explain_easy.t.e)]
     ├─TableReader(Build)	9990.00	root		data:Selection
-    │ └─Selection	9990.00	cop[tikv]		not(isnull(test.t.e))
+    │ └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.e))
     │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	9990.00	root		data:Selection
-      └─Selection	9990.00	cop[tikv]		not(isnull(test.t.e))
+      └─Selection	9990.00	cop[tikv]		not(isnull(explain_easy.t.e))
         └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 drop table if exists t;
 delete from mysql.opt_rule_blacklist where name="aggregation_push_down";

--- a/cmd/explaintest/r/explain_foreign_key.result
+++ b/cmd/explaintest/r/explain_foreign_key.result
@@ -1,5 +1,4 @@
 set @@foreign_key_checks=1;
-use test;
 drop table if exists t1,t2;
 create table t1 (id int key);
 create table t2 (id int key, foreign key fk(id) references t1(id) ON UPDATE CASCADE ON DELETE CASCADE);
@@ -137,7 +136,7 @@ Update	N/A	root		N/A
 explain format = 'brief' delete t_1,t_2 from t_1 join t_2 where t_1.id=t_2.id and t_1.id > 0;
 id	estRows	task	access object	operator info
 Delete	N/A	root		N/A
-├─MergeJoin	4166.67	root		inner join, left key:test.t_1.id, right key:test.t_2.id
+├─MergeJoin	4166.67	root		inner join, left key:explain_foreign_key.t_1.id, right key:explain_foreign_key.t_2.id
 │ ├─TableReader(Build)	3333.33	root		data:TableRangeScan
 │ │ └─TableRangeScan	3333.33	cop[tikv]	table:t_2	range:(0,+inf], keep order:true, stats:pseudo
 │ └─TableReader(Probe)	3333.33	root		data:TableRangeScan
@@ -158,7 +157,7 @@ Update	N/A	root		N/A
 explain format = 'brief' delete t_1,t_2 from t_1 join t_2 where t_1.id=t_2.id and t_1.id > 0;
 id	estRows	task	access object	operator info
 Delete	N/A	root		N/A
-└─MergeJoin	4166.67	root		inner join, left key:test.t_1.id, right key:test.t_2.id
+└─MergeJoin	4166.67	root		inner join, left key:explain_foreign_key.t_1.id, right key:explain_foreign_key.t_2.id
   ├─TableReader(Build)	3333.33	root		data:TableRangeScan
   │ └─TableRangeScan	3333.33	cop[tikv]	table:t_2	range:(0,+inf], keep order:true, stats:pseudo
   └─TableReader(Probe)	3333.33	root		data:TableRangeScan

--- a/cmd/explaintest/r/explain_generate_column_substitute.result
+++ b/cmd/explaintest/r/explain_generate_column_substitute.result
@@ -1,6 +1,5 @@
 set tidb_cost_model_version=1;
 set names utf8mb4;
-use test;
 drop table if exists t;
 create table t(a int, b real, c bigint as ((a+1)) virtual, e real as ((b+a)));
 insert into t values (1, 2.0, default, default), (2, 2.1, default, default), (5, 3.0, default, default),
@@ -96,7 +95,7 @@ a	b	c	e
 0	0	1	0
 desc select * from t order by a+1;
 id	estRows	task	access object	operator info
-Projection_13	10000.00	root		test.t.a, test.t.b, test.t.c, test.t.e
+Projection_13	10000.00	root		explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.b, explain_generate_column_substitute.t.c, explain_generate_column_substitute.t.e
 └─IndexLookUp_12	10000.00	root		
   ├─IndexFullScan_10(Build)	10000.00	cop[tikv]	table:t, index:idx_c(c)	keep order:true, stats:pseudo
   └─TableRowIDScan_11(Probe)	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
@@ -172,7 +171,7 @@ insert into t values (1, 2.0, default, default), (2, 2.1, default, default), (5,
 (5, -1.0, default, default), (0, 0.0, default, default), (-1, -2.0, default, default), (0, 0, default, default);
 desc select * from t where a+1=3;
 id	estRows	task	access object	operator info
-Projection_4	10.00	root		test.t.a, test.t.b, test.t.c, test.t.e
+Projection_4	10.00	root		explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.b, explain_generate_column_substitute.t.c, explain_generate_column_substitute.t.e
 └─IndexLookUp_10	10.00	root		
   ├─IndexRangeScan_8(Build)	10.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	range:[3,3], keep order:false, stats:pseudo
   └─TableRowIDScan_9(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
@@ -181,7 +180,7 @@ a	b	c	e
 2	2.1	3	4.1
 desc select a+1 from t where a+1=3;
 id	estRows	task	access object	operator info
-Projection_4	10.00	root		plus(test.t.a, 1)->Column#8
+Projection_4	10.00	root		plus(explain_generate_column_substitute.t.a, 1)->Column#8
 └─IndexReader_6	10.00	root		index:IndexRangeScan_5
   └─IndexRangeScan_5	10.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	range:[3,3], keep order:false, stats:pseudo
 select a+1 from t where a+1=3;
@@ -189,7 +188,7 @@ a+1
 3
 desc select c from t where a+1=3;
 id	estRows	task	access object	operator info
-Projection_4	10.00	root		test.t.c
+Projection_4	10.00	root		explain_generate_column_substitute.t.c
 └─IndexReader_6	10.00	root		index:IndexRangeScan_5
   └─IndexRangeScan_5	10.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	range:[3,3], keep order:false, stats:pseudo
 select c from t where a+1=3;
@@ -197,7 +196,7 @@ c
 3
 desc select * from t where b+a=3;
 id	estRows	task	access object	operator info
-Projection_4	10.00	root		test.t.a, test.t.b, test.t.c, test.t.e
+Projection_4	10.00	root		explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.b, explain_generate_column_substitute.t.c, explain_generate_column_substitute.t.e
 └─IndexLookUp_10	10.00	root		
   ├─IndexRangeScan_8(Build)	10.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	range:[3,3], keep order:false, stats:pseudo
   └─TableRowIDScan_9(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
@@ -206,7 +205,7 @@ a	b	c	e
 1	2	2	3
 desc select b+a from t where b+a=3;
 id	estRows	task	access object	operator info
-Projection_4	10.00	root		plus(test.t.b, cast(test.t.a, double BINARY))->Column#8
+Projection_4	10.00	root		plus(explain_generate_column_substitute.t.b, cast(explain_generate_column_substitute.t.a, double BINARY))->Column#8
 └─IndexReader_6	10.00	root		index:IndexRangeScan_5
   └─IndexRangeScan_5	10.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	range:[3,3], keep order:false, stats:pseudo
 select b+a from t where b+a=3;
@@ -214,7 +213,7 @@ b+a
 3
 desc select e from t where b+a=3;
 id	estRows	task	access object	operator info
-Projection_4	10.00	root		test.t.e
+Projection_4	10.00	root		explain_generate_column_substitute.t.e
 └─IndexReader_6	10.00	root		index:IndexRangeScan_5
   └─IndexRangeScan_5	10.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	range:[3,3], keep order:false, stats:pseudo
 select e from t where b+a=3;
@@ -222,7 +221,7 @@ e
 3
 desc select a+1 from t where a+1 in (1, 2, 3);
 id	estRows	task	access object	operator info
-Projection_4	30.00	root		plus(test.t.a, 1)->Column#8
+Projection_4	30.00	root		plus(explain_generate_column_substitute.t.a, 1)->Column#8
 └─IndexReader_6	30.00	root		index:IndexRangeScan_5
   └─IndexRangeScan_5	30.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo
 select a+1 from t where a+1 in (1, 2, 3);
@@ -233,7 +232,7 @@ a+1
 3
 desc select * from t where a+1 in (1, 2, 3);
 id	estRows	task	access object	operator info
-Projection_4	30.00	root		test.t.a, test.t.b, test.t.c, test.t.e
+Projection_4	30.00	root		explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.b, explain_generate_column_substitute.t.c, explain_generate_column_substitute.t.e
 └─IndexLookUp_10	30.00	root		
   ├─IndexRangeScan_8(Build)	30.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo
   └─TableRowIDScan_9(Probe)	30.00	cop[tikv]	table:t	keep order:false, stats:pseudo
@@ -245,7 +244,7 @@ a	b	c	e
 0	0	1	0
 desc select a+1 from t where a+1 between 1 and 4;
 id	estRows	task	access object	operator info
-Projection_4	250.00	root		plus(test.t.a, 1)->Column#8
+Projection_4	250.00	root		plus(explain_generate_column_substitute.t.a, 1)->Column#8
 └─IndexReader_6	250.00	root		index:IndexRangeScan_5
   └─IndexRangeScan_5	250.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	range:[1,4], keep order:false, stats:pseudo
 select a+1 from t where a+1 between 1 and 4;
@@ -256,7 +255,7 @@ a+1
 3
 desc select * from t where a+1 between 1 and 4;
 id	estRows	task	access object	operator info
-Projection_4	250.00	root		test.t.a, test.t.b, test.t.c, test.t.e
+Projection_4	250.00	root		explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.b, explain_generate_column_substitute.t.c, explain_generate_column_substitute.t.e
 └─IndexLookUp_10	250.00	root		
   ├─IndexRangeScan_8(Build)	250.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	range:[1,4], keep order:false, stats:pseudo
   └─TableRowIDScan_9(Probe)	250.00	cop[tikv]	table:t	keep order:false, stats:pseudo
@@ -268,8 +267,8 @@ a	b	c	e
 0	0	1	0
 desc select * from t order by a+1;
 id	estRows	task	access object	operator info
-Projection_5	10000.00	root		test.t.a, test.t.b, test.t.c, test.t.e
-└─Projection_13	10000.00	root		test.t.a, test.t.b, test.t.c, test.t.e, plus(test.t.a, 1), plus(test.t.b, cast(test.t.a, double BINARY))
+Projection_5	10000.00	root		explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.b, explain_generate_column_substitute.t.c, explain_generate_column_substitute.t.e
+└─Projection_13	10000.00	root		explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.b, explain_generate_column_substitute.t.c, explain_generate_column_substitute.t.e, plus(explain_generate_column_substitute.t.a, 1), plus(explain_generate_column_substitute.t.b, cast(explain_generate_column_substitute.t.a, double BINARY))
   └─IndexLookUp_12	10000.00	root		
     ├─IndexFullScan_10(Build)	10000.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	keep order:true, stats:pseudo
     └─TableRowIDScan_11(Probe)	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
@@ -284,7 +283,7 @@ a	b	c	e
 5	-1	6	4
 desc select a+1 from t order by a+1;
 id	estRows	task	access object	operator info
-Projection_5	10000.00	root		plus(test.t.a, 1)->Column#9
+Projection_5	10000.00	root		plus(explain_generate_column_substitute.t.a, 1)->Column#9
 └─IndexReader_14	10000.00	root		index:IndexFullScan_13
   └─IndexFullScan_13	10000.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	keep order:true, stats:pseudo
 select a+1 from t order by a+1;
@@ -298,7 +297,7 @@ a+1
 6
 desc select b+a from t order by b+a;
 id	estRows	task	access object	operator info
-Projection_5	10000.00	root		plus(test.t.b, cast(test.t.a, double BINARY))->Column#9
+Projection_5	10000.00	root		plus(explain_generate_column_substitute.t.b, cast(explain_generate_column_substitute.t.a, double BINARY))->Column#9
 └─IndexReader_14	10000.00	root		index:IndexFullScan_13
   └─IndexFullScan_13	10000.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	keep order:true, stats:pseudo
 select b+a from t order by b+a;
@@ -346,7 +345,7 @@ alter table t add UNIQUE expr_idx_e((b+a));
 insert into t values (2, 2.1, default, default);
 desc select * from t where a+1 = 3;
 id	estRows	task	access object	operator info
-Projection_4	1.00	root		test.t.a, test.t.b, test.t.c, test.t.e
+Projection_4	1.00	root		explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.b, explain_generate_column_substitute.t.c, explain_generate_column_substitute.t.e
 └─Point_Get_5	1.00	root	table:t, index:expr_idx_c(`a` + 1)	
 drop table if exists t0;
 create table t0(c0 float(24), c1 double as (c0) unique);
@@ -434,36 +433,36 @@ insert into t values (1, "A"), (2, "B"), (3, "C"), (4, "D"), (5, "E"), (6, "F");
 analyze table t;
 desc format = 'brief' select * from t where (lower(b) = "a" and a+1 = 2) or (lower(b) = "b" and a+1 = 5);
 id	estRows	task	access object	operator info
-Projection	1.00	root		test.t.a, test.t.b
+Projection	1.00	root		explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.b
 └─IndexLookUp	1.00	root		
   ├─IndexRangeScan(Build)	1.00	cop[tikv]	table:t, index:expression_index(lower(`b`), `a` + 1)	range:["a" 2,"a" 2], ["b" 5,"b" 5], keep order:false
   └─TableRowIDScan(Probe)	1.00	cop[tikv]	table:t	keep order:false
 desc format = 'brief' select * from t where not (lower(b) >= "a");
 id	estRows	task	access object	operator info
-Projection	0.00	root		test.t.a, test.t.b
+Projection	0.00	root		explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.b
 └─IndexLookUp	0.00	root		
   ├─IndexRangeScan(Build)	0.00	cop[tikv]	table:t, index:expression_index(lower(`b`), `a` + 1)	range:[-inf,"a"), keep order:false
   └─TableRowIDScan(Probe)	0.00	cop[tikv]	table:t	keep order:false
 desc format = 'brief' select count(upper(b)) from t group by upper(b);
 id	estRows	task	access object	operator info
-StreamAgg	4.80	root		group by:upper(test.t.b), funcs:count(upper(test.t.b))->Column#7
+StreamAgg	4.80	root		group by:upper(explain_generate_column_substitute.t.b), funcs:count(upper(explain_generate_column_substitute.t.b))->Column#7
 └─IndexReader	6.00	root		index:IndexFullScan
   └─IndexFullScan	6.00	cop[tikv]	table:t, index:expression_index_2(upper(`b`))	keep order:true
 desc format = 'brief' select max(upper(b)) from t group by upper(b);
 id	estRows	task	access object	operator info
-StreamAgg	4.80	root		group by:upper(test.t.b), funcs:max(upper(test.t.b))->Column#7
+StreamAgg	4.80	root		group by:upper(explain_generate_column_substitute.t.b), funcs:max(upper(explain_generate_column_substitute.t.b))->Column#7
 └─IndexReader	6.00	root		index:IndexFullScan
   └─IndexFullScan	6.00	cop[tikv]	table:t, index:expression_index_2(upper(`b`))	keep order:true
 desc format = 'brief' select count(upper(b)) from t use index() group by upper(b);
 id	estRows	task	access object	operator info
 HashAgg	6.00	root		group by:Column#9, funcs:count(Column#8)->Column#7
-└─Projection	6.00	root		upper(test.t.b)->Column#8, upper(test.t.b)->Column#9
+└─Projection	6.00	root		upper(explain_generate_column_substitute.t.b)->Column#8, upper(explain_generate_column_substitute.t.b)->Column#9
   └─TableReader	6.00	root		data:TableFullScan
     └─TableFullScan	6.00	cop[tikv]	table:t	keep order:false
 desc format = 'brief' select max(upper(b)) from t use index() group by upper(b);
 id	estRows	task	access object	operator info
 HashAgg	6.00	root		group by:Column#9, funcs:max(Column#8)->Column#7
-└─Projection	6.00	root		upper(test.t.b)->Column#8, upper(test.t.b)->Column#9
+└─Projection	6.00	root		upper(explain_generate_column_substitute.t.b)->Column#8, upper(explain_generate_column_substitute.t.b)->Column#9
   └─TableReader	6.00	root		data:TableFullScan
     └─TableFullScan	6.00	cop[tikv]	table:t	keep order:false
 drop table if exists t;
@@ -600,13 +599,13 @@ begin;
 delete from t2 where c_decimal > c_double/2 order by c_int, c_str, c_double, c_decimal limit 1;
 desc format='brief' select t2.c_enum from t2,t1 where t1.c_int - 1 = t2.c_int - 1 order  by t2.c_enum;
 id	estRows	task	access object	operator info
-Sort	12487.50	root		test.t2.c_enum
-└─HashJoin	12487.50	root		inner join, equal:[eq(minus(test.t1.c_int, 1), minus(test.t2.c_int, 1))]
+Sort	12487.50	root		explain_generate_column_substitute.t2.c_enum
+└─HashJoin	12487.50	root		inner join, equal:[eq(minus(explain_generate_column_substitute.t1.c_int, 1), minus(explain_generate_column_substitute.t2.c_int, 1))]
   ├─IndexReader(Build)	9990.00	root		index:IndexFullScan
   │ └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:expression_index_2(`c_int` - 1)	keep order:false, stats:pseudo
-  └─Projection(Probe)	10000.00	root		test.t2.c_enum, minus(test.t2.c_int, 1), test.t2._tidb_rowid
-    └─UnionScan	8000.00	root		not(isnull(minus(test.t2.c_int, 1)))
-      └─Selection	8000.00	root		not(isnull(minus(test.t2.c_int, 1)))
+  └─Projection(Probe)	10000.00	root		explain_generate_column_substitute.t2.c_enum, minus(explain_generate_column_substitute.t2.c_int, 1), explain_generate_column_substitute.t2._tidb_rowid
+    └─UnionScan	8000.00	root		not(isnull(minus(explain_generate_column_substitute.t2.c_int, 1)))
+      └─Selection	8000.00	root		not(isnull(minus(explain_generate_column_substitute.t2.c_int, 1)))
         └─TableReader	10000.00	root		data:TableFullScan
           └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 select t2.c_enum from t2,t1 where t1.c_int - 1 = t2.c_int - 1 order  by t2.c_enum;
@@ -631,15 +630,15 @@ create table t1 (c_int int, c_decimal decimal(12, 6), primary key (c_int) nonclu
 create table t2 like t1;
 explain format = 'brief' select /*+ agg_to_cop() */ * from t1 where c_decimal in (select c_decimal from t2 where t2.c_int + 1 = 8 + 1);
 id	estRows	task	access object	operator info
-HashJoin	9.99	root		inner join, equal:[eq(test.t2.c_decimal, test.t1.c_decimal)]
-├─HashAgg(Build)	7.99	root		group by:test.t2.c_decimal, funcs:firstrow(test.t2.c_decimal)->test.t2.c_decimal
+HashJoin	9.99	root		inner join, equal:[eq(explain_generate_column_substitute.t2.c_decimal, explain_generate_column_substitute.t1.c_decimal)]
+├─HashAgg(Build)	7.99	root		group by:explain_generate_column_substitute.t2.c_decimal, funcs:firstrow(explain_generate_column_substitute.t2.c_decimal)->explain_generate_column_substitute.t2.c_decimal
 │ └─IndexLookUp	7.99	root		
 │   ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t2, index:expression_index(`c_int` + 1)	range:[9,9], keep order:false, stats:pseudo
-│   └─HashAgg(Probe)	7.99	cop[tikv]		group by:test.t2.c_decimal, 
-│     └─Selection	9.99	cop[tikv]		not(isnull(test.t2.c_decimal))
+│   └─HashAgg(Probe)	7.99	cop[tikv]		group by:explain_generate_column_substitute.t2.c_decimal, 
+│     └─Selection	9.99	cop[tikv]		not(isnull(explain_generate_column_substitute.t2.c_decimal))
 │       └─TableRowIDScan	10.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 └─TableReader(Probe)	9990.00	root		data:Selection
-  └─Selection	9990.00	cop[tikv]		not(isnull(test.t1.c_decimal))
+  └─Selection	9990.00	cop[tikv]		not(isnull(explain_generate_column_substitute.t1.c_decimal))
     └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 drop table t1;
 drop table t2;
@@ -651,15 +650,15 @@ id
 1
 desc format = 'brief' SELECT id FROM person ignore index(`city`) WHERE address_info->>"$.city" = 'Beijing';
 id	estRows	task	access object	operator info
-Projection	8000.00	root		test.person.id
+Projection	8000.00	root		explain_generate_column_substitute.person.id
 └─TableReader	8000.00	root		data:Selection
-  └─Selection	8000.00	cop[tikv]		eq(json_unquote(cast(json_extract(test.person.address_info, "$.city"), var_string(16777216))), "Beijing")
+  └─Selection	8000.00	cop[tikv]		eq(json_unquote(cast(json_extract(explain_generate_column_substitute.person.address_info, "$.city"), var_string(16777216))), "Beijing")
     └─TableFullScan	10000.00	cop[tikv]	table:person	keep order:false, stats:pseudo
 SELECT id FROM person force index(`city`) WHERE address_info->>"$.city" = 'Beijing';
 id
 desc format = 'brief' SELECT id FROM person force index(`city`) WHERE address_info->>"$.city" = 'Beijing';
 id	estRows	task	access object	operator info
-Projection	10.00	root		test.person.id
+Projection	10.00	root		explain_generate_column_substitute.person.id
 └─IndexReader	10.00	root		index:IndexRangeScan
   └─IndexRangeScan	10.00	cop[tikv]	table:person, index:city(city)	range:["Beijing","Beijing"], keep order:false, stats:pseudo
 drop table person;
@@ -674,7 +673,7 @@ aaaaa	aaaaaa
 desc format = 'brief' select * from t ignore index(bx) where concat(a, a) = 'aaaaaaaaaa';
 id	estRows	task	access object	operator info
 TableReader	8000.00	root		data:Selection
-└─Selection	8000.00	cop[tikv]		eq(concat(test.t.a, test.t.a), "aaaaaaaaaa")
+└─Selection	8000.00	cop[tikv]		eq(concat(explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.a), "aaaaaaaaaa")
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select * from t force index(bx) where concat(a, a) = 'aaaaaaaaaa';
 a	b
@@ -691,16 +690,16 @@ id
 1
 desc format = 'brief' SELECT id FROM person ignore index(`city`) WHERE address_info->>"$.city" = 'Beijing';
 id	estRows	task	access object	operator info
-Projection	8000.00	root		test.person.id
+Projection	8000.00	root		explain_generate_column_substitute.person.id
 └─TableReader	8000.00	root		data:Selection
-  └─Selection	8000.00	cop[tikv]		eq(json_unquote(cast(json_extract(test.person.address_info, "$.city"), var_string(16777216))), "Beijing")
+  └─Selection	8000.00	cop[tikv]		eq(json_unquote(cast(json_extract(explain_generate_column_substitute.person.address_info, "$.city"), var_string(16777216))), "Beijing")
     └─TableFullScan	10000.00	cop[tikv]	table:person	keep order:false, stats:pseudo
 SELECT id FROM person force index(`city`) WHERE address_info->>"$.city" = 'Beijing';
 id
 1
 desc format = 'brief' SELECT id FROM person force index(`city`) WHERE address_info->>"$.city" = 'Beijing';
 id	estRows	task	access object	operator info
-Projection	10.00	root		test.person.id
+Projection	10.00	root		explain_generate_column_substitute.person.id
 └─IndexReader	10.00	root		index:IndexRangeScan
   └─IndexRangeScan	10.00	cop[tikv]	table:person, index:city(city)	range:["Beijing","Beijing"], keep order:false, stats:pseudo
 drop table person;
@@ -715,7 +714,7 @@ aaaaa	aaaaaaaaaa
 desc format = 'brief' select * from t ignore index(bx) where concat(a, a) = 'aaaaaaaaaa';
 id	estRows	task	access object	operator info
 TableReader	8000.00	root		data:Selection
-└─Selection	8000.00	cop[tikv]		eq(concat(test.t.a, test.t.a), "aaaaaaaaaa")
+└─Selection	8000.00	cop[tikv]		eq(concat(explain_generate_column_substitute.t.a, explain_generate_column_substitute.t.a), "aaaaaaaaaa")
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select * from t force index(bx) where concat(a, a) = 'aaaaaaaaaa';
 a	b

--- a/cmd/explaintest/r/explain_shard_index.result
+++ b/cmd/explaintest/r/explain_shard_index.result
@@ -1,74 +1,73 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists test3, test5;
 create table test3(id int primary key clustered, a int, b int, unique key uk_expr((tidb_shard(a)),a));
 create table test5(id int primary key clustered, a int, b int, unique key uk_expr((tidb_shard(a)),a,b));
 explain format=brief select * from test3 where a=100;
 id	estRows	task	access object	operator info
-Projection	1.00	root		test.test3.id, test.test3.a, test.test3.b
+Projection	1.00	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
 └─Point_Get	1.00	root	table:test3, index:uk_expr(tidb_shard(`a`), a)	
 explain format=brief select * from test3 where a=100 and (b = 100 or b = 200);
 id	estRows	task	access object	operator info
-Projection	0.00	root		test.test3.id, test.test3.a, test.test3.b
-└─Selection	0.00	root		or(eq(test.test3.b, 100), eq(test.test3.b, 200))
+Projection	0.00	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
+└─Selection	0.00	root		or(eq(explain_shard_index.test3.b, 100), eq(explain_shard_index.test3.b, 200))
   └─Point_Get	1.00	root	table:test3, index:uk_expr(tidb_shard(`a`), a)	
 explain format=brief select * from test3 where tidb_shard(a) = 8;
 id	estRows	task	access object	operator info
-Projection	10.00	root		test.test3.id, test.test3.a, test.test3.b
+Projection	10.00	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
 └─IndexLookUp	10.00	root		
   ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:test3, index:uk_expr(tidb_shard(`a`), a)	range:[8,8], keep order:false, stats:pseudo
   └─TableRowIDScan(Probe)	10.00	cop[tikv]	table:test3	keep order:false, stats:pseudo
 explain format=brief select * from test3 where a=100 or b = 200;
 id	estRows	task	access object	operator info
-Projection	8000.00	root		test.test3.id, test.test3.a, test.test3.b
-└─Selection	8000.00	root		or(and(eq(tidb_shard(test.test3.a), 8), eq(test.test3.a, 100)), eq(test.test3.b, 200))
+Projection	8000.00	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
+└─Selection	8000.00	root		or(and(eq(tidb_shard(explain_shard_index.test3.a), 8), eq(explain_shard_index.test3.a, 100)), eq(explain_shard_index.test3.b, 200))
   └─TableReader	10000.00	root		data:TableFullScan
     └─TableFullScan	10000.00	cop[tikv]	table:test3	keep order:false, stats:pseudo
 explain format=brief select * from test3 where a=100 or a = 300;
 id	estRows	task	access object	operator info
-Projection	2.00	root		test.test3.id, test.test3.a, test.test3.b
+Projection	2.00	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
 └─Batch_Point_Get	2.00	root	table:test3, index:uk_expr(tidb_shard(`a`), a)	keep order:false, desc:false
 explain format=brief select * from test3 where a=100 or a = 300 or a > 997;
 id	estRows	task	access object	operator info
-Projection	8000.00	root		test.test3.id, test.test3.a, test.test3.b
-└─Selection	8000.00	root		or(and(eq(tidb_shard(test.test3.a), 8), eq(test.test3.a, 100)), or(and(eq(tidb_shard(test.test3.a), 227), eq(test.test3.a, 300)), gt(test.test3.a, 997)))
+Projection	8000.00	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
+└─Selection	8000.00	root		or(and(eq(tidb_shard(explain_shard_index.test3.a), 8), eq(explain_shard_index.test3.a, 100)), or(and(eq(tidb_shard(explain_shard_index.test3.a), 227), eq(explain_shard_index.test3.a, 300)), gt(explain_shard_index.test3.a, 997)))
   └─TableReader	10000.00	root		data:TableFullScan
     └─TableFullScan	10000.00	cop[tikv]	table:test3	keep order:false, stats:pseudo
 explain format=brief select * from test3 where ((a=100 and b = 100) or a = 200) and b = 300;
 id	estRows	task	access object	operator info
-Projection	0.01	root		test.test3.id, test.test3.a, test.test3.b
+Projection	0.01	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
 └─TableReader	0.01	root		data:Selection
-  └─Selection	0.01	cop[tikv]		eq(test.test3.b, 300), or(0, eq(test.test3.a, 200))
+  └─Selection	0.01	cop[tikv]		eq(explain_shard_index.test3.b, 300), or(0, eq(explain_shard_index.test3.a, 200))
     └─TableFullScan	10000.00	cop[tikv]	table:test3	keep order:false, stats:pseudo
 explain format=brief select * from test3 where a = b;
 id	estRows	task	access object	operator info
-Projection	8000.00	root		test.test3.id, test.test3.a, test.test3.b
+Projection	8000.00	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
 └─TableReader	8000.00	root		data:Selection
-  └─Selection	8000.00	cop[tikv]		eq(test.test3.a, test.test3.b)
+  └─Selection	8000.00	cop[tikv]		eq(explain_shard_index.test3.a, explain_shard_index.test3.b)
     └─TableFullScan	10000.00	cop[tikv]	table:test3	keep order:false, stats:pseudo
 explain format=brief select * from test3 where a = b and b = 100;
 id	estRows	task	access object	operator info
-Projection	0.00	root		test.test3.id, test.test3.a, test.test3.b
-└─Selection	0.00	root		eq(test.test3.b, 100)
+Projection	0.00	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
+└─Selection	0.00	root		eq(explain_shard_index.test3.b, 100)
   └─Point_Get	1.00	root	table:test3, index:uk_expr(tidb_shard(`a`), a)	
 explain format=brief select * from test5 where a=100 and b = 100;
 id	estRows	task	access object	operator info
-Projection	1.00	root		test.test5.id, test.test5.a, test.test5.b
+Projection	1.00	root		explain_shard_index.test5.id, explain_shard_index.test5.a, explain_shard_index.test5.b
 └─Point_Get	1.00	root	table:test5, index:uk_expr(tidb_shard(`a`), a, b)	
 explain format=brief select * from test5 where (a=100 and b = 100) or  (a=200 and b = 200);
 id	estRows	task	access object	operator info
-Projection	2.00	root		test.test5.id, test.test5.a, test.test5.b
+Projection	2.00	root		explain_shard_index.test5.id, explain_shard_index.test5.a, explain_shard_index.test5.b
 └─Batch_Point_Get	2.00	root	table:test5, index:uk_expr(tidb_shard(`a`), a, b)	keep order:false, desc:false
 explain format=brief select a+b from test5 where (a, b) in ((100, 100), (200, 200));
 id	estRows	task	access object	operator info
-Projection	2.00	root		plus(test.test5.a, test.test5.b)->Column#5
+Projection	2.00	root		plus(explain_shard_index.test5.a, explain_shard_index.test5.b)->Column#5
 └─Batch_Point_Get	2.00	root	table:test5, index:uk_expr(tidb_shard(`a`), a, b)	keep order:false, desc:false
 explain format=brief SELECT * FROM test3 WHERE a IN (100);
 id	estRows	task	access object	operator info
-Projection	1.00	root		test.test3.id, test.test3.a, test.test3.b
+Projection	1.00	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
 └─Point_Get	1.00	root	table:test3, index:uk_expr(tidb_shard(`a`), a)	
 explain format=brief SELECT * FROM test3 WHERE a IN (100, 200, 300);
 id	estRows	task	access object	operator info
-Projection	3.00	root		test.test3.id, test.test3.a, test.test3.b
+Projection	3.00	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
 └─Batch_Point_Get	3.00	root	table:test3, index:uk_expr(tidb_shard(`a`), a)	keep order:false, desc:false
 drop table if exists test3, test5;

--- a/cmd/explaintest/r/index_join.result
+++ b/cmd/explaintest/r/index_join.result
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t1, t2;
 create table t1(a bigint, b bigint, index idx(a));
 create table t2(a bigint, b bigint, index idx(a));
@@ -10,24 +9,24 @@ set session tidb_hashagg_partial_concurrency = 1;
 set session tidb_hashagg_final_concurrency = 1;
 explain format = 'brief' select /*+ TIDB_INLJ(t1, t2) */ * from t1 join t2 on t1.a=t2.a;
 id	estRows	task	access object	operator info
-Projection	5.00	root		test.t1.a, test.t1.b, test.t2.a, test.t2.b
-└─IndexJoin	5.00	root		inner join, inner:IndexLookUp, outer key:test.t2.a, inner key:test.t1.a, equal cond:eq(test.t2.a, test.t1.a)
+Projection	5.00	root		index_join.t1.a, index_join.t1.b, index_join.t2.a, index_join.t2.b
+└─IndexJoin	5.00	root		inner join, inner:IndexLookUp, outer key:index_join.t2.a, inner key:index_join.t1.a, equal cond:eq(index_join.t2.a, index_join.t1.a)
   ├─TableReader(Build)	1.00	root		data:Selection
-  │ └─Selection	1.00	cop[tikv]		not(isnull(test.t2.a))
+  │ └─Selection	1.00	cop[tikv]		not(isnull(index_join.t2.a))
   │   └─TableFullScan	1.00	cop[tikv]	table:t2	keep order:false
   └─IndexLookUp(Probe)	5.00	root		
-    ├─Selection(Build)	5.00	cop[tikv]		not(isnull(test.t1.a))
-    │ └─IndexRangeScan	5.00	cop[tikv]	table:t1, index:idx(a)	range: decided by [eq(test.t1.a, test.t2.a)], keep order:false
+    ├─Selection(Build)	5.00	cop[tikv]		not(isnull(index_join.t1.a))
+    │ └─IndexRangeScan	5.00	cop[tikv]	table:t1, index:idx(a)	range: decided by [eq(index_join.t1.a, index_join.t2.a)], keep order:false
     └─TableRowIDScan(Probe)	5.00	cop[tikv]	table:t1	keep order:false
 explain format = 'brief' select * from t1 join t2 on t1.a=t2.a;
 id	estRows	task	access object	operator info
-Projection	5.00	root		test.t1.a, test.t1.b, test.t2.a, test.t2.b
-└─HashJoin	5.00	root		inner join, equal:[eq(test.t2.a, test.t1.a)]
+Projection	5.00	root		index_join.t1.a, index_join.t1.b, index_join.t2.a, index_join.t2.b
+└─HashJoin	5.00	root		inner join, equal:[eq(index_join.t2.a, index_join.t1.a)]
   ├─TableReader(Build)	1.00	root		data:Selection
-  │ └─Selection	1.00	cop[tikv]		not(isnull(test.t2.a))
+  │ └─Selection	1.00	cop[tikv]		not(isnull(index_join.t2.a))
   │   └─TableFullScan	1.00	cop[tikv]	table:t2	keep order:false
   └─TableReader(Probe)	5.00	root		data:Selection
-    └─Selection	5.00	cop[tikv]		not(isnull(test.t1.a))
+    └─Selection	5.00	cop[tikv]		not(isnull(index_join.t1.a))
       └─TableFullScan	5.00	cop[tikv]	table:t1	keep order:false
 drop table if exists t1, t2;
 create table t1(a int not null, b int not null);
@@ -35,11 +34,11 @@ create table t2(a int not null, b int not null, key a(a));
 set @@tidb_opt_insubq_to_join_and_agg=0;
 explain format = 'brief' select /*+ TIDB_INLJ(t2@sel_2) */ * from t1 where t1.a in (select t2.a from t2);
 id	estRows	task	access object	operator info
-IndexJoin	8000.00	root		semi join, inner:IndexReader, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)
+IndexJoin	8000.00	root		semi join, inner:IndexReader, outer key:index_join.t1.a, inner key:index_join.t2.a, equal cond:eq(index_join.t1.a, index_join.t2.a)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 └─IndexReader(Probe)	12500.00	root		index:IndexRangeScan
-  └─IndexRangeScan	12500.00	cop[tikv]	table:t2, index:a(a)	range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo
+  └─IndexRangeScan	12500.00	cop[tikv]	table:t2, index:a(a)	range: decided by [eq(index_join.t2.a, index_join.t1.a)], keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message
 set @@tidb_opt_insubq_to_join_and_agg=1;
@@ -48,10 +47,10 @@ create table t1(a int not null, b int not null, key a(a));
 create table t2(a int not null, b int not null, key a(a));
 explain format = 'brief' select /*+ TIDB_INLJ(t1) */ * from t1 where t1.a in (select t2.a from t2);
 id	estRows	task	access object	operator info
-IndexJoin	10000.00	root		inner join, inner:IndexLookUp, outer key:test.t2.a, inner key:test.t1.a, equal cond:eq(test.t2.a, test.t1.a)
-├─StreamAgg(Build)	8000.00	root		group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a
+IndexJoin	10000.00	root		inner join, inner:IndexLookUp, outer key:index_join.t2.a, inner key:index_join.t1.a, equal cond:eq(index_join.t2.a, index_join.t1.a)
+├─StreamAgg(Build)	8000.00	root		group by:index_join.t2.a, funcs:firstrow(index_join.t2.a)->index_join.t2.a
 │ └─IndexReader	10000.00	root		index:IndexFullScan
 │   └─IndexFullScan	10000.00	cop[tikv]	table:t2, index:a(a)	keep order:true, stats:pseudo
 └─IndexLookUp(Probe)	10000.00	root		
-  ├─IndexRangeScan(Build)	10000.00	cop[tikv]	table:t1, index:a(a)	range: decided by [eq(test.t1.a, test.t2.a)], keep order:false, stats:pseudo
+  ├─IndexRangeScan(Build)	10000.00	cop[tikv]	table:t1, index:a(a)	range: decided by [eq(index_join.t1.a, index_join.t2.a)], keep order:false, stats:pseudo
   └─TableRowIDScan(Probe)	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo

--- a/cmd/explaintest/r/naaj.result
+++ b/cmd/explaintest/r/naaj.result
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 set @@session.tidb_enable_null_aware_anti_join=1;
 select "***************************************************** PART 1 *****************************************************************" as name;
 name
@@ -11,7 +10,7 @@ insert into naaj_A values (1,1,1);
 insert into naaj_B values (1,2,2);
 explain format = 'brief' select (a, b) not in (select a, b from naaj_B) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)]
+HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)]
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -21,7 +20,7 @@ select (a, b) not in (select a, b from naaj_B) from naaj_A;
 1
 explain format = 'brief' select * from naaj_A where (a, b) not in (select a, b from naaj_B);
 id	estRows	task	access object	operator info
-HashJoin	8000.00	root		Null-aware anti semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)]
+HashJoin	8000.00	root		Null-aware anti semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)]
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -43,7 +42,7 @@ select * from naaj_A where (a, b) not in (select a, b from naaj_B);
 a	b	c
 explain format = 'brief' select (a, b) not in (select a, b from naaj_B where naaj_A.c > naaj_B.c) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:gt(test.naaj_a.c, test.naaj_b.c)
+HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:gt(naaj.naaj_a.c, naaj.naaj_b.c)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -53,7 +52,7 @@ select (a, b) not in (select a, b from naaj_B where naaj_A.c > naaj_B.c) from na
 1
 explain format = 'brief' select * from naaj_A where (a, b) not in (select a, b from naaj_B where naaj_A.c > naaj_B.c);
 id	estRows	task	access object	operator info
-HashJoin	8000.00	root		Null-aware anti semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:gt(test.naaj_a.c, test.naaj_b.c)
+HashJoin	8000.00	root		Null-aware anti semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:gt(naaj.naaj_a.c, naaj.naaj_b.c)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -63,7 +62,7 @@ a	b	c
 1	1	1
 explain format = 'brief' select (a, b) not in (select a, b from naaj_B where naaj_A.a != naaj_B.a) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:ne(test.naaj_a.a, test.naaj_b.a)
+HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:ne(naaj.naaj_a.a, naaj.naaj_b.a)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -73,7 +72,7 @@ select (a, b) not in (select a, b from naaj_B where naaj_A.a != naaj_B.a) from n
 1
 explain format = 'brief' select * from naaj_A where (a, b) not in (select a, b from naaj_B where naaj_A.a != naaj_B.a);
 id	estRows	task	access object	operator info
-HashJoin	8000.00	root		Null-aware anti semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:ne(test.naaj_a.a, test.naaj_b.a)
+HashJoin	8000.00	root		Null-aware anti semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:ne(naaj.naaj_a.a, naaj.naaj_b.a)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -136,7 +135,7 @@ insert into naaj_B values(2, null, 2);
 insert into naaj_B values(null, null, 2);
 explain format = 'brief' select (a, b) not in (select a, b from naaj_B where naaj_A.c > naaj_B.c) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:gt(test.naaj_a.c, test.naaj_b.c)
+HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:gt(naaj.naaj_a.c, naaj.naaj_b.c)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -146,7 +145,7 @@ select (a, b) not in (select a, b from naaj_B where naaj_A.c > naaj_B.c) from na
 1
 explain format = 'brief' select * from naaj_A where (a, b) not in (select a, b from naaj_B  where naaj_A.c > naaj_B.c);
 id	estRows	task	access object	operator info
-HashJoin	8000.00	root		Null-aware anti semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:gt(test.naaj_a.c, test.naaj_b.c)
+HashJoin	8000.00	root		Null-aware anti semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:gt(naaj.naaj_a.c, naaj.naaj_b.c)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -156,7 +155,7 @@ a	b	c
 1	NULL	1
 explain format = 'brief' select (a, b) not in (select a, b from naaj_B where naaj_A.c = naaj_B.c) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		anti left outer semi join, equal:[eq(test.naaj_a.c, test.naaj_b.c)], other cond:eq(test.naaj_a.a, test.naaj_b.a), eq(test.naaj_a.b, test.naaj_b.b)
+HashJoin	10000.00	root		anti left outer semi join, equal:[eq(naaj.naaj_a.c, naaj.naaj_b.c)], other cond:eq(naaj.naaj_a.a, naaj.naaj_b.a), eq(naaj.naaj_a.b, naaj.naaj_b.b)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -166,7 +165,7 @@ select (a, b) not in (select a, b from naaj_B where naaj_A.c = naaj_B.c) from na
 1
 explain format = 'brief' select * from naaj_A where (a, b) not in (select a, b from naaj_B  where naaj_A.c = naaj_B.c);
 id	estRows	task	access object	operator info
-HashJoin	8000.00	root		anti semi join, equal:[eq(test.naaj_a.c, test.naaj_b.c)], other cond:eq(test.naaj_a.a, test.naaj_b.a), eq(test.naaj_a.b, test.naaj_b.b)
+HashJoin	8000.00	root		anti semi join, equal:[eq(naaj.naaj_a.c, naaj.naaj_b.c)], other cond:eq(naaj.naaj_a.a, naaj.naaj_b.a), eq(naaj.naaj_a.b, naaj.naaj_b.b)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -184,7 +183,7 @@ insert into naaj_A values (1,1,1);
 insert into naaj_B values (1,2,2);
 explain format = 'brief' select (a, b) != all (select a, b from naaj_B) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)]
+HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)]
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -194,9 +193,9 @@ select (a, b) != all (select a, b from naaj_B) from naaj_A;
 1
 explain format = 'brief' select * from naaj_A where (a, b) != all (select a, b from naaj_B);
 id	estRows	task	access object	operator info
-Projection	8000.00	root		test.naaj_a.a, test.naaj_a.b, test.naaj_a.c
+Projection	8000.00	root		naaj.naaj_a.a, naaj.naaj_a.b, naaj.naaj_a.c
 └─Selection	8000.00	root		Column#9
-  └─HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)]
+  └─HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)]
     ├─TableReader(Build)	10000.00	root		data:TableFullScan
     │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -218,7 +217,7 @@ select * from naaj_A where (a, b) != all (select a, b from naaj_B);
 a	b	c
 explain format = 'brief' select (a, b) != all (select a, b from naaj_B where naaj_A.c > naaj_B.c) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:gt(test.naaj_a.c, test.naaj_b.c)
+HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:gt(naaj.naaj_a.c, naaj.naaj_b.c)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -228,9 +227,9 @@ select (a, b) != all (select a, b from naaj_B where naaj_A.c > naaj_B.c) from na
 1
 explain format = 'brief' select * from naaj_A where (a, b) != all (select a, b from naaj_B where naaj_A.c > naaj_B.c);
 id	estRows	task	access object	operator info
-Projection	8000.00	root		test.naaj_a.a, test.naaj_a.b, test.naaj_a.c
+Projection	8000.00	root		naaj.naaj_a.a, naaj.naaj_a.b, naaj.naaj_a.c
 └─Selection	8000.00	root		Column#9
-  └─HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:gt(test.naaj_a.c, test.naaj_b.c)
+  └─HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:gt(naaj.naaj_a.c, naaj.naaj_b.c)
     ├─TableReader(Build)	10000.00	root		data:TableFullScan
     │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -240,7 +239,7 @@ a	b	c
 1	1	1
 explain format = 'brief' select (a, b) != all (select a, b from naaj_B where naaj_A.a != naaj_B.a) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:ne(test.naaj_a.a, test.naaj_b.a)
+HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:ne(naaj.naaj_a.a, naaj.naaj_b.a)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -250,9 +249,9 @@ select (a, b) != all (select a, b from naaj_B where naaj_A.a != naaj_B.a) from n
 1
 explain format = 'brief' select * from naaj_A where (a, b) != all (select a, b from naaj_B where naaj_A.a != naaj_B.a);
 id	estRows	task	access object	operator info
-Projection	8000.00	root		test.naaj_a.a, test.naaj_a.b, test.naaj_a.c
+Projection	8000.00	root		naaj.naaj_a.a, naaj.naaj_a.b, naaj.naaj_a.c
 └─Selection	8000.00	root		Column#9
-  └─HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:ne(test.naaj_a.a, test.naaj_b.a)
+  └─HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:ne(naaj.naaj_a.a, naaj.naaj_b.a)
     ├─TableReader(Build)	10000.00	root		data:TableFullScan
     │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -315,7 +314,7 @@ insert into naaj_B values(2, null, 2);
 insert into naaj_B values(null, null, 2);
 explain format = 'brief' select (a, b) != all (select a, b from naaj_B where naaj_A.c > naaj_B.c) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:gt(test.naaj_a.c, test.naaj_b.c)
+HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:gt(naaj.naaj_a.c, naaj.naaj_b.c)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -325,9 +324,9 @@ select (a, b) != all (select a, b from naaj_B where naaj_A.c > naaj_B.c) from na
 1
 explain format = 'brief' select * from naaj_A where (a, b) != all (select a, b from naaj_B  where naaj_A.c > naaj_B.c);
 id	estRows	task	access object	operator info
-Projection	8000.00	root		test.naaj_a.a, test.naaj_a.b, test.naaj_a.c
+Projection	8000.00	root		naaj.naaj_a.a, naaj.naaj_a.b, naaj.naaj_a.c
 └─Selection	8000.00	root		Column#9
-  └─HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a) eq(test.naaj_a.b, test.naaj_b.b)], other cond:gt(test.naaj_a.c, test.naaj_b.c)
+  └─HashJoin	10000.00	root		Null-aware anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a) eq(naaj.naaj_a.b, naaj.naaj_b.b)], other cond:gt(naaj.naaj_a.c, naaj.naaj_b.c)
     ├─TableReader(Build)	10000.00	root		data:TableFullScan
     │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -337,7 +336,7 @@ a	b	c
 1	NULL	1
 explain format = 'brief' select (a, b) != all (select a, b from naaj_B where naaj_A.c = naaj_B.c) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin	10000.00	root		anti left outer semi join, equal:[eq(test.naaj_a.c, test.naaj_b.c)], other cond:eq(test.naaj_a.a, test.naaj_b.a), eq(test.naaj_a.b, test.naaj_b.b)
+HashJoin	10000.00	root		anti left outer semi join, equal:[eq(naaj.naaj_a.c, naaj.naaj_b.c)], other cond:eq(naaj.naaj_a.a, naaj.naaj_b.a), eq(naaj.naaj_a.b, naaj.naaj_b.b)
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
 │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -347,9 +346,9 @@ select (a, b) != all (select a, b from naaj_B where naaj_A.c = naaj_B.c) from na
 1
 explain format = 'brief' select * from naaj_A where (a, b) != all (select a, b from naaj_B  where naaj_A.c = naaj_B.c);
 id	estRows	task	access object	operator info
-Projection	8000.00	root		test.naaj_a.a, test.naaj_a.b, test.naaj_a.c
+Projection	8000.00	root		naaj.naaj_a.a, naaj.naaj_a.b, naaj.naaj_a.c
 └─Selection	8000.00	root		Column#9
-  └─HashJoin	10000.00	root		anti left outer semi join, equal:[eq(test.naaj_a.c, test.naaj_b.c)], other cond:eq(test.naaj_a.a, test.naaj_b.a), eq(test.naaj_a.b, test.naaj_b.b)
+  └─HashJoin	10000.00	root		anti left outer semi join, equal:[eq(naaj.naaj_a.c, naaj.naaj_b.c)], other cond:eq(naaj.naaj_a.a, naaj.naaj_b.a), eq(naaj.naaj_a.b, naaj.naaj_b.b)
     ├─TableReader(Build)	10000.00	root		data:TableFullScan
     │ └─TableFullScan	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
@@ -372,10 +371,10 @@ a	b	c
 1	1	1
 explain select (a+1,b*2) not in (select a, b from naaj_B) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin_9	10000.00	root		Null-aware anti left outer semi join, equal:[eq(Column#14, test.naaj_b.a) eq(Column#15, test.naaj_b.b)]
+HashJoin_9	10000.00	root		Null-aware anti left outer semi join, equal:[eq(Column#14, naaj.naaj_b.a) eq(Column#15, naaj.naaj_b.b)]
 ├─TableReader_14(Build)	10000.00	root		data:TableFullScan_13
 │ └─TableFullScan_13	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
-└─Projection_10(Probe)	10000.00	root		plus(test.naaj_a.a, 1)->Column#14, mul(test.naaj_a.b, 2)->Column#15
+└─Projection_10(Probe)	10000.00	root		plus(naaj.naaj_a.a, 1)->Column#14, mul(naaj.naaj_a.b, 2)->Column#15
   └─TableReader_12	10000.00	root		data:TableFullScan_11
     └─TableFullScan_11	10000.00	cop[tikv]	table:naaj_A	keep order:false, stats:pseudo
 select (a+1,b*2) not in (select a, b from naaj_B) from naaj_A;
@@ -388,24 +387,24 @@ select (a+1,b*2) not in (select a, b from naaj_B) from naaj_A;
 explain select * from naaj_A where (a+1,b*2) not in (select a+1, b-1 from naaj_B);
 id	estRows	task	access object	operator info
 HashJoin_9	8000.00	root		Null-aware anti semi join, equal:[eq(Column#13, Column#9) eq(Column#14, Column#10)]
-├─Projection_13(Build)	10000.00	root		plus(test.naaj_b.a, 1)->Column#9, minus(test.naaj_b.b, 1)->Column#10
+├─Projection_13(Build)	10000.00	root		plus(naaj.naaj_b.a, 1)->Column#9, minus(naaj.naaj_b.b, 1)->Column#10
 │ └─TableReader_15	10000.00	root		data:TableFullScan_14
 │   └─TableFullScan_14	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
-└─Projection_10(Probe)	10000.00	root		test.naaj_a.a, test.naaj_a.b, test.naaj_a.c, plus(test.naaj_a.a, 1)->Column#13, mul(test.naaj_a.b, 2)->Column#14
+└─Projection_10(Probe)	10000.00	root		naaj.naaj_a.a, naaj.naaj_a.b, naaj.naaj_a.c, plus(naaj.naaj_a.a, 1)->Column#13, mul(naaj.naaj_a.b, 2)->Column#14
   └─TableReader_12	10000.00	root		data:TableFullScan_11
     └─TableFullScan_11	10000.00	cop[tikv]	table:naaj_A	keep order:false, stats:pseudo
 select * from naaj_A where (a+1,b*2) not in (select a, b from naaj_B);
 a	b	c
 explain select (a+1,b*2) not in (select a, b=1 from naaj_B where naaj_A.a = naaj_B.a) from naaj_A;
 id	estRows	task	access object	operator info
-HashJoin_9	10000.00	root		anti left outer semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a)], other cond:eq(mul(test.naaj_a.b, 2), eq(test.naaj_b.b, 1)), eq(plus(test.naaj_a.a, 1), test.naaj_b.a)
+HashJoin_9	10000.00	root		anti left outer semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a)], other cond:eq(mul(naaj.naaj_a.b, 2), eq(naaj.naaj_b.b, 1)), eq(plus(naaj.naaj_a.a, 1), naaj.naaj_b.a)
 ├─TableReader_13(Build)	10000.00	root		data:TableFullScan_12
 │ └─TableFullScan_12	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader_11(Probe)	10000.00	root		data:TableFullScan_10
   └─TableFullScan_10	10000.00	cop[tikv]	table:naaj_A	keep order:false, stats:pseudo
 explain select * from naaj_A where (a+1,b*2) not in (select a, b=1 from naaj_B where naaj_A.a = naaj_B.a);
 id	estRows	task	access object	operator info
-HashJoin_9	8000.00	root		anti semi join, equal:[eq(test.naaj_a.a, test.naaj_b.a)], other cond:eq(mul(test.naaj_a.b, 2), eq(test.naaj_b.b, 1)), eq(plus(test.naaj_a.a, 1), test.naaj_b.a)
+HashJoin_9	8000.00	root		anti semi join, equal:[eq(naaj.naaj_a.a, naaj.naaj_b.a)], other cond:eq(mul(naaj.naaj_a.b, 2), eq(naaj.naaj_b.b, 1)), eq(plus(naaj.naaj_a.a, 1), naaj.naaj_b.a)
 ├─TableReader_13(Build)	10000.00	root		data:TableFullScan_12
 │ └─TableFullScan_12	10000.00	cop[tikv]	table:naaj_B	keep order:false, stats:pseudo
 └─TableReader_11(Probe)	10000.00	root		data:TableFullScan_10

--- a/cmd/explaintest/r/vitess_hash.result
+++ b/cmd/explaintest/r/vitess_hash.result
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t;
 create table t(
 customer_id bigint,
@@ -11,19 +10,19 @@ primary key (customer_id, id)
 create index t_vitess_shard on t((vitess_hash(customer_id) >> 56));
 explain format = 'brief' select customer_id from t where (vitess_hash(customer_id) >> 56) = x'd6' ORDER BY id;
 id	estRows	task	access object	operator info
-Projection	10.00	root		test.t.customer_id
-└─Sort	10.00	root		test.t.id
+Projection	10.00	root		vitess_hash.t.customer_id
+└─Sort	10.00	root		vitess_hash.t.id
   └─IndexLookUp	10.00	root		
     ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:t_vitess_shard(vitess_hash(`customer_id`) >> 56)	range:[214,214], keep order:false, stats:pseudo
     └─TableRowIDScan(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select id from t where (vitess_hash(customer_id) >> 56) IN (x'e0', x'e1') AND id BETWEEN 2 AND 5 ORDER BY id;
 id	estRows	task	access object	operator info
-Projection	0.50	root		test.t.id
-└─Sort	0.50	root		test.t.id
-  └─Projection	0.50	root		test.t.id, rightshift(vitess_hash(test.t.customer_id), 56)
+Projection	0.50	root		vitess_hash.t.id
+└─Sort	0.50	root		vitess_hash.t.id
+  └─Projection	0.50	root		vitess_hash.t.id, rightshift(vitess_hash(vitess_hash.t.customer_id), 56)
     └─IndexLookUp	0.50	root		
       ├─IndexRangeScan(Build)	20.00	cop[tikv]	table:t, index:t_vitess_shard(vitess_hash(`customer_id`) >> 56)	range:[224,224], [225,225], keep order:false, stats:pseudo
-      └─Selection(Probe)	0.50	cop[tikv]		ge(test.t.id, 2), le(test.t.id, 5)
+      └─Selection(Probe)	0.50	cop[tikv]		ge(vitess_hash.t.id, 2), le(vitess_hash.t.id, 5)
         └─TableRowIDScan	20.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select hex(vitess_hash(1123)) from t;
 id	estRows	task	access object	operator info

--- a/cmd/explaintest/r/window_function.result
+++ b/cmd/explaintest/r/window_function.result
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t;
 create table t (a int, b int, c timestamp, index idx(a));
 set @@tidb_enable_window_function = 1;
@@ -7,101 +6,101 @@ set @@session.tidb_window_concurrency = 1;
 explain format = 'brief' select sum(a) over() from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
-└─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over()
+└─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over()
   └─IndexReader	10000.00	root		index:IndexFullScan
     └─IndexFullScan	10000.00	cop[tikv]	table:t, index:idx(a)	keep order:false, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
-└─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a)
+└─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a)
   └─IndexReader	10000.00	root		index:IndexFullScan
     └─IndexFullScan	10000.00	cop[tikv]	table:t, index:idx(a)	keep order:true, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a order by b) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
-└─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b range between unbounded preceding and current row)
-  └─Sort	10000.00	root		test.t.a, test.t.b
+└─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a order by window_function.t.b range between unbounded preceding and current row)
+  └─Sort	10000.00	root		window_function.t.a, window_function.t.b
     └─TableReader	10000.00	root		data:TableFullScan
       └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a order by b rows unbounded preceding) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
-└─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b rows between unbounded preceding and current row)
-  └─Sort	10000.00	root		test.t.a, test.t.b
+└─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a order by window_function.t.b rows between unbounded preceding and current row)
+  └─Sort	10000.00	root		window_function.t.a, window_function.t.b
     └─TableReader	10000.00	root		data:TableFullScan
       └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a order by b rows between 1 preceding and 1 following) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
-└─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b rows between 1 preceding and 1 following)
-  └─Sort	10000.00	root		test.t.a, test.t.b
+└─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a order by window_function.t.b rows between 1 preceding and 1 following)
+  └─Sort	10000.00	root		window_function.t.a, window_function.t.b
     └─TableReader	10000.00	root		data:TableFullScan
       └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a order by b range between 1 preceding and 1 following) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
-└─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b range between 1 preceding and 1 following)
-  └─Sort	10000.00	root		test.t.a, test.t.b
+└─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a order by window_function.t.b range between 1 preceding and 1 following)
+  └─Sort	10000.00	root		window_function.t.a, window_function.t.b
     └─TableReader	10000.00	root		data:TableFullScan
       └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a order by c range between interval '2:30' minute_second preceding and interval '2:30' minute_second following) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
-└─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.c range between interval "2:30" "MINUTE_SECOND" preceding and interval "2:30" "MINUTE_SECOND" following)
-  └─Sort	10000.00	root		test.t.a, test.t.c
+└─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a order by window_function.t.c range between interval "2:30" "MINUTE_SECOND" preceding and interval "2:30" "MINUTE_SECOND" following)
+  └─Sort	10000.00	root		window_function.t.a, window_function.t.c
     └─TableReader	10000.00	root		data:TableFullScan
       └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 set @@session.tidb_window_concurrency = 4;
 explain format = 'brief' select sum(a) over() from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
-└─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over()
+└─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over()
   └─IndexReader	10000.00	root		index:IndexFullScan
     └─IndexFullScan	10000.00	cop[tikv]	table:t, index:idx(a)	keep order:false, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
-└─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a)
+└─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a)
   └─IndexReader	10000.00	root		index:IndexFullScan
     └─IndexFullScan	10000.00	cop[tikv]	table:t, index:idx(a)	keep order:true, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a order by b) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
 └─Shuffle	10000.00	root		execution info: concurrency:4, data sources:[TableReader]
-  └─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b range between unbounded preceding and current row)
-    └─Sort	10000.00	root		test.t.a, test.t.b
+  └─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a order by window_function.t.b range between unbounded preceding and current row)
+    └─Sort	10000.00	root		window_function.t.a, window_function.t.b
       └─TableReader	10000.00	root		data:TableFullScan
         └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a order by b rows unbounded preceding) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
 └─Shuffle	10000.00	root		execution info: concurrency:4, data sources:[TableReader]
-  └─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b rows between unbounded preceding and current row)
-    └─Sort	10000.00	root		test.t.a, test.t.b
+  └─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a order by window_function.t.b rows between unbounded preceding and current row)
+    └─Sort	10000.00	root		window_function.t.a, window_function.t.b
       └─TableReader	10000.00	root		data:TableFullScan
         └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a order by b rows between 1 preceding and 1 following) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
 └─Shuffle	10000.00	root		execution info: concurrency:4, data sources:[TableReader]
-  └─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b rows between 1 preceding and 1 following)
-    └─Sort	10000.00	root		test.t.a, test.t.b
+  └─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a order by window_function.t.b rows between 1 preceding and 1 following)
+    └─Sort	10000.00	root		window_function.t.a, window_function.t.b
       └─TableReader	10000.00	root		data:TableFullScan
         └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a order by b range between 1 preceding and 1 following) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
 └─Shuffle	10000.00	root		execution info: concurrency:4, data sources:[TableReader]
-  └─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b range between 1 preceding and 1 following)
-    └─Sort	10000.00	root		test.t.a, test.t.b
+  └─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a order by window_function.t.b range between 1 preceding and 1 following)
+    └─Sort	10000.00	root		window_function.t.a, window_function.t.b
       └─TableReader	10000.00	root		data:TableFullScan
         └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select sum(a) over(partition by a order by c range between interval '2:30' minute_second preceding and interval '2:30' minute_second following) from t;
 id	estRows	task	access object	operator info
 Projection	10000.00	root		Column#6->Column#7
 └─Shuffle	10000.00	root		execution info: concurrency:4, data sources:[TableReader]
-  └─Window	10000.00	root		sum(cast(test.t.a, decimal(10,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.c range between interval "2:30" "MINUTE_SECOND" preceding and interval "2:30" "MINUTE_SECOND" following)
-    └─Sort	10000.00	root		test.t.a, test.t.c
+  └─Window	10000.00	root		sum(cast(window_function.t.a, decimal(10,0) BINARY))->Column#6 over(partition by window_function.t.a order by window_function.t.c range between interval "2:30" "MINUTE_SECOND" preceding and interval "2:30" "MINUTE_SECOND" following)
+    └─Sort	10000.00	root		window_function.t.a, window_function.t.c
       └─TableReader	10000.00	root		data:TableFullScan
         └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t1;
@@ -111,8 +110,8 @@ analyze table t1;
 explain format = 'brief' select sum(a) over(partition by b) from t1;
 id	estRows	task	access object	operator info
 Projection	2.00	root		Column#4->Column#5
-└─Window	2.00	root		sum(cast(test.t1.a, decimal(10,0) BINARY))->Column#4 over(partition by test.t1.b)
-  └─Sort	2.00	root		test.t1.b
+└─Window	2.00	root		sum(cast(window_function.t1.a, decimal(10,0) BINARY))->Column#4 over(partition by window_function.t1.b)
+  └─Sort	2.00	root		window_function.t1.b
     └─TableReader	2.00	root		data:TableFullScan
       └─TableFullScan	2.00	cop[tikv]	table:t1	keep order:false
 insert into t1 values(3, 3);
@@ -121,7 +120,7 @@ explain format = 'brief' select sum(a) over(partition by b) from t1;
 id	estRows	task	access object	operator info
 Projection	3.00	root		Column#4->Column#5
 └─Shuffle	3.00	root		execution info: concurrency:2, data sources:[TableReader]
-  └─Window	3.00	root		sum(cast(test.t1.a, decimal(10,0) BINARY))->Column#4 over(partition by test.t1.b)
-    └─Sort	3.00	root		test.t1.b
+  └─Window	3.00	root		sum(cast(window_function.t1.a, decimal(10,0) BINARY))->Column#4 over(partition by window_function.t1.b)
+    └─Sort	3.00	root		window_function.t1.b
       └─TableReader	3.00	root		data:TableFullScan
         └─TableFullScan	3.00	cop[tikv]	table:t1	keep order:false

--- a/cmd/explaintest/t/black_list.test
+++ b/cmd/explaintest/t/black_list.test
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t;
 create table t (a int);
 

--- a/cmd/explaintest/t/collation_agg_func.test
+++ b/cmd/explaintest/t/collation_agg_func.test
@@ -99,6 +99,3 @@ desc format='brief' select max(d collate utf8mb4_bin) from tt;
 --error 1253
 select max(d collate utf8mb4_bin) from tt;
 
-# cleanup environment
-drop database collation_agg_func;
-use test

--- a/cmd/explaintest/t/collation_check_use_collation.test
+++ b/cmd/explaintest/t/collation_check_use_collation.test
@@ -120,5 +120,3 @@ SELECT (v0.c0)NOT LIKE(BINARY v0.c0) FROM v0;
 SELECT v0.c0 FROM v0 WHERE (v0.c0)NOT LIKE(BINARY v0.c0);
 desc format='brief' SELECT v0.c0 FROM v0 WHERE (v0.c0)NOT LIKE(BINARY v0.c0);
 
-# cleanup environment
-use test

--- a/cmd/explaintest/t/collation_misc.test
+++ b/cmd/explaintest/t/collation_misc.test
@@ -82,5 +82,3 @@ select * from information_schema.COLLATION_CHARACTER_SET_APPLICABILITY where COL
 # charset
 show charset;
 show collation;
-
-use test;

--- a/cmd/explaintest/t/cte.test
+++ b/cmd/explaintest/t/cte.test
@@ -1,5 +1,6 @@
 set tidb_cost_model_version=1;
-use test;
+drop database if exists cte1;
+create database cte1;
 # case 1
 drop table if exists tbl_0;
 create table tbl_0(a int);
@@ -259,7 +260,7 @@ explain select * from t1 where exists(with recursive cte1 as (select c1, c2 from
 select * from t1 where exists(with recursive cte1 as (select c1, c2 from t2 union all select c1+1 as c1, c2+1 as c2 from cte1 where cte1.c2=t1.c2) select c1 from cte1);
 # Some cases to Test Create View With CTE and checkout Database
 # With name is the same as the table name
-use test;
+use cte;
 drop table if exists t1, t2;
 drop view if exists v1;
 create table t1 (a int);
@@ -269,12 +270,11 @@ insert into t2 values (1), (2), (3), (4), (5);
 drop view if exists v1,v2;
 create view v1 as with t1 as (select a from t2 where t2.a=3 union select t2.a+1 from t1,t2 where t1.a=t2.a) select * from t1 order by a desc limit 5;
 create view v2 as with recursive t1 as ( select a from t2 where t2.a=3 union select t2.a+1 from t1,t2 where t1.a=t2.a) select * from t1 order by a desc limit 5;
-create database if not exists test1;
-use test1;
-select * from test.v1;
-select * from test.v2;
+use cte1;
+select * from cte.v1;
+select * from cte.v2;
 # case
-use test;
+use cte;
 drop table if exists t ,t1, t2;
 create table t(a int);
 insert into t values (0);
@@ -284,28 +284,28 @@ create table t2 (c int);
 insert into t2 values (0);
 drop view if exists v1;
 create view v1 as with t1 as (with t11 as (select * from t) select * from t1, t2) select * from t1;
-use test1;
-select * from test.v1;
+use cte1;
+select * from cte.v1;
 # case
-use test;
+use cte;
 drop table if exists t11111;
 create table t11111 (d int);
 insert into t11111 values (123), (223), (323);
 drop view if exists v1;
 create view v1 as WITH t123 AS (WITH t11111 AS ( SELECT * FROM t1 ) SELECT ( WITH t2 AS ( SELECT ( WITH t23 AS ( SELECT * FROM t11111 ) SELECT * FROM t23 LIMIT 1 ) FROM t11111 ) SELECT *  FROM t2  LIMIT 1  )  FROM t11111, t2 ) SELECT * FROM t11111;
-use test1;
-select * from test.v1;
+use cte1;
+select * from cte.v1;
 # case
-use test;
+use cte;
 drop table if exists t1;
 create table t1 (a int);
 insert into t1 values (1);
 drop view if exists v1;
 create view v1 as SELECT (WITH qn AS (SELECT 10*a as a FROM t1),qn2 AS (SELECT 3*a AS b FROM qn) SELECT * from qn2 LIMIT 1) FROM t1;
-use test1;
-select * from test.v1;
+use cte1;
+select * from cte.v1;
 # case
-use test;
+use cte;
 drop table if exists t1,t2;
 create table t1 (a int);
 insert into t1 values (0), (1);
@@ -313,8 +313,8 @@ create table t2 (b int);
 insert into t2 values  (4), (5);
 drop view if exists v1;
 create view v1 as with t1 as (with t11 as (select * from t1) select * from t1, t2) select * from t1;
-use test1;
-select * from test.v1;
+use cte1;
+select * from cte.v1;
 # case
 CREATE TABLE `t_cqmg3b` (
   `wkey` int(11) DEFAULT NULL,

--- a/cmd/explaintest/t/explain-non-select-stmt.test
+++ b/cmd/explaintest/t/explain-non-select-stmt.test
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t;
 create table t(a bigint, b bigint);
 explain format = 'brief' insert into t values(1, 1);

--- a/cmd/explaintest/t/explain_cte.test
+++ b/cmd/explaintest/t/explain_cte.test
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t1, t2;
 create table t1 (c1 int primary key, c2 int, index c2 (c2));
 create table t2 (c1 int unique, c2 int);

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -1,6 +1,5 @@
 set tidb_cost_model_version=1;
 set @@sql_mode = 'strict_trans_tables';
-use test;
 drop table if exists t1, t2, t3, t4;
 create table t1 (c1 int primary key, c2 int, c3 int, index c2 (c2));
 create table t2 (c1 int unique, c2 int);

--- a/cmd/explaintest/t/explain_foreign_key.test
+++ b/cmd/explaintest/t/explain_foreign_key.test
@@ -1,5 +1,4 @@
 set @@foreign_key_checks=1;
-use test;
 drop table if exists t1,t2;
 create table t1 (id int key);
 create table t2 (id int key, foreign key fk(id) references t1(id) ON UPDATE CASCADE ON DELETE CASCADE);

--- a/cmd/explaintest/t/explain_generate_column_substitute.test
+++ b/cmd/explaintest/t/explain_generate_column_substitute.test
@@ -1,6 +1,5 @@
 set tidb_cost_model_version=1;
 set names utf8mb4;
-use test;
 drop table if exists t;
 create table t(a int, b real, c bigint as ((a+1)) virtual, e real as ((b+a)));
 insert into t values (1, 2.0, default, default), (2, 2.1, default, default), (5, 3.0, default, default),

--- a/cmd/explaintest/t/explain_shard_index.test
+++ b/cmd/explaintest/t/explain_shard_index.test
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists test3, test5;
 create table test3(id int primary key clustered, a int, b int, unique key uk_expr((tidb_shard(a)),a));
 create table test5(id int primary key clustered, a int, b int, unique key uk_expr((tidb_shard(a)),a,b));

--- a/cmd/explaintest/t/index_join.test
+++ b/cmd/explaintest/t/index_join.test
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t1, t2;
 create table t1(a bigint, b bigint, index idx(a));
 create table t2(a bigint, b bigint, index idx(a));

--- a/cmd/explaintest/t/naaj.test
+++ b/cmd/explaintest/t/naaj.test
@@ -1,6 +1,5 @@
 set tidb_cost_model_version=1;
 # naaj.test file is for null-aware anti join
-use test;
 set @@session.tidb_enable_null_aware_anti_join=1;
 # assert the cases for the left side without null.
 select "***************************************************** PART 1 *****************************************************************" as name;

--- a/cmd/explaintest/t/vitess_hash.test
+++ b/cmd/explaintest/t/vitess_hash.test
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t;
 create table t(
     customer_id bigint,

--- a/cmd/explaintest/t/window_function.test
+++ b/cmd/explaintest/t/window_function.test
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=1;
-use test;
 drop table if exists t;
 create table t (a int, b int, c timestamp, index idx(a));
 set @@tidb_enable_window_function = 1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/45961

Problem Summary: remove `use test` in explaintest, avoid environmental problems.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
