### PR TITLE
autoid_service: fix etcd path prefix in keyspace scenario

### DIFF
--- a/autoid_service/autoid.go
+++ b/autoid_service/autoid.go
@@ -46,7 +46,7 @@ var (
 )
 
 const (
-	autoIDLeaderPath = "tidb/autoid/leader"
+	autoIDLeaderPath = "/tidb/autoid/leader"
 )
 
 type autoIDKey struct {

--- a/autoid_service/autoid.go
+++ b/autoid_service/autoid.go
@@ -46,7 +46,7 @@ var (
 )
 
 const (
-	autoIDLeaderPath = "/tidb/autoid/leader"
+	autoIDLeaderPath = "tidb/autoid/leader"
 )
 
 type autoIDKey struct {
@@ -271,7 +271,9 @@ func New(selfAddr string, etcdAddr []string, store kv.Storage, tlsConfig *tls.Co
 		},
 		TLS: tlsConfig,
 	})
-	etcd.SetEtcdCliByNamespace(cli, keyspace.MakeKeyspaceEtcdNamespace(store.GetCodec()))
+	if store.GetCodec().GetKeyspace() != nil {
+		etcd.SetEtcdCliByNamespace(cli, keyspace.MakeKeyspaceEtcdNamespaceSlash(store.GetCodec()))
+	}
 	if err != nil {
 		panic(err)
 	}

--- a/keyspace/keyspace.go
+++ b/keyspace/keyspace.go
@@ -40,6 +40,14 @@ func MakeKeyspaceEtcdNamespace(c tikv.Codec) string {
 	return fmt.Sprintf(tidbKeyspaceEtcdPathPrefix+"%d", c.GetKeyspaceID())
 }
 
+// MakeKeyspaceEtcdNamespaceSlash return the keyspace prefix path for etcd namespace, and end with a slash.
+func MakeKeyspaceEtcdNamespaceSlash(c tikv.Codec) string {
+	if c.GetAPIVersion() == kvrpcpb.APIVersion_V1 {
+		return ""
+	}
+	return fmt.Sprintf(tidbKeyspaceEtcdPathPrefix+"%d/", c.GetKeyspaceID())
+}
+
 // GetKeyspaceNameBySettings is used to get Keyspace name setting.
 func GetKeyspaceNameBySettings() (keyspaceName string) {
 	keyspaceName = config.GetGlobalKeyspaceName()

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -595,7 +595,7 @@ func newSinglePointAlloc(store kv.Storage, dbID, tblID int64, isUnsigned bool) *
 			AutoSyncInterval: 30 * time.Second,
 			TLS:              ebd.TLSConfig(),
 		})
-		etcd.SetEtcdCliByNamespace(etcdCli, keyspace.MakeKeyspaceEtcdNamespace(store.GetCodec()))
+		etcd.SetEtcdCliByNamespace(etcdCli, keyspace.MakeKeyspaceEtcdNamespaceSlash(store.GetCodec()))
 		if err != nil {
 			logutil.BgLogger().Error("fail to connect etcd, fallback to default", zap.String("category", "autoid client"), zap.Error(err))
 			return nil

--- a/meta/autoid/autoid_service.go
+++ b/meta/autoid/autoid_service.go
@@ -58,7 +58,7 @@ type clientDiscover struct {
 }
 
 const (
-	autoIDLeaderPath = "/tidb/autoid/leader"
+	autoIDLeaderPath = "tidb/autoid/leader"
 )
 
 func (d *clientDiscover) GetClient(ctx context.Context) (autoid.AutoIDAllocClient, error) {

--- a/meta/autoid/autoid_service.go
+++ b/meta/autoid/autoid_service.go
@@ -58,7 +58,7 @@ type clientDiscover struct {
 }
 
 const (
-	autoIDLeaderPath = "tidb/autoid/leader"
+	autoIDLeaderPath = "/tidb/autoid/leader"
 )
 
 func (d *clientDiscover) GetClient(ctx context.Context) (autoid.AutoIDAllocClient, error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->
Fix the prefix of auto id service etcd path.



Issue Number: ref https://github.com/pingcap/tidb/issues/46457

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Manual test (add detailed scripts or steps below)

If set keyspace-name:
![image](https://github.com/pingcap/tidb/assets/3659421/d84a42f4-32bc-41a5-95b5-8e9373e58cfd)


If not set keyspace-name:
![image](https://github.com/pingcap/tidb/assets/3659421/ec378fd1-34ea-4785-9437-d1d931ecca3b)




### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
autoid_service: fix etcd path prefix in keyspace scenario
```
