### PR TITLE
executor: pre-alloc chunks to optimize `SortExec` in 

### DIFF
--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -198,7 +198,7 @@ func (c *hashRowContainer) GetAllMatchedRows(probeHCtx *hashContext, probeSideRo
 	}
 	var mayMatchedRow chunk.Row
 	for _, ptr := range innerPtrs {
-		mayMatchedRow, c.chkBuf, err = c.rowContainer.GetRowAndAppendToChunk(ptr, c.chkBuf)
+		mayMatchedRow, c.chkBuf, err = c.rowContainer.GetRowAndAppendToChunkIfInDisk(ptr, c.chkBuf)
 		if err != nil {
 			return nil, err
 		}
@@ -256,7 +256,7 @@ func (c *hashRowContainer) GetMatchedRowsAndPtrs(probeKey uint64, probeRow chunk
 	c.chkBufSizeForOneProbe = 0
 
 	for i, ptr := range innerPtrs {
-		matchedRow, c.chkBuf, err = c.rowContainer.GetRowAndAppendToChunk(ptr, c.chkBuf)
+		matchedRow, c.chkBuf, err = c.rowContainer.GetRowAndAppendToChunkIfInDisk(ptr, c.chkBuf)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -299,7 +299,7 @@ func (c *hashRowContainer) GetNullBucketRows(probeHCtx *hashContext, probeSideRo
 	)
 	matched = matched[:0]
 	for _, nullEntry := range c.hashNANullBucket.entries {
-		mayMatchedRow, c.chkBuf, err = c.rowContainer.GetRowAndAppendToChunk(nullEntry.ptr, c.chkBuf)
+		mayMatchedRow, c.chkBuf, err = c.rowContainer.GetRowAndAppendToChunkIfInDisk(nullEntry.ptr, c.chkBuf)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #46482

Problem Summary:

`SortExec` allocates one `chunk` for each row. It will waste a lot of resource of GC and costs a lot of CPU. Some tiny modification can give big performance boost.

### What is changed and how it works?

For a non-partitioned table: Use the chunk provided from the caller of `Next` directly.

For a partitioned table: allocate a chunk with 1 capacity for each partition and use it to store the row. Reset it after the row is copied to the `req` chunk.

This PR will not use more memory, because these rows definitely need to take some space to store.

It also does some refractor:

1. Rename the `GetSortedRowAndAppendToChunk` to `GetSortedRowAndAppendToChunkIfInDisk`.
2. Add a new function called `GetSortedRowAndAlwaysAppendToChunk`

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Benchmark

#### Before Optimize

```
BenchmarkSortExec
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[0_0])
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[0_0])-16         	       7	 150890938 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[1_0])
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[1_0])-16         	       6	 203682007 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[0],_ndvs:_[1_0])
BenchmarkSortExec/(rows:300000,_orderBy:[0],_ndvs:_[1_0])-16           	      51	  23461198 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[1],_ndvs:_[1_0])
BenchmarkSortExec/(rows:300000,_orderBy:[1],_ndvs:_[1_0])-16           	       7	 151321210 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[10000_0])
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[10000_0])-16     	       6	 176116501 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[0],_ndvs:_[10000_0])
BenchmarkSortExec/(rows:300000,_orderBy:[0],_ndvs:_[10000_0])-16       	       8	 135298789 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[1],_ndvs:_[10000_0])
BenchmarkSortExec/(rows:300000,_orderBy:[1],_ndvs:_[10000_0])-16       	       7	 147731749 ns/op

BenchmarkSortExecSpillToDisk
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[0_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[0_0])-16         	       1	2790049989 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[1_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[1_0])-16         	       1	2841506814 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0],_ndvs:_[1_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0],_ndvs:_[1_0])-16           	       1	2488387349 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[1],_ndvs:_[1_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[1],_ndvs:_[1_0])-16           	       1	2876884818 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[10000_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[10000_0])-16     	       1	2979303378 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0],_ndvs:_[10000_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0],_ndvs:_[10000_0])-16       	       1	2759128916 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[1],_ndvs:_[10000_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[1],_ndvs:_[10000_0])-16       	       1	2807877151 ns/op

#### After Optimize

BenchmarkSortExec
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[0_0])
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[0_0])-16         	       8	 138264852 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[1_0])
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[1_0])-16         	       6	 196635575 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[0],_ndvs:_[1_0])
BenchmarkSortExec/(rows:300000,_orderBy:[0],_ndvs:_[1_0])-16           	      64	  19148087 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[1],_ndvs:_[1_0])
BenchmarkSortExec/(rows:300000,_orderBy:[1],_ndvs:_[1_0])-16           	       8	 147118740 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[10000_0])
BenchmarkSortExec/(rows:300000,_orderBy:[0_1],_ndvs:_[10000_0])-16     	       7	 165089771 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[0],_ndvs:_[10000_0])
BenchmarkSortExec/(rows:300000,_orderBy:[0],_ndvs:_[10000_0])-16       	       9	 122365299 ns/op
BenchmarkSortExec/(rows:300000,_orderBy:[1],_ndvs:_[10000_0])
BenchmarkSortExec/(rows:300000,_orderBy:[1],_ndvs:_[10000_0])-16       	       8	 144205677 ns/op

BenchmarkSortExecSpillToDisk
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[0_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[0_0])-16         	       1	1389535239 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[1_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[1_0])-16         	       1	1448958115 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0],_ndvs:_[1_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0],_ndvs:_[1_0])-16           	       1	1234142313 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[1],_ndvs:_[1_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[1],_ndvs:_[1_0])-16           	       1	1402156900 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[10000_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0_1],_ndvs:_[10000_0])-16     	       1	1455535196 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0],_ndvs:_[10000_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[0],_ndvs:_[10000_0])-16       	       1	1385695018 ns/op
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[1],_ndvs:_[10000_0])
BenchmarkSortExecSpillToDisk/(rows:300000,_orderBy:[1],_ndvs:_[10000_0])-16       	       1	1407418131 ns/op
```

The performance improves 50%+ for a `tmpfs` storage.

### Release note

```release-note
Improve the sort performance when the data has been spilled to disk.
```
