### PR TITLE
autoid_service: fix potential 'duplicated entry' error when tidb exit…

### DIFF
--- a/autoid_service/autoid.go
+++ b/autoid_service/autoid.go
@@ -317,7 +317,7 @@ func MockForTest(store kv.Storage) *mockClient {
 
 // Close closes the Service and clean up resource.
 func (s *Service) Close() {
-	if s.leaderShip != nil {
+	if s.leaderShip != nil && s.leaderShip.IsOwner() {
 		for k, v := range s.autoIDMap {
 			if v.base > 0 {
 				err := v.forceRebase(context.Background(), s.store, k.dbID, k.tblID, v.base, v.isUnsigned)


### PR DESCRIPTION
This is a cherry-pick of #46445

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46444 

Problem Summary:

### What is changed and how it works?

If the autoid service node is not leader, it should not save the cached id back to tikv.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - See the [steps in the comments of #46444](https://github.com/pingcap/tidb/issues/46444#issuecomment-1697132996)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix potential 'duplicated entry' error when tidb exit for AUTO_ID_CACHE=1 tables.
The bug could happen when a tidb is the autoid_service leader previously, and exit as non-leader, it stores staled next autoid value to tikv in a force rebase way. If the value is loaded again, the autoid decreases and could cause duplicates.
```
