### PR TITLE
planner: introduce a new empirical rule into the Skyline pruning

### DIFF
--- a/planner/core/casetest/integration_test.go
+++ b/planner/core/casetest/integration_test.go
@@ -1583,10 +1583,12 @@ func TestFixControl45132(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec(`use test`)
 	tk.MustExec(`create table t (a int, b int, key(a))`)
-	for i := 0; i < 10; i++ {
-		tk.MustExec(`insert into t values (1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1), (1, 1)`)
+	values := make([]string, 0, 101)
+	for i := 0; i < 100; i++ {
+		values = append(values, "(1, 1)")
 	}
-	tk.MustExec(`insert into t values (2, 2)`) // count(1) : count(2) == 100 : 1
+	values = append(values, "(2, 2)") // count(1) : count(2) == 100 : 1
+	tk.MustExec(`insert into t values ` + strings.Join(values, ","))
 	for i := 0; i < 7; i++ {
 		tk.MustExec(`insert into t select * from t`)
 	}

--- a/planner/core/casetest/integration_test.go
+++ b/planner/core/casetest/integration_test.go
@@ -1608,6 +1608,12 @@ func TestFixControl45132(t *testing.T) {
 		`TableReader_7 128.00 root  data:Selection_6`,
 		`└─Selection_6 128.00 cop[tikv]  eq(test.t.a, 2)`,
 		`  └─TableFullScan_5 12928.00 cop[tikv] table:t keep order:false`))
+
+	tk.MustExec(`set @@tidb_opt_fix_control = "45132:0"`)
+	tk.MustQuery(`explain select * from t where a=2`).Check(testkit.Rows(
+		`TableReader_7 128.00 root  data:Selection_6`,
+		`└─Selection_6 128.00 cop[tikv]  eq(test.t.a, 2)`,
+		`  └─TableFullScan_5 12928.00 cop[tikv] table:t keep order:false`))
 }
 
 func TestFixControl44262(t *testing.T) {

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -728,7 +728,7 @@ func compareCandidates(sctx sessionctx.Context, prop *property.PhysicalProperty,
 	// This rule is empirical but not always correct.
 	// If x's range row count is significantly lower than y's, for example, 1000 times, we think x is better.
 	if lhs.path.CountAfterAccess > 100 && rhs.path.CountAfterAccess > 100 && // to prevent some extreme cases, e.g. 0.01 : 10
-		len(lhs.path.PartialIndexPaths) == 0 && len(rhs.path.PartialIndexPaths) == 0 && // not IndexMerge
+		len(lhs.path.PartialIndexPaths) == 0 && len(rhs.path.PartialIndexPaths) == 0 && // not IndexMerge since its row count estimation is not accurate enough
 		prop.ExpectedCnt == 0 { // Limit may affect access row count
 		threshold := float64(fixcontrol.GetIntWithDefault(sctx.GetSessionVars().OptimizerFixControl, fixcontrol.Fix45132, 1000))
 		if threshold > 0 { // set it to 0 to disable this rule

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -729,11 +729,13 @@ func compareCandidates(sctx sessionctx.Context, lhs, rhs *candidatePath) int {
 	// If x's range row count is significantly lower than y's, for example, 1000 times, we think x is better.
 	if lhs.path.CountAfterAccess > 100 && rhs.path.CountAfterAccess > 100 {
 		threshold := float64(fixcontrol.GetIntWithDefault(sctx.GetSessionVars().OptimizerFixControl, fixcontrol.Fix45132, 1000))
-		if lhs.path.CountAfterAccess/rhs.path.CountAfterAccess > threshold {
-			return -1
-		}
-		if rhs.path.CountAfterAccess/lhs.path.CountAfterAccess > threshold {
-			return 1
+		if threshold > 0 { // set it to 0 to disable this rule
+			if lhs.path.CountAfterAccess/rhs.path.CountAfterAccess > threshold {
+				return -1
+			}
+			if rhs.path.CountAfterAccess/lhs.path.CountAfterAccess > threshold {
+				return 1
+			}
 		}
 	}
 

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -729,7 +729,7 @@ func compareCandidates(sctx sessionctx.Context, prop *property.PhysicalProperty,
 	// If x's range row count is significantly lower than y's, for example, 1000 times, we think x is better.
 	if lhs.path.CountAfterAccess > 100 && rhs.path.CountAfterAccess > 100 && // to prevent some extreme cases, e.g. 0.01 : 10
 		len(lhs.path.PartialIndexPaths) == 0 && len(rhs.path.PartialIndexPaths) == 0 && // not IndexMerge since its row count estimation is not accurate enough
-		prop.ExpectedCnt == 0 { // Limit may affect access row count
+		prop.ExpectedCnt == math.MaxFloat64 { // Limit may affect access row count
 		threshold := float64(fixcontrol.GetIntWithDefault(sctx.GetSessionVars().OptimizerFixControl, fixcontrol.Fix45132, 1000))
 		if threshold > 0 { // set it to 0 to disable this rule
 			if lhs.path.CountAfterAccess/rhs.path.CountAfterAccess > threshold {

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -726,9 +726,9 @@ func compareIndexBack(lhs, rhs *candidatePath) (int, bool) {
 // The return value is 1 if lhs is better, -1 if rhs is better, 0 if they are equivalent or not comparable.
 func compareCandidates(sctx sessionctx.Context, lhs, rhs *candidatePath) int {
 	// This rule is empirical but not always correct.
-	// If x's range row count is significantly lower than y's, for example, 500 times, we think x is better.
+	// If x's range row count is significantly lower than y's, for example, 1000 times, we think x is better.
 	if lhs.path.CountAfterAccess > 100 && rhs.path.CountAfterAccess > 100 {
-		threshold := float64(fixcontrol.GetIntWithDefault(sctx.GetSessionVars().OptimizerFixControl, fixcontrol.Fix45132, 500))
+		threshold := float64(fixcontrol.GetIntWithDefault(sctx.GetSessionVars().OptimizerFixControl, fixcontrol.Fix45132, 1000))
 		if lhs.path.CountAfterAccess/rhs.path.CountAfterAccess > threshold {
 			return -1
 		}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/planner/cardinality"
 	"github.com/pingcap/tidb/planner/property"
 	"github.com/pingcap/tidb/planner/util"
+	"github.com/pingcap/tidb/planner/util/fixcontrol"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
@@ -727,11 +728,11 @@ func compareCandidates(sctx sessionctx.Context, lhs, rhs *candidatePath) int {
 	// This rule is empirical but not always correct.
 	// If x's range row count is significantly lower than y's, for example, 500 times, we think x is better.
 	if lhs.path.CountAfterAccess > 100 && rhs.path.CountAfterAccess > 100 {
-		n := 500.0
-		if lhs.path.CountAfterAccess/rhs.path.CountAfterAccess > n {
+		threshold := float64(fixcontrol.GetIntWithDefault(sctx.GetSessionVars().OptimizerFixControl, fixcontrol.Fix45132, 500))
+		if lhs.path.CountAfterAccess/rhs.path.CountAfterAccess > threshold {
 			return -1
 		}
-		if rhs.path.CountAfterAccess/lhs.path.CountAfterAccess > n {
+		if rhs.path.CountAfterAccess/lhs.path.CountAfterAccess > threshold {
 			return 1
 		}
 	}

--- a/planner/util/fixcontrol/get.go
+++ b/planner/util/fixcontrol/get.go
@@ -32,6 +32,8 @@ const (
 	// Fix44855 controls whether to use a more accurate upper bound when estimating row count of index
 	// range scan under inner side of index join.
 	Fix44855 uint64 = 44855
+	// Fix45132 controls whether to use access range row count to determine access path on the Skyline pruning.
+	Fix45132 uint64 = 45132
 )
 
 // GetStr fetches the given key from the fix control map as a string type.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45132

Problem Summary: planner: introduce a new empirical rule into the Skyline pruning

### What is changed and how it works?

Add a new empirical rule to the Skyline pruning: If x's range row count is significantly lower than y's, for example, 1000 times, we think x is better than y and prune y from the candidate.

Use fixcontrol to control this behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
