### PR TITLE
bootstrap: add summary field for system table `tidb_background_subtask`

### DIFF
--- a/ddl/constant.go
+++ b/ddl/constant.go
@@ -61,7 +61,7 @@ const (
 		state_update_time bigint,
 		meta longblob,
 		error BLOB,
-		execution_info json,
+		summary json,
 		key idx_task_key(task_key))`
 	// BackgroundSubtaskHistoryTableSQL is the CREATE TABLE SQL of `tidb_background_subtask_history`.
 	BackgroundSubtaskHistoryTableSQL = `create table tidb_background_subtask_history (
@@ -77,6 +77,6 @@ const (
 		start_time bigint,
 		state_update_time bigint,
 		meta longblob,
-		execution_info json,
+		summary json,
 		unique key(namespace, task_key))`
 )

--- a/ddl/constant.go
+++ b/ddl/constant.go
@@ -25,10 +25,6 @@ const (
 	ReorgTable = "tidb_ddl_reorg"
 	// HistoryTable stores the history DDL jobs.
 	HistoryTable = "tidb_ddl_history"
-	// BackgroundSubtaskTable stores the information of backfill jobs.
-	BackgroundSubtaskTable = "tidb_background_subtask"
-	// BackgroundSubtaskHistoryTable stores the information of history backfill jobs.
-	BackgroundSubtaskHistoryTable = "tidb_background_subtask_history"
 
 	// JobTableID is the table ID of `tidb_ddl_job`.
 	JobTableID = meta.MaxInt48 - 1
@@ -50,7 +46,7 @@ const (
 	// HistoryTableSQL is the CREATE TABLE SQL of `tidb_ddl_history`.
 	HistoryTableSQL = "create table " + HistoryTable + "(job_id bigint not null, job_meta longblob, db_name char(64), table_name char(64), schema_ids text(65535), table_ids text(65535), create_time datetime, primary key(job_id))"
 	// BackgroundSubtaskTableSQL is the CREATE TABLE SQL of `tidb_background_subtask`.
-	BackgroundSubtaskTableSQL = "create table " + BackgroundSubtaskTable + `(
+	BackgroundSubtaskTableSQL = `create table tidb_background_subtask (
 		id bigint not null auto_increment primary key,
 		step int,
 		namespace varchar(256),
@@ -65,9 +61,10 @@ const (
 		state_update_time bigint,
 		meta longblob,
 		error BLOB,
+		execution_info json,
 		key idx_task_key(task_key))`
 	// BackgroundSubtaskHistoryTableSQL is the CREATE TABLE SQL of `tidb_background_subtask_history`.
-	BackgroundSubtaskHistoryTableSQL = "create table " + BackgroundSubtaskHistoryTable + `(
+	BackgroundSubtaskHistoryTableSQL = `create table tidb_background_subtask_history (
 	 	id bigint not null auto_increment primary key,
 		namespace varchar(256),
 		task_key varchar(256),
@@ -80,5 +77,6 @@ const (
 		start_time bigint,
 		state_update_time bigint,
 		meta longblob,
+		execution_info json,
 		unique key(namespace, task_key))`
 )

--- a/disttask/framework/proto/task.go
+++ b/disttask/framework/proto/task.go
@@ -92,8 +92,9 @@ type Subtask struct {
 	// UpdateTime is the time when the subtask is updated.
 	// it can be used as subtask end time if the subtask is finished.
 	// it's 0 if it hasn't started yet.
-	UpdateTime time.Time
-	Meta       []byte
+	UpdateTime    time.Time
+	Meta          []byte
+	ExecutionInfo string
 }
 
 // NewSubtask create a new subtask.

--- a/disttask/framework/proto/task.go
+++ b/disttask/framework/proto/task.go
@@ -92,9 +92,9 @@ type Subtask struct {
 	// UpdateTime is the time when the subtask is updated.
 	// it can be used as subtask end time if the subtask is finished.
 	// it's 0 if it hasn't started yet.
-	UpdateTime    time.Time
-	Meta          []byte
-	ExecutionInfo string
+	UpdateTime time.Time
+	Meta       []byte
+	Summary    string
 }
 
 // NewSubtask create a new subtask.

--- a/disttask/framework/storage/task_table.go
+++ b/disttask/framework/storage/task_table.go
@@ -311,7 +311,7 @@ func (stm *TaskManager) AddNewSubTask(globalTaskID int64, step int64, designated
 	}
 
 	_, err := stm.executeSQLWithNewSession(stm.ctx, `insert into mysql.tidb_background_subtask
-		(task_key, step, exec_id, meta, state, type, checkpoint, execution_info)
+		(task_key, step, exec_id, meta, state, type, checkpoint, summary)
 		values (%?, %?, %?, %?, %?, %?, %?, %?)`,
 		globalTaskID, step, designatedTiDBID, meta, st, proto.Type2Int(tp), []byte{}, `'{}'`)
 	if err != nil {
@@ -540,7 +540,7 @@ func (stm *TaskManager) UpdateGlobalTaskAndAddSubTasks(gTask *proto.Task, subtas
 		for _, subtask := range subtasks {
 			// TODO: insert subtasks in batch
 			_, err = ExecSQL(stm.ctx, se, `insert into mysql.tidb_background_subtask
-					(step, task_key, exec_id, meta, state, type, checkpoint, execution_info)
+					(step, task_key, exec_id, meta, state, type, checkpoint, summary)
 					values (%?, %?, %?, %?, %?, %?, %?, %?)`,
 				gTask.Step, gTask.ID, subtask.SchedulerID, subtask.Meta, subtaskState, proto.Type2Int(subtask.Type), []byte{}, `'{}'`)
 			if err != nil {

--- a/disttask/framework/storage/task_table.go
+++ b/disttask/framework/storage/task_table.go
@@ -313,7 +313,7 @@ func (stm *TaskManager) AddNewSubTask(globalTaskID int64, step int64, designated
 	_, err := stm.executeSQLWithNewSession(stm.ctx, `insert into mysql.tidb_background_subtask
 		(task_key, step, exec_id, meta, state, type, checkpoint, summary)
 		values (%?, %?, %?, %?, %?, %?, %?, %?)`,
-		globalTaskID, step, designatedTiDBID, meta, st, proto.Type2Int(tp), []byte{}, `'{}'`)
+		globalTaskID, step, designatedTiDBID, meta, st, proto.Type2Int(tp), []byte{}, "{}")
 	if err != nil {
 		return err
 	}
@@ -542,7 +542,7 @@ func (stm *TaskManager) UpdateGlobalTaskAndAddSubTasks(gTask *proto.Task, subtas
 			_, err = ExecSQL(stm.ctx, se, `insert into mysql.tidb_background_subtask
 					(step, task_key, exec_id, meta, state, type, checkpoint, summary)
 					values (%?, %?, %?, %?, %?, %?, %?, %?)`,
-				gTask.Step, gTask.ID, subtask.SchedulerID, subtask.Meta, subtaskState, proto.Type2Int(subtask.Type), []byte{}, `'{}'`)
+				gTask.Step, gTask.ID, subtask.SchedulerID, subtask.Meta, subtaskState, proto.Type2Int(subtask.Type), []byte{}, "{}")
 			if err != nil {
 				return err
 			}

--- a/disttask/framework/storage/task_table.go
+++ b/disttask/framework/storage/task_table.go
@@ -285,14 +285,15 @@ func row2SubTask(r chunk.Row) *proto.Subtask {
 		updateTime = time.Unix(ts, 0)
 	}
 	task := &proto.Subtask{
-		ID:          r.GetInt64(0),
-		Step:        r.GetInt64(1),
-		Type:        proto.Int2Type(int(r.GetInt64(5))),
-		SchedulerID: r.GetString(6),
-		State:       r.GetString(8),
-		Meta:        r.GetBytes(12),
-		StartTime:   startTime,
-		UpdateTime:  updateTime,
+		ID:            r.GetInt64(0),
+		Step:          r.GetInt64(1),
+		Type:          proto.Int2Type(int(r.GetInt64(5))),
+		SchedulerID:   r.GetString(6),
+		State:         r.GetString(8),
+		Meta:          r.GetBytes(12),
+		ExecutionInfo: r.GetString(14),
+		StartTime:     startTime,
+		UpdateTime:    updateTime,
 	}
 	tid, err := strconv.Atoi(r.GetString(3))
 	if err != nil {
@@ -310,9 +311,9 @@ func (stm *TaskManager) AddNewSubTask(globalTaskID int64, step int64, designated
 	}
 
 	_, err := stm.executeSQLWithNewSession(stm.ctx, `insert into mysql.tidb_background_subtask
-		(task_key, step, exec_id, meta, state, type, checkpoint)
-		values (%?, %?, %?, %?, %?, %?, %?)`,
-		globalTaskID, step, designatedTiDBID, meta, st, proto.Type2Int(tp), []byte{})
+		(task_key, step, exec_id, meta, state, type, checkpoint, execution_info)
+		values (%?, %?, %?, %?, %?, %?, %?, %?)`,
+		globalTaskID, step, designatedTiDBID, meta, st, proto.Type2Int(tp), []byte{}, `'{}'`)
 	if err != nil {
 		return err
 	}
@@ -539,9 +540,9 @@ func (stm *TaskManager) UpdateGlobalTaskAndAddSubTasks(gTask *proto.Task, subtas
 		for _, subtask := range subtasks {
 			// TODO: insert subtasks in batch
 			_, err = ExecSQL(stm.ctx, se, `insert into mysql.tidb_background_subtask
-					(step, task_key, exec_id, meta, state, type, checkpoint)
-					values (%?, %?, %?, %?, %?, %?, %?)`,
-				gTask.Step, gTask.ID, subtask.SchedulerID, subtask.Meta, subtaskState, proto.Type2Int(subtask.Type), []byte{})
+					(step, task_key, exec_id, meta, state, type, checkpoint, execution_info)
+					values (%?, %?, %?, %?, %?, %?, %?, %?)`,
+				gTask.Step, gTask.ID, subtask.SchedulerID, subtask.Meta, subtaskState, proto.Type2Int(subtask.Type), []byte{}, `'{}'`)
 			if err != nil {
 				return err
 			}

--- a/disttask/framework/storage/task_table.go
+++ b/disttask/framework/storage/task_table.go
@@ -285,15 +285,15 @@ func row2SubTask(r chunk.Row) *proto.Subtask {
 		updateTime = time.Unix(ts, 0)
 	}
 	task := &proto.Subtask{
-		ID:            r.GetInt64(0),
-		Step:          r.GetInt64(1),
-		Type:          proto.Int2Type(int(r.GetInt64(5))),
-		SchedulerID:   r.GetString(6),
-		State:         r.GetString(8),
-		Meta:          r.GetBytes(12),
-		ExecutionInfo: r.GetString(14),
-		StartTime:     startTime,
-		UpdateTime:    updateTime,
+		ID:          r.GetInt64(0),
+		Step:        r.GetInt64(1),
+		Type:        proto.Int2Type(int(r.GetInt64(5))),
+		SchedulerID: r.GetString(6),
+		State:       r.GetString(8),
+		Meta:        r.GetBytes(12),
+		Summary:     r.GetString(14),
+		StartTime:   startTime,
+		UpdateTime:  updateTime,
 	}
 	tid, err := strconv.Atoi(r.GetString(3))
 	if err != nil {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -973,7 +973,7 @@ const (
 	//   create table `mysql.tidb_runaway_watch` and table `mysql.tidb_runaway_watch_done`
 	//   to persist runaway watch and deletion of runaway watch at 7.3.
 	version172 = 172
-	// version 173 add column `execution_info` to `mysql.tidb_background_subtask`.
+	// version 173 add column `summary` to `mysql.tidb_background_subtask`.
 	version173 = 173
 )
 
@@ -2718,7 +2718,7 @@ func upgradeToVer173(s Session, ver int64) {
 	if ver >= version173 {
 		return
 	}
-	doReentrantDDL(s, "ALTER TABLE mysql.tidb_background_subtask ADD COLUMN `execution_info` JSON", infoschema.ErrColumnExists)
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_background_subtask ADD COLUMN `summary` JSON", infoschema.ErrColumnExists)
 }
 
 func writeOOMAction(s Session) {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -974,11 +974,13 @@ const (
 	//   create table `mysql.tidb_runaway_watch` and table `mysql.tidb_runaway_watch_done`
 	//   to persist runaway watch and deletion of runaway watch at 7.3.
 	version172 = 172
+	// version 173 add column `execution_info` to `mysql.tidb_background_subtask`.
+	version173 = 173
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version172
+var currentBootstrapVersion int64 = version173
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1119,6 +1121,7 @@ var (
 		upgradeToVer170,
 		upgradeToVer171,
 		upgradeToVer172,
+		upgradeToVer173,
 	}
 )
 
@@ -2557,8 +2560,8 @@ func upgradeToVer136(s Session, ver int64) {
 		return
 	}
 	mustExecute(s, CreateGlobalTask)
-	doReentrantDDL(s, fmt.Sprintf("ALTER TABLE mysql.%s DROP INDEX namespace", ddl.BackgroundSubtaskTable), dbterror.ErrCantDropFieldOrKey)
-	doReentrantDDL(s, fmt.Sprintf("ALTER TABLE mysql.%s ADD INDEX idx_task_key(task_key)", ddl.BackgroundSubtaskTable), dbterror.ErrDupKeyName)
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_background_subtask DROP INDEX namespace", dbterror.ErrCantDropFieldOrKey)
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_background_subtask ADD INDEX idx_task_key(task_key)", dbterror.ErrDupKeyName)
 }
 
 func upgradeToVer137(_ Session, _ int64) {
@@ -2710,6 +2713,13 @@ func upgradeToVer172(s Session, ver int64) {
 	mustExecute(s, "DROP TABLE IF EXISTS mysql.tidb_runaway_quarantined_watch")
 	mustExecute(s, CreateRunawayWatchTable)
 	mustExecute(s, CreateDoneRunawayWatchTable)
+}
+
+func upgradeToVer173(s Session, ver int64) {
+	if ver >= version173 {
+		return
+	}
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_background_subtask ADD COLUMN `execution_info` JSON", infoschema.ErrColumnExists)
 }
 
 func writeOOMAction(s Session) {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/bindinfo"
 	"github.com/pingcap/tidb/config"
-	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tidb/expression"

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -251,6 +251,31 @@ func TestDDLTableCreateBackfillTable(t *testing.T) {
 	dom.Close()
 }
 
+func TestDDLBackgroundSubtaskTable(t *testing.T) {
+	store, dom := CreateStoreAndBootstrap(t)
+	defer func() {
+		dom.Close()
+		require.NoError(t, store.Close())
+	}()
+	se := CreateSessionAndSetID(t, store)
+
+	MustExec(t, se, "use mysql")
+	for i := 1; i < 10; i++ {
+		MustExec(t, se, "insert into mysql.tidb_background_subtask(id, state, checkpoint, execution_info) values (?, ?, ?, ?);", i, 0, "", "{}")
+	}
+	for i := 2; i < 10; i++ {
+		MustExec(t, se, `update tidb_background_subtask set execution_info = json_set(execution_info, "$.row_count", ?) where id = ?;`, i, i)
+	}
+	r := MustExecToRecodeSet(t, se, "select sum(json_extract(execution_info, '$.row_count')) from tidb_background_subtask;")
+	req := r.NewChunk(nil)
+	err := r.Next(context.Background(), req)
+	require.NoError(t, err)
+	row := req.GetRow(0)
+	require.Equal(t, 1, row.Len())
+	require.Equal(t, 54, row.GetInt64(0))
+	require.NoError(t, r.Close())
+}
+
 // TestUpgrade tests upgrading
 func TestUpgrade(t *testing.T) {
 	ctx := context.Background()

--- a/session/bootstraptest/BUILD.bazel
+++ b/session/bootstraptest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//config",
         "//ddl",

--- a/session/bootstraptest/bootstrap_upgrade_test.go
+++ b/session/bootstraptest/bootstrap_upgrade_test.go
@@ -335,7 +335,7 @@ func TestUpgradeVersionForUpgradeHTTPOp(t *testing.T) {
 	seLatestV := session.CreateSessionAndSetID(t, store)
 	ver, err = session.GetBootstrapVersion(seLatestV)
 	require.NoError(t, err)
-	require.Equal(t, session.SupportUpgradeHTTPOpVer+1, ver)
+	require.Less(t, session.SupportUpgradeHTTPOpVer, ver)
 	// Current cluster state is upgrading.
 	isUpgrading, err = session.IsUpgradingClusterState(seLatestV)
 	require.NoError(t, err)

--- a/session/bootstraptest/bootstrap_upgrade_test.go
+++ b/session/bootstraptest/bootstrap_upgrade_test.go
@@ -335,7 +335,7 @@ func TestUpgradeVersionForUpgradeHTTPOp(t *testing.T) {
 	seLatestV := session.CreateSessionAndSetID(t, store)
 	ver, err = session.GetBootstrapVersion(seLatestV)
 	require.NoError(t, err)
-	require.Less(t, session.SupportUpgradeHTTPOpVer, ver)
+	require.Equal(t, session.CurrentBootstrapVersion+1, ver)
 	// Current cluster state is upgrading.
 	isUpgrading, err = session.IsUpgradingClusterState(seLatestV)
 	require.NoError(t, err)

--- a/session/bootstraptest/bootstrap_upgrade_test.go
+++ b/session/bootstraptest/bootstrap_upgrade_test.go
@@ -827,7 +827,7 @@ func TestUpgradeWithPauseDDL(t *testing.T) {
 			" PARTITION `p4` VALUES LESS THAN (7096))"))
 }
 
-func TestDDLBackgroundSubtaskTable(t *testing.T) {
+func TestDDLBackgroundSubtaskTableSummary(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46258

Problem Summary:

We need a field to record the subtask execution statistic(for example, affected row count). Basically, there are three options:

1. Add a field `row_count INTEGER` to `tidb_background_subtask`.
2. Serialize the `row_count` in `meta BLOB` of `tidb_background_subtask`.
3. Add a field `summary JSON` to `tidb_background_subtask`.

For option 1,  it is not extensive to collect more execution statistic. For option 2, it is not convenient to collect the information without deserializing the whole `meta` blob value.

Option 3 is a better choice since we make json functions GA in TiDB v6.5.0.

Example usage:

```sql
mysql> show create table tidb_background_subtask;
+-------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table                   | Create Table                                                                                                                                                           |
+-------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| tidb_background_subtask | CREATE TABLE `tidb_background_subtask` (
  `id` int(11) DEFAULT NULL,
  `summary` json DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+-------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

Create subtask:
```sql
insert into tidb_background_subtask values (1, '{}');
```

Update row count:
```sql
update tidb_background_subtask set summary= json_set(summary, "$.row_count", "255") where id = 1;
```

Collect total row count:

```sql
mysql> table tidb_background_subtask;
+------+----------------------+
| id   | summary              |
+------+----------------------+
|    1 | {"row_count": "255"} |
|    2 | {"row_count": "2"}   |
|    3 | {"row_count": "3"}   |
+------+----------------------+

mysql> select json_extract(summary, '$.row_count') from tidb_background_subtask;
+---------------------------------------------+
| json_extract(summary, '$.row_count')        |
+---------------------------------------------+
| "255"                                       |
| "2"                                         |
| "3"                                         |
+---------------------------------------------+

mysql> select sum(json_extract(summary, '$.row_count')) from tidb_background_subtask;
+--------------------------------------------------+
| sum(json_extract(summary, '$.row_count'))        |
+--------------------------------------------------+
|                                              260 |
+--------------------------------------------------+
1 row in set (0.01 sec)
```

### What is changed and how it works?

Add a field `summary JSON` to `tidb_background_subtask`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
