### PR TITLE
session, sessionctx: show restricted session variables in `show session_states`

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -4290,42 +4290,39 @@ func (s *session) EncodeSessionStates(ctx context.Context,
 	sessionStates.SystemVars = make(map[string]string)
 	for _, sv := range variable.GetSysVars() {
 		switch {
-		case sv.HasNoneScope(), sv.HasInstanceScope(), !sv.HasSessionScope():
+		case sv.HasNoneScope(), !sv.HasSessionScope():
 			// Hidden attribute is deprecated.
 			// None-scoped variables cannot be modified.
-			// Instance-scoped variables don't need to be encoded.
 			// Noop variables should also be migrated even if they are noop.
 			continue
 		case sv.ReadOnly:
 			// Skip read-only variables here. We encode them into SessionStates manually.
 			continue
-		case !hasRestrictVarPriv && sem.IsEnabled() && sem.IsInvisibleSysVar(sv.Name):
-			val, keep, err := s.sessionVars.GetSessionStatesSystemVar(sv.Name)
-			if err != nil {
-				return err
-			} else if !keep {
-				continue
-			} else if sv.HasGlobalScope() {
-				globalVal, err := sv.GetGlobalFromHook(ctx, s.sessionVars)
-				if err != nil {
-					return err
-				}
-				// If the session value is the same with the global one, skip it.
-				if val == globalVal {
-					continue
-				}
-			} else if val == sv.Value {
-				// SysVar.Value stands for the default value.
-				continue
-			}
-			// 1. The RESTRICTED_VARIABLES_ADMIN is revoked after setting the session variable.
-			// 2. The global variable is updated after the session is created.
-			return sessionstates.ErrCannotMigrateSession.GenWithStackByArgs(fmt.Sprintf("session has set invisible variable '%s'", sv.Name))
 		}
 		// Get all session variables because the default values may change between versions.
-		if val, keep, err := s.sessionVars.GetSessionStatesSystemVar(sv.Name); err != nil {
+		val, keep, err := s.sessionVars.GetSessionStatesSystemVar(sv.Name)
+		switch {
+		case err != nil:
 			return err
-		} else if keep {
+		case !keep:
+			continue
+		case !hasRestrictVarPriv && sem.IsEnabled() && sem.IsInvisibleSysVar(sv.Name):
+			// If the variable has a global scope, it should be the same with the global one.
+			// Otherwise, it should be the same with the default value.
+			defaultVal := sv.Value
+			if sv.HasGlobalScope() {
+				// If the session value is the same with the global one, skip it.
+				if defaultVal, err = sv.GetGlobalFromHook(ctx, s.sessionVars); err != nil {
+					return err
+				}
+			}
+			if val != defaultVal {
+				// Case 1: the RESTRICTED_VARIABLES_ADMIN is revoked after setting the session variable.
+				// Case 2: the global variable is updated after the session is created.
+				// In any case, the variable can't be set in the new session, so give up.
+				return sessionstates.ErrCannotMigrateSession.GenWithStackByArgs(fmt.Sprintf("session has set invisible variable '%s'", sv.Name))
+			}
+		default:
 			sessionStates.SystemVars[sv.Name] = val
 		}
 	}

--- a/sessionctx/sessionstates/BUILD.bazel
+++ b/sessionctx/sessionstates/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "//config",
         "//errno",
         "//expression",
+        "//parser/auth",
         "//parser/mysql",
         "//parser/terror",
         "//server",

--- a/sessionctx/sessionstates/BUILD.bazel
+++ b/sessionctx/sessionstates/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     ],
     embed = [":sessionstates"],
     flaky = True,
-    shard_count = 14,
+    shard_count = 15,
     deps = [
         "//config",
         "//errno",

--- a/sessionctx/sessionstates/session_token_test.go
+++ b/sessionctx/sessionstates/session_token_test.go
@@ -128,12 +128,7 @@ func TestSignAlgo(t *testing.T) {
 }
 
 func TestVerifyToken(t *testing.T) {
-	tempDir := t.TempDir()
-	certPath := filepath.Join(tempDir, "test1_cert.pem")
-	keyPath := filepath.Join(tempDir, "test1_key.pem")
-	createRSACert(t, certPath, keyPath)
-	SetKeyPath(keyPath)
-	SetCertPath(certPath)
+	SetupSigningCertForTest(t)
 
 	// check succeeds
 	token, tokenBytes := createNewToken(t, "test_user")
@@ -264,4 +259,14 @@ func createNewToken(t *testing.T, username string) (*SessionToken, []byte) {
 func createRSACert(t *testing.T, certPath, keyPath string) {
 	err := util.CreateCertificates(certPath, keyPath, 4096, x509.RSA, x509.UnknownSignatureAlgorithm)
 	require.NoError(t, err)
+}
+
+// SetupSigningCertForTest sets signing cert.
+func SetupSigningCertForTest(t *testing.T) {
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "test1_cert.pem")
+	keyPath := filepath.Join(tempDir, "test1_key.pem")
+	createRSACert(t, certPath, keyPath)
+	SetKeyPath(keyPath)
+	SetCertPath(certPath)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46216

Problem Summary:
If the user has `RESTRICTED_VARIABLES_ADMIN` when SEM is enabled, the invisible session variables should also be migrated.

### What is changed and how it works?
1. Compare the restricted session variable values with the global or default one
2. If they are different and the user has `RESTRICTED_VARIABLES_ADMIN`, migrate the variable
3. If they are different but the use doesn't have `RESTRICTED_VARIABLES_ADMIN`, report an error

Other:
- Remove the check of `sv.HasInstanceScope()` just in case some variables may have both instance and session scopes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
