### PR TITLE
sessionctx/variable: change @@tidb_shard_allocate_step default value to 64

### DIFF
--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -17,7 +17,6 @@ package variable
 import (
 	"context"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/pingcap/tidb/config"
@@ -1223,7 +1222,7 @@ const (
 	DefTiDBRedactLog                               = false
 	DefTiDBRestrictedReadOnly                      = false
 	DefTiDBSuperReadOnly                           = false
-	DefTiDBShardAllocateStep                       = math.MaxInt64
+	DefTiDBShardAllocateStep                       = 64
 	DefTiDBEnableTelemetry                         = false
 	DefTiDBEnableParallelApply                     = false
 	DefTiDBPartitionPruneMode                      = "dynamic"

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/parser/auth"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/session"
@@ -417,6 +418,8 @@ func TestShardRowIDBitsStep(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists shard_t;")
 	tk.MustExec("create table shard_t (a int) shard_row_id_bits = 15;")
+	tk.MustQuery("select @@tidb_shard_allocate_step;").Check(
+		testkit.Rows(strconv.Itoa(variable.DefTiDBShardAllocateStep)))
 	tk.MustExec("set @@tidb_shard_allocate_step=3;")
 	tk.MustExec("insert into shard_t values (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11);")
 	rows := tk.MustQuery("select _tidb_rowid from shard_t;").Rows()


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46583 

Problem Summary:

Hotspot have not been evenly distributed even with SHARD_ROW_ID_BITS set.

### What is changed and how it works?


Within the same transaction, the insert statements use the same start_ts when writing.
When calculating the high bits of the shard bits for writing rowid, it will hash based on the current transaction's start_ts.
This ensures that the same random bits are obtained, while the low bits of auto-id continue to increment.

If the user batch insert a lot of rows within one transaction, those new records have the same high bits,
and the lower bits are also continuous.
We use @@tidb_shard_allocate_step to control the lower bits, i.e. the step control how many ids to be continuous.
Turn it to a smaller value to make the hotspots more evenly distributed.

Why not set the default value to 1?
Because the performance of writing a continuous batch on the tikv side is better than writing a disordered sequent.
So we need to consider both the hotspot issue and sequential write performance, and choose a good balance.

Note, since @@tidb_shard_allocate_step is a global session variable and persisted, this PR does not change the persisted value.
**It means that the change only take effect on the newly boostraped cluster, or a cluster that never touch the value of this variable.**
I think that is reasonable, because if a user touched the value before, they should have set it to a good value.
And otherwise a newly bootstraped of upgraded cluster use this better default value.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
