### PR TITLE
planner: sink limit down to index merge table side under union and intersection case

### DIFF
--- a/planner/core/casetest/physicalplantest/physical_plan_test.go
+++ b/planner/core/casetest/physicalplantest/physical_plan_test.go
@@ -2608,6 +2608,8 @@ func TestIndexMergeSinkLimit(t *testing.T) {
 	tk.MustExec("set tidb_cost_model_version=1")
 	tk.MustExec(" CREATE TABLE `t2` (  `a` int(11) DEFAULT NULL,  `b` int(11) DEFAULT NULL,  `c` int(11) DEFAULT NULL,  KEY `a` (`a`),  KEY `b` (`b`)) ")
 	tk.MustExec("insert into t2 values(1,2,1),(2,1,1),(3,3,1)")
+	tk.MustExec("create table t(a int, j json, index kj((cast(j as signed array))))")
+	tk.MustExec("insert into t values(1, '[1,2,3]')")
 
 	for i, ts := range input {
 		testdata.OnRecord(func() {

--- a/planner/core/casetest/physicalplantest/physical_plan_test.go
+++ b/planner/core/casetest/physicalplantest/physical_plan_test.go
@@ -2589,3 +2589,33 @@ func TestIndexMergeOrderPushDown(t *testing.T) {
 		tk.MustQuery("show warnings").Check(testkit.Rows(output[i].Warning...))
 	}
 }
+
+func TestIndexMergeSinkLimit(t *testing.T) {
+	var (
+		input  []string
+		output []struct {
+			SQL     string
+			Plan    []string
+			Warning []string
+		}
+	)
+	planSuiteData := GetPlanSuiteData()
+	planSuiteData.LoadTestCases(t, &input, &output)
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_cost_model_version=1")
+	tk.MustExec(" CREATE TABLE `t2` (  `a` int(11) DEFAULT NULL,  `b` int(11) DEFAULT NULL,  `c` int(11) DEFAULT NULL,  KEY `a` (`a`),  KEY `b` (`b`)) ")
+	tk.MustExec("insert into t2 values(1,2,1),(2,1,1),(3,3,1)")
+
+	for i, ts := range input {
+		testdata.OnRecord(func() {
+			output[i].SQL = ts
+			output[i].Plan = testdata.ConvertRowsToStrings(tk.MustQuery(ts).Rows())
+			output[i].Warning = testdata.ConvertRowsToStrings(tk.MustQuery("show warnings").Rows())
+		})
+		tk.MustQuery(ts).Check(testkit.Rows(output[i].Plan...))
+		tk.MustQuery("show warnings").Check(testkit.Rows(output[i].Warning...))
+	}
+}

--- a/planner/core/casetest/physicalplantest/testdata/plan_suite_in.json
+++ b/planner/core/casetest/physicalplantest/testdata/plan_suite_in.json
@@ -1346,7 +1346,13 @@
       "select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 and c=1 limit 2",
       "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 or b=1 limit 2; -- test sink limit to index side of union index merge case, because of table side is pure table scan",
       "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 limit 2; -- test sink limit to table side of intersection index merge case, because of intersection case special",
-      "select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 limit 2"
+      "select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 limit 2",
+      "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where (1 member of (j)) limit 1; -- index merge union case, sink limit into index side and embed another one inside index merge reader",
+      "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where json_contains(j, '[1, 2, 3]') limit 1; -- index merge intersection case, sink limit into table side",
+      "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where json_overlaps(j, '[1, 2, 3]') limit 1; -- index merge union case, sink limit above selection above index merge reader, because json_overlaps can't be pushed down",
+      "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where (1 member of (j) and a=1 ) limit 1; -- index merge union case, sink limit to table side, because selection exists on table side",
+      "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where json_contains(j, '[1, 2, 3]') and a=1 limit 1; -- index merge intersection case, sink limit to table side because selection exists on table side",
+      "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where json_overlaps(j, '[1, 2, 3]') and a=1 limit 1; -- index merge union case, sink limit above selection above index merge reader, because json_overlaps can't be pushed down"
     ]
   }
 ]

--- a/planner/core/casetest/physicalplantest/testdata/plan_suite_in.json
+++ b/planner/core/casetest/physicalplantest/testdata/plan_suite_in.json
@@ -1337,5 +1337,16 @@
       "select * from tcommon where (a = 1 and c = 2) or (b = 1) order by c limit 2",
       "select * from thash use index(idx_ac, idx_bc) where a = 1 or b = 1 order by c limit 2"
     ]
+  },
+  {
+    "name": "TestIndexMergeSinkLimit",
+    "cases": [
+      "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 or b=1 and c=1 limit 2; -- test sink limit to table side of union index merge case, because of table side selection",
+      "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 and c=1 limit 2; -- test sink limit to table side of intersection index merge case, because of table side selection",
+      "select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 and c=1 limit 2",
+      "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 or b=1 limit 2; -- test sink limit to index side of union index merge case, because of table side is pure table scan",
+      "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 limit 2; -- test sink limit to table side of intersection index merge case, because of intersection case special",
+      "select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 limit 2"
+    ]
   }
 ]

--- a/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+++ b/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
@@ -8741,6 +8741,83 @@
         "SQL": "select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 limit 2",
         "Plan": null,
         "Warning": null
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where (1 member of (j)) limit 1; -- index merge union case, sink limit into index side and embed another one inside index merge reader",
+        "Plan": [
+          "IndexMerge 0.00 root  type: union, limit embedded(offset:0, count:1)",
+          "├─Limit(Build) 0.00 cop[tikv]  offset:0, count:1",
+          "│ └─IndexRangeScan 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
+          "└─TableRowIDScan(Probe) 1.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where json_contains(j, '[1, 2, 3]') limit 1; -- index merge intersection case, sink limit into table side",
+        "Plan": [
+          "IndexMerge 0.00 root  type: intersection",
+          "├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
+          "├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[2,2], keep order:false, stats:pseudo",
+          "├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[3,3], keep order:false, stats:pseudo",
+          "└─Limit(Probe) 0.00 cop[tikv]  offset:0, count:1",
+          "  └─TableRowIDScan 0.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where json_overlaps(j, '[1, 2, 3]') limit 1; -- index merge union case, sink limit above selection above index merge reader, because json_overlaps can't be pushed down",
+        "Plan": [
+          "Limit 1.00 root  offset:0, count:1",
+          "└─Selection 1.00 root  json_overlaps(test.t.j, cast(\"[1, 2, 3]\", json BINARY))",
+          "  └─IndexMerge 0.00 root  type: union",
+          "    ├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
+          "    ├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[2,2], keep order:false, stats:pseudo",
+          "    ├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[3,3], keep order:false, stats:pseudo",
+          "    └─TableRowIDScan(Probe) 0.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warning": [
+          "Warning 1105 Scalar function 'json_overlaps'(signature: Unspecified, return type: bigint(20)) is not supported to push down to storage layer now."
+        ]
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where (1 member of (j) and a=1 ) limit 1; -- index merge union case, sink limit to table side, because selection exists on table side",
+        "Plan": [
+          "IndexMerge 0.00 root  type: union",
+          "├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
+          "└─Limit(Probe) 0.00 cop[tikv]  offset:0, count:1",
+          "  └─Selection 0.00 cop[tikv]  eq(test.t.a, 1)",
+          "    └─TableRowIDScan 1.25 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where json_contains(j, '[1, 2, 3]') and a=1 limit 1; -- index merge intersection case, sink limit to table side because selection exists on table side",
+        "Plan": [
+          "IndexMerge 0.00 root  type: intersection",
+          "├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
+          "├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[2,2], keep order:false, stats:pseudo",
+          "├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[3,3], keep order:false, stats:pseudo",
+          "└─Limit(Probe) 0.00 cop[tikv]  offset:0, count:1",
+          "  └─Selection 0.00 cop[tikv]  eq(test.t.a, 1)",
+          "    └─TableRowIDScan 1.25 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where json_overlaps(j, '[1, 2, 3]') and a=1 limit 1; -- index merge union case, sink limit above selection above index merge reader, because json_overlaps can't be pushed down",
+        "Plan": [
+          "Limit 1.00 root  offset:0, count:1",
+          "└─Selection 1.00 root  json_overlaps(test.t.j, cast(\"[1, 2, 3]\", json BINARY))",
+          "  └─IndexMerge 1.00 root  type: union",
+          "    ├─IndexRangeScan(Build) 1.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
+          "    ├─IndexRangeScan(Build) 1.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[2,2], keep order:false, stats:pseudo",
+          "    ├─IndexRangeScan(Build) 1.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[3,3], keep order:false, stats:pseudo",
+          "    └─Selection(Probe) 1.00 cop[tikv]  eq(test.t.a, 1)",
+          "      └─TableRowIDScan 1.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warning": [
+          "Warning 1105 Scalar function 'json_overlaps'(signature: Unspecified, return type: bigint(20)) is not supported to push down to storage layer now."
+        ]
       }
     ]
   }

--- a/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+++ b/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
@@ -8688,24 +8688,26 @@
       {
         "SQL": "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 or b=1 and c=1 limit 2; -- test sink limit to table side of union index merge case, because of table side selection",
         "Plan": [
-          "IndexMerge 0.00 root  type: union",
-          "├─IndexRangeScan(Build) 2.00 cop[tikv] table:t2, index:a(a) range:[1,1], keep order:false, stats:pseudo",
-          "├─IndexRangeScan(Build) 2.00 cop[tikv] table:t2, index:b(b) range:[1,1], keep order:false, stats:pseudo",
-          "└─Limit(Probe) 0.00 cop[tikv]  offset:0, count:2",
-          "  └─Selection 0.00 cop[tikv]  or(eq(test.t2.a, 1), and(eq(test.t2.b, 1), eq(test.t2.c, 1)))",
-          "    └─TableRowIDScan 3.99 cop[tikv] table:t2 keep order:false, stats:pseudo"
+          "Limit 2.00 root  offset:0, count:2",
+          "└─IndexMerge 0.00 root  type: union",
+          "  ├─IndexRangeScan(Build) 2.00 cop[tikv] table:t2, index:a(a) range:[1,1], keep order:false, stats:pseudo",
+          "  ├─IndexRangeScan(Build) 2.00 cop[tikv] table:t2, index:b(b) range:[1,1], keep order:false, stats:pseudo",
+          "  └─Limit(Probe) 0.00 cop[tikv]  offset:0, count:2",
+          "    └─Selection 0.00 cop[tikv]  or(eq(test.t2.a, 1), and(eq(test.t2.b, 1), eq(test.t2.c, 1)))",
+          "      └─TableRowIDScan 3.99 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "Warning": null
       },
       {
         "SQL": "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 and c=1 limit 2; -- test sink limit to table side of intersection index merge case, because of table side selection",
         "Plan": [
-          "IndexMerge 0.01 root  type: intersection",
-          "├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:a(a) range:[1,1], keep order:false, stats:pseudo",
-          "├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:b(b) range:[1,1], keep order:false, stats:pseudo",
-          "└─Limit(Probe) 0.01 cop[tikv]  offset:0, count:2",
-          "  └─Selection 0.01 cop[tikv]  eq(test.t2.c, 1)",
-          "    └─TableRowIDScan 0.01 cop[tikv] table:t2 keep order:false, stats:pseudo"
+          "Limit 0.00 root  offset:0, count:2",
+          "└─IndexMerge 0.01 root  type: intersection",
+          "  ├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:a(a) range:[1,1], keep order:false, stats:pseudo",
+          "  ├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:b(b) range:[1,1], keep order:false, stats:pseudo",
+          "  └─Limit(Probe) 0.01 cop[tikv]  offset:0, count:2",
+          "    └─Selection 0.01 cop[tikv]  eq(test.t2.c, 1)",
+          "      └─TableRowIDScan 0.01 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "Warning": null
       },
@@ -8729,11 +8731,12 @@
       {
         "SQL": "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 limit 2; -- test sink limit to table side of intersection index merge case, because of intersection case special",
         "Plan": [
-          "IndexMerge 0.01 root  type: intersection",
-          "├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:a(a) range:[1,1], keep order:false, stats:pseudo",
-          "├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:b(b) range:[1,1], keep order:false, stats:pseudo",
-          "└─Limit(Probe) 0.01 cop[tikv]  offset:0, count:2",
-          "  └─TableRowIDScan 0.01 cop[tikv] table:t2 keep order:false, stats:pseudo"
+          "Limit 0.01 root  offset:0, count:2",
+          "└─IndexMerge 0.01 root  type: intersection",
+          "  ├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:a(a) range:[1,1], keep order:false, stats:pseudo",
+          "  ├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:b(b) range:[1,1], keep order:false, stats:pseudo",
+          "  └─Limit(Probe) 0.01 cop[tikv]  offset:0, count:2",
+          "    └─TableRowIDScan 0.01 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "Warning": null
       },
@@ -8755,12 +8758,13 @@
       {
         "SQL": "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where json_contains(j, '[1, 2, 3]') limit 1; -- index merge intersection case, sink limit into table side",
         "Plan": [
-          "IndexMerge 0.00 root  type: intersection",
-          "├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
-          "├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[2,2], keep order:false, stats:pseudo",
-          "├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[3,3], keep order:false, stats:pseudo",
-          "└─Limit(Probe) 0.00 cop[tikv]  offset:0, count:1",
-          "  └─TableRowIDScan 0.00 cop[tikv] table:t keep order:false, stats:pseudo"
+          "Limit 1.00 root  offset:0, count:1",
+          "└─IndexMerge 0.00 root  type: intersection",
+          "  ├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
+          "  ├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[2,2], keep order:false, stats:pseudo",
+          "  ├─IndexRangeScan(Build) 0.00 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[3,3], keep order:false, stats:pseudo",
+          "  └─Limit(Probe) 0.00 cop[tikv]  offset:0, count:1",
+          "    └─TableRowIDScan 0.00 cop[tikv] table:t keep order:false, stats:pseudo"
         ],
         "Warning": null
       },
@@ -8782,24 +8786,26 @@
       {
         "SQL": "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where (1 member of (j) and a=1 ) limit 1; -- index merge union case, sink limit to table side, because selection exists on table side",
         "Plan": [
-          "IndexMerge 0.00 root  type: union",
-          "├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
-          "└─Limit(Probe) 0.00 cop[tikv]  offset:0, count:1",
-          "  └─Selection 0.00 cop[tikv]  eq(test.t.a, 1)",
-          "    └─TableRowIDScan 1.25 cop[tikv] table:t keep order:false, stats:pseudo"
+          "Limit 1.00 root  offset:0, count:1",
+          "└─IndexMerge 0.00 root  type: union",
+          "  ├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
+          "  └─Limit(Probe) 0.00 cop[tikv]  offset:0, count:1",
+          "    └─Selection 0.00 cop[tikv]  eq(test.t.a, 1)",
+          "      └─TableRowIDScan 1.25 cop[tikv] table:t keep order:false, stats:pseudo"
         ],
         "Warning": null
       },
       {
         "SQL": "explain format = 'brief' select /*+ use_index(t, kj) */ * from t where json_contains(j, '[1, 2, 3]') and a=1 limit 1; -- index merge intersection case, sink limit to table side because selection exists on table side",
         "Plan": [
-          "IndexMerge 0.00 root  type: intersection",
-          "├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
-          "├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[2,2], keep order:false, stats:pseudo",
-          "├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[3,3], keep order:false, stats:pseudo",
-          "└─Limit(Probe) 0.00 cop[tikv]  offset:0, count:1",
-          "  └─Selection 0.00 cop[tikv]  eq(test.t.a, 1)",
-          "    └─TableRowIDScan 1.25 cop[tikv] table:t keep order:false, stats:pseudo"
+          "Limit 1.00 root  offset:0, count:1",
+          "└─IndexMerge 0.00 root  type: intersection",
+          "  ├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[1,1], keep order:false, stats:pseudo",
+          "  ├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[2,2], keep order:false, stats:pseudo",
+          "  ├─IndexRangeScan(Build) 1.25 cop[tikv] table:t, index:kj(cast(`j` as signed array)) range:[3,3], keep order:false, stats:pseudo",
+          "  └─Limit(Probe) 0.00 cop[tikv]  offset:0, count:1",
+          "    └─Selection 0.00 cop[tikv]  eq(test.t.a, 1)",
+          "      └─TableRowIDScan 1.25 cop[tikv] table:t keep order:false, stats:pseudo"
         ],
         "Warning": null
       },

--- a/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+++ b/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
@@ -8681,5 +8681,67 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestIndexMergeSinkLimit",
+    "Cases": [
+      {
+        "SQL": "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 or b=1 and c=1 limit 2; -- test sink limit to table side of union index merge case, because of table side selection",
+        "Plan": [
+          "IndexMerge 0.00 root  type: union",
+          "├─IndexRangeScan(Build) 2.00 cop[tikv] table:t2, index:a(a) range:[1,1], keep order:false, stats:pseudo",
+          "├─IndexRangeScan(Build) 2.00 cop[tikv] table:t2, index:b(b) range:[1,1], keep order:false, stats:pseudo",
+          "└─Limit(Probe) 0.00 cop[tikv]  offset:0, count:2",
+          "  └─Selection 0.00 cop[tikv]  or(eq(test.t2.a, 1), and(eq(test.t2.b, 1), eq(test.t2.c, 1)))",
+          "    └─TableRowIDScan 3.99 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 and c=1 limit 2; -- test sink limit to table side of intersection index merge case, because of table side selection",
+        "Plan": [
+          "IndexMerge 0.01 root  type: intersection",
+          "├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:a(a) range:[1,1], keep order:false, stats:pseudo",
+          "├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:b(b) range:[1,1], keep order:false, stats:pseudo",
+          "└─Limit(Probe) 0.01 cop[tikv]  offset:0, count:2",
+          "  └─Selection 0.01 cop[tikv]  eq(test.t2.c, 1)",
+          "    └─TableRowIDScan 0.01 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 and c=1 limit 2",
+        "Plan": null,
+        "Warning": null
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 or b=1 limit 2; -- test sink limit to index side of union index merge case, because of table side is pure table scan",
+        "Plan": [
+          "IndexMerge 2.00 root  type: union, limit embedded(offset:0, count:2)",
+          "├─Limit(Build) 1.00 cop[tikv]  offset:0, count:2",
+          "│ └─IndexRangeScan 1.00 cop[tikv] table:t2, index:a(a) range:[1,1], keep order:false, stats:pseudo",
+          "├─Limit(Build) 1.00 cop[tikv]  offset:0, count:2",
+          "│ └─IndexRangeScan 1.00 cop[tikv] table:t2, index:b(b) range:[1,1], keep order:false, stats:pseudo",
+          "└─TableRowIDScan(Probe) 2.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "explain format = 'brief' select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 limit 2; -- test sink limit to table side of intersection index merge case, because of intersection case special",
+        "Plan": [
+          "IndexMerge 0.01 root  type: intersection",
+          "├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:a(a) range:[1,1], keep order:false, stats:pseudo",
+          "├─IndexRangeScan(Build) 10.00 cop[tikv] table:t2, index:b(b) range:[1,1], keep order:false, stats:pseudo",
+          "└─Limit(Probe) 0.01 cop[tikv]  offset:0, count:2",
+          "  └─TableRowIDScan 0.01 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 limit 2",
+        "Plan": null,
+        "Warning": null
+      }
+    ]
   }
 ]

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -977,9 +977,6 @@ func (ds *DataSource) isPointGetConvertableSchema() bool {
 func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter *PlanCounterTp, opt *physicalOptimizeOp) (t task, cntPlan int64, err error) {
 	// If ds is an inner plan in an IndexJoin, the IndexJoin will generate an inner plan by itself,
 	// and set inner child prop nil, so here we do nothing.
-	if strings.HasPrefix(ds.SCtx().GetSessionVars().StmtCtx.OriginalSQL, "explain select /*+ use_index_merge(t2, a, b) */ * from t2 where a=1 and b=1 and c=1 limit 1") {
-		fmt.Println(1)
-	}
 	if prop == nil {
 		planCounter.Dec(1)
 		return nil, 1, nil

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1266,9 +1266,6 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 }
 
 // convertToIndexMergeScan builds the index merge scan for intersection or union cases.
-// for property.CopMultiReadTaskType with intersection case:
-//
-//	we could
 func (ds *DataSource) convertToIndexMergeScan(prop *property.PhysicalProperty, candidate *candidatePath, _ *physicalOptimizeOp) (task task, err error) {
 	if prop.IsFlashProp() || prop.TaskTp == property.CopSingleReadTaskType {
 		return invalidTask, nil

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1276,6 +1276,10 @@ func (ds *DataSource) convertToIndexMergeScan(prop *property.PhysicalProperty, c
 	if !prop.IsSortItemEmpty() && !candidate.isMatchProp {
 		return invalidTask, nil
 	}
+	// while for now, we still can not push the sort prop to the intersection index plan side, temporarily banned here.
+	if !prop.IsSortItemEmpty() && candidate.path.IndexMergeIsIntersection {
+		return invalidTask, nil
+	}
 	failpoint.Inject("forceIndexMergeKeepOrder", func(_ failpoint.Value) {
 		if len(candidate.path.PartialIndexPaths) > 0 && !candidate.path.IndexMergeIsIntersection {
 			if prop.IsSortItemEmpty() {

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -913,15 +913,16 @@ func (p *PhysicalLimit) attach2Task(tasks ...task) task {
 					t = cop.convertToRootTask(p.SCtx())
 					sunk = true
 				}
-				if cop.indexPlanFinished {
-					// cop.indexPlanFinished = true indicates the table side is not a pure table-scan, so we could only append the limit upon the table plan.
-					suspendLimitAboveTablePlan()
-				} else {
-					// todo: cop.indexPlanFinished = false indicates the table side is a pure table-scan, so we sink the limit as index merge embedded push-down Limit theoretically.
-					// todo: while currently in the execution layer, intersection concurrency framework is not quickly suitable for us to do the limit cut down or the order by operation.
-					// so currently, we just put the limit at the top of table plan rather than a embedded pushedLimit inside indexMergeReader.
-					suspendLimitAboveTablePlan()
-				}
+				// if cop.indexPlanFinished = true
+				// 		indicates the table side is not a pure table-scan, so we could only append the limit upon the table plan.
+				//		suspendLimitAboveTablePlan()
+				// else
+				// 		todo: cop.indexPlanFinished = false indicates the table side is a pure table-scan, so we sink the limit as index merge embedded push-down Limit theoretically.
+				// 		todo: while currently in the execution layer, intersection concurrency framework is not quickly suitable for us to do the limit cut down or the order by operation.
+				// 		so currently, we just put the limit at the top of table plan rather than a embedded pushedLimit inside indexMergeReader.
+				// 		t = cop.convertToRootTask(p.SCtx())
+				//		sunk = p.sinkIntoIndexMerge(t)
+				suspendLimitAboveTablePlan()
 			} else {
 				// otherwise, suspend the limit out of index merge reader.
 				t = cop.convertToRootTask(p.SCtx())

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -15,6 +15,8 @@
 package core
 
 import (
+	"math"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/expression"
@@ -39,7 +41,6 @@ import (
 	"github.com/pingcap/tidb/util/size"
 	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
-	"math"
 )
 
 var (


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46313
Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: sink limit down to index merge table side under union and intersection case
```
