### PR TITLE
expression: fix wrong result for unsigned non-const int cmp const duration

### DIFF
--- a/expression/integration_test/integration_test.go
+++ b/expression/integration_test/integration_test.go
@@ -7814,7 +7814,7 @@ func TestIfFunctionWithNull(t *testing.T) {
 		testkit.Rows("20000 35100"))
 }
 
-func TestIssue41733(t *testing.T) {
+func TestIssue41733AndIssue45410(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("create database testIssue41733")
@@ -7845,11 +7845,8 @@ func TestIssue41733(t *testing.T) {
 	tk.MustExec("INSERT IGNORE INTO t_big(c0) VALUES (1E20)")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1264 Out of range value for column 'c0' at row 1"))
 	tk.MustQuery("select * from t_big;").Check(testkit.Rows("18446744073709551615"))
-}
 
-func TestIssue45410(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
+	// Issue 45410
 	tk.MustExec("create database testIssue45410")
 	defer tk.MustExec("drop database testIssue45410")
 	tk.MustExec("use testIssue45410")

--- a/expression/integration_test/integration_test.go
+++ b/expression/integration_test/integration_test.go
@@ -7846,3 +7846,16 @@ func TestIssue41733(t *testing.T) {
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1264 Out of range value for column 'c0' at row 1"))
 	tk.MustQuery("select * from t_big;").Check(testkit.Rows("18446744073709551615"))
 }
+
+func TestIssue45410(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create database testIssue45410")
+	defer tk.MustExec("drop database testIssue45410")
+	tk.MustExec("use testIssue45410")
+
+	tk.MustExec("DROP TABLE IF EXISTS t1;")
+	tk.MustExec("CREATE TABLE t1 (c1 TINYINT(1) UNSIGNED NOT NULL );")
+	tk.MustExec("INSERT INTO t1 VALUES (0);")
+	tk.MustQuery("SELECT c1>=CAST('-787360724' AS TIME) FROM t1;").Check(testkit.Rows("1"))
+}

--- a/types/datum.go
+++ b/types/datum.go
@@ -1214,9 +1214,10 @@ func (d *Datum) convertToUint(sc *stmtctx.StatementContext, target *FieldType) (
 	case KindMysqlDuration:
 		dec := d.GetMysqlDuration().ToNumber()
 		err = dec.Round(dec, 0, ModeHalfUp)
-		ival, err1 := dec.ToInt()
-		if err1 == nil {
-			val, err = ConvertIntToUint(sc, ival, upperBound, tp)
+		var err1 error
+		val, err1 = ConvertDecimalToUint(sc, dec, upperBound, tp)
+		if err == nil {
+			err = err1
 		}
 	case KindMysqlDecimal:
 		val, err = ConvertDecimalToUint(sc, d.GetMysqlDecimal(), upperBound, tp)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/45410

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
