### PR TITLE
parser,config: Correct handling of display width deprecation except for zerofill and tinyint(1)

### DIFF
--- a/executor/test/showtest/show_test.go
+++ b/executor/test/showtest/show_test.go
@@ -1647,11 +1647,21 @@ func TestShowCreateTableWithIntegerDisplayLengthWarnings(t *testing.T) {
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1064 You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use [parser:1681]Integer display width is deprecated and will be removed in a future release.",
 		"Warning 1064 You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use [parser:1681]Integer display width is deprecated and will be removed in a future release."))
 	tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
-		"  `a` tinyint DEFAULT NULL,\n" +
+		"  `a` tinyint(1) DEFAULT NULL,\n" +
 		"  `b` smallint DEFAULT NULL,\n" +
 		"  `c` mediumint DEFAULT NULL,\n" +
 		"  `d` int DEFAULT NULL,\n" +
 		"  `e` bigint DEFAULT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id int primary key, c1 bool, c2 int(10) zerofill)")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1064 You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use [parser:1681]Integer display width is deprecated and will be removed in a future release."))
+	tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
+		"  `id` int NOT NULL,\n" +
+		"  `c1` tinyint(1) DEFAULT NULL,\n" +
+		"  `c2` int(10) unsigned zerofill DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 }
 

--- a/parser/types/BUILD.bazel
+++ b/parser/types/BUILD.bazel
@@ -27,7 +27,7 @@ go_test(
     ],
     embed = [":types"],
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//parser",
         "//parser/ast",

--- a/parser/types/field_type_test.go
+++ b/parser/types/field_type_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/charset"
 	"github.com/pingcap/tidb/parser/mysql"
+
 	// import parser_driver
 	_ "github.com/pingcap/tidb/parser/test_driver"
 	. "github.com/pingcap/tidb/parser/types"
@@ -318,7 +319,6 @@ func TestCompactStr(t *testing.T) {
 		{mysql.TypeLong, 10, mysql.ZerofillFlag, `int(10)`, `int(10)`},
 	}
 	for _, cc := range cases {
-
 		ft := NewFieldType(cc.t)
 		ft.SetFlen(cc.flen)
 		ft.SetFlag(cc.flags)

--- a/parser/types/field_type_test.go
+++ b/parser/types/field_type_test.go
@@ -299,3 +299,34 @@ func TestFieldTypeEqual(t *testing.T) {
 	ft1.SetFlen(23)
 	require.Equal(t, true, ft1.Equal(ft2))
 }
+
+func TestCompactStr(t *testing.T) {
+	cases := []struct {
+		t     byte   // Field Type
+		flen  int    // Field Length
+		flags uint   // Field Flags, e.g. ZEROFILL
+		e1    string // Expected string with TiDBStrictIntegerDisplayWidth disabled
+		e2    string // Expected string with TiDBStrictIntegerDisplayWidth enabled
+	}{
+		// TINYINT(1) is considered a bool by connectors, this should always display
+		// the display length.
+		{mysql.TypeTiny, 1, 0, `tinyint(1)`, `tinyint(1)`},
+		{mysql.TypeTiny, 2, 0, `tinyint(2)`, `tinyint`},
+
+		// If the ZEROFILL flag is set the display length should not be hidden.
+		{mysql.TypeLong, 10, 0, `int(10)`, `int`},
+		{mysql.TypeLong, 10, mysql.ZerofillFlag, `int(10)`, `int(10)`},
+	}
+	for _, cc := range cases {
+
+		ft := NewFieldType(cc.t)
+		ft.SetFlen(cc.flen)
+		ft.SetFlag(cc.flags)
+
+		TiDBStrictIntegerDisplayWidth = false
+		require.Equal(t, cc.e1, ft.CompactStr())
+
+		TiDBStrictIntegerDisplayWidth = true
+		require.Equal(t, cc.e2, ft.CompactStr())
+	}
+}

--- a/parser/types/field_type_test.go
+++ b/parser/types/field_type_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/charset"
 	"github.com/pingcap/tidb/parser/mysql"
-
 	// import parser_driver
 	_ "github.com/pingcap/tidb/parser/test_driver"
 	. "github.com/pingcap/tidb/parser/types"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46650 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Display width deprecation now excludes `tinyint(1)` and types with `ZEROFILL`. This improves compatibility with MySQL Connectors.
```
