### PR TITLE
planner: support `default_collation_for_utf8mb4` for _utf8mb4'text'

### DIFF
--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1203,6 +1203,17 @@ func initConstantRepertoire(c *expression.Constant) {
 	}
 }
 
+func (er *expressionRewriter) adjustUTF8MB4Collation(tp *types.FieldType) {
+	if tp.GetFlag()&mysql.UnderScoreCharsetFlag > 0 && charset.CharsetUTF8MB4 == tp.GetCharset() {
+		var collation string
+		collation, er.err = er.sctx.GetSessionVars().GetSessionOrGlobalSystemVar(context.Background(), variable.DefaultCollationForUTF8MB4)
+		if er.err != nil {
+			return
+		}
+		tp.SetCollate(collation)
+	}
+}
+
 // Leave implements Visitor interface.
 func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok bool) {
 	if er.err != nil {
@@ -1227,6 +1238,10 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		v.Datum.SetValue(v.Datum.GetValue(), retType)
 		value := &expression.Constant{Value: v.Datum, RetType: retType}
 		initConstantRepertoire(value)
+		er.adjustUTF8MB4Collation(retType)
+		if er.err != nil {
+			return retNode, false
+		}
 		er.ctxStackAppend(value, types.EmptyName)
 	case *driver.ParamMarkerExpr:
 		var value *expression.Constant
@@ -1235,6 +1250,10 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 			return retNode, false
 		}
 		initConstantRepertoire(value)
+		er.adjustUTF8MB4Collation(value.RetType)
+		if er.err != nil {
+			return retNode, false
+		}
 		er.ctxStackAppend(value, types.EmptyName)
 	case *ast.VariableExpr:
 		er.rewriteVariable(v)

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1205,12 +1205,7 @@ func initConstantRepertoire(c *expression.Constant) {
 
 func (er *expressionRewriter) adjustUTF8MB4Collation(tp *types.FieldType) {
 	if tp.GetFlag()&mysql.UnderScoreCharsetFlag > 0 && charset.CharsetUTF8MB4 == tp.GetCharset() {
-		var collation string
-		collation, er.err = er.sctx.GetSessionVars().GetSessionOrGlobalSystemVar(context.Background(), variable.DefaultCollationForUTF8MB4)
-		if er.err != nil {
-			return
-		}
-		tp.SetCollate(collation)
+		tp.SetCollate(er.sctx.GetSessionVars().DefaultCollationForUTF8MB4)
 	}
 }
 

--- a/planner/core/expression_rewriter_test.go
+++ b/planner/core/expression_rewriter_test.go
@@ -418,3 +418,23 @@ func TestColResolutionSubqueryWithUnionAll(t *testing.T) {
 	tk.MustExec("create table t(a int);")
 	tk.MustQuery("select * from t where  exists ( select a from ( select a from t1 union all select a from t2) u where t.a=u.a);").Check(testkit.Rows())
 }
+
+func TestDefaultCollationForUTF8MB4(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec(`set @a = 'xx'`)
+	// utf8mb4_bin
+	tk.MustQuery("select * from information_schema.COLLATIONS where IS_DEFAULT='Yes' and CHARACTER_SET_NAME='utf8mb4'").Check(testkit.Rows("utf8mb4_bin utf8mb4 46 Yes Yes 1"))
+	tk.MustQuery("select collation(_utf8mb4'12345')").Check(testkit.Rows("utf8mb4_bin"))
+	tk.MustQuery("select collation(_utf8mb4'xxx' collate utf8mb4_general_ci);").Check(testkit.Rows("utf8mb4_general_ci"))
+	tk.MustQuery("select collation(_utf8mb4'@a')").Check(testkit.Rows("utf8mb4_bin"))
+	tk.MustQuery("select collation(_utf8mb4'@a' collate utf8mb4_general_ci);").Check(testkit.Rows("utf8mb4_general_ci"))
+	// utf8mb4_0900_ai_ci
+	tk.MustExec("set @@session.default_collation_for_utf8mb4='utf8mb4_0900_ai_ci'")
+	tk.MustQuery("select * from information_schema.COLLATIONS where IS_DEFAULT='Yes' and CHARACTER_SET_NAME='utf8mb4'").Check(testkit.Rows("utf8mb4_bin utf8mb4 46 Yes Yes 1"))
+	tk.MustQuery("select collation(_utf8mb4'12345')").Check(testkit.Rows("utf8mb4_0900_ai_ci"))
+	tk.MustQuery("select collation(_utf8mb4'12345' collate utf8mb4_general_ci);").Check(testkit.Rows("utf8mb4_general_ci"))
+	tk.MustQuery("select collation(_utf8mb4'@a')").Check(testkit.Rows("utf8mb4_0900_ai_ci"))
+	tk.MustQuery("select collation(_utf8mb4'@a' collate utf8mb4_general_ci);").Check(testkit.Rows("utf8mb4_general_ci"))
+}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -977,6 +977,9 @@ type SessionVars struct {
 	// SkipUTF8Check check on input value.
 	SkipUTF8Check bool
 
+	// DefaultCollationForUTF8MB4 indicates the default collation of UTF8MB4.
+	DefaultCollationForUTF8MB4 string
+
 	// BatchInsert indicates if we should split insert data into multiple batches.
 	BatchInsert bool
 
@@ -2013,6 +2016,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		EnableLateMaterialization:     DefTiDBOptEnableLateMaterialization,
 		TiFlashComputeDispatchPolicy:  tiflashcompute.DispatchPolicyConsistentHash,
 		ResourceGroupName:             resourcegroup.DefaultResourceGroupName,
+		DefaultCollationForUTF8MB4:    mysql.DefaultCollationName,
 	}
 	vars.KVVars = tikvstore.NewVariables(&vars.Killed)
 	vars.Concurrency = Concurrency{

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1407,6 +1407,9 @@ var defaultSysVars = []*SysVar{
 			vars.StmtCtx.AppendWarning(ErrWarnDeprecatedSyntaxNoReplacement.FastGenByArgs(DefaultCollationForUTF8MB4))
 		}
 		return coll, err
+	}, SetSession: func(s *SessionVars, val string) error {
+		s.DefaultCollationForUTF8MB4 = val
+		return nil
 	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: SQLLogBin, Value: On, Type: TypeBool},
 	{Scope: ScopeGlobal | ScopeSession, Name: TimeZone, Value: "SYSTEM", IsHintUpdatable: true, Validation: func(varErrFunctionsNoopImpls *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46666

Problem Summary:
Support the behavior:

> Any statement containing a string literal of the form _utf8mb4'some text' without a COLLATE clause.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
