### PR TITLE
ddl: fix taskNodes temporarily

### DIFF
--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -247,7 +247,14 @@ func (d *dispatcher) onRunning() error {
 
 func (d *dispatcher) replaceDeadNodesIfAny() error {
 	if len(d.taskNodes) == 0 {
-		return errors.Errorf("len(d.taskNodes) == 0, onNextStage is not invoked before onRunning")
+		serverNodes, err := d.impl.GetEligibleInstances(d.ctx, d.task)
+		if err != nil {
+			return err
+		}
+		d.taskNodes = make([]string, len(serverNodes))
+		for i := range serverNodes {
+			d.taskNodes[i] = disttaskutil.GenerateExecID(serverNodes[i].IP, serverNodes[i].Port)
+		}
 	}
 	d.liveNodeFetchTick++
 	if d.liveNodeFetchTick == d.liveNodeFetchInterval {

--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -247,13 +247,10 @@ func (d *dispatcher) onRunning() error {
 
 func (d *dispatcher) replaceDeadNodesIfAny() error {
 	if len(d.taskNodes) == 0 {
-		serverNodes, err := d.impl.GetEligibleInstances(d.ctx, d.task)
+		var err error
+		d.taskNodes, err = d.taskMgr.GetSchedulerIDsByTaskIDAndStep(d.task.ID, d.task.Step)
 		if err != nil {
 			return err
-		}
-		d.taskNodes = make([]string, len(serverNodes))
-		for i := range serverNodes {
-			d.taskNodes[i] = disttaskutil.GenerateExecID(serverNodes[i].IP, serverNodes[i].Port)
 		}
 	}
 	d.liveNodeFetchTick++

--- a/disttask/framework/storage/task_table.go
+++ b/disttask/framework/storage/task_table.go
@@ -511,6 +511,26 @@ func (stm *TaskManager) GetSchedulerIDsByTaskID(taskID int64) ([]string, error) 
 	return instanceIDs, nil
 }
 
+// GetSchedulerIDsByTaskIDAndStep gets the scheduler IDs of the given global task ID and step.
+func (stm *TaskManager) GetSchedulerIDsByTaskIDAndStep(taskID int64, step int64) ([]string, error) {
+	rs, err := stm.executeSQLWithNewSession(stm.ctx, `select distinct(exec_id) from mysql.tidb_background_subtask
+		where task_key = %? and step = %?`, taskID, step)
+	if err != nil {
+		return nil, err
+	}
+	if len(rs) == 0 {
+		return nil, nil
+	}
+
+	instanceIDs := make([]string, 0, len(rs))
+	for _, r := range rs {
+		id := r.GetString(0)
+		instanceIDs = append(instanceIDs, id)
+	}
+
+	return instanceIDs, nil
+}
+
 // IsSchedulerCanceled checks if subtask 'execID' of task 'taskID' has been canceled somehow.
 func (stm *TaskManager) IsSchedulerCanceled(taskID int64, execID string) (bool, error) {
 	rs, err := stm.executeSQLWithNewSession(stm.ctx, "select 1 from mysql.tidb_background_subtask where task_key = %? and exec_id = %?", taskID, execID)


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com><!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46258

Problem Summary: When dispatcher fails, the new dispatcher will pick up the running task while not invoking `onNextStage`. In this case, we need to fallback to task table for `taskNodes`.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
