### PR TITLE
test: fix an unit test that is too strict

### DIFF
--- a/br/pkg/lightning/backend/external/split_test.go
+++ b/br/pkg/lightning/backend/external/split_test.go
@@ -69,20 +69,20 @@ notExhausted:
 	lenStatFiles := len(statFiles)
 	require.Equal(t, lenDataFiles, lenStatFiles)
 	require.Greater(t, lenDataFiles, 0)
-	require.Greater(t, len(splitKeys), 0)
-
-	// splitKeys should be strictly increasing
-	for i := 1; i < len(splitKeys); i++ {
-		cmp := bytes.Compare(splitKeys[i], splitKeys[i-1])
-		require.Equal(t, 1, cmp, "splitKeys: %v", splitKeys)
-	}
-	// first splitKeys should be strictly greater than lastEndKey
-	cmp := bytes.Compare(splitKeys[0], lastEndKey)
-	require.Equal(t, 1, cmp, "splitKeys: %v, lastEndKey: %v", splitKeys, lastEndKey)
-	// last splitKeys should be strictly less than endKey
-	if endKey != nil {
-		cmp = bytes.Compare(splitKeys[len(splitKeys)-1], endKey)
-		require.Equal(t, -1, cmp, "splitKeys: %v, endKey: %v", splitKeys, endKey)
+	if len(splitKeys) > 0 {
+		// splitKeys should be strictly increasing
+		for i := 1; i < len(splitKeys); i++ {
+			cmp := bytes.Compare(splitKeys[i], splitKeys[i-1])
+			require.Equal(t, 1, cmp, "splitKeys: %v", splitKeys)
+		}
+		// first splitKeys should be strictly greater than lastEndKey
+		cmp := bytes.Compare(splitKeys[0], lastEndKey)
+		require.Equal(t, 1, cmp, "splitKeys: %v, lastEndKey: %v", splitKeys, lastEndKey)
+		// last splitKeys should be strictly less than endKey
+		if endKey != nil {
+			cmp = bytes.Compare(splitKeys[len(splitKeys)-1], endKey)
+			require.Equal(t, -1, cmp, "splitKeys: %v, endKey: %v", splitKeys, endKey)
+		}
 	}
 
 	lastEndKey = endKey


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46678

Problem Summary:

### What is changed and how it works?

`splitKeys` can be empty.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

manually specify the seed

```
func TestGeneralProperties(t *testing.T) {
	seed := time.Now().Unix()
	rand.Seed(uint64(1693902578))
	t.Logf("seed: %d", seed)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
