### PR TITLE
statistics: avoid frequently calling stats cache when to auto analyze

### DIFF
--- a/executor/test/analyzetest/BUILD.bazel
+++ b/executor/test/analyzetest/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "//sessionctx/variable",
         "//statistics",
         "//statistics/handle",
+        "//statistics/handle/autoanalyze",
         "//store/mockstore",
         "//tablecodec",
         "//testkit",

--- a/executor/test/analyzetest/analyze_test.go
+++ b/executor/test/analyzetest/analyze_test.go
@@ -2180,8 +2180,10 @@ func testKillAutoAnalyze(t *testing.T, ver int) {
 	oriStart := tk.MustQuery("select @@tidb_auto_analyze_start_time").Rows()[0][0].(string)
 	oriEnd := tk.MustQuery("select @@tidb_auto_analyze_end_time").Rows()[0][0].(string)
 	handle.AutoAnalyzeMinCnt = 0
+	autoanalyze.DisableAutoAnalyzeIntervalForTest = true
 	defer func() {
 		handle.AutoAnalyzeMinCnt = 1000
+		autoanalyze.DisableAutoAnalyzeIntervalForTest = false
 		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_start_time='%v'", oriStart))
 		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_end_time='%v'", oriEnd))
 	}()

--- a/executor/test/analyzetest/analyze_test.go
+++ b/executor/test/analyzetest/analyze_test.go
@@ -2266,7 +2266,7 @@ func TestKillAutoAnalyzeIndex(t *testing.T) {
 	handle.AutoAnalyzeMinCnt = 0
 	autoanalyze.DisableAutoAnalyzeIntervalForTest = true
 	defer func() {
-		autoanalyze.DisableAutoAnalyzeIntervalForTest = falseit
+		autoanalyze.DisableAutoAnalyzeIntervalForTest = false
 		handle.AutoAnalyzeMinCnt = 1000
 		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_start_time='%v'", oriStart))
 		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_end_time='%v'", oriEnd))

--- a/executor/test/analyzetest/analyze_test.go
+++ b/executor/test/analyzetest/analyze_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/statistics/handle"
+	"github.com/pingcap/tidb/statistics/handle/autoanalyze"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/testkit"
@@ -2263,7 +2264,9 @@ func TestKillAutoAnalyzeIndex(t *testing.T) {
 	oriStart := tk.MustQuery("select @@tidb_auto_analyze_start_time").Rows()[0][0].(string)
 	oriEnd := tk.MustQuery("select @@tidb_auto_analyze_end_time").Rows()[0][0].(string)
 	handle.AutoAnalyzeMinCnt = 0
+	autoanalyze.DisableAutoAnalyzeIntervalForTest = true
 	defer func() {
+		autoanalyze.DisableAutoAnalyzeIntervalForTest = falseit
 		handle.AutoAnalyzeMinCnt = 1000
 		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_start_time='%v'", oriStart))
 		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_end_time='%v'", oriEnd))

--- a/statistics/handle/BUILD.bazel
+++ b/statistics/handle/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//sessionctx/variable",
         "//sessiontxn",
         "//statistics",
+        "//statistics/handle/autoanalyze",
         "//statistics/handle/cache",
         "//statistics/handle/lockstats",
         "//statistics/handle/metrics",

--- a/statistics/handle/autoanalyze/BUILD.bazel
+++ b/statistics/handle/autoanalyze/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "autoanalyze",
+    srcs = ["auto_analyze.go"],
+    importpath = "github.com/pingcap/tidb/statistics/handle/autoanalyze",
+    visibility = ["//visibility:public"],
+)

--- a/statistics/handle/autoanalyze/auto_analyze.go
+++ b/statistics/handle/autoanalyze/auto_analyze.go
@@ -1,0 +1,68 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autoanalyze
+
+import (
+	"math/rand"
+	"time"
+)
+
+const (
+	// maxAutoAnalyzeInterval is the max interval time for a table's auto analyze.
+	maxAutoAnalyzeInterval = 10 * time.Minute
+	// minAutoAnalyzeInterval is the min interval time for a table's auto analyze.
+	minAutoAnalyzeInterval = 5 * time.Minute
+)
+
+// AutoAnalyze is used to store the recent analyzed tables.
+type AutoAnalyze struct {
+	recentAnalyzedTables map[int64]time.Time // tid -> ts
+}
+
+// NewAutoAnalyze returns a new AutoAnalyze.
+func NewAutoAnalyze() *AutoAnalyze {
+	return &AutoAnalyze{
+		recentAnalyzedTables: make(map[int64]time.Time),
+	}
+}
+
+// AddRecentAnalyzedTables adds a table to the recent analyzed tables.
+func (a *AutoAnalyze) AddRecentAnalyzedTables(tid int64, ts time.Time) {
+	s := rand.Int63n(60 * 5) //nolint:gosec
+	a.recentAnalyzedTables[tid] =
+		ts.Add(minAutoAnalyzeInterval + time.Duration(s)*time.Second)
+}
+
+// IsRecentAnalyzedTables checks whether a table is recently analyzed.
+func (a *AutoAnalyze) IsRecentAnalyzedTables(tid int64) bool {
+	ts, ok := a.recentAnalyzedTables[tid]
+	if time.Since(ts) > maxAutoAnalyzeInterval {
+		delete(a.recentAnalyzedTables, tid)
+		return false
+	}
+	return ok
+}
+
+// GCRecentAnalyzedTables removes the old tables from the recent analyzed tables.
+func (a *AutoAnalyze) GCRecentAnalyzedTables() {
+	if len(a.recentAnalyzedTables) < 1000 {
+		return
+	}
+	for k, ts := range a.recentAnalyzedTables {
+		if time.Since(ts) > maxAutoAnalyzeInterval {
+			delete(a.recentAnalyzedTables, k)
+		}
+	}
+}

--- a/statistics/handle/autoanalyze/auto_analyze.go
+++ b/statistics/handle/autoanalyze/auto_analyze.go
@@ -54,6 +54,9 @@ func (a *AutoAnalyze) IsRecentAnalyzedTables(tid int64) bool {
 		return false
 	}
 	ts, ok := a.recentAnalyzedTables[tid]
+	if !ok {
+		return false
+	}
 	if time.Since(ts) > maxAutoAnalyzeInterval {
 		delete(a.recentAnalyzedTables, tid)
 		return false

--- a/statistics/handle/autoanalyze/auto_analyze.go
+++ b/statistics/handle/autoanalyze/auto_analyze.go
@@ -26,6 +26,9 @@ const (
 	minAutoAnalyzeInterval = 5 * time.Minute
 )
 
+// DisableAutoAnalyzeIntervalForTest is used to disable the auto analyze interval for test.
+var DisableAutoAnalyzeIntervalForTest = false
+
 // AutoAnalyze is used to store the recent analyzed tables.
 type AutoAnalyze struct {
 	recentAnalyzedTables map[int64]time.Time // tid -> ts
@@ -47,6 +50,9 @@ func (a *AutoAnalyze) AddRecentAnalyzedTables(tid int64, ts time.Time) {
 
 // IsRecentAnalyzedTables checks whether a table is recently analyzed.
 func (a *AutoAnalyze) IsRecentAnalyzedTables(tid int64) bool {
+	if DisableAutoAnalyzeIntervalForTest {
+		return false
+	}
 	ts, ok := a.recentAnalyzedTables[tid]
 	if time.Since(ts) > maxAutoAnalyzeInterval {
 		delete(a.recentAnalyzedTables, tid)

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
+	"github.com/pingcap/tidb/statistics/handle/autoanalyze"
 	"github.com/pingcap/tidb/statistics/handle/cache"
 	handle_metrics "github.com/pingcap/tidb/statistics/handle/metrics"
 	"github.com/pingcap/tidb/table"
@@ -120,7 +121,8 @@ type Handle struct {
 		sync.RWMutex
 	}
 
-	lease atomic2.Duration
+	lease       atomic2.Duration
+	autoanalyze *autoanalyze.AutoAnalyze
 }
 
 func (h *Handle) withRestrictedSQLExecutor(ctx context.Context, fn func(context.Context, sqlexec.RestrictedSQLExecutor) ([]chunk.Row, []*ast.ResultField, error)) ([]chunk.Row, []*ast.ResultField, error) {
@@ -211,6 +213,7 @@ func NewHandle(ctx, initStatsCtx sessionctx.Context, lease time.Duration, pool s
 		sysProcTracker:          tracker,
 		autoAnalyzeProcIDGetter: autoAnalyzeProcIDGetter,
 		InitStatsDone:           make(chan struct{}),
+		autoanalyze:             autoanalyze.NewAutoAnalyze(),
 	}
 	handle.initStatsCtx = initStatsCtx
 	handle.lease.Store(lease)

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -63,9 +63,6 @@ const (
 
 // Handle can update stats info periodically.
 type Handle struct {
-	// this gpool is used to reuse goroutine in the mergeGlobalStatsTopN.
-	gpool *gp.Pool
-
 	pool sessionPool
 
 	// initStatsCtx is the ctx only used for initStats
@@ -73,6 +70,9 @@ type Handle struct {
 
 	// sysProcTracker is used to track sys process like analyze
 	sysProcTracker sessionctx.SysProcTracker
+
+	// this gpool is used to reuse goroutine in the mergeGlobalStatsTopN.
+	gpool *gp.Pool
 
 	// autoAnalyzeProcIDGetter is used to generate auto analyze ID.
 	autoAnalyzeProcIDGetter func() uint64
@@ -92,6 +92,8 @@ type Handle struct {
 	// It can be read by multiple readers at the same time without acquiring lock, but it can be
 	// written only after acquiring the lock.
 	statsCache *cache.StatsCachePointer
+
+	autoanalyze *autoanalyze.AutoAnalyze
 
 	// globalMap contains all the delta map from collectors when we dump them to KV.
 	globalMap struct {
@@ -121,8 +123,7 @@ type Handle struct {
 		sync.RWMutex
 	}
 
-	lease       atomic2.Duration
-	autoanalyze *autoanalyze.AutoAnalyze
+	lease atomic2.Duration
 }
 
 func (h *Handle) withRestrictedSQLExecutor(ctx context.Context, fn func(context.Context, sqlexec.RestrictedSQLExecutor) ([]chunk.Row, []*ast.ResultField, error)) ([]chunk.Row, []*ast.ResultField, error) {

--- a/statistics/handle/updatetest/BUILD.bazel
+++ b/statistics/handle/updatetest/BUILD.bazel
@@ -16,6 +16,7 @@ go_test(
         "//sessionctx/variable",
         "//statistics",
         "//statistics/handle",
+        "//statistics/handle/autoanalyze",
         "//statistics/handle/cache",
         "//testkit",
         "//testkit/testsetup",

--- a/statistics/handle/updatetest/update_test.go
+++ b/statistics/handle/updatetest/update_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/statistics/handle"
+	"github.com/pingcap/tidb/statistics/handle/autoanalyze"
 	"github.com/pingcap/tidb/statistics/handle/cache"
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/types"
@@ -1078,8 +1079,10 @@ func TestAutoAnalyzeRatio(t *testing.T) {
 	oriStart := tk.MustQuery("select @@tidb_auto_analyze_start_time").Rows()[0][0].(string)
 	oriEnd := tk.MustQuery("select @@tidb_auto_analyze_end_time").Rows()[0][0].(string)
 	handle.AutoAnalyzeMinCnt = 0
+	autoanalyze.DisableAutoAnalyzeIntervalForTest = true
 	defer func() {
 		handle.AutoAnalyzeMinCnt = 1000
+		autoanalyze.DisableAutoAnalyzeIntervalForTest = false
 		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_start_time='%v'", oriStart))
 		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_end_time='%v'", oriEnd))
 	}()

--- a/statistics/handle/updatetest/update_test.go
+++ b/statistics/handle/updatetest/update_test.go
@@ -358,6 +358,10 @@ func TestUpdatePartition(t *testing.T) {
 func TestAutoUpdate(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	testKit := testkit.NewTestKit(t, store)
+	autoanalyze.DisableAutoAnalyzeIntervalForTest = true
+	defer func() {
+		autoanalyze.DisableAutoAnalyzeIntervalForTest = false
+	}()
 	testkit.WithPruneMode(testKit, variable.Static, func() {
 		testKit.MustExec("use test")
 		testKit.MustExec("create table t (a varchar(20))")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46715

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

before:

<img width="1379" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/86ba11e0-7104-4808-b3f1-2becf515f0e5">

after:


![image](https://github.com/pingcap/tidb/assets/3427324/f69a6b57-0035-4ae8-8065-16729a4dd491)


With the same insertion rate, the new algorithm can reduce the number of "get" invocations.


- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
