### PR TITLE
tests: check `InContainer()` for `TestCPUValue` and `TestGetCgroupCPU()` test cases

### DIFF
--- a/util/cgroup/cgroup_cpu_test.go
+++ b/util/cgroup/cgroup_cpu_test.go
@@ -66,6 +66,11 @@ func checkKernelVersionNewerThan(t *testing.T, major, minor int) bool {
 }
 
 func TestGetCgroupCPU(t *testing.T) {
+	// If it's not in the container,
+	// it will have less files and the test case will fail forever.
+	if !InContainer() {
+		t.Skip("Not in container, skip this test case.")
+	}
 	exit := make(chan struct{})
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {

--- a/util/cpu/BUILD.bazel
+++ b/util/cpu/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "//resourcemanager/scheduler",
         "//resourcemanager/util",
         "//testkit/testsetup",
+        "//util/cgroup",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",

--- a/util/cpu/cpu_test.go
+++ b/util/cpu/cpu_test.go
@@ -27,37 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCPUValue(t *testing.T) {
-	observer := cpu.NewCPUObserver()
-	exit := make(chan struct{})
-	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for {
-				select {
-				case <-exit:
-					return
-				default:
-					runtime.Gosched()
-				}
-			}
-		}()
-	}
-	observer.Start()
-	for n := 0; n < 10; n++ {
-		time.Sleep(1 * time.Second)
-		value, unsupported := cpu.GetCPUUsage()
-		require.False(t, unsupported)
-		require.Greater(t, value, 0.0)
-		require.Less(t, value, 1.0)
-	}
-	observer.Stop()
-	close(exit)
-	wg.Wait()
-}
-
 func TestFailpointCPUValue(t *testing.T) {
 	failpoint.Enable("github.com/pingcap/tidb/util/cgroup/GetCgroupCPUErr", "return(true)")
 	defer func() {
@@ -82,7 +51,7 @@ func TestFailpointCPUValue(t *testing.T) {
 	}
 	observer.Start()
 	for n := 0; n < 10; n++ {
-		time.Sleep(1 * time.Second)
+		time.Sleep(100 * time.Millisecond)
 		value, unsupported := cpu.GetCPUUsage()
 		require.True(t, unsupported)
 		require.Equal(t, value, 0.0)

--- a/util/cpu/cpu_test.go
+++ b/util/cpu/cpu_test.go
@@ -53,7 +53,7 @@ func TestCPUValue(t *testing.T) {
 	}
 	observer.Start()
 	for n := 0; n < 10; n++ {
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 		value, unsupported := cpu.GetCPUUsage()
 		require.False(t, unsupported)
 		require.Greater(t, value, 0.0)
@@ -88,7 +88,7 @@ func TestFailpointCPUValue(t *testing.T) {
 	}
 	observer.Start()
 	for n := 0; n < 10; n++ {
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 		value, unsupported := cpu.GetCPUUsage()
 		require.True(t, unsupported)
 		require.Equal(t, value, 0.0)

--- a/util/cpu/cpu_test.go
+++ b/util/cpu/cpu_test.go
@@ -53,7 +53,7 @@ func TestCPUValue(t *testing.T) {
 	}
 	observer.Start()
 	for n := 0; n < 10; n++ {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(1 * time.Millisecond)
 		value, unsupported := cpu.GetCPUUsage()
 		require.False(t, unsupported)
 		require.Greater(t, value, 0.0)
@@ -88,7 +88,7 @@ func TestFailpointCPUValue(t *testing.T) {
 	}
 	observer.Start()
 	for n := 0; n < 10; n++ {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(1 * time.Millisecond)
 		value, unsupported := cpu.GetCPUUsage()
 		require.True(t, unsupported)
 		require.Equal(t, value, 0.0)

--- a/util/cpu/cpu_test.go
+++ b/util/cpu/cpu_test.go
@@ -29,8 +29,10 @@ import (
 )
 
 func TestCPUValue(t *testing.T) {
+	// If it's not in the container,
+	// it will have less files and the test case will fail forever.
 	if !cgroup.InContainer() {
-		t.Skip()
+		t.Skip("Not in container, skip this test case.")
 	}
 	observer := cpu.NewCPUObserver()
 	exit := make(chan struct{})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary: The `TestCPUValue` test case always fails when execute in local machine without `InContainer() == true`.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
