### PR TITLE
planner: fix incompatible behaviors between prep and non-prep stateme… | tidb-test=pr/2145

### DIFF
--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -1534,6 +1534,19 @@ func TestIssue33067(t *testing.T) {
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 }
 
+func TestIssue42439(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`CREATE TABLE UK_MU16407 (COL3 timestamp NULL DEFAULT NULL, UNIQUE KEY U3(COL3))`)
+	tk.MustExec(`insert into UK_MU16407 values("1985-08-31 18:03:27")`)
+	tk.MustExec(`PREPARE st FROM 'SELECT COL3 FROM UK_MU16407 WHERE COL3>?'`)
+	tk.MustExec(`set @a='2039-1-19 3:14:40'`)
+	tk.MustExec(`execute st using @a`) // no error
+	tk.MustExec(`set @a='1950-1-19 3:14:40'`)
+	tk.MustQuery(`execute st using @a`).Check(testkit.Rows(`1985-08-31 18:03:27`))
+}
+
 func TestIssue29486(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -161,8 +161,8 @@ func convertPoint(sctx sessionctx.Context, point *point, tp *types.FieldType) (*
 	casted, err := point.value.ConvertTo(sc, tp)
 	if err != nil {
 		if sctx.GetSessionVars().StmtCtx.InPreparedPlanBuilding {
-			// do not ignore these errors if in prepared plan building for safety
-			return nil, errors.Trace(err)
+			// skip plan cache in this case for safety.
+			sctx.GetSessionVars().StmtCtx.SetSkipPlanCache(errors.Errorf("%s when converting %v", err.Error(), point.value))
 		}
 		//revive:disable:empty-block
 		if tp.GetType() == mysql.TypeYear && terror.ErrorEqual(err, types.ErrWarnDataOutOfRange) {


### PR DESCRIPTION
This is an manual cherry-pick of #42443

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42439

Problem Summary: planner: fix incompatible behaviors between prep and non-prep statements when converting date/time values

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
