### PR TITLE
variable: make the default value of tidb_shard_allocate_step smaller

### DIFF
--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -1235,7 +1235,7 @@ const (
 	DefTiDBRedactLog                               = false
 	DefTiDBRestrictedReadOnly                      = false
 	DefTiDBSuperReadOnly                           = false
-	DefTiDBShardAllocateStep                       = math.MaxInt64
+	DefTiDBShardAllocateStep                       = 200
 	DefTiDBEnableTelemetry                         = false
 	DefTiDBEnableParallelApply                     = false
 	DefTiDBPartitionPruneMode                      = "dynamic"

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -17,7 +17,6 @@ package variable
 import (
 	"context"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/pingcap/tidb/config"

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -414,6 +414,7 @@ func TestTableFromMeta(t *testing.T) {
 func TestShardRowIDBitsStep(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
+	tk.MustQuery("select @@tidb_shard_allocate_step").Check(testkit.Rows("200"))
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists shard_t;")
 	tk.MustExec("create table shard_t (a int) shard_row_id_bits = 15;")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46745

Problem Summary:

### What is changed and how it works?
Change the default value to 200.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Change the default value of `tidb_shard_allocate_step` to 200 to make it suitable to avoid hotspot of the large transactions.
```
