### PR TITLE
util: memory: fix segfaults in meminfo when VirtualMemory errors

### DIFF
--- a/util/memory/meminfo.go
+++ b/util/memory/meminfo.go
@@ -53,7 +53,7 @@ func MemTotalNormal() (uint64, error) {
 	}
 	v, err := mem.VirtualMemory()
 	if err != nil {
-		return v.Total, err
+		return 0, err
 	}
 	memLimit.set(v.Total, time.Now())
 	return v.Total, nil
@@ -67,7 +67,7 @@ func MemUsedNormal() (uint64, error) {
 	}
 	v, err := mem.VirtualMemory()
 	if err != nil {
-		return v.Used, err
+		return 0, err
 	}
 	memUsage.set(v.Used, time.Now())
 	return v.Used, nil


### PR DESCRIPTION
Issue number: close #46761

Problem Summary:

When VirtualMemory() returns an error, the actual value of `v` is nil, so returning v.Total when err != nil was causing segfaults

### What is changed and how it works?

Simply return 0 when there is an error instead of trying to dereference nil


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test


### Release note

```release-note
util: memory: fix a bad error handling case which could cause a segmentation fault in case of error
```
