### PR TITLE
types, collation: utf8mb4_0900_bin shouldn't have RestoreData

### DIFF
--- a/parser/mysql/charset.go
+++ b/parser/mysql/charset.go
@@ -79,7 +79,7 @@ var CharsetIDs = map[string]uint8{
 }
 
 // Collations maps MySQL collation ID to its name.
-var Collations = map[uint8]string{
+var Collations = map[uint16]string{
 	1:   "big5_chinese_ci",
 	2:   "latin2_czech_cs",
 	3:   "dec8_swedish_ci",
@@ -300,10 +300,11 @@ var Collations = map[uint8]string{
 	246: "utf8mb4_unicode_520_ci",
 	247: "utf8mb4_vietnamese_ci",
 	255: "utf8mb4_0900_ai_ci",
+	309: "utf8mb4_0900_bin",
 }
 
 // CollationNames maps MySQL collation name to its ID
-var CollationNames = map[string]uint8{
+var CollationNames = map[string]uint16{
 	"big5_chinese_ci":          1,
 	"latin2_czech_cs":          2,
 	"dec8_swedish_ci":          3,
@@ -524,6 +525,7 @@ var CollationNames = map[string]uint8{
 	"utf8mb4_unicode_520_ci":   246,
 	"utf8mb4_vietnamese_ci":    247,
 	"utf8mb4_0900_ai_ci":       255,
+	"utf8mb4_0900_bin":         309,
 }
 
 // MySQL collation information.

--- a/server/conn.go
+++ b/server/conn.go
@@ -191,7 +191,10 @@ func (cc *clientConn) SetCtx(ctx *TiDBContext) {
 }
 
 func (cc *clientConn) String() string {
-	collationStr := mysql.Collations[cc.collation]
+	// MySQL converts a collation from u32 to char in the protocol, so the value could be wrong. It works fine for the
+	// default parameters (and libmysql seems not to provide any way to specify the collation other than the default
+	// one), so it's not a big problem.
+	collationStr := mysql.Collations[uint16(cc.collation)]
 	return fmt.Sprintf("id:%d, addr:%s status:%b, collation:%s, user:%s",
 		cc.connectionID, cc.bufReadConn.RemoteAddr(), cc.ctx.Status(), collationStr, cc.user,
 	)

--- a/tests/integrationtest/r/collation_misc_disabled.result
+++ b/tests/integrationtest/r/collation_misc_disabled.result
@@ -118,3 +118,10 @@ binary	binary	63	Yes	Yes	1
 ascii_bin	ascii	65	Yes	Yes	1
 utf8_bin	utf8	83	Yes	Yes	1
 gbk_bin	gbk	87	Yes	Yes	1
+create database if not exists cd_test_utf8mb4_0900_bin;
+use cd_test_utf8mb4_0900_bin;
+create table t (id varchar(255) primary key clustered, a varchar(255) collate utf8mb4_0900_bin, b varchar(255) collate utf8mb4_bin, key idx(a, b));
+insert into t values ("1", "a    ", "a");
+select /*+USE_INDEX(t, idx)*/ * from t;
+id	a	b
+1	a    	a

--- a/tests/integrationtest/r/collation_misc_enabled.result
+++ b/tests/integrationtest/r/collation_misc_enabled.result
@@ -135,3 +135,10 @@ utf8mb4_0900_bin	utf8mb4	309		Yes	1
 utf8mb4_bin	utf8mb4	46	Yes	Yes	1
 utf8mb4_general_ci	utf8mb4	45		Yes	1
 utf8mb4_unicode_ci	utf8mb4	224		Yes	1
+create database if not exists cd_test_utf8mb4_0900_bin;
+use cd_test_utf8mb4_0900_bin;
+create table t (id varchar(255) primary key clustered, a varchar(255) collate utf8mb4_0900_bin, b varchar(255) collate utf8mb4_bin, key idx(a, b));
+insert into t values ("1", "a    ", "a");
+select /*+USE_INDEX(t, idx)*/ * from t;
+id	a	b
+1	a    	a

--- a/tests/integrationtest/t/collation_misc.test
+++ b/tests/integrationtest/t/collation_misc.test
@@ -82,3 +82,10 @@ select * from information_schema.COLLATION_CHARACTER_SET_APPLICABILITY where COL
 # charset
 show charset;
 show collation;
+
+# Issue46690
+create database if not exists cd_test_utf8mb4_0900_bin;
+use cd_test_utf8mb4_0900_bin;
+create table t (id varchar(255) primary key clustered, a varchar(255) collate utf8mb4_0900_bin, b varchar(255) collate utf8mb4_bin, key idx(a, b));
+insert into t values ("1", "a    ", "a");
+select /*+USE_INDEX(t, idx)*/ * from t;

--- a/types/etc.go
+++ b/types/etc.go
@@ -121,7 +121,8 @@ func IsNonBinaryStr(ft *FieldType) bool {
 func NeedRestoredData(ft *FieldType) bool {
 	if collate.NewCollationEnabled() &&
 		IsNonBinaryStr(ft) &&
-		!(collate.IsBinCollation(ft.GetCollate()) && !IsTypeVarchar(ft.GetType())) {
+		(!collate.IsBinCollation(ft.GetCollate()) || IsTypeVarchar(ft.GetType())) &&
+		ft.GetCollate() != "utf8mb4_0900_bin" {
 		return true
 	}
 	return false

--- a/types/etc_test.go
+++ b/types/etc_test.go
@@ -307,3 +307,40 @@ func TestIsTypeNumeric(t *testing.T) {
 	res = IsTypeNumeric('t')
 	require.False(t, res)
 }
+
+func TestNeedRestoredData(t *testing.T) {
+	type testCase struct {
+		tp      byte
+		charset string
+		collate string
+		result  bool
+	}
+	cases := []testCase{
+		{mysql.TypeString, "binary", "binary", false},
+		{mysql.TypeVarString, "binary", "binary", false},
+		{mysql.TypeString, "utf8mb4", "utf8mb4_bin", false},
+		{mysql.TypeVarString, "utf8mb4", "utf8mb4_bin", true},
+		{mysql.TypeString, "utf8mb4", "utf8mb4_general_ci", true},
+		{mysql.TypeVarString, "utf8mb4", "utf8mb4_general_ci", true},
+		{mysql.TypeString, "utf8mb4", "utf8mb4_unicode_ci", true},
+		{mysql.TypeVarString, "utf8mb4", "utf8mb4_unicode_ci", true},
+		{mysql.TypeString, "utf8mb4", "utf8mb4_0900_ai_ci", true},
+		{mysql.TypeVarString, "utf8mb4", "utf8mb4_0900_ai_ci", true},
+		{mysql.TypeString, "utf8mb4", "utf8mb4_0900_bin", false},
+		{mysql.TypeVarString, "utf8mb4", "utf8mb4_0900_bin", false},
+		{mysql.TypeString, "gbk", "gbk_bin", true},
+		{mysql.TypeVarString, "gbk", "gbk_bin", true},
+		{mysql.TypeString, "gbk", "gbk_chinese_ci", true},
+		{mysql.TypeVarString, "gbk", "gbk_chinese_ci", true},
+	}
+
+	for _, c := range cases {
+		ft := NewFieldTypeBuilder().
+			SetType(c.tp).
+			SetCharset(c.charset).
+			SetCollate(c.collate).
+			Build()
+
+		require.Equal(t, c.result, NeedRestoredData(&ft), "NeedRestoredData of tp: %d charset: %s collate: %s should be %t", c.tp, c.charset, c.collate, c.result)
+	}
+}

--- a/util/collate/collate.go
+++ b/util/collate/collate.go
@@ -360,7 +360,8 @@ func ConvertAndGetBinCollation(collate string) Collator {
 func IsBinCollation(collate string) bool {
 	return collate == charset.CollationASCII || collate == charset.CollationLatin1 ||
 		collate == charset.CollationUTF8 || collate == charset.CollationUTF8MB4 ||
-		collate == charset.CollationBin
+		collate == charset.CollationBin || collate == "utf8mb4_0900_bin"
+	// TODO: define a constant to reference collations
 }
 
 // CollationToProto converts collation from string to int32(used by protocol).


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #46690

Problem Summary:

This PR fixed three problems:

1. Add `utf8mb4_0900_bin` to the collation to id map in the `parser/mysql`. Without this field, it'll be converted to `utf8mb4_bin` (the default collation) when it's serialized into protobuf.
2. Fix the `IsBinCollation` for `utf8mb4_0900_bin`.
3. Make sure the `utf8mb4_0900_bin` doesn't need restore.

The composition of these three bugs make the behavior really weird.

1. When writing the index, because `IsBinCollation` is false while `NeedRestoreData` is true, it will write the original data into the index value.
2. When decoding the restore data (in unistore or tikv), the collation is `utf8mb4_bin` (because of the first problem), so it tries to decode an integer from the `RestoreData`, and it'll definitely fail. See the behavior tracked in issue https://github.com/pingcap/tidb/issues/46690

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
None
```
