### PR TITLE
test: add lock to avoid data race

### DIFF
--- a/br/pkg/lightning/backend/local/localhelper_test.go
+++ b/br/pkg/lightning/backend/local/localhelper_test.go
@@ -250,6 +250,8 @@ func (c *testSplitClient) GetOperator(ctx context.Context, regionID uint64) (*pd
 }
 
 func (c *testSplitClient) ScanRegions(ctx context.Context, key, endKey []byte, limit int) ([]*split.RegionInfo, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.hook != nil {
 		key, endKey, limit = c.hook.BeforeScanRegions(ctx, key, endKey, limit)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46783

Problem Summary:

```
WARNING: DATA RACE
Read at 0x00c000ac1f58 by goroutine 144:
  slices.insertionSortCmpFunc[go.shape.*uint8]()
      GOROOT/src/slices/zsortanyfunc.go:12 +0xc4
  slices.pdqsortCmpFunc[go.shape.*uint8]()
      GOROOT/src/slices/zsortanyfunc.go:73 +0x6c8
  slices.SortFunc[go.shape.[]*github.com/pingcap/tidb/store/pdtypes.Region,go.shape.*uint8]()
      GOROOT/src/slices/sort.go:28 +0xc6
  github.com/pingcap/tidb/store/pdtypes.(*RegionTree).ScanRange()
      store/pdtypes/region_tree.go:55 +0x7b
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*testSplitClient).ScanRegions()
      br/pkg/lightning/backend/local/localhelper_test.go:257 +0x1cf
  github.com/pingcap/tidb/br/pkg/restore/split.PaginateScanRegion.func1()
      br/pkg/restore/split/split.go:106 +0x1b6
  github.com/pingcap/tidb/br/pkg/utils.WithRetry.func1()
      br/pkg/utils/retry.go:57 +0x41
  github.com/pingcap/tidb/br/pkg/utils.WithRetryV2[go.shape.struct {}]()
      br/pkg/utils/retry.go:75 +0xe1
  github.com/pingcap/tidb/br/pkg/utils.WithRetry()
      br/pkg/utils/retry.go:56 +0x8c
  github.com/pingcap/tidb/br/pkg/restore/split.PaginateScanRegion()
      br/pkg/restore/split/split.go:101 +0x28f
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).generateJobForRange()
      br/pkg/lightning/backend/local/local.go:1264 +0x2ec
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).generateAndSendJob.func1()
      br/pkg/lightning/backend/local/local.go:1196 +0x1f9
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      external/org_golang_x_sync/errgroup/errgroup.go:75 +0x76

Previous write at 0x00c000ac1f58 by goroutine 145:
  slices.insertionSortCmpFunc[go.shape.*uint8]()
      GOROOT/src/slices/zsortanyfunc.go:13 +0x1ca
  slices.pdqsortCmpFunc[go.shape.*uint8]()
      GOROOT/src/slices/zsortanyfunc.go:73 +0x6c8
  slices.SortFunc[go.shape.[]*github.com/pingcap/tidb/store/pdtypes.Region,go.shape.*uint8]()
      GOROOT/src/slices/sort.go:28 +0xc6
  github.com/pingcap/tidb/store/pdtypes.(*RegionTree).ScanRange()
      store/pdtypes/region_tree.go:55 +0x7b
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*testSplitClient).ScanRegions()
      br/pkg/lightning/backend/local/localhelper_test.go:257 +0x1cf
  github.com/pingcap/tidb/br/pkg/restore/split.PaginateScanRegion.func1()
      br/pkg/restore/split/split.go:106 +0x1b6
  github.com/pingcap/tidb/br/pkg/utils.WithRetry.func1()
      br/pkg/utils/retry.go:57 +0x41
  github.com/pingcap/tidb/br/pkg/utils.WithRetryV2[go.shape.struct {}]()
      br/pkg/utils/retry.go:75 +0xe1
  github.com/pingcap/tidb/br/pkg/utils.WithRetry()
      br/pkg/utils/retry.go:56 +0x8c
  github.com/pingcap/tidb/br/pkg/restore/split.PaginateScanRegion()
      br/pkg/restore/split/split.go:101 +0x28f
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).generateJobForRange()
      br/pkg/lightning/backend/local/local.go:1264 +0x2ec
  github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).generateAndSendJob.func1()
      br/pkg/lightning/backend/local/local.go:1196 +0x1f9
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      external/org_golang_x_sync/errgroup/errgroup.go:75 +0x76
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
