### PR TITLE
sessionctx: add testcase for set_var hint

### DIFF
--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -2536,7 +2536,12 @@ func (s *SessionVars) SetSystemVarWithOldValAsRet(name string, val string) (stri
 	if err != nil {
 		return "", err
 	}
-	oldV := s.systems[sv.Name]
+	// The map s.systems[sv.Name] is lazy initialized. If we directly read it, we might read empty result.
+	// Since this code path is not a hot path, we directly call GetSessionOrGlobalSystemVar to get the value safely.
+	oldV, err := s.GetSessionOrGlobalSystemVar(context.Background(), sv.Name)
+	if err != nil {
+		return "", err
+	}
 	return oldV, sv.SetSessionFromHook(s, val)
 }
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -2536,7 +2536,7 @@ func (s *SessionVars) SetSystemVarWithOldValAsRet(name string, val string) (stri
 	if err != nil {
 		return "", err
 	}
-	oldV := sv.Value
+	oldV := s.systems[sv.Name]
 	return oldV, sv.SetSessionFromHook(s, val)
 }
 

--- a/sessionctx/variable/setvar_test.go
+++ b/sessionctx/variable/setvar_test.go
@@ -152,3 +152,15 @@ func TestSetVarHintBreakCache(t *testing.T) {
 	tk.MustExec("SELECT * FROM t WHERE b < 5 AND a = 2;")
 	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("1"))
 }
+
+func TestSetVarHintWithCurrentValNotDefaultVal(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustQuery("select @@max_execution_time").Check(testkit.Rows("0"))
+	tk.MustExec("set @@max_execution_time=1000")
+	tk.MustQuery("select @@max_execution_time").Check(testkit.Rows("1000"))
+	tk.MustQuery("select /*+ set_var(max_execution_time=100) */ @@max_execution_time").Check(testkit.Rows("100"))
+	// The value is the changed value 1000, not the default value 0.
+	tk.MustQuery("select @@max_execution_time").Check(testkit.Rows("1000"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/45892

Problem Summary:

### What is changed and how it works?

We lost the case that SET_VAR is used after the session var has already changed to a value rather than the default one.
This time, we must restore it to the already changed value, not the default value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
