### PR TITLE
memory: return memory delta from jsonObjectAgg#MergePartialResult

### DIFF
--- a/executor/aggfuncs/func_json_objectagg.go
+++ b/executor/aggfuncs/func_json_objectagg.go
@@ -76,7 +76,6 @@ func (e *jsonObjectAgg) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
-		key = strings.Clone(key)
 
 		if keyIsNull {
 			return 0, types.ErrJSONDocumentNULLKey
@@ -86,6 +85,7 @@ func (e *jsonObjectAgg) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup
 			return 0, types.ErrInvalidJSONCharset.GenWithStackByArgs(e.args[0].GetType().GetCharset())
 		}
 
+		key = strings.Clone(key)
 		value, err := e.args[1].Eval(row)
 		if err != nil {
 			return 0, errors.Trace(err)
@@ -203,5 +203,5 @@ func (*jsonObjectAgg) MergePartialResult(_ sessionctx.Context, src, dst PartialR
 			p2.bInMap++
 		}
 	}
-	return 0, nil
+	return memDelta, nil
 }


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #46806

Problem Summary:
`jsonObjectAgg#MergePartialResult` should return memory delta to the caller.
Currently 0 is always returned.

### What is changed and how it works?
`memDelta` is returned from `jsonObjectAgg#MergePartialResult`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [x] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
