### PR TITLE
partition: fix unstable test TestExchangePartitionStates

### DIFF
--- a/table/tables/test/partition/partition_test.go
+++ b/table/tables/test/partition/partition_test.go
@@ -747,6 +747,8 @@ func TestExchangePartitionStates(t *testing.T) {
 			res := tk4.MustQuery(`admin show ddl jobs where db_name = '` + strings.ToLower(dbName) + `' and table_name = '` + tableName + `' and job_type = 'exchange partition'`).Rows()
 			if len(res) == 1 && res[0][pos] == s {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
+				// Sleep 50ms to wait load InforSchema finish, issue #46815.
+				gotime.Sleep(50 * gotime.Millisecond)
 				break
 			}
 			gotime.Sleep(50 * gotime.Millisecond)

--- a/table/tables/test/partition/partition_test.go
+++ b/table/tables/test/partition/partition_test.go
@@ -846,6 +846,8 @@ func TestAddKeyPartitionStates(t *testing.T) {
 		for {
 			res := tk4.MustQuery(`admin show ddl jobs where db_name = '` + strings.ToLower(dbName) + `' and table_name = 't' and job_type like 'alter table%'`).Rows()
 			if len(res) == 1 && res[0][i] == s {
+				// Sleep 50ms to wait load InforSchema finish.
+				gotime.Sleep(50 * gotime.Millisecond)
 				break
 			}
 			gotime.Sleep(10 * gotime.Millisecond)

--- a/table/tables/test/partition/partition_test.go
+++ b/table/tables/test/partition/partition_test.go
@@ -747,12 +747,12 @@ func TestExchangePartitionStates(t *testing.T) {
 			res := tk4.MustQuery(`admin show ddl jobs where db_name = '` + strings.ToLower(dbName) + `' and table_name = '` + tableName + `' and job_type = 'exchange partition'`).Rows()
 			if len(res) == 1 && res[0][pos] == s {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
-				// Sleep 50ms to wait load InforSchema finish, issue #46815.
-				gotime.Sleep(50 * gotime.Millisecond)
 				break
 			}
 			gotime.Sleep(50 * gotime.Millisecond)
 		}
+		// Sleep 50ms to wait load InforSchema finish, issue #46815.
+		gotime.Sleep(50 * gotime.Millisecond)
 	}
 	waitFor("t", "write only", 4)
 	tk3.MustExec(`BEGIN`)
@@ -846,12 +846,12 @@ func TestAddKeyPartitionStates(t *testing.T) {
 		for {
 			res := tk4.MustQuery(`admin show ddl jobs where db_name = '` + strings.ToLower(dbName) + `' and table_name = 't' and job_type like 'alter table%'`).Rows()
 			if len(res) == 1 && res[0][i] == s {
-				// Sleep 50ms to wait load InforSchema finish.
-				gotime.Sleep(50 * gotime.Millisecond)
 				break
 			}
 			gotime.Sleep(10 * gotime.Millisecond)
 		}
+		// Sleep 50ms to wait load InforSchema finish.
+		gotime.Sleep(50 * gotime.Millisecond)
 	}
 	waitFor(4, "delete only")
 	tk3.MustExec(`BEGIN`)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46815

Problem Summary:

### What is changed and how it works?

Two ways to reproduce the error:
1. run many times, let the competitive occur:
```
$ go test --tags=intest --run="TestExchangePartitionStates" 
```
2.  make the competitive easier to occur: 
```
$ git diff
diff --git a/table/tables/test/partition/partition_test.go b/table/tables/test/partition/partition_test.go
index 2f218db..702a0d1 100644
--- a/table/tables/test/partition/partition_test.go
+++ b/table/tables/test/partition/partition_test.go
@@ -749,7 +749,7 @@ func TestExchangePartitionStates(t *testing.T) {
                                logutil.BgLogger().Info("Got state", zap.String("State", s))
                                break
                        }
-                       gotime.Sleep(50 * gotime.Millisecond)
+                       gotime.Sleep(1 * gotime.Millisecond)
                }
        }
        waitFor("t", "write only", 4)

$ go test --tags=intest --run="TestExchangePartitionStates" 

```


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
