### PR TITLE
planner, stats: clean the called of Index.CheckStats

### DIFF
--- a/planner/cardinality/row_count_index.go
+++ b/planner/cardinality/row_count_index.go
@@ -209,7 +209,6 @@ func isSingleColIdxNullRange(idx *statistics.Index, ran *ranger.Range) bool {
 
 // It uses the modifyCount to adjust the influence of modifications on the table.
 func getIndexRowCountForStatsV2(sctx sessionctx.Context, idx *statistics.Index, coll *statistics.HistColl, indexRanges []*ranger.Range, realtimeRowCount, modifyCount int64) (float64, error) {
-	idx.CheckStats()
 	sc := sctx.GetSessionVars().StmtCtx
 	debugTrace := sc.EnableOptimizerDebugTrace
 	if debugTrace {

--- a/statistics/index.go
+++ b/statistics/index.go
@@ -121,7 +121,6 @@ func (idx *Index) String() string {
 
 // TotalRowCount returns the total count of this index.
 func (idx *Index) TotalRowCount() float64 {
-	idx.CheckStats()
 	if idx.StatsVer >= Version2 {
 		return idx.Histogram.TotalRowCount() + float64(idx.TopN.TotalCount())
 	}
@@ -183,7 +182,6 @@ func (idx *Index) MemoryUsage() CacheItemMemoryUsage {
 // QueryBytes is used to query the count of specified bytes.
 // The input sctx is just for debug trace, you can pass nil safely if that's not needed.
 func (idx *Index) QueryBytes(sctx sessionctx.Context, d []byte) (result uint64) {
-	idx.CheckStats()
 	if sctx != nil && sctx.GetSessionVars().StmtCtx.EnableOptimizerDebugTrace {
 		debugtrace.EnterContextCommon(sctx)
 		defer func() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/46867

Problem Summary:

### What is changed and how it works?

We will change the codes of the stats' async load since we want to reduce the persistent memory objects of statistics.

The entrance of the index's async load is very messy. This PR reduces the entrance to only one.

All other entrances will be called after the `GetRowCountByIndexRanges`'s `IsInvalid` checking.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
