### PR TITLE
test: fix rand.Read will generate same key

### DIFF
--- a/br/pkg/lightning/backend/external/split_test.go
+++ b/br/pkg/lightning/backend/external/split_test.go
@@ -42,10 +42,14 @@ func TestGeneralProperties(t *testing.T) {
 	for i := range keys {
 		keyLen := rand.Intn(100) + 1
 		valueLen := rand.Intn(100) + 1
-		keys[i] = make([]byte, keyLen)
-		values[i] = make([]byte, valueLen)
-		rand.Read(keys[i])
-		rand.Read(values[i])
+		keys[i] = make([]byte, keyLen+2)
+		values[i] = make([]byte, valueLen+2)
+		rand.Read(keys[i][:keyLen])
+		rand.Read(values[i][:valueLen])
+		keys[i][keyLen] = byte(i / 255)
+		keys[i][keyLen+1] = byte(i % 255)
+		values[i][valueLen] = byte(i / 255)
+		values[i][valueLen+1] = byte(i % 255)
 	}
 
 	dataFiles, statFiles, err := MockExternalEngine(memStore, keys, values)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46869

Problem Summary:

### What is changed and how it works?

as title

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
