### PR TITLE
statistics: add pool in the buildBucket4Merging to reuse datum

### DIFF
--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -128,8 +128,8 @@ func (hg *Histogram) GetLower(idx int) *types.Datum {
 	return &d
 }
 
-// GetLowerToDatum gets the lower bound of bucket `idx` to datum.
-func (hg *Histogram) GetLowerToDatum(idx int, d *types.Datum) {
+// LowerToDatum gets the lower bound of bucket `idx` to datum.
+func (hg *Histogram) LowerToDatum(idx int, d *types.Datum) {
 	hg.Bounds.GetRow(2*idx).DatumWithBuffer(0, hg.Tp, d)
 }
 
@@ -139,8 +139,8 @@ func (hg *Histogram) GetUpper(idx int) *types.Datum {
 	return &d
 }
 
-// GetUpperToDatum gets the upper bound of bucket `idx` to datum.
-func (hg *Histogram) GetUpperToDatum(idx int, d *types.Datum) {
+// UpperToDatum gets the upper bound of bucket `idx` to datum.
+func (hg *Histogram) UpperToDatum(idx int, d *types.Datum) {
 	hg.Bounds.GetRow(2*idx).DatumWithBuffer(0, hg.Tp, d)
 }
 
@@ -1151,8 +1151,8 @@ func (hg *Histogram) buildBucket4Merging() []*bucket4Merging {
 	buckets := make([]*bucket4Merging, 0, hg.Len())
 	for i := 0; i < hg.Len(); i++ {
 		b := newbucket4MergingForRecycle()
-		hg.GetLowerToDatum(i, b.lower)
-		hg.GetUpperToDatum(i, b.upper)
+		hg.LowerToDatum(i, b.lower)
+		hg.UpperToDatum(i, b.upper)
 		b.Repeat = hg.Buckets[i].Repeat
 		b.NDV = hg.Buckets[i].NDV
 		b.Count = hg.Buckets[i].Count

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -101,12 +101,6 @@ type scalar struct {
 // EmptyScalarSize is the size of empty scalar.
 const EmptyScalarSize = int64(unsafe.Sizeof(scalar{}))
 
-var datumPool = sync.Pool{
-	New: func() any {
-		return &types.Datum{}
-	},
-}
-
 // NewHistogram creates a new histogram.
 func NewHistogram(id, ndv, nullCount int64, version uint64, tp *types.FieldType, bucketSize int, totColSize int64) *Histogram {
 	if tp.EvalType() == types.ETString {
@@ -134,9 +128,9 @@ func (hg *Histogram) GetLower(idx int) *types.Datum {
 	return &d
 }
 
-// GetLowerFromPool gets the lower bound of bucket `idx` from pool.
-func (hg *Histogram) GetLowerFromPool(idx int) *types.Datum {
-	return hg.Bounds.GetRowDatumFromPool(2*idx, 0, hg.Tp, &datumPool)
+// GetLowerToDatum gets the lower bound of bucket `idx` to datum.
+func (hg *Histogram) GetLowerToDatum(idx int, d *types.Datum) {
+	hg.Bounds.GetRow(2*idx).DatumWithBuffer(0, hg.Tp, d)
 }
 
 // GetUpper gets the upper bound of bucket `idx`.
@@ -145,9 +139,9 @@ func (hg *Histogram) GetUpper(idx int) *types.Datum {
 	return &d
 }
 
-// GetUpperFromPool gets the upper bound of bucket `idx` from pool.
-func (hg *Histogram) GetUpperFromPool(idx int) *types.Datum {
-	return hg.Bounds.GetRowDatumFromPool(2*idx+1, 0, hg.Tp, &datumPool)
+// GetUpperToDatum gets the upper bound of bucket `idx` to datum.
+func (hg *Histogram) GetUpperToDatum(idx int, d *types.Datum) {
+	hg.Bounds.GetRow(2*idx).DatumWithBuffer(0, hg.Tp, d)
 }
 
 // MemoryUsage returns the total memory usage of this Histogram.
@@ -1157,12 +1151,8 @@ func (hg *Histogram) buildBucket4Merging() []*bucket4Merging {
 	buckets := make([]*bucket4Merging, 0, hg.Len())
 	for i := 0; i < hg.Len(); i++ {
 		b := newbucket4MergingForRecycle()
-		lower := hg.GetLowerFromPool(i)
-		lower.Copy(b.lower)
-		datumPool.Put(lower)
-		upper := hg.GetUpperFromPool(i)
-		upper.Copy(b.upper)
-		datumPool.Put(upper)
+		hg.GetLowerToDatum(i, b.lower)
+		hg.GetUpperToDatum(i, b.upper)
 		b.Repeat = hg.Buckets[i].Repeat
 		b.NDV = hg.Buckets[i].NDV
 		b.Count = hg.Buckets[i].Count
@@ -1532,7 +1522,6 @@ func MergePartitionHist2GlobalHist(sc *stmtctx.StatementContext, hists []*Histog
 		}
 		globalHist.AppendBucketWithNDV(bucket.lower, bucket.upper, bucket.Count, bucket.Repeat, bucket.NDV)
 	}
-	datumPool.Put(minValue)
 	return globalHist, nil
 }
 

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -141,7 +141,7 @@ func (hg *Histogram) GetUpper(idx int) *types.Datum {
 
 // UpperToDatum gets the upper bound of bucket `idx` to datum.
 func (hg *Histogram) UpperToDatum(idx int, d *types.Datum) {
-	hg.Bounds.GetRow(2*idx).DatumWithBuffer(0, hg.Tp, d)
+	hg.Bounds.GetRow(2*idx+1).DatumWithBuffer(0, hg.Tp, d)
 }
 
 // MemoryUsage returns the total memory usage of this Histogram.

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -375,7 +375,7 @@ func (c *Chunk) GetRowDatumFromPool(
 	pool *sync.Pool) *types.Datum {
 	r := c.GetRow(idx)
 	d := pool.Get().(*types.Datum)
-	r.GetDatumWithBuffer(colIdx, tp, d)
+	r.DatumWithBuffer(colIdx, tp, d)
 	return d
 }
 

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -15,7 +15,6 @@
 package chunk
 
 import (
-	"sync"
 	"unsafe"
 
 	"github.com/pingcap/errors"
@@ -366,17 +365,6 @@ func (c *Chunk) GetRow(idx int) Row {
 		return Row{c: c, idx: c.sel[idx]}
 	}
 	return Row{c: c, idx: idx}
-}
-
-// GetRowDatumFromPool gets the Row in the chunk with the row index.
-func (c *Chunk) GetRowDatumFromPool(
-	idx int, colIdx int,
-	tp *types.FieldType,
-	pool *sync.Pool) *types.Datum {
-	r := c.GetRow(idx)
-	d := pool.Get().(*types.Datum)
-	r.DatumWithBuffer(colIdx, tp, d)
-	return d
 }
 
 // AppendRow appends a row to the chunk.

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -15,6 +15,7 @@
 package chunk
 
 import (
+	"sync"
 	"unsafe"
 
 	"github.com/pingcap/errors"
@@ -365,6 +366,17 @@ func (c *Chunk) GetRow(idx int) Row {
 		return Row{c: c, idx: c.sel[idx]}
 	}
 	return Row{c: c, idx: idx}
+}
+
+// GetRowDatumFromPool gets the Row in the chunk with the row index.
+func (c *Chunk) GetRowDatumFromPool(
+	idx int, colIdx int,
+	tp *types.FieldType,
+	pool *sync.Pool) *types.Datum {
+	r := c.GetRow(idx)
+	d := pool.Get().(*types.Datum)
+	r.GetDatumWithBuffer(colIdx, tp, d)
+	return d
 }
 
 // AppendRow appends a row to the chunk.

--- a/util/chunk/row.go
+++ b/util/chunk/row.go
@@ -122,7 +122,7 @@ func (r Row) GetDatumRow(fields []*types.FieldType) []types.Datum {
 // GetDatumRowWithBuffer gets datum using the buffer datumRow.
 func (r Row) GetDatumRowWithBuffer(fields []*types.FieldType, datumRow []types.Datum) []types.Datum {
 	for colIdx := 0; colIdx < len(datumRow); colIdx++ {
-		r.GetDatumWithBuffer(colIdx, fields[colIdx], &datumRow[colIdx])
+		r.DatumWithBuffer(colIdx, fields[colIdx], &datumRow[colIdx])
 	}
 	return datumRow
 }
@@ -130,12 +130,12 @@ func (r Row) GetDatumRowWithBuffer(fields []*types.FieldType, datumRow []types.D
 // GetDatum implements the chunk.Row interface.
 func (r Row) GetDatum(colIdx int, tp *types.FieldType) types.Datum {
 	var d types.Datum
-	r.GetDatumWithBuffer(colIdx, tp, &d)
+	r.DatumWithBuffer(colIdx, tp, &d)
 	return d
 }
 
-// GetDatumWithBuffer gets datum using the buffer d.
-func (r Row) GetDatumWithBuffer(colIdx int, tp *types.FieldType, d *types.Datum) {
+// DatumWithBuffer gets datum using the buffer d.
+func (r Row) DatumWithBuffer(colIdx int, tp *types.FieldType, d *types.Datum) {
 	switch tp.GetType() {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 		if !r.IsNull(colIdx) {
@@ -205,7 +205,6 @@ func (r Row) GetDatumWithBuffer(colIdx int, tp *types.FieldType, d *types.Datum)
 	if r.IsNull(colIdx) {
 		d.SetNull()
 	}
-	return
 }
 
 // GetRaw returns the underlying raw bytes with the colIdx.

--- a/util/chunk/row.go
+++ b/util/chunk/row.go
@@ -135,7 +135,7 @@ func (r Row) GetDatum(colIdx int, tp *types.FieldType) types.Datum {
 }
 
 // GetDatumWithBuffer gets datum using the buffer d.
-func (r Row) GetDatumWithBuffer(colIdx int, tp *types.FieldType, d *types.Datum) types.Datum {
+func (r Row) GetDatumWithBuffer(colIdx int, tp *types.FieldType, d *types.Datum) {
 	switch tp.GetType() {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 		if !r.IsNull(colIdx) {
@@ -205,7 +205,7 @@ func (r Row) GetDatumWithBuffer(colIdx int, tp *types.FieldType, d *types.Datum)
 	if r.IsNull(colIdx) {
 		d.SetNull()
 	}
-	return *d
+	return
 }
 
 // GetRaw returns the underlying raw bytes with the colIdx.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46804

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)


before: 

```
$  go test -run=^$ -bench=BenchmarkMergePartitionHist2GlobalHist -benchmem github.com/pingcap/tidb/statistics  

goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/statistics
BenchmarkMergePartitionHist2GlobalHist/Size1000-8                     14          75695795 ns/op        45846930 B/op     782037 allocs/op
BenchmarkMergePartitionHist2GlobalHist/Size10000-8                     1        1669962708 ns/op        601507720 B/op  10201122 allocs/op
BenchmarkMergePartitionHist2GlobalHist/Size100000-8                    1        24380916125 ns/op       5989421424 B/op 101480169 allocs/op
PASS
ok      github.com/pingcap/tidb/statistics      30.015s
```

after:

```
$ go test -run=^$ -bench=BenchmarkMergePartitionHist2GlobalHist -benchmem github.com/pingcap/tidb/statistics
goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/statistics
BenchmarkMergePartitionHist2GlobalHist/Size1000-8                     21          50100944 ns/op        26460268 B/op     381136 allocs/op
BenchmarkMergePartitionHist2GlobalHist/Size10000-8                     1        1330470875 ns/op        406708560 B/op   6142843 allocs/op
BenchmarkMergePartitionHist2GlobalHist/Size100000-8                    1        24889564666 ns/op       4066911992 B/op 61428000 allocs/op
PASS
ok      github.com/pingcap/tidb/statistics      30.540s


```


- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
