### PR TITLE
planner: update binding's original_sql when upgrading

### DIFF
--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -136,9 +136,9 @@ func (h *BindHandle) Reset(ctx sessionctx.Context) {
 func (h *BindHandle) Update(fullLoad bool) (err error) {
 	h.bindInfo.Lock()
 	lastUpdateTime := h.bindInfo.lastUpdateTime
-	timeCondition := fmt.Sprintf("WHERE update_time>'%s'", lastUpdateTime.String())
-	if fullLoad {
-		timeCondition = ""
+	var timeCondition string
+	if !fullLoad {
+		timeCondition = fmt.Sprintf("WHERE update_time>'%s'", lastUpdateTime.String())
 	}
 
 	exec := h.sctx.Context.(sqlexec.RestrictedSQLExecutor)

--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -136,9 +136,9 @@ func (h *BindHandle) Reset(ctx sessionctx.Context) {
 func (h *BindHandle) Update(fullLoad bool) (err error) {
 	h.bindInfo.Lock()
 	lastUpdateTime := h.bindInfo.lastUpdateTime
-	updateTime := lastUpdateTime.String()
+	timeCondition := fmt.Sprintf("WHERE update_time>'%s'", lastUpdateTime.String())
 	if fullLoad {
-		updateTime = "0000-00-00 00:00:00"
+		timeCondition = ""
 	}
 
 	exec := h.sctx.Context.(sqlexec.RestrictedSQLExecutor)
@@ -146,8 +146,10 @@ func (h *BindHandle) Update(fullLoad bool) (err error) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBindInfo)
 	// No need to acquire the session context lock for ExecRestrictedSQL, it
 	// uses another background session.
-	rows, _, err := exec.ExecRestrictedSQL(ctx, nil, `SELECT original_sql, bind_sql, default_db, status, create_time, update_time, charset, collation, source, sql_digest, plan_digest
-	FROM mysql.bind_info WHERE update_time > %? ORDER BY update_time, create_time`, updateTime)
+	selectStmt := fmt.Sprintf(`SELECT original_sql, bind_sql, default_db, status, create_time,
+       update_time, charset, collation, source, sql_digest, plan_digest FROM mysql.bind_info
+       %s ORDER BY update_time, create_time`, timeCondition)
+	rows, _, err := exec.ExecRestrictedSQL(ctx, nil, selectStmt)
 
 	if err != nil {
 		h.bindInfo.Unlock()

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -2782,14 +2782,11 @@ func upgradeToVer175(s Session, ver int64) {
 			if originalNormalizedSQL == newNormalizedSQL {
 				continue // no need to update
 			}
-			_, err = s.ExecuteInternal(ctx, fmt.Sprintf("UPDATE mysql.bind_info SET original_sql='%s' WHERE original_sql='%s'", newNormalizedSQL, originalNormalizedSQL))
-			if err != nil {
-				logutil.BgLogger().Fatal("upgradeToVer175 error", zap.Error(err))
-				return
-			}
+			mustExecute(s, fmt.Sprintf("UPDATE mysql.bind_info SET original_sql='%s' WHERE original_sql='%s'", newNormalizedSQL, originalNormalizedSQL))
 		}
 		req.Reset()
 	}
+	rs.Close()
 }
 
 func writeOOMAction(s Session) {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -984,11 +984,15 @@ const (
 	//   add column `step`, `error`; delete unique key; and add key idx_state_update_time
 	//   to `mysql.tidb_background_subtask_history`.
 	version174 = 174
+
+	// version 175
+	//   update normalized bindings of `in (?)` to `in (...)` to solve #44298.
+	version175 = 175
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version173
+var currentBootstrapVersion int64 = version175
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1131,6 +1135,7 @@ var (
 		upgradeToVer172,
 		upgradeToVer173,
 		upgradeToVer174,
+		upgradeToVer175,
 	}
 )
 
@@ -2735,6 +2740,55 @@ func upgradeToVer174(s Session, ver int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_background_subtask_history DROP INDEX `namespace`", dbterror.ErrCantDropFieldOrKey)
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_background_subtask_history ADD INDEX `idx_task_key`(`task_key`)", dbterror.ErrDupKeyName)
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_background_subtask_history ADD INDEX `idx_state_update_time`(`state_update_time`)", dbterror.ErrDupKeyName)
+}
+
+func upgradeToVer175(s Session, ver int64) {
+	if ver >= version175 {
+		return
+	}
+	// update normalized bindings of `in (?)` to `in (...)` to solve the issue #44298 that
+	//  bindings for `in (?)` can't work for `in (?, ?, ?)`.
+	// after this update, multiple bindings may have the same `original_sql`, but it's OK.
+
+	var err error
+	mustExecute(s, "BEGIN PESSIMISTIC")
+	defer func() {
+		if err != nil {
+			mustExecute(s, "ROLLBACK")
+			return
+		}
+		mustExecute(s, "COMMIT")
+	}()
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
+	rs, err := s.ExecuteInternal(ctx, "SELECT original_sql, bind_sql FROM mysql.bind_info WHERE source != 'builtin'")
+	if err != nil {
+		logutil.BgLogger().Fatal("upgradeToVer175 error", zap.Error(err))
+		return
+	}
+	req := rs.NewChunk(nil)
+	for {
+		err = rs.Next(ctx, req)
+		if err != nil {
+			logutil.BgLogger().Fatal("upgradeToVer175 error", zap.Error(err))
+			return
+		}
+		if req.NumRows() == 0 {
+			break
+		}
+		for i := 0; i < req.NumRows(); i++ {
+			originalNormalizedSQL, bindSQL := req.GetRow(i).GetString(0), req.GetRow(i).GetString(1)
+			newNormalizedSQL := parser.NormalizeForBinding(bindSQL)
+			// update `in (?)` to `in (...)`
+			if originalNormalizedSQL == newNormalizedSQL {
+				continue // no need to update
+			}
+			_, err = s.ExecuteInternal(ctx, fmt.Sprintf("UPDATE mysql.bind_info SET original_sql='%s' WHERE original_sql='%s'", newNormalizedSQL, originalNormalizedSQL))
+			if err != nil {
+				return
+			}
+		}
+		req.Reset()
+	}
 }
 
 func writeOOMAction(s Session) {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -2784,6 +2784,7 @@ func upgradeToVer175(s Session, ver int64) {
 			}
 			_, err = s.ExecuteInternal(ctx, fmt.Sprintf("UPDATE mysql.bind_info SET original_sql='%s' WHERE original_sql='%s'", newNormalizedSQL, originalNormalizedSQL))
 			if err != nil {
+				logutil.BgLogger().Fatal("upgradeToVer175 error", zap.Error(err))
 				return
 			}
 		}

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
@@ -2237,4 +2238,82 @@ func TestTiDBUpgradeToVer170(t *testing.T) {
 	require.NoError(t, err)
 	require.Less(t, int64(ver169), ver)
 	dom.Close()
+}
+
+func TestTiDBBindingInListToVer175(t *testing.T) {
+	ctx := context.Background()
+	store, _ := CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	// bootstrap as version174
+	ver174 := version174
+	seV174 := CreateSessionAndSetID(t, store)
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMeta(txn)
+	err = m.FinishBootstrap(int64(ver174))
+	require.NoError(t, err)
+	MustExec(t, seV174, fmt.Sprintf("update mysql.tidb set variable_value=%d where variable_name='tidb_server_version'", ver174))
+	err = txn.Commit(context.Background())
+	require.NoError(t, err)
+	unsetStoreBootstrapped(store.UUID())
+
+	// create some bindings at version174
+	MustExec(t, seV174, "use test")
+	MustExec(t, seV174, "create table t (a int, b int, c int, key(c))")
+	MustExec(t, seV174, "insert into mysql.bind_info values ('select * from `test` . `t` where `a` in ( ... )', 'SELECT /*+ use_index(`t` `c`)*/ * FROM `test`.`t` WHERE `a` IN (1,2,3)', 'test', 'enabled', '2023-09-13 14:41:38.319', '2023-09-13 14:41:35.319', 'utf8', 'utf8_general_ci', 'manual', '', '')")
+	MustExec(t, seV174, "insert into mysql.bind_info values ('select * from `test` . `t` where `a` in ( ? )', 'SELECT /*+ use_index(`t` `c`)*/ * FROM `test`.`t` WHERE `a` IN (1)', 'test', 'enabled', '2023-09-13 14:41:38.319', '2023-09-13 14:41:36.319', 'utf8', 'utf8_general_ci', 'manual', '', '')")
+	MustExec(t, seV174, "insert into mysql.bind_info values ('select * from `test` . `t` where `a` in ( ? ) and `b` in ( ... )', 'SELECT /*+ use_index(`t` `c`)*/ * FROM `test`.`t` WHERE `a` IN (1) AND `b` IN (1,2,3)', 'test', 'enabled', '2023-09-13 14:41:37.319', '2023-09-13 14:41:38.319', 'utf8', 'utf8_general_ci', 'manual', '', '')")
+
+	showBindings := func(s Session) (records []string) {
+		MustExec(t, s, "admin reload bindings")
+		res := MustExecToRecodeSet(t, s, "show global bindings")
+		chk := res.NewChunk(nil)
+		for {
+			require.NoError(t, res.Next(ctx, chk))
+			if chk.NumRows() == 0 {
+				break
+			}
+			for i := 0; i < chk.NumRows(); i++ {
+				originalSQL := chk.GetRow(i).GetString(0)
+				bindSQL := chk.GetRow(i).GetString(1)
+				records = append(records, fmt.Sprintf("%s:%s", bindSQL, originalSQL))
+			}
+		}
+		sort.Strings(records)
+		return
+	}
+	bindings := showBindings(seV174)
+	// on ver174, `in (1)` and `in (1,2,3)` have different normalized results: `in (?)` and `in (...)`
+	require.Equal(t, []string{"SELECT /*+ use_index(`t` `c`)*/ * FROM `test`.`t` WHERE `a` IN (1) AND `b` IN (1,2,3):select * from `test` . `t` where `a` in ( ? ) and `b` in ( ... )",
+		"SELECT /*+ use_index(`t` `c`)*/ * FROM `test`.`t` WHERE `a` IN (1):select * from `test` . `t` where `a` in ( ? )",
+		"SELECT /*+ use_index(`t` `c`)*/ * FROM `test`.`t` WHERE `a` IN (1,2,3):select * from `test` . `t` where `a` in ( ... )"}, bindings)
+
+	// upgrade to ver175
+	domCurVer, err := BootstrapSession(store)
+	require.NoError(t, err)
+	defer domCurVer.Close()
+	seCurVer := CreateSessionAndSetID(t, store)
+	ver, err := getBootstrapVersion(seCurVer)
+	require.NoError(t, err)
+	require.Equal(t, currentBootstrapVersion, ver)
+
+	// `in (?)` becomes to `in ( ... )`
+	bindings = showBindings(seCurVer)
+	require.Equal(t, []string{"SELECT /*+ use_index(`t` `c`)*/ * FROM `test`.`t` WHERE `a` IN (1) AND `b` IN (1,2,3):select * from `test` . `t` where `a` in ( ... ) and `b` in ( ... )",
+		"SELECT /*+ use_index(`t` `c`)*/ * FROM `test`.`t` WHERE `a` IN (1):select * from `test` . `t` where `a` in ( ... )"}, bindings)
+
+	planFromBinding := func(s Session, q string) {
+		MustExec(t, s, q)
+		res := MustExecToRecodeSet(t, s, "select @@last_plan_from_binding")
+		chk := res.NewChunk(nil)
+		require.NoError(t, res.Next(ctx, chk))
+		require.Equal(t, int64(1), chk.GetRow(0).GetInt64(0))
+	}
+	planFromBinding(seCurVer, "select * from test.t where a in (1)")
+	planFromBinding(seCurVer, "select * from test.t where a in (1,2,3)")
+	planFromBinding(seCurVer, "select * from test.t where a in (1,2,3,4,5,6,7)")
+	planFromBinding(seCurVer, "select * from test.t where a in (1,2,3,4,5,6,7) and b in(1)")
+	planFromBinding(seCurVer, "select * from test.t where a in (1,2,3,4,5,6,7) and b in(1,2,3,4)")
+	planFromBinding(seCurVer, "select * from test.t where a in (7) and b in(1,2,3,4)")
 }

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -2248,6 +2248,7 @@ func TestTiDBBindingInListToVer175(t *testing.T) {
 	// bootstrap as version174
 	ver174 := version174
 	seV174 := CreateSessionAndSetID(t, store)
+	defer seV174.Close()
 	txn, err := store.Begin()
 	require.NoError(t, err)
 	m := meta.NewMeta(txn)
@@ -2280,6 +2281,7 @@ func TestTiDBBindingInListToVer175(t *testing.T) {
 				records = append(records, fmt.Sprintf("%s:%s", bindSQL, originalSQL))
 			}
 		}
+		require.NoError(t, res.Close())
 		sort.Strings(records)
 		return
 	}
@@ -2294,6 +2296,7 @@ func TestTiDBBindingInListToVer175(t *testing.T) {
 	require.NoError(t, err)
 	defer domCurVer.Close()
 	seCurVer := CreateSessionAndSetID(t, store)
+	defer seCurVer.Close()
 	ver, err := getBootstrapVersion(seCurVer)
 	require.NoError(t, err)
 	require.Equal(t, currentBootstrapVersion, ver)
@@ -2309,6 +2312,7 @@ func TestTiDBBindingInListToVer175(t *testing.T) {
 		chk := res.NewChunk(nil)
 		require.NoError(t, res.Next(ctx, chk))
 		require.Equal(t, int64(1), chk.GetRow(0).GetInt64(0))
+		require.NoError(t, res.Close())
 	}
 	planFromBinding(seCurVer, "select * from test.t where a in (1)")
 	planFromBinding(seCurVer, "select * from test.t where a in (1,2,3)")

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -2248,7 +2248,6 @@ func TestTiDBBindingInListToVer175(t *testing.T) {
 	// bootstrap as version174
 	ver174 := version174
 	seV174 := CreateSessionAndSetID(t, store)
-	defer seV174.Close()
 	txn, err := store.Begin()
 	require.NoError(t, err)
 	m := meta.NewMeta(txn)
@@ -2296,7 +2295,6 @@ func TestTiDBBindingInListToVer175(t *testing.T) {
 	require.NoError(t, err)
 	defer domCurVer.Close()
 	seCurVer := CreateSessionAndSetID(t, store)
-	defer seCurVer.Close()
 	ver, err := getBootstrapVersion(seCurVer)
 	require.NoError(t, err)
 	require.Equal(t, currentBootstrapVersion, ver)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #44298

Problem Summary: planner: update binding's original_sql when upgrading

### What is changed and how it works?

Following https://github.com/pingcap/tidb/pull/46896, update binding's original_sql when upgrading to make it compatible.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
