### PR TITLE
planner: refactor to make `colStatsUsageMap` thread-safe

### DIFF
--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -99,10 +99,7 @@ type Handle struct {
 	}
 
 	// colMap contains all the column stats usage information from collectors when we dump them to KV.
-	colMap struct {
-		data colStatsUsageMap
-		sync.Mutex
-	}
+	colMap *colStatsUsageMap
 
 	// StatsLoad is used to load stats concurrently
 	StatsLoad StatsLoad
@@ -188,9 +185,7 @@ func (h *Handle) Clear() {
 	h.globalMap.Lock()
 	h.globalMap.data = make(tableDeltaMap)
 	h.globalMap.Unlock()
-	h.colMap.Lock()
-	h.colMap.data = make(colStatsUsageMap)
-	h.colMap.Unlock()
+	h.colMap.reset()
 	h.mu.Unlock()
 }
 
@@ -221,7 +216,7 @@ func NewHandle(ctx, initStatsCtx sessionctx.Context, lease time.Duration, pool s
 	}
 	handle.statsCache = statsCache
 	handle.globalMap.data = make(tableDeltaMap)
-	handle.colMap.data = make(colStatsUsageMap)
+	handle.colMap = newColStatsUsageMap()
 	handle.StatsLoad.SubCtxs = make([]sessionctx.Context, cfg.Performance.StatsLoadConcurrency)
 	handle.StatsLoad.NeededItemsCh = make(chan *NeededItemTask, cfg.Performance.StatsLoadQueueSize)
 	handle.StatsLoad.TimeoutItemsCh = make(chan *NeededItemTask, cfg.Performance.StatsLoadQueueSize)

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -99,7 +99,7 @@ type Handle struct {
 	}
 
 	// colMap contains all the column stats usage information from collectors when we dump them to KV.
-	colMap *colStatsUsageMap
+	colMap *statsUsage
 
 	// StatsLoad is used to load stats concurrently
 	StatsLoad StatsLoad

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -216,7 +216,7 @@ func NewHandle(ctx, initStatsCtx sessionctx.Context, lease time.Duration, pool s
 	}
 	handle.statsCache = statsCache
 	handle.globalMap.data = make(tableDeltaMap)
-	handle.colMap = newColStatsUsageMap()
+	handle.colMap = newStatsUsage()
 	handle.StatsLoad.SubCtxs = make([]sessionctx.Context, cfg.Performance.StatsLoadConcurrency)
 	handle.StatsLoad.NeededItemsCh = make(chan *NeededItemTask, cfg.Performance.StatsLoadQueueSize)
 	handle.StatsLoad.TimeoutItemsCh = make(chan *NeededItemTask, cfg.Performance.StatsLoadQueueSize)

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -71,7 +71,7 @@ type statsUsage struct {
 	lock  sync.RWMutex
 }
 
-func newColStatsUsageMap() *statsUsage {
+func newStatsUsage() *statsUsage {
 	return &statsUsage{
 		usage: make(map[model.TableItemID]time.Time),
 	}
@@ -125,7 +125,7 @@ type SessionStatsCollector struct {
 func NewSessionStatsCollector() *SessionStatsCollector {
 	return &SessionStatsCollector{
 		mapper: make(tableDeltaMap),
-		colMap: newColStatsUsageMap(),
+		colMap: newStatsUsage(),
 	}
 }
 
@@ -148,7 +148,7 @@ func (s *SessionStatsCollector) ClearForTest() {
 	s.Lock()
 	defer s.Unlock()
 	s.mapper = make(tableDeltaMap)
-	s.colMap = newColStatsUsageMap()
+	s.colMap = newStatsUsage()
 	s.next = nil
 	s.deleted = false
 }
@@ -167,7 +167,7 @@ func (h *Handle) NewSessionStatsCollector() *SessionStatsCollector {
 	newCollector := &SessionStatsCollector{
 		mapper: make(tableDeltaMap),
 		next:   h.listHead.next,
-		colMap: newColStatsUsageMap(),
+		colMap: newStatsUsage(),
 	}
 	h.listHead.next = newCollector
 	return newCollector
@@ -377,7 +377,7 @@ const (
 // and remove closed session's collector.
 func (h *Handle) sweepList() {
 	deltaMap := make(tableDeltaMap)
-	colMap := newColStatsUsageMap()
+	colMap := newStatsUsage()
 	prev := h.listHead
 	prev.Lock()
 	for curr := prev.next; curr != nil; curr = curr.next {

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -92,6 +92,9 @@ func (m *statsUsage) getUsageAndReset() map[model.TableItemID]time.Time {
 }
 
 func (m *statsUsage) merge(other map[model.TableItemID]time.Time) {
+	if len(other) == 0 {
+		return
+	}
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	for id, t := range other {

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -67,8 +67,8 @@ func (m tableDeltaMap) merge(deltaMap tableDeltaMap) {
 
 // statsUsage maps (tableID, columnID) to the last time when the column stats are used(needed).
 type statsUsage struct {
-	lock  sync.RWMutex
 	usage map[model.TableItemID]time.Time
+	lock  sync.RWMutex
 }
 
 func newColStatsUsageMap() *statsUsage {

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -66,27 +66,51 @@ func (m tableDeltaMap) merge(deltaMap tableDeltaMap) {
 }
 
 // colStatsUsageMap maps (tableID, columnID) to the last time when the column stats are used(needed).
-type colStatsUsageMap map[model.TableItemID]time.Time
+type colStatsUsageMap struct {
+	lock  sync.RWMutex
+	usage map[model.TableItemID]time.Time
+}
 
-func (m colStatsUsageMap) merge(other colStatsUsageMap) {
+func newColStatsUsageMap() *colStatsUsageMap {
+	return &colStatsUsageMap{
+		usage: make(map[model.TableItemID]time.Time),
+	}
+}
+
+func (m *colStatsUsageMap) reset() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.usage = make(map[model.TableItemID]time.Time)
+}
+
+func (m *colStatsUsageMap) getUsageAndReset() map[model.TableItemID]time.Time {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	ret := m.usage
+	m.usage = make(map[model.TableItemID]time.Time)
+	return ret
+}
+
+func (m *colStatsUsageMap) merge(other map[model.TableItemID]time.Time) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	for id, t := range other {
-		if mt, ok := m[id]; !ok || mt.Before(t) {
-			m[id] = t
+		if mt, ok := m.usage[id]; !ok || mt.Before(t) {
+			m.usage[id] = t
 		}
 	}
 }
 
-func merge(s *SessionStatsCollector, deltaMap tableDeltaMap, colMap colStatsUsageMap) {
+func merge(s *SessionStatsCollector, deltaMap tableDeltaMap, colMap *colStatsUsageMap) {
 	deltaMap.merge(s.mapper)
 	s.mapper = make(tableDeltaMap)
-	colMap.merge(s.colMap)
-	s.colMap = make(colStatsUsageMap)
+	colMap.merge(s.colMap.getUsageAndReset())
 }
 
 // SessionStatsCollector is a list item that holds the delta mapper. If you want to write or read mapper, you must lock it.
 type SessionStatsCollector struct {
 	mapper tableDeltaMap
-	colMap colStatsUsageMap
+	colMap *colStatsUsageMap
 	next   *SessionStatsCollector
 	sync.Mutex
 
@@ -98,7 +122,7 @@ type SessionStatsCollector struct {
 func NewSessionStatsCollector() *SessionStatsCollector {
 	return &SessionStatsCollector{
 		mapper: make(tableDeltaMap),
-		colMap: make(colStatsUsageMap),
+		colMap: newColStatsUsageMap(),
 	}
 }
 
@@ -121,13 +145,13 @@ func (s *SessionStatsCollector) ClearForTest() {
 	s.Lock()
 	defer s.Unlock()
 	s.mapper = make(tableDeltaMap)
-	s.colMap = make(colStatsUsageMap)
+	s.colMap = newColStatsUsageMap()
 	s.next = nil
 	s.deleted = false
 }
 
 // UpdateColStatsUsage updates the last time when the column stats are used(needed).
-func (s *SessionStatsCollector) UpdateColStatsUsage(colMap colStatsUsageMap) {
+func (s *SessionStatsCollector) UpdateColStatsUsage(colMap map[model.TableItemID]time.Time) {
 	s.Lock()
 	defer s.Unlock()
 	s.colMap.merge(colMap)
@@ -140,7 +164,7 @@ func (h *Handle) NewSessionStatsCollector() *SessionStatsCollector {
 	newCollector := &SessionStatsCollector{
 		mapper: make(tableDeltaMap),
 		next:   h.listHead.next,
-		colMap: make(colStatsUsageMap),
+		colMap: newColStatsUsageMap(),
 	}
 	h.listHead.next = newCollector
 	return newCollector
@@ -350,7 +374,7 @@ const (
 // and remove closed session's collector.
 func (h *Handle) sweepList() {
 	deltaMap := make(tableDeltaMap)
-	colMap := make(colStatsUsageMap)
+	colMap := newColStatsUsageMap()
 	prev := h.listHead
 	prev.Lock()
 	for curr := prev.next; curr != nil; curr = curr.next {
@@ -371,9 +395,7 @@ func (h *Handle) sweepList() {
 	h.globalMap.Lock()
 	h.globalMap.data.merge(deltaMap)
 	h.globalMap.Unlock()
-	h.colMap.Lock()
-	h.colMap.data.merge(colMap)
-	h.colMap.Unlock()
+	h.colMap.merge(colMap.getUsageAndReset())
 }
 
 // DumpStatsDeltaToKV sweeps the whole list and updates the global map, then we dumps every table that held in map to KV.
@@ -526,14 +548,9 @@ func (h *Handle) DumpColStatsUsageToKV() error {
 		return nil
 	}
 	h.sweepList()
-	h.colMap.Lock()
-	colMap := h.colMap.data
-	h.colMap.data = make(colStatsUsageMap)
-	h.colMap.Unlock()
+	colMap := h.colMap.getUsageAndReset()
 	defer func() {
-		h.colMap.Lock()
-		h.colMap.data.merge(colMap)
-		h.colMap.Unlock()
+		h.colMap.merge(colMap)
 	}()
 	type pair struct {
 		lastUsedAt string


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46905

Problem Summary: planner: refactor to make `colStatsUsageMap` thread-safe

### What is changed and how it works?

No logical change, just refactor, create a separate structure for `colStatsUsage`, and hide the lock in it to make it thread-safe.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
