### PR TITLE
ttl: fix potential go leak for ttl in test

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -995,7 +995,7 @@ func (do *Domain) Close() {
 	}
 	ttlJobManager := do.ttlJobManager.Load()
 	if ttlJobManager != nil {
-		logutil.BgLogger().Info("stop ttlJobManager")
+		logutil.BgLogger().Info("stopping ttlJobManager")
 		ttlJobManager.Stop()
 		err := ttlJobManager.WaitStopped(context.Background(), func() time.Duration {
 			if intest.InTest {

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -995,6 +995,7 @@ func (do *Domain) Close() {
 	}
 	ttlJobManager := do.ttlJobManager.Load()
 	if ttlJobManager != nil {
+		logutil.BgLogger().Info("stop ttlJobManager")
 		ttlJobManager.Stop()
 		err := ttlJobManager.WaitStopped(context.Background(), func() time.Duration {
 			if intest.InTest {
@@ -1004,6 +1005,8 @@ func (do *Domain) Close() {
 		}())
 		if err != nil {
 			logutil.BgLogger().Warn("fail to wait until the ttl job manager stop", zap.Error(err))
+		} else {
+			logutil.BgLogger().Info("ttlJobManager exited.")
 		}
 	}
 	do.releaseServerID(context.Background())
@@ -2915,17 +2918,9 @@ func (do *Domain) serverIDKeeper() {
 
 // StartTTLJobManager creates and starts the ttl job manager
 func (do *Domain) StartTTLJobManager() {
-	do.wg.Run(func() {
-		defer func() {
-			logutil.BgLogger().Info("ttlJobManager exited.")
-		}()
-
-		ttlJobManager := ttlworker.NewJobManager(do.ddl.GetID(), do.sysSessionPool, do.store, do.etcdClient, do.ddl.OwnerManager().IsOwner)
-		do.ttlJobManager.Store(ttlJobManager)
-		ttlJobManager.Start()
-
-		<-do.exit
-	}, "ttlJobManager")
+	ttlJobManager := ttlworker.NewJobManager(do.ddl.GetID(), do.sysSessionPool, do.store, do.etcdClient, do.ddl.OwnerManager().IsOwner)
+	do.ttlJobManager.Store(ttlJobManager)
+	ttlJobManager.Start()
 }
 
 // TTLJobManager returns the ttl job manager on this domain


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46948

### What is changed and how it works?

In the previous code, the ttlJobManager is created and started in a background goroutine:

https://github.com/pingcap/tidb/blob/a7e3176f30e0dff6d993eda0ddd1b64776ad98f6/domain/domain.go#L2917-L2929

It has a probability that if a test runs very fast and `domain.Close` will be called before `do.ttlJobManager.Store(ttlJobManager) `. The ttlJobManager will not stop anymore.

In this PR, we just move ttlJobManager's create and start out of the goroutine.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
