### PR TITLE
planner: EXPLAIN will make SET_VAR not SQL level

### DIFF
--- a/executor/bind.go
+++ b/executor/bind.go
@@ -136,6 +136,10 @@ func (e *SQLBindExec) createSQLBind() error {
 	// is necessary to avoid 'create binding' been recorded as 'explain'.
 	saveStmtCtx := e.Ctx().GetSessionVars().StmtCtx
 	defer func() {
+		// But we need to restore the SET_VAR's setting.
+		for name, val := range e.Ctx().GetSessionVars().StmtCtx.SetVarHintRestore {
+			saveStmtCtx.AddSetVarHintRestore(name, val)
+		}
 		e.Ctx().GetSessionVars().StmtCtx = saveStmtCtx
 	}()
 

--- a/planner/core/plan_test.go
+++ b/planner/core/plan_test.go
@@ -439,7 +439,6 @@ func TestNthPlanHint(t *testing.T) {
 	tk.MustQuery("explain format='hint' select /*+ nth_plan(1) nth_plan(2) */ * from t where a=1 and b=1").Check(testkit.Rows(
 		"use_index(@`sel_1` `test`.`t` `a_2`), no_order_index(@`sel_1` `test`.`t` `a_2`), nth_plan(1), nth_plan(2)"))
 	tk.MustQuery("show warnings").Check(testkit.Rows(
-		"Warning 1105 NTH_PLAN() is defined more than once, only the last definition takes effect: NTH_PLAN(2)",
 		"Warning 1105 NTH_PLAN() is defined more than once, only the last definition takes effect: NTH_PLAN(2)"))
 
 	// Test the correctness of generated plans.

--- a/sessionctx/variable/setvar_test.go
+++ b/sessionctx/variable/setvar_test.go
@@ -130,6 +130,10 @@ func TestSetVarNonStringOrEnum(t *testing.T) {
 	tk2.MustQuery("select /*+ set_var(max_execution_time=100) */ @@max_execution_time").Check(testkit.Rows("100"))
 	// The value is the changed value 2000, not the default value 0 or the global value 1000.
 	tk2.MustQuery("select @@max_execution_time").Check(testkit.Rows("2000"))
+
+	tk2.MustExec("explain analyze select /*+ set_var(max_execution_time=100) */ @@max_execution_time")
+	// The value is the changed value 2000, not the default value 0 or the global value 1000.
+	tk2.MustQuery("select @@max_execution_time").Check(testkit.Rows("2000"))
 }
 
 func TestSetVarStringOrEnum(t *testing.T) {

--- a/sessionctx/variable/setvar_test.go
+++ b/sessionctx/variable/setvar_test.go
@@ -134,6 +134,14 @@ func TestSetVarNonStringOrEnum(t *testing.T) {
 	tk2.MustExec("explain analyze select /*+ set_var(max_execution_time=100) */ @@max_execution_time")
 	// The value is the changed value 2000, not the default value 0 or the global value 1000.
 	tk2.MustQuery("select @@max_execution_time").Check(testkit.Rows("2000"))
+
+	tk2.MustExec("use test")
+	tk2.MustExec("create table t(a int)")
+	tk2.MustExec("create global binding for select * from t where a = 1 and sleep(0.1) using select /*+ SET_VAR(max_execution_time=500) */ * from t where a = 1 and sleep(0.1)")
+	tk2.MustQuery("select @@max_execution_time").Check(testkit.Rows("2000"))
+	tk2.MustQuery("select * from t where a = 1 and sleep(0.1)").Check(testkit.Rows())
+	tk2.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
+	tk2.MustQuery("select @@max_execution_time").Check(testkit.Rows("2000"))
 }
 
 func TestSetVarStringOrEnum(t *testing.T) {

--- a/util/hint/hint_processor.go
+++ b/util/hint/hint_processor.go
@@ -89,8 +89,6 @@ func ExtractTableHintsFromStmtNode(node ast.Node, sctx sessionctx.Context) []*as
 		// check duplicated hints
 		checkInsertStmtHintDuplicated(node, sctx)
 		return x.TableHints
-	case *ast.ExplainStmt:
-		return ExtractTableHintsFromStmtNode(x.Stmt, sctx)
 	default:
 		return nil
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46958, close #46888

Problem Summary:

### What is changed and how it works?

The explain stmt will enter the Optimize twice. Make the func `AddSetVarHintRestore` add the already changed value into the restore map.
![image](https://github.com/pingcap/tidb/assets/7846227/6e9a3992-506f-48f3-bd08-061b1932f63c)


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
