### PR TITLE
make async commit configurable (example pr)

### DIFF
--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -75,6 +75,7 @@ const (
 	defaultChecksumTableConcurrency   = 2
 	defaultTableConcurrency           = 6
 	defaultIndexConcurrency           = 2
+	defaultEnableAsyncCommit          = "ON"
 
 	// defaultMetaSchemaName is the default database name used to store lightning metadata
 	defaultMetaSchemaName     = "lightning_metadata"
@@ -134,6 +135,7 @@ type DBStore struct {
 	BuildStatsConcurrency      int               `toml:"build-stats-concurrency" json:"build-stats-concurrency"`
 	IndexSerialScanConcurrency int               `toml:"index-serial-scan-concurrency" json:"index-serial-scan-concurrency"`
 	ChecksumTableConcurrency   int               `toml:"checksum-table-concurrency" json:"checksum-table-concurrency"`
+	EnableAsyncCommit          string            `toml:"enable-async-commit" json:"enable-async-commit"`
 	Vars                       map[string]string `toml:"-" json:"vars"`
 
 	IOTotalBytes *atomic.Uint64 `toml:"-" json:"-"`
@@ -788,6 +790,7 @@ func NewConfig() *Config {
 			DistSQLScanConcurrency:     defaultDistSQLScanConcurrency,
 			IndexSerialScanConcurrency: defaultIndexSerialScanConcurrency,
 			ChecksumTableConcurrency:   defaultChecksumTableConcurrency,
+			EnableAsyncCommit:          defaultEnableAsyncCommit,
 		},
 		Cron: Cron{
 			SwitchMode:     Duration{Duration: 5 * time.Minute},
@@ -1129,6 +1132,9 @@ func (cfg *Config) DefaultVarsForImporterAndLocalBackend() {
 	}
 	if cfg.TiDB.ChecksumTableConcurrency == 0 {
 		cfg.TiDB.ChecksumTableConcurrency = defaultChecksumTableConcurrency
+	}
+	if len(cfg.TiDB.EnableAsyncCommit) == 0 {
+		cfg.TiDB.EnableAsyncCommit = defaultEnableAsyncCommit
 	}
 }
 

--- a/br/pkg/lightning/restore/tidb.go
+++ b/br/pkg/lightning/restore/tidb.go
@@ -87,6 +87,7 @@ func DBFromConfig(ctx context.Context, dsn config.DBStore) (*sql.DB, error) {
 		"tidb_distsql_scan_concurrency":      strconv.Itoa(dsn.DistSQLScanConcurrency),
 		"tidb_index_serial_scan_concurrency": strconv.Itoa(dsn.IndexSerialScanConcurrency),
 		"tidb_checksum_table_concurrency":    strconv.Itoa(dsn.ChecksumTableConcurrency),
+		"tidb_enable_async_commit":           dsn.EnableAsyncCommit,
 
 		// after https://github.com/pingcap/tidb/pull/17102 merge,
 		// we need set session to true for insert auto_random value in TiDB Backend


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

this is an example pr to demonstrate my idea. Will add more detail and test later

during our test on stale read on tidb, we find out that there's unbalance read traffic to some of the tikv nodes. During our investigation, we find out that i's async_commit will cause the lagging of `resolved_ts`. Before we make stale read more stable, I'm looking for adding an option in lightning to disable the async_commit

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
