### PR TITLE
planner: refactor to make `tableStatsDelta` thread-safe

### DIFF
--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -92,7 +92,7 @@ type Handle struct {
 	// written only after acquiring the lock.
 	statsCache *cache.StatsCachePointer
 
-	// globalMap contains all the delta map from collectors when we dump them to KV.
+	// tableDelta contains all the delta map from collectors when we dump them to KV.
 	tableDelta *tableDelta
 
 	// statsUsage contains all the column stats usage information from collectors when we dump them to KV.

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -93,13 +93,10 @@ type Handle struct {
 	statsCache *cache.StatsCachePointer
 
 	// globalMap contains all the delta map from collectors when we dump them to KV.
-	globalMap struct {
-		data tableDeltaMap
-		sync.Mutex
-	}
+	tableDelta *tableDelta
 
-	// colMap contains all the column stats usage information from collectors when we dump them to KV.
-	colMap *statsUsage
+	// statsUsage contains all the column stats usage information from collectors when we dump them to KV.
+	statsUsage *statsUsage
 
 	// StatsLoad is used to load stats concurrently
 	StatsLoad StatsLoad
@@ -182,10 +179,8 @@ func (h *Handle) Clear() {
 	h.mu.ctx.GetSessionVars().EnableChunkRPC = false
 	h.mu.ctx.GetSessionVars().SetProjectionConcurrency(0)
 	h.listHead.ClearForTest()
-	h.globalMap.Lock()
-	h.globalMap.data = make(tableDeltaMap)
-	h.globalMap.Unlock()
-	h.colMap.reset()
+	h.tableDelta = newTableDelta()
+	h.statsUsage.reset()
 	h.mu.Unlock()
 }
 
@@ -215,8 +210,8 @@ func NewHandle(ctx, initStatsCtx sessionctx.Context, lease time.Duration, pool s
 		return nil, err
 	}
 	handle.statsCache = statsCache
-	handle.globalMap.data = make(tableDeltaMap)
-	handle.colMap = newStatsUsage()
+	handle.tableDelta = newTableDelta()
+	handle.statsUsage = newStatsUsage()
 	handle.StatsLoad.SubCtxs = make([]sessionctx.Context, cfg.Performance.StatsLoadConcurrency)
 	handle.StatsLoad.NeededItemsCh = make(chan *NeededItemTask, cfg.Performance.StatsLoadQueueSize)
 	handle.StatsLoad.TimeoutItemsCh = make(chan *NeededItemTask, cfg.Performance.StatsLoadQueueSize)

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -179,7 +179,7 @@ func (h *Handle) Clear() {
 	h.mu.ctx.GetSessionVars().EnableChunkRPC = false
 	h.mu.ctx.GetSessionVars().SetProjectionConcurrency(0)
 	h.listHead.ClearForTest()
-	h.tableDelta = newTableDelta()
+	h.tableDelta.reset()
 	h.statsUsage.reset()
 	h.mu.Unlock()
 }

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -55,6 +55,12 @@ func newTableDelta() *tableDelta {
 	}
 }
 
+func (m *tableDelta) reset() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.delta = make(map[int64]variable.TableDelta)
+}
+
 func (m *tableDelta) getAndReset() map[int64]variable.TableDelta {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -61,7 +61,7 @@ func (m *tableDelta) reset() {
 	m.delta = make(map[int64]variable.TableDelta)
 }
 
-func (m *tableDelta) getAndReset() map[int64]variable.TableDelta {
+func (m *tableDelta) getDeltaAndReset() map[int64]variable.TableDelta {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	ret := m.delta
@@ -139,7 +139,7 @@ func (m *statsUsage) merge(other map[model.TableItemID]time.Time) {
 }
 
 func merge(s *SessionStatsCollector, deltaMap *tableDelta, colMap *statsUsage) {
-	deltaMap.merge(s.mapper.getAndReset())
+	deltaMap.merge(s.mapper.getDeltaAndReset())
 	colMap.merge(s.statsUsage.getUsageAndReset())
 }
 
@@ -428,7 +428,7 @@ func (h *Handle) sweepList() {
 		}
 	}
 	prev.Unlock()
-	h.tableDelta.merge(deltaMap.getAndReset())
+	h.tableDelta.merge(deltaMap.getDeltaAndReset())
 	h.statsUsage.merge(colMap.getUsageAndReset())
 }
 
@@ -436,7 +436,7 @@ func (h *Handle) sweepList() {
 // If the mode is `DumpDelta`, it will only dump that delta info that `Modify Count / Table Count` greater than a ratio.
 func (h *Handle) DumpStatsDeltaToKV(mode dumpMode) error {
 	h.sweepList()
-	deltaMap := h.tableDelta.getAndReset()
+	deltaMap := h.tableDelta.getDeltaAndReset()
 	defer func() {
 		h.tableDelta.merge(deltaMap)
 	}()

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -97,7 +97,7 @@ func (m *tableDelta) merge(deltaMap map[int64]variable.TableDelta) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	for id, item := range deltaMap {
-		m.update(id, item.Delta, item.Count, &item.ColSize)
+		updateTableDeltaMap(m.delta, id, item.Delta, item.Count, &item.ColSize)
 	}
 }
 

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -42,9 +42,34 @@ import (
 	"go.uber.org/zap"
 )
 
-type tableDeltaMap map[int64]variable.TableDelta
+// tableDelta is used to collect tables' change information.
+// All methods of it are thread-safe.
+type tableDelta struct {
+	delta map[int64]variable.TableDelta // map[tableID]delta
+	lock  sync.Mutex
+}
 
-func (m tableDeltaMap) update(id int64, delta int64, count int64, colSize *map[int64]int64) {
+func newTableDelta() *tableDelta {
+	return &tableDelta{
+		delta: make(map[int64]variable.TableDelta),
+	}
+}
+
+func (m *tableDelta) getAndReset() map[int64]variable.TableDelta {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	ret := m.delta
+	m.delta = make(map[int64]variable.TableDelta)
+	return ret
+}
+
+func (m *tableDelta) update(id int64, delta int64, count int64, colSize *map[int64]int64) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	updateTableDeltaMap(m.delta, id, delta, count, colSize)
+}
+
+func updateTableDeltaMap(m map[int64]variable.TableDelta, id int64, delta int64, count int64, colSize *map[int64]int64) {
 	item := m[id]
 	item.Delta += delta
 	item.Count += count
@@ -59,13 +84,16 @@ func (m tableDeltaMap) update(id int64, delta int64, count int64, colSize *map[i
 	m[id] = item
 }
 
-func (m tableDeltaMap) merge(deltaMap tableDeltaMap) {
+func (m *tableDelta) merge(deltaMap map[int64]variable.TableDelta) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	for id, item := range deltaMap {
 		m.update(id, item.Delta, item.Count, &item.ColSize)
 	}
 }
 
 // statsUsage maps (tableID, columnID) to the last time when the column stats are used(needed).
+// All methods of it are thread-safe.
 type statsUsage struct {
 	usage map[model.TableItemID]time.Time
 	lock  sync.RWMutex
@@ -104,15 +132,14 @@ func (m *statsUsage) merge(other map[model.TableItemID]time.Time) {
 	}
 }
 
-func merge(s *SessionStatsCollector, deltaMap tableDeltaMap, colMap *statsUsage) {
-	deltaMap.merge(s.mapper)
-	s.mapper = make(tableDeltaMap)
+func merge(s *SessionStatsCollector, deltaMap *tableDelta, colMap *statsUsage) {
+	deltaMap.merge(s.mapper.getAndReset())
 	colMap.merge(s.statsUsage.getUsageAndReset())
 }
 
 // SessionStatsCollector is a list item that holds the delta mapper. If you want to write or read mapper, you must lock it.
 type SessionStatsCollector struct {
-	mapper     tableDeltaMap
+	mapper     *tableDelta
 	statsUsage *statsUsage
 	next       *SessionStatsCollector
 	sync.Mutex
@@ -124,7 +151,7 @@ type SessionStatsCollector struct {
 // NewSessionStatsCollector initializes a new SessionStatsCollector.
 func NewSessionStatsCollector() *SessionStatsCollector {
 	return &SessionStatsCollector{
-		mapper:     make(tableDeltaMap),
+		mapper:     newTableDelta(),
 		statsUsage: newStatsUsage(),
 	}
 }
@@ -147,7 +174,7 @@ func (s *SessionStatsCollector) Update(id int64, delta int64, count int64, colSi
 func (s *SessionStatsCollector) ClearForTest() {
 	s.Lock()
 	defer s.Unlock()
-	s.mapper = make(tableDeltaMap)
+	s.mapper = newTableDelta()
 	s.statsUsage = newStatsUsage()
 	s.next = nil
 	s.deleted = false
@@ -165,7 +192,7 @@ func (h *Handle) NewSessionStatsCollector() *SessionStatsCollector {
 	h.listHead.Lock()
 	defer h.listHead.Unlock()
 	newCollector := &SessionStatsCollector{
-		mapper:     make(tableDeltaMap),
+		mapper:     newTableDelta(),
 		next:       h.listHead.next,
 		statsUsage: newStatsUsage(),
 	}
@@ -376,7 +403,7 @@ const (
 // sweepList will loop over the list, merge each session's local stats into handle
 // and remove closed session's collector.
 func (h *Handle) sweepList() {
-	deltaMap := make(tableDeltaMap)
+	deltaMap := newTableDelta()
 	colMap := newStatsUsage()
 	prev := h.listHead
 	prev.Lock()
@@ -395,25 +422,17 @@ func (h *Handle) sweepList() {
 		}
 	}
 	prev.Unlock()
-	h.globalMap.Lock()
-	h.globalMap.data.merge(deltaMap)
-	h.globalMap.Unlock()
-	h.colMap.merge(colMap.getUsageAndReset())
+	h.tableDelta.merge(deltaMap.getAndReset())
+	h.statsUsage.merge(colMap.getUsageAndReset())
 }
 
 // DumpStatsDeltaToKV sweeps the whole list and updates the global map, then we dumps every table that held in map to KV.
 // If the mode is `DumpDelta`, it will only dump that delta info that `Modify Count / Table Count` greater than a ratio.
 func (h *Handle) DumpStatsDeltaToKV(mode dumpMode) error {
 	h.sweepList()
-	h.globalMap.Lock()
-	deltaMap := h.globalMap.data
-	h.globalMap.data = make(tableDeltaMap)
-	h.globalMap.Unlock()
+	deltaMap := h.tableDelta.getAndReset()
 	defer func() {
-		h.globalMap.Lock()
-		deltaMap.merge(h.globalMap.data)
-		h.globalMap.data = deltaMap
-		h.globalMap.Unlock()
+		h.tableDelta.merge(deltaMap)
 	}()
 	// TODO: pass in do.InfoSchema() to DumpStatsDeltaToKV.
 	is := func() infoschema.InfoSchema {
@@ -431,7 +450,7 @@ func (h *Handle) DumpStatsDeltaToKV(mode dumpMode) error {
 			return errors.Trace(err)
 		}
 		if updated {
-			deltaMap.update(id, -item.Delta, -item.Count, nil)
+			updateTableDeltaMap(deltaMap, id, -item.Delta, -item.Count, nil)
 		}
 		if err = h.dumpTableStatColSizeToKV(id, item); err != nil {
 			delete(deltaMap, id)
@@ -551,9 +570,9 @@ func (h *Handle) DumpColStatsUsageToKV() error {
 		return nil
 	}
 	h.sweepList()
-	colMap := h.colMap.getUsageAndReset()
+	colMap := h.statsUsage.getUsageAndReset()
 	defer func() {
-		h.colMap.merge(colMap)
+		h.statsUsage.merge(colMap)
 	}()
 	type pair struct {
 		lastUsedAt string

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -91,6 +91,9 @@ func updateTableDeltaMap(m map[int64]variable.TableDelta, id int64, delta int64,
 }
 
 func (m *tableDelta) merge(deltaMap map[int64]variable.TableDelta) {
+	if len(deltaMap) == 0 {
+		return
+	}
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	for id, item := range deltaMap {

--- a/statistics/handle/update_list_test.go
+++ b/statistics/handle/update_list_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestInsertAndDelete(t *testing.T) {
 	h := Handle{
-		listHead: &SessionStatsCollector{mapper: make(tableDelta)},
+		listHead: &SessionStatsCollector{mapper: newTableDelta()},
 	}
 	var items []*SessionStatsCollector
 	for i := 0; i < 5; i++ {

--- a/statistics/handle/update_list_test.go
+++ b/statistics/handle/update_list_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestInsertAndDelete(t *testing.T) {
 	h := Handle{
-		listHead: &SessionStatsCollector{mapper: make(tableDeltaMap)},
+		listHead: &SessionStatsCollector{mapper: make(tableDelta)},
 	}
 	var items []*SessionStatsCollector
 	for i := 0; i < 5; i++ {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46905

Problem Summary: planner: refactor to make tableStatsDelta thread-safe

### What is changed and how it works?

No logical change, just refactor

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
