### PR TITLE
lightning: allow configure the SQL-statement-length for logical mode

### DIFF
--- a/br/pkg/lightning/importer/import.go
+++ b/br/pkg/lightning/importer/import.go
@@ -343,7 +343,7 @@ func NewImportControllerWithPauser(
 	switch cfg.TikvImporter.Backend {
 	case config.BackendTiDB:
 		encodingBuilder = tidb.NewEncodingBuilder()
-		backendObj = tidb.NewTiDBBackend(ctx, db, cfg.Conflict, errorMgr)
+		backendObj = tidb.NewTiDBBackend(ctx, db, cfg.Conflict, errorMgr, int(cfg.TikvImporter.SQLStatementLength))
 	case config.BackendLocal:
 		var rLimit local.RlimT
 		rLimit, err = local.GetSystemRLimit()

--- a/br/tests/lightning_tidb_duplicate_data/error.toml
+++ b/br/tests/lightning_tidb_duplicate_data/error.toml
@@ -1,3 +1,4 @@
 [tikv-importer]
 backend = "tidb"
 on-duplicate = "error"
+sql-statement-length = 1

--- a/br/tests/lightning_tidb_duplicate_data/ignore.toml
+++ b/br/tests/lightning_tidb_duplicate_data/ignore.toml
@@ -1,3 +1,4 @@
 [tikv-importer]
 backend = "tidb"
 on-duplicate = "ignore"
+sql-statement-length = 1

--- a/br/tests/lightning_tidb_duplicate_data/replace.toml
+++ b/br/tests/lightning_tidb_duplicate_data/replace.toml
@@ -1,3 +1,4 @@
 [tikv-importer]
 backend = "tidb"
 on-duplicate = "replace"
+sql-statement-length = 1

--- a/br/tidb-lightning.toml
+++ b/br/tidb-lightning.toml
@@ -138,6 +138,11 @@ addr = "127.0.0.1:8287"
 #local-writer-mem-cache-size = '128MiB'
 # Limit the write bandwidth to each tikv store. The unit is 'Bytes per second'. 0 means no limit.
 #store-write-bwlimit = 0
+# The desired length of each INSERT/REPLACE statement sent to the downstream TiDB in each single transaction.
+# This is not a hard limit; the actual SQL executed may be longer or shorter depending on the actual content imported.
+# The default is 1.0 MiB which is optimized for import speed when Lightning is the only client of the cluster.
+# This value may be decreased to reduce the stress on the cluster due to large transaction.
+#sql-statement-length = '1MiB'
 
 [mydumper]
 # block size of file reading


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46607

Problem Summary:

### What is changed and how it works?

Added a config value `tikv-importer.sql-statement-length` which controls how long the INSERT statement would be when using logical mode.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
In Lightning logical mode, the length of the INSERT statements executed downstream can now be changed from the default 1.0 MiB. Decreasing this allows reducing performance impact caused by large transaction.
```
