### PR TITLE
executor, statistics: add logs in failpoint to debug flaky test

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -532,7 +532,7 @@ func StartAnalyzeJob(sctx sessionctx.Context, job *statistics.AnalyzeJob) {
 	failpoint.Inject("DebugAnalyzeJobOperations", func(val failpoint.Value) {
 		if val.(bool) {
 			logutil.BgLogger().Info("StartAnalyzeJob",
-				zap.String("start_time", job.StartTime.UTC().Format(types.TimeFormat)),
+				zap.Time("start_time", job.StartTime),
 				zap.Uint64("job id", *job.ID),
 			)
 		}
@@ -601,7 +601,7 @@ func FinishAnalyzeMergeJob(sctx sessionctx.Context, job *statistics.AnalyzeJob, 
 	failpoint.Inject("DebugAnalyzeJobOperations", func(val failpoint.Value) {
 		if val.(bool) {
 			logutil.BgLogger().Info("FinishAnalyzeMergeJob",
-				zap.String("end_time", job.EndTime.UTC().Format(types.TimeFormat)),
+				zap.Time("end_time", job.EndTime),
 				zap.Uint64("job id", *job.ID),
 			)
 		}
@@ -646,8 +646,9 @@ func FinishAnalyzeJob(sctx sessionctx.Context, job *statistics.AnalyzeJob, analy
 		if val.(bool) {
 			logutil.BgLogger().Info("FinishAnalyzeJob",
 				zap.Int64("increase processed_rows", job.Progress.GetDeltaCount()),
-				zap.String("end_time", job.EndTime.UTC().Format(types.TimeFormat)),
+				zap.Time("end_time", job.EndTime),
 				zap.Uint64("job id", *job.ID),
+				zap.Error(analyzeErr),
 			)
 		}
 	})

--- a/executor/test/analyzetest/analyze_test.go
+++ b/executor/test/analyzetest/analyze_test.go
@@ -3116,6 +3116,12 @@ func TestAutoAnalyzeSkipColumnTypes(t *testing.T) {
 // TestAnalyzeMVIndex tests analyzing the mv index use some real data in the table.
 // It checks the analyze jobs, async loading and the stats content in the memory.
 func TestAnalyzeMVIndex(t *testing.T) {
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/DebugAnalyzeJobOperations", "return(true)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/statistics/handle/DebugAnalyzeJobOperations", "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/executor/DebugAnalyzeJobOperations"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/statistics/handle/DebugAnalyzeJobOperations"))
+	}()
 	// 1. prepare the table and insert data
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	h := dom.StatsHandle()

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/pingcap/failpoint"
 	"math"
 	"slices"
 	"strconv"
@@ -1700,6 +1701,17 @@ func (h *Handle) InsertAnalyzeJob(job *statistics.AnalyzeJob, instance string, p
 	}
 	job.ID = new(uint64)
 	*job.ID = rows[0].GetUint64(0)
+	failpoint.Inject("DebugAnalyzeJobOperations", func(val failpoint.Value) {
+		if val.(bool) {
+			logutil.BgLogger().Info("InsertAnalyzeJob",
+				zap.String("table_schema", job.DBName),
+				zap.String("table_name", job.TableName),
+				zap.String("partition_name", job.PartitionName),
+				zap.String("job_info", jobInfo),
+				zap.Uint64("job_id", *job.ID),
+			)
+		}
+	})
 	return nil
 }
 

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap/failpoint"
 	"math"
 	"slices"
 	"strconv"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/ngaut/pools"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/config"
 	ddlUtil "github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/infoschema"


### PR DESCRIPTION

### What problem does this PR solve?


Issue Number: ref #46992

Problem Summary:

Please see the issue.

### What is changed and how it works?

Add some logs that will only be printed in this flaky test case.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
