### PR TITLE
br: not use the custom http client for gcs

### DIFF
--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -296,6 +296,9 @@ func NewGCSStorage(ctx context.Context, gcs *backuppb.GCS, opts *ExternalStorage
 	if gcs.Endpoint != "" {
 		clientOps = append(clientOps, option.WithEndpoint(gcs.Endpoint))
 	}
+	// the HTTPClient should has credential, currently the HTTPClient only has the http.Transport.
+	// So we remove the HTTPClient in the storage.New().
+	// Issue: https: //github.com/pingcap/tidb/issues/47022
 	if opts.HTTPClient != nil {
 		clientOps = append(clientOps, option.WithHTTPClient(opts.HTTPClient))
 	}

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -144,7 +144,9 @@ type ExternalStorageOptions struct {
 	NoCredentials bool
 
 	// HTTPClient to use. The created storage may ignore this field if it is not
-	// directly using HTTP (e.g. the local storage).
+	// directly using HTTP (e.g. the local storage) or use self-design HTTP client
+	// with credential (e.g. the gcs).
+	// NOTICE: the HTTPClient is only used by s3 storage and azure blob storage.
 	HTTPClient *http.Client
 
 	// CheckPermissions check the given permission in New() function.
@@ -197,6 +199,9 @@ func New(ctx context.Context, backend *backuppb.StorageBackend, opts *ExternalSt
 		if backend.Gcs == nil {
 			return nil, errors.Annotate(berrors.ErrStorageInvalidConfig, "GCS config not found")
 		}
+		// the HTTPClient should has credential, currently the HTTPClient only has the http.Transport.
+		// Issue: https: //github.com/pingcap/tidb/issues/47022
+		opts.HTTPClient = nil
 		return NewGCSStorage(ctx, backend.Gcs, opts)
 	case *backuppb.StorageBackend_AzureBlobStorage:
 		return newAzureBlobStorage(ctx, backend.AzureBlobStorage, opts)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47022 

Problem Summary:
the custom http client for gcs should has the credential, but currently we don't provide it.
### What is changed and how it works?
don't use the custom http client for gcs
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
