### PR TITLE
ddl: fix duplicate inforSchema information of rename tables

### DIFF
--- a/ddl/db_rename_test.go
+++ b/ddl/db_rename_test.go
@@ -293,3 +293,15 @@ func TestRenameMultiTables(t *testing.T) {
 	tk.MustExec("drop database test1")
 	tk.MustExec("drop database test")
 }
+
+func TestRenameMultiTablesIssue47064(t *testing.T) {
+	store := testkit.CreateMockStore(t, mockstore.WithDDLChecker())
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1(a int)")
+	tk.MustExec("create table t2(a int)")
+	tk.MustExec("create database test1")
+	tk.MustExec("rename table test.t1 to test1.t1, test.t2 to test1.t2")
+	tk.MustQuery("select column_name from information_schema.columns where table_name = 't1'").Check(testkit.Rows("a"))
+}

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -1377,9 +1377,12 @@ func updateSchemaVersion(d *ddlCtx, t *meta.Meta, job *model.Job, multiInfos ...
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
-		affects := make([]*model.AffectedOption, len(newSchemaIDs))
+		affects := make([]*model.AffectedOption, len(newSchemaIDs)-1)
 		for i, newSchemaID := range newSchemaIDs {
-			affects[i] = &model.AffectedOption{
+			if i == 0 {
+				continue
+			}
+			affects[i-1] = &model.AffectedOption{
 				SchemaID:    newSchemaID,
 				TableID:     tableIDs[i],
 				OldTableID:  tableIDs[i],

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -1379,6 +1379,7 @@ func updateSchemaVersion(d *ddlCtx, t *meta.Meta, job *model.Job, multiInfos ...
 		}
 		affects := make([]*model.AffectedOption, len(newSchemaIDs)-1)
 		for i, newSchemaID := range newSchemaIDs {
+			// Do not add the first table to AffectedOpts. Related issue tidb#47064.
 			if i == 0 {
 				continue
 			}

--- a/ddl/tests/fk/foreign_key_test.go
+++ b/ddl/tests/fk/foreign_key_test.go
@@ -1566,7 +1566,7 @@ func TestRenameTablesWithForeignKey(t *testing.T) {
 	// check the schema diff
 	diff := getLatestSchemaDiff(t, tk)
 	require.Equal(t, model.ActionRenameTables, diff.Type)
-	require.Equal(t, 3, len(diff.AffectedOpts))
+	require.Equal(t, 2, len(diff.AffectedOpts))
 
 	// check referred foreign key information.
 	t1ReferredFKs := getTableInfoReferredForeignKeys(t, dom, "test", "t1")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47064

Problem Summary:

### What is changed and how it works?

it seems lead to ApplyDiff twice for the first table of rename table list.

https://github.com/pingcap/tidb/blob/4bd39b5fd712f06b1c4594418a88ee1740f6f1aa/ddl/ddl_worker.go#L1381C2-L1381C2

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
