### PR TITLE
*: add resource group name when dispatch req to tiflash

### DIFF
--- a/executor/internal/mpp/local_mpp_coordinator.go
+++ b/executor/internal/mpp/local_mpp_coordinator.go
@@ -229,6 +229,7 @@ func (c *localMppCoordinator) appendMPPDispatchReq(pf *plannercore.Fragment) err
 			CoordinatorAddress:     c.coordinatorAddr,
 			ReportExecutionSummary: c.reportExecutionInfo,
 			State:                  kv.MppTaskReady,
+			ResourceGroupName:      c.sessionCtx.GetSessionVars().ResourceGroupName,
 		}
 		c.reqMap[req.ID] = &mppRequestReport{mppReq: req, receivedReport: false, errMsg: "", executionSummaries: nil}
 		c.mppReqs = append(c.mppReqs, req)

--- a/executor/internal/mpp/local_mpp_coordinator.go
+++ b/executor/internal/mpp/local_mpp_coordinator.go
@@ -229,7 +229,6 @@ func (c *localMppCoordinator) appendMPPDispatchReq(pf *plannercore.Fragment) err
 			CoordinatorAddress:     c.coordinatorAddr,
 			ReportExecutionSummary: c.reportExecutionInfo,
 			State:                  kv.MppTaskReady,
-			ResourceGroupName:      c.sessionCtx.GetSessionVars().ResourceGroupName,
 		}
 		c.reqMap[req.ID] = &mppRequestReport{mppReq: req, receivedReport: false, errMsg: "", executionSummaries: nil}
 		c.mppReqs = append(c.mppReqs, req)

--- a/kv/mpp.go
+++ b/kv/mpp.go
@@ -154,6 +154,7 @@ type MPPDispatchRequest struct {
 	CoordinatorAddress     string
 	ReportExecutionSummary bool
 	State                  MppTaskStates
+	ResourceGroupName      string
 }
 
 // CancelMPPTasksParam represents parameter for MPPClient's CancelMPPTasks

--- a/kv/mpp.go
+++ b/kv/mpp.go
@@ -154,7 +154,6 @@ type MPPDispatchRequest struct {
 	CoordinatorAddress     string
 	ReportExecutionSummary bool
 	State                  MppTaskStates
-	ResourceGroupName      string
 }
 
 // CancelMPPTasksParam represents parameter for MPPClient's CancelMPPTasks

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -1276,6 +1276,9 @@ func (b *batchCopIterator) handleTaskOnce(ctx context.Context, bo *backoff.Backo
 		RecordTimeStat: true,
 		RecordScanStat: true,
 		TaskId:         b.req.TaskID,
+		ResourceControlContext: &kvrpcpb.ResourceControlContext{
+			ResourceGroupName: b.req.ResourceGroupName,
+		},
 	})
 	if b.req.ResourceGroupTagger != nil {
 		b.req.ResourceGroupTagger(req)

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -1276,9 +1276,6 @@ func (b *batchCopIterator) handleTaskOnce(ctx context.Context, bo *backoff.Backo
 		RecordTimeStat: true,
 		RecordScanStat: true,
 		TaskId:         b.req.TaskID,
-		ResourceControlContext: &kvrpcpb.ResourceControlContext{
-			ResourceGroupName: b.req.ResourceGroupName,
-		},
 	})
 	if b.req.ResourceGroupTagger != nil {
 		b.req.ResourceGroupTagger(req)

--- a/store/copr/mpp.go
+++ b/store/copr/mpp.go
@@ -108,6 +108,7 @@ func (c *MPPClient) DispatchMPPTask(param kv.DispatchMPPTaskParam) (resp *mpp.Di
 		CoordinatorAddress:     req.CoordinatorAddress,
 		ReportExecutionSummary: req.ReportExecutionSummary,
 		MppVersion:             req.MppVersion.ToInt64(),
+		ResourceGroupName:      req.ResourceGroupName,
 	}
 
 	mppReq := &mpp.DispatchTaskRequest{

--- a/store/copr/mpp.go
+++ b/store/copr/mpp.go
@@ -108,7 +108,6 @@ func (c *MPPClient) DispatchMPPTask(param kv.DispatchMPPTaskParam) (resp *mpp.Di
 		CoordinatorAddress:     req.CoordinatorAddress,
 		ReportExecutionSummary: req.ReportExecutionSummary,
 		MppVersion:             req.MppVersion.ToInt64(),
-		ResourceGroupName:      req.ResourceGroupName,
 	}
 
 	mppReq := &mpp.DispatchTaskRequest{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47093

Problem Summary:

### What is changed and how it works?
This is part of tiflash resource control.
Add resource group name to cop/batchCop/MPP req when dispatching to tiflash.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. setup tidb cluster with one or more tiflash instances
2. run following sqls:
```
create resource group rg1 ru_per_sec = 1000 burstable = false;
create resource group rg2 ru_per_sec = 1000 burstable = false;
create resource group rg3 ru_per_sec = 1000 burstable = false;

set tidb_allow_mpp=0;
set @@tidb_allow_tiflash_cop = 1;
set @@tidb_allow_batch_cop = 0;
explain analyze select /*+ resource_group(rg1) */ * from t1;

set tidb_allow_mpp=0;
set @@tidb_allow_tiflash_cop = 1;
set @@tidb_allow_batch_cop = 2;
explain analyze select /*+ resource_group(rg2) */ * from t1;
```
3. check tiflash log, we can see resource group is added, so tiflash resource control will work as expected.

![5DhMOvlGKe](https://github.com/pingcap/tidb/assets/7493273/629407b0-236a-4e3f-b7db-d18be2c39c6f)
![6kXh2R8KNw](https://github.com/pingcap/tidb/assets/7493273/4f3e6e7c-09de-4066-a511-e4febfee35d5)
![FrbflSexwi](https://github.com/pingcap/tidb/assets/7493273/3a4f9346-f457-4e87-9e43-3a7367c025f9)


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
