### PR TITLE
metrics: add metric for ru consumption of tiflash

### DIFF
--- a/metrics/grafana/tidb_resource_control.json
+++ b/metrics/grafana/tidb_resource_control.json
@@ -133,6 +133,15 @@
           "intervalFactor": 2,
           "legendFormat": "total",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"tiflash\"}) by (name)",
+          "hide": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "tiflash-{{name}}",
+          "refId": "C"
         }
       ],
       "thresholds": [],


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
the following metrics are same, one is from pd, one is from tiflash
pd metric:
![kD6H62XsJT](https://github.com/pingcap/tidb/assets/7493273/58bc407f-cb54-413e-a7b6-0791b56ec6b9)
tiflash metric:
![311e530b-f89a-4a01-9d57-c28c2731640f](https://github.com/pingcap/tidb/assets/7493273/414b731a-9323-480d-a3db-f23407bbb483)

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
