### PR TITLE
metric: fix label name

### DIFF
--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -20110,7 +20110,7 @@
             },
             {
               "exemplar": true,
-              "expr": "histogram_quantile(0.5, sum(rate(tidb_distsql_copr_resp_size_bucket{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(rate(tidb_distsql_copr_resp_size_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le))",
               "hide": false,
               "interval": "",
               "legendFormat": "P50",
@@ -20119,7 +20119,7 @@
             },
             {
               "exemplar": true,
-              "expr": "histogram_quantile(0.8, sum(rate(tidb_distsql_copr_resp_size_bucket{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.8, sum(rate(tidb_distsql_copr_resp_size_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le))",
               "hide": false,
               "interval": "",
               "legendFormat": "P80",
@@ -20128,7 +20128,7 @@
             },
             {
               "exemplar": true,
-              "expr": "histogram_quantile(0.99, sum(rate(tidb_distsql_copr_resp_size_bucket{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(tidb_distsql_copr_resp_size_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le))",
               "hide": false,
               "interval": "",
               "legendFormat": "P99",
@@ -20242,7 +20242,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\", state=\"restored\"}[1m])) by(task_id)",
+              "expr": "sum(rate(tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", state=\"restored\"}[1m])) by(task_id)",
               "interval": "",
               "legendFormat": "encode - {{task_id}}",
               "queryType": "randomWalk",
@@ -20250,7 +20250,7 @@
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\", state=\"written\"}[1m])) by(task_id)",
+              "expr": "sum(rate(tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", state=\"written\"}[1m])) by(task_id)",
               "hide": false,
               "interval": "",
               "legendFormat": "deliver - {{task_id}}",
@@ -20258,7 +20258,7 @@
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\", state=\"imported\"}[1m])) by(task_id)",
+              "expr": "sum(rate(tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", state=\"imported\"}[1m])) by(task_id)",
               "hide": false,
               "interval": "",
               "legendFormat": "import kv - {{task_id}}",
@@ -20354,7 +20354,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\", state=\"restored\"}",
+              "expr": "tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", state=\"restored\"}",
               "interval": "",
               "legendFormat": "encoded source size - {{task_id}} - {{instance}}",
               "queryType": "randomWalk",
@@ -20362,7 +20362,7 @@
             },
             {
               "exemplar": true,
-              "expr": "tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\", state=\"written\"}",
+              "expr": "tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", state=\"written\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "delivered kv size - {{task_id}} - {{instance}}",
@@ -20370,7 +20370,7 @@
             },
             {
               "exemplar": true,
-              "expr": "sum(tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\", state=\"total_restore\"}) by(task_id)",
+              "expr": "sum(tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", state=\"total_restore\"}) by(task_id)",
               "hide": false,
               "interval": "",
               "legendFormat": "total source data size - {{task_id}}",
@@ -20378,7 +20378,7 @@
             },
             {
               "exemplar": true,
-              "expr": "tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\", state=\"imported\"}",
+              "expr": "tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", state=\"imported\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "imported kv size - {{task_id}} - {{instance}}",
@@ -20474,7 +20474,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "tidb_import_block_deliver_kv_pairs_sum{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\"}",
+              "expr": "tidb_import_block_deliver_kv_pairs_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{kind}} kv - {{task_id}} - {{instance}}",
               "queryType": "randomWalk",
@@ -20572,7 +20572,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(tidb_import_row_encode_seconds_sum{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\"}[2m]) / rate(tidb_import_row_encode_seconds_count{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\"}[2m])",
+              "expr": "rate(tidb_import_row_encode_seconds_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[2m]) / rate(tidb_import_row_encode_seconds_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[2m])",
               "interval": "",
               "legendFormat": "encode - {{instance}} - {{task_id}}",
               "queryType": "randomWalk",
@@ -20580,7 +20580,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(tidb_import_block_deliver_seconds_sum{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\"}[2m]) / rate(tidb_import_block_deliver_seconds_count{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\"}[2m])",
+              "expr": "rate(tidb_import_block_deliver_seconds_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[2m]) / rate(tidb_import_block_deliver_seconds_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[2m])",
               "hide": false,
               "interval": "",
               "legendFormat": "deliver - {{instance}} - {{task_id}}",
@@ -20588,7 +20588,7 @@
             },
             {
               "exemplar": true,
-              "expr": "rate(tidb_import_row_read_seconds_sum{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\"}[2m]) / rate(tidb_import_row_read_seconds_count{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", instance=~\"$instance\"}[2m])",
+              "expr": "rate(tidb_import_row_read_seconds_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[2m]) / rate(tidb_import_row_read_seconds_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[2m])",
               "hide": false,
               "interval": "",
               "legendFormat": "read - {{instance}} - {{task_id}}",
@@ -20737,7 +20737,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "min(tikv_config_rocksdb{k8s_cluster=\"$k8s_cluster\", cluster_id=~\".*$tidb_cluster\", name=\"hard_pending_compaction_bytes_limit\"}) by (instance)",
+              "expr": "min(tikv_config_rocksdb{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", name=\"hard_pending_compaction_bytes_limit\"}) by (instance)",
               "format": "time_series",
               "instant": false,
               "interval": "",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47113

Problem Summary:

tidb cluster label should be `tidb_cluster`, not `cluster_id`

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
