### PR TITLE
statistics: clean up lock info when the table is deleted

### DIFF
--- a/statistics/handle/gc.go
+++ b/statistics/handle/gc.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/statistics/handle/cache"
+	"github.com/pingcap/tidb/statistics/handle/lockstats"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mathutil"
@@ -37,8 +38,9 @@ import (
 
 const gcLastTSVarName = "tidb_stats_gc_last_ts"
 
-// GCStats will garbage collect the useless stats info. For dropped tables, we will first update their version so that
-// other tidb could know that table is deleted.
+// GCStats will garbage collect the useless stats' info.
+// For dropped tables, we will first update their version
+// so that other tidb could know that table is deleted.
 func (h *Handle) GCStats(is infoschema.InfoSchema, ddlLease time.Duration) (err error) {
 	ctx := context.Background()
 	// To make sure that all the deleted tables' schema and stats info have been acknowledged to all tidb,
@@ -49,6 +51,8 @@ func (h *Handle) GCStats(is infoschema.InfoSchema, ddlLease time.Duration) (err 
 	if now < offset {
 		return nil
 	}
+
+	// Get the last gc time.
 	gcVer := now - offset
 	lastGC, err := h.GetLastGCTimestamp(ctx)
 	if err != nil {
@@ -60,6 +64,7 @@ func (h *Handle) GCStats(is infoschema.InfoSchema, ddlLease time.Duration) (err 
 		}
 		err = h.writeGCTimestampToKV(ctx, gcVer)
 	}()
+
 	rows, _, err := h.execRestrictedSQL(ctx, "select table_id from mysql.stats_meta where version >= %? and version < %?", lastGC, gcVer)
 	if err != nil {
 		return errors.Trace(err)
@@ -75,11 +80,13 @@ func (h *Handle) GCStats(is infoschema.InfoSchema, ddlLease time.Duration) (err 
 			}
 		}
 	}
+
 	if err := h.ClearOutdatedHistoryStats(); err != nil {
 		logutil.BgLogger().Warn("failed to gc outdated historical stats",
 			zap.Duration("duration", variable.HistoricalStatsDuration.Load()),
 			zap.Error(err))
 	}
+
 	return h.removeDeletedExtendedStats(gcVer)
 }
 
@@ -351,6 +358,9 @@ func (h *Handle) DeleteTableStatsFromKV(statsIDs []int64) (err error) {
 			return err
 		}
 		if _, err = exec.ExecuteInternal(ctx, "delete from mysql.analyze_options where table_id = %?", statsID); err != nil {
+			return err
+		}
+		if _, err = exec.ExecuteInternal(ctx, lockstats.DeleteLockSQL, statsID); err != nil {
 			return err
 		}
 	}

--- a/statistics/handle/handletest/lockstats/BUILD.bazel
+++ b/statistics/handle/handletest/lockstats/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 14,
+    shard_count = 19,
     deps = [
         "//config",
         "//domain",

--- a/statistics/handle/handletest/lockstats/BUILD.bazel
+++ b/statistics/handle/handletest/lockstats/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 19,
+    shard_count = 21,
     deps = [
         "//config",
         "//domain",

--- a/statistics/handle/handletest/lockstats/lock_partition_stats_test.go
+++ b/statistics/handle/handletest/lockstats/lock_partition_stats_test.go
@@ -420,7 +420,7 @@ func TestExchangePartitionShouldChangeNothing(t *testing.T) {
 	require.Equal(t, 2, num)
 }
 
-func TestNewPartitionShouldLockedIfWholeTableLocked(t *testing.T) {
+func TestNewPartitionShouldBeLockedIfWholeTableLocked(t *testing.T) {
 	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
 
 	handle := dom.StatsHandle()

--- a/statistics/handle/handletest/lockstats/lock_partition_stats_test.go
+++ b/statistics/handle/handletest/lockstats/lock_partition_stats_test.go
@@ -17,6 +17,7 @@ package lockstats
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
@@ -28,8 +29,8 @@ import (
 const selectTableLockSQL = "select count(*) from mysql.stats_table_locked"
 
 func TestLockAndUnlockPartitionStats(t *testing.T) {
-	_, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
-	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
+	handle := dom.StatsHandle()
 	// Get partition stats.
 	p0Id := tbl.GetPartitionInfo().Definitions[0].ID
 	partitionStats := handle.GetPartitionStats(tbl, p0Id)
@@ -70,9 +71,9 @@ func TestLockAndUnlockPartitionStats(t *testing.T) {
 }
 
 func TestLockAndUnlockPartitionsStats(t *testing.T) {
-	_, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
+	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
 
-	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	handle := dom.StatsHandle()
 	// Get partition stats.
 	p0Id := tbl.GetPartitionInfo().Definitions[0].ID
 	partition0Stats := handle.GetPartitionStats(tbl, p0Id)
@@ -125,9 +126,9 @@ func TestLockAndUnlockPartitionsStats(t *testing.T) {
 }
 
 func TestLockAndUnlockPartitionStatsRepeatedly(t *testing.T) {
-	_, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
+	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
 
-	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	handle := dom.StatsHandle()
 	// Get partition stats.
 	p0Id := tbl.GetPartitionInfo().Definitions[0].ID
 	partition0Stats := handle.GetPartitionStats(tbl, p0Id)
@@ -167,9 +168,9 @@ func TestLockAndUnlockPartitionStatsRepeatedly(t *testing.T) {
 // TestSkipLockPartition tests that skip locking partition stats
 // when the whole table is already locked.
 func TestSkipLockPartition(t *testing.T) {
-	_, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
+	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
 
-	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	handle := dom.StatsHandle()
 	// Get partition stats.
 	p0Id := tbl.GetPartitionInfo().Definitions[0].ID
 	partition0Stats := handle.GetPartitionStats(tbl, p0Id)
@@ -195,9 +196,9 @@ func TestSkipLockPartition(t *testing.T) {
 }
 
 func TestUnlockOnePartitionOfLockedTableWouldFail(t *testing.T) {
-	_, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
+	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
 
-	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	handle := dom.StatsHandle()
 	// Get partition stats.
 	p0Id := tbl.GetPartitionInfo().Definitions[0].ID
 	partition0Stats := handle.GetPartitionStats(tbl, p0Id)
@@ -228,9 +229,9 @@ func TestUnlockOnePartitionOfLockedTableWouldFail(t *testing.T) {
 }
 
 func TestUnlockTheWholeTableWouldUnlockLockedPartitionsAndGenerateWarning(t *testing.T) {
-	_, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
+	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
 
-	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	handle := dom.StatsHandle()
 	// Get partition stats.
 	p0Id := tbl.GetPartitionInfo().Definitions[0].ID
 	partition0Stats := handle.GetPartitionStats(tbl, p0Id)
@@ -282,7 +283,143 @@ func TestSkipLockALotOfPartitions(t *testing.T) {
 	))
 }
 
-func setupTestEnvironmentWithPartitionedTableT(t *testing.T) (kv.Storage, *testkit.TestKit, *model.TableInfo) {
+func TestReorganizePartitionShouldCleanUpLockInfo(t *testing.T) {
+	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
+
+	handle := dom.StatsHandle()
+	// Get partition stats.
+	p0Id := tbl.GetPartitionInfo().Definitions[0].ID
+	partition0Stats := handle.GetPartitionStats(tbl, p0Id)
+	for _, col := range partition0Stats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+	p1Id := tbl.GetPartitionInfo().Definitions[1].ID
+	partition1Stats := handle.GetPartitionStats(tbl, p1Id)
+	for _, col := range partition1Stats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+
+	tk.MustExec("lock stats t partition p0, p1")
+	rows := tk.MustQuery(selectTableLockSQL).Rows()
+	num, _ := strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, 2, num)
+
+	// Reorg to merge partition p0 and p1.
+	tk.MustExec("alter table t reorganize partition p0, p1 into (partition p0 values less than (20))")
+
+	// GC stats.
+	ddlLease := time.Duration(0)
+	require.Nil(t, handle.GCStats(dom.InfoSchema(), ddlLease))
+
+	// Check the lock info is cleaned up.
+	rows = tk.MustQuery(selectTableLockSQL).Rows()
+	num, _ = strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, 0, num)
+}
+
+func TestDropPartitionShouldCleanUpLockInfo(t *testing.T) {
+	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
+
+	handle := dom.StatsHandle()
+	// Get partition stats.
+	p0Id := tbl.GetPartitionInfo().Definitions[0].ID
+	partition0Stats := handle.GetPartitionStats(tbl, p0Id)
+	for _, col := range partition0Stats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+	p1Id := tbl.GetPartitionInfo().Definitions[1].ID
+	partition1Stats := handle.GetPartitionStats(tbl, p1Id)
+	for _, col := range partition1Stats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+
+	tk.MustExec("lock stats t partition p0, p1")
+	rows := tk.MustQuery(selectTableLockSQL).Rows()
+	num, _ := strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, 2, num)
+
+	// Drop partition p0.
+	tk.MustExec("alter table t drop partition p0")
+
+	// GC stats.
+	ddlLease := time.Duration(0)
+	require.Nil(t, handle.GCStats(dom.InfoSchema(), ddlLease))
+
+	// Check the lock info is cleaned up.
+	rows = tk.MustQuery(selectTableLockSQL).Rows()
+	num, _ = strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, 1, num)
+}
+
+func TestExchangePartitionShouldChangeNothing(t *testing.T) {
+	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
+
+	handle := dom.StatsHandle()
+	// Get partition stats.
+	p0Id := tbl.GetPartitionInfo().Definitions[0].ID
+	partition0Stats := handle.GetPartitionStats(tbl, p0Id)
+	for _, col := range partition0Stats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+	p1Id := tbl.GetPartitionInfo().Definitions[1].ID
+	partition1Stats := handle.GetPartitionStats(tbl, p1Id)
+	for _, col := range partition1Stats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+
+	tk.MustExec("lock stats t partition p0, p1")
+	rows := tk.MustQuery(selectTableLockSQL).Rows()
+	num, _ := strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, 2, num)
+
+	// Create a new table and exchange partition p0 with it.
+	tk.MustExec("create table t1(a int, b varchar(10), index idx_b (b))")
+	tk.MustExec("alter table t exchange partition p0 with table t1")
+
+	// GC stats.
+	ddlLease := time.Duration(0)
+	require.Nil(t, handle.GCStats(dom.InfoSchema(), ddlLease))
+
+	// Nothing changed.
+	rows = tk.MustQuery(selectTableLockSQL).Rows()
+	num, _ = strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, 2, num)
+}
+
+func TestNewPartitionShouldLockedIfWholeTableLocked(t *testing.T) {
+	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
+
+	handle := dom.StatsHandle()
+	// Get partition stats.
+	p0Id := tbl.GetPartitionInfo().Definitions[0].ID
+	partition0Stats := handle.GetPartitionStats(tbl, p0Id)
+	for _, col := range partition0Stats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+	p1Id := tbl.GetPartitionInfo().Definitions[1].ID
+	partition1Stats := handle.GetPartitionStats(tbl, p1Id)
+	for _, col := range partition1Stats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+
+	tk.MustExec("lock stats t")
+	rows := tk.MustQuery(selectTableLockSQL).Rows()
+	num, _ := strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, 3, num)
+
+	// Add a new partition.
+	tk.MustExec("alter table t add partition (partition p2 values less than (30))")
+
+	// Check the new partition is locked.
+	tk.MustExec("analyze table t partition p2")
+
+	// Check the new partition is locked.
+	tk.MustQuery("show warnings").Check(testkit.Rows(
+		"Warning 1105 skip analyze locked table: test.t partition (p2)",
+	))
+}
+
+func setupTestEnvironmentWithPartitionedTableT(t *testing.T) (kv.Storage, *domain.Domain, *testkit.TestKit, *model.TableInfo) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("set @@tidb_analyze_version = 1")
@@ -293,5 +430,5 @@ func setupTestEnvironmentWithPartitionedTableT(t *testing.T) (kv.Storage, *testk
 	tbl, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.Nil(t, err)
 
-	return store, tk, tbl.Meta()
+	return store, dom, tk, tbl.Meta()
 }

--- a/statistics/handle/handletest/lockstats/lock_table_stats_test.go
+++ b/statistics/handle/handletest/lockstats/lock_table_stats_test.go
@@ -30,9 +30,9 @@ import (
 )
 
 func TestLockAndUnlockTableStats(t *testing.T) {
-	_, tk, tbl := setupTestEnvironmentWithTableT(t)
+	_, dom, tk, tbl := setupTestEnvironmentWithTableT(t)
 
-	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	handle := dom.StatsHandle()
 	tblStats := handle.GetTableStats(tbl)
 	for _, col := range tblStats.Columns {
 		require.True(t, col.IsStatsInitialized())
@@ -68,9 +68,9 @@ func TestLockAndUnlockTableStats(t *testing.T) {
 }
 
 func TestLockAndUnlockPartitionedTableStats(t *testing.T) {
-	_, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
+	_, dom, tk, tbl := setupTestEnvironmentWithPartitionedTableT(t)
 
-	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	handle := dom.StatsHandle()
 	tblStats := handle.GetTableStats(tbl)
 	for _, col := range tblStats.Columns {
 		require.True(t, col.IsStatsInitialized())
@@ -99,9 +99,9 @@ func TestLockAndUnlockPartitionedTableStats(t *testing.T) {
 }
 
 func TestLockTableAndUnlockTableStatsRepeatedly(t *testing.T) {
-	_, tk, tbl := setupTestEnvironmentWithTableT(t)
+	_, dom, tk, tbl := setupTestEnvironmentWithTableT(t)
 
-	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	handle := dom.StatsHandle()
 	tblStats := handle.GetTableStats(tbl)
 	for _, col := range tblStats.Columns {
 		require.True(t, col.IsStatsInitialized())
@@ -219,9 +219,9 @@ func TestLockAndUnlockTablesStats(t *testing.T) {
 }
 
 func TestLockAndUnlockTablePrivilege(t *testing.T) {
-	store, tk, tbl := setupTestEnvironmentWithTableT(t)
+	store, dom, tk, tbl := setupTestEnvironmentWithTableT(t)
 
-	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	handle := dom.StatsHandle()
 	tblStats := handle.GetTableStats(tbl)
 	for _, col := range tblStats.Columns {
 		require.True(t, col.IsStatsInitialized())
@@ -279,9 +279,9 @@ func TestLockAndUnlockTablePrivilege(t *testing.T) {
 }
 
 func TestShowStatsLockedTablePrivilege(t *testing.T) {
-	store, tk, tbl := setupTestEnvironmentWithTableT(t)
+	store, dom, tk, tbl := setupTestEnvironmentWithTableT(t)
 
-	handle := domain.GetDomain(tk.Session()).StatsHandle()
+	handle := dom.StatsHandle()
 	tblStats := handle.GetTableStats(tbl)
 	for _, col := range tblStats.Columns {
 		require.True(t, col.IsStatsInitialized())
@@ -336,7 +336,32 @@ func TestSkipLockALotOfTables(t *testing.T) {
 	))
 }
 
-func setupTestEnvironmentWithTableT(t *testing.T) (kv.Storage, *testkit.TestKit, *model.TableInfo) {
+func TestDropTableShouldCleanUpLockInfo(t *testing.T) {
+	_, dom, tk, tbl := setupTestEnvironmentWithTableT(t)
+
+	handle := dom.StatsHandle()
+	tblStats := handle.GetTableStats(tbl)
+	for _, col := range tblStats.Columns {
+		require.True(t, col.IsStatsInitialized())
+	}
+	tk.MustExec("lock stats t")
+
+	rows := tk.MustQuery(selectTableLockSQL).Rows()
+	num, _ := strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, 1, num)
+
+	// GC stats.
+	tk.MustExec("drop table t")
+	ddlLease := time.Duration(0)
+	require.Nil(t, handle.GCStats(dom.InfoSchema(), ddlLease))
+
+	// Check if the lock info is cleaned up.
+	rows = tk.MustQuery(selectTableLockSQL).Rows()
+	num, _ = strconv.Atoi(rows[0][0].(string))
+	require.Equal(t, 0, num)
+}
+
+func setupTestEnvironmentWithTableT(t *testing.T) (kv.Storage, *domain.Domain, *testkit.TestKit, *model.TableInfo) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("set @@tidb_analyze_version = 1")
@@ -347,5 +372,5 @@ func setupTestEnvironmentWithTableT(t *testing.T) (kv.Storage, *testkit.TestKit,
 	tbl, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.Nil(t, err)
 
-	return store, tk, tbl.Meta()
+	return store, dom, tk, tbl.Meta()
 }

--- a/statistics/handle/lockstats/unlock_stats.go
+++ b/statistics/handle/lockstats/unlock_stats.go
@@ -27,7 +27,8 @@ import (
 const (
 	selectDeltaSQL = "SELECT count, modify_count, version FROM mysql.stats_table_locked WHERE table_id = %?"
 	updateDeltaSQL = "UPDATE mysql.stats_meta SET version = %?, count = count + %?, modify_count = modify_count + %? WHERE table_id = %?"
-	deleteLockSQL  = "DELETE FROM mysql.stats_table_locked WHERE table_id = %?"
+	// DeleteLockSQL is used to delete the locked table record.
+	DeleteLockSQL = "DELETE FROM mysql.stats_table_locked WHERE table_id = %?"
 )
 
 // RemoveLockedTables remove tables from table locked records.
@@ -188,7 +189,7 @@ func updateStatsAndUnlockTable(ctx context.Context, exec sqlexec.RestrictedSQLEx
 	_, _, err = exec.ExecRestrictedSQL(
 		ctx,
 		useCurrentSession,
-		deleteLockSQL, tid,
+		DeleteLockSQL, tid,
 	)
 	return err
 }

--- a/statistics/handle/lockstats/unlock_stats_test.go
+++ b/statistics/handle/lockstats/unlock_stats_test.go
@@ -148,7 +148,7 @@ func TestUpdateStatsAndUnlockTable(t *testing.T) {
 				exec.EXPECT().ExecRestrictedSQL(
 					ctx,
 					useCurrentSession,
-					deleteLockSQL,
+					DeleteLockSQL,
 					gomock.Eq([]interface{}{tt.tableID}),
 				).Return(nil, nil, nil)
 			} else {
@@ -209,7 +209,7 @@ func TestRemoveLockedTables(t *testing.T) {
 	exec.EXPECT().ExecRestrictedSQL(
 		gomock.All(&ctxMatcher{}),
 		useCurrentSession,
-		deleteLockSQL,
+		DeleteLockSQL,
 		gomock.Eq([]interface{}{int64(1)}),
 	).Return(nil, nil, nil)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/46351

Problem Summary:

### What is changed and how it works?

- We can clean up lock info when the table or partition is deleted now.
- Added more tests for the partitioned table.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
