### PR TITLE
lightning: fix forgetting multiple regionJob use same IngestData

### DIFF
--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -1033,7 +1033,7 @@ func (e *Engine) GetTS() uint64 {
 }
 
 // IncRef implements IngestData interface.
-func (e *Engine) IncRef() {}
+func (*Engine) IncRef() {}
 
 // Finish implements IngestData interface.
 func (e *Engine) Finish(totalBytes, totalCount int64) {

--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -1032,6 +1032,9 @@ func (e *Engine) GetTS() uint64 {
 	return e.TS
 }
 
+// IncRef implements IngestData interface.
+func (e *Engine) IncRef() {}
+
 // Finish implements IngestData interface.
 func (e *Engine) Finish(totalBytes, totalCount int64) {
 	e.importedKVSize.Add(totalBytes)

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -1211,6 +1211,7 @@ func (local *Backend) generateAndSendJob(
 				return err
 			}
 			for _, job := range jobs {
+				data.IncRef()
 				jobWg.Add(1)
 				select {
 				case <-egCtx.Done():
@@ -1344,7 +1345,12 @@ func (local *Backend) startWorker(
 					return err2
 				}
 				// 1 "needRescan" job becomes len(jobs) "regionScanned" jobs.
-				jobWg.Add(len(jobs) - 1)
+				newJobCnt := len(jobs) - 1
+				jobWg.Add(newJobCnt)
+				for newJobCnt > 0 {
+					job.ingestData.IncRef()
+					newJobCnt--
+				}
 				for _, j := range jobs {
 					j.lastRetryableErr = job.lastRetryableErr
 					jobOutCh <- j

--- a/br/pkg/lightning/backend/local/local_test.go
+++ b/br/pkg/lightning/backend/local/local_test.go
@@ -1207,6 +1207,8 @@ func (m mockIngestData) NewIter(ctx context.Context, lowerBound, upperBound []by
 
 func (m mockIngestData) GetTS() uint64 { return 0 }
 
+func (m mockIngestData) IncRef() {}
+
 func (m mockIngestData) Finish(_, _ int64) {}
 
 func TestCheckPeersBusy(t *testing.T) {

--- a/br/pkg/lightning/common/ingest_data.go
+++ b/br/pkg/lightning/common/ingest_data.go
@@ -27,6 +27,10 @@ type IngestData interface {
 	NewIter(ctx context.Context, lowerBound, upperBound []byte) ForwardIter
 	// GetTS will be used as the start/commit TS of the data.
 	GetTS() uint64
+	// IncRef should be called every time when IngestData is referred by regionJob.
+	// Multiple regionJob can share one IngestData. Same amount of Finish should be
+	// called to release the IngestData.
+	IncRef()
 	// Finish will be called when the data is ingested successfully.
 	Finish(totalBytes, totalCount int64)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #45719

Problem Summary:

When scan region, one IngestData may be assigned to multiple regionJob if the key ranges of IngestData belongs multiple regions. And we will call `Finish()` for each of regionJob. But we have put `m.memBuf.Destroy()` in `Finish()` so the data slice will be sent back to buffer pool and be reused while other regiobJob still reads it.

### What is changed and how it works?

Add `IncRef()` as a reference count, but not easy to use.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

test it in a large cluster test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
