### PR TITLE
statistics: remove useless copy in the MergePartitionStats2GlobalStats

### DIFF
--- a/statistics/handle/globalstats/global_stats.go
+++ b/statistics/handle/globalstats/global_stats.go
@@ -247,7 +247,7 @@ func (g *GlobalStatusHandler) MergePartitionStats2GlobalStats(
 		}
 
 		// Merge FMSketch.
-		globalStats.Fms[i] = allFms[i][0].Copy()
+		globalStats.Fms[i] = allFms[i][0]
 		for j := 1; j < len(allFms[i]); j++ {
 			globalStats.Fms[i].MergeFMSketch(allFms[i][j])
 			allFms[i][j].DestroyAndPutToPool()

--- a/statistics/handle/globalstats/global_stats.go
+++ b/statistics/handle/globalstats/global_stats.go
@@ -214,7 +214,7 @@ func (g *GlobalStatusHandler) MergePartitionStats2GlobalStats(
 			continue
 		}
 		// Merge CMSketch.
-		globalStats.Cms[i] = allCms[i][0].Copy()
+		globalStats.Cms[i] = allCms[i][0]
 		for j := 1; j < len(allCms[i]); j++ {
 			err = globalStats.Cms[i].MergeCMSketch(allCms[i][j])
 			if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary:

### What is changed and how it works?

just remove useless code

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
