### PR TITLE
ddl: fix unexpected concurrency exceed quota during adding index

### DIFF
--- a/ddl/backfilling_read_index.go
+++ b/ddl/backfilling_read_index.go
@@ -144,8 +144,6 @@ func (r *readIndexExecutor) RunSubtask(ctx context.Context, subtask *proto.Subta
 		return err
 	}
 
-	// TODO(tangenta): when we support running subtasks concurrently,
-	// we should ignore "concurrency quota exceeded" error if possible.
 	r.bc.ResetWorkers(r.job.ID, r.index.ID)
 
 	r.summary.UpdateRowCount(subtask.ID, totalRowCount.Load())

--- a/ddl/backfilling_read_index.go
+++ b/ddl/backfilling_read_index.go
@@ -144,6 +144,10 @@ func (r *readIndexExecutor) RunSubtask(ctx context.Context, subtask *proto.Subta
 		return err
 	}
 
+	// TODO(tangenta): when we support running subtasks concurrently,
+	// we should ignore "concurrency quota exceeded" error if possible.
+	r.bc.ResetWorkers(r.job.ID, r.index.ID)
+
 	r.summary.UpdateRowCount(subtask.ID, totalRowCount.Load())
 	return nil
 }

--- a/tests/realtikvtest/addindextest/add_index_test.go
+++ b/tests/realtikvtest/addindextest/add_index_test.go
@@ -142,7 +142,8 @@ func TestAddIndexDistBasic(t *testing.T) {
 	tk.MustExec("use test;")
 	tk.MustExec(`set global tidb_enable_dist_task=1;`)
 
-	tk.MustExec("create table t(a bigint auto_random primary key) partition by hash(a) partitions 8;")
+	tk.MustExec("create table t(a bigint auto_random primary key) partition by hash(a) partitions 20;")
+	tk.MustExec("insert into t values (), (), (), (), (), ()")
 	tk.MustExec("insert into t values (), (), (), (), (), ()")
 	tk.MustExec("insert into t values (), (), (), (), (), ()")
 	tk.MustExec("insert into t values (), (), (), (), (), ()")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47164

Problem Summary:

`BackendCtx.Register` reocrd the concurrency. If it exceeds 16, an error will be reported.

### What is changed and how it works?

Reset this counter every time a subtask is finished.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
