### PR TITLE
cli: avoid glog flags inject into tidb cli

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1171,7 +1171,7 @@ func isAllRemovedConfigItems(items []string) bool {
 // The function enforceCmdArgs is used to merge the config file with command arguments:
 // For example, if you start TiDB by the command "./tidb-server --port=3000", the port number should be
 // overwritten to 3000 and ignore the port number in the config file.
-func InitializeConfig(confPath string, configCheck, configStrict bool, enforceCmdArgs func(*Config, fset *flag.FlagSet), fset *flag.FlagSet) {
+func InitializeConfig(confPath string, configCheck, configStrict bool, enforceCmdArgs func(*Config, *flag.FlagSet), fset *flag.FlagSet) {
 	cfg := GetGlobalConfig()
 	var err error
 	if confPath != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"math"
 	"os"
@@ -1170,7 +1171,7 @@ func isAllRemovedConfigItems(items []string) bool {
 // The function enforceCmdArgs is used to merge the config file with command arguments:
 // For example, if you start TiDB by the command "./tidb-server --port=3000", the port number should be
 // overwritten to 3000 and ignore the port number in the config file.
-func InitializeConfig(confPath string, configCheck, configStrict bool, enforceCmdArgs func(*Config)) {
+func InitializeConfig(confPath string, configCheck, configStrict bool, enforceCmdArgs func(*Config, fset *flag.FlagSet), fset *flag.FlagSet) {
 	cfg := GetGlobalConfig()
 	var err error
 	if confPath != "" {
@@ -1208,7 +1209,7 @@ func InitializeConfig(confPath string, configCheck, configStrict bool, enforceCm
 			os.Exit(1)
 		}
 	}
-	enforceCmdArgs(cfg)
+	enforceCmdArgs(cfg, fset)
 
 	if err := cfg.Valid(); err != nil {
 		if !filepath.IsAbs(confPath) {

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -236,6 +236,8 @@ func init() {
 	keyspaceName = flag.String(nmKeyspaceName, "", "keyspace name.")
 	serviceScope = flag.String(nmTiDBServiceScope, "", "tidb service scope")
 	help = flag.Bool("help", false, "show the usage")
+	// Ignore errors; CommandLine is set for ExitOnError.
+	// nolint:errcheck
 	flag.CommandLine.Parse(os.Args[1:])
 }
 

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -186,59 +186,59 @@ var (
 )
 
 func initflag() {
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	version = flagBoolean(nmVersion, false, "print version information and exit")
-	configPath = flag.String(nmConfig, "", "config file path")
-	configCheck = flagBoolean(nmConfigCheck, false, "check config file validity and exit")
-	configStrict = flagBoolean(nmConfigStrict, false, "enforce config file validity")
+	fset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	version = flagBoolean(fset, nmVersion, false, "print version information and exit")
+	configPath = fset.String(nmConfig, "", "config file path")
+	configCheck = flagBoolean(fset, nmConfigCheck, false, "check config file validity and exit")
+	configStrict = flagBoolean(fset, nmConfigStrict, false, "enforce config file validity")
 
 	// Base
-	store = flag.String(nmStore, "unistore", "registered store name, [tikv, mocktikv, unistore]")
-	storePath = flag.String(nmStorePath, "/tmp/tidb", "tidb storage path")
-	host = flag.String(nmHost, "0.0.0.0", "tidb server host")
-	advertiseAddress = flag.String(nmAdvertiseAddress, "", "tidb server advertise IP")
-	port = flag.String(nmPort, "4000", "tidb server port")
-	cors = flag.String(nmCors, "", "tidb server allow cors origin")
-	socket = flag.String(nmSocket, "/tmp/tidb-{Port}.sock", "The socket file to use for connection.")
-	enableBinlog = flagBoolean(nmEnableBinlog, false, "enable generate binlog")
-	runDDL = flagBoolean(nmRunDDL, true, "run ddl worker on this tidb-server")
-	ddlLease = flag.String(nmDdlLease, "45s", "schema lease duration, very dangerous to change only if you know what you do")
-	tokenLimit = flag.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")
-	pluginDir = flag.String(nmPluginDir, "/data/deploy/plugin", "the folder that hold plugin")
-	pluginLoad = flag.String(nmPluginLoad, "", "wait load plugin name(separated by comma)")
-	affinityCPU = flag.String(nmAffinityCPU, "", "affinity cpu (cpu-no. separated by comma, e.g. 1,2,3)")
-	repairMode = flagBoolean(nmRepairMode, false, "enable admin repair mode")
-	repairList = flag.String(nmRepairList, "", "admin repair table list")
-	tempDir = flag.String(nmTempDir, config.DefTempDir, "tidb temporary directory")
+	store = fset.String(nmStore, "unistore", "registered store name, [tikv, mocktikv, unistore]")
+	storePath = fset.String(nmStorePath, "/tmp/tidb", "tidb storage path")
+	host = fset.String(nmHost, "0.0.0.0", "tidb server host")
+	advertiseAddress = fset.String(nmAdvertiseAddress, "", "tidb server advertise IP")
+	port = fset.String(nmPort, "4000", "tidb server port")
+	cors = fset.String(nmCors, "", "tidb server allow cors origin")
+	socket = fset.String(nmSocket, "/tmp/tidb-{Port}.sock", "The socket file to use for connection.")
+	enableBinlog = flagBoolean(fset, nmEnableBinlog, false, "enable generate binlog")
+	runDDL = flagBoolean(fset, nmRunDDL, true, "run ddl worker on this tidb-server")
+	ddlLease = fset.String(nmDdlLease, "45s", "schema lease duration, very dangerous to change only if you know what you do")
+	tokenLimit = fset.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")
+	pluginDir = fset.String(nmPluginDir, "/data/deploy/plugin", "the folder that hold plugin")
+	pluginLoad = fset.String(nmPluginLoad, "", "wait load plugin name(separated by comma)")
+	affinityCPU = fset.String(nmAffinityCPU, "", "affinity cpu (cpu-no. separated by comma, e.g. 1,2,3)")
+	repairMode = flagBoolean(fset, nmRepairMode, false, "enable admin repair mode")
+	repairList = fset.String(nmRepairList, "", "admin repair table list")
+	tempDir = fset.String(nmTempDir, config.DefTempDir, "tidb temporary directory")
 
 	// Log
-	logLevel = flag.String(nmLogLevel, "info", "log level: info, debug, warn, error, fatal")
-	logFile = flag.String(nmLogFile, "", "log file path")
-	logSlowQuery = flag.String(nmLogSlowQuery, "", "slow query file path")
+	logLevel = fset.String(nmLogLevel, "info", "log level: info, debug, warn, error, fatal")
+	logFile = fset.String(nmLogFile, "", "log file path")
+	logSlowQuery = fset.String(nmLogSlowQuery, "", "slow query file path")
 
 	// Status
-	reportStatus = flagBoolean(nmReportStatus, true, "If enable status report HTTP service.")
-	statusHost = flag.String(nmStatusHost, "0.0.0.0", "tidb server status host")
-	statusPort = flag.String(nmStatusPort, "10080", "tidb server status port")
-	metricsAddr = flag.String(nmMetricsAddr, "", "prometheus pushgateway address, leaves it empty will disable prometheus push.")
-	metricsInterval = flag.Uint(nmMetricsInterval, 15, "prometheus client push interval in second, set \"0\" to disable prometheus push.")
+	reportStatus = flagBoolean(fset, nmReportStatus, true, "If enable status report HTTP service.")
+	statusHost = fset.String(nmStatusHost, "0.0.0.0", "tidb server status host")
+	statusPort = fset.String(nmStatusPort, "10080", "tidb server status port")
+	metricsAddr = fset.String(nmMetricsAddr, "", "prometheus pushgateway address, leaves it empty will disable prometheus push.")
+	metricsInterval = fset.Uint(nmMetricsInterval, 15, "prometheus client push interval in second, set \"0\" to disable prometheus push.")
 
 	// PROXY Protocol
-	proxyProtocolNetworks = flag.String(nmProxyProtocolNetworks, "", "proxy protocol networks allowed IP or *, empty mean disable proxy protocol support")
-	proxyProtocolHeaderTimeout = flag.Uint(nmProxyProtocolHeaderTimeout, 5, "proxy protocol header read timeout, unit is second. (Deprecated: as proxy protocol using lazy mode, header read timeout no longer used)")
-	proxyProtocolFallbackable = flagBoolean(nmProxyProtocolFallbackable, false, "enable proxy protocol fallback mode. If it is enabled, connection will return the client IP address when the client does not send PROXY Protocol Header and it will not return any error. (Note: This feature it does NOT follow the PROXY Protocol SPEC)")
+	proxyProtocolNetworks = fset.String(nmProxyProtocolNetworks, "", "proxy protocol networks allowed IP or *, empty mean disable proxy protocol support")
+	proxyProtocolHeaderTimeout = fset.Uint(nmProxyProtocolHeaderTimeout, 5, "proxy protocol header read timeout, unit is second. (Deprecated: as proxy protocol using lazy mode, header read timeout no longer used)")
+	proxyProtocolFallbackable = flagBoolean(fset, nmProxyProtocolFallbackable, false, "enable proxy protocol fallback mode. If it is enabled, connection will return the client IP address when the client does not send PROXY Protocol Header and it will not return any error. (Note: This feature it does NOT follow the PROXY Protocol SPEC)")
 
 	// Bootstrap and security
-	initializeSecure = flagBoolean(nmInitializeSecure, false, "bootstrap tidb-server in secure mode")
-	initializeInsecure = flagBoolean(nmInitializeInsecure, true, "bootstrap tidb-server in insecure mode")
-	initializeSQLFile = flag.String(nmInitializeSQLFile, "", "SQL file to execute on first bootstrap")
-	disconnectOnExpiredPassword = flagBoolean(nmDisconnectOnExpiredPassword, true, "the server disconnects the client when the password is expired")
-	keyspaceName = flag.String(nmKeyspaceName, "", "keyspace name.")
-	serviceScope = flag.String(nmTiDBServiceScope, "", "tidb service scope")
-	help = flag.Bool("help", false, "show the usage")
+	initializeSecure = flagBoolean(fset, nmInitializeSecure, false, "bootstrap tidb-server in secure mode")
+	initializeInsecure = flagBoolean(fset, nmInitializeInsecure, true, "bootstrap tidb-server in insecure mode")
+	initializeSQLFile = fset.String(nmInitializeSQLFile, "", "SQL file to execute on first bootstrap")
+	disconnectOnExpiredPassword = flagBoolean(fset, nmDisconnectOnExpiredPassword, true, "the server disconnects the client when the password is expired")
+	keyspaceName = fset.String(nmKeyspaceName, "", "keyspace name.")
+	serviceScope = fset.String(nmTiDBServiceScope, "", "tidb service scope")
+	help = fset.Bool("help", false, "show the usage")
 	// Ignore errors; CommandLine is set for ExitOnError.
 	// nolint:errcheck
-	flag.CommandLine.Parse(os.Args[1:])
+	fset.Parse(os.Args[1:])
 }
 
 func main() {
@@ -487,7 +487,7 @@ func parseDuration(lease string) time.Duration {
 	return dur
 }
 
-func flagBoolean(name string, defaultVal bool, usage string) *bool {
+func flagBoolean(fset *flag.FlagSet, name string, defaultVal bool, usage string) *bool {
 	if !defaultVal {
 		// Fix #4125, golang do not print default false value in usage, so we append it.
 		usage = fmt.Sprintf("%s (default false)", usage)

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -185,7 +185,7 @@ var (
 	help                        *bool
 )
 
-func init() {
+func initflag() {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	version = flagBoolean(nmVersion, false, "print version information and exit")
 	configPath = flag.String(nmConfig, "", "config file path")
@@ -242,6 +242,7 @@ func init() {
 }
 
 func main() {
+	initflag()
 	if *help {
 		flag.Usage()
 		os.Exit(0)

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -134,59 +134,112 @@ const (
 )
 
 var (
-	version      = flagBoolean(nmVersion, false, "print version information and exit")
-	configPath   = flag.String(nmConfig, "", "config file path")
-	configCheck  = flagBoolean(nmConfigCheck, false, "check config file validity and exit")
+	version      *bool
+	configPath   *string
+	configCheck  *bool
+	configStrict *bool
+
+	// Base
+	store            *string
+	storePath        *string
+	host             *string
+	advertiseAddress *string
+	port             *string
+	cors             *string
+	socket           *string
+	enableBinlog     *bool
+	runDDL           *bool
+	ddlLease         *string
+	tokenLimit       *int
+	pluginDir        *string
+	pluginLoad       *string
+	affinityCPU      *string
+	repairMode       *bool
+	repairList       *string
+	tempDir          *string
+
+	// Log
+	logLevel     *string
+	logFile      *string
+	logSlowQuery *string
+
+	// Status
+	reportStatus    *bool
+	statusHost      *string
+	statusPort      *string
+	metricsAddr     *string
+	metricsInterval *uint
+
+	// PROXY Protocol
+	proxyProtocolNetworks      *string
+	proxyProtocolHeaderTimeout *uint
+	proxyProtocolFallbackable  *bool
+
+	// Bootstrap and security
+	initializeSecure            *bool
+	initializeInsecure          *bool
+	initializeSQLFile           *string
+	disconnectOnExpiredPassword *bool
+	keyspaceName                *string
+	serviceScope                *string
+	help                        *bool
+)
+
+func init() {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	version = flagBoolean(nmVersion, false, "print version information and exit")
+	configPath = flag.String(nmConfig, "", "config file path")
+	configCheck = flagBoolean(nmConfigCheck, false, "check config file validity and exit")
 	configStrict = flagBoolean(nmConfigStrict, false, "enforce config file validity")
 
 	// Base
-	store            = flag.String(nmStore, "unistore", "registered store name, [tikv, mocktikv, unistore]")
-	storePath        = flag.String(nmStorePath, "/tmp/tidb", "tidb storage path")
-	host             = flag.String(nmHost, "0.0.0.0", "tidb server host")
+	store = flag.String(nmStore, "unistore", "registered store name, [tikv, mocktikv, unistore]")
+	storePath = flag.String(nmStorePath, "/tmp/tidb", "tidb storage path")
+	host = flag.String(nmHost, "0.0.0.0", "tidb server host")
 	advertiseAddress = flag.String(nmAdvertiseAddress, "", "tidb server advertise IP")
-	port             = flag.String(nmPort, "4000", "tidb server port")
-	cors             = flag.String(nmCors, "", "tidb server allow cors origin")
-	socket           = flag.String(nmSocket, "/tmp/tidb-{Port}.sock", "The socket file to use for connection.")
-	enableBinlog     = flagBoolean(nmEnableBinlog, false, "enable generate binlog")
-	runDDL           = flagBoolean(nmRunDDL, true, "run ddl worker on this tidb-server")
-	ddlLease         = flag.String(nmDdlLease, "45s", "schema lease duration, very dangerous to change only if you know what you do")
-	tokenLimit       = flag.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")
-	pluginDir        = flag.String(nmPluginDir, "/data/deploy/plugin", "the folder that hold plugin")
-	pluginLoad       = flag.String(nmPluginLoad, "", "wait load plugin name(separated by comma)")
-	affinityCPU      = flag.String(nmAffinityCPU, "", "affinity cpu (cpu-no. separated by comma, e.g. 1,2,3)")
-	repairMode       = flagBoolean(nmRepairMode, false, "enable admin repair mode")
-	repairList       = flag.String(nmRepairList, "", "admin repair table list")
-	tempDir          = flag.String(nmTempDir, config.DefTempDir, "tidb temporary directory")
+	port = flag.String(nmPort, "4000", "tidb server port")
+	cors = flag.String(nmCors, "", "tidb server allow cors origin")
+	socket = flag.String(nmSocket, "/tmp/tidb-{Port}.sock", "The socket file to use for connection.")
+	enableBinlog = flagBoolean(nmEnableBinlog, false, "enable generate binlog")
+	runDDL = flagBoolean(nmRunDDL, true, "run ddl worker on this tidb-server")
+	ddlLease = flag.String(nmDdlLease, "45s", "schema lease duration, very dangerous to change only if you know what you do")
+	tokenLimit = flag.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")
+	pluginDir = flag.String(nmPluginDir, "/data/deploy/plugin", "the folder that hold plugin")
+	pluginLoad = flag.String(nmPluginLoad, "", "wait load plugin name(separated by comma)")
+	affinityCPU = flag.String(nmAffinityCPU, "", "affinity cpu (cpu-no. separated by comma, e.g. 1,2,3)")
+	repairMode = flagBoolean(nmRepairMode, false, "enable admin repair mode")
+	repairList = flag.String(nmRepairList, "", "admin repair table list")
+	tempDir = flag.String(nmTempDir, config.DefTempDir, "tidb temporary directory")
 
 	// Log
-	logLevel     = flag.String(nmLogLevel, "info", "log level: info, debug, warn, error, fatal")
-	logFile      = flag.String(nmLogFile, "", "log file path")
+	logLevel = flag.String(nmLogLevel, "info", "log level: info, debug, warn, error, fatal")
+	logFile = flag.String(nmLogFile, "", "log file path")
 	logSlowQuery = flag.String(nmLogSlowQuery, "", "slow query file path")
 
 	// Status
-	reportStatus    = flagBoolean(nmReportStatus, true, "If enable status report HTTP service.")
-	statusHost      = flag.String(nmStatusHost, "0.0.0.0", "tidb server status host")
-	statusPort      = flag.String(nmStatusPort, "10080", "tidb server status port")
-	metricsAddr     = flag.String(nmMetricsAddr, "", "prometheus pushgateway address, leaves it empty will disable prometheus push.")
+	reportStatus = flagBoolean(nmReportStatus, true, "If enable status report HTTP service.")
+	statusHost = flag.String(nmStatusHost, "0.0.0.0", "tidb server status host")
+	statusPort = flag.String(nmStatusPort, "10080", "tidb server status port")
+	metricsAddr = flag.String(nmMetricsAddr, "", "prometheus pushgateway address, leaves it empty will disable prometheus push.")
 	metricsInterval = flag.Uint(nmMetricsInterval, 15, "prometheus client push interval in second, set \"0\" to disable prometheus push.")
 
 	// PROXY Protocol
-	proxyProtocolNetworks      = flag.String(nmProxyProtocolNetworks, "", "proxy protocol networks allowed IP or *, empty mean disable proxy protocol support")
+	proxyProtocolNetworks = flag.String(nmProxyProtocolNetworks, "", "proxy protocol networks allowed IP or *, empty mean disable proxy protocol support")
 	proxyProtocolHeaderTimeout = flag.Uint(nmProxyProtocolHeaderTimeout, 5, "proxy protocol header read timeout, unit is second. (Deprecated: as proxy protocol using lazy mode, header read timeout no longer used)")
-	proxyProtocolFallbackable  = flagBoolean(nmProxyProtocolFallbackable, false, "enable proxy protocol fallback mode. If it is enabled, connection will return the client IP address when the client does not send PROXY Protocol Header and it will not return any error. (Note: This feature it does NOT follow the PROXY Protocol SPEC)")
+	proxyProtocolFallbackable = flagBoolean(nmProxyProtocolFallbackable, false, "enable proxy protocol fallback mode. If it is enabled, connection will return the client IP address when the client does not send PROXY Protocol Header and it will not return any error. (Note: This feature it does NOT follow the PROXY Protocol SPEC)")
 
 	// Bootstrap and security
-	initializeSecure            = flagBoolean(nmInitializeSecure, false, "bootstrap tidb-server in secure mode")
-	initializeInsecure          = flagBoolean(nmInitializeInsecure, true, "bootstrap tidb-server in insecure mode")
-	initializeSQLFile           = flag.String(nmInitializeSQLFile, "", "SQL file to execute on first bootstrap")
+	initializeSecure = flagBoolean(nmInitializeSecure, false, "bootstrap tidb-server in secure mode")
+	initializeInsecure = flagBoolean(nmInitializeInsecure, true, "bootstrap tidb-server in insecure mode")
+	initializeSQLFile = flag.String(nmInitializeSQLFile, "", "SQL file to execute on first bootstrap")
 	disconnectOnExpiredPassword = flagBoolean(nmDisconnectOnExpiredPassword, true, "the server disconnects the client when the password is expired")
-	keyspaceName                = flag.String(nmKeyspaceName, "", "keyspace name.")
-	serviceScope                = flag.String(nmTiDBServiceScope, "", "tidb service scope")
-)
+	keyspaceName = flag.String(nmKeyspaceName, "", "keyspace name.")
+	serviceScope = flag.String(nmTiDBServiceScope, "", "tidb service scope")
+	help = flag.Bool("help", false, "show the usage")
+	flag.CommandLine.Parse(os.Args[1:])
+}
 
 func main() {
-	help := flag.Bool("help", false, "show the usage")
-	flag.Parse()
 	if *help {
 		flag.Usage()
 		os.Exit(0)

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -185,7 +185,7 @@ var (
 	help                        *bool
 )
 
-func initflag() {
+func initflag() *flag.FlagSet {
 	fset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	version = flagBoolean(fset, nmVersion, false, "print version information and exit")
 	configPath = fset.String(nmConfig, "", "config file path")
@@ -243,11 +243,12 @@ func initflag() {
 		fset.Usage()
 		os.Exit(0)
 	}
+	return fset
 }
 
 func main() {
-	initflag()
-	config.InitializeConfig(*configPath, *configCheck, *configStrict, overrideConfig)
+	fset := initflag()
+	config.InitializeConfig(*configPath, *configCheck, *configStrict, overrideConfig, fset)
 	if *version {
 		setVersions()
 		fmt.Println(printer.GetTiDBInfo())
@@ -491,15 +492,15 @@ func flagBoolean(fset *flag.FlagSet, name string, defaultVal bool, usage string)
 	if !defaultVal {
 		// Fix #4125, golang do not print default false value in usage, so we append it.
 		usage = fmt.Sprintf("%s (default false)", usage)
-		return flag.Bool(name, defaultVal, usage)
+		return fset.Bool(name, defaultVal, usage)
 	}
-	return flag.Bool(name, defaultVal, usage)
+	return fset.Bool(name, defaultVal, usage)
 }
 
 // overrideConfig considers command arguments and overrides some config items in the Config.
-func overrideConfig(cfg *config.Config) {
+func overrideConfig(cfg *config.Config, fset *flag.FlagSet) {
 	actualFlags := make(map[string]bool)
-	flag.Visit(func(f *flag.Flag) {
+	fset.Visit(func(f *flag.Flag) {
 		actualFlags[f.Name] = true
 	})
 

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -239,14 +239,14 @@ func initflag() {
 	// Ignore errors; CommandLine is set for ExitOnError.
 	// nolint:errcheck
 	fset.Parse(os.Args[1:])
+	if *help {
+		fset.Usage()
+		os.Exit(0)
+	}
 }
 
 func main() {
 	initflag()
-	if *help {
-		flag.Usage()
-		os.Exit(0)
-	}
 	config.InitializeConfig(*configPath, *configCheck, *configStrict, overrideConfig)
 	if *version {
 		setVersions()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47204

Problem Summary:

### What is changed and how it works?

In the initial version, the initialization process would include glog. Now, with this update, we have made a few changes. After the main function starts, the ```initflag``` function will be cleared first, and then the program will continue to execute.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```
tidb-server --help

  -log-file string
        log file path
  -log-slow-query string
        slow query file path

```


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
