### PR TITLE
*: remove useless cache in the MergePartitionStats2GlobalStats

### DIFF
--- a/statistics/handle/globalstats/global_stats.go
+++ b/statistics/handle/globalstats/global_stats.go
@@ -134,7 +134,7 @@ func MergePartitionStats2GlobalStats(
 		}
 
 		for i := 0; i < globalStats.Num; i++ {
-			// GetStatsInfo will return the copy of the statsInfo, so we don't need to worry about the memory problem.
+			// GetStatsInfo will return the copy of the statsInfo, so we don't need to worry about the data race.
 			// partitionStats will be released after the for loop.
 			hg, cms, topN, fms, analyzed := partitionStats.GetStatsInfo(histIDs[i], isIndex)
 			skipPartition := false

--- a/statistics/handle/globalstats/global_stats.go
+++ b/statistics/handle/globalstats/global_stats.go
@@ -123,9 +123,7 @@ func MergePartitionStats2GlobalStats(
 		}
 		tableInfo := partitionTable.Meta()
 		var partitionStats *statistics.Table
-		// If pre-load partition stats isn't provided, then we load partition stats directly and set it into allPartitionStats
-		var err1 error
-		partitionStats, err1 = loadTablePartitionStatsFn(tableInfo, &def)
+		partitionStats, err1 := loadTablePartitionStatsFn(tableInfo, &def)
 		if err1 != nil {
 			if skipMissingPartitionStats && types.ErrPartitionStatsMissing.Equal(err) {
 				globalStats.MissingPartitionStats = append(globalStats.MissingPartitionStats, fmt.Sprintf("partition `%s`", def.Name.L))

--- a/statistics/handle/globalstats/global_stats.go
+++ b/statistics/handle/globalstats/global_stats.go
@@ -134,6 +134,8 @@ func MergePartitionStats2GlobalStats(
 		}
 
 		for i := 0; i < globalStats.Num; i++ {
+			// GetStatsInfo will return the copy of the statsInfo, so we don't need to worry about the memory problem.
+			// partitionStats will be released after the for loop.
 			hg, cms, topN, fms, analyzed := partitionStats.GetStatsInfo(histIDs[i], isIndex)
 			skipPartition := false
 			if !analyzed {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/47219

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
