### PR TITLE
ddl, sysvar: remove `Switch EnableMDL` logs

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1229,7 +1229,6 @@ func (d *ddl) SwitchMDL(enable bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
-	logutil.BgLogger().Info("Switch EnableMDL 1", zap.Bool("arg", enable), zap.Bool("value", variable.EnableMDL.Load()))
 	// Disable MDL for test.
 	if enable && !variable.DefTiDBEnableConcurrentDDL {
 		sql := fmt.Sprintf("UPDATE HIGH_PRIORITY %[1]s.%[2]s SET VARIABLE_VALUE = %[4]d WHERE VARIABLE_NAME = '%[3]s'",
@@ -1248,7 +1247,6 @@ func (d *ddl) SwitchMDL(enable bool) error {
 		return nil
 	}
 
-	logutil.BgLogger().Info("Switch EnableMDL 2", zap.Bool("arg", enable), zap.Bool("value", variable.EnableMDL.Load()))
 	isEnableBefore := variable.EnableMDL.Load()
 	if isEnableBefore == enable {
 		return nil
@@ -1270,9 +1268,7 @@ func (d *ddl) SwitchMDL(enable bool) error {
 		return errors.New("please wait for all jobs done")
 	}
 
-	logutil.BgLogger().Info("Switch EnableMDL 3", zap.Bool("arg", enable), zap.Bool("value", variable.EnableMDL.Load()))
 	variable.EnableMDL.Store(enable)
-	logutil.BgLogger().Info("Switch EnableMDL 4", zap.Bool("arg", enable), zap.Bool("value", variable.EnableMDL.Load()))
 
 	err = kv.RunInNewTxn(kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL), d.store, true, func(ctx context.Context, txn kv.Transaction) error {
 		m := meta.NewMeta(txn)

--- a/sessionctx/variable/BUILD.bazel
+++ b/sessionctx/variable/BUILD.bazel
@@ -67,7 +67,6 @@ go_library(
         "@org_golang_x_exp//maps",
         "@org_golang_x_exp//slices",
         "@org_uber_go_atomic//:atomic",
-        "@org_uber_go_zap//:zap",
     ],
 )
 

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -48,7 +48,6 @@ import (
 	tikvcfg "github.com/tikv/client-go/v2/config"
 	tikvstore "github.com/tikv/client-go/v2/kv"
 	atomic2 "go.uber.org/atomic"
-	"go.uber.org/zap"
 )
 
 // All system variables declared here are ordered by their scopes, which follow the order of scopes below:
@@ -1115,9 +1114,7 @@ var defaultSysVars = []*SysVar{
 		return BoolToOnOff(EnableConcurrentDDL.Load()), nil
 	}},
 	{Scope: ScopeGlobal, Name: TiDBEnableMDL, Value: BoolToOnOff(DefTiDBEnableMDL), Type: TypeBool, SetGlobal: func(_ context.Context, vars *SessionVars, val string) error {
-		logutil.BgLogger().Info("mdl related variable status in setting status", zap.Bool("EnableMDL", EnableMDL.Load()), zap.Bool("EnableConcurrentDDL", EnableConcurrentDDL.Load()))
 		if EnableMDL.Load() != TiDBOptOn(val) {
-			logutil.BgLogger().Info("Switch EnableMDL", zap.Bool("val", TiDBOptOn(val)))
 			err := SwitchMDL(TiDBOptOn(val))
 			if err != nil {
 				return err


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #47224

Problem Summary:

Remove the redundant logs.

### What is changed and how it works?

These logs are added for debugging UTs and understanding the logic of "Enable MDL". They are quite meaningless, so should be removed from the released codes. I forgot to remove them in https://github.com/pingcap/tidb/pull/45980.

It only affects 6.5.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  
