### PR TITLE
disttask: remove scheduler/dispatcher id from logs and refinement

### DIFF
--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -16,7 +16,6 @@ package dispatcher
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -80,10 +79,11 @@ type Dispatcher interface {
 // BaseDispatcher is the base struct for Dispatcher.
 // each task type embed this struct and implement the Extension interface.
 type BaseDispatcher struct {
-	ctx      context.Context
-	taskMgr  *storage.TaskManager
-	Task     *proto.Task
-	logCtx   context.Context
+	ctx     context.Context
+	taskMgr *storage.TaskManager
+	Task    *proto.Task
+	logCtx  context.Context
+	// serverID, it's value is ip:port now.
 	serverID string
 	// when RegisterDispatcherFactory, the factory MUST initialize this field.
 	Extension
@@ -105,12 +105,13 @@ var MockOwnerChange func()
 
 // NewBaseDispatcher creates a new BaseDispatcher.
 func NewBaseDispatcher(ctx context.Context, taskMgr *storage.TaskManager, serverID string, task *proto.Task) *BaseDispatcher {
-	logPrefix := fmt.Sprintf("task_id: %d, task_type: %s, server_id: %s", task.ID, task.Type, serverID)
+	logCtx := logutil.WithFields(context.Background(), zap.Int64("task-id", task.ID),
+		zap.String("task-type", task.Type))
 	return &BaseDispatcher{
 		ctx:                   ctx,
 		taskMgr:               taskMgr,
 		Task:                  task,
-		logCtx:                logutil.WithKeyValue(context.Background(), "dispatcher", logPrefix),
+		logCtx:                logCtx,
 		serverID:              serverID,
 		liveNodes:             nil,
 		liveNodeFetchInterval: DefaultLiveNodesCheckInterval,

--- a/disttask/framework/dispatcher/dispatcher_manager.go
+++ b/disttask/framework/dispatcher/dispatcher_manager.go
@@ -81,12 +81,13 @@ func (dm *Manager) clearRunningTasks() {
 // Dispatcher schedule and monitor tasks.
 // The scheduling task number is limited by size of gPool.
 type Manager struct {
-	ctx      context.Context
-	cancel   context.CancelFunc
-	taskMgr  *storage.TaskManager
-	wg       tidbutil.WaitGroupWrapper
-	gPool    *spool.Pool
-	inited   bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+	taskMgr *storage.TaskManager
+	wg      tidbutil.WaitGroupWrapper
+	gPool   *spool.Pool
+	inited  bool
+	// serverID, it's value is ip:port now.
 	serverID string
 
 	runningTasks struct {

--- a/disttask/framework/scheduler/scheduler.go
+++ b/disttask/framework/scheduler/scheduler.go
@@ -16,7 +16,6 @@ package scheduler
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -60,12 +59,11 @@ type BaseScheduler struct {
 
 // NewBaseScheduler creates a new BaseScheduler.
 func NewBaseScheduler(_ context.Context, id string, taskID int64, taskTable TaskTable) *BaseScheduler {
-	logPrefix := fmt.Sprintf("id: %s, task_id: %d", id, taskID)
 	schedulerImpl := &BaseScheduler{
 		id:        id,
 		taskID:    taskID,
 		taskTable: taskTable,
-		logCtx:    logutil.WithKeyValue(context.Background(), "scheduler", logPrefix),
+		logCtx:    logutil.WithFields(context.Background(), zap.Int64("task-id", taskID)),
 	}
 	return schedulerImpl
 }
@@ -424,7 +422,7 @@ func (s *BaseScheduler) onError(err error) {
 	if err == nil {
 		return
 	}
-	err = errors.WithStack(err)
+	err = errors.Trace(err)
 	logutil.Logger(s.logCtx).Error("onError", zap.Error(err))
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46258

Problem Summary:

### What is changed and how it works?

remove scheduler/dispatcher id from logs, the server log itself will identify where we're in

avoid stack overriding in scheduler.OnErr using errors.Trace

some comments

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
run import into task, check logs
```

[2023/09/25 19:48:00.041 +08:00] [INFO] [dispatcher.go:481] [onNextStage] [task-id=90001] [task-type=ImportInto] [current-step=3] [next-step=4]
....
[2023/09/25 19:47:59.141 +08:00] [INFO] [scheduler.go:131] ["scheduler run a step"] [task-id=90001] [step=3] [concurrency=4]

```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
