### PR TITLE
*: add resource group name for cancel/establish req for tiflash

### DIFF
--- a/executor/internal/mpp/local_mpp_coordinator.go
+++ b/executor/internal/mpp/local_mpp_coordinator.go
@@ -456,8 +456,8 @@ func (c *localMppCoordinator) handleDispatchReq(ctx context.Context, bo *backoff
 	}
 	// only root task should establish a stream conn with tiFlash to receive result.
 	taskMeta := &mpp.TaskMeta{StartTs: req.StartTs, GatherId: c.gatherID, QueryTs: req.MppQueryID.QueryTs, LocalQueryId: req.MppQueryID.LocalQueryID, TaskId: req.ID, ServerId: req.MppQueryID.ServerID,
-		Address:    req.Meta.GetAddress(),
-		MppVersion: req.MppVersion.ToInt64(),
+		Address:           req.Meta.GetAddress(),
+		MppVersion:        req.MppVersion.ToInt64(),
 		ResourceGroupName: req.ResourceGroupName,
 	}
 	c.receiveResults(req, taskMeta, bo)

--- a/executor/internal/mpp/local_mpp_coordinator.go
+++ b/executor/internal/mpp/local_mpp_coordinator.go
@@ -208,6 +208,10 @@ func (c *localMppCoordinator) appendMPPDispatchReq(pf *plannercore.Fragment) err
 			return errors.Trace(err)
 		}
 
+		rgName := c.sessionCtx.GetSessionVars().ResourceGroupName
+		if !variable.EnableResourceControl.Load() {
+			rgName = ""
+		}
 		logutil.BgLogger().Info("Dispatch mpp task", zap.Uint64("timestamp", mppTask.StartTs),
 			zap.Int64("ID", mppTask.ID), zap.Uint64("QueryTs", mppTask.MppQueryID.QueryTs), zap.Uint64("LocalQueryId", mppTask.MppQueryID.LocalQueryID),
 			zap.Uint64("ServerID", mppTask.MppQueryID.ServerID), zap.String("address", mppTask.Meta.GetAddress()),
@@ -215,11 +219,8 @@ func (c *localMppCoordinator) appendMPPDispatchReq(pf *plannercore.Fragment) err
 			zap.Int64("mpp-version", mppTask.MppVersion.ToInt64()),
 			zap.String("exchange-compression-mode", pf.ExchangeSender.CompressionMode.Name()),
 			zap.Uint64("GatherID", c.gatherID),
+			zap.String("resource_group", rgName),
 		)
-		rgName := c.sessionCtx.GetSessionVars().ResourceGroupName
-		if !variable.EnableResourceControl.Load() {
-			rgName = ""
-		}
 		req := &kv.MPPDispatchRequest{
 			Data:                   pbData,
 			Meta:                   mppTask.Meta,
@@ -457,6 +458,7 @@ func (c *localMppCoordinator) handleDispatchReq(ctx context.Context, bo *backoff
 	taskMeta := &mpp.TaskMeta{StartTs: req.StartTs, GatherId: c.gatherID, QueryTs: req.MppQueryID.QueryTs, LocalQueryId: req.MppQueryID.LocalQueryID, TaskId: req.ID, ServerId: req.MppQueryID.ServerID,
 		Address:    req.Meta.GetAddress(),
 		MppVersion: req.MppVersion.ToInt64(),
+		ResourceGroupName: req.ResourceGroupName,
 	}
 	c.receiveResults(req, taskMeta, bo)
 }

--- a/store/copr/mpp.go
+++ b/store/copr/mpp.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/driver/backoff"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"

--- a/store/copr/mpp.go
+++ b/store/copr/mpp.go
@@ -234,13 +234,13 @@ func (c *MPPClient) EstablishMPPConns(param kv.EstablishMPPConnsParam) (*tikvrpc
 	connReq := &mpp.EstablishMPPConnectionRequest{
 		SenderMeta: taskMeta,
 		ReceiverMeta: &mpp.TaskMeta{
-			StartTs:      req.StartTs,
-			GatherId:     req.GatherID,
-			QueryTs:      req.MppQueryID.QueryTs,
-			LocalQueryId: req.MppQueryID.LocalQueryID,
-			ServerId:     req.MppQueryID.ServerID,
-			MppVersion:   req.MppVersion.ToInt64(),
-			TaskId:       -1,
+			StartTs:           req.StartTs,
+			GatherId:          req.GatherID,
+			QueryTs:           req.MppQueryID.QueryTs,
+			LocalQueryId:      req.MppQueryID.LocalQueryID,
+			ServerId:          req.MppQueryID.ServerID,
+			MppVersion:        req.MppVersion.ToInt64(),
+			TaskId:            -1,
 			ResourceGroupName: req.ResourceGroupName,
 		},
 	}

--- a/store/copr/mpp.go
+++ b/store/copr/mpp.go
@@ -102,10 +102,6 @@ func (c *MPPClient) DispatchMPPTask(param kv.DispatchMPPTaskParam) (resp *mpp.Di
 		}
 	}
 
-	rgName := req.ResourceGroupName
-	if !variable.EnableResourceControl.Load() {
-		rgName = ""
-	}
 	// meta for current task.
 	taskMeta := &mpp.TaskMeta{StartTs: req.StartTs, QueryTs: req.MppQueryID.QueryTs, LocalQueryId: req.MppQueryID.LocalQueryID, TaskId: req.ID, ServerId: req.MppQueryID.ServerID,
 		GatherId:               req.GatherID,
@@ -113,7 +109,7 @@ func (c *MPPClient) DispatchMPPTask(param kv.DispatchMPPTaskParam) (resp *mpp.Di
 		CoordinatorAddress:     req.CoordinatorAddress,
 		ReportExecutionSummary: req.ReportExecutionSummary,
 		MppVersion:             req.MppVersion.ToInt64(),
-		ResourceGroupName:      rgName,
+		ResourceGroupName:      req.ResourceGroupName,
 	}
 
 	mppReq := &mpp.DispatchTaskRequest{
@@ -203,7 +199,7 @@ func (c *MPPClient) CancelMPPTasks(param kv.CancelMPPTasksParam) {
 
 	firstReq := reqs[0]
 	killReq := &mpp.CancelTaskRequest{
-		Meta: &mpp.TaskMeta{StartTs: firstReq.StartTs, GatherId: firstReq.GatherID, QueryTs: firstReq.MppQueryID.QueryTs, LocalQueryId: firstReq.MppQueryID.LocalQueryID, ServerId: firstReq.MppQueryID.ServerID, MppVersion: firstReq.MppVersion.ToInt64()},
+		Meta: &mpp.TaskMeta{StartTs: firstReq.StartTs, GatherId: firstReq.GatherID, QueryTs: firstReq.MppQueryID.QueryTs, LocalQueryId: firstReq.MppQueryID.LocalQueryID, ServerId: firstReq.MppQueryID.ServerID, MppVersion: firstReq.MppVersion.ToInt64(), ResourceGroupName: firstReq.ResourceGroupName},
 	}
 
 	wrappedReq := tikvrpc.NewRequest(tikvrpc.CmdMPPCancel, killReq, kvrpcpb.Context{})
@@ -246,6 +242,7 @@ func (c *MPPClient) EstablishMPPConns(param kv.EstablishMPPConnsParam) (*tikvrpc
 			ServerId:     req.MppQueryID.ServerID,
 			MppVersion:   req.MppVersion.ToInt64(),
 			TaskId:       -1,
+			ResourceGroupName: req.ResourceGroupName,
 		},
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47274

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. tiup start cluster
2. connect to tidb and run a query and cancel it
3. check tiflash log, we can see resource group name in cancel request.
<img width="1338" alt="image" src="https://github.com/pingcap/tidb/assets/7493273/cad9c26b-20bf-4737-9f59-b3771b5ac30c">

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
