### PR TITLE
ebs br: provide fsr warmup to tikv data volumes

### DIFF
--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -526,7 +526,7 @@ func (e *EC2Session) WaitVolumesCreated(volumeIDMap map[string]string, progress 
 	for len(pendingVolumes) > 0 {
 		// check every 5 seconds
 		time.Sleep(5 * time.Second)
-		log.Info("check pending snapshots", zap.Int("count", len(pendingVolumes)))
+		log.Info("check pending volumes", zap.Int("count", len(pendingVolumes)))
 		resp, err := e.ec2.DescribeVolumes(&ec2.DescribeVolumesInput{
 			VolumeIds: pendingVolumes,
 		})

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -298,7 +298,7 @@ func (e *EC2Session) EnableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string)
 
 	if len(resp.Unsuccessful) > 0 {
 		log.Warn("not all snapshots enabled FSR")
-		return nil, errors.Errorf("Some snapshot fails to enable FSR, such as %s, error code is %v", resp.Unsuccessful[0].SnapshotId, resp.Unsuccessful[0].FastSnapshotRestoreStateErrors)
+		return nil, errors.Errorf("Some snapshot fails to enable FSR, such as %s, error code is %v", *resp.Unsuccessful[0].SnapshotId, resp.Unsuccessful[0].FastSnapshotRestoreStateErrors)
 	}
 
 	log.Info("Enable FSR issued")
@@ -308,11 +308,9 @@ func (e *EC2Session) EnableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string)
 
 // WaitDataFSREnabled waits FSR for data volume snapshots are all enabled
 func (e *EC2Session) WaitDataFSREnabled(snapShotIDs []*string, targetAZ string, progress glue.Progress) error {
-
 	pendingSnapshots := make([]*string, 0, len(snapShotIDs))
-	for _, snaphotID := range snapShotIDs {
-		pendingSnapshots = append(pendingSnapshots, snaphotID)
-	}
+
+	pendingSnapshots = append(pendingSnapshots, snapShotIDs...)
 
 	log.Info("starts check fsr pending snapshots", zap.Any("snapshots", pendingSnapshots))
 	for {
@@ -349,10 +347,6 @@ func (e *EC2Session) WaitDataFSREnabled(snapShotIDs []*string, targetAZ string, 
 		}
 		pendingSnapshots = uncompletedSnapshots
 	}
-
-	log.Info("all snaashots are fsr enabled.")
-	return nil
-
 }
 
 // DisableDataFSR disables FSR for data volume snapshots
@@ -372,7 +366,7 @@ func (e *EC2Session) DisableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string
 
 	if len(resp.Unsuccessful) > 0 {
 		log.Warn("not all snapshots disabled FSR")
-		return errors.Errorf("Some snapshot fails to disable FSR, such as %s, error code is %v", resp.Unsuccessful[0].SnapshotId, resp.Unsuccessful[0].FastSnapshotRestoreStateErrors)
+		return errors.Errorf("Some snapshot fails to disable FSR, such as %s, error code is %v", *resp.Unsuccessful[0].SnapshotId, resp.Unsuccessful[0].FastSnapshotRestoreStateErrors)
 	}
 
 	log.Info("Disable FSR issued")

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -344,7 +344,7 @@ func (e *EC2Session) WaitDataFSREnabled(snapShotIDs []*string, targetAZ string, 
 			return errors.Trace(err)
 		}
 
-		var uncompletedSnapshots map[string]struct{}
+		uncompletedSnapshots := make(map[string]struct{})
 		for _, fastRestore := range result.FastSnapshotRestores {
 			_, found := pendingSnapshots[*fastRestore.SnapshotId]
 			if found {

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -310,45 +310,49 @@ func (e *EC2Session) EnableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string)
 func (e *EC2Session) WaitDataFSREnabled(snapShotIDs []*string, targetAZ string, progress glue.Progress) error {
 
 	pendingSnapshots := make([]*string, 0, len(snapShotIDs))
-	for volID := range snapIDMap {
-		snapID := snapIDMap[volID]
-		pendingSnapshots = append(pendingSnapshots, &snapID)
+	for _, snaphotID := range snapShotIDs {
+		pendingSnapshots = append(pendingSnapshots, snaphotID)
 	}
-	snapProgressMap := make([]*string, len(snapShotIDs))
 
-	log.Info("starts check pending snapshots", zap.Any("snapshots", pendingSnapshots))
+	log.Info("starts check fsr pending snapshots", zap.Any("snapshots", pendingSnapshots))
 	for {
 		if len(pendingSnapshots) == 0 {
-			log.Info("all pending volume snapshots are finished.")
-			return totalVolumeSize, nil
+			log.Info("all snapshots fsr enablement is finished.")
+			return nil
 		}
 
-		// check pending snapshots every 5 seconds
-		time.Sleep(5 * time.Second)
-		log.Info("check pending snapshots", zap.Int("count", len(pendingSnapshots)))
-		resp, err := e.ec2.DescribeSnapshots(&ec2.DescribeSnapshotsInput{
-			SnapshotIds: pendingSnapshots,
-		})
+		// check pending snapshots every 1 minute
+		time.Sleep(1 * time.Minute)
+		log.Info("check snapshots not fsr enabled", zap.Int("count", len(pendingSnapshots)))
+		input := &ec2.DescribeFastSnapshotRestoresInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("state"),
+					Values: []*string{aws.String("disabled"), aws.String("disabling"), aws.String("enabling"), aws.String("optimizing")},
+				},
+				{
+					Name:   aws.String("availability-zone"),
+					Values: []*string{aws.String(targetAZ)},
+				},
+			},
+		}
+
+		result, err := e.ec2.DescribeFastSnapshotRestores(input)
 		if err != nil {
-			return 0, errors.Trace(err)
+			return errors.Trace(err)
 		}
 
 		var uncompletedSnapshots []*string
-		for _, s := range resp.Snapshots {
-			if *s.State == ec2.SnapshotStateCompleted {
-				log.Info("snapshot completed", zap.String("id", *s.SnapshotId))
-			} else {
-				log.Debug("snapshot creating...", zap.Stringer("snap", s))
-				uncompletedSnapshots = append(uncompletedSnapshots, s.SnapshotId)
-			}
-			currSnapProgress := e.extractSnapProgress(s.Progress)
-			if currSnapProgress > snapProgressMap[*s.SnapshotId] {
-				progress.IncBy(currSnapProgress - snapProgressMap[*s.SnapshotId])
-				snapProgressMap[*s.SnapshotId] = currSnapProgress
-			}
+		for _, fastRestore := range result.FastSnapshotRestores {
+			uncompletedSnapshots = append(uncompletedSnapshots, fastRestore.SnapshotId)
+			progress.IncBy(int64(len(pendingSnapshots) - len(uncompletedSnapshots)))
 		}
 		pendingSnapshots = uncompletedSnapshots
 	}
+
+	log.Info("all snaashots are fsr enabled.")
+	return nil
+
 }
 
 // DisableDataFSR disables FSR for data volume snapshots

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -291,12 +291,10 @@ func (e *EC2Session) EnableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string)
 
 	eg, _ := errgroup.WithContext(context.Background())
 
-	workerPool := utils.NewWorkerPool(uint(len(snapshotsIDsMap)), "enable snapshot FSR")
-
 	for availableZone := range snapshotsIDsMap {
 		targetAZ := availableZone
-		workerPool.ApplyOnErrorGroup(eg, func() error {
-			log.Info("enable fsr for snapshots", zap.String("available zone", availableZone))
+		eg.Go(func() error {
+			log.Info("enable fsr for snapshots", zap.String("available zone", targetAZ))
 			resp, err := e.ec2.EnableFastSnapshotRestores(&ec2.EnableFastSnapshotRestoresInput{
 				AvailabilityZones: []*string{&targetAZ},
 				SourceSnapshotIds: snapshotsIDsMap[targetAZ],
@@ -379,11 +377,9 @@ func (e *EC2Session) DisableDataFSR(snapshotsIDsMap map[string][]*string) error 
 
 	eg, _ := errgroup.WithContext(context.Background())
 
-	workerPool := utils.NewWorkerPool(uint(len(snapshotsIDsMap)), "disable snapshot FSR")
-
 	for availableZone := range snapshotsIDsMap {
 		targetAZ := availableZone
-		workerPool.ApplyOnErrorGroup(eg, func() error {
+		eg.Go(func() error {
 			resp, err := e.ec2.DisableFastSnapshotRestores(&ec2.DisableFastSnapshotRestoresInput{
 				AvailabilityZones: []*string{&targetAZ},
 				SourceSnapshotIds: snapshotsIDsMap[targetAZ],

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -282,10 +282,18 @@ func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string) {
 }
 
 // EnableDataFSR enables FSR for data volume snapshots
-func (e *EC2Session) EnableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string) ([]*string, error) {
-	sourceSnapshotIDs := fetchTargetSnapshots(meta)
+func (e *EC2Session) EnableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string) ([]*string, string, error) {
+	originalAZ, sourceSnapshotIDs := fetchTargetSnapshots(meta)
 
-	log.Info("Start enable FSR for", zap.Int("snapshot number", len(sourceSnapshotIDs)), zap.Any("Snapshots", sourceSnapshotIDs), zap.String("available zone", targetAZ))
+	if originalAZ == "" {
+		return nil, "", errors.Errorf("empty backup meta")
+	}
+
+	log.Info("Start enable FSR for", zap.Int("snapshot number", len(sourceSnapshotIDs)), zap.Any("Snapshots", sourceSnapshotIDs), zap.String("available zone", targetAZ), zap.String("original AZ", originalAZ))
+
+	if targetAZ == "" {
+		targetAZ = originalAZ
+	}
 
 	resp, err := e.ec2.EnableFastSnapshotRestores(&ec2.EnableFastSnapshotRestoresInput{
 		AvailabilityZones: []*string{&targetAZ},
@@ -293,17 +301,17 @@ func (e *EC2Session) EnableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string)
 	})
 
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, targetAZ, errors.Trace(err)
 	}
 
 	if len(resp.Unsuccessful) > 0 {
 		log.Warn("not all snapshots enabled FSR")
-		return nil, errors.Errorf("Some snapshot fails to enable FSR, such as %s, error code is %v", *resp.Unsuccessful[0].SnapshotId, resp.Unsuccessful[0].FastSnapshotRestoreStateErrors)
+		return nil, targetAZ, errors.Errorf("Some snapshot fails to enable FSR, such as %s, error code is %v", *resp.Unsuccessful[0].SnapshotId, resp.Unsuccessful[0].FastSnapshotRestoreStateErrors)
 	}
 
 	log.Info("Enable FSR issued")
 
-	return sourceSnapshotIDs, nil
+	return sourceSnapshotIDs, targetAZ, nil
 }
 
 // WaitDataFSREnabled waits FSR for data volume snapshots are all enabled
@@ -316,7 +324,7 @@ func (e *EC2Session) WaitDataFSREnabled(snapShotIDs []*string, targetAZ string, 
 		pendingSnapshots[*str] = struct{}{}
 	}
 
-	log.Info("starts check fsr pending snapshots", zap.Any("snapshots", pendingSnapshots))
+	log.Info("starts check fsr pending snapshots", zap.Any("snapshots", pendingSnapshots), zap.String("available zone", targetAZ))
 	for {
 		if len(pendingSnapshots) == 0 {
 			log.Info("all snapshots fsr enablement is finished.")
@@ -363,10 +371,13 @@ func (e *EC2Session) WaitDataFSREnabled(snapShotIDs []*string, targetAZ string, 
 
 // DisableDataFSR disables FSR for data volume snapshots
 func (e *EC2Session) DisableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string) error {
-	sourceSnapshotIDs := fetchTargetSnapshots(meta)
+	originAZ, sourceSnapshotIDs := fetchTargetSnapshots(meta)
 
-	log.Info("Start disable FSR", zap.Int("snapshot number", len(sourceSnapshotIDs)), zap.Any("Snapshots", sourceSnapshotIDs), zap.String("available zone", targetAZ))
+	log.Info("Start disable FSR", zap.Int("snapshot number", len(sourceSnapshotIDs)), zap.Any("Snapshots", sourceSnapshotIDs), zap.String("available zone", targetAZ), zap.String("original AZ", originAZ))
 
+	if targetAZ == "" {
+		targetAZ = originAZ
+	}
 	resp, err := e.ec2.DisableFastSnapshotRestores(&ec2.DisableFastSnapshotRestoresInput{
 		AvailabilityZones: []*string{&targetAZ},
 		SourceSnapshotIds: sourceSnapshotIDs,
@@ -386,8 +397,15 @@ func (e *EC2Session) DisableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string
 	return nil
 }
 
-func fetchTargetSnapshots(meta *config.EBSBasedBRMeta) []*string {
+func fetchTargetSnapshots(meta *config.EBSBasedBRMeta) (string, []*string) {
 	var sourceSnapshotIDs []*string
+
+	if len(meta.TiKVComponent.Stores) == 0 {
+		return "", nil
+	}
+
+	originalAZ := meta.TiKVComponent.Stores[0].Volumes[0].VolumeAZ
+
 	for i := range meta.TiKVComponent.Stores {
 		store := meta.TiKVComponent.Stores[i]
 		for j := range store.Volumes {
@@ -399,7 +417,7 @@ func fetchTargetSnapshots(meta *config.EBSBasedBRMeta) []*string {
 		}
 	}
 
-	return sourceSnapshotIDs
+	return originalAZ, sourceSnapshotIDs
 }
 
 // CreateVolumes create volumes from snapshots

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -348,6 +348,11 @@ func (e *EC2Session) WaitDataFSREnabled(snapShotIDs []*string, targetAZ string, 
 		for _, fastRestore := range result.FastSnapshotRestores {
 			_, found := pendingSnapshots[*fastRestore.SnapshotId]
 			if found {
+				// Detect some conflict states
+				if strings.EqualFold(*fastRestore.State, "disabled") || strings.EqualFold(*fastRestore.State, "disabling") {
+					log.Error("detect conflict status", zap.String("snapshot", *fastRestore.SnapshotId), zap.String("status", *fastRestore.State))
+					return errors.Errorf("status of snapshot %s is %s ", *fastRestore.SnapshotId, *fastRestore.State))
+				}
 				uncompletedSnapshots[*fastRestore.SnapshotId] = struct{}{}
 			}
 		}

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -27,6 +27,7 @@ import (
 const (
 	pollingPendingSnapshotInterval = 30 * time.Second
 	errCodeTooManyPendingSnapshots = "PendingSnapshotLimitExceeded"
+	maxConcurrentFSRJob            = 200
 )
 
 type EC2Session struct {
@@ -279,6 +280,78 @@ func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string) {
 	}
 	_ = eg.Wait()
 	log.Info("delete snapshot end", zap.Int("need-to-del", len(snapIDMap)), zap.Int32("deleted", deletedCnt.Load()))
+}
+
+// EnableDataFSR enables FSR for data volume snapshots
+func (e *EC2Session) EnableDataFSR(meta *config.EBSBasedBRMeta) error {
+	var sourceSnapshotIDs, availableZones []*string
+	for i := range meta.TiKVComponent.Stores {
+		store := meta.TiKVComponent.Stores[i]
+		for j := range store.Volumes {
+			oldVol := store.Volumes[j]
+			// Handle data volume snapshots only
+			if strings.Compare(oldVol.Type, "storage.data-dir") == 0 {
+				sourceSnapshotIDs = append(sourceSnapshotIDs, &oldVol.SnapshotID)
+				availableZones = append(availableZones, &oldVol.VolumeAZ)
+			}
+		}
+	}
+
+	log.Info("Start enable FSR for", zap.Int("snapshot number", len(sourceSnapshotIDs)), zap.Any("Snapshots", sourceSnapshotIDs))
+
+	resp, err := e.ec2.EnableFastSnapshotRestores(&ec2.EnableFastSnapshotRestoresInput{
+		AvailabilityZones: availableZones,
+		SourceSnapshotIds: sourceSnapshotIDs,
+	})
+
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if len(resp.Unsuccessful) > 0 {
+		log.Warn("not all snapshots enabled FSR")
+		return errors.Errorf("Some snapshot fails to enable FSR, such as %s, error code is %v", resp.Unsuccessful[0].SnapshotId, resp.Unsuccessful[0].FastSnapshotRestoreStateErrors)
+	}
+
+	log.Info("Enable FSR succeed")
+
+	return nil
+}
+
+// DisableDataFSR disables FSR for data volume snapshots
+func (e *EC2Session) DisableDataFSR(meta *config.EBSBasedBRMeta) error {
+	var sourceSnapshotIDs, availableZones []*string
+	for i := range meta.TiKVComponent.Stores {
+		store := meta.TiKVComponent.Stores[i]
+		for j := range store.Volumes {
+			oldVol := store.Volumes[j]
+			// Handle data volume snapshots only
+			if strings.Compare(oldVol.Type, "storage.data-dir") == 0 {
+				sourceSnapshotIDs = append(sourceSnapshotIDs, &oldVol.SnapshotID)
+				availableZones = append(availableZones, &oldVol.VolumeAZ)
+			}
+		}
+	}
+
+	log.Info("Start disable FSR", zap.Int("snapshot number", len(sourceSnapshotIDs)), zap.Any("Snapshots", sourceSnapshotIDs))
+
+	resp, err := e.ec2.DisableFastSnapshotRestores(&ec2.DisableFastSnapshotRestoresInput{
+		AvailabilityZones: availableZones,
+		SourceSnapshotIds: sourceSnapshotIDs,
+	})
+
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if len(resp.Unsuccessful) > 0 {
+		log.Warn("not all snapshots disabled FSR")
+		return errors.Errorf("Some snapshot fails to disable FSR, such as %s, error code is %v", resp.Unsuccessful[0].SnapshotId, resp.Unsuccessful[0].FastSnapshotRestoreStateErrors)
+	}
+
+	log.Info("disable FSR succeed")
+
+	return nil
 }
 
 // CreateVolumes create volumes from snapshots

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -351,7 +351,7 @@ func (e *EC2Session) WaitDataFSREnabled(snapShotIDs []*string, targetAZ string, 
 				// Detect some conflict states
 				if strings.EqualFold(*fastRestore.State, "disabled") || strings.EqualFold(*fastRestore.State, "disabling") {
 					log.Error("detect conflict status", zap.String("snapshot", *fastRestore.SnapshotId), zap.String("status", *fastRestore.State))
-					return errors.Errorf("status of snapshot %s is %s ", *fastRestore.SnapshotId, *fastRestore.State))
+					return errors.Errorf("status of snapshot %s is %s ", *fastRestore.SnapshotId, *fastRestore.State)
 				}
 				uncompletedSnapshots[*fastRestore.SnapshotId] = struct{}{}
 			}

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -285,7 +285,7 @@ func (e *EC2Session) DeleteSnapshots(snapIDMap map[string]string) {
 func (e *EC2Session) EnableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string) ([]*string, string, error) {
 	originalAZ, sourceSnapshotIDs := fetchTargetSnapshots(meta)
 
-	if originalAZ == "" {
+	if len(sourceSnapshotIDs) == 0 {
 		return nil, "", errors.Errorf("empty backup meta")
 	}
 
@@ -372,6 +372,10 @@ func (e *EC2Session) WaitDataFSREnabled(snapShotIDs []*string, targetAZ string, 
 // DisableDataFSR disables FSR for data volume snapshots
 func (e *EC2Session) DisableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string) error {
 	originAZ, sourceSnapshotIDs := fetchTargetSnapshots(meta)
+
+	if len(sourceSnapshotIDs) == 0 {
+		return nil
+	}
 
 	log.Info("Start disable FSR", zap.Int("snapshot number", len(sourceSnapshotIDs)), zap.Any("Snapshots", sourceSnapshotIDs), zap.String("available zone", targetAZ), zap.String("original AZ", originAZ))
 

--- a/br/pkg/config/ebs.go
+++ b/br/pkg/config/ebs.go
@@ -100,6 +100,14 @@ func (c *EBSBasedBRMeta) GetStoreCount() uint64 {
 	return uint64(len(c.TiKVComponent.Stores))
 }
 
+func (c *EBSBasedBRMeta) GetTiKVVolumeCount() uint64 {
+	if c.TiKVComponent == nil || len(c.TiKVComponent.Stores) == 0 {
+		return 0
+	}
+	// Assume TiKV nodes are symmetric
+	return uint64(len(c.TiKVComponent.Stores[0].Volumes))
+}
+
 func (c *EBSBasedBRMeta) String() string {
 	cfg, err := json.Marshal(c)
 	if err != nil {

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -80,6 +80,7 @@ const (
 	flagDryRun            = "dry-run"
 	// TODO used for local test, should be removed later
 	flagSkipAWS                       = "skip-aws"
+	flagUseFSR                        = "use-fsr"
 	flagCloudAPIConcurrency           = "cloud-api-concurrency"
 	flagWithSysTable                  = "with-sys-table"
 	flagOperatorPausedGCAndSchedulers = "operator-paused-gc-and-scheduler"

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -139,6 +139,7 @@ func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 		"batch size for ddl to create a batch of tables once.")
 	flags.Bool(flagWithSysTable, false, "whether restore system privilege tables on default setting")
 	flags.StringArrayP(FlagResetSysUsers, "", []string{"cloud_admin", "root"}, "whether reset these users after restoration")
+	flags.Bool(flagUseFSR, false, "whether enable FSR for AWS snapshots")
 	_ = flags.MarkHidden(FlagResetSysUsers)
 	_ = flags.MarkHidden(FlagMergeRegionSizeBytes)
 	_ = flags.MarkHidden(FlagMergeRegionKeyCount)

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -218,6 +218,7 @@ type RestoreConfig struct {
 	VolumeThroughput    int64                 `json:"volume-throughput" toml:"volume-throughput"`
 	ProgressFile        string                `json:"progress-file" toml:"progress-file"`
 	TargetAZ            string                `json:"target-az" toml:"target-az"`
+	UseFSR              bool                  `json:"use-fsr" toml:"use-fsr"`
 }
 
 // DefineRestoreFlags defines common flags for the restore tidb command.
@@ -387,6 +388,11 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 		}
 
 		cfg.TargetAZ, err = flags.GetString(flagTargetAZ)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		cfg.UseFSR, err = flags.GetBool(flagUseFSR)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/br/pkg/task/restore_data.go
+++ b/br/pkg/task/restore_data.go
@@ -159,23 +159,6 @@ func RunResolveKvData(c context.Context, g glue.Glue, cmdName string, cfg *Resto
 
 	//TODO: restore volume type into origin type
 	//ModifyVolume(*ec2.ModifyVolumeInput) (*ec2.ModifyVolumeOutput, error) by backupmeta
-	// this is used for cloud restoration
-	err = client.Init(g, mgr.GetStorage())
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer client.Close()
-	log.Info("start to clear system user for cloud")
-	err = client.ClearSystemUsers(ctx, cfg.ResetSysUsers)
-
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// since we cannot reset tiflash automaticlly. so we should start it manually
-	if err = client.ResetTiFlashReplicas(ctx, g, mgr.GetStorage()); err != nil {
-		return errors.Trace(err)
-	}
 	progress.Close()
 	summary.CollectDuration("restore duration", time.Since(startAll))
 	summary.SetSuccessStatus(true)

--- a/br/pkg/task/restore_data.go
+++ b/br/pkg/task/restore_data.go
@@ -159,6 +159,17 @@ func RunResolveKvData(c context.Context, g glue.Glue, cmdName string, cfg *Resto
 
 	//TODO: restore volume type into origin type
 	//ModifyVolume(*ec2.ModifyVolumeInput) (*ec2.ModifyVolumeOutput, error) by backupmeta
+
+	err = client.Init(g, mgr.GetStorage())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer client.Close()
+	// since we cannot reset tiflash automaticlly. so we should start it manually
+	if err = client.ResetTiFlashReplicas(ctx, g, mgr.GetStorage()); err != nil {
+		return errors.Trace(err)
+	}
+
 	progress.Close()
 	summary.CollectDuration("restore duration", time.Since(startAll))
 	summary.SetSuccessStatus(true)

--- a/br/pkg/task/restore_ebs_meta.go
+++ b/br/pkg/task/restore_ebs_meta.go
@@ -244,12 +244,14 @@ func (h *restoreEBSMetaHelper) restoreVolumes(progress glue.Progress) (map[strin
 
 	// Turn on FSR for TiKV data snapshots
 	if h.cfg.UseFSR {
-		snapshotsIDs, err := ec2Session.EnableDataFSR(h.metaInfo, h.cfg.TargetAZ)
+		snapshotsIDs, targetAZ, err := ec2Session.EnableDataFSR(h.metaInfo, h.cfg.TargetAZ)
 		if err != nil {
 			return nil, 0, errors.Trace(err)
 		}
 
-		err = ec2Session.WaitDataFSREnabled(snapshotsIDs, h.cfg.TargetAZ, progress)
+		h.cfg.TargetAZ = targetAZ
+
+		err = ec2Session.WaitDataFSREnabled(snapshotsIDs, targetAZ, progress)
 		if err != nil {
 			return nil, 0, errors.Trace(err)
 		}

--- a/br/pkg/task/restore_ebs_meta.go
+++ b/br/pkg/task/restore_ebs_meta.go
@@ -241,6 +241,7 @@ func (h *restoreEBSMetaHelper) restoreVolumes(progress glue.Progress) (map[strin
 
 		if h.cfg.UseFSR {
 			err = ec2Session.DisableDataFSR(snapshotsIDsMap)
+			log.Error("disable fsr failed", zap.Error(err))
 		}
 	}()
 
@@ -250,7 +251,6 @@ func (h *restoreEBSMetaHelper) restoreVolumes(progress glue.Progress) (map[strin
 		if err != nil {
 			return nil, 0, errors.Trace(err)
 		}
-
 	}
 
 	volumeIDMap, err = ec2Session.CreateVolumes(h.metaInfo,

--- a/br/pkg/task/restore_ebs_meta.go
+++ b/br/pkg/task/restore_ebs_meta.go
@@ -244,12 +244,15 @@ func (h *restoreEBSMetaHelper) restoreVolumes(progress glue.Progress) (map[strin
 
 	// Turn on FSR for TiKV data snapshots
 	if h.cfg.UseFSR {
-		err = ec2Session.EnableDataFSR(h.metaInfo, h.cfg.TargetAZ)
+		snapshotsIDs, err := ec2Session.EnableDataFSR(h.metaInfo, h.cfg.TargetAZ)
 		if err != nil {
 			return nil, 0, errors.Trace(err)
 		}
 
-		log.Info("FSR for data volume snapshots are enabled")
+		err = ec2Session.WaitDataFSREnabled(snapshotsIDs, h.cfg.TargetAZ, progress)
+		if err != nil {
+			return nil, 0, errors.Trace(err)
+		}
 	}
 
 	volumeIDMap, err = ec2Session.CreateVolumes(h.metaInfo,

--- a/br/pkg/task/restore_ebs_meta.go
+++ b/br/pkg/task/restore_ebs_meta.go
@@ -237,12 +237,14 @@ func (h *restoreEBSMetaHelper) restoreVolumes(progress glue.Progress) (map[strin
 			ec2Session.DeleteVolumes(volumeIDMap)
 		}
 
-		err = ec2Session.DisableDataFSR(h.metaInfo)
+		if h.cfg.UseFSR {
+			err = ec2Session.DisableDataFSR(h.metaInfo, h.cfg.TargetAZ)
+		}
 	}()
 
 	// Turn on FSR for TiKV data snapshots
 	if h.cfg.UseFSR {
-		err = ec2Session.EnableDataFSR(h.metaInfo)
+		err = ec2Session.EnableDataFSR(h.metaInfo, h.cfg.TargetAZ)
 		if err != nil {
 			return nil, 0, errors.Trace(err)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number:
close #47271
close #47273 

Problem Summary:

### What is changed and how it works?

This PR addresses 2 issues
1. EBS snapshot restore can do FSR based warmup to tikv data volumes. A new parameter of`use-fsr` is introduced to  `br` command. Set it to `true` to use FSR to warmup tikv data volumes.
2. Get rid of unnecessary removal of some users from mysql.user table at the end of restore

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
Run real EBS restore job and check the BR pod log to verify.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
