### PR TITLE
placement: supports follower role with evict-leader hint

### DIFF
--- a/ddl/placement/rule.go
+++ b/ddl/placement/rule.go
@@ -206,24 +206,11 @@ func NewRules(role PeerRoleType, replicas uint64, cnstr string) ([]*Rule, error)
 		}
 
 		for labels, cnt := range constraints2 {
-			innerLabels := strings.Split(labels, ",")
-			overrideRole := role
-			newLabels := make([]string, 0, len(innerLabels))
-			for _, str := range innerLabels {
-				if strings.HasPrefix(str, attributePrefix) {
-					switch str[1:] {
-					case attributeEvictLeader:
-						if role == Voter {
-							overrideRole = Follower
-						}
-					default:
-						return rules, fmt.Errorf("%w: unsupported attribute '%s'", ErrUnsupportedConstraint, str)
-					}
-					continue
-				}
-				newLabels = append(newLabels, str)
+			lbs, overrideRole, err := preCheckDictConstraintStr(labels, role)
+			if err != nil {
+				return rules, err
 			}
-			labelConstraints, err := NewConstraints(newLabels)
+			labelConstraints, err := NewConstraints(lbs)
 			if err != nil {
 				return rules, err
 			}

--- a/ddl/placement/rule_test.go
+++ b/ddl/placement/rule_test.go
@@ -139,6 +139,32 @@ func TestNewRuleAndNewRules(t *testing.T) {
 		err:   ErrInvalidConstraintsMappingWrongSeparator,
 	})
 
+	tests = append(tests, TestCase{
+		name:  "normal dict constraint with evict leader attribute",
+		input: `{"+zone=sh,-zone=bj":2, "+zone=sh,#evict-leader": 1}`,
+		output: []*Rule{
+			NewRule(Voter, 2, NewConstraintsDirect(
+				NewConstraintDirect("zone", In, "sh"),
+				NewConstraintDirect("zone", NotIn, "bj"),
+			)),
+			NewRule(Follower, 1, NewConstraintsDirect(
+				NewConstraintDirect("zone", In, "sh"),
+			)),
+		},
+	})
+
+	tests = append(tests, TestCase{
+		name:  "invalid constraints with invalid format",
+		input: `{"+zone=sh,-zone=bj":2, "+zone=sh,evict-leader": 1}`,
+		err:   ErrInvalidConstraintFormat,
+	})
+
+	tests = append(tests, TestCase{
+		name:  "invalid constraints with undetermined attribute",
+		input: `{"+zone=sh,-zone=bj":2, "+zone=sh,#reject-follower": 1}`,
+		err:   ErrUnsupportedConstraint,
+	})
+
 	for _, tt := range tests {
 		comment := fmt.Sprintf("[%s]", tt.name)
 		output, err := NewRules(Voter, tt.replicas, tt.input)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46304

Problem Summary:

Currently, all `FOLLOWER_CONSTRAINTS` will set the role in the rule to be `voter`. It can cover major scenarios and reduce the user's burden. but in some scenarios cannot cover, like:

there are three az, zone1, zone2, zone3. the user wants the replicas in zone 1 and zone 2 can be the leader, and normal situations, the leader should be placed in zone 1, if zone 1 is gone, the leader is better in zone 2. and zone3 reject be the leader,  zone 3 can be seen as a backup zone, it's not used to serve.

maybe we can enhance the `FOLLOWER_CONSTRAINTS`, like
#####  add attribute
```
Dictionary:  e.g. {"+region=us-east": 2, "+region=us-west,#evict-leader": 1}
```
`#evict-leader` explains voters should be followers, and reject becoming leaders.

full SQL will like this:
```
CREATE PLACEMENT POLICY `mydeploy`  LEADER_CONSTRAINTS='{"+region=us-east-1": 1}' FOLLOWER_CONSTRAINTS='{"+region=us-east-1": 1,  "+region=use-east-2":2, "+region=us-west,#evict-leader": 1};
```

#### alternative plan

**warn**: this is the current easy way to achieve this issue scenario. we would be supported `leader_preferences` in the future to define the leader choice priority.

### What is changed and how it works?

add new keywords.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
