### PR TITLE
util: change log level to debug calculating stale read ts

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -6636,7 +6636,7 @@ func CalAppropriateTime(minTime, maxTime, minSafeTime time.Time) time.Time {
 //     and with it, a read request won't fail because it's bigger than the latest SafeTS.
 func calAppropriateTime(minTime, maxTime, minSafeTime time.Time) time.Time {
 	if minSafeTime.Before(minTime) || minSafeTime.After(maxTime) {
-		logutil.BgLogger().Warn("calAppropriateTime",
+		logutil.BgLogger().Debug("calAppropriateTime",
 			zap.Time("minTime", minTime),
 			zap.Time("maxTime", maxTime),
 			zap.Time("minSafeTime", minSafeTime))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #47308 

Problem Summary:
Change log level to debug for
```
[2023/09/22 22:58:36.055 +00:00] [WARN] [builtin_time.go:6639] [calAppropriateTime] [minTime=2023/09/22 22:57:36.055 +00:00] [maxTime=2023/09/22 22:58:36.055 +00:00] [minSafeTime=2023/09/22 22:57:35.289 +00:00]
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test


Side effects


Documentation

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
