### PR TITLE
planner: unify ways to execute SQLs in stats_handle package

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -117,13 +117,13 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 		case infoschema.TableStatistics:
 			e.setDataForStatistics(sctx, dbs)
 		case infoschema.TableTables:
-			err = e.setDataFromTables(ctx, sctx, dbs)
+			err = e.setDataFromTables(sctx, dbs)
 		case infoschema.TableReferConst:
 			err = e.setDataFromReferConst(sctx, dbs)
 		case infoschema.TableSequences:
 			e.setDataFromSequences(sctx, dbs)
 		case infoschema.TablePartitions:
-			err = e.setDataFromPartitions(ctx, sctx, dbs)
+			err = e.setDataFromPartitions(sctx, dbs)
 		case infoschema.TableClusterInfo:
 			err = e.dataForTiDBClusterInfo(sctx)
 		case infoschema.TableAnalyzeStatus:
@@ -487,8 +487,8 @@ func (e *memtableRetriever) setDataFromReferConst(sctx sessionctx.Context, schem
 	return nil
 }
 
-func (e *memtableRetriever) setDataFromTables(ctx context.Context, sctx sessionctx.Context, schemas []*model.DBInfo) error {
-	err := cache.TableRowStatsCache.Update(ctx, sctx)
+func (e *memtableRetriever) setDataFromTables(sctx sessionctx.Context, schemas []*model.DBInfo) error {
+	err := cache.TableRowStatsCache.Update(sctx)
 	if err != nil {
 		return err
 	}
@@ -899,9 +899,9 @@ func calcCharOctLength(lenInChar int, cs string) int {
 	return lenInBytes
 }
 
-func (e *memtableRetriever) setDataFromPartitions(ctx context.Context, sctx sessionctx.Context, schemas []*model.DBInfo) error {
+func (e *memtableRetriever) setDataFromPartitions(sctx sessionctx.Context, schemas []*model.DBInfo) error {
 	cache := cache.TableRowStatsCache
-	err := cache.Update(ctx, sctx)
+	err := cache.Update(sctx)
 	if err != nil {
 		return err
 	}

--- a/statistics/handle/autoanalyze/BUILD.bazel
+++ b/statistics/handle/autoanalyze/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//infoschema",
-        "//kv",
         "//metrics",
         "//parser/ast",
         "//parser/model",

--- a/statistics/handle/autoanalyze/autoanalyze.go
+++ b/statistics/handle/autoanalyze/autoanalyze.go
@@ -64,7 +64,7 @@ func parseAnalyzePeriod(start, end string) (time.Time, time.Time, error) {
 
 func getAutoAnalyzeParameters(sctx sessionctx.Context) map[string]string {
 	sql := "select variable_name, variable_value from mysql.global_variables where variable_name in (%?, %?, %?)"
-	rows, _, err := statsutil.ExecRows(sctx, sql, variable.TiDBAutoAnalyzeRatio, variable.TiDBAutoAnalyzeStartTime, variable.TiDBAutoAnalyzeEndTime)
+	rows, _, err := statsutil.ExecWithOpts(sctx, nil, sql, variable.TiDBAutoAnalyzeRatio, variable.TiDBAutoAnalyzeStartTime, variable.TiDBAutoAnalyzeEndTime)
 	if err != nil {
 		return map[string]string{}
 	}

--- a/statistics/handle/autoanalyze/autoanalyze.go
+++ b/statistics/handle/autoanalyze/autoanalyze.go
@@ -15,7 +15,6 @@
 package autoanalyze
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -25,7 +24,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/infoschema"
-	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
@@ -64,10 +62,9 @@ func parseAnalyzePeriod(start, end string) (time.Time, time.Time, error) {
 	return s, e, err
 }
 
-func getAutoAnalyzeParameters(exec sqlexec.RestrictedSQLExecutor) map[string]string {
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+func getAutoAnalyzeParameters(sctx sessionctx.Context) map[string]string {
 	sql := "select variable_name, variable_value from mysql.global_variables where variable_name in (%?, %?, %?)"
-	rows, _, err := exec.ExecRestrictedSQL(ctx, nil, sql, variable.TiDBAutoAnalyzeRatio, variable.TiDBAutoAnalyzeStartTime, variable.TiDBAutoAnalyzeEndTime)
+	rows, _, err := statsutil.ExecRows(sctx, sql, variable.TiDBAutoAnalyzeRatio, variable.TiDBAutoAnalyzeStartTime, variable.TiDBAutoAnalyzeEndTime)
 	if err != nil {
 		return map[string]string{}
 	}
@@ -103,9 +100,8 @@ func HandleAutoAnalyze(sctx sessionctx.Context,
 			logutil.BgLogger().Error("HandleAutoAnalyze panicked", zap.Any("error", r), zap.Stack("stack"))
 		}
 	}()
-	exec := sctx.(sqlexec.RestrictedSQLExecutor)
 	dbs := is.AllSchemaNames()
-	parameters := getAutoAnalyzeParameters(exec)
+	parameters := getAutoAnalyzeParameters(sctx)
 	autoAnalyzeRatio := parseAutoAnalyzeRatio(parameters[variable.TiDBAutoAnalyzeRatio])
 	start, end, err := parseAnalyzePeriod(parameters[variable.TiDBAutoAnalyzeStartTime], parameters[variable.TiDBAutoAnalyzeEndTime])
 	if err != nil {
@@ -168,7 +164,7 @@ func HandleAutoAnalyze(sctx sessionctx.Context,
 			if pi == nil {
 				statsTbl := opt.GetTableStats(tblInfo)
 				sql := "analyze table %n.%n"
-				analyzed := autoAnalyzeTable(sctx, exec, opt, tblInfo, statsTbl, autoAnalyzeRatio, sql, db, tblInfo.Name.O)
+				analyzed := autoAnalyzeTable(sctx, opt, tblInfo, statsTbl, autoAnalyzeRatio, sql, db, tblInfo.Name.O)
 				if analyzed {
 					// analyze one table at a time to let it get the freshest parameters.
 					// others will be analyzed next round which is just 3s later.
@@ -184,7 +180,7 @@ func HandleAutoAnalyze(sctx sessionctx.Context,
 				}
 			}
 			if pruneMode == variable.Dynamic {
-				analyzed := autoAnalyzePartitionTableInDynamicMode(sctx, exec, opt, tblInfo, partitionDefs, db, autoAnalyzeRatio)
+				analyzed := autoAnalyzePartitionTableInDynamicMode(sctx, opt, tblInfo, partitionDefs, db, autoAnalyzeRatio)
 				if analyzed {
 					return true
 				}
@@ -193,7 +189,7 @@ func HandleAutoAnalyze(sctx sessionctx.Context,
 			for _, def := range partitionDefs {
 				sql := "analyze table %n.%n partition %n"
 				statsTbl := opt.GetPartitionStats(tblInfo, def.ID)
-				analyzed := autoAnalyzeTable(sctx, exec, opt, tblInfo, statsTbl, autoAnalyzeRatio, sql, db, tblInfo.Name.O, def.Name.O)
+				analyzed := autoAnalyzeTable(sctx, opt, tblInfo, statsTbl, autoAnalyzeRatio, sql, db, tblInfo.Name.O, def.Name.O)
 				if analyzed {
 					return true
 				}
@@ -207,7 +203,6 @@ func HandleAutoAnalyze(sctx sessionctx.Context,
 var AutoAnalyzeMinCnt int64 = 1000
 
 func autoAnalyzeTable(sctx sessionctx.Context,
-	exec sqlexec.RestrictedSQLExecutor,
 	opt *Opt,
 	tblInfo *model.TableInfo, statsTbl *statistics.Table,
 	ratio float64, sql string, params ...interface{}) bool {
@@ -222,7 +217,7 @@ func autoAnalyzeTable(sctx sessionctx.Context,
 		logutil.BgLogger().Info("auto analyze triggered", zap.String("category", "stats"), zap.String("sql", escaped), zap.String("reason", reason))
 		tableStatsVer := sctx.GetSessionVars().AnalyzeVersion
 		statistics.CheckAnalyzeVerOnTable(statsTbl, &tableStatsVer)
-		execAutoAnalyze(sctx, exec, opt, tableStatsVer, sql, params...)
+		execAutoAnalyze(sctx, opt, tableStatsVer, sql, params...)
 		return true
 	}
 	for _, idx := range tblInfo.Indices {
@@ -236,7 +231,7 @@ func autoAnalyzeTable(sctx sessionctx.Context,
 			logutil.BgLogger().Info("auto analyze for unanalyzed", zap.String("category", "stats"), zap.String("sql", escaped))
 			tableStatsVer := sctx.GetSessionVars().AnalyzeVersion
 			statistics.CheckAnalyzeVerOnTable(statsTbl, &tableStatsVer)
-			execAutoAnalyze(sctx, exec, opt, tableStatsVer, sqlWithIdx, paramsWithIdx...)
+			execAutoAnalyze(sctx, opt, tableStatsVer, sqlWithIdx, paramsWithIdx...)
 			return true
 		}
 	}
@@ -288,7 +283,6 @@ func TableAnalyzed(tbl *statistics.Table) bool {
 }
 
 func autoAnalyzePartitionTableInDynamicMode(sctx sessionctx.Context,
-	exec sqlexec.RestrictedSQLExecutor,
 	opt *Opt,
 	tblInfo *model.TableInfo, partitionDefs []model.PartitionDefinition,
 	db string, ratio float64) bool {
@@ -335,7 +329,7 @@ func autoAnalyzePartitionTableInDynamicMode(sctx sessionctx.Context,
 			logutil.BgLogger().Info("auto analyze triggered", zap.String("category", "stats"),
 				zap.String("table", tblInfo.Name.String()),
 				zap.Any("partitions", partitionNames[start:end]))
-			execAutoAnalyze(sctx, exec, opt, tableStatsVer, sql, params...)
+			execAutoAnalyze(sctx, opt, tableStatsVer, sql, params...)
 		}
 		return true
 	}
@@ -366,7 +360,7 @@ func autoAnalyzePartitionTableInDynamicMode(sctx sessionctx.Context,
 					zap.String("table", tblInfo.Name.String()),
 					zap.String("index", idx.Name.String()),
 					zap.Any("partitions", partitionNames[start:end]))
-				execAutoAnalyze(sctx, exec, opt, tableStatsVer, sql, params...)
+				execAutoAnalyze(sctx, opt, tableStatsVer, sql, params...)
 			}
 			return true
 		}
@@ -381,12 +375,11 @@ var execOptionForAnalyze = map[int]sqlexec.OptionFuncAlias{
 }
 
 func execAutoAnalyze(sctx sessionctx.Context,
-	exec sqlexec.RestrictedSQLExecutor,
 	opt *Opt,
 	statsVer int,
 	sql string, params ...interface{}) {
 	startTime := time.Now()
-	_, _, err := execRestrictedSQLWithStatsVer(sctx, exec, opt, statsVer, sql, params...)
+	_, _, err := execAnalyzeStmt(sctx, opt, statsVer, sql, params...)
 	dur := time.Since(startTime)
 	metrics.AutoAnalyzeHistogram.Observe(dur.Seconds())
 	if err != nil {
@@ -401,12 +394,10 @@ func execAutoAnalyze(sctx sessionctx.Context,
 	}
 }
 
-func execRestrictedSQLWithStatsVer(sctx sessionctx.Context,
-	exec sqlexec.RestrictedSQLExecutor,
+func execAnalyzeStmt(sctx sessionctx.Context,
 	opt *Opt,
 	statsVer int,
 	sql string, params ...interface{}) ([]chunk.Row, []*ast.ResultField, error) {
-	ctx := statsutil.StatsCtx(context.Background())
 	pruneMode := sctx.GetSessionVars().PartitionPruneMode.Load()
 	analyzeSnapshot := sctx.GetSessionVars().EnableAnalyzeSnapshot
 	optFuncs := []sqlexec.OptionFuncAlias{
@@ -416,5 +407,5 @@ func execRestrictedSQLWithStatsVer(sctx sessionctx.Context,
 		sqlexec.ExecOptionUseCurSession,
 		sqlexec.ExecOptionWithSysProcTrack(opt.AutoAnalyzeProcIDGetter(), opt.SysProcTracker.Track, opt.SysProcTracker.UnTrack),
 	}
-	return exec.ExecRestrictedSQL(ctx, optFuncs, sql, params...)
+	return statsutil.ExecWithOpts(sctx, optFuncs, sql, params...)
 }

--- a/statistics/handle/cache/BUILD.bazel
+++ b/statistics/handle/cache/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "//types",
         "//util/chunk",
         "//util/logutil",
-        "//util/sqlexec",
         "//util/syncutil",
         "@org_uber_go_zap//:zap",
     ],

--- a/statistics/handle/cache/statscacheinner.go
+++ b/statistics/handle/cache/statscacheinner.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
-	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/syncutil"
 	"go.uber.org/zap"
 )
@@ -229,14 +228,14 @@ func (c *StatsTableRowCache) Update(ctx context.Context, sctx sessionctx.Context
 	ctx = util.StatsCtx(ctx)
 	if time.Since(c.modifyTime) < tableStatsCacheExpiry {
 		if len(c.dirtyIDs) > 0 {
-			tableRows, err := getRowCountTables(ctx, sctx, c.dirtyIDs...)
+			tableRows, err := getRowCountTables(sctx, c.dirtyIDs...)
 			if err != nil {
 				return err
 			}
 			for id, tr := range tableRows {
 				c.tableRows[id] = tr
 			}
-			colLength, err := getColLengthTables(ctx, sctx, c.dirtyIDs...)
+			colLength, err := getColLengthTables(sctx, c.dirtyIDs...)
 			if err != nil {
 				return err
 			}
@@ -247,11 +246,11 @@ func (c *StatsTableRowCache) Update(ctx context.Context, sctx sessionctx.Context
 		}
 		return nil
 	}
-	tableRows, err := getRowCountTables(ctx, sctx)
+	tableRows, err := getRowCountTables(sctx)
 	if err != nil {
 		return err
 	}
-	colLength, err := getColLengthTables(ctx, sctx)
+	colLength, err := getColLengthTables(sctx)
 	if err != nil {
 		return err
 	}
@@ -262,16 +261,15 @@ func (c *StatsTableRowCache) Update(ctx context.Context, sctx sessionctx.Context
 	return nil
 }
 
-func getRowCountTables(ctx context.Context, sctx sessionctx.Context, tableIDs ...int64) (map[int64]uint64, error) {
-	exec := sctx.(sqlexec.RestrictedSQLExecutor)
+func getRowCountTables(sctx sessionctx.Context, tableIDs ...int64) (map[int64]uint64, error) {
 	var rows []chunk.Row
 	var err error
 	if len(tableIDs) == 0 {
-		rows, _, err = exec.ExecRestrictedSQL(ctx, nil, "select table_id, count from mysql.stats_meta")
+		rows, _, err = util.ExecRows(sctx, "select table_id, count from mysql.stats_meta")
 	} else {
 		inTblIDs := buildInTableIDsString(tableIDs)
 		sql := "select table_id, count from mysql.stats_meta where " + inTblIDs
-		rows, _, err = exec.ExecRestrictedSQL(ctx, nil, sql)
+		rows, _, err = util.ExecRows(sctx, sql)
 	}
 	if err != nil {
 		return nil, err
@@ -304,17 +302,16 @@ type tableHistID struct {
 	histID  int64
 }
 
-func getColLengthTables(ctx context.Context, sctx sessionctx.Context, tableIDs ...int64) (map[tableHistID]uint64, error) {
-	exec := sctx.(sqlexec.RestrictedSQLExecutor)
+func getColLengthTables(sctx sessionctx.Context, tableIDs ...int64) (map[tableHistID]uint64, error) {
 	var rows []chunk.Row
 	var err error
 	if len(tableIDs) == 0 {
 		sql := "select table_id, hist_id, tot_col_size from mysql.stats_histograms where is_index = 0"
-		rows, _, err = exec.ExecRestrictedSQL(ctx, nil, sql)
+		rows, _, err = util.ExecRows(sctx, sql)
 	} else {
 		inTblIDs := buildInTableIDsString(tableIDs)
 		sql := "select table_id, hist_id, tot_col_size from mysql.stats_histograms where is_index = 0 and " + inTblIDs
-		rows, _, err = exec.ExecRestrictedSQL(ctx, nil, sql)
+		rows, _, err = util.ExecRows(sctx, sql)
 	}
 	if err != nil {
 		return nil, err

--- a/statistics/handle/cache/statscacheinner.go
+++ b/statistics/handle/cache/statscacheinner.go
@@ -263,11 +263,11 @@ func getRowCountTables(sctx sessionctx.Context, tableIDs ...int64) (map[int64]ui
 	var rows []chunk.Row
 	var err error
 	if len(tableIDs) == 0 {
-		rows, _, err = util.ExecRows(sctx, "select table_id, count from mysql.stats_meta")
+		rows, _, err = util.ExecWithOpts(sctx, nil, "select table_id, count from mysql.stats_meta")
 	} else {
 		inTblIDs := buildInTableIDsString(tableIDs)
 		sql := "select table_id, count from mysql.stats_meta where " + inTblIDs
-		rows, _, err = util.ExecRows(sctx, sql)
+		rows, _, err = util.ExecWithOpts(sctx, nil, sql)
 	}
 	if err != nil {
 		return nil, err

--- a/statistics/handle/cache/statscacheinner.go
+++ b/statistics/handle/cache/statscacheinner.go
@@ -15,7 +15,6 @@
 package cache
 
 import (
-	"context"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -222,10 +221,9 @@ func (c *StatsTableRowCache) GetColLength(id tableHistID) uint64 {
 }
 
 // Update tries to update the cache.
-func (c *StatsTableRowCache) Update(ctx context.Context, sctx sessionctx.Context) error {
+func (c *StatsTableRowCache) Update(sctx sessionctx.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	ctx = util.StatsCtx(ctx)
 	if time.Since(c.modifyTime) < tableStatsCacheExpiry {
 		if len(c.dirtyIDs) > 0 {
 			tableRows, err := getRowCountTables(sctx, c.dirtyIDs...)

--- a/statistics/handle/cache/statscacheinner.go
+++ b/statistics/handle/cache/statscacheinner.go
@@ -305,11 +305,11 @@ func getColLengthTables(sctx sessionctx.Context, tableIDs ...int64) (map[tableHi
 	var err error
 	if len(tableIDs) == 0 {
 		sql := "select table_id, hist_id, tot_col_size from mysql.stats_histograms where is_index = 0"
-		rows, _, err = util.ExecRows(sctx, sql)
+		rows, _, err = util.ExecWithOpts(sctx, nil, sql)
 	} else {
 		inTblIDs := buildInTableIDsString(tableIDs)
 		sql := "select table_id, hist_id, tot_col_size from mysql.stats_histograms where is_index = 0 and " + inTblIDs
-		rows, _, err = util.ExecRows(sctx, sql)
+		rows, _, err = util.ExecWithOpts(sctx, nil, sql)
 	}
 	if err != nil {
 		return nil, err

--- a/statistics/handle/extstats/BUILD.bazel
+++ b/statistics/handle/extstats/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//statistics/handle/util",
         "//util/logutil",
         "//util/mathutil",
-        "//util/sqlexec",
         "@com_github_pingcap_errors//:errors",
         "@org_uber_go_zap//:zap",
     ],

--- a/statistics/handle/gc.go
+++ b/statistics/handle/gc.go
@@ -17,7 +17,6 @@ package handle
 import (
 	"context"
 	"encoding/json"
-	"github.com/pingcap/tidb/sessionctx"
 	"strconv"
 	"time"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/terror"
+	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/statistics/handle/cache"

--- a/statistics/handle/gc.go
+++ b/statistics/handle/gc.go
@@ -17,6 +17,7 @@ package handle
 import (
 	"context"
 	"encoding/json"
+	"github.com/pingcap/tidb/sessionctx"
 	"strconv"
 	"time"
 
@@ -55,7 +56,7 @@ func (h *Handle) GCStats(is infoschema.InfoSchema, ddlLease time.Duration) (err 
 
 	// Get the last gc time.
 	gcVer := now - offset
-	lastGC, err := h.GetLastGCTimestamp(ctx)
+	lastGC, err := h.GetLastGCTimestamp()
 	if err != nil {
 		return err
 	}
@@ -66,7 +67,7 @@ func (h *Handle) GCStats(is infoschema.InfoSchema, ddlLease time.Duration) (err 
 		err = h.writeGCTimestampToKV(ctx, gcVer)
 	}()
 
-	rows, _, err := h.execRestrictedSQL(ctx, "select table_id from mysql.stats_meta where version >= %? and version < %?", lastGC, gcVer)
+	rows, _, err := h.execRows("select table_id from mysql.stats_meta where version >= %? and version < %?", lastGC, gcVer)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -92,8 +93,8 @@ func (h *Handle) GCStats(is infoschema.InfoSchema, ddlLease time.Duration) (err 
 }
 
 // GetLastGCTimestamp loads the last gc time from mysql.tidb.
-func (h *Handle) GetLastGCTimestamp(ctx context.Context) (uint64, error) {
-	rows, _, err := h.execRestrictedSQL(ctx, "SELECT HIGH_PRIORITY variable_value FROM mysql.tidb WHERE variable_name=%?", gcLastTSVarName)
+func (h *Handle) GetLastGCTimestamp() (uint64, error) {
+	rows, _, err := h.execRows("SELECT HIGH_PRIORITY variable_value FROM mysql.tidb WHERE variable_name=%?", gcLastTSVarName)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
@@ -109,7 +110,7 @@ func (h *Handle) GetLastGCTimestamp(ctx context.Context) (uint64, error) {
 }
 
 func (h *Handle) writeGCTimestampToKV(ctx context.Context, newTS uint64) error {
-	_, _, err := h.execRestrictedSQL(ctx,
+	_, _, err := h.execRows(
 		"insert into mysql.tidb (variable_name, variable_value) values (%?, %?) on duplicate key update variable_value = %?",
 		gcLastTSVarName,
 		newTS,
@@ -119,15 +120,14 @@ func (h *Handle) writeGCTimestampToKV(ctx context.Context, newTS uint64) error {
 }
 
 func (h *Handle) gcTableStats(is infoschema.InfoSchema, physicalID int64) error {
-	ctx := context.Background()
-	rows, _, err := h.execRestrictedSQL(ctx, "select is_index, hist_id from mysql.stats_histograms where table_id = %?", physicalID)
+	rows, _, err := h.execRows("select is_index, hist_id from mysql.stats_histograms where table_id = %?", physicalID)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// The table has already been deleted in stats and acknowledged to all tidb,
 	// we can safely remove the meta info now.
 	if len(rows) == 0 {
-		_, _, err = h.execRestrictedSQL(ctx, "delete from mysql.stats_meta where table_id = %?", physicalID)
+		_, _, err = h.execRows("delete from mysql.stats_meta where table_id = %?", physicalID)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -164,7 +164,7 @@ func (h *Handle) gcTableStats(is infoschema.InfoSchema, physicalID int64) error 
 		}
 	}
 	// Mark records in mysql.stats_extended as `deleted`.
-	rows, _, err = h.execRestrictedSQL(ctx, "select name, column_ids from mysql.stats_extended where table_id = %? and status in (%?, %?)", physicalID, statistics.ExtendedStatsAnalyzed, statistics.ExtendedStatsInited)
+	rows, _, err = h.execRows("select name, column_ids from mysql.stats_extended where table_id = %? and status in (%?, %?)", physicalID, statistics.ExtendedStatsAnalyzed, statistics.ExtendedStatsInited)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -209,9 +209,9 @@ func (h *Handle) ClearOutdatedHistoryStats() error {
 		return err
 	}
 	defer h.pool.Put(se)
-	exec := se.(sqlexec.SQLExecutor)
+	sctx := se.(sessionctx.Context)
 	sql := "select count(*) from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
-	rs, err := exec.ExecuteInternal(ctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
+	rs, err := util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 	if err != nil {
 		return err
 	}
@@ -226,12 +226,12 @@ func (h *Handle) ClearOutdatedHistoryStats() error {
 	count := rows[0].GetInt64(0)
 	if count > 0 {
 		sql = "delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
-		_, err = exec.ExecuteInternal(ctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
+		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 		if err != nil {
 			return err
 		}
 		sql = "delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
-		_, err = exec.ExecuteInternal(ctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
+		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 		logutil.BgLogger().Info("clear outdated historical stats")
 		return err
 	}
@@ -244,23 +244,22 @@ func (h *Handle) gcHistoryStatsFromKV(physicalID int64) error {
 		return err
 	}
 	defer h.pool.Put(se)
-	exec := se.(sqlexec.SQLExecutor)
-	ctx := util.StatsCtx(context.Background())
+	sctx := se.(sessionctx.Context)
 
-	_, err = exec.ExecuteInternal(ctx, "begin pessimistic")
+	_, err = util.Exec(sctx, "begin pessimistic")
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer func() {
-		err = util.FinishTransaction(ctx, exec, err)
+		err = util.FinishTransaction(sctx, err)
 	}()
 	sql := "delete from mysql.stats_history where table_id = %?"
-	_, err = exec.ExecuteInternal(ctx, sql, physicalID)
+	_, err = util.Exec(sctx, sql, physicalID)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	sql = "delete from mysql.stats_meta_history where table_id = %?"
-	_, err = exec.ExecuteInternal(ctx, sql, physicalID)
+	_, err = util.Exec(sctx, sql, physicalID)
 	return err
 }
 
@@ -271,43 +270,42 @@ func (h *Handle) deleteHistStatsFromKV(physicalID int64, histID int64, isIndex i
 		return err
 	}
 	defer h.pool.Put(se)
-	exec := se.(sqlexec.SQLExecutor)
-	ctx := util.StatsCtx(context.Background())
+	sctx := se.(sessionctx.Context)
 
-	_, err = exec.ExecuteInternal(ctx, "begin")
+	_, err = util.Exec(sctx, "begin")
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer func() {
-		err = util.FinishTransaction(ctx, exec, err)
+		err = util.FinishTransaction(sctx, err)
 	}()
 	startTS, err := getSessionTxnStartTS(se)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// First of all, we update the version. If this table doesn't exist, it won't have any problem. Because we cannot delete anything.
-	if _, err = exec.ExecuteInternal(ctx, "update mysql.stats_meta set version = %? where table_id = %? ", startTS, physicalID); err != nil {
+	if _, err = util.Exec(sctx, "update mysql.stats_meta set version = %? where table_id = %? ", startTS, physicalID); err != nil {
 		return err
 	}
 	// delete histogram meta
-	if _, err = exec.ExecuteInternal(ctx, "delete from mysql.stats_histograms where table_id = %? and hist_id = %? and is_index = %?", physicalID, histID, isIndex); err != nil {
+	if _, err = util.Exec(sctx, "delete from mysql.stats_histograms where table_id = %? and hist_id = %? and is_index = %?", physicalID, histID, isIndex); err != nil {
 		return err
 	}
 	// delete top n data
-	if _, err = exec.ExecuteInternal(ctx, "delete from mysql.stats_top_n where table_id = %? and hist_id = %? and is_index = %?", physicalID, histID, isIndex); err != nil {
+	if _, err = util.Exec(sctx, "delete from mysql.stats_top_n where table_id = %? and hist_id = %? and is_index = %?", physicalID, histID, isIndex); err != nil {
 		return err
 	}
 	// delete all buckets
-	if _, err = exec.ExecuteInternal(ctx, "delete from mysql.stats_buckets where table_id = %? and hist_id = %? and is_index = %?", physicalID, histID, isIndex); err != nil {
+	if _, err = util.Exec(sctx, "delete from mysql.stats_buckets where table_id = %? and hist_id = %? and is_index = %?", physicalID, histID, isIndex); err != nil {
 		return err
 	}
 	// delete all fm sketch
-	if _, err := exec.ExecuteInternal(ctx, "delete from mysql.stats_fm_sketch where table_id = %? and hist_id = %? and is_index = %?", physicalID, histID, isIndex); err != nil {
+	if _, err := util.Exec(sctx, "delete from mysql.stats_fm_sketch where table_id = %? and hist_id = %? and is_index = %?", physicalID, histID, isIndex); err != nil {
 		return err
 	}
 	if isIndex == 0 {
 		// delete the record in mysql.column_stats_usage
-		if _, err = exec.ExecuteInternal(ctx, "delete from mysql.column_stats_usage where table_id = %? and column_id = %?", physicalID, histID); err != nil {
+		if _, err = util.Exec(sctx, "delete from mysql.column_stats_usage where table_id = %? and column_id = %?", physicalID, histID); err != nil {
 			return err
 		}
 	}
@@ -322,14 +320,13 @@ func (h *Handle) DeleteTableStatsFromKV(statsIDs []int64) (err error) {
 		return err
 	}
 	defer h.pool.Put(se)
-	exec := se.(sqlexec.SQLExecutor)
-	ctx := util.StatsCtx(context.Background())
-	_, err = exec.ExecuteInternal(ctx, "begin")
+	sctx := se.(sessionctx.Context)
+	_, err = util.Exec(sctx, "begin")
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer func() {
-		err = util.FinishTransaction(ctx, exec, err)
+		err = util.FinishTransaction(sctx, err)
 	}()
 	startTS, err := getSessionTxnStartTS(se)
 	if err != nil {
@@ -337,31 +334,31 @@ func (h *Handle) DeleteTableStatsFromKV(statsIDs []int64) (err error) {
 	}
 	for _, statsID := range statsIDs {
 		// We only update the version so that other tidb will know that this table is deleted.
-		if _, err = exec.ExecuteInternal(ctx, "update mysql.stats_meta set version = %? where table_id = %? ", startTS, statsID); err != nil {
+		if _, err = util.Exec(sctx, "update mysql.stats_meta set version = %? where table_id = %? ", startTS, statsID); err != nil {
 			return err
 		}
-		if _, err = exec.ExecuteInternal(ctx, "delete from mysql.stats_histograms where table_id = %?", statsID); err != nil {
+		if _, err = util.Exec(sctx, "delete from mysql.stats_histograms where table_id = %?", statsID); err != nil {
 			return err
 		}
-		if _, err = exec.ExecuteInternal(ctx, "delete from mysql.stats_buckets where table_id = %?", statsID); err != nil {
+		if _, err = util.Exec(sctx, "delete from mysql.stats_buckets where table_id = %?", statsID); err != nil {
 			return err
 		}
-		if _, err = exec.ExecuteInternal(ctx, "delete from mysql.stats_top_n where table_id = %?", statsID); err != nil {
+		if _, err = util.Exec(sctx, "delete from mysql.stats_top_n where table_id = %?", statsID); err != nil {
 			return err
 		}
-		if _, err = exec.ExecuteInternal(ctx, "update mysql.stats_extended set version = %?, status = %? where table_id = %? and status in (%?, %?)", startTS, statistics.ExtendedStatsDeleted, statsID, statistics.ExtendedStatsAnalyzed, statistics.ExtendedStatsInited); err != nil {
+		if _, err = util.Exec(sctx, "update mysql.stats_extended set version = %?, status = %? where table_id = %? and status in (%?, %?)", startTS, statistics.ExtendedStatsDeleted, statsID, statistics.ExtendedStatsAnalyzed, statistics.ExtendedStatsInited); err != nil {
 			return err
 		}
-		if _, err = exec.ExecuteInternal(ctx, "delete from mysql.stats_fm_sketch where table_id = %?", statsID); err != nil {
+		if _, err = util.Exec(sctx, "delete from mysql.stats_fm_sketch where table_id = %?", statsID); err != nil {
 			return err
 		}
-		if _, err = exec.ExecuteInternal(ctx, "delete from mysql.column_stats_usage where table_id = %?", statsID); err != nil {
+		if _, err = util.Exec(sctx, "delete from mysql.column_stats_usage where table_id = %?", statsID); err != nil {
 			return err
 		}
-		if _, err = exec.ExecuteInternal(ctx, "delete from mysql.analyze_options where table_id = %?", statsID); err != nil {
+		if _, err = util.Exec(sctx, "delete from mysql.analyze_options where table_id = %?", statsID); err != nil {
 			return err
 		}
-		if _, err = exec.ExecuteInternal(ctx, lockstats.DeleteLockSQL, statsID); err != nil {
+		if _, err = util.Exec(sctx, lockstats.DeleteLockSQL, statsID); err != nil {
 			return err
 		}
 	}
@@ -374,16 +371,15 @@ func (h *Handle) removeDeletedExtendedStats(version uint64) (err error) {
 		return err
 	}
 	defer h.pool.Put(se)
-	exec := se.(sqlexec.SQLExecutor)
-	ctx := util.StatsCtx(context.Background())
-	_, err = exec.ExecuteInternal(ctx, "begin pessimistic")
+	sctx := se.(sessionctx.Context)
+	_, err = util.Exec(sctx, "begin pessimistic")
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer func() {
-		err = util.FinishTransaction(ctx, exec, err)
+		err = util.FinishTransaction(sctx, err)
 	}()
 	const sql = "delete from mysql.stats_extended where status = %? and version < %?"
-	_, err = exec.ExecuteInternal(ctx, sql, statistics.ExtendedStatsDeleted, version)
+	_, err = util.Exec(sctx, sql, statistics.ExtendedStatsDeleted, version)
 	return
 }

--- a/statistics/handle/history/BUILD.bazel
+++ b/statistics/handle/history/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//sessionctx",
         "//statistics/handle/cache",
         "//statistics/handle/util",
-        "//util/sqlexec",
         "@com_github_pingcap_errors//:errors",
     ],
 )

--- a/statistics/handle/storage/read.go
+++ b/statistics/handle/storage/read.go
@@ -601,7 +601,8 @@ func StatsMetaByTableIDFromStorage(sctx sessionctx.Context, tableID int64, snaps
 		rows, _, err = util.ExecRows(sctx,
 			"SELECT version, modify_count, count from mysql.stats_meta where table_id = %? order by version", tableID)
 	} else {
-		rows, _, err = util.ExecWithOpts(sctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionWithSnapshot(snapshot)},
+		rows, _, err = util.ExecWithOpts(sctx,
+			[]sqlexec.OptionFuncAlias{sqlexec.ExecOptionWithSnapshot(snapshot), sqlexec.ExecOptionUseCurSession},
 			"SELECT version, modify_count, count from mysql.stats_meta where table_id = %? order by version", tableID)
 	}
 	if err != nil || len(rows) == 0 {

--- a/statistics/handle/storage/read.go
+++ b/statistics/handle/storage/read.go
@@ -596,14 +596,12 @@ func loadNeededIndexHistograms(reader *StatsReader, statsCache *cache.StatsCache
 
 // StatsMetaByTableIDFromStorage gets the stats meta of a table from storage.
 func StatsMetaByTableIDFromStorage(sctx sessionctx.Context, tableID int64, snapshot uint64) (version uint64, modifyCount, count int64, err error) {
-	ctx := util.StatsCtx(context.Background())
 	var rows []chunk.Row
-	exec := sctx.(sqlexec.RestrictedSQLExecutor)
 	if snapshot == 0 {
-		rows, _, err = exec.ExecRestrictedSQL(ctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession},
+		rows, _, err = util.ExecRows(sctx,
 			"SELECT version, modify_count, count from mysql.stats_meta where table_id = %? order by version", tableID)
 	} else {
-		rows, _, err = exec.ExecRestrictedSQL(ctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession, sqlexec.ExecOptionWithSnapshot(snapshot)},
+		rows, _, err = util.ExecWithOpts(sctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionWithSnapshot(snapshot)},
 			"SELECT version, modify_count, count from mysql.stats_meta where table_id = %? order by version", tableID)
 	}
 	if err != nil || len(rows) == 0 {

--- a/statistics/handle/usage/index_usage.go
+++ b/statistics/handle/usage/index_usage.go
@@ -15,7 +15,6 @@
 package usage
 
 import (
-	"context"
 	"strings"
 	"sync"
 	"time"
@@ -153,8 +152,6 @@ var (
 
 // DumpIndexUsageToKV will dump in-memory index usage information to KV.
 func DumpIndexUsageToKV(sctx sessionctx.Context, listHead *SessionIndexUsageCollector) error {
-	ctx := util.StatsCtx(context.Background())
-	exec := sctx.(sqlexec.RestrictedSQLExecutor)
 	mapper := sweepIdxUsageList(listHead)
 	type FullIndexUsageInformation struct {
 		information IndexUsageInformation
@@ -180,7 +177,7 @@ func DumpIndexUsageToKV(sctx sessionctx.Context, listHead *SessionIndexUsageColl
 			}
 		}
 		sqlexec.MustFormatSQL(sql, "on duplicate key update query_count=query_count+values(query_count),rows_selected=rows_selected+values(rows_selected),last_used_at=greatest(last_used_at, values(last_used_at))")
-		if _, _, err := exec.ExecRestrictedSQL(ctx, useCurrentSession, sql.String()); err != nil {
+		if _, _, err := util.ExecRows(sctx, sql.String()); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -193,8 +190,6 @@ func GCIndexUsageOnKV(sctx sessionctx.Context) error {
 	// We periodically delete the usage information of non-existent indexes through information_schema.tidb_indexes.
 	// This sql will delete the usage information of those indexes that not in information_schema.tidb_indexes.
 	sql := `delete from mysql.SCHEMA_INDEX_USAGE as stats where stats.index_id not in (select idx.index_id from information_schema.tidb_indexes as idx)`
-	ctx := util.StatsCtx(context.Background())
-	exec := sctx.(sqlexec.RestrictedSQLExecutor)
-	_, _, err := exec.ExecRestrictedSQL(ctx, useCurrentSession, sql)
+	_, _, err := util.ExecRows(sctx, sql)
 	return err
 }

--- a/statistics/handle/usage/index_usage.go
+++ b/statistics/handle/usage/index_usage.go
@@ -145,11 +145,6 @@ func sweepIdxUsageList(listHead *SessionIndexUsageCollector) indexUsageMap {
 // batchInsertSize is the batch size used by internal SQL to insert values to some system table.
 const batchInsertSize = 10
 
-var (
-	// useCurrentSession to make sure the sql is executed in current session.
-	useCurrentSession = []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession}
-)
-
 // DumpIndexUsageToKV will dump in-memory index usage information to KV.
 func DumpIndexUsageToKV(sctx sessionctx.Context, listHead *SessionIndexUsageCollector) error {
 	mapper := sweepIdxUsageList(listHead)

--- a/statistics/handle/util/util.go
+++ b/statistics/handle/util/util.go
@@ -76,6 +76,5 @@ func ExecWithOpts(sctx sessionctx.Context, opts []sqlexec.OptionFuncAlias, sql s
 	if !ok {
 		return nil, nil, errors.Errorf("invalid sql executor")
 	}
-	opts = append(opts, sqlexec.ExecOptionUseCurSession)
 	return sqlExec.ExecRestrictedSQL(StatsCtx(context.Background()), opts, sql, args...)
 }

--- a/statistics/handle/util/util.go
+++ b/statistics/handle/util/util.go
@@ -32,15 +32,11 @@ func StatsCtx(ctx context.Context) context.Context {
 }
 
 // FinishTransaction will execute `commit` when error is nil, otherwise `rollback`.
-func FinishTransaction(ctx context.Context, exec interface{}, err error) error {
-	sqlExec, ok := exec.(sqlexec.SQLExecutor)
-	if !ok {
-		return errors.Errorf("invalid sql executor")
-	}
+func FinishTransaction(sctx sessionctx.Context, err error) error {
 	if err == nil {
-		_, err = sqlExec.ExecuteInternal(ctx, "commit")
+		_, err = Exec(sctx, "commit")
 	} else {
-		_, err1 := sqlExec.ExecuteInternal(ctx, "rollback")
+		_, err1 := Exec(sctx, "rollback")
 		terror.Log(errors.Trace(err1))
 	}
 	return errors.Trace(err)
@@ -55,11 +51,31 @@ func GetStartTS(sctx sessionctx.Context) (uint64, error) {
 	return txn.StartTS(), nil
 }
 
-// Read is a helper function to execute sql and return rows and fields.
-func Read(exec interface{}, sql string, args ...interface{}) (rows []chunk.Row, fields []*ast.ResultField, err error) {
-	sqlExec, ok := exec.(sqlexec.RestrictedSQLExecutor)
+// Exec is a helper function to execute sql and return RecordSet.
+func Exec(sctx sessionctx.Context, sql string, args ...interface{}) (sqlexec.RecordSet, error) {
+	sqlExec, ok := sctx.(sqlexec.SQLExecutor)
+	if !ok {
+		return nil, errors.Errorf("invalid sql executor")
+	}
+	// TODO: use RestrictedSQLExecutor + ExecOptionUseCurSession instead of SQLExecutor
+	return sqlExec.ExecuteInternal(StatsCtx(context.Background()), sql, args...)
+}
+
+// ExecRows is a helper function to execute sql and return rows and fields.
+func ExecRows(sctx sessionctx.Context, sql string, args ...interface{}) (rows []chunk.Row, fields []*ast.ResultField, err error) {
+	sqlExec, ok := sctx.(sqlexec.RestrictedSQLExecutor)
 	if !ok {
 		return nil, nil, errors.Errorf("invalid sql executor")
 	}
 	return sqlExec.ExecRestrictedSQL(StatsCtx(context.Background()), []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession}, sql, args...)
+}
+
+// ExecWithOpts is a helper function to execute sql and return rows and fields.
+func ExecWithOpts(sctx sessionctx.Context, opts []sqlexec.OptionFuncAlias, sql string, args ...interface{}) (rows []chunk.Row, fields []*ast.ResultField, err error) {
+	sqlExec, ok := sctx.(sqlexec.RestrictedSQLExecutor)
+	if !ok {
+		return nil, nil, errors.Errorf("invalid sql executor")
+	}
+	opts = append(opts, sqlexec.ExecOptionUseCurSession)
+	return sqlExec.ExecRestrictedSQL(StatsCtx(context.Background()), opts, sql, args...)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46905

Problem Summary: planner: unify ways to execute SQLs in stats_handle package
 
### What is changed and how it works?

planner: unify ways to execute SQLs in stats_handle package

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
