### PR TITLE
lightning: add `OWNERS` in folders owned by lightning

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -29,7 +29,9 @@ aliases:
     - XuHuaiyu
     - zanmato1984
   sig-approvers-lightning: # approvers for lightning module
+    - Benjamin20372
     - D3Hunter
-    - lance6716
     - gmhdbjd
+    - lance6716
     - lichunzhu
+    - okJiang

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,7 +11,7 @@ aliases:
   sig-approvers-autoid-service: # approvers for auto-id service
     - bb7133
     - tiancaiamao
-  sig-approvers-br: # approvers for br pkg
+  sig-approvers-br: # approvers for br module
     - BornChanger
     - 3pointer
     - YuJuncen
@@ -28,3 +28,8 @@ aliases:
     - windtalker
     - XuHuaiyu
     - zanmato1984
+  sig-approvers-lightning: # approvers for lightning module
+    - D3Hunter
+    - lance6716
+    - gmhdbjd
+    - lichunzhu

--- a/br/cmd/tidb-lightning-ctl/OWNERS
+++ b/br/cmd/tidb-lightning-ctl/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+options:
+  no_parent_owners: true
+approvers:
+  - sig-approvers-lightning

--- a/br/cmd/tidb-lightning/OWNERS
+++ b/br/cmd/tidb-lightning/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+options:
+  no_parent_owners: true
+approvers:
+  - sig-approvers-lightning

--- a/br/pkg/lightning/OWNERS
+++ b/br/pkg/lightning/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+options:
+  no_parent_owners: true
+approvers:
+  - sig-approvers-lightning


### PR DESCRIPTION
Issue Number: close #47301

Problem Summary:

### What is changed and how it works?

- Add alias `sig-approvers-lightning` in `/OWNERS_ALIASES` file.
- Add `OWNERS` file to folders:
  - `br/pkg/lightning`
  - `br/cmd/tidb-lightning`
  - `br/cmd/tidb-lightning-ctl`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility
- [x] None

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility
- [x] No need


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
