### PR TITLE
disttask: persist business error to subtask table

### DIFF
--- a/ddl/backfilling_dist_scheduler.go
+++ b/ddl/backfilling_dist_scheduler.go
@@ -72,7 +72,7 @@ func NewBackfillSubtaskExecutor(_ context.Context, taskMeta []byte, d *ddl,
 		if indexInfo == nil {
 			logutil.BgLogger().Warn("index info not found", zap.String("category", "ddl-ingest"),
 				zap.Int64("table ID", tbl.Meta().ID), zap.Int64("index ID", eid))
-			return nil, errors.New("index info not found")
+			return nil, errors.Errorf("index info not found: %d", eid)
 		}
 		indexInfos = append(indexInfos, indexInfo)
 	}
@@ -140,7 +140,7 @@ func (s *backfillDistScheduler) Init(ctx context.Context) error {
 	// we use the first index uniqueness here.
 	idx := model.FindIndexInfoByID(tbl.Meta().Indices, bgm.EleIDs[0])
 	if idx == nil {
-		return errors.Trace(errors.New("index info not found"))
+		return errors.Trace(errors.Errorf("index info not found: %d", bgm.EleIDs[0]))
 	}
 	bc, err := ingest.LitBackCtxMgr.Register(ctx, idx.Unique, job.ID, d.etcdCli, job.ReorgMeta.ResourceGroupName)
 	if err != nil {

--- a/disttask/framework/handle/handle.go
+++ b/disttask/framework/handle/handle.go
@@ -77,7 +77,10 @@ func WaitGlobalTask(ctx context.Context, globalTask *proto.Task) error {
 		case <-ticker.C:
 			found, err := globalTaskManager.GetTaskByIDWithHistory(globalTask.ID)
 			if err != nil {
-				return errors.Errorf("cannot get global task with ID %d, err %s", globalTask.ID, err.Error())
+				logutil.Logger(ctx).Error("cannot get global task during waiting",
+					zap.Int64("task-id", globalTask.ID),
+					zap.Error(err))
+				continue
 			}
 
 			if found == nil {

--- a/disttask/framework/scheduler/manager.go
+++ b/disttask/framework/scheduler/manager.go
@@ -149,7 +149,7 @@ func (m *Manager) fetchAndHandleRunnableTasks(ctx context.Context) {
 		case <-ticker.C:
 			tasks, err := m.taskTable.GetGlobalTasksInStates(proto.TaskStateRunning, proto.TaskStateReverting)
 			if err != nil {
-				m.onError(err)
+				m.logErr(err)
 				continue
 			}
 			m.onRunnableTasks(ctx, tasks)
@@ -169,7 +169,7 @@ func (m *Manager) fetchAndFastCancelTasks(ctx context.Context) {
 		case <-ticker.C:
 			tasks, err := m.taskTable.GetGlobalTasksInStates(proto.TaskStateReverting)
 			if err != nil {
-				m.onError(err)
+				m.logErr(err)
 				continue
 			}
 			m.onCanceledTasks(ctx, tasks)
@@ -177,11 +177,11 @@ func (m *Manager) fetchAndFastCancelTasks(ctx context.Context) {
 			// cancel pending/running subtasks, and mark them as paused.
 			pausingTasks, err := m.taskTable.GetGlobalTasksInStates(proto.TaskStatePausing)
 			if err != nil {
-				m.onError(err)
+				m.logErr(err)
 				continue
 			}
 			if err := m.onPausingTasks(pausingTasks); err != nil {
-				m.onError(err)
+				m.logErr(err)
 				continue
 			}
 		}
@@ -198,7 +198,7 @@ func (m *Manager) onRunnableTasks(ctx context.Context, tasks []*proto.Task) {
 			proto.TaskStateRunning, proto.TaskStateReverting)
 		if err != nil {
 			logutil.Logger(m.logCtx).Error("check subtask exist failed", zap.Error(err))
-			m.onError(err)
+			m.logErr(err)
 			continue
 		}
 		if !exist {
@@ -214,7 +214,7 @@ func (m *Manager) onRunnableTasks(ctx context.Context, tasks []*proto.Task) {
 		// pool closed.
 		if err != nil {
 			m.removeHandlingTask(task.ID)
-			m.onError(err)
+			m.logErr(err)
 			return
 		}
 	}
@@ -289,13 +289,14 @@ func (m *Manager) onRunnableTask(ctx context.Context, task *proto.Task) {
 	// runCtx only used in scheduler.Run, cancel in m.fetchAndFastCancelTasks.
 	factory := getSchedulerFactory(task.Type)
 	if factory == nil {
-		m.onError(errors.Errorf("task type %s not found", task.Type))
+		err := errors.Errorf("task type %s not found", task.Type)
+		m.logErrAndPersist(err, task.ID)
 		return
 	}
 	scheduler := factory(ctx, m.id, task, m.taskTable)
 	err := scheduler.Init(ctx)
 	if err != nil {
-		m.onError(err)
+		m.logErrAndPersist(err, task.ID)
 		return
 	}
 	defer scheduler.Close()
@@ -318,7 +319,7 @@ func (m *Manager) onRunnableTask(ctx context.Context, task *proto.Task) {
 		})
 		task, err := m.taskTable.GetGlobalTaskByID(task.ID)
 		if err != nil {
-			m.onError(err)
+			m.logErr(err)
 			return
 		}
 		if task.State != proto.TaskStateRunning && task.State != proto.TaskStateReverting {
@@ -330,7 +331,7 @@ func (m *Manager) onRunnableTask(ctx context.Context, task *proto.Task) {
 			proto.TaskStatePending, proto.TaskStateRevertPending,
 			// for the case that the tidb is restarted when the subtask is running.
 			proto.TaskStateRunning, proto.TaskStateReverting); err != nil {
-			m.onError(err)
+			m.logErr(err)
 			return
 		} else if !exist {
 			continue
@@ -373,11 +374,14 @@ func (m *Manager) removeHandlingTask(id int64) {
 	delete(m.mu.handlingTasks, id)
 }
 
-// onError handles the error.
-func (m *Manager) onError(err error) {
-	if err == nil {
-		return
-	}
-
+func (m *Manager) logErr(err error) {
 	logutil.Logger(m.logCtx).Error("task manager error", zap.Error(err))
+}
+
+func (m *Manager) logErrAndPersist(err error, taskID int64) {
+	m.logErr(err)
+	err1 := m.taskTable.UpdateErrorToSubtask(m.id, taskID, err)
+	if err1 != nil {
+		logutil.Logger(m.logCtx).Error("update to subtask failed", zap.Error(err1))
+	}
 }

--- a/disttask/framework/scheduler/manager.go
+++ b/disttask/framework/scheduler/manager.go
@@ -375,13 +375,13 @@ func (m *Manager) removeHandlingTask(id int64) {
 }
 
 func (m *Manager) logErr(err error) {
-	logutil.Logger(m.logCtx).Error("task manager error", zap.Error(err))
+	logutil.Logger(m.logCtx).Error("task manager error", zap.Error(err), zap.Stack("stack"))
 }
 
 func (m *Manager) logErrAndPersist(err error, taskID int64) {
 	m.logErr(err)
 	err1 := m.taskTable.UpdateErrorToSubtask(m.id, taskID, err)
 	if err1 != nil {
-		logutil.Logger(m.logCtx).Error("update to subtask failed", zap.Error(err1))
+		logutil.Logger(m.logCtx).Error("update to subtask failed", zap.Error(err1), zap.Stack("stack"))
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46258

Problem Summary:

- `WaitGlobalTask` may exit before cleaning up the global task, which can cause unexpected behavior.
- The error returned by `scheduler.Init()` should persist to subtask table instead of constantly retrying.

### What is changed and how it works?

As the title said.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
