### PR TITLE
statistics: quickly exit FindTopN and LocateBucket

### DIFF
--- a/statistics/cmsketch.go
+++ b/statistics/cmsketch.go
@@ -648,7 +648,7 @@ func (c *TopN) FindTopN(d []byte) int {
 		}
 		return -1
 	}
-	if bytes.Compare(c.TopN[len(c.TopN)-1].Encoded, d) < -1 {
+	if bytes.Compare(c.TopN[len(c.TopN)-1].Encoded, d) < 0 {
 		return -1
 	}
 	idx, match := slices.BinarySearchFunc(c.TopN, d, func(a TopNMeta, b []byte) int {

--- a/statistics/cmsketch.go
+++ b/statistics/cmsketch.go
@@ -639,6 +639,18 @@ func (c *TopN) FindTopN(d []byte) int {
 	if c == nil {
 		return -1
 	}
+	if len(c.TopN) == 0 {
+		return -1
+	}
+	if len(c.TopN) == 1 {
+		if bytes.Equal(c.TopN[0].Encoded, d) {
+			return 0
+		}
+		return -1
+	}
+	if bytes.Compare(c.TopN[len(c.TopN)-1].Encoded, d) < -1 {
+		return -1
+	}
 	idx, match := slices.BinarySearchFunc(c.TopN, d, func(a TopNMeta, b []byte) int {
 		return bytes.Compare(a.Encoded, b)
 	})

--- a/util/chunk/compare.go
+++ b/util/chunk/compare.go
@@ -223,8 +223,8 @@ func Compare(row Row, colIdx int, ad *types.Datum) int {
 // LowerBound searches on the non-decreasing Column colIdx,
 // returns the smallest index i such that the value at row i is not less than `d`.
 func (c *Chunk) LowerBound(colIdx int, d *types.Datum) (index int, match bool) {
-	if Compare(c.GetRow(c.NumRows()), colIdx, d) > 0 {
-		return c.NumRows() + 1, false
+	if Compare(c.GetRow(c.NumRows()-1), colIdx, d) > 0 {
+		return c.NumRows(), false
 	}
 	index = sort.Search(c.NumRows(), func(i int) bool {
 		cmp := Compare(c.GetRow(i), colIdx, d)

--- a/util/chunk/compare.go
+++ b/util/chunk/compare.go
@@ -223,6 +223,9 @@ func Compare(row Row, colIdx int, ad *types.Datum) int {
 // LowerBound searches on the non-decreasing Column colIdx,
 // returns the smallest index i such that the value at row i is not less than `d`.
 func (c *Chunk) LowerBound(colIdx int, d *types.Datum) (index int, match bool) {
+	if Compare(c.GetRow(c.NumRows()), colIdx, d) > 0 {
+		return c.NumRows() + 1, false
+	}
 	index = sort.Search(c.NumRows(), func(i int) bool {
 		cmp := Compare(c.GetRow(i), colIdx, d)
 		if cmp == 0 {

--- a/util/chunk/compare.go
+++ b/util/chunk/compare.go
@@ -223,7 +223,7 @@ func Compare(row Row, colIdx int, ad *types.Datum) int {
 // LowerBound searches on the non-decreasing Column colIdx,
 // returns the smallest index i such that the value at row i is not less than `d`.
 func (c *Chunk) LowerBound(colIdx int, d *types.Datum) (index int, match bool) {
-	if Compare(c.GetRow(c.NumRows()-1), colIdx, d) > 0 {
+	if Compare(c.GetRow(c.NumRows()-1), colIdx, d) < 0 {
 		return c.NumRows(), false
 	}
 	index = sort.Search(c.NumRows(), func(i int) bool {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #47219

Problem Summary:

### What is changed and how it works?

Golang's binarysearch does not check boundary conditions first, so we check boundary conditions first to quickly terminate the binary search.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
