### PR TITLE
server: Change zlib compression level

### DIFF
--- a/server/internal/packetio.go
+++ b/server/internal/packetio.go
@@ -381,12 +381,13 @@ func (cw *compressedWriter) Flush() error {
 	// https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_compression_packet.html
 	// suggests a MIN_COMPRESS_LENGTH of 50.
 	minCompressLength := 50
+	zlibCompressDefaultLevel := 6
 	data := cw.buf.Bytes()
 	cw.buf.Reset()
 
 	switch cw.compressionAlgorithm {
 	case mysql.CompressionZlib:
-		w, err = zlib.NewWriterLevel(&payload, zlib.HuffmanOnly)
+		w, err = zlib.NewWriterLevel(&payload, zlibCompressDefaultLevel)
 	case mysql.CompressionZstd:
 		w, err = zstd.NewWriter(&payload, zstd.WithEncoderLevel(cw.zstdLevel))
 	default:

--- a/server/internal/packetio_test.go
+++ b/server/internal/packetio_test.go
@@ -242,10 +242,10 @@ func TestCompressedWriterLong(t *testing.T) {
 		cw.Flush()
 
 		// Header:
-		// 3c 00 00   Compressed length: 60
+		// 18 00 00   Compressed length: 24
 		// 00         Packetnr: 0
 		// 45 00 00   Uncompressed length: 69
-		compressedLength := []byte{0x3c, 0x0, 0x0}
+		compressedLength := []byte{0x18, 0x0, 0x0}
 		packetNr := []byte{0x0}
 		uncompressedLength := []byte{0x45, 0x0, 0x0}
 		require.Equal(t, compressedLength, testdata.Bytes()[:3])


### PR DESCRIPTION
This was `flate.HuffmanOnly` (-2) to 6 to match what MySQL does.

Note that `compress/flate` doesn't define a const for level 6.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47278 

Problem Summary:

Related: https://github.com/pingcap/tidb/pull/36780

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The compression level for zlib level was updated to match the compression level of MySQL
```
