### PR TITLE
*: make tidb_query_log_max_len could affect more logs

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2025,7 +2025,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		// For `execute stmt` SQL, should reset the SQL digest with the prepare SQL digest.
 		goCtx := context.Background()
 		if variable.EnablePProfSQLCPU.Load() && len(prepareStmt.NormalizedSQL) > 0 {
-			goCtx = pprof.WithLabels(goCtx, pprof.Labels("sql", util.QueryStrForLog(prepareStmt.NormalizedSQL)))
+			goCtx = pprof.WithLabels(goCtx, pprof.Labels("sql", FormatSQL(prepareStmt.NormalizedSQL).String()))
 			pprof.SetGoroutineLabels(goCtx)
 		}
 		if topsqlstate.TopSQLEnabled() && prepareStmt.SQLDigest != nil {

--- a/server/conn.go
+++ b/server/conn.go
@@ -92,7 +92,6 @@ import (
 	"github.com/pingcap/tidb/sessiontxn"
 	storeerr "github.com/pingcap/tidb/store/driver/error"
 	"github.com/pingcap/tidb/tablecodec"
-	tidbutil "github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/arena"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/dbterror/exeerrors"
@@ -2522,10 +2521,10 @@ func (cc getLastStmtInConn) String() string {
 		if cc.ctx.GetSessionVars().EnableRedactLog {
 			sql = parser.Normalize(sql)
 		}
-		return tidbutil.QueryStrForLog(sql)
+		return executor.FormatSQL(sql).String()
 	case mysql.ComStmtExecute, mysql.ComStmtFetch:
 		stmtID := binary.LittleEndian.Uint32(data[0:4])
-		return tidbutil.QueryStrForLog(cc.preparedStmt2String(stmtID))
+		return executor.FormatSQL(cc.preparedStmt2String(stmtID)).String()
 	case mysql.ComStmtClose, mysql.ComStmtReset:
 		stmtID := binary.LittleEndian.Uint32(data[0:4])
 		return mysql.Command2Str[cmd] + " " + strconv.Itoa(int(stmtID))
@@ -2553,10 +2552,10 @@ func (cc getLastStmtInConn) PProfLabel() string {
 	case mysql.ComStmtReset:
 		return "ResetStmt"
 	case mysql.ComQuery, mysql.ComStmtPrepare:
-		return parser.Normalize(tidbutil.QueryStrForLog(string(hack.String(data))))
+		return parser.Normalize(executor.FormatSQL(string(hack.String(data))).String())
 	case mysql.ComStmtExecute, mysql.ComStmtFetch:
 		stmtID := binary.LittleEndian.Uint32(data[0:4])
-		return tidbutil.QueryStrForLog(cc.preparedStmt2StringNoArgs(stmtID))
+		return executor.FormatSQL(cc.preparedStmt2StringNoArgs(stmtID)).String()
 	default:
 		return ""
 	}

--- a/util/misc.go
+++ b/util/misc.go
@@ -614,15 +614,6 @@ func GetLocalIP() string {
 	return ""
 }
 
-// QueryStrForLog trim the query if the query length more than 4096
-func QueryStrForLog(query string) string {
-	const size = 4096
-	if len(query) > size {
-		return query[:size] + fmt.Sprintf("(len: %d)", len(query))
-	}
-	return query
-}
-
 // CreateCertificates creates and writes a cert based on the params.
 func CreateCertificates(certpath string, keypath string, rsaKeySize int, pubKeyAlgo x509.PublicKeyAlgorithm,
 	signAlgo x509.SignatureAlgorithm) error {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47398

Problem Summary:
Use `FormatSQL` to replace `QueryStrForLog`.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  * start a cluster.
  * `set global tidb_query_log_max_len = 5`
  * make a dispatched error with long statement.
  * check the logs.
```
mysql> select * from abfdasf;
ERROR 1146 (42S02): Table 'test.abfdasf' doesn't exist

[2023/10/04 17:03:33.495 -07:00] [INFO] [conn.go:1098] ["command dispatched failed"] [conn=2097154] [session_alias=] [connInfo="id:2097154, addr:[::1]:52348 status:10, collation:utf8mb4_0900_ai_ci, user:root"] [command=Query] [status="inTxn:0, autocommit:1"] [sql=selec(len:21)] [txn_mode=PESSIMISTIC] [timestamp=0] [err="[schema:1146]Table 'test.abfdasf' doesn't exist"]
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
