### PR TITLE
disttask: fix too much log on cleanup

### DIFF
--- a/disttask/framework/dispatcher/dispatcher_manager.go
+++ b/disttask/framework/dispatcher/dispatcher_manager.go
@@ -307,7 +307,6 @@ var WaitCleanUpFinished = make(chan struct{})
 //
 //	tasks with global sort should clean up tmp files stored on S3.
 func (dm *Manager) doCleanUpRoutine() {
-	logutil.Logger(dm.ctx).Info("cleanUp routine start")
 	tasks, err := dm.taskMgr.GetGlobalTasksInStates(
 		proto.TaskStateFailed,
 		proto.TaskStateReverted,
@@ -317,6 +316,10 @@ func (dm *Manager) doCleanUpRoutine() {
 		logutil.BgLogger().Warn("cleanUp routine failed", zap.Error(err))
 		return
 	}
+	if len(tasks) == 0 {
+		return
+	}
+	logutil.Logger(dm.ctx).Info("cleanUp routine start")
 	err = dm.cleanUpFinishedTasks(tasks)
 	if err != nil {
 		logutil.BgLogger().Warn("cleanUp routine failed", zap.Error(err))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46258

Problem Summary:

### What is changed and how it works?

short circuit when no work to do to avoid log too much

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - change interval manaully to 5 seconds, checks logs.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
