### PR TITLE
planner: fix explain panic when using VALUES statement

### DIFF
--- a/planner/core/plan_test.go
+++ b/planner/core/plan_test.go
@@ -754,3 +754,12 @@ func TestIssue40535(t *testing.T) {
 	tk.MustExec("(select /*+ agg_to_cop()*/ locate(t1.c3, t1.c3) as r0, t1.c3 as r1 from t1 where not( IsNull(t1.c1)) order by r0,r1) union all (select concat_ws(',', t2.c2, t2.c1) as r0, t2.c1 as r1 from t2 order by r0, r1) order by 1 limit 273;")
 	require.Empty(t, tk.Session().LastMessage())
 }
+
+func TestExplainValuesStatement(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	_, err := tk.Exec("EXPLAIN FORMAT = TRADITIONAL ((VALUES ROW ()) ORDER BY 1)")
+	require.Error(t, err)
+	require.Regexp(t, ".*Unknown table ''.*", err.Error())
+}

--- a/planner/core/plan_test.go
+++ b/planner/core/plan_test.go
@@ -759,7 +759,5 @@ func TestExplainValuesStatement(t *testing.T) {
 	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 
-	_, err := tk.Exec("EXPLAIN FORMAT = TRADITIONAL ((VALUES ROW ()) ORDER BY 1)")
-	require.Error(t, err)
-	require.Regexp(t, ".*Unknown table ''.*", err.Error())
+	tk.MustMatchErrMsg("EXPLAIN FORMAT = TRADITIONAL ((VALUES ROW ()) ORDER BY 1)", ".*Unknown table ''.*")
 }

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -626,6 +626,11 @@ func ExtractSelectAndNormalizeDigest(stmtNode ast.StmtNode, specifiledDB string,
 			if parenthesesIdx != -1 && parenthesesIdx < idx {
 				idx = parenthesesIdx
 			}
+			// If the SQL is `EXPLAIN ((VALUES ROW ()) ORDER BY 1);`, the idx will be -1.
+			if idx == -1 {
+				hash := parser.DigestNormalized(normalizeExplainSQL)
+				return x.Stmt, normalizeExplainSQL, hash.String(), nil
+			}
 			normalizeSQL := normalizeExplainSQL[idx:]
 			hash := parser.DigestNormalized(normalizeSQL)
 			return x.Stmt, normalizeSQL, hash.String(), nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/45957

Problem Summary:

### What is changed and how it works?

Fixed the explain panic issue when using the VALUES statement.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed the Explain panic problem when using the VALUES statement
```
