### PR TITLE
planner: speed up the process of loading partition table stats

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1780,7 +1780,7 @@ func (rc *Client) GoUpdateMetaAndLoadStats(ctx context.Context, inCh <-chan *Cre
 				zap.Int64("new id", tbl.Table.ID),
 			)
 			start := time.Now()
-			if err := rc.statsHandler.LoadStatsFromJSON(rc.dom.InfoSchema(), oldTable.Stats); err != nil {
+			if err := rc.statsHandler.LoadStatsFromJSON(ctx, rc.dom.InfoSchema(), oldTable.Stats); err != nil {
 				log.Error("analyze table failed", zap.Any("table", oldTable.Stats), zap.Error(err))
 			}
 			log.Info("restore stat done",

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1780,7 +1780,7 @@ func (rc *Client) GoUpdateMetaAndLoadStats(ctx context.Context, inCh <-chan *Cre
 				zap.Int64("new id", tbl.Table.ID),
 			)
 			start := time.Now()
-			if err := rc.statsHandler.LoadStatsFromJSON(ctx, rc.dom.InfoSchema(), oldTable.Stats); err != nil {
+			if err := rc.statsHandler.LoadStatsFromJSON(ctx, rc.dom.InfoSchema(), oldTable.Stats, 0); err != nil {
 				log.Error("analyze table failed", zap.Any("table", oldTable.Stats), zap.Error(err))
 			}
 			log.Info("restore stat done",

--- a/executor/load_stats.go
+++ b/executor/load_stats.go
@@ -88,5 +88,5 @@ func (e *LoadStatsInfo) Update(data []byte) error {
 	if h == nil {
 		return errors.New("Load Stats: handle is nil")
 	}
-	return h.LoadStatsFromJSON(e.Ctx.GetInfoSchema().(infoschema.InfoSchema), jsonTbl)
+	return h.LoadStatsFromJSON(context.Background(), e.Ctx.GetInfoSchema().(infoschema.InfoSchema), jsonTbl)
 }

--- a/executor/load_stats.go
+++ b/executor/load_stats.go
@@ -88,5 +88,5 @@ func (e *LoadStatsInfo) Update(data []byte) error {
 	if h == nil {
 		return errors.New("Load Stats: handle is nil")
 	}
-	return h.LoadStatsFromJSON(context.Background(), e.Ctx.GetInfoSchema().(infoschema.InfoSchema), jsonTbl)
+	return h.LoadStatsFromJSON(context.Background(), e.Ctx.GetInfoSchema().(infoschema.InfoSchema), jsonTbl, 0)
 }

--- a/executor/plan_replayer.go
+++ b/executor/plan_replayer.go
@@ -463,7 +463,7 @@ func loadStats(ctx sessionctx.Context, f *zip.File) error {
 	if h == nil {
 		return errors.New("plan replayer: hanlde is nil")
 	}
-	return h.LoadStatsFromJSON(ctx.GetInfoSchema().(infoschema.InfoSchema), jsonTbl)
+	return h.LoadStatsFromJSON(context.Background(), ctx.GetInfoSchema().(infoschema.InfoSchema), jsonTbl)
 }
 
 // Update updates the data of the corresponding table.

--- a/executor/plan_replayer.go
+++ b/executor/plan_replayer.go
@@ -463,7 +463,7 @@ func loadStats(ctx sessionctx.Context, f *zip.File) error {
 	if h == nil {
 		return errors.New("plan replayer: hanlde is nil")
 	}
-	return h.LoadStatsFromJSON(context.Background(), ctx.GetInfoSchema().(infoschema.InfoSchema), jsonTbl)
+	return h.LoadStatsFromJSON(context.Background(), ctx.GetInfoSchema().(infoschema.InfoSchema), jsonTbl, 0)
 }
 
 // Update updates the data of the corresponding table.

--- a/planner/core/casetest/cbotest/cbo_test.go
+++ b/planner/core/casetest/cbotest/cbo_test.go
@@ -49,7 +49,7 @@ func loadTableStats(fileName string, dom *domain.Domain) error {
 		return err
 	}
 	statsHandle := dom.StatsHandle()
-	err = statsHandle.LoadStatsFromJSON(dom.InfoSchema(), statsTbl)
+	err = statsHandle.LoadStatsFromJSON(context.Background(), dom.InfoSchema(), statsTbl)
 	if err != nil {
 		return err
 	}

--- a/planner/core/casetest/cbotest/cbo_test.go
+++ b/planner/core/casetest/cbotest/cbo_test.go
@@ -49,7 +49,7 @@ func loadTableStats(fileName string, dom *domain.Domain) error {
 		return err
 	}
 	statsHandle := dom.StatsHandle()
-	err = statsHandle.LoadStatsFromJSON(context.Background(), dom.InfoSchema(), statsTbl)
+	err = statsHandle.LoadStatsFromJSON(context.Background(), dom.InfoSchema(), statsTbl, 0)
 	if err != nil {
 		return err
 	}

--- a/statistics/handle/BUILD.bazel
+++ b/statistics/handle/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//types",
         "//util",
         "//util/chunk",
+        "//util/intest",
         "//util/logutil",
         "//util/mathutil",
         "//util/sqlexec",
@@ -70,7 +71,7 @@ go_test(
     embed = [":handle"],
     flaky = True,
     race = "on",
-    shard_count = 26,
+    shard_count = 28,
     deps = [
         "//config",
         "//domain",

--- a/statistics/handle/dump.go
+++ b/statistics/handle/dump.go
@@ -208,7 +208,7 @@ func (h *Handle) tableStatsToJSON(dbName string, tableInfo *model.TableInfo, phy
 // LoadStatsFromJSON will load statistic from JSONTable, and save it to the storage.
 func (h *Handle) LoadStatsFromJSON(ctx context.Context, is infoschema.InfoSchema,
 	jsonTbl *storage.JSONTable, concurrencyForPartition uint8) error {
-	nCPU := uint8(runtime.NumCPU())
+	nCPU := uint8(runtime.GOMAXPROCS(0))
 	if concurrencyForPartition == 0 {
 		concurrencyForPartition = nCPU / 2 // default
 	}

--- a/statistics/handle/dump.go
+++ b/statistics/handle/dump.go
@@ -231,7 +231,7 @@ func (h *Handle) LoadStatsFromJSON(ctx context.Context, is infoschema.InfoSchema
 			h.gpool.Go(func() {
 				defer func() {
 					if r := recover(); r != nil {
-						err := errors.New(fmt.Sprintf("%v", r))
+						err := fmt.Errorf("%v", r)
 						e.CompareAndSwap(nil, &err)
 					}
 					wg.Done()

--- a/statistics/handle/dump_test.go
+++ b/statistics/handle/dump_test.go
@@ -15,8 +15,11 @@
 package handle_test
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/domain"
@@ -104,7 +107,7 @@ func TestConversion(t *testing.T) {
 	wg.Run(func() {
 		require.Nil(t, h.Update(is))
 	})
-	err = h.LoadStatsFromJSON(is, jsonTbl)
+	err = h.LoadStatsFromJSON(context.Background(), is, jsonTbl)
 	wg.Wait()
 	require.NoError(t, err)
 	loadTblInStorage := h.GetTableStats(tableInfo.Meta())
@@ -170,9 +173,88 @@ func TestLoadGlobalStats(t *testing.T) {
 	require.Equal(t, 0, len(clearedStats.Partitions))
 
 	// load global-stats back
-	require.Nil(t, dom.StatsHandle().LoadStatsFromJSON(dom.InfoSchema(), globalStats))
+	require.Nil(t, dom.StatsHandle().LoadStatsFromJSON(context.Background(), dom.InfoSchema(), globalStats))
 	loadedStats := getStatsJSON(t, dom, "test", "t")
 	require.Equal(t, 3, len(loadedStats.Partitions)) // p0, p1, global
+}
+
+func TestLoadPartitionStats(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_analyze_version = 2")
+	tk.MustExec("set @@tidb_partition_prune_mode = 'dynamic'")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, key(a)) partition by hash(a) partitions 8")
+	vals := make([]string, 0, 5000)
+	for i := 0; i < 5000; i++ {
+		vals = append(vals, fmt.Sprintf("(%v)", i))
+	}
+	tk.MustExec("insert into t values " + strings.Join(vals, ","))
+	tk.MustExec("analyze table t")
+
+	table, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	tableInfo := table.Meta()
+	jsonTbl, err := dom.StatsHandle().DumpStatsToJSON("test", tableInfo, nil, true)
+	require.NoError(t, err)
+	pi := tableInfo.GetPartitionInfo()
+	originPartStats := make([]*statistics.Table, 0, len(pi.Definitions))
+	for _, def := range pi.Definitions {
+		originPartStats = append(originPartStats, dom.StatsHandle().GetPartitionStats(tableInfo, def.ID))
+	}
+	originGlobalStats := dom.StatsHandle().GetTableStats(tableInfo)
+
+	// remove all statistics
+	tk.MustExec("delete from mysql.stats_meta")
+	tk.MustExec("delete from mysql.stats_histograms")
+	tk.MustExec("delete from mysql.stats_buckets")
+	dom.StatsHandle().Clear()
+	clearedStats := getStatsJSON(t, dom, "test", "t")
+	require.Equal(t, 0, len(clearedStats.Partitions))
+
+	// load stats back
+	require.Nil(t, dom.StatsHandle().LoadStatsFromJSON(context.Background(), dom.InfoSchema(), jsonTbl))
+
+	// compare
+	for i, def := range pi.Definitions {
+		newPartStats := dom.StatsHandle().GetPartitionStats(tableInfo, def.ID)
+		requireTableEqual(t, originPartStats[i], newPartStats)
+	}
+	requireTableEqual(t, originGlobalStats, dom.StatsHandle().GetTableStats(tableInfo))
+}
+
+func TestLoadPartitionStatsErrPanic(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_analyze_version = 2")
+	tk.MustExec("set @@tidb_partition_prune_mode = 'dynamic'")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, key(a)) partition by hash(a) partitions 8")
+	vals := make([]string, 0, 5000)
+	for i := 0; i < 5000; i++ {
+		vals = append(vals, fmt.Sprintf("(%v)", i))
+	}
+	tk.MustExec("insert into t values " + strings.Join(vals, ","))
+	tk.MustExec("analyze table t")
+
+	table, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	tableInfo := table.Meta()
+	jsonTbl, err := dom.StatsHandle().DumpStatsToJSON("test", tableInfo, nil, true)
+	require.NoError(t, err)
+
+	ctx := context.WithValue(context.Background(), handle.TestLoadStatsErr{}, func(tableInfo *model.TableInfo, physicalID int64, jsonTbl *storage.JSONTable) error {
+		return errors.New("ERROR")
+	})
+	err = dom.StatsHandle().LoadStatsFromJSON(ctx, dom.InfoSchema(), jsonTbl)
+	require.ErrorContains(t, err, "ERROR")
+	ctx = context.WithValue(context.Background(), handle.TestLoadStatsErr{}, func(tableInfo *model.TableInfo, physicalID int64, jsonTbl *storage.JSONTable) error {
+		panic("PANIC")
+	})
+	err = dom.StatsHandle().LoadStatsFromJSON(ctx, dom.InfoSchema(), jsonTbl)
+	require.ErrorContains(t, err, "PANIC") // recover panic as an error
 }
 
 func TestDumpPartitions(t *testing.T) {
@@ -212,7 +294,7 @@ PARTITION BY RANGE ( a ) (
 	tk.MustExec("delete from mysql.stats_buckets")
 	h.Clear()
 
-	err = h.LoadStatsFromJSON(dom.InfoSchema(), jsonTbl)
+	err = h.LoadStatsFromJSON(context.Background(), dom.InfoSchema(), jsonTbl)
 	require.NoError(t, err)
 	for i, def := range pi.Definitions {
 		tt := h.GetPartitionStats(tableInfo, def.ID)
@@ -273,7 +355,7 @@ func TestDumpCMSketchWithTopN(t *testing.T) {
 
 	jsonTable, err := h.DumpStatsToJSON("test", tableInfo, nil, true)
 	require.NoError(t, err)
-	err = h.LoadStatsFromJSON(is, jsonTable)
+	err = h.LoadStatsFromJSON(context.Background(), is, jsonTable)
 	require.NoError(t, err)
 	stat = h.GetTableStats(tableInfo)
 	cmsFromJSON := stat.Columns[tableInfo.Columns[0].ID].CMSketch.Copy()
@@ -325,7 +407,7 @@ func TestDumpExtendedStats(t *testing.T) {
 	wg.Run(func() {
 		require.Nil(t, h.Update(is))
 	})
-	err = h.LoadStatsFromJSON(is, jsonTbl)
+	err = h.LoadStatsFromJSON(context.Background(), is, jsonTbl)
 	wg.Wait()
 	require.NoError(t, err)
 	loadTblInStorage := h.GetTableStats(tableInfo.Meta())
@@ -374,7 +456,7 @@ func TestDumpVer2Stats(t *testing.T) {
 	statsCacheTbl := h.GetTableStats(tableInfo.Meta())
 	requireTableEqual(t, loadTbl, statsCacheTbl)
 
-	err = h.LoadStatsFromJSON(is, loadJSONTable)
+	err = h.LoadStatsFromJSON(context.Background(), is, loadJSONTable)
 	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsCacheTbl = h.GetTableStats(tableInfo.Meta())
@@ -426,7 +508,7 @@ func TestLoadStatsForNewCollation(t *testing.T) {
 	statsCacheTbl := h.GetTableStats(tableInfo.Meta())
 	requireTableEqual(t, loadTbl, statsCacheTbl)
 
-	err = h.LoadStatsFromJSON(is, loadJSONTable)
+	err = h.LoadStatsFromJSON(context.Background(), is, loadJSONTable)
 	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsCacheTbl = h.GetTableStats(tableInfo.Meta())
@@ -524,7 +606,7 @@ func TestLoadStatsFromOldVersion(t *testing.T) {
 }`
 	jsonTbl := &storage.JSONTable{}
 	require.NoError(t, json.Unmarshal([]byte(statsJSONFromOldVersion), jsonTbl))
-	require.NoError(t, h.LoadStatsFromJSON(is, jsonTbl))
+	require.NoError(t, h.LoadStatsFromJSON(context.Background(), is, jsonTbl))
 	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	statsTbl := h.GetTableStats(tbl.Meta())

--- a/statistics/handle/dump_test.go
+++ b/statistics/handle/dump_test.go
@@ -107,7 +107,7 @@ func TestConversion(t *testing.T) {
 	wg.Run(func() {
 		require.Nil(t, h.Update(is))
 	})
-	err = h.LoadStatsFromJSON(context.Background(), is, jsonTbl)
+	err = h.LoadStatsFromJSON(context.Background(), is, jsonTbl, 0)
 	wg.Wait()
 	require.NoError(t, err)
 	loadTblInStorage := h.GetTableStats(tableInfo.Meta())
@@ -173,7 +173,7 @@ func TestLoadGlobalStats(t *testing.T) {
 	require.Equal(t, 0, len(clearedStats.Partitions))
 
 	// load global-stats back
-	require.Nil(t, dom.StatsHandle().LoadStatsFromJSON(context.Background(), dom.InfoSchema(), globalStats))
+	require.Nil(t, dom.StatsHandle().LoadStatsFromJSON(context.Background(), dom.InfoSchema(), globalStats, 0))
 	loadedStats := getStatsJSON(t, dom, "test", "t")
 	require.Equal(t, 3, len(loadedStats.Partitions)) // p0, p1, global
 }
@@ -214,7 +214,7 @@ func TestLoadPartitionStats(t *testing.T) {
 	require.Equal(t, 0, len(clearedStats.Partitions))
 
 	// load stats back
-	require.Nil(t, dom.StatsHandle().LoadStatsFromJSON(context.Background(), dom.InfoSchema(), jsonTbl))
+	require.Nil(t, dom.StatsHandle().LoadStatsFromJSON(context.Background(), dom.InfoSchema(), jsonTbl, 0))
 
 	// compare
 	for i, def := range pi.Definitions {
@@ -248,12 +248,12 @@ func TestLoadPartitionStatsErrPanic(t *testing.T) {
 	ctx := context.WithValue(context.Background(), handle.TestLoadStatsErr{}, func(tableInfo *model.TableInfo, physicalID int64, jsonTbl *storage.JSONTable) error {
 		return errors.New("ERROR")
 	})
-	err = dom.StatsHandle().LoadStatsFromJSON(ctx, dom.InfoSchema(), jsonTbl)
+	err = dom.StatsHandle().LoadStatsFromJSON(ctx, dom.InfoSchema(), jsonTbl, 0)
 	require.ErrorContains(t, err, "ERROR")
 	ctx = context.WithValue(context.Background(), handle.TestLoadStatsErr{}, func(tableInfo *model.TableInfo, physicalID int64, jsonTbl *storage.JSONTable) error {
 		panic("PANIC")
 	})
-	err = dom.StatsHandle().LoadStatsFromJSON(ctx, dom.InfoSchema(), jsonTbl)
+	err = dom.StatsHandle().LoadStatsFromJSON(ctx, dom.InfoSchema(), jsonTbl, 0)
 	require.ErrorContains(t, err, "PANIC") // recover panic as an error
 }
 
@@ -294,7 +294,7 @@ PARTITION BY RANGE ( a ) (
 	tk.MustExec("delete from mysql.stats_buckets")
 	h.Clear()
 
-	err = h.LoadStatsFromJSON(context.Background(), dom.InfoSchema(), jsonTbl)
+	err = h.LoadStatsFromJSON(context.Background(), dom.InfoSchema(), jsonTbl, 0)
 	require.NoError(t, err)
 	for i, def := range pi.Definitions {
 		tt := h.GetPartitionStats(tableInfo, def.ID)
@@ -355,7 +355,7 @@ func TestDumpCMSketchWithTopN(t *testing.T) {
 
 	jsonTable, err := h.DumpStatsToJSON("test", tableInfo, nil, true)
 	require.NoError(t, err)
-	err = h.LoadStatsFromJSON(context.Background(), is, jsonTable)
+	err = h.LoadStatsFromJSON(context.Background(), is, jsonTable, 0)
 	require.NoError(t, err)
 	stat = h.GetTableStats(tableInfo)
 	cmsFromJSON := stat.Columns[tableInfo.Columns[0].ID].CMSketch.Copy()
@@ -407,7 +407,7 @@ func TestDumpExtendedStats(t *testing.T) {
 	wg.Run(func() {
 		require.Nil(t, h.Update(is))
 	})
-	err = h.LoadStatsFromJSON(context.Background(), is, jsonTbl)
+	err = h.LoadStatsFromJSON(context.Background(), is, jsonTbl, 0)
 	wg.Wait()
 	require.NoError(t, err)
 	loadTblInStorage := h.GetTableStats(tableInfo.Meta())
@@ -456,7 +456,7 @@ func TestDumpVer2Stats(t *testing.T) {
 	statsCacheTbl := h.GetTableStats(tableInfo.Meta())
 	requireTableEqual(t, loadTbl, statsCacheTbl)
 
-	err = h.LoadStatsFromJSON(context.Background(), is, loadJSONTable)
+	err = h.LoadStatsFromJSON(context.Background(), is, loadJSONTable, 0)
 	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsCacheTbl = h.GetTableStats(tableInfo.Meta())
@@ -508,7 +508,7 @@ func TestLoadStatsForNewCollation(t *testing.T) {
 	statsCacheTbl := h.GetTableStats(tableInfo.Meta())
 	requireTableEqual(t, loadTbl, statsCacheTbl)
 
-	err = h.LoadStatsFromJSON(context.Background(), is, loadJSONTable)
+	err = h.LoadStatsFromJSON(context.Background(), is, loadJSONTable, 0)
 	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsCacheTbl = h.GetTableStats(tableInfo.Meta())
@@ -606,7 +606,7 @@ func TestLoadStatsFromOldVersion(t *testing.T) {
 }`
 	jsonTbl := &storage.JSONTable{}
 	require.NoError(t, json.Unmarshal([]byte(statsJSONFromOldVersion), jsonTbl))
-	require.NoError(t, h.LoadStatsFromJSON(context.Background(), is, jsonTbl))
+	require.NoError(t, h.LoadStatsFromJSON(context.Background(), is, jsonTbl, 0))
 	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	statsTbl := h.GetTableStats(tbl.Meta())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47183

Problem Summary: planner: speed up the process of loading partition table stats

### What is changed and how it works?

planner: speed up the process of loading partition table stats

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
