### PR TITLE
planner: do not convert update to point get if the expr has sub-query

### DIFF
--- a/pkg/parser/ast/expressions.go
+++ b/pkg/parser/ast/expressions.go
@@ -981,7 +981,7 @@ type ParamMarkerExpr interface {
 	SetOrder(int)
 }
 
-// ParenthesesExpr is the parentheses expression.
+// ParenthesesExpr is the parentheses' expression.
 type ParenthesesExpr struct {
 	exprNode
 	// Expr is the expression in parentheses.

--- a/pkg/planner/core/plan_test.go
+++ b/pkg/planner/core/plan_test.go
@@ -755,6 +755,22 @@ func TestIssue40535(t *testing.T) {
 	require.Empty(t, tk.Session().LastMessage())
 }
 
+func TestIssue47445(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("CREATE TABLE golang1 ( `fcbpdt` CHAR (8) COLLATE utf8_general_ci NOT NULL, `fcbpsq` VARCHAR (20) COLLATE utf8_general_ci NOT NULL, `procst` char (4) COLLATE utf8_general_ci DEFAULT NULL,`cipstx` VARCHAR (105) COLLATE utf8_general_ci DEFAULT NULL, `cipsst` CHAR (4) COLLATE utf8_general_ci DEFAULT NULL, `dyngtg` VARCHAR(4) COLLATE utf8_general_ci DEFAULT NULL, `blncdt` VARCHAR (8) COLLATE utf8_general_ci DEFAULT NULL, PRIMARY KEY ( fcbpdt, fcbpsq ))")
+	tk.MustExec("insert into golang1 values('20230925','12023092502158016','abc','','','','')")
+	tk.MustExec("create table golang2 (`sysgrp` varchar(20) NOT NULL,`procst` varchar(8) NOT NULL,`levlid` int(11) NOT NULL,PRIMARY key (procst));")
+	tk.MustExec("insert into golang2 VALUES('COMMON','ACSC',90)")
+	tk.MustExec("insert into golang2 VALUES('COMMON','abc',8)")
+	tk.MustExec("insert into golang2 VALUES('COMMON','CH02',6)")
+	tk.MustExec("UPDATE golang1 a SET procst =(CASE WHEN ( SELECT levlid FROM golang2 b WHERE b.sysgrp = 'COMMON' AND b.procst = 'ACSC' ) > ( SELECT levlid FROM golang2 c WHERE c.sysgrp = 'COMMON' AND c.procst = a.procst ) THEN 'ACSC' ELSE a.procst END ), cipstx = 'CI010000', cipsst = 'ACSC', dyngtg = 'EAYT', blncdt= '20230925' WHERE fcbpdt = '20230925' AND fcbpsq = '12023092502158016'")
+	tk.MustQuery("select * from golang1").Check(testkit.Rows("20230925 12023092502158016 ACSC CI010000 ACSC EAYT 20230925"))
+	tk.MustExec("UPDATE golang1 a SET procst= (SELECT 1 FROM golang2 c WHERE c.procst = a.procst) WHERE fcbpdt = '20230925' AND fcbpsq = '12023092502158016'")
+	tk.MustQuery("select * from golang1").Check(testkit.Rows("20230925 12023092502158016 1 CI010000 ACSC EAYT 20230925"))
+}
+
 func TestExplainValuesStatement(t *testing.T) {
 	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -1557,8 +1557,11 @@ type subQueryChecker struct {
 }
 
 func (s *subQueryChecker) Enter(in ast.Node) (node ast.Node, skipChildren bool) {
-	switch in.(type) {
-	case *ast.SubqueryExpr:
+	if s.hasSubQuery {
+		return in, true
+	}
+
+	if _, ok := in.(*ast.SubqueryExpr); ok {
 		s.hasSubQuery = true
 		return in, true
 	}
@@ -1579,7 +1582,9 @@ func isExprHasSubQuery(expr ast.Node) bool {
 
 func checkIfAssignmentListHasSubQuery(list []*ast.Assignment) bool {
 	for _, a := range list {
-		return isExprHasSubQuery(a)
+		if isExprHasSubQuery(a) {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -1580,7 +1580,10 @@ func (s *subQueryChecker) Leave(in ast.Node) (ast.Node, bool) {
 
 func isExprHasSubQuery(expr ast.Node) bool {
 	checker := subQueryCheckerPool.Get().(*subQueryChecker)
-	defer subQueryCheckerPool.Put(checker)
+	defer func() {
+		checker.hasSubQuery = false
+		subQueryCheckerPool.Put(checker)
+	}()
 	expr.Accept(checker)
 	return checker.hasSubQuery
 }

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -1581,6 +1581,7 @@ func (s *subQueryChecker) Leave(in ast.Node) (ast.Node, bool) {
 func isExprHasSubQuery(expr ast.Node) bool {
 	checker := subQueryCheckerPool.Get().(*subQueryChecker)
 	defer func() {
+		// Do not forget to reset the flag.
 		checker.hasSubQuery = false
 		subQueryCheckerPool.Put(checker)
 	}()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!
 
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/47445

Problem Summary:

### What is changed and how it works?
- do not convert update to point get if the expr has sub-query
	- covered the case expr
	- covered the parentheses case expr
	- covered the parentheses sub-query expr
	- covered the sub-query expr (do we really need this? I copied the code from the old code)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/47454#issuecomment-1751972453)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed TiDB incorrectly converts update statement to point get plan issue
```
