### PR TITLE
br: modify how to parse the add index job args

### DIFF
--- a/br/pkg/restore/ingestrec/ingest_recorder.go
+++ b/br/pkg/restore/ingestrec/ingest_recorder.go
@@ -80,6 +80,10 @@ func (i *IngestRecorder) AddJob(job *model.Job) error {
 	}
 
 	allIndexIDs := make([]int64, 1)
+	// The job.Args is either `Multi-index: ([]int64, ...)`,
+	// or `Single-index: (int64, ...)`.
+	// TODO: it's better to use the public function to parse the
+	// job's Args.
 	if err := job.DecodeArgs(&allIndexIDs[0]); err != nil {
 		if err = job.DecodeArgs(&allIndexIDs); err != nil {
 			return errors.Trace(err)

--- a/br/pkg/restore/ingestrec/ingest_recorder.go
+++ b/br/pkg/restore/ingestrec/ingest_recorder.go
@@ -79,9 +79,11 @@ func (i *IngestRecorder) AddJob(job *model.Job) error {
 		return nil
 	}
 
-	var indexID int64 = 0
-	if err := job.DecodeArgs(&indexID); err != nil {
-		return errors.Trace(err)
+	allIndexIDs := make([]int64, 1)
+	if err := job.DecodeArgs(&allIndexIDs[0]); err != nil {
+		if err = job.DecodeArgs(&allIndexIDs); err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	tableindexes, exists := i.items[job.TableID]
@@ -92,9 +94,11 @@ func (i *IngestRecorder) AddJob(job *model.Job) error {
 
 	// the current information of table/index might be modified by other ddl jobs,
 	// therefore update the index information at last
-	tableindexes[indexID] = &IngestIndexInfo{
-		IsPrimary: job.Type == model.ActionAddPrimaryKey,
-		Updated:   false,
+	for _, indexID := range allIndexIDs {
+		tableindexes[indexID] = &IngestIndexInfo{
+			IsPrimary: job.Type == model.ActionAddPrimaryKey,
+			Updated:   false,
+		}
 	}
 
 	return nil

--- a/br/pkg/stream/rewrite_meta_rawkv.go
+++ b/br/pkg/stream/rewrite_meta_rawkv.go
@@ -840,15 +840,16 @@ func (sr *SchemasReplace) deleteRange(job *model.Job) error {
 				zap.Int64("oldTableID", job.TableID))
 			return nil
 		}
-		var indexID int64
-		var ifExists bool
+		indexIDs := make([]int64, 1)
+		ifExists := make([]bool, 1)
 		var partitionIDs []int64
-		if err := job.DecodeArgs(&indexID, &ifExists, &partitionIDs); err != nil {
-			return errors.Trace(err)
+		if err := job.DecodeArgs(&indexIDs[0], &ifExists[0], &partitionIDs); err != nil {
+			if err = job.DecodeArgs(&indexIDs, &ifExists, &partitionIDs); err != nil {
+				return errors.Trace(err)
+			}
 		}
 
 		var elementID int64 = 1
-		indexIDs := []int64{indexID}
 
 		if len(partitionIDs) > 0 {
 			for _, oldPid := range partitionIDs {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47451 

Problem Summary:
currently the `addindex` ddl job's `Args[0]` might be `[]int64` instead of `int64`.

### What is changed and how it works?
retry to parse by `[]int64` when failed to parse by `int64`.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
