### PR TITLE
ddl: no more sleep when meets nonRetryable error

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -836,7 +836,6 @@ func (w *worker) HandleDDLJobTable(d *ddlCtx, job *model.Job) (int64, error) {
 
 	// If error is non-retryable, we can ignore the sleep.
 	if runJobErr != nil && errorIsRetryable(runJobErr, job) {
-		// Omit the ErrPausedDDLJob
 		w.jobLogger(job).Info("run DDL job failed, sleeps a while then retries it.",
 			zap.Duration("waitTime", GetWaitTimeWhenErrorOccurred()), zap.Error(runJobErr))
 		// wait a while to retry again. If we don't wait here, DDL will retry this job immediately,

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -840,7 +840,7 @@ func (w *worker) HandleDDLJobTable(d *ddlCtx, job *model.Job) (int64, error) {
 		w.jobLogger(job).Info("run DDL job failed, sleeps a while then retries it.",
 			zap.Duration("waitTime", GetWaitTimeWhenErrorOccurred()), zap.Error(runJobErr))
 		// In test and job is cancelling we can ignore the sleep.
-		if !(intest.InTest && job.IsCancelling()) {
+		if !(intest.InTest && job.IsCancelling()) && errorIsRetryable(runJobErr, job) {
 			// wait a while to retry again. If we don't wait here, DDL will retry this job immediately,
 			// which may act like a deadlock.
 			time.Sleep(GetWaitTimeWhenErrorOccurred())

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -836,11 +836,12 @@ func (w *worker) HandleDDLJobTable(d *ddlCtx, job *model.Job) (int64, error) {
 	w.registerSync(job)
 
 	if runJobErr != nil && !dbterror.ErrPausedDDLJob.Equal(runJobErr) {
-		// Omit the ErrPausedDDLJob
-		w.jobLogger(job).Info("run DDL job failed, sleeps a while then retries it.",
-			zap.Duration("waitTime", GetWaitTimeWhenErrorOccurred()), zap.Error(runJobErr))
 		// In test and job is cancelling we can ignore the sleep.
+		// Or error is non-Retryable.
 		if !(intest.InTest && job.IsCancelling()) && errorIsRetryable(runJobErr, job) {
+			// Omit the ErrPausedDDLJob
+			w.jobLogger(job).Info("run DDL job failed, sleeps a while then retries it.",
+				zap.Duration("waitTime", GetWaitTimeWhenErrorOccurred()), zap.Error(runJobErr))
 			// wait a while to retry again. If we don't wait here, DDL will retry this job immediately,
 			// which may act like a deadlock.
 			time.Sleep(GetWaitTimeWhenErrorOccurred())

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -834,8 +834,8 @@ func (w *worker) HandleDDLJobTable(d *ddlCtx, job *model.Job) (int64, error) {
 	}
 	w.registerSync(job)
 
+	// If error is non-retryable, we can ignore the sleep.
 	if runJobErr != nil && errorIsRetryable(runJobErr, job) {
-		// If error is non-retryable, we can ignore the sleep.
 		// Omit the ErrPausedDDLJob
 		w.jobLogger(job).Info("run DDL job failed, sleeps a while then retries it.",
 			zap.Duration("waitTime", GetWaitTimeWhenErrorOccurred()), zap.Error(runJobErr))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47455

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

run SQL below,
```
create table t ( obj json, arr json, nil json, t json, f json, i json, ui json, f64 json, str json, nul json );
insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '20200826173501', '20201123', '20200826173501.123456', '\"2020-08-26 17:35:01.123456\"', null);
alter table t modify obj datetime;
```

`alter table` return error directly, no more sleep.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
