### PR TITLE
types, json: use a more accurate way to judge whether int64/uint64 can be converted to float64

### DIFF
--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -1190,6 +1190,7 @@ func TestHashChunkRow(t *testing.T) {
 
 	testHashChunkRowEqual(t, types.CreateBinaryJSON(int64(1)), types.CreateBinaryJSON(float64(1.0)), true)
 	testHashChunkRowEqual(t, types.CreateBinaryJSON(uint64(math.MaxUint64)), types.CreateBinaryJSON(float64(math.MaxUint64)), false)
+	testHashChunkRowEqual(t, types.CreateBinaryJSON(int64(math.MinInt64)), types.CreateBinaryJSON(float64(math.MinInt64)), true)
 }
 
 func TestValueSizeOfSignedInt(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #46233 close #45686

Problem Summary:

`x == int64(float64(x))` is not a safe way to judge whether an integer can be converted to float64. I judged whether this integer has too long fraction part to tell whether it's safe to be converted to float64.

### What is changed and how it works?

I changed the condition to convert to float64 for integers in json.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

### Release note

```release-note
Fix the issue that the hash join result of large integers and float is incorrect.
```
