### PR TITLE
gomod: fix MinSafeTS might be set to MaxUint64 permanently

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -7054,13 +7054,13 @@ def go_deps():
         name = "com_github_tikv_client_go_v2",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sha256 = "2a345685fc8d9c23349ebc5c7f6aba495a286df5ab57a35575597edfccdba7eb",
-        strip_prefix = "github.com/tikv/client-go/v2@v2.0.8-0.20230925032502-44b0cf7aba2b",
+        sha256 = "43c1cc06bfb94431d4e78c6d961080e9a4e8ceaba22bee60617b7c009640e601",
+        strip_prefix = "github.com/tikv/client-go/v2@v2.0.8-0.20231009020855-652de4de2da7",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20230925032502-44b0cf7aba2b.zip",
-            "http://ats.apps.svc/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20230925032502-44b0cf7aba2b.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20230925032502-44b0cf7aba2b.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20230925032502-44b0cf7aba2b.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20231009020855-652de4de2da7.zip",
+            "http://ats.apps.svc/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20231009020855-652de4de2da7.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20231009020855-652de4de2da7.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20231009020855-652de4de2da7.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tdakkota/asciicheck v0.2.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.8-0.20230925032502-44b0cf7aba2b
+	github.com/tikv/client-go/v2 v2.0.8-0.20231009020855-652de4de2da7
 	github.com/tikv/pd/client v0.0.0-20230912103610-2f57a9f050eb
 	github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966
 	github.com/twmb/murmur3 v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -1024,8 +1024,8 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJf
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
-github.com/tikv/client-go/v2 v2.0.8-0.20230925032502-44b0cf7aba2b h1:aujuc5iCkUVMTmzP/pu6sKoxtvzqNLdawFV44MCOtWA=
-github.com/tikv/client-go/v2 v2.0.8-0.20230925032502-44b0cf7aba2b/go.mod h1:ArIf1ebIbAY50A/pNnFjBAmTrRSas5AO22G4YMTPE+g=
+github.com/tikv/client-go/v2 v2.0.8-0.20231009020855-652de4de2da7 h1:MFlxIoXGSsK92ekVetYfK64QAlKqNSM7dPSMCWCjcXs=
+github.com/tikv/client-go/v2 v2.0.8-0.20231009020855-652de4de2da7/go.mod h1:AjaU1PM3aVQih/zsYvc5sE9z7dAMxV+e881GNeZGTck=
 github.com/tikv/pd/client v0.0.0-20230912103610-2f57a9f050eb h1:hAcH9tFjQzQ3+ofrAHm4ajOTLliYCOfXpj3+boKOtac=
 github.com/tikv/pd/client v0.0.0-20230912103610-2f57a9f050eb/go.mod h1:E+6qtPu8fJm5kNjvKWPVFqSgNAFPk07y2EjD03GWzuI=
 github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966 h1:quvGphlmUVU+nhpFa4gg4yJyTRJ13reZMDHrKwYw53M=


### PR DESCRIPTION
Signed-off-by: husharp <jinhao.hu@pingcap.com><!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47468

Problem Summary:

### What is changed and how it works?
The core question is getting safe ts in client-go
- we introduce `PD API` to not execute `go func which for KV request`, resulting in not updating `safeTSMap`. 		 
    - `updateMinSafeTS` relies on  `safeTSMap` which makes sense(because actually, we can call `updateMinSafeTS` to `kvReuqestUpdater`[to indicate func base]).
- And we need to update `minsafeTS` to make sure when API fails we can fall back to the original way which is by kv request.
- But the core problem is:  **`updateMinSafeTS` will return `maxUnit64` when the first kv request returns 0 and then although `PD API` returns correctly[maybe kv is not initialized], TS can not change `maxUnit64`.**
   - to resolve this question, we need to regard `maxUnit64` as 0 which means there is an initial state.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
