### PR TITLE
executor, planner: fix plan_replayer zip format

### DIFF
--- a/executor/plan_replayer.go
+++ b/executor/plan_replayer.go
@@ -486,7 +486,7 @@ func (e *PlanReplayerLoadInfo) Update(data []byte) error {
 			continue
 		}
 		path := strings.Split(zipFile.Name, "/")
-		if len(path) == 2 && strings.Compare(path[0], "schema") == 0 {
+		if len(path) == 2 && strings.Compare(path[0], "schema") == 0 && zipFile.Mode().IsRegular() {
 			err = createSchemaAndItems(e.Ctx, zipFile)
 			if err != nil {
 				return err
@@ -503,7 +503,7 @@ func (e *PlanReplayerLoadInfo) Update(data []byte) error {
 	// build view next
 	for _, zipFile := range z.File {
 		path := strings.Split(zipFile.Name, "/")
-		if len(path) == 2 && strings.Compare(path[0], "view") == 0 {
+		if len(path) == 2 && strings.Compare(path[0], "view") == 0 && zipFile.Mode().IsRegular() {
 			err = createSchemaAndItems(e.Ctx, zipFile)
 			if err != nil {
 				return err
@@ -514,7 +514,7 @@ func (e *PlanReplayerLoadInfo) Update(data []byte) error {
 	// load stats
 	for _, zipFile := range z.File {
 		path := strings.Split(zipFile.Name, "/")
-		if len(path) == 2 && strings.Compare(path[0], "stats") == 0 {
+		if len(path) == 2 && strings.Compare(path[0], "stats") == 0 && zipFile.Mode().IsRegular() {
 			err = loadStats(e.Ctx, zipFile)
 			if err != nil {
 				return err


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #46474 

Problem Summary:

If the zip file dumped by `plan replayer dump` is unzipped and zipped again, a normal compression software will always add entries for directories, such as `stats/`... They are just directories and cannot be read, so we should skip them to avoid returning error.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > The basic function of `plan replayer` has been covered by existing tests. It's hard to add tests for this PR as it needs cooperation with other compression software. I've considered to add an existing `zip` file as test data, but we cannot promise that a dumped file can be decoded by any version of TiDB right? so it'll need to be updated in the future 🤔 .

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that if the zip file dumped by `plan replayer` is decompressed and compressed again, it cannot be loaded into TiDB.
```
