### PR TITLE
types: new context defination for `types` package and move some string flags to it

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1344,7 +1344,7 @@ func getDefaultValue(ctx sessionctx.Context, col *table.Column, option *ast.Colu
 		if tp == mysql.TypeBit || tp == mysql.TypeString || tp == mysql.TypeVarchar ||
 			tp == mysql.TypeVarString || tp == mysql.TypeEnum || tp == mysql.TypeSet {
 			// For BinaryLiteral or bit fields, we decode the default value to utf8 string.
-			str, err := v.GetBinaryStringDecoded(nil, col.GetCharset())
+			str, err := v.GetBinaryStringDecoded(types.StrictFlags, col.GetCharset())
 			if err != nil {
 				// Overwrite the decoding error with invalid default value error.
 				err = dbterror.ErrInvalidDefaultValue.GenWithStackByArgs(col.Name.O)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1942,6 +1942,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	} else {
 		sc = vars.InitStatementContext()
 	}
+	var typeConvFlags types.Flags
 	sc.TimeZone = vars.Location()
 	sc.TaskID = stmtctx.AllocateTaskID()
 	sc.CTEStorageMap = map[int]*CTEStorages{}
@@ -2137,9 +2138,12 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.IgnoreZeroInDate = true
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 	}
-	sc.SkipUTF8Check = vars.SkipUTF8Check
-	sc.SkipASCIICheck = vars.SkipASCIICheck
-	sc.SkipUTF8MB4Check = !globalConfig.Instance.CheckMb4ValueInUTF8.Load()
+
+	typeConvFlags = typeConvFlags.
+		WithSkipUTF8Check(vars.SkipUTF8Check).
+		WithSkipSACIICheck(vars.SkipASCIICheck).
+		WithSkipUTF8MB4Check(!globalConfig.Instance.CheckMb4ValueInUTF8.Load())
+
 	vars.PlanCacheParams.Reset()
 	if priority := mysql.PriorityEnum(atomic.LoadInt32(&variable.ForcePriority)); priority != mysql.NoPriority {
 		sc.Priority = priority
@@ -2165,6 +2169,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.RuntimeStatsColl = execdetails.NewRuntimeStatsColl(reuseObj)
 	}
 
+	sc.TypeConvContext = types.NewContext(typeConvFlags, sc.TimeZone, sc.AppendWarning)
 	sc.TblInfo2UnionScan = make(map[*model.TableInfo]bool)
 	errCount, warnCount := vars.StmtCtx.NumErrorWarnings()
 	vars.SysErrorCount = errCount

--- a/sessionctx/stmtctx/BUILD.bazel
+++ b/sessionctx/stmtctx/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//parser/model",
         "//parser/mysql",
         "//parser/terror",
+        "//types/context",
         "//util/disk",
         "//util/execdetails",
         "//util/memory",

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
+	typectx "github.com/pingcap/tidb/types/context"
 	"github.com/pingcap/tidb/util/disk"
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/memory"
@@ -149,6 +150,9 @@ type StatementContext struct {
 	// Set the following variables before execution
 	StmtHints
 
+	// TypeConvContext is used to indicate how make the type conversation.
+	TypeConvContext typectx.Context
+
 	// IsDDLJobInQueue is used to mark whether the DDL job is put into the queue.
 	// If IsDDLJobInQueue is true, it means the DDL job is in the queue of storage, and it can be handled by the DDL worker.
 	IsDDLJobInQueue               bool
@@ -181,9 +185,6 @@ type StatementContext struct {
 	AllowInvalidDate              bool
 	IgnoreNoPartition             bool
 	IgnoreExplainIDSuffix         bool
-	SkipUTF8Check                 bool
-	SkipASCIICheck                bool
-	SkipUTF8MB4Check              bool
 	MultiSchemaInfo               *model.MultiSchemaInfo
 	// If the select statement was like 'select * from t as of timestamp ...' or in a stale read transaction
 	// or is affected by the tidb_read_staleness session variable, then the statement will be makred as isStaleness

--- a/types/BUILD.bazel
+++ b/types/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     srcs = [
         "binary_literal.go",
         "compare.go",
+        "context.go",
         "convert.go",
         "core_time.go",
         "datum.go",
@@ -50,6 +51,7 @@ go_library(
         "//parser/terror",
         "//parser/types",
         "//sessionctx/stmtctx",
+        "//types/context",
         "//util/collate",
         "//util/dbterror",
         "//util/hack",

--- a/types/context.go
+++ b/types/context.go
@@ -1,0 +1,33 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/pingcap/tidb/types/context"
+
+// TODO: move a contents in `types/context/context.go` to this file after refactor finished.
+// Because package `types` has a dependency on `sessionctx/stmtctx`, we need a separate package `type/context` to define
+// context objects during refactor works.
+
+// Context is an alias of `context.Context`
+type Context = context.Context
+
+// Flags is an alias of `Flags`
+type Flags = context.Flags
+
+// StrictFlags is a flags with a fields unset and has the most strict behavior.
+const StrictFlags = context.StrictFlags
+
+// NewContext creates a new `Context`
+var NewContext = context.NewContext

--- a/types/context/BUILD.bazel
+++ b/types/context/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "context",
+    srcs = ["context.go"],
+    importpath = "github.com/pingcap/tidb/types/context",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "context_test",
+    timeout = "short",
+    srcs = ["context_test.go"],
+    embed = [":context"],
+    flaky = True,
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/types/context/context.go
+++ b/types/context/context.go
@@ -1,0 +1,141 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import "time"
+
+// StrictFlags is a flags with a fields unset and has the most strict behavior.
+const StrictFlags Flags = 0
+
+// Flags indicates how to handle the conversion of a value.
+type Flags uint16
+
+const (
+	// FlagIgnoreTruncateErr indicates to ignore the truncate error.
+	// If this flag is set, `FlagTruncateAsWarning` will be ignored.
+	FlagIgnoreTruncateErr Flags = 1 << iota
+	// FlagTruncateAsWarning indicates to append the truncate error to warnings instead of returning it to user.
+	FlagTruncateAsWarning
+	// FlagClipNegativeToZero indicates to clip the value to zero when casting a negative value to an unsigned integer.
+	// When this flag is set and the clip happens, an overflow error occurs and how to handle it will be determined by flags
+	// `FlagIgnoreOverflowError` and `FlagOverflowAsWarning`.
+	FlagClipNegativeToZero
+	// FlagIgnoreOverflowError indicates to ignore the overflow error.
+	// If this flag is set, `FlagOverflowAsWarning` will be ignored.
+	FlagIgnoreOverflowError
+	// FlagOverflowAsWarning indicates to append the overflow error to warnings instead of returning it to user.
+	FlagOverflowAsWarning
+	// FlagIgnoreZeroDateErr indicates to ignore the zero-date error.
+	// See: https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_no_zero_date for details about the "zero-date" error.
+	// If this flag is set, `FlagZeroDateAsWarning` will be ignored.
+	FlagIgnoreZeroDateErr
+	// FlagZeroDateAsWarning indicates to append the zero-date error to warnings instead of returning it to user.
+	FlagZeroDateAsWarning
+	// FlagIgnoreZeroInDateErr indicates to ignore the zero-in-date error.
+	// See: https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_no_zero_in_date for details about the "zero-in-date" error.
+	FlagIgnoreZeroInDateErr
+	// FlagZeroInDateAsWarning indicates to append the zero-in-date error to warnings instead of returning it to user.
+	FlagZeroInDateAsWarning
+	// FlagIgnoreInvalidDateErr indicates to ignore the invalid-date error.
+	// See: https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_allow_invalid_dates for details about the "invalid-date" error.
+	FlagIgnoreInvalidDateErr
+	// FlagInvalidDateAsWarning indicates to append the invalid-date error to warnings instead of returning it to user.
+	FlagInvalidDateAsWarning
+	// FlagSkipASCIICheck indicates to skip the ASCII check when converting the value to an ASCII string.
+	FlagSkipASCIICheck
+	// FlagSkipUTF8Check indicates to skip the UTF8 check when converting the value to an UTF8MB3 string.
+	FlagSkipUTF8Check
+	// FlagSkipUTF8MB4Check indicates to skip the UTF8MB4 check when converting the value to an UTF8 string.
+	FlagSkipUTF8MB4Check
+)
+
+// SkipASCIICheck indicates whether the flag `FlagSkipASCIICheck` is set
+func (f Flags) SkipASCIICheck() bool {
+	return f&FlagSkipASCIICheck != 0
+}
+
+// WithSkipSACIICheck returns a new flags with `FlagSkipASCIICheck` set/unset according to the skip parameter
+func (f Flags) WithSkipSACIICheck(skip bool) Flags {
+	if skip {
+		return f | FlagSkipASCIICheck
+	}
+	return f &^ FlagSkipASCIICheck
+}
+
+// SkipUTF8Check indicates whether the flag `FlagSkipUTF8Check` is set
+func (f Flags) SkipUTF8Check() bool {
+	return f&FlagSkipUTF8Check != 0
+}
+
+// WithSkipUTF8Check returns a new flags with `FlagSkipUTF8Check` set/unset according to the skip parameter
+func (f Flags) WithSkipUTF8Check(skip bool) Flags {
+	if skip {
+		return f | FlagSkipUTF8Check
+	}
+	return f &^ FlagSkipUTF8Check
+}
+
+// SkipUTF8MB4Check indicates whether the flag `FlagSkipUTF8MB4Check` is set
+func (f Flags) SkipUTF8MB4Check() bool {
+	return f&FlagSkipUTF8MB4Check != 0
+}
+
+// WithSkipUTF8MB4Check returns a new flags with `FlagSkipUTF8MB4Check` set/unset according to the skip parameter
+func (f Flags) WithSkipUTF8MB4Check(skip bool) Flags {
+	if skip {
+		return f | FlagSkipUTF8MB4Check
+	}
+	return f &^ FlagSkipUTF8MB4Check
+}
+
+// Context provides the information when converting between different types.
+type Context struct {
+	flags           Flags
+	loc             *time.Location
+	appendWarningFn func(err error)
+}
+
+// NewContext creates a new `Context`
+func NewContext(flags Flags, loc *time.Location, appendWarningFn func(err error)) Context {
+	return Context{
+		flags:           flags,
+		loc:             loc,
+		appendWarningFn: appendWarningFn,
+	}
+}
+
+// Flags returns the flags of the context
+func (c *Context) Flags() Flags {
+	return c.flags
+}
+
+// WithFlags returns a new context with the flags set to the given value
+func (c *Context) WithFlags(f Flags) Context {
+	ctx := *c
+	ctx.flags = f
+	return ctx
+}
+
+// Location returns the location of the context
+func (c *Context) Location() *time.Location {
+	return c.loc
+}
+
+// AppendWarning appends the error to warning. If the inner `appendWarningFn` is nil, do nothing.
+func (c *Context) AppendWarning(err error) {
+	if fn := c.appendWarningFn; fn != nil {
+		fn(err)
+	}
+}

--- a/types/context/context_test.go
+++ b/types/context/context_test.go
@@ -1,0 +1,97 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithNewFlags(t *testing.T) {
+	ctx := NewContext(FlagSkipASCIICheck, time.UTC, nil)
+	ctx2 := ctx.WithFlags(FlagSkipUTF8Check)
+	require.Equal(t, FlagSkipASCIICheck, ctx.Flags())
+	require.Equal(t, FlagSkipUTF8Check, ctx2.Flags())
+	require.Equal(t, time.UTC, ctx.Location())
+	require.Equal(t, time.UTC, ctx2.Location())
+}
+
+func TestStringFlags(t *testing.T) {
+	cases := []struct {
+		name    string
+		flag    Flags
+		readFn  func(f Flags) bool
+		writeFn func(f Flags, skip bool) Flags
+	}{
+		{
+			name: "FlagSkipASCIICheck",
+			flag: FlagSkipASCIICheck,
+			readFn: func(f Flags) bool {
+				return f.SkipASCIICheck()
+			},
+			writeFn: func(f Flags, skip bool) Flags {
+				return f.WithSkipSACIICheck(skip)
+			},
+		},
+		{
+			name: "FlagSkipUTF8Check",
+			flag: FlagSkipUTF8Check,
+			readFn: func(f Flags) bool {
+				return f.SkipUTF8Check()
+			},
+			writeFn: func(f Flags, skip bool) Flags {
+				return f.WithSkipUTF8Check(skip)
+			},
+		},
+		{
+			name: "FlagSkipUTF8MB4Check",
+			flag: FlagSkipUTF8MB4Check,
+			readFn: func(f Flags) bool {
+				return f.SkipUTF8MB4Check()
+			},
+			writeFn: func(f Flags, skip bool) Flags {
+				return f.WithSkipUTF8MB4Check(skip)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		msg := fmt.Sprintf("case: %s", c.name)
+
+		// read
+		require.False(t, c.readFn(StrictFlags), msg)
+		require.False(t, c.readFn(Flags(0)), msg)
+		require.True(t, c.readFn(c.flag), msg)
+
+		// set
+		f := c.writeFn(Flags(0), true)
+		require.Equal(t, c.flag, f, msg)
+		require.True(t, c.readFn(f), msg)
+		f = c.writeFn(^Flags(0), true)
+		require.Equal(t, ^Flags(0), f, msg)
+		require.True(t, c.readFn(f), msg)
+
+		// unset
+		f = c.writeFn(Flags(0), false)
+		require.Equal(t, Flags(0), f, msg)
+		require.False(t, c.readFn(f), msg)
+		f = c.writeFn(^Flags(0), false)
+		require.Equal(t, ^c.flag, f, msg)
+		require.False(t, c.readFn(f), msg)
+	}
+}

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -399,23 +399,22 @@ func TestConvertToStringWithCheck(t *testing.T) {
 	nhUTF8 := "你好"
 	nhUTF8MB4 := "你好👋"
 	nhUTF8Invalid := "你好" + string([]byte{0x81})
-	type SC = *stmtctx.StatementContext
 	tests := []struct {
-		input      string
-		outputChs  string
-		setStmtCtx func(ctx *stmtctx.StatementContext)
-		output     string
+		input     string
+		outputChs string
+		newFlags  func(flags Flags) Flags
+		output    string
 	}{
-		{nhUTF8, "utf8mb4", func(s SC) { s.SkipUTF8Check = false }, nhUTF8},
-		{nhUTF8MB4, "utf8mb4", func(s SC) { s.SkipUTF8Check = false }, nhUTF8MB4},
-		{nhUTF8, "utf8mb4", func(s SC) { s.SkipUTF8Check = true }, nhUTF8},
-		{nhUTF8MB4, "utf8mb4", func(s SC) { s.SkipUTF8Check = true }, nhUTF8MB4},
-		{nhUTF8Invalid, "utf8mb4", func(s SC) { s.SkipUTF8Check = true }, nhUTF8Invalid},
-		{nhUTF8Invalid, "utf8mb4", func(s SC) { s.SkipUTF8Check = false }, ""},
-		{nhUTF8Invalid, "ascii", func(s SC) { s.SkipASCIICheck = false }, ""},
-		{nhUTF8Invalid, "ascii", func(s SC) { s.SkipASCIICheck = true }, nhUTF8Invalid},
-		{nhUTF8MB4, "utf8", func(s SC) { s.SkipUTF8MB4Check = false }, ""},
-		{nhUTF8MB4, "utf8", func(s SC) { s.SkipUTF8MB4Check = true }, nhUTF8MB4},
+		{nhUTF8, "utf8mb4", func(f Flags) Flags { return f.WithSkipUTF8Check(false) }, nhUTF8},
+		{nhUTF8MB4, "utf8mb4", func(f Flags) Flags { return f.WithSkipUTF8Check(false) }, nhUTF8MB4},
+		{nhUTF8, "utf8mb4", func(f Flags) Flags { return f.WithSkipUTF8Check(true) }, nhUTF8},
+		{nhUTF8MB4, "utf8mb4", func(f Flags) Flags { return f.WithSkipUTF8Check(true) }, nhUTF8MB4},
+		{nhUTF8Invalid, "utf8mb4", func(f Flags) Flags { return f.WithSkipUTF8Check(true) }, nhUTF8Invalid},
+		{nhUTF8Invalid, "utf8mb4", func(f Flags) Flags { return f.WithSkipUTF8Check(false) }, ""},
+		{nhUTF8Invalid, "ascii", func(f Flags) Flags { return f.WithSkipSACIICheck(false) }, ""},
+		{nhUTF8Invalid, "ascii", func(f Flags) Flags { return f.WithSkipSACIICheck(true) }, nhUTF8Invalid},
+		{nhUTF8MB4, "utf8", func(f Flags) Flags { return f.WithSkipUTF8MB4Check(false) }, ""},
+		{nhUTF8MB4, "utf8", func(f Flags) Flags { return f.WithSkipUTF8MB4Check(true) }, nhUTF8MB4},
 	}
 	for _, tt := range tests {
 		ft := NewFieldType(mysql.TypeVarchar)
@@ -423,7 +422,8 @@ func TestConvertToStringWithCheck(t *testing.T) {
 		ft.SetCharset(tt.outputChs)
 		inputDatum := NewStringDatum(tt.input)
 		sc := new(stmtctx.StatementContext)
-		tt.setStmtCtx(sc)
+		flags := tt.newFlags(sc.TypeConvContext.Flags())
+		sc.TypeConvContext = sc.TypeConvContext.WithFlags(flags)
 		outputDatum, err := inputDatum.ConvertTo(sc, ft)
 		if len(tt.output) == 0 {
 			require.True(t, charset.ErrInvalidCharacterString.Equal(err), tt)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47478 , close #47479

### What is changed and how it works?

refactor types package to define a new `Context` to handle value conversation.

1. introduce a new package `types/context` for `Context`. The new package is not necessary after refactor done, we should merge it with `types` package after refactor finished.
2. Define some flags we should use in the later refactor works.
3. Delete fields `SkipUTF8Check` ,  `SkipASCIICheck` and  `SkipUTF8MB4Check` and use the flags in `Context` instead in some functions.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
