### PR TITLE
ddl: preserve index order for multi-schema change

### DIFF
--- a/ddl/multi_schema_change.go
+++ b/ddl/multi_schema_change.go
@@ -333,7 +333,7 @@ func mergeAddIndex(info *model.MultiSchemaInfo) {
 			// Foreign key requires the order of adding indexes is unchanged.
 			return
 		}
-		if subJob.Type == model.ActionAddIndex {
+		if subJob.Type == model.ActionAddIndex || subJob.Type == model.ActionAddPrimaryKey {
 			if i == 0 {
 				consistentUnique = subJob.Args[0].(bool)
 			} else {

--- a/ddl/multi_schema_change_test.go
+++ b/ddl/multi_schema_change_test.go
@@ -1223,6 +1223,21 @@ func TestMultiSchemaChangeAddIndexChangeColumn(t *testing.T) {
 	tk.MustExec("admin check table t;")
 }
 
+func TestMultiSchemaChangeAddIndexOrder(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("create table t (a int);")
+	tk.MustExec("insert into t values (123);")
+	tk.MustExec("alter table t add index i(a), add primary key (a);")
+	result := "t CREATE TABLE `t` (\n" +
+		"  `a` int(11) NOT NULL,\n" +
+		"  KEY `i` (`a`),\n" +
+		"  PRIMARY KEY (`a`) /*T![clustered_index] NONCLUSTERED */\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"
+	tk.MustQuery("show create table t;").Check(testkit.Rows(result))
+}
+
 func TestMultiSchemaChangeMixedWithUpdate(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #41602

Problem Summary:

#47135 changes the order of adding indexes, which is unexpected.

```
mysql> alter table t add index i(a), add primary key (a);
Query OK, 0 rows affected (4.82 sec)

mysql> show create table t;
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                                      |
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `a` int(11) NOT NULL,
  PRIMARY KEY (`a`) /*T![clustered_index] NONCLUSTERED */,
  KEY `i` (`a`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)
```


### What is changed and how it works?

Take `add primary` jobs the same as `add index` jobs.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
