### PR TITLE
br: fix add ingest index as sub job

### DIFF
--- a/br/pkg/restore/ingestrec/ingest_recorder.go
+++ b/br/pkg/restore/ingestrec/ingest_recorder.go
@@ -69,13 +69,13 @@ func notAddIndexJob(job *model.Job) bool {
 		job.Type != model.ActionAddPrimaryKey
 }
 
-func notSynced(job *model.Job) bool {
-	return job.State != model.JobStateSynced
+func notSynced(job *model.Job, isSubJob bool) bool {
+	return (job.State != model.JobStateSynced) && !(isSubJob && job.State == model.JobStateDone)
 }
 
 // AddJob firstly filters the ingest index add operation job, and records it into IngestRecorder.
-func (i *IngestRecorder) AddJob(job *model.Job) error {
-	if job == nil || notIngestJob(job) || notAddIndexJob(job) || notSynced(job) {
+func (i *IngestRecorder) AddJob(job *model.Job, isSubJob bool) error {
+	if job == nil || notIngestJob(job) || notAddIndexJob(job) || notSynced(job, isSubJob) {
 		return nil
 	}
 

--- a/br/pkg/restore/ingestrec/ingest_recorder_test.go
+++ b/br/pkg/restore/ingestrec/ingest_recorder_test.go
@@ -147,7 +147,7 @@ func TestAddIngestRecorder(t *testing.T) {
 			getIndex(1, []string{"x", "y"}),
 		},
 		nil,
-	))
+	), false)
 	require.NoError(t, err)
 	recorder.UpdateIndexInfo(allSchemas)
 	err = recorder.Iterate(noItem)
@@ -163,7 +163,7 @@ func TestAddIngestRecorder(t *testing.T) {
 			getIndex(1, []string{"x", "y"}),
 		},
 		nil,
-	))
+	), false)
 	require.NoError(t, err)
 	recorder.UpdateIndexInfo(allSchemas)
 	err = recorder.Iterate(noItem)
@@ -179,7 +179,7 @@ func TestAddIngestRecorder(t *testing.T) {
 			getIndex(1, []string{"x", "y"}),
 		},
 		nil,
-	))
+	), false)
 	require.NoError(t, err)
 	recorder.UpdateIndexInfo(allSchemas)
 	err = recorder.Iterate(noItem)
@@ -197,7 +197,7 @@ func TestAddIngestRecorder(t *testing.T) {
 				getIndex(1, []string{"x", "y"}),
 			},
 			json.RawMessage(`[1, "a"]`),
-		))
+		), false)
 		require.NoError(t, err)
 		f, cnt := hasOneItem(1, "%n,%n", []interface{}{"x", "y"})
 		recorder.UpdateIndexInfo(allSchemas)
@@ -218,7 +218,27 @@ func TestAddIngestRecorder(t *testing.T) {
 				getIndex(1, []string{"x", "y"}),
 			},
 			json.RawMessage(`[1, "a"]`),
-		))
+		), false)
+		require.NoError(t, err)
+		f, cnt := hasOneItem(1, "%n,%n", []interface{}{"x", "y"})
+		recorder.UpdateIndexInfo(allSchemas)
+		err = recorder.Iterate(f)
+		require.NoError(t, err)
+		require.Equal(t, *cnt, 1)
+	}
+
+	{
+		// a sub job as add primary index job
+		err = recorder.AddJob(fakeJob(
+			model.ReorgTypeLitMerge,
+			model.ActionAddPrimaryKey,
+			model.JobStateDone,
+			1000,
+			[]*model.IndexInfo{
+				getIndex(1, []string{"x", "y"}),
+			},
+			json.RawMessage(`[1, "a"]`),
+		), true)
 		require.NoError(t, err)
 		f, cnt := hasOneItem(1, "%n,%n", []interface{}{"x", "y"})
 		recorder.UpdateIndexInfo(allSchemas)
@@ -293,7 +313,7 @@ func TestIndexesKind(t *testing.T) {
 			getIndex(1, []string{"x"}),
 		},
 		json.RawMessage(`[1, "a"]`),
-	))
+	), false)
 	require.NoError(t, err)
 	recorder.UpdateIndexInfo(allSchemas)
 	var (
@@ -371,7 +391,7 @@ func TestRewriteTableID(t *testing.T) {
 			getIndex(1, []string{"x", "y"}),
 		},
 		json.RawMessage(`[1, "a"]`),
-	))
+	), false)
 	require.NoError(t, err)
 	recorder.UpdateIndexInfo(allSchemas)
 	recorder.RewriteTableID(func(tableID int64) (int64, bool, error) {

--- a/br/pkg/stream/rewrite_meta_rawkv.go
+++ b/br/pkg/stream/rewrite_meta_rawkv.go
@@ -649,7 +649,7 @@ func (sr *SchemasReplace) RewriteKvEntry(e *kv.Entry, cf string) (*kv.Entry, err
 				return nil, nil
 			}
 
-			return nil, sr.restoreFromHistory(job)
+			return nil, sr.restoreFromHistory(job, false)
 		}
 		return nil, nil
 	}
@@ -678,14 +678,14 @@ func (sr *SchemasReplace) RewriteKvEntry(e *kv.Entry, cf string) (*kv.Entry, err
 	return nil, nil
 }
 
-func (sr *SchemasReplace) restoreFromHistory(job *model.Job) error {
+func (sr *SchemasReplace) restoreFromHistory(job *model.Job, isSubJob bool) error {
 	if !job.IsCancelled() {
 		switch job.Type {
 		case model.ActionAddIndex, model.ActionAddPrimaryKey:
 			if job.State == model.JobStateRollbackDone {
 				return sr.deleteRange(job)
 			}
-			err := sr.ingestRecorder.AddJob(job)
+			err := sr.ingestRecorder.AddJob(job, isSubJob)
 			return errors.Trace(err)
 		case model.ActionDropSchema, model.ActionDropTable, model.ActionTruncateTable, model.ActionDropIndex, model.ActionDropPrimaryKey,
 			model.ActionDropTablePartition, model.ActionTruncateTablePartition, model.ActionDropColumn,
@@ -694,7 +694,8 @@ func (sr *SchemasReplace) restoreFromHistory(job *model.Job) error {
 		case model.ActionMultiSchemaChange:
 			for i, sub := range job.MultiSchemaInfo.SubJobs {
 				proxyJob := sub.ToProxyJob(job, i)
-				if err := sr.restoreFromHistory(&proxyJob); err != nil {
+				// ASSERT: the proxyJob can not be MultiSchemaInfo anymore
+				if err := sr.restoreFromHistory(&proxyJob, true); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47482

Problem Summary:
When use multi schema info job, the final sub job's state is done instead of synced
### What is changed and how it works?
check whether its state is Done when it is a sub job.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
