### PR TITLE
session, tidb-server: fix `with-mock-upgrade` doesn't work

### DIFF
--- a/session/bootstraptest/bootstrap_upgrade_test.go
+++ b/session/bootstraptest/bootstrap_upgrade_test.go
@@ -228,7 +228,7 @@ func TestUpgradeVersion75(t *testing.T) {
 }
 
 func TestUpgradeVersionMockLatest(t *testing.T) {
-	*session.WithMockUpgrade = true
+	session.WithMockUpgrade = true
 
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -291,7 +291,7 @@ func TestUpgradeVersionMockLatest(t *testing.T) {
 
 // TestUpgradeVersionWithUpgradeHTTPOp tests SupportUpgradeHTTPOpVer upgrade SupportUpgradeHTTPOpVer++ with HTTP op.
 func TestUpgradeVersionWithUpgradeHTTPOp(t *testing.T) {
-	*session.WithMockUpgrade = true
+	session.WithMockUpgrade = true
 	session.MockUpgradeToVerLatestKind = session.MockSimpleUpgradeToVerLatest
 
 	store, dom := session.CreateStoreAndBootstrap(t)
@@ -339,7 +339,7 @@ func TestUpgradeVersionWithUpgradeHTTPOp(t *testing.T) {
 
 // TestUpgradeVersionWithoutUpgradeHTTPOp tests SupportUpgradeHTTPOpVer upgrade SupportUpgradeHTTPOpVer++ without HTTP op.
 func TestUpgradeVersionWithoutUpgradeHTTPOp(t *testing.T) {
-	*session.WithMockUpgrade = true
+	session.WithMockUpgrade = true
 	session.MockUpgradeToVerLatestKind = session.MockSimpleUpgradeToVerLatest
 
 	store, dom := session.CreateStoreAndBootstrap(t)
@@ -463,7 +463,7 @@ func checkDDLJobExecSucc(t *testing.T, se session.Session, jobID int64) {
 // Then we do re-upgrade(This operation will pause all DDL jobs by the system).
 func TestUpgradeVersionForSystemPausedJob(t *testing.T) {
 	// Mock a general and a reorg job in boostrap.
-	*session.WithMockUpgrade = true
+	session.WithMockUpgrade = true
 	session.MockUpgradeToVerLatestKind = session.MockSimpleUpgradeToVerLatest
 
 	store, dom := session.CreateStoreAndBootstrap(t)
@@ -740,7 +740,7 @@ func TestUpgradeWithPauseDDL(t *testing.T) {
 	}
 	session.TestHook = tc
 
-	*session.WithMockUpgrade = true
+	session.WithMockUpgrade = true
 	seV := session.CreateSessionAndSetID(t, store)
 	txn, err := store.Begin()
 	require.NoError(t, err)

--- a/session/mock_bootstrap.go
+++ b/session/mock_bootstrap.go
@@ -28,11 +28,11 @@ import (
 )
 
 // WithMockUpgrade is a flag identify whether tests run with mock upgrading.
-var WithMockUpgrade *bool
+var WithMockUpgrade bool
 
 // RegisterMockUpgradeFlag registers the mock upgrade flag.
 func RegisterMockUpgradeFlag(fSet *flag.FlagSet) {
-	WithMockUpgrade = fSet.Bool("with-mock-upgrade", false, "whether tests run with mock upgrade")
+	WithMockUpgrade = *(fSet.Bool("with-mock-upgrade", false, "whether tests run with mock upgrade"))
 }
 
 var allDDLs = []string{
@@ -133,7 +133,7 @@ var TestHook = TestCallback{}
 
 // modifyBootstrapVersionForTest is used to test SupportUpgradeHTTPOpVer upgrade SupportUpgradeHTTPOpVer++.
 func modifyBootstrapVersionForTest(ver int64) {
-	if !*WithMockUpgrade {
+	if !WithMockUpgrade {
 		return
 	}
 
@@ -152,7 +152,7 @@ const (
 var MockUpgradeToVerLatestKind = defaultMockUpgradeToVerLatest
 
 func addMockBootstrapVersionForTest(s Session) {
-	if !*WithMockUpgrade {
+	if !WithMockUpgrade {
 		return
 	}
 

--- a/session/mock_bootstrap.go
+++ b/session/mock_bootstrap.go
@@ -28,7 +28,12 @@ import (
 )
 
 // WithMockUpgrade is a flag identify whether tests run with mock upgrading.
-var WithMockUpgrade = flag.Bool("with-mock-upgrade", false, "whether tests run with mock upgrade")
+var WithMockUpgrade *bool
+
+// RegisterMockUpgradeFlag registers the mock upgrade flag.
+func RegisterMockUpgradeFlag(fSet *flag.FlagSet) {
+	WithMockUpgrade = fSet.Bool("with-mock-upgrade", false, "whether tests run with mock upgrade")
+}
 
 var allDDLs = []string{
 	"create unique index c3_index on mock_sys_partition (c1)",

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -236,6 +236,7 @@ func initflag() *flag.FlagSet {
 	keyspaceName = fset.String(nmKeyspaceName, "", "keyspace name.")
 	serviceScope = fset.String(nmTiDBServiceScope, "", "tidb service scope")
 	help = fset.Bool("help", false, "show the usage")
+	session.RegisterMockUpgradeFlag(fset)
 	// Ignore errors; CommandLine is set for ExitOnError.
 	// nolint:errcheck
 	fset.Parse(os.Args[1:])

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -185,7 +185,7 @@ var (
 	help                        *bool
 )
 
-func initflag() *flag.FlagSet {
+func initFlagSet() *flag.FlagSet {
 	fset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	version = flagBoolean(fset, nmVersion, false, "print version information and exit")
 	configPath = fset.String(nmConfig, "", "config file path")
@@ -248,7 +248,7 @@ func initflag() *flag.FlagSet {
 }
 
 func main() {
-	fset := initflag()
+	fset := initFlagSet()
 	config.InitializeConfig(*configPath, *configCheck, *configStrict, overrideConfig, fset)
 	if *version {
 		setVersions()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/47493

Problem Summary:
After https://github.com/pingcap/tidb/pull/47205, we ran the TiDB binary with `--with-mock-upgrade true` failed.

### What is changed and how it works?
Add `with-mock-upgrade` to FlagSet in initFlag.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
After this PR, we do `./tidb-server --with-mock-upgrade true` successfully.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
