### PR TITLE
types, *: move truncate flags to the types context

### DIFF
--- a/br/pkg/lightning/backend/kv/session.go
+++ b/br/pkg/lightning/backend/kv/session.go
@@ -287,11 +287,13 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 	vars.StmtCtx.InInsertStmt = true
 	vars.StmtCtx.BatchCheck = true
 	vars.StmtCtx.BadNullAsWarning = !sqlMode.HasStrictMode()
-	vars.StmtCtx.TruncateAsWarning = !sqlMode.HasStrictMode()
 	vars.StmtCtx.OverflowAsWarning = !sqlMode.HasStrictMode()
 	vars.StmtCtx.AllowInvalidDate = sqlMode.HasAllowInvalidDatesMode()
 	vars.StmtCtx.IgnoreZeroInDate = !sqlMode.HasStrictMode() || sqlMode.HasAllowInvalidDatesMode()
 	vars.SQLMode = sqlMode
+
+	typeFlags := vars.StmtCtx.TypeFlags().WithTruncateAsWarning(!sqlMode.HasStrictMode())
+	vars.StmtCtx.SetTypeFlags(typeFlags)
 	if options.SysVars != nil {
 		for k, v := range options.SysVars {
 			// since 6.3(current master) tidb checks whether we can set a system variable

--- a/br/pkg/lightning/backend/tidb/tidb.go
+++ b/br/pkg/lightning/backend/tidb/tidb.go
@@ -455,7 +455,7 @@ func (enc *tidbEncoder) appendSQL(sb *strings.Builder, datum *types.Datum, _ *ta
 
 	case types.KindMysqlBit:
 		var buffer [20]byte
-		intValue, err := datum.GetBinaryLiteral().ToInt(nil)
+		intValue, err := datum.GetBinaryLiteral().ToInt(types.DefaultNoWarningContext)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -163,12 +163,15 @@ func initSessCtx(
 		return errors.Trace(err)
 	}
 	sessCtx.GetSessionVars().StmtCtx.BadNullAsWarning = !sqlMode.HasStrictMode()
-	sessCtx.GetSessionVars().StmtCtx.TruncateAsWarning = !sqlMode.HasStrictMode()
 	sessCtx.GetSessionVars().StmtCtx.OverflowAsWarning = !sqlMode.HasStrictMode()
 	sessCtx.GetSessionVars().StmtCtx.AllowInvalidDate = sqlMode.HasAllowInvalidDatesMode()
 	sessCtx.GetSessionVars().StmtCtx.DividedByZeroAsWarning = !sqlMode.HasStrictMode()
 	sessCtx.GetSessionVars().StmtCtx.IgnoreZeroInDate = !sqlMode.HasStrictMode() || sqlMode.HasAllowInvalidDatesMode()
 	sessCtx.GetSessionVars().StmtCtx.NoZeroDate = sqlMode.HasStrictMode()
+
+	typeFlags := sessCtx.GetSessionVars().StmtCtx.TypeFlags().WithTruncateAsWarning(!sqlMode.HasStrictMode())
+	sessCtx.GetSessionVars().StmtCtx.SetTypeFlags(typeFlags)
+
 	// Prevent initializing the mock context in the workers concurrently.
 	// For details, see https://github.com/pingcap/tidb/issues/40879.
 	_ = sessCtx.GetDomainInfoSchema()

--- a/pkg/executor/aggfuncs/func_group_concat.go
+++ b/pkg/executor/aggfuncs/func_group_concat.go
@@ -72,7 +72,7 @@ func (e *baseGroupConcat4String) AppendFinalResult2Chunk(_ sessionctx.Context, p
 
 func (e *baseGroupConcat4String) handleTruncateError(sctx sessionctx.Context) (err error) {
 	if atomic.CompareAndSwapInt32(e.truncated, 0, 1) {
-		if !sctx.GetSessionVars().StmtCtx.TruncateAsWarning {
+		if !sctx.GetSessionVars().StmtCtx.TypeFlags().TruncateAsWarning() {
 			return expression.ErrCutValueGroupConcat.GenWithStackByArgs(e.args[0].String())
 		}
 		sctx.GetSessionVars().StmtCtx.AppendWarning(expression.ErrCutValueGroupConcat.GenWithStackByArgs(e.args[0].String()))

--- a/pkg/executor/coprocessor.go
+++ b/pkg/executor/coprocessor.go
@@ -182,14 +182,14 @@ func (h *CoprocessorDAGHandler) buildDAGExecutor(req *coprocessor.Request) (exec
 	}
 
 	stmtCtx := h.sctx.GetSessionVars().StmtCtx
-	stmtCtx.SetFlagsFromPBFlag(dagReq.Flags)
+
 	tz, err := timeutil.ConstructTimeZone(dagReq.TimeZoneName, int(dagReq.TimeZoneOffset))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	stmtCtx.SetTimeZone(tz)
 	h.sctx.GetSessionVars().TimeZone = tz
+	stmtCtx.InitFromPBFlagAndTz(dagReq.Flags, tz)
+
 	h.dagReq = dagReq
 	is := h.sctx.GetInfoSchema().(infoschema.InfoSchema)
 	// Build physical plan.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -908,6 +908,13 @@ func (e *CheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	}
 	defer func() { e.done = true }()
 
+	// See the comment of `ColumnInfos2ColumnsAndNames`. It's fixing #42341
+	originalTypeFlags := e.Ctx().GetSessionVars().StmtCtx.TypeFlags()
+	defer func() {
+		e.Ctx().GetSessionVars().StmtCtx.SetTypeFlags(originalTypeFlags)
+	}()
+	e.Ctx().GetSessionVars().StmtCtx.SetTypeFlags(originalTypeFlags.WithIgnoreTruncateErr(true))
+
 	idxNames := make([]string, 0, len(e.indexInfos))
 	for _, idx := range e.indexInfos {
 		if idx.MVIndex {
@@ -2063,6 +2070,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 
 	sc.InRestrictedSQL = vars.InRestrictedSQL
 	switch stmt := s.(type) {
+	// `ResetUpdateStmtCtx` and `ResetDeleteStmtCtx` may modify the flags, so we'll need to store them.
 	case *ast.UpdateStmt:
 		ResetUpdateStmtCtx(sc, stmt, vars)
 	case *ast.DeleteStmt:
@@ -2076,17 +2084,17 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.BadNullAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 		sc.IgnoreNoPartition = stmt.IgnoreErr
 		sc.ErrAutoincReadFailedAsWarning = stmt.IgnoreErr
-		sc.TruncateAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 		sc.DividedByZeroAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 		sc.IgnoreZeroInDate = !vars.SQLMode.HasNoZeroInDateMode() || !vars.SQLMode.HasNoZeroDateMode() || !vars.StrictSQLMode || stmt.IgnoreErr || sc.AllowInvalidDate
 		sc.Priority = stmt.Priority
+		sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(!vars.StrictSQLMode || stmt.IgnoreErr))
 	case *ast.CreateTableStmt, *ast.AlterTableStmt:
 		sc.InCreateOrAlterStmt = true
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 		sc.IgnoreZeroInDate = !vars.SQLMode.HasNoZeroInDateMode() || !vars.StrictSQLMode || sc.AllowInvalidDate
 		sc.NoZeroDate = vars.SQLMode.HasNoZeroDateMode()
-		sc.TruncateAsWarning = !vars.StrictSQLMode
+		sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(!vars.StrictSQLMode))
 	case *ast.LoadDataStmt:
 		sc.InLoadDataStmt = true
 		// return warning instead of error when load data meet no partition for value
@@ -2101,7 +2109,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.OverflowAsWarning = true
 
 		// Return warning for truncate error in selection.
-		sc.TruncateAsWarning = true
+		sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true))
 		sc.IgnoreZeroInDate = true
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 		if opts := stmt.SelectStmtOpts; opts != nil {
@@ -2112,11 +2120,11 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	case *ast.SetOprStmt:
 		sc.InSelectStmt = true
 		sc.OverflowAsWarning = true
-		sc.TruncateAsWarning = true
+		sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true))
 		sc.IgnoreZeroInDate = true
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 	case *ast.ShowStmt:
-		sc.IgnoreTruncate.Store(true)
+		sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true))
 		sc.IgnoreZeroInDate = true
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 		if stmt.Tp == ast.ShowWarnings || stmt.Tp == ast.ShowErrors || stmt.Tp == ast.ShowSessionStates {
@@ -2124,26 +2132,24 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 			sc.SetWarnings(vars.StmtCtx.GetWarnings())
 		}
 	case *ast.SplitRegionStmt:
-		sc.IgnoreTruncate.Store(false)
+		sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(false))
 		sc.IgnoreZeroInDate = true
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 	case *ast.SetSessionStatesStmt:
 		sc.InSetSessionStatesStmt = true
-		sc.IgnoreTruncate.Store(true)
+		sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true))
 		sc.IgnoreZeroInDate = true
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 	default:
-		sc.IgnoreTruncate.Store(true)
+		sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true))
 		sc.IgnoreZeroInDate = true
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 	}
 
-	sc.UpdateTypeFlags(func(flags types.Flags) types.Flags {
-		return flags.
-			WithSkipUTF8Check(vars.SkipUTF8Check).
-			WithSkipSACIICheck(vars.SkipASCIICheck).
-			WithSkipUTF8MB4Check(!globalConfig.Instance.CheckMb4ValueInUTF8.Load())
-	})
+	sc.SetTypeFlags(sc.TypeFlags().
+		WithSkipUTF8Check(vars.SkipUTF8Check).
+		WithSkipSACIICheck(vars.SkipASCIICheck).
+		WithSkipUTF8MB4Check(!globalConfig.Instance.CheckMb4ValueInUTF8.Load()))
 
 	vars.PlanCacheParams.Reset()
 	if priority := mysql.PriorityEnum(atomic.LoadInt32(&variable.ForcePriority)); priority != mysql.NoPriority {
@@ -2193,12 +2199,12 @@ func ResetUpdateStmtCtx(sc *stmtctx.StatementContext, stmt *ast.UpdateStmt, vars
 	sc.InUpdateStmt = true
 	sc.DupKeyAsWarning = stmt.IgnoreErr
 	sc.BadNullAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
-	sc.TruncateAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 	sc.DividedByZeroAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 	sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 	sc.IgnoreZeroInDate = !vars.SQLMode.HasNoZeroInDateMode() || !vars.SQLMode.HasNoZeroDateMode() || !vars.StrictSQLMode || stmt.IgnoreErr || sc.AllowInvalidDate
 	sc.Priority = stmt.Priority
 	sc.IgnoreNoPartition = stmt.IgnoreErr
+	sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(!vars.StrictSQLMode || stmt.IgnoreErr))
 }
 
 // ResetDeleteStmtCtx resets statement context for DeleteStmt.
@@ -2206,11 +2212,11 @@ func ResetDeleteStmtCtx(sc *stmtctx.StatementContext, stmt *ast.DeleteStmt, vars
 	sc.InDeleteStmt = true
 	sc.DupKeyAsWarning = stmt.IgnoreErr
 	sc.BadNullAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
-	sc.TruncateAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 	sc.DividedByZeroAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 	sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 	sc.IgnoreZeroInDate = !vars.SQLMode.HasNoZeroInDateMode() || !vars.SQLMode.HasNoZeroDateMode() || !vars.StrictSQLMode || stmt.IgnoreErr || sc.AllowInvalidDate
 	sc.Priority = stmt.Priority
+	sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(!vars.StrictSQLMode || stmt.IgnoreErr))
 }
 
 func setOptionForTopSQL(sc *stmtctx.StatementContext, snapshot kv.Snapshot) {

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -706,7 +706,7 @@ func (e *InsertValues) fillRow(ctx context.Context, row []types.Datum, hasValue 
 		if err != nil && gCol.FieldType.IsArray() {
 			return nil, completeError(tbl, gCol.Offset, rowIdx, err)
 		}
-		if e.Ctx().GetSessionVars().StmtCtx.HandleTruncate(err) != nil {
+		if e.Ctx().GetSessionVars().StmtCtx.TypeCtx.HandleTruncate(err) != nil {
 			return nil, err
 		}
 		row[colIdx], err = table.CastValue(e.Ctx(), val, gCol.ToInfo(), false, false)
@@ -791,7 +791,7 @@ func setDatumAutoIDAndCast(ctx sessionctx.Context, d *types.Datum, id int64, col
 		// Auto ID is out of range.
 		sc := ctx.GetSessionVars().StmtCtx
 		insertPlan, ok := sc.GetPlan().(*core.Insert)
-		if ok && sc.TruncateAsWarning && len(insertPlan.OnDuplicate) > 0 {
+		if ok && sc.TypeFlags().TruncateAsWarning() && len(insertPlan.OnDuplicate) > 0 {
 			// Fix issue #38950: AUTO_INCREMENT is incompatible with mysql
 			// An auto id out of range error occurs in `insert ignore into ... on duplicate ...`.
 			// We should allow the SQL to be executed successfully.

--- a/pkg/executor/load_data.go
+++ b/pkg/executor/load_data.go
@@ -99,8 +99,9 @@ func setNonRestrictiveFlags(stmtCtx *stmtctx.StatementContext) {
 	// TODO: DupKeyAsWarning represents too many "ignore error" paths, the
 	// meaning of this flag is not clear. I can only reuse it here.
 	stmtCtx.DupKeyAsWarning = true
-	stmtCtx.TruncateAsWarning = true
 	stmtCtx.BadNullAsWarning = true
+
+	stmtCtx.SetTypeFlags(stmtCtx.TypeFlags().WithTruncateAsWarning(true))
 }
 
 // NewLoadDataWorker creates a new LoadDataWorker that is ready to work.

--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -141,11 +141,11 @@ func TestLoadData(t *testing.T) {
 	selectSQL := "select * from load_data_test;"
 
 	sc := ctx.GetSessionVars().StmtCtx
-	originIgnoreTruncate := sc.IgnoreTruncate.Load()
+	oldFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(originIgnoreTruncate)
+		sc.SetTypeFlags(oldFlags)
 	}()
-	sc.IgnoreTruncate.Store(false)
+	sc.SetTypeFlags(oldFlags.WithIgnoreTruncateErr(false))
 	// fields and lines are default, ReadOneBatchRows returns data is nil
 	tests := []testCase{
 		// In MySQL we have 4 warnings: 1*"Incorrect integer value: '' for column 'id' at row", 3*"Row 1 doesn't contain data for all columns"

--- a/pkg/executor/test/writetest/write_test.go
+++ b/pkg/executor/test/writetest/write_test.go
@@ -1317,11 +1317,11 @@ func TestIssue18681(t *testing.T) {
 	ctx.GetSessionVars().StmtCtx.BadNullAsWarning = true
 
 	sc := ctx.GetSessionVars().StmtCtx
-	originIgnoreTruncate := sc.IgnoreTruncate.Load()
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(originIgnoreTruncate)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
-	sc.IgnoreTruncate.Store(false)
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 	tests := []testCase{
 		{[]byte("true\tfalse\t0\t1\n"), []string{"1|0|0|1"}, "Records: 1  Deleted: 0  Skipped: 0  Warnings: 0"},
 	}

--- a/pkg/expression/aggregation/aggregation.go
+++ b/pkg/expression/aggregation/aggregation.go
@@ -140,7 +140,7 @@ func (af *aggFunction) ResetContext(sc *stmtctx.StatementContext, evalCtx *AggEv
 	evalCtx.Value.SetNull()
 }
 
-func (af *aggFunction) updateSum(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext, row chunk.Row) error {
+func (af *aggFunction) updateSum(ctx types.Context, evalCtx *AggEvaluateContext, row chunk.Row) error {
 	a := af.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {
@@ -158,7 +158,7 @@ func (af *aggFunction) updateSum(sc *stmtctx.StatementContext, evalCtx *AggEvalu
 			return nil
 		}
 	}
-	evalCtx.Value, err = calculateSum(sc, evalCtx.Value, value)
+	evalCtx.Value, err = calculateSum(ctx, evalCtx.Value, value)
 	if err != nil {
 		return err
 	}

--- a/pkg/expression/aggregation/avg.go
+++ b/pkg/expression/aggregation/avg.go
@@ -27,7 +27,7 @@ type avgFunction struct {
 	aggFunction
 }
 
-func (af *avgFunction) updateAvg(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext, row chunk.Row) error {
+func (af *avgFunction) updateAvg(ctx types.Context, evalCtx *AggEvaluateContext, row chunk.Row) error {
 	a := af.Args[1]
 	value, err := a.Eval(row)
 	if err != nil {
@@ -36,7 +36,7 @@ func (af *avgFunction) updateAvg(sc *stmtctx.StatementContext, evalCtx *AggEvalu
 	if value.IsNull() {
 		return nil
 	}
-	evalCtx.Value, err = calculateSum(sc, evalCtx.Value, value)
+	evalCtx.Value, err = calculateSum(ctx, evalCtx.Value, value)
 	if err != nil {
 		return err
 	}
@@ -60,9 +60,9 @@ func (af *avgFunction) ResetContext(sc *stmtctx.StatementContext, evalCtx *AggEv
 func (af *avgFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row chunk.Row) (err error) {
 	switch af.Mode {
 	case Partial1Mode, CompleteMode:
-		err = af.updateSum(sc, evalCtx, row)
+		err = af.updateSum(sc.TypeCtx, evalCtx, row)
 	case Partial2Mode, FinalMode:
-		err = af.updateAvg(sc, evalCtx, row)
+		err = af.updateAvg(sc.TypeCtx, evalCtx, row)
 	case DedupMode:
 		panic("DedupMode is not supported now.")
 	}

--- a/pkg/expression/aggregation/sum.go
+++ b/pkg/expression/aggregation/sum.go
@@ -26,7 +26,7 @@ type sumFunction struct {
 
 // Update implements Aggregation interface.
 func (sf *sumFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row chunk.Row) error {
-	return sf.updateSum(sc, evalCtx, row)
+	return sf.updateSum(sc.TypeCtx, evalCtx, row)
 }
 
 // GetResult implements Aggregation interface.

--- a/pkg/expression/aggregation/util.go
+++ b/pkg/expression/aggregation/util.go
@@ -55,7 +55,7 @@ func (d *distinctChecker) Check(values []types.Datum) (bool, error) {
 }
 
 // calculateSum adds v to sum.
-func calculateSum(sc *stmtctx.StatementContext, sum, v types.Datum) (data types.Datum, err error) {
+func calculateSum(ctx types.Context, sum, v types.Datum) (data types.Datum, err error) {
 	// for avg and sum calculation
 	// avg and sum use decimal for integer and decimal type, use float for others
 	// see https://dev.mysql.com/doc/refman/5.7/en/group-by-functions.html
@@ -64,7 +64,7 @@ func calculateSum(sc *stmtctx.StatementContext, sum, v types.Datum) (data types.
 	case types.KindNull:
 	case types.KindInt64, types.KindUint64:
 		var d *types.MyDecimal
-		d, err = v.ToDecimal(sc)
+		d, err = v.ToDecimal(ctx)
 		if err == nil {
 			data = types.NewDecimalDatum(d)
 		}
@@ -72,7 +72,7 @@ func calculateSum(sc *stmtctx.StatementContext, sum, v types.Datum) (data types.
 		v.Copy(&data)
 	default:
 		var f float64
-		f, err = v.ToFloat64(sc)
+		f, err = v.ToFloat64(ctx)
 		if err == nil {
 			data = types.NewFloat64Datum(f)
 		}

--- a/pkg/expression/builtin_arithmetic.go
+++ b/pkg/expression/builtin_arithmetic.go
@@ -727,7 +727,7 @@ func (s *builtinArithmeticDivideDecimalSig) evalDecimal(row chunk.Row) (*types.M
 		return c, true, handleDivisionByZeroError(s.ctx)
 	} else if err == types.ErrTruncated {
 		sc := s.ctx.GetSessionVars().StmtCtx
-		err = sc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
+		err = sc.TypeCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
 	} else if err == nil {
 		_, frac := c.PrecisionAndFrac()
 		if frac < s.baseBuiltinFunc.tp.GetDecimal() {
@@ -846,7 +846,7 @@ func (s *builtinArithmeticIntDivideDecimalSig) evalInt(row chunk.Row) (ret int64
 		return 0, true, handleDivisionByZeroError(s.ctx)
 	}
 	if err == types.ErrTruncated {
-		err = sc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
+		err = sc.TypeCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
 	}
 	if err == types.ErrOverflow {
 		newErr := errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c)

--- a/pkg/expression/builtin_arithmetic_vec.go
+++ b/pkg/expression/builtin_arithmetic_vec.go
@@ -95,7 +95,7 @@ func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(input *chunk.Chunk, r
 			result.SetNull(i, true)
 			continue
 		} else if err == types.ErrTruncated {
-			if err = sc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", to)); err != nil {
+			if err = sc.TypeCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", to)); err != nil {
 				return err
 			}
 		} else if err == nil {
@@ -617,7 +617,7 @@ func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(input *chunk.Chunk, re
 			continue
 		}
 		if err == types.ErrTruncated {
-			err = sc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
+			err = sc.TypeCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
 		} else if err == types.ErrOverflow {
 			newErr := errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c)
 			err = sc.HandleOverflow(newErr, newErr)

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -534,7 +534,7 @@ func convertJSON2Tp(evalType types.EvalType) func(*stmtctx.StatementContext, typ
 			if item.TypeCode != types.JSONTypeCodeString {
 				return nil, ErrInvalidJSONForFuncIndex
 			}
-			return types.ProduceStrWithSpecifiedTp(string(item.GetString()), tp, sc, false)
+			return types.ProduceStrWithSpecifiedTp(string(item.GetString()), tp, sc.TypeCtx, false)
 		}
 	case types.ETInt:
 		return func(sc *stmtctx.StatementContext, item types.BinaryJSON, tp *types.FieldType) (any, error) {
@@ -552,7 +552,7 @@ func convertJSON2Tp(evalType types.EvalType) func(*stmtctx.StatementContext, typ
 			if item.TypeCode != types.JSONTypeCodeFloat64 && item.TypeCode != types.JSONTypeCodeInt64 && item.TypeCode != types.JSONTypeCodeUint64 {
 				return nil, ErrInvalidJSONForFuncIndex
 			}
-			return types.ConvertJSONToFloat(sc, item)
+			return types.ConvertJSONToFloat(sc.TypeCtx, item)
 		}
 	case types.ETDatetime:
 		return func(sc *stmtctx.StatementContext, item types.BinaryJSON, tp *types.FieldType) (any, error) {
@@ -730,7 +730,7 @@ func (b *builtinCastIntAsStringSig) evalString(row chunk.Row) (res string, isNul
 	if tp.GetType() == mysql.TypeYear && res == "0" {
 		res = "0000"
 	}
-	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx, false)
+	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx.TypeCtx, false)
 	if err != nil {
 		return res, false, err
 	}
@@ -790,7 +790,7 @@ func (b *builtinCastIntAsDurationSig) evalDuration(row chunk.Row) (res types.Dur
 			err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
 		}
 		if types.ErrTruncatedWrongVal.Equal(err) {
-			err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+			err = b.ctx.GetSessionVars().StmtCtx.TypeCtx.HandleTruncate(err)
 		}
 		return res, true, err
 	}
@@ -1045,7 +1045,7 @@ func (b *builtinCastRealAsStringSig) evalString(row chunk.Row) (res string, isNu
 		// If we strconv.FormatFloat the value with 64bits, the result is incorrect!
 		bits = 32
 	}
-	res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(val, 'f', -1, bits), b.tp, b.ctx.GetSessionVars().StmtCtx, false)
+	res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(val, 'f', -1, bits), b.tp, b.ctx.GetSessionVars().StmtCtx.TypeCtx, false)
 	if err != nil {
 		return res, false, err
 	}
@@ -1102,7 +1102,7 @@ func (b *builtinCastRealAsDurationSig) evalDuration(row chunk.Row) (res types.Du
 	res, _, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, strconv.FormatFloat(val, 'f', -1, 64), b.tp.GetDecimal())
 	if err != nil {
 		if types.ErrTruncatedWrongVal.Equal(err) {
-			err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+			err = b.ctx.GetSessionVars().StmtCtx.TypeCtx.HandleTruncate(err)
 			// ErrTruncatedWrongVal needs to be considered NULL.
 			return res, true, err
 		}
@@ -1191,7 +1191,7 @@ func (b *builtinCastDecimalAsStringSig) evalString(row chunk.Row) (res string, i
 		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
-	res, err = types.ProduceStrWithSpecifiedTp(string(val.ToString()), b.tp, sc, false)
+	res, err = types.ProduceStrWithSpecifiedTp(string(val.ToString()), b.tp, sc.TypeCtx, false)
 	if err != nil {
 		return res, false, err
 	}
@@ -1279,7 +1279,7 @@ func (b *builtinCastDecimalAsDurationSig) evalDuration(row chunk.Row) (res types
 	}
 	res, _, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, string(val.ToString()), b.tp.GetDecimal())
 	if types.ErrTruncatedWrongVal.Equal(err) {
-		err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+		err = b.ctx.GetSessionVars().StmtCtx.TypeCtx.HandleTruncate(err)
 		// ErrTruncatedWrongVal needs to be considered NULL.
 		return res, true, err
 	}
@@ -1301,8 +1301,7 @@ func (b *builtinCastStringAsStringSig) evalString(row chunk.Row) (res string, is
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
-	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, sc, false)
+	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx.TypeCtx, false)
 	if err != nil {
 		return res, false, err
 	}
@@ -1367,7 +1366,7 @@ func (b *builtinCastStringAsIntSig) evalInt(row chunk.Row) (res int64, isNull bo
 	var ures uint64
 	sc := b.ctx.GetSessionVars().StmtCtx
 	if !isNegative {
-		ures, err = types.StrToUint(sc, val, true)
+		ures, err = types.StrToUint(sc.TypeCtx, val, true)
 		res = int64(ures)
 
 		if err == nil && !mysql.HasUnsignedFlag(b.tp.GetFlag()) && ures > uint64(math.MaxInt64) {
@@ -1376,7 +1375,7 @@ func (b *builtinCastStringAsIntSig) evalInt(row chunk.Row) (res int64, isNull bo
 	} else if b.inUnion && mysql.HasUnsignedFlag(b.tp.GetFlag()) {
 		res = 0
 	} else {
-		res, err = types.StrToInt(sc, val, true)
+		res, err = types.StrToInt(sc.TypeCtx, val, true)
 		if err == nil && mysql.HasUnsignedFlag(b.tp.GetFlag()) {
 			// If overflow, don't append this warnings
 			sc.AppendWarning(types.ErrCastNegIntAsUnsigned)
@@ -1412,7 +1411,7 @@ func (b *builtinCastStringAsRealSig) evalReal(row chunk.Row) (res float64, isNul
 		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
-	res, err = types.StrToFloat(sc, val, true)
+	res, err = types.StrToFloat(sc.TypeCtx, val, true)
 	if err != nil {
 		return 0, false, err
 	}
@@ -1450,7 +1449,7 @@ func (b *builtinCastStringAsDecimalSig) evalDecimal(row chunk.Row) (res *types.M
 		if err == types.ErrTruncated {
 			err = types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", []byte(val))
 		}
-		err = sc.HandleTruncate(err)
+		err = sc.TypeCtx.HandleTruncate(err)
 		if err != nil {
 			return res, false, err
 		}
@@ -1507,7 +1506,7 @@ func (b *builtinCastStringAsDurationSig) evalDuration(row chunk.Row) (res types.
 	res, isNull, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, val, b.tp.GetDecimal())
 	if types.ErrTruncatedWrongVal.Equal(err) {
 		sc := b.ctx.GetSessionVars().StmtCtx
-		err = sc.HandleTruncate(err)
+		err = sc.TypeCtx.HandleTruncate(err)
 	}
 	return res, isNull, err
 }
@@ -1620,7 +1619,7 @@ func (b *builtinCastTimeAsStringSig) evalString(row chunk.Row) (res string, isNu
 		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
-	res, err = types.ProduceStrWithSpecifiedTp(val.String(), b.tp, sc, false)
+	res, err = types.ProduceStrWithSpecifiedTp(val.String(), b.tp, sc.TypeCtx, false)
 	if err != nil {
 		return res, false, err
 	}
@@ -1753,7 +1752,7 @@ func (b *builtinCastDurationAsStringSig) evalString(row chunk.Row) (res string, 
 		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
-	res, err = types.ProduceStrWithSpecifiedTp(val.String(), b.tp, sc, false)
+	res, err = types.ProduceStrWithSpecifiedTp(val.String(), b.tp, sc.TypeCtx, false)
 	if err != nil {
 		return res, false, err
 	}
@@ -1855,7 +1854,7 @@ func (b *builtinCastJSONAsRealSig) evalReal(row chunk.Row) (res float64, isNull 
 		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
-	res, err = types.ConvertJSONToFloat(sc, val)
+	res, err = types.ConvertJSONToFloat(sc.TypeCtx, val)
 	return
 }
 
@@ -1875,7 +1874,7 @@ func (b *builtinCastJSONAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyD
 		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
-	res, err = types.ConvertJSONToDecimal(sc, val)
+	res, err = types.ConvertJSONToDecimal(sc.TypeCtx, val)
 	if err != nil {
 		return res, false, err
 	}
@@ -1898,7 +1897,7 @@ func (b *builtinCastJSONAsStringSig) evalString(row chunk.Row) (res string, isNu
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	s, err := types.ProduceStrWithSpecifiedTp(val.String(), b.tp, b.ctx.GetSessionVars().StmtCtx, false)
+	s, err := types.ProduceStrWithSpecifiedTp(val.String(), b.tp, b.ctx.GetSessionVars().StmtCtx.TypeCtx, false)
 	if err != nil {
 		return res, false, err
 	}
@@ -1961,7 +1960,7 @@ func (b *builtinCastJSONAsTimeSig) evalTime(row chunk.Row) (res types.Time, isNu
 		return res, isNull, err
 	default:
 		err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), val.String())
-		return res, true, b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+		return res, true, b.ctx.GetSessionVars().StmtCtx.TypeCtx.HandleTruncate(err)
 	}
 }
 
@@ -2003,12 +2002,12 @@ func (b *builtinCastJSONAsDurationSig) evalDuration(row chunk.Row) (res types.Du
 		res, _, err = types.ParseDuration(stmtCtx, s, b.tp.GetDecimal())
 		if types.ErrTruncatedWrongVal.Equal(err) {
 			sc := b.ctx.GetSessionVars().StmtCtx
-			err = sc.HandleTruncate(err)
+			err = sc.TypeCtx.HandleTruncate(err)
 		}
 		return res, isNull, err
 	default:
 		err = types.ErrTruncatedWrongVal.GenWithStackByArgs("TIME", val.String())
-		return res, true, stmtCtx.HandleTruncate(err)
+		return res, true, stmtCtx.TypeCtx.HandleTruncate(err)
 	}
 }
 

--- a/pkg/expression/builtin_compare_test.go
+++ b/pkg/expression/builtin_compare_test.go
@@ -233,11 +233,11 @@ func TestIntervalFunc(t *testing.T) {
 	ctx := createContext(t)
 
 	sc := ctx.GetSessionVars().StmtCtx
-	origin := sc.IgnoreTruncate.Load()
-	sc.IgnoreTruncate.Store(true)
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(origin)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	for _, test := range []struct {
 		args   []types.Datum
@@ -289,13 +289,14 @@ func TestIntervalFunc(t *testing.T) {
 func TestGreatestLeastFunc(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	originIgnoreTruncate := sc.IgnoreTruncate.Load()
-	sc.IgnoreTruncate.Store(true)
+	oldTypeFlags := sc.TypeFlags()
+	defer func() {
+		sc.SetTypeFlags(oldTypeFlags)
+	}()
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
+
 	decG := &types.MyDecimal{}
 	decL := &types.MyDecimal{}
-	defer func() {
-		sc.IgnoreTruncate.Store(originIgnoreTruncate)
-	}()
 
 	for _, test := range []struct {
 		args             []interface{}

--- a/pkg/expression/builtin_control_test.go
+++ b/pkg/expression/builtin_control_test.go
@@ -61,11 +61,11 @@ func TestCaseWhen(t *testing.T) {
 func TestIf(t *testing.T) {
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
-	origin := stmtCtx.IgnoreTruncate.Load()
-	stmtCtx.IgnoreTruncate.Store(true)
+	oldTypeFlags := stmtCtx.TypeFlags()
 	defer func() {
-		stmtCtx.IgnoreTruncate.Store(origin)
+		stmtCtx.SetTypeFlags(oldTypeFlags)
 	}()
+	stmtCtx.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 	tbl := []struct {
 		Arg1 interface{}
 		Arg2 interface{}

--- a/pkg/expression/builtin_math_test.go
+++ b/pkg/expression/builtin_math_test.go
@@ -61,11 +61,11 @@ func TestAbs(t *testing.T) {
 func TestCeil(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	tmpIT := sc.IgnoreTruncate.Load()
-	sc.IgnoreTruncate.Store(true)
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(tmpIT)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	type testCase struct {
 		arg    interface{}
@@ -177,11 +177,11 @@ func TestExp(t *testing.T) {
 func TestFloor(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	tmpIT := sc.IgnoreTruncate.Load()
-	sc.IgnoreTruncate.Store(true)
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(tmpIT)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	genDuration := func(h, m, s int64) types.Duration {
 		duration := time.Duration(h)*time.Hour +
@@ -631,11 +631,11 @@ func TestConv(t *testing.T) {
 func TestSign(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	tmpIT := sc.IgnoreTruncate.Load()
-	sc.IgnoreTruncate.Store(true)
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(tmpIT)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	for _, tt := range []struct {
 		num []interface{}
@@ -666,7 +666,12 @@ func TestSign(t *testing.T) {
 func TestDegrees(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	sc.IgnoreTruncate.Store(false)
+	oldTypeFlags := sc.TypeFlags()
+	defer func() {
+		sc.SetTypeFlags(oldTypeFlags)
+	}()
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(false))
+
 	cases := []struct {
 		args       interface{}
 		expected   float64

--- a/pkg/expression/builtin_op_test.go
+++ b/pkg/expression/builtin_op_test.go
@@ -70,11 +70,11 @@ func TestUnary(t *testing.T) {
 func TestLogicAnd(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	origin := sc.IgnoreTruncate.Load()
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(origin)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
-	sc.IgnoreTruncate.Store(true)
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	cases := []struct {
 		args     []interface{}
@@ -243,11 +243,11 @@ func TestBitXor(t *testing.T) {
 func TestBitOr(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	origin := sc.IgnoreTruncate.Load()
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(origin)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
-	sc.IgnoreTruncate.Store(true)
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	cases := []struct {
 		args     []interface{}
@@ -289,11 +289,11 @@ func TestBitOr(t *testing.T) {
 func TestLogicOr(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	origin := sc.IgnoreTruncate.Load()
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(origin)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
-	sc.IgnoreTruncate.Store(true)
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	cases := []struct {
 		args     []interface{}
@@ -395,11 +395,11 @@ func TestBitAnd(t *testing.T) {
 func TestBitNeg(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	origin := sc.IgnoreTruncate.Load()
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(origin)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
-	sc.IgnoreTruncate.Store(true)
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	cases := []struct {
 		args     []interface{}
@@ -441,11 +441,11 @@ func TestBitNeg(t *testing.T) {
 func TestUnaryNot(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	origin := sc.IgnoreTruncate.Load()
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(origin)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
-	sc.IgnoreTruncate.Store(true)
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	cases := []struct {
 		args     []interface{}
@@ -495,11 +495,11 @@ func TestUnaryNot(t *testing.T) {
 func TestIsTrueOrFalse(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	origin := sc.IgnoreTruncate.Load()
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(origin)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
-	sc.IgnoreTruncate.Store(true)
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	testCases := []struct {
 		args    []interface{}
@@ -602,11 +602,11 @@ func TestIsTrueOrFalse(t *testing.T) {
 func TestLogicXor(t *testing.T) {
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
-	origin := sc.IgnoreTruncate.Load()
+	oldTypeFlags := sc.TypeFlags()
 	defer func() {
-		sc.IgnoreTruncate.Store(origin)
+		sc.SetTypeFlags(oldTypeFlags)
 	}()
-	sc.IgnoreTruncate.Store(true)
+	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	cases := []struct {
 		args     []interface{}

--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -1210,7 +1210,7 @@ func (b *builtinValuesIntSig) evalInt(_ chunk.Row) (int64, bool, error) {
 		}
 		if len(val) < 8 {
 			var binary types.BinaryLiteral = val
-			v, err := binary.ToInt(b.ctx.GetSessionVars().StmtCtx)
+			v, err := binary.ToInt(b.ctx.GetSessionVars().StmtCtx.TypeCtx)
 			if err != nil {
 				return 0, true, errors.Trace(err)
 			}

--- a/pkg/expression/builtin_other_test.go
+++ b/pkg/expression/builtin_other_test.go
@@ -32,11 +32,11 @@ import (
 func TestBitCount(t *testing.T) {
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
-	origin := stmtCtx.IgnoreTruncate.Load()
-	stmtCtx.IgnoreTruncate.Store(true)
+	oldTypeFlags := stmtCtx.TypeFlags()
 	defer func() {
-		stmtCtx.IgnoreTruncate.Store(origin)
+		stmtCtx.SetTypeFlags(oldTypeFlags)
 	}()
+	stmtCtx.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 	fc := funcs[ast.BitCount]
 	var bitCountCases = []struct {
 		origin interface{}
@@ -67,8 +67,8 @@ func TestBitCount(t *testing.T) {
 			require.Nil(t, test.count)
 			continue
 		}
-		sc := stmtctx.NewStmtCtx()
-		sc.IgnoreTruncate.Store(true)
+		sc := stmtctx.NewStmtCtxWithTimeZone(stmtCtx.TimeZone())
+		sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true))
 		res, err := count.ToInt64(sc)
 		require.NoError(t, err)
 		require.Equal(t, test.count, res)

--- a/pkg/expression/builtin_string_test.go
+++ b/pkg/expression/builtin_string_test.go
@@ -393,11 +393,11 @@ func TestConcatWSSig(t *testing.T) {
 func TestLeft(t *testing.T) {
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
-	origin := stmtCtx.IgnoreTruncate.Load()
-	stmtCtx.IgnoreTruncate.Store(true)
+	oldTypeFlags := stmtCtx.TypeFlags()
 	defer func() {
-		stmtCtx.IgnoreTruncate.Store(origin)
+		stmtCtx.SetTypeFlags(oldTypeFlags)
 	}()
+	stmtCtx.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	cases := []struct {
 		args   []interface{}
@@ -443,11 +443,11 @@ func TestLeft(t *testing.T) {
 func TestRight(t *testing.T) {
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
-	origin := stmtCtx.IgnoreTruncate.Load()
-	stmtCtx.IgnoreTruncate.Store(true)
+	oldTypeFlags := stmtCtx.TypeFlags()
 	defer func() {
-		stmtCtx.IgnoreTruncate.Store(origin)
+		stmtCtx.SetTypeFlags(oldTypeFlags)
 	}()
+	stmtCtx.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	cases := []struct {
 		args   []interface{}
@@ -956,11 +956,11 @@ func TestSubstringIndex(t *testing.T) {
 func TestSpace(t *testing.T) {
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
-	origin := stmtCtx.IgnoreTruncate.Load()
-	stmtCtx.IgnoreTruncate.Store(true)
+	oldTypeFlags := stmtCtx.TypeFlags()
 	defer func() {
-		stmtCtx.IgnoreTruncate.Store(origin)
+		stmtCtx.SetTypeFlags(oldTypeFlags)
 	}()
+	stmtCtx.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	cases := []struct {
 		arg    interface{}
@@ -1388,7 +1388,8 @@ func TestBitLength(t *testing.T) {
 
 func TestChar(t *testing.T) {
 	ctx := createContext(t)
-	ctx.GetSessionVars().StmtCtx.IgnoreTruncate.Store(true)
+	typeFlags := ctx.GetSessionVars().StmtCtx.TypeFlags()
+	ctx.GetSessionVars().StmtCtx.SetTypeFlags(typeFlags.WithIgnoreTruncateErr(true))
 	tbl := []struct {
 		str      string
 		iNum     int64
@@ -1509,11 +1510,11 @@ func TestFindInSet(t *testing.T) {
 func TestField(t *testing.T) {
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
-	origin := stmtCtx.IgnoreTruncate.Load()
-	stmtCtx.IgnoreTruncate.Store(true)
+	oldTypeFlags := stmtCtx.TypeFlags()
 	defer func() {
-		stmtCtx.IgnoreTruncate.Store(origin)
+		stmtCtx.SetTypeFlags(oldTypeFlags)
 	}()
+	stmtCtx.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	tbl := []struct {
 		argLst []interface{}
@@ -1991,8 +1992,8 @@ func TestFormat(t *testing.T) {
 		testutil.DatumEqual(t, types.NewDatum(tt.ret), r)
 	}
 
-	origConfig := ctx.GetSessionVars().StmtCtx.TruncateAsWarning
-	ctx.GetSessionVars().StmtCtx.TruncateAsWarning = true
+	origTypeFlags := ctx.GetSessionVars().StmtCtx.TypeFlags()
+	ctx.GetSessionVars().StmtCtx.SetTypeFlags(origTypeFlags.WithTruncateAsWarning(true))
 	for _, tt := range formatTests1 {
 		f, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(tt.number, tt.precision)))
 		require.NoError(t, err)
@@ -2009,7 +2010,7 @@ func TestFormat(t *testing.T) {
 			ctx.GetSessionVars().StmtCtx.SetWarnings([]stmtctx.SQLWarn{})
 		}
 	}
-	ctx.GetSessionVars().StmtCtx.TruncateAsWarning = origConfig
+	ctx.GetSessionVars().StmtCtx.SetTypeFlags(origTypeFlags)
 
 	f2, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(formatTests2.number, formatTests2.precision, formatTests2.locale)))
 	require.NoError(t, err)
@@ -2306,7 +2307,8 @@ func TestBin(t *testing.T) {
 	fc := funcs[ast.Bin]
 	dtbl := tblToDtbl(tbl)
 	ctx := mock.NewContext()
-	ctx.GetSessionVars().StmtCtx.IgnoreTruncate.Store(true)
+	typeFlags := ctx.GetSessionVars().StmtCtx.TypeFlags()
+	ctx.GetSessionVars().StmtCtx.SetTypeFlags(typeFlags.WithIgnoreTruncateErr(true))
 	for _, c := range dtbl {
 		f, err := fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)

--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -600,7 +600,7 @@ func calculateTimeDiff(sc *stmtctx.StatementContext, lhs, rhs types.Time) (d typ
 	d = lhs.Sub(sc, &rhs)
 	d.Duration, err = types.TruncateOverflowMySQLTime(d.Duration)
 	if types.ErrTruncatedWrongVal.Equal(err) {
-		err = sc.HandleTruncate(err)
+		err = sc.TypeCtx.HandleTruncate(err)
 	}
 	return d, err != nil, err
 }
@@ -615,7 +615,7 @@ func calculateDurationTimeDiff(ctx sessionctx.Context, lhs, rhs types.Duration) 
 	d.Duration, err = types.TruncateOverflowMySQLTime(d.Duration)
 	if types.ErrTruncatedWrongVal.Equal(err) {
 		sc := ctx.GetSessionVars().StmtCtx
-		err = sc.HandleTruncate(err)
+		err = sc.TypeCtx.HandleTruncate(err)
 	}
 	return d, err != nil, err
 }
@@ -2275,7 +2275,7 @@ func (b *builtinTimeSig) evalDuration(row chunk.Row) (res types.Duration, isNull
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, _, err = types.ParseDuration(sc, expr, fsp)
 	if types.ErrTruncatedWrongVal.Equal(err) {
-		err = sc.HandleTruncate(err)
+		err = sc.TypeCtx.HandleTruncate(err)
 	}
 	return res, isNull, err
 }
@@ -5570,7 +5570,7 @@ func (b *builtinSecToTimeSig) evalDuration(row chunk.Row) (types.Duration, bool,
 		minute = 59
 		second = 59
 		demical = 0
-		err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("time", strconv.FormatFloat(secondsFloat, 'f', -1, 64)))
+		err = b.ctx.GetSessionVars().StmtCtx.TypeCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("time", strconv.FormatFloat(secondsFloat, 'f', -1, 64)))
 		if err != nil {
 			return types.Duration{}, err != nil, err
 		}

--- a/pkg/expression/builtin_time_test.go
+++ b/pkg/expression/builtin_time_test.go
@@ -1492,11 +1492,11 @@ func TestStrToDate(t *testing.T) {
 func TestFromDays(t *testing.T) {
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
-	origin := stmtCtx.IgnoreTruncate.Load()
-	stmtCtx.IgnoreTruncate.Store(true)
+	oldTypeFlags := stmtCtx.TypeFlags()
 	defer func() {
-		stmtCtx.IgnoreTruncate.Store(origin)
+		stmtCtx.SetTypeFlags(oldTypeFlags)
 	}()
+	stmtCtx.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 	tests := []struct {
 		day    int64
 		expect string
@@ -1781,7 +1781,7 @@ func TestTimestampDiff(t *testing.T) {
 	}
 
 	sc := ctx.GetSessionVars().StmtCtx
-	sc.IgnoreTruncate.Store(true)
+	sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true))
 	sc.IgnoreZeroInDate = true
 	resetStmtContext(ctx)
 	f, err := fc.getFunction(ctx, datumsToConstants([]types.Datum{types.NewStringDatum("DAY"),
@@ -2721,11 +2721,11 @@ func TestTimeToSec(t *testing.T) {
 func TestSecToTime(t *testing.T) {
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
-	origin := stmtCtx.IgnoreTruncate.Load()
-	stmtCtx.IgnoreTruncate.Store(true)
+	oldTypeFlags := stmtCtx.TypeFlags()
 	defer func() {
-		stmtCtx.IgnoreTruncate.Store(origin)
+		stmtCtx.SetTypeFlags(oldTypeFlags)
 	}()
+	stmtCtx.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 
 	fc := funcs[ast.SecToTime]
 

--- a/pkg/expression/builtin_time_vec.go
+++ b/pkg/expression/builtin_time_vec.go
@@ -1928,7 +1928,7 @@ func (b *builtinSecToTimeSig) vecEvalDuration(input *chunk.Chunk, result *chunk.
 			minute = 59
 			second = 59
 			demical = 0
-			err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("time", strconv.FormatFloat(secondsFloat, 'f', -1, 64)))
+			err = b.ctx.GetSessionVars().StmtCtx.TypeCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("time", strconv.FormatFloat(secondsFloat, 'f', -1, 64)))
 			if err != nil {
 				return err
 			}
@@ -2411,7 +2411,7 @@ func (b *builtinTimeSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Colum
 
 		res, _, err := types.ParseDuration(sc, expr, fsp)
 		if types.ErrTruncatedWrongVal.Equal(err) {
-			err = sc.HandleTruncate(err)
+			err = sc.TypeCtx.HandleTruncate(err)
 		}
 		if err != nil {
 			return err

--- a/pkg/expression/builtin_time_vec_test.go
+++ b/pkg/expression/builtin_time_vec_test.go
@@ -581,7 +581,8 @@ func BenchmarkVectorizedBuiltinTimeFunc(b *testing.B) {
 func TestVecMonth(t *testing.T) {
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().SQLMode |= mysql.ModeNoZeroDate
-	ctx.GetSessionVars().StmtCtx.TruncateAsWarning = true
+	typeFlags := ctx.GetSessionVars().StmtCtx.TypeFlags()
+	ctx.GetSessionVars().StmtCtx.SetTypeFlags(typeFlags.WithTruncateAsWarning(true))
 	input := chunk.New([]*types.FieldType{types.NewFieldType(mysql.TypeDatetime)}, 3, 3)
 	input.Reset()
 	input.AppendTime(0, types.ZeroDate)
@@ -594,6 +595,6 @@ func TestVecMonth(t *testing.T) {
 	require.Equal(t, 0, len(ctx.GetSessionVars().StmtCtx.GetWarnings()))
 
 	ctx.GetSessionVars().StmtCtx.InInsertStmt = true
-	ctx.GetSessionVars().StmtCtx.TruncateAsWarning = false
+	ctx.GetSessionVars().StmtCtx.SetTypeFlags(typeFlags.WithTruncateAsWarning(false))
 	require.NoError(t, f.vecEvalInt(input, result))
 }

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -422,7 +422,7 @@ func (col *Column) EvalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, 
 			return 0, true, nil
 		}
 		if val.Kind() == types.KindMysqlBit {
-			val, err := val.GetBinaryLiteral().ToInt(ctx.GetSessionVars().StmtCtx)
+			val, err := val.GetBinaryLiteral().ToInt(ctx.GetSessionVars().StmtCtx.TypeCtx)
 			return int64(val), err != nil, err
 		}
 		res, err := val.ToInt64(ctx.GetSessionVars().StmtCtx)

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -278,13 +278,13 @@ func (c *Constant) EvalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, 
 	if c.GetType().GetType() == mysql.TypeNull || dt.IsNull() {
 		return 0, true, nil
 	} else if dt.Kind() == types.KindBinaryLiteral {
-		val, err := dt.GetBinaryLiteral().ToInt(ctx.GetSessionVars().StmtCtx)
+		val, err := dt.GetBinaryLiteral().ToInt(ctx.GetSessionVars().StmtCtx.TypeCtx)
 		return int64(val), err != nil, err
 	} else if c.GetType().Hybrid() || dt.Kind() == types.KindString {
 		res, err := dt.ToInt64(ctx.GetSessionVars().StmtCtx)
 		return res, false, err
 	} else if dt.Kind() == types.KindMysqlBit {
-		uintVal, err := dt.GetBinaryLiteral().ToInt(ctx.GetSessionVars().StmtCtx)
+		uintVal, err := dt.GetBinaryLiteral().ToInt(ctx.GetSessionVars().StmtCtx.TypeCtx)
 		return int64(uintVal), false, err
 	}
 	return dt.GetInt64(), false, nil
@@ -303,7 +303,7 @@ func (c *Constant) EvalReal(ctx sessionctx.Context, row chunk.Row) (float64, boo
 		return 0, true, nil
 	}
 	if c.GetType().Hybrid() || dt.Kind() == types.KindBinaryLiteral || dt.Kind() == types.KindString {
-		res, err := dt.ToFloat64(ctx.GetSessionVars().StmtCtx)
+		res, err := dt.ToFloat64(ctx.GetSessionVars().StmtCtx.TypeCtx)
 		return res, false, err
 	}
 	return dt.GetFloat64(), false, nil
@@ -337,7 +337,7 @@ func (c *Constant) EvalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.My
 	if c.GetType().GetType() == mysql.TypeNull || dt.IsNull() {
 		return nil, true, nil
 	}
-	res, err := dt.ToDecimal(ctx.GetSessionVars().StmtCtx)
+	res, err := dt.ToDecimal(ctx.GetSessionVars().StmtCtx.TypeCtx)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -208,7 +208,7 @@ func foldConstant(expr Expression) (Expression, bool) {
 				// of Constant to nil is ok.
 				return &Constant{Value: value, RetType: x.RetType}, false
 			}
-			if isTrue, err := value.ToBool(sc); err == nil && isTrue == 0 {
+			if isTrue, err := value.ToBool(sc.TypeCtx); err == nil && isTrue == 0 {
 				// This Constant is created to compose the result expression of EvaluateExprWithNull when InNullRejectCheck
 				// is true. We just check whether the result expression is null or false and then let it die. Basically,
 				// the constant is used once briefly and will not be retained for a long time. Hence setting DeferredExpr

--- a/pkg/expression/errors.go
+++ b/pkg/expression/errors.go
@@ -76,7 +76,7 @@ func handleInvalidTimeError(ctx sessionctx.Context, err error) error {
 		return err
 	}
 	sc := ctx.GetSessionVars().StmtCtx
-	err = sc.HandleTruncate(err)
+	err = sc.TypeCtx.HandleTruncate(err)
 	if ctx.GetSessionVars().StrictSQLMode && (sc.InInsertStmt || sc.InUpdateStmt || sc.InDeleteStmt) {
 		return err
 	}
@@ -104,7 +104,7 @@ func handleAllowedPacketOverflowed(ctx sessionctx.Context, exprName string, maxA
 	sc := ctx.GetSessionVars().StmtCtx
 
 	// insert|update|delete ignore ...
-	if sc.TruncateAsWarning {
+	if sc.TypeFlags().TruncateAsWarning() {
 		sc.AppendWarning(err)
 		return nil
 	}

--- a/pkg/expression/evaluator_test.go
+++ b/pkg/expression/evaluator_test.go
@@ -206,7 +206,7 @@ func TestBinopComparison(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		val, err := v.ToBool(ctx.GetSessionVars().StmtCtx)
+		val, err := v.ToBool(ctx.GetSessionVars().StmtCtx.TypeCtx)
 		require.NoError(t, err)
 		require.Equal(t, tt.result, val)
 	}
@@ -407,10 +407,10 @@ func TestBinopNumeric(t *testing.T) {
 		default:
 			// we use float64 as the result type check for all.
 			sc := ctx.GetSessionVars().StmtCtx
-			f, err := v.ToFloat64(sc)
+			f, err := v.ToFloat64(sc.TypeCtx)
 			require.NoError(t, err)
 			d := types.NewDatum(tt.ret)
-			r, err := d.ToFloat64(sc)
+			r, err := d.ToFloat64(sc.TypeCtx)
 			require.NoError(t, err)
 			require.Equal(t, r, f)
 		}

--- a/pkg/expression/helper.go
+++ b/pkg/expression/helper.go
@@ -182,7 +182,7 @@ func getStmtTimestamp(ctx sessionctx.Context) (time.Time, error) {
 		return now, err
 	}
 
-	timestamp, err := types.StrToFloat(sessionVars.StmtCtx, timestampStr, false)
+	timestamp, err := types.StrToFloat(sessionVars.StmtCtx.TypeCtx, timestampStr, false)
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/pkg/expression/main_test.go
+++ b/pkg/expression/main_test.go
@@ -59,7 +59,7 @@ func createContext(t *testing.T) *mock.Context {
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().StmtCtx.SetTimeZone(time.Local)
 	sc := ctx.GetSessionVars().StmtCtx
-	sc.TruncateAsWarning = true
+	sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true))
 	require.NoError(t, ctx.GetSessionVars().SetSystemVar("max_allowed_packet", "67108864"))
 	ctx.GetSessionVars().PlanColumnID.Store(0)
 	return ctx

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -419,7 +419,7 @@ func (sf *ScalarFunction) Eval(row chunk.Row) (d types.Datum, err error) {
 			res, err = types.ParseEnum(tp.GetElems(), str, tp.GetCollate())
 			if ctx := sf.GetCtx(); ctx != nil {
 				if sc := ctx.GetSessionVars().StmtCtx; sc != nil {
-					err = sc.HandleTruncate(err)
+					err = sc.TypeCtx.HandleTruncate(err)
 				}
 			}
 		} else {

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -277,7 +277,7 @@ func Selectivity(
 			ret *= 0
 			mask &^= 1 << uint64(i)
 			delete(notCoveredConstants, i)
-		} else if isTrue, err := c.Value.ToBool(sc); err == nil {
+		} else if isTrue, err := c.Value.ToBool(sc.TypeCtx); err == nil {
 			if isTrue == 0 {
 				// c is false
 				ret *= 0

--- a/pkg/planner/core/casetest/physicalplantest/physical_plan_test.go
+++ b/pkg/planner/core/casetest/physicalplantest/physical_plan_test.go
@@ -123,7 +123,7 @@ func TestRefine(t *testing.T) {
 		stmt, err := p.ParseOneStmt(tt, "", "")
 		require.NoError(t, err, comment)
 		sc := tk.Session().GetSessionVars().StmtCtx
-		sc.IgnoreTruncate.Store(false)
+		sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(false))
 		p, _, err := planner.Optimize(context.TODO(), tk.Session(), stmt, is)
 		require.NoError(t, err, comment)
 		testdata.OnRecord(func() {
@@ -156,7 +156,7 @@ func TestAggEliminator(t *testing.T) {
 		stmt, err := p.ParseOneStmt(tt, "", "")
 		require.NoError(t, err, comment)
 		sc := tk.Session().GetSessionVars().StmtCtx
-		sc.IgnoreTruncate.Store(false)
+		sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(false))
 		p, _, err := planner.Optimize(context.TODO(), tk.Session(), stmt, is)
 		require.NoError(t, err)
 		testdata.OnRecord(func() {

--- a/pkg/planner/core/logical_plans.go
+++ b/pkg/planner/core/logical_plans.go
@@ -372,7 +372,7 @@ func (p *LogicalJoin) extractFDForOuterJoin(filtersFromApply []expression.Expres
 		// if one of the inner condition is constant false, the inner side are all null, left make constant all of that.
 		for _, one := range innerCondition {
 			if c, ok := one.(*expression.Constant); ok && c.DeferredExpr == nil && c.ParamMarker == nil {
-				if isTrue, err := c.Value.ToBool(p.SCtx().GetSessionVars().StmtCtx); err == nil {
+				if isTrue, err := c.Value.ToBool(p.SCtx().GetSessionVars().StmtCtx.TypeCtx); err == nil {
 					if isTrue == 0 {
 						// c is false
 						opt.InnerIsFalse = true

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3029,7 +3029,7 @@ func handleAnalyzeOptionsV2(opts []ast.AnalyzeOpt) (map[ast.AnalyzeOptionType]ui
 			optMap[opt.Type] = v
 		case ast.AnalyzeOptSampleRate:
 			// Only Int/Float/decimal is accepted, so pass nil here is safe.
-			fVal, err := datumValue.ToFloat64(nil)
+			fVal, err := datumValue.ToFloat64(types.DefaultNoWarningContext)
 			if err != nil {
 				return nil, err
 			}
@@ -3092,7 +3092,7 @@ func handleAnalyzeOptions(opts []ast.AnalyzeOpt, statsVer int) (map[ast.AnalyzeO
 			optMap[opt.Type] = v
 		case ast.AnalyzeOptSampleRate:
 			// Only Int/Float/decimal is accepted, so pass nil here is safe.
-			fVal, err := datumValue.ToFloat64(nil)
+			fVal, err := datumValue.ToFloat64(types.DefaultNoWarningContext)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -518,7 +518,7 @@ func newListPartitionPruner(ctx sessionctx.Context, tbl table.Table, partitionNa
 func (l *listPartitionPruner) locatePartition(cond expression.Expression) (tables.ListPartitionLocation, bool, error) {
 	switch sf := cond.(type) {
 	case *expression.Constant:
-		b, err := sf.Value.ToBool(l.ctx.GetSessionVars().StmtCtx)
+		b, err := sf.Value.ToBool(l.ctx.GetSessionVars().StmtCtx.TypeCtx)
 		if err == nil && b == 0 {
 			// A constant false expression.
 			return nil, false, nil
@@ -1297,7 +1297,7 @@ type rangePruner struct {
 
 func (p *rangePruner) partitionRangeForExpr(sctx sessionctx.Context, expr expression.Expression) (start int, end int, ok bool) {
 	if constExpr, ok := expr.(*expression.Constant); ok {
-		if b, err := constExpr.Value.ToBool(sctx.GetSessionVars().StmtCtx); err == nil && b == 0 {
+		if b, err := constExpr.Value.ToBool(sctx.GetSessionVars().StmtCtx.TypeCtx); err == nil && b == 0 {
 			// A constant false expression.
 			return 0, 0, true
 		}

--- a/pkg/planner/core/rule_predicate_push_down.go
+++ b/pkg/planner/core/rule_predicate_push_down.go
@@ -447,7 +447,7 @@ func isNullRejected(ctx sessionctx.Context, schema *expression.Schema, expr expr
 		}
 		if x.Value.IsNull() {
 			return true
-		} else if isTrue, err := x.Value.ToBool(sc); err == nil && isTrue == 0 {
+		} else if isTrue, err := x.Value.ToBool(sc.TypeCtxOrDefault()); err == nil && isTrue == 0 {
 			return true
 		}
 	}
@@ -707,7 +707,7 @@ func Conds2TableDual(p LogicalPlan, conds []expression.Expression) LogicalPlan {
 	if expression.MaybeOverOptimized4PlanCache(p.SCtx(), []expression.Expression{con}) {
 		return nil
 	}
-	if isTrue, err := con.Value.ToBool(sc); (err == nil && isTrue == 0) || con.Value.IsNull() {
+	if isTrue, err := con.Value.ToBool(sc.TypeCtxOrDefault()); (err == nil && isTrue == 0) || con.Value.IsNull() {
 		dual := LogicalTableDual{}.Init(p.SCtx(), p.SelectBlockOffset())
 		dual.SetSchema(p.Schema())
 		return dual
@@ -729,7 +729,7 @@ func DeleteTrueExprs(p LogicalPlan, conds []expression.Expression) []expression.
 			continue
 		}
 		sc := p.SCtx().GetSessionVars().StmtCtx
-		if isTrue, err := con.Value.ToBool(sc); err == nil && isTrue == 1 {
+		if isTrue, err := con.Value.ToBool(sc.TypeCtx); err == nil && isTrue == 1 {
 			continue
 		}
 		newConds = append(newConds, cond)

--- a/pkg/server/internal/parse/parse.go
+++ b/pkg/server/internal/parse/parse.go
@@ -246,7 +246,7 @@ func ExecArgs(sc *stmtctx.StatementContext, params []expression.Expression, boun
 				args[i] = types.NewDecimalDatum(nil)
 			} else {
 				var dec types.MyDecimal
-				err = sc.HandleTruncate(dec.FromString(v))
+				err = sc.TypeCtx.HandleTruncate(dec.FromString(v))
 				if err != nil {
 					return err
 				}

--- a/pkg/sessionctx/stmtctx/BUILD.bazel
+++ b/pkg/sessionctx/stmtctx/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/domain/resourcegroup",
-        "//pkg/errno",
         "//pkg/parser",
         "//pkg/parser/ast",
         "//pkg/parser/model",
@@ -52,7 +51,6 @@ go_test(
         "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//util",
-        "@org_uber_go_atomic//:atomic",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/domain/resourcegroup"
-	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -174,13 +173,11 @@ type StatementContext struct {
 	InCreateOrAlterStmt           bool
 	InSetSessionStatesStmt        bool
 	InPreparedPlanBuilding        bool
-	IgnoreTruncate                atomic2.Bool
 	IgnoreZeroInDate              bool
 	NoZeroDate                    bool
 	DupKeyAsWarning               bool
 	BadNullAsWarning              bool
 	DividedByZeroAsWarning        bool
-	TruncateAsWarning             bool
 	OverflowAsWarning             bool
 	ErrAutoincReadFailedAsWarning bool
 	InShowWarning                 bool
@@ -1016,39 +1013,6 @@ func (sc *StatementContext) AppendExtraError(warn error) {
 	}
 }
 
-// HandleTruncate ignores or returns the error based on the StatementContext state.
-func (sc *StatementContext) HandleTruncate(err error) error {
-	// TODO: At present we have not checked whether the error can be ignored or treated as warning.
-	// We will do that later, and then append WarnDataTruncated instead of the error itself.
-	if err == nil {
-		return nil
-	}
-
-	err = errors.Cause(err)
-	if e, ok := err.(*errors.Error); !ok ||
-		(e.Code() != errno.ErrTruncatedWrongValue &&
-			e.Code() != errno.ErrDataTooLong &&
-			e.Code() != errno.ErrTruncatedWrongValueForField &&
-			e.Code() != errno.ErrWarnDataOutOfRange &&
-			e.Code() != errno.ErrDataOutOfRange &&
-			e.Code() != errno.ErrBadNumber &&
-			e.Code() != errno.ErrWrongValueForType &&
-			e.Code() != errno.ErrDatetimeFunctionOverflow &&
-			e.Code() != errno.WarnDataTruncated &&
-			e.Code() != errno.ErrIncorrectDatetimeValue) {
-		return err
-	}
-
-	if sc.IgnoreTruncate.Load() {
-		return nil
-	}
-	if sc.TruncateAsWarning {
-		sc.AppendWarning(err)
-		return nil
-	}
-	return err
-}
-
 // HandleOverflow treats ErrOverflow as warnings or returns the error based on the StmtCtx.OverflowAsWarning state.
 func (sc *StatementContext) HandleOverflow(err error, warnErr error) error {
 	if err == nil {
@@ -1166,7 +1130,8 @@ func (sc *StatementContext) ShouldClipToZero() bool {
 // ShouldIgnoreOverflowError indicates whether we should ignore the error when type conversion overflows,
 // so we can leave it for further processing like clipping values less than 0 to 0 for unsigned integer types.
 func (sc *StatementContext) ShouldIgnoreOverflowError() bool {
-	if (sc.InInsertStmt && sc.TruncateAsWarning) || sc.InLoadDataStmt {
+	// TODO: move this function into `/types` pkg
+	if (sc.InInsertStmt && sc.TypeCtx.Flags().TruncateAsWarning()) || sc.InLoadDataStmt {
 		return true
 	}
 	return false
@@ -1182,9 +1147,9 @@ func (sc *StatementContext) PushDownFlags() uint64 {
 	} else if sc.InSelectStmt {
 		flags |= model.FlagInSelectStmt
 	}
-	if sc.IgnoreTruncate.Load() {
+	if sc.TypeCtx.Flags().IgnoreTruncateErr() {
 		flags |= model.FlagIgnoreTruncate
-	} else if sc.TruncateAsWarning {
+	} else if sc.TypeCtx.Flags().TruncateAsWarning() {
 		flags |= model.FlagTruncateAsWarning
 	}
 	if sc.OverflowAsWarning {
@@ -1249,15 +1214,21 @@ func (sc *StatementContext) CopTasksDetails() *CopTasksDetails {
 	return d
 }
 
-// SetFlagsFromPBFlag set the flag of StatementContext from a `tipb.SelectRequest.Flags`.
-func (sc *StatementContext) SetFlagsFromPBFlag(flags uint64) {
-	sc.IgnoreTruncate.Store((flags & model.FlagIgnoreTruncate) > 0)
-	sc.TruncateAsWarning = (flags & model.FlagTruncateAsWarning) > 0
+// InitFromPBFlagAndTz set the flag and timezone of StatementContext from a `tipb.SelectRequest.Flags` and `*time.Location`.
+func (sc *StatementContext) InitFromPBFlagAndTz(flags uint64, tz *time.Location) {
 	sc.InInsertStmt = (flags & model.FlagInInsertStmt) > 0
 	sc.InSelectStmt = (flags & model.FlagInSelectStmt) > 0
+	sc.InDeleteStmt = (flags & model.FlagInUpdateOrDeleteStmt) > 0
 	sc.OverflowAsWarning = (flags & model.FlagOverflowAsWarning) > 0
 	sc.IgnoreZeroInDate = (flags & model.FlagIgnoreZeroInDate) > 0
 	sc.DividedByZeroAsWarning = (flags & model.FlagDividedByZeroAsWarning) > 0
+	sc.SetTimeZone(tz)
+
+	typeFlags := sc.TypeCtx.Flags()
+	typeFlags = typeFlags.
+		WithIgnoreTruncateErr((flags & model.FlagIgnoreTruncate) > 0).
+		WithTruncateAsWarning((flags & model.FlagTruncateAsWarning) > 0)
+	sc.TypeCtx = typectx.NewContext(typeFlags, tz, sc.AppendWarning)
 }
 
 // GetLockWaitStartTime returns the statement pessimistic lock wait start time
@@ -1394,6 +1365,18 @@ func (sc *StatementContext) RecordedStatsLoadStatusCnt() (cnt int) {
 		cnt += status.recordedColIdxCount()
 	}
 	return
+}
+
+// TypeCtxOrDefault returns the reference to the `TypeCtx` inside the statement context.
+// If the statement context is nil, it'll return a newly created default type context.
+// **don't** use this function if you can make sure the `sc` is not nil. We should limit the usage of this function as
+// little as possible.
+func (sc *StatementContext) TypeCtxOrDefault() typectx.Context {
+	if sc != nil {
+		return sc.TypeCtx
+	}
+
+	return typectx.DefaultNoWarningContext
 }
 
 // UsedStatsInfoForTable records stats that are used during query and their information.

--- a/pkg/sessionctx/stmtctx/stmtctx_test.go
+++ b/pkg/sessionctx/stmtctx/stmtctx_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/util"
-	"go.uber.org/atomic"
 )
 
 func TestCopTasksDetails(t *testing.T) {
@@ -95,19 +94,19 @@ func TestStatementContextPushDownFLags(t *testing.T) {
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.InUpdateStmt = true }), 16},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.InDeleteStmt = true }), 16},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.InSelectStmt = true }), 32},
-		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.IgnoreTruncate = *atomic.NewBool(true) }), 1},
-		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.TruncateAsWarning = true }), 2},
+		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true)) }), 1},
+		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true)) }), 2},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.OverflowAsWarning = true }), 64},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.IgnoreZeroInDate = true }), 128},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.DividedByZeroAsWarning = true }), 256},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.InLoadDataStmt = true }), 1024},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) {
 			sc.InSelectStmt = true
-			sc.TruncateAsWarning = true
+			sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true))
 		}), 34},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) {
 			sc.DividedByZeroAsWarning = true
-			sc.IgnoreTruncate = *atomic.NewBool(true)
+			sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true))
 		}), 257},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) {
 			sc.InUpdateStmt = true

--- a/pkg/store/mockstore/mockcopr/cop_handler_dag.go
+++ b/pkg/store/mockstore/mockcopr/cop_handler_dag.go
@@ -103,12 +103,11 @@ func (h coprHandler) buildDAGExecutor(req *coprocessor.Request) (*dagContext, ex
 		return nil, nil, nil, errors.Trace(err)
 	}
 
-	sc := flagsToStatementContext(dagReq.Flags)
 	tz, err := timeutil.ConstructTimeZone(dagReq.TimeZoneName, int(dagReq.TimeZoneOffset))
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)
 	}
-	sc.SetTimeZone(tz)
+	sc := flagsAndTzToStatementContext(dagReq.Flags, tz)
 
 	ctx := &dagContext{
 		dagReq:    dagReq,
@@ -126,13 +125,6 @@ func (h coprHandler) buildDAGExecutor(req *coprocessor.Request) (*dagContext, ex
 		return nil, nil, nil, errors.Trace(err)
 	}
 	return ctx, e, dagReq, err
-}
-
-// constructTimeZone constructs timezone by name first. When the timezone name
-// is set, the daylight saving problem must be considered. Otherwise the
-// timezone offset in seconds east of UTC is used to constructed the timezone.
-func constructTimeZone(name string, offset int) (*time.Location, error) {
-	return timeutil.ConstructTimeZone(name, offset)
 }
 
 func (h coprHandler) buildExec(ctx *dagContext, curr *tipb.Executor) (executor, *tipb.Executor, error) {
@@ -466,18 +458,10 @@ func (e *evalContext) decodeRelatedColumnVals(relatedColOffsets []int, value [][
 	return nil
 }
 
-// flagsToStatementContext creates a StatementContext from a `tipb.SelectRequest.Flags`.
-func flagsToStatementContext(flags uint64) *stmtctx.StatementContext {
-	sc := stmtctx.NewStmtCtx()
-	sc.IgnoreTruncate.Store((flags & model.FlagIgnoreTruncate) > 0)
-	sc.TruncateAsWarning = (flags & model.FlagTruncateAsWarning) > 0
-	sc.InInsertStmt = (flags & model.FlagInInsertStmt) > 0
-	sc.InSelectStmt = (flags & model.FlagInSelectStmt) > 0
-	sc.InDeleteStmt = (flags & model.FlagInUpdateOrDeleteStmt) > 0
-	sc.OverflowAsWarning = (flags & model.FlagOverflowAsWarning) > 0
-	sc.IgnoreZeroInDate = (flags & model.FlagIgnoreZeroInDate) > 0
-	sc.DividedByZeroAsWarning = (flags & model.FlagDividedByZeroAsWarning) > 0
-	// TODO set FlagInSetOprStmt,
+// flagsAndTzToStatementContext creates a StatementContext from a `tipb.SelectRequest.Flags`.
+func flagsAndTzToStatementContext(flags uint64, tz *time.Location) *stmtctx.StatementContext {
+	sc := new(stmtctx.StatementContext)
+	sc.InitFromPBFlagAndTz(flags, tz)
 	return sc
 }
 

--- a/pkg/store/mockstore/mockcopr/executor.go
+++ b/pkg/store/mockstore/mockcopr/executor.go
@@ -414,7 +414,7 @@ func evalBool(exprs []expression.Expression, row []types.Datum, ctx *stmtctx.Sta
 			return false, nil
 		}
 
-		isBool, err := data.ToBool(ctx)
+		isBool, err := data.ToBool(ctx.TypeCtx)
 		isBool, err = expression.HandleOverflowOnSelection(ctx, isBool, err)
 		if err != nil {
 			return false, errors.Trace(err)

--- a/pkg/store/mockstore/unistore/cophandler/BUILD.bazel
+++ b/pkg/store/mockstore/unistore/cophandler/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
         "//pkg/util/codec",
         "//pkg/util/collate",
         "//pkg/util/rowcodec",
+        "//pkg/util/timeutil",
         "@com_github_pingcap_badger//:badger",
         "@com_github_pingcap_badger//y",
         "@com_github_pingcap_kvproto//pkg/coprocessor",

--- a/pkg/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/closure_exec.go
@@ -799,7 +799,7 @@ func (e *closureExecutor) processSelection(needCollectDetail bool) (gotRow bool,
 		if d.IsNull() {
 			gotRow = false
 		} else {
-			isTrue, err := d.ToBool(e.sc)
+			isTrue, err := d.ToBool(e.sc.TypeCtx)
 			isTrue, err = expression.HandleOverflowOnSelection(e.sc, isTrue, err)
 			if err != nil {
 				return false, errors.Trace(err)

--- a/pkg/store/mockstore/unistore/cophandler/mpp.go
+++ b/pkg/store/mockstore/unistore/cophandler/mpp.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
+	"github.com/pingcap/tidb/pkg/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/atomic"
 )
@@ -573,10 +574,11 @@ func HandleMPPDAGReq(dbReader *dbreader.DBReader, req *coprocessor.Request, mppC
 		startTS:   req.StartTs,
 		keyRanges: req.Ranges,
 	}
+	tz, err := timeutil.ConstructTimeZone(dagReq.TimeZoneName, int(dagReq.TimeZoneOffset))
 	builder := mppExecBuilder{
 		dbReader: dbReader,
 		mppCtx:   mppCtx,
-		sc:       flagsToStatementContext(dagReq.Flags),
+		sc:       flagsAndTzToStatementContext(dagReq.Flags, tz),
 		dagReq:   dagReq,
 		dagCtx:   dagCtx,
 	}

--- a/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
@@ -1133,7 +1133,7 @@ func (e *selExec) next() (*chunk.Chunk, error) {
 				if d.IsNull() {
 					passCheck = false
 				} else {
-					isBool, err := d.ToBool(e.sc)
+					isBool, err := d.ToBool(e.sc.TypeCtx)
 					if err != nil {
 						return nil, errors.Trace(err)
 					}

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -322,7 +322,7 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 			zap.Uint64("conn", ctx.GetSessionVars().ConnectionID), zap.Error(err))
 	}
 
-	err = sc.HandleTruncate(err)
+	err = sc.TypeCtx.HandleTruncate(err)
 	err = sc.HandleOverflow(err, err)
 
 	if forceIgnoreTruncate {

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -398,7 +398,7 @@ func flatten(sc *stmtctx.StatementContext, data types.Datum, ret *types.Datum) e
 		return nil
 	case types.KindBinaryLiteral, types.KindMysqlBit:
 		// We don't need to handle errors here since the literal is ensured to be able to store in uint64 in convertToMysqlBit.
-		val, err := data.GetBinaryLiteral().ToInt(sc)
+		val, err := data.GetBinaryLiteral().ToInt(sc.TypeCtx)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/pkg/types/binary_literal.go
+++ b/pkg/types/binary_literal.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 )
 
 // BinaryLiteral is the internal type for storing bit / hex literal type.
@@ -102,7 +101,7 @@ func (b BinaryLiteral) ToBitLiteralString(trimLeadingZero bool) string {
 }
 
 // ToInt returns the int value for the literal.
-func (b BinaryLiteral) ToInt(sc *stmtctx.StatementContext) (uint64, error) {
+func (b BinaryLiteral) ToInt(ctx Context) (uint64, error) {
 	buf := trimLeadingZeroBytes(b)
 	length := len(buf)
 	if length == 0 {
@@ -110,9 +109,7 @@ func (b BinaryLiteral) ToInt(sc *stmtctx.StatementContext) (uint64, error) {
 	}
 	if length > 8 {
 		var err = ErrTruncatedWrongVal.FastGenByArgs("BINARY", b)
-		if sc != nil {
-			err = sc.HandleTruncate(err)
-		}
+		err = ctx.HandleTruncate(err)
 		return math.MaxUint64, err
 	}
 	// Note: the byte-order is BigEndian.

--- a/pkg/types/binary_literal_test.go
+++ b/pkg/types/binary_literal_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -207,11 +206,11 @@ func TestBinaryLiteral(t *testing.T) {
 			{"0x1010ffff8080ff12", 0x1010ffff8080ff12, false},
 			{"0x1010ffff8080ff12ff", 0xffffffffffffffff, true},
 		}
-		sc := stmtctx.NewStmtCtx()
+		ctx := DefaultNoWarningContext
 		for _, item := range tbl {
 			hex, err := ParseHexStr(item.Input)
 			require.NoError(t, err)
-			intValue, err := hex.ToInt(sc)
+			intValue, err := hex.ToInt(ctx)
 			if item.HasError {
 				require.Error(t, err)
 			} else {

--- a/pkg/types/compare_test.go
+++ b/pkg/types/compare_test.go
@@ -147,7 +147,7 @@ func TestCompare(t *testing.T) {
 
 func compareForTest(a, b interface{}) (int, error) {
 	sc := stmtctx.NewStmtCtx()
-	sc.IgnoreTruncate.Store(true)
+	sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true))
 	aDatum := NewDatum(a)
 	bDatum := NewDatum(b)
 	return aDatum.Compare(sc, &bDatum, collate.GetBinaryCollator())
@@ -169,7 +169,7 @@ func TestCompareDatum(t *testing.T) {
 		{MinNotNullDatum(), MaxValueDatum(), -1},
 	}
 	sc := stmtctx.NewStmtCtx()
-	sc.IgnoreTruncate.Store(true)
+	sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true))
 	for i, tt := range cmpTbl {
 		ret, err := tt.lhs.Compare(sc, &tt.rhs, collate.GetBinaryCollator())
 		require.NoError(t, err)

--- a/pkg/types/context.go
+++ b/pkg/types/context.go
@@ -14,7 +14,9 @@
 
 package types
 
-import "github.com/pingcap/tidb/pkg/types/context"
+import (
+	"github.com/pingcap/tidb/pkg/types/context"
+)
 
 // TODO: move a contents in `types/context/context.go` to this file after refactor finished.
 // Because package `types` has a dependency on `sessionctx/stmtctx`, we need a separate package `type/context` to define
@@ -31,3 +33,6 @@ const StrictFlags = context.StrictFlags
 
 // NewContext creates a new `Context`
 var NewContext = context.NewContext
+
+// DefaultNoWarningContext is an alias of `DefaultNoWarningContext`
+var DefaultNoWarningContext = context.DefaultNoWarningContext

--- a/pkg/types/context/BUILD.bazel
+++ b/pkg/types/context/BUILD.bazel
@@ -2,10 +2,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "context",
-    srcs = ["context.go"],
+    srcs = [
+        "context.go",
+        "truncate.go",
+    ],
     importpath = "github.com/pingcap/tidb/pkg/types/context",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/util/intest"],
+    deps = [
+        "//pkg/errno",
+        "//pkg/util/intest",
+        "@com_github_pingcap_errors//:errors",
+    ],
 )
 
 go_test(

--- a/pkg/types/context/context.go
+++ b/pkg/types/context/context.go
@@ -104,6 +104,32 @@ func (f Flags) WithSkipUTF8MB4Check(skip bool) Flags {
 	return f &^ FlagSkipUTF8MB4Check
 }
 
+// IgnoreTruncateErr indicates whether the flag `FlagIgnoreTruncateErr` is set
+func (f Flags) IgnoreTruncateErr() bool {
+	return f&FlagIgnoreTruncateErr != 0
+}
+
+// WithIgnoreTruncateErr returns a new flags with `FlagIgnoreTruncateErr` set/unset according to the skip parameter
+func (f Flags) WithIgnoreTruncateErr(ignore bool) Flags {
+	if ignore {
+		return f | FlagIgnoreTruncateErr
+	}
+	return f &^ FlagIgnoreTruncateErr
+}
+
+// TruncateAsWarning indicates whether the flag `FlagTruncateAsWarning` is set
+func (f Flags) TruncateAsWarning() bool {
+	return f&FlagTruncateAsWarning != 0
+}
+
+// WithTruncateAsWarning returns a new flags with `FlagTruncateAsWarning` set/unset according to the skip parameter
+func (f Flags) WithTruncateAsWarning(warn bool) Flags {
+	if warn {
+		return f | FlagTruncateAsWarning
+	}
+	return f &^ FlagTruncateAsWarning
+}
+
 // Context provides the information when converting between different types.
 type Context struct {
 	flags           Flags
@@ -164,3 +190,8 @@ func (c *Context) AppendWarning(err error) {
 func (c *Context) AppendWarningFunc() func(err error) {
 	return c.appendWarningFn
 }
+
+// DefaultNoWarningContext is the context without any special configuration
+var DefaultNoWarningContext = NewContext(StrictFlags, time.UTC, func(_ error) {
+	// the error is ignored
+})

--- a/pkg/types/context/truncate.go
+++ b/pkg/types/context/truncate.go
@@ -1,0 +1,53 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/errno"
+)
+
+// HandleTruncate ignores or returns the error based on the Context state.
+func (c *Context) HandleTruncate(err error) error {
+	// TODO: At present we have not checked whether the error can be ignored or treated as warning.
+	// We will do that later, and then append WarnDataTruncated instead of the error itself.
+	if err == nil {
+		return nil
+	}
+
+	err = errors.Cause(err)
+	if e, ok := err.(*errors.Error); !ok ||
+		(e.Code() != errno.ErrTruncatedWrongValue &&
+			e.Code() != errno.ErrDataTooLong &&
+			e.Code() != errno.ErrTruncatedWrongValueForField &&
+			e.Code() != errno.ErrWarnDataOutOfRange &&
+			e.Code() != errno.ErrDataOutOfRange &&
+			e.Code() != errno.ErrBadNumber &&
+			e.Code() != errno.ErrWrongValueForType &&
+			e.Code() != errno.ErrDatetimeFunctionOverflow &&
+			e.Code() != errno.WarnDataTruncated &&
+			e.Code() != errno.ErrIncorrectDatetimeValue) {
+		return err
+	}
+
+	if c.Flags().IgnoreTruncateErr() {
+		return nil
+	}
+	if c.Flags().TruncateAsWarning() {
+		c.AppendWarning(err)
+		return nil
+	}
+	return err
+}

--- a/pkg/types/time.go
+++ b/pkg/types/time.go
@@ -1045,7 +1045,7 @@ func parseDatetime(sc *stmtctx.StatementContext, str string, fsp int, isFloat bo
 		l := len(seps[0])
 		// Values specified as numbers
 		if isFloat {
-			numOfTime, err := StrToInt(sc, seps[0], false)
+			numOfTime, err := StrToInt(sc.TypeCtxOrDefault(), seps[0], false)
 			if err != nil {
 				return ZeroDatetime, errors.Trace(ErrWrongValue.GenWithStackByArgs(DateTimeStr, str))
 			}
@@ -2045,7 +2045,7 @@ func ParseTimeFromNum(sc *stmtctx.StatementContext, num int64, tp byte, fsp int)
 	// MySQL compatibility: 0 should not be converted to null, see #11203
 	if num == 0 {
 		zt := NewTime(ZeroCoreTime, tp, DefaultFsp)
-		if sc != nil && sc.InCreateOrAlterStmt && !sc.TruncateAsWarning && sc.NoZeroDate {
+		if sc != nil && sc.InCreateOrAlterStmt && !sc.TypeFlags().TruncateAsWarning() && sc.NoZeroDate {
 			switch tp {
 			case mysql.TypeTimestamp:
 				return zt, ErrTruncatedWrongVal.GenWithStackByArgs(TimestampStr, "0")

--- a/pkg/util/codec/codec.go
+++ b/pkg/util/codec/codec.go
@@ -110,7 +110,7 @@ func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparab
 			b = append(b, decimalFlag)
 			b, err = EncodeDecimal(b, vals[i].GetMysqlDecimal(), vals[i].Length(), vals[i].Frac())
 			if terror.ErrorEqual(err, types.ErrTruncated) {
-				err = sc.HandleTruncate(err)
+				err = sc.TypeCtx.HandleTruncate(err)
 			} else if terror.ErrorEqual(err, types.ErrOverflow) {
 				err = sc.HandleOverflow(err, err)
 			}
@@ -121,7 +121,7 @@ func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparab
 		case types.KindMysqlBit, types.KindBinaryLiteral:
 			// We don't need to handle errors here since the literal is ensured to be able to store in uint64 in convertToMysqlBit.
 			var val uint64
-			val, err = vals[i].GetBinaryLiteral().ToInt(sc)
+			val, err = vals[i].GetBinaryLiteral().ToInt(sc.TypeCtxOrDefault())
 			terror.Log(errors.Trace(err))
 			b = encodeUnsignedInt(b, val, comparable1)
 		case types.KindMysqlJSON:
@@ -167,7 +167,7 @@ func EstimateValueSize(sc *stmtctx.StatementContext, val types.Datum) (int, erro
 	case types.KindMysqlSet:
 		l = valueSizeOfUnsignedInt(val.GetMysqlSet().Value)
 	case types.KindMysqlBit, types.KindBinaryLiteral:
-		val, err := val.GetBinaryLiteral().ToInt(sc)
+		val, err := val.GetBinaryLiteral().ToInt(sc.TypeCtxOrDefault())
 		terror.Log(errors.Trace(err))
 		l = valueSizeOfUnsignedInt(val)
 	case types.KindMysqlJSON:
@@ -381,7 +381,7 @@ func encodeHashChunkRowIdx(sc *stmtctx.StatementContext, row chunk.Row, tp *type
 	case mysql.TypeBit:
 		// We don't need to handle errors here since the literal is ensured to be able to store in uint64 in convertToMysqlBit.
 		flag = uvarintFlag
-		v, err1 := types.BinaryLiteral(row.GetBytes(idx)).ToInt(sc)
+		v, err1 := types.BinaryLiteral(row.GetBytes(idx)).ToInt(sc.TypeCtxOrDefault())
 		terror.Log(errors.Trace(err1))
 		b = unsafe.Slice((*byte)(unsafe.Pointer(&v)), unsafe.Sizeof(v))
 	case mysql.TypeJSON:
@@ -626,7 +626,7 @@ func HashChunkSelected(sc *stmtctx.StatementContext, h []hash.Hash64, chk *chunk
 			} else {
 				// We don't need to handle errors here since the literal is ensured to be able to store in uint64 in convertToMysqlBit.
 				buf[0] = uvarintFlag
-				v, err1 := types.BinaryLiteral(column.GetBytes(i)).ToInt(sc)
+				v, err1 := types.BinaryLiteral(column.GetBytes(i)).ToInt(sc.TypeCtxOrDefault())
 				terror.Log(errors.Trace(err1))
 				b = unsafe.Slice((*byte)(unsafe.Pointer(&v)), sizeUint64)
 			}
@@ -1260,7 +1260,7 @@ func HashGroupKey(sc *stmtctx.StatementContext, n int, col *chunk.Column, buf []
 				buf[i] = append(buf[i], decimalFlag)
 				buf[i], err = EncodeDecimal(buf[i], &ds[i], ft.GetFlen(), ft.GetDecimal())
 				if terror.ErrorEqual(err, types.ErrTruncated) {
-					err = sc.HandleTruncate(err)
+					err = sc.TypeCtx.HandleTruncate(err)
 				} else if terror.ErrorEqual(err, types.ErrOverflow) {
 					err = sc.HandleOverflow(err, err)
 				}

--- a/pkg/util/codec/codec_test.go
+++ b/pkg/util/codec/codec_test.go
@@ -720,12 +720,12 @@ func TestDecimal(t *testing.T) {
 	}
 	for _, decimalNums := range tblCmp {
 		d1 := types.NewDatum(decimalNums.Arg1)
-		dec1, err := d1.ToDecimal(sc)
+		dec1, err := d1.ToDecimal(sc.TypeCtxOrDefault())
 		require.NoError(t, err)
 		d1.SetMysqlDecimal(dec1)
 
 		d2 := types.NewDatum(decimalNums.Arg2)
-		dec2, err := d2.ToDecimal(sc)
+		dec2, err := d2.ToDecimal(sc.TypeCtxOrDefault())
 		require.NoError(t, err)
 		d2.SetMysqlDecimal(dec2)
 
@@ -778,7 +778,7 @@ func TestDecimal(t *testing.T) {
 	_, err = EncodeDecimal(nil, d, 12, 10)
 	require.Truef(t, terror.ErrorEqual(err, types.ErrOverflow), "err %v", err)
 
-	sc.IgnoreTruncate.Store(true)
+	sc.SetTypeFlags(types.StrictFlags.WithIgnoreTruncateErr(true))
 	decimalDatum := types.NewDatum(d)
 	decimalDatum.SetLength(20)
 	decimalDatum.SetFrac(5)

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -209,7 +209,7 @@ func (r *builder) buildFromConstant(expr *expression.Constant) []*point {
 		return nil
 	}
 
-	val, err := dt.ToBool(r.sc)
+	val, err := dt.ToBool(r.sc.TypeCtx)
 	if err != nil {
 		r.err = err
 		return nil

--- a/pkg/util/rowcodec/common.go
+++ b/pkg/util/rowcodec/common.go
@@ -338,7 +338,7 @@ func appendDatumForChecksum(buf []byte, dat *data.Datum, typ byte) (out []byte, 
 		out = binary.LittleEndian.AppendUint64(buf, dat.GetMysqlSet().Value)
 	case mysql.TypeBit:
 		// ticdc transforms a bit value as the following way, no need to handle truncate error here.
-		v, _ := dat.GetBinaryLiteral().ToInt(nil)
+		v, _ := dat.GetBinaryLiteral().ToInt(data.DefaultNoWarningContext)
 		out = binary.LittleEndian.AppendUint64(buf, v)
 	case mysql.TypeJSON:
 		out = appendLengthValue(buf, []byte(dat.GetMysqlJSON().String()))

--- a/pkg/util/rowcodec/encoder.go
+++ b/pkg/util/rowcodec/encoder.go
@@ -194,7 +194,7 @@ func encodeValueDatum(sc *stmtctx.StatementContext, d *types.Datum, buffer []byt
 	case types.KindBinaryLiteral, types.KindMysqlBit:
 		// We don't need to handle errors here since the literal is ensured to be able to store in uint64 in convertToMysqlBit.
 		var val uint64
-		val, err = d.GetBinaryLiteral().ToInt(sc)
+		val, err = d.GetBinaryLiteral().ToInt(sc.TypeCtxOrDefault())
 		if err != nil {
 			return
 		}
@@ -205,7 +205,7 @@ func encodeValueDatum(sc *stmtctx.StatementContext, d *types.Datum, buffer []byt
 		buffer, err = codec.EncodeDecimal(buffer, d.GetMysqlDecimal(), d.Length(), d.Frac())
 		if err != nil && sc != nil {
 			if terror.ErrorEqual(err, types.ErrTruncated) {
-				err = sc.HandleTruncate(err)
+				err = sc.TypeCtx.HandleTruncate(err)
 			} else if terror.ErrorEqual(err, types.ErrOverflow) {
 				err = sc.HandleOverflow(err, err)
 			}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #47511

### What is changed and how it works?

Move the `IgnoreTruncateErr` and `TruncateAsWarning` flags from the `stmtctx` to `types.Context` flags.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

These refractors are covered by existing tests.

### Release note

```release-note
None
```
