### PR TITLE
distask: fix panic on refresh task fails or returns nil

### DIFF
--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -137,12 +137,16 @@ func (*BaseDispatcher) Close() {
 }
 
 // refreshTask fetch task state from tidb_global_task table.
-func (d *BaseDispatcher) refreshTask() (err error) {
-	d.Task, err = d.taskMgr.GetGlobalTaskByID(d.Task.ID)
+func (d *BaseDispatcher) refreshTask() error {
+	newTask, err := d.taskMgr.GetGlobalTaskByID(d.Task.ID)
 	if err != nil {
 		logutil.Logger(d.logCtx).Error("refresh task failed", zap.Error(err))
+		return err
 	}
-	return err
+	if newTask != nil {
+		d.Task = newTask
+	}
+	return nil
 }
 
 // scheduleTask schedule the task execution step by step.

--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -143,6 +143,7 @@ func (d *BaseDispatcher) refreshTask() error {
 		logutil.Logger(d.logCtx).Error("refresh task failed", zap.Error(err))
 		return err
 	}
+	// newTask might be nil when GC routine move the task into history table.
 	if newTask != nil {
 		d.Task = newTask
 	}

--- a/disttask/framework/dispatcher/dispatcher_manager.go
+++ b/disttask/framework/dispatcher/dispatcher_manager.go
@@ -274,10 +274,12 @@ func (dm *Manager) startDispatcher(task *proto.Task) {
 			dm.failTask(task, err)
 			return
 		}
-		defer dispatcher.Close()
+		defer func() {
+			dispatcher.Close()
+			dm.delRunningTask(task.ID)
+		}()
 		dm.setRunningTask(task, dispatcher)
 		dispatcher.ExecuteTask()
-		dm.delRunningTask(task.ID)
 		dm.finishCh <- struct{}{}
 	})
 }

--- a/disttask/importinto/job.go
+++ b/disttask/importinto/job.go
@@ -202,7 +202,8 @@ func (ti *DistImporter) SubmitTask(ctx context.Context) (int64, *proto.Task, err
 	ti.taskID = taskID
 	ti.logger = ti.logger.With(zap.Int64("task-id", globalTask.ID))
 
-	ti.logger.Info("job submitted to global task queue", zap.Int64("job-id", jobID))
+	ti.logger.Info("job submitted to global task queue",
+		zap.Int64("job-id", jobID), zap.Int64("thread-cnt", plan.ThreadCnt))
 
 	return jobID, globalTask, nil
 }

--- a/disttask/importinto/subtask_executor.go
+++ b/disttask/importinto/subtask_executor.go
@@ -65,7 +65,7 @@ func newImportMinimalTaskExecutor0(t *importStepMinimalTask) MiniTaskExecutor {
 
 func (e *importMinimalTaskExecutor) Run(ctx context.Context, dataWriter, indexWriter backend.EngineWriter) error {
 	logger := logutil.BgLogger().With(zap.String("type", proto.ImportInto), zap.Int64("table-id", e.mTtask.Plan.TableInfo.ID))
-	logger.Info("run minimal task")
+	logger.Info("execute chunk")
 	failpoint.Inject("waitBeforeSortChunk", func() {
 		time.Sleep(3 * time.Second)
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47520

Problem Summary:

### What is changed and how it works?

fix panic on refresh task fails or returns nil which makes dispatcher.Task nil
move delRunningTask of manager into defer

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
return `nil, nil`, `nil, err`, `task, nil` on GetGlobalTaskByID, check dispatcher.Task is always not nil, and updated correctly.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
