### PR TITLE
planner: Refactor framework of rule engine.(Support interaction rule of new rule engine )

### DIFF
--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -163,12 +163,12 @@ func (op *logicalOptimizeOp) recordFinalLogicalPlan(final LogicalPlan) {
 type logicalOptRule interface {
 	/* Return Parameters:
 	1. LogicalPlan: The optimized LogicalPlan after rule is applied
-	2. error: If there is error during the rule optimizer, it will be thrown
-	3. bool: Used to judge whether the plan is changed or not by logical rule.
-	         If the plan is changed, it will return true.
-	         The default value is false. It means that no interaction rule will be triggered.
+	2. bool: Used to judge whether the plan is changed or not by logical rule.
+		 If the plan is changed, it will return true.
+		 The default value is false. It means that no interaction rule will be triggered.
+	3. error: If there is error during the rule optimizer, it will be thrown
 	*/
-	optimize(context.Context, LogicalPlan, *logicalOptimizeOp) (LogicalPlan, error, bool)
+	optimize(context.Context, LogicalPlan, *logicalOptimizeOp) (LogicalPlan, bool, error)
 	name() string
 }
 
@@ -1149,7 +1149,7 @@ func logicalOptimize(ctx context.Context, flag uint64, logic LogicalPlan) (Logic
 		}
 		opt.appendBeforeRuleOptimize(i, rule.name(), logic)
 		var planChanged bool
-		logic, err, planChanged = rule.optimize(ctx, logic, opt)
+		logic, planChanged, err = rule.optimize(ctx, logic, opt)
 		if err != nil {
 			return nil, err
 		}
@@ -1163,7 +1163,7 @@ func logicalOptimize(ctx context.Context, flag uint64, logic LogicalPlan) (Logic
 	// Trigger the interaction rule
 	for i, rule := range againRuleList {
 		opt.appendBeforeRuleOptimize(i, rule.name(), logic)
-		logic, err, _ = rule.optimize(ctx, logic, opt)
+		logic, _, err = rule.optimize(ctx, logic, opt)
 		if err != nil {
 			return nil, err
 		}

--- a/planner/core/plan_stats.go
+++ b/planner/core/plan_stats.go
@@ -33,10 +33,10 @@ import (
 
 type collectPredicateColumnsPoint struct{}
 
-func (collectPredicateColumnsPoint) optimize(_ context.Context, plan LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (collectPredicateColumnsPoint) optimize(_ context.Context, plan LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	if plan.SCtx().GetSessionVars().InRestrictedSQL {
-		return plan, nil, planChanged
+		return plan, planChanged, nil
 	}
 	predicateNeeded := variable.EnableColumnTracking.Load()
 	syncWait := plan.SCtx().GetSessionVars().StatsLoadSyncWait * time.Millisecond.Nanoseconds()
@@ -46,7 +46,7 @@ func (collectPredicateColumnsPoint) optimize(_ context.Context, plan LogicalPlan
 		plan.SCtx().UpdateColStatsUsage(predicateColumns)
 	}
 	if !histNeeded {
-		return plan, nil, planChanged
+		return plan, planChanged, nil
 	}
 
 	// Prepare the table metadata to avoid repeatedly fetching from the infoSchema below.
@@ -70,9 +70,9 @@ func (collectPredicateColumnsPoint) optimize(_ context.Context, plan LogicalPlan
 	histNeededItems := collectHistNeededItems(histNeededColumns, histNeededIndices)
 	if histNeeded && len(histNeededItems) > 0 {
 		err := RequestLoadStats(plan.SCtx(), histNeededItems, syncWait)
-		return plan, err, planChanged
+		return plan, planChanged, err
 	}
-	return plan, nil, planChanged
+	return plan, planChanged, nil
 }
 
 func (collectPredicateColumnsPoint) name() string {
@@ -81,16 +81,16 @@ func (collectPredicateColumnsPoint) name() string {
 
 type syncWaitStatsLoadPoint struct{}
 
-func (syncWaitStatsLoadPoint) optimize(_ context.Context, plan LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (syncWaitStatsLoadPoint) optimize(_ context.Context, plan LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	if plan.SCtx().GetSessionVars().InRestrictedSQL {
-		return plan, nil, planChanged
+		return plan, planChanged, nil
 	}
 	if plan.SCtx().GetSessionVars().StmtCtx.IsSyncStatsFailed {
-		return plan, nil, planChanged
+		return plan, planChanged, nil
 	}
 	err := SyncWaitStatsLoad(plan)
-	return plan, err, planChanged
+	return plan, planChanged, err
 }
 
 func (syncWaitStatsLoadPoint) name() string {

--- a/planner/core/plan_stats.go
+++ b/planner/core/plan_stats.go
@@ -33,9 +33,10 @@ import (
 
 type collectPredicateColumnsPoint struct{}
 
-func (collectPredicateColumnsPoint) optimize(_ context.Context, plan LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error) {
+func (collectPredicateColumnsPoint) optimize(_ context.Context, plan LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	if plan.SCtx().GetSessionVars().InRestrictedSQL {
-		return plan, nil
+		return plan, nil, changedFlag
 	}
 	predicateNeeded := variable.EnableColumnTracking.Load()
 	syncWait := plan.SCtx().GetSessionVars().StatsLoadSyncWait * time.Millisecond.Nanoseconds()
@@ -45,7 +46,7 @@ func (collectPredicateColumnsPoint) optimize(_ context.Context, plan LogicalPlan
 		plan.SCtx().UpdateColStatsUsage(predicateColumns)
 	}
 	if !histNeeded {
-		return plan, nil
+		return plan, nil, changedFlag
 	}
 
 	// Prepare the table metadata to avoid repeatedly fetching from the infoSchema below.
@@ -69,9 +70,9 @@ func (collectPredicateColumnsPoint) optimize(_ context.Context, plan LogicalPlan
 	histNeededItems := collectHistNeededItems(histNeededColumns, histNeededIndices)
 	if histNeeded && len(histNeededItems) > 0 {
 		err := RequestLoadStats(plan.SCtx(), histNeededItems, syncWait)
-		return plan, err
+		return plan, err, changedFlag
 	}
-	return plan, nil
+	return plan, nil, changedFlag
 }
 
 func (collectPredicateColumnsPoint) name() string {
@@ -80,15 +81,16 @@ func (collectPredicateColumnsPoint) name() string {
 
 type syncWaitStatsLoadPoint struct{}
 
-func (syncWaitStatsLoadPoint) optimize(_ context.Context, plan LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error) {
+func (syncWaitStatsLoadPoint) optimize(_ context.Context, plan LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	if plan.SCtx().GetSessionVars().InRestrictedSQL {
-		return plan, nil
+		return plan, nil, changedFlag
 	}
 	if plan.SCtx().GetSessionVars().StmtCtx.IsSyncStatsFailed {
-		return plan, nil
+		return plan, nil, changedFlag
 	}
 	err := SyncWaitStatsLoad(plan)
-	return plan, err
+	return plan, err, changedFlag
 }
 
 func (syncWaitStatsLoadPoint) name() string {

--- a/planner/core/rule_aggregation_elimination.go
+++ b/planner/core/rule_aggregation_elimination.go
@@ -254,25 +254,26 @@ func wrapCastFunction(ctx sessionctx.Context, arg expression.Expression, targetT
 	return expression.BuildCastFunction(ctx, arg, targetTp)
 }
 
-func (a *aggregationEliminator) optimize(ctx context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+func (a *aggregationEliminator) optimize(ctx context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	newChildren := make([]LogicalPlan, 0, len(p.Children()))
 	for _, child := range p.Children() {
-		newChild, err := a.optimize(ctx, child, opt)
+		newChild, err, changedFlag := a.optimize(ctx, child, opt)
 		if err != nil {
-			return nil, err
+			return nil, err, changedFlag
 		}
 		newChildren = append(newChildren, newChild)
 	}
 	p.SetChildren(newChildren...)
 	agg, ok := p.(*LogicalAggregation)
 	if !ok {
-		return p, nil
+		return p, nil, changedFlag
 	}
 	a.tryToEliminateDistinct(agg, opt)
 	if proj := a.tryToEliminateAggregation(agg, opt); proj != nil {
-		return proj, nil
+		return proj, nil, changedFlag
 	}
-	return p, nil
+	return p, nil, changedFlag
 }
 
 func (*aggregationEliminator) name() string {

--- a/planner/core/rule_aggregation_elimination.go
+++ b/planner/core/rule_aggregation_elimination.go
@@ -255,25 +255,25 @@ func wrapCastFunction(ctx sessionctx.Context, arg expression.Expression, targetT
 }
 
 func (a *aggregationEliminator) optimize(ctx context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	newChildren := make([]LogicalPlan, 0, len(p.Children()))
 	for _, child := range p.Children() {
-		newChild, err, changedFlag := a.optimize(ctx, child, opt)
+		newChild, err, planChanged := a.optimize(ctx, child, opt)
 		if err != nil {
-			return nil, err, changedFlag
+			return nil, err, planChanged
 		}
 		newChildren = append(newChildren, newChild)
 	}
 	p.SetChildren(newChildren...)
 	agg, ok := p.(*LogicalAggregation)
 	if !ok {
-		return p, nil, changedFlag
+		return p, nil, planChanged
 	}
 	a.tryToEliminateDistinct(agg, opt)
 	if proj := a.tryToEliminateAggregation(agg, opt); proj != nil {
-		return proj, nil, changedFlag
+		return proj, nil, planChanged
 	}
-	return p, nil, changedFlag
+	return p, nil, planChanged
 }
 
 func (*aggregationEliminator) name() string {

--- a/planner/core/rule_aggregation_push_down.go
+++ b/planner/core/rule_aggregation_push_down.go
@@ -431,8 +431,10 @@ func (*aggregationPushDownSolver) pushAggCrossUnion(agg *LogicalAggregation, uni
 	return newAgg, nil
 }
 
-func (a *aggregationPushDownSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
-	return a.aggPushDown(p, opt)
+func (a *aggregationPushDownSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
+	newLogicalPlan, err := a.aggPushDown(p, opt)
+	return newLogicalPlan, err, changedFlag
 }
 
 func (a *aggregationPushDownSolver) tryAggPushDownForUnion(union *LogicalUnionAll, agg *LogicalAggregation, opt *logicalOptimizeOp) error {

--- a/planner/core/rule_aggregation_push_down.go
+++ b/planner/core/rule_aggregation_push_down.go
@@ -431,10 +431,10 @@ func (*aggregationPushDownSolver) pushAggCrossUnion(agg *LogicalAggregation, uni
 	return newAgg, nil
 }
 
-func (a *aggregationPushDownSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (a *aggregationPushDownSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	newLogicalPlan, err := a.aggPushDown(p, opt)
-	return newLogicalPlan, err, planChanged
+	return newLogicalPlan, planChanged, err
 }
 
 func (a *aggregationPushDownSolver) tryAggPushDownForUnion(union *LogicalUnionAll, agg *LogicalAggregation, opt *logicalOptimizeOp) error {

--- a/planner/core/rule_aggregation_push_down.go
+++ b/planner/core/rule_aggregation_push_down.go
@@ -432,9 +432,9 @@ func (*aggregationPushDownSolver) pushAggCrossUnion(agg *LogicalAggregation, uni
 }
 
 func (a *aggregationPushDownSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	newLogicalPlan, err := a.aggPushDown(p, opt)
-	return newLogicalPlan, err, changedFlag
+	return newLogicalPlan, err, planChanged
 }
 
 func (a *aggregationPushDownSolver) tryAggPushDownForUnion(union *LogicalUnionAll, agg *LogicalAggregation, opt *logicalOptimizeOp) error {

--- a/planner/core/rule_aggregation_skew_rewrite.go
+++ b/planner/core/rule_aggregation_skew_rewrite.go
@@ -274,24 +274,24 @@ func appendSkewDistinctAggRewriteTraceStep(agg *LogicalAggregation, result Logic
 }
 
 func (a *skewDistinctAggRewriter) optimize(ctx context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	newChildren := make([]LogicalPlan, 0, len(p.Children()))
 	for _, child := range p.Children() {
-		newChild, err, changedFlag := a.optimize(ctx, child, opt)
+		newChild, err, planChanged := a.optimize(ctx, child, opt)
 		if err != nil {
-			return nil, err, changedFlag
+			return nil, err, planChanged
 		}
 		newChildren = append(newChildren, newChild)
 	}
 	p.SetChildren(newChildren...)
 	agg, ok := p.(*LogicalAggregation)
 	if !ok {
-		return p, nil, changedFlag
+		return p, nil, planChanged
 	}
 	if newAgg := a.rewriteSkewDistinctAgg(agg, opt); newAgg != nil {
-		return newAgg, nil, changedFlag
+		return newAgg, nil, planChanged
 	}
-	return p, nil, changedFlag
+	return p, nil, planChanged
 }
 
 func (*skewDistinctAggRewriter) name() string {

--- a/planner/core/rule_aggregation_skew_rewrite.go
+++ b/planner/core/rule_aggregation_skew_rewrite.go
@@ -273,25 +273,25 @@ func appendSkewDistinctAggRewriteTraceStep(agg *LogicalAggregation, result Logic
 	opt.appendStepToCurrent(agg.ID(), agg.TP(), reason, action)
 }
 
-func (a *skewDistinctAggRewriter) optimize(ctx context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (a *skewDistinctAggRewriter) optimize(ctx context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	newChildren := make([]LogicalPlan, 0, len(p.Children()))
 	for _, child := range p.Children() {
-		newChild, err, planChanged := a.optimize(ctx, child, opt)
+		newChild, planChanged, err := a.optimize(ctx, child, opt)
 		if err != nil {
-			return nil, err, planChanged
+			return nil, planChanged, err
 		}
 		newChildren = append(newChildren, newChild)
 	}
 	p.SetChildren(newChildren...)
 	agg, ok := p.(*LogicalAggregation)
 	if !ok {
-		return p, nil, planChanged
+		return p, planChanged, nil
 	}
 	if newAgg := a.rewriteSkewDistinctAgg(agg, opt); newAgg != nil {
-		return newAgg, nil, planChanged
+		return newAgg, planChanged, nil
 	}
-	return p, nil, planChanged
+	return p, planChanged, nil
 }
 
 func (*skewDistinctAggRewriter) name() string {

--- a/planner/core/rule_build_key_info.go
+++ b/planner/core/rule_build_key_info.go
@@ -26,9 +26,9 @@ import (
 type buildKeySolver struct{}
 
 func (*buildKeySolver) optimize(_ context.Context, p LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	buildKeyInfo(p)
-	return p, nil, changedFlag
+	return p, nil, planChanged
 }
 
 // buildKeyInfo recursively calls LogicalPlan's BuildKeyInfo method.

--- a/planner/core/rule_build_key_info.go
+++ b/planner/core/rule_build_key_info.go
@@ -25,10 +25,10 @@ import (
 
 type buildKeySolver struct{}
 
-func (*buildKeySolver) optimize(_ context.Context, p LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (*buildKeySolver) optimize(_ context.Context, p LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	buildKeyInfo(p)
-	return p, nil, planChanged
+	return p, planChanged, nil
 }
 
 // buildKeyInfo recursively calls LogicalPlan's BuildKeyInfo method.

--- a/planner/core/rule_build_key_info.go
+++ b/planner/core/rule_build_key_info.go
@@ -25,9 +25,10 @@ import (
 
 type buildKeySolver struct{}
 
-func (*buildKeySolver) optimize(_ context.Context, p LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error) {
+func (*buildKeySolver) optimize(_ context.Context, p LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	buildKeyInfo(p)
-	return p, nil
+	return p, nil, changedFlag
 }
 
 // buildKeyInfo recursively calls LogicalPlan's BuildKeyInfo method.

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -32,9 +32,9 @@ type columnPruner struct {
 }
 
 func (*columnPruner) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	err := lp.PruneColumns(lp.Schema().Columns, opt)
-	return lp, err, changedFlag
+	return lp, err, planChanged
 }
 
 // ExprsHasSideEffects checks if any of the expressions has side effects.

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -31,9 +31,10 @@ import (
 type columnPruner struct {
 }
 
-func (*columnPruner) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+func (*columnPruner) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	err := lp.PruneColumns(lp.Schema().Columns, opt)
-	return lp, err
+	return lp, err, changedFlag
 }
 
 // ExprsHasSideEffects checks if any of the expressions has side effects.

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -31,10 +31,10 @@ import (
 type columnPruner struct {
 }
 
-func (*columnPruner) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (*columnPruner) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	err := lp.PruneColumns(lp.Schema().Columns, opt)
-	return lp, err, planChanged
+	return lp, planChanged, err
 }
 
 // ExprsHasSideEffects checks if any of the expressions has side effects.

--- a/planner/core/rule_constant_propagation.go
+++ b/planner/core/rule_constant_propagation.go
@@ -50,7 +50,7 @@ type constantPropagationSolver struct {
 // which is mainly implemented in the interface "constantPropagation" of LogicalPlan.
 // Currently only the Logical Join implements this function. (Used for the subquery in FROM List)
 // In the future, the Logical Apply will implements this function. (Used for the subquery in WHERE or SELECT list)
-func (cp *constantPropagationSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (cp *constantPropagationSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	// constant propagation root plan
 	newRoot := p.constantPropagation(nil, 0, opt)
@@ -61,9 +61,9 @@ func (cp *constantPropagationSolver) optimize(_ context.Context, p LogicalPlan, 
 	}
 
 	if newRoot == nil {
-		return p, nil, planChanged
+		return p, planChanged, nil
 	}
-	return newRoot, nil, planChanged
+	return newRoot, planChanged, nil
 }
 
 // execOptimize optimize constant propagation exclude root plan node

--- a/planner/core/rule_constant_propagation.go
+++ b/planner/core/rule_constant_propagation.go
@@ -50,7 +50,8 @@ type constantPropagationSolver struct {
 // which is mainly implemented in the interface "constantPropagation" of LogicalPlan.
 // Currently only the Logical Join implements this function. (Used for the subquery in FROM List)
 // In the future, the Logical Apply will implements this function. (Used for the subquery in WHERE or SELECT list)
-func (cp *constantPropagationSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+func (cp *constantPropagationSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	// constant propagation root plan
 	newRoot := p.constantPropagation(nil, 0, opt)
 
@@ -60,9 +61,9 @@ func (cp *constantPropagationSolver) optimize(_ context.Context, p LogicalPlan, 
 	}
 
 	if newRoot == nil {
-		return p, nil
+		return p, nil, changedFlag
 	}
-	return newRoot, nil
+	return newRoot, nil, changedFlag
 }
 
 // execOptimize optimize constant propagation exclude root plan node

--- a/planner/core/rule_constant_propagation.go
+++ b/planner/core/rule_constant_propagation.go
@@ -51,7 +51,7 @@ type constantPropagationSolver struct {
 // Currently only the Logical Join implements this function. (Used for the subquery in FROM List)
 // In the future, the Logical Apply will implements this function. (Used for the subquery in WHERE or SELECT list)
 func (cp *constantPropagationSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	// constant propagation root plan
 	newRoot := p.constantPropagation(nil, 0, opt)
 
@@ -61,9 +61,9 @@ func (cp *constantPropagationSolver) optimize(_ context.Context, p LogicalPlan, 
 	}
 
 	if newRoot == nil {
-		return p, nil, changedFlag
+		return p, nil, planChanged
 	}
-	return newRoot, nil, changedFlag
+	return newRoot, nil, planChanged
 }
 
 // execOptimize optimize constant propagation exclude root plan node

--- a/planner/core/rule_decorrelate.go
+++ b/planner/core/rule_decorrelate.go
@@ -193,7 +193,8 @@ func (*decorrelateSolver) aggDefaultValueMap(agg *LogicalAggregation) map[int]*e
 }
 
 // optimize implements logicalOptRule interface.
-func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	if apply, ok := p.(*LogicalApply); ok {
 		outerPlan := apply.children[0]
 		innerPlan := apply.children[1]
@@ -272,13 +273,13 @@ func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *lo
 				proj.SetSchema(apply.Schema())
 				proj.Exprs = append(expression.Column2Exprs(outerPlan.Schema().Clone().Columns), proj.Exprs...)
 				apply.SetSchema(expression.MergeSchema(outerPlan.Schema(), innerPlan.Schema()))
-				np, err := s.optimize(ctx, p, opt)
+				np, err, changedFlag := s.optimize(ctx, p, opt)
 				if err != nil {
-					return nil, err
+					return nil, err, changedFlag
 				}
 				proj.SetChildren(np)
 				appendMoveProjTraceStep(apply, np, proj, opt)
-				return proj, nil
+				return proj, nil, changedFlag
 			}
 			appendRemoveProjTraceStep(apply, proj, opt)
 			return s.optimize(ctx, p, opt)
@@ -313,7 +314,7 @@ func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *lo
 				for i, col := range outerPlan.Schema().Columns {
 					first, err := aggregation.NewAggFuncDesc(agg.SCtx(), ast.AggFuncFirstRow, []expression.Expression{col}, false)
 					if err != nil {
-						return nil, err
+						return nil, err, changedFlag
 					}
 					newAggFuncs = append(newAggFuncs, first)
 
@@ -343,20 +344,20 @@ func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *lo
 					}
 					desc, err := aggregation.NewAggFuncDesc(agg.SCtx(), agg.AggFuncs[i].Name, aggArgs, agg.AggFuncs[i].HasDistinct)
 					if err != nil {
-						return nil, err
+						return nil, err, changedFlag
 					}
 					newAggFuncs = append(newAggFuncs, desc)
 				}
 				agg.AggFuncs = newAggFuncs
-				np, err := s.optimize(ctx, p, opt)
+				np, err, changedFlag := s.optimize(ctx, p, opt)
 				if err != nil {
-					return nil, err
+					return nil, err, changedFlag
 				}
 				agg.SetChildren(np)
 				appendPullUpAggTraceStep(apply, np, agg, opt)
 				// TODO: Add a Projection if any argument of aggregate funcs or group by items are scalar functions.
 				// agg.buildProjectionIfNecessary()
-				return agg, nil
+				return agg, nil, changedFlag
 			}
 			// We can pull up the equal conditions below the aggregation as the join key of the apply, if only
 			// the equal conditions contain the correlated column of this apply.
@@ -391,7 +392,7 @@ func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *lo
 							if agg.schema.ColumnIndex(eqCond.GetArgs()[1].(*expression.Column)) == -1 {
 								newFunc, err := aggregation.NewAggFuncDesc(apply.SCtx(), ast.AggFuncFirstRow, []expression.Expression{clonedCol}, false)
 								if err != nil {
-									return nil, err
+									return nil, err, changedFlag
 								}
 								agg.AggFuncs = append(agg.AggFuncs, newFunc)
 								agg.schema.Append(clonedCol)
@@ -444,18 +445,18 @@ func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *lo
 NoOptimize:
 	// CTE's logical optimization is independent.
 	if _, ok := p.(*LogicalCTE); ok {
-		return p, nil
+		return p, nil, changedFlag
 	}
 	newChildren := make([]LogicalPlan, 0, len(p.Children()))
 	for _, child := range p.Children() {
-		np, err := s.optimize(ctx, child, opt)
+		np, err, changedFlag := s.optimize(ctx, child, opt)
 		if err != nil {
-			return nil, err
+			return nil, err, changedFlag
 		}
 		newChildren = append(newChildren, np)
 	}
 	p.SetChildren(newChildren...)
-	return p, nil
+	return p, nil, changedFlag
 }
 
 func (*decorrelateSolver) name() string {

--- a/planner/core/rule_decorrelate.go
+++ b/planner/core/rule_decorrelate.go
@@ -193,7 +193,7 @@ func (*decorrelateSolver) aggDefaultValueMap(agg *LogicalAggregation) map[int]*e
 }
 
 // optimize implements logicalOptRule interface.
-func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	if apply, ok := p.(*LogicalApply); ok {
 		outerPlan := apply.children[0]
@@ -273,13 +273,13 @@ func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *lo
 				proj.SetSchema(apply.Schema())
 				proj.Exprs = append(expression.Column2Exprs(outerPlan.Schema().Clone().Columns), proj.Exprs...)
 				apply.SetSchema(expression.MergeSchema(outerPlan.Schema(), innerPlan.Schema()))
-				np, err, planChanged := s.optimize(ctx, p, opt)
+				np, planChanged, err := s.optimize(ctx, p, opt)
 				if err != nil {
-					return nil, err, planChanged
+					return nil, planChanged, err
 				}
 				proj.SetChildren(np)
 				appendMoveProjTraceStep(apply, np, proj, opt)
-				return proj, nil, planChanged
+				return proj, planChanged, nil
 			}
 			appendRemoveProjTraceStep(apply, proj, opt)
 			return s.optimize(ctx, p, opt)
@@ -314,7 +314,7 @@ func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *lo
 				for i, col := range outerPlan.Schema().Columns {
 					first, err := aggregation.NewAggFuncDesc(agg.SCtx(), ast.AggFuncFirstRow, []expression.Expression{col}, false)
 					if err != nil {
-						return nil, err, planChanged
+						return nil, planChanged, err
 					}
 					newAggFuncs = append(newAggFuncs, first)
 
@@ -344,20 +344,20 @@ func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *lo
 					}
 					desc, err := aggregation.NewAggFuncDesc(agg.SCtx(), agg.AggFuncs[i].Name, aggArgs, agg.AggFuncs[i].HasDistinct)
 					if err != nil {
-						return nil, err, planChanged
+						return nil, planChanged, err
 					}
 					newAggFuncs = append(newAggFuncs, desc)
 				}
 				agg.AggFuncs = newAggFuncs
-				np, err, planChanged := s.optimize(ctx, p, opt)
+				np, planChanged, err := s.optimize(ctx, p, opt)
 				if err != nil {
-					return nil, err, planChanged
+					return nil, planChanged, err
 				}
 				agg.SetChildren(np)
 				appendPullUpAggTraceStep(apply, np, agg, opt)
 				// TODO: Add a Projection if any argument of aggregate funcs or group by items are scalar functions.
 				// agg.buildProjectionIfNecessary()
-				return agg, nil, planChanged
+				return agg, planChanged, nil
 			}
 			// We can pull up the equal conditions below the aggregation as the join key of the apply, if only
 			// the equal conditions contain the correlated column of this apply.
@@ -392,7 +392,7 @@ func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *lo
 							if agg.schema.ColumnIndex(eqCond.GetArgs()[1].(*expression.Column)) == -1 {
 								newFunc, err := aggregation.NewAggFuncDesc(apply.SCtx(), ast.AggFuncFirstRow, []expression.Expression{clonedCol}, false)
 								if err != nil {
-									return nil, err, planChanged
+									return nil, planChanged, err
 								}
 								agg.AggFuncs = append(agg.AggFuncs, newFunc)
 								agg.schema.Append(clonedCol)
@@ -445,18 +445,18 @@ func (s *decorrelateSolver) optimize(ctx context.Context, p LogicalPlan, opt *lo
 NoOptimize:
 	// CTE's logical optimization is independent.
 	if _, ok := p.(*LogicalCTE); ok {
-		return p, nil, planChanged
+		return p, planChanged, nil
 	}
 	newChildren := make([]LogicalPlan, 0, len(p.Children()))
 	for _, child := range p.Children() {
-		np, err, planChanged := s.optimize(ctx, child, opt)
+		np, planChanged, err := s.optimize(ctx, child, opt)
 		if err != nil {
-			return nil, err, planChanged
+			return nil, planChanged, err
 		}
 		newChildren = append(newChildren, np)
 	}
 	p.SetChildren(newChildren...)
-	return p, nil, planChanged
+	return p, planChanged, nil
 }
 
 func (*decorrelateSolver) name() string {

--- a/planner/core/rule_derive_topn_from_window.go
+++ b/planner/core/rule_derive_topn_from_window.go
@@ -117,8 +117,8 @@ func windowIsTopN(p *LogicalSelection) (bool, uint64) {
 }
 
 func (*deriveTopNFromWindow) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
-	return p.deriveTopN(opt), nil, changedFlag
+	planChanged := false
+	return p.deriveTopN(opt), nil, planChanged
 }
 
 func (s *baseLogicalPlan) deriveTopN(opt *logicalOptimizeOp) LogicalPlan {

--- a/planner/core/rule_derive_topn_from_window.go
+++ b/planner/core/rule_derive_topn_from_window.go
@@ -116,8 +116,9 @@ func windowIsTopN(p *LogicalSelection) (bool, uint64) {
 	return false, 0
 }
 
-func (*deriveTopNFromWindow) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
-	return p.deriveTopN(opt), nil
+func (*deriveTopNFromWindow) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
+	return p.deriveTopN(opt), nil, changedFlag
 }
 
 func (s *baseLogicalPlan) deriveTopN(opt *logicalOptimizeOp) LogicalPlan {

--- a/planner/core/rule_derive_topn_from_window.go
+++ b/planner/core/rule_derive_topn_from_window.go
@@ -116,9 +116,9 @@ func windowIsTopN(p *LogicalSelection) (bool, uint64) {
 	return false, 0
 }
 
-func (*deriveTopNFromWindow) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (*deriveTopNFromWindow) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
-	return p.deriveTopN(opt), nil, planChanged
+	return p.deriveTopN(opt), planChanged, nil
 }
 
 func (s *baseLogicalPlan) deriveTopN(opt *logicalOptimizeOp) LogicalPlan {

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -167,10 +167,10 @@ type projectionEliminator struct {
 }
 
 // optimize implements the logicalOptRule interface.
-func (pe *projectionEliminator) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (pe *projectionEliminator) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	root := pe.eliminate(lp, make(map[string]*expression.Column), false, opt)
-	return root, nil, planChanged
+	return root, planChanged, nil
 }
 
 // eliminate eliminates the redundant projection in a logical plan.

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -167,9 +167,10 @@ type projectionEliminator struct {
 }
 
 // optimize implements the logicalOptRule interface.
-func (pe *projectionEliminator) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+func (pe *projectionEliminator) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	root := pe.eliminate(lp, make(map[string]*expression.Column), false, opt)
-	return root, nil
+	return root, nil, changedFlag
 }
 
 // eliminate eliminates the redundant projection in a logical plan.

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -168,9 +168,9 @@ type projectionEliminator struct {
 
 // optimize implements the logicalOptRule interface.
 func (pe *projectionEliminator) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	root := pe.eliminate(lp, make(map[string]*expression.Column), false, opt)
-	return root, nil, changedFlag
+	return root, nil, planChanged
 }
 
 // eliminate eliminates the redundant projection in a logical plan.

--- a/planner/core/rule_generate_column_substitute.go
+++ b/planner/core/rule_generate_column_substitute.go
@@ -36,13 +36,14 @@ type ExprColumnMap map[expression.Expression]*expression.Column
 // For example: select a+1 from t order by a+1, with a virtual generate column c as (a+1) and
 // an index on c. We need to replace a+1 with c so that we can use the index on c.
 // See also https://dev.mysql.com/doc/refman/8.0/en/generated-column-index-optimizations.html
-func (gc *gcSubstituter) optimize(ctx context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+func (gc *gcSubstituter) optimize(ctx context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	exprToColumn := make(ExprColumnMap)
 	collectGenerateColumn(lp, exprToColumn)
 	if len(exprToColumn) == 0 {
-		return lp, nil
+		return lp, nil, changedFlag
 	}
-	return gc.substitute(ctx, lp, exprToColumn, opt), nil
+	return gc.substitute(ctx, lp, exprToColumn, opt), nil, changedFlag
 }
 
 // collectGenerateColumn collect the generate column and save them to a map from their expressions to themselves.

--- a/planner/core/rule_generate_column_substitute.go
+++ b/planner/core/rule_generate_column_substitute.go
@@ -36,14 +36,14 @@ type ExprColumnMap map[expression.Expression]*expression.Column
 // For example: select a+1 from t order by a+1, with a virtual generate column c as (a+1) and
 // an index on c. We need to replace a+1 with c so that we can use the index on c.
 // See also https://dev.mysql.com/doc/refman/8.0/en/generated-column-index-optimizations.html
-func (gc *gcSubstituter) optimize(ctx context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (gc *gcSubstituter) optimize(ctx context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	exprToColumn := make(ExprColumnMap)
 	collectGenerateColumn(lp, exprToColumn)
 	if len(exprToColumn) == 0 {
-		return lp, nil, planChanged
+		return lp, planChanged, nil
 	}
-	return gc.substitute(ctx, lp, exprToColumn, opt), nil, planChanged
+	return gc.substitute(ctx, lp, exprToColumn, opt), planChanged, nil
 }
 
 // collectGenerateColumn collect the generate column and save them to a map from their expressions to themselves.

--- a/planner/core/rule_generate_column_substitute.go
+++ b/planner/core/rule_generate_column_substitute.go
@@ -37,13 +37,13 @@ type ExprColumnMap map[expression.Expression]*expression.Column
 // an index on c. We need to replace a+1 with c so that we can use the index on c.
 // See also https://dev.mysql.com/doc/refman/8.0/en/generated-column-index-optimizations.html
 func (gc *gcSubstituter) optimize(ctx context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	exprToColumn := make(ExprColumnMap)
 	collectGenerateColumn(lp, exprToColumn)
 	if len(exprToColumn) == 0 {
-		return lp, nil, changedFlag
+		return lp, nil, planChanged
 	}
-	return gc.substitute(ctx, lp, exprToColumn, opt), nil, changedFlag
+	return gc.substitute(ctx, lp, exprToColumn, opt), nil, planChanged
 }
 
 // collectGenerateColumn collect the generate column and save them to a map from their expressions to themselves.

--- a/planner/core/rule_join_elimination.go
+++ b/planner/core/rule_join_elimination.go
@@ -246,9 +246,9 @@ func (o *outerJoinEliminator) doOptimize(p LogicalPlan, aggCols []*expression.Co
 }
 
 func (o *outerJoinEliminator) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	p, err := o.doOptimize(p, nil, nil, opt)
-	return p, err, changedFlag
+	return p, err, planChanged
 }
 
 func (*outerJoinEliminator) name() string {

--- a/planner/core/rule_join_elimination.go
+++ b/planner/core/rule_join_elimination.go
@@ -245,10 +245,10 @@ func (o *outerJoinEliminator) doOptimize(p LogicalPlan, aggCols []*expression.Co
 	return p, nil
 }
 
-func (o *outerJoinEliminator) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (o *outerJoinEliminator) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	p, err := o.doOptimize(p, nil, nil, opt)
-	return p, err, planChanged
+	return p, planChanged, err
 }
 
 func (*outerJoinEliminator) name() string {

--- a/planner/core/rule_join_elimination.go
+++ b/planner/core/rule_join_elimination.go
@@ -245,9 +245,10 @@ func (o *outerJoinEliminator) doOptimize(p LogicalPlan, aggCols []*expression.Co
 	return p, nil
 }
 
-func (o *outerJoinEliminator) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+func (o *outerJoinEliminator) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	p, err := o.doOptimize(p, nil, nil, opt)
-	return p, err
+	return p, err, changedFlag
 }
 
 func (*outerJoinEliminator) name() string {

--- a/planner/core/rule_join_reorder.go
+++ b/planner/core/rule_join_reorder.go
@@ -223,13 +223,13 @@ type joinTypeWithExtMsg struct {
 }
 
 func (s *joinReOrderSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	tracer := &joinReorderTrace{cost: map[string]float64{}, opt: opt}
 	tracer.traceJoinReorder(p)
 	p, err := s.optimizeRecursive(p.SCtx(), p, tracer)
 	tracer.traceJoinReorder(p)
 	appendJoinReorderTraceStep(tracer, p, opt)
-	return p, err, changedFlag
+	return p, err, planChanged
 }
 
 // optimizeRecursive recursively collects join groups and applies join reorder algorithm for each group.

--- a/planner/core/rule_join_reorder.go
+++ b/planner/core/rule_join_reorder.go
@@ -222,14 +222,14 @@ type joinTypeWithExtMsg struct {
 	outerBindCondition []expression.Expression
 }
 
-func (s *joinReOrderSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (s *joinReOrderSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	tracer := &joinReorderTrace{cost: map[string]float64{}, opt: opt}
 	tracer.traceJoinReorder(p)
 	p, err := s.optimizeRecursive(p.SCtx(), p, tracer)
 	tracer.traceJoinReorder(p)
 	appendJoinReorderTraceStep(tracer, p, opt)
-	return p, err, planChanged
+	return p, planChanged, err
 }
 
 // optimizeRecursive recursively collects join groups and applies join reorder algorithm for each group.

--- a/planner/core/rule_join_reorder.go
+++ b/planner/core/rule_join_reorder.go
@@ -222,13 +222,14 @@ type joinTypeWithExtMsg struct {
 	outerBindCondition []expression.Expression
 }
 
-func (s *joinReOrderSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+func (s *joinReOrderSolver) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	tracer := &joinReorderTrace{cost: map[string]float64{}, opt: opt}
 	tracer.traceJoinReorder(p)
 	p, err := s.optimizeRecursive(p.SCtx(), p, tracer)
 	tracer.traceJoinReorder(p)
 	appendJoinReorderTraceStep(tracer, p, opt)
-	return p, err
+	return p, err, changedFlag
 }
 
 // optimizeRecursive recursively collects join groups and applies join reorder algorithm for each group.

--- a/planner/core/rule_max_min_eliminate.go
+++ b/planner/core/rule_max_min_eliminate.go
@@ -37,8 +37,8 @@ type maxMinEliminator struct {
 }
 
 func (a *maxMinEliminator) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
-	return a.eliminateMaxMin(p, opt), nil, changedFlag
+	planChanged := false
+	return a.eliminateMaxMin(p, opt), nil, planChanged
 }
 
 // composeAggsByInnerJoin composes the scalar aggregations by cartesianJoin.

--- a/planner/core/rule_max_min_eliminate.go
+++ b/planner/core/rule_max_min_eliminate.go
@@ -36,9 +36,9 @@ import (
 type maxMinEliminator struct {
 }
 
-func (a *maxMinEliminator) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (a *maxMinEliminator) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
-	return a.eliminateMaxMin(p, opt), nil, planChanged
+	return a.eliminateMaxMin(p, opt), planChanged, nil
 }
 
 // composeAggsByInnerJoin composes the scalar aggregations by cartesianJoin.

--- a/planner/core/rule_max_min_eliminate.go
+++ b/planner/core/rule_max_min_eliminate.go
@@ -36,8 +36,9 @@ import (
 type maxMinEliminator struct {
 }
 
-func (a *maxMinEliminator) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
-	return a.eliminateMaxMin(p, opt), nil
+func (a *maxMinEliminator) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
+	return a.eliminateMaxMin(p, opt), nil, changedFlag
 }
 
 // composeAggsByInnerJoin composes the scalar aggregations by cartesianJoin.

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -61,10 +61,10 @@ const FullRange = -1
 // partitionProcessor is here because it's easier to prune partition after predicate push down.
 type partitionProcessor struct{}
 
-func (s *partitionProcessor) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (s *partitionProcessor) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	p, err := s.rewriteDataSource(lp, opt)
-	return p, err, planChanged
+	return p, planChanged, err
 }
 
 func (s *partitionProcessor) rewriteDataSource(lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -61,9 +61,10 @@ const FullRange = -1
 // partitionProcessor is here because it's easier to prune partition after predicate push down.
 type partitionProcessor struct{}
 
-func (s *partitionProcessor) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+func (s *partitionProcessor) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	p, err := s.rewriteDataSource(lp, opt)
-	return p, err
+	return p, err, changedFlag
 }
 
 func (s *partitionProcessor) rewriteDataSource(lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -62,9 +62,9 @@ const FullRange = -1
 type partitionProcessor struct{}
 
 func (s *partitionProcessor) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	p, err := s.rewriteDataSource(lp, opt)
-	return p, err, changedFlag
+	return p, err, planChanged
 }
 
 func (s *partitionProcessor) rewriteDataSource(lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -43,9 +43,9 @@ type exprPrefixAdder struct {
 }
 
 func (*ppdSolver) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	_, p := lp.PredicatePushDown(nil, opt)
-	return p, nil, changedFlag
+	return p, nil, planChanged
 }
 
 func addSelection(p LogicalPlan, child LogicalPlan, conditions []expression.Expression, chIdx int, opt *logicalOptimizeOp) {

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -42,10 +42,10 @@ type exprPrefixAdder struct {
 	lengths   []int
 }
 
-func (*ppdSolver) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (*ppdSolver) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	_, p := lp.PredicatePushDown(nil, opt)
-	return p, nil, planChanged
+	return p, planChanged, nil
 }
 
 func addSelection(p LogicalPlan, child LogicalPlan, conditions []expression.Expression, chIdx int, opt *logicalOptimizeOp) {

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -42,9 +42,10 @@ type exprPrefixAdder struct {
 	lengths   []int
 }
 
-func (*ppdSolver) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+func (*ppdSolver) optimize(_ context.Context, lp LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	_, p := lp.PredicatePushDown(nil, opt)
-	return p, nil
+	return p, nil, changedFlag
 }
 
 func addSelection(p LogicalPlan, child LogicalPlan, conditions []expression.Expression, chIdx int, opt *logicalOptimizeOp) {

--- a/planner/core/rule_predicate_simplification.go
+++ b/planner/core/rule_predicate_simplification.go
@@ -66,8 +66,8 @@ func findPredicateType(expr expression.Expression) (*expression.Column, predicat
 }
 
 func (*predicateSimplification) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
-	return p.predicateSimplification(opt), nil, changedFlag
+	planChanged := false
+	return p.predicateSimplification(opt), nil, planChanged
 }
 
 func (s *baseLogicalPlan) predicateSimplification(opt *logicalOptimizeOp) LogicalPlan {

--- a/planner/core/rule_predicate_simplification.go
+++ b/planner/core/rule_predicate_simplification.go
@@ -65,8 +65,9 @@ func findPredicateType(expr expression.Expression) (*expression.Column, predicat
 	return nil, otherPredicate
 }
 
-func (*predicateSimplification) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
-	return p.predicateSimplification(opt), nil
+func (*predicateSimplification) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
+	return p.predicateSimplification(opt), nil, changedFlag
 }
 
 func (s *baseLogicalPlan) predicateSimplification(opt *logicalOptimizeOp) LogicalPlan {

--- a/planner/core/rule_predicate_simplification.go
+++ b/planner/core/rule_predicate_simplification.go
@@ -65,9 +65,9 @@ func findPredicateType(expr expression.Expression) (*expression.Column, predicat
 	return nil, otherPredicate
 }
 
-func (*predicateSimplification) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (*predicateSimplification) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
-	return p.predicateSimplification(opt), nil, planChanged
+	return p.predicateSimplification(opt), planChanged, nil
 }
 
 func (s *baseLogicalPlan) predicateSimplification(opt *logicalOptimizeOp) LogicalPlan {

--- a/planner/core/rule_push_down_sequence.go
+++ b/planner/core/rule_push_down_sequence.go
@@ -24,8 +24,8 @@ func (*pushDownSequenceSolver) name() string {
 }
 
 func (pdss *pushDownSequenceSolver) optimize(_ context.Context, lp LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
-	return pdss.recursiveOptimize(nil, lp), nil, changedFlag
+	planChanged := false
+	return pdss.recursiveOptimize(nil, lp), nil, planChanged
 }
 
 func (pdss *pushDownSequenceSolver) recursiveOptimize(pushedSequence *LogicalSequence, lp LogicalPlan) LogicalPlan {

--- a/planner/core/rule_push_down_sequence.go
+++ b/planner/core/rule_push_down_sequence.go
@@ -23,9 +23,9 @@ func (*pushDownSequenceSolver) name() string {
 	return "push_down_sequence"
 }
 
-func (pdss *pushDownSequenceSolver) optimize(_ context.Context, lp LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (pdss *pushDownSequenceSolver) optimize(_ context.Context, lp LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
-	return pdss.recursiveOptimize(nil, lp), nil, planChanged
+	return pdss.recursiveOptimize(nil, lp), planChanged, nil
 }
 
 func (pdss *pushDownSequenceSolver) recursiveOptimize(pushedSequence *LogicalSequence, lp LogicalPlan) LogicalPlan {

--- a/planner/core/rule_push_down_sequence.go
+++ b/planner/core/rule_push_down_sequence.go
@@ -23,8 +23,9 @@ func (*pushDownSequenceSolver) name() string {
 	return "push_down_sequence"
 }
 
-func (pdss *pushDownSequenceSolver) optimize(_ context.Context, lp LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error) {
-	return pdss.recursiveOptimize(nil, lp), nil
+func (pdss *pushDownSequenceSolver) optimize(_ context.Context, lp LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
+	return pdss.recursiveOptimize(nil, lp), nil, changedFlag
 }
 
 func (pdss *pushDownSequenceSolver) recursiveOptimize(pushedSequence *LogicalSequence, lp LogicalPlan) LogicalPlan {

--- a/planner/core/rule_resolve_grouping_expand.go
+++ b/planner/core/rule_resolve_grouping_expand.go
@@ -73,11 +73,11 @@ type resolveExpand struct {
 //
 // Expand operator itself is kind like a projection, while difference is that it has a multi projection list, named as leveled projection.
 func (*resolveExpand) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	// As you see, Expand's leveled projection should be built after all column-prune is done. So we just make generating-leveled-projection
 	// as the last rule of logical optimization, which is more clear. (spark has column prune action before building expand)
 	newLogicalPlan, err := genExpand(p, opt)
-	return newLogicalPlan, err, changedFlag
+	return newLogicalPlan, err, planChanged
 }
 
 func (*resolveExpand) name() string {

--- a/planner/core/rule_resolve_grouping_expand.go
+++ b/planner/core/rule_resolve_grouping_expand.go
@@ -72,10 +72,12 @@ type resolveExpand struct {
 //	                              (upper required)   (grouping sets columns appended)
 //
 // Expand operator itself is kind like a projection, while difference is that it has a multi projection list, named as leveled projection.
-func (*resolveExpand) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+func (*resolveExpand) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	// As you see, Expand's leveled projection should be built after all column-prune is done. So we just make generating-leveled-projection
 	// as the last rule of logical optimization, which is more clear. (spark has column prune action before building expand)
-	return genExpand(p, opt)
+	newLogicalPlan, err := genExpand(p, opt)
+	return newLogicalPlan, err, changedFlag
 }
 
 func (*resolveExpand) name() string {

--- a/planner/core/rule_resolve_grouping_expand.go
+++ b/planner/core/rule_resolve_grouping_expand.go
@@ -72,12 +72,12 @@ type resolveExpand struct {
 //	                              (upper required)   (grouping sets columns appended)
 //
 // Expand operator itself is kind like a projection, while difference is that it has a multi projection list, named as leveled projection.
-func (*resolveExpand) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (*resolveExpand) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	// As you see, Expand's leveled projection should be built after all column-prune is done. So we just make generating-leveled-projection
 	// as the last rule of logical optimization, which is more clear. (spark has column prune action before building expand)
 	newLogicalPlan, err := genExpand(p, opt)
-	return newLogicalPlan, err, planChanged
+	return newLogicalPlan, planChanged, err
 }
 
 func (*resolveExpand) name() string {

--- a/planner/core/rule_result_reorder.go
+++ b/planner/core/rule_result_reorder.go
@@ -40,12 +40,12 @@ type resultReorder struct {
 }
 
 func (rs *resultReorder) optimize(_ context.Context, lp LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	ordered := rs.completeSort(lp)
 	if !ordered {
 		lp = rs.injectSort(lp)
 	}
-	return lp, nil, changedFlag
+	return lp, nil, planChanged
 }
 
 func (rs *resultReorder) completeSort(lp LogicalPlan) bool {

--- a/planner/core/rule_result_reorder.go
+++ b/planner/core/rule_result_reorder.go
@@ -39,13 +39,13 @@ This rule reorders results by modifying or injecting a Sort operator:
 type resultReorder struct {
 }
 
-func (rs *resultReorder) optimize(_ context.Context, lp LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (rs *resultReorder) optimize(_ context.Context, lp LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	ordered := rs.completeSort(lp)
 	if !ordered {
 		lp = rs.injectSort(lp)
 	}
-	return lp, nil, planChanged
+	return lp, planChanged, nil
 }
 
 func (rs *resultReorder) completeSort(lp LogicalPlan) bool {

--- a/planner/core/rule_result_reorder.go
+++ b/planner/core/rule_result_reorder.go
@@ -39,12 +39,13 @@ This rule reorders results by modifying or injecting a Sort operator:
 type resultReorder struct {
 }
 
-func (rs *resultReorder) optimize(_ context.Context, lp LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error) {
+func (rs *resultReorder) optimize(_ context.Context, lp LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
 	ordered := rs.completeSort(lp)
 	if !ordered {
 		lp = rs.injectSort(lp)
 	}
-	return lp, nil
+	return lp, nil, changedFlag
 }
 
 func (rs *resultReorder) completeSort(lp LogicalPlan) bool {

--- a/planner/core/rule_semi_join_rewrite.go
+++ b/planner/core/rule_semi_join_rewrite.go
@@ -25,10 +25,10 @@ import (
 type semiJoinRewriter struct {
 }
 
-func (smj *semiJoinRewriter) optimize(_ context.Context, p LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (smj *semiJoinRewriter) optimize(_ context.Context, p LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
 	newLogicalPlan, err := smj.recursivePlan(p)
-	return newLogicalPlan, err, planChanged
+	return newLogicalPlan, planChanged, err
 }
 
 func (*semiJoinRewriter) name() string {

--- a/planner/core/rule_semi_join_rewrite.go
+++ b/planner/core/rule_semi_join_rewrite.go
@@ -26,9 +26,9 @@ type semiJoinRewriter struct {
 }
 
 func (smj *semiJoinRewriter) optimize(_ context.Context, p LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
+	planChanged := false
 	newLogicalPlan, err := smj.recursivePlan(p)
-	return newLogicalPlan, err, changedFlag
+	return newLogicalPlan, err, planChanged
 }
 
 func (*semiJoinRewriter) name() string {

--- a/planner/core/rule_semi_join_rewrite.go
+++ b/planner/core/rule_semi_join_rewrite.go
@@ -25,8 +25,10 @@ import (
 type semiJoinRewriter struct {
 }
 
-func (smj *semiJoinRewriter) optimize(_ context.Context, p LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error) {
-	return smj.recursivePlan(p)
+func (smj *semiJoinRewriter) optimize(_ context.Context, p LogicalPlan, _ *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
+	newLogicalPlan, err := smj.recursivePlan(p)
+	return newLogicalPlan, err, changedFlag
 }
 
 func (*semiJoinRewriter) name() string {

--- a/planner/core/rule_topn_push_down.go
+++ b/planner/core/rule_topn_push_down.go
@@ -29,8 +29,8 @@ type pushDownTopNOptimizer struct {
 }
 
 func (*pushDownTopNOptimizer) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
-	changedFlag := false
-	return p.pushDownTopN(nil, opt), nil, changedFlag
+	planChanged := false
+	return p.pushDownTopN(nil, opt), nil, planChanged
 }
 
 func (s *baseLogicalPlan) pushDownTopN(topN *LogicalTopN, opt *logicalOptimizeOp) LogicalPlan {

--- a/planner/core/rule_topn_push_down.go
+++ b/planner/core/rule_topn_push_down.go
@@ -28,9 +28,9 @@ import (
 type pushDownTopNOptimizer struct {
 }
 
-func (*pushDownTopNOptimizer) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+func (*pushDownTopNOptimizer) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, bool, error) {
 	planChanged := false
-	return p.pushDownTopN(nil, opt), nil, planChanged
+	return p.pushDownTopN(nil, opt), planChanged, nil
 }
 
 func (s *baseLogicalPlan) pushDownTopN(topN *LogicalTopN, opt *logicalOptimizeOp) LogicalPlan {

--- a/planner/core/rule_topn_push_down.go
+++ b/planner/core/rule_topn_push_down.go
@@ -28,8 +28,9 @@ import (
 type pushDownTopNOptimizer struct {
 }
 
-func (*pushDownTopNOptimizer) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
-	return p.pushDownTopN(nil, opt), nil
+func (*pushDownTopNOptimizer) optimize(_ context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error, bool) {
+	changedFlag := false
+	return p.pushDownTopN(nil, opt), nil, changedFlag
 }
 
 func (s *baseLogicalPlan) pushDownTopN(topN *LogicalTopN, opt *logicalOptimizeOp) LogicalPlan {


### PR DESCRIPTION
### What problem does this PR solve?

This PR mainly add the interaction rule framework in new rule engine. It doesn't be enabled by default.
The interaction rule will be trigger when it satisfies following conditions:
1. The related rule has been trigger and changed the plan
2. The interaction rule is enabled

The `optimizer` interface of logical rule has been changed. This PR add a new bool return value which used to flag whether plan changed or not during this logical rule.
If the logical rule changed the plan, it will return true. 

In this PR, I just add a new framework and not enable the interaction progress. So all of rules plan changed flag is false.

Issue Number: close #43360

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > The basic function of all logical rule has been covered by existing tests. Because this is an architectural adjustment, its correctness can be verified as long as the existing test can pass.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
