### PR TITLE
testkit: fix memtracker leak in testkit

### DIFF
--- a/testkit/BUILD.bazel
+++ b/testkit/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "testkit",
@@ -31,6 +31,7 @@ go_library(
         "//store/driver",
         "//store/mockstore",
         "//testkit/testenv",
+        "//types",
         "//util",
         "//util/breakpoint",
         "//util/chunk",
@@ -50,4 +51,13 @@ go_library(
         "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",
     ],
+)
+
+go_test(
+    name = "testkit_test",
+    timeout = "short",
+    srcs = ["testkit_test.go"],
+    embed = [":testkit"],
+    flaky = True,
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/testkit/testkit_test.go
+++ b/testkit/testkit_test.go
@@ -1,0 +1,34 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testkit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiStatementInTk tests whether statement context will leak with multi-statements in testkit. See #47365
+func TestMultiStatementInTk(t *testing.T) {
+	store := CreateMockStore(t)
+	tk := NewTestKit(t, store)
+	tk.MustExec("use test")
+	require.Len(t, tk.Session().GetSessionVars().MemTracker.GetChildrenForTest(), 0)
+	for i := 0; i < 100; i++ {
+		// should return the first result set
+		tk.MustQuery("select 1;select 2;").Check(Rows("1"))
+		require.Len(t, tk.Session().GetSessionVars().MemTracker.GetChildrenForTest(), 0)
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #47365 

Problem Summary:

Run multiple statements in testkit will cause resource leak. The record set is not closed properly and the memtracker on the statement context is not detached.

### What is changed and how it works?

Drain out and close the record set before run the next statement. This PR doesn't return the resultset of the following statements. It kept the original behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
