### PR TITLE
executor: Fix crash during sort spill

### DIFF
--- a/util/chunk/row_container.go
+++ b/util/chunk/row_container.go
@@ -78,7 +78,7 @@ func (m *mutexForRowContainer) RUnlock() {
 	m.rLock.RUnlock()
 }
 
-type SpillHelper interface {
+type spillHelper interface {
 	preSpillAction()
 	hasEnoughDataToSpill(t *memory.Tracker) bool
 }
@@ -124,7 +124,7 @@ func (c *RowContainer) ShallowCopyWithNewMutex() *RowContainer {
 	return &newRC
 }
 
-func (c *RowContainer) preSpillAction() {
+func (_ *RowContainer) preSpillAction() {
 }
 
 // SpillToDisk spills data to disk. This function may be called in parallel.
@@ -270,7 +270,7 @@ func (c *RowContainer) AllocChunk() (chk *Chunk) {
 func (c *RowContainer) GetChunk(chkIdx int) (*Chunk, error) {
 	c.m.RLock()
 	defer c.m.RUnlock()
-	return c.GetChunk(chkIdx)
+	return c.getChunk(chkIdx)
 }
 
 func (c *RowContainer) getChunk(chkIdx int) (*Chunk, error) {
@@ -373,7 +373,7 @@ func (c *RowContainer) ActionSpillForTest() *SpillDiskAction {
 	return c.actionSpill
 }
 
-func (c *RowContainer) hasEnoughDataToSpill(_ *memory.Tracker) bool {
+func (_ *RowContainer) hasEnoughDataToSpill(_ *memory.Tracker) bool {
 	// should check the memory consumed as SortAndSpillDiskAction?
 	return true
 }
@@ -429,7 +429,7 @@ func (a *SpillDiskAction) Action(t *memory.Tracker) {
 	a.action(t, a.c)
 }
 
-func (a *SpillDiskAction) action(t *memory.Tracker, spillHelper SpillHelper) {
+func (a *SpillDiskAction) action(t *memory.Tracker, spillHelper spillHelper) {
 	a.m.Lock()
 	defer a.m.Unlock()
 
@@ -601,6 +601,7 @@ func (c *SortedRowContainer) sort() {
 	sort.Slice(c.ptrM.rowPtrs, c.keyColumnsLess)
 }
 
+// SpillToDisk spills data to disk. This function may be called in parallel.
 func (c *SortedRowContainer) SpillToDisk(preSpill func()) {
 	c.ptrM.Lock()
 	defer c.ptrM.Unlock()

--- a/util/chunk/row_container.go
+++ b/util/chunk/row_container.go
@@ -124,7 +124,7 @@ func (c *RowContainer) ShallowCopyWithNewMutex() *RowContainer {
 	return &newRC
 }
 
-func (_ *RowContainer) preSpillAction() {
+func (*RowContainer) preSpillAction() {
 }
 
 // SpillToDisk spills data to disk. This function may be called in parallel.
@@ -373,7 +373,7 @@ func (c *RowContainer) ActionSpillForTest() *SpillDiskAction {
 	return c.actionSpill
 }
 
-func (_ *RowContainer) hasEnoughDataToSpill(_ *memory.Tracker) bool {
+func (*RowContainer) hasEnoughDataToSpill(_ *memory.Tracker) bool {
 	// should check the memory consumed as SortAndSpillDiskAction?
 	return true
 }

--- a/util/chunk/row_container_test.go
+++ b/util/chunk/row_container_test.go
@@ -75,7 +75,7 @@ func TestSel(t *testing.T) {
 		require.Equal(t, n-1, i)
 	}
 	checkByIter(NewMultiIterator(NewIterator4RowContainer(rc), NewIterator4Chunk(chk)))
-	rc.SpillToDisk(rc)
+	rc.SpillToDisk(rc.preSpill)
 	err := rc.m.records.spillError
 	require.NoError(t, err)
 	require.True(t, rc.AlreadySpilledSafeForTest())
@@ -378,7 +378,7 @@ func TestRowContainerReaderInDisk(t *testing.T) {
 	})
 
 	rc, allRows := insertBytesRowsIntoRowContainer(t, 16, 16)
-	rc.SpillToDisk(rc)
+	rc.SpillToDisk(rc.preSpill)
 
 	reader := NewRowContainerReader(rc)
 	defer reader.Close()
@@ -399,7 +399,7 @@ func TestCloseRowContainerReader(t *testing.T) {
 	})
 
 	rc, allRows := insertBytesRowsIntoRowContainer(t, 16, 16)
-	rc.SpillToDisk(rc)
+	rc.SpillToDisk(rc.preSpill)
 
 	// read 8.5 of these chunks
 	reader := NewRowContainerReader(rc)
@@ -443,7 +443,7 @@ func TestConcurrentSpillWithRowContainerReader(t *testing.T) {
 			}
 		}
 	}()
-	rc.SpillToDisk(rc)
+	rc.SpillToDisk(rc.preSpill)
 	wg.Wait()
 }
 
@@ -465,7 +465,7 @@ func TestReadAfterSpillWithRowContainerReader(t *testing.T) {
 			reader.Next()
 		}
 	}
-	rc.SpillToDisk(rc)
+	rc.SpillToDisk(rc.preSpill)
 	for i := 8; i < 16; i++ {
 		for j := 0; j < 1024; j++ {
 			row := reader.Current()
@@ -536,7 +536,7 @@ func benchmarkRowContainerReaderInDiskWithRowLength(b *testing.B, rowLength int)
 
 	// create a row container which stores the data in disk
 	rc := NewRowContainer(fields, 1<<10)
-	rc.SpillToDisk(rc)
+	rc.SpillToDisk(rc.preSpill)
 
 	// insert `b.N * 1<<10` rows (`b.N` chunks) into the rc
 	for i := 0; i < b.N; i++ {

--- a/util/chunk/row_container_test.go
+++ b/util/chunk/row_container_test.go
@@ -188,6 +188,41 @@ func TestSortedRowContainerSortSpillAction(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestPanicDuringSortedRowContainerSpill(t *testing.T) {
+	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
+	byItemsDesc := []bool{false}
+	keyColumns := []int{0}
+	keyCmpFuncs := []CompareFunc{cmpInt64}
+	sz := 20
+	rc := NewSortedRowContainer(fields, sz, byItemsDesc, keyColumns, keyCmpFuncs)
+
+	chk := NewChunkWithCapacity(fields, sz)
+	for i := 0; i < sz; i++ {
+		chk.AppendInt64(0, int64(i))
+	}
+	var tracker *memory.Tracker
+	var err error
+	tracker = rc.GetMemTracker()
+	tracker.SetBytesLimit(chk.MemoryUsage() + int64(8*chk.NumRows()) + 1)
+	tracker.FallbackOldAndSetNewAction(rc.ActionSpillForTest())
+	require.False(t, rc.AlreadySpilledSafeForTest())
+	err = rc.Add(chk)
+	require.NoError(t, err)
+	rc.actionSpill.WaitForTest()
+	require.False(t, rc.AlreadySpilledSafeForTest())
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/util/chunk/errorDuringSortRowContainer", "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/util/chunk/errorDuringSortRowContainer"))
+	}()
+	err = rc.Add(chk)
+	require.NoError(t, err)
+	rc.actionSpill.WaitForTest()
+
+	_, err = rc.GetRow(RowPtr{})
+	require.EqualError(t, err, "sort meet error")
+}
+
 func TestRowContainerResetAndAction(t *testing.T) {
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
 	sz := 20

--- a/util/chunk/row_container_test.go
+++ b/util/chunk/row_container_test.go
@@ -75,7 +75,7 @@ func TestSel(t *testing.T) {
 		require.Equal(t, n-1, i)
 	}
 	checkByIter(NewMultiIterator(NewIterator4RowContainer(rc), NewIterator4Chunk(chk)))
-	rc.SpillToDisk(rc.preSpill)
+	rc.SpillToDisk(rc.preSpillAction)
 	err := rc.m.records.spillError
 	require.NoError(t, err)
 	require.True(t, rc.AlreadySpilledSafeForTest())
@@ -378,7 +378,7 @@ func TestRowContainerReaderInDisk(t *testing.T) {
 	})
 
 	rc, allRows := insertBytesRowsIntoRowContainer(t, 16, 16)
-	rc.SpillToDisk(rc.preSpill)
+	rc.SpillToDisk(rc.preSpillAction)
 
 	reader := NewRowContainerReader(rc)
 	defer reader.Close()
@@ -399,7 +399,7 @@ func TestCloseRowContainerReader(t *testing.T) {
 	})
 
 	rc, allRows := insertBytesRowsIntoRowContainer(t, 16, 16)
-	rc.SpillToDisk(rc.preSpill)
+	rc.SpillToDisk(rc.preSpillAction)
 
 	// read 8.5 of these chunks
 	reader := NewRowContainerReader(rc)
@@ -443,7 +443,7 @@ func TestConcurrentSpillWithRowContainerReader(t *testing.T) {
 			}
 		}
 	}()
-	rc.SpillToDisk(rc.preSpill)
+	rc.SpillToDisk(rc.preSpillAction)
 	wg.Wait()
 }
 
@@ -465,7 +465,7 @@ func TestReadAfterSpillWithRowContainerReader(t *testing.T) {
 			reader.Next()
 		}
 	}
-	rc.SpillToDisk(rc.preSpill)
+	rc.SpillToDisk(rc.preSpillAction)
 	for i := 8; i < 16; i++ {
 		for j := 0; j < 1024; j++ {
 			row := reader.Current()
@@ -536,7 +536,7 @@ func benchmarkRowContainerReaderInDiskWithRowLength(b *testing.B, rowLength int)
 
 	// create a row container which stores the data in disk
 	rc := NewRowContainer(fields, 1<<10)
-	rc.SpillToDisk(rc.preSpill)
+	rc.SpillToDisk(rc.preSpillAction)
 
 	// insert `b.N * 1<<10` rows (`b.N` chunks) into the rc
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47538

Problem Summary:

### What is changed and how it works?
1. Add a new interface `SpillHelper` and use a common function `(a *SpillDiskAction) action(t *memory.Tracker, spillHelper SpillHelper)` to unify the code of `(a *SpillDiskAction) Action(t *memory.Tracker)` and `(a *SortAndSpillDiskAction) Action(t *memory.Tracker)`
2. Rename `(c *SortedRowContainer) sortAndSpillToDisk()` to `(c *SortedRowContainer) SpillToDisk()`, hide `Sort()` into `SpillToDisk()`
3. Let `Sort` hold both of `ptrM.Lock()` and `c.m.RLock()`
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
