### PR TITLE
importinto: switch tikv mode on write&ingest step

### DIFF
--- a/disttask/importinto/BUILD.bazel
+++ b/disttask/importinto/BUILD.bazel
@@ -92,7 +92,7 @@ go_test(
     embed = [":importinto"],
     flaky = True,
     race = "on",
-    shard_count = 13,
+    shard_count = 14,
     deps = [
         "//br/pkg/lightning/backend",
         "//br/pkg/lightning/backend/external",

--- a/disttask/importinto/dispatcher.go
+++ b/disttask/importinto/dispatcher.go
@@ -150,11 +150,15 @@ func (dsp *ImportDispatcherExt) OnTick(ctx context.Context, task *proto.Task) {
 	dsp.registerTask(ctx, task)
 }
 
+func (*ImportDispatcherExt) isImporting2TiKV(task *proto.Task) bool {
+	return task.Step == StepImport || task.Step == StepWriteAndIngest
+}
+
 func (dsp *ImportDispatcherExt) switchTiKVMode(ctx context.Context, task *proto.Task) {
 	dsp.updateCurrentTask(task)
 	// only import step need to switch to IMPORT mode,
 	// If TiKV is in IMPORT mode during checksum, coprocessor will time out.
-	if dsp.disableTiKVImportMode.Load() || task.Step != StepImport {
+	if dsp.disableTiKVImportMode.Load() || !dsp.isImporting2TiKV(task) {
 		return
 	}
 

--- a/disttask/importinto/dispatcher_test.go
+++ b/disttask/importinto/dispatcher_test.go
@@ -174,3 +174,12 @@ func (s *importIntoSuite) TestGetStepOfEncode() {
 	s.Equal(StepImport, getStepOfEncode(false))
 	s.Equal(StepEncodeAndSort, getStepOfEncode(true))
 }
+
+func TestIsImporting2TiKV(t *testing.T) {
+	ext := &ImportDispatcherExt{}
+	require.False(t, ext.isImporting2TiKV(&proto.Task{Step: StepEncodeAndSort}))
+	require.False(t, ext.isImporting2TiKV(&proto.Task{Step: StepMergeSort}))
+	require.False(t, ext.isImporting2TiKV(&proto.Task{Step: StepPostProcess}))
+	require.True(t, ext.isImporting2TiKV(&proto.Task{Step: StepImport}))
+	require.True(t, ext.isImporting2TiKV(&proto.Task{Step: StepWriteAndIngest}))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47546

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
add some wait when write&ingest tikv, run global sort integration test, see we switched tikv mode
```
[2023/10/11 15:57:13.589 +08:00] [INFO] [tikv_mode.go:60] ["switch tikv mode"] [task-id=1] [mode=Import]
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
