### PR TITLE
statistics: add branch check for BinarySearchRemoveVal

### DIFF
--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -287,6 +287,12 @@ func (hg *Histogram) BucketToString(bktID, idxCols int) string {
 // BinarySearchRemoveVal removes the value from the TopN using binary search.
 func (hg *Histogram) BinarySearchRemoveVal(valCntPairs TopNMeta) {
 	lowIdx, highIdx := 0, hg.Len()-1
+	if cmpResult := bytes.Compare(hg.Bounds.Column(0).GetRaw(highIdx*2+1), valCntPairs.Encoded); cmpResult < 0 {
+		return
+	}
+	if cmpResult := bytes.Compare(hg.Bounds.Column(0).GetRaw(lowIdx), valCntPairs.Encoded); cmpResult > 0 {
+		return
+	}
 	for lowIdx <= highIdx {
 		midIdx := (lowIdx + highIdx) / 2
 		cmpResult := bytes.Compare(hg.Bounds.Column(0).GetRaw(midIdx*2), valCntPairs.Encoded)

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -287,11 +287,14 @@ func (hg *Histogram) BucketToString(bktID, idxCols int) string {
 // BinarySearchRemoveVal removes the value from the TopN using binary search.
 func (hg *Histogram) BinarySearchRemoveVal(valCntPairs TopNMeta) {
 	lowIdx, highIdx := 0, hg.Len()-1
-	if cmpResult := bytes.Compare(hg.Bounds.Column(0).GetRaw(highIdx*2+1), valCntPairs.Encoded); cmpResult < 0 {
-		return
-	}
-	if cmpResult := bytes.Compare(hg.Bounds.Column(0).GetRaw(lowIdx), valCntPairs.Encoded); cmpResult > 0 {
-		return
+	// if hg is too small, we don't need to check the branch. because the cost is more than binary search.
+	if hg.Len() > 4 {
+		if cmpResult := bytes.Compare(hg.Bounds.Column(0).GetRaw(highIdx*2+1), valCntPairs.Encoded); cmpResult < 0 {
+			return
+		}
+		if cmpResult := bytes.Compare(hg.Bounds.Column(0).GetRaw(lowIdx), valCntPairs.Encoded); cmpResult > 0 {
+			return
+		}
 	}
 	for lowIdx <= highIdx {
 		midIdx := (lowIdx + highIdx) / 2


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #47275

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

before:

```
$ go test -run=^$ -bench=BenchmarkMergePartTopN2GlobalTopNWithHists -benchmem github.com/pingcap/tidb/statistics/handle/globalstats
goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/statistics/handle/globalstats
BenchmarkMergePartTopN2GlobalTopNWithHists/Size100-8               79554             13026 ns/op             120 B/op          2 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size1000-8               9308            129048 ns/op             120 B/op          2 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size10000-8               710           1495563 ns/op             120 B/op          2 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size100000-8               60          18915999 ns/op             120 B/op          2 allocs/op

```

after

```
$ go test -run=^$ -bench=BenchmarkMergePartTopN2GlobalTopNWithHists -benchmem github.com/pingcap/tidb/statistics/handle/globalstats
goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/statistics/handle/globalstats
BenchmarkMergePartTopN2GlobalTopNWithHists/Size100-8               93171             12890 ns/op             120 B/op          2 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size1000-8               9405            127764 ns/op             120 B/op          2 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size10000-8               876           1357216 ns/op             120 B/op          2 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size100000-8               61          18243436 ns/op             120 B/op          2 allocs/op
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
