### PR TITLE
statistics: avoid copy twice when to decode the topn

### DIFF
--- a/statistics/cmsketch.go
+++ b/statistics/cmsketch.go
@@ -440,20 +440,26 @@ func DecodeCMSketchAndTopN(data []byte, topNRows []chunk.Row) (*CMSketch, *TopN,
 	if data == nil && len(topNRows) == 0 {
 		return nil, nil, nil
 	}
-	topn := DecodeTopN(topNRows)
+	pbTopN := make([]*tipb.CMSketchTopN, 0, len(topNRows))
+	for _, row := range topNRows {
+		data := make([]byte, len(row.GetBytes(0)))
+		copy(data, row.GetBytes(0))
+		pbTopN = append(pbTopN, &tipb.CMSketchTopN{
+			Data:  data,
+			Count: row.GetUint64(1),
+		})
+	}
 	if len(data) == 0 {
-		return nil, topn, nil
+		return nil, TopNFromProto(pbTopN), nil
 	}
 	p := &tipb.CMSketch{}
 	err := p.Unmarshal(data)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	cms, err := DecodeCMSketch(data)
-	if err != nil {
-		return nil, topn, err
-	}
-	return cms, topn, nil
+	p.TopN = pbTopN
+	cm, topN := CMSketchAndTopNFromProto(p)
+	return cm, topN, nil
 }
 
 // DecodeTopN decodes a TopN from the given byte slice.

--- a/statistics/cmsketch.go
+++ b/statistics/cmsketch.go
@@ -464,16 +464,14 @@ func DecodeCMSketchAndTopN(data []byte, topNRows []chunk.Row) (*CMSketch, *TopN,
 
 // DecodeTopN decodes a TopN from the given byte slice.
 func DecodeTopN(topNRows []chunk.Row) (*TopN, error) {
-	pbTopN := make([]*tipb.CMSketchTopN, 0, len(topNRows))
+	topN := NewTopN(len(topNRows))
 	for _, row := range topNRows {
 		data := make([]byte, len(row.GetBytes(0)))
 		copy(data, row.GetBytes(0))
-		pbTopN = append(pbTopN, &tipb.CMSketchTopN{
-			Data:  data,
-			Count: row.GetUint64(1),
-		})
+		topN.AppendTopN(data, row.GetUint64(1))
 	}
-	return TopNFromProto(pbTopN), nil
+	topN.Sort()
+	return topN, nil
 }
 
 // DecodeCMSketch encodes the given CMSketch to byte slice.

--- a/statistics/handle/storage/read.go
+++ b/statistics/handle/storage/read.go
@@ -133,7 +133,7 @@ func TopNFromStorage(sctx sessionctx.Context, tblID int64, isIndex int, histID i
 	if err != nil || len(rows) == 0 {
 		return nil, err
 	}
-	return statistics.DecodeTopN(rows)
+	return statistics.DecodeTopN(rows), nil
 }
 
 // FMSketchFromStorage reads FMSketch from storage


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #47275

Problem Summary:

### What is changed and how it works?

the first one is in the DecodeTopN. DecodeTopN called TopNFromProto. it will copy again.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
