### PR TITLE
lightning/import: enlarge default checksum timeout

### DIFF
--- a/br/pkg/lightning/backend/local/checksum.go
+++ b/br/pkg/lightning/backend/local/checksum.go
@@ -55,10 +55,14 @@ var (
 	MinDistSQLScanConcurrency = 4
 
 	// DefaultBackoffWeight is the default value of tidb_backoff_weight for checksum.
-	// when TiKV client encounters an error of "region not leader", it will keep retrying every 500 ms.
-	// If it still fails after 2 * 20 = 40 seconds, it will return "region unavailable".
-	// If we increase the BackOffWeight to 6, then the TiKV client will keep retrying for 120 seconds.
-	DefaultBackoffWeight = 3 * tikvstore.DefBackOffWeight
+	// RegionRequestSender will retry within a maxSleep time, default is 2 * 20 = 40 seconds.
+	// When TiKV client encounters an error of "region not leader", it will keep
+	// retrying every 500 ms, if it still fails after maxSleep, it will return "region unavailable".
+	// When there are many pending compaction bytes, TiKV might not respond within 1m,
+	// and report "rpcError:wait recvLoop timeout,timeout:1m0s", and retry might
+	// time out again.
+	// so we enlarge it to 30 * 20 = 10 minutes.
+	DefaultBackoffWeight = 15 * tikvstore.DefBackOffWeight
 )
 
 // RemoteChecksum represents a checksum result got from tidb.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47566

Problem Summary:

### What is changed and how it works?
	// When there are many pending compaction bytes, TiKV might not respond within 1m,
	// and report "rpcError:wait recvLoop timeout,timeout:1m0s", and retry might
	// time out again.
	// so we enlarge it to 30 * 20 = 10 minutes.

for import into, user can workaround by set session var `tidb_backoff_weight`, but have to waste a round of import

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below) 
 run import into integration test, check that the weight is current value
- [ ] No need to test
  > - only enlarge default timeout setting.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
