### PR TITLE
disttask: only start dispatcherManager when enable_dist_task

### DIFF
--- a/disttask/framework/dispatcher/dispatcher.go
+++ b/disttask/framework/dispatcher/dispatcher.go
@@ -703,6 +703,7 @@ func (d *BaseDispatcher) VerifyTaskStateTransform(from, to string) bool {
 	return VerifyTaskStateTransformImpl(from, to)
 }
 
+// VerifyTaskStateTransformImpl verifies whether the task state transform is valid. Exported for tests.
 func VerifyTaskStateTransformImpl(from, to string) bool {
 	rules := map[string][]string{
 		proto.TaskStatePending: {

--- a/disttask/framework/dispatcher/dispatcher_test.go
+++ b/disttask/framework/dispatcher/dispatcher_test.go
@@ -488,7 +488,7 @@ func TestVerifyTaskStateTransform(t *testing.T) {
 		{proto.TaskStateCanceled, proto.TaskStateRunning, false},
 	}
 	for _, tc := range testCases {
-		require.Equal(t, tc.expect, dispatcher.VerifyTaskStateTransform(tc.oldState, tc.newState))
+		require.Equal(t, tc.expect, dispatcher.VerifyTaskStateTransformImpl(tc.oldState, tc.newState))
 	}
 }
 

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1518,7 +1518,7 @@ func (do *Domain) distTaskFrameworkLoop(ctx context.Context, taskManager *storag
 			stopDispatchIfNeeded()
 			return
 		case <-ticker.C:
-			if do.ddl.OwnerManager().IsOwner() {
+			if do.ddl.OwnerManager().IsOwner() && variable.EnableDistTask.Load() {
 				startDispatchIfNeeded()
 			} else {
 				stopDispatchIfNeeded()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46258

Problem Summary:
It's unnecessary to start dispatcherManager when tidb_enable_dist_task=0.
### What is changed and how it works?
1. Only start dispatcherManager when tidb_enable_dist_task=1.
2. Refine some logs.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
