### PR TITLE
executor: Fix crash during sort spill

### DIFF
--- a/executor/sort.go
+++ b/executor/sort.go
@@ -238,7 +238,10 @@ func (e *SortExec) fetchRowChunks(ctx context.Context) error {
 		}
 	})
 	if e.rowChunks.NumRow() > 0 {
-		e.rowChunks.Sort()
+		err := e.rowChunks.Sort()
+		if err != nil {
+			return err
+		}
 		e.partitionList = append(e.partitionList, e.rowChunks)
 	}
 	return nil

--- a/util/chunk/row_container.go
+++ b/util/chunk/row_container.go
@@ -373,9 +373,6 @@ func (c *RowContainer) ActionSpillForTest() *SpillDiskAction {
 	return c.actionSpill
 }
 
-// SpillDiskAction implements memory.ActionOnExceed for chunk.List. If
-// the memory quota of a query is exceeded, SpillDiskAction.Action is
-// triggered.
 type baseSpillDiskAction struct {
 	memory.BaseOOMAction
 	m    sync.Mutex
@@ -388,6 +385,9 @@ type baseSpillDiskAction struct {
 	testWg             sync.WaitGroup
 }
 
+// SpillDiskAction implements memory.ActionOnExceed for chunk.List. If
+// the memory quota of a query is exceeded, SpillDiskAction.Action is
+// triggered.
 type SpillDiskAction struct {
 	c *RowContainer
 	*baseSpillDiskAction

--- a/util/chunk/row_container.go
+++ b/util/chunk/row_container.go
@@ -643,7 +643,7 @@ func (c *SortedRowContainer) ActionSpill() *SortAndSpillDiskAction {
 	if c.actionSpill == nil {
 		c.actionSpill = &SortAndSpillDiskAction{
 			c:                   c,
-			baseSpillDiskAction: &baseSpillDiskAction{cond: spillStatusCond{sync.NewCond(new(sync.Mutex)), notSpilled}},
+			baseSpillDiskAction: c.RowContainer.ActionSpill().baseSpillDiskAction,
 		}
 	}
 	return c.actionSpill
@@ -652,16 +652,8 @@ func (c *SortedRowContainer) ActionSpill() *SortAndSpillDiskAction {
 // ActionSpillForTest returns a SortAndSpillDiskAction for sorting and spilling over to disk for test.
 func (c *SortedRowContainer) ActionSpillForTest() *SortAndSpillDiskAction {
 	c.actionSpill = &SortAndSpillDiskAction{
-		c: c,
-		baseSpillDiskAction: &baseSpillDiskAction{
-			testSyncInputFunc: func() {
-				c.actionSpill.testWg.Add(1)
-			},
-			testSyncOutputFunc: func() {
-				c.actionSpill.testWg.Done()
-			},
-			cond: spillStatusCond{sync.NewCond(new(sync.Mutex)), notSpilled},
-		},
+		c:                   c,
+		baseSpillDiskAction: c.RowContainer.ActionSpillForTest().baseSpillDiskAction,
 	}
 	return c.actionSpill
 }

--- a/util/chunk/row_container.go
+++ b/util/chunk/row_container.go
@@ -492,7 +492,8 @@ type SortedRowContainer struct {
 		// rowPtrs store the chunk index and row index for each row.
 		// rowPtrs != nil indicates the pointer is initialized and sorted.
 		// It will get an ErrCannotAddBecauseSorted when trying to insert data if rowPtrs != nil.
-		rowPtrs []RowPtr
+		rowPtrs   []RowPtr
+		sortError error
 	}
 
 	ByItemsDesc []bool
@@ -502,7 +503,7 @@ type SortedRowContainer struct {
 	keyCmpFuncs []CompareFunc
 
 	actionSpill *SortAndSpillDiskAction
-	//memTracker  *memory.Tracker
+	memTracker  *memory.Tracker
 
 	// Sort is a time-consuming operation, we need to set a checkpoint to detect
 	// the outside signal periodically.
@@ -525,6 +526,7 @@ func (c *SortedRowContainer) Close() error {
 	defer c.ptrM.Unlock()
 	c.GetMemTracker().Consume(int64(-8 * c.NumRow()))
 	c.ptrM.rowPtrs = nil
+	c.ptrM.sortError = nil
 	return c.RowContainer.Close()
 }
 
@@ -574,7 +576,8 @@ func (c *SortedRowContainer) Sort() (ret error) {
 	ret = nil
 	defer func() {
 		if r := recover(); r != nil {
-			ret = fmt.Errorf("%v", r)
+			c.ptrM.sortError = fmt.Errorf("%v", r)
+			ret = c.ptrM.sortError
 		}
 	}()
 	if c.ptrM.rowPtrs != nil {
@@ -626,6 +629,9 @@ func (c *SortedRowContainer) Add(chk *Chunk) (err error) {
 func (c *SortedRowContainer) GetSortedRow(idx int) (Row, error) {
 	c.ptrM.RLock()
 	defer c.ptrM.RUnlock()
+	if c.ptrM.sortError != nil {
+		return Row{}, c.ptrM.sortError
+	}
 	ptr := c.ptrM.rowPtrs[idx]
 	return c.RowContainer.GetRow(ptr)
 }
@@ -634,6 +640,9 @@ func (c *SortedRowContainer) GetSortedRow(idx int) (Row, error) {
 func (c *SortedRowContainer) GetSortedRowAndAlwaysAppendToChunk(idx int, chk *Chunk) (Row, *Chunk, error) {
 	c.ptrM.RLock()
 	defer c.ptrM.RUnlock()
+	if c.ptrM.sortError != nil {
+		return Row{}, nil, c.ptrM.sortError
+	}
 	ptr := c.ptrM.rowPtrs[idx]
 	return c.RowContainer.GetRowAndAlwaysAppendToChunk(ptr, chk)
 }

--- a/util/chunk/row_container.go
+++ b/util/chunk/row_container.go
@@ -130,7 +130,6 @@ func (c *RowContainer) SpillToDisk() {
 }
 
 func (*RowContainer) hasEnoughDataToSpill(_ *memory.Tracker) bool {
-	// should check the memory consumed as SortAndSpillDiskAction?
 	return true
 }
 
@@ -600,6 +599,7 @@ func (c *SortedRowContainer) Sort() (ret error) {
 	return
 }
 
+// SpillToDisk spills data to disk. This function may be called in parallel.
 func (c *SortedRowContainer) SpillToDisk() {
 	err := c.Sort()
 	c.RowContainer.spillToDisk(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47538

Problem Summary:

### What is changed and how it works?
- Add base struct `baseSpillDiskAction` for `SpillDiskAction` and `SortAndSpillDiskAction`, so `SortAndSpillDiskAction` don't have to hold a useless `RowContainer`
- Add a new interface SpillHelper and use a common function (a *baseSpillDiskAction) action(t *memory.Tracker, spillHelper SpillHelper) to unify the code of (a *SpillDiskAction) Action(t *memory.Tracker) and (a *SortAndSpillDiskAction) Action(t *memory.Tracker)
- Add recover function in `c *SortedRowContainer) Sort()` to avoid panic
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
