### PR TITLE
planner: capsulate stats cache behind an interface

### DIFF
--- a/domain/domain_sysvars.go
+++ b/domain/domain_sysvars.go
@@ -43,6 +43,10 @@ func (do *Domain) initDomainSysVars() {
 
 // setStatsCacheCapacity sets statsCache cap
 func (do *Domain) setStatsCacheCapacity(c int64) {
+	statsHandle := do.StatsHandle()
+	if statsHandle == nil { // from test
+		return
+	}
 	do.StatsHandle().SetStatsCacheCapacity(c)
 }
 

--- a/statistics/handle/bootstrap.go
+++ b/statistics/handle/bootstrap.go
@@ -16,6 +16,7 @@ package handle
 
 import (
 	"context"
+	"github.com/pingcap/tidb/statistics/handle/cache"
 	"strconv"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
-	"github.com/pingcap/tidb/statistics/handle/cache"
 	"github.com/pingcap/tidb/statistics/handle/util"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -36,7 +36,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (h *Handle) initStatsMeta4Chunk(is infoschema.InfoSchema, cache *cache.StatsCache, iter *chunk.Iterator4Chunk) {
+func (h *Handle) initStatsMeta4Chunk(is infoschema.InfoSchema, cache util.StatsCache, iter *chunk.Iterator4Chunk) {
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		physicalID := row.GetInt64(1)
 		// The table is read-only. Please do not modify it.
@@ -63,7 +63,7 @@ func (h *Handle) initStatsMeta4Chunk(is infoschema.InfoSchema, cache *cache.Stat
 	}
 }
 
-func (h *Handle) initStatsMeta(is infoschema.InfoSchema) (*cache.StatsCache, error) {
+func (h *Handle) initStatsMeta(is infoschema.InfoSchema) (util.StatsCache, error) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
 	sql := "select HIGH_PRIORITY version, table_id, modify_count, count from mysql.stats_meta"
 	rc, err := util.Exec(h.initStatsCtx, sql)
@@ -71,7 +71,7 @@ func (h *Handle) initStatsMeta(is infoschema.InfoSchema) (*cache.StatsCache, err
 		return nil, errors.Trace(err)
 	}
 	defer terror.Call(rc.Close)
-	tables, err := cache.NewStatsCache()
+	tables, err := cache.NewStatsCacheImpl()
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (h *Handle) initStatsMeta(is infoschema.InfoSchema) (*cache.StatsCache, err
 	return tables, nil
 }
 
-func (h *Handle) initStatsHistograms4ChunkLite(is infoschema.InfoSchema, cache *cache.StatsCache, iter *chunk.Iterator4Chunk) {
+func (h *Handle) initStatsHistograms4ChunkLite(is infoschema.InfoSchema, cache util.StatsCache, iter *chunk.Iterator4Chunk) {
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		tblID := row.GetInt64(0)
 		table, ok := cache.Get(tblID)
@@ -161,7 +161,7 @@ func (h *Handle) initStatsHistograms4ChunkLite(is infoschema.InfoSchema, cache *
 	}
 }
 
-func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache *cache.StatsCache, iter *chunk.Iterator4Chunk) {
+func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache util.StatsCache, iter *chunk.Iterator4Chunk) {
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		tblID, statsVer := row.GetInt64(0), row.GetInt64(8)
 		table, ok := cache.Get(tblID)
@@ -231,7 +231,7 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache *cach
 	}
 }
 
-func (h *Handle) initStatsHistogramsLite(is infoschema.InfoSchema, cache *cache.StatsCache) error {
+func (h *Handle) initStatsHistogramsLite(is infoschema.InfoSchema, cache util.StatsCache) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
 	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, distinct_count, version, null_count, tot_col_size, stats_ver, correlation, flag, last_analyze_pos from mysql.stats_histograms"
 	rc, err := util.Exec(h.initStatsCtx, sql)
@@ -254,7 +254,7 @@ func (h *Handle) initStatsHistogramsLite(is infoschema.InfoSchema, cache *cache.
 	return nil
 }
 
-func (h *Handle) initStatsHistograms(is infoschema.InfoSchema, cache *cache.StatsCache) error {
+func (h *Handle) initStatsHistograms(is infoschema.InfoSchema, cache util.StatsCache) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
 	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, distinct_count, version, null_count, cm_sketch, tot_col_size, stats_ver, correlation, flag, last_analyze_pos from mysql.stats_histograms"
 	rc, err := util.Exec(h.initStatsCtx, sql)
@@ -277,7 +277,7 @@ func (h *Handle) initStatsHistograms(is infoschema.InfoSchema, cache *cache.Stat
 	return nil
 }
 
-func (*Handle) initStatsTopN4Chunk(cache *cache.StatsCache, iter *chunk.Iterator4Chunk) {
+func (*Handle) initStatsTopN4Chunk(cache util.StatsCache, iter *chunk.Iterator4Chunk) {
 	affectedIndexes := make(map[*statistics.Index]struct{})
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		table, ok := cache.Get(row.GetInt64(0))
@@ -303,7 +303,7 @@ func (*Handle) initStatsTopN4Chunk(cache *cache.StatsCache, iter *chunk.Iterator
 	}
 }
 
-func (h *Handle) initStatsTopN(cache *cache.StatsCache) error {
+func (h *Handle) initStatsTopN(cache util.StatsCache) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
 	sql := "select HIGH_PRIORITY table_id, hist_id, value, count from mysql.stats_top_n where is_index = 1"
 	rc, err := util.Exec(h.initStatsCtx, sql)
@@ -326,7 +326,7 @@ func (h *Handle) initStatsTopN(cache *cache.StatsCache) error {
 	return nil
 }
 
-func (*Handle) initStatsFMSketch4Chunk(cache *cache.StatsCache, iter *chunk.Iterator4Chunk) {
+func (*Handle) initStatsFMSketch4Chunk(cache util.StatsCache, iter *chunk.Iterator4Chunk) {
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		table, ok := cache.Get(row.GetInt64(0))
 		if !ok {
@@ -353,7 +353,7 @@ func (*Handle) initStatsFMSketch4Chunk(cache *cache.StatsCache, iter *chunk.Iter
 	}
 }
 
-func (h *Handle) initStatsFMSketch(cache *cache.StatsCache) error {
+func (h *Handle) initStatsFMSketch(cache util.StatsCache) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
 	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, value from mysql.stats_fm_sketch"
 	rc, err := util.Exec(h.initStatsCtx, sql)
@@ -376,7 +376,7 @@ func (h *Handle) initStatsFMSketch(cache *cache.StatsCache) error {
 	return nil
 }
 
-func (*Handle) initStatsBuckets4Chunk(cache *cache.StatsCache, iter *chunk.Iterator4Chunk) {
+func (*Handle) initStatsBuckets4Chunk(cache util.StatsCache, iter *chunk.Iterator4Chunk) {
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		tableID, isIndex, histID := row.GetInt64(0), row.GetInt64(1), row.GetInt64(2)
 		table, ok := cache.Get(tableID)
@@ -426,7 +426,7 @@ func (*Handle) initStatsBuckets4Chunk(cache *cache.StatsCache, iter *chunk.Itera
 	}
 }
 
-func (h *Handle) initStatsBuckets(cache *cache.StatsCache) error {
+func (h *Handle) initStatsBuckets(cache util.StatsCache) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
 	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, count, repeats, lower_bound, upper_bound, ndv from mysql.stats_buckets order by table_id, is_index, hist_id, bucket_id"
 	rc, err := util.Exec(h.initStatsCtx, sql)
@@ -486,7 +486,7 @@ func (h *Handle) InitStatsLite(is infoschema.InfoSchema) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	h.initStatsCache(cache)
+	h.Replace(cache)
 	return nil
 }
 
@@ -539,7 +539,7 @@ func (h *Handle) InitStats(is infoschema.InfoSchema) (err error) {
 			}
 		}
 	}
-	h.initStatsCache(cache)
+	h.Replace(cache)
 	return nil
 }
 

--- a/statistics/handle/bootstrap.go
+++ b/statistics/handle/bootstrap.go
@@ -16,7 +16,6 @@ package handle
 
 import (
 	"context"
-	"github.com/pingcap/tidb/statistics/handle/cache"
 	"strconv"
 	"time"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
+	"github.com/pingcap/tidb/statistics/handle/cache"
 	"github.com/pingcap/tidb/statistics/handle/util"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"

--- a/statistics/handle/cache/BUILD.bazel
+++ b/statistics/handle/cache/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//config",
         "//statistics",
         "//statistics/handle/cache/internal/testutil",
+        "//statistics/handle/util",
         "//util/benchdaily",
     ],
 )

--- a/statistics/handle/cache/statscache.go
+++ b/statistics/handle/cache/statscache.go
@@ -20,31 +20,33 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/statistics/handle/cache/internal/metrics"
+	"github.com/pingcap/tidb/statistics/handle/util"
 )
 
-// StatsCachePointer is used to cache the stats of a table.
-type StatsCachePointer struct {
+// StatsCacheImpl implements util.StatsCache.
+type StatsCacheImpl struct {
 	atomic.Pointer[StatsCache]
 }
 
-// NewStatsCachePointer creates a new StatsCache.
-func NewStatsCachePointer() (*StatsCachePointer, error) {
+// NewStatsCacheImpl creates a new StatsCache.
+func NewStatsCacheImpl() (util.StatsCache, error) {
 	newCache, err := NewStatsCache()
 	if err != nil {
 		return nil, err
 	}
-	result := StatsCachePointer{}
+	result := &StatsCacheImpl{}
 	result.Store(newCache)
-	return &result, nil
+	return result, nil
 }
 
-// Load loads the cached stats from the cache.
-func (s *StatsCachePointer) Load() *StatsCache {
-	return s.Pointer.Load()
+// Replace replaces this cache.
+func (s *StatsCacheImpl) Replace(cache util.StatsCache) {
+	x := cache.(*StatsCacheImpl)
+	s.replace(x.Load())
 }
 
-// Replace replaces the cache with the new cache.
-func (s *StatsCachePointer) Replace(newCache *StatsCache) {
+// replace replaces the cache with the new cache.
+func (s *StatsCacheImpl) replace(newCache *StatsCache) {
 	old := s.Swap(newCache)
 	if old != nil {
 		old.Close()
@@ -53,10 +55,57 @@ func (s *StatsCachePointer) Replace(newCache *StatsCache) {
 }
 
 // UpdateStatsCache updates the cache with the new cache.
-func (s *StatsCachePointer) UpdateStatsCache(newCache *StatsCache, tables []*statistics.Table, deletedIDs []int64) {
+func (s *StatsCacheImpl) UpdateStatsCache(tables []*statistics.Table, deletedIDs []int64) {
 	if enableQuota := config.GetGlobalConfig().Performance.EnableStatsCacheMemQuota; enableQuota {
 		s.Load().Update(tables, deletedIDs)
 	} else {
-		s.Replace(newCache.CopyAndUpdate(tables, deletedIDs))
+		newCache := s.Load().CopyAndUpdate(tables, deletedIDs)
+		s.replace(newCache)
 	}
+}
+
+// Close closes this cache.
+func (s *StatsCacheImpl) Close() {
+	s.Load().Close()
+}
+
+// Clear clears this cache.
+func (s *StatsCacheImpl) Clear() {
+	// TODO
+}
+
+// MemConsumed returns its memory usage.
+func (s *StatsCacheImpl) MemConsumed() (size int64) {
+	return s.Load().Cost()
+}
+
+// Get returns the specified table's stats.
+func (s *StatsCacheImpl) Get(tableID int64) (*statistics.Table, bool) {
+	return s.Load().Get(tableID)
+}
+
+// Put puts this table stats into the cache.
+func (s *StatsCacheImpl) Put(id int64, t *statistics.Table) {
+	s.Load().put(id, t)
+}
+
+// MaxTableStatsVersion returns the version of the current cache, which is defined as
+// the max table stats version the cache has in its lifecycle.
+func (s *StatsCacheImpl) MaxTableStatsVersion() uint64 {
+	return s.Load().Version()
+}
+
+// Values returns all values in this cache.
+func (s *StatsCacheImpl) Values() []*statistics.Table {
+	return s.Load().Values()
+}
+
+// Len returns the length of this cache.
+func (s *StatsCacheImpl) Len() int {
+	return s.Load().Len()
+}
+
+// SetStatsCacheCapacity sets the cache's capacity.
+func (s *StatsCacheImpl) SetStatsCacheCapacity(c int64) {
+	s.Load().SetCapacity(c)
 }

--- a/statistics/handle/cache/statscache.go
+++ b/statistics/handle/cache/statscache.go
@@ -15,14 +15,14 @@
 package cache
 
 import (
-	"github.com/pingcap/tidb/util/logutil"
-	"go.uber.org/zap"
 	"sync/atomic"
 
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/statistics/handle/cache/internal/metrics"
 	"github.com/pingcap/tidb/statistics/handle/util"
+	"github.com/pingcap/tidb/util/logutil"
+	"go.uber.org/zap"
 )
 
 // StatsCacheImpl implements util.StatsCache.

--- a/statistics/handle/cache/statscache.go
+++ b/statistics/handle/cache/statscache.go
@@ -15,6 +15,8 @@
 package cache
 
 import (
+	"github.com/pingcap/tidb/util/logutil"
+	"go.uber.org/zap"
 	"sync/atomic"
 
 	"github.com/pingcap/tidb/config"
@@ -71,7 +73,12 @@ func (s *StatsCacheImpl) Close() {
 
 // Clear clears this cache.
 func (s *StatsCacheImpl) Clear() {
-	// TODO
+	cache, err := NewStatsCache()
+	if err != nil {
+		logutil.BgLogger().Warn("create stats cache failed", zap.Error(err))
+		return
+	}
+	s.replace(cache)
 }
 
 // MemConsumed returns its memory usage.

--- a/statistics/handle/cache/statscacheinner.go
+++ b/statistics/handle/cache/statscacheinner.go
@@ -56,6 +56,7 @@ func NewStatsCache() (*StatsCache, error) {
 }
 
 // StatsCache caches the tables in memory for Handle.
+// TODO: hide this structure or merge it into StatsCacheImpl.
 type StatsCache struct {
 	c internal.StatsCacheInner
 	// the max table stats version the cache has in its lifecycle.

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -432,7 +432,6 @@ const updateStatsCacheRetryCnt = 5
 // TODO: move this method to the `extstats` package.
 func (h *Handle) ReloadExtendedStatistics() error {
 	return h.callWithSCtx(func(sctx sessionctx.Context) error {
-		for retry := updateStatsCacheRetryCnt; retry > 0; retry-- {
 			tables := make([]*statistics.Table, 0, h.Len())
 			for _, tbl := range h.Values() {
 				t, err := storage.ExtendedStatsFromStorage(sctx, tbl.Copy(), tbl.PhysicalID, true)
@@ -443,8 +442,6 @@ func (h *Handle) ReloadExtendedStatistics() error {
 			}
 			h.UpdateStatsCache(tables, nil)
 			return nil
-		}
-		return fmt.Errorf("update stats cache failed for %d attempts", updateStatsCacheRetryCnt)
 	}, util.FlagWrapTxn)
 }
 

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -432,16 +432,16 @@ const updateStatsCacheRetryCnt = 5
 // TODO: move this method to the `extstats` package.
 func (h *Handle) ReloadExtendedStatistics() error {
 	return h.callWithSCtx(func(sctx sessionctx.Context) error {
-			tables := make([]*statistics.Table, 0, h.Len())
-			for _, tbl := range h.Values() {
-				t, err := storage.ExtendedStatsFromStorage(sctx, tbl.Copy(), tbl.PhysicalID, true)
-				if err != nil {
-					return err
-				}
-				tables = append(tables, t)
+		tables := make([]*statistics.Table, 0, h.Len())
+		for _, tbl := range h.Values() {
+			t, err := storage.ExtendedStatsFromStorage(sctx, tbl.Copy(), tbl.PhysicalID, true)
+			if err != nil {
+				return err
 			}
-			h.UpdateStatsCache(tables, nil)
-			return nil
+			tables = append(tables, t)
+		}
+		h.UpdateStatsCache(tables, nil)
+		return nil
 	}, util.FlagWrapTxn)
 }
 

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -16,6 +16,7 @@ package handle
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/statistics/handle/cache"
 	"math"
 	"time"
 
@@ -29,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/statistics/handle/autoanalyze"
-	"github.com/pingcap/tidb/statistics/handle/cache"
 	"github.com/pingcap/tidb/statistics/handle/extstats"
 	"github.com/pingcap/tidb/statistics/handle/globalstats"
 	"github.com/pingcap/tidb/statistics/handle/history"
@@ -85,9 +85,8 @@ type Handle struct {
 	// SessionStatsList contains all the stats collector required by session.
 	*usage.SessionStatsList
 
-	// It can be read by multiple readers at the same time without acquiring lock, but it can be
-	// written only after acquiring the lock.
-	statsCache *cache.StatsCachePointer
+	// StatsCache ...
+	util.StatsCache
 
 	// StatsLoad is used to load stats concurrently
 	StatsLoad StatsLoad
@@ -105,12 +104,7 @@ func (h *Handle) execRows(sql string, args ...interface{}) (rows []chunk.Row, fi
 
 // Clear the statsCache, only for test.
 func (h *Handle) Clear() {
-	cache, err := cache.NewStatsCache()
-	if err != nil {
-		logutil.BgLogger().Warn("create stats cache failed", zap.Error(err))
-		return
-	}
-	h.statsCache.Replace(cache)
+	h.StatsCache.Clear()
 	for len(h.ddlEventCh) > 0 {
 		<-h.ddlEventCh
 	}
@@ -136,12 +130,12 @@ func NewHandle(_, initStatsCtx sessionctx.Context, lease time.Duration, pool uti
 
 	handle.initStatsCtx = initStatsCtx
 	handle.lease.Store(lease)
-	statsCache, err := cache.NewStatsCachePointer()
+	statsCache, err := cache.NewStatsCacheImpl()
 	if err != nil {
 		return nil, err
 	}
-	handle.statsCache = statsCache
-	handle.StatsHistory = history.NewStatsHistory(pool, statsCache)
+	handle.StatsCache = statsCache
+	handle.StatsHistory = history.NewStatsHistory(pool, handle.StatsCache)
 	handle.StatsLoad.SubCtxs = make([]sessionctx.Context, cfg.Performance.StatsLoadConcurrency)
 	handle.StatsLoad.NeededItemsCh = make(chan *NeededItemTask, cfg.Performance.StatsLoadQueueSize)
 	handle.StatsLoad.TimeoutItemsCh = make(chan *NeededItemTask, cfg.Performance.StatsLoadQueueSize)
@@ -161,13 +155,8 @@ func (h *Handle) SetLease(lease time.Duration) {
 
 // UpdateStatsHealthyMetrics updates stats healthy distribution metrics according to stats cache.
 func (h *Handle) UpdateStatsHealthyMetrics() {
-	v := h.statsCache.Load()
-	if v == nil {
-		return
-	}
-
 	distribution := make([]int64, 5)
-	for _, tbl := range v.Values() {
+	for _, tbl := range h.Values() {
 		healthy, ok := tbl.GetStatsHealthy()
 		if !ok {
 			continue
@@ -190,15 +179,14 @@ func (h *Handle) UpdateStatsHealthyMetrics() {
 
 // Update reads stats meta from store and updates the stats map.
 func (h *Handle) Update(is infoschema.InfoSchema) error {
-	oldCache := h.statsCache.Load()
-	lastVersion := oldCache.Version()
+	lastVersion := h.MaxTableStatsVersion()
 	// We need this because for two tables, the smaller version may write later than the one with larger version.
 	// Consider the case that there are two tables A and B, their version and commit time is (A0, A1) and (B0, B1),
 	// and A0 < B0 < B1 < A1. We will first read the stats of B, and update the lastVersion to B0, but we cannot read
 	// the table stats of A0 if we read stats that greater than lastVersion which is B0.
 	// We can read the stats if the diff between commit time and version is less than three lease.
 	offset := util.DurationToTS(3 * h.Lease())
-	if oldCache.Version() >= offset {
+	if h.MaxTableStatsVersion() >= offset {
 		lastVersion = lastVersion - offset
 	} else {
 		lastVersion = 0
@@ -221,7 +209,7 @@ func (h *Handle) Update(is infoschema.InfoSchema) error {
 			continue
 		}
 		tableInfo := table.Meta()
-		if oldTbl, ok := oldCache.Get(physicalID); ok && oldTbl.Version >= version && tableInfo.UpdateTS == oldTbl.TblInfoUpdateTS {
+		if oldTbl, ok := h.Get(physicalID); ok && oldTbl.Version >= version && tableInfo.UpdateTS == oldTbl.TblInfoUpdateTS {
 			continue
 		}
 		tbl, err := h.TableStatsFromStorage(tableInfo, physicalID, false, 0)
@@ -241,7 +229,7 @@ func (h *Handle) Update(is infoschema.InfoSchema) error {
 		tbl.TblInfoUpdateTS = tableInfo.UpdateTS
 		tables = append(tables, tbl)
 	}
-	h.updateStatsCache(oldCache, tables, deletedTableIDs)
+	h.UpdateStatsCache(tables, deletedTableIDs)
 	return nil
 }
 
@@ -288,11 +276,11 @@ func (h *Handle) mergePartitionStats2GlobalStats(
 	return
 }
 
-// GetMemConsumed returns the mem size of statscache consumed
-func (h *Handle) GetMemConsumed() (size int64) {
-	size = h.statsCache.Load().Cost()
-	return
-}
+//// GetMemConsumed returns the mem size of statscache consumed
+//func (h *Handle) GetMemConsumed() (size int64) {
+//	size = h.statsCache.Load().Cost()
+//	return
+//}
 
 // GetTableStats retrieves the statistics table from cache, and the cache will be updated by a goroutine.
 func (h *Handle) GetTableStats(tblInfo *model.TableInfo) *statistics.Table {
@@ -307,48 +295,25 @@ func (h *Handle) GetPartitionStats(tblInfo *model.TableInfo, pid int64) *statist
 		tbl.PhysicalID = pid
 		return tbl
 	}
-	statsCache := h.statsCache.Load()
-	tbl, ok := statsCache.Get(pid)
+	tbl, ok := h.Get(pid)
 	if !ok {
 		tbl = statistics.PseudoTable(tblInfo, false)
 		tbl.PhysicalID = pid
-		if tblInfo.GetPartitionInfo() == nil || h.statsCacheLen() < 64 {
-			h.updateStatsCache(statsCache, []*statistics.Table{tbl}, nil)
+		if tblInfo.GetPartitionInfo() == nil || h.Len() < 64 {
+			h.UpdateStatsCache([]*statistics.Table{tbl}, nil)
 		}
 		return tbl
 	}
 	return tbl
 }
 
-func (h *Handle) statsCacheLen() int {
-	return h.statsCache.Load().Len()
-}
-
-func (h *Handle) initStatsCache(newCache *cache.StatsCache) {
-	h.statsCache.Replace(newCache)
-}
-
-// updateStatsCache will update statsCache into non COW mode.
-// If it is in the COW mode. it overrides the global statsCache with a new one, it may fail
-// if the global statsCache has been modified by others already.
-// Callers should add retry loop if necessary.
-func (h *Handle) updateStatsCache(newCache *cache.StatsCache, tables []*statistics.Table, deletedIDs []int64) (updated bool) {
-	h.statsCache.UpdateStatsCache(newCache, tables, deletedIDs)
-	return true
-}
-
 // LoadNeededHistograms will load histograms for those needed columns/indices.
 func (h *Handle) LoadNeededHistograms() (err error) {
 	err = h.callWithSCtx(func(sctx sessionctx.Context) error {
 		loadFMSketch := config.GetGlobalConfig().Performance.EnableLoadFMSketch
-		return storage.LoadNeededHistograms(sctx, h.statsCache, loadFMSketch)
+		return storage.LoadNeededHistograms(sctx, h.StatsCache, loadFMSketch)
 	}, util.FlagWrapTxn)
 	return err
-}
-
-// LastUpdateVersion gets the last update version.
-func (h *Handle) LastUpdateVersion() uint64 {
-	return h.statsCache.Load().Version()
 }
 
 // FlushStats flushes the cached stats update into store.
@@ -368,7 +333,7 @@ func (h *Handle) FlushStats() {
 func (h *Handle) TableStatsFromStorage(tableInfo *model.TableInfo, physicalID int64, loadAll bool, snapshot uint64) (statsTbl *statistics.Table, err error) {
 	err = h.callWithSCtx(func(sctx sessionctx.Context) error {
 		var ok bool
-		statsTbl, ok = h.statsCache.Load().Get(physicalID)
+		statsTbl, ok = h.Get(physicalID)
 		if !ok {
 			statsTbl = nil
 		}
@@ -445,7 +410,7 @@ func (h *Handle) SaveMetaToStorage(tableID, count, modifyCount int64, source str
 func (h *Handle) InsertExtendedStats(statsName string, colIDs []int64, tp int, tableID int64, ifNotExists bool) (err error) {
 	var statsVer uint64
 	err = h.callWithSCtx(func(sctx sessionctx.Context) error {
-		statsVer, err = storage.InsertExtendedStats(sctx, h.updateStatsCache, h.statsCache.Load(), statsName, colIDs, tp, tableID, ifNotExists)
+		statsVer, err = storage.InsertExtendedStats(sctx, h.StatsCache, statsName, colIDs, tp, tableID, ifNotExists)
 		return err
 	})
 	if err == nil && statsVer != 0 {
@@ -458,7 +423,7 @@ func (h *Handle) InsertExtendedStats(statsName string, colIDs []int64, tp int, t
 func (h *Handle) MarkExtendedStatsDeleted(statsName string, tableID int64, ifExists bool) (err error) {
 	var statsVer uint64
 	err = h.callWithSCtx(func(sctx sessionctx.Context) error {
-		statsVer, err = storage.MarkExtendedStatsDeleted(sctx, h.updateStatsCache, h.statsCache.Load(), statsName, tableID, ifExists)
+		statsVer, err = storage.MarkExtendedStatsDeleted(sctx, h.StatsCache, statsName, tableID, ifExists)
 		return err
 	})
 	if err == nil && statsVer != 0 {
@@ -474,18 +439,16 @@ const updateStatsCacheRetryCnt = 5
 func (h *Handle) ReloadExtendedStatistics() error {
 	return h.callWithSCtx(func(sctx sessionctx.Context) error {
 		for retry := updateStatsCacheRetryCnt; retry > 0; retry-- {
-			oldCache := h.statsCache.Load()
-			tables := make([]*statistics.Table, 0, oldCache.Len())
-			for _, tbl := range oldCache.Values() {
+			tables := make([]*statistics.Table, 0, h.Len())
+			for _, tbl := range h.Values() {
 				t, err := storage.ExtendedStatsFromStorage(sctx, tbl.Copy(), tbl.PhysicalID, true)
 				if err != nil {
 					return err
 				}
 				tables = append(tables, t)
 			}
-			if h.updateStatsCache(oldCache, tables, nil) {
-				return nil
-			}
+			h.UpdateStatsCache(tables, nil)
+			return nil
 		}
 		return fmt.Errorf("update stats cache failed for %d attempts", updateStatsCacheRetryCnt)
 	}, util.FlagWrapTxn)
@@ -550,24 +513,11 @@ func (h *Handle) RecordHistoricalStatsToStorage(dbName string, tableInfo *model.
 	return version, err
 }
 
-// SetStatsCacheCapacity sets capacity
-func (h *Handle) SetStatsCacheCapacity(c int64) {
-	if h == nil {
-		return
-	}
-	v := h.statsCache.Load()
-	if v == nil {
-		return
-	}
-	sc := v
-	sc.SetCapacity(c)
-	logutil.BgLogger().Info("update stats cache capacity successfully", zap.Int64("capacity", c))
-}
-
 // Close stops the background
 func (h *Handle) Close() {
 	h.gpool.Close()
-	h.statsCache.Load().Close()
+	//h.statsCache.Load().Close()
+	h.StatsCache.Close()
 }
 
 const (

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -16,7 +16,6 @@ package handle
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/statistics/handle/cache"
 	"math"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/statistics/handle/autoanalyze"
+	"github.com/pingcap/tidb/statistics/handle/cache"
 	"github.com/pingcap/tidb/statistics/handle/extstats"
 	"github.com/pingcap/tidb/statistics/handle/globalstats"
 	"github.com/pingcap/tidb/statistics/handle/history"
@@ -276,12 +276,6 @@ func (h *Handle) mergePartitionStats2GlobalStats(
 	return
 }
 
-//// GetMemConsumed returns the mem size of statscache consumed
-//func (h *Handle) GetMemConsumed() (size int64) {
-//	size = h.statsCache.Load().Cost()
-//	return
-//}
-
 // GetTableStats retrieves the statistics table from cache, and the cache will be updated by a goroutine.
 func (h *Handle) GetTableStats(tblInfo *model.TableInfo) *statistics.Table {
 	return h.GetPartitionStats(tblInfo, tblInfo.ID)
@@ -516,7 +510,6 @@ func (h *Handle) RecordHistoricalStatsToStorage(dbName string, tableInfo *model.
 // Close stops the background
 func (h *Handle) Close() {
 	h.gpool.Close()
-	//h.statsCache.Load().Close()
 	h.StatsCache.Close()
 }
 

--- a/statistics/handle/handletest/handle_test.go
+++ b/statistics/handle/handletest/handle_test.go
@@ -127,7 +127,7 @@ func TestVersion(t *testing.T) {
 	testKit.MustExec("update mysql.stats_meta set version = ? where table_id = ?", 2*unit, tableInfo1.ID)
 
 	require.NoError(t, h.Update(is))
-	require.Equal(t, 2*unit, h.LastUpdateVersion())
+	require.Equal(t, 2*unit, h.MaxTableStatsVersion())
 	statsTbl1 := h.GetTableStats(tableInfo1)
 	require.False(t, statsTbl1.Pseudo)
 
@@ -140,7 +140,7 @@ func TestVersion(t *testing.T) {
 	// A smaller version write, and we can still read it.
 	testKit.MustExec("update mysql.stats_meta set version = ? where table_id = ?", unit, tableInfo2.ID)
 	require.NoError(t, h.Update(is))
-	require.Equal(t, 2*unit, h.LastUpdateVersion())
+	require.Equal(t, 2*unit, h.MaxTableStatsVersion())
 	statsTbl2 := h.GetTableStats(tableInfo2)
 	require.False(t, statsTbl2.Pseudo)
 
@@ -149,7 +149,7 @@ func TestVersion(t *testing.T) {
 	offset := 3 * unit
 	testKit.MustExec("update mysql.stats_meta set version = ? where table_id = ?", offset+4, tableInfo1.ID)
 	require.NoError(t, h.Update(is))
-	require.Equal(t, offset+uint64(4), h.LastUpdateVersion())
+	require.Equal(t, offset+uint64(4), h.MaxTableStatsVersion())
 	statsTbl1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(1), statsTbl1.RealtimeCount)
 
@@ -158,7 +158,7 @@ func TestVersion(t *testing.T) {
 	// A smaller version write, and we can still read it.
 	testKit.MustExec("update mysql.stats_meta set version = ? where table_id = ?", offset+3, tableInfo2.ID)
 	require.NoError(t, h.Update(is))
-	require.Equal(t, offset+uint64(4), h.LastUpdateVersion())
+	require.Equal(t, offset+uint64(4), h.MaxTableStatsVersion())
 	statsTbl2 = h.GetTableStats(tableInfo2)
 	require.Equal(t, int64(1), statsTbl2.RealtimeCount)
 
@@ -167,7 +167,7 @@ func TestVersion(t *testing.T) {
 	// A smaller version write, and we cannot read it. Because at this time, lastThree Version is 4.
 	testKit.MustExec("update mysql.stats_meta set version = 1 where table_id = ?", tableInfo2.ID)
 	require.NoError(t, h.Update(is))
-	require.Equal(t, offset+uint64(4), h.LastUpdateVersion())
+	require.Equal(t, offset+uint64(4), h.MaxTableStatsVersion())
 	statsTbl2 = h.GetTableStats(tableInfo2)
 	require.Equal(t, int64(1), statsTbl2.RealtimeCount)
 

--- a/statistics/handle/handletest/statstest/stats_test.go
+++ b/statistics/handle/handletest/statstest/stats_test.go
@@ -171,7 +171,7 @@ func testInitStatsMemTrace(t *testing.T) {
 	h := dom.StatsHandle()
 	is := dom.InfoSchema()
 	h.Clear()
-	require.Equal(t, h.GetMemConsumed(), int64(0))
+	require.Equal(t, h.MemConsumed(), int64(0))
 	require.NoError(t, h.InitStats(is))
 
 	var memCostTot int64
@@ -182,7 +182,7 @@ func testInitStatsMemTrace(t *testing.T) {
 		memCostTot += tStats.MemoryUsage().TotalMemUsage
 	}
 
-	require.Equal(t, h.GetMemConsumed(), memCostTot)
+	require.Equal(t, h.MemConsumed(), memCostTot)
 }
 
 func TestInitStatsMemTraceWithLite(t *testing.T) {

--- a/statistics/handle/history/history_stats.go
+++ b/statistics/handle/history/history_stats.go
@@ -29,11 +29,11 @@ import (
 // statsHistoryImpl implements util.StatsHistory.
 type statsHistoryImpl struct {
 	pool       util.SessionPool
-	statsCache *cache.StatsCachePointer
+	statsCache util.StatsCache
 }
 
 // NewStatsHistory creates a new StatsHistory.
-func NewStatsHistory(pool util.SessionPool, statsCache *cache.StatsCachePointer) util.StatsHistory {
+func NewStatsHistory(pool util.SessionPool, statsCache util.StatsCache) util.StatsHistory {
 	return &statsHistoryImpl{
 		pool:       pool,
 		statsCache: statsCache,
@@ -45,11 +45,7 @@ func (sh *statsHistoryImpl) RecordHistoricalStatsMeta(tableID int64, version uin
 	if version == 0 {
 		return
 	}
-	sc := sh.statsCache.Load()
-	if sc == nil {
-		return
-	}
-	tbl, ok := sc.Get(tableID)
+	tbl, ok := sh.statsCache.Get(tableID)
 	if !ok {
 		return
 	}

--- a/statistics/handle/storage/gc.go
+++ b/statistics/handle/storage/gc.go
@@ -383,8 +383,7 @@ func writeGCTimestampToKV(sctx sessionctx.Context, newTS uint64) error {
 
 // MarkExtendedStatsDeleted update the status of mysql.stats_extended to be `deleted` and the version of mysql.stats_meta.
 func MarkExtendedStatsDeleted(sctx sessionctx.Context,
-	updateStatsCache func(newCache *cache.StatsCache, tables []*statistics.Table, deletedIDs []int64) (updated bool),
-	currentCache *cache.StatsCache,
+	statsCache util.StatsCache,
 	statsName string, tableID int64, ifExists bool) (statsVer uint64, err error) {
 	rows, _, err := util.ExecRows(sctx, "SELECT name FROM mysql.stats_extended WHERE name = %? and table_id = %? and status in (%?, %?)", statsName, tableID, statistics.ExtendedStatsInited, statistics.ExtendedStatsAnalyzed)
 	if err != nil {
@@ -407,7 +406,7 @@ func MarkExtendedStatsDeleted(sctx sessionctx.Context,
 	defer func() {
 		err1 := util.FinishTransaction(sctx, err)
 		if err == nil && err1 == nil {
-			removeExtendedStatsItem(currentCache, updateStatsCache, tableID, statsName)
+			removeExtendedStatsItem(statsCache, tableID, statsName)
 		}
 		err = err1
 	}()

--- a/statistics/handle/storage/read.go
+++ b/statistics/handle/storage/read.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
-	"github.com/pingcap/tidb/statistics/handle/cache"
 	"github.com/pingcap/tidb/statistics/handle/util"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -479,7 +478,7 @@ func LoadHistogram(sctx sessionctx.Context, tableID int64, isIndex int, histID i
 }
 
 // LoadNeededHistograms will load histograms for those needed columns/indices.
-func LoadNeededHistograms(sctx sessionctx.Context, statsCache *cache.StatsCachePointer, loadFMSketch bool) (err error) {
+func LoadNeededHistograms(sctx sessionctx.Context, statsCache util.StatsCache, loadFMSketch bool) (err error) {
 	items := statistics.HistogramNeededItems.AllItems()
 	for _, item := range items {
 		if !item.IsIndex {
@@ -494,9 +493,8 @@ func LoadNeededHistograms(sctx sessionctx.Context, statsCache *cache.StatsCacheP
 	return nil
 }
 
-func loadNeededColumnHistograms(sctx sessionctx.Context, statsCache *cache.StatsCachePointer, col model.TableItemID, loadFMSketch bool) (err error) {
-	oldCache := statsCache.Load()
-	tbl, ok := oldCache.Get(col.TableID)
+func loadNeededColumnHistograms(sctx sessionctx.Context, statsCache util.StatsCache, col model.TableItemID, loadFMSketch bool) (err error) {
+	tbl, ok := statsCache.Get(col.TableID)
 	if !ok {
 		return nil
 	}
@@ -544,21 +542,19 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsCache *cache.Stats
 	}
 	// Reload the latest stats cache, otherwise the `updateStatsCache` may fail with high probability, because functions
 	// like `GetPartitionStats` called in `fmSketchFromStorage` would have modified the stats cache already.
-	oldCache = statsCache.Load()
-	tbl, ok = oldCache.Get(col.TableID)
+	tbl, ok = statsCache.Get(col.TableID)
 	if !ok {
 		return nil
 	}
 	tbl = tbl.Copy()
 	tbl.Columns[c.ID] = colHist
-	statsCache.UpdateStatsCache(oldCache, []*statistics.Table{tbl}, nil)
+	statsCache.UpdateStatsCache([]*statistics.Table{tbl}, nil)
 	statistics.HistogramNeededItems.Delete(col)
 	return nil
 }
 
-func loadNeededIndexHistograms(sctx sessionctx.Context, statsCache *cache.StatsCachePointer, idx model.TableItemID, loadFMSketch bool) (err error) {
-	oldCache := statsCache.Load()
-	tbl, ok := oldCache.Get(idx.TableID)
+func loadNeededIndexHistograms(sctx sessionctx.Context, statsCache util.StatsCache, idx model.TableItemID, loadFMSketch bool) (err error) {
+	tbl, ok := statsCache.Get(idx.TableID)
 	if !ok {
 		return nil
 	}
@@ -596,14 +592,13 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, statsCache *cache.StatsC
 		StatsLoadedStatus: statistics.NewStatsFullLoadStatus()}
 	index.LastAnalyzePos.Copy(&idxHist.LastAnalyzePos)
 
-	oldCache = statsCache.Load()
-	tbl, ok = oldCache.Get(idx.TableID)
+	tbl, ok = statsCache.Get(idx.TableID)
 	if !ok {
 		return nil
 	}
 	tbl = tbl.Copy()
 	tbl.Indices[idx.ID] = idxHist
-	statsCache.UpdateStatsCache(oldCache, []*statistics.Table{tbl}, nil)
+	statsCache.UpdateStatsCache([]*statistics.Table{tbl}, nil)
 	statistics.HistogramNeededItems.Delete(idx)
 	return nil
 }

--- a/statistics/handle/util/interfaces.go
+++ b/statistics/handle/util/interfaces.go
@@ -93,3 +93,40 @@ type StatsAnalyze interface {
 
 	// TODO: HandleAutoAnalyze
 }
+
+// StatsCache is used to manage all table statistics in memory
+type StatsCache interface {
+	// Close closes this cache.
+	Close()
+
+	// Clear clears this cache.
+	Clear()
+
+	// MemConsumed returns its memory usage.
+	MemConsumed() (size int64)
+
+	// Get returns the specified table's stats.
+	Get(tableID int64) (*statistics.Table, bool)
+
+	// Put puts this table stats into the cache.
+	Put(tableID int64, t *statistics.Table)
+
+	// UpdateStatsCache updates the cache.
+	UpdateStatsCache(addedTables []*statistics.Table, deletedTableIDs []int64)
+
+	// MaxTableStatsVersion returns the version of the current cache, which is defined as
+	// the max table stats version the cache has in its lifecycle.
+	MaxTableStatsVersion() uint64
+
+	// Values returns all values in this cache.
+	Values() []*statistics.Table
+
+	// Len returns the length of this cache.
+	Len() int
+
+	// SetStatsCacheCapacity sets the cache's capacity.
+	SetStatsCacheCapacity(capBytes int64)
+
+	// Replace replaces this cache.
+	Replace(cache StatsCache)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46905

Problem Summary: planner: capsulate stats cache behind an interface

### What is changed and how it works?

planner: capsulate stats cache behind an interface

No logical change, just code movement and refactor.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
