### PR TITLE
statistics: fix entry too large when to save historical stats

### DIFF
--- a/pkg/statistics/handle/history/history_stats.go
+++ b/pkg/statistics/handle/history/history_stats.go
@@ -140,7 +140,7 @@ func RecordHistoricalStatsMeta(sctx sessionctx.Context, tableID int64, version u
 
 // Max column size is 6MB. Refer https://docs.pingcap.com/tidb/dev/tidb-limitations/#limitation-on-a-single-column
 // but here is 3MB, because stats_history has other info except stats_data.
-const maxColumnSize = 6 << 19
+const maxColumnSize = 5 << 20
 
 // RecordHistoricalStatsToStorage records the given table's stats data to mysql.stats_history
 func RecordHistoricalStatsToStorage(sctx sessionctx.Context, physicalID int64, js *storage.JSONTable) (uint64, error) {

--- a/pkg/statistics/handle/history/history_stats.go
+++ b/pkg/statistics/handle/history/history_stats.go
@@ -68,7 +68,7 @@ func (sh *statsHistoryImpl) RecordHistoricalStatsToStorage(dbName string, tableI
 	err = util.CallWithSCtx(sh.pool, func(sctx sessionctx.Context) error {
 		version, err = RecordHistoricalStatsToStorage(sctx, physicalID, js)
 		return err
-	})
+	}, util.FlagWrapTxn)
 	return version, err
 }
 

--- a/pkg/statistics/handle/history/history_stats.go
+++ b/pkg/statistics/handle/history/history_stats.go
@@ -139,7 +139,7 @@ func RecordHistoricalStatsMeta(sctx sessionctx.Context, tableID int64, version u
 }
 
 // Max column size is 6MB. Refer https://docs.pingcap.com/tidb/dev/tidb-limitations/#limitation-on-a-single-column
-// but here is 3MB, because stats_history has other info except stats_data.
+// but here is less than 6MB, because stats_history has other info except stats_data.
 const maxColumnSize = 5 << 20
 
 // RecordHistoricalStatsToStorage records the given table's stats data to mysql.stats_history

--- a/pkg/statistics/handle/history/history_stats.go
+++ b/pkg/statistics/handle/history/history_stats.go
@@ -68,7 +68,7 @@ func (sh *statsHistoryImpl) RecordHistoricalStatsToStorage(dbName string, tableI
 	err = util.CallWithSCtx(sh.pool, func(sctx sessionctx.Context) error {
 		version, err = RecordHistoricalStatsToStorage(sctx, physicalID, js)
 		return err
-	}, util.FlagWrapTxn)
+	})
 	return version, err
 }
 
@@ -139,7 +139,8 @@ func RecordHistoricalStatsMeta(sctx sessionctx.Context, tableID int64, version u
 }
 
 // Max column size is 6MB. Refer https://docs.pingcap.com/tidb/dev/tidb-limitations/#limitation-on-a-single-column
-const maxColumnSize = 6 << 20
+// but here is 3MB, because stats_history has other info except stats_data.
+const maxColumnSize = 6 << 19
 
 // RecordHistoricalStatsToStorage records the given table's stats data to mysql.stats_history
 func RecordHistoricalStatsToStorage(sctx sessionctx.Context, physicalID int64, js *storage.JSONTable) (uint64, error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47649

Problem Summary:

### What is changed and how it works?

Set the json block of RecordHistoricalStatsToStorage to be smaller. Previously, the json block was 6MB, and with the other columns added, it would exceed the limit.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)


<img width="1383" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/77953aea-e443-4d28-8374-9466bf69427f">


we update tidb at 15:30, we cannot see fail after 

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
