### PR TITLE
planner: move more methods from StatsHandle to its sub-packages

### DIFF
--- a/pkg/statistics/handle/cache/BUILD.bazel
+++ b/pkg/statistics/handle/cache/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/statistics/handle/cache/internal/lfu",
         "//pkg/statistics/handle/cache/internal/mapcache",
         "//pkg/statistics/handle/cache/internal/metrics",
+        "//pkg/statistics/handle/metrics",
         "//pkg/statistics/handle/util",
         "//pkg/types",
         "//pkg/util/chunk",

--- a/pkg/statistics/handle/dump_test.go
+++ b/pkg/statistics/handle/dump_test.go
@@ -245,12 +245,12 @@ func TestLoadPartitionStatsErrPanic(t *testing.T) {
 	jsonTbl, err := dom.StatsHandle().DumpStatsToJSON("test", tableInfo, nil, true)
 	require.NoError(t, err)
 
-	ctx := context.WithValue(context.Background(), handle.TestLoadStatsErr{}, func(tableInfo *model.TableInfo, physicalID int64, jsonTbl *storage.JSONTable) error {
+	ctx := context.WithValue(context.Background(), handle.TestLoadStatsErr{}, func(tableInfo *model.TableInfo, physicalID int64, jsonTbl interface{}) error {
 		return errors.New("ERROR")
 	})
 	err = dom.StatsHandle().LoadStatsFromJSON(ctx, dom.InfoSchema(), jsonTbl, 0)
 	require.ErrorContains(t, err, "ERROR")
-	ctx = context.WithValue(context.Background(), handle.TestLoadStatsErr{}, func(tableInfo *model.TableInfo, physicalID int64, jsonTbl *storage.JSONTable) error {
+	ctx = context.WithValue(context.Background(), handle.TestLoadStatsErr{}, func(tableInfo *model.TableInfo, physicalID int64, jsonTbl interface{}) error {
 		panic("PANIC")
 	})
 	err = dom.StatsHandle().LoadStatsFromJSON(ctx, dom.InfoSchema(), jsonTbl, 0)

--- a/pkg/statistics/handle/util/interfaces.go
+++ b/pkg/statistics/handle/util/interfaces.go
@@ -229,6 +229,10 @@ type StatsReadWriter interface {
 	// SaveMetaToStorage saves stats meta to the storage.
 	SaveMetaToStorage(tableID, count, modifyCount int64, source string) (err error)
 
+	// SaveStatsFromJSON saves stats from JSON to the storage.
+	// TODO: use *storage.JSONTable instead of interface{} (which is used to avoid cycle import).
+	SaveStatsFromJSON(tableInfo *model.TableInfo, physicalID int64, jsonTbl interface{}) error
+
 	// Methods for extended stast.
 
 	// InsertExtendedStats inserts a record into mysql.stats_extended and update version in mysql.stats_meta.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46905

Problem Summary: planner: move more methods from StatsHandle to its sub-packages

### What is changed and how it works?

planner: move more methods from StatsHandle to its sub-packages

No logical change, just refactor.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
