### PR TITLE
linter: setup a linter to validate constructor

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -145,6 +145,7 @@ nogo(
                "//build/linter/asciicheck",
                "//build/linter/bodyclose",
                "//build/linter/bootstrap",
+               "//build/linter/constructor",
                "//build/linter/deferrecover",
                "//build/linter/durationcheck",
                "//build/linter/etcdconfig",

--- a/build/linter/constructor/BUILD.bazel
+++ b/build/linter/constructor/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "constructor",
+    srcs = ["analyzer.go"],
+    importpath = "github.com/pingcap/tidb/build/linter/constructor",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_fatih_structtag//:structtag",
+        "@org_golang_x_tools//go/analysis",
+        "@org_golang_x_tools//go/ast/inspector",
+    ],
+)
+
+go_test(
+    name = "constructor_test",
+    timeout = "short",
+    srcs = ["analyzer_test.go"],
+    flaky = True,
+    deps = [
+        ":constructor",
+        "@org_golang_x_tools//go/analysis/analysistest",
+    ],
+)

--- a/build/linter/constructor/analyzer.go
+++ b/build/linter/constructor/analyzer.go
@@ -1,0 +1,176 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constructor
+
+import (
+	"go/ast"
+	"go/types"
+	"slices"
+	"strings"
+
+	"github.com/fatih/structtag"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Analyzer is the analyzer struct of constructor.
+// constructor only allows constructing a struct manually in some specific functions, which is specified with tags for
+// `constructor.Constructor` field.
+//
+// It can detect the following pattern and give error (if not in constructor functions):
+//
+// 1. Create struct directly, like `SomeStruct{}` or `&SomeStruct{}`.
+// 2. Create struct with `new`: `new(SomeStruct)`
+// 3. Struct literal in slice or other struct: `[]SomeStruct{{}}`
+// 4. Define variables through `var`: `var a SomeStruct`.
+// 5. Implicit zero value in other struct literal: `type OtherStruct struct{SomeStruct}; other := OtherStruct{}`
+//
+// TODO: verify whether this linter can work well with generics
+var Analyzer = &analysis.Analyzer{
+	Name:     "constructor",
+	Doc:      "Check developers don't create structs manually without using constructors",
+	Requires: []*analysis.Analyzer{},
+	Run:      run,
+}
+
+func getConstructorList(t types.Type) []string {
+	structTyp, ok := t.(*types.Struct)
+	if !ok {
+		var ptr *types.Pointer
+		// It's also possible to construct a pointer directly, e.g. []*Struct{{}}
+		if ptr, ok = t.(*types.Pointer); !ok {
+			return nil
+		}
+
+		structTyp, ok = ptr.Elem().Underlying().(*types.Struct)
+		if !ok {
+			return nil
+		}
+	}
+	var ctors []string
+	for i := 0; i < structTyp.NumFields(); i++ {
+		field := structTyp.Field(i)
+		named, ok := field.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+		if named.Obj().Name() == "Constructor" && named.Obj().Pkg().Path() == "github.com/pingcap/tidb/util/linter/constructor" {
+			tags, err := structtag.Parse(structTyp.Tag(i))
+			// skip invalid tags
+			if err != nil {
+				continue
+			}
+			ctorTag, err := tags.Get("ctor")
+			if err != nil {
+				continue
+			}
+			ctors = strings.Split(ctorTag.Value(), ",")
+			continue
+		}
+
+		if fieldStruct, ok := named.Underlying().(*types.Struct); ok {
+			ctors = append(ctors, getConstructorList(fieldStruct)...)
+		}
+	}
+	return ctors
+}
+
+func assertInConstructor(pass *analysis.Pass, n ast.Node, stack []ast.Node, ctors []string) bool {
+	// check whether this call is in `ctor`
+	for i := len(stack) - 1; i >= 0; i-- {
+		funcDecl, ok := stack[i].(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+
+		if !slices.Contains(ctors, funcDecl.Name.Name) {
+			pass.Reportf(n.Pos(), "struct can only be constructed in constructors %s", strings.Join(ctors, ", "))
+			return false
+		}
+
+		return true
+	}
+	return true
+}
+
+func handleCompositeLit(pass *analysis.Pass, n *ast.CompositeLit, push bool, stack []ast.Node) bool {
+	if !push {
+		return false
+	}
+
+	t := pass.TypesInfo.TypeOf(n).Underlying()
+	if t == nil {
+		return true
+	}
+
+	ctors := getConstructorList(t)
+	if len(ctors) == 0 {
+		return true
+	}
+
+	return assertInConstructor(pass, n, stack, ctors)
+}
+
+func handleCallExpr(pass *analysis.Pass, n *ast.CallExpr, push bool, stack []ast.Node) bool {
+	fun, ok := n.Fun.(*ast.Ident)
+	if !ok {
+		return true
+	}
+	if fun.Name != "new" || len(n.Args) == 0 {
+		return true
+	}
+
+	t := pass.TypesInfo.TypeOf(n).Underlying()
+	ctors := getConstructorList(t)
+	if len(ctors) == 0 {
+		return true
+	}
+
+	return assertInConstructor(pass, n, stack, ctors)
+}
+
+func handleValueSpec(pass *analysis.Pass, n *ast.ValueSpec, _ bool, stack []ast.Node) bool {
+	t := pass.TypesInfo.TypeOf(n.Type)
+	if t == nil {
+		return true
+	}
+
+	ctors := getConstructorList(t.Underlying())
+	if len(ctors) == 0 {
+		return true
+	}
+
+	return assertInConstructor(pass, n, stack, ctors)
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		i := inspector.New([]*ast.File{file})
+
+		i.WithStack([]ast.Node{&ast.CompositeLit{}, &ast.CallExpr{}, &ast.ValueSpec{}}, func(n ast.Node, push bool, stack []ast.Node) bool {
+			switch n := n.(type) {
+			case *ast.CompositeLit:
+				return handleCompositeLit(pass, n, push, stack)
+			case *ast.CallExpr:
+				return handleCallExpr(pass, n, push, stack)
+			case *ast.ValueSpec:
+				return handleValueSpec(pass, n, push, stack)
+			}
+
+			return true
+		})
+	}
+	return nil, nil
+}

--- a/build/linter/constructor/analyzer_test.go
+++ b/build/linter/constructor/analyzer_test.go
@@ -1,0 +1,33 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !intest
+
+package constructor_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/build/linter/constructor"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// TODO: investigate the CI environment and check how to run this test in CI.
+// The CI environment doesn't have `go` executable in $PATH.
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	pkgs := []string{"t", "github.com/pingcap/tidb/util/linter/constructor"}
+	analysistest.Run(t, testdata, constructor.Analyzer, pkgs...)
+}

--- a/build/linter/constructor/testdata/src/github.com/pingcap/tidb/util/linter/constructor/BUILD.bazel
+++ b/build/linter/constructor/testdata/src/github.com/pingcap/tidb/util/linter/constructor/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "constructor",
+    srcs = ["constructorflag.go"],
+    importpath = "github.com/pingcap/tidb/build/linter/constructor/testdata/src/github.com/pingcap/tidb/util/linter/constructor",
+    visibility = ["//visibility:public"],
+)

--- a/build/linter/constructor/testdata/src/github.com/pingcap/tidb/util/linter/constructor/constructorflag.go
+++ b/build/linter/constructor/testdata/src/github.com/pingcap/tidb/util/linter/constructor/constructorflag.go
@@ -1,0 +1,28 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constructor
+
+// This file is copied from `/util/linter/constructor` to help test
+
+// Constructor is an empty struct to mark the constructor function
+// Example:
+//
+//	type StatementContext struct {
+//	    _ constructor.Constructor `ctor:"NewStmtCtx"`
+//	}
+//
+// The linter `constructor` will then ignore all manual construction of the struct in `NewStmtCtx`, and return error
+// for all other constructions.
+type Constructor struct{}

--- a/build/linter/constructor/testdata/src/t/BUILD.bazel
+++ b/build/linter/constructor/testdata/src/t/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "t",
+    srcs = ["construct.go"],
+    importpath = "github.com/pingcap/tidb/build/linter/constructor/testdata/src/t",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/util/linter/constructor"],
+)

--- a/build/linter/constructor/testdata/src/t/construct.go
+++ b/build/linter/constructor/testdata/src/t/construct.go
@@ -1,0 +1,76 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package t
+
+import (
+	"github.com/pingcap/tidb/pkg/util/linter/constructor"
+)
+
+// StructWithSpecificConstructor is a struct with `Constructor`
+type StructWithSpecificConstructor struct {
+	_ constructor.Constructor `ctor:"NewStructWithSpecificConstructor,AnotherConstructor"`
+
+	otherField string
+}
+
+// NewStructWithSpecificConstructor creates a new `StructWithSpecificConstructor`
+// this function should work fine
+func NewStructWithSpecificConstructor() *StructWithSpecificConstructor {
+	_ = new(StructWithSpecificConstructor)
+	var _ StructWithSpecificConstructor
+	return &StructWithSpecificConstructor{}
+}
+
+// AnotherConstructor gives another constructor of StructWithSpecificConstructor
+func AnotherConstructor() *StructWithSpecificConstructor {
+	return &StructWithSpecificConstructor{}
+}
+
+func otherFunction() {
+	_ = NewStructWithSpecificConstructor()
+	_ = AnotherConstructor()
+
+	_ = StructWithSpecificConstructor{}     // want `struct can only be constructed in constructors NewStructWithSpecificConstructor, AnotherConstructor`
+	_ = &StructWithSpecificConstructor{}    // want `struct can only be constructed in constructors NewStructWithSpecificConstructor, AnotherConstructor`
+	_ = []StructWithSpecificConstructor{{}} // want `struct can only be constructed in constructors NewStructWithSpecificConstructor, AnotherConstructor`
+	_ = []*StructWithSpecificConstructor{
+		{otherField: "a"}, // want `struct can only be constructed in constructors NewStructWithSpecificConstructor, AnotherConstructor`
+		{},                // want `struct can only be constructed in constructors NewStructWithSpecificConstructor, AnotherConstructor`
+	}
+
+	// anonymous struct
+	_ = struct { // want `struct can only be constructed in constructors NewStructWithSpecificConstructor`
+		_ constructor.Constructor `ctor:"NewStructWithSpecificConstructor"`
+	}{}
+
+	// new
+	_ = new(StructWithSpecificConstructor) // want `struct can only be constructed in constructors NewStructWithSpecificConstructor, AnotherConstructor`
+
+	// var
+	var _ StructWithSpecificConstructor  // want `struct can only be constructed in constructors NewStructWithSpecificConstructor, AnotherConstructor`
+	var _ *StructWithSpecificConstructor // want `struct can only be constructed in constructors NewStructWithSpecificConstructor, AnotherConstructor`
+
+	type compositeImplicitInitiate1 struct {
+		StructWithSpecificConstructor
+	}
+	var _ compositeImplicitInitiate1    // want `struct can only be constructed in constructors NewStructWithSpecificConstructor, AnotherConstructor`
+	_ = new(compositeImplicitInitiate1) // want `struct can only be constructed in constructors NewStructWithSpecificConstructor, AnotherConstructor`
+
+	// pointer field is allowed
+	type compositeImplicitInitiate2 struct {
+		*StructWithSpecificConstructor
+	}
+	var _ compositeImplicitInitiate2
+}

--- a/build/nogo_config.json
+++ b/build/nogo_config.json
@@ -1266,6 +1266,14 @@
       "external/": "no need to vet third party code"
     }
   },
+  "constructor": {
+    "exclude_files": {
+      "parser/parser.go": "parser/parser.go code",
+      ".*_generated\\.go$": "ignore generated code",
+      "external/": "no need to vet third party code",
+      "build/linter/constructor/testdata/": "no need to vet the test inside the linter"
+    }
+  },
   "deferrecover": {
     "exclude_files": {
       "pkg/parser/parser.go": "parser/parser.go code",

--- a/pkg/sessionctx/stmtctx/BUILD.bazel
+++ b/pkg/sessionctx/stmtctx/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/util/disk",
         "//pkg/util/execdetails",
         "//pkg/util/intest",
+        "//pkg/util/linter/constructor",
         "//pkg/util/memory",
         "//pkg/util/nocopy",
         "//pkg/util/resourcegrouptag",

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/disk"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/intest"
+	"github.com/pingcap/tidb/pkg/util/linter/constructor"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/nocopy"
 	"github.com/pingcap/tidb/pkg/util/resourcegrouptag"
@@ -152,6 +153,8 @@ type StatementContext struct {
 	// NoCopy indicates that this struct cannot be copied because
 	// copying this object will make the copied TypeCtx field to refer a wrong `AppendWarnings` func.
 	_ nocopy.NoCopy
+
+	_ constructor.Constructor `ctor:"NewStmtCtx,NewStmtCtxWithTimeZone,Reset"`
 
 	// TypeCtx is used to indicate how make the type conversation.
 	TypeCtx typectx.Context

--- a/pkg/util/linter/constructor/BUILD.bazel
+++ b/pkg/util/linter/constructor/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "constructor",
+    srcs = ["constructorflag.go"],
+    importpath = "github.com/pingcap/tidb/pkg/util/linter/constructor",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/linter/constructor/constructorflag.go
+++ b/pkg/util/linter/constructor/constructorflag.go
@@ -1,0 +1,26 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constructor
+
+// Constructor is an empty struct to mark the constructor function
+// Example:
+//
+//	type StatementContext struct {
+//	    _ constructor.Constructor `ctor:"NewStmtCtx"`
+//	}
+//
+// The linter `constructor` will then ignore all manual construction of the struct in `NewStmtCtx`, and return error
+// for all other constructions.
+type Constructor struct{}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #47660

Add a linter to ensure the `stmtCtx` is constructed correctly, at least the `AppendWarning` of `TypeCtx` is set.

Problem Summary:

### What is changed and how it works?

A simple linter, as documented in the comment, it will detect the following cases:

1. Create struct directly, like `SomeStruct{}` or `&SomeStruct{}`.
2. Create struct with `new`: `new(SomeStruct)`
3. Struct literal in slice or other struct: `[]SomeStruct{{}}, []*SomeStruct{{}}`
4. Define variables through `var`: `var a SomeStruct`.
5. Implicit zero value in other struct literal: `type OtherStruct struct{SomeStruct}; other := OtherStruct{}`

After this PR is merged, the `StmtCtx` can only be constructed through:

```go
stmtctx.NewStmtCtx()
stmtctx.NewStmtCtxWithTimeZone()
```

Or `Reset` an existing `StmtCtx`.

Though we still exposed the `TypeCtx` and the code can still modify the `TimeZone` and `TypeCtx` manually, but it's easier to modify and protect them in the future (e.g. make the `TypeCtx` private).

To add the constructor validator to a struct, you can add the `_ constructor.Constructor` field like the following example:

```go
type someStruct struct {
    _ constructor.Constructor `ctor:"NewSomeStruct"`
}
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
