### PR TITLE
disttask: add sleep when subtask == nil

### DIFF
--- a/pkg/disttask/framework/scheduler/scheduler.go
+++ b/pkg/disttask/framework/scheduler/scheduler.go
@@ -219,6 +219,7 @@ func (s *BaseScheduler) run(ctx context.Context, task *proto.Task) error {
 			if newTask.Step != task.Step || newTask.State != task.State {
 				break
 			}
+			time.Sleep(checkTime)
 			continue
 		}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46258

Problem Summary:

### What is changed and how it works?
When subtask == nil but task is running, sleep for a while.
Very likely to happen when some tidb node is the tail, and some tidb node already processed all subtasks.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
![6d33da70-f1cd-4ca4-bccb-569d7b10485f](https://github.com/pingcap/tidb/assets/26179892/ffd87daf-6c0d-4934-8ae6-57ab9b21f713)
The cop request qps is really high.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
