### PR TITLE
planner: move more methods from StatsHandle to its sub-packages

### DIFF
--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -76,6 +76,22 @@ func (sa *statsAnalyze) HandleAutoAnalyze(is infoschema.InfoSchema) (analyzed bo
 	return
 }
 
+// CheckAnalyzeVersion checks whether all the statistics versions of this table's columns and indexes are the same.
+func (sa *statsAnalyze) CheckAnalyzeVersion(tblInfo *model.TableInfo, physicalIDs []int64, version *int) bool {
+	// We simply choose one physical id to get its stats.
+	var tbl *statistics.Table
+	for _, pid := range physicalIDs {
+		tbl = sa.statsHandle.GetPartitionStats(tblInfo, pid)
+		if !tbl.Pseudo {
+			break
+		}
+	}
+	if tbl == nil || tbl.Pseudo {
+		return true
+	}
+	return statistics.CheckAnalyzeVerOnTable(tbl, version)
+}
+
 func parseAutoAnalyzeRatio(ratio string) float64 {
 	autoAnalyzeRatio, err := strconv.ParseFloat(ratio, 64)
 	if err != nil {

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -70,7 +70,7 @@ func (h *Handle) initStatsMeta(is infoschema.InfoSchema) (util.StatsCache, error
 		return nil, errors.Trace(err)
 	}
 	defer terror.Call(rc.Close)
-	tables, err := cache.NewStatsCacheImpl(h, h.TableStatsFromStorage)
+	tables, err := cache.NewStatsCacheImpl(h)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/statistics/handle/cache/BUILD.bazel
+++ b/pkg/statistics/handle/cache/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/statistics/handle/cache/internal/lfu",
         "//pkg/statistics/handle/cache/internal/mapcache",
         "//pkg/statistics/handle/cache/internal/metrics",
+        "//pkg/statistics/handle/metrics",
         "//pkg/statistics/handle/util",
         "//pkg/types",
         "//pkg/util/chunk",

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -20,10 +20,10 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/infoschema"
-	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/cache/internal/metrics"
+	handle_metrics "github.com/pingcap/tidb/pkg/statistics/handle/metrics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -34,21 +34,17 @@ import (
 type StatsCacheImpl struct {
 	atomic.Pointer[StatsCache]
 
-	statsHandle           util.StatsHandle
-	tableStatsFromStorage func(tableInfo *model.TableInfo, physicalID int64, loadAll bool, snapshot uint64) (statsTbl *statistics.Table, err error)
+	statsHandle util.StatsHandle
 }
 
 // NewStatsCacheImpl creates a new StatsCache.
-func NewStatsCacheImpl(statsHandle util.StatsHandle,
-	tableStatsFromStorage func(tableInfo *model.TableInfo, physicalID int64, loadAll bool, snapshot uint64) (statsTbl *statistics.Table, err error),
-) (util.StatsCache, error) {
+func NewStatsCacheImpl(statsHandle util.StatsHandle) (util.StatsCache, error) {
 	newCache, err := NewStatsCache()
 	if err != nil {
 		return nil, err
 	}
 	result := &StatsCacheImpl{
-		statsHandle:           statsHandle,
-		tableStatsFromStorage: tableStatsFromStorage,
+		statsHandle: statsHandle,
 	}
 	result.Store(newCache)
 	return result, nil
@@ -56,7 +52,7 @@ func NewStatsCacheImpl(statsHandle util.StatsHandle,
 
 // NewStatsCacheImplForTest creates a new StatsCache for test.
 func NewStatsCacheImplForTest() (util.StatsCache, error) {
-	return NewStatsCacheImpl(nil, nil)
+	return NewStatsCacheImpl(nil)
 }
 
 // Update reads stats meta from store and updates the stats map.
@@ -100,7 +96,7 @@ func (s *StatsCacheImpl) Update(is infoschema.InfoSchema) error {
 		if oldTbl, ok := s.Get(physicalID); ok && oldTbl.Version >= version && tableInfo.UpdateTS == oldTbl.TblInfoUpdateTS {
 			continue
 		}
-		tbl, err := s.tableStatsFromStorage(tableInfo, physicalID, false, 0)
+		tbl, err := s.statsHandle.TableStatsFromStorage(tableInfo, physicalID, false, 0)
 		// Error is not nil may mean that there are some ddl changes on this table, we will not update it.
 		if err != nil {
 			logutil.BgLogger().Error("error occurred when read table stats", zap.String("category", "stats"), zap.String("table", tableInfo.Name.O), zap.Error(err))
@@ -195,4 +191,28 @@ func (s *StatsCacheImpl) Len() int {
 // SetStatsCacheCapacity sets the cache's capacity.
 func (s *StatsCacheImpl) SetStatsCacheCapacity(c int64) {
 	s.Load().SetCapacity(c)
+}
+
+// UpdateStatsHealthyMetrics updates stats healthy distribution metrics according to stats cache.
+func (s *StatsCacheImpl) UpdateStatsHealthyMetrics() {
+	distribution := make([]int64, 5)
+	for _, tbl := range s.Values() {
+		healthy, ok := tbl.GetStatsHealthy()
+		if !ok {
+			continue
+		}
+		if healthy < 50 {
+			distribution[0]++
+		} else if healthy < 80 {
+			distribution[1]++
+		} else if healthy < 100 {
+			distribution[2]++
+		} else {
+			distribution[3]++
+		}
+		distribution[4]++
+	}
+	for i, val := range distribution {
+		handle_metrics.StatsHealthyGauges[i].Set(float64(val))
+	}
 }

--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "json.go",
         "read.go",
         "save.go",
+        "stats_read_writer.go",
         "update.go",
     ],
     importpath = "github.com/pingcap/tidb/pkg/statistics/handle/storage",

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -1,0 +1,185 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/statistics"
+	"github.com/pingcap/tidb/pkg/statistics/handle/util"
+)
+
+// statsReadWriter implements the util.StatsReadWriter interface.
+type statsReadWriter struct {
+	statsHandler util.StatsHandle
+}
+
+// NewStatsReadWriter creates a new StatsReadWriter.
+func NewStatsReadWriter(statsHandler util.StatsHandle) util.StatsReadWriter {
+	return &statsReadWriter{statsHandler: statsHandler}
+}
+
+// StatsMetaCountAndModifyCount reads count and modify_count for the given table from mysql.stats_meta.
+func (s *statsReadWriter) StatsMetaCountAndModifyCount(tableID int64) (count, modifyCount int64, err error) {
+	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		count, modifyCount, _, err = StatsMetaCountAndModifyCount(sctx, tableID)
+		return err
+	}, util.FlagWrapTxn)
+	return
+}
+
+// TableStatsFromStorage loads table stats info from storage.
+func (s *statsReadWriter) TableStatsFromStorage(tableInfo *model.TableInfo, physicalID int64, loadAll bool, snapshot uint64) (statsTbl *statistics.Table, err error) {
+	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		var ok bool
+		statsTbl, ok = s.statsHandler.Get(physicalID)
+		if !ok {
+			statsTbl = nil
+		}
+		statsTbl, err = TableStatsFromStorage(sctx, snapshot, tableInfo, physicalID, loadAll, s.statsHandler.Lease(), statsTbl)
+		return err
+	}, util.FlagWrapTxn)
+	return
+}
+
+// SaveStatsToStorage saves the stats to storage.
+// If count is negative, both count and modify count would not be used and not be written to the table. Unless, corresponding
+// fields in the stats_meta table will be updated.
+// TODO: refactor to reduce the number of parameters
+func (s *statsReadWriter) SaveStatsToStorage(tableID int64, count, modifyCount int64, isIndex int, hg *statistics.Histogram,
+	cms *statistics.CMSketch, topN *statistics.TopN, statsVersion int, isAnalyzed int64, updateAnalyzeTime bool, source string) (err error) {
+	var statsVer uint64
+	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		statsVer, err = SaveStatsToStorage(sctx, tableID,
+			count, modifyCount, isIndex, hg, cms, topN, statsVersion, isAnalyzed, updateAnalyzeTime)
+		return err
+	})
+	if err == nil && statsVer != 0 {
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source)
+	}
+	return
+}
+
+// SaveMetaToStorage saves stats meta to the storage.
+func (s *statsReadWriter) SaveMetaToStorage(tableID, count, modifyCount int64, source string) (err error) {
+	var statsVer uint64
+	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		statsVer, err = SaveMetaToStorage(sctx, tableID, count, modifyCount)
+		return err
+	})
+	if err == nil && statsVer != 0 {
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source)
+	}
+	return
+}
+
+// InsertExtendedStats inserts a record into mysql.stats_extended and update version in mysql.stats_meta.
+func (s *statsReadWriter) InsertExtendedStats(statsName string, colIDs []int64, tp int, tableID int64, ifNotExists bool) (err error) {
+	var statsVer uint64
+	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		statsVer, err = InsertExtendedStats(sctx, s.statsHandler, statsName, colIDs, tp, tableID, ifNotExists)
+		return err
+	})
+	if err == nil && statsVer != 0 {
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats")
+	}
+	return
+}
+
+// MarkExtendedStatsDeleted update the status of mysql.stats_extended to be `deleted` and the version of mysql.stats_meta.
+func (s *statsReadWriter) MarkExtendedStatsDeleted(statsName string, tableID int64, ifExists bool) (err error) {
+	var statsVer uint64
+	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		statsVer, err = MarkExtendedStatsDeleted(sctx, s.statsHandler, statsName, tableID, ifExists)
+		return err
+	})
+	if err == nil && statsVer != 0 {
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats")
+	}
+	return
+}
+
+// SaveExtendedStatsToStorage writes extended stats of a table into mysql.stats_extended.
+func (s *statsReadWriter) SaveExtendedStatsToStorage(tableID int64, extStats *statistics.ExtendedStatsColl, isLoad bool) (err error) {
+	var statsVer uint64
+	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		statsVer, err = SaveExtendedStatsToStorage(sctx, tableID, extStats, isLoad)
+		return err
+	})
+	if err == nil && statsVer != 0 {
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats")
+	}
+	return
+}
+
+// SaveStatsFromJSON saves stats from JSON to the storage.
+func (s *statsReadWriter) SaveStatsFromJSON(tableInfo *model.TableInfo, physicalID int64, jsonTblI interface{}) error {
+	jsonTbl := jsonTblI.(*JSONTable)
+	tbl, err := TableStatsFromJSON(tableInfo, physicalID, jsonTbl)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, col := range tbl.Columns {
+		// loadStatsFromJSON doesn't support partition table now.
+		// The table level count and modify_count would be overridden by the SaveMetaToStorage below, so we don't need
+		// to care about them here.
+		err = s.SaveStatsToStorage(tbl.PhysicalID, tbl.RealtimeCount, 0, 0, &col.Histogram, col.CMSketch, col.TopN, int(col.GetStatsVer()), 1, false, "load stats")
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	for _, idx := range tbl.Indices {
+		// loadStatsFromJSON doesn't support partition table now.
+		// The table level count and modify_count would be overridden by the SaveMetaToStorage below, so we don't need
+		// to care about them here.
+		err = s.SaveStatsToStorage(tbl.PhysicalID, tbl.RealtimeCount, 0, 1, &idx.Histogram, idx.CMSketch, idx.TopN, int(idx.GetStatsVer()), 1, false, "load stats")
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	err = s.SaveExtendedStatsToStorage(tbl.PhysicalID, tbl.ExtendedStats, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return s.SaveMetaToStorage(tbl.PhysicalID, tbl.RealtimeCount, tbl.ModifyCount, "load stats")
+}
+
+// LoadNeededHistograms will load histograms for those needed columns/indices.
+func (s *statsReadWriter) LoadNeededHistograms() (err error) {
+	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		loadFMSketch := config.GetGlobalConfig().Performance.EnableLoadFMSketch
+		return LoadNeededHistograms(sctx, s.statsHandler, loadFMSketch)
+	}, util.FlagWrapTxn)
+	return err
+}
+
+// ReloadExtendedStatistics drops the cache for extended statistics and reload data from mysql.stats_extended.
+func (s *statsReadWriter) ReloadExtendedStatistics() error {
+	return util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		tables := make([]*statistics.Table, 0, s.statsHandler.Len())
+		for _, tbl := range s.statsHandler.Values() {
+			t, err := ExtendedStatsFromStorage(sctx, tbl.Copy(), tbl.PhysicalID, true)
+			if err != nil {
+				return err
+			}
+			tables = append(tables, t)
+		}
+		s.statsHandler.UpdateStatsCache(tables, nil)
+		return nil
+	}, util.FlagWrapTxn)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46905

Problem Summary: planner: move more methods from StatsHandle to its sub-packages

### What is changed and how it works?

planner: move more methods from StatsHandle to its sub-packages

No logical change, just refactor.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
