### PR TITLE
importinto: add more logs to external backend, disable parallel sort

### DIFF
--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/util/mathutil",
         "//pkg/util/size",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_jfcg_sorty_v2//:sorty",
         "@com_github_pingcap_errors//:errors",
         "@org_golang_x_sync//errgroup",

--- a/br/pkg/lightning/backend/external/writer.go
+++ b/br/pkg/lightning/backend/external/writer.go
@@ -428,6 +428,7 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 			zap.Duration("write-time", writeDuration),
 			zap.String("sort-speed(kv/s)", getSpeed(uint64(kvCnt), sortDuration.Seconds(), false)),
 			zap.String("write-speed(bytes/s)", getSpeed(savedBytes, writeDuration.Seconds(), true)),
+			zap.String("writerID", w.writerID),
 		)
 	}()
 

--- a/br/pkg/lightning/backend/external/writer.go
+++ b/br/pkg/lightning/backend/external/writer.go
@@ -428,7 +428,7 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 			zap.Duration("write-time", writeDuration),
 			zap.String("sort-speed(kv/s)", getSpeed(uint64(kvCnt), sortDuration.Seconds(), false)),
 			zap.String("write-speed(bytes/s)", getSpeed(savedBytes, writeDuration.Seconds(), true)),
-			zap.String("writerID", w.writerID),
+			zap.String("writer-id", w.writerID),
 		)
 	}()
 

--- a/br/pkg/lightning/backend/external/writer.go
+++ b/br/pkg/lightning/backend/external/writer.go
@@ -19,10 +19,12 @@ import (
 	"context"
 	"encoding/hex"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/jfcg/sorty/v2"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/lightning/backend"
@@ -384,9 +386,23 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 		return err
 	}
 
-	ts := time.Now()
-	var savedBytes uint64
+	var (
+		savedBytes                  uint64
+		statSize                    int
+		sortDuration, writeDuration time.Duration
+		writeStartTime              time.Time
+	)
 
+	getSpeed := func(n uint64, dur float64, isBytes bool) string {
+		if dur == 0 {
+			return "-"
+		}
+		if isBytes {
+			return units.BytesSize(float64(n) / dur)
+		}
+		return units.HumanSize(float64(n) / dur)
+	}
+	kvCnt := len(w.writeBatch)
 	defer func() {
 		w.currentSeq++
 		err1, err2 := dataWriter.Close(ctx), statWriter.Close(ctx)
@@ -403,23 +419,38 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 			err = err2
 			return
 		}
+		writeDuration = time.Since(writeStartTime)
 		logger.Info("flush kv",
-			zap.Duration("time", time.Since(ts)),
 			zap.Uint64("bytes", savedBytes),
-			zap.Any("rate", float64(savedBytes)/1024.0/1024.0/time.Since(ts).Seconds()))
+			zap.Int("kv-cnt", kvCnt),
+			zap.Int("stat-size", statSize),
+			zap.Duration("sort-time", sortDuration),
+			zap.Duration("write-time", writeDuration),
+			zap.String("sort-speed(kv/s)", getSpeed(uint64(kvCnt), sortDuration.Seconds(), false)),
+			zap.String("write-speed(bytes/s)", getSpeed(savedBytes, writeDuration.Seconds(), true)),
+		)
 	}()
 
-	sorty.MaxGor = min(8, uint64(variable.GetDDLReorgWorkerCounter()))
-	sorty.Sort(len(w.writeBatch), func(i, j, r, s int) bool {
-		if bytes.Compare(w.writeBatch[i].Key, w.writeBatch[j].Key) < 0 {
-			if r != s {
-				w.writeBatch[r], w.writeBatch[s] = w.writeBatch[s], w.writeBatch[r]
+	sortStart := time.Now()
+	if w.shareMu != nil {
+		sorty.MaxGor = min(8, uint64(variable.GetDDLReorgWorkerCounter()))
+		sorty.Sort(len(w.writeBatch), func(i, j, r, s int) bool {
+			if bytes.Compare(w.writeBatch[i].Key, w.writeBatch[j].Key) < 0 {
+				if r != s {
+					w.writeBatch[r], w.writeBatch[s] = w.writeBatch[s], w.writeBatch[r]
+				}
+				return true
 			}
-			return true
-		}
-		return false
-	})
+			return false
+		})
+	} else {
+		slices.SortFunc(w.writeBatch[:], func(i, j common.KvPair) int {
+			return bytes.Compare(i.Key, j.Key)
+		})
+	}
+	sortDuration = time.Since(sortStart)
 
+	writeStartTime = time.Now()
 	w.kvStore, err = NewKeyValueStore(ctx, dataWriter, w.rc)
 	if err != nil {
 		return err
@@ -435,7 +466,9 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 	}
 
 	w.kvStore.Close()
-	_, err = statWriter.Write(ctx, w.rc.encode())
+	encodedStat := w.rc.encode()
+	statSize = len(encodedStat)
+	_, err = statWriter.Write(ctx, encodedStat)
 	if err != nil {
 		return err
 	}

--- a/pkg/disttask/importinto/encode_and_sort_operator.go
+++ b/pkg/disttask/importinto/encode_and_sort_operator.go
@@ -158,7 +158,7 @@ func newChunkWorker(ctx context.Context, op *encodeAndSortOperator, indexMemoryS
 			builder := external.NewWriterBuilder().
 				SetOnCloseFunc(func(summary *external.WriterSummary) {
 					op.sharedVars.mergeIndexSummary(indexID, summary)
-				}).SetMemorySizeLimit(indexMemorySizeLimit).SetMutex(&op.sharedVars.ShareMu)
+				}).SetMemorySizeLimit(indexMemorySizeLimit)
 			prefix := subtaskPrefix(op.taskID, op.subtaskID)
 			// writer id for index: index/{indexID}/{workerID}
 			writerID := path.Join("index", strconv.Itoa(int(indexID)), workerUUID)
@@ -168,7 +168,7 @@ func newChunkWorker(ctx context.Context, op *encodeAndSortOperator, indexMemoryS
 
 		// sorted data kv storage path: /{taskID}/{subtaskID}/data/{workerID}
 		builder := external.NewWriterBuilder().
-			SetOnCloseFunc(op.sharedVars.mergeDataSummary).SetMutex(&op.sharedVars.ShareMu)
+			SetOnCloseFunc(op.sharedVars.mergeDataSummary)
 		prefix := subtaskPrefix(op.taskID, op.subtaskID)
 		// writer id for data: data/{workerID}
 		writerID := path.Join("data", workerUUID)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #47572

Problem Summary:

### What is changed and how it works?

add more logs to external backend, disable parallel sort to speed up encode&sort

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

with a case of 150g, import takes 58m after vs 70m before, mainly speed up encode&sort step. and CPU curve became more smooth.
after
![image](https://github.com/pingcap/tidb/assets/3312245/9469b905-7b37-4de4-b595-2de23180d1d5)
before
![image](https://github.com/pingcap/tidb/assets/3312245/d8963b15-7f45-4e25-8cd2-9ae74d05bf44)

flush log looks like this:
```
[2023/10/16 16:27:57.768 +00:00] [INFO] [writer.go:445] ["flush kv"] [bytes=268339017] [kv-cnt=18160] [stat-size=42504] [sort-time=250.47596ms] [write-time=1.781394854s] [sort-speed(kv/s)=72.5kB] [write-speed(bytes/s)=143.7MiB] [writerID=data/56625710-9837-4c0e-a3f1-b35490f9a008]
[2023/10/16 16:27:57.963 +00:00] [INFO] [writer.go:445] ["flush kv"] [bytes=268339452] [kv-cnt=18160] [stat-size=42504] [sort-time=53.950553ms] [write-time=1.635531465s] [sort-speed(kv/s)=336.6kB] [write-speed(bytes/s)=156.5MiB] [writerID=data/22a1c4ea-b6aa-4a39-9896-b4a461578107]
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
