### PR TITLE
session/variable: forbid changing @@global.require_secure_transport to 'on' with SEM enabled #47677

### DIFF
--- a/sessionctx/sessionstates/BUILD.bazel
+++ b/sessionctx/sessionstates/BUILD.bazel
@@ -30,7 +30,7 @@ go_test(
     ],
     embed = [":sessionstates"],
     flaky = True,
-    shard_count = 14,
+    shard_count = 15,
     deps = [
         "//config",
         "//errno",

--- a/sessionctx/sessionstates/session_states_test.go
+++ b/sessionctx/sessionstates/session_states_test.go
@@ -16,6 +16,7 @@ package sessionstates_test
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/binary"
 	"fmt"
 	"strconv"
@@ -1483,4 +1484,16 @@ func getResetBytes(stmtID uint32) []byte {
 	pos++
 	binary.LittleEndian.PutUint32(buf[pos:], stmtID)
 	return buf
+}
+
+func TestIssue47665(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.Session().GetSessionVars().TLSConnectionState = &tls.ConnectionState{} // unrelated mock for the test.
+	originSEM := config.GetGlobalConfig().Security.EnableSEM
+	config.GetGlobalConfig().Security.EnableSEM = true
+	tk.MustGetErrMsg("set @@global.require_secure_transport = on", "require_secure_transport can not be set to ON with SEM(security enhanced mode) enabled")
+	config.GetGlobalConfig().Security.EnableSEM = originSEM
+	tk.MustExec("set @@global.require_secure_transport = on")
+	tk.MustExec("set @@global.require_secure_transport = off") // recover to default value
 }

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1033,6 +1033,15 @@ var defaultSysVars = []*SysVar{
 			return nil
 		}, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
 			if vars.StmtCtx.StmtType == "Set" && TiDBOptOn(normalizedValue) {
+				// On tidbcloud dedicated cluster with the default configuration, if an user modify
+				// @@global.require_secure_transport=on, he can not login the cluster anymore!
+				// A workaround for this is making require_secure_transport read-only for that case.
+				// SEM(security enhanced mode) is enabled by default with only that settings.
+				cfg := config.GetGlobalConfig()
+				if cfg.Security.EnableSEM {
+					return "", errors.New("require_secure_transport can not be set to ON with SEM(security enhanced mode) enabled")
+				}
+
 				// Refuse to set RequireSecureTransport to ON if the connection
 				// issuing the change is not secure. This helps reduce the chance of users being locked out.
 				if vars.TLSConnectionState == nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47665

Problem Summary:

The configuration for TiDB Cloud dedicated cluster is:

```
require_secure_transport: OFF
ssl_ca : /var/lib/tidb-server-tls/ca.crt
ssl_cert : /var/lib/tidb-server-tls/tls.crt
ssl_key: /var/lib/tidb-server-tls/tls.key
```

We just provide the `ca.crt` file for the the users to connect the TiDB cluster. When `require_secure_transport = OFF`, there is no problem.


**But if the user set the value of require_secure_transport to 'ON', the users can not connect to the cluster anymore!**


This is because the new configuration require the mysql client to pass all `ca.crt` `tls.crt` `tls.key` correctly, while the user only have  the `ca.crt` file.

### What is changed and how it works?

To prevent the user from losing access of the cluster, we can forbid changing `require_secure_transport` system variable to 'on' as a workaround, then the user can not modify it and trigger the issue.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

Modify the config.toml.example:
```
# Security Enhanced Mode (SEM) restricts the "SUPER" privilege and requires fine-grained privileges instead.
enable-sem = true
```
```
./bin/tidb-server -config ./pkg/config/config.toml.example
mysql -h 127.0.0.1 -u root -P 4000
```
```
mysql> set @@global.require_secure_transport = on;
ERROR 1105 (HY000): require_secure_transport can not be set to ON with SEM(security enhanced mode) enabled
```


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [X] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Forbid changing @@global.require_secure_transport variable to 'on' when SEM(security enhanced mode) is enabled
```
