### PR TITLE
gc_worker_test: Print error to the failure message when mustGetNone encounters unexpected error

### DIFF
--- a/pkg/store/gcworker/gc_worker_test.go
+++ b/pkg/store/gcworker/gc_worker_test.go
@@ -207,7 +207,7 @@ func (s *mockGCWorkerSuite) mustGetNone(t *testing.T, key string, ts uint64) {
 	if err != nil {
 		// unistore gc is based on compaction filter.
 		// So skip the error check if err == nil.
-		require.True(t, kv.ErrNotExist.Equal(err))
+		require.True(t, kv.ErrNotExist.Equal(err), "unexpected error: %+q", err)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #47023

Problem Summary:

#47023 mentions that the test TestLeaderTick is unstable, however I failed to reproduce it locally, and nothing helpful was found in the log of that failure. This PR tries to print the detail of the error when it fails on the same place again.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
