### PR TITLE
planner: move more methods from StatsHandle to its sub-packages

### DIFF
--- a/pkg/executor/analyze_worker.go
+++ b/pkg/executor/analyze_worker.go
@@ -19,9 +19,9 @@ import (
 	"sync/atomic"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/statistics"
-	"github.com/pingcap/tidb/pkg/statistics/handle"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -61,7 +61,8 @@ func (worker *analyzeSaveStatsWorker) run(ctx context.Context, analyzeSnapshot b
 			worker.errCh <- errors.Trace(exeerrors.ErrQueryInterrupted)
 			return
 		}
-		err := handle.SaveTableStatsToStorage(worker.sctx, results, analyzeSnapshot, util.StatsMetaHistorySourceAnalyze)
+		statsHandle := domain.GetDomain(worker.sctx).StatsHandle()
+		err := statsHandle.SaveTableStatsToStorage(results, analyzeSnapshot, util.StatsMetaHistorySourceAnalyze)
 		if err != nil {
 			logutil.Logger(ctx).Error("save table stats to storage failed", zap.Error(err))
 			finishJobWithLog(worker.sctx, results.Job, err)

--- a/pkg/statistics/handle/BUILD.bazel
+++ b/pkg/statistics/handle/BUILD.bazel
@@ -37,7 +37,6 @@ go_library(
         "//pkg/util",
         "//pkg/util/chunk",
         "//pkg/util/logutil",
-        "//pkg/util/sqlexec",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_tiancaiamao_gp//:gp",

--- a/pkg/statistics/handle/ddl.go
+++ b/pkg/statistics/handle/ddl.go
@@ -15,20 +15,11 @@
 package handle
 
 import (
-	"context"
-
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/parser/model"
-	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics/handle/globalstats"
-	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
-	statsutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
-	"github.com/pingcap/tidb/pkg/types"
-	"github.com/pingcap/tidb/pkg/util/sqlexec"
 )
 
 // HandleDDLEvent begins to process a ddl task.
@@ -40,7 +31,7 @@ func (h *Handle) HandleDDLEvent(t *util.Event) error {
 			return err
 		}
 		for _, id := range ids {
-			if err := h.insertTableStats2KV(t.TableInfo, id); err != nil {
+			if err := h.InsertTableStats2KV(t.TableInfo, id); err != nil {
 				return err
 			}
 		}
@@ -50,7 +41,7 @@ func (h *Handle) HandleDDLEvent(t *util.Event) error {
 			return err
 		}
 		for _, id := range ids {
-			if err := h.resetTableStats2KVForDrop(id); err != nil {
+			if err := h.ResetTableStats2KVForDrop(id); err != nil {
 				return err
 			}
 		}
@@ -60,13 +51,13 @@ func (h *Handle) HandleDDLEvent(t *util.Event) error {
 			return err
 		}
 		for _, id := range ids {
-			if err := h.insertColStats2KV(id, t.ColumnInfos); err != nil {
+			if err := h.InsertColStats2KV(id, t.ColumnInfos); err != nil {
 				return err
 			}
 		}
 	case model.ActionAddTablePartition, model.ActionTruncateTablePartition:
 		for _, def := range t.PartInfo.Definitions {
-			if err := h.insertTableStats2KV(t.TableInfo, def.ID); err != nil {
+			if err := h.InsertTableStats2KV(t.TableInfo, def.ID); err != nil {
 				return err
 			}
 		}
@@ -81,14 +72,14 @@ func (h *Handle) HandleDDLEvent(t *util.Event) error {
 			}
 		}
 		for _, def := range t.PartInfo.Definitions {
-			if err := h.resetTableStats2KVForDrop(def.ID); err != nil {
+			if err := h.ResetTableStats2KVForDrop(def.ID); err != nil {
 				return err
 			}
 		}
 	case model.ActionReorganizePartition:
 		for _, def := range t.PartInfo.Definitions {
 			// TODO: Should we trigger analyze instead of adding 0s?
-			if err := h.insertTableStats2KV(t.TableInfo, def.ID); err != nil {
+			if err := h.InsertTableStats2KV(t.TableInfo, def.ID); err != nil {
 				return err
 			}
 			// Do not update global stats, since the data have not changed!
@@ -97,7 +88,7 @@ func (h *Handle) HandleDDLEvent(t *util.Event) error {
 		// Add partitioning
 		for _, def := range t.PartInfo.Definitions {
 			// TODO: Should we trigger analyze instead of adding 0s?
-			if err := h.insertTableStats2KV(t.TableInfo, def.ID); err != nil {
+			if err := h.InsertTableStats2KV(t.TableInfo, def.ID); err != nil {
 				return err
 			}
 		}
@@ -107,19 +98,11 @@ func (h *Handle) HandleDDLEvent(t *util.Event) error {
 		// Note that t.TableInfo is the current (new) table info
 		// and t.PartInfo.NewTableID is actually the old table ID!
 		// (see onReorganizePartition)
-		return h.changeGlobalStatsID(t.PartInfo.NewTableID, t.TableInfo.ID)
+		return h.ChangeGlobalStatsID(t.PartInfo.NewTableID, t.TableInfo.ID)
 	case model.ActionFlashbackCluster:
-		return h.updateStatsVersion()
+		return h.UpdateStatsVersion()
 	}
 	return nil
-}
-
-// updateStatsVersion will set statistics version to the newest TS,
-// then tidb-server will reload automatic.
-func (h *Handle) updateStatsVersion() error {
-	return h.callWithSCtx(func(sctx sessionctx.Context) error {
-		return storage.UpdateStatsVersion(sctx)
-	}, statsutil.FlagWrapTxn)
 }
 
 // updateGlobalStats will trigger the merge of global-stats when we drop table partition
@@ -128,18 +111,6 @@ func (h *Handle) updateGlobalStats(tblInfo *model.TableInfo) error {
 	return h.callWithSCtx(func(sctx sessionctx.Context) error {
 		return globalstats.UpdateGlobalStats(sctx, tblInfo, h.gpool, h.TableStatsFromStorage, h.TableInfoByID, h.callWithSCtx, h.SaveStatsToStorage)
 	})
-}
-
-func (h *Handle) changeGlobalStatsID(from, to int64) (err error) {
-	return h.callWithSCtx(func(sctx sessionctx.Context) error {
-		for _, table := range []string{"stats_meta", "stats_top_n", "stats_fm_sketch", "stats_buckets", "stats_histograms", "column_stats_usage"} {
-			_, err = statsutil.Exec(sctx, "update mysql."+table+" set table_id = %? where table_id = %?", to, from)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	}, statsutil.FlagWrapTxn)
 }
 
 func (h *Handle) getInitStateTableIDs(tblInfo *model.TableInfo) (ids []int64, err error) {
@@ -164,126 +135,4 @@ func (h *Handle) getInitStateTableIDs(tblInfo *model.TableInfo) (ids []int64, er
 // DDLEventCh returns ddl events channel in handle.
 func (h *Handle) DDLEventCh() chan *util.Event {
 	return h.ddlEventCh
-}
-
-// insertTableStats2KV inserts a record standing for a new table to stats_meta and inserts some records standing for the
-// new columns and indices which belong to this table.
-func (h *Handle) insertTableStats2KV(info *model.TableInfo, physicalID int64) (err error) {
-	statsVer := uint64(0)
-	defer func() {
-		if err == nil && statsVer != 0 {
-			h.RecordHistoricalStatsMeta(physicalID, statsVer, statsutil.StatsMetaHistorySourceSchemaChange)
-		}
-	}()
-
-	return h.callWithSCtx(func(sctx sessionctx.Context) error {
-		startTS, err := statsutil.GetStartTS(sctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if _, err := statsutil.Exec(sctx, "insert into mysql.stats_meta (version, table_id) values(%?, %?)", startTS, physicalID); err != nil {
-			return err
-		}
-		statsVer = startTS
-		for _, col := range info.Columns {
-			if _, err := statsutil.Exec(sctx, "insert into mysql.stats_histograms (table_id, is_index, hist_id, distinct_count, version) values(%?, 0, %?, 0, %?)", physicalID, col.ID, startTS); err != nil {
-				return err
-			}
-		}
-		for _, idx := range info.Indices {
-			if _, err := statsutil.Exec(sctx, "insert into mysql.stats_histograms (table_id, is_index, hist_id, distinct_count, version) values(%?, 1, %?, 0, %?)", physicalID, idx.ID, startTS); err != nil {
-				return err
-			}
-		}
-		return nil
-	}, statsutil.FlagWrapTxn)
-}
-
-// resetTableStats2KV resets the count to 0.
-func (h *Handle) resetTableStats2KVForDrop(physicalID int64) (err error) {
-	statsVer := uint64(0)
-	defer func() {
-		if err == nil && statsVer != 0 {
-			h.RecordHistoricalStatsMeta(physicalID, statsVer, statsutil.StatsMetaHistorySourceSchemaChange)
-		}
-	}()
-
-	return h.callWithSCtx(func(sctx sessionctx.Context) error {
-		startTS, err := statsutil.GetStartTS(sctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if _, err := statsutil.Exec(sctx, "update mysql.stats_meta set version=%? where table_id =%?", startTS, physicalID); err != nil {
-			return err
-		}
-		return nil
-	}, statsutil.FlagWrapTxn)
-}
-
-// insertColStats2KV insert a record to stats_histograms with distinct_count 1 and insert a bucket to stats_buckets with default value.
-// This operation also updates version.
-func (h *Handle) insertColStats2KV(physicalID int64, colInfos []*model.ColumnInfo) (err error) {
-	statsVer := uint64(0)
-	defer func() {
-		if err == nil && statsVer != 0 {
-			h.RecordHistoricalStatsMeta(physicalID, statsVer, statsutil.StatsMetaHistorySourceSchemaChange)
-		}
-	}()
-
-	return h.callWithSCtx(func(sctx sessionctx.Context) error {
-		startTS, err := statsutil.GetStartTS(sctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
-
-		// First of all, we update the version.
-		_, err = statsutil.Exec(sctx, "update mysql.stats_meta set version = %? where table_id = %?", startTS, physicalID)
-		if err != nil {
-			return err
-		}
-		statsVer = startTS
-		// If we didn't update anything by last SQL, it means the stats of this table does not exist.
-		if sctx.GetSessionVars().StmtCtx.AffectedRows() > 0 {
-			// By this step we can get the count of this table, then we can sure the count and repeats of bucket.
-			var rs sqlexec.RecordSet
-			rs, err = statsutil.Exec(sctx, "select count from mysql.stats_meta where table_id = %?", physicalID)
-			if err != nil {
-				return err
-			}
-			defer terror.Call(rs.Close)
-			req := rs.NewChunk(nil)
-			err = rs.Next(context.Background(), req)
-			if err != nil {
-				return err
-			}
-			count := req.GetRow(0).GetInt64(0)
-			for _, colInfo := range colInfos {
-				value := types.NewDatum(colInfo.GetOriginDefaultValue())
-				value, err = value.ConvertTo(sctx.GetSessionVars().StmtCtx, &colInfo.FieldType)
-				if err != nil {
-					return err
-				}
-				if value.IsNull() {
-					// If the adding column has default value null, all the existing rows have null value on the newly added column.
-					if _, err := statsutil.Exec(sctx, "insert into mysql.stats_histograms (version, table_id, is_index, hist_id, distinct_count, null_count) values (%?, %?, 0, %?, 0, %?)", startTS, physicalID, colInfo.ID, count); err != nil {
-						return err
-					}
-				} else {
-					// If this stats exists, we insert histogram meta first, the distinct_count will always be one.
-					if _, err := statsutil.Exec(sctx, "insert into mysql.stats_histograms (version, table_id, is_index, hist_id, distinct_count, tot_col_size) values (%?, %?, 0, %?, 1, %?)", startTS, physicalID, colInfo.ID, int64(len(value.GetBytes()))*count); err != nil {
-						return err
-					}
-					value, err = value.ConvertTo(sctx.GetSessionVars().StmtCtx, types.NewFieldType(mysql.TypeBlob))
-					if err != nil {
-						return err
-					}
-					// There must be only one bucket for this new column and the value is the default value.
-					if _, err := statsutil.Exec(sctx, "insert into mysql.stats_buckets (table_id, is_index, hist_id, bucket_id, repeats, count, lower_bound, upper_bound) values (%?, 0, %?, 0, %?, %?, %?, %?)", physicalID, colInfo.ID, count, count, value.GetBytes(), value.GetBytes()); err != nil {
-						return err
-					}
-				}
-			}
-		}
-		return nil
-	}, statsutil.FlagWrapTxn)
 }

--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -220,29 +220,6 @@ func (h *Handle) FlushStats() {
 	}
 }
 
-// SaveTableStatsToStorage saves the stats of a table to storage.
-func (h *Handle) SaveTableStatsToStorage(results *statistics.AnalyzeResults, analyzeSnapshot bool, source string) (err error) {
-	return h.callWithSCtx(func(sctx sessionctx.Context) error {
-		return SaveTableStatsToStorage(sctx, results, analyzeSnapshot, source)
-	})
-}
-
-// SaveTableStatsToStorage saves the stats of a table to storage.
-func SaveTableStatsToStorage(sctx sessionctx.Context, results *statistics.AnalyzeResults, analyzeSnapshot bool, source string) error {
-	statsVer, err := storage.SaveTableStatsToStorage(sctx, results, analyzeSnapshot)
-	if err == nil && statsVer != 0 {
-		tableID := results.TableID.GetStatisticsID()
-		if err1 := history.RecordHistoricalStatsMeta(sctx, tableID, statsVer, source); err1 != nil {
-			logutil.BgLogger().Error("record historical stats meta failed",
-				zap.Int64("table-id", tableID),
-				zap.Uint64("version", statsVer),
-				zap.String("source", source),
-				zap.Error(err1))
-		}
-	}
-	return err
-}
-
 // BuildExtendedStats build extended stats for column groups if needed based on the column samples.
 func (h *Handle) BuildExtendedStats(tableID int64, cols []*model.ColumnInfo, collectors []*statistics.SampleCollector) (es *statistics.ExtendedStatsColl, err error) {
 	err = h.callWithSCtx(func(sctx sessionctx.Context) error {

--- a/pkg/statistics/handle/history/history_stats.go
+++ b/pkg/statistics/handle/history/history_stats.go
@@ -62,16 +62,18 @@ func (sh *statsHistoryImpl) RecordHistoricalStatsToStorage(dbName string, tableI
 }
 
 // RecordHistoricalStatsMeta records stats meta of the specified version to stats_meta_history table.
-func (sh *statsHistoryImpl) RecordHistoricalStatsMeta(tableID int64, version uint64, source string) {
+func (sh *statsHistoryImpl) RecordHistoricalStatsMeta(tableID int64, version uint64, source string, enforce bool) {
 	if version == 0 {
 		return
 	}
-	tbl, ok := sh.statsHandle.Get(tableID)
-	if !ok {
-		return
-	}
-	if !tbl.IsInitialized() {
-		return
+	if !enforce {
+		tbl, ok := sh.statsHandle.Get(tableID)
+		if !ok {
+			return
+		}
+		if !tbl.IsInitialized() {
+			return
+		}
 	}
 	err := util.CallWithSCtx(sh.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		return RecordHistoricalStatsMeta(sctx, tableID, version, source)

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -25,11 +25,14 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics"
 	handle_metrics "github.com/pingcap/tidb/pkg/statistics/handle/metrics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 )
@@ -42,6 +45,163 @@ type statsReadWriter struct {
 // NewStatsReadWriter creates a new StatsReadWriter.
 func NewStatsReadWriter(statsHandler util.StatsHandle) util.StatsReadWriter {
 	return &statsReadWriter{statsHandler: statsHandler}
+}
+
+// InsertColStats2KV insert a record to stats_histograms with distinct_count 1 and insert a bucket to stats_buckets with default value.
+// This operation also updates version.
+func (s *statsReadWriter) InsertColStats2KV(physicalID int64, colInfos []*model.ColumnInfo) (err error) {
+	statsVer := uint64(0)
+	defer func() {
+		if err == nil && statsVer != 0 {
+			s.statsHandler.RecordHistoricalStatsMeta(physicalID, statsVer, util.StatsMetaHistorySourceSchemaChange)
+		}
+	}()
+
+	return util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		startTS, err := util.GetStartTS(sctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		// First of all, we update the version.
+		_, err = util.Exec(sctx, "update mysql.stats_meta set version = %? where table_id = %?", startTS, physicalID)
+		if err != nil {
+			return err
+		}
+		statsVer = startTS
+		// If we didn't update anything by last SQL, it means the stats of this table does not exist.
+		if sctx.GetSessionVars().StmtCtx.AffectedRows() > 0 {
+			// By this step we can get the count of this table, then we can sure the count and repeats of bucket.
+			var rs sqlexec.RecordSet
+			rs, err = util.Exec(sctx, "select count from mysql.stats_meta where table_id = %?", physicalID)
+			if err != nil {
+				return err
+			}
+			defer terror.Call(rs.Close)
+			req := rs.NewChunk(nil)
+			err = rs.Next(context.Background(), req)
+			if err != nil {
+				return err
+			}
+			count := req.GetRow(0).GetInt64(0)
+			for _, colInfo := range colInfos {
+				value := types.NewDatum(colInfo.GetOriginDefaultValue())
+				value, err = value.ConvertTo(sctx.GetSessionVars().StmtCtx, &colInfo.FieldType)
+				if err != nil {
+					return err
+				}
+				if value.IsNull() {
+					// If the adding column has default value null, all the existing rows have null value on the newly added column.
+					if _, err := util.Exec(sctx, "insert into mysql.stats_histograms (version, table_id, is_index, hist_id, distinct_count, null_count) values (%?, %?, 0, %?, 0, %?)", startTS, physicalID, colInfo.ID, count); err != nil {
+						return err
+					}
+				} else {
+					// If this stats exists, we insert histogram meta first, the distinct_count will always be one.
+					if _, err := util.Exec(sctx, "insert into mysql.stats_histograms (version, table_id, is_index, hist_id, distinct_count, tot_col_size) values (%?, %?, 0, %?, 1, %?)", startTS, physicalID, colInfo.ID, int64(len(value.GetBytes()))*count); err != nil {
+						return err
+					}
+					value, err = value.ConvertTo(sctx.GetSessionVars().StmtCtx, types.NewFieldType(mysql.TypeBlob))
+					if err != nil {
+						return err
+					}
+					// There must be only one bucket for this new column and the value is the default value.
+					if _, err := util.Exec(sctx, "insert into mysql.stats_buckets (table_id, is_index, hist_id, bucket_id, repeats, count, lower_bound, upper_bound) values (%?, 0, %?, 0, %?, %?, %?, %?)", physicalID, colInfo.ID, count, count, value.GetBytes(), value.GetBytes()); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		return nil
+	}, util.FlagWrapTxn)
+}
+
+// InsertTableStats2KV inserts a record standing for a new table to stats_meta and inserts some records standing for the
+// new columns and indices which belong to this table.
+func (s *statsReadWriter) InsertTableStats2KV(info *model.TableInfo, physicalID int64) (err error) {
+	statsVer := uint64(0)
+	defer func() {
+		if err == nil && statsVer != 0 {
+			s.statsHandler.RecordHistoricalStatsMeta(physicalID, statsVer, util.StatsMetaHistorySourceSchemaChange)
+		}
+	}()
+
+	return util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		startTS, err := util.GetStartTS(sctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if _, err := util.Exec(sctx, "insert into mysql.stats_meta (version, table_id) values(%?, %?)", startTS, physicalID); err != nil {
+			return err
+		}
+		statsVer = startTS
+		for _, col := range info.Columns {
+			if _, err := util.Exec(sctx, "insert into mysql.stats_histograms (table_id, is_index, hist_id, distinct_count, version) values(%?, 0, %?, 0, %?)", physicalID, col.ID, startTS); err != nil {
+				return err
+			}
+		}
+		for _, idx := range info.Indices {
+			if _, err := util.Exec(sctx, "insert into mysql.stats_histograms (table_id, is_index, hist_id, distinct_count, version) values(%?, 1, %?, 0, %?)", physicalID, idx.ID, startTS); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, util.FlagWrapTxn)
+}
+
+// ChangeGlobalStatsID changes the table ID in global-stats to the new table ID.
+func (s *statsReadWriter) ChangeGlobalStatsID(from, to int64) (err error) {
+	return util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		for _, table := range []string{"stats_meta", "stats_top_n", "stats_fm_sketch", "stats_buckets", "stats_histograms", "column_stats_usage"} {
+			_, err = util.Exec(sctx, "update mysql."+table+" set table_id = %? where table_id = %?", to, from)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}, util.FlagWrapTxn)
+}
+
+// ResetTableStats2KVForDrop resets the count to 0.
+func (s *statsReadWriter) ResetTableStats2KVForDrop(physicalID int64) (err error) {
+	statsVer := uint64(0)
+	defer func() {
+		if err == nil && statsVer != 0 {
+			s.statsHandler.RecordHistoricalStatsMeta(physicalID, statsVer, util.StatsMetaHistorySourceSchemaChange)
+		}
+	}()
+
+	return util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		startTS, err := util.GetStartTS(sctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if _, err := util.Exec(sctx, "update mysql.stats_meta set version=%? where table_id =%?", startTS, physicalID); err != nil {
+			return err
+		}
+		return nil
+	}, util.FlagWrapTxn)
+}
+
+// UpdateStatsVersion will set statistics version to the newest TS,
+// then tidb-server will reload automatic.
+func (s *statsReadWriter) UpdateStatsVersion() error {
+	return util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		return UpdateStatsVersion(sctx)
+	}, util.FlagWrapTxn)
+}
+
+// SaveTableStatsToStorage saves the stats of a table to storage.
+func (s *statsReadWriter) SaveTableStatsToStorage(results *statistics.AnalyzeResults, analyzeSnapshot bool, source string) (err error) {
+	var statsVer uint64
+	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		statsVer, err = SaveTableStatsToStorage(sctx, results, analyzeSnapshot)
+		return err
+	})
+	if err == nil && statsVer != 0 {
+		tableID := results.TableID.GetStatisticsID()
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source)
+	}
+	return err
 }
 
 // StatsMetaCountAndModifyCount reads count and modify_count for the given table from mysql.stats_meta.
@@ -85,8 +245,8 @@ func (s *statsReadWriter) SaveStatsToStorage(tableID int64, count, modifyCount i
 	return
 }
 
-// SaveMetaToStorage saves stats meta to the storage.
-func (s *statsReadWriter) SaveMetaToStorage(tableID, count, modifyCount int64, source string) (err error) {
+// saveMetaToStorage saves stats meta to the storage.
+func (s *statsReadWriter) saveMetaToStorage(tableID, count, modifyCount int64, source string) (err error) {
 	var statsVer uint64
 	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		statsVer, err = SaveMetaToStorage(sctx, tableID, count, modifyCount)
@@ -135,39 +295,6 @@ func (s *statsReadWriter) SaveExtendedStatsToStorage(tableID int64, extStats *st
 		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats")
 	}
 	return
-}
-
-// SaveStatsFromJSON saves stats from JSON to the storage.
-func (s *statsReadWriter) SaveStatsFromJSON(tableInfo *model.TableInfo, physicalID int64, jsonTblI interface{}) error {
-	jsonTbl := jsonTblI.(*util.JSONTable)
-	tbl, err := TableStatsFromJSON(tableInfo, physicalID, jsonTbl)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	for _, col := range tbl.Columns {
-		// loadStatsFromJSON doesn't support partition table now.
-		// The table level count and modify_count would be overridden by the SaveMetaToStorage below, so we don't need
-		// to care about them here.
-		err = s.SaveStatsToStorage(tbl.PhysicalID, tbl.RealtimeCount, 0, 0, &col.Histogram, col.CMSketch, col.TopN, int(col.GetStatsVer()), 1, false, "load stats")
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	for _, idx := range tbl.Indices {
-		// loadStatsFromJSON doesn't support partition table now.
-		// The table level count and modify_count would be overridden by the SaveMetaToStorage below, so we don't need
-		// to care about them here.
-		err = s.SaveStatsToStorage(tbl.PhysicalID, tbl.RealtimeCount, 0, 1, &idx.Histogram, idx.CMSketch, idx.TopN, int(idx.GetStatsVer()), 1, false, "load stats")
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	err = s.SaveExtendedStatsToStorage(tbl.PhysicalID, tbl.ExtendedStats, true)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return s.SaveMetaToStorage(tbl.PhysicalID, tbl.RealtimeCount, tbl.ModifyCount, "load stats")
 }
 
 // LoadNeededHistograms will load histograms for those needed columns/indices.
@@ -485,5 +612,5 @@ func (s *statsReadWriter) loadStatsFromJSON(tableInfo *model.TableInfo, physical
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return s.SaveMetaToStorage(tbl.PhysicalID, tbl.RealtimeCount, tbl.ModifyCount, util.StatsMetaHistorySourceLoadStats)
+	return s.saveMetaToStorage(tbl.PhysicalID, tbl.RealtimeCount, tbl.ModifyCount, util.StatsMetaHistorySourceLoadStats)
 }

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -53,7 +53,7 @@ func (s *statsReadWriter) InsertColStats2KV(physicalID int64, colInfos []*model.
 	statsVer := uint64(0)
 	defer func() {
 		if err == nil && statsVer != 0 {
-			s.statsHandler.RecordHistoricalStatsMeta(physicalID, statsVer, util.StatsMetaHistorySourceSchemaChange)
+			s.statsHandler.RecordHistoricalStatsMeta(physicalID, statsVer, util.StatsMetaHistorySourceSchemaChange, false)
 		}
 	}()
 
@@ -121,7 +121,7 @@ func (s *statsReadWriter) InsertTableStats2KV(info *model.TableInfo, physicalID 
 	statsVer := uint64(0)
 	defer func() {
 		if err == nil && statsVer != 0 {
-			s.statsHandler.RecordHistoricalStatsMeta(physicalID, statsVer, util.StatsMetaHistorySourceSchemaChange)
+			s.statsHandler.RecordHistoricalStatsMeta(physicalID, statsVer, util.StatsMetaHistorySourceSchemaChange, false)
 		}
 	}()
 
@@ -166,7 +166,7 @@ func (s *statsReadWriter) ResetTableStats2KVForDrop(physicalID int64) (err error
 	statsVer := uint64(0)
 	defer func() {
 		if err == nil && statsVer != 0 {
-			s.statsHandler.RecordHistoricalStatsMeta(physicalID, statsVer, util.StatsMetaHistorySourceSchemaChange)
+			s.statsHandler.RecordHistoricalStatsMeta(physicalID, statsVer, util.StatsMetaHistorySourceSchemaChange, false)
 		}
 	}()
 
@@ -199,7 +199,7 @@ func (s *statsReadWriter) SaveTableStatsToStorage(results *statistics.AnalyzeRes
 	})
 	if err == nil && statsVer != 0 {
 		tableID := results.TableID.GetStatisticsID()
-		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source)
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source, true)
 	}
 	return err
 }
@@ -240,7 +240,7 @@ func (s *statsReadWriter) SaveStatsToStorage(tableID int64, count, modifyCount i
 		return err
 	})
 	if err == nil && statsVer != 0 {
-		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source)
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source, false)
 	}
 	return
 }
@@ -253,7 +253,7 @@ func (s *statsReadWriter) saveMetaToStorage(tableID, count, modifyCount int64, s
 		return err
 	})
 	if err == nil && statsVer != 0 {
-		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source)
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source, false)
 	}
 	return
 }
@@ -266,7 +266,7 @@ func (s *statsReadWriter) InsertExtendedStats(statsName string, colIDs []int64, 
 		return err
 	})
 	if err == nil && statsVer != 0 {
-		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats")
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats", false)
 	}
 	return
 }
@@ -279,7 +279,7 @@ func (s *statsReadWriter) MarkExtendedStatsDeleted(statsName string, tableID int
 		return err
 	})
 	if err == nil && statsVer != 0 {
-		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats")
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats", false)
 	}
 	return
 }
@@ -292,7 +292,7 @@ func (s *statsReadWriter) SaveExtendedStatsToStorage(tableID int64, extStats *st
 		return err
 	})
 	if err == nil && statsVer != 0 {
-		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats")
+		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats", false)
 	}
 	return
 }

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -120,7 +120,7 @@ func (s *statsUsageImpl) dumpTableStatCountToKV(is infoschema.InfoSchema, physic
 	statsVersion := uint64(0)
 	defer func() {
 		if err == nil && statsVersion != 0 {
-			s.statsHandle.RecordHistoricalStatsMeta(physicalTableID, statsVersion, "flush stats")
+			s.statsHandle.RecordHistoricalStatsMeta(physicalTableID, statsVersion, "flush stats", false)
 		}
 	}()
 	if delta.Count == 0 {

--- a/pkg/statistics/handle/util/interfaces.go
+++ b/pkg/statistics/handle/util/interfaces.go
@@ -213,6 +213,7 @@ type StatsLock interface {
 }
 
 // StatsReadWriter is used to read and write stats to the storage.
+// TODO: merge and remove some methods.
 type StatsReadWriter interface {
 	// TableStatsFromStorage loads table stats info from storage.
 	TableStatsFromStorage(tableInfo *model.TableInfo, physicalID int64, loadAll bool, snapshot uint64) (statsTbl *statistics.Table, err error)
@@ -226,19 +227,29 @@ type StatsReadWriter interface {
 	// ReloadExtendedStatistics drops the cache for extended statistics and reload data from mysql.stats_extended.
 	ReloadExtendedStatistics() error
 
-	//// SaveTableStatsToStorage saves the stats of a table to storage.
-	//SaveTableStatsToStorage(results *statistics.AnalyzeResults, analyzeSnapshot bool, source string) (err error)
-
 	// SaveStatsToStorage save the stats data to the storage.
 	SaveStatsToStorage(tableID int64, count, modifyCount int64, isIndex int, hg *statistics.Histogram,
 		cms *statistics.CMSketch, topN *statistics.TopN, statsVersion int, isAnalyzed int64, updateAnalyzeTime bool, source string) (err error)
 
-	// SaveMetaToStorage saves stats meta to the storage.
-	SaveMetaToStorage(tableID, count, modifyCount int64, source string) (err error)
+	// SaveTableStatsToStorage saves the stats of a table to storage.
+	SaveTableStatsToStorage(results *statistics.AnalyzeResults, analyzeSnapshot bool, source string) (err error)
 
-	// SaveStatsFromJSON saves stats from JSON to the storage.
-	// TODO: use *storage.JSONTable instead of interface{} (which is used to avoid cycle import).
-	SaveStatsFromJSON(tableInfo *model.TableInfo, physicalID int64, jsonTbl interface{}) error
+	// InsertColStats2KV inserts columns stats to kv.
+	InsertColStats2KV(physicalID int64, colInfos []*model.ColumnInfo) (err error)
+
+	// InsertTableStats2KV inserts a record standing for a new table to stats_meta and inserts some records standing for the
+	// new columns and indices which belong to this table.
+	InsertTableStats2KV(info *model.TableInfo, physicalID int64) (err error)
+
+	// UpdateStatsVersion will set statistics version to the newest TS,
+	// then tidb-server will reload automatic.
+	UpdateStatsVersion() error
+
+	// ResetTableStats2KVForDrop resets the count to 0.
+	ResetTableStats2KVForDrop(physicalID int64) (err error)
+
+	// ChangeGlobalStatsID changes the global stats ID.
+	ChangeGlobalStatsID(from, to int64) (err error)
 
 	// TableStatsToJSON dumps table stats to JSON.
 	TableStatsToJSON(dbName string, tableInfo *model.TableInfo, physicalID int64, snapshot uint64) (*JSONTable, error)

--- a/pkg/statistics/handle/util/interfaces.go
+++ b/pkg/statistics/handle/util/interfaces.go
@@ -94,7 +94,7 @@ type StatsUsage interface {
 // StatsHistory is used to manage historical stats.
 type StatsHistory interface {
 	// RecordHistoricalStatsMeta records stats meta of the specified version to stats_meta_history.
-	RecordHistoricalStatsMeta(tableID int64, version uint64, source string)
+	RecordHistoricalStatsMeta(tableID int64, version uint64, source string, enforce bool)
 
 	// CheckHistoricalStatsEnable check whether historical stats is enabled.
 	CheckHistoricalStatsEnable() (enable bool, err error)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46905

Problem Summary: planner: move more methods from StatsHandle to its sub-packages

### What is changed and how it works?

planner: move more methods from StatsHandle to its sub-packages

No logical change, just refactor.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
