### PR TITLE
disttask: fix upgrade missing create framework_meta 

### DIFF
--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -2827,6 +2827,7 @@ func upgradeToVer176(s Session, ver int64) {
 		return
 	}
 	mustExecute(s, CreateGlobalTaskHistory)
+	mustExecute(s, CreateDistFrameworkMeta)
 }
 
 func writeOOMAction(s Session) {

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1013,7 +1013,6 @@ const (
 
 	// version 177
 	//   add `mysql.dist_framework_meta`
-	//   make sure upgrading from v7.4 to higher version, `mysql.dist_framework_meta` exists.
 	version177 = 177
 )
 
@@ -2835,7 +2834,6 @@ func upgradeToVer176(s Session, ver int64) {
 	mustExecute(s, CreateGlobalTaskHistory)
 }
 
-// for users upgrade from v7.4 to higher version, make sure dist_framework_meta exists.
 func upgradeToVer177(s Session, ver int64) {
 	if ver >= version177 {
 		return

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -2838,6 +2838,7 @@ func upgradeToVer177(s Session, ver int64) {
 	if ver >= version177 {
 		return
 	}
+	// ignore error when upgrading from v7.4 to higher version.
 	doReentrantDDL(s, CreateDistFrameworkMeta, infoschema.ErrTableExists)
 }
 

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1008,7 +1008,7 @@ const (
 	version175 = 175
 
 	// version 176
-	//   add `mysql.tidb_global_task_history`, `mysql.dist_framework_meta`
+	//   add `mysql.tidb_global_task_history`
 	version176 = 176
 
 	// version 177
@@ -2833,7 +2833,6 @@ func upgradeToVer176(s Session, ver int64) {
 		return
 	}
 	mustExecute(s, CreateGlobalTaskHistory)
-	mustExecute(s, CreateDistFrameworkMeta)
 }
 
 // for users upgrade from v7.4 to higher version, make sure dist_framework_meta exists.

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -2086,6 +2086,35 @@ func TestTiDBUpgradeToVer176(t *testing.T) {
 	require.NoError(t, err)
 	require.Less(t, int64(ver175), ver)
 	MustExec(t, seV175, "SELECT * from mysql.tidb_global_task_history")
-	MustExec(t, seV175, "SELECT * from mysql.dist_framework_meta")
+	dom.Close()
+}
+
+func TestTiDBUpgradeToVer177(t *testing.T) {
+	store, _ := CreateStoreAndBootstrap(t)
+	defer func() {
+		require.NoError(t, store.Close())
+	}()
+	ver176 := version176
+	seV176 := CreateSessionAndSetID(t, store)
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMeta(txn)
+	err = m.FinishBootstrap(int64(ver176))
+	require.NoError(t, err)
+	MustExec(t, seV176, fmt.Sprintf("update mysql.tidb set variable_value=%d where variable_name='tidb_server_version'", ver176))
+	err = txn.Commit(context.Background())
+	require.NoError(t, err)
+
+	unsetStoreBootstrapped(store.UUID())
+	ver, err := getBootstrapVersion(seV176)
+	require.NoError(t, err)
+	require.Equal(t, int64(ver176), ver)
+
+	dom, err := BootstrapSession(store)
+	require.NoError(t, err)
+	ver, err = getBootstrapVersion(seV176)
+	require.NoError(t, err)
+	require.Less(t, int64(ver176), ver)
+	MustExec(t, seV176, "SELECT * from mysql.dist_framework_meta")
 	dom.Close()
 }

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -2085,5 +2085,7 @@ func TestTiDBUpgradeToVer176(t *testing.T) {
 	ver, err = getBootstrapVersion(seV175)
 	require.NoError(t, err)
 	require.Less(t, int64(ver175), ver)
+	MustExec(t, seV175, "SELECT * from mysql.tidb_global_task_history")
+	MustExec(t, seV175, "SELECT * from mysql.dist_framework_meta")
 	dom.Close()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47593 

Problem Summary:
forget to add dist_framework_meta when upgrading from version < v7.4 to v7.4 or higher.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
