### PR TITLE
placement: fix the issue cannot create dict follower constraints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -186,7 +186,7 @@ require (
 	github.com/eapache/go-resiliency v1.2.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
-	github.com/fatih/structtag v1.2.0 // indirect
+	github.com/fatih/structtag v1.2.0
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect

--- a/pkg/ddl/placement/rule_test.go
+++ b/pkg/ddl/placement/rule_test.go
@@ -172,7 +172,7 @@ func TestNewRuleAndNewRules(t *testing.T) {
 
 	for _, tt := range tests {
 		comment := fmt.Sprintf("[%s]", tt.name)
-		output, err := NewRules(Voter, tt.replicas, tt.input)
+		output, err := newRules(Voter, tt.replicas, tt.input)
 		if tt.err == nil {
 			require.NoError(t, err, comment)
 			matchRules(tt.output, output, comment, t)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/47741
Problem Summary:

Minimal reproduce step 

```
mysql> CREATE PLACEMENT POLICY ssd FOLLOWER_CONSTRAINTS="{+disk=ssd: 1}";
ERROR 1105 (HY000): label constraints with invalid REPLICAS: count of replicas in dict constrains is 1, but got 2: invalid FollowerConstraints
```
### What is changed and how it works?

skip the checks.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
