### PR TITLE
expression: check condition when pushing down `INET_NTOA` to TiFlash

### DIFF
--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -524,8 +524,11 @@ func TestExprPushDownToFlash(t *testing.T) {
 	enumColumn := genColumn(mysql.TypeEnum, 10)
 	durationColumn := genColumn(mysql.TypeDuration, 11)
 	// uint64 col
-	uintColumn := genColumn(mysql.TypeLonglong, 12)
-	uintColumn.RetType.AddFlag(mysql.UnsignedFlag)
+	uint64Column := genColumn(mysql.TypeLonglong, 12)
+	uint64Column.RetType.AddFlag(mysql.UnsignedFlag)
+
+	uint32Column := genColumn(mysql.TypeLong, 13)
+	uint32Column.RetType.AddFlag(mysql.UnsignedFlag)
 
 	function, err := NewFunction(mock.NewContext(), ast.JSONLength, types.NewFieldType(mysql.TypeLonglong), jsonColumn)
 	require.NoError(t, err)
@@ -800,9 +803,13 @@ func TestExprPushDownToFlash(t *testing.T) {
 	exprs = append(exprs, function)
 
 	// InetNtoa
-	function, err = NewFunction(mock.NewContext(), ast.InetNtoa, types.NewFieldType(mysql.TypeLonglong), stringColumn)
-	require.NoError(t, err)
-	exprs = append(exprs, function)
+	{
+		tp := types.NewFieldType(mysql.TypeLong)
+		tp.SetFlag(mysql.UnsignedFlag)
+		function, err = NewFunction(mock.NewContext(), ast.InetNtoa, tp, uint32Column)
+		require.NoError(t, err)
+		exprs = append(exprs, function)
+	}
 
 	// Inet6Aton
 	function, err = NewFunction(mock.NewContext(), ast.Inet6Aton, types.NewFieldType(mysql.TypeString), stringColumn)
@@ -1285,7 +1292,7 @@ func TestExprPushDownToFlash(t *testing.T) {
 		}
 		return groupingFunc, err
 	}
-	function, err = NewFunctionWithInit(mock.NewContext(), ast.Grouping, types.NewFieldType(mysql.TypeLonglong), init, uintColumn)
+	function, err = NewFunctionWithInit(mock.NewContext(), ast.Grouping, types.NewFieldType(mysql.TypeLonglong), init, uint64Column)
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -1204,7 +1204,7 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 		switch sourceType.GetType() {
 		case mysql.TypeLong, mysql.TypeShort, mysql.TypeTiny:
 			/*
-				TiFlash only support 4 bytes unsigned integer
+				TiFlash only support unsigned integer(size <= 4 bytes)
 				MySQL will return default value and warning if failed to cast into 4 bytes unsigned integer(include `Out of range`).
 					Warning 1411: Incorrect integer value: '`?`.`?`.`?`' for function inet_ntoa
 			*/

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -1160,7 +1160,7 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 		ast.Sqrt, ast.Log, ast.Log2, ast.Log10, ast.Ln, ast.Exp, ast.Pow, ast.Sign,
 		ast.Radians, ast.Degrees, ast.Conv, ast.CRC32,
 		ast.JSONLength, ast.JSONExtract, ast.JSONUnquote, ast.Repeat,
-		ast.InetNtoa, ast.InetAton, ast.Inet6Ntoa, ast.Inet6Aton,
+		ast.InetAton, ast.Inet6Ntoa, ast.Inet6Aton,
 		ast.Coalesce, ast.ASCII, ast.Length, ast.Trim, ast.Position, ast.Format, ast.Elt,
 		ast.LTrim, ast.RTrim, ast.Lpad, ast.Rpad,
 		ast.Hour, ast.Minute, ast.Second, ast.MicroSecond,
@@ -1198,6 +1198,17 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 			tipb.ScalarFuncSig_ReverseUTF8,
 			tipb.ScalarFuncSig_Reverse:
 			return true
+		}
+	case ast.InetNtoa:
+		sourceType := function.GetArgs()[0].GetType()
+		switch sourceType.GetType() {
+		case mysql.TypeLong, mysql.TypeShort, mysql.TypeTiny:
+			/*
+				TiFlash only support 4 bytes unsigned integer
+				MySQL will return default value and warning if failed to cast into 4 bytes unsigned integer(include `Out of range`).
+					Warning 1411: Incorrect integer value: '`?`.`?`.`?`' for function inet_ntoa
+			*/
+			return mysql.HasUnsignedFlag(sourceType.GetFlag())
 		}
 	case ast.Cast:
 		sourceType := function.GetArgs()[0].GetType()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46598

Problem Summary:

- MySQL will return default value and warning if failed to cast into 4 bytes unsigned integer(include `Out of range`).
  - Warning 1411: Incorrect integer value: '`?`.`?`.`?`' for function inet_ntoa
- Make `INET_NTOA` support unsigned integer data type(size <= 4 bytes).
- Make TiFlash support unsigned integer(size <= 4 bytes). https://github.com/pingcap/tiflash/pull/8210 

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
