### PR TITLE
local backend: fix log been eaten when failed on execute region job

### DIFF
--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -1692,7 +1692,10 @@ func (local *Backend) doImport(ctx context.Context, engine common.Engine, region
 	if err != nil {
 		firstErr.Set(err)
 		workerCancel()
-		_ = workGroup.Wait()
+		err2 := workGroup.Wait()
+		if !common.IsContextCanceledError(err2) {
+			log.FromContext(ctx).Error("worker meets error", zap.Error(err2))
+		}
 		return firstErr.Get()
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47781

Problem Summary:

### What is changed and how it works?
log error of worker waitgroup if it's not context cancelled

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
temporary change code, send a dummy job in `generateAndSendJob` then wait 5 second, and let `executeJob` always return `the remaining storage capacity of TiKV` error, see we can see the eaten log
```log
[2023/10/19 16:01:56.812 +08:00] [ERROR] [local.go:1677] ["worker meets error"] [error="the remaining storage capacity of TiKV(%!s(MISSING)) is less than 10%; please increase the storage capacity of TiKV
and try again"] [errorVerbose="the remaining storage capacity of TiKV(%!s(MISSING)) is less than 10%; please increase the storage capacity of TiKV and try again\ngithub.com/pingcap/tidb/br/pkg/lightning/b
ackend/local.(*Backend).executeJob\n\t/Users/jujiajia/code/pingcap/tidb/br/pkg/lightning/backend/local/local.go:1405\ngithub.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).startWorker\n\t/Users/jujiajia/code/pingcap/tidb/br/pkg/lightning/backend/local/local.go:1340\ngithub.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).doImport.func5\n\t/Users/jujiajia/code/pingcap/tidb/br/pkg/lightning/backend/local/local.go:1657\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/Users/jujiajia/go/pkg/mod/golang.org/x/sync@v0.3.0/errgroup/errgroup.go:75\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1197"]
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
