### PR TITLE
types: fix the behavior when inserting a big scientific notation number to keep it same with mysql

### DIFF
--- a/pkg/executor/insert_test.go
+++ b/pkg/executor/insert_test.go
@@ -1593,3 +1593,25 @@ func TestInsertLockUnchangedKeys(t *testing.T) {
 		}
 	}
 }
+
+// see issue https://github.com/pingcap/tidb/issues/47787
+func TestInsertBigScientificNotation(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec("create table t1(id int, a int)")
+
+	tk.MustExec("set @@SQL_MODE='STRICT_TRANS_TABLES'")
+	err := tk.ExecToErr("insert into t1 values(1, '1e100')")
+	require.EqualError(t, err, "[types:1264]Out of range value for column 'a' at row 1")
+	err = tk.ExecToErr("insert into t1 values(2, '-1e100')")
+	require.EqualError(t, err, "[types:1264]Out of range value for column 'a' at row 1")
+	tk.MustQuery("select id, a from t1").Check(testkit.Rows())
+
+	tk.MustExec("set @@SQL_MODE=''")
+	tk.MustExec("insert into t1 values(1, '1e100')")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1264 Out of range value for column 'a' at row 1"))
+	tk.MustExec("insert into t1 values(2, '-1e100')")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1264 Out of range value for column 'a' at row 1"))
+	tk.MustQuery("select id, a from t1 order by id asc").Check(testkit.Rows("1 2147483647", "2 -2147483648"))
+}

--- a/pkg/types/convert.go
+++ b/pkg/types/convert.go
@@ -389,7 +389,7 @@ func getValidIntPrefix(ctx Context, str string, isFuncCast bool) (string, error)
 		if err != nil {
 			return floatPrefix, errors.Trace(err)
 		}
-		return floatStrToIntStr(ctx, floatPrefix, str)
+		return floatStrToIntStr(floatPrefix, str)
 	}
 
 	validLen := 0
@@ -445,6 +445,9 @@ func roundIntStr(numNextDot byte, intStr string) string {
 	return string(retStr)
 }
 
+var maxUintStr = strconv.FormatUint(math.MaxUint64, 10)
+var minIntStr = strconv.FormatInt(math.MinInt64, 10)
+
 // floatStrToIntStr converts a valid float string into valid integer string which can be parsed by
 // strconv.ParseInt, we can't parse float first then convert it to string because precision will
 // be lost. For example, the string value "18446744073709551615" which is the max number of unsigned
@@ -452,7 +455,7 @@ func roundIntStr(numNextDot byte, intStr string) string {
 //
 // This func will find serious overflow such as the len of intStr > 20 (without prefix `+/-`)
 // however, it will not check whether the intStr overflow BIGINT.
-func floatStrToIntStr(ctx Context, validFloat string, oriStr string) (intStr string, _ error) {
+func floatStrToIntStr(validFloat string, oriStr string) (intStr string, _ error) {
 	var dotIdx = -1
 	var eIdx = -1
 	for i := 0; i < len(validFloat); i++ {
@@ -500,7 +503,12 @@ func floatStrToIntStr(ctx Context, validFloat string, oriStr string) (intStr str
 	}
 	exp, err := strconv.Atoi(validFloat[eIdx+1:])
 	if err != nil {
-		return validFloat, errors.Trace(err)
+		if digits[0] == '-' {
+			intStr = minIntStr
+		} else {
+			intStr = maxUintStr
+		}
+		return intStr, ErrOverflow.GenWithStackByArgs("BIGINT", oriStr)
 	}
 	intCnt += exp
 	if exp >= 0 && (intCnt > 21 || intCnt < 0) {
@@ -508,8 +516,12 @@ func floatStrToIntStr(ctx Context, validFloat string, oriStr string) (intStr str
 		// MaxUint64 has 20 decimal digits.
 		// And the intCnt may contain the len of `+/-`,
 		// so I use 21 here as the early detection.
-		ctx.AppendWarning(ErrOverflow.GenWithStackByArgs("BIGINT", oriStr))
-		return validFloat[:eIdx], nil
+		if digits[0] == '-' {
+			intStr = minIntStr
+		} else {
+			intStr = maxUintStr
+		}
+		return intStr, ErrOverflow.GenWithStackByArgs("BIGINT", oriStr)
 	}
 	if intCnt <= 0 {
 		intStr = "0"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47787

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix the behavior when inserting a big scientific notation number to keep it same with mysql
```
