### PR TITLE
pkg/ddl: fix an issue where endkey usage issues caused index loss

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -73,7 +73,8 @@ import (
 
 const (
 	// currentVersion is for all new DDL jobs.
-	currentVersion = 1
+	// 1 for the DDL job created <= 7.4.0.
+	currentVersion = 2
 	// DDLOwnerKey is the ddl owner path that is saved to etcd, and it's exported for testing.
 	DDLOwnerKey = "/tidb/ddl/fg/owner"
 	// addingDDLJobPrefix is the path prefix used to record the newly added DDL job, and it's saved to etcd.

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -73,7 +73,8 @@ import (
 
 const (
 	// currentVersion is for all new DDL jobs.
-	// 1 for the DDL job created <= 7.4.0.
+	// 1 for the DDL job created <= v7.4.0.
+	// For fix #46306(whether end key is included or not in the table range) to add version 2.
 	currentVersion = 2
 	// DDLOwnerKey is the ddl owner path that is saved to etcd, and it's exported for testing.
 	DDLOwnerKey = "/tidb/ddl/fg/owner"

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -894,7 +894,7 @@ func CleanupDDLReorgHandles(job *model.Job, s *sess.Session) {
 func (r *reorgHandler) GetDDLReorgHandle(job *model.Job) (element *meta.Element, startKey, endKey kv.Key, physicalTableID int64, err error) {
 	element, startKey, endKey, physicalTableID, err = getDDLReorgHandle(r.s, job)
 	if job.Version < currentVersion && err == nil {
-		logutil.BgLogger().Info("job get reorg handle", zap.String("category", "ddl"),
+		logutil.BgLogger().Info("job get table range for old version jobs", zap.String("category", "ddl"),
 			zap.Int64("jobID", job.ID), zap.Int64("job version", job.Version), zap.Int64("physical table ID", physicalTableID),
 			zap.String("startKey", hex.EncodeToString(startKey)),
 			zap.String("current endKey", hex.EncodeToString(endKey)),

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -892,5 +892,15 @@ func CleanupDDLReorgHandles(job *model.Job, s *sess.Session) {
 
 // GetDDLReorgHandle gets the latest processed DDL reorganize position.
 func (r *reorgHandler) GetDDLReorgHandle(job *model.Job) (element *meta.Element, startKey, endKey kv.Key, physicalTableID int64, err error) {
-	return getDDLReorgHandle(r.s, job)
+	element, startKey, endKey, physicalTableID, err = getDDLReorgHandle(r.s, job)
+	if job.Version < currentVersion && err == nil {
+		logutil.BgLogger().Info("job get reorg handle", zap.String("category", "ddl"),
+			zap.Int64("jobID", job.ID), zap.Int64("job version", job.Version), zap.Int64("physical table ID", physicalTableID),
+			zap.String("startKey", hex.EncodeToString(startKey)),
+			zap.String("current endKey", hex.EncodeToString(endKey)),
+			zap.String("endKey next", hex.EncodeToString(endKey.Next())))
+		endKey = endKey.Next()
+	}
+
+	return
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46306

Problem Summary:
Ref: https://github.com/pingcap/tidb/pull/45679. Before this PR(#45679 ), we used [startKey, endKey] with endInclude as the table range. After this PR we used [startKey, endKey.next).
We do "add index" on a branch without #45679, then get startKey and endKey with the range [startKey, endKey]. 
Then we do upgrade, we will continue to "add index" in the branch with #45679. And we use [startKey, endKey).

### What is changed and how it works?
If the old version upgrades to the new version, we add Next to the endKey.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

deploy v7.1.1+ cluster
`set @@global.tidb_ddl_enable_fast_reorg = 0;`
Create a table and import 3.5 million rows.

Do `alter table t add index idx(a, b);`, and when it backfills 700,000+ indexes, kill the cluster.
Then upgrade this cluster to master.
After upgrading successfully, do `admin check index t idx` 

Result:
* Before this PR, we will get an error like `ERROR 8223 (HY000): data inconsistency in table: t, index: idx, handle: 3572562, index-values:"" != record-values:"handle: 3572562, values: [KindString 131 KindString xxx]"`
* After this PR, we get `Query OK`.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
