### PR TITLE
ddl: fix delete range drop indices not entirely

### DIFF
--- a/pkg/ddl/delete_range.go
+++ b/pkg/ddl/delete_range.go
@@ -368,7 +368,6 @@ func insertJobIntoDeleteRangeTable(ctx context.Context, sctx sessionctx.Context,
 			}
 		}
 	case model.ActionDropIndex, model.ActionDropPrimaryKey:
-		tableID := job.TableID
 		var indexName interface{}
 		var partitionIDs []int64
 		ifExists := make([]bool, 1)
@@ -378,26 +377,18 @@ func insertJobIntoDeleteRangeTable(ctx context.Context, sctx sessionctx.Context,
 				return errors.Trace(err)
 			}
 		}
-		for _, indexID := range allIndexIDs {
-			// partitionIDs len is 0 if the dropped index is a global index, even if it is a partitioned table.
-			if len(partitionIDs) == 0 {
-				startKey := tablecodec.EncodeTableIndexPrefix(tableID, indexID)
-				endKey := tablecodec.EncodeTableIndexPrefix(tableID, indexID+1)
-				elemID := ea.allocForIndexID(tableID, indexID)
-				return doInsert(ctx, s, job.ID, elemID, startKey, endKey, now, fmt.Sprintf("index ID is %d", indexID))
+		// partitionIDs len is 0 if the dropped index is a global index, even if it is a partitioned table.
+		if len(partitionIDs) == 0 {
+			return doBatchDeleteIndiceRange(ctx, s, job.ID, job.TableID, allIndexIDs, now, ea)
+		}
+		failpoint.Inject("checkDropGlobalIndex", func(val failpoint.Value) {
+			if val.(bool) {
+				panic("drop global index must not delete partition index range")
 			}
-			failpoint.Inject("checkDropGlobalIndex", func(val failpoint.Value) {
-				if val.(bool) {
-					panic("drop global index must not delete partition index range")
-				}
-			})
-			for _, pid := range partitionIDs {
-				startKey := tablecodec.EncodeTableIndexPrefix(pid, indexID)
-				endKey := tablecodec.EncodeTableIndexPrefix(pid, indexID+1)
-				elemID := ea.allocForIndexID(pid, indexID)
-				if err := doInsert(ctx, s, job.ID, elemID, startKey, endKey, now, fmt.Sprintf("partition table ID is %d", pid)); err != nil {
-					return errors.Trace(err)
-				}
+		})
+		for _, pid := range partitionIDs {
+			if err := doBatchDeleteIndiceRange(ctx, s, job.ID, pid, allIndexIDs, now, ea); err != nil {
+				return errors.Trace(err)
 			}
 		}
 	case model.ActionDropColumn:

--- a/pkg/ddl/delete_range.go
+++ b/pkg/ddl/delete_range.go
@@ -368,6 +368,7 @@ func insertJobIntoDeleteRangeTable(ctx context.Context, sctx sessionctx.Context,
 			}
 		}
 	case model.ActionDropIndex, model.ActionDropPrimaryKey:
+		tableID := job.TableID
 		var indexName interface{}
 		var partitionIDs []int64
 		ifExists := make([]bool, 1)
@@ -377,18 +378,29 @@ func insertJobIntoDeleteRangeTable(ctx context.Context, sctx sessionctx.Context,
 				return errors.Trace(err)
 			}
 		}
-		// partitionIDs len is 0 if the dropped index is a global index, even if it is a partitioned table.
-		if len(partitionIDs) == 0 {
-			return doBatchDeleteIndiceRange(ctx, s, job.ID, job.TableID, allIndexIDs, now, ea)
-		}
-		failpoint.Inject("checkDropGlobalIndex", func(val failpoint.Value) {
-			if val.(bool) {
-				panic("drop global index must not delete partition index range")
+		for _, indexID := range allIndexIDs {
+			// partitionIDs len is 0 if the dropped index is a global index, even if it is a partitioned table.
+			if len(partitionIDs) == 0 {
+				startKey := tablecodec.EncodeTableIndexPrefix(tableID, indexID)
+				endKey := tablecodec.EncodeTableIndexPrefix(tableID, indexID+1)
+				elemID := ea.allocForIndexID(tableID, indexID)
+				if err := doInsert(ctx, s, job.ID, elemID, startKey, endKey, now, fmt.Sprintf("index ID is %d", indexID)); err != nil {
+					return errors.Trace(err)
+				}
+				continue
 			}
-		})
-		for _, pid := range partitionIDs {
-			if err := doBatchDeleteIndiceRange(ctx, s, job.ID, pid, allIndexIDs, now, ea); err != nil {
-				return errors.Trace(err)
+			failpoint.Inject("checkDropGlobalIndex", func(val failpoint.Value) {
+				if val.(bool) {
+					panic("drop global index must not delete partition index range")
+				}
+			})
+			for _, pid := range partitionIDs {
+				startKey := tablecodec.EncodeTableIndexPrefix(pid, indexID)
+				endKey := tablecodec.EncodeTableIndexPrefix(pid, indexID+1)
+				elemID := ea.allocForIndexID(pid, indexID)
+				if err := doInsert(ctx, s, job.ID, elemID, startKey, endKey, now, fmt.Sprintf("partition table ID is %d", pid)); err != nil {
+					return errors.Trace(err)
+				}
 			}
 		}
 	case model.ActionDropColumn:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47825 

Problem Summary:
delete range drop indices not entirely

### What is changed and how it works?
drop all the indices if they are global.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
