### PR TITLE
types: more strict for `types.StrictFlags`

### DIFF
--- a/br/pkg/lightning/backend/kv/session.go
+++ b/br/pkg/lightning/backend/kv/session.go
@@ -314,9 +314,7 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 		}
 	}
 	vars.StmtCtx.SetTimeZone(vars.Location())
-	vars.StmtCtx.SetTypeFlags(types.StrictFlags.
-		WithClipNegativeToZero(true),
-	)
+	vars.StmtCtx.SetTypeFlags(types.StrictFlags)
 	if err := vars.SetSystemVar("timestamp", strconv.FormatInt(options.Timestamp, 10)); err != nil {
 		logger.Warn("new session: failed to set timestamp",
 			log.ShortError(err))

--- a/br/pkg/lightning/backend/tidb/tidb.go
+++ b/br/pkg/lightning/backend/tidb/tidb.go
@@ -455,7 +455,7 @@ func (enc *tidbEncoder) appendSQL(sb *strings.Builder, datum *types.Datum, _ *ta
 
 	case types.KindMysqlBit:
 		var buffer [20]byte
-		intValue, err := datum.GetBinaryLiteral().ToInt(types.DefaultNoWarningContext)
+		intValue, err := datum.GetBinaryLiteral().ToInt(types.DefaultStmtNoWarningContext)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -164,8 +164,7 @@ func initSessCtx(
 	sessCtx.GetSessionVars().StmtCtx.IgnoreZeroInDate = !sqlMode.HasStrictMode() || sqlMode.HasAllowInvalidDatesMode()
 	sessCtx.GetSessionVars().StmtCtx.NoZeroDate = sqlMode.HasStrictMode()
 	sessCtx.GetSessionVars().StmtCtx.SetTypeFlags(types.StrictFlags.
-		WithTruncateAsWarning(!sqlMode.HasStrictMode()).
-		WithClipNegativeToZero(true),
+		WithTruncateAsWarning(!sqlMode.HasStrictMode()),
 	)
 
 	// Prevent initializing the mock context in the workers concurrently.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2163,10 +2163,10 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		WithSkipUTF8Check(vars.SkipUTF8Check).
 		WithSkipSACIICheck(vars.SkipASCIICheck).
 		WithSkipUTF8MB4Check(!globalConfig.Instance.CheckMb4ValueInUTF8.Load()).
-		// WithClipNegativeToZero indicates whether values less than 0 should be clipped to 0 for unsigned integer types.
+		// WithAllowNegativeToUnsigned with false value indicates values less than 0 should be clipped to 0 for unsigned integer types.
 		// This is the case for `insert`, `update`, `alter table`, `create table` and `load data infile` statements, when not in strict SQL mode.
 		// see https://dev.mysql.com/doc/refman/5.7/en/out-of-range-and-overflow.html
-		WithClipNegativeToZero(sc.InInsertStmt || sc.InLoadDataStmt || sc.InUpdateStmt || sc.InCreateOrAlterStmt),
+		WithAllowNegativeToUnsigned(!sc.InInsertStmt && !sc.InLoadDataStmt && !sc.InUpdateStmt && !sc.InCreateOrAlterStmt),
 	)
 
 	vars.PlanCacheParams.Reset()

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -480,9 +480,7 @@ var fakeSctx = newFakeSctx()
 
 func newFakeSctx() *stmtctx.StatementContext {
 	sc := stmtctx.NewStmtCtx()
-	sc.SetTypeFlags(types.StrictFlags.
-		WithClipNegativeToZero(true),
-	)
+	sc.SetTypeFlags(types.StrictFlags)
 	return sc
 }
 

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3028,7 +3028,7 @@ func handleAnalyzeOptionsV2(opts []ast.AnalyzeOpt) (map[ast.AnalyzeOptionType]ui
 			optMap[opt.Type] = v
 		case ast.AnalyzeOptSampleRate:
 			// Only Int/Float/decimal is accepted, so pass nil here is safe.
-			fVal, err := datumValue.ToFloat64(types.DefaultNoWarningContext)
+			fVal, err := datumValue.ToFloat64(types.DefaultStmtNoWarningContext)
 			if err != nil {
 				return nil, err
 			}
@@ -3091,7 +3091,7 @@ func handleAnalyzeOptions(opts []ast.AnalyzeOpt, statsVer int) (map[ast.AnalyzeO
 			optMap[opt.Type] = v
 		case ast.AnalyzeOptSampleRate:
 			// Only Int/Float/decimal is accepted, so pass nil here is safe.
-			fVal, err := datumValue.ToFloat64(types.DefaultNoWarningContext)
+			fVal, err := datumValue.ToFloat64(types.DefaultStmtNoWarningContext)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -428,7 +428,7 @@ type StatementContext struct {
 // NewStmtCtx creates a new statement context
 func NewStmtCtx() *StatementContext {
 	sc := &StatementContext{}
-	sc.typeCtx = typectx.NewContext(typectx.StrictFlags, time.UTC, sc.AppendWarning)
+	sc.typeCtx = typectx.NewContext(typectx.DefaultStmtFlags, time.UTC, sc.AppendWarning)
 	return sc
 }
 
@@ -436,14 +436,14 @@ func NewStmtCtx() *StatementContext {
 func NewStmtCtxWithTimeZone(tz *time.Location) *StatementContext {
 	intest.Assert(tz)
 	sc := &StatementContext{}
-	sc.typeCtx = typectx.NewContext(typectx.StrictFlags, tz, sc.AppendWarning)
+	sc.typeCtx = typectx.NewContext(typectx.DefaultStmtFlags, tz, sc.AppendWarning)
 	return sc
 }
 
 // Reset resets a statement context
 func (sc *StatementContext) Reset() {
 	*sc = StatementContext{
-		typeCtx: typectx.NewContext(typectx.StrictFlags, time.UTC, sc.AppendWarning),
+		typeCtx: typectx.NewContext(typectx.DefaultStmtFlags, time.UTC, sc.AppendWarning),
 	}
 }
 
@@ -1223,10 +1223,10 @@ func (sc *StatementContext) InitFromPBFlagAndTz(flags uint64, tz *time.Location)
 	sc.IgnoreZeroInDate = (flags & model.FlagIgnoreZeroInDate) > 0
 	sc.DividedByZeroAsWarning = (flags & model.FlagDividedByZeroAsWarning) > 0
 	sc.SetTimeZone(tz)
-	sc.SetTypeFlags(typectx.StrictFlags.
+	sc.SetTypeFlags(typectx.DefaultStmtFlags.
 		WithIgnoreTruncateErr((flags & model.FlagIgnoreTruncate) > 0).
 		WithTruncateAsWarning((flags & model.FlagTruncateAsWarning) > 0).
-		WithClipNegativeToZero(sc.InInsertStmt),
+		WithAllowNegativeToUnsigned(!sc.InInsertStmt),
 	)
 }
 
@@ -1375,7 +1375,7 @@ func (sc *StatementContext) TypeCtxOrDefault() typectx.Context {
 		return sc.typeCtx
 	}
 
-	return typectx.DefaultNoWarningContext
+	return typectx.DefaultStmtNoWarningContext
 }
 
 // UsedStatsInfoForTable records stats that are used during query and their information.

--- a/pkg/sessionctx/stmtctx/stmtctx_test.go
+++ b/pkg/sessionctx/stmtctx/stmtctx_test.go
@@ -316,7 +316,7 @@ func TestStmtHintsClone(t *testing.T) {
 
 func TestNewStmtCtx(t *testing.T) {
 	sc := stmtctx.NewStmtCtx()
-	require.Equal(t, types.StrictFlags, sc.TypeFlags())
+	require.Equal(t, types.DefaultStmtFlags, sc.TypeFlags())
 	require.Same(t, time.UTC, sc.TimeZone())
 	require.Same(t, time.UTC, sc.TimeZone())
 	sc.AppendWarning(errors.New("err1"))
@@ -327,7 +327,7 @@ func TestNewStmtCtx(t *testing.T) {
 
 	tz := time.FixedZone("UTC+1", 2*60*60)
 	sc = stmtctx.NewStmtCtxWithTimeZone(tz)
-	require.Equal(t, types.StrictFlags, sc.TypeFlags())
+	require.Equal(t, types.DefaultStmtFlags, sc.TypeFlags())
 	require.Same(t, tz, sc.TimeZone())
 	require.Same(t, tz, sc.TimeZone())
 	sc.AppendWarning(errors.New("err2"))
@@ -347,10 +347,10 @@ func TestSetStmtCtxTimeZone(t *testing.T) {
 
 func TestSetStmtCtxTypeFlags(t *testing.T) {
 	sc := stmtctx.NewStmtCtx()
-	require.Equal(t, types.StrictFlags, sc.TypeFlags())
+	require.Equal(t, types.DefaultStmtFlags, sc.TypeFlags())
 
-	sc.SetTypeFlags(typectx.FlagClipNegativeToZero | typectx.FlagSkipASCIICheck)
-	require.Equal(t, typectx.FlagClipNegativeToZero|typectx.FlagSkipASCIICheck, sc.TypeFlags())
+	sc.SetTypeFlags(typectx.FlagAllowNegativeToUnsigned | typectx.FlagSkipASCIICheck)
+	require.Equal(t, typectx.FlagAllowNegativeToUnsigned|typectx.FlagSkipASCIICheck, sc.TypeFlags())
 	require.Equal(t, sc.TypeFlags(), sc.TypeFlags())
 
 	sc.SetTypeFlags(typectx.FlagSkipASCIICheck | typectx.FlagSkipUTF8Check | typectx.FlagInvalidDateAsWarning)
@@ -360,24 +360,24 @@ func TestSetStmtCtxTypeFlags(t *testing.T) {
 
 func TestResetStmtCtx(t *testing.T) {
 	sc := stmtctx.NewStmtCtx()
-	require.Equal(t, types.StrictFlags, sc.TypeFlags())
+	require.Equal(t, types.DefaultStmtFlags, sc.TypeFlags())
 
 	tz := time.FixedZone("UTC+1", 2*60*60)
 	sc.SetTimeZone(tz)
-	sc.SetTypeFlags(typectx.FlagClipNegativeToZero | typectx.FlagSkipASCIICheck)
+	sc.SetTypeFlags(typectx.FlagAllowNegativeToUnsigned | typectx.FlagSkipASCIICheck)
 	sc.AppendWarning(errors.New("err1"))
 	sc.InRestrictedSQL = true
 	sc.StmtType = "Insert"
 
 	require.Same(t, tz, sc.TimeZone())
-	require.Equal(t, typectx.FlagClipNegativeToZero|typectx.FlagSkipASCIICheck, sc.TypeFlags())
+	require.Equal(t, typectx.FlagAllowNegativeToUnsigned|typectx.FlagSkipASCIICheck, sc.TypeFlags())
 	require.Equal(t, 1, len(sc.GetWarnings()))
 
 	sc.Reset()
 	require.Same(t, time.UTC, sc.TimeZone())
 	require.Same(t, time.UTC, sc.TimeZone())
-	require.Equal(t, types.StrictFlags, sc.TypeFlags())
-	require.Equal(t, types.StrictFlags, sc.TypeFlags())
+	require.Equal(t, types.DefaultStmtFlags, sc.TypeFlags())
+	require.Equal(t, types.DefaultStmtFlags, sc.TypeFlags())
 	require.False(t, sc.InRestrictedSQL)
 	require.Empty(t, sc.StmtType)
 	require.Equal(t, 0, len(sc.GetWarnings()))

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -713,7 +713,7 @@ func FillVirtualColumnValue(virtualRetTypes []*types.FieldType, virtualColumnInd
 			}
 
 			// Clip to zero if get negative value after cast to unsigned.
-			if mysql.HasUnsignedFlag(colInfos[idx].FieldType.GetFlag()) && !castDatum.IsNull() && !sctx.GetSessionVars().StmtCtx.TypeFlags().ClipNegativeToZero() {
+			if mysql.HasUnsignedFlag(colInfos[idx].FieldType.GetFlag()) && !castDatum.IsNull() && sctx.GetSessionVars().StmtCtx.TypeFlags().AllowNegativeToUnsigned() {
 				switch datum.Kind() {
 				case types.KindInt64:
 					if datum.GetInt64() < 0 {

--- a/pkg/types/binary_literal_test.go
+++ b/pkg/types/binary_literal_test.go
@@ -206,7 +206,7 @@ func TestBinaryLiteral(t *testing.T) {
 			{"0x1010ffff8080ff12", 0x1010ffff8080ff12, false},
 			{"0x1010ffff8080ff12ff", 0xffffffffffffffff, true},
 		}
-		ctx := DefaultNoWarningContext
+		ctx := DefaultStmtNoWarningContext
 		for _, item := range tbl {
 			hex, err := ParseHexStr(item.Input)
 			require.NoError(t, err)

--- a/pkg/types/context.go
+++ b/pkg/types/context.go
@@ -34,5 +34,10 @@ const StrictFlags = context.StrictFlags
 // NewContext creates a new `Context`
 var NewContext = context.NewContext
 
-// DefaultNoWarningContext is an alias of `DefaultNoWarningContext`
-var DefaultNoWarningContext = context.DefaultNoWarningContext
+// DefaultStmtFlags is the default flags for statement context with the flag `FlagAllowNegativeToUnsigned` set.
+// TODO: make DefaultStmtFlags to be equal with StrictFlags, and setting flag `FlagAllowNegativeToUnsigned`
+// is only for make the code to be equivalent with the old implement during refactoring.
+const DefaultStmtFlags = context.DefaultStmtFlags
+
+// DefaultStmtNoWarningContext is an alias of `DefaultStmtNoWarningContext`
+var DefaultStmtNoWarningContext = context.DefaultStmtNoWarningContext

--- a/pkg/types/context/context_test.go
+++ b/pkg/types/context/context_test.go
@@ -39,13 +39,13 @@ func TestSimpleOnOffFlags(t *testing.T) {
 		writeFn func(Flags, bool) Flags
 	}{
 		{
-			name: "FlagClipNegativeToZero",
-			flag: FlagClipNegativeToZero,
+			name: "FlagAllowNegativeToUnsigned",
+			flag: FlagAllowNegativeToUnsigned,
 			readFn: func(f Flags) bool {
-				return f.ClipNegativeToZero()
+				return f.AllowNegativeToUnsigned()
 			},
 			writeFn: func(f Flags, clip bool) Flags {
-				return f.WithClipNegativeToZero(clip)
+				return f.WithAllowNegativeToUnsigned(clip)
 			},
 		},
 		{

--- a/pkg/types/convert.go
+++ b/pkg/types/convert.go
@@ -146,7 +146,7 @@ func ConvertUintToInt(val uint64, upperBound int64, tp byte) (int64, error) {
 
 // ConvertIntToUint converts an int value to an uint value.
 func ConvertIntToUint(flags Flags, val int64, upperBound uint64, tp byte) (uint64, error) {
-	if val < 0 && flags.ClipNegativeToZero() {
+	if val < 0 && !flags.AllowNegativeToUnsigned() {
 		return 0, overflow(val, tp)
 	}
 
@@ -170,7 +170,7 @@ func ConvertUintToUint(val uint64, upperBound uint64, tp byte) (uint64, error) {
 func ConvertFloatToUint(flags Flags, fval float64, upperBound uint64, tp byte) (uint64, error) {
 	val := RoundFloat(fval)
 	if val < 0 {
-		if flags.ClipNegativeToZero() {
+		if !flags.AllowNegativeToUnsigned() {
 			return 0, overflow(val, tp)
 		}
 		return uint64(int64(val)), overflow(val, tp)

--- a/pkg/types/convert_test.go
+++ b/pkg/types/convert_test.go
@@ -472,7 +472,7 @@ func TestConvertToBinaryString(t *testing.T) {
 }
 
 func testStrToInt(t *testing.T, str string, expect int64, truncateAsErr bool, expectErr error) {
-	ctx := DefaultNoWarningContext.WithFlags(StrictFlags.WithIgnoreTruncateErr(!truncateAsErr))
+	ctx := DefaultStmtNoWarningContext.WithFlags(DefaultStmtFlags.WithIgnoreTruncateErr(!truncateAsErr))
 	val, err := StrToInt(ctx, str, false)
 	if expectErr != nil {
 		require.Truef(t, terror.ErrorEqual(err, expectErr), "err %v", err)
@@ -483,7 +483,7 @@ func testStrToInt(t *testing.T, str string, expect int64, truncateAsErr bool, ex
 }
 
 func testStrToUint(t *testing.T, str string, expect uint64, truncateAsErr bool, expectErr error) {
-	ctx := DefaultNoWarningContext.WithFlags(StrictFlags.WithIgnoreTruncateErr(!truncateAsErr))
+	ctx := DefaultStmtNoWarningContext.WithFlags(DefaultStmtFlags.WithIgnoreTruncateErr(!truncateAsErr))
 	val, err := StrToUint(ctx, str, false)
 	if expectErr != nil {
 		require.Truef(t, terror.ErrorEqual(err, expectErr), "err %v", err)
@@ -494,7 +494,7 @@ func testStrToUint(t *testing.T, str string, expect uint64, truncateAsErr bool, 
 }
 
 func testStrToFloat(t *testing.T, str string, expect float64, truncateAsErr bool, expectErr error) {
-	ctx := DefaultNoWarningContext.WithFlags(StrictFlags.WithIgnoreTruncateErr(!truncateAsErr))
+	ctx := DefaultStmtNoWarningContext.WithFlags(DefaultStmtFlags.WithIgnoreTruncateErr(!truncateAsErr))
 	val, err := StrToFloat(ctx, str, false)
 	if expectErr != nil {
 		require.Truef(t, terror.ErrorEqual(err, expectErr), "err %v", err)
@@ -927,7 +927,7 @@ func TestGetValidInt(t *testing.T) {
 		{"123e+", "123", true},
 		{"123de", "123", true},
 	}
-	sc.SetTypeFlags(StrictFlags)
+	sc.SetTypeFlags(DefaultStmtFlags)
 	sc.InSelectStmt = false
 	for _, tt := range tests2 {
 		prefix, err := getValidIntPrefix(sc.TypeCtxOrDefault(), tt.origin, false)
@@ -963,7 +963,7 @@ func TestGetValidFloat(t *testing.T) {
 		{"9-3", "9"},
 		{"1001001\\u0000\\u0000\\u0000", "1001001"},
 	}
-	ctx := DefaultNoWarningContext
+	ctx := DefaultStmtNoWarningContext
 	for _, tt := range tests {
 		prefix, _ := getValidFloatPrefix(ctx, tt.origin, false)
 		require.Equal(t, tt.valid, prefix)
@@ -1105,7 +1105,7 @@ func TestConvertJSONToFloat(t *testing.T) {
 		{in: "123.456hello", out: 123.456, ty: JSONTypeCodeString, err: true},
 		{in: "1234", out: 1234, ty: JSONTypeCodeString},
 	}
-	ctx := DefaultNoWarningContext
+	ctx := DefaultStmtNoWarningContext
 	for _, tt := range tests {
 		j := CreateBinaryJSON(tt.in)
 		require.Equal(t, tt.ty, j.TypeCode)
@@ -1134,7 +1134,7 @@ func TestConvertJSONToDecimal(t *testing.T) {
 		{in: `false`, out: NewDecFromStringForTest("0")},
 		{in: `null`, out: NewDecFromStringForTest("0"), err: true},
 	}
-	ctx := DefaultNoWarningContext
+	ctx := DefaultStmtNoWarningContext
 	for _, tt := range tests {
 		j, err := ParseBinaryJSONFromString(tt.in)
 		require.NoError(t, err)

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -631,7 +631,7 @@ func (d *Datum) SetValue(val interface{}, tp *types.FieldType) {
 // Compare compares datum to another datum.
 // Notes: don't rely on datum.collation to get the collator, it's tend to buggy.
 func (d *Datum) Compare(sc *stmtctx.StatementContext, ad *Datum, comparer collate.Collator) (int, error) {
-	typeCtx := DefaultNoWarningContext
+	typeCtx := DefaultStmtNoWarningContext
 	if sc != nil {
 		typeCtx = sc.TypeCtx()
 	}

--- a/pkg/types/datum_test.go
+++ b/pkg/types/datum_test.go
@@ -56,7 +56,7 @@ func TestDatum(t *testing.T) {
 func testDatumToBool(t *testing.T, in interface{}, res int) {
 	datum := NewDatum(in)
 	res64 := int64(res)
-	ctx := DefaultNoWarningContext.WithFlags(StrictFlags.WithIgnoreTruncateErr(true))
+	ctx := DefaultStmtNoWarningContext.WithFlags(DefaultStmtFlags.WithIgnoreTruncateErr(true))
 	b, err := datum.ToBool(ctx)
 	require.NoError(t, err)
 	require.Equal(t, res64, b)
@@ -107,7 +107,7 @@ func TestToBool(t *testing.T) {
 	require.NoError(t, err)
 	testDatumToBool(t, v, 1)
 	d := NewDatum(&invalidMockType{})
-	ctx := DefaultNoWarningContext.WithFlags(StrictFlags.WithIgnoreTruncateErr(true))
+	ctx := DefaultStmtNoWarningContext.WithFlags(DefaultStmtFlags.WithIgnoreTruncateErr(true))
 	_, err = d.ToBool(ctx)
 	require.Error(t, err)
 }

--- a/pkg/util/codec/codec_test.go
+++ b/pkg/util/codec/codec_test.go
@@ -778,7 +778,7 @@ func TestDecimal(t *testing.T) {
 	_, err = EncodeDecimal(nil, d, 12, 10)
 	require.Truef(t, terror.ErrorEqual(err, types.ErrOverflow), "err %v", err)
 
-	sc.SetTypeFlags(types.StrictFlags.WithIgnoreTruncateErr(true))
+	sc.SetTypeFlags(types.DefaultStmtFlags.WithIgnoreTruncateErr(true))
 	decimalDatum := types.NewDatum(d)
 	decimalDatum.SetLength(20)
 	decimalDatum.SetFrac(5)

--- a/pkg/util/rowcodec/common.go
+++ b/pkg/util/rowcodec/common.go
@@ -338,7 +338,7 @@ func appendDatumForChecksum(buf []byte, dat *data.Datum, typ byte) (out []byte, 
 		out = binary.LittleEndian.AppendUint64(buf, dat.GetMysqlSet().Value)
 	case mysql.TypeBit:
 		// ticdc transforms a bit value as the following way, no need to handle truncate error here.
-		v, _ := dat.GetBinaryLiteral().ToInt(data.DefaultNoWarningContext)
+		v, _ := dat.GetBinaryLiteral().ToInt(data.DefaultStmtNoWarningContext)
 		out = binary.LittleEndian.AppendUint64(buf, v)
 	case mysql.TypeJSON:
 		out = appendLengthValue(buf, []byte(dat.GetMysqlJSON().String()))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47829

### What is changed and how it works?

- Replace `FlagClipNegativeToZero` with `FlagAllowNegativeToUnsigned` which has a opposite semantics to make the `StrictFlags` (all-zero value) more strict.
- Introduce `DefaultStmtFlags` with `FlagAllowNegativeToUnsigned` set to 1 to keep it same behavior with old implement.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
