### PR TITLE
planner: unify the way to handle txn in `statshandle`

### DIFF
--- a/pkg/statistics/handle/history/history_stats.go
+++ b/pkg/statistics/handle/history/history_stats.go
@@ -77,7 +77,7 @@ func (sh *statsHistoryImpl) RecordHistoricalStatsMeta(tableID int64, version uin
 	}
 	err := util.CallWithSCtx(sh.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		return RecordHistoricalStatsMeta(sctx, tableID, version, source)
-	})
+	}, util.FlagWrapTxn)
 	if err != nil { // just log the error, hide the error from the outside caller.
 		logutil.BgLogger().Error("record historical stats meta failed",
 			zap.Int64("table-id", tableID),
@@ -112,14 +112,6 @@ func RecordHistoricalStatsMeta(sctx sessionctx.Context, tableID int64, version u
 		return errors.New("no historical meta stats can be recorded")
 	}
 	modifyCount, count := rows[0].GetInt64(0), rows[0].GetInt64(1)
-
-	_, err = util.Exec(sctx, "begin pessimistic")
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer func() {
-		err = util.FinishTransaction(sctx, err)
-	}()
 
 	const sql = "REPLACE INTO mysql.stats_meta_history(table_id, modify_count, count, version, source, create_time) VALUES (%?, %?, %?, %?, %?, NOW())"
 	if _, err := util.Exec(sctx, sql, tableID, modifyCount, count, version, source); err != nil {

--- a/pkg/statistics/handle/storage/gc.go
+++ b/pkg/statistics/handle/storage/gc.go
@@ -388,16 +388,10 @@ func MarkExtendedStatsDeleted(sctx sessionctx.Context,
 		logutil.BgLogger().Warn("unexpected duplicate extended stats records found", zap.String("name", statsName), zap.Int64("table_id", tableID))
 	}
 
-	_, err = util.Exec(sctx, "begin pessimistic")
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
 	defer func() {
-		err1 := util.FinishTransaction(sctx, err)
-		if err == nil && err1 == nil {
+		if err == nil {
 			removeExtendedStatsItem(statsCache, tableID, statsName)
 		}
-		err = err1
 	}()
 	version, err := util.GetStartTS(sctx)
 	if err != nil {

--- a/pkg/statistics/handle/storage/json.go
+++ b/pkg/statistics/handle/storage/json.go
@@ -285,13 +285,6 @@ func BlocksToJSONTable(blocks [][]byte) (*util.JSONTable, error) {
 
 // TableHistoricalStatsToJSON converts the historical stats of a table to JSONTable.
 func TableHistoricalStatsToJSON(sctx sessionctx.Context, physicalID int64, snapshot uint64) (jt *util.JSONTable, exist bool, err error) {
-	if _, err := util.Exec(sctx, "begin"); err != nil {
-		return nil, false, err
-	}
-	defer func() {
-		err = util.FinishTransaction(sctx, err)
-	}()
-
 	// get meta version
 	rows, _, err := util.ExecRows(sctx, "select distinct version from mysql.stats_meta_history where table_id = %? and version <= %? order by version desc limit 1", physicalID, snapshot)
 	if err != nil {

--- a/pkg/statistics/handle/storage/save.go
+++ b/pkg/statistics/handle/storage/save.go
@@ -125,13 +125,6 @@ func SaveTableStatsToStorage(sctx sessionctx.Context,
 	needDumpFMS := results.TableID.IsPartitionTable()
 	tableID := results.TableID.GetStatisticsID()
 	ctx := util.StatsCtx
-	_, err = util.Exec(sctx, "begin pessimistic")
-	if err != nil {
-		return 0, err
-	}
-	defer func() {
-		err = util.FinishTransaction(sctx, err)
-	}()
 	txn, err := sctx.Txn(true)
 	if err != nil {
 		return 0, err
@@ -334,13 +327,6 @@ func SaveTableStatsToStorage(sctx sessionctx.Context,
 func SaveStatsToStorage(sctx sessionctx.Context,
 	tableID int64, count, modifyCount int64, isIndex int, hg *statistics.Histogram,
 	cms *statistics.CMSketch, topN *statistics.TopN, statsVersion int, isAnalyzed int64, updateAnalyzeTime bool) (statsVer uint64, err error) {
-	_, err = util.Exec(sctx, "begin pessimistic")
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-	defer func() {
-		err = util.FinishTransaction(sctx, err)
-	}()
 	version, err := util.GetStartTS(sctx)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -404,13 +390,6 @@ func SaveStatsToStorage(sctx sessionctx.Context,
 func SaveMetaToStorage(
 	sctx sessionctx.Context,
 	tableID, count, modifyCount int64) (statsVer uint64, err error) {
-	_, err = util.Exec(sctx, "begin")
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-	defer func() {
-		err = util.FinishTransaction(sctx, err)
-	}()
 	version, err := util.GetStartTS(sctx)
 	if err != nil {
 		return 0, errors.Trace(err)

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -196,7 +196,7 @@ func (s *statsReadWriter) SaveTableStatsToStorage(results *statistics.AnalyzeRes
 	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		statsVer, err = SaveTableStatsToStorage(sctx, results, analyzeSnapshot)
 		return err
-	})
+	}, util.FlagWrapTxn)
 	if err == nil && statsVer != 0 {
 		tableID := results.TableID.GetStatisticsID()
 		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source, true)
@@ -238,7 +238,7 @@ func (s *statsReadWriter) SaveStatsToStorage(tableID int64, count, modifyCount i
 		statsVer, err = SaveStatsToStorage(sctx, tableID,
 			count, modifyCount, isIndex, hg, cms, topN, statsVersion, isAnalyzed, updateAnalyzeTime)
 		return err
-	})
+	}, util.FlagWrapTxn)
 	if err == nil && statsVer != 0 {
 		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source, false)
 	}
@@ -251,7 +251,7 @@ func (s *statsReadWriter) saveMetaToStorage(tableID, count, modifyCount int64, s
 	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		statsVer, err = SaveMetaToStorage(sctx, tableID, count, modifyCount)
 		return err
-	})
+	}, util.FlagWrapTxn)
 	if err == nil && statsVer != 0 {
 		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, source, false)
 	}
@@ -264,7 +264,7 @@ func (s *statsReadWriter) InsertExtendedStats(statsName string, colIDs []int64, 
 	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		statsVer, err = InsertExtendedStats(sctx, s.statsHandler, statsName, colIDs, tp, tableID, ifNotExists)
 		return err
-	})
+	}, util.FlagWrapTxn)
 	if err == nil && statsVer != 0 {
 		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats", false)
 	}
@@ -277,7 +277,7 @@ func (s *statsReadWriter) MarkExtendedStatsDeleted(statsName string, tableID int
 	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		statsVer, err = MarkExtendedStatsDeleted(sctx, s.statsHandler, statsName, tableID, ifExists)
 		return err
-	})
+	}, util.FlagWrapTxn)
 	if err == nil && statsVer != 0 {
 		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats", false)
 	}
@@ -290,7 +290,7 @@ func (s *statsReadWriter) SaveExtendedStatsToStorage(tableID int64, extStats *st
 	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		statsVer, err = SaveExtendedStatsToStorage(sctx, tableID, extStats, isLoad)
 		return err
-	})
+	}, util.FlagWrapTxn)
 	if err == nil && statsVer != 0 {
 		s.statsHandler.RecordHistoricalStatsMeta(tableID, statsVer, "extended stats", false)
 	}

--- a/pkg/statistics/handle/storage/update.go
+++ b/pkg/statistics/handle/storage/update.go
@@ -111,13 +111,6 @@ func InsertExtendedStats(sctx sessionctx.Context,
 	}
 	strColIDs := string(bytes)
 
-	_, err = statsutil.Exec(sctx, "begin pessimistic")
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-	defer func() {
-		err = statsutil.FinishTransaction(sctx, err)
-	}()
 	// No need to use `exec.ExecuteInternal` since we have acquired the lock.
 	rows, _, err := statsutil.ExecRows(sctx, "SELECT name, type, column_ids FROM mysql.stats_extended WHERE table_id = %? and status in (%?, %?)", tableID, statistics.ExtendedStatsInited, statistics.ExtendedStatsAnalyzed)
 	if err != nil {
@@ -170,13 +163,6 @@ func SaveExtendedStatsToStorage(sctx sessionctx.Context,
 		return 0, nil
 	}
 
-	_, err = statsutil.Exec(sctx, "begin pessimistic")
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-	defer func() {
-		err = statsutil.FinishTransaction(sctx, err)
-	}()
 	version, err := statsutil.GetStartTS(sctx)
 	if err != nil {
 		return 0, errors.Trace(err)

--- a/pkg/statistics/handle/util/util.go
+++ b/pkg/statistics/handle/util/util.go
@@ -174,7 +174,7 @@ func UpdateSCtxVarsForStats(sctx sessionctx.Context) error {
 // WrapTxn uses a transaction here can let different SQLs in this operation have the same data visibility.
 func WrapTxn(sctx sessionctx.Context, f func(sctx sessionctx.Context) error) (err error) {
 	// TODO: check whether this sctx is already in a txn
-	if _, _, err := ExecRows(sctx, "begin"); err != nil {
+	if _, _, err := ExecRows(sctx, "BEGIN PESSIMISTIC"); err != nil {
 		return err
 	}
 	defer func() {

--- a/pkg/statistics/handle/util/util.go
+++ b/pkg/statistics/handle/util/util.go
@@ -69,7 +69,7 @@ type SessionPool interface {
 // finishTransaction will execute `commit` when error is nil, otherwise `rollback`.
 func finishTransaction(sctx sessionctx.Context, err error) error {
 	if err == nil {
-		_, _, err = ExecRows(sctx, "commit")
+		_, _, err = ExecRows(sctx, "COMMIT")
 	} else {
 		_, _, err1 := ExecRows(sctx, "rollback")
 		terror.Log(errors.Trace(err1))

--- a/pkg/statistics/handle/util/util.go
+++ b/pkg/statistics/handle/util/util.go
@@ -66,8 +66,8 @@ type SessionPool interface {
 	Put(pools.Resource)
 }
 
-// FinishTransaction will execute `commit` when error is nil, otherwise `rollback`.
-func FinishTransaction(sctx sessionctx.Context, err error) error {
+// finishTransaction will execute `commit` when error is nil, otherwise `rollback`.
+func finishTransaction(sctx sessionctx.Context, err error) error {
 	if err == nil {
 		_, _, err = ExecRows(sctx, "commit")
 	} else {
@@ -178,7 +178,7 @@ func WrapTxn(sctx sessionctx.Context, f func(sctx sessionctx.Context) error) (er
 		return err
 	}
 	defer func() {
-		err = FinishTransaction(sctx, err)
+		err = finishTransaction(sctx, err)
 	}()
 	err = f(sctx)
 	return


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46905

Problem Summary: planner: unify the way to handle txn in `statshandle`

### What is changed and how it works?

 planner: unify the way to handle txn in `statshandle`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
