### PR TITLE
planner: fix a panic during column pruning

### DIFF
--- a/pkg/executor/explain_test.go
+++ b/pkg/executor/explain_test.go
@@ -83,6 +83,57 @@ func checkMemoryInfo(t *testing.T, tk *testkit.TestKit, sql string) {
 	}
 }
 
+func TestIssue47331(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec(`create table t1(
+		id1 varchar(2) DEFAULT '00',
+		id2 varchar(30) NOT NULL,
+		id3 datetime DEFAULT NULL,
+		id4 varchar(100) NOT NULL DEFAULT 'ecifdata',
+		id5 datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		id6 int(11) DEFAULT NULL,
+		id7 int(11) DEFAULT NULL,
+		UNIQUE KEY UI_id2 (id2),
+		KEY ix_id1 (id1)
+	)`)
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec(`create table t2(
+		id10 varchar(40) NOT NULL,
+		id2 varchar(30) NOT NULL,
+		KEY IX_id2 (id2),
+		PRIMARY KEY (id10)
+	)`)
+	tk.MustExec("drop table if exists t3")
+	tk.MustExec(`create table t3(
+		id20 varchar(40) DEFAULT NULL,
+		UNIQUE KEY IX_id20 (id20)
+	)`)
+	tk.MustExec(`
+		explain
+		UPDATE t1 a
+		SET a.id1 = '04',
+			a.id3 = CURRENT_TIMESTAMP,
+			a.id4 = SUBSTRING_INDEX(USER(), '@', 1),
+			a.id5 = CURRENT_TIMESTAMP
+		WHERE a.id1 = '03'
+			AND a.id6 - IFNULL(a.id7, 0) =
+				(
+					SELECT COUNT(1)
+					FROM t2 b, t3 c
+					WHERE b.id10 = c.id20
+						AND b.id2 = a.id2
+						AND b.id2 in (
+							SELECT rn.id2
+							FROM t1 rn
+							WHERE rn.id1 = '03'
+						)
+				);
+	`)
+}
+
 func TestMemoryAndDiskUsageAfterClose(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -316,7 +316,8 @@ func (s *joinReOrderSolver) optimizeRecursive(ctx sessionctx.Context, p LogicalP
 			proj := LogicalProjection{
 				Exprs: expression.Column2Exprs(originalSchema.Columns),
 			}.Init(p.SCtx(), p.SelectBlockOffset())
-			proj.SetSchema(originalSchema)
+			// Clone the schema here, because the schema may be changed by the projection optimization later.
+			proj.SetSchema(originalSchema.Clone())
 			proj.SetChildren(p)
 			p = proj
 		}

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -316,7 +316,7 @@ func (s *joinReOrderSolver) optimizeRecursive(ctx sessionctx.Context, p LogicalP
 			proj := LogicalProjection{
 				Exprs: expression.Column2Exprs(originalSchema.Columns),
 			}.Init(p.SCtx(), p.SelectBlockOffset())
-			// Clone the schema here, because the schema may be changed by the projection optimization later.
+			// Clone the schema here, because the schema may be changed by column pruning rules.
 			proj.SetSchema(originalSchema.Clone())
 			proj.SetChildren(p)
 			p = proj


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/47331

Problem Summary:

### What is changed and how it works?

Through my investigation, I identified several key points:
1. The panic occurs during DeriveStats: p.StatsInfo().ColNDVs[selfSchema.Columns[i].UniqueID] = childProfile.RowCount.
2. There's a discrepancy in the number of expressions and schema columns: the plan has 8 expressions but only 7 columns in the schema.
3. The logic plan causing the panic is a projection (ID 25), generated by the joinReOrderSolver.
4. Post-debugging, I noted that the schema undergoes changes after the LogicalProjection.PruneColumns process.
5. On further debugging the PruneColumns function individually, I discovered that the schema of projection#25 is affected even before it's reached in the process.
6. This led me to suspect a memory issue. Notably, projection#18 and projection#25 appear to share the same schema memory address (0x14006b557c0).
7. Consequently, when a column is pruned from projection#18, projection#25 becomes corrupted, leading to a mismatch between expressions and columns.

So I cloned that schema and made sure we didn't have this kind of problem anymore.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a panic issue during column pruning
```
