### PR TITLE
tests: fix path of LDFLAGS for global kill e2e test

### DIFF
--- a/tests/globalkilltest/Dockerfile
+++ b/tests/globalkilltest/Dockerfile
@@ -32,8 +32,8 @@ WORKDIR /go/src/github.com/pingcap/tidb
 
 COPY go.mod .
 COPY go.sum .
-COPY parser/go.mod parser/go.mod
-COPY parser/go.sum parser/go.sum
+COPY pkg/parser/go.mod pkg/parser/go.mod
+COPY pkg/parser/go.sum pkg/parser/go.sum
 
 ARG GOPROXY
 RUN GO111MODULE=on GOPROXY=${GOPROXY} go mod download

--- a/tests/globalkilltest/Makefile
+++ b/tests/globalkilltest/Makefile
@@ -17,16 +17,16 @@ OUT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/bin)
 
 include $(BASE_DIR)/Makefile.common
 
-GLOBAL_KILL_TEST_SERVER_LDFLAGS =  -X "github.com/pingcap/tidb/domain.ldflagIsGlobalKillTest=1"
-GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/domain.ldflagServerIDTTL=10"
-GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/domain.ldflagServerIDTimeToKeepAlive=1"
-GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/domain.ldflagServerIDTimeToCheckPDConnectionRestored=1"
-GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/domain.ldflagLostConnectionToPDTimeout=5"
-GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/store.ldflagGetEtcdAddrsFromConfig=1"
+GLOBAL_KILL_TEST_SERVER_LDFLAGS =  -X "github.com/pingcap/tidb/pkg/domain.ldflagIsGlobalKillTest=1"
+GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/pkg/domain.ldflagServerIDTTL=10"
+GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/pkg/domain.ldflagServerIDTimeToKeepAlive=1"
+GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/pkg/domain.ldflagServerIDTimeToCheckPDConnectionRestored=1"
+GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/pkg/domain.ldflagLostConnectionToPDTimeout=5"
+GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/pkg/store.ldflagGetEtcdAddrsFromConfig=1"
 
-GLOBAL_KILL_TEST_SERVER_LDFLAGS +=  -X "github.com/pingcap/tidb/util/globalconn.ldflagIsGlobalKillTest=1"
-GLOBAL_KILL_TEST_SERVER_LDFLAGS +=  -X "github.com/pingcap/tidb/util/globalconn.ldflagServerIDBits32=2"
-GLOBAL_KILL_TEST_SERVER_LDFLAGS +=  -X "github.com/pingcap/tidb/util/globalconn.ldflagLocalConnIDBits32=4"
+GLOBAL_KILL_TEST_SERVER_LDFLAGS +=  -X "github.com/pingcap/tidb/pkg/util/globalconn.ldflagIsGlobalKillTest=1"
+GLOBAL_KILL_TEST_SERVER_LDFLAGS +=  -X "github.com/pingcap/tidb/pkg/util/globalconn.ldflagServerIDBits32=2"
+GLOBAL_KILL_TEST_SERVER_LDFLAGS +=  -X "github.com/pingcap/tidb/pkg/util/globalconn.ldflagLocalConnIDBits32=4"
 
 .PHONY: server buildsucc
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47895 

Problem Summary: Global kill e2e test failed

### What is changed and how it works?

Fix path of LDFLAGS related to path changed by https://github.com/pingcap/tidb/pull/47123.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
