### PR TITLE
*: update owner op message

### DIFF
--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -329,7 +329,7 @@ func (d *ddl) checkAndUpdateClusterState(needUpdate bool) error {
 
 	ownerOp := owner.OpNone
 	if stateInfo.State == syncer.StateUpgrading {
-		ownerOp = owner.OpGetUpgradingState
+		ownerOp = owner.OpSyncUpgradingState
 	}
 	err = d.ownerManager.SetOwnerOpValue(d.ctx, ownerOp)
 	if err != nil {

--- a/pkg/owner/manager.go
+++ b/pkg/owner/manager.go
@@ -76,18 +76,23 @@ type OpType byte
 
 // List operation of types.
 const (
-	OpNone              OpType = 0
-	OpGetUpgradingState OpType = 1
+	OpNone               OpType = 0
+	OpSyncUpgradingState OpType = 1
 )
 
 // String implements fmt.Stringer interface.
 func (ot OpType) String() string {
 	switch ot {
-	case OpGetUpgradingState:
-		return "get upgrading state"
+	case OpSyncUpgradingState:
+		return "sync upgrading state"
 	default:
 		return "none"
 	}
+}
+
+// IsSyncedUpgradingState represents whether the upgrading state is synchronized.
+func (ot OpType) IsSyncedUpgradingState() bool {
+	return ot == OpSyncUpgradingState
 }
 
 // DDLOwnerChecker is used to check whether tidb is owner.

--- a/pkg/session/sync_upgrade.go
+++ b/pkg/session/sync_upgrade.go
@@ -61,11 +61,11 @@ func SyncUpgradeState(s sessionctx.Context, timeout time.Duration) error {
 		childCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 		op, err = owner.GetOwnerOpValue(childCtx, dom.EtcdClient(), ddl.DDLOwnerKey, "upgrade bootstrap")
 		cancel()
-		if err == nil && op.String() == owner.OpGetUpgradingState.String() {
+		if err == nil && op.IsSyncedUpgradingState() {
 			break
 		}
 		if i%10 == 0 {
-			logger.Warn("get owner op failed", zap.Stringer("state", op), zap.Error(err))
+			logger.Warn("get owner op failed", zap.Stringer("op", op), zap.Error(err))
 		}
 		time.Sleep(interval)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/47903

Problem Summary:
` [INFO] [job_table.go:343] ["[ddl] the owner sets owner operator value"] [ownerOp="get upgrading state"]`
The `ownerOp` info doesn't quite match.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
