### PR TITLE
ddl: fix panic in pause

### DIFF
--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2093,9 +2093,11 @@ func (w *worker) executeDistGlobalTask(reorgInfo *reorgInfo) error {
 				return err
 			}
 			err = handle.WaitGlobalTask(ctx, task)
-			if w.isReorgPaused(reorgInfo.Job.ID) {
-				logutil.BgLogger().Warn("job paused by user", zap.String("category", "ddl"), zap.Error(err))
-				return dbterror.ErrPausedDDLJob.GenWithStackByArgs(reorgInfo.Job.ID)
+			if err := w.isReorgRunnable(reorgInfo.Job.ID, true); err != nil {
+				if dbterror.ErrPausedDDLJob.Equal(err) {
+					logutil.BgLogger().Warn("job paused by user", zap.String("category", "ddl"), zap.Error(err))
+					return dbterror.ErrPausedDDLJob.GenWithStackByArgs(reorgInfo.Job.ID)
+				}
 			}
 			return err
 		})
@@ -2124,9 +2126,12 @@ func (w *worker) executeDistGlobalTask(reorgInfo *reorgInfo) error {
 			failpoint.Inject("pauseAfterDistTaskSuccess", func() {
 				MockDMLExecutionOnTaskFinished()
 			})
-			if w.isReorgPaused(reorgInfo.Job.ID) {
-				logutil.BgLogger().Warn("job paused by user", zap.String("category", "ddl"), zap.Error(err))
-				return dbterror.ErrPausedDDLJob.GenWithStackByArgs(reorgInfo.Job.ID)
+
+			if err := w.isReorgRunnable(reorgInfo.Job.ID, true); err != nil {
+				if dbterror.ErrPausedDDLJob.Equal(err) {
+					logutil.BgLogger().Warn("job paused by user", zap.String("category", "ddl"), zap.Error(err))
+					return dbterror.ErrPausedDDLJob.GenWithStackByArgs(reorgInfo.Job.ID)
+				}
 			}
 			return err
 		})
@@ -2155,7 +2160,7 @@ func (w *worker) executeDistGlobalTask(reorgInfo *reorgInfo) error {
 					}
 					if err = handle.CancelGlobalTask(taskKey); err != nil {
 						logutil.BgLogger().Error("cancel global task error", zap.String("category", "ddl"), zap.String("task_key", taskKey), zap.Error(err))
-						// continue to cancel global task
+						// continue to cancel global task.
 						continue
 					}
 				}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47902 

Problem Summary:
reorgCtx for reorgJob is cleaned up since worker is closed when calling isReorgPaused.
### What is changed and how it works?
Use isReorgRunnable to ignore the check.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
