### PR TITLE
ddl, parser: fix the DDL job version using issue

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -73,9 +73,7 @@ import (
 
 const (
 	// currentVersion is for all new DDL jobs.
-	// 1 for the DDL job created <= v7.4.0.
-	// For fix #46306(whether end key is included or not in the table range) to add version 2.
-	currentVersion = 2
+	currentVersion = 1
 	// DDLOwnerKey is the ddl owner path that is saved to etcd, and it's exported for testing.
 	DDLOwnerKey = "/tidb/ddl/fg/owner"
 	// addingDDLJobPrefix is the path prefix used to record the newly added DDL job, and it's saved to etcd.
@@ -1409,7 +1407,7 @@ func GetDDLInfoWithNewTxn(s sessionctx.Context) (*Info, error) {
 	return info, err
 }
 
-// GetDDLInfo returns DDL information.
+// GetDDLInfo returns DDL information and only uses for testing.
 func GetDDLInfo(s sessionctx.Context) (*Info, error) {
 	var err error
 	info := &Info{}

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -8992,5 +8992,6 @@ func NewDDLReorgMeta(ctx sessionctx.Context) *model.DDLReorgMeta {
 		WarningsCount:     make(map[errors.ErrorID]int64),
 		Location:          &model.TimeZoneLocation{Name: tzName, Offset: tzOffset},
 		ResourceGroupName: ctx.GetSessionVars().ResourceGroupName,
+		Version:           model.CurrentReorgMetaVersion,
 	}
 }

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -181,6 +181,7 @@ func (w *worker) runReorgJob(reorgInfo *reorgInfo, tblInfo *model.TableInfo,
 			Warnings:      make(map[errors.ErrorID]*terror.Error),
 			WarningsCount: make(map[errors.ErrorID]int64),
 			Location:      &model.TimeZoneLocation{Name: time.UTC.String(), Offset: 0},
+			Version:       model.CurrentReorgMetaVersion,
 		}
 	}
 
@@ -893,9 +894,9 @@ func CleanupDDLReorgHandles(job *model.Job, s *sess.Session) {
 // GetDDLReorgHandle gets the latest processed DDL reorganize position.
 func (r *reorgHandler) GetDDLReorgHandle(job *model.Job) (element *meta.Element, startKey, endKey kv.Key, physicalTableID int64, err error) {
 	element, startKey, endKey, physicalTableID, err = getDDLReorgHandle(r.s, job)
-	if job.Version < currentVersion && err == nil {
-		logutil.BgLogger().Info("job get table range for old version jobs", zap.String("category", "ddl"),
-			zap.Int64("jobID", job.ID), zap.Int64("job version", job.Version), zap.Int64("physical table ID", physicalTableID),
+	if job.ReorgMeta != nil && job.ReorgMeta.Version == model.ReorgMetaVersion0 && err == nil {
+		logutil.BgLogger().Info("job get table range for old version ReorgMetas", zap.String("category", "ddl"),
+			zap.Int64("jobID", job.ID), zap.Int64("job ReorgMeta version", job.ReorgMeta.Version), zap.Int64("physical table ID", physicalTableID),
 			zap.String("startKey", hex.EncodeToString(startKey)),
 			zap.String("current endKey", hex.EncodeToString(endKey)),
 			zap.String("endKey next", hex.EncodeToString(endKey.Next())))

--- a/pkg/parser/model/reorg.go
+++ b/pkg/parser/model/reorg.go
@@ -31,7 +31,16 @@ type DDLReorgMeta struct {
 	IsDistReorg       bool                             `json:"is_dist_reorg"`
 	UseCloudStorage   bool                             `json:"use_cloud_storage"`
 	ResourceGroupName string                           `json:"resource_group_name"`
+	Version           int64                            `json:"version"`
 }
+
+const (
+	// ReorgMetaVersion0 is the minimum version of DDLReorgMeta.
+	ReorgMetaVersion0 = int64(0)
+	// CurrentReorgMetaVersion is the current version of DDLReorgMeta.
+	// For fix #46306(whether end key is included or not in the table range) to add the version to 1.
+	CurrentReorgMetaVersion = int64(1)
+)
 
 // ReorgType indicates which process is used for the data reorganization.
 type ReorgType int8


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/47912, close https://github.com/pingcap/tidb/issues/47910

Problem Summary:
After https://github.com/pingcap/tidb/pull/3993, we using `job.Version` like 
```
	if job.Version <= currentVersion {
		err = w.delRangeManager.addDelRangeJob(ctx, job)
	} else {
		err = dbterror.ErrInvalidDDLJobVersion.GenWithStackByArgs(job.Version, currentVersion)
	}
```

So, when we add the `currentVersion` value(https://github.com/pingcap/tidb/pull/47818) and have two versions TiDB has an issue.

### What is changed and how it works?
Use `ReorgMeta`'s version instead of `Job`'s.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  * Case 1
deploy v7.1.0 cluster with 2 tidb.
Then upgrade this cluster to master one by one.
**Result**: After this PR, upgrade successfully.

  * Case 2(Manual test in https://github.com/pingcap/tidb/pull/47884 )
deploy v7.1.1+ cluster with 1 tidb
set @@global.tidb_ddl_enable_fast_reorg = 0;
Create a table and import 3.5 million rows.
Do alter table t add index idx(a, b);, and when it backfills 700,000+ indexes, kill the cluster.
Then upgrade this cluster to master.
After upgrading successfully, do admin check index t idx
**Result**: we get Query OK.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
