### PR TITLE
types: move overflow settings from `stmtctx.StatementContext` to `types.Flags`

### DIFF
--- a/br/pkg/lightning/backend/kv/session.go
+++ b/br/pkg/lightning/backend/kv/session.go
@@ -287,7 +287,6 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 	vars.StmtCtx.InInsertStmt = true
 	vars.StmtCtx.BatchCheck = true
 	vars.StmtCtx.BadNullAsWarning = !sqlMode.HasStrictMode()
-	vars.StmtCtx.OverflowAsWarning = !sqlMode.HasStrictMode()
 	vars.StmtCtx.AllowInvalidDate = sqlMode.HasAllowInvalidDatesMode()
 	vars.StmtCtx.IgnoreZeroInDate = !sqlMode.HasStrictMode() || sqlMode.HasAllowInvalidDatesMode()
 	vars.SQLMode = sqlMode
@@ -314,7 +313,9 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 		}
 	}
 	vars.StmtCtx.SetTimeZone(vars.Location())
-	vars.StmtCtx.SetTypeFlags(types.StrictFlags)
+	vars.StmtCtx.SetTypeFlags(types.StrictFlags.
+		WithOverflowAsWarning(!sqlMode.HasStrictMode()),
+	)
 	if err := vars.SetSystemVar("timestamp", strconv.FormatInt(options.Timestamp, 10)); err != nil {
 		logger.Warn("new session: failed to set timestamp",
 			log.ShortError(err))

--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -158,13 +158,13 @@ func initSessCtx(
 	}
 	sessCtx.GetSessionVars().StmtCtx.SetTimeZone(sessCtx.GetSessionVars().Location())
 	sessCtx.GetSessionVars().StmtCtx.BadNullAsWarning = !sqlMode.HasStrictMode()
-	sessCtx.GetSessionVars().StmtCtx.OverflowAsWarning = !sqlMode.HasStrictMode()
 	sessCtx.GetSessionVars().StmtCtx.AllowInvalidDate = sqlMode.HasAllowInvalidDatesMode()
 	sessCtx.GetSessionVars().StmtCtx.DividedByZeroAsWarning = !sqlMode.HasStrictMode()
 	sessCtx.GetSessionVars().StmtCtx.IgnoreZeroInDate = !sqlMode.HasStrictMode() || sqlMode.HasAllowInvalidDatesMode()
 	sessCtx.GetSessionVars().StmtCtx.NoZeroDate = sqlMode.HasStrictMode()
 	sessCtx.GetSessionVars().StmtCtx.SetTypeFlags(types.StrictFlags.
-		WithTruncateAsWarning(!sqlMode.HasStrictMode()),
+		WithTruncateAsWarning(!sqlMode.HasStrictMode()).
+		WithOverflowAsWarning(!sqlMode.HasStrictMode()),
 	)
 
 	// Prevent initializing the mock context in the workers concurrently.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2114,15 +2114,15 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.IgnoreNoPartition = true
 	case *ast.SelectStmt:
 		sc.InSelectStmt = true
-
-		// see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-strict
-		// said "For statements such as SELECT that do not change data, invalid values
-		// generate a warning in strict mode, not an error."
-		// and https://dev.mysql.com/doc/refman/5.7/en/out-of-range-and-overflow.html
-		sc.OverflowAsWarning = true
-
 		// Return warning for truncate error in selection.
-		sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true))
+		sc.SetTypeFlags(sc.TypeFlags().
+			WithTruncateAsWarning(true).
+			// see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-strict
+			// said "For statements such as SELECT that do not change data, invalid values
+			// generate a warning in strict mode, not an error."
+			// and https://dev.mysql.com/doc/refman/5.7/en/out-of-range-and-overflow.html
+			WithOverflowAsWarning(true),
+		)
 		sc.IgnoreZeroInDate = true
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 		if opts := stmt.SelectStmtOpts; opts != nil {
@@ -2132,8 +2132,10 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.WeakConsistency = isWeakConsistencyRead(ctx, stmt)
 	case *ast.SetOprStmt:
 		sc.InSelectStmt = true
-		sc.OverflowAsWarning = true
-		sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true))
+		sc.SetTypeFlags(sc.TypeFlags().
+			WithTruncateAsWarning(true).
+			WithOverflowAsWarning(true),
+		)
 		sc.IgnoreZeroInDate = true
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
 	case *ast.ShowStmt:

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -98,7 +98,7 @@ func TestCastFunctions(t *testing.T) {
 	defer func() {
 		sc.InSelectStmt = oldInSelectStmt
 	}()
-	sc.OverflowAsWarning = true
+	sc.SetTypeFlags(sc.TypeFlags().WithOverflowAsWarning(true))
 
 	// cast('18446744073709551616' as unsigned);
 	tp1 := types.NewFieldTypeBuilder().SetType(mysql.TypeLonglong).SetFlag(mysql.BinaryFlag).SetFlen(mysql.MaxIntWidth).SetCharset(charset.CharsetBin).SetCollate(charset.CollationBin).BuildP()

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -181,7 +181,6 @@ type StatementContext struct {
 	DupKeyAsWarning               bool
 	BadNullAsWarning              bool
 	DividedByZeroAsWarning        bool
-	OverflowAsWarning             bool
 	ErrAutoincReadFailedAsWarning bool
 	InShowWarning                 bool
 	UseCache                      bool
@@ -1026,7 +1025,7 @@ func (sc *StatementContext) HandleOverflow(err error, warnErr error) error {
 		return nil
 	}
 
-	if sc.OverflowAsWarning {
+	if sc.TypeFlags().OverflowAsWarning() {
 		sc.AppendWarning(warnErr)
 		return nil
 	}
@@ -1142,7 +1141,7 @@ func (sc *StatementContext) PushDownFlags() uint64 {
 	} else if sc.TypeFlags().TruncateAsWarning() {
 		flags |= model.FlagTruncateAsWarning
 	}
-	if sc.OverflowAsWarning {
+	if sc.TypeFlags().OverflowAsWarning() {
 		flags |= model.FlagOverflowAsWarning
 	}
 	if sc.IgnoreZeroInDate {
@@ -1209,14 +1208,14 @@ func (sc *StatementContext) InitFromPBFlagAndTz(flags uint64, tz *time.Location)
 	sc.InInsertStmt = (flags & model.FlagInInsertStmt) > 0
 	sc.InSelectStmt = (flags & model.FlagInSelectStmt) > 0
 	sc.InDeleteStmt = (flags & model.FlagInUpdateOrDeleteStmt) > 0
-	sc.OverflowAsWarning = (flags & model.FlagOverflowAsWarning) > 0
 	sc.IgnoreZeroInDate = (flags & model.FlagIgnoreZeroInDate) > 0
 	sc.DividedByZeroAsWarning = (flags & model.FlagDividedByZeroAsWarning) > 0
 	sc.SetTimeZone(tz)
 	sc.SetTypeFlags(typectx.DefaultStmtFlags.
 		WithIgnoreTruncateErr((flags & model.FlagIgnoreTruncate) > 0).
 		WithTruncateAsWarning((flags & model.FlagTruncateAsWarning) > 0).
-		WithAllowNegativeToUnsigned(!sc.InInsertStmt),
+		WithAllowNegativeToUnsigned(!sc.InInsertStmt).
+		WithOverflowAsWarning((flags & model.FlagOverflowAsWarning) > 0),
 	)
 }
 

--- a/pkg/sessionctx/stmtctx/stmtctx_test.go
+++ b/pkg/sessionctx/stmtctx/stmtctx_test.go
@@ -96,7 +96,7 @@ func TestStatementContextPushDownFLags(t *testing.T) {
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.InSelectStmt = true }), 32},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true)) }), 1},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true)) }), 2},
-		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.OverflowAsWarning = true }), 64},
+		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithOverflowAsWarning(true)) }), 64},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.IgnoreZeroInDate = true }), 128},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.DividedByZeroAsWarning = true }), 256},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.InLoadDataStmt = true }), 1024},

--- a/pkg/types/context/context.go
+++ b/pkg/types/context/context.go
@@ -81,6 +81,32 @@ func (f Flags) WithAllowNegativeToUnsigned(clip bool) Flags {
 	return f &^ FlagAllowNegativeToUnsigned
 }
 
+// IgnoreOverflowError indicates whether the flag `FlagIgnoreOverflowError` is set
+func (f Flags) IgnoreOverflowError() bool {
+	return f&FlagIgnoreOverflowError != 0
+}
+
+// WithIgnoreOverflowError returns a new flags with `FlagIgnoreOverflowError` set/unset according to the ignore parameter
+func (f Flags) WithIgnoreOverflowError(ignore bool) Flags {
+	if ignore {
+		return f | FlagIgnoreOverflowError
+	}
+	return f &^ FlagIgnoreOverflowError
+}
+
+// OverflowAsWarning indicates whether the flag `FlagOverflowAsWarning` is set
+func (f Flags) OverflowAsWarning() bool {
+	return f&FlagOverflowAsWarning != 0
+}
+
+// WithOverflowAsWarning returns a new flags with `FlagOverflowAsWarning` set/unset according to the warn parameter
+func (f Flags) WithOverflowAsWarning(warn bool) Flags {
+	if warn {
+		return f | FlagOverflowAsWarning
+	}
+	return f &^ FlagOverflowAsWarning
+}
+
 // SkipASCIICheck indicates whether the flag `FlagSkipASCIICheck` is set
 func (f Flags) SkipASCIICheck() bool {
 	return f&FlagSkipASCIICheck != 0

--- a/pkg/types/context/context_test.go
+++ b/pkg/types/context/context_test.go
@@ -49,6 +49,26 @@ func TestSimpleOnOffFlags(t *testing.T) {
 			},
 		},
 		{
+			name: "FlagIgnoreOverflowError",
+			flag: FlagIgnoreOverflowError,
+			readFn: func(f Flags) bool {
+				return f.IgnoreOverflowError()
+			},
+			writeFn: func(f Flags, ignore bool) Flags {
+				return f.WithIgnoreOverflowError(ignore)
+			},
+		},
+		{
+			name: "FlagOverflowAsWarning",
+			flag: FlagOverflowAsWarning,
+			readFn: func(f Flags) bool {
+				return f.OverflowAsWarning()
+			},
+			writeFn: func(f Flags, warn bool) Flags {
+				return f.WithOverflowAsWarning(warn)
+			},
+		},
+		{
 			name: "FlagSkipASCIICheck",
 			flag: FlagSkipASCIICheck,
 			readFn: func(f Flags) bool {

--- a/pkg/types/datum_test.go
+++ b/pkg/types/datum_test.go
@@ -413,8 +413,10 @@ func TestEstimatedMemUsage(t *testing.T) {
 
 func TestChangeReverseResultByUpperLowerBound(t *testing.T) {
 	sc := stmtctx.NewStmtCtx()
-	sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true))
-	sc.OverflowAsWarning = true
+	sc.SetTypeFlags(sc.TypeFlags().
+		WithIgnoreTruncateErr(true).
+		WithOverflowAsWarning(true),
+	)
 	// TODO: add more reserve convert tests for each pair of convert type.
 	testData := []struct {
 		a         Datum

--- a/pkg/util/codec/codec_test.go
+++ b/pkg/util/codec/codec_test.go
@@ -785,7 +785,7 @@ func TestDecimal(t *testing.T) {
 	_, err = EncodeValue(sc, nil, decimalDatum)
 	require.NoError(t, err)
 
-	sc.OverflowAsWarning = true
+	sc.SetTypeFlags(sc.TypeFlags().WithOverflowAsWarning(true))
 	decimalDatum.SetLength(12)
 	decimalDatum.SetFrac(10)
 	_, err = EncodeValue(sc, nil, decimalDatum)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47517

### What is changed and how it works?

This PR just move some overflow error settings from  `stmtctx.StatementContext` to `types.Flags` to decouple them with `stmtctx`.

TODO: we should make all functions provides in `types` to respect `types.Context`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
