### PR TITLE
planner: Fix the issue that may generate many plandigests when the inner table is clustered

### DIFF
--- a/pkg/planner/core/casetest/BUILD.bazel
+++ b/pkg/planner/core/casetest/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 19,
+    shard_count = 20,
     deps = [
         "//pkg/domain",
         "//pkg/parser",

--- a/pkg/planner/core/casetest/plan_test.go
+++ b/pkg/planner/core/casetest/plan_test.go
@@ -154,6 +154,44 @@ func TestNormalizedPlan(t *testing.T) {
 	}
 }
 
+func TestIssue47634(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t3,t4")
+	tk.MustExec("create table t3(a int, b int, c int);")
+	tk.MustExec("create table t4(a int, b int, c int, primary key (a, b) clustered);")
+	tk.MustExec("create table t5(a int, b int, c int, key idx_a_b (a, b));")
+	tk.Session().GetSessionVars().PlanID.Store(0)
+	queriesGroup1 := []string{
+		"explain select /*+ inl_join(t4) */ * from t3 join t4 on t3.b = t4.b where t4.a = 1;",
+		"explain select /*+ inl_join(t5) */ * from t3 join t5 on t3.b = t5.b where t5.a = 1;",
+	}
+	queriesGroup2 := []string{
+		"explain select /*+ inl_join(t4) */ * from t3 join t4 on t3.b = t4.b where t4.a = 2;",
+		"explain select /*+ inl_join(t5) */ * from t3 join t5 on t3.b = t5.b where t5.a = 2;",
+	}
+	for i := 0; i < len(queriesGroup1); i++ {
+		query1 := queriesGroup1[i]
+		query2 := queriesGroup2[i]
+		t.Run(query1+" vs "+query2, func(t *testing.T) {
+			tk.MustExec(query1)
+			info1 := tk.Session().ShowProcess()
+			require.NotNil(t, info1)
+			p1, ok := info1.Plan.(core.Plan)
+			require.True(t, ok)
+			_, digest1 := core.NormalizePlan(p1)
+			tk.MustExec(query2)
+			info2 := tk.Session().ShowProcess()
+			require.NotNil(t, info2)
+			p2, ok := info2.Plan.(core.Plan)
+			require.True(t, ok)
+			_, digest2 := core.NormalizePlan(p2)
+			require.Equal(t, digest1, digest2)
+		})
+	}
+}
+
 func TestNormalizedPlanForDiffStore(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/casetest/testdata/plan_normalized_suite_out.json
+++ b/pkg/planner/core/casetest/testdata/plan_normalized_suite_out.json
@@ -95,7 +95,7 @@
           " │ └─Selection       cop  gt(test.t1.c, ?)",
           " │   └─TableFullScan cop  table:t1, range:[?,?], keep order:false",
           " └─TableReader       root ",
-          "   └─TableRangeScan  cop  table:t2, range: decided by [test.t1.a], keep order:false"
+          "   └─TableRangeScan  cop  table:t2, keep order:false"
         ]
       },
       {
@@ -128,7 +128,7 @@
           " │ └─Selection       cop  gt(test.t1.c, ?)",
           " │   └─TableFullScan cop  table:t1, range:[?,?], keep order:false",
           " └─TableReader       root ",
-          "   └─TableRangeScan  cop  table:t2, range: decided by [test.t1.a], keep order:false"
+          "   └─TableRangeScan  cop  table:t2, keep order:false"
         ]
       },
       {

--- a/pkg/planner/core/explain.go
+++ b/pkg/planner/core/explain.go
@@ -183,10 +183,11 @@ func (p *PhysicalTableScan) ExplainNormalizedInfo() string {
 func (p *PhysicalTableScan) OperatorInfo(normalized bool) string {
 	var buffer strings.Builder
 	if len(p.rangeInfo) > 0 {
-		// TODO: deal with normalized case
-		buffer.WriteString("range: decided by ")
-		buffer.WriteString(p.rangeInfo)
-		buffer.WriteString(", ")
+		if !normalized {
+			buffer.WriteString("range: decided by ")
+			buffer.WriteString(p.rangeInfo)
+			buffer.WriteString(", ")
+		}
 	} else if p.haveCorCol() {
 		if normalized {
 			buffer.WriteString("range: decided by ")


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #47634  
Problem Summary:
After pr:[#38259](https://github.com/pingcap/tidb/pull/38259) queries with the same plan have different plan_digest in information_schema.statement_summary
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
