### PR TITLE
lightning: every HTTP retry should use its own request

### DIFF
--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -164,10 +164,13 @@ func pdRequestWithCode(
 		return 0, nil, errors.Trace(err)
 	}
 	reqURL := fmt.Sprintf("%s/%s", u, prefix)
-	var resp *http.Response
+	var (
+		req  *http.Request
+		resp *http.Response
+	)
 	count := 0
 	for {
-		req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+		req, err = http.NewRequestWithContext(ctx, method, reqURL, body)
 		if err != nil {
 			return 0, nil, errors.Trace(err)
 		}

--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -164,13 +164,13 @@ func pdRequestWithCode(
 		return 0, nil, errors.Trace(err)
 	}
 	reqURL := fmt.Sprintf("%s/%s", u, prefix)
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
-	if err != nil {
-		return 0, nil, errors.Trace(err)
-	}
 	var resp *http.Response
 	count := 0
 	for {
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+		if err != nil {
+			return 0, nil, errors.Trace(err)
+		}
 		resp, err = cli.Do(req) //nolint:bodyclose
 		count++
 		failpoint.Inject("InjectClosed", func(v failpoint.Value) {

--- a/br/pkg/pdutil/pd_serial_test.go
+++ b/br/pkg/pdutil/pd_serial_test.go
@@ -3,6 +3,7 @@
 package pdutil
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -186,9 +187,18 @@ func TestPDRequestRetry(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	cli := http.DefaultClient
+	cli.Transport = http.DefaultTransport.(*http.Transport).Clone()
+	// although the real code doesn't disable keep alive, we need to disable it
+	// in test to avoid the connection being reused and #47930 can't appear. The
+	// real code will only meet #47930 when go's internal http client just dropped
+	// all idle connections.
+	cli.Transport.(*http.Transport).DisableKeepAlives = true
+
 	taddr := ts.URL
-	_, reqErr := pdRequest(ctx, taddr, "", cli, http.MethodGet, nil)
+	body := bytes.NewBuffer([]byte("test"))
+	_, reqErr := pdRequest(ctx, taddr, "", cli, http.MethodPost, body)
 	require.NoError(t, reqErr)
+
 	ts.Close()
 	count = 0
 	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -197,6 +207,7 @@ func TestPDRequestRetry(t *testing.T) {
 			w.WriteHeader(http.StatusGatewayTimeout)
 			return
 		}
+
 		w.WriteHeader(http.StatusOK)
 	}))
 	taddr = ts.URL

--- a/br/pkg/pdutil/pd_serial_test.go
+++ b/br/pkg/pdutil/pd_serial_test.go
@@ -198,7 +198,6 @@ func TestPDRequestRetry(t *testing.T) {
 	body := bytes.NewBuffer([]byte("test"))
 	_, reqErr := pdRequest(ctx, taddr, "", cli, http.MethodPost, body)
 	require.NoError(t, reqErr)
-
 	ts.Close()
 	count = 0
 	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -207,7 +206,6 @@ func TestPDRequestRetry(t *testing.T) {
 			w.WriteHeader(http.StatusGatewayTimeout)
 			return
 		}
-
 		w.WriteHeader(http.StatusOK)
 	}))
 	taddr = ts.URL


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47930

Problem Summary:

### What is changed and how it works?

http.Client.Do will read the body of request, so the request should not be reused.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
