### PR TITLE
executor: use statusPort to retrieve tiproxy grpc services

### DIFF
--- a/pkg/executor/memtable_reader.go
+++ b/pkg/executor/memtable_reader.go
@@ -464,9 +464,9 @@ func (e *clusterLogRetriever) startRetrieving(
 			util.WithRecovery(func() {
 				defer close(ch)
 
-				// The TiDB provides diagnostics service via status address
+				// TiDB and TiProxy provide diagnostics service via status address
 				remote := address
-				if serverType == "tidb" {
+				if serverType == "tidb" || serverType == "tiproxy" {
 					remote = statusAddr
 				}
 				conn, err := grpc.Dial(remote, opt)

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -2395,7 +2395,7 @@ func FetchClusterServerInfoWithoutPrivilegeCheck(ctx context.Context, sctx sessi
 	for i, srv := range serversInfo {
 		address := srv.Address
 		remote := address
-		if srv.ServerType == "tidb" {
+		if srv.ServerType == "tidb" || srv.ServerType == "tiproxy" {
 			remote = srv.StatusAddr
 		}
 		wg.Add(1)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47962

Problem Summary: Use the correct addr to dial grpc services.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support cluster_[load,hardware,log,system_info} for nightly tiproxy
```
