### PR TITLE
types: fix the behavior of casting json string to integers

### DIFF
--- a/pkg/types/convert.go
+++ b/pkg/types/convert.go
@@ -630,12 +630,17 @@ func ConvertJSONToInt(sc *stmtctx.StatementContext, j BinaryJSON, unsigned bool,
 		return int64(u), sc.HandleOverflow(err, err)
 	case JSONTypeCodeString:
 		str := string(hack.String(j.GetString()))
-		if !unsigned {
-			r, e := StrToInt(sc.TypeCtxOrDefault(), str, false)
-			return r, sc.HandleOverflow(e, e)
+		// The behavior of casting json string as an integer is consistent with casting a string as an integer.
+		// See the `builtinCastStringAsIntSig` in `expression` pkg. The only difference is that this function
+		// doesn't append any warning. This behavior is compatible with MySQL.
+		isNegative := len(str) > 1 && str[0] == '-'
+		if !isNegative {
+			r, err := StrToUint(sc.TypeCtxOrDefault(), str, false)
+			return int64(r), sc.HandleOverflow(err, err)
 		}
-		u, err := StrToUint(sc.TypeCtxOrDefault(), str, false)
-		return int64(u), sc.HandleOverflow(err, err)
+
+		r, err := StrToInt(sc.TypeCtxOrDefault(), str, false)
+		return r, sc.HandleOverflow(err, err)
 	}
 	return 0, errors.New("Unknown type code in JSON")
 }

--- a/tests/integrationtest/r/expression/json.result
+++ b/tests/integrationtest/r/expression/json.result
@@ -602,3 +602,18 @@ json_extract('[{"a": [1,2,3,4]}]', '$[0].a[0 to last]')
 select json_extract('[{"a": [1,2,3,4]}]', '$[0].a[0 to 2]');
 json_extract('[{"a": [1,2,3,4]}]', '$[0].a[0 to 2]')
 [1, 2, 3]
+drop table if exists t;
+create table t (a json);
+insert into t values ('"-1"');
+insert into t values ('"18446744073709551615"');
+insert into t values ('"18446744073709552000"');
+select a, cast(a as unsigned) from t;
+a	cast(a as unsigned)
+"-1"	18446744073709551615
+"18446744073709551615"	18446744073709551615
+"18446744073709552000"	18446744073709551615
+select a, cast(a as signed) from t;
+a	cast(a as signed)
+"-1"	-1
+"18446744073709551615"	-1
+"18446744073709552000"	-1

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -359,3 +359,13 @@ select json_extract('[{"a": [1,2,3,4]}]', '$[0].a[1 to 100]');
 select json_extract('[{"a": [1,2,3,4]}]', '$[0].a[0 to last]');
 select json_extract('[{"a": [1,2,3,4]}]', '$[0].a[0 to 2]');
 
+# TestCastJSONStringToInteger
+drop table if exists t;
+create table t (a json);
+insert into t values ('"-1"');
+insert into t values ('"18446744073709551615"');
+insert into t values ('"18446744073709552000"');
+-- sorted_result
+select a, cast(a as unsigned) from t;
+-- sorted_result
+select a, cast(a as signed) from t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #47864 

Problem Summary:

Previously, the behavior of casting json string to integers is not consistent with casting normal string to integers. Now they have the same behavior and is compatible with MySQL.

### What is changed and how it works?

I follow the nearly the same behavior as `builtinCastStringAsIntSig`, but doesn't append any warnings.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

### Release note

```release-note
Fix the issue that json string representing a negative value cannot be converted to unsigned integer.
```
