### PR TITLE
planner: introduce a new fix-control flag to control whether to cache plans that access generated columns

### DIFF
--- a/pkg/planner/core/plan_cacheable_checker.go
+++ b/pkg/planner/core/plan_cacheable_checker.go
@@ -580,7 +580,7 @@ func isPhysicalPlanCacheable(sctx sessionctx.Context, p PhysicalPlan, paramNum, 
 	case *PhysicalMemTable:
 		return false, "PhysicalMemTable plan is un-cacheable"
 	case *PhysicalIndexMergeReader:
-		if x.AccessMVIndex {
+		if x.AccessMVIndex && !enablePlanCacheForGeneratedCols(sctx) {
 			return false, "the plan with IndexMerge accessing Multi-Valued Index is un-cacheable"
 		}
 		underIndexMerge = true
@@ -622,6 +622,10 @@ func getMaxParamLimit(sctx sessionctx.Context) int {
 	return v
 }
 
+func enablePlanCacheForGeneratedCols(sctx sessionctx.Context) bool {
+	return fixcontrol.GetBoolWithDefault(sctx.GetSessionVars().GetOptimizerFixControlMap(), fixcontrol.Fix45798, false)
+}
+
 // checkTableCacheable checks whether a query accessing this table is cacheable.
 func checkTableCacheable(ctx context.Context, sctx sessionctx.Context, schema infoschema.InfoSchema, node *ast.TableName, isNonPrep bool) (cacheable bool, reason string) {
 	tableSchema := node.Schema
@@ -653,9 +657,12 @@ func checkTableCacheable(ctx context.Context, sctx sessionctx.Context, schema in
 		*/
 		return false, "query accesses partitioned tables is un-cacheable"
 	}
-	for _, col := range tb.Cols() {
-		if col.IsGenerated() {
-			return false, "query accesses generated columns is un-cacheable"
+
+	if !enablePlanCacheForGeneratedCols(sctx) {
+		for _, col := range tb.Cols() {
+			if col.IsGenerated() {
+				return false, "query accesses generated columns is un-cacheable"
+			}
 		}
 	}
 	if tb.Meta().TempTableType != model.TempTableNone {

--- a/pkg/planner/core/plan_cacheable_checker.go
+++ b/pkg/planner/core/plan_cacheable_checker.go
@@ -625,6 +625,9 @@ func getMaxParamLimit(sctx sessionctx.Context) int {
 func enablePlanCacheForGeneratedCols(sctx sessionctx.Context) bool {
 	// disable this by default since it's not well tested.
 	// TODO: complete its test and enable it by default.
+	if sctx == nil || sctx.GetSessionVars() == nil || sctx.GetSessionVars().GetOptimizerFixControlMap() == nil {
+		return false
+	}
 	return fixcontrol.GetBoolWithDefault(sctx.GetSessionVars().GetOptimizerFixControlMap(), fixcontrol.Fix45798, false)
 }
 

--- a/pkg/planner/core/plan_cacheable_checker.go
+++ b/pkg/planner/core/plan_cacheable_checker.go
@@ -623,6 +623,8 @@ func getMaxParamLimit(sctx sessionctx.Context) int {
 }
 
 func enablePlanCacheForGeneratedCols(sctx sessionctx.Context) bool {
+	// disable this by default since it's not well tested.
+	// TODO: complete its test and enable it by default.
 	return fixcontrol.GetBoolWithDefault(sctx.GetSessionVars().GetOptimizerFixControlMap(), fixcontrol.Fix45798, false)
 }
 

--- a/pkg/planner/util/fixcontrol/get.go
+++ b/pkg/planner/util/fixcontrol/get.go
@@ -34,6 +34,8 @@ const (
 	Fix44855 uint64 = 44855
 	// Fix45132 controls whether to use access range row count to determine access path on the Skyline pruning.
 	Fix45132 uint64 = 45132
+	// Fix45798 controls whether to cache plans that access generated columns.
+	Fix45798 uint64 = 45798
 )
 
 // GetStr fetches the given key from the fix control map as a string type.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #45798

Problem Summary: planner: introduce a new fix-control flag to control whether to cache plans that access generated columns

### What is changed and how it works?

planner: introduce a new fix-control flag to control whether to cache plans that access generated columns

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
