### PR TITLE
domain: use with kv timeout feature schema load kv timeout

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -795,7 +795,7 @@ func (do *Domain) loadSchemaInLoop(ctx context.Context, lease time.Duration) {
 	defer util.Recover(metrics.LabelDomain, "loadSchemaInLoop", nil, true)
 	// Lease renewal can run at any frequency.
 	// Use lease/2 here as recommend by paper.
-	ticker := time.NewTicker(lease / 2)
+	ticker := time.NewTicker(lease / 10)
 	defer func() {
 		ticker.Stop()
 		do.wg.Done()

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -184,6 +184,7 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 		loadSchemaDurationTotal.Observe(time.Since(beginTime).Seconds())
 	}()
 	snapshot := do.store.GetSnapshot(kv.NewVersion(startTS))
+	snapshot.SetOption(kv.TiKVClientReadTimeout, uint64(3000)) // 3000ms.
 	m := meta.NewSnapshotMeta(snapshot)
 	neededSchemaVersion, err := m.GetSchemaVersionWithNonEmptyDiff()
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:
Use kv timeout feature for schema reload.

### What is changed and how it works?

When the leader peer of meta region is slow, use kv timeout could help alleviated by enabling the KV read timeout, avoid errors like "schema lease expire". For example when injecting slowness into the meta region TiKV node,

![img_v2_bdffa267-615e-43ef-8ff3-2afc80a499fg](https://github.com/pingcap/tidb/assets/3692139/79fea7ae-8b30-4725-89cd-32a8fc732f5f)



### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test


Side effects


Documentation


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
