### PR TITLE
planner: fix mpp task spreading blocked by virtual column substitution

### DIFF
--- a/pkg/executor/test/tiflashtest/BUILD.bazel
+++ b/pkg/executor/test/tiflashtest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 39,
+    shard_count = 40,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/executor/test/tiflashtest/tiflash_test.go
+++ b/pkg/executor/test/tiflashtest/tiflash_test.go
@@ -1735,6 +1735,42 @@ func TestMppStoreCntWithErrors(t *testing.T) {
 	require.Nil(t, failpoint.Disable(mppStoreCountPDError))
 }
 
+func TestMPP47766(t *testing.T) {
+	store := testkit.CreateMockStore(t, withMockTiFlash(1))
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@session.tidb_allow_mpp=1")
+	tk.MustExec("set @@session.tidb_enforce_mpp=1")
+	tk.MustExec("set @@session.tidb_allow_tiflash_cop=off")
+
+	tk.MustExec("CREATE TABLE `traces` (" +
+		"  `test_time` timestamp NOT NULL," +
+		"  `test_time_gen` date GENERATED ALWAYS AS (date(`test_time`)) VIRTUAL," +
+		"  KEY `traces_date_idx` (`test_time_gen`)" +
+		")")
+	tk.MustExec("alter table `traces` set tiflash replica 1")
+	tb := external.GetTableByName(t, tk, "test", "traces")
+	err := domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
+	require.NoError(t, err)
+	tk.MustQuery("explain select date(test_time), count(1) as test_date from `traces` group by 1").Check(testkit.Rows(
+		"Projection_4 8000.00 root  test.traces.test_time_gen->Column#5, Column#4",
+		"└─HashAgg_8 8000.00 root  group by:test.traces.test_time_gen, funcs:count(1)->Column#4, funcs:firstrow(test.traces.test_time_gen)->test.traces.test_time_gen",
+		"  └─TableReader_20 10000.00 root  MppVersion: 2, data:ExchangeSender_19",
+		"    └─ExchangeSender_19 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+		"      └─TableFullScan_18 10000.00 mpp[tiflash] table:traces keep order:false, stats:pseudo"))
+	tk.MustQuery("explain select /*+ read_from_storage(tiflash[traces]) */ date(test_time) as test_date, count(1) from `traces` group by 1").Check(testkit.Rows(
+		"TableReader_31 8000.00 root  MppVersion: 2, data:ExchangeSender_30",
+		"└─ExchangeSender_30 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+		"  └─Projection_5 8000.00 mpp[tiflash]  date(test.traces.test_time)->Column#5, Column#4",
+		"    └─Projection_26 8000.00 mpp[tiflash]  Column#4, test.traces.test_time",
+		"      └─HashAgg_27 8000.00 mpp[tiflash]  group by:Column#13, funcs:sum(Column#14)->Column#4, funcs:firstrow(Column#15)->test.traces.test_time",
+		"        └─ExchangeReceiver_29 8000.00 mpp[tiflash]  ",
+		"          └─ExchangeSender_28 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#13, collate: binary]",
+		"            └─HashAgg_25 8000.00 mpp[tiflash]  group by:Column#17, funcs:count(1)->Column#14, funcs:firstrow(Column#16)->Column#15",
+		"              └─Projection_32 10000.00 mpp[tiflash]  test.traces.test_time->Column#16, date(test.traces.test_time)->Column#17",
+		"                └─TableFullScan_15 10000.00 mpp[tiflash] table:traces keep order:false, stats:pseudo"))
+}
+
 func TestUnionScan(t *testing.T) {
 	store := testkit.CreateMockStore(t, withMockTiFlash(2))
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/rule_generate_column_substitute.go
+++ b/pkg/planner/core/rule_generate_column_substitute.go
@@ -60,6 +60,12 @@ func collectGenerateColumn(lp LogicalPlan, exprToColumn ExprColumnMap) {
 	if !ok {
 		return
 	}
+	// detect the read_from_storage(tiflash) hints, since virtual column will
+	// block the mpp task spreading (only supporting MPP table scan), causing
+	// mpp plan fail the cost comparison with tikv index plan.
+	if ds.preferStoreType&preferTiFlash != 0 {
+		return
+	}
 	for _, p := range ds.possibleAccessPaths {
 		if p.IsTablePath() {
 			continue


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/47766

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix mpp task spreading blocked by virtual column substitution
```
