### PR TITLE
lightning/backend/external: prevent escaping buffered slice to heap

### DIFF
--- a/br/pkg/lightning/backend/external/byte_reader.go
+++ b/br/pkg/lightning/backend/external/byte_reader.go
@@ -44,7 +44,7 @@ type byteReader struct {
 	curBufOffset int
 	smallBuf     []byte
 
-	retPointersV2 []*slice
+	retPointers []*slice
 
 	concurrentReader struct {
 		largeBufferPool *membuf.Buffer
@@ -206,7 +206,7 @@ func (r *byteReader) readNBytes(n int) (*slice, error) {
 			offset: originOffset,
 			length: readLen,
 		}
-		r.retPointersV2 = append(r.retPointersV2, ret)
+		r.retPointers = append(r.retPointers, ret)
 		return ret, nil
 	}
 	// If the reader has fewer than n bytes remaining in current buffer,
@@ -244,21 +244,21 @@ func (s slice) get() []byte {
 }
 
 func (r *byteReader) reset() {
-	for i := range r.retPointersV2 {
-		r.retPointersV2[i] = nil
+	for i := range r.retPointers {
+		r.retPointers[i] = nil
 	}
-	r.retPointersV2 = r.retPointersV2[:0]
+	r.retPointers = r.retPointers[:0]
 }
 
 func (r *byteReader) cloneSlices() {
-	for i := range r.retPointersV2 {
-		copied := make([]byte, r.retPointersV2[i].length)
-		copy(copied, r.retPointersV2[i].buf[r.retPointersV2[i].offset:])
-		r.retPointersV2[i].buf = copied
-		r.retPointersV2[i].offset = 0
-		r.retPointersV2[i].length = len(copied)
+	for i := range r.retPointers {
+		copied := make([]byte, r.retPointers[i].length)
+		copy(copied, r.retPointers[i].buf[r.retPointers[i].offset:])
+		r.retPointers[i].buf = copied
+		r.retPointers[i].offset = 0
+		r.retPointers[i].length = len(copied)
 	}
-	r.retPointersV2 = r.retPointersV2[:0]
+	r.retPointers = r.retPointers[:0]
 }
 
 func (r *byteReader) next(n int) []byte {

--- a/br/pkg/lightning/backend/external/byte_reader_test.go
+++ b/br/pkg/lightning/backend/external/byte_reader_test.go
@@ -98,7 +98,7 @@ func testByteReaderNormal(t *testing.T, useConcurrency bool) {
 	require.NoError(t, err)
 	y, err := br.readNBytes(2)
 	require.NoError(t, err)
-	x = *y
+	x = y.get()
 	require.Equal(t, 2, len(x))
 	require.Equal(t, byte('a'), x[0])
 	require.Equal(t, byte('b'), x[1])
@@ -108,7 +108,7 @@ func testByteReaderNormal(t *testing.T, useConcurrency bool) {
 	require.NoError(t, err)
 	y, err = br.readNBytes(5) // Read all the data.
 	require.NoError(t, err)
-	x = *y
+	x = y.get()
 	require.Equal(t, 5, len(x))
 	require.Equal(t, byte('e'), x[4])
 	require.NoError(t, br.Close())
@@ -128,7 +128,7 @@ func testByteReaderNormal(t *testing.T, useConcurrency bool) {
 	require.NoError(t, err)
 	// Pollute mockExtStore to verify if the slice is not affected.
 	copy(ms.src, []byte("xyz"))
-	x = *y
+	x = y.get()
 	require.Equal(t, 3, len(x))
 	require.Equal(t, byte('c'), x[2])
 	require.NoError(t, br.Close())
@@ -140,7 +140,7 @@ func testByteReaderNormal(t *testing.T, useConcurrency bool) {
 	require.NoError(t, err)
 	// Pollute mockExtStore to verify if the slice is not affected.
 	copy(ms.src, []byte("xyz"))
-	x = *y
+	x = y.get()
 	require.Equal(t, 2, len(x))
 	require.Equal(t, byte('b'), x[1])
 	br.reset()
@@ -155,13 +155,13 @@ func TestByteReaderClone(t *testing.T) {
 	require.NoError(t, err)
 	y2, err := br.readNBytes(1)
 	require.NoError(t, err)
-	x1, x2 := *y1, *y2
+	x1, x2 := y1.get(), y2.get()
 	require.Len(t, x1, 2)
 	require.Len(t, x2, 1)
 	require.Equal(t, byte('0'), x1[0])
 	require.Equal(t, byte('2'), x2[0])
 	require.NoError(t, br.reload()) // Perform a read to overwrite buffer.
-	x1, x2 = *y1, *y2
+	x1, x2 = y1.get(), y2.get()
 	require.Len(t, x1, 2)
 	require.Len(t, x2, 1)
 	require.Equal(t, byte('4'), x1[0]) // Verify if the buffer is overwritten.
@@ -175,14 +175,14 @@ func TestByteReaderClone(t *testing.T) {
 	require.NoError(t, err)
 	y2, err = br.readNBytes(1)
 	require.NoError(t, err)
-	x1, x2 = *y1, *y2
+	x1, x2 = y1.get(), y2.get()
 	require.Len(t, x1, 2)
 	require.Len(t, x2, 1)
 	require.Equal(t, byte('0'), x1[0])
 	require.Equal(t, byte('2'), x2[0])
 	br.cloneSlices()
 	require.NoError(t, br.reload()) // Perform a read to overwrite buffer.
-	x1, x2 = *y1, *y2
+	x1, x2 = y1.get(), y2.get()
 	require.Len(t, x1, 2)
 	require.Len(t, x2, 1)
 	require.Equal(t, byte('0'), x1[0]) // Verify if the buffer is NOT overwritten.
@@ -198,17 +198,17 @@ func TestByteReaderAuxBuf(t *testing.T) {
 	require.NoError(t, err)
 	y2, err := br.readNBytes(2)
 	require.NoError(t, err)
-	require.Equal(t, []byte("0"), *y1)
-	require.Equal(t, []byte("12"), *y2)
+	require.Equal(t, []byte("0"), y1.get())
+	require.Equal(t, []byte("12"), y2.get())
 
 	y3, err := br.readNBytes(1)
 	require.NoError(t, err)
 	y4, err := br.readNBytes(2)
 	require.NoError(t, err)
-	require.Equal(t, []byte("3"), *y3)
-	require.Equal(t, []byte("45"), *y4)
-	require.Equal(t, []byte("0"), *y1)
-	require.Equal(t, []byte("12"), *y2)
+	require.Equal(t, []byte("3"), y3.get())
+	require.Equal(t, []byte("45"), y4.get())
+	require.Equal(t, []byte("0"), y1.get())
+	require.Equal(t, []byte("12"), y2.get())
 }
 
 func TestReset(t *testing.T) {
@@ -242,7 +242,7 @@ func testReset(t *testing.T, useConcurrency bool) {
 	br, err := newByteReader(context.Background(), newRsc(), bufSize)
 	require.NoError(t, err)
 	end := 0
-	toCheck := make([]*[]byte, 0, 10)
+	toCheck := make([]*slice, 0, 10)
 	for end < len(src) {
 		n := rand.Intn(len(src) - end)
 		if n == 0 {
@@ -256,8 +256,8 @@ func testReset(t *testing.T, useConcurrency bool) {
 		l := end
 		r := end
 		for i := len(toCheck) - 1; i >= 0; i-- {
-			l -= len(*toCheck[i])
-			require.Equal(t, src[l:r], *toCheck[i])
+			l -= len(toCheck[i].get())
+			require.Equal(t, src[l:r], toCheck[i].get())
 			r = l
 		}
 
@@ -366,7 +366,7 @@ func TestSwitchMode(t *testing.T) {
 			break
 		}
 		require.NoError(t, err)
-		totalCnt += len(*y)
+		totalCnt += len(y.get())
 	}
 	require.Equal(t, fileSize, totalCnt)
 

--- a/br/pkg/lightning/backend/external/kv_reader.go
+++ b/br/pkg/lightning/backend/external/kv_reader.go
@@ -55,7 +55,7 @@ func (r *kvReader) nextKV() (key, val []byte, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	keyLen := int(binary.BigEndian.Uint64(*lenBytes))
+	keyLen := int(binary.BigEndian.Uint64(lenBytes.get()))
 	keyPtr, err := r.byteReader.readNBytes(keyLen)
 	if err != nil {
 		return nil, nil, noEOF(err)
@@ -64,12 +64,12 @@ func (r *kvReader) nextKV() (key, val []byte, err error) {
 	if err != nil {
 		return nil, nil, noEOF(err)
 	}
-	valLen := int(binary.BigEndian.Uint64(*lenBytes))
+	valLen := int(binary.BigEndian.Uint64(lenBytes.get()))
 	valPtr, err := r.byteReader.readNBytes(valLen)
 	if err != nil {
 		return nil, nil, noEOF(err)
 	}
-	return *keyPtr, *valPtr, nil
+	return keyPtr.get(), valPtr.get(), nil
 }
 
 // noEOF converts the EOF error to io.ErrUnexpectedEOF.

--- a/br/pkg/lightning/backend/external/stat_reader.go
+++ b/br/pkg/lightning/backend/external/stat_reader.go
@@ -45,12 +45,12 @@ func (r *statsReader) nextProp() (*rangeProperty, error) {
 	if err != nil {
 		return nil, err
 	}
-	propLen := int(binary.BigEndian.Uint32(*lenBytes))
+	propLen := int(binary.BigEndian.Uint32(lenBytes.get()))
 	propBytes, err := r.byteReader.readNBytes(propLen)
 	if err != nil {
 		return nil, noEOF(err)
 	}
-	return decodeProp(*propBytes), nil
+	return decodeProp(propBytes.get()), nil
 }
 
 func (r *statsReader) Close() error {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #47757

Problem Summary:

![image](https://github.com/pingcap/tidb/assets/24713065/ea09a2fd-2681-4d30-bbef-3595dca41ebd)

https://github.com/pingcap/tidb/blob/30288c77c7e84a9c596a8145dca27748468f9e51/br/pkg/lightning/backend/external/byte_reader.go#L199-L206

The buffered slice is unexpectedly moved to heap, leading to unnecessary memory allocation for each key.

```
./byte_reader.go:199:7: leaking param content: r
./byte_reader.go:200:2: moved to heap: b
./byte_reader.go:209:2: moved to heap: auxBuf
./byte_reader.go:209:16: make([]byte, n) escapes to heap
```

According to verbose escape analysis, `b` escapes because we assign the address of local variables to a slice on heap:
```
./byte_reader.go:200:2: b escapes to heap:
./byte_reader.go:200:2:   flow: ret = &b:
./byte_reader.go:200:2:     from &b (address-of) at ./byte_reader.go:203:10
./byte_reader.go:200:2:     from ret := &b (assign) at ./byte_reader.go:203:7
./byte_reader.go:200:2:   flow: {heap} = ret:
./byte_reader.go:200:2:     from append(r.retPointers, ret) (call parameter) at ./byte_reader.go:204:25
```

### What is changed and how it works?

This PR stores the buffer's start offset and length instead of the address. Although it looks like boilerplate, it is worth to reduce the memory allocation.

After this PR, `b` does not escape anymore:
```
./byte_reader.go:217:16: (*byteReader).readNBytes ignoring self-assignment in r.retPointersV2 = r.retPointersV2[:0]
./byte_reader.go:199:7: leaking param content: r
./byte_reader.go:204:10: &slice{...} escapes to heap
./byte_reader.go:214:16: make([]byte, n) escapes to heap
```

![image](https://github.com/pingcap/tidb/assets/24713065/ea182c21-45ea-46d2-9835-62a3cda3edec)

And here is the memory usage comparison:

![image](https://github.com/pingcap/tidb/assets/24713065/a09dc307-a546-4232-840d-bf50bad1b111)

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  See above screenshot.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
