### PR TITLE
admin: fix `admin recover index` with CommonHandle table in TiKV env | tidb-test=pr/2231 

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -612,12 +612,12 @@ func (b *executorBuilder) buildRecoverIndex(v *plannercore.RecoverIndex) exec.Ex
 		physicalID:       t.Meta().ID,
 	}
 	sessCtx := e.Ctx().GetSessionVars().StmtCtx
-	e.handleCols = buildHandleColsForExec(sessCtx, tblInfo, index.Meta(), e.columns)
+	e.handleCols = buildHandleColsForExec(sessCtx, tblInfo, e.columns)
 	return e
 }
 
 func buildHandleColsForExec(sctx *stmtctx.StatementContext, tblInfo *model.TableInfo,
-	idxInfo *model.IndexInfo, allColInfo []*model.ColumnInfo) plannercore.HandleCols {
+	allColInfo []*model.ColumnInfo) plannercore.HandleCols {
 	if !tblInfo.IsCommonHandle {
 		extraColPos := len(allColInfo) - 1
 		intCol := &expression.Column{
@@ -677,7 +677,7 @@ func (b *executorBuilder) buildCleanupIndex(v *plannercore.CleanupIndex) exec.Ex
 		batchSize:    20000,
 	}
 	sessCtx := e.Ctx().GetSessionVars().StmtCtx
-	e.handleCols = buildHandleColsForExec(sessCtx, tblInfo, index.Meta(), e.columns)
+	e.handleCols = buildHandleColsForExec(sessCtx, tblInfo, e.columns)
 	return e
 }
 

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -562,7 +562,9 @@ func buildIdxColsConcatHandleCols(tblInfo *model.TableInfo, indexInfo *model.Ind
 
 	if tblInfo.IsCommonHandle {
 		for _, c := range pkCols {
-			columns = append(columns, tblInfo.Columns[c.Offset])
+			if model.FindColumnInfo(columns, c.Name.L) == nil {
+				columns = append(columns, tblInfo.Columns[c.Offset])
+			}
 		}
 		return columns
 	}
@@ -633,8 +635,12 @@ func buildHandleColsForExec(sctx *stmtctx.StatementContext, tblInfo *model.Table
 		}
 	}
 	pkIdx := tables.FindPrimaryIndex(tblInfo)
-	for i, c := range pkIdx.Columns {
-		tblCols[c.Offset].Index = len(idxInfo.Columns) + i
+	for _, c := range pkIdx.Columns {
+		for j, colInfo := range allColInfo {
+			if colInfo.Name.L == c.Name.L {
+				tblCols[c.Offset].Index = j
+			}
+		}
 	}
 	return plannercore.NewCommonHandleCols(sctx, tblInfo, pkIdx, tblCols)
 }

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -362,6 +362,7 @@ func TestClusteredIndexAdminRecoverIndex(t *testing.T) {
 	sc := ctx.GetSessionVars().StmtCtx
 
 	// Some index entries are missed.
+	// Recover an index don't covered by clustered index.
 	txn, err := store.Begin()
 	require.NoError(t, err)
 	cHandle := testutil.MustNewCommonHandle(t, "1", "3")
@@ -377,6 +378,7 @@ func TestClusteredIndexAdminRecoverIndex(t *testing.T) {
 	tk.MustQuery("SELECT COUNT(*) FROM t USE INDEX(idx)").Check(testkit.Rows("3"))
 	tk.MustExec("admin check table t;")
 
+	// Recover an index covered by clustered index.
 	idx1Info := tblInfo.FindIndexByName("idx1")
 	indexOpr1 := tables.NewIndex(tblInfo.ID, tblInfo, idx1Info)
 	txn, err = store.Begin()

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -345,7 +345,7 @@ func TestClusteredIndexAdminRecoverIndex(t *testing.T) {
 	tblName := model.NewCIStr("t")
 
 	// Test no corruption case.
-	tk.MustExec("create table t (a varchar(255), b int, c char(10), primary key(a, c), index idx(b));")
+	tk.MustExec("create table t (a varchar(255), b int, c char(10), primary key(a, c), index idx(b), index idx1(c));")
 	tk.MustExec("insert into t values ('1', 2, '3'), ('1', 2, '4'), ('1', 2, '5');")
 	tk.MustQuery("admin recover index t `primary`;").Check(testkit.Rows("0 0"))
 	tk.MustQuery("admin recover index t `idx`;").Check(testkit.Rows("0 3"))
@@ -375,6 +375,22 @@ func TestClusteredIndexAdminRecoverIndex(t *testing.T) {
 	tk.MustQuery("SELECT COUNT(*) FROM t USE INDEX(idx)").Check(testkit.Rows("2"))
 	tk.MustQuery("admin recover index t idx").Check(testkit.Rows("1 3"))
 	tk.MustQuery("SELECT COUNT(*) FROM t USE INDEX(idx)").Check(testkit.Rows("3"))
+	tk.MustExec("admin check table t;")
+
+	idx1Info := tblInfo.FindIndexByName("idx1")
+	indexOpr1 := tables.NewIndex(tblInfo.ID, tblInfo, idx1Info)
+	txn, err = store.Begin()
+	require.NoError(t, err)
+	err = indexOpr1.Delete(sc, txn, types.MakeDatums("3"), cHandle)
+	require.NoError(t, err)
+	err = txn.Commit(context.Background())
+	require.NoError(t, err)
+	tk.MustGetErrCode("admin check table t", mysql.ErrDataInconsistent)
+	tk.MustGetErrCode("admin check index t idx1", mysql.ErrDataInconsistent)
+
+	tk.MustQuery("SELECT COUNT(*) FROM t USE INDEX(idx1)").Check(testkit.Rows("2"))
+	tk.MustQuery("admin recover index t idx1").Check(testkit.Rows("1 3"))
+	tk.MustQuery("SELECT COUNT(*) FROM t USE INDEX(idx1)").Check(testkit.Rows("3"))
 	tk.MustExec("admin check table t;")
 }
 

--- a/tests/integrationtest/r/expression/charset_and_collation.result
+++ b/tests/integrationtest/r/expression/charset_and_collation.result
@@ -745,6 +745,9 @@ a	b	c	d	e	f	g	h	i
 1	啊	啊	啊  	啊  	啊	啊  	🐸	🐸
 admin check table t;
 
+admin recover index t a;
+ADDED_COUNT	SCAN_COUNT
+0	1
 alter table t add column n char(10) COLLATE utf8mb4_unicode_ci;
 alter table t add index n(n);
 update t set n = '吧';

--- a/tests/integrationtest/t/expression/charset_and_collation.test
+++ b/tests/integrationtest/t/expression/charset_and_collation.test
@@ -356,8 +356,7 @@ select * from t use index(ud);
 select * from t use index(e);
 select * from t use index(ue);
 admin check table t;
-# TODO: fix https://github.com/pingcap/tidb/issues/47687
-# admin recover index t a;
+admin recover index t a;
 alter table t add column n char(10) COLLATE utf8mb4_unicode_ci;
 alter table t add index n(n);
 update t set n = '吧';


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47687

Problem Summary: In TiKV env, tableFullScan can't process schema have same columns which make it paniced.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
