### PR TITLE
ddl: Ensure correct errors for duplicate constraint names | tidb-test=pr/2231

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -1251,6 +1251,11 @@ error = '''
 Check constraint '%s' refers to non-existing column '%s'.
 '''
 
+["ddl:3822"]
+error = '''
+Duplicate check constraint name '%s'.
+'''
+
 ["ddl:3823"]
 error = '''
 Column '%s' cannot be used in a check constraint '%s': needed in a foreign key constraint referential action.

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -1828,16 +1828,26 @@ func setEmptyConstraintName(namesMap map[string]bool, constr *ast.Constraint) {
 
 func checkConstraintNames(tableName model.CIStr, constraints []*ast.Constraint) error {
 	constrNames := map[string]bool{}
-	checkConstraints := make([]*ast.Constraint, 0, len(constraints))
+	fkNames := map[string]bool{}
 
 	// Check not empty constraint name whether is duplicated.
 	for _, constr := range constraints {
-		err := checkDuplicateConstraint(constrNames, constr.Name, constr.Tp)
-		if err != nil {
-			return errors.Trace(err)
+		if constr.Tp == ast.ConstraintForeignKey {
+			err := checkDuplicateConstraint(fkNames, constr.Name, constr.Tp)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		} else {
+			err := checkDuplicateConstraint(constrNames, constr.Name, constr.Tp)
+			if err != nil {
+				return errors.Trace(err)
+			}
 		}
+	}
 
-		// Set empty constraint names.
+	// Set empty constraint names.
+	checkConstraints := make([]*ast.Constraint, 0, len(constraints))
+	for _, constr := range constraints {
 		if constr.Tp != ast.ConstraintForeignKey {
 			setEmptyConstraintName(constrNames, constr)
 		}

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -7252,7 +7252,7 @@ func (d *ddl) createIndex(ctx sessionctx.Context, ti ast.Ident, keyType ast.Inde
 	if indexInfo := t.Meta().FindIndexByName(indexName.L); indexInfo != nil {
 		if indexInfo.State != model.StatePublic {
 			// NOTE: explicit error message. See issue #18363.
-			err = dbterror.ErrDupKeyName.GenWithStack("index already exist %s; "+
+			err = dbterror.ErrDupKeyName.GenWithStack("Duplicate key name '%s'; "+
 				"a background job is trying to add the same index, "+
 				"please check by `ADMIN SHOW DDL JOBS`", indexName)
 		} else {

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -7246,7 +7246,7 @@ func (d *ddl) createIndex(ctx sessionctx.Context, ti ast.Ident, keyType ast.Inde
 				"a background job is trying to add the same index, "+
 				"please check by `ADMIN SHOW DDL JOBS`", indexName)
 		} else {
-			err = dbterror.ErrDupKeyName.GenWithStack("index already exist %s", indexName)
+			err = dbterror.ErrDupKeyName.GenWithStackByArgs(indexName)
 		}
 		if ifNotExists {
 			ctx.GetSessionVars().StmtCtx.AppendNote(err)

--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -285,3 +285,25 @@ func TestError(t *testing.T) {
 		require.Equal(t, uint16(err.Code()), code)
 	}
 }
+
+func TestCheckDuplicateConstraint(t *testing.T) {
+	constrNames := map[string]bool{}
+
+	// Foreign Key
+	err := checkDuplicateConstraint(constrNames, "f1", ast.ConstraintForeignKey)
+	require.NoError(t, err)
+	err = checkDuplicateConstraint(constrNames, "f1", ast.ConstraintForeignKey)
+	require.EqualError(t, err, "[ddl:1826]Duplicate foreign key constraint name 'f1'")
+
+	// Check constraint
+	err = checkDuplicateConstraint(constrNames, "c1", ast.ConstraintCheck)
+	require.NoError(t, err)
+	err = checkDuplicateConstraint(constrNames, "c1", ast.ConstraintCheck)
+	require.EqualError(t, err, "[ddl:3822]Duplicate check constraint name 'c1'.")
+
+	// Unique contraints etc
+	err = checkDuplicateConstraint(constrNames, "u1", ast.ConstraintUniq)
+	require.NoError(t, err)
+	err = checkDuplicateConstraint(constrNames, "u1", ast.ConstraintUniq)
+	require.EqualError(t, err, "[ddl:1061]Duplicate key name 'u1'")
+}

--- a/pkg/util/dbterror/ddl_terror.go
+++ b/pkg/util/dbterror/ddl_terror.go
@@ -484,6 +484,8 @@ var (
 			" Use the LPAD function to zero-pad numbers, or store the formatted numbers in a CHAR column.",
 		), nil),
 	)
+	// ErrCheckConstraintDupName is for duplicate check constraint names
+	ErrCheckConstraintDupName = ClassDDL.NewStd(mysql.ErrCheckConstraintDupName)
 )
 
 // ReorgRetryableErrCodes is the error codes that are retryable for reorganization.

--- a/tests/integrationtest/r/ddl/db_integration.result
+++ b/tests/integrationtest/r/ddl/db_integration.result
@@ -139,7 +139,7 @@ Error 1166 (42000): Incorrect column name '_tidb_rowid'
 create table aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(a int);
 Error 1059 (42000): Identifier name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' is too long
 create table test_error_code1 (c1 int, c2 int, key aa (c1, c2), key aa (c1));
-Error 1061 (42000): duplicate key name aa
+Error 1061 (42000): Duplicate key name 'aa'
 create table test_error_code1 (c1 int, c2 int, c3 int, key(c_not_exist));
 Error 1072 (42000): column does not exist: c_not_exist
 create table test_error_code1 (c1 int, c2 int, c3 int, primary key(c_not_exist));
@@ -240,7 +240,7 @@ alter table test_error_code_succ add index idx (c_not_exist);
 Error 1072 (42000): column does not exist: c_not_exist
 alter table test_error_code_succ add index idx (c1);
 alter table test_error_code_succ add index idx (c1);
-Error 1061 (42000): index already exist idx
+Error 1061 (42000): Duplicate key name 'idx'
 alter table test_error_code_succ drop index idx_not_exist;
 Error 1091 (42000): index idx_not_exist doesn't exist
 alter table test_error_code_succ drop column c3;

--- a/tests/integrationtest/r/ddl/multi_schema_change.result
+++ b/tests/integrationtest/r/ddl/multi_schema_change.result
@@ -217,7 +217,7 @@ Error 1176 (42000): Key 't' doesn't exist in table 't'
 drop table if exists t;
 create table t (a int, b int, c int, index t(a));
 alter table t drop index t, add index t(b);
-Error 1061 (42000): index already exist t
+Error 1061 (42000): Duplicate key name 't'
 drop table if exists t;
 create table t (a int, b int, c int, index t(a));
 alter table t add index t1(b), drop index t1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48040 

Problem Summary:

Ensure correct error codes and error text for duplicate constraint names.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Duplicate check constraints now use the correct error code and text
```
