### PR TITLE
ddl: constraint name uniquness is enforced for check constraints

### DIFF
--- a/pkg/ddl/constraint.go
+++ b/pkg/ddl/constraint.go
@@ -148,6 +148,21 @@ func checkAddCheckConstraint(t *meta.Meta, job *model.Job) (*model.DBInfo, *mode
 		}
 		// if not, that means constraint was in intermediate state.
 	}
+
+	tblInfos, err := t.ListTables(schemaID)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	for _, tbl := range tblInfos {
+		if tbl.ID != tblInfo.ID {
+			if constraintInfo := tbl.FindConstraintInfoByName(constraintInfo1.Name.L); constraintInfo != nil {
+				job.State = model.JobStateCancelled
+				return nil, nil, nil, nil, infoschema.ErrCheckConstraintDupName.GenWithStackByArgs(constraintInfo1.Name.L)
+			}
+		}
+	}
+
 	return dbInfo, tblInfo, constraintInfo2, constraintInfo1, nil
 }
 

--- a/pkg/ddl/constraint.go
+++ b/pkg/ddl/constraint.go
@@ -149,18 +149,10 @@ func checkAddCheckConstraint(t *meta.Meta, job *model.Job) (*model.DBInfo, *mode
 		// if not, that means constraint was in intermediate state.
 	}
 
-	tblInfos, err := t.ListTables(schemaID)
+	err = checkConstraintNamesNotExists(t, schemaID, []*model.ConstraintInfo{constraintInfo1})
 	if err != nil {
+		job.State = model.JobStateCancelled
 		return nil, nil, nil, nil, err
-	}
-
-	for _, tbl := range tblInfos {
-		if tbl.ID != tblInfo.ID {
-			if constraintInfo := tbl.FindConstraintInfoByName(constraintInfo1.Name.L); constraintInfo != nil {
-				job.State = model.JobStateCancelled
-				return nil, nil, nil, nil, infoschema.ErrCheckConstraintDupName.GenWithStackByArgs(constraintInfo1.Name.L)
-			}
-		}
 	}
 
 	return dbInfo, tblInfo, constraintInfo2, constraintInfo1, nil

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -1508,8 +1508,10 @@ func checkConstraintNamesNotExists(t *meta.Meta, schemaID int64, constraints []*
 
 	for _, tb := range tbInfos {
 		for _, constraint := range constraints {
-			if constraintInfo := tb.FindConstraintInfoByName(constraint.Name.L); constraintInfo != nil {
-				return infoschema.ErrCheckConstraintDupName.GenWithStackByArgs(constraint.Name.L)
+			if constraint.State != model.StateWriteOnly {
+				if constraintInfo := tb.FindConstraintInfoByName(constraint.Name.L); constraintInfo != nil {
+					return infoschema.ErrCheckConstraintDupName.GenWithStackByArgs(constraint.Name.L)
+				}
 			}
 		}
 	}

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -1497,14 +1497,17 @@ func checkTableNotExists(d *ddlCtx, t *meta.Meta, schemaID int64, tableName stri
 	return checkTableNotExistsFromStore(t, schemaID, tableName)
 }
 
-func checkConstraintNamesNotExists(t *meta.Meta, schemaID int64, constrains []*model.ConstraintInfo) error {
+func checkConstraintNamesNotExists(t *meta.Meta, schemaID int64, constraints []*model.ConstraintInfo) error {
+	if len(constraints) == 0 {
+		return nil
+	}
 	tbInfos, err := t.ListTables(schemaID)
 	if err != nil {
 		return err
 	}
 
 	for _, tb := range tbInfos {
-		for _, constraint := range constrains {
+		for _, constraint := range constraints {
 			if constraintInfo := tb.FindConstraintInfoByName(constraint.Name.L); constraintInfo != nil {
 				return infoschema.ErrCheckConstraintDupName.GenWithStackByArgs(constraint.Name.L)
 			}

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -65,6 +65,15 @@ func createTable(d *ddlCtx, t *meta.Meta, job *model.Job, fkCheck bool) (*model.
 		}
 		return tbInfo, errors.Trace(err)
 	}
+
+	err = checkConstraintNamesNotExists(t, schemaID, tbInfo.Constraints)
+	if err != nil {
+		if infoschema.ErrCheckConstraintDupName.Equal(err) {
+			job.State = model.JobStateCancelled
+		}
+		return tbInfo, errors.Trace(err)
+	}
+
 	retryable, err := checkTableForeignKeyValidInOwner(d, t, job, tbInfo, fkCheck)
 	if err != nil {
 		if !retryable {
@@ -1486,6 +1495,23 @@ func checkTableNotExists(d *ddlCtx, t *meta.Meta, schemaID int64, tableName stri
 	}
 
 	return checkTableNotExistsFromStore(t, schemaID, tableName)
+}
+
+func checkConstraintNamesNotExists(t *meta.Meta, schemaID int64, constrains []*model.ConstraintInfo) error {
+	tbInfos, err := t.ListTables(schemaID)
+	if err != nil {
+		return err
+	}
+
+	for _, tb := range tbInfos {
+		for _, constraint := range constrains {
+			if constraintInfo := tb.FindConstraintInfoByName(constraint.Name.L); constraintInfo != nil {
+				return infoschema.ErrCheckConstraintDupName.GenWithStackByArgs(constraint.Name.L)
+			}
+		}
+	}
+
+	return nil
 }
 
 func checkTableIDNotExists(t *meta.Meta, schemaID, tableID int64) error {

--- a/tests/integrationtest/r/ddl/constraint.result
+++ b/tests/integrationtest/r/ddl/constraint.result
@@ -480,55 +480,55 @@ select * from s;
 a
 1
 drop table if exists t1, t2;
-CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0));
+CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t1 CHECK (c2 > 0));
 insert into t1 values (2, 2);
 Error 3819 (HY000): Check constraint 't1_chk_1' is violated.
 insert into t1 values (9, 2);
 Error 3819 (HY000): Check constraint 't1_chk_2' is violated.
 insert into t1 values (14, -4);
-Error 3819 (HY000): Check constraint 'c2_positive' is violated.
+Error 3819 (HY000): Check constraint 'c2_positive_for_t1' is violated.
 insert into t1(c1) values (9);
 Error 3819 (HY000): Check constraint 't1_chk_2' is violated.
 insert into t1(c2) values (-3);
-Error 3819 (HY000): Check constraint 'c2_positive' is violated.
+Error 3819 (HY000): Check constraint 'c2_positive_for_t1' is violated.
 insert into t1 values (14, 4);
 insert into t1 values (null, 4);
 insert into t1 values (13, null);
 insert into t1 values (null, null);
 insert into t1(c1) values (null);
 insert into t1(c2) values (null);
-CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15));
+CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t2 CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15));
 insert into t2(c1, c2) values (11, 1);
 Error 3819 (HY000): Check constraint 't2_chk_3' is violated.
 insert into t2(c1, c2) values (12, 7);
 drop table if exists t1, t2;
-CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0));
+CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t1 CHECK (c2 > 0));
 insert into t1 values (11, 12), (12, 13), (13, 14), (14, 15), (15, 16);
 update t1 set c2 = -c2;
-Error 3819 (HY000): Check constraint 'c2_positive' is violated.
+Error 3819 (HY000): Check constraint 'c2_positive_for_t1' is violated.
 update t1 set c2 = c1;
 Error 3819 (HY000): Check constraint 't1_chk_1' is violated.
 update t1 set c1 = c1 - 10;
 Error 3819 (HY000): Check constraint 't1_chk_2' is violated.
 update t1 set c2 = -10 where c2 = 12;
-Error 3819 (HY000): Check constraint 'c2_positive' is violated.
-CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15));
+Error 3819 (HY000): Check constraint 'c2_positive_for_t1' is violated.
+CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t2 CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15));
 insert into t2(c1, c2) values (11, 12), (12, 13), (13, 14), (14, 15), (15, 16);
 update t2 set c2 = c2 - 10;
 Error 3819 (HY000): Check constraint 't2_chk_3' is violated.
 update t2 set c2 = c2 - 5;
 drop table if exists t1, t2;
-CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0)) partition by hash(c2) partitions 5;
+CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t1 CHECK (c2 > 0)) partition by hash(c2) partitions 5;
 insert into t1 values (11, 12), (12, 13), (13, 14), (14, 15), (15, 16);
 update t1 set c2 = -c2;
-Error 3819 (HY000): Check constraint 'c2_positive' is violated.
+Error 3819 (HY000): Check constraint 'c2_positive_for_t1' is violated.
 update t1 set c2 = c1;
 Error 3819 (HY000): Check constraint 't1_chk_1' is violated.
 update t1 set c1 = c1 - 10;
 Error 3819 (HY000): Check constraint 't1_chk_2' is violated.
 update t1 set c2 = -10 where c2 = 12;
-Error 3819 (HY000): Check constraint 'c2_positive' is violated.
-CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15)) partition by hash(c2) partitions 5;
+Error 3819 (HY000): Check constraint 'c2_positive_for_t1' is violated.
+CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t2 CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15)) partition by hash(c2) partitions 5;
 insert into t2(c1, c2) values (11, 12), (12, 13), (13, 14), (14, 15), (15, 16);
 update t2 set c2 = c2 - 10;
 Error 3819 (HY000): Check constraint 't2_chk_3' is violated.

--- a/tests/integrationtest/t/ddl/constraint.test
+++ b/tests/integrationtest/t/ddl/constraint.test
@@ -469,7 +469,7 @@ select * from s;
 
 # TestCheckConstraintOnInsert
 drop table if exists t1, t2;
-CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0));
+CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t1 CHECK (c2 > 0));
 -- error 3819
 insert into t1 values (2, 2);
 -- error 3819
@@ -486,14 +486,14 @@ insert into t1 values (13, null);
 insert into t1 values (null, null);
 insert into t1(c1) values (null);
 insert into t1(c2) values (null);
-CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15));
+CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t2 CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15));
 -- error 3819
 insert into t2(c1, c2) values (11, 1);
 insert into t2(c1, c2) values (12, 7);
 
 # TestCheckConstraintOnUpdate
 drop table if exists t1, t2;
-CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0));
+CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t1 CHECK (c2 > 0));
 insert into t1 values (11, 12), (12, 13), (13, 14), (14, 15), (15, 16);
 -- error 3819
 update t1 set c2 = -c2;
@@ -503,7 +503,7 @@ update t1 set c2 = c1;
 update t1 set c1 = c1 - 10;
 -- error 3819
 update t1 set c2 = -10 where c2 = 12;
-CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15));
+CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t2 CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15));
 insert into t2(c1, c2) values (11, 12), (12, 13), (13, 14), (14, 15), (15, 16);
 -- error 3819
 update t2 set c2 = c2 - 10;
@@ -511,7 +511,7 @@ update t2 set c2 = c2 - 5;
 
 # TestCheckConstraintOnUpdateWithPartition
 drop table if exists t1, t2;
-CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0)) partition by hash(c2) partitions 5;
+CREATE TABLE t1 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t1 CHECK (c2 > 0)) partition by hash(c2) partitions 5;
 insert into t1 values (11, 12), (12, 13), (13, 14), (14, 15), (15, 16);
 -- error 3819
 update t1 set c2 = -c2;
@@ -521,7 +521,7 @@ update t1 set c2 = c1;
 update t1 set c1 = c1 - 10;
 -- error 3819
 update t1 set c2 = -10 where c2 = 12;
-CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15)) partition by hash(c2) partitions 5;
+CREATE TABLE t2 (CHECK (c1 <> c2), c1 INT CHECK (c1 > 10), c2 INT CONSTRAINT c2_positive_for_t2 CHECK (c2 > 0), c3 int as (c1 + c2) check(c3 > 15)) partition by hash(c2) partitions 5;
 insert into t2(c1, c2) values (11, 12), (12, 13), (13, 14), (14, 15), (15, 16);
 -- error 3819
 update t2 set c2 = c2 - 10;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48038

Problem Summary:
Currently, when `tidb_enable_check_constraint` is ON, the uniqueness of constraint names is not enforced by the check constraint when creating a table creation. This PR fixes this problem and enforces check constraints.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
