### PR TITLE
external: set the period of checking merge iter hotspot according to the key size

### DIFF
--- a/br/pkg/lightning/backend/external/iter.go
+++ b/br/pkg/lightning/backend/external/iter.go
@@ -187,7 +187,7 @@ func newMergeIter[
 	}
 	// We check the hotspot when the elements size is almost the same as the concurrent reader buffer size.
 	// So that we don't drop too many bytes if the hotspot shifts to other files.
-	if sampleKeySize == 0 {
+	if sampleKeySize == 0 || sampleKeySize/sampleKeyCnt == 0 {
 		i.checkHotspotPeriod = 10000
 	} else {
 		i.checkHotspotPeriod = max(1000, ConcurrentReaderBufferSizePerConc*ConcurrentReaderConcurrency/(sampleKeySize/sampleKeyCnt))

--- a/br/pkg/lightning/backend/external/iter.go
+++ b/br/pkg/lightning/backend/external/iter.go
@@ -81,15 +81,16 @@ func (h *mergeHeap[T]) Pop() interface{} {
 }
 
 type mergeIter[T heapElem, R sortedReader[T]] struct {
-	h               mergeHeap[T]
-	readers         []*R
-	curr            T
-	lastReaderIdx   int
-	err             error
-	hotspotMap      map[int]int
-	checkHotspotCnt int
-	lastHotspotIdx  int
-	elemFromHotspot *T
+	h                  mergeHeap[T]
+	readers            []*R
+	curr               T
+	lastReaderIdx      int
+	err                error
+	hotspotMap         map[int]int
+	checkHotspotCnt    int
+	checkHotspotPeriod int
+	lastHotspotIdx     int
+	elemFromHotspot    *T
 
 	logger *zap.Logger
 }
@@ -151,6 +152,8 @@ func newMergeIter[
 		hotspotMap:    make(map[int]int),
 		logger:        logger,
 	}
+	sampleKeySize := 0
+	sampleKeyCnt := 0
 	for j := range i.readers {
 		if i.readers[j] == nil {
 			continue
@@ -179,7 +182,12 @@ func newMergeIter[
 			elem:      e,
 			readerIdx: j,
 		})
+		sampleKeySize += len(e.sortKey())
+		sampleKeyCnt++
 	}
+	// We check the hotspot when the elements size is almost the same as the concurrent reader buffer size.
+	// So that we don't drop too many bytes if the hotspot shifts to other files.
+	i.checkHotspotPeriod = ConcurrentReaderBufferSizePerConc * ConcurrentReaderConcurrency / (sampleKeySize / sampleKeyCnt)
 	heap.Init(&i.h)
 	return i, nil
 }
@@ -210,8 +218,6 @@ func (i *mergeIter[T, R]) currElem() T {
 	return i.curr
 }
 
-var checkHotspotPeriod = 1000
-
 // next forwards the iterator to the next element. It returns false if there is
 // no available element.
 func (i *mergeIter[T, R]) next() bool {
@@ -222,12 +228,12 @@ func (i *mergeIter[T, R]) next() bool {
 		i.checkHotspotCnt++
 
 		// check hotspot every checkPeriod times
-		if i.checkHotspotCnt == checkHotspotPeriod {
+		if i.checkHotspotCnt == i.checkHotspotPeriod {
 			oldHotspotIdx := i.lastHotspotIdx
 			i.lastHotspotIdx = -1
 			for idx, cnt := range i.hotspotMap {
 				// currently only one reader will become hotspot
-				if cnt > (checkHotspotPeriod / 2) {
+				if cnt > (i.checkHotspotPeriod / 2) {
 					i.lastHotspotIdx = idx
 					break
 				}

--- a/br/pkg/lightning/backend/external/iter.go
+++ b/br/pkg/lightning/backend/external/iter.go
@@ -187,7 +187,11 @@ func newMergeIter[
 	}
 	// We check the hotspot when the elements size is almost the same as the concurrent reader buffer size.
 	// So that we don't drop too many bytes if the hotspot shifts to other files.
-	i.checkHotspotPeriod = ConcurrentReaderBufferSizePerConc * ConcurrentReaderConcurrency / (sampleKeySize / sampleKeyCnt)
+	if sampleKeySize == 0 {
+		i.checkHotspotPeriod = 10000
+	} else {
+		i.checkHotspotPeriod = max(1000, ConcurrentReaderBufferSizePerConc*ConcurrentReaderConcurrency/(sampleKeySize/sampleKeyCnt))
+	}
 	heap.Init(&i.h)
 	return i, nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47923

Problem Summary:
If a hotspot is detected, the reader would change to concurrent mode and read 32M data by default.
If the hotspot shifts to other files, the previous reader will drop the unread byte to release memory. If dropping too many bytes, the whole performance would be very bad.

### What is changed and how it works?
Set the period of checking merge iter hotspot according to the key size.
For example, if the average key size is 0.1K (by sampling), then we can check the hotspot every
(32M / 0.1K) = 320000 KVs.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
before:
<img width="430" alt="image" src="https://github.com/pingcap/tidb/assets/17380469/1f6dd6f4-3f12-48d9-b317-5efa62aa64ba">
after:
<img width="307" alt="image" src="https://github.com/pingcap/tidb/assets/17380469/be930c81-e2a2-4f9e-bf2f-4452f3d344cc">

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
