### PR TITLE
executor: reuse chunk for GetMatchedRowsAndPtrs calls

### DIFF
--- a/pkg/executor/benchmark_test.go
+++ b/pkg/executor/benchmark_test.go
@@ -1132,6 +1132,16 @@ func BenchmarkHashJoinExec(b *testing.B) {
 	b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
 		benchmarkHashJoinExecWithCase(b, cas)
 	})
+
+	cols = []*types.FieldType{
+		types.NewFieldType(mysql.TypeLonglong),
+	}
+	cas = defaultHashJoinTestCase(cols, 0, false)
+	cas.keyIdx = []int{0}
+	cas.disk = true
+	b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
+		benchmarkHashJoinExecWithCase(b, cas)
+	})
 }
 
 func BenchmarkOuterHashJoinExec(b *testing.B) {

--- a/pkg/executor/hash_table.go
+++ b/pkg/executor/hash_table.go
@@ -289,10 +289,9 @@ func (c *hashRowContainer) GetMatchedRowsAndPtrs(probeKey uint64, probeRow chunk
 	var (
 		matchedDataSize     = int64(cap(matched))*rowSize + int64(cap(matchedPtrs))*rowPtrSize
 		needTrackMemUsage   = cap(innerPtrs) > signalCheckpointForJoinMask
-		lastChunkBufPointer *chunk.Chunk
+		lastChunkBufPointer = c.chkBuf
 		memDelta            int64
 	)
-	c.chkBuf = nil
 	c.memTracker.Consume(-c.chkBufSizeForOneProbe)
 	if needTrackMemUsage {
 		c.memTracker.Consume(int64(cap(innerPtrs)) * rowPtrSize)
@@ -310,7 +309,7 @@ func (c *hashRowContainer) GetMatchedRowsAndPtrs(probeKey uint64, probeRow chunk
 		if err != nil {
 			return nil, nil, err
 		}
-		if needTrackMemUsage && c.chkBuf != lastChunkBufPointer && lastChunkBufPointer != nil {
+		if c.chkBuf != lastChunkBufPointer && lastChunkBufPointer != nil {
 			lastChunkSize := lastChunkBufPointer.MemoryUsage()
 			c.chkBufSizeForOneProbe += lastChunkSize
 			memDelta += lastChunkSize


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/48082
Problem Summary:

### What is changed and how it works?
Reuse chunk for GetMatchedRowsAndPtrs.
Add a new benchmark case.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
BenchmarkHashJoinExec
```
Old:
 go test -benchmem -run=^$ -bench ^BenchmarkHashJoinExec$ github.com/pingcap/tidb/pkg/executor
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/pkg/executor
cpu: 13th Gen Intel(R) Core(TM) i9-13900KF
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-32                   2         625585277 ns/op        2428636920 B/op   512892 allocs/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                    19          64306968 ns/op        278193261 B/op    112877 allocs/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)-32                      2         510499472 ns/op        3491117756 B/op  2213412 allocs/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                             26020             48058 ns/op           87853 B/op        934 allocs/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-32                         79          16758415 ns/op        15902526 B/op     512736 allocs/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                           92          15112195 ns/op        12524965 B/op     112666 allocs/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)],_concurency:4,_joinKeyIdx:_[0],_disk:true)-32                                    9         123780841 ns/op        894195201 B/op   1714292 allocs/op


New:
go test -benchmem -run=^$ -bench ^BenchmarkHashJoinExec$ github.com/pingcap/tidb/pkg/executor                      
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/pkg/executor
cpu: 13th Gen Intel(R) Core(TM) i9-13900KF
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-32                   2         627044000 ns/op        2428678160 B/op   512971 allocs/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                    18          63483060 ns/op        278192079 B/op    112888 allocs/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)-32                      2         502814122 ns/op        3639970448 B/op  1216829 allocs/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                             28047             48197 ns/op           87847 B/op        934 allocs/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-32                         70          16853512 ns/op        15902144 B/op     512739 allocs/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-32                           82          14872368 ns/op        12524746 B/op     112660 allocs/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)],_concurency:4,_joinKeyIdx:_[0],_disk:true)-32                                   22          53258487 ns/op        40282174 B/op    1113179 allocs/op
```

Profile for the new case:  left is the master, right is this pr.
![image](https://github.com/pingcap/tidb/assets/14054293/e9f2c78c-23b0-40f3-9bf2-e611e0f8e8aa)



- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
