### PR TITLE
*: support cgroup with systemd

### DIFF
--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -266,6 +266,7 @@ func main() {
 		checkTempStorageQuota()
 	}
 	setupLog()
+	memory.InitMemoryHook()
 	setupExtensions()
 	setupStmtSummary()
 

--- a/pkg/util/memory/meminfo.go
+++ b/pkg/util/memory/meminfo.go
@@ -171,6 +171,9 @@ func init() {
 }
 
 // InitMemoryHook initializes the memory hook.
+// It is to solve the problem that tidb cannot read cgroup in the systemd.
+// so if we are not in the container, we compare the cgroup memory limit and the physical memory,
+// the cgroup memory limit is smaller, we use the cgroup memory hook.
 func InitMemoryHook() {
 	if !cgroup.InContainer() {
 		cgroupValue, err := cgroup.GetMemoryLimit()

--- a/pkg/util/memory/meminfo.go
+++ b/pkg/util/memory/meminfo.go
@@ -176,7 +176,7 @@ func init() {
 // the cgroup memory limit is smaller, we use the cgroup memory hook.
 func InitMemoryHook() {
 	if cgroup.InContainer() {
-		logutil.BgLogger().Info("use cgroup memory hook because TiDB is in the docker.")
+		logutil.BgLogger().Info("use cgroup memory hook because TiDB is in the container")
 		return
 	}
 	cgroupValue, err := cgroup.GetMemoryLimit()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47442

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

1、with systemd 

run tidb-server 

```
[Unit]
Description=tidb

[Service]
Type=simple
Restart=always
ExecStart=/usr/bin/tidb
StandardOutput=journal
MemoryMax=500M

[Install]
WantedBy=multi-user.target
```

you will see the log like this.

```
 [2023/10/30 11:00:49.325 +00:00] [INFO] [meminfo.go:188] ["use cgroup memory hook"] [cgroupMemorySize=524288000] [physicalMemorySize=32900468736]
```

2、without systemd

you will see.

```
[2023/10/30 10:47:16.154 +00:00] [INFO] [meminfo.go:190] ["use physical memory hook"] [cgroupMemorySize=9223372036854775807] [physicalMemorySize=32900468736]
```



- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
*: support cgroup with systemd
```
