### PR TITLE
test: fix flaky TestAlterAddConstraintStateChange3

### DIFF
--- a/pkg/ddl/constraint_test.go
+++ b/pkg/ddl/constraint_test.go
@@ -17,6 +17,7 @@ package ddl_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ddl/util/callback"
@@ -243,6 +244,8 @@ func TestAlterAddConstraintStateChange3(t *testing.T) {
 	callback.OnJobUpdatedExported.Store(&onJobUpdatedExportedFunc3)
 	d.SetHook(callback)
 	tk.MustExec("alter table t add constraint c3 check ( a > 10)")
+	// Issue TiDB#48123.
+	time.Sleep(50 * time.Millisecond)
 	tk.MustQuery("select * from t").Check(testkit.Rows("12"))
 	tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n  `a` int(11) DEFAULT NULL,\nCONSTRAINT `c3` CHECK ((`a` > 10))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48123

Problem Summary:

There seems a race between:

https://github.com/pingcap/tidb/blob/3894bc5232183d8107482cae4f6c121a71478cb8/pkg/ddl/constraint_test.go#L239C43-L239C43

and

https://github.com/pingcap/tidb/blob/3894bc5232183d8107482cae4f6c121a71478cb8/pkg/ddl/constraint_test.go#L247C1-L247C1

The reason is:
1. When model.StatePublic,  L245 "alter table t add constraint c3 check ( a > 10)" return, and go on L246、L247.
2. However，the Hook set local constraint state to model.StateWriteReorganization at L234.
3. if L247 go faster than Hook L239，it will read the the not public state，then error occur.

How to reproduce:
before Hook L239, we add a line "time.Sleep(50 * time.Millisecond)" to make the race more competitive, then run the tests.


### What is changed and how it works?

Sleep 50ms after add constraints to wait Hook finish. 50ms is enough generally for the simple sql "insert into t values(1)".

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
