### PR TITLE
planner: fix the issue that the optimizer terminates the optimization process for `DataSource` too early

### DIFF
--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1070,14 +1070,14 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 			prop.CanAddEnforcer = true
 		}
 
-		if bestTaskWithoutEnforce != nil && !bestTaskWithoutEnforce.invalid() {
-			curIsBest, cerr := compareTaskCost(ds.SCtx(), bestTaskWithoutEnforce, t, opt)
+		if bestUnenforcedPlan != nil && !bestUnenforcedPlan.invalid() {
+			curIsBest, cerr := compareTaskCost(ds.SCtx(), bestUnenforcedPlan, t, opt)
 			if cerr != nil {
 				err = cerr
 				return
 			}
 			if curIsBest {
-				t = bestTaskWithoutEnforce
+				t = bestUnenforcedPlan
 			}
 		}
 

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1053,8 +1053,10 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 			ds.storeTask(prop, unenforcedTask)
 			return unenforcedTask, cnt, nil
 		}
-		cntPlan += cnt
+
+		// Then, explore the bestTask with enforced prop
 		prop.CanAddEnforcer = true
+		cntPlan += cnt
 		prop.SortItems = []property.SortItem{}
 		prop.MPPPartitionTp = property.AnyType
 	} else if prop.MPPPartitionTp != property.AnyType {

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1038,20 +1038,20 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 		return
 	}
 	var cnt int64
-	var bestTaskWithoutEnforce task
+	var bestUnenforcedPlan task
 	// If prop.CanAddEnforcer is true, the prop.SortItems need to be set nil for ds.findBestTask.
 	// Before function return, reset it for enforcing task prop and storing map<prop,task>.
 	oldProp := prop.CloneEssentialFields()
 	if prop.CanAddEnforcer {
 		// First, get the bestTask without enforced prop
 		prop.CanAddEnforcer = false
-		bestTaskWithoutEnforce, cnt, err = ds.findBestTask(prop, planCounter, opt)
+		bestUnenforcedPlan, cnt, err = ds.findBestTask(prop, planCounter, opt)
 		if err != nil {
 			return nil, 0, err
 		}
-		if bestTaskWithoutEnforce != invalidTask && !ds.exploreEnforcedPlan() {
-			ds.storeTask(prop, bestTaskWithoutEnforce)
-			return bestTaskWithoutEnforce, cnt, nil
+		if bestUnenforcedPlan != invalidTask && !ds.exploreEnforcedPlan() {
+			ds.storeTask(prop, bestUnenforcedPlan)
+			return bestUnenforcedPlan, cnt, nil
 		}
 		cntPlan += cnt
 		prop.CanAddEnforcer = true

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1038,20 +1038,20 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 		return
 	}
 	var cnt int64
-	var bestUnenforcedPlan task
+	var unenforcedTask task
 	// If prop.CanAddEnforcer is true, the prop.SortItems need to be set nil for ds.findBestTask.
 	// Before function return, reset it for enforcing task prop and storing map<prop,task>.
 	oldProp := prop.CloneEssentialFields()
 	if prop.CanAddEnforcer {
 		// First, get the bestTask without enforced prop
 		prop.CanAddEnforcer = false
-		bestUnenforcedPlan, cnt, err = ds.findBestTask(prop, planCounter, opt)
+		unenforcedTask, cnt, err = ds.findBestTask(prop, planCounter, opt)
 		if err != nil {
 			return nil, 0, err
 		}
-		if bestUnenforcedPlan != invalidTask && !ds.exploreEnforcedPlan() {
-			ds.storeTask(prop, bestUnenforcedPlan)
-			return bestUnenforcedPlan, cnt, nil
+		if !unenforcedTask.invalid() && !ds.exploreEnforcedPlan() {
+			ds.storeTask(prop, unenforcedTask)
+			return unenforcedTask, cnt, nil
 		}
 		cntPlan += cnt
 		prop.CanAddEnforcer = true
@@ -1070,14 +1070,14 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 			prop.CanAddEnforcer = true
 		}
 
-		if bestUnenforcedPlan != nil && !bestUnenforcedPlan.invalid() {
-			curIsBest, cerr := compareTaskCost(ds.SCtx(), bestUnenforcedPlan, t, opt)
+		if unenforcedTask != nil && !unenforcedTask.invalid() {
+			curIsBest, cerr := compareTaskCost(ds.SCtx(), unenforcedTask, t, opt)
 			if cerr != nil {
 				err = cerr
 				return
 			}
 			if curIsBest {
-				t = bestUnenforcedPlan
+				t = unenforcedTask
 			}
 		}
 

--- a/pkg/planner/util/fixcontrol/get.go
+++ b/pkg/planner/util/fixcontrol/get.go
@@ -36,6 +36,8 @@ const (
 	Fix45132 uint64 = 45132
 	// Fix45798 controls whether to cache plans that access generated columns.
 	Fix45798 uint64 = 45798
+	// Fix46177 controls whether to explore enforced plans for DataSource if it has already found an unenforced plan.
+	Fix46177 uint64 = 46177
 )
 
 // GetStr fetches the given key from the fix control map as a string type.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46177

Problem Summary: planner: fix the issue that the optimizer terminates the optimization process for `DataSource` too early

### What is changed and how it works?

fix the issue that the optimizer terminates the optimization process for `DataSource` too early

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
