### PR TITLE
restore: refactor split code for two phase split.

### DIFF
--- a/br/pkg/errors/errors.go
+++ b/br/pkg/errors/errors.go
@@ -40,10 +40,12 @@ var (
 	ErrEnvNotSpecified           = errors.Normalize("environment variable not found", errors.RFCCodeText("BR:Common:ErrEnvNotSpecified"))
 	ErrUnsupportedOperation      = errors.Normalize("the operation is not supported", errors.RFCCodeText("BR:Common:ErrUnsupportedOperation"))
 
-	ErrPDUpdateFailed    = errors.Normalize("failed to update PD", errors.RFCCodeText("BR:PD:ErrPDUpdateFailed"))
-	ErrPDLeaderNotFound  = errors.Normalize("PD leader not found", errors.RFCCodeText("BR:PD:ErrPDLeaderNotFound"))
-	ErrPDInvalidResponse = errors.Normalize("PD invalid response", errors.RFCCodeText("BR:PD:ErrPDInvalidResponse"))
-	ErrPDBatchScanRegion = errors.Normalize("batch scan region", errors.RFCCodeText("BR:PD:ErrPDBatchScanRegion"))
+	ErrPDUpdateFailed         = errors.Normalize("failed to update PD", errors.RFCCodeText("BR:PD:ErrPDUpdateFailed"))
+	ErrPDLeaderNotFound       = errors.Normalize("PD leader not found", errors.RFCCodeText("BR:PD:ErrPDLeaderNotFound"))
+	ErrPDInvalidResponse      = errors.Normalize("PD invalid response", errors.RFCCodeText("BR:PD:ErrPDInvalidResponse"))
+	ErrPDBatchScanRegion      = errors.Normalize("batch scan region", errors.RFCCodeText("BR:PD:ErrPDBatchScanRegion"))
+	ErrPDUnknownScatterResult = errors.Normalize("failed to wait region scattered", errors.RFCCodeText("BR:PD:ErrPDUknownScatterResult"))
+	ErrPDSplitFailed          = errors.Normalize("failed to wait region splitted", errors.RFCCodeText("BR:PD:ErrPDUknownScatterResult"))
 
 	ErrBackupChecksumMismatch    = errors.Normalize("backup checksum mismatch", errors.RFCCodeText("BR:Backup:ErrBackupChecksumMismatch"))
 	ErrBackupInvalidRange        = errors.Normalize("backup range invalid", errors.RFCCodeText("BR:Backup:ErrBackupInvalidRange"))

--- a/br/pkg/restore/import_retry.go
+++ b/br/pkg/restore/import_retry.go
@@ -257,7 +257,7 @@ func (r *RPCResult) StrategyForRetryGoError() RetryStrategy {
 	// we should unwrap the error or we cannot get the write gRPC status.
 	if gRPCErr, ok := status.FromError(errors.Cause(r.Err)); ok {
 		switch gRPCErr.Code() {
-		case codes.Unavailable, codes.Aborted, codes.ResourceExhausted:
+		case codes.Unavailable, codes.Aborted, codes.ResourceExhausted, codes.DeadlineExceeded:
 			return StrategyFromThisRegion
 		}
 	}

--- a/br/pkg/restore/merge.go
+++ b/br/pkg/restore/merge.go
@@ -119,10 +119,15 @@ func MergeFileRanges(
 	rangeTree := rtree.NewRangeTree()
 	for key := range filesMap {
 		files := filesMap[key]
+		rangeSize := uint64(0)
+		for _, f := range filesMap[key] {
+			rangeSize += f.Size_
+		}
 		if out := rangeTree.InsertRange(rtree.Range{
 			StartKey: files[0].GetStartKey(),
 			EndKey:   files[0].GetEndKey(),
 			Files:    files,
+			Size:     rangeSize,
 		}); out != nil {
 			return nil, nil, errors.Annotatef(berrors.ErrRestoreInvalidRange,
 				"duplicate range %s files %+v", out, files)
@@ -136,6 +141,7 @@ func MergeFileRanges(
 			continue
 		}
 		sortedRanges[i-1].EndKey = sortedRanges[i].EndKey
+		sortedRanges[i-1].Size += sortedRanges[i].Size
 		sortedRanges[i-1].Files = append(sortedRanges[i-1].Files, sortedRanges[i].Files...)
 		// TODO: this is slow when there are lots of ranges need to merge.
 		sortedRanges = append(sortedRanges[:i], sortedRanges[i+1:]...)

--- a/br/pkg/restore/pipeline_items.go
+++ b/br/pkg/restore/pipeline_items.go
@@ -243,6 +243,7 @@ func NewTiKVSender(
 	cli TiKVRestorer,
 	updateCh glue.Progress,
 	splitConcurrency uint,
+	granularity string,
 ) (BatchSender, error) {
 	inCh := make(chan DrainResult, defaultChannelSize)
 	midCh := make(chan drainResultAndDone, defaultChannelSize)
@@ -257,7 +258,13 @@ func NewTiKVSender(
 
 	sender.wg.Add(2)
 	go sender.splitWorker(ctx, inCh, midCh, splitConcurrency)
-	go sender.restoreWorker(ctx, midCh)
+	if granularity == string(CoarseGrained) {
+		outCh := make(chan drainResultAndDone, defaultChannelSize)
+		go sender.blockPipelineWorker(ctx, midCh, outCh)
+		go sender.restoreWorker(ctx, outCh)
+	} else {
+		go sender.restoreWorker(ctx, midCh)
+	}
 	return sender, nil
 }
 
@@ -270,6 +277,26 @@ func (b *tikvSender) Close() {
 type drainResultAndDone struct {
 	result DrainResult
 	done   func()
+}
+
+func (b *tikvSender) blockPipelineWorker(ctx context.Context,
+	inCh <-chan drainResultAndDone,
+	outCh chan<- drainResultAndDone,
+) {
+	defer close(outCh)
+	res := make([]drainResultAndDone, 0, defaultChannelSize)
+	for dr := range inCh {
+		res = append(res, dr)
+	}
+
+	for _, dr := range res {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			outCh <- dr
+		}
+	}
 }
 
 func (b *tikvSender) splitWorker(ctx context.Context,
@@ -385,6 +412,7 @@ func (b *tikvSender) restoreWorker(ctx context.Context, ranges <-chan drainResul
 			if !ok {
 				return
 			}
+
 			files := r.result.Files()
 			// There has been a worker in the `RestoreSSTFiles` procedure.
 			// Spawning a raw goroutine won't make too many requests to TiKV.

--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -33,6 +33,25 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type retryTimeKey struct{}
+
+var retryTimes = new(retryTimeKey)
+
+type Granularity string
+
+const (
+	FineGrained   Granularity = "fine-grained"
+	CoarseGrained Granularity = "coarse-grained"
+)
+
+type SplitContext struct {
+	isRawKv     bool
+	needScatter bool
+	waitScatter bool
+	storeCount  int
+	onSplit     OnSplitFunc
+}
+
 // RegionSplitter is a executor of region split by rules.
 type RegionSplitter struct {
 	client split.SplitClient
@@ -48,15 +67,18 @@ func NewRegionSplitter(client split.SplitClient) *RegionSplitter {
 // OnSplitFunc is called before split a range.
 type OnSplitFunc func(key [][]byte)
 
-// Split executes a region split. It will split regions by the rewrite rules,
+// ExecuteSplit executes regions split and make sure new splitted regions are balance.
+// It will split regions by the rewrite rules,
 // then it will split regions by the end key of each range.
 // tableRules includes the prefix of a table, since some ranges may have
 // a prefix with record sequence or index sequence.
 // note: all ranges and rewrite rules must have raw key.
-func (rs *RegionSplitter) Split(
+func (rs *RegionSplitter) ExecuteSplit(
 	ctx context.Context,
 	ranges []rtree.Range,
 	rewriteRules *RewriteRules,
+	storeCount int,
+	granularity string,
 	isRawKv bool,
 	onSplit OnSplitFunc,
 ) error {
@@ -71,95 +93,433 @@ func (rs *RegionSplitter) Split(
 		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
 
-	startTime := time.Now()
 	// Sort the range for getting the min and max key of the ranges
+	// TODO: this sort may not needed if we sort tables after creatation outside.
 	sortedRanges, errSplit := SortRanges(ranges, rewriteRules)
 	if errSplit != nil {
 		return errors.Trace(errSplit)
 	}
-	minKey := codec.EncodeBytesExt(nil, sortedRanges[0].StartKey, isRawKv)
-	maxKey := codec.EncodeBytesExt(nil, sortedRanges[len(sortedRanges)-1].EndKey, isRawKv)
-	interval := split.SplitRetryInterval
-	scatterRegions := make([]*split.RegionInfo, 0)
-SplitRegions:
-	for i := 0; i < split.SplitRetryTimes; i++ {
-		regions, errScan := split.PaginateScanRegion(ctx, rs.client, minKey, maxKey, split.ScanRegionPaginationLimit)
-		if errScan != nil {
-			if berrors.ErrPDBatchScanRegion.Equal(errScan) {
-				log.Warn("inconsistent region info get.", logutil.ShortError(errScan))
-				time.Sleep(time.Second)
-				continue SplitRegions
-			}
-			return errors.Trace(errScan)
+	sortedKeys := make([][]byte, 0, len(sortedRanges))
+	totalRangeSize := uint64(0)
+	for _, r := range sortedRanges {
+		sortedKeys = append(sortedKeys, r.EndKey)
+		totalRangeSize += r.Size
+	}
+	sctx := SplitContext{
+		isRawKv:     isRawKv,
+		needScatter: true,
+		waitScatter: false,
+		onSplit:     onSplit,
+		storeCount:  storeCount,
+	}
+	if granularity == string(CoarseGrained) {
+		return rs.executeSplitByRanges(ctx, sctx, sortedRanges)
+	}
+	return rs.executeSplitByKeys(ctx, sctx, sortedKeys)
+}
+
+func (rs *RegionSplitter) executeSplitByRanges(
+	ctx context.Context,
+	splitContext SplitContext,
+	sortedRanges []rtree.Range,
+) error {
+	startTime := time.Now()
+	minKey := codec.EncodeBytesExt(nil, sortedRanges[0].StartKey, splitContext.isRawKv)
+	maxKey := codec.EncodeBytesExt(nil, sortedRanges[len(sortedRanges)-1].EndKey, splitContext.isRawKv)
+
+	err := utils.WithRetry(ctx, func() error {
+		regions, err := split.PaginateScanRegion(ctx, rs.client, minKey, maxKey, split.ScanRegionPaginationLimit)
+		if err != nil {
+			return err
 		}
-		splitKeyMap := getSplitKeys(rewriteRules, sortedRanges, regions, isRawKv)
+		lastSortedIndex := 0
+		sortedIndex := 0
+		splitRangeMap := make(map[uint64][]rtree.Range)
+		regionMap := make(map[uint64]*split.RegionInfo)
+	loop:
+		for _, region := range regions {
+			regionMap[region.Region.GetId()] = region
+			// collect all sortedKeys belong to this region
+			if len(region.Region.GetEndKey()) == 0 {
+				splitRangeMap[region.Region.GetId()] = sortedRanges[lastSortedIndex:]
+				break
+			}
+			for {
+				encodeKey := codec.EncodeBytesExt(nil, sortedRanges[sortedIndex].StartKey, splitContext.isRawKv)
+				if bytes.Compare(encodeKey, region.Region.GetEndKey()) >= 0 {
+					//                  start    end
+					// range:            |--------|
+					// region: |---------|
+					// pick up this range due to region end key is exclusive.
+					splitRangeMap[region.Region.GetId()] = sortedRanges[lastSortedIndex:sortedIndex]
+					lastSortedIndex = sortedIndex
+					// reach the region end key and break for next region
+					break
+				}
+				sortedIndex += 1
+				if sortedIndex >= len(sortedRanges) {
+					splitRangeMap[region.Region.GetId()] = sortedRanges[lastSortedIndex:]
+					// has reach the region files' end
+					break loop
+				}
+			}
+		}
+
+		workerPool := utils.NewWorkerPool(uint(splitContext.storeCount), "split ranges")
+		eg, ectx := errgroup.WithContext(ctx)
+		for rID, rgs := range splitRangeMap {
+			region := regionMap[rID]
+			ranges := rgs
+			sctx := splitContext
+			sctx.waitScatter = true
+			workerPool.ApplyOnErrorGroup(eg, func() error {
+				var newRegions []*split.RegionInfo
+				rangeSize := uint64(0)
+				allKeys := make([][]byte, 0, len(ranges))
+				if len(ranges) <= 1 {
+					// we may have splitted in last restore run.
+					return nil
+				}
+				for _, rg := range ranges {
+					rangeSize += rg.Size
+					allKeys = append(allKeys, rg.EndKey)
+				}
+				expectSplitSize := rangeSize / uint64(sctx.storeCount)
+				size := uint64(0)
+				keys := make([][]byte, 0, sctx.storeCount)
+				for _, rg := range ranges {
+					if size >= expectSplitSize {
+						// collect enough ranges, choose this one
+						keys = append(keys, rg.EndKey)
+						log.Info("choose the split key", zap.Uint64("split size", size), logutil.Key("key", rg.EndKey))
+						size = 0
+					}
+					size += rg.Size
+				}
+				keys = keys[:sctx.storeCount-1]
+				log.Info("get split ranges for region",
+					zap.Int("keys", len(keys)),
+					zap.Uint64("expect split size", expectSplitSize),
+					zap.Uint64("total range size", rangeSize),
+					zap.Bool("need scatter", sctx.needScatter),
+					zap.Bool("wait scatter", sctx.waitScatter),
+					logutil.Keys(keys),
+					logutil.Region(region.Region))
+				newRegions, err := rs.splitAndScatterRegions(ectx, sctx, region, keys)
+				if err != nil {
+					return err
+				}
+				if len(newRegions) != len(keys) {
+					log.Warn("split key count and new region count mismatch",
+						zap.Int("new region count", len(newRegions)),
+						zap.Int("split key count", len(keys)))
+				}
+				sctx.onSplit(keys)
+				sctx.needScatter = false
+				return rs.executeSplitByKeys(ectx, sctx, allKeys)
+			})
+		}
+		return eg.Wait()
+	}, newSplitBackoffer())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	log.Info("finish splitting and scattering regions by ranges",
+		zap.Duration("take", time.Since(startTime)))
+	return nil
+}
+
+// executeSplitByKeys will split regions by **sorted** keys with following steps.
+// 1. locate regions with correspond keys.
+// 2. split these regions with correspond keys.
+// 3. make sure new splitted regions are balanced.
+func (rs *RegionSplitter) executeSplitByKeys(
+	ctx context.Context,
+	splitContext SplitContext,
+	sortedKeys [][]byte,
+) error {
+	var mutex sync.Mutex
+	startTime := time.Now()
+	minKey := codec.EncodeBytesExt(nil, sortedKeys[0], splitContext.isRawKv)
+	maxKey := codec.EncodeBytesExt(nil, sortedKeys[len(sortedKeys)-1], splitContext.isRawKv)
+	scatterRegions := make([]*split.RegionInfo, 0)
+	regionsMap := make(map[uint64]*split.RegionInfo)
+
+	err := utils.WithRetry(ctx, func() error {
+		clear(regionsMap)
+		regions, err := split.PaginateScanRegion(ctx, rs.client, minKey, maxKey, split.ScanRegionPaginationLimit)
+		if err != nil {
+			return err
+		}
+		splitKeyMap := getSplitKeys(splitContext, sortedKeys, regions)
 		regionMap := make(map[uint64]*split.RegionInfo)
 		for _, region := range regions {
 			regionMap[region.Region.GetId()] = region
 		}
-		for regionID, keys := range splitKeyMap {
-			log.Info("get split keys for region", zap.Int("len", len(keys)), zap.Uint64("region", regionID))
-			var newRegions []*split.RegionInfo
+		workerPool := utils.NewWorkerPool(8, "split keys")
+		eg, ectx := errgroup.WithContext(ctx)
+		for regionID, splitKeys := range splitKeyMap {
 			region := regionMap[regionID]
-			log.Info("split regions",
-				logutil.Region(region.Region), logutil.Keys(keys), rtree.ZapRanges(ranges))
-			newRegions, errSplit = rs.splitAndScatterRegions(ctx, region, keys)
-			if errSplit != nil {
-				if strings.Contains(errSplit.Error(), "no valid key") {
-					for _, key := range keys {
-						// Region start/end keys are encoded. split_region RPC
-						// requires raw keys (without encoding).
-						log.Error("split regions no valid key",
-							logutil.Key("startKey", region.Region.StartKey),
-							logutil.Key("endKey", region.Region.EndKey),
-							logutil.Key("key", codec.EncodeBytesExt(nil, key, isRawKv)),
-							rtree.ZapRanges(ranges))
+			keys := splitKeys
+			sctx := splitContext
+			workerPool.ApplyOnErrorGroup(eg, func() error {
+				log.Info("get split keys for split regions",
+					logutil.Region(region.Region), logutil.Keys(keys),
+					zap.Bool("need scatter", sctx.needScatter))
+				newRegions, err := rs.splitAndScatterRegions(ectx, sctx, region, keys)
+				if err != nil {
+					return err
+				}
+				if len(newRegions) != len(keys) {
+					log.Warn("split key count and new region count mismatch",
+						zap.Int("new region count", len(newRegions)),
+						zap.Int("split key count", len(keys)))
+				}
+				if sctx.needScatter {
+					log.Info("scattered regions", zap.Int("count", len(newRegions)))
+					mutex.Lock()
+					for _, r := range newRegions {
+						regionsMap[r.Region.Id] = r
 					}
-					return errors.Trace(errSplit)
+					mutex.Unlock()
 				}
-				interval = 2 * interval
-				if interval > split.SplitMaxRetryInterval {
-					interval = split.SplitMaxRetryInterval
-				}
-				time.Sleep(interval)
-				log.Warn("split regions failed, retry",
-					zap.Error(errSplit),
-					logutil.Region(region.Region),
-					logutil.Leader(region.Leader),
-					logutil.Keys(keys), rtree.ZapRanges(ranges))
-				continue SplitRegions
-			}
-			log.Info("scattered regions", zap.Int("count", len(newRegions)))
-			if len(newRegions) != len(keys) {
-				log.Warn("split key count and new region count mismatch",
-					zap.Int("new region count", len(newRegions)),
-					zap.Int("split key count", len(keys)))
-			}
-			scatterRegions = append(scatterRegions, newRegions...)
-			onSplit(keys)
+				sctx.onSplit(keys)
+				return nil
+			})
 		}
-		break
+		err = eg.Wait()
+		if err != nil {
+			return err
+		}
+		for _, r := range regionsMap {
+			// merge all scatter regions
+			scatterRegions = append(scatterRegions, r)
+		}
+		return nil
+	}, newSplitBackoffer())
+	if err != nil {
+		return errors.Trace(err)
 	}
-	if errSplit != nil {
-		return errors.Trace(errSplit)
-	}
-	log.Info("start to wait for scattering regions",
-		zap.Int("regions", len(scatterRegions)), zap.Duration("take", time.Since(startTime)))
-
-	leftCnt := rs.WaitForScatterRegions(ctx, scatterRegions, split.ScatterWaitUpperInterval)
-	if leftCnt == 0 {
-		log.Info("waiting for scattering regions done",
-			zap.Int("regions", len(scatterRegions)), zap.Duration("take", time.Since(startTime)))
-	} else {
-		log.Warn("waiting for scattering regions timeout",
-			zap.Int("NotScatterCount", leftCnt),
-			zap.Int("TotalScatterCount", len(scatterRegions)),
-			zap.Int("regions", len(scatterRegions)),
+	if len(scatterRegions) > 0 {
+		log.Info("finish splitting and scattering regions. and starts to wait", zap.Int("regions", len(scatterRegions)),
 			zap.Duration("take", time.Since(startTime)))
+		rs.waitRegionsScattered(ctx, scatterRegions, split.ScatterWaitUpperInterval)
+	} else {
+		log.Info("finish splitting regions.", zap.Duration("take", time.Since(startTime)))
 	}
 	return nil
 }
 
+func (rs *RegionSplitter) splitAndScatterRegions(
+	ctx context.Context, splitContext SplitContext, regionInfo *split.RegionInfo, keys [][]byte,
+) ([]*split.RegionInfo, error) {
+	if len(keys) < 1 {
+		return []*split.RegionInfo{regionInfo}, nil
+	}
+
+	newRegions, err := rs.splitRegionsSync(ctx, regionInfo, keys)
+	if err != nil {
+		if strings.Contains(err.Error(), "no valid key") {
+			for _, key := range keys {
+				// Region start/end keys are encoded. split_region RPC
+				// requires raw keys (without encoding).
+				log.Error("split regions no valid key",
+					logutil.Key("startKey", regionInfo.Region.StartKey),
+					logutil.Key("endKey", regionInfo.Region.EndKey),
+					logutil.Key("key", codec.EncodeBytesExt(nil, key, splitContext.isRawKv)))
+			}
+		}
+		return nil, errors.Trace(err)
+	}
+	if splitContext.needScatter {
+		// To make region leader balanced. need scatter origin one too
+		if splitContext.waitScatter {
+			rs.ScatterRegionsSync(ctx, append(newRegions, regionInfo))
+		} else {
+			rs.ScatterRegionsAsync(ctx, append(newRegions, regionInfo))
+		}
+	}
+	return newRegions, nil
+}
+
+// splitRegionsSync perform batchSplit on a region by keys
+// and then check the batch split success or not.
+func (rs *RegionSplitter) splitRegionsSync(
+	ctx context.Context, regionInfo *split.RegionInfo, keys [][]byte,
+) ([]*split.RegionInfo, error) {
+	if len(keys) == 0 {
+		return []*split.RegionInfo{regionInfo}, nil
+	}
+	newRegions, err := rs.client.BatchSplitRegions(ctx, regionInfo, keys)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	rs.waitRegionsSplitted(ctx, newRegions)
+	return newRegions, nil
+}
+
+// ScatterRegionsAsync scatter the regions.
+// for same reason just log and ignore error.
+// See the comments of function waitRegionScattered.
+func (rs *RegionSplitter) ScatterRegionsAsync(ctx context.Context, newRegions []*split.RegionInfo) {
+	log.Info("start to scatter regions", zap.Int("regions", len(newRegions)))
+	// the retry is for the temporary network errors during sending request.
+	err := utils.WithRetry(ctx, func() error {
+		err := rs.client.ScatterRegions(ctx, newRegions)
+		if isUnsupportedError(err) {
+			log.Warn("batch scatter isn't supported, rollback to old method", logutil.ShortError(err))
+			rs.ScatterRegionsSequentially(
+				ctx, newRegions,
+				// backoff about 6s, or we give up scattering this region.
+				&split.ExponentialBackoffer{
+					Attempts:    7,
+					BaseBackoff: 100 * time.Millisecond,
+				})
+			return nil
+		}
+		return err
+	}, &split.ExponentialBackoffer{Attempts: 3, BaseBackoff: 500 * time.Millisecond})
+	if err != nil {
+		log.Warn("failed to scatter regions", logutil.ShortError(err))
+	}
+}
+
+// ScatterRegionsSync scatter the regions and wait these region scattered from PD.
+// for same reason just log and ignore error.
+// See the comments of function waitRegionScattered.
+func (rs *RegionSplitter) ScatterRegionsSync(ctx context.Context, newRegions []*split.RegionInfo) {
+	rs.ScatterRegionsAsync(ctx, newRegions)
+	rs.waitRegionsScattered(ctx, newRegions, split.ScatterWaitUpperInterval)
+}
+
+// waitRegionsSplitted check multiple regions have finished the split.
+func (rs *RegionSplitter) waitRegionsSplitted(ctx context.Context, splitRegions []*split.RegionInfo) {
+	// Wait for a while until the regions successfully split.
+	for _, region := range splitRegions {
+		rs.waitRegionSplitted(ctx, region.Region.Id)
+	}
+}
+
+// waitRegionSplitted check single region has finished the split.
+func (rs *RegionSplitter) waitRegionSplitted(ctx context.Context, regionID uint64) {
+	state := utils.InitialRetryState(
+		split.SplitCheckMaxRetryTimes,
+		split.SplitCheckInterval,
+		split.SplitMaxCheckInterval,
+	)
+	err := utils.WithRetry(ctx, func() error { //nolint: errcheck
+		ok, err := rs.hasHealthyRegion(ctx, regionID)
+		if err != nil {
+			log.Warn("wait for split failed", zap.Uint64("regionID", regionID), zap.Error(err))
+			return err
+		}
+		if ok {
+			return nil
+		}
+		return errors.Annotate(berrors.ErrPDSplitFailed, "wait region splitted failed")
+	}, &state)
+	if err != nil {
+		log.Warn("failed to split regions", logutil.ShortError(err))
+	}
+}
+
+// waitRegionsScattered try to wait mutilple regions scatterd in 3 minutes.
+// this could timeout, but if many regions scatterd the restore could continue
+// so we don't wait long time here.
+func (rs *RegionSplitter) waitRegionsScattered(ctx context.Context, scatterRegions []*split.RegionInfo, timeout time.Duration) {
+	log.Info("start to wait for scattering regions", zap.Int("regions", len(scatterRegions)))
+	startTime := time.Now()
+	scatterCount := 0
+	for _, region := range scatterRegions {
+		rs.waitRegionScattered(ctx, region)
+		if time.Since(startTime) > timeout {
+			break
+		}
+		scatterCount++
+	}
+	if scatterCount == len(scatterRegions) {
+		log.Info("waiting for scattering regions done",
+			zap.Int("regions", len(scatterRegions)),
+			zap.Duration("take", time.Since(startTime)))
+	} else {
+		log.Warn("waiting for scattering regions timeout",
+			zap.Int("scatterCount", scatterCount),
+			zap.Int("regions", len(scatterRegions)),
+			zap.Duration("take", time.Since(startTime)))
+	}
+}
+
+// waitRegionsScattered try to wait single region scatterd
+// because we may not get the accurate result of scatter region.
+// even we got error here the scatter could also succeed.
+// so add a warn log and ignore error does make sense here.
+func (rs *RegionSplitter) waitRegionScattered(ctx context.Context, regionInfo *split.RegionInfo) {
+	state := utils.InitialRetryState(split.ScatterWaitMaxRetryTimes, split.ScatterWaitInterval, split.ScatterMaxWaitInterval)
+	retryCount := 0
+	err := utils.WithRetry(ctx, func() error {
+		ctx1 := context.WithValue(ctx, retryTimes, retryCount)
+		ok, _, err := rs.isScatterRegionFinished(ctx1, regionInfo.Region.Id)
+		if err != nil {
+			log.Warn("scatter region failed: do not have the region",
+				logutil.Region(regionInfo.Region))
+			return err
+		}
+		if ok {
+			return nil
+		}
+		retryCount++
+		return errors.Annotatef(berrors.ErrPDUnknownScatterResult, "try wait region scatter")
+	}, &state)
+	if err != nil {
+		log.Warn("wait scatter region meet error", logutil.Region(regionInfo.Region), logutil.ShortError(err))
+	}
+}
+
+// ScatterRegionsSequentially scatter the region with some backoffer.
+// This function is for testing the retry mechanism.
+// For a real cluster, directly use ScatterRegions would be fine.
+func (rs *RegionSplitter) ScatterRegionsSequentially(ctx context.Context, newRegions []*split.RegionInfo, backoffer utils.Backoffer) {
+	newRegionSet := make(map[uint64]*split.RegionInfo, len(newRegions))
+	for _, newRegion := range newRegions {
+		newRegionSet[newRegion.Region.Id] = newRegion
+	}
+
+	if err := utils.WithRetry(ctx, func() error {
+		log.Info("trying to scatter regions...", zap.Int("remain", len(newRegionSet)))
+		var errs error
+		for _, region := range newRegionSet {
+			err := rs.client.ScatterRegion(ctx, region)
+			if err == nil {
+				// it is safe according to the Go language spec.
+				delete(newRegionSet, region.Region.Id)
+			} else if !split.PdErrorCanRetry(err) {
+				log.Warn("scatter meet error cannot be retried, skipping",
+					logutil.ShortError(err),
+					logutil.Region(region.Region),
+				)
+				delete(newRegionSet, region.Region.Id)
+			}
+			errs = multierr.Append(errs, err)
+		}
+		return errs
+	}, backoffer); err != nil {
+		log.Warn("Some regions haven't been scattered because errors.",
+			zap.Int("count", len(newRegionSet)),
+			// if all region are failed to scatter, the short error might also be verbose...
+			logutil.ShortError(err),
+			logutil.AbbreviatedArray("failed-regions", newRegionSet, func(i interface{}) []string {
+				m := i.(map[uint64]*split.RegionInfo)
+				result := make([]string, 0, len(m))
+				for id := range m {
+					result = append(result, strconv.Itoa(int(id)))
+				}
+				return result
+			}),
+		)
+	}
+}
+
+// hasHealthyRegion is used to check whether region splitted success
 func (rs *RegionSplitter) hasHealthyRegion(ctx context.Context, regionID uint64) (bool, error) {
 	regionInfo, err := rs.client.GetRegionByID(ctx, regionID)
 	if err != nil {
@@ -212,7 +572,6 @@ func (rs *RegionSplitter) isScatterRegionFinished(ctx context.Context, regionID 
 	if retryTimes > 3 {
 		log.Info("get operator", zap.Uint64("regionID", regionID), zap.Stringer("resp", resp))
 	}
-	// If the current operator of the region is not 'scatter-region', we could assume
 	// that 'scatter-operator' has finished
 	if string(resp.GetDesc()) != "scatter-region" {
 		return true, false, nil
@@ -227,39 +586,7 @@ func (rs *RegionSplitter) isScatterRegionFinished(ctx context.Context, regionID 
 	}
 }
 
-func (rs *RegionSplitter) waitForSplit(ctx context.Context, regionID uint64) {
-	interval := split.SplitCheckInterval
-	for i := 0; i < split.SplitCheckMaxRetryTimes; i++ {
-		ok, err := rs.hasHealthyRegion(ctx, regionID)
-		if err != nil {
-			log.Warn("wait for split failed", zap.Error(err))
-			return
-		}
-		if ok {
-			break
-		}
-		interval = 2 * interval
-		if interval > split.SplitMaxCheckInterval {
-			interval = split.SplitMaxCheckInterval
-		}
-		time.Sleep(interval)
-	}
-}
-
-type retryTimeKey struct{}
-
-var retryTimes = new(retryTimeKey)
-
-func mapRegionInfoSlice(regionInfos []*split.RegionInfo) map[uint64]*split.RegionInfo {
-	regionInfoMap := make(map[uint64]*split.RegionInfo)
-	for _, info := range regionInfos {
-		regionID := info.Region.GetId()
-		regionInfoMap[regionID] = info
-	}
-	return regionInfoMap
-}
-
-func (rs *RegionSplitter) WaitForScatterRegions(ctx context.Context, regionInfos []*split.RegionInfo, timeout time.Duration) int {
+func (rs *RegionSplitter) WaitForScatterRegionsTimeout(ctx context.Context, regionInfos []*split.RegionInfo, timeout time.Duration) int {
 	var (
 		startTime   = time.Now()
 		interval    = split.ScatterWaitInterval
@@ -294,13 +621,12 @@ func (rs *RegionSplitter) WaitForScatterRegions(ctx context.Context, regionInfos
 		}
 
 		if len(reScatterRegions) > 0 {
-			rs.ScatterRegions(ctx1, reScatterRegions)
+			rs.ScatterRegionsAsync(ctx1, reScatterRegions)
 		}
 
 		if time.Since(startTime) > timeout {
 			break
 		}
-
 		retryCnt += 1
 		interval = 2 * interval
 		if interval > split.ScatterMaxWaitInterval {
@@ -312,141 +638,21 @@ func (rs *RegionSplitter) WaitForScatterRegions(ctx context.Context, regionInfos
 	return len(leftRegions)
 }
 
-func (rs *RegionSplitter) splitAndScatterRegions(
-	ctx context.Context, regionInfo *split.RegionInfo, keys [][]byte,
-) ([]*split.RegionInfo, error) {
-	if len(keys) == 0 {
-		return []*split.RegionInfo{regionInfo}, nil
+func mapRegionInfoSlice(regionInfos []*split.RegionInfo) map[uint64]*split.RegionInfo {
+	regionInfoMap := make(map[uint64]*split.RegionInfo)
+	for _, info := range regionInfos {
+		regionID := info.Region.GetId()
+		regionInfoMap[regionID] = info
 	}
-
-	newRegions, err := rs.client.BatchSplitRegions(ctx, regionInfo, keys)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	// There would be some regions be scattered twice, e.g.:
-	// |--1-|--2-+----|-3--|
-	//      |    +(t1)|
-	//      +(t1_r4)  |
-	//                +(t2_r42)
-	// When spliting at `t1_r4`, we would scatter region 1, 2.
-	// When spliting at `t2_r42`, we would scatter region 2, 3.
-	// Because we don't split at t1 anymore.
-	// The trick here is a pinky promise: never scatter regions you haven't imported any data.
-	// In this scenario, it is the last region after spliting (applying to >= 5.0).
-	if bytes.Equal(newRegions[len(newRegions)-1].Region.StartKey, keys[len(keys)-1]) {
-		newRegions = newRegions[:len(newRegions)-1]
-	}
-	rs.ScatterRegions(ctx, newRegions)
-	return newRegions, nil
-}
-
-// ScatterRegionsWithBackoffer scatter the region with some backoffer.
-// This function is for testing the retry mechanism.
-// For a real cluster, directly use ScatterRegions would be fine.
-func (rs *RegionSplitter) ScatterRegionsWithBackoffer(ctx context.Context, newRegions []*split.RegionInfo, backoffer utils.Backoffer) {
-	newRegionSet := make(map[uint64]*split.RegionInfo, len(newRegions))
-	for _, newRegion := range newRegions {
-		newRegionSet[newRegion.Region.Id] = newRegion
-	}
-
-	if err := utils.WithRetry(ctx, func() error {
-		log.Info("trying to scatter regions...", zap.Int("remain", len(newRegionSet)))
-		var errs error
-		for _, region := range newRegionSet {
-			err := rs.client.ScatterRegion(ctx, region)
-			if err == nil {
-				// it is safe according to the Go language spec.
-				delete(newRegionSet, region.Region.Id)
-			} else if !split.PdErrorCanRetry(err) {
-				log.Warn("scatter meet error cannot be retried, skipping",
-					logutil.ShortError(err),
-					logutil.Region(region.Region),
-				)
-				delete(newRegionSet, region.Region.Id)
-			}
-			errs = multierr.Append(errs, err)
-		}
-		return errs
-	}, backoffer); err != nil {
-		log.Warn("Some regions haven't been scattered because errors.",
-			zap.Int("count", len(newRegionSet)),
-			// if all region are failed to scatter, the short error might also be verbose...
-			logutil.ShortError(err),
-			logutil.AbbreviatedArray("failed-regions", newRegionSet, func(i interface{}) []string {
-				m := i.(map[uint64]*split.RegionInfo)
-				result := make([]string, 0, len(m))
-				for id := range m {
-					result = append(result, strconv.Itoa(int(id)))
-				}
-				return result
-			}),
-		)
-	}
-}
-
-// isUnsupportedError checks whether we should fallback to ScatterRegion API when meeting the error.
-func isUnsupportedError(err error) bool {
-	s, ok := status.FromError(errors.Cause(err))
-	if !ok {
-		// Not a gRPC error. Something other went wrong.
-		return false
-	}
-	// In two conditions, we fallback to ScatterRegion:
-	// (1) If the RPC endpoint returns UNIMPLEMENTED. (This is just for making test cases not be so magic.)
-	// (2) If the Message is "region 0 not found":
-	//     In fact, PD reuses the gRPC endpoint `ScatterRegion` for the batch version of scattering.
-	//     When the request contains the field `regionIDs`, it would use the batch version,
-	//     Otherwise, it uses the old version and scatter the region with `regionID` in the request.
-	//     When facing 4.x, BR(which uses v5.x PD clients and call `ScatterRegions`!) would set `regionIDs`
-	//     which would be ignored by protocol buffers, and leave the `regionID` be zero.
-	//     Then the older version of PD would try to search the region with ID 0.
-	//     (Then it consistently fails, and returns "region 0 not found".)
-	return s.Code() == codes.Unimplemented ||
-		strings.Contains(s.Message(), "region 0 not found")
-}
-
-// ScatterRegions scatter the regions.
-func (rs *RegionSplitter) ScatterRegions(ctx context.Context, newRegions []*split.RegionInfo) {
-	for _, region := range newRegions {
-		// Wait for a while until the regions successfully split.
-		rs.waitForSplit(ctx, region.Region.Id)
-	}
-
-	// the retry is for the temporary network errors during sending request.
-	err := utils.WithRetry(ctx, func() error {
-		err := rs.client.ScatterRegions(ctx, newRegions)
-		if isUnsupportedError(err) {
-			log.Warn("batch scatter isn't supported, rollback to old method", logutil.ShortError(err))
-			rs.ScatterRegionsWithBackoffer(
-				ctx, newRegions,
-				// backoff about 6s, or we give up scattering this region.
-				&split.ExponentialBackoffer{
-					Attempts:    7,
-					BaseBackoff: 100 * time.Millisecond,
-				})
-			return nil
-		}
-		if err != nil {
-			log.Warn("scatter region meet error", logutil.ShortError(err))
-		}
-		return err
-	}, &split.ExponentialBackoffer{Attempts: 3, BaseBackoff: 500 * time.Millisecond})
-
-	if err != nil {
-		log.Warn("failed to batch scatter region", logutil.ShortError(err))
-	}
+	return regionInfoMap
 }
 
 // getSplitKeys checks if the regions should be split by the end key of
 // the ranges, groups the split keys by region id.
-func getSplitKeys(rewriteRules *RewriteRules, ranges []rtree.Range, regions []*split.RegionInfo, isRawKv bool) map[uint64][][]byte {
+func getSplitKeys(splitContext SplitContext, keys [][]byte, regions []*split.RegionInfo) map[uint64][][]byte {
 	splitKeyMap := make(map[uint64][][]byte)
-	checkKeys := make([][]byte, 0)
-	for _, rg := range ranges {
-		checkKeys = append(checkKeys, rg.EndKey)
-	}
-	for _, key := range checkKeys {
-		if region := NeedSplit(key, regions, isRawKv); region != nil {
+	for _, key := range keys {
+		if region := NeedSplit(key, regions, splitContext.isRawKv); region != nil {
 			splitKeys, ok := splitKeyMap[region.Region.GetId()]
 			if !ok {
 				splitKeys = make([][]byte, 0, 1)
@@ -641,8 +847,12 @@ func (helper *LogSplitHelper) splitRegionByPoints(
 		return nil
 	}
 
+	sctx := SplitContext{
+		storeCount: 0,
+	}
+
 	helper.pool.ApplyOnErrorGroup(helper.eg, func() error {
-		newRegions, errSplit := regionSplitter.splitAndScatterRegions(ctx, region, splitPoints)
+		newRegions, errSplit := regionSplitter.splitAndScatterRegions(ctx, sctx, region, splitPoints)
 		if errSplit != nil {
 			log.Warn("failed to split the scaned region", zap.Error(errSplit))
 			_, startKey, _ := codec.DecodeBytes(region.Region.StartKey, nil)
@@ -652,7 +862,7 @@ func (helper *LogSplitHelper) splitRegionByPoints(
 				startKey = point
 			}
 
-			return regionSplitter.Split(ctx, ranges, nil, false, func([][]byte) {})
+			return regionSplitter.ExecuteSplit(ctx, ranges, nil, 0, "", false, func([][]byte) {})
 		}
 		select {
 		case <-ctx.Done():
@@ -840,7 +1050,7 @@ func (helper *LogSplitHelper) Split(ctx context.Context) error {
 		regionSplitter := NewRegionSplitter(helper.client)
 		// It is too expensive to stop recovery and wait for a small number of regions
 		// to complete scatter, so the maximum waiting time is reduced to 1 minute.
-		_ = regionSplitter.WaitForScatterRegions(ctx, scatterRegions, time.Minute)
+		_ = regionSplitter.WaitForScatterRegionsTimeout(ctx, scatterRegions, time.Minute)
 	}()
 
 	iter := helper.iterator()
@@ -907,4 +1117,54 @@ func (splitIter *LogFilesIterWithSplitHelper) TryNext(ctx context.Context) iter.
 	res := iter.Emit(splitIter.buffer[splitIter.next])
 	splitIter.next += 1
 	return res
+}
+
+// isUnsupportedError checks whether we should fallback to ScatterRegion API when meeting the error.
+func isUnsupportedError(err error) bool {
+	s, ok := status.FromError(errors.Cause(err))
+	if !ok {
+		// Not a gRPC error. Something other went wrong.
+		return false
+	}
+	// In two conditions, we fallback to ScatterRegion:
+	// (1) If the RPC endpoint returns UNIMPLEMENTED. (This is just for making test cases not be so magic.)
+	// (2) If the Message is "region 0 not found":
+	//     In fact, PD reuses the gRPC endpoint `ScatterRegion` for the batch version of scattering.
+	//     When the request contains the field `regionIDs`, it would use the batch version,
+	//     Otherwise, it uses the old version and scatter the region with `regionID` in the request.
+	//     When facing 4.x, BR(which uses v5.x PD clients and call `ScatterRegions`!) would set `regionIDs`
+	//     which would be ignored by protocol buffers, and leave the `regionID` be zero.
+	//     Then the older version of PD would try to search the region with ID 0.
+	//     (Then it consistently fails, and returns "region 0 not found".)
+	return s.Code() == codes.Unimplemented ||
+		strings.Contains(s.Message(), "region 0 not found")
+}
+
+type splitBackoffer struct {
+	state utils.RetryState
+}
+
+func newSplitBackoffer() *splitBackoffer {
+	return &splitBackoffer{
+		state: utils.InitialRetryState(split.SplitRetryTimes, split.SplitRetryInterval, split.SplitMaxRetryInterval),
+	}
+}
+
+func (bo *splitBackoffer) NextBackoff(err error) time.Duration {
+	switch {
+	case berrors.ErrPDBatchScanRegion.Equal(err):
+		log.Warn("inconsistent region info get.", logutil.ShortError(err))
+		return time.Second
+	case strings.Contains(err.Error(), "no valid key"):
+		bo.state.GiveUp()
+		return 0
+	case berrors.ErrRestoreInvalidRange.Equal(err):
+		bo.state.GiveUp()
+		return 0
+	}
+	return bo.state.ExponentialBackoff()
+}
+
+func (bo *splitBackoffer) Attempt() int {
+	return bo.state.Attempt()
 }

--- a/br/pkg/restore/split/client.go
+++ b/br/pkg/restore/split/client.go
@@ -365,6 +365,7 @@ func sendSplitRegionRequest(ctx context.Context, c *pdClient, regionInfo *Region
 	if resp.RegionError != nil {
 		log.Warn("fail to split region",
 			logutil.Region(regionInfo.Region),
+			logutil.Keys(keys),
 			zap.Stringer("regionErr", resp.RegionError))
 		*splitErrors = multierr.Append(*splitErrors,
 			errors.Annotatef(berrors.ErrRestoreSplitFailed, "split region failed: err=%v", resp.RegionError))

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -294,7 +294,7 @@ func TestScatterFinishInTime(t *testing.T) {
 	regionSplitter := restore.NewRegionSplitter(client)
 
 	ctx := context.Background()
-	err := regionSplitter.Split(ctx, ranges, rewriteRules, false, func(key [][]byte) {})
+	err := regionSplitter.ExecuteSplit(ctx, ranges, rewriteRules, 0, "", false, func(key [][]byte) {})
 	require.NoError(t, err)
 	regions := client.GetAllRegions()
 	if !validateRegions(regions) {
@@ -320,7 +320,7 @@ func TestScatterFinishInTime(t *testing.T) {
 
 	// When using a exponential backoffer, if we try to backoff more than 40 times in 10 regions,
 	// it would cost time unacceptable.
-	regionSplitter.ScatterRegionsWithBackoffer(ctx,
+	regionSplitter.ScatterRegionsSequentially(ctx,
 		regionInfos,
 		assertRetryLessThan(t, 40))
 }
@@ -448,7 +448,7 @@ func runWaitScatter(t *testing.T, client *TestClient) {
 		regions = append(regions, info)
 	}
 	regionSplitter := restore.NewRegionSplitter(client)
-	leftCnt := regionSplitter.WaitForScatterRegions(ctx, regions, 2000*time.Second)
+	leftCnt := regionSplitter.WaitForScatterRegionsTimeout(ctx, regions, 2000*time.Second)
 	require.Equal(t, leftCnt, 0)
 }
 
@@ -458,7 +458,7 @@ func runTestSplitAndScatterWith(t *testing.T, client *TestClient) {
 	regionSplitter := restore.NewRegionSplitter(client)
 
 	ctx := context.Background()
-	err := regionSplitter.Split(ctx, ranges, rewriteRules, false, func(key [][]byte) {})
+	err := regionSplitter.ExecuteSplit(ctx, ranges, rewriteRules, 0, "", false, func(key [][]byte) {})
 	require.NoError(t, err)
 	regions := client.GetAllRegions()
 	if !validateRegions(regions) {
@@ -482,7 +482,7 @@ func runTestSplitAndScatterWith(t *testing.T, client *TestClient) {
 		scattered[regionInfo.Region.Id] = true
 		return nil
 	}
-	regionSplitter.ScatterRegions(ctx, regionInfos)
+	regionSplitter.ScatterRegionsSync(ctx, regionInfos)
 	for key := range regions {
 		if key == alwaysFailedRegionID {
 			require.Falsef(t, scattered[key], "always failed region %d was scattered successfully", key)
@@ -504,7 +504,7 @@ func TestRawSplit(t *testing.T) {
 	ctx := context.Background()
 
 	regionSplitter := restore.NewRegionSplitter(client)
-	err := regionSplitter.Split(ctx, ranges, nil, true, func(key [][]byte) {})
+	err := regionSplitter.ExecuteSplit(ctx, ranges, nil, 0, "", true, func(key [][]byte) {})
 	require.NoError(t, err)
 	regions := client.GetAllRegions()
 	expectedKeys := []string{"", "aay", "bba", "bbh", "cca", ""}
@@ -829,7 +829,7 @@ func TestRestoreFailed(t *testing.T) {
 	r := &fakeRestorer{
 		tableIDIsInsequence: true,
 	}
-	sender, err := restore.NewTiKVSender(context.TODO(), r, nil, 1)
+	sender, err := restore.NewTiKVSender(context.TODO(), r, nil, 1, string(restore.FineGrained))
 	require.NoError(t, err)
 	dctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -852,7 +852,7 @@ func TestSplitFailed(t *testing.T) {
 		fakeRanges("bcy", "cad", "xxy"),
 	}
 	r := &fakeRestorer{errorInSplit: true, tableIDIsInsequence: true}
-	sender, err := restore.NewTiKVSender(context.TODO(), r, nil, 1)
+	sender, err := restore.NewTiKVSender(context.TODO(), r, nil, 1, string(restore.FineGrained))
 	require.NoError(t, err)
 	dctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/br/pkg/restore/util.go
+++ b/br/pkg/restore/util.go
@@ -517,7 +517,7 @@ func SplitRanges(
 		isRawKv,
 	))
 
-	return splitter.Split(ctx, ranges, rewriteRules, isRawKv, func(keys [][]byte) {
+	return splitter.ExecuteSplit(ctx, ranges, rewriteRules, client.GetStoreCount(), client.GetGranularity(), isRawKv, func(keys [][]byte) {
 		for range keys {
 			updateCh.Inc()
 		}

--- a/br/pkg/rtree/rtree.go
+++ b/br/pkg/rtree/rtree.go
@@ -16,6 +16,7 @@ type Range struct {
 	StartKey []byte
 	EndKey   []byte
 	Files    []*backuppb.File
+	Size     uint64
 }
 
 // BytesAndKeys returns total bytes and keys in a range.

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1490,7 +1490,7 @@ func createRestoreClient(ctx context.Context, g glue.Glue, cfg *RestoreConfig, m
 	client.SetCrypter(&cfg.CipherInfo)
 	client.SetConcurrency(uint(cfg.Concurrency))
 	client.SetSwitchModeInterval(cfg.SwitchModeInterval)
-	client.InitClients(u, false, false)
+	client.InitClients(ctx, u, false, false)
 
 	rawKVClient, err := newRawBatchClient(ctx, cfg.PD, cfg.TLS)
 	if err != nil {

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -162,7 +162,7 @@ func (bo *importerBackoffer) NextBackoff(err error) time.Duration {
 			bo.attempt = 0
 		default:
 			switch status.Code(e) {
-			case codes.Unavailable, codes.Aborted:
+			case codes.Unavailable, codes.Aborted, codes.DeadlineExceeded:
 				bo.delayTime = 2 * bo.delayTime
 				bo.attempt--
 			default:

--- a/errors.toml
+++ b/errors.toml
@@ -176,6 +176,11 @@ error = '''
 PD leader not found
 '''
 
+["BR:PD:ErrPDUknownScatterResult"]
+error = '''
+failed to wait region splitted
+'''
+
 ["BR:PD:ErrPDUpdateFailed"]
 error = '''
 failed to update PD


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/33937

Problem Summary:
split too many regions on the same node. will become bottleneck of a large scale cluster restoration.

### What is changed and how it works?
1. introduce 2-phase split during restore. when enable fine-grained restore. it will pick keys by store count, and doing a two-phase split scatter. which will save time from scatter-heavy workloads.
2. refactor code and unified `utils.retry` for all related backoffer.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

without this change:
<img width="1092" alt="image" src="https://github.com/pingcap/tidb/assets/5906259/31b0b20d-cba5-484c-a5d9-5dafa226e493">

with this change:
<img width="1393" alt="image" src="https://github.com/pingcap/tidb/assets/5906259/f4876dac-abc2-40c6-be4f-bb0e4f32c7e1">

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
restore: improve performance by reduce scatter operations.
```
