### PR TITLE
domain: add resolve lock logic for mvcc get key loading schema diff

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -191,7 +191,7 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 		return nil, false, 0, nil, err
 	}
 	// fetch the commit timestamp of the schema diff
-	schemaTs, err := do.getTimestampForSchemaVersionWithNonEmptyDiff(m, neededSchemaVersion)
+	schemaTs, err := do.getTimestampForSchemaVersionWithNonEmptyDiff(m, neededSchemaVersion, startTS)
 	if err != nil {
 		logutil.BgLogger().Warn("failed to get schema version", zap.Error(err), zap.Int64("version", neededSchemaVersion))
 		schemaTs = 0
@@ -259,18 +259,18 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 }
 
 // Returns the timestamp of a schema version, which is the commit timestamp of the schema diff
-func (do *Domain) getTimestampForSchemaVersionWithNonEmptyDiff(m *meta.Meta, version int64) (int64, error) {
+func (do *Domain) getTimestampForSchemaVersionWithNonEmptyDiff(m *meta.Meta, version int64, startTS uint64) (int64, error) {
 	tikvStore, ok := do.Store().(helper.Storage)
 	if ok {
-		helper := helper.NewHelper(tikvStore)
-		data, err := helper.GetMvccByEncodedKey(m.EncodeSchemaDiffKey(version))
+		newHelper := helper.NewHelper(tikvStore)
+		mvccResp, err := newHelper.GetMvccByEncodedKeyWithTS(m.EncodeSchemaDiffKey(version), startTS)
 		if err != nil {
 			return 0, err
 		}
-		if data == nil || data.Info == nil || len(data.Info.Writes) == 0 {
+		if mvccResp == nil || mvccResp.Info == nil || len(mvccResp.Info.Writes) == 0 {
 			return 0, errors.Errorf("There is no Write MVCC info for the schema version")
 		}
-		return int64(data.Info.Writes[0].CommitTs), nil
+		return int64(mvccResp.Info.Writes[0].CommitTs), nil
 	}
 	return 0, errors.Errorf("cannot get store from domain")
 }

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -94,11 +94,12 @@ func NewHelper(store Storage) *Helper {
 	}
 }
 
+// MaxBackoffTimeoutForMvccGet is a derived value from previous implementation possible experiencing value 5000ms.
+const MaxBackoffTimeoutForMvccGet = 5000
+
 // GetMvccByEncodedKeyWithTS get the MVCC value by the specific encoded key, if lock is encountered it would be resolved.
 func (h *Helper) GetMvccByEncodedKeyWithTS(encodedKey kv.Key, startTS uint64) (*kvrpcpb.MvccGetByKeyResponse, error) {
-	// A derived value from previous implementation possible experiencing value 5000ms.
-	MaxBackoffTimeout := 5000
-	bo := tikv.NewBackofferWithVars(context.Background(), MaxBackoffTimeout, nil)
+	bo := tikv.NewBackofferWithVars(context.Background(), MaxBackoffTimeoutForMvccGet, nil)
 	tikvReq := tikvrpc.NewRequest(tikvrpc.CmdMvccGetByKey, &kvrpcpb.MvccGetByKeyRequest{Key: encodedKey})
 	for {
 		keyLocation, err := h.RegionCache.LocateKey(bo, encodedKey)

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -94,9 +94,11 @@ func NewHelper(store Storage) *Helper {
 	}
 }
 
-// GetMvccByEncodedKey get the MVCC value by the specific encoded key.
-func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyResponse, error) {
-	bo := tikv.NewBackofferWithVars(context.Background(), 5000, nil)
+// GetMvccByEncodedKeyWithTS get the MVCC value by the specific encoded key, if lock is encountered it would be resolved.
+func (h *Helper) GetMvccByEncodedKeyWithTS(encodedKey kv.Key, startTS uint64) (*kvrpcpb.MvccGetByKeyResponse, error) {
+	// A derived value from previous implementation possible experiencing value 5000ms.
+	MaxBackoffTimeout := 5000
+	bo := tikv.NewBackofferWithVars(context.Background(), MaxBackoffTimeout, nil)
 	tikvReq := tikvrpc.NewRequest(tikvrpc.CmdMvccGetByKey, &kvrpcpb.MvccGetByKeyRequest{Key: encodedKey})
 	for {
 		keyLocation, err := h.RegionCache.LocateKey(bo, encodedKey)
@@ -106,7 +108,7 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 
 		kvResp, err := h.Store.SendReq(bo, tikvReq, keyLocation.Region, time.Minute)
 		if err != nil {
-			logutil.BgLogger().Info("get MVCC by encoded key failed",
+			logutil.BgLogger().Warn("get MVCC by encoded key failed",
 				zap.Stringer("encodeKey", encodedKey),
 				zap.Reflect("region", keyLocation.Region),
 				zap.Stringer("keyLocation", keyLocation),
@@ -114,6 +116,7 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 				zap.Error(err))
 			return nil, errors.Trace(err)
 		}
+
 		regionErr, err := kvResp.GetRegionError()
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -124,9 +127,10 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 			}
 			continue
 		}
+
 		mvccResp := kvResp.Resp.(*kvrpcpb.MvccGetByKeyResponse)
 		if errMsg := mvccResp.GetError(); errMsg != "" {
-			logutil.BgLogger().Info("get MVCC by encoded key failed",
+			logutil.BgLogger().Warn("get MVCC by encoded key failed",
 				zap.Stringer("encodeKey", encodedKey),
 				zap.Reflect("region", keyLocation.Region),
 				zap.Stringer("keyLocation", keyLocation),
@@ -134,8 +138,57 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 				zap.String("error", errMsg))
 			return nil, errors.New(errMsg)
 		}
+		if mvccResp.Info == nil {
+			errMsg := "Invalid mvcc response result, the info field is nil"
+			logutil.BgLogger().Warn(errMsg,
+				zap.Stringer("encodeKey", encodedKey),
+				zap.Reflect("region", keyLocation.Region),
+				zap.Stringer("keyLocation", keyLocation),
+				zap.Reflect("kvResp", kvResp))
+			return nil, errors.New(errMsg)
+		}
+
+		// Try to resolve the lock and retry mvcc get again if the input startTS is a valid value.
+		if startTS > 0 && mvccResp.Info.GetLock() != nil {
+			lockInfo := mvccResp.Info.GetLock()
+			lock := &txnlock.Lock{
+				Key:             []byte(encodedKey),
+				Primary:         lockInfo.GetPrimary(),
+				TxnID:           lockInfo.GetStartTs(),
+				TTL:             lockInfo.GetTtl(),
+				TxnSize:         lockInfo.GetTxnSize(),
+				LockType:        lockInfo.GetType(),
+				UseAsyncCommit:  lockInfo.GetUseAsyncCommit(),
+				LockForUpdateTS: lockInfo.GetForUpdateTs(),
+			}
+			// Disable for read to avoid async resolve.
+			resolveLocksOpts := txnlock.ResolveLocksOptions{
+				CallerStartTS: startTS,
+				Locks:         []*txnlock.Lock{lock},
+				Lite:          true,
+				ForRead:       false,
+				Detail:        nil,
+			}
+			resolveLockRes, err := h.Store.GetLockResolver().ResolveLocksWithOpts(bo, resolveLocksOpts)
+			if err != nil {
+				return nil, err
+			}
+			msBeforeExpired := resolveLockRes.TTL
+			if msBeforeExpired > 0 {
+				if err = bo.BackoffWithCfgAndMaxSleep(tikv.BoTxnLock(), int(msBeforeExpired),
+					errors.Errorf("resolve lock fails lock: %v", lock)); err != nil {
+					return nil, err
+				}
+			}
+			continue
+		}
 		return mvccResp, nil
 	}
+}
+
+// GetMvccByEncodedKey get the MVCC value by the specific encoded key.
+func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyResponse, error) {
+	return h.GetMvccByEncodedKeyWithTS(encodedKey, 0)
 }
 
 // MvccKV wraps the key's mvcc info in tikv.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #48281

Problem Summary:
Handle lock error reading mvcc get schema diff key to avoid unexpected schema cache invalidation.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->



Side effects


Documentation


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix unhandled lock error reading schema diff key using mvcc interface.
```
