### PR TITLE
infoschema: refine info cache logic to reduce the impact of DDL on information schema cache

### DIFF
--- a/pkg/infoschema/cache.go
+++ b/pkg/infoschema/cache.go
@@ -99,13 +99,16 @@ func (h *InfoCache) getSchemaByTimestampNoLock(ts uint64) (InfoSchema, bool) {
 	// moreover, the most likely hit element in the array is the first one in steady mode
 	// thus it may have better performance than binary search
 	for i, is := range h.cache {
-		if is.timestamp == 0 || (i > 0 && h.cache[i-1].infoschema.SchemaMetaVersion() != is.infoschema.SchemaMetaVersion()+1) {
-			// the schema version doesn't have a timestamp or there is a gap in the schema cache
-			// ignore all the schema cache equals or less than this version in search by timestamp
-			break
+		if is.timestamp == 0 || ts < uint64(is.timestamp) {
+			continue
 		}
-		if ts >= uint64(is.timestamp) {
-			// found the largest version before the given ts
+
+		if i > 0 {
+			if h.cache[i-1].infoschema.SchemaMetaVersion() == is.infoschema.SchemaMetaVersion()+1 && uint64(h.cache[i-1].timestamp) > ts {
+				return is.infoschema, true
+			}
+			break
+		} else {
 			return is.infoschema, true
 		}
 	}

--- a/pkg/infoschema/cache.go
+++ b/pkg/infoschema/cache.go
@@ -100,14 +100,22 @@ func (h *InfoCache) getSchemaByTimestampNoLock(ts uint64) (InfoSchema, bool) {
 	// thus it may have better performance than binary search
 	for i, is := range h.cache {
 		if is.timestamp == 0 || ts < uint64(is.timestamp) {
+			// is.timestamp == 0 means the schema ts is unknown, so we can't use it, then just skip it.
+			// ts < is.timestamp means the schema is newer than ts, so we can't use it too, just skip it to find the older one.
 			continue
 		}
+		// ts >= is.timestamp must be true after the above condition.
 		if i == 0 {
+			// the first element is the latest schema, so we can return it directly.
 			return is.infoschema, true
 		}
 		if h.cache[i-1].infoschema.SchemaMetaVersion() == is.infoschema.SchemaMetaVersion()+1 && uint64(h.cache[i-1].timestamp) > ts {
+			// This first condition is to make sure the schema version is continuous. If last(cache[i-1]) schema-version is 10,
+			// but current(cache[i]) schema-version is not 9, then current schema is not suitable for ts.
+			// The second condition is to make sure the cache[i-1].timestamp > ts >= cache[i].timestamp, then the current schema is suitable for ts.
 			return is.infoschema, true
 		}
+		// current schema is not suitable for ts, then break the loop to avoid the unnecessary search.
 		break
 	}
 

--- a/pkg/infoschema/cache.go
+++ b/pkg/infoschema/cache.go
@@ -102,15 +102,13 @@ func (h *InfoCache) getSchemaByTimestampNoLock(ts uint64) (InfoSchema, bool) {
 		if is.timestamp == 0 || ts < uint64(is.timestamp) {
 			continue
 		}
-
-		if i > 0 {
-			if h.cache[i-1].infoschema.SchemaMetaVersion() == is.infoschema.SchemaMetaVersion()+1 && uint64(h.cache[i-1].timestamp) > ts {
-				return is.infoschema, true
-			}
-			break
-		} else {
+		if i == 0 {
 			return is.infoschema, true
 		}
+		if h.cache[i-1].infoschema.SchemaMetaVersion() == is.infoschema.SchemaMetaVersion()+1 && uint64(h.cache[i-1].timestamp) > ts {
+			return is.infoschema, true
+		}
+		break
 	}
 
 	logutil.BgLogger().Debug("SCHEMA CACHE no schema found")

--- a/pkg/infoschema/test/cachetest/BUILD.bazel
+++ b/pkg/infoschema/test/cachetest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 6,
+    shard_count = 7,
     deps = [
         "//pkg/infoschema",
         "//pkg/testkit/testsetup",

--- a/pkg/infoschema/test/cachetest/cache_test.go
+++ b/pkg/infoschema/test/cachetest/cache_test.go
@@ -15,6 +15,7 @@
 package cachetest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -210,4 +211,83 @@ func TestReSize(t *testing.T) {
 	require.Nil(t, ic.GetByVersion(2))
 	require.Nil(t, ic.GetByVersion(3))
 	require.Equal(t, is4, ic.GetByVersion(4))
+}
+
+func TestCacheWithSchemaTsZero(t *testing.T) {
+	ic := infoschema.NewCache(16)
+	require.NotNil(t, ic)
+
+	for i := 1; i <= 8; i++ {
+		ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, int64(i)), uint64(i))
+	}
+
+	checkFn := func(start, end int64, exist bool) {
+		require.True(t, start <= end)
+		latestSchemaVersion := ic.GetLatest().SchemaMetaVersion()
+		for ts := start; ts <= end; ts++ {
+			is := ic.GetBySnapshotTS(uint64(ts))
+			if exist {
+				require.NotNil(t, is, fmt.Sprintf("ts %d", ts))
+				if ts > latestSchemaVersion {
+					require.Equal(t, latestSchemaVersion, is.SchemaMetaVersion(), fmt.Sprintf("ts %d", ts))
+				} else {
+					require.Equal(t, ts, is.SchemaMetaVersion(), fmt.Sprintf("ts %d", ts))
+				}
+			} else {
+				require.Nil(t, is, fmt.Sprintf("ts %d", ts))
+			}
+		}
+	}
+	checkFn(1, 8, true)
+	checkFn(8, 10, true)
+
+	// mock for meet error There is no Write MVCC info for the schema version
+	ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, 9), 0)
+	checkFn(1, 7, true)
+	checkFn(8, 9, false)
+	checkFn(9, 10, false)
+
+	for i := 10; i <= 16; i++ {
+		ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, int64(i)), uint64(i))
+		checkFn(1, 7, true)
+		checkFn(8, 9, false)
+		checkFn(10, 16, true)
+	}
+	require.Equal(t, 16, ic.Size())
+
+	// refill the cache
+	ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, 9), 9)
+	checkFn(1, 16, true)
+	require.Equal(t, 16, ic.Size())
+
+	// Test more than capacity
+	ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, 17), 17)
+	checkFn(1, 1, false)
+	checkFn(2, 17, true)
+	checkFn(2, 20, true)
+	require.Equal(t, 16, ic.Size())
+
+	// Test for there is a hole in the middle.
+	ic = infoschema.NewCache(16)
+
+	// mock for restart with full load the latest version schema.
+	ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, 100), 100)
+	checkFn(1, 99, false)
+	checkFn(100, 100, true)
+
+	for i := 1; i <= 16; i++ {
+		ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, int64(i)), uint64(i))
+	}
+	checkFn(1, 1, false)
+	checkFn(2, 15, true)
+	checkFn(16, 16, false)
+	checkFn(100, 100, true)
+	require.Equal(t, 16, ic.Size())
+
+	for i := 85; i < 100; i++ {
+		ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, int64(i)), uint64(i))
+	}
+	checkFn(1, 84, false)
+	checkFn(85, 100, true)
+	require.Equal(t, 16, ic.Size())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48285

Problem Summary: refine info cache logic to reduce the impact of DDL on information schema cache

### What is changed and how it works?

Do same test in #48285,  with this PR, the impact of `failed to get schema version` to stale read QPS is much smaller.

```
[2023/11/04 09:44:04.794 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3234]
[2023/11/04 09:44:18.787 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3280]
[2023/11/04 09:44:20.885 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3281]
[2023/11/04 09:44:37.502 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3332]
[2023/11/04 09:44:48.265 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3363]
[2023/11/04 09:45:10.305 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3431]
[2023/11/04 09:45:34.291 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3499]
[2023/11/04 09:45:45.170 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3531]
[2023/11/04 09:46:12.471 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3612]
[2023/11/04 09:46:20.786 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3638]
[2023/11/04 09:46:24.319 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3648]
[2023/11/04 09:46:26.283 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3655]
[2023/11/04 09:46:45.023 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3708]
[2023/11/04 09:46:50.798 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3728]
[2023/11/04 09:47:12.034 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3785]
[2023/11/04 09:47:39.571 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3869]
[2023/11/04 09:47:45.348 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=3888]
[2023/11/04 09:49:10.819 +08:00] [WARN] [domain.go:196] ["failed to get schema version"] [error="There is no Write MVCC info for the schema version"] [version=4136]
```

The the related metric is following, as you can see, the QPS is much more stable and load snapshot ops is much lower.

<img width="1455" alt="image" src="https://github.com/pingcap/tidb/assets/26020263/dbdd5c57-bd8a-4143-8a12-02954ea5471d">

**Before This PR**

<img width="1460" alt="image" src="https://github.com/pingcap/tidb/assets/26020263/467b6b88-dc65-4c52-8cb5-9140ff3072d1">


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
