### PR TITLE
[DNM]*: test stale read  

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -44,7 +44,6 @@ import (
 	"github.com/pingcap/tidb/util/topsql"
 	topsqlstate "github.com/pingcap/tidb/util/topsql/state"
 	"github.com/tikv/client-go/v2/tikvrpc"
-	"github.com/tikv/client-go/v2/txnkv/transaction"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	atomicutil "go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -891,9 +890,7 @@ func (w *worker) HandleDDLJobTable(d *ddlCtx, job *model.Job) (int64, error) {
 	writeBinlog(d.binlogCli, txn, job)
 	// reset the SQL digest to make topsql work right.
 	w.sess.GetSessionVars().StmtCtx.ResetSQLDigest(job.Query)
-	transaction.MockRandomSleepBeforeCommitSecondaryKeys = true
 	err = w.sess.commit()
-	transaction.MockRandomSleepBeforeCommitSecondaryKeys = false
 	d.unlockSchemaVersion(job.ID)
 	if err != nil {
 		return 0, err

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -191,7 +191,7 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 		return nil, false, 0, nil, err
 	}
 	// fetch the commit timestamp of the schema diff
-	schemaTs, err := do.getTimestampForSchemaVersionWithNonEmptyDiff(m, neededSchemaVersion)
+	schemaTs, err := do.getTimestampForSchemaVersionWithNonEmptyDiff(m, neededSchemaVersion, startTS)
 	if err != nil {
 		logutil.BgLogger().Warn("failed to get schema version", zap.Error(err), zap.Int64("version", neededSchemaVersion))
 		schemaTs = 0
@@ -259,18 +259,18 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 }
 
 // Returns the timestamp of a schema version, which is the commit timestamp of the schema diff
-func (do *Domain) getTimestampForSchemaVersionWithNonEmptyDiff(m *meta.Meta, version int64) (int64, error) {
+func (do *Domain) getTimestampForSchemaVersionWithNonEmptyDiff(m *meta.Meta, version int64, startTS uint64) (int64, error) {
 	tikvStore, ok := do.Store().(helper.Storage)
 	if ok {
-		helper := helper.NewHelper(tikvStore)
-		data, err := helper.GetMvccByEncodedKey(m.EncodeSchemaDiffKey(version))
+		newHelper := helper.NewHelper(tikvStore)
+		mvccResp, err := newHelper.GetMvccByEncodedKeyWithTS(m.EncodeSchemaDiffKey(version), startTS)
 		if err != nil {
 			return 0, err
 		}
-		if data == nil || data.Info == nil || len(data.Info.Writes) == 0 {
+		if mvccResp == nil || mvccResp.Info == nil || len(mvccResp.Info.Writes) == 0 {
 			return 0, errors.Errorf("There is no Write MVCC info for the schema version")
 		}
-		return int64(data.Info.Writes[0].CommitTs), nil
+		return int64(mvccResp.Info.Writes[0].CommitTs), nil
 	}
 	return 0, errors.Errorf("cannot get store from domain")
 }

--- a/go.mod
+++ b/go.mod
@@ -271,4 +271,4 @@ replace (
 	go.opencensus.io => go.opencensus.io v0.23.1-0.20220331163232-052120675fac
 )
 
-replace github.com/tikv/client-go/v2 => github.com/crazycs520/client-go/v2 v2.0.0-alpha.0.20231104022544-2fde36372134
+replace github.com/tikv/client-go/v2 => github.com/crazycs520/client-go/v2 v2.0.0-alpha.0.20231104024048-0bb32a7d1bd3

--- a/go.mod
+++ b/go.mod
@@ -270,3 +270,5 @@ replace (
 	github.com/pingcap/tidb/parser => ./parser
 	go.opencensus.io => go.opencensus.io v0.23.1-0.20220331163232-052120675fac
 )
+
+replace github.com/tikv/client-go/v2 => github.com/crazycs520/client-go/v2 v2.0.0-alpha.0.20231104022544-2fde36372134

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/crazycs520/client-go/v2 v2.0.0-alpha.0.20231104022544-2fde36372134 h1:hyX7jBgI/Uw9ABUi4AC/Yb9w4GrRvS9YBNqizB03f10=
-github.com/crazycs520/client-go/v2 v2.0.0-alpha.0.20231104022544-2fde36372134/go.mod h1:mmVCLP2OqWvQJPOIevQPZvGphzh/oq9vv8J5LDfpadQ=
+github.com/crazycs520/client-go/v2 v2.0.0-alpha.0.20231104024048-0bb32a7d1bd3 h1:FKCcW3XhUiJ9SDo8t5eejClL7f4r1nxlnJCRlJRYAzU=
+github.com/crazycs520/client-go/v2 v2.0.0-alpha.0.20231104024048-0bb32a7d1bd3/go.mod h1:mmVCLP2OqWvQJPOIevQPZvGphzh/oq9vv8J5LDfpadQ=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 h1:iwZdTE0PVqJCos1vaoKsclOGD3ADKpshg3SRtYBbwso=

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/crazycs520/client-go/v2 v2.0.0-alpha.0.20231104022544-2fde36372134 h1:hyX7jBgI/Uw9ABUi4AC/Yb9w4GrRvS9YBNqizB03f10=
+github.com/crazycs520/client-go/v2 v2.0.0-alpha.0.20231104022544-2fde36372134/go.mod h1:mmVCLP2OqWvQJPOIevQPZvGphzh/oq9vv8J5LDfpadQ=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 h1:iwZdTE0PVqJCos1vaoKsclOGD3ADKpshg3SRtYBbwso=
@@ -935,8 +937,6 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
-github.com/tikv/client-go/v2 v2.0.4-0.20231020030327-4ecf7c282e37 h1:x4x8yO7tHtxOepMGpPnnLMVw2geDsrYbbbB7k+0zusY=
-github.com/tikv/client-go/v2 v2.0.4-0.20231020030327-4ecf7c282e37/go.mod h1:mmVCLP2OqWvQJPOIevQPZvGphzh/oq9vv8J5LDfpadQ=
 github.com/tikv/pd/client v0.0.0-20221031025758-80f0d8ca4d07 h1:ckPpxKcl75mO2N6a4cJXiZH43hvcHPpqc9dh1TmH1nc=
 github.com/tikv/pd/client v0.0.0-20221031025758-80f0d8ca4d07/go.mod h1:CipBxPfxPUME+BImx9MUYXCnAVLS3VJUr3mnSJwh40A=
 github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144 h1:kl4KhGNsJIbDHS9/4U9yQo1UcPQM0kOMJHn29EoH/Ro=

--- a/infoschema/cache.go
+++ b/infoschema/cache.go
@@ -109,15 +109,16 @@ func (h *InfoCache) getSchemaByTimestampNoLock(ts uint64) (InfoSchema, bool) {
 	// moreover, the most likely hit element in the array is the first one in steady mode
 	// thus it may have better performance than binary search
 	for i, is := range h.cache {
-		if is.timestamp == 0 || (i > 0 && h.cache[i-1].infoschema.SchemaMetaVersion() != is.infoschema.SchemaMetaVersion()+1) {
-			// the schema version doesn't have a timestamp or there is a gap in the schema cache
-			// ignore all the schema cache equals or less than this version in search by timestamp
-			break
+		if is.timestamp == 0 || ts < uint64(is.timestamp) {
+			continue
 		}
-		if ts >= uint64(is.timestamp) {
-			// found the largest version before the given ts
+		if i == 0 {
 			return is.infoschema, true
 		}
+		if h.cache[i-1].infoschema.SchemaMetaVersion() == is.infoschema.SchemaMetaVersion()+1 && uint64(h.cache[i-1].timestamp) > ts {
+			return is.infoschema, true
+		}
+		break
 	}
 
 	logutil.BgLogger().Debug("SCHEMA CACHE no schema found")

--- a/infoschema/cache_test.go
+++ b/infoschema/cache_test.go
@@ -15,6 +15,7 @@
 package infoschema_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pingcap/tidb/infoschema"
@@ -210,4 +211,83 @@ func TestReSize(t *testing.T) {
 	require.Nil(t, ic.GetByVersion(2))
 	require.Nil(t, ic.GetByVersion(3))
 	require.Equal(t, is4, ic.GetByVersion(4))
+}
+
+func TestCacheWithSchemaTsZero(t *testing.T) {
+	ic := infoschema.NewCache(16)
+	require.NotNil(t, ic)
+
+	for i := 1; i <= 8; i++ {
+		ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, int64(i)), uint64(i))
+	}
+
+	checkFn := func(start, end int64, exist bool) {
+		require.True(t, start <= end)
+		latestSchemaVersion := ic.GetLatest().SchemaMetaVersion()
+		for ts := start; ts <= end; ts++ {
+			is := ic.GetBySnapshotTS(uint64(ts))
+			if exist {
+				require.NotNil(t, is, fmt.Sprintf("ts %d", ts))
+				if ts > latestSchemaVersion {
+					require.Equal(t, latestSchemaVersion, is.SchemaMetaVersion(), fmt.Sprintf("ts %d", ts))
+				} else {
+					require.Equal(t, ts, is.SchemaMetaVersion(), fmt.Sprintf("ts %d", ts))
+				}
+			} else {
+				require.Nil(t, is, fmt.Sprintf("ts %d", ts))
+			}
+		}
+	}
+	checkFn(1, 8, true)
+	checkFn(8, 10, true)
+
+	// mock for meet error There is no Write MVCC info for the schema version
+	ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, 9), 0)
+	checkFn(1, 7, true)
+	checkFn(8, 9, false)
+	checkFn(9, 10, false)
+
+	for i := 10; i <= 16; i++ {
+		ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, int64(i)), uint64(i))
+		checkFn(1, 7, true)
+		checkFn(8, 9, false)
+		checkFn(10, 16, true)
+	}
+	require.Equal(t, 16, ic.Size())
+
+	// refill the cache
+	ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, 9), 9)
+	checkFn(1, 16, true)
+	require.Equal(t, 16, ic.Size())
+
+	// Test more than capacity
+	ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, 17), 17)
+	checkFn(1, 1, false)
+	checkFn(2, 17, true)
+	checkFn(2, 20, true)
+	require.Equal(t, 16, ic.Size())
+
+	// Test for there is a hole in the middle.
+	ic = infoschema.NewCache(16)
+
+	// mock for restart with full load the latest version schema.
+	ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, 100), 100)
+	checkFn(1, 99, false)
+	checkFn(100, 100, true)
+
+	for i := 1; i <= 16; i++ {
+		ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, int64(i)), uint64(i))
+	}
+	checkFn(1, 1, false)
+	checkFn(2, 15, true)
+	checkFn(16, 16, false)
+	checkFn(100, 100, true)
+	require.Equal(t, 16, ic.Size())
+
+	for i := 85; i < 100; i++ {
+		ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, int64(i)), uint64(i))
+	}
+	checkFn(1, 84, false)
+	checkFn(85, 100, true)
+	require.Equal(t, 16, ic.Size())
 }

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -94,9 +94,12 @@ func NewHelper(store Storage) *Helper {
 	}
 }
 
-// GetMvccByEncodedKey get the MVCC value by the specific encoded key.
-func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyResponse, error) {
-	bo := tikv.NewBackofferWithVars(context.Background(), 5000, nil)
+// MaxBackoffTimeoutForMvccGet is a derived value from previous implementation possible experiencing value 5000ms.
+const MaxBackoffTimeoutForMvccGet = 5000
+
+// GetMvccByEncodedKeyWithTS get the MVCC value by the specific encoded key, if lock is encountered it would be resolved.
+func (h *Helper) GetMvccByEncodedKeyWithTS(encodedKey kv.Key, startTS uint64) (*kvrpcpb.MvccGetByKeyResponse, error) {
+	bo := tikv.NewBackofferWithVars(context.Background(), MaxBackoffTimeoutForMvccGet, nil)
 	tikvReq := tikvrpc.NewRequest(tikvrpc.CmdMvccGetByKey, &kvrpcpb.MvccGetByKeyRequest{Key: encodedKey})
 	for {
 		keyLocation, err := h.RegionCache.LocateKey(bo, encodedKey)
@@ -106,7 +109,7 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 
 		kvResp, err := h.Store.SendReq(bo, tikvReq, keyLocation.Region, time.Minute)
 		if err != nil {
-			logutil.BgLogger().Info("get MVCC by encoded key failed",
+			logutil.BgLogger().Warn("get MVCC by encoded key failed",
 				zap.Stringer("encodeKey", encodedKey),
 				zap.Reflect("region", keyLocation.Region),
 				zap.Stringer("keyLocation", keyLocation),
@@ -114,6 +117,7 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 				zap.Error(err))
 			return nil, errors.Trace(err)
 		}
+
 		regionErr, err := kvResp.GetRegionError()
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -124,9 +128,10 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 			}
 			continue
 		}
+
 		mvccResp := kvResp.Resp.(*kvrpcpb.MvccGetByKeyResponse)
 		if errMsg := mvccResp.GetError(); errMsg != "" {
-			logutil.BgLogger().Info("get MVCC by encoded key failed",
+			logutil.BgLogger().Warn("get MVCC by encoded key failed",
 				zap.Stringer("encodeKey", encodedKey),
 				zap.Reflect("region", keyLocation.Region),
 				zap.Stringer("keyLocation", keyLocation),
@@ -134,8 +139,57 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 				zap.String("error", errMsg))
 			return nil, errors.New(errMsg)
 		}
+		if mvccResp.Info == nil {
+			errMsg := "Invalid mvcc response result, the info field is nil"
+			logutil.BgLogger().Warn(errMsg,
+				zap.Stringer("encodeKey", encodedKey),
+				zap.Reflect("region", keyLocation.Region),
+				zap.Stringer("keyLocation", keyLocation),
+				zap.Reflect("kvResp", kvResp))
+			return nil, errors.New(errMsg)
+		}
+
+		// Try to resolve the lock and retry mvcc get again if the input startTS is a valid value.
+		if startTS > 0 && mvccResp.Info.GetLock() != nil {
+			lockInfo := mvccResp.Info.GetLock()
+			lock := &txnlock.Lock{
+				Key:             []byte(encodedKey),
+				Primary:         lockInfo.GetPrimary(),
+				TxnID:           lockInfo.GetStartTs(),
+				TTL:             lockInfo.GetTtl(),
+				TxnSize:         lockInfo.GetTxnSize(),
+				LockType:        lockInfo.GetType(),
+				UseAsyncCommit:  lockInfo.GetUseAsyncCommit(),
+				LockForUpdateTS: lockInfo.GetForUpdateTs(),
+			}
+			// Disable for read to avoid async resolve.
+			resolveLocksOpts := txnlock.ResolveLocksOptions{
+				CallerStartTS: startTS,
+				Locks:         []*txnlock.Lock{lock},
+				Lite:          true,
+				ForRead:       false,
+				Detail:        nil,
+			}
+			resolveLockRes, err := h.Store.GetLockResolver().ResolveLocksWithOpts(bo, resolveLocksOpts)
+			if err != nil {
+				return nil, err
+			}
+			msBeforeExpired := resolveLockRes.TTL
+			if msBeforeExpired > 0 {
+				if err = bo.BackoffWithCfgAndMaxSleep(tikv.BoTxnLock(), int(msBeforeExpired),
+					errors.Errorf("resolve lock fails lock: %v", lock)); err != nil {
+					return nil, err
+				}
+			}
+			continue
+		}
 		return mvccResp, nil
 	}
+}
+
+// GetMvccByEncodedKey get the MVCC value by the specific encoded key.
+func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyResponse, error) {
+	return h.GetMvccByEncodedKeyWithTS(encodedKey, 0)
 }
 
 // MvccKV wraps the key's mvcc info in tikv.

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -152,6 +152,11 @@ func (h *Helper) GetMvccByEncodedKeyWithTS(encodedKey kv.Key, startTS uint64) (*
 		// Try to resolve the lock and retry mvcc get again if the input startTS is a valid value.
 		if startTS > 0 && mvccResp.Info.GetLock() != nil {
 			lockInfo := mvccResp.Info.GetLock()
+			logutil.BgLogger().Info("get MVCC by encoded key encounter lock",
+				zap.Stringer("encodeKey", encodedKey),
+				zap.Reflect("region", keyLocation.Region),
+				zap.Stringer("keyLocation", keyLocation),
+				zap.Any("lock", lockInfo))
 			lock := &txnlock.Lock{
 				Key:             []byte(encodedKey),
 				Primary:         lockInfo.GetPrimary(),


### PR DESCRIPTION
### What is changed and how it works?

This PR contains following PR:

- https://github.com/pingcap/tidb/pull/48293
- https://github.com/pingcap/tidb/pull/48282

And this PR add debug log and injected sleep before commit secondaries for DDL transaction.

Test

***workload***

stale read and write

```shell
sysbench --config-file=sysbench.conf stale_read.lua --threads=20 --read_staleness=-60 --kv_read_timeout=100 --max_execution_time=400 --mysql-ignore-errors=all run
```

DDL workload:

```shell
bin/loadgen bench --sql="create database test0;create table test0.t0 (a int);drop table test0.t0;drop database test0;select sleep(2);" --thread 1 
```



And TiDB have many following lock, indicate that get schema diff mvcc info meet lock.

```
> rg 'encoded key encounter lock'
tidb.log:[2023/11/04 10:44:49.559 +08:00] [INFO] [helper.go:155] ["get MVCC by encoded key encounter lock"] [encodeKey=6d446966663a323033ff3800000000000000f80000000000000073] [region={}] [keyLocation="region { region id: 29, ver: 7, confVer: 17 },startKey:6d446966663a313930ff3100000000000000f80000000000000073,endKey:748000000000000004"] [lock="start_ts:445399928546263069 primary:\"mDB:1579\\000\\376\\000\\000\\000\\000\\000\\000\\000hTable:15\\37781\\000\\000\\000\\000\\000\\000\\371\" short_value:\"{\\\"version\\\":2038,\\\"type\\\":3,\\\"schema_id\\\":1579,\\\"table_id\\\":1581,\\\"old_table_id\\\":0,\\\"old_schema_id\\\":0,\\\"affected_options\\\":null}\" "]
tidb.log:[2023/11/04 10:44:49.716 +08:00] [INFO] [helper.go:155] ["get MVCC by encoded key encounter lock"] [encodeKey=6d446966663a323034ff3000000000000000f80000000000000073] [region={}] [keyLocation="region { region id: 29, ver: 7, confVer: 17 },startKey:6d446966663a313930ff3100000000000000f80000000000000073,endKey:748000000000000004"] [lock="start_ts:445399928585584664 primary:\"mDB:1579\\000\\376\\000\\000\\000\\000\\000\\000\\000hTable:15\\37781\\000\\000\\000\\000\\000\\000\\371\" short_value:\"{\\\"version\\\":2040,\\\"type\\\":4,\\\"schema_id\\\":1579,\\\"table_id\\\":1581,\\\"old_table_id\\\":0,\\\"old_schema_id\\\":0,\\\"affected_options\\\":null}\" "]
tidb.log:[2023/11/04 10:44:49.784 +08:00] [INFO] [helper.go:155] ["get MVCC by encoded key encounter lock"] [encodeKey=6d446966663a323034ff3100000000000000f80000000000000073] [region={}] [keyLocation="region { region id: 29, ver: 7, confVer: 17 },startKey:6d446966663a313930ff3100000000000000f80000000000000073,endKey:748000000000000004"] [lock="start_ts:445399928598691882 primary:\"mDB:1579\\000\\376\\000\\000\\000\\000\\000\\000\\000hTable:15\\37781\\000\\000\\000\\000\\000\\000\\371\" short_value:\"{\\\"version\\\":2041,\\\"type\\\":4,\\\"schema_id\\\":1579,\\\"table_id\\\":1581,\\\"old_table_id\\\":0,\\\"old_schema_id\\\":0,\\\"affected_options\\\":null}\" "]
tidb.log:[2023/11/04 10:44:49.962 +08:00] [INFO] [helper.go:155] ["get MVCC by encoded key encounter lock"] [encodeKey=6d446966663a323034ff3300000000000000f80000000000000073] [region={}] [keyLocation="region { region id: 29, ver: 7, confVer: 17 },startKey:6d446966663a313930ff3100000000000000f80000000000000073,endKey:748000000000000004"] [lock="start_ts:445399928651120663 primary:\"mDBs\\000\\000\\000\\000\\000\\372\\000\\000\\000\\000\\000\\000\\000hDB:1579\\000\\376\" short_value:\"{\\\"version\\\":2043,\\\"type\\\":2,\\\"schema_id\\\":1579,\\\"table_id\\\":0,\\\"old_table_id\\\":0,\\\"old_schema_id\\\":0,\\\"affected_options\\\":null}\" "]
...
58900:[2023/11/04 11:07:39.227 +08:00] [INFO] [helper.go:155] ["get MVCC by encoded key encounter lock"] [encodeKey=6d446966663a353935ff3600000000000000f80000000000000073] [region={}] [keyLocation="region { region id: 2105, ver: 9, confVer: 17 },startKey:6d446966663a313936ff3400000000000000f80000000000000073,endKey:6d536368656d615665ff7273696f6e4b6579ff0000000000000000f70000000000000073"] [lock="start_ts:445400287591792688 primary:\"mDBs\\000\\000\\000\\000\\000\\372\\000\\000\\000\\000\\000\\000\\000hDB:4513\\000\\376\" short_value:\"{\\\"version\\\":5956,\\\"type\\\":2,\\\"schema_id\\\":4513,\\\"table_id\\\":0,\\\"old_table_id\\\":0,\\\"old_schema_id\\\":0,\\\"affected_options\\\":null}\" "]
58941:[2023/11/04 11:07:41.636 +08:00] [INFO] [helper.go:155] ["get MVCC by encoded key encounter lock"] [encodeKey=6d446966663a353935ff3900000000000000f80000000000000073] [region={}] [keyLocation="region { region id: 2105, ver: 9, confVer: 17 },startKey:6d446966663a313936ff3400000000000000f80000000000000073,endKey:6d536368656d615665ff7273696f6e4b6579ff0000000000000000f70000000000000073"] [lock="start_ts:445400288221200431 primary:\"mDB:4519\\000\\376\\000\\000\\000\\000\\000\\000\\000hTable:45\\37721\\000\\000\\000\\000\\000\\000\\371\" short_value:\"{\\\"version\\\":5959,\\\"type\\\":4,\\\"schema_id\\\":4519,\\\"table_id\\\":4521,\\\"old_table_id\\\":0,\\\"old_schema_id\\\":0,\\\"affected_options\\\":null}\" "]
58948:[2023/11/04 11:07:41.738 +08:00] [INFO] [helper.go:155] ["get MVCC by encoded key encounter lock"] [encodeKey=6d446966663a353936ff3000000000000000f80000000000000073] [region={}] [keyLocation="region { region id: 2105, ver: 9, confVer: 17 },startKey:6d446966663a313936ff3400000000000000f80000000000000073,endKey:6d536368656d615665ff7273696f6e4b6579ff0000000000000000f70000000000000073"] [lock="start_ts:445400288247152696 primary:\"mDB:4519\\000\\376\\000\\000\\000\\000\\000\\000\\000hTable:45\\37721\\000\\000\\000\\000\\000\\000\\371\" short_value:\"{\\\"version\\\":5960,\\\"type\\\":4,\\\"schema_id\\\":4519,\\\"table_id\\\":4521,\\\"old_table_id\\\":0,\\\"old_schema_id\\\":0,\\\"affected_options\\\":null}\" "]
58956:[2023/11/04 11:07:41.839 +08:00] [INFO] [helper.go:155] ["get MVCC by encoded key encounter lock"] [encodeKey=6d446966663a353936ff3100000000000000f80000000000000073] [region={}] [keyLocation="region { region id: 2105, ver: 9, confVer: 17 },startKey:6d446966663a313936ff3400000000000000f80000000000000073,endKey:6d536368656d615665ff7273696f6e4b6579ff0000000000000000f70000000000000073"] [lock="start_ts:445400288273367101 primary:\"mDB:4519\\000\\376\\000\\000\\000\\000\\000\\000\\000hTable:45\\37721\\000\\000\\000\\000\\000\\000\\371\" short_value:\"{\\\"version\\\":5961,\\\"type\\\":4,\\\"schema_id\\\":4519,\\\"table_id\\\":4521,\\\"old_table_id\\\":0,\\\"old_schema_id\\\":0,\\\"affected_options\\\":null}\" "]
58971:[2023/11/04 11:07:41.992 +08:00] [INFO] [helper.go:155] ["get MVCC by encoded key encounter lock"] [encodeKey=6d446966663a353936ff3200000000000000f80000000000000073] [region={}] [keyLocation="region { region id: 2105, ver: 9, confVer: 17 },startKey:6d446966663a313936ff3400000000000000f80000000000000073,endKey:6d536368656d615665ff7273696f6e4b6579ff0000000000000000f70000000000000073"] [lock="start_ts:445400288312688719 primary:\"mDBs\\000\\000\\000\\000\\000\\372\\000\\000\\000\\000\\000\\000\\000hDB:4519\\000\\376\" short_value:\"{\\\"version\\\":5962,\\\"type\\\":2,\\\"schema_id\\\":4519,\\\"table_id\\\":0,\\\"old_table_id\\\":0,\\\"old_schema_id\\\":0,\\\"affected_options\\\":null}\" "]
58979:[2023/11/04 11:07:42.094 +08:00] [INFO] [helper.go:155] ["get MVCC by encoded key encounter lock"] [encodeKey=6d446966663a353936ff3300000000000000f80000000000000073] [region={}] [keyLocation="region { region id: 2105, ver: 9, confVer: 17 },startKey:6d446966663a313936ff3400000000000000f80000000000000073,endKey:6d536368656d615665ff7273696f6e4b6579ff0000000000000000f70000000000000073"] [lock="start_ts:445400288352010242 primary:\"mDBs\\000\\000\\000\\000\\000\\372\\000\\000\\000\\000\\000\\000\\000hDB:4519\\000\\376\" short_value:\"{\\\"version\\\":5963,\\\"type\\\":2,\\\"schema_id\\\":4519,\\\"table_id\\\":0,\\\"old_table_id\\\":0,\\\"old_schema_id\\\":0,\\\"affected_options\\\":null}\" "]
...
...
...
>  rg 'encoded key encounter lock' | wc
   1967   55076 1406522
```

And there is no `failed to get schema version` log:

```shell
# rg 'failed to get schema version' | rg -v 'version=0'
# rg 'failed to get schema version' | rg -v 'version=0' | wc
      0       0       0
#
```

The  metrics is:

<img width="1446" alt="image" src="https://github.com/pingcap/tidb/assets/26020263/937577a1-215b-4c0c-8efb-c25c222326af">

