### PR TITLE
planner/core: keep sort operator when ordered by tablesample

### DIFF
--- a/tests/integrationtest/r/executor/sample.result
+++ b/tests/integrationtest/r/executor/sample.result
@@ -178,12 +178,14 @@ a
 2100
 4500
 select a from t use index (idx_0) tablesample regions() order by a;
-a
-1000
-1001
-2100
-4500
-show warnings;
-Level	Code	Message
-Warning	8128	Invalid TABLESAMPLE: plan not supported
+Error 8128 (HY000): Invalid TABLESAMPLE: plan not supported
+DROP TABLE IF EXISTS a;
+CREATE TABLE a (pk bigint unsigned primary key clustered, v text);
+INSERT INTO a WITH RECURSIVE b(pk) AS (SELECT 1 UNION ALL SELECT pk+1 FROM b WHERE pk < 1000) SELECT pk, 'a' FROM b;
+INSERT INTO a WITH RECURSIVE b(pk) AS (SELECT 1 UNION ALL SELECT pk+1 FROM b WHERE pk < 1000) SELECT pk + (1<<63), 'b' FROM b;
+SPLIT TABLE a BY (500);
+SELECT * FROM a TABLESAMPLE REGIONS() ORDER BY pk;
+pk	v
+500	a
+9223372036854775809	b
 set @@global.tidb_scatter_region=default;

--- a/tests/integrationtest/t/executor/sample.test
+++ b/tests/integrationtest/t/executor/sample.test
@@ -119,7 +119,15 @@ split table t between (0) and (10000) regions 5;
 insert into t values (1000, 1, '1'), (1001, 1, '1'), (2100, 2, '2'), (4500, 3, '3');
 create index idx_0 on t (b);
 select a from t tablesample regions() order by a;
+-- error 8128
 select a from t use index (idx_0) tablesample regions() order by a;
-show warnings;
+
+# TestTableSampleUnsignedIntHandle
+DROP TABLE IF EXISTS a;
+CREATE TABLE a (pk bigint unsigned primary key clustered, v text);
+INSERT INTO a WITH RECURSIVE b(pk) AS (SELECT 1 UNION ALL SELECT pk+1 FROM b WHERE pk < 1000) SELECT pk, 'a' FROM b;
+INSERT INTO a WITH RECURSIVE b(pk) AS (SELECT 1 UNION ALL SELECT pk+1 FROM b WHERE pk < 1000) SELECT pk + (1<<63), 'b' FROM b;
+SPLIT TABLE a BY (500);
+SELECT * FROM a TABLESAMPLE REGIONS() ORDER BY pk;
 
 set @@global.tidb_scatter_region=default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48253

Problem Summary:

`TableSampleExecutor` does not process unsigned int handles. They are treated as the signed handles.

### What is changed and how it works?

Always keep the sort operator when a `TABLESAMPLE` query contains `ORDER BY` clause.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
