### PR TITLE
copr: fix copr cache panic when `tidb_enable_collect_execution_info` is off

### DIFF
--- a/pkg/executor/distsql_test.go
+++ b/pkg/executor/distsql_test.go
@@ -569,3 +569,25 @@ func TestCoprocessorBatchByStore(t *testing.T) {
 		}
 	}
 }
+
+func TestCoprCacheWithoutExecutionInfo(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk1 := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id int)")
+	tk.MustExec("insert into t values(1), (2), (3)")
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/cophandler/mockCopCacheInUnistore", `return(123)`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/cophandler/mockCopCacheInUnistore"))
+	}()
+
+	defer tk.MustExec("set @@tidb_enable_collect_execution_info=1")
+	ctx := context.WithValue(context.Background(), "CheckSelectRequestHook", func(_ *kv.Request) {
+		tk1.MustExec("set @@tidb_enable_collect_execution_info=0")
+	})
+	tk.MustQuery("select * from t").Check(testkit.Rows("1", "2", "3"))
+	tk.MustQueryWithContext(ctx, "select * from t").Check(testkit.Rows("1", "2", "3"))
+}

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1685,7 +1685,13 @@ func (worker *copIteratorWorker) handleCopCache(task *copTask, resp *copResponse
 				resp.pbResp.Range = nil
 			}
 		}
-		resp.detail.CoprCacheHit = true
+		// If the coprocessor cache key of the task is same whether `worker.enableCollectExecutionInfo` is true or false,
+		// the cache may be hit when `worker.enableCollectExecutionInfo` is false, but the `detail` is nil.
+		// Check `resp.detail` to avoid panic.
+		// Details: https://github.com/pingcap/tidb/issues/48212
+		if resp.detail != nil {
+			resp.detail.CoprCacheHit = true
+		}
 		return nil
 	}
 	copr_metrics.CoprCacheCounterMiss.Add(1)

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1685,8 +1685,9 @@ func (worker *copIteratorWorker) handleCopCache(task *copTask, resp *copResponse
 				resp.pbResp.Range = nil
 			}
 		}
-		// If the coprocessor cache key of the task is same whether `worker.enableCollectExecutionInfo` is true or false,
-		// the cache may be hit when `worker.enableCollectExecutionInfo` is false, but the `detail` is nil.
+		// `worker.enableCollectExecutionInfo` is loaded from the instance's config. Because it's not related to the request,
+		// the cache key can be same when `worker.enableCollectExecutionInfo` is true or false.
+		// When `worker.enableCollectExecutionInfo` is false, the `resp.detail` is nil, and hit cache is still possible.
 		// Check `resp.detail` to avoid panic.
 		// Details: https://github.com/pingcap/tidb/issues/48212
 		if resp.detail != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48212

Problem Summary:

Goroutine panic because of nil pointer dereference.

### What is changed and how it works?

When coprocessor cache is hit, check the details before set execution info.

Because some internal tasks may lead to cache hit when `tidb_enable_collect_execution_info` is turned off, so this need to be checked.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  



```bash
# shell1
tiup playground nightly --kv=3 --mode=tikv-slim
# shell2
export TIKV_PATH=127.0.0.1:2379
export TIDB_TEST_STORE_NAME=tikv
make integrationtest
```

- Before

It may panic like the log in #48212

- After

No panic

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
