### PR TITLE
disttask: correct the usage of context

### DIFF
--- a/tests/realtikvtest/addindextest1/BUILD.bazel
+++ b/tests/realtikvtest/addindextest1/BUILD.bazel
@@ -11,6 +11,10 @@ go_test(
     deps = [
         "//pkg/config",
         "//pkg/ddl",
+        "//pkg/ddl/util/callback",
+        "//pkg/disttask/framework/dispatcher",
+        "//pkg/disttask/framework/proto",
+        "//pkg/parser/model",
         "//pkg/testkit",
         "//tests/realtikvtest",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/tests/realtikvtest/addindextest1/BUILD.bazel
+++ b/tests/realtikvtest/addindextest1/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "addindextest1_test",
-    timeout = "short",
+    timeout = "long",
     srcs = [
         "disttask_test.go",
         "main_test.go",

--- a/tests/realtikvtest/addindextest1/disttask_test.go
+++ b/tests/realtikvtest/addindextest1/disttask_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
+	"github.com/pingcap/tidb/pkg/ddl/util/callback"
+	"github.com/pingcap/tidb/pkg/disttask/framework/dispatcher"
+	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
+	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/tests/realtikvtest"
 	"github.com/stretchr/testify/require"
@@ -118,74 +122,73 @@ func TestAddIndexDistCancel(t *testing.T) {
 	tk.MustExec(`set global tidb_enable_dist_task=0;`)
 }
 
-// TODO: flaky test which can't find the root cause, will run it later.
-// func TestAddIndexDistPauseAndResume(t *testing.T) {
-// 	store, dom := realtikvtest.CreateMockStoreAndDomainAndSetup(t)
-// 	if store.Name() != "TiKV" {
-// 		t.Skip("TiKV store only")
-// 	}
+func TestAddIndexDistPauseAndResume(t *testing.T) {
+	store, dom := realtikvtest.CreateMockStoreAndDomainAndSetup(t)
+	if store.Name() != "TiKV" {
+		t.Skip("TiKV store only")
+	}
 
-// 	tk := testkit.NewTestKit(t, store)
-// 	tk1 := testkit.NewTestKit(t, store)
-// 	tk.MustExec("drop database if exists test;")
-// 	tk.MustExec("create database test;")
-// 	tk.MustExec("use test;")
+	tk := testkit.NewTestKit(t, store)
+	tk1 := testkit.NewTestKit(t, store)
+	tk.MustExec("drop database if exists test;")
+	tk.MustExec("create database test;")
+	tk.MustExec("use test;")
 
-// 	tk.MustExec("create table t(a bigint auto_random primary key) partition by hash(a) partitions 8;")
-// 	tk.MustExec("insert into t values (), (), (), (), (), ()")
-// 	tk.MustExec("insert into t values (), (), (), (), (), ()")
-// 	tk.MustExec("insert into t values (), (), (), (), (), ()")
-// 	tk.MustExec("insert into t values (), (), (), (), (), ()")
-// 	tk.MustExec("split table t between (3) and (8646911284551352360) regions 50;")
+	tk.MustExec("create table t(a bigint auto_random primary key) partition by hash(a) partitions 8;")
+	tk.MustExec("insert into t values (), (), (), (), (), ()")
+	tk.MustExec("insert into t values (), (), (), (), (), ()")
+	tk.MustExec("insert into t values (), (), (), (), (), ()")
+	tk.MustExec("insert into t values (), (), (), (), (), ()")
+	tk.MustExec("split table t between (3) and (8646911284551352360) regions 50;")
 
-// 	ddl.MockDMLExecutionAddIndexSubTaskFinish = func() {
-// 		row := tk1.MustQuery("select job_id from mysql.tidb_ddl_job").Rows()
-// 		require.Equal(t, 1, len(row))
-// 		jobID := row[0][0].(string)
-// 		tk1.MustExec("admin pause ddl jobs " + jobID)
-// 		<-ddl.TestSyncChan
-// 	}
+	ddl.MockDMLExecutionAddIndexSubTaskFinish = func() {
+		row := tk1.MustQuery("select job_id from mysql.tidb_ddl_job").Rows()
+		require.Equal(t, 1, len(row))
+		jobID := row[0][0].(string)
+		tk1.MustExec("admin pause ddl jobs " + jobID)
+		<-ddl.TestSyncChan
+	}
 
-// 	dispatcher.MockDMLExecutionOnPausedState = func(task *proto.Task) {
-// 		row := tk1.MustQuery("select job_id from mysql.tidb_ddl_job").Rows()
-// 		require.Equal(t, 1, len(row))
-// 		jobID := row[0][0].(string)
-// 		tk1.MustExec("admin resume ddl jobs " + jobID)
-// 	}
+	dispatcher.MockDMLExecutionOnPausedState = func(task *proto.Task) {
+		row := tk1.MustQuery("select job_id from mysql.tidb_ddl_job").Rows()
+		require.Equal(t, 1, len(row))
+		jobID := row[0][0].(string)
+		tk1.MustExec("admin resume ddl jobs " + jobID)
+	}
 
-// 	ddl.MockDMLExecutionOnTaskFinished = func() {
-// 		row := tk1.MustQuery("select job_id from mysql.tidb_ddl_job").Rows()
-// 		require.Equal(t, 1, len(row))
-// 		jobID := row[0][0].(string)
-// 		tk1.MustExec("admin pause ddl jobs " + jobID)
-// 	}
+	ddl.MockDMLExecutionOnTaskFinished = func() {
+		row := tk1.MustQuery("select job_id from mysql.tidb_ddl_job").Rows()
+		require.Equal(t, 1, len(row))
+		jobID := row[0][0].(string)
+		tk1.MustExec("admin pause ddl jobs " + jobID)
+	}
 
-// 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockDMLExecutionAddIndexSubTaskFinish", "3*return(true)"))
-// 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/disttask/framework/dispatcher/mockDMLExecutionOnPausedState", "return(true)"))
-// 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/syncDDLTaskPause", "return()"))
-// 	tk.MustExec(`set global tidb_enable_dist_task=1;`)
-// 	tk.MustExec("alter table t add index idx1(a);")
-// 	tk.MustExec("admin check table t;")
-// 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockDMLExecutionAddIndexSubTaskFinish"))
-// 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/dispatcher/mockDMLExecutionOnPausedState"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockDMLExecutionAddIndexSubTaskFinish", "3*return(true)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/disttask/framework/dispatcher/mockDMLExecutionOnPausedState", "return(true)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/syncDDLTaskPause", "return()"))
+	tk.MustExec(`set global tidb_enable_dist_task=1;`)
+	tk.MustExec("alter table t add index idx1(a);")
+	tk.MustExec("admin check table t;")
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockDMLExecutionAddIndexSubTaskFinish"))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/dispatcher/mockDMLExecutionOnPausedState"))
 
-// 	// dist task succeed, job paused and resumed.
-// 	var hook = &callback.TestDDLCallback{Do: dom}
-// 	var resumeFunc = func(job *model.Job) {
-// 		if job.IsPaused() {
-// 			row := tk1.MustQuery("select job_id from mysql.tidb_ddl_job").Rows()
-// 			require.Equal(t, 1, len(row))
-// 			jobID := row[0][0].(string)
-// 			tk1.MustExec("admin resume ddl jobs " + jobID)
-// 		}
-// 	}
-// 	hook.OnJobUpdatedExported.Store(&resumeFunc)
-// 	dom.DDL().SetHook(hook.Clone())
-// 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/pauseAfterDistTaskFinished", "1*return(true)"))
-// 	tk.MustExec("alter table t add index idx3(a);")
-// 	tk.MustExec("admin check table t;")
-// 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/pauseAfterDistTaskFinished"))
-// 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/syncDDLTaskPause"))
+	// dist task succeed, job paused and resumed.
+	var hook = &callback.TestDDLCallback{Do: dom}
+	var resumeFunc = func(job *model.Job) {
+		if job.IsPaused() {
+			row := tk1.MustQuery("select job_id from mysql.tidb_ddl_job").Rows()
+			require.Equal(t, 1, len(row))
+			jobID := row[0][0].(string)
+			tk1.MustExec("admin resume ddl jobs " + jobID)
+		}
+	}
+	hook.OnJobUpdatedExported.Store(&resumeFunc)
+	dom.DDL().SetHook(hook.Clone())
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/pauseAfterDistTaskFinished", "1*return(true)"))
+	tk.MustExec("alter table t add index idx3(a);")
+	tk.MustExec("admin check table t;")
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/pauseAfterDistTaskFinished"))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/syncDDLTaskPause"))
 
-// 	tk.MustExec(`set global tidb_enable_dist_task=0;`)
-// }
+	tk.MustExec(`set global tidb_enable_dist_task=0;`)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48303

Problem Summary:

After cancelling the job, I found that the ingest worker did not stop. Instead, it was waiting for the server side(TiKV):

```
11 @ 0x1c2d6ee 0x1c3e185 0x21cf23c 0x225699a 0x2256987 0x2255c1f 0x22548da 0x2255a73 0x3d9bb96 0x3d999f1 0x3d98066 0x3d8942b 0x3d88f47 0x3d8be0e 0x3ac2a96 0x1c625c1
#	0x21cf23b	google.golang.org/grpc/internal/transport.(*Stream).waitOnHeader+0x7b			/go/pkg/mod/google.golang.org/grpc@v1.59.0/internal/transport/transport.go:327
#	0x2256999	google.golang.org/grpc/internal/transport.(*Stream).RecvCompress+0xb9			/go/pkg/mod/google.golang.org/grpc@v1.59.0/internal/transport/transport.go:342
#	0x2256986	google.golang.org/grpc.(*csAttempt).recvMsg+0xa6					/go/pkg/mod/google.golang.org/grpc@v1.59.0/stream.go:1070
#	0x2255c1e	google.golang.org/grpc.(*clientStream).RecvMsg.func1+0x1e				/go/pkg/mod/google.golang.org/grpc@v1.59.0/stream.go:927
#	0x22548d9	google.golang.org/grpc.(*clientStream).withRetry+0x139					/go/pkg/mod/google.golang.org/grpc@v1.59.0/stream.go:776
#	0x2255a72	google.golang.org/grpc.(*clientStream).RecvMsg+0x112					/go/pkg/mod/google.golang.org/grpc@v1.59.0/stream.go:926
#	0x3d9bb95	github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).doWrite.func5+0x2b5	/home/jenkins/agent/workspace/build-common/go/src/github.com/pingcap/tidb/br/pkg/lightning/backend/local/region_job.go:354
#	0x3d999f0	github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).doWrite+0x1890	/home/jenkins/agent/workspace/build-common/go/src/github.com/pingcap/tidb/br/pkg/lightning/backend/local/region_job.go:389
#	0x3d98065	github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).writeToTiKV+0x25	/home/jenkins/agent/workspace/build-common/go/src/github.com/pingcap/tidb/br/pkg/lightning/backend/local/region_job.go:189
#	0x3d8942a	github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).executeJob+0xaa	/home/jenkins/agent/workspace/build-common/go/src/github.com/pingcap/tidb/br/pkg/lightning/backend/local/local.go:1435
#	0x3d88f46	github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).startWorker+0x1c6	/home/jenkins/agent/workspace/build-common/go/src/github.com/pingcap/tidb/br/pkg/lightning/backend/local/local.go:1344
#	0x3d8be0d	github.com/pingcap/tidb/br/pkg/lightning/backend/local.(*Backend).doImport.func5+0x2d	/home/jenkins/agent/workspace/build-common/go/src/github.com/pingcap/tidb/br/pkg/lightning/backend/local/local.go:1677
#	0x3ac2a95	golang.org/x/sync/errgroup.(*Group).Go.func1+0x55
```

Normally, it should quit when the related context is canceled.

```go
func (s *Stream) waitOnHeader() {
	if s.headerChan == nil {
		// On the server headerChan is always nil since a stream originates
		// only after having received headers.
		return
	}
	select {
	case <-s.ctx.Done():
		// Close the stream to prevent headers/trailers from changing after
		// this function returns.
		s.ct.CloseStream(s, ContextErr(s.ctx.Err()))
		// headerChan could possibly not be closed yet if closeStream raced
		// with operateHeaders; wait until it is closed explicitly here.
		<-s.headerChan
	case <-s.headerChan:
	}
}
```

Finally I found that the context passed to the local backend is wrong. It should be "task context" instead of "manager context", because the latter will only be canceled when the TiDB process exits.

As for the problem of getting stuck, there should be other solutions: https://github.com/pingcap/tidb/issues/48352.

### What is changed and how it works?

- For scheduler methods such as `Init()`, `Run()`, `Pause()`, etc., we pass the task context.
- For interactions with the task table, we pass the manager context.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
