### PR TITLE
disttask: fix split region batch panic

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -301,6 +301,7 @@ go_test(
         "//pkg/util/mock",
         "//pkg/util/sem",
         "//pkg/util/sqlexec",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_ngaut_pools//:pools",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/pkg/ddl/backfilling_dispatcher.go
+++ b/pkg/ddl/backfilling_dispatcher.go
@@ -299,16 +299,7 @@ func generateNonPartitionPlan(
 		return nil, err
 	}
 
-	var regionBatch int
-	avgTasksPerInstance := len(recordRegionMetas) / instanceCnt
-	if useCloud {
-		regionBatch = min(100, avgTasksPerInstance)
-	} else {
-		// Make subtask large enough to reduce the overhead of local/global flush.
-		avgTasksPerDisk := int(int64(variable.DDLDiskQuota.Load()) / int64(config.SplitRegionSize))
-		regionBatch = min(avgTasksPerDisk, avgTasksPerInstance)
-	}
-	regionBatch = max(regionBatch, 1)
+	regionBatch := calculateRegionBatch(len(recordRegionMetas), instanceCnt, !useCloud)
 
 	subTaskMetas := make([][]byte, 0, 4)
 	sort.Slice(recordRegionMetas, func(i, j int) bool {
@@ -339,6 +330,20 @@ func generateNonPartitionPlan(
 		subTaskMetas = append(subTaskMetas, metaBytes)
 	}
 	return subTaskMetas, nil
+}
+
+func calculateRegionBatch(totalRegionCnt int, instanceCnt int, useLocalDisk bool) int {
+	var regionBatch int
+	avgTasksPerInstance := totalRegionCnt / instanceCnt
+	if useLocalDisk {
+		// Make subtask large enough to reduce the overhead of local/global flush.
+		avgTasksPerDisk := int(int64(variable.DDLDiskQuota.Load()) / int64(config.SplitRegionSize))
+		regionBatch = min(avgTasksPerDisk, avgTasksPerInstance)
+	} else {
+		regionBatch = min(100, avgTasksPerInstance)
+	}
+	regionBatch = max(regionBatch, 1)
+	return regionBatch
 }
 
 func generateGlobalSortIngestPlan(

--- a/pkg/ddl/backfilling_dispatcher.go
+++ b/pkg/ddl/backfilling_dispatcher.go
@@ -299,13 +299,16 @@ func generateNonPartitionPlan(
 		return nil, err
 	}
 
-	regionBatch := 100
-	if !useCloud {
+	var regionBatch int
+	avgTasksPerInstance := len(recordRegionMetas) / instanceCnt
+	if useCloud {
+		regionBatch = min(100, avgTasksPerInstance)
+	} else {
 		// Make subtask large enough to reduce the overhead of local/global flush.
-		quota := variable.DDLDiskQuota.Load()
-		regionBatch = int(int64(quota) / int64(config.SplitRegionSize))
+		avgTasksPerDisk := int(int64(variable.DDLDiskQuota.Load()) / int64(config.SplitRegionSize))
+		regionBatch = min(avgTasksPerDisk, avgTasksPerInstance)
 	}
-	regionBatch = min(regionBatch, len(recordRegionMetas)/instanceCnt)
+	regionBatch = max(regionBatch, 1)
 
 	subTaskMetas := make([][]byte, 0, 4)
 	sort.Slice(recordRegionMetas, func(i, j int) bool {

--- a/pkg/ddl/export_test.go
+++ b/pkg/ddl/export_test.go
@@ -70,3 +70,6 @@ func ConvertRowToHandleAndIndexDatum(
 
 // ExtractDatumByOffsetsForTest is used for test.
 var ExtractDatumByOffsetsForTest = extractDatumByOffsets
+
+// CalculateRegionBatchForTest is used for test.
+var CalculateRegionBatchForTest = calculateRegionBatch

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -192,3 +192,36 @@ func TestGlobalSortMultiSchemaChange(t *testing.T) {
 	tk.MustExec("set @@global.tidb_enable_dist_task = 0;")
 	tk.MustExec("set @@global.tidb_cloud_storage_uri = '';")
 }
+
+func TestAddIndexIngestShowReorgTp(t *testing.T) {
+	gcsHost, gcsPort, cloudStorageURI := genStorageURI(t)
+	opt := fakestorage.Options{
+		Scheme:     "http",
+		Host:       gcsHost,
+		Port:       gcsPort,
+		PublicHost: gcsHost,
+	}
+	server, err := fakestorage.NewServerWithOptions(opt)
+	require.NoError(t, err)
+	t.Cleanup(server.Stop)
+
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("drop database if exists addindexlit;")
+	tk.MustExec("create database addindexlit;")
+	tk.MustExec("use addindexlit;")
+	tk.MustExec("set @@global.tidb_cloud_storage_uri = '" + cloudStorageURI + "';")
+	tk.MustExec("set @@global.tidb_enable_dist_task = 0;")
+	tk.MustExec("set @@global.tidb_ddl_enable_fast_reorg = 1;")
+
+	tk.MustExec("create table t (a int);")
+	tk.MustExec("insert into t values (1), (2), (3);")
+	tk.MustExec("alter table t add index idx(a);")
+
+	rows := tk.MustQuery("admin show ddl jobs 1;").Rows()
+	require.Len(t, rows, 1)
+	jobType, rowCnt := rows[0][3].(string), rows[0][7].(string)
+	require.True(t, strings.Contains(jobType, "ingest"))
+	require.False(t, strings.Contains(jobType, "cloud"))
+	require.Equal(t, rowCnt, "3")
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48347

Problem Summary:

### What is changed and how it works?

- Set lower bound of `regionBatch` to `1`.
- Do not print "cloud" in `ADMIN SHOW DDL JOBS` for the add-index jobs that running with `tidb_enable_dist_task` disabled.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
