### PR TITLE
disttask: fix wrong plan when filterByRole

### DIFF
--- a/pkg/ddl/backfilling_dispatcher.go
+++ b/pkg/ddl/backfilling_dispatcher.go
@@ -70,6 +70,7 @@ func (dsp *BackfillingDispatcherExt) OnNextSubtasksBatch(
 	ctx context.Context,
 	taskHandle dispatcher.TaskHandle,
 	gTask *proto.Task,
+	serverInfo []*infosync.ServerInfo,
 	nextStep proto.Step,
 ) (taskMeta [][]byte, err error) {
 	logger := logutil.BgLogger().With(
@@ -95,12 +96,7 @@ func (dsp *BackfillingDispatcherExt) OnNextSubtasksBatch(
 		if tblInfo.Partition != nil {
 			return generatePartitionPlan(tblInfo)
 		}
-		is, err := dsp.GetEligibleInstances(ctx, gTask)
-		if err != nil {
-			return nil, err
-		}
-		instanceCnt := len(is)
-		return generateNonPartitionPlan(dsp.d, tblInfo, job, dsp.GlobalSort, instanceCnt)
+		return generateNonPartitionPlan(dsp.d, tblInfo, job, dsp.GlobalSort, len(serverInfo))
 	case StepMergeSort:
 		res, err := generateMergePlan(taskHandle, gTask, logger)
 		if err != nil {

--- a/pkg/ddl/backfilling_dispatcher.go
+++ b/pkg/ddl/backfilling_dispatcher.go
@@ -191,12 +191,12 @@ func (*BackfillingDispatcherExt) OnErrStage(_ context.Context, _ dispatcher.Task
 }
 
 // GetEligibleInstances implements dispatcher.Extension interface.
-func (*BackfillingDispatcherExt) GetEligibleInstances(ctx context.Context, _ *proto.Task) ([]*infosync.ServerInfo, error) {
+func (*BackfillingDispatcherExt) GetEligibleInstances(ctx context.Context, _ *proto.Task) ([]*infosync.ServerInfo, bool, error) {
 	serverInfos, err := dispatcher.GenerateSchedulerNodes(ctx)
 	if err != nil {
-		return nil, err
+		return nil, true, err
 	}
-	return serverInfos, nil
+	return serverInfos, true, nil
 }
 
 // IsRetryableErr implements dispatcher.Extension.IsRetryableErr interface.

--- a/pkg/ddl/backfilling_dispatcher_test.go
+++ b/pkg/ddl/backfilling_dispatcher_test.go
@@ -68,7 +68,9 @@ func TestBackfillingDispatcherLocalMode(t *testing.T) {
 	// 1.1 OnNextSubtasksBatch
 	gTask.Step = dsp.GetNextStep(gTask)
 	require.Equal(t, ddl.StepReadIndex, gTask.Step)
-	metas, err := dsp.OnNextSubtasksBatch(context.Background(), nil, gTask, gTask.Step)
+	serverInfos, err := dsp.GetEligibleInstances(context.Background(), gTask)
+	require.NoError(t, err)
+	metas, err := dsp.OnNextSubtasksBatch(context.Background(), nil, gTask, serverInfos, gTask.Step)
 	require.NoError(t, err)
 	require.Equal(t, len(tblInfo.Partition.Definitions), len(metas))
 	for i, par := range tblInfo.Partition.Definitions {
@@ -81,7 +83,7 @@ func TestBackfillingDispatcherLocalMode(t *testing.T) {
 	gTask.State = proto.TaskStateRunning
 	gTask.Step = dsp.GetNextStep(gTask)
 	require.Equal(t, proto.StepDone, gTask.Step)
-	metas, err = dsp.OnNextSubtasksBatch(context.Background(), nil, gTask, gTask.Step)
+	metas, err = dsp.OnNextSubtasksBatch(context.Background(), nil, gTask, serverInfos, gTask.Step)
 	require.NoError(t, err)
 	require.Len(t, metas, 0)
 
@@ -98,7 +100,7 @@ func TestBackfillingDispatcherLocalMode(t *testing.T) {
 	// 2.1 empty table
 	tk.MustExec("create table t1(id int primary key, v int)")
 	gTask = createAddIndexGlobalTask(t, dom, "test", "t1", proto.Backfill, false)
-	metas, err = dsp.OnNextSubtasksBatch(context.Background(), nil, gTask, gTask.Step)
+	metas, err = dsp.OnNextSubtasksBatch(context.Background(), nil, gTask, serverInfos, gTask.Step)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(metas))
 	// 2.2 non empty table.
@@ -110,7 +112,7 @@ func TestBackfillingDispatcherLocalMode(t *testing.T) {
 	gTask = createAddIndexGlobalTask(t, dom, "test", "t2", proto.Backfill, false)
 	// 2.2.1 stepInit
 	gTask.Step = dsp.GetNextStep(gTask)
-	metas, err = dsp.OnNextSubtasksBatch(context.Background(), nil, gTask, gTask.Step)
+	metas, err = dsp.OnNextSubtasksBatch(context.Background(), nil, gTask, serverInfos, gTask.Step)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(metas))
 	require.Equal(t, ddl.StepReadIndex, gTask.Step)
@@ -118,7 +120,7 @@ func TestBackfillingDispatcherLocalMode(t *testing.T) {
 	gTask.State = proto.TaskStateRunning
 	gTask.Step = dsp.GetNextStep(gTask)
 	require.Equal(t, proto.StepDone, gTask.Step)
-	metas, err = dsp.OnNextSubtasksBatch(context.Background(), nil, gTask, gTask.Step)
+	metas, err = dsp.OnNextSubtasksBatch(context.Background(), nil, gTask, serverInfos, gTask.Step)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(metas))
 }
@@ -154,9 +156,11 @@ func TestBackfillingDispatcherGlobalSortMode(t *testing.T) {
 	taskID, err := mgr.AddNewGlobalTask(task.Key, proto.Backfill, 1, task.Meta)
 	require.NoError(t, err)
 	task.ID = taskID
+	serverInfos, err := dsp.GetEligibleInstances(context.Background(), task)
+	require.NoError(t, err)
 
 	// 1. to read-index stage
-	subtaskMetas, err := dsp.OnNextSubtasksBatch(ctx, dsp, task, dsp.GetNextStep(task))
+	subtaskMetas, err := dsp.OnNextSubtasksBatch(ctx, dsp, task, serverInfos, dsp.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
 	task.Step = ext.GetNextStep(task)
@@ -197,7 +201,7 @@ func TestBackfillingDispatcherGlobalSortMode(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/forceMergeSort"))
 	})
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, dsp, task, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, dsp, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
 	task.Step = ext.GetNextStep(task)
@@ -236,13 +240,13 @@ func TestBackfillingDispatcherGlobalSortMode(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockWriteIngest"))
 	})
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, dsp, task, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, dsp, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
 	task.Step = ext.GetNextStep(task)
 	require.Equal(t, ddl.StepWriteAndIngest, task.Step)
 	// 4. to done stage.
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, dsp, task, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, dsp, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 0)
 	task.Step = ext.GetNextStep(task)

--- a/pkg/ddl/backfilling_dispatcher_test.go
+++ b/pkg/ddl/backfilling_dispatcher_test.go
@@ -68,7 +68,7 @@ func TestBackfillingDispatcherLocalMode(t *testing.T) {
 	// 1.1 OnNextSubtasksBatch
 	gTask.Step = dsp.GetNextStep(gTask)
 	require.Equal(t, ddl.StepReadIndex, gTask.Step)
-	serverInfos, err := dsp.GetEligibleInstances(context.Background(), gTask)
+	serverInfos, _, err := dsp.GetEligibleInstances(context.Background(), gTask)
 	require.NoError(t, err)
 	metas, err := dsp.OnNextSubtasksBatch(context.Background(), nil, gTask, serverInfos, gTask.Step)
 	require.NoError(t, err)
@@ -156,7 +156,7 @@ func TestBackfillingDispatcherGlobalSortMode(t *testing.T) {
 	taskID, err := mgr.AddNewGlobalTask(task.Key, proto.Backfill, 1, task.Meta)
 	require.NoError(t, err)
 	task.ID = taskID
-	serverInfos, err := dsp.GetEligibleInstances(context.Background(), task)
+	serverInfos, _, err := dsp.GetEligibleInstances(context.Background(), task)
 	require.NoError(t, err)
 
 	// 1. to read-index stage

--- a/pkg/disttask/framework/dispatcher/dispatcher.go
+++ b/pkg/disttask/framework/dispatcher/dispatcher.go
@@ -625,8 +625,14 @@ func (d *BaseDispatcher) handlePlanErr(err error) error {
 	return d.updateTask(proto.TaskStateFailed, nil, RetrySQLTimes)
 }
 
+// MockServerInfo exported for dispatcher_test.go
+var MockServerInfo []*infosync.ServerInfo
+
 // GenerateSchedulerNodes generate a eligible TiDB nodes.
 func GenerateSchedulerNodes(ctx context.Context) (serverNodes []*infosync.ServerInfo, err error) {
+	failpoint.Inject("mockSchedulerNodes", func() {
+		failpoint.Return(MockServerInfo, nil)
+	})
 	var serverInfos map[string]*infosync.ServerInfo
 	_, etcd := ctx.Value("etcd").(bool)
 	if intest.InTest && !etcd {

--- a/pkg/disttask/framework/dispatcher/dispatcher.go
+++ b/pkg/disttask/framework/dispatcher/dispatcher.go
@@ -560,7 +560,6 @@ func (d *BaseDispatcher) onNextStage() (err error) {
 			return err
 		}
 		if filter {
-			/// filter by role.
 			serverNodes, err = d.filterByRole(serverNodes)
 			if err != nil {
 				return err

--- a/pkg/disttask/framework/dispatcher/dispatcher.go
+++ b/pkg/disttask/framework/dispatcher/dispatcher.go
@@ -674,7 +674,9 @@ func (d *BaseDispatcher) filterByRole(infos []*infosync.ServerInfo) ([]*infosync
 
 // GetAllSchedulerIDs gets all the scheduler IDs.
 func (d *BaseDispatcher) GetAllSchedulerIDs(ctx context.Context, task *proto.Task) ([]string, error) {
-	serverInfos, err := d.GetEligibleInstances(ctx, task)
+	// We get all servers instead of eligible servers here
+	// because eligible servers may change during the task execution.
+	serverInfos, err := GenerateSchedulerNodes(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/disttask/framework/dispatcher/dispatcher.go
+++ b/pkg/disttask/framework/dispatcher/dispatcher.go
@@ -374,13 +374,15 @@ func (d *BaseDispatcher) replaceDeadNodesIfAny() error {
 			return err
 		}
 
-		eligibleServerInfos, err := d.GetEligibleInstances(d.ctx, d.Task)
+		eligibleServerInfos, filter, err := d.GetEligibleInstances(d.ctx, d.Task)
 		if err != nil {
 			return err
 		}
-		eligibleServerInfos, err = d.filterByRole(eligibleServerInfos)
-		if err != nil {
-			return err
+		if filter {
+			eligibleServerInfos, err = d.filterByRole(eligibleServerInfos)
+			if err != nil {
+				return err
+			}
 		}
 		newInfos := serverInfos[:0]
 		for _, m := range serverInfos {
@@ -551,16 +553,18 @@ func (d *BaseDispatcher) onNextStage() (err error) {
 	for {
 		// 3. generate a batch of subtasks.
 		/// select all available TiDB nodes for task.
-		serverNodes, err := d.GetEligibleInstances(d.ctx, d.Task)
+		serverNodes, filter, err := d.GetEligibleInstances(d.ctx, d.Task)
 		logutil.Logger(d.logCtx).Debug("eligible instances", zap.Int("num", len(serverNodes)))
 
 		if err != nil {
 			return err
 		}
-		/// filter by role.
-		serverNodes, err = d.filterByRole(serverNodes)
-		if err != nil {
-			return err
+		if filter {
+			/// filter by role.
+			serverNodes, err = d.filterByRole(serverNodes)
+			if err != nil {
+				return err
+			}
 		}
 		logutil.Logger(d.logCtx).Info("eligible instances", zap.Int("num", len(serverNodes)))
 		if len(serverNodes) == 0 {

--- a/pkg/disttask/framework/dispatcher/dispatcher_test.go
+++ b/pkg/disttask/framework/dispatcher/dispatcher_test.go
@@ -61,8 +61,8 @@ func (*testDispatcherExt) OnErrStage(_ context.Context, _ dispatcher.TaskHandle,
 
 var mockedAllServerInfos = []*infosync.ServerInfo{}
 
-func (*testDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, error) {
-	return mockedAllServerInfos, nil
+func (*testDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, bool, error) {
+	return mockedAllServerInfos, true, nil
 }
 
 func (*testDispatcherExt) IsRetryableErr(error) bool {
@@ -99,8 +99,9 @@ func (n *numberExampleDispatcherExt) OnErrStage(_ context.Context, _ dispatcher.
 	return nil, nil
 }
 
-func (*numberExampleDispatcherExt) GetEligibleInstances(ctx context.Context, _ *proto.Task) ([]*infosync.ServerInfo, error) {
-	return dispatcher.GenerateSchedulerNodes(ctx)
+func (*numberExampleDispatcherExt) GetEligibleInstances(ctx context.Context, _ *proto.Task) ([]*infosync.ServerInfo, bool, error) {
+	serverInfo, err := dispatcher.GenerateSchedulerNodes(ctx)
+	return serverInfo, true, err
 }
 
 func (*numberExampleDispatcherExt) IsRetryableErr(error) bool {

--- a/pkg/disttask/framework/dispatcher/dispatcher_test.go
+++ b/pkg/disttask/framework/dispatcher/dispatcher_test.go
@@ -51,7 +51,7 @@ type testDispatcherExt struct{}
 func (*testDispatcherExt) OnTick(_ context.Context, _ *proto.Task) {
 }
 
-func (*testDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, _ *proto.Task, _ proto.Step) (metas [][]byte, err error) {
+func (*testDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, _ *proto.Task, _ []*infosync.ServerInfo, _ proto.Step) (metas [][]byte, err error) {
 	return nil, nil
 }
 
@@ -78,7 +78,7 @@ type numberExampleDispatcherExt struct{}
 func (*numberExampleDispatcherExt) OnTick(_ context.Context, _ *proto.Task) {
 }
 
-func (n *numberExampleDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, task *proto.Task, _ proto.Step) (metas [][]byte, err error) {
+func (n *numberExampleDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, task *proto.Task, _ []*infosync.ServerInfo, _ proto.Step) (metas [][]byte, err error) {
 	switch task.Step {
 	case proto.StepInit:
 		for i := 0; i < subtaskCnt; i++ {

--- a/pkg/disttask/framework/dispatcher/dispatcher_test.go
+++ b/pkg/disttask/framework/dispatcher/dispatcher_test.go
@@ -157,7 +157,7 @@ func TestGetInstance(t *testing.T) {
 		return gtk.Session(), nil
 	}, 1, 1, time.Second)
 	defer pool.Close()
-
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/disttask/framework/dispatcher/mockSchedulerNodes", "return()"))
 	dspManager, mgr := MockDispatcherManager(t, pool)
 	// test no server
 	task := &proto.Task{ID: 1, Type: proto.TaskTypeExample}
@@ -173,7 +173,7 @@ func TestGetInstance(t *testing.T) {
 	uuids := []string{"ddl_id_1", "ddl_id_2"}
 	serverIDs := []string{"10.123.124.10:32457", "[ABCD:EF01:2345:6789:ABCD:EF01:2345:6789]:65535"}
 
-	mockedAllServerInfos = []*infosync.ServerInfo{
+	dispatcher.MockServerInfo = []*infosync.ServerInfo{
 		{
 			ID:   uuids[0],
 			IP:   "10.123.124.10",
@@ -214,6 +214,7 @@ func TestGetInstance(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, instanceIDs, len(serverIDs))
 	require.ElementsMatch(t, instanceIDs, serverIDs)
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/dispatcher/mockSchedulerNodes"))
 }
 
 func TestTaskFailInManager(t *testing.T) {

--- a/pkg/disttask/framework/dispatcher/interface.go
+++ b/pkg/disttask/framework/dispatcher/interface.go
@@ -73,7 +73,8 @@ type Extension interface {
 
 	// GetEligibleInstances is used to get the eligible instances for the task.
 	// on certain condition we may want to use some instances to do the task, such as instances with more disk.
-	GetEligibleInstances(ctx context.Context, task *proto.Task) ([]*infosync.ServerInfo, error)
+	// The bool return value indicates whether filter instances by role.
+	GetEligibleInstances(ctx context.Context, task *proto.Task) ([]*infosync.ServerInfo, bool, error)
 
 	// IsRetryableErr is used to check whether the error occurred in dispatcher is retryable.
 	IsRetryableErr(err error) bool

--- a/pkg/disttask/framework/dispatcher/interface.go
+++ b/pkg/disttask/framework/dispatcher/interface.go
@@ -64,7 +64,7 @@ type Extension interface {
 	// 	1. task is pending and entering it's first step.
 	// 	2. subtasks dispatched has all finished with no error.
 	// when next step is StepDone, it should return nil, nil.
-	OnNextSubtasksBatch(ctx context.Context, h TaskHandle, task *proto.Task, step proto.Step) (subtaskMetas [][]byte, err error)
+	OnNextSubtasksBatch(ctx context.Context, h TaskHandle, task *proto.Task, serverInfo []*infosync.ServerInfo, step proto.Step) (subtaskMetas [][]byte, err error)
 
 	// OnErrStage is called when:
 	// 	1. subtask is finished with error.

--- a/pkg/disttask/framework/framework_dynamic_dispatch_test.go
+++ b/pkg/disttask/framework/framework_dynamic_dispatch_test.go
@@ -37,7 +37,7 @@ var _ dispatcher.Extension = (*testDynamicDispatcherExt)(nil)
 
 func (*testDynamicDispatcherExt) OnTick(_ context.Context, _ *proto.Task) {}
 
-func (dsp *testDynamicDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, gTask *proto.Task, _ proto.Step) (metas [][]byte, err error) {
+func (dsp *testDynamicDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, gTask *proto.Task, _ []*infosync.ServerInfo, _ proto.Step) (metas [][]byte, err error) {
 	// step1
 	if gTask.Step == proto.StepInit {
 		dsp.cnt++

--- a/pkg/disttask/framework/framework_dynamic_dispatch_test.go
+++ b/pkg/disttask/framework/framework_dynamic_dispatch_test.go
@@ -72,7 +72,7 @@ func (dsp *testDynamicDispatcherExt) GetNextStep(task *proto.Task) proto.Step {
 	}
 }
 
-func (*testDynamicDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, error) {
+func (*testDynamicDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, bool, error) {
 	return generateSchedulerNodes4Test()
 }
 

--- a/pkg/disttask/framework/framework_err_handling_test.go
+++ b/pkg/disttask/framework/framework_err_handling_test.go
@@ -70,7 +70,7 @@ func (p *planErrDispatcherExt) OnErrStage(_ context.Context, _ dispatcher.TaskHa
 	return []byte("planErrTask"), nil
 }
 
-func (*planErrDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, error) {
+func (*planErrDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, bool, error) {
 	return generateSchedulerNodes4Test()
 }
 
@@ -104,7 +104,7 @@ func (*planNotRetryableErrDispatcherExt) OnErrStage(_ context.Context, _ dispatc
 	return nil, errors.New("not retryable err")
 }
 
-func (*planNotRetryableErrDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, error) {
+func (*planNotRetryableErrDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, bool, error) {
 	return generateSchedulerNodes4Test()
 }
 

--- a/pkg/disttask/framework/framework_err_handling_test.go
+++ b/pkg/disttask/framework/framework_err_handling_test.go
@@ -40,7 +40,7 @@ var (
 func (*planErrDispatcherExt) OnTick(_ context.Context, _ *proto.Task) {
 }
 
-func (p *planErrDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, gTask *proto.Task, _ proto.Step) (metas [][]byte, err error) {
+func (p *planErrDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, gTask *proto.Task, _ []*infosync.ServerInfo, _ proto.Step) (metas [][]byte, err error) {
 	if gTask.Step == proto.StepInit {
 		if p.callTime == 0 {
 			p.callTime++
@@ -96,7 +96,7 @@ type planNotRetryableErrDispatcherExt struct {
 func (*planNotRetryableErrDispatcherExt) OnTick(_ context.Context, _ *proto.Task) {
 }
 
-func (p *planNotRetryableErrDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, _ *proto.Task, _ proto.Step) (metas [][]byte, err error) {
+func (p *planNotRetryableErrDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, _ *proto.Task, _ []*infosync.ServerInfo, _ proto.Step) (metas [][]byte, err error) {
 	return nil, errors.New("not retryable err")
 }
 

--- a/pkg/disttask/framework/framework_ha_test.go
+++ b/pkg/disttask/framework/framework_ha_test.go
@@ -70,7 +70,7 @@ func (*haTestDispatcherExt) OnErrStage(ctx context.Context, h dispatcher.TaskHan
 	return nil, nil
 }
 
-func (*haTestDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, error) {
+func (*haTestDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, bool, error) {
 	return generateSchedulerNodes4Test()
 }
 

--- a/pkg/disttask/framework/framework_ha_test.go
+++ b/pkg/disttask/framework/framework_ha_test.go
@@ -37,7 +37,7 @@ var _ dispatcher.Extension = (*haTestDispatcherExt)(nil)
 func (*haTestDispatcherExt) OnTick(_ context.Context, _ *proto.Task) {
 }
 
-func (dsp *haTestDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, gTask *proto.Task, _ proto.Step) (metas [][]byte, err error) {
+func (dsp *haTestDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, gTask *proto.Task, _ []*infosync.ServerInfo, _ proto.Step) (metas [][]byte, err error) {
 	if gTask.Step == proto.StepInit {
 		dsp.cnt = 10
 		return [][]byte{

--- a/pkg/disttask/framework/framework_rollback_test.go
+++ b/pkg/disttask/framework/framework_rollback_test.go
@@ -57,7 +57,7 @@ func (*rollbackDispatcherExt) OnErrStage(_ context.Context, _ dispatcher.TaskHan
 	return []byte("rollbacktask1"), nil
 }
 
-func (*rollbackDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, error) {
+func (*rollbackDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, bool, error) {
 	return generateSchedulerNodes4Test()
 }
 

--- a/pkg/disttask/framework/framework_rollback_test.go
+++ b/pkg/disttask/framework/framework_rollback_test.go
@@ -41,7 +41,7 @@ var rollbackCnt atomic.Int32
 func (*rollbackDispatcherExt) OnTick(_ context.Context, _ *proto.Task) {
 }
 
-func (dsp *rollbackDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, gTask *proto.Task, _ proto.Step) (metas [][]byte, err error) {
+func (dsp *rollbackDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, gTask *proto.Task, _ []*infosync.ServerInfo, _ proto.Step) (metas [][]byte, err error) {
 	if gTask.Step == proto.StepInit {
 		dsp.cnt = 3
 		return [][]byte{

--- a/pkg/disttask/framework/framework_test.go
+++ b/pkg/disttask/framework/framework_test.go
@@ -77,20 +77,20 @@ func (dsp *testDispatcherExt) GetNextStep(task *proto.Task) proto.Step {
 	}
 }
 
-func generateSchedulerNodes4Test() ([]*infosync.ServerInfo, error) {
+func generateSchedulerNodes4Test() ([]*infosync.ServerInfo, bool, error) {
 	serverInfos := infosync.MockGlobalServerInfoManagerEntry.GetAllServerInfo()
 	if len(serverInfos) == 0 {
-		return nil, errors.New("not found instance")
+		return nil, true, errors.New("not found instance")
 	}
 
 	serverNodes := make([]*infosync.ServerInfo, 0, len(serverInfos))
 	for _, serverInfo := range serverInfos {
 		serverNodes = append(serverNodes, serverInfo)
 	}
-	return serverNodes, nil
+	return serverNodes, true, nil
 }
 
-func (*testDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, error) {
+func (*testDispatcherExt) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, bool, error) {
 	return generateSchedulerNodes4Test()
 }
 

--- a/pkg/disttask/framework/framework_test.go
+++ b/pkg/disttask/framework/framework_test.go
@@ -44,7 +44,7 @@ var _ dispatcher.Extension = (*testDispatcherExt)(nil)
 func (*testDispatcherExt) OnTick(_ context.Context, _ *proto.Task) {
 }
 
-func (dsp *testDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, gTask *proto.Task, _ proto.Step) (metas [][]byte, err error) {
+func (dsp *testDispatcherExt) OnNextSubtasksBatch(_ context.Context, _ dispatcher.TaskHandle, gTask *proto.Task, _ []*infosync.ServerInfo, _ proto.Step) (metas [][]byte, err error) {
 	if gTask.Step == proto.StepInit {
 		dsp.cnt = 3
 		return [][]byte{

--- a/pkg/disttask/importinto/dispatcher.go
+++ b/pkg/disttask/importinto/dispatcher.go
@@ -364,16 +364,17 @@ func (dsp *ImportDispatcherExt) OnErrStage(ctx context.Context, handle dispatche
 }
 
 // GetEligibleInstances implements dispatcher.Extension interface.
-func (*ImportDispatcherExt) GetEligibleInstances(ctx context.Context, gTask *proto.Task) ([]*infosync.ServerInfo, error) {
+func (*ImportDispatcherExt) GetEligibleInstances(ctx context.Context, gTask *proto.Task) ([]*infosync.ServerInfo, bool, error) {
 	taskMeta := &TaskMeta{}
 	err := json.Unmarshal(gTask.Meta, taskMeta)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, true, errors.Trace(err)
 	}
 	if len(taskMeta.EligibleInstances) > 0 {
-		return taskMeta.EligibleInstances, nil
+		return taskMeta.EligibleInstances, false, nil
 	}
-	return dispatcher.GenerateSchedulerNodes(ctx)
+	serverInfo, err := dispatcher.GenerateSchedulerNodes(ctx)
+	return serverInfo, true, err
 }
 
 // IsRetryableErr implements dispatcher.Extension interface.

--- a/pkg/disttask/importinto/dispatcher.go
+++ b/pkg/disttask/importinto/dispatcher.go
@@ -300,21 +300,13 @@ func (dsp *ImportDispatcherExt) OnNextSubtasksBatch(
 		return nil, errors.Errorf("unknown step %d", gTask.Step)
 	}
 
-	executeNodesCnt := 0
-	// For non-dist mode.
-	if len(taskMeta.EligibleInstances) > 0 {
-		executeNodesCnt = len(taskMeta.EligibleInstances)
-	} else {
-		executeNodesCnt = len(serverInfos)
-	}
-
 	planCtx := planner.PlanCtx{
 		Ctx:                  ctx,
 		TaskID:               gTask.ID,
 		PreviousSubtaskMetas: previousSubtaskMetas,
 		GlobalSort:           dsp.GlobalSort,
 		NextTaskStep:         nextStep,
-		ExecuteNodesCnt:      executeNodesCnt,
+		ExecuteNodesCnt:      len(serverInfos),
 	}
 	logicalPlan := &LogicalPlan{}
 	if err := logicalPlan.FromTaskMeta(gTask.Meta); err != nil {

--- a/pkg/disttask/importinto/dispatcher_test.go
+++ b/pkg/disttask/importinto/dispatcher_test.go
@@ -65,7 +65,7 @@ func (s *importIntoSuite) TestDispatcherGetEligibleInstances() {
 	gTask := &proto.Task{Meta: []byte("{}")}
 	ctx := context.WithValue(context.Background(), "etcd", true)
 	s.enableFailPoint("github.com/pingcap/tidb/pkg/domain/infosync/mockGetAllServerInfo", mockedAllServerInfos)
-	eligibleInstances, err := dsp.GetEligibleInstances(ctx, gTask)
+	eligibleInstances, _, err := dsp.GetEligibleInstances(ctx, gTask)
 	s.NoError(err)
 	// order of slice is not stable, change to map
 	resultMap := map[string]*infosync.ServerInfo{}
@@ -75,7 +75,7 @@ func (s *importIntoSuite) TestDispatcherGetEligibleInstances() {
 	s.Equal(serverInfoMap, resultMap)
 
 	gTask.Meta = []byte(`{"EligibleInstances":[{"ip": "1.1.1.1", "listening_port": 4000}]}`)
-	eligibleInstances, err = dsp.GetEligibleInstances(ctx, gTask)
+	eligibleInstances, _, err = dsp.GetEligibleInstances(ctx, gTask)
 	s.NoError(err)
 	s.Equal([]*infosync.ServerInfo{{IP: "1.1.1.1", Port: 4000}}, eligibleInstances)
 }

--- a/pkg/disttask/importinto/dispatcher_testkit_test.go
+++ b/pkg/disttask/importinto/dispatcher_testkit_test.go
@@ -91,7 +91,7 @@ func TestDispatcherExtLocalSort(t *testing.T) {
 	// to import stage, job should be running
 	d := dsp.MockDispatcher(task)
 	ext := importinto.ImportDispatcherExt{}
-	serverInfos, err := ext.GetEligibleInstances(context.Background(), task)
+	serverInfos, _, err := ext.GetEligibleInstances(context.Background(), task)
 	require.NoError(t, err)
 	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
@@ -221,7 +221,7 @@ func TestDispatcherExtGlobalSort(t *testing.T) {
 	ext := importinto.ImportDispatcherExt{
 		GlobalSort: true,
 	}
-	serverInfos, err := ext.GetEligibleInstances(context.Background(), task)
+	serverInfos, _, err := ext.GetEligibleInstances(context.Background(), task)
 	require.NoError(t, err)
 	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)

--- a/pkg/disttask/importinto/dispatcher_testkit_test.go
+++ b/pkg/disttask/importinto/dispatcher_testkit_test.go
@@ -91,7 +91,9 @@ func TestDispatcherExtLocalSort(t *testing.T) {
 	// to import stage, job should be running
 	d := dsp.MockDispatcher(task)
 	ext := importinto.ImportDispatcherExt{}
-	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, ext.GetNextStep(task))
+	serverInfos, err := ext.GetEligibleInstances(context.Background(), task)
+	require.NoError(t, err)
+	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
 	task.Step = ext.GetNextStep(task)
@@ -112,7 +114,7 @@ func TestDispatcherExtLocalSort(t *testing.T) {
 		require.NoError(t, manager.FinishSubtask(s.ID, []byte("{}")))
 	}
 	// to post-process stage, job should be running and in validating step
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
 	task.Step = ext.GetNextStep(task)
@@ -122,7 +124,7 @@ func TestDispatcherExtLocalSort(t *testing.T) {
 	require.Equal(t, "running", gotJobInfo.Status)
 	require.Equal(t, "validating", gotJobInfo.Step)
 	// on next stage, job should be finished
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 0)
 	task.Step = ext.GetNextStep(task)
@@ -219,7 +221,9 @@ func TestDispatcherExtGlobalSort(t *testing.T) {
 	ext := importinto.ImportDispatcherExt{
 		GlobalSort: true,
 	}
-	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, ext.GetNextStep(task))
+	serverInfos, err := ext.GetEligibleInstances(context.Background(), task)
+	require.NoError(t, err)
+	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 2)
 	task.Step = ext.GetNextStep(task)
@@ -276,7 +280,7 @@ func TestDispatcherExtGlobalSort(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/importinto/forceMergeSort"))
 	})
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
 	task.Step = ext.GetNextStep(task)
@@ -314,7 +318,7 @@ func TestDispatcherExtGlobalSort(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/importinto/mockWriteIngestSpecs"))
 	})
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 2)
 	task.Step = ext.GetNextStep(task)
@@ -324,7 +328,7 @@ func TestDispatcherExtGlobalSort(t *testing.T) {
 	require.Equal(t, "running", gotJobInfo.Status)
 	require.Equal(t, "importing", gotJobInfo.Step)
 	// on next stage, to post-process stage
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
 	task.Step = ext.GetNextStep(task)
@@ -334,7 +338,7 @@ func TestDispatcherExtGlobalSort(t *testing.T) {
 	require.Equal(t, "running", gotJobInfo.Status)
 	require.Equal(t, "validating", gotJobInfo.Step)
 	// next stage, done
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, serverInfos, ext.GetNextStep(task))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 0)
 	task.Step = ext.GetNextStep(task)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48368

Problem Summary:
1. serverNodes used in OnNextStageBatch didn't filter by role.
2. serverNodes may change during planning and dispatching phase, may lead to inconsistency of task nodes.
### What is changed and how it works?
```
server:= d.GetEligibleInstance()
server:=d.filterByRole(server)
subtasks := d.OnNextStageBatch(server)
d.dispatchSubtasks(subtasks, server)
```
Using the above logic, the planner will use consistent serverNodes in plan and dispatching phase.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Enhance planning of dist task
```
