### PR TITLE
*: fix platform dependent utils charsToString

### DIFF
--- a/pkg/util/sys/linux/BUILD.bazel
+++ b/pkg/util/sys/linux/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:android": [
+            "@org_golang_x_exp//constraints",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
@@ -35,6 +36,7 @@ go_library(
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
+            "@org_golang_x_exp//constraints",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [

--- a/pkg/util/sys/linux/sys_linux.go
+++ b/pkg/util/sys/linux/sys_linux.go
@@ -19,8 +19,21 @@ import (
 	"net"
 	"syscall"
 
+	"golang.org/x/exp/constraints"
 	"golang.org/x/sys/unix"
 )
+
+func charsToString[T constraints.Integer](ca []T) string {
+	s := make([]byte, len(ca))
+	var lens int
+	for ; lens < len(ca); lens++ {
+		if ca[lens] == 0 {
+			break
+		}
+		s[lens] = uint8(ca[lens])
+	}
+	return string(s[0:lens])
+}
 
 // OSVersion returns version info of operation system.
 // e.g. Linux 4.15.0-45-generic.x86_64
@@ -29,17 +42,6 @@ func OSVersion() (osVersion string, err error) {
 	err = syscall.Uname(&un)
 	if err != nil {
 		return
-	}
-	charsToString := func(ca []int8) string {
-		s := make([]byte, len(ca))
-		var lens int
-		for ; lens < len(ca); lens++ {
-			if ca[lens] == 0 {
-				break
-			}
-			s[lens] = uint8(ca[lens])
-		}
-		return string(s[0:lens])
 	}
 	osVersion = charsToString(un.Sysname[:]) + " " + charsToString(un.Release[:]) + "." + charsToString(un.Machine[:])
 	return


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: input of `charsToString` is not always `int8`, it is probably `uint8` on some platforms.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
