### PR TITLE
planner: don't inline CTE when it's consumed by a recursive CTE

### DIFF
--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -1067,6 +1067,8 @@ type CommonTableExpression struct {
 
 	// Record how many consumers the current cte has
 	ConsumerCount int
+	// ConsumedByRecursiveCTE records whether this CTE is used by a recursive CTE
+	ConsumedByRecursiveCTE bool
 }
 
 // Restore implements Node interface

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -3952,3 +3952,17 @@ p	o	v	a
 3	5	5	3
 3	9	9	9
 set @@tidb_enable_pipelined_window_function=DEFAULT;
+drop table if exists a,b,temp;
+create table a (id int);
+create table b (id int);
+create table temp (lvl int);
+with a as (select 8 as id from dual), maxa as (select max(id) as max_id from a), b as ( with recursive temp as ( select 1 as lvl from dual union all select lvl+1 from temp, maxa where lvl < max_id ) select * from temp ) select * from b;
+lvl
+1
+2
+3
+4
+5
+6
+7
+8

--- a/tests/integrationtest/t/planner/core/integration.test
+++ b/tests/integrationtest/t/planner/core/integration.test
@@ -2071,4 +2071,9 @@ set @@tidb_enable_pipelined_window_function=0;
 select *, first_value(v) over (partition by p order by o range between 3.1 preceding and 2.9 following) as a from planner__core__integration.first_range;
 set @@tidb_enable_pipelined_window_function=DEFAULT;
 
-
+# TestIssue47603
+drop table if exists a,b,temp;
+create table a (id int);
+create table b (id int);
+create table temp (lvl int);
+with a as (select 8 as id from dual), maxa as (select max(id) as max_id from a), b as ( with recursive temp as ( select 1 as lvl from dual union all select lvl+1 from temp, maxa where lvl < max_id ) select * from temp ) select * from b;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #47603 

Problem Summary:

When a CTE containing aggregation is inlined into a recursive CTE, it may return error.

### What is changed and how it works?

I add some logic in preprocess to detect whether a CTE is consumed by a recursive CTE, if so (and it contains an aggregation), don't inline it.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix the issue that a CTE with aggregation can be automatically inlined into a recursive CTE and cause error.
```
