### PR TITLE
expression: use parameter ctx to do evaluate instead of the inner one for all builtinFuncs

### DIFF
--- a/pkg/executor/aggfuncs/builder.go
+++ b/pkg/executor/aggfuncs/builder.go
@@ -457,7 +457,7 @@ func buildGroupConcat(ctx sessionctx.Context, aggFuncDesc *aggregation.AggFuncDe
 	default:
 		// The last arg is promised to be a not-null string constant, so the error can be ignored.
 		c, _ := aggFuncDesc.Args[len(aggFuncDesc.Args)-1].(*expression.Constant)
-		sep, _, err := c.EvalString(nil, chunk.Row{})
+		sep, _, err := c.EvalString(ctx, chunk.Row{})
 		// This err should never happen.
 		if err != nil {
 			panic(fmt.Sprintf("Error happened when buildGroupConcat: %s", err.Error()))

--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -97,6 +97,7 @@ go_library(
         "//pkg/util/encrypt",
         "//pkg/util/generatedexpr",
         "//pkg/util/hack",
+        "//pkg/util/intest",
         "//pkg/util/intset",
         "//pkg/util/logutil",
         "//pkg/util/mathutil",

--- a/pkg/expression/builtin_arithmetic.go
+++ b/pkg/expression/builtin_arithmetic.go
@@ -214,12 +214,12 @@ func (s *builtinArithmeticPlusIntSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticPlusIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
+	a, isNull, err := s.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
-	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
+	b, isNull, err := s.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -266,11 +266,11 @@ func (s *builtinArithmeticPlusDecimalSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticPlusDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
+	a, isNull, err := s.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
-	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
+	b, isNull, err := s.args[1].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
@@ -296,11 +296,11 @@ func (s *builtinArithmeticPlusRealSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticPlusRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	a, isLHSNull, err := s.args[0].EvalReal(s.ctx, row)
+	a, isLHSNull, err := s.args[0].EvalReal(ctx, row)
 	if err != nil {
 		return 0, isLHSNull, err
 	}
-	b, isRHSNull, err := s.args[1].EvalReal(s.ctx, row)
+	b, isRHSNull, err := s.args[1].EvalReal(ctx, row)
 	if err != nil {
 		return 0, isRHSNull, err
 	}
@@ -364,11 +364,11 @@ func (s *builtinArithmeticMinusRealSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticMinusRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
+	a, isNull, err := s.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
+	b, isNull, err := s.args[1].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -389,11 +389,11 @@ func (s *builtinArithmeticMinusDecimalSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticMinusDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
+	a, isNull, err := s.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
-	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
+	b, isNull, err := s.args[1].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
@@ -419,16 +419,16 @@ func (s *builtinArithmeticMinusIntSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticMinusIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
+	a, isNull, err := s.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
-	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
+	b, isNull, err := s.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	forceToSigned := s.ctx.GetSessionVars().SQLMode.HasNoUnsignedSubtractionMode()
+	forceToSigned := ctx.GetSessionVars().SQLMode.HasNoUnsignedSubtractionMode()
 	isLHSUnsigned := mysql.HasUnsignedFlag(s.args[0].GetType().GetFlag())
 	isRHSUnsigned := mysql.HasUnsignedFlag(s.args[1].GetType().GetFlag())
 
@@ -573,11 +573,11 @@ func (s *builtinArithmeticMultiplyIntSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticMultiplyRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
+	a, isNull, err := s.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
+	b, isNull, err := s.args[1].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -589,11 +589,11 @@ func (s *builtinArithmeticMultiplyRealSig) evalReal(ctx sessionctx.Context, row 
 }
 
 func (s *builtinArithmeticMultiplyDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
+	a, isNull, err := s.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
-	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
+	b, isNull, err := s.args[1].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
@@ -609,12 +609,12 @@ func (s *builtinArithmeticMultiplyDecimalSig) evalDecimal(ctx sessionctx.Context
 }
 
 func (s *builtinArithmeticMultiplyIntUnsignedSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
+	a, isNull, err := s.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	unsignedA := uint64(a)
-	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
+	b, isNull, err := s.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -627,11 +627,11 @@ func (s *builtinArithmeticMultiplyIntUnsignedSig) evalInt(ctx sessionctx.Context
 }
 
 func (s *builtinArithmeticMultiplyIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
+	a, isNull, err := s.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
+	b, isNull, err := s.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -689,16 +689,16 @@ func (s *builtinArithmeticDivideDecimalSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticDivideRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
+	a, isNull, err := s.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
+	b, isNull, err := s.args[1].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	if b == 0 {
-		return 0, true, handleDivisionByZeroError(s.ctx)
+		return 0, true, handleDivisionByZeroError(ctx)
 	}
 	result := a / b
 	if math.IsInf(result, 0) {
@@ -708,12 +708,12 @@ func (s *builtinArithmeticDivideRealSig) evalReal(ctx sessionctx.Context, row ch
 }
 
 func (s *builtinArithmeticDivideDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
+	a, isNull, err := s.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
 
-	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
+	b, isNull, err := s.args[1].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
@@ -721,9 +721,9 @@ func (s *builtinArithmeticDivideDecimalSig) evalDecimal(ctx sessionctx.Context, 
 	c := &types.MyDecimal{}
 	err = types.DecimalDiv(a, b, c, types.DivFracIncr)
 	if err == types.ErrDivByZero {
-		return c, true, handleDivisionByZeroError(s.ctx)
+		return c, true, handleDivisionByZeroError(ctx)
 	} else if err == types.ErrTruncated {
-		sc := s.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		err = sc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
 	} else if err == nil {
 		_, frac := c.PrecisionAndFrac()
@@ -787,10 +787,6 @@ func (s *builtinArithmeticIntDivideDecimalSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticIntDivideIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	return s.evalIntWithCtx(s.ctx, row)
-}
-
-func (s *builtinArithmeticIntDivideIntSig) evalIntWithCtx(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
 	b, bIsNull, err := s.args[1].EvalInt(ctx, row)
 	if bIsNull || err != nil {
 		return 0, bIsNull, err
@@ -828,10 +824,10 @@ func (s *builtinArithmeticIntDivideIntSig) evalIntWithCtx(ctx sessionctx.Context
 }
 
 func (s *builtinArithmeticIntDivideDecimalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (ret int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	var num [2]*types.MyDecimal
 	for i, arg := range s.args {
-		num[i], isNull, err = arg.EvalDecimal(s.ctx, row)
+		num[i], isNull, err = arg.EvalDecimal(ctx, row)
 		if isNull || err != nil {
 			return 0, isNull, err
 		}
@@ -840,7 +836,7 @@ func (s *builtinArithmeticIntDivideDecimalSig) evalInt(ctx sessionctx.Context, r
 	c := &types.MyDecimal{}
 	err = types.DecimalDiv(num[0], num[1], c, types.DivFracIncr)
 	if err == types.ErrDivByZero {
-		return 0, true, handleDivisionByZeroError(s.ctx)
+		return 0, true, handleDivisionByZeroError(ctx)
 	}
 	if err == types.ErrTruncated {
 		err = sc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
@@ -974,16 +970,16 @@ func (s *builtinArithmeticModRealSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticModRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
+	b, isNull, err := s.args[1].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
 	if b == 0 {
-		return 0, true, handleDivisionByZeroError(s.ctx)
+		return 0, true, handleDivisionByZeroError(ctx)
 	}
 
-	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
+	a, isNull, err := s.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1002,18 +998,18 @@ func (s *builtinArithmeticModDecimalSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticModDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
+	a, isNull, err := s.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
-	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
+	b, isNull, err := s.args[1].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
 	c := &types.MyDecimal{}
 	err = types.DecimalMod(a, b, c)
 	if err == types.ErrDivByZero {
-		return c, true, handleDivisionByZeroError(s.ctx)
+		return c, true, handleDivisionByZeroError(ctx)
 	}
 	return c, err != nil, err
 }
@@ -1029,16 +1025,16 @@ func (s *builtinArithmeticModIntUnsignedUnsignedSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticModIntUnsignedUnsignedSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
+	b, isNull, err := s.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
 	if b == 0 {
-		return 0, true, handleDivisionByZeroError(s.ctx)
+		return 0, true, handleDivisionByZeroError(ctx)
 	}
 
-	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
+	a, isNull, err := s.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1059,14 +1055,14 @@ func (s *builtinArithmeticModIntUnsignedSignedSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticModIntUnsignedSignedSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
+	b, isNull, err := s.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	if b == 0 {
-		return 0, true, handleDivisionByZeroError(s.ctx)
+		return 0, true, handleDivisionByZeroError(ctx)
 	}
-	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
+	a, isNull, err := s.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1092,16 +1088,16 @@ func (s *builtinArithmeticModIntSignedUnsignedSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticModIntSignedUnsignedSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
+	b, isNull, err := s.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
 	if b == 0 {
-		return 0, true, handleDivisionByZeroError(s.ctx)
+		return 0, true, handleDivisionByZeroError(ctx)
 	}
 
-	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
+	a, isNull, err := s.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1127,16 +1123,16 @@ func (s *builtinArithmeticModIntSignedSignedSig) Clone() builtinFunc {
 }
 
 func (s *builtinArithmeticModIntSignedSignedSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
+	b, isNull, err := s.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
 	if b == 0 {
-		return 0, true, handleDivisionByZeroError(s.ctx)
+		return 0, true, handleDivisionByZeroError(ctx)
 	}
 
-	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
+	a, isNull, err := s.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}

--- a/pkg/expression/builtin_arithmetic_vec.go
+++ b/pkg/expression/builtin_arithmetic_vec.go
@@ -32,7 +32,7 @@ func (b *builtinArithmeticMultiplyRealSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticMultiplyRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -41,7 +41,7 @@ func (b *builtinArithmeticMultiplyRealSig) vecEvalReal(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -65,7 +65,7 @@ func (b *builtinArithmeticDivideDecimalSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -74,7 +74,7 @@ func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(ctx sessionctx.Contex
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -83,14 +83,14 @@ func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(ctx sessionctx.Contex
 	y := buf.Decimals()
 	var to types.MyDecimal
 	var frac int
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		err = types.DecimalDiv(&x[i], &y[i], &to, types.DivFracIncr)
 		if err == types.ErrDivByZero {
-			if err = handleDivisionByZeroError(b.ctx); err != nil {
+			if err = handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -126,11 +126,11 @@ func (b *builtinArithmeticModIntUnsignedUnsignedSig) vecEvalInt(ctx sessionctx.C
 		return err
 	}
 	defer b.bufAllocator.put(lh)
-	if err := b.args[0].VecEvalInt(b.ctx, input, lh); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
 	// reuse result as rh to avoid buf allocate
-	if err := b.args[1].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -144,7 +144,7 @@ func (b *builtinArithmeticModIntUnsignedUnsignedSig) vecEvalInt(ctx sessionctx.C
 			if rh.IsNull(i) {
 				continue
 			}
-			if err := handleDivisionByZeroError(b.ctx); err != nil {
+			if err := handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			rh.SetNull(i, true)
@@ -171,11 +171,11 @@ func (b *builtinArithmeticModIntUnsignedSignedSig) vecEvalInt(ctx sessionctx.Con
 	}
 	defer b.bufAllocator.put(lh)
 
-	if err := b.args[0].VecEvalInt(b.ctx, input, lh); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
 	// reuse result as rh to avoid buf allocate
-	if err := b.args[1].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	rh := result
@@ -188,7 +188,7 @@ func (b *builtinArithmeticModIntUnsignedSignedSig) vecEvalInt(ctx sessionctx.Con
 			if rh.IsNull(i) {
 				continue
 			}
-			if err := handleDivisionByZeroError(b.ctx); err != nil {
+			if err := handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			rh.SetNull(i, true)
@@ -219,11 +219,11 @@ func (b *builtinArithmeticModIntSignedUnsignedSig) vecEvalInt(ctx sessionctx.Con
 	}
 	defer b.bufAllocator.put(lh)
 
-	if err := b.args[0].VecEvalInt(b.ctx, input, lh); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
 	// reuse result as rh to avoid buf allocate
-	if err := b.args[1].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	rh := result
@@ -236,7 +236,7 @@ func (b *builtinArithmeticModIntSignedUnsignedSig) vecEvalInt(ctx sessionctx.Con
 			if rh.IsNull(i) {
 				continue
 			}
-			if err := handleDivisionByZeroError(b.ctx); err != nil {
+			if err := handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			rh.SetNull(i, true)
@@ -267,11 +267,11 @@ func (b *builtinArithmeticModIntSignedSignedSig) vecEvalInt(ctx sessionctx.Conte
 	}
 	defer b.bufAllocator.put(lh)
 
-	if err := b.args[0].VecEvalInt(b.ctx, input, lh); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
 	// reuse result as rh to avoid buf allocate
-	if err := b.args[1].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	rh := result
@@ -284,7 +284,7 @@ func (b *builtinArithmeticModIntSignedSignedSig) vecEvalInt(ctx sessionctx.Conte
 			if rh.IsNull(i) {
 				continue
 			}
-			if err := handleDivisionByZeroError(b.ctx); err != nil {
+			if err := handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			rh.SetNull(i, true)
@@ -305,7 +305,7 @@ func (b *builtinArithmeticMinusRealSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticMinusRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -314,7 +314,7 @@ func (b *builtinArithmeticMinusRealSig) vecEvalReal(ctx sessionctx.Context, inpu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -338,7 +338,7 @@ func (b *builtinArithmeticMinusDecimalSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticMinusDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -347,7 +347,7 @@ func (b *builtinArithmeticMinusDecimalSig) vecEvalDecimal(ctx sessionctx.Context
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -381,11 +381,11 @@ func (b *builtinArithmeticMinusIntSig) vecEvalInt(ctx sessionctx.Context, input 
 	}
 	defer b.bufAllocator.put(lh)
 
-	if err := b.args[0].VecEvalInt(b.ctx, input, lh); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
 
-	if err := b.args[1].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -396,7 +396,7 @@ func (b *builtinArithmeticMinusIntSig) vecEvalInt(ctx sessionctx.Context, input 
 	rhi64s := rh.Int64s()
 	resulti64s := result.Int64s()
 
-	forceToSigned := b.ctx.GetSessionVars().SQLMode.HasNoUnsignedSubtractionMode()
+	forceToSigned := ctx.GetSessionVars().SQLMode.HasNoUnsignedSubtractionMode()
 	isLHSUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
 	isRHSUnsigned := mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag())
 
@@ -433,10 +433,10 @@ func (b *builtinArithmeticModRealSig) vecEvalReal(ctx sessionctx.Context, input 
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	result.MergeNulls(buf)
@@ -447,7 +447,7 @@ func (b *builtinArithmeticModRealSig) vecEvalReal(ctx sessionctx.Context, input 
 			continue
 		}
 		if y[i] == 0 {
-			if err := handleDivisionByZeroError(b.ctx); err != nil {
+			if err := handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -464,7 +464,7 @@ func (b *builtinArithmeticModDecimalSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticModDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -473,7 +473,7 @@ func (b *builtinArithmeticModDecimalSig) vecEvalDecimal(ctx sessionctx.Context, 
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -487,7 +487,7 @@ func (b *builtinArithmeticModDecimalSig) vecEvalDecimal(ctx sessionctx.Context, 
 		}
 		err = types.DecimalMod(&x[i], &y[i], &to)
 		if err == types.ErrDivByZero {
-			if err := handleDivisionByZeroError(b.ctx); err != nil {
+			if err := handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -506,7 +506,7 @@ func (b *builtinArithmeticPlusRealSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticPlusRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -515,7 +515,7 @@ func (b *builtinArithmeticPlusRealSig) vecEvalReal(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -539,7 +539,7 @@ func (b *builtinArithmeticMultiplyDecimalSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticMultiplyDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -548,7 +548,7 @@ func (b *builtinArithmeticMultiplyDecimalSig) vecEvalDecimal(ctx sessionctx.Cont
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -577,7 +577,7 @@ func (b *builtinArithmeticIntDivideDecimalSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	n := input.NumRows()
 	var err error
 	var buf [2]*chunk.Column
@@ -588,7 +588,7 @@ func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(ctx sessionctx.Context
 		}
 		defer b.bufAllocator.put(buf[i])
 
-		err = arg.VecEvalDecimal(b.ctx, input, buf[i])
+		err = arg.VecEvalDecimal(ctx, input, buf[i])
 		if err != nil {
 			return err
 		}
@@ -611,7 +611,7 @@ func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(ctx sessionctx.Context
 		c := &types.MyDecimal{}
 		err = types.DecimalDiv(&num[0][i], &num[1][i], c, types.DivFracIncr)
 		if err == types.ErrDivByZero {
-			if err = handleDivisionByZeroError(b.ctx); err != nil {
+			if err = handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -656,7 +656,7 @@ func (b *builtinArithmeticMultiplyIntSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticMultiplyIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -666,7 +666,7 @@ func (b *builtinArithmeticMultiplyIntSig) vecEvalInt(ctx sessionctx.Context, inp
 	}
 	defer b.bufAllocator.put(buf)
 
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -695,7 +695,7 @@ func (b *builtinArithmeticDivideRealSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticDivideRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -704,7 +704,7 @@ func (b *builtinArithmeticDivideRealSig) vecEvalReal(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -716,7 +716,7 @@ func (b *builtinArithmeticDivideRealSig) vecEvalReal(ctx sessionctx.Context, inp
 			continue
 		}
 		if y[i] == 0 {
-			if err := handleDivisionByZeroError(b.ctx); err != nil {
+			if err := handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -742,12 +742,12 @@ func (b *builtinArithmeticIntDivideIntSig) vecEvalInt(ctx sessionctx.Context, in
 	}
 	defer b.bufAllocator.put(lhsBuf)
 
-	if err := b.args[0].VecEvalInt(b.ctx, input, lhsBuf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, lhsBuf); err != nil {
 		return err
 	}
 
 	// reuse result as rhsBuf to avoid buf allocate
-	if err := b.args[1].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -763,18 +763,18 @@ func (b *builtinArithmeticIntDivideIntSig) vecEvalInt(ctx sessionctx.Context, in
 
 	switch {
 	case isLHSUnsigned && isRHSUnsigned:
-		err = b.divideUU(result, lhsI64s, rhsI64s, resultI64s)
+		err = b.divideUU(ctx, result, lhsI64s, rhsI64s, resultI64s)
 	case isLHSUnsigned && !isRHSUnsigned:
-		err = b.divideUS(result, lhsI64s, rhsI64s, resultI64s)
+		err = b.divideUS(ctx, result, lhsI64s, rhsI64s, resultI64s)
 	case !isLHSUnsigned && isRHSUnsigned:
-		err = b.divideSU(result, lhsI64s, rhsI64s, resultI64s)
+		err = b.divideSU(ctx, result, lhsI64s, rhsI64s, resultI64s)
 	case !isLHSUnsigned && !isRHSUnsigned:
-		err = b.divideSS(result, lhsI64s, rhsI64s, resultI64s)
+		err = b.divideSS(ctx, result, lhsI64s, rhsI64s, resultI64s)
 	}
 	return err
 }
 
-func (b *builtinArithmeticIntDivideIntSig) divideUU(result *chunk.Column, lhsI64s, rhsI64s, resultI64s []int64) error {
+func (b *builtinArithmeticIntDivideIntSig) divideUU(ctx sessionctx.Context, result *chunk.Column, lhsI64s, rhsI64s, resultI64s []int64) error {
 	for i := 0; i < len(lhsI64s); i++ {
 		if result.IsNull(i) {
 			continue
@@ -782,7 +782,7 @@ func (b *builtinArithmeticIntDivideIntSig) divideUU(result *chunk.Column, lhsI64
 		lhs, rhs := lhsI64s[i], rhsI64s[i]
 
 		if rhs == 0 {
-			if err := handleDivisionByZeroError(b.ctx); err != nil {
+			if err := handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -793,14 +793,14 @@ func (b *builtinArithmeticIntDivideIntSig) divideUU(result *chunk.Column, lhsI64
 	return nil
 }
 
-func (b *builtinArithmeticIntDivideIntSig) divideUS(result *chunk.Column, lhsI64s, rhsI64s, resultI64s []int64) error {
+func (b *builtinArithmeticIntDivideIntSig) divideUS(ctx sessionctx.Context, result *chunk.Column, lhsI64s, rhsI64s, resultI64s []int64) error {
 	for i := 0; i < len(lhsI64s); i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		lhs, rhs := lhsI64s[i], rhsI64s[i]
 		if rhs == 0 {
-			if err := handleDivisionByZeroError(b.ctx); err != nil {
+			if err := handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -815,7 +815,7 @@ func (b *builtinArithmeticIntDivideIntSig) divideUS(result *chunk.Column, lhsI64
 	return nil
 }
 
-func (b *builtinArithmeticIntDivideIntSig) divideSU(result *chunk.Column, lhsI64s, rhsI64s, resultI64s []int64) error {
+func (b *builtinArithmeticIntDivideIntSig) divideSU(ctx sessionctx.Context, result *chunk.Column, lhsI64s, rhsI64s, resultI64s []int64) error {
 	for i := 0; i < len(lhsI64s); i++ {
 		if result.IsNull(i) {
 			continue
@@ -823,7 +823,7 @@ func (b *builtinArithmeticIntDivideIntSig) divideSU(result *chunk.Column, lhsI64
 		lhs, rhs := lhsI64s[i], rhsI64s[i]
 
 		if rhs == 0 {
-			if err := handleDivisionByZeroError(b.ctx); err != nil {
+			if err := handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -838,7 +838,7 @@ func (b *builtinArithmeticIntDivideIntSig) divideSU(result *chunk.Column, lhsI64
 	return nil
 }
 
-func (b *builtinArithmeticIntDivideIntSig) divideSS(result *chunk.Column, lhsI64s, rhsI64s, resultI64s []int64) error {
+func (b *builtinArithmeticIntDivideIntSig) divideSS(ctx sessionctx.Context, result *chunk.Column, lhsI64s, rhsI64s, resultI64s []int64) error {
 	for i := 0; i < len(lhsI64s); i++ {
 		if result.IsNull(i) {
 			continue
@@ -846,7 +846,7 @@ func (b *builtinArithmeticIntDivideIntSig) divideSS(result *chunk.Column, lhsI64
 		lhs, rhs := lhsI64s[i], rhsI64s[i]
 
 		if rhs == 0 {
-			if err := handleDivisionByZeroError(b.ctx); err != nil {
+			if err := handleDivisionByZeroError(ctx); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -872,12 +872,12 @@ func (b *builtinArithmeticPlusIntSig) vecEvalInt(ctx sessionctx.Context, input *
 	}
 	defer b.bufAllocator.put(lh)
 
-	if err := b.args[0].VecEvalInt(b.ctx, input, lh); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
 
 	// reuse result as rh to avoid buf allocate
-	if err := b.args[1].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -983,7 +983,7 @@ func (b *builtinArithmeticPlusDecimalSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticPlusDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -992,7 +992,7 @@ func (b *builtinArithmeticPlusDecimalSig) vecEvalDecimal(ctx sessionctx.Context,
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1020,7 +1020,7 @@ func (b *builtinArithmeticMultiplyIntUnsignedSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticMultiplyIntUnsignedSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -1030,7 +1030,7 @@ func (b *builtinArithmeticMultiplyIntUnsignedSig) vecEvalInt(ctx sessionctx.Cont
 	}
 	defer b.bufAllocator.put(buf)
 
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -484,8 +484,8 @@ func newFakeSctx() *stmtctx.StatementContext {
 	return sc
 }
 
-func (b *castJSONAsArrayFunctionSig) evalJSON(_ sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+func (b *castJSONAsArrayFunctionSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -634,8 +634,8 @@ func (b *builtinCastIntAsIntSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastIntAsIntSig) evalInt(_ sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalInt(b.ctx, row)
+func (b *builtinCastIntAsIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
+	res, isNull, err = b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return
 	}
@@ -655,8 +655,8 @@ func (b *builtinCastIntAsRealSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastIntAsRealSig) evalReal(_ sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+func (b *builtinCastIntAsRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -685,8 +685,8 @@ func (b *builtinCastIntAsDecimalSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastIntAsDecimalSig) evalDecimal(_ sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+func (b *builtinCastIntAsDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -703,7 +703,7 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(_ sessionctx.Context, row chunk
 	} else {
 		res = types.NewDecFromUint(uint64(val))
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
 	err = sc.HandleOverflow(err, err)
 	return res, isNull, err
@@ -719,8 +719,8 @@ func (b *builtinCastIntAsStringSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastIntAsStringSig) evalString(_ sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+func (b *builtinCastIntAsStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -733,11 +733,11 @@ func (b *builtinCastIntAsStringSig) evalString(_ sessionctx.Context, row chunk.R
 	if tp.GetType() == mysql.TypeYear && res == "0" {
 		res = "0000"
 	}
-	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
+	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
 	if err != nil {
 		return res, false, err
 	}
-	return padZeroForBinaryType(res, b.tp, b.ctx)
+	return padZeroForBinaryType(res, b.tp, ctx)
 }
 
 type builtinCastIntAsTimeSig struct {
@@ -750,8 +750,8 @@ func (b *builtinCastIntAsTimeSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastIntAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+func (b *builtinCastIntAsTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -759,11 +759,11 @@ func (b *builtinCastIntAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row) 
 	if b.args[0].GetType().GetType() == mysql.TypeYear {
 		res, err = types.ParseTimeFromYear(val)
 	} else {
-		res, err = types.ParseTimeFromNum(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), val, b.tp.GetType(), b.tp.GetDecimal())
+		res, err = types.ParseTimeFromNum(ctx.GetSessionVars().StmtCtx.TypeCtx(), val, b.tp.GetType(), b.tp.GetDecimal())
 	}
 
 	if err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	if b.tp.GetType() == mysql.TypeDate {
 		// Truncate hh:mm:ss part if the type is Date.
@@ -782,18 +782,18 @@ func (b *builtinCastIntAsDurationSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastIntAsDurationSig) evalDuration(_ sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+func (b *builtinCastIntAsDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 	dur, err := types.NumberToDuration(val, b.tp.GetDecimal())
 	if err != nil {
 		if types.ErrOverflow.Equal(err) {
-			err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
+			err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
 		}
 		if types.ErrTruncatedWrongVal.Equal(err) {
-			err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+			err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
 		}
 		return res, true, err
 	}
@@ -810,8 +810,8 @@ func (b *builtinCastIntAsJSONSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastIntAsJSONSig) evalJSON(_ sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+func (b *builtinCastIntAsJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -835,8 +835,8 @@ func (b *builtinCastRealAsJSONSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastRealAsJSONSig) evalJSON(_ sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+func (b *builtinCastRealAsJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	// FIXME: `select json_type(cast(1111.11 as json))` should return `DECIMAL`, we return `DOUBLE` now.
 	return types.CreateBinaryJSON(val), isNull, err
 }
@@ -851,8 +851,8 @@ func (b *builtinCastDecimalAsJSONSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDecimalAsJSONSig) evalJSON(_ sessionctx.Context, row chunk.Row) (types.BinaryJSON, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+func (b *builtinCastDecimalAsJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (types.BinaryJSON, bool, error) {
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return types.BinaryJSON{}, true, err
 	}
@@ -874,8 +874,8 @@ func (b *builtinCastStringAsJSONSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastStringAsJSONSig) evalJSON(_ sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+func (b *builtinCastStringAsJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -913,8 +913,8 @@ func (b *builtinCastDurationAsJSONSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDurationAsJSONSig) evalJSON(_ sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+func (b *builtinCastDurationAsJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -932,8 +932,8 @@ func (b *builtinCastTimeAsJSONSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastTimeAsJSONSig) evalJSON(_ sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
+func (b *builtinCastTimeAsJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -953,8 +953,8 @@ func (b *builtinCastRealAsRealSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastRealAsRealSig) evalReal(_ sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalReal(b.ctx, row)
+func (b *builtinCastRealAsRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
+	res, isNull, err = b.args[0].EvalReal(ctx, row)
 	if b.inUnion && mysql.HasUnsignedFlag(b.tp.GetFlag()) && res < 0 {
 		res = 0
 	}
@@ -971,8 +971,8 @@ func (b *builtinCastRealAsIntSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastRealAsIntSig) evalInt(_ sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+func (b *builtinCastRealAsIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -982,12 +982,12 @@ func (b *builtinCastRealAsIntSig) evalInt(_ sessionctx.Context, row chunk.Row) (
 		res = 0
 	} else {
 		var uintVal uint64
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		uintVal, err = types.ConvertFloatToUint(sc.TypeFlags(), val, types.IntergerUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
 		res = int64(uintVal)
 	}
 	if types.ErrOverflow.Equal(err) {
-		err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
+		err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
 	}
 	return res, isNull, err
 }
@@ -1002,8 +1002,8 @@ func (b *builtinCastRealAsDecimalSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastRealAsDecimalSig) evalDecimal(_ sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+func (b *builtinCastRealAsDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1012,7 +1012,7 @@ func (b *builtinCastRealAsDecimalSig) evalDecimal(_ sessionctx.Context, row chun
 		err = res.FromFloat64(val)
 		if types.ErrOverflow.Equal(err) {
 			warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0])
-			err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
+			err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
 		} else if types.ErrTruncated.Equal(err) {
 			// This behavior is consistent with MySQL.
 			err = nil
@@ -1021,7 +1021,7 @@ func (b *builtinCastRealAsDecimalSig) evalDecimal(_ sessionctx.Context, row chun
 			return res, false, err
 		}
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
 	err = sc.HandleOverflow(err, err)
 	return res, false, err
@@ -1037,8 +1037,8 @@ func (b *builtinCastRealAsStringSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastRealAsStringSig) evalString(_ sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+func (b *builtinCastRealAsStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1050,11 +1050,11 @@ func (b *builtinCastRealAsStringSig) evalString(_ sessionctx.Context, row chunk.
 		// If we strconv.FormatFloat the value with 64bits, the result is incorrect!
 		bits = 32
 	}
-	res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(val, 'f', -1, bits), b.tp, b.ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
+	res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(val, 'f', -1, bits), b.tp, ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
 	if err != nil {
 		return res, false, err
 	}
-	return padZeroForBinaryType(res, b.tp, b.ctx)
+	return padZeroForBinaryType(res, b.tp, ctx)
 }
 
 type builtinCastRealAsTimeSig struct {
@@ -1067,8 +1067,8 @@ func (b *builtinCastRealAsTimeSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastRealAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+func (b *builtinCastRealAsTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, true, err
 	}
@@ -1077,10 +1077,10 @@ func (b *builtinCastRealAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row)
 	if fv == "0" {
 		return types.ZeroTime, false, nil
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err := types.ParseTimeFromFloatString(sc.TypeCtx(), fv, b.tp.GetType(), b.tp.GetDecimal())
 	if err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	if b.tp.GetType() == mysql.TypeDate {
 		// Truncate hh:mm:ss part if the type is Date.
@@ -1099,15 +1099,15 @@ func (b *builtinCastRealAsDurationSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastRealAsDurationSig) evalDuration(_ sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+func (b *builtinCastRealAsDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	res, _, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), strconv.FormatFloat(val, 'f', -1, 64), b.tp.GetDecimal())
+	res, _, err = types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), strconv.FormatFloat(val, 'f', -1, 64), b.tp.GetDecimal())
 	if err != nil {
 		if types.ErrTruncatedWrongVal.Equal(err) {
-			err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+			err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
 			// ErrTruncatedWrongVal needs to be considered NULL.
 			return res, true, err
 		}
@@ -1125,8 +1125,8 @@ func (b *builtinCastDecimalAsDecimalSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDecimalAsDecimalSig) evalDecimal(_ sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
-	evalDecimal, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+func (b *builtinCastDecimalAsDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
+	evalDecimal, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1134,7 +1134,7 @@ func (b *builtinCastDecimalAsDecimalSig) evalDecimal(_ sessionctx.Context, row c
 	if !(b.inUnion && mysql.HasUnsignedFlag(b.tp.GetFlag()) && evalDecimal.IsNegative()) {
 		*res = *evalDecimal
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
 	err = sc.HandleOverflow(err, err)
 	return res, false, err
@@ -1150,8 +1150,8 @@ func (b *builtinCastDecimalAsIntSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDecimalAsIntSig) evalInt(_ sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+func (b *builtinCastDecimalAsIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1175,7 +1175,7 @@ func (b *builtinCastDecimalAsIntSig) evalInt(_ sessionctx.Context, row chunk.Row
 
 	if types.ErrOverflow.Equal(err) {
 		warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", val)
-		err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
+		err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
 	}
 
 	return res, false, err
@@ -1191,17 +1191,17 @@ func (b *builtinCastDecimalAsStringSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDecimalAsStringSig) evalString(_ sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+func (b *builtinCastDecimalAsStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceStrWithSpecifiedTp(string(val.ToString()), b.tp, sc.TypeCtx(), false)
 	if err != nil {
 		return res, false, err
 	}
-	return padZeroForBinaryType(res, b.tp, b.ctx)
+	return padZeroForBinaryType(res, b.tp, ctx)
 }
 
 type builtinCastDecimalAsRealSig struct {
@@ -1228,8 +1228,8 @@ func (b *builtinCastDecimalAsRealSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDecimalAsRealSig) evalReal(_ sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+func (b *builtinCastDecimalAsRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1251,15 +1251,15 @@ func (b *builtinCastDecimalAsTimeSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDecimalAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+func (b *builtinCastDecimalAsTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ParseTimeFromFloatString(sc.TypeCtx(), string(val.ToString()), b.tp.GetType(), b.tp.GetDecimal())
 	if err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	if b.tp.GetType() == mysql.TypeDate {
 		// Truncate hh:mm:ss part if the type is Date.
@@ -1278,14 +1278,14 @@ func (b *builtinCastDecimalAsDurationSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDecimalAsDurationSig) evalDuration(_ sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+func (b *builtinCastDecimalAsDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return res, true, err
 	}
-	res, _, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), string(val.ToString()), b.tp.GetDecimal())
+	res, _, err = types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), string(val.ToString()), b.tp.GetDecimal())
 	if types.ErrTruncatedWrongVal.Equal(err) {
-		err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+		err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
 		// ErrTruncatedWrongVal needs to be considered NULL.
 		return res, true, err
 	}
@@ -1302,16 +1302,16 @@ func (b *builtinCastStringAsStringSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastStringAsStringSig) evalString(_ sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalString(b.ctx, row)
+func (b *builtinCastStringAsStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
+	res, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
+	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
 	if err != nil {
 		return res, false, err
 	}
-	return padZeroForBinaryType(res, b.tp, b.ctx)
+	return padZeroForBinaryType(res, b.tp, ctx)
 }
 
 type builtinCastStringAsIntSig struct {
@@ -1328,13 +1328,13 @@ func (b *builtinCastStringAsIntSig) Clone() builtinFunc {
 // see https://dev.mysql.com/doc/refman/5.7/en/out-of-range-and-overflow.html.
 // When an out-of-range value is assigned to an integer column, MySQL stores the value representing the corresponding endpoint of the column data type range. If it is in select statement, it will return the
 // endpoint value with a warning.
-func (b *builtinCastStringAsIntSig) handleOverflow(origRes int64, origStr string, origErr error, isNegative bool) (res int64, err error) {
+func (*builtinCastStringAsIntSig) handleOverflow(ctx sessionctx.Context, origRes int64, origStr string, origErr error, isNegative bool) (res int64, err error) {
 	res, err = origRes, origErr
 	if err == nil {
 		return
 	}
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	if types.ErrOverflow.Equal(origErr) {
 		if isNegative {
 			res = math.MinInt64
@@ -1348,17 +1348,17 @@ func (b *builtinCastStringAsIntSig) handleOverflow(origRes int64, origStr string
 	return
 }
 
-func (b *builtinCastStringAsIntSig) evalInt(_ sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
+func (b *builtinCastStringAsIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
 	if b.args[0].GetType().Hybrid() || IsBinaryLiteral(b.args[0]) {
-		return b.args[0].EvalInt(b.ctx, row)
+		return b.args[0].EvalInt(ctx, row)
 	}
 
 	// Take the implicit evalInt path if possible.
 	if CanImplicitEvalInt(b.args[0]) {
-		return b.args[0].EvalInt(b.ctx, row)
+		return b.args[0].EvalInt(ctx, row)
 	}
 
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1370,7 +1370,7 @@ func (b *builtinCastStringAsIntSig) evalInt(_ sessionctx.Context, row chunk.Row)
 	}
 
 	var ures uint64
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	if !isNegative {
 		ures, err = types.StrToUint(sc.TypeCtx(), val, true)
 		res = int64(ures)
@@ -1388,7 +1388,7 @@ func (b *builtinCastStringAsIntSig) evalInt(_ sessionctx.Context, row chunk.Row)
 		}
 	}
 
-	res, err = b.handleOverflow(res, val, err, isNegative)
+	res, err = b.handleOverflow(ctx, res, val, err, isNegative)
 	return res, false, err
 }
 
@@ -1402,21 +1402,21 @@ func (b *builtinCastStringAsRealSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastStringAsRealSig) evalReal(_ sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
+func (b *builtinCastStringAsRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
 	if IsBinaryLiteral(b.args[0]) {
-		return b.args[0].EvalReal(b.ctx, row)
+		return b.args[0].EvalReal(ctx, row)
 	}
 
 	// Take the implicit evalReal path if possible.
 	if CanImplicitEvalReal(b.args[0]) {
-		return b.args[0].EvalReal(b.ctx, row)
+		return b.args[0].EvalReal(ctx, row)
 	}
 
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.StrToFloat(sc.TypeCtx(), val, true)
 	if err != nil {
 		return 0, false, err
@@ -1438,18 +1438,18 @@ func (b *builtinCastStringAsDecimalSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastStringAsDecimalSig) evalDecimal(_ sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
+func (b *builtinCastStringAsDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
 	if IsBinaryLiteral(b.args[0]) {
-		return b.args[0].EvalDecimal(b.ctx, row)
+		return b.args[0].EvalDecimal(ctx, row)
 	}
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 	val = strings.TrimSpace(val)
 	isNegative := len(val) > 1 && val[0] == '-'
 	res = new(types.MyDecimal)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	if !(b.inUnion && mysql.HasUnsignedFlag(b.tp.GetFlag()) && isNegative) {
 		err = res.FromString([]byte(val))
 		if err == types.ErrTruncated {
@@ -1475,18 +1475,18 @@ func (b *builtinCastStringAsTimeSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastStringAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+func (b *builtinCastStringAsTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ParseTime(sc.TypeCtx(), val, b.tp.GetType(), b.tp.GetDecimal(), nil)
 	if err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
-	if res.IsZero() && b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, res.String()))
+	if res.IsZero() && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, res.String()))
 	}
 	if b.tp.GetType() == mysql.TypeDate {
 		// Truncate hh:mm:ss part if the type is Date.
@@ -1505,14 +1505,14 @@ func (b *builtinCastStringAsDurationSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastStringAsDurationSig) evalDuration(_ sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+func (b *builtinCastStringAsDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	res, isNull, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), val, b.tp.GetDecimal())
+	res, isNull, err = types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), val, b.tp.GetDecimal())
 	if types.ErrTruncatedWrongVal.Equal(err) {
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		err = sc.HandleTruncate(err)
 	}
 	return res, isNull, err
@@ -1528,15 +1528,15 @@ func (b *builtinCastTimeAsTimeSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastTimeAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalTime(b.ctx, row)
+func (b *builtinCastTimeAsTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
+	res, isNull, err = b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	if res, err = res.Convert(sc.TypeCtx(), b.tp.GetType()); err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	res, err = res.RoundFrac(sc.TypeCtx(), b.tp.GetDecimal())
 	if b.tp.GetType() == mysql.TypeDate {
@@ -1557,12 +1557,12 @@ func (b *builtinCastTimeAsIntSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastTimeAsIntSig) evalInt(_ sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
+func (b *builtinCastTimeAsIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	t, err := val.RoundFrac(sc.TypeCtx(), types.DefaultFsp)
 	if err != nil {
 		return res, false, err
@@ -1581,8 +1581,8 @@ func (b *builtinCastTimeAsRealSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastTimeAsRealSig) evalReal(_ sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
+func (b *builtinCastTimeAsRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1600,12 +1600,12 @@ func (b *builtinCastTimeAsDecimalSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastTimeAsDecimalSig) evalDecimal(_ sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
+func (b *builtinCastTimeAsDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), val.ToNumber(), b.tp)
 	err = sc.HandleOverflow(err, err)
 	return res, false, err
@@ -1621,17 +1621,17 @@ func (b *builtinCastTimeAsStringSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastTimeAsStringSig) evalString(_ sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
+func (b *builtinCastTimeAsStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceStrWithSpecifiedTp(val.String(), b.tp, sc.TypeCtx(), false)
 	if err != nil {
 		return res, false, err
 	}
-	return padZeroForBinaryType(res, b.tp, b.ctx)
+	return padZeroForBinaryType(res, b.tp, ctx)
 }
 
 type builtinCastTimeAsDurationSig struct {
@@ -1644,8 +1644,8 @@ func (b *builtinCastTimeAsDurationSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastTimeAsDurationSig) evalDuration(_ sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
+func (b *builtinCastTimeAsDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1653,7 +1653,7 @@ func (b *builtinCastTimeAsDurationSig) evalDuration(_ sessionctx.Context, row ch
 	if err != nil {
 		return res, false, err
 	}
-	res, err = res.RoundFrac(b.tp.GetDecimal(), b.ctx.GetSessionVars().Location())
+	res, err = res.RoundFrac(b.tp.GetDecimal(), ctx.GetSessionVars().Location())
 	return res, false, err
 }
 
@@ -1667,12 +1667,12 @@ func (b *builtinCastDurationAsDurationSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDurationAsDurationSig) evalDuration(_ sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalDuration(b.ctx, row)
+func (b *builtinCastDurationAsDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
+	res, isNull, err = b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	res, err = res.RoundFrac(b.tp.GetDecimal(), b.ctx.GetSessionVars().Location())
+	res, err = res.RoundFrac(b.tp.GetDecimal(), ctx.GetSessionVars().Location())
 	return res, false, err
 }
 
@@ -1686,12 +1686,12 @@ func (b *builtinCastDurationAsIntSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDurationAsIntSig) evalInt(_ sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+func (b *builtinCastDurationAsIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	dur, err := val.RoundFrac(types.DefaultFsp, b.ctx.GetSessionVars().Location())
+	dur, err := val.RoundFrac(types.DefaultFsp, ctx.GetSessionVars().Location())
 	if err != nil {
 		return res, false, err
 	}
@@ -1709,8 +1709,8 @@ func (b *builtinCastDurationAsRealSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDurationAsRealSig) evalReal(_ sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+func (b *builtinCastDurationAsRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1731,15 +1731,15 @@ func (b *builtinCastDurationAsDecimalSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDurationAsDecimalSig) evalDecimal(_ sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+func (b *builtinCastDurationAsDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 	if val.Fsp, err = types.CheckFsp(val.Fsp); err != nil {
 		return res, false, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), val.ToNumber(), b.tp)
 	err = sc.HandleOverflow(err, err)
 	return res, false, err
@@ -1755,17 +1755,17 @@ func (b *builtinCastDurationAsStringSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDurationAsStringSig) evalString(_ sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+func (b *builtinCastDurationAsStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceStrWithSpecifiedTp(val.String(), b.tp, sc.TypeCtx(), false)
 	if err != nil {
 		return res, false, err
 	}
-	return padZeroForBinaryType(res, b.tp, b.ctx)
+	return padZeroForBinaryType(res, b.tp, ctx)
 }
 
 func padZeroForBinaryType(s string, tp *types.FieldType, ctx sessionctx.Context) (string, bool, error) {
@@ -1795,19 +1795,19 @@ func (b *builtinCastDurationAsTimeSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastDurationAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+func (b *builtinCastDurationAsTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
-	ts, err := getStmtTimestamp(b.ctx)
+	sc := ctx.GetSessionVars().StmtCtx
+	ts, err := getStmtTimestamp(ctx)
 	if err != nil {
 		ts = gotime.Now()
 	}
 	res, err = val.ConvertToTimeWithTimestamp(sc.TypeCtx(), b.tp.GetType(), ts)
 	if err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	res, err = res.RoundFrac(sc.TypeCtx(), b.tp.GetDecimal())
 	return res, false, err
@@ -1823,8 +1823,8 @@ func (b *builtinCastJSONAsJSONSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastJSONAsJSONSig) evalJSON(_ sessionctx.Context, row chunk.Row) (val types.BinaryJSON, isNull bool, err error) {
-	return b.args[0].EvalJSON(b.ctx, row)
+func (b *builtinCastJSONAsJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (val types.BinaryJSON, isNull bool, err error) {
+	return b.args[0].EvalJSON(ctx, row)
 }
 
 type builtinCastJSONAsIntSig struct {
@@ -1837,12 +1837,12 @@ func (b *builtinCastJSONAsIntSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastJSONAsIntSig) evalInt(_ sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+func (b *builtinCastJSONAsIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ConvertJSONToInt64(sc.TypeCtx(), val, mysql.HasUnsignedFlag(b.tp.GetFlag()))
 	err = sc.HandleOverflow(err, err)
 	return
@@ -1858,12 +1858,12 @@ func (b *builtinCastJSONAsRealSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastJSONAsRealSig) evalReal(_ sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+func (b *builtinCastJSONAsRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ConvertJSONToFloat(sc.TypeCtx(), val)
 	return
 }
@@ -1878,12 +1878,12 @@ func (b *builtinCastJSONAsDecimalSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastJSONAsDecimalSig) evalDecimal(_ sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+func (b *builtinCastJSONAsDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ConvertJSONToDecimal(sc.TypeCtx(), val)
 	if err != nil {
 		return res, false, err
@@ -1903,12 +1903,12 @@ func (b *builtinCastJSONAsStringSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastJSONAsStringSig) evalString(_ sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+func (b *builtinCastJSONAsStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	s, err := types.ProduceStrWithSpecifiedTp(val.String(), b.tp, b.ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
+	s, err := types.ProduceStrWithSpecifiedTp(val.String(), b.tp, ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
 	if err != nil {
 		return res, false, err
 	}
@@ -1925,8 +1925,8 @@ func (b *builtinCastJSONAsTimeSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastJSONAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+func (b *builtinCastJSONAsTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1943,14 +1943,14 @@ func (b *builtinCastJSONAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row)
 	case types.JSONTypeCodeDuration:
 		duration := val.GetDuration()
 
-		sc := b.ctx.GetSessionVars().StmtCtx
-		ts, err := getStmtTimestamp(b.ctx)
+		sc := ctx.GetSessionVars().StmtCtx
+		ts, err := getStmtTimestamp(ctx)
 		if err != nil {
 			ts = gotime.Now()
 		}
 		res, err = duration.ConvertToTimeWithTimestamp(sc.TypeCtx(), b.tp.GetType(), ts)
 		if err != nil {
-			return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+			return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 		}
 		res, err = res.RoundFrac(sc.TypeCtx(), b.tp.GetDecimal())
 		return res, isNull, err
@@ -1959,10 +1959,10 @@ func (b *builtinCastJSONAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row)
 		if err != nil {
 			return res, false, err
 		}
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		res, err = types.ParseTime(sc.TypeCtx(), s, b.tp.GetType(), b.tp.GetDecimal(), nil)
 		if err != nil {
-			return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+			return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 		}
 		if b.tp.GetType() == mysql.TypeDate {
 			// Truncate hh:mm:ss part if the type is Date.
@@ -1971,7 +1971,7 @@ func (b *builtinCastJSONAsTimeSig) evalTime(_ sessionctx.Context, row chunk.Row)
 		return res, isNull, err
 	default:
 		err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), val.String())
-		return res, true, b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+		return res, true, ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
 	}
 }
 
@@ -1985,13 +1985,13 @@ func (b *builtinCastJSONAsDurationSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinCastJSONAsDurationSig) evalDuration(_ sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+func (b *builtinCastJSONAsDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
+	val, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 
 	switch val.TypeCode {
 	case types.JSONTypeCodeDate, types.JSONTypeCodeDatetime, types.JSONTypeCodeTimestamp:
@@ -2000,7 +2000,7 @@ func (b *builtinCastJSONAsDurationSig) evalDuration(_ sessionctx.Context, row ch
 		if err != nil {
 			return res, false, err
 		}
-		res, err = res.RoundFrac(b.tp.GetDecimal(), b.ctx.GetSessionVars().Location())
+		res, err = res.RoundFrac(b.tp.GetDecimal(), ctx.GetSessionVars().Location())
 		return res, isNull, err
 	case types.JSONTypeCodeDuration:
 		res = val.GetDuration()
@@ -2012,7 +2012,7 @@ func (b *builtinCastJSONAsDurationSig) evalDuration(_ sessionctx.Context, row ch
 		}
 		res, _, err = types.ParseDuration(stmtCtx.TypeCtx(), s, b.tp.GetDecimal())
 		if types.ErrTruncatedWrongVal.Equal(err) {
-			sc := b.ctx.GetSessionVars().StmtCtx
+			sc := ctx.GetSessionVars().StmtCtx
 			err = sc.HandleTruncate(err)
 		}
 		return res, isNull, err
@@ -2141,6 +2141,7 @@ func BuildCastFunctionWithCheck(ctx sessionctx.Context, expr Expression, tp *typ
 		FuncName: model.NewCIStr(ast.Cast),
 		RetType:  tp,
 		Function: f,
+		ctx:      ctx,
 	}
 	// We do not fold CAST if the eval type of this scalar function is ETJson
 	// since we may reset the flag of the field type of CastAsJson later which
@@ -2387,7 +2388,7 @@ func TryPushCastIntoControlFunctionForHybridType(ctx sessionctx.Context, expr Ex
 			if err != nil {
 				return expr
 			}
-			sf.RetType, sf.Function = f.getRetTp(), f
+			sf.RetType, sf.Function, sf.ctx = f.getRetTp(), f, ctx
 			return sf
 		}
 	case ast.Case:
@@ -2412,7 +2413,7 @@ func TryPushCastIntoControlFunctionForHybridType(ctx sessionctx.Context, expr Ex
 		if err != nil {
 			return expr
 		}
-		sf.RetType, sf.Function = f.getRetTp(), f
+		sf.RetType, sf.Function, sf.ctx = f.getRetTp(), f, ctx
 		return sf
 	case ast.Elt:
 		hasHybrid := false
@@ -2430,7 +2431,7 @@ func TryPushCastIntoControlFunctionForHybridType(ctx sessionctx.Context, expr Ex
 		if err != nil {
 			return expr
 		}
-		sf.RetType, sf.Function = f.getRetTp(), f
+		sf.RetType, sf.Function, sf.ctx = f.getRetTp(), f, ctx
 		return sf
 	default:
 		return expr

--- a/pkg/expression/builtin_cast_bench_test.go
+++ b/pkg/expression/builtin_cast_bench_test.go
@@ -19,14 +19,15 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/mock"
 )
 
-func genCastIntAsInt() (*builtinCastIntAsIntSig, *chunk.Chunk, *chunk.Column) {
+func genCastIntAsInt(ctx sessionctx.Context) (*builtinCastIntAsIntSig, *chunk.Chunk, *chunk.Column) {
 	col := &Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}
-	baseFunc, err := newBaseBuiltinFunc(mock.NewContext(), "", []Expression{col}, types.NewFieldType(mysql.TypeLonglong))
+	baseFunc, err := newBaseBuiltinFunc(ctx, "", []Expression{col}, types.NewFieldType(mysql.TypeLonglong))
 	if err != nil {
 		panic(err)
 	}
@@ -41,8 +42,8 @@ func genCastIntAsInt() (*builtinCastIntAsIntSig, *chunk.Chunk, *chunk.Column) {
 }
 
 func BenchmarkCastIntAsIntRow(b *testing.B) {
-	cast, input, _ := genCastIntAsInt()
-	ctx := cast.ctx
+	ctx := mock.NewContext()
+	cast, input, _ := genCastIntAsInt(ctx)
 	it := chunk.NewIterator4Chunk(input)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -55,8 +56,8 @@ func BenchmarkCastIntAsIntRow(b *testing.B) {
 }
 
 func BenchmarkCastIntAsIntVec(b *testing.B) {
-	cast, input, result := genCastIntAsInt()
-	ctx := cast.ctx
+	ctx := mock.NewContext()
+	cast, input, result := genCastIntAsInt(ctx)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if err := cast.vecEvalInt(ctx, input, result); err != nil {

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -1450,8 +1450,8 @@ func TestWrapWithCastAsJSON(t *testing.T) {
 }
 
 func TestCastIntAsIntVec(t *testing.T) {
-	cast, input, result := genCastIntAsInt()
-	ctx := cast.ctx
+	ctx := mock.NewContext()
+	cast, input, result := genCastIntAsInt(ctx)
 	require.NoError(t, cast.vecEvalInt(ctx, input, result))
 	i64s := result.Int64s()
 	it := chunk.NewIterator4Chunk(input)

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -34,7 +34,7 @@ func (b *builtinCastIntAsDurationSig) vecEvalDuration(ctx sessionctx.Context, in
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -49,10 +49,10 @@ func (b *builtinCastIntAsDurationSig) vecEvalDuration(ctx sessionctx.Context, in
 		dur, err := types.NumberToDuration(i64s[i], b.tp.GetDecimal())
 		if err != nil {
 			if types.ErrOverflow.Equal(err) {
-				err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
+				err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
 			}
 			if types.ErrTruncatedWrongVal.Equal(err) {
-				err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+				err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
 			}
 			if err != nil {
 				return err
@@ -70,7 +70,7 @@ func (*builtinCastIntAsDurationSig) vectorized() bool {
 }
 
 func (b *builtinCastIntAsIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	if b.inUnion && mysql.HasUnsignedFlag(b.tp.GetFlag()) {
@@ -97,7 +97,7 @@ func (b *builtinCastIntAsRealSig) vecEvalReal(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -135,7 +135,7 @@ func (*builtinCastIntAsRealSig) vectorized() bool {
 }
 
 func (b *builtinCastRealAsRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -170,7 +170,7 @@ func (b *builtinCastTimeAsJSONSig) vecEvalJSON(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -202,7 +202,7 @@ func (b *builtinCastRealAsStringSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -218,7 +218,7 @@ func (b *builtinCastRealAsStringSig) vecEvalString(ctx sessionctx.Context, input
 	var res string
 	f64s := buf.Float64s()
 	result.ReserveString(n)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i, v := range f64s {
 		if buf.IsNull(i) {
 			result.AppendNull()
@@ -228,7 +228,7 @@ func (b *builtinCastRealAsStringSig) vecEvalString(ctx sessionctx.Context, input
 		if err != nil {
 			return err
 		}
-		res, isNull, err = padZeroForBinaryType(res, b.tp, b.ctx)
+		res, isNull, err = padZeroForBinaryType(res, b.tp, ctx)
 		if err != nil {
 			return err
 		}
@@ -252,11 +252,11 @@ func (b *builtinCastDecimalAsStringSig) vecEvalString(ctx sessionctx.Context, in
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	vas := buf.Decimals()
 	result.ReserveString(n)
 	for i, v := range vas {
@@ -268,7 +268,7 @@ func (b *builtinCastDecimalAsStringSig) vecEvalString(ctx sessionctx.Context, in
 		if e != nil {
 			return e
 		}
-		str, b, e1 := padZeroForBinaryType(res, b.tp, b.ctx)
+		str, b, e1 := padZeroForBinaryType(res, b.tp, ctx)
 		if e1 != nil {
 			return e1
 		}
@@ -292,7 +292,7 @@ func (b *builtinCastTimeAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -300,7 +300,7 @@ func (b *builtinCastTimeAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context, inp
 	result.MergeNulls(buf)
 	times := buf.Times()
 	decs := result.Decimals()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	dec := new(types.MyDecimal)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -328,7 +328,7 @@ func (b *builtinCastDurationAsIntSig) vecEvalInt(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -345,7 +345,7 @@ func (b *builtinCastDurationAsIntSig) vecEvalInt(ctx sessionctx.Context, input *
 
 		duration.Duration = ds[i]
 		duration.Fsp = fsp
-		dur, err := duration.RoundFrac(types.DefaultFsp, b.ctx.GetSessionVars().Location())
+		dur, err := duration.RoundFrac(types.DefaultFsp, ctx.GetSessionVars().Location())
 		if err != nil {
 			return err
 		}
@@ -368,7 +368,7 @@ func (b *builtinCastIntAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -376,7 +376,7 @@ func (b *builtinCastIntAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *chu
 	result.MergeNulls(buf)
 	times := result.Times()
 	i64s := buf.Int64s()
-	stmt := b.ctx.GetSessionVars().StmtCtx
+	stmt := ctx.GetSessionVars().StmtCtx
 	fsp := b.tp.GetDecimal()
 
 	var tm types.Time
@@ -392,7 +392,7 @@ func (b *builtinCastIntAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *chu
 		}
 
 		if err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
+			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -418,7 +418,7 @@ func (b *builtinCastRealAsJSONSig) vecEvalJSON(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 	f64s := buf.Float64s()
@@ -445,14 +445,14 @@ func (b *builtinCastJSONAsRealSig) vecEvalReal(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 
 	result.ResizeFloat64(n, false)
 	result.MergeNulls(buf)
 	f64s := result.Float64s()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -476,7 +476,7 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -484,8 +484,8 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *ch
 	result.MergeNulls(buf)
 	times := result.Times()
 
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
-	ts, err := getStmtTimestamp(b.ctx)
+	stmtCtx := ctx.GetSessionVars().StmtCtx
+	ts, err := getStmtTimestamp(ctx)
 	if err != nil {
 		ts = gotime.Now()
 	}
@@ -512,10 +512,10 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *ch
 		case types.JSONTypeCodeDuration:
 			duration := val.GetDuration()
 
-			sc := b.ctx.GetSessionVars().StmtCtx
+			sc := ctx.GetSessionVars().StmtCtx
 			tm, err := duration.ConvertToTimeWithTimestamp(sc.TypeCtx(), b.tp.GetType(), ts)
 			if err != nil {
-				if err = handleInvalidTimeError(b.ctx, err); err != nil {
+				if err = handleInvalidTimeError(ctx, err); err != nil {
 					return err
 				}
 				result.SetNull(i, true)
@@ -533,7 +533,7 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *ch
 			}
 			tm, err := types.ParseTime(stmtCtx.TypeCtx(), s, b.tp.GetType(), fsp, nil)
 			if err != nil {
-				if err = handleInvalidTimeError(b.ctx, err); err != nil {
+				if err = handleInvalidTimeError(ctx, err); err != nil {
 					return err
 				}
 				result.SetNull(i, true)
@@ -546,7 +546,7 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *ch
 			}
 		default:
 			err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), val.String())
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
+			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -566,7 +566,7 @@ func (b *builtinCastRealAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -574,7 +574,7 @@ func (b *builtinCastRealAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *ch
 	result.MergeNulls(buf)
 	times := result.Times()
 	f64s := buf.Float64s()
-	stmt := b.ctx.GetSessionVars().StmtCtx
+	stmt := ctx.GetSessionVars().StmtCtx
 	fsp := b.tp.GetDecimal()
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
@@ -587,7 +587,7 @@ func (b *builtinCastRealAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *ch
 		}
 		tm, err := types.ParseTimeFromFloatString(stmt.TypeCtx(), fv, b.tp.GetType(), fsp)
 		if err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
+			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -607,13 +607,13 @@ func (*builtinCastDecimalAsDecimalSig) vectorized() bool {
 }
 
 func (b *builtinCastDecimalAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 
 	n := input.NumRows()
 	decs := result.Decimals()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	conditionUnionAndUnsigned := b.inUnion && mysql.HasUnsignedFlag(b.tp.GetFlag())
 	dec := new(types.MyDecimal)
 	for i := 0; i < n; i++ {
@@ -644,7 +644,7 @@ func (b *builtinCastDurationAsTimeSig) vecEvalTime(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -653,8 +653,8 @@ func (b *builtinCastDurationAsTimeSig) vecEvalTime(ctx sessionctx.Context, input
 	var duration types.Duration
 	ds := buf.GoDurations()
 	times := result.Times()
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
-	ts, err := getStmtTimestamp(b.ctx)
+	stmtCtx := ctx.GetSessionVars().StmtCtx
+	ts, err := getStmtTimestamp(ctx)
 	if err != nil {
 		ts = gotime.Now()
 	}
@@ -668,7 +668,7 @@ func (b *builtinCastDurationAsTimeSig) vecEvalTime(ctx sessionctx.Context, input
 		duration.Fsp = fsp
 		tm, err := duration.ConvertToTimeWithTimestamp(stmtCtx.TypeCtx(), b.tp.GetType(), ts)
 		if err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
+			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -694,7 +694,7 @@ func (b *builtinCastIntAsStringSig) vecEvalString(ctx sessionctx.Context, input 
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -717,12 +717,12 @@ func (b *builtinCastIntAsStringSig) vecEvalString(ctx sessionctx.Context, input 
 		if isYearType && str == "0" {
 			str = "0000"
 		}
-		str, err = types.ProduceStrWithSpecifiedTp(str, b.tp, b.ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
+		str, err = types.ProduceStrWithSpecifiedTp(str, b.tp, ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
 		if err != nil {
 			return err
 		}
 		var d bool
-		str, d, err = padZeroForBinaryType(str, b.tp, b.ctx)
+		str, d, err = padZeroForBinaryType(str, b.tp, ctx)
 		if err != nil {
 			return err
 		}
@@ -746,7 +746,7 @@ func (b *builtinCastRealAsIntSig) vecEvalInt(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -766,12 +766,12 @@ func (b *builtinCastRealAsIntSig) vecEvalInt(ctx sessionctx.Context, input *chun
 			i64s[i] = 0
 		} else {
 			var uintVal uint64
-			sc := b.ctx.GetSessionVars().StmtCtx
+			sc := ctx.GetSessionVars().StmtCtx
 			uintVal, err = types.ConvertFloatToUint(sc.TypeFlags(), f64s[i], types.IntergerUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
 			i64s[i] = int64(uintVal)
 		}
 		if types.ErrOverflow.Equal(err) {
-			err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
+			err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
 		}
 		if err != nil {
 			return err
@@ -791,7 +791,7 @@ func (b *builtinCastTimeAsRealSig) vecEvalReal(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeFloat64(n, false)
@@ -805,7 +805,7 @@ func (b *builtinCastTimeAsRealSig) vecEvalReal(ctx sessionctx.Context, input *ch
 		f64, err := times[i].ToNumber().ToFloat64()
 		if err != nil {
 			if types.ErrOverflow.Equal(err) {
-				err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
+				err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
 			}
 			if err != nil {
 				return err
@@ -829,7 +829,7 @@ func (b *builtinCastStringAsJSONSig) vecEvalJSON(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -893,14 +893,14 @@ func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeDecimal(n, false)
 	result.MergeNulls(buf)
 	bufreal := buf.Float64s()
 	resdecimal := result.Decimals()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -909,7 +909,7 @@ func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context, inp
 			if err = resdecimal[i].FromFloat64(bufreal[i]); err != nil {
 				if types.ErrOverflow.Equal(err) {
 					warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0])
-					err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
+					err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
 				} else if types.ErrTruncated.Equal(err) {
 					// This behavior is consistent with MySQL.
 					err = nil
@@ -935,12 +935,12 @@ func (*builtinCastStringAsIntSig) vectorized() bool {
 func (b *builtinCastStringAsIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 	if b.args[0].GetType().Hybrid() || IsBinaryLiteral(b.args[0]) {
-		return b.args[0].VecEvalInt(b.ctx, input, result)
+		return b.args[0].VecEvalInt(ctx, input, result)
 	}
 
 	// Take the implicit evalInt path if possible.
 	if CanImplicitEvalInt(b.args[0]) {
-		return b.args[0].VecEvalInt(b.ctx, input, result)
+		return b.args[0].VecEvalInt(ctx, input, result)
 	}
 
 	result.ResizeInt64(n, false)
@@ -949,11 +949,11 @@ func (b *builtinCastStringAsIntSig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.MergeNulls(buf)
-	typeCtx := b.ctx.GetSessionVars().StmtCtx.TypeCtx()
+	typeCtx := ctx.GetSessionVars().StmtCtx.TypeCtx()
 	i64s := result.Int64s()
 	isUnsigned := mysql.HasUnsignedFlag(b.tp.GetFlag())
 	unionUnsigned := isUnsigned && b.inUnion
@@ -982,7 +982,7 @@ func (b *builtinCastStringAsIntSig) vecEvalInt(ctx sessionctx.Context, input *ch
 				typeCtx.AppendWarning(types.ErrCastNegIntAsUnsigned)
 			}
 		}
-		res, err = b.handleOverflow(res, val, err, isNegative)
+		res, err = b.handleOverflow(ctx, res, val, err, isNegative)
 		if err != nil {
 			return err
 		}
@@ -1002,7 +1002,7 @@ func (b *builtinCastStringAsDurationSig) vecEvalDuration(ctx sessionctx.Context,
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeGoDuration(n, false)
@@ -1012,10 +1012,10 @@ func (b *builtinCastStringAsDurationSig) vecEvalDuration(ctx sessionctx.Context,
 		if result.IsNull(i) {
 			continue
 		}
-		dur, isNull, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), buf.GetString(i), b.tp.GetDecimal())
+		dur, isNull, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), buf.GetString(i), b.tp.GetDecimal())
 		if err != nil {
 			if types.ErrTruncatedWrongVal.Equal(err) {
-				err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+				err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
 			}
 			if err != nil {
 				return err
@@ -1041,7 +1041,7 @@ func (b *builtinCastDurationAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context,
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeDecimal(n, false)
@@ -1049,7 +1049,7 @@ func (b *builtinCastDurationAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context,
 	d64s := result.Decimals()
 	var duration types.Duration
 	ds := buf.GoDurations()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	fsp := b.args[0].GetType().GetDecimal()
 	if fsp, err = types.CheckFsp(fsp); err != nil {
 		return err
@@ -1080,7 +1080,7 @@ func (b *builtinCastIntAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context, inpu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1090,7 +1090,7 @@ func (b *builtinCastIntAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context, inpu
 	result.ResizeDecimal(n, false)
 	result.MergeNulls(buf)
 	decs := result.Decimals()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	dec := new(types.MyDecimal)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -1126,7 +1126,7 @@ func (b *builtinCastIntAsJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	nums := buf.Int64s()
@@ -1165,7 +1165,7 @@ func (*builtinCastJSONAsJSONSig) vectorized() bool {
 }
 
 func (b *builtinCastJSONAsJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalJSON(b.ctx, input, result)
+	return b.args[0].VecEvalJSON(ctx, input, result)
 }
 
 func (*builtinCastJSONAsStringSig) vectorized() bool {
@@ -1179,7 +1179,7 @@ func (b *builtinCastJSONAsStringSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1189,7 +1189,7 @@ func (b *builtinCastJSONAsStringSig) vecEvalString(ctx sessionctx.Context, input
 			result.AppendNull()
 			continue
 		}
-		s, err := types.ProduceStrWithSpecifiedTp(buf.GetJSON(i).String(), b.tp, b.ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
+		s, err := types.ProduceStrWithSpecifiedTp(buf.GetJSON(i).String(), b.tp, ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
 		if err != nil {
 			return err
 		}
@@ -1209,7 +1209,7 @@ func (b *builtinCastDurationAsRealSig) vecEvalReal(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1248,14 +1248,14 @@ func (b *builtinCastJSONAsIntSig) vecEvalInt(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 
 	result.ResizeInt64(n, false)
 	result.MergeNulls(buf)
 	i64s := result.Int64s()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	tc := sc.TypeCtx()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -1280,7 +1280,7 @@ func (b *builtinCastRealAsDurationSig) vecEvalDuration(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeGoDuration(n, false)
@@ -1291,10 +1291,10 @@ func (b *builtinCastRealAsDurationSig) vecEvalDuration(ctx sessionctx.Context, i
 		if result.IsNull(i) {
 			continue
 		}
-		dur, _, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), strconv.FormatFloat(f64s[i], 'f', -1, 64), b.tp.GetDecimal())
+		dur, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), strconv.FormatFloat(f64s[i], 'f', -1, 64), b.tp.GetDecimal())
 		if err != nil {
 			if types.ErrTruncatedWrongVal.Equal(err) {
-				err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+				err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
 				if err != nil {
 					return err
 				}
@@ -1320,7 +1320,7 @@ func (b *builtinCastTimeAsDurationSig) vecEvalDuration(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(arg0)
-	if err := b.args[0].VecEvalTime(b.ctx, input, arg0); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, arg0); err != nil {
 		return err
 	}
 	arg0s := arg0.Times()
@@ -1335,7 +1335,7 @@ func (b *builtinCastTimeAsDurationSig) vecEvalDuration(ctx sessionctx.Context, i
 		if err != nil {
 			return err
 		}
-		d, err = d.RoundFrac(b.tp.GetDecimal(), b.ctx.GetSessionVars().Location())
+		d, err = d.RoundFrac(b.tp.GetDecimal(), ctx.GetSessionVars().Location())
 		if err != nil {
 			return err
 		}
@@ -1350,7 +1350,7 @@ func (*builtinCastDurationAsDurationSig) vectorized() bool {
 
 func (b *builtinCastDurationAsDurationSig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	var err error
-	if err = b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+	if err = b.args[0].VecEvalDuration(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -1364,7 +1364,7 @@ func (b *builtinCastDurationAsDurationSig) vecEvalDuration(ctx sessionctx.Contex
 			continue
 		}
 		dur.Duration = v
-		rd, err = dur.RoundFrac(b.tp.GetDecimal(), b.ctx.GetSessionVars().Location())
+		rd, err = dur.RoundFrac(b.tp.GetDecimal(), ctx.GetSessionVars().Location())
 		if err != nil {
 			return err
 		}
@@ -1384,13 +1384,13 @@ func (b *builtinCastDurationAsStringSig) vecEvalString(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
 
 	var res string
 	var isNull bool
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	result.ReserveString(n)
 	fsp := b.args[0].GetType().GetDecimal()
 	for i := 0; i < n; i++ {
@@ -1402,7 +1402,7 @@ func (b *builtinCastDurationAsStringSig) vecEvalString(ctx sessionctx.Context, i
 		if err != nil {
 			return err
 		}
-		res, isNull, err = padZeroForBinaryType(res, b.tp, b.ctx)
+		res, isNull, err = padZeroForBinaryType(res, b.tp, ctx)
 		if err != nil {
 			return err
 		}
@@ -1426,7 +1426,7 @@ func (b *builtinCastDecimalAsRealSig) vecEvalReal(ctx sessionctx.Context, input 
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1448,7 +1448,7 @@ func (b *builtinCastDecimalAsRealSig) vecEvalReal(ctx sessionctx.Context, input 
 		res, err := d[i].ToFloat64()
 		if err != nil {
 			if types.ErrOverflow.Equal(err) {
-				err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
+				err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
 			}
 			if err != nil {
 				return err
@@ -1472,7 +1472,7 @@ func (b *builtinCastDecimalAsTimeSig) vecEvalTime(ctx sessionctx.Context, input 
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1480,7 +1480,7 @@ func (b *builtinCastDecimalAsTimeSig) vecEvalTime(ctx sessionctx.Context, input 
 	result.MergeNulls(buf)
 	times := result.Times()
 	decimals := buf.Decimals()
-	stmt := b.ctx.GetSessionVars().StmtCtx
+	stmt := ctx.GetSessionVars().StmtCtx
 	fsp := b.tp.GetDecimal()
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
@@ -1488,7 +1488,7 @@ func (b *builtinCastDecimalAsTimeSig) vecEvalTime(ctx sessionctx.Context, input 
 		}
 		tm, err := types.ParseTimeFromFloatString(stmt.TypeCtx(), string(decimals[i].ToString()), b.tp.GetType(), fsp)
 		if err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
+			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -1514,7 +1514,7 @@ func (b *builtinCastTimeAsIntSig) vecEvalInt(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1522,7 +1522,7 @@ func (b *builtinCastTimeAsIntSig) vecEvalInt(ctx sessionctx.Context, input *chun
 	result.MergeNulls(buf)
 	times := buf.Times()
 	i64s := result.Int64s()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -1545,12 +1545,12 @@ func (*builtinCastTimeAsTimeSig) vectorized() bool {
 
 func (b *builtinCastTimeAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, result); err != nil {
 		return err
 	}
 
 	times := result.Times()
-	stmt := b.ctx.GetSessionVars().StmtCtx
+	stmt := ctx.GetSessionVars().StmtCtx
 	fsp := b.tp.GetDecimal()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -1558,7 +1558,7 @@ func (b *builtinCastTimeAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *ch
 		}
 		res, err := times[i].Convert(stmt.TypeCtx(), b.tp.GetType())
 		if err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
+			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -1589,13 +1589,13 @@ func (b *builtinCastTimeAsStringSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
 	var res string
 	var isNull bool
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	vas := buf.Times()
 	result.ReserveString(n)
 	for i, v := range vas {
@@ -1607,7 +1607,7 @@ func (b *builtinCastTimeAsStringSig) vecEvalString(ctx sessionctx.Context, input
 		if err != nil {
 			return err
 		}
-		res, isNull, err = padZeroForBinaryType(res, b.tp, b.ctx)
+		res, isNull, err = padZeroForBinaryType(res, b.tp, ctx)
 		if err != nil {
 			return err
 		}
@@ -1631,10 +1631,10 @@ func (b *builtinCastJSONAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	result.ResizeDecimal(n, false)
 	result.MergeNulls(buf)
 	res := result.Decimals()
@@ -1661,12 +1661,12 @@ func (*builtinCastStringAsRealSig) vectorized() bool {
 
 func (b *builtinCastStringAsRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	if IsBinaryLiteral(b.args[0]) {
-		return b.args[0].VecEvalReal(b.ctx, input, result)
+		return b.args[0].VecEvalReal(ctx, input, result)
 	}
 
 	// Take the implicit evalReal path if possible.
 	if CanImplicitEvalReal(b.args[0]) {
-		return b.args[0].VecEvalReal(b.ctx, input, result)
+		return b.args[0].VecEvalReal(ctx, input, result)
 	}
 
 	n := input.NumRows()
@@ -1675,14 +1675,14 @@ func (b *builtinCastStringAsRealSig) vecEvalReal(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
 	result.ResizeFloat64(n, false)
 	result.MergeNulls(buf)
 	ret := result.Float64s()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -1710,7 +1710,7 @@ func (*builtinCastStringAsDecimalSig) vectorized() bool {
 
 func (b *builtinCastStringAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	if IsBinaryLiteral(b.args[0]) {
-		return b.args[0].VecEvalDecimal(b.ctx, input, result)
+		return b.args[0].VecEvalDecimal(ctx, input, result)
 	}
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get()
@@ -1718,13 +1718,13 @@ func (b *builtinCastStringAsDecimalSig) vecEvalDecimal(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeDecimal(n, false)
 	result.MergeNulls(buf)
 	res := result.Decimals()
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -1757,14 +1757,14 @@ func (b *builtinCastStringAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
 	result.MergeNulls(buf)
 	times := result.Times()
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 	fsp := b.tp.GetDecimal()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -1775,14 +1775,14 @@ func (b *builtinCastStringAsTimeSig) vecEvalTime(ctx sessionctx.Context, input *
 			if errors.Is(err, strconv.ErrSyntax) || errors.Is(err, strconv.ErrRange) {
 				err = types.ErrIncorrectDatetimeValue.GenWithStackByArgs(buf.GetString(i))
 			}
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
+			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
 			continue
 		}
-		if tm.IsZero() && b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
-			err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, tm.String()))
+		if tm.IsZero() && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
+			err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, tm.String()))
 			if err != nil {
 				return err
 			}
@@ -1809,7 +1809,7 @@ func (b *builtinCastDecimalAsIntSig) vecEvalInt(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1841,7 +1841,7 @@ func (b *builtinCastDecimalAsIntSig) vecEvalInt(ctx sessionctx.Context, input *c
 
 		if types.ErrOverflow.Equal(err) {
 			warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", d64s[i])
-			err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
+			err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
 		}
 
 		if err != nil {
@@ -1862,7 +1862,7 @@ func (b *builtinCastDecimalAsDurationSig) vecEvalDuration(ctx sessionctx.Context
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1874,10 +1874,10 @@ func (b *builtinCastDecimalAsDurationSig) vecEvalDuration(ctx sessionctx.Context
 		if result.IsNull(i) {
 			continue
 		}
-		dur, _, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), string(args[i].ToString()), b.tp.GetDecimal())
+		dur, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), string(args[i].ToString()), b.tp.GetDecimal())
 		if err != nil {
 			if types.ErrTruncatedWrongVal.Equal(err) {
-				err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+				err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
 				if err != nil {
 					return err
 				}
@@ -1903,13 +1903,13 @@ func (b *builtinCastStringAsStringSig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
 	var res string
 	var isNull bool
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	result.ReserveString(n)
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
@@ -1920,7 +1920,7 @@ func (b *builtinCastStringAsStringSig) vecEvalString(ctx sessionctx.Context, inp
 		if err != nil {
 			return err
 		}
-		res, isNull, err = padZeroForBinaryType(res, b.tp, b.ctx)
+		res, isNull, err = padZeroForBinaryType(res, b.tp, ctx)
 		if err != nil {
 			return err
 		}
@@ -1944,11 +1944,11 @@ func (b *builtinCastJSONAsDurationSig) vecEvalDuration(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 
 	result.ResizeGoDuration(n, false)
 	result.MergeNulls(buf)
@@ -1967,7 +1967,7 @@ func (b *builtinCastJSONAsDurationSig) vecEvalDuration(ctx sessionctx.Context, i
 			if err != nil {
 				return err
 			}
-			d, err = d.RoundFrac(b.tp.GetDecimal(), b.ctx.GetSessionVars().Location())
+			d, err = d.RoundFrac(b.tp.GetDecimal(), ctx.GetSessionVars().Location())
 			if err != nil {
 				return err
 			}
@@ -2013,7 +2013,7 @@ func (b *builtinCastDecimalAsJSONSig) vecEvalJSON(ctx sessionctx.Context, input 
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -2046,7 +2046,7 @@ func (b *builtinCastDurationAsJSONSig) vecEvalJSON(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
 

--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -239,7 +239,7 @@ func (b *builtinCoalesceIntSig) Clone() builtinFunc {
 
 func (b *builtinCoalesceIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalInt(b.ctx, row)
+		res, isNull, err = a.EvalInt(ctx, row)
 		if err != nil || !isNull {
 			break
 		}
@@ -261,7 +261,7 @@ func (b *builtinCoalesceRealSig) Clone() builtinFunc {
 
 func (b *builtinCoalesceRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalReal(b.ctx, row)
+		res, isNull, err = a.EvalReal(ctx, row)
 		if err != nil || !isNull {
 			break
 		}
@@ -283,7 +283,7 @@ func (b *builtinCoalesceDecimalSig) Clone() builtinFunc {
 
 func (b *builtinCoalesceDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalDecimal(b.ctx, row)
+		res, isNull, err = a.EvalDecimal(ctx, row)
 		if err != nil || !isNull {
 			break
 		}
@@ -305,7 +305,7 @@ func (b *builtinCoalesceStringSig) Clone() builtinFunc {
 
 func (b *builtinCoalesceStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalString(b.ctx, row)
+		res, isNull, err = a.EvalString(ctx, row)
 		if err != nil || !isNull {
 			break
 		}
@@ -328,7 +328,7 @@ func (b *builtinCoalesceTimeSig) Clone() builtinFunc {
 func (b *builtinCoalesceTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
 	fsp := b.tp.GetDecimal()
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalTime(b.ctx, row)
+		res, isNull, err = a.EvalTime(ctx, row)
 		res.SetFsp(fsp)
 		if err != nil || !isNull {
 			break
@@ -351,7 +351,7 @@ func (b *builtinCoalesceDurationSig) Clone() builtinFunc {
 
 func (b *builtinCoalesceDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalDuration(b.ctx, row)
+		res, isNull, err = a.EvalDuration(ctx, row)
 		res.Fsp = b.tp.GetDecimal()
 		if err != nil || !isNull {
 			break
@@ -374,7 +374,7 @@ func (b *builtinCoalesceJSONSig) Clone() builtinFunc {
 
 func (b *builtinCoalesceJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalJSON(b.ctx, row)
+		res, isNull, err = a.EvalJSON(ctx, row)
 		if err != nil || !isNull {
 			break
 		}
@@ -585,13 +585,13 @@ func (b *builtinGreatestIntSig) Clone() builtinFunc {
 // evalInt evals a builtinGreatestIntSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_greatest
 func (b *builtinGreatestIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (max int64, isNull bool, err error) {
-	max, isNull, err = b.args[0].EvalInt(b.ctx, row)
+	max, isNull, err = b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return max, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v int64
-		v, isNull, err = b.args[i].EvalInt(b.ctx, row)
+		v, isNull, err = b.args[i].EvalInt(ctx, row)
 		if isNull || err != nil {
 			return max, isNull, err
 		}
@@ -615,13 +615,13 @@ func (b *builtinGreatestRealSig) Clone() builtinFunc {
 // evalReal evals a builtinGreatestRealSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_greatest
 func (b *builtinGreatestRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (max float64, isNull bool, err error) {
-	max, isNull, err = b.args[0].EvalReal(b.ctx, row)
+	max, isNull, err = b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return max, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v float64
-		v, isNull, err = b.args[i].EvalReal(b.ctx, row)
+		v, isNull, err = b.args[i].EvalReal(ctx, row)
 		if isNull || err != nil {
 			return max, isNull, err
 		}
@@ -645,13 +645,13 @@ func (b *builtinGreatestDecimalSig) Clone() builtinFunc {
 // evalDecimal evals a builtinGreatestDecimalSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_greatest
 func (b *builtinGreatestDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (max *types.MyDecimal, isNull bool, err error) {
-	max, isNull, err = b.args[0].EvalDecimal(b.ctx, row)
+	max, isNull, err = b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return max, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v *types.MyDecimal
-		v, isNull, err = b.args[i].EvalDecimal(b.ctx, row)
+		v, isNull, err = b.args[i].EvalDecimal(ctx, row)
 		if isNull || err != nil {
 			return max, isNull, err
 		}
@@ -675,13 +675,13 @@ func (b *builtinGreatestStringSig) Clone() builtinFunc {
 // evalString evals a builtinGreatestStringSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_greatest
 func (b *builtinGreatestStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (max string, isNull bool, err error) {
-	max, isNull, err = b.args[0].EvalString(b.ctx, row)
+	max, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return max, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v string
-		v, isNull, err = b.args[i].EvalString(b.ctx, row)
+		v, isNull, err = b.args[i].EvalString(ctx, row)
 		if isNull || err != nil {
 			return max, isNull, err
 		}
@@ -707,13 +707,13 @@ func (b *builtinGreatestCmpStringAsTimeSig) Clone() builtinFunc {
 // evalString evals a builtinGreatestCmpStringAsTimeSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_greatest
 func (b *builtinGreatestCmpStringAsTimeSig) evalString(ctx sessionctx.Context, row chunk.Row) (strRes string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < len(b.args); i++ {
-		v, isNull, err := b.args[i].EvalString(b.ctx, row)
+		v, isNull, err := b.args[i].EvalString(ctx, row)
 		if isNull || err != nil {
 			return "", true, err
 		}
-		v, err = doTimeConversionForGL(b.cmpAsDate, b.ctx, sc, v)
+		v, err = doTimeConversionForGL(b.cmpAsDate, ctx, sc, v)
 		if err != nil {
 			return v, true, err
 		}
@@ -763,7 +763,7 @@ func (b *builtinGreatestTimeSig) Clone() builtinFunc {
 
 func (b *builtinGreatestTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
 	for i := 0; i < len(b.args); i++ {
-		v, isNull, err := b.args[i].EvalTime(b.ctx, row)
+		v, isNull, err := b.args[i].EvalTime(ctx, row)
 		if isNull || err != nil {
 			return types.ZeroTime, true, err
 		}
@@ -772,10 +772,10 @@ func (b *builtinGreatestTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row)
 		}
 	}
 	// Convert ETType Time value to MySQL actual type, distinguish date and datetime
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	resTimeTp := getAccurateTimeTypeForGLRet(b.cmpAsDate)
 	if res, err = res.Convert(sc.TypeCtx(), resTimeTp); err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	return res, false, nil
 }
@@ -792,7 +792,7 @@ func (b *builtinGreatestDurationSig) Clone() builtinFunc {
 
 func (b *builtinGreatestDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
 	for i := 0; i < len(b.args); i++ {
-		v, isNull, err := b.args[i].EvalDuration(b.ctx, row)
+		v, isNull, err := b.args[i].EvalDuration(ctx, row)
 		if isNull || err != nil {
 			return types.Duration{}, true, err
 		}
@@ -883,13 +883,13 @@ func (b *builtinLeastIntSig) Clone() builtinFunc {
 // evalInt evals a builtinLeastIntSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_least
 func (b *builtinLeastIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (min int64, isNull bool, err error) {
-	min, isNull, err = b.args[0].EvalInt(b.ctx, row)
+	min, isNull, err = b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return min, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v int64
-		v, isNull, err = b.args[i].EvalInt(b.ctx, row)
+		v, isNull, err = b.args[i].EvalInt(ctx, row)
 		if isNull || err != nil {
 			return min, isNull, err
 		}
@@ -913,13 +913,13 @@ func (b *builtinLeastRealSig) Clone() builtinFunc {
 // evalReal evals a builtinLeastRealSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#functionleast
 func (b *builtinLeastRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (min float64, isNull bool, err error) {
-	min, isNull, err = b.args[0].EvalReal(b.ctx, row)
+	min, isNull, err = b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return min, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v float64
-		v, isNull, err = b.args[i].EvalReal(b.ctx, row)
+		v, isNull, err = b.args[i].EvalReal(ctx, row)
 		if isNull || err != nil {
 			return min, isNull, err
 		}
@@ -943,13 +943,13 @@ func (b *builtinLeastDecimalSig) Clone() builtinFunc {
 // evalDecimal evals a builtinLeastDecimalSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#functionleast
 func (b *builtinLeastDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (min *types.MyDecimal, isNull bool, err error) {
-	min, isNull, err = b.args[0].EvalDecimal(b.ctx, row)
+	min, isNull, err = b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return min, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v *types.MyDecimal
-		v, isNull, err = b.args[i].EvalDecimal(b.ctx, row)
+		v, isNull, err = b.args[i].EvalDecimal(ctx, row)
 		if isNull || err != nil {
 			return min, isNull, err
 		}
@@ -973,13 +973,13 @@ func (b *builtinLeastStringSig) Clone() builtinFunc {
 // evalString evals a builtinLeastStringSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#functionleast
 func (b *builtinLeastStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (min string, isNull bool, err error) {
-	min, isNull, err = b.args[0].EvalString(b.ctx, row)
+	min, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return min, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v string
-		v, isNull, err = b.args[i].EvalString(b.ctx, row)
+		v, isNull, err = b.args[i].EvalString(ctx, row)
 		if isNull || err != nil {
 			return min, isNull, err
 		}
@@ -1005,13 +1005,13 @@ func (b *builtinLeastCmpStringAsTimeSig) Clone() builtinFunc {
 // evalString evals a builtinLeastCmpStringAsTimeSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#functionleast
 func (b *builtinLeastCmpStringAsTimeSig) evalString(ctx sessionctx.Context, row chunk.Row) (strRes string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < len(b.args); i++ {
-		v, isNull, err := b.args[i].EvalString(b.ctx, row)
+		v, isNull, err := b.args[i].EvalString(ctx, row)
 		if isNull || err != nil {
 			return "", true, err
 		}
-		v, err = doTimeConversionForGL(b.cmpAsDate, b.ctx, sc, v)
+		v, err = doTimeConversionForGL(b.cmpAsDate, ctx, sc, v)
 		if err != nil {
 			return v, true, err
 		}
@@ -1037,7 +1037,7 @@ func (b *builtinLeastTimeSig) Clone() builtinFunc {
 
 func (b *builtinLeastTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
 	for i := 0; i < len(b.args); i++ {
-		v, isNull, err := b.args[i].EvalTime(b.ctx, row)
+		v, isNull, err := b.args[i].EvalTime(ctx, row)
 		if isNull || err != nil {
 			return types.ZeroTime, true, err
 		}
@@ -1046,10 +1046,10 @@ func (b *builtinLeastTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (r
 		}
 	}
 	// Convert ETType Time value to MySQL actual type, distinguish date and datetime
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	resTimeTp := getAccurateTimeTypeForGLRet(b.cmpAsDate)
 	if res, err = res.Convert(sc.TypeCtx(), resTimeTp); err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	return res, false, nil
 }
@@ -1076,7 +1076,7 @@ func (b *builtinLeastDurationSig) Clone() builtinFunc {
 
 func (b *builtinLeastDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
 	for i := 0; i < len(b.args); i++ {
-		v, isNull, err := b.args[i].EvalDuration(b.ctx, row)
+		v, isNull, err := b.args[i].EvalDuration(ctx, row)
 		if isNull || err != nil {
 			return types.Duration{}, true, err
 		}
@@ -1148,7 +1148,7 @@ func (b *builtinIntervalIntSig) Clone() builtinFunc {
 // evalInt evals a builtinIntervalIntSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_interval
 func (b *builtinIntervalIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -1158,19 +1158,19 @@ func (b *builtinIntervalIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (
 	isUint1 := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
 	var idx int
 	if b.hasNullable {
-		idx, err = b.linearSearch(arg0, isUint1, b.args[1:], row)
+		idx, err = b.linearSearch(ctx, arg0, isUint1, b.args[1:], row)
 	} else {
-		idx, err = b.binSearch(arg0, isUint1, b.args[1:], row)
+		idx, err = b.binSearch(ctx, arg0, isUint1, b.args[1:], row)
 	}
 	return int64(idx), err != nil, err
 }
 
 // linearSearch linearly scans the argument least to find the position of the first value that is larger than the given target.
-func (b *builtinIntervalIntSig) linearSearch(target int64, isUint1 bool, args []Expression, row chunk.Row) (i int, err error) {
+func (b *builtinIntervalIntSig) linearSearch(ctx sessionctx.Context, target int64, isUint1 bool, args []Expression, row chunk.Row) (i int, err error) {
 	i = 0
 	for ; i < len(args); i++ {
 		isUint2 := mysql.HasUnsignedFlag(args[i].GetType().GetFlag())
-		arg, isNull, err := args[i].EvalInt(b.ctx, row)
+		arg, isNull, err := args[i].EvalInt(ctx, row)
 		if err != nil {
 			return 0, err
 		}
@@ -1198,11 +1198,11 @@ func (b *builtinIntervalIntSig) linearSearch(target int64, isUint1 bool, args []
 // All arguments are treated as integers.
 // It is required that arg[0] < args[1] < args[2] < ... < args[n] for this function to work correctly.
 // This is because a binary search is used (very fast).
-func (b *builtinIntervalIntSig) binSearch(target int64, isUint1 bool, args []Expression, row chunk.Row) (_ int, err error) {
+func (b *builtinIntervalIntSig) binSearch(ctx sessionctx.Context, target int64, isUint1 bool, args []Expression, row chunk.Row) (_ int, err error) {
 	i, j, cmp := 0, len(args), false
 	for i < j {
 		mid := i + (j-i)/2
-		v, isNull, err1 := args[mid].EvalInt(b.ctx, row)
+		v, isNull, err1 := args[mid].EvalInt(ctx, row)
 		if err1 != nil {
 			err = err1
 			break
@@ -1245,7 +1245,7 @@ func (b *builtinIntervalRealSig) Clone() builtinFunc {
 // evalInt evals a builtinIntervalRealSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_interval
 func (b *builtinIntervalRealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalReal(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -1254,17 +1254,17 @@ func (b *builtinIntervalRealSig) evalInt(ctx sessionctx.Context, row chunk.Row) 
 	}
 	var idx int
 	if b.hasNullable {
-		idx, err = b.linearSearch(arg0, b.args[1:], row)
+		idx, err = b.linearSearch(ctx, arg0, b.args[1:], row)
 	} else {
-		idx, err = b.binSearch(arg0, b.args[1:], row)
+		idx, err = b.binSearch(ctx, arg0, b.args[1:], row)
 	}
 	return int64(idx), err != nil, err
 }
 
-func (b *builtinIntervalRealSig) linearSearch(target float64, args []Expression, row chunk.Row) (i int, err error) {
+func (b *builtinIntervalRealSig) linearSearch(ctx sessionctx.Context, target float64, args []Expression, row chunk.Row) (i int, err error) {
 	i = 0
 	for ; i < len(args); i++ {
-		arg, isNull, err := args[i].EvalReal(b.ctx, row)
+		arg, isNull, err := args[i].EvalReal(ctx, row)
 		if err != nil {
 			return 0, err
 		}
@@ -1275,11 +1275,11 @@ func (b *builtinIntervalRealSig) linearSearch(target float64, args []Expression,
 	return i, nil
 }
 
-func (b *builtinIntervalRealSig) binSearch(target float64, args []Expression, row chunk.Row) (_ int, err error) {
+func (b *builtinIntervalRealSig) binSearch(ctx sessionctx.Context, target float64, args []Expression, row chunk.Row) (_ int, err error) {
 	i, j := 0, len(args)
 	for i < j {
 		mid := i + (j-i)/2
-		v, isNull, err1 := args[mid].EvalReal(b.ctx, row)
+		v, isNull, err1 := args[mid].EvalReal(ctx, row)
 		if err1 != nil {
 			err = err1
 			break
@@ -2020,12 +2020,8 @@ func (b *builtinLTIntSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinLTIntSig) evalIntWithCtx(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLT(CompareInt(ctx, b.args[0], b.args[1], row, row))
-}
-
 func (b *builtinLTIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLT(CompareInt(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLT(CompareInt(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinLTRealSig struct {
@@ -2039,7 +2035,7 @@ func (b *builtinLTRealSig) Clone() builtinFunc {
 }
 
 func (b *builtinLTRealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLT(CompareReal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLT(CompareReal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinLTDecimalSig struct {
@@ -2053,7 +2049,7 @@ func (b *builtinLTDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinLTDecimalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLT(CompareDecimal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLT(CompareDecimal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinLTStringSig struct {
@@ -2067,7 +2063,7 @@ func (b *builtinLTStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinLTStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLT(CompareStringWithCollationInfo(b.ctx, b.args[0], b.args[1], row, row, b.collation))
+	return resOfLT(CompareStringWithCollationInfo(ctx, b.args[0], b.args[1], row, row, b.collation))
 }
 
 type builtinLTDurationSig struct {
@@ -2081,7 +2077,7 @@ func (b *builtinLTDurationSig) Clone() builtinFunc {
 }
 
 func (b *builtinLTDurationSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLT(CompareDuration(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLT(CompareDuration(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinLTTimeSig struct {
@@ -2095,7 +2091,7 @@ func (b *builtinLTTimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinLTTimeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLT(CompareTime(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLT(CompareTime(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinLTJSONSig struct {
@@ -2109,7 +2105,7 @@ func (b *builtinLTJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinLTJSONSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLT(CompareJSON(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLT(CompareJSON(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinLEIntSig struct {
@@ -2123,7 +2119,7 @@ func (b *builtinLEIntSig) Clone() builtinFunc {
 }
 
 func (b *builtinLEIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLE(CompareInt(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLE(CompareInt(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinLERealSig struct {
@@ -2137,7 +2133,7 @@ func (b *builtinLERealSig) Clone() builtinFunc {
 }
 
 func (b *builtinLERealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLE(CompareReal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLE(CompareReal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinLEDecimalSig struct {
@@ -2151,7 +2147,7 @@ func (b *builtinLEDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinLEDecimalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLE(CompareDecimal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLE(CompareDecimal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinLEStringSig struct {
@@ -2165,7 +2161,7 @@ func (b *builtinLEStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinLEStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLE(CompareStringWithCollationInfo(b.ctx, b.args[0], b.args[1], row, row, b.collation))
+	return resOfLE(CompareStringWithCollationInfo(ctx, b.args[0], b.args[1], row, row, b.collation))
 }
 
 type builtinLEDurationSig struct {
@@ -2179,7 +2175,7 @@ func (b *builtinLEDurationSig) Clone() builtinFunc {
 }
 
 func (b *builtinLEDurationSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLE(CompareDuration(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLE(CompareDuration(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinLETimeSig struct {
@@ -2193,7 +2189,7 @@ func (b *builtinLETimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinLETimeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLE(CompareTime(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLE(CompareTime(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinLEJSONSig struct {
@@ -2207,7 +2203,7 @@ func (b *builtinLEJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinLEJSONSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfLE(CompareJSON(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfLE(CompareJSON(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGTIntSig struct {
@@ -2221,7 +2217,7 @@ func (b *builtinGTIntSig) Clone() builtinFunc {
 }
 
 func (b *builtinGTIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGT(CompareInt(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGT(CompareInt(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGTRealSig struct {
@@ -2235,7 +2231,7 @@ func (b *builtinGTRealSig) Clone() builtinFunc {
 }
 
 func (b *builtinGTRealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGT(CompareReal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGT(CompareReal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGTDecimalSig struct {
@@ -2249,7 +2245,7 @@ func (b *builtinGTDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinGTDecimalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGT(CompareDecimal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGT(CompareDecimal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGTStringSig struct {
@@ -2263,7 +2259,7 @@ func (b *builtinGTStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinGTStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGT(CompareStringWithCollationInfo(b.ctx, b.args[0], b.args[1], row, row, b.collation))
+	return resOfGT(CompareStringWithCollationInfo(ctx, b.args[0], b.args[1], row, row, b.collation))
 }
 
 type builtinGTDurationSig struct {
@@ -2277,7 +2273,7 @@ func (b *builtinGTDurationSig) Clone() builtinFunc {
 }
 
 func (b *builtinGTDurationSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGT(CompareDuration(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGT(CompareDuration(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGTTimeSig struct {
@@ -2291,7 +2287,7 @@ func (b *builtinGTTimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinGTTimeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGT(CompareTime(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGT(CompareTime(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGTJSONSig struct {
@@ -2305,7 +2301,7 @@ func (b *builtinGTJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinGTJSONSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGT(CompareJSON(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGT(CompareJSON(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGEIntSig struct {
@@ -2319,7 +2315,7 @@ func (b *builtinGEIntSig) Clone() builtinFunc {
 }
 
 func (b *builtinGEIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGE(CompareInt(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGE(CompareInt(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGERealSig struct {
@@ -2333,7 +2329,7 @@ func (b *builtinGERealSig) Clone() builtinFunc {
 }
 
 func (b *builtinGERealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGE(CompareReal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGE(CompareReal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGEDecimalSig struct {
@@ -2347,7 +2343,7 @@ func (b *builtinGEDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinGEDecimalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGE(CompareDecimal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGE(CompareDecimal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGEStringSig struct {
@@ -2361,7 +2357,7 @@ func (b *builtinGEStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinGEStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGE(CompareStringWithCollationInfo(b.ctx, b.args[0], b.args[1], row, row, b.collation))
+	return resOfGE(CompareStringWithCollationInfo(ctx, b.args[0], b.args[1], row, row, b.collation))
 }
 
 type builtinGEDurationSig struct {
@@ -2375,7 +2371,7 @@ func (b *builtinGEDurationSig) Clone() builtinFunc {
 }
 
 func (b *builtinGEDurationSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGE(CompareDuration(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGE(CompareDuration(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGETimeSig struct {
@@ -2389,7 +2385,7 @@ func (b *builtinGETimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinGETimeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGE(CompareTime(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGE(CompareTime(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinGEJSONSig struct {
@@ -2403,7 +2399,7 @@ func (b *builtinGEJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinGEJSONSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfGE(CompareJSON(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfGE(CompareJSON(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinEQIntSig struct {
@@ -2417,7 +2413,7 @@ func (b *builtinEQIntSig) Clone() builtinFunc {
 }
 
 func (b *builtinEQIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfEQ(CompareInt(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfEQ(CompareInt(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinEQRealSig struct {
@@ -2431,7 +2427,7 @@ func (b *builtinEQRealSig) Clone() builtinFunc {
 }
 
 func (b *builtinEQRealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfEQ(CompareReal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfEQ(CompareReal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinEQDecimalSig struct {
@@ -2445,7 +2441,7 @@ func (b *builtinEQDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinEQDecimalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfEQ(CompareDecimal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfEQ(CompareDecimal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinEQStringSig struct {
@@ -2459,7 +2455,7 @@ func (b *builtinEQStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinEQStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfEQ(CompareStringWithCollationInfo(b.ctx, b.args[0], b.args[1], row, row, b.collation))
+	return resOfEQ(CompareStringWithCollationInfo(ctx, b.args[0], b.args[1], row, row, b.collation))
 }
 
 type builtinEQDurationSig struct {
@@ -2473,7 +2469,7 @@ func (b *builtinEQDurationSig) Clone() builtinFunc {
 }
 
 func (b *builtinEQDurationSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfEQ(CompareDuration(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfEQ(CompareDuration(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinEQTimeSig struct {
@@ -2487,7 +2483,7 @@ func (b *builtinEQTimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinEQTimeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfEQ(CompareTime(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfEQ(CompareTime(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinEQJSONSig struct {
@@ -2501,7 +2497,7 @@ func (b *builtinEQJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinEQJSONSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfEQ(CompareJSON(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfEQ(CompareJSON(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinNEIntSig struct {
@@ -2515,7 +2511,7 @@ func (b *builtinNEIntSig) Clone() builtinFunc {
 }
 
 func (b *builtinNEIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfNE(CompareInt(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfNE(CompareInt(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinNERealSig struct {
@@ -2529,7 +2525,7 @@ func (b *builtinNERealSig) Clone() builtinFunc {
 }
 
 func (b *builtinNERealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfNE(CompareReal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfNE(CompareReal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinNEDecimalSig struct {
@@ -2543,7 +2539,7 @@ func (b *builtinNEDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinNEDecimalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfNE(CompareDecimal(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfNE(CompareDecimal(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinNEStringSig struct {
@@ -2557,7 +2553,7 @@ func (b *builtinNEStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinNEStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfNE(CompareStringWithCollationInfo(b.ctx, b.args[0], b.args[1], row, row, b.collation))
+	return resOfNE(CompareStringWithCollationInfo(ctx, b.args[0], b.args[1], row, row, b.collation))
 }
 
 type builtinNEDurationSig struct {
@@ -2571,7 +2567,7 @@ func (b *builtinNEDurationSig) Clone() builtinFunc {
 }
 
 func (b *builtinNEDurationSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfNE(CompareDuration(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfNE(CompareDuration(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinNETimeSig struct {
@@ -2585,7 +2581,7 @@ func (b *builtinNETimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinNETimeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfNE(CompareTime(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfNE(CompareTime(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinNEJSONSig struct {
@@ -2599,7 +2595,7 @@ func (b *builtinNEJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinNEJSONSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	return resOfNE(CompareJSON(b.ctx, b.args[0], b.args[1], row, row))
+	return resOfNE(CompareJSON(ctx, b.args[0], b.args[1], row, row))
 }
 
 type builtinNullEQIntSig struct {
@@ -2613,11 +2609,11 @@ func (b *builtinNullEQIntSig) Clone() builtinFunc {
 }
 
 func (b *builtinNullEQIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return 0, isNull0, err
 	}
-	arg1, isNull1, err := b.args[1].EvalInt(b.ctx, row)
+	arg1, isNull1, err := b.args[1].EvalInt(ctx, row)
 	if err != nil {
 		return 0, isNull1, err
 	}
@@ -2661,11 +2657,11 @@ func (b *builtinNullEQRealSig) Clone() builtinFunc {
 }
 
 func (b *builtinNullEQRealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalReal(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalReal(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
-	arg1, isNull1, err := b.args[1].EvalReal(b.ctx, row)
+	arg1, isNull1, err := b.args[1].EvalReal(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -2692,11 +2688,11 @@ func (b *builtinNullEQDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinNullEQDecimalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalDecimal(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalDecimal(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
-	arg1, isNull1, err := b.args[1].EvalDecimal(b.ctx, row)
+	arg1, isNull1, err := b.args[1].EvalDecimal(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -2723,11 +2719,11 @@ func (b *builtinNullEQStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinNullEQStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalString(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalString(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
-	arg1, isNull1, err := b.args[1].EvalString(b.ctx, row)
+	arg1, isNull1, err := b.args[1].EvalString(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -2754,11 +2750,11 @@ func (b *builtinNullEQDurationSig) Clone() builtinFunc {
 }
 
 func (b *builtinNullEQDurationSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalDuration(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalDuration(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
-	arg1, isNull1, err := b.args[1].EvalDuration(b.ctx, row)
+	arg1, isNull1, err := b.args[1].EvalDuration(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -2785,11 +2781,11 @@ func (b *builtinNullEQTimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinNullEQTimeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalTime(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalTime(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
-	arg1, isNull1, err := b.args[1].EvalTime(b.ctx, row)
+	arg1, isNull1, err := b.args[1].EvalTime(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -2816,11 +2812,11 @@ func (b *builtinNullEQJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinNullEQJSONSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalJSON(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalJSON(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
-	arg1, isNull1, err := b.args[1].EvalJSON(b.ctx, row)
+	arg1, isNull1, err := b.args[1].EvalJSON(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}

--- a/pkg/expression/builtin_compare_vec.go
+++ b/pkg/expression/builtin_compare_vec.go
@@ -32,13 +32,13 @@ func (b *builtinGreatestDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 
 	d64s := result.Decimals()
 	for j := 1; j < len(b.args); j++ {
-		if err := b.args[j].VecEvalDecimal(b.ctx, input, buf); err != nil {
+		if err := b.args[j].VecEvalDecimal(ctx, input, buf); err != nil {
 			return err
 		}
 		result.MergeNulls(buf)
@@ -66,13 +66,13 @@ func (b *builtinLeastDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 
 	d64s := result.Decimals()
 	for j := 1; j < len(b.args); j++ {
-		if err := b.args[j].VecEvalDecimal(b.ctx, input, buf); err != nil {
+		if err := b.args[j].VecEvalDecimal(ctx, input, buf); err != nil {
 			return err
 		}
 
@@ -101,13 +101,13 @@ func (b *builtinLeastIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
 	i64s := result.Int64s()
 	for j := 1; j < len(b.args); j++ {
-		if err := b.args[j].VecEvalInt(b.ctx, input, buf); err != nil {
+		if err := b.args[j].VecEvalInt(ctx, input, buf); err != nil {
 			return err
 		}
 
@@ -136,13 +136,13 @@ func (b *builtinGreatestIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
 	i64s := result.Int64s()
 	for j := 1; j < len(b.args); j++ {
-		if err := b.args[j].VecEvalInt(b.ctx, input, buf); err != nil {
+		if err := b.args[j].VecEvalInt(ctx, input, buf); err != nil {
 			return err
 		}
 
@@ -177,7 +177,7 @@ func (b *builtinGEIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err = b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err = b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err = b.bufAllocator.get()
@@ -185,7 +185,7 @@ func (b *builtinGEIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err = b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err = b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -207,13 +207,13 @@ func (b *builtinLeastRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 
 	f64s := result.Float64s()
 	for j := 1; j < len(b.args); j++ {
-		if err := b.args[j].VecEvalReal(b.ctx, input, buf); err != nil {
+		if err := b.args[j].VecEvalReal(ctx, input, buf); err != nil {
 			return err
 		}
 
@@ -236,7 +236,7 @@ func (b *builtinLeastStringSig) vectorized() bool {
 }
 
 func (b *builtinLeastStringSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalString(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -258,7 +258,7 @@ func (b *builtinLeastStringSig) vecEvalString(ctx sessionctx.Context, input *chu
 	dst := buf2
 	dst.ReserveString(n)
 	for j := 1; j < len(b.args); j++ {
-		if err := b.args[j].VecEvalString(b.ctx, input, arg); err != nil {
+		if err := b.args[j].VecEvalString(ctx, input, arg); err != nil {
 			return err
 		}
 		for i := 0; i < n; i++ {
@@ -297,7 +297,7 @@ func (b *builtinEQIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err = b.bufAllocator.get()
@@ -305,7 +305,7 @@ func (b *builtinEQIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -329,7 +329,7 @@ func (b *builtinNEIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err = b.bufAllocator.get()
@@ -337,7 +337,7 @@ func (b *builtinNEIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -361,7 +361,7 @@ func (b *builtinGTIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err = b.bufAllocator.get()
@@ -369,7 +369,7 @@ func (b *builtinGTIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -391,7 +391,7 @@ func (b *builtinNullEQIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -400,7 +400,7 @@ func (b *builtinNullEQIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 	}
 	defer b.bufAllocator.put(buf1)
 	result.ResizeInt64(n, false)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag()), buf0, buf1, result)
@@ -425,7 +425,7 @@ func (b *builtinIntervalIntSig) vectorized() bool {
 
 func (b *builtinIntervalIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	var err error
-	if err = b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err = b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	i64s := result.Int64s()
@@ -437,9 +437,9 @@ func (b *builtinIntervalIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 			continue
 		}
 		if b.hasNullable {
-			idx, err = b.linearSearch(v, mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), b.args[1:], input.GetRow(i))
+			idx, err = b.linearSearch(ctx, v, mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), b.args[1:], input.GetRow(i))
 		} else {
-			idx, err = b.binSearch(v, mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), b.args[1:], input.GetRow(i))
+			idx, err = b.binSearch(ctx, v, mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), b.args[1:], input.GetRow(i))
 		}
 		if err != nil {
 			return err
@@ -460,7 +460,7 @@ func (b *builtinIntervalRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -474,9 +474,9 @@ func (b *builtinIntervalRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 			continue
 		}
 		if b.hasNullable {
-			idx, err = b.linearSearch(f64s[i], b.args[1:], input.GetRow(i))
+			idx, err = b.linearSearch(ctx, f64s[i], b.args[1:], input.GetRow(i))
 		} else {
-			idx, err = b.binSearch(f64s[i], b.args[1:], input.GetRow(i))
+			idx, err = b.binSearch(ctx, f64s[i], b.args[1:], input.GetRow(i))
 		}
 		if err != nil {
 			return err
@@ -499,7 +499,7 @@ func (b *builtinLEIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err = b.bufAllocator.get()
@@ -507,7 +507,7 @@ func (b *builtinLEIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -531,7 +531,7 @@ func (b *builtinLTIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err = b.bufAllocator.get()
@@ -539,7 +539,7 @@ func (b *builtinLTIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -635,7 +635,7 @@ func (b *builtinGreatestCmpStringAsTimeSig) vectorized() bool {
 }
 
 func (b *builtinGreatestCmpStringAsTimeSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	n := input.NumRows()
 
 	dstStrings := make([]string, n)
@@ -643,7 +643,7 @@ func (b *builtinGreatestCmpStringAsTimeSig) vecEvalString(ctx sessionctx.Context
 	dstNullMap := make([]bool, n)
 
 	for j := 0; j < len(b.args); j++ {
-		if err := b.args[j].VecEvalString(b.ctx, input, result); err != nil {
+		if err := b.args[j].VecEvalString(ctx, input, result); err != nil {
 			return err
 		}
 		for i := 0; i < n; i++ {
@@ -654,7 +654,7 @@ func (b *builtinGreatestCmpStringAsTimeSig) vecEvalString(ctx sessionctx.Context
 			// NOTE: can't use Column.GetString because it returns an unsafe string, copy the row instead.
 			argTimeStr := string(result.GetBytes(i))
 			var err error
-			argTimeStr, err = doTimeConversionForGL(b.cmpAsDate, b.ctx, sc, argTimeStr)
+			argTimeStr, err = doTimeConversionForGL(b.cmpAsDate, ctx, sc, argTimeStr)
 			if err != nil {
 				return err
 			}
@@ -687,13 +687,13 @@ func (b *builtinGreatestRealSig) vecEvalReal(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 
 	f64s := result.Float64s()
 	for j := 1; j < len(b.args); j++ {
-		if err := b.args[j].VecEvalReal(b.ctx, input, buf); err != nil {
+		if err := b.args[j].VecEvalReal(ctx, input, buf); err != nil {
 			return err
 		}
 
@@ -716,7 +716,7 @@ func (b *builtinLeastCmpStringAsTimeSig) vectorized() bool {
 }
 
 func (b *builtinLeastCmpStringAsTimeSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	n := input.NumRows()
 
 	dstStrings := make([]string, n)
@@ -724,7 +724,7 @@ func (b *builtinLeastCmpStringAsTimeSig) vecEvalString(ctx sessionctx.Context, i
 	dstNullMap := make([]bool, n)
 
 	for j := 0; j < len(b.args); j++ {
-		if err := b.args[j].VecEvalString(b.ctx, input, result); err != nil {
+		if err := b.args[j].VecEvalString(ctx, input, result); err != nil {
 			return err
 		}
 		for i := 0; i < n; i++ {
@@ -735,7 +735,7 @@ func (b *builtinLeastCmpStringAsTimeSig) vecEvalString(ctx sessionctx.Context, i
 			// NOTE: can't use Column.GetString because it returns an unsafe string, copy the row instead.
 			argTimeStr := string(result.GetBytes(i))
 			var err error
-			argTimeStr, err = doTimeConversionForGL(b.cmpAsDate, b.ctx, sc, argTimeStr)
+			argTimeStr, err = doTimeConversionForGL(b.cmpAsDate, ctx, sc, argTimeStr)
 			if err != nil {
 				return err
 			}
@@ -762,7 +762,7 @@ func (b *builtinGreatestStringSig) vectorized() bool {
 }
 
 func (b *builtinGreatestStringSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalString(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -783,7 +783,7 @@ func (b *builtinGreatestStringSig) vecEvalString(ctx sessionctx.Context, input *
 	dst := buf2
 	dst.ReserveString(n)
 	for j := 1; j < len(b.args); j++ {
-		if err := b.args[j].VecEvalString(b.ctx, input, arg); err != nil {
+		if err := b.args[j].VecEvalString(ctx, input, arg); err != nil {
 			return err
 		}
 		for i := 0; i < n; i++ {
@@ -823,7 +823,7 @@ func (b *builtinGreatestTimeSig) vecEvalTime(ctx sessionctx.Context, input *chun
 
 	result.ResizeTime(n, false)
 	for argIdx := 0; argIdx < len(b.args); argIdx++ {
-		if err := b.args[argIdx].VecEvalTime(b.ctx, input, buf); err != nil {
+		if err := b.args[argIdx].VecEvalTime(ctx, input, buf); err != nil {
 			return err
 		}
 		result.MergeNulls(buf)
@@ -838,7 +838,7 @@ func (b *builtinGreatestTimeSig) vecEvalTime(ctx sessionctx.Context, input *chun
 			}
 		}
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	resTimeTp := getAccurateTimeTypeForGLRet(b.cmpAsDate)
 	for rowIdx := 0; rowIdx < n; rowIdx++ {
 		resTimes := result.Times()
@@ -864,7 +864,7 @@ func (b *builtinLeastTimeSig) vecEvalTime(ctx sessionctx.Context, input *chunk.C
 
 	result.ResizeTime(n, false)
 	for argIdx := 0; argIdx < len(b.args); argIdx++ {
-		if err := b.args[argIdx].VecEvalTime(b.ctx, input, buf); err != nil {
+		if err := b.args[argIdx].VecEvalTime(ctx, input, buf); err != nil {
 			return err
 		}
 		result.MergeNulls(buf)
@@ -879,7 +879,7 @@ func (b *builtinLeastTimeSig) vecEvalTime(ctx sessionctx.Context, input *chunk.C
 			}
 		}
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	resTimeTp := getAccurateTimeTypeForGLRet(b.cmpAsDate)
 	for rowIdx := 0; rowIdx < n; rowIdx++ {
 		resTimes := result.Times()
@@ -905,7 +905,7 @@ func (b *builtinGreatestDurationSig) vecEvalDuration(ctx sessionctx.Context, inp
 
 	result.ResizeGoDuration(n, false)
 	for argIdx := 0; argIdx < len(b.args); argIdx++ {
-		if err := b.args[argIdx].VecEvalDuration(b.ctx, input, buf); err != nil {
+		if err := b.args[argIdx].VecEvalDuration(ctx, input, buf); err != nil {
 			return err
 		}
 		result.MergeNulls(buf)
@@ -937,7 +937,7 @@ func (b *builtinLeastDurationSig) vecEvalDuration(ctx sessionctx.Context, input 
 
 	result.ResizeGoDuration(n, false)
 	for argIdx := 0; argIdx < len(b.args); argIdx++ {
-		if err := b.args[argIdx].VecEvalDuration(b.ctx, input, buf); err != nil {
+		if err := b.args[argIdx].VecEvalDuration(ctx, input, buf); err != nil {
 			return err
 		}
 		result.MergeNulls(buf)

--- a/pkg/expression/builtin_compare_vec_generated.go
+++ b/pkg/expression/builtin_compare_vec_generated.go
@@ -31,7 +31,7 @@ func (b *builtinLTRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -39,7 +39,7 @@ func (b *builtinLTRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -69,7 +69,7 @@ func (b *builtinLTDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -77,7 +77,7 @@ func (b *builtinLTDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -107,7 +107,7 @@ func (b *builtinLTStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -115,7 +115,7 @@ func (b *builtinLTStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -143,7 +143,7 @@ func (b *builtinLTTimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -151,7 +151,7 @@ func (b *builtinLTTimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -181,7 +181,7 @@ func (b *builtinLTDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -189,7 +189,7 @@ func (b *builtinLTDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -219,7 +219,7 @@ func (b *builtinLTJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -227,7 +227,7 @@ func (b *builtinLTJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalJSON(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -255,7 +255,7 @@ func (b *builtinLERealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -263,7 +263,7 @@ func (b *builtinLERealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -293,7 +293,7 @@ func (b *builtinLEDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -301,7 +301,7 @@ func (b *builtinLEDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -331,7 +331,7 @@ func (b *builtinLEStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -339,7 +339,7 @@ func (b *builtinLEStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -367,7 +367,7 @@ func (b *builtinLETimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -375,7 +375,7 @@ func (b *builtinLETimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -405,7 +405,7 @@ func (b *builtinLEDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -413,7 +413,7 @@ func (b *builtinLEDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -443,7 +443,7 @@ func (b *builtinLEJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -451,7 +451,7 @@ func (b *builtinLEJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalJSON(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -479,7 +479,7 @@ func (b *builtinGTRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -487,7 +487,7 @@ func (b *builtinGTRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -517,7 +517,7 @@ func (b *builtinGTDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -525,7 +525,7 @@ func (b *builtinGTDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -555,7 +555,7 @@ func (b *builtinGTStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -563,7 +563,7 @@ func (b *builtinGTStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -591,7 +591,7 @@ func (b *builtinGTTimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -599,7 +599,7 @@ func (b *builtinGTTimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -629,7 +629,7 @@ func (b *builtinGTDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -637,7 +637,7 @@ func (b *builtinGTDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -667,7 +667,7 @@ func (b *builtinGTJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -675,7 +675,7 @@ func (b *builtinGTJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalJSON(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -703,7 +703,7 @@ func (b *builtinGERealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -711,7 +711,7 @@ func (b *builtinGERealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -741,7 +741,7 @@ func (b *builtinGEDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -749,7 +749,7 @@ func (b *builtinGEDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -779,7 +779,7 @@ func (b *builtinGEStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -787,7 +787,7 @@ func (b *builtinGEStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -815,7 +815,7 @@ func (b *builtinGETimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -823,7 +823,7 @@ func (b *builtinGETimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -853,7 +853,7 @@ func (b *builtinGEDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -861,7 +861,7 @@ func (b *builtinGEDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -891,7 +891,7 @@ func (b *builtinGEJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -899,7 +899,7 @@ func (b *builtinGEJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalJSON(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -927,7 +927,7 @@ func (b *builtinEQRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -935,7 +935,7 @@ func (b *builtinEQRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -965,7 +965,7 @@ func (b *builtinEQDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -973,7 +973,7 @@ func (b *builtinEQDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1003,7 +1003,7 @@ func (b *builtinEQStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1011,7 +1011,7 @@ func (b *builtinEQStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1039,7 +1039,7 @@ func (b *builtinEQTimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1047,7 +1047,7 @@ func (b *builtinEQTimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1077,7 +1077,7 @@ func (b *builtinEQDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1085,7 +1085,7 @@ func (b *builtinEQDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1115,7 +1115,7 @@ func (b *builtinEQJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1123,7 +1123,7 @@ func (b *builtinEQJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalJSON(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1151,7 +1151,7 @@ func (b *builtinNERealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1159,7 +1159,7 @@ func (b *builtinNERealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1189,7 +1189,7 @@ func (b *builtinNEDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1197,7 +1197,7 @@ func (b *builtinNEDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1227,7 +1227,7 @@ func (b *builtinNEStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1235,7 +1235,7 @@ func (b *builtinNEStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1263,7 +1263,7 @@ func (b *builtinNETimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1271,7 +1271,7 @@ func (b *builtinNETimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1301,7 +1301,7 @@ func (b *builtinNEDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1309,7 +1309,7 @@ func (b *builtinNEDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1339,7 +1339,7 @@ func (b *builtinNEJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1347,7 +1347,7 @@ func (b *builtinNEJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalJSON(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1375,7 +1375,7 @@ func (b *builtinNullEQRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1383,7 +1383,7 @@ func (b *builtinNullEQRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1417,7 +1417,7 @@ func (b *builtinNullEQDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1425,7 +1425,7 @@ func (b *builtinNullEQDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1459,7 +1459,7 @@ func (b *builtinNullEQStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1467,7 +1467,7 @@ func (b *builtinNullEQStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1499,7 +1499,7 @@ func (b *builtinNullEQTimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1507,7 +1507,7 @@ func (b *builtinNullEQTimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1541,7 +1541,7 @@ func (b *builtinNullEQDurationSig) vecEvalInt(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1549,7 +1549,7 @@ func (b *builtinNullEQDurationSig) vecEvalInt(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1583,7 +1583,7 @@ func (b *builtinNullEQJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1591,7 +1591,7 @@ func (b *builtinNullEQJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalJSON(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1647,10 +1647,10 @@ func (b *builtinCoalesceIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 	for j := 0; j < len(b.args); j++ {
-		err := b.args[j].VecEvalInt(b.ctx, input, buf1)
+		err := b.args[j].VecEvalInt(ctx, input, buf1)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -1704,10 +1704,10 @@ func (b *builtinCoalesceRealSig) vecEvalReal(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 	for j := 0; j < len(b.args); j++ {
-		err := b.args[j].VecEvalReal(b.ctx, input, buf1)
+		err := b.args[j].VecEvalReal(ctx, input, buf1)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -1761,10 +1761,10 @@ func (b *builtinCoalesceDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 	for j := 0; j < len(b.args); j++ {
-		err := b.args[j].VecEvalDecimal(b.ctx, input, buf1)
+		err := b.args[j].VecEvalDecimal(ctx, input, buf1)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -1812,7 +1812,7 @@ func (b *builtinCoalesceStringSig) vecEvalString(ctx sessionctx.Context, input *
 	argLen := len(b.args)
 
 	bufs := make([]*chunk.Column, argLen)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 	for i := 0; i < argLen; i++ {
 		buf, err := b.bufAllocator.get()
@@ -1820,7 +1820,7 @@ func (b *builtinCoalesceStringSig) vecEvalString(ctx sessionctx.Context, input *
 			return err
 		}
 		defer b.bufAllocator.put(buf)
-		err = b.args[i].VecEvalString(b.ctx, input, buf)
+		err = b.args[i].VecEvalString(ctx, input, buf)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -1881,10 +1881,10 @@ func (b *builtinCoalesceTimeSig) vecEvalTime(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 	for j := 0; j < len(b.args); j++ {
-		err := b.args[j].VecEvalTime(b.ctx, input, buf1)
+		err := b.args[j].VecEvalTime(ctx, input, buf1)
 		fsp := b.tp.GetDecimal()
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
@@ -1940,10 +1940,10 @@ func (b *builtinCoalesceDurationSig) vecEvalDuration(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 	for j := 0; j < len(b.args); j++ {
-		err := b.args[j].VecEvalDuration(b.ctx, input, buf1)
+		err := b.args[j].VecEvalDuration(ctx, input, buf1)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -1991,7 +1991,7 @@ func (b *builtinCoalesceJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chun
 	argLen := len(b.args)
 
 	bufs := make([]*chunk.Column, argLen)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 	for i := 0; i < argLen; i++ {
 		buf, err := b.bufAllocator.get()
@@ -1999,7 +1999,7 @@ func (b *builtinCoalesceJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chun
 			return err
 		}
 		defer b.bufAllocator.put(buf)
-		err = b.args[i].VecEvalJSON(b.ctx, input, buf)
+		err = b.args[i].VecEvalJSON(ctx, input, buf)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {

--- a/pkg/expression/builtin_control.go
+++ b/pkg/expression/builtin_control.go
@@ -338,21 +338,21 @@ func (b *builtinCaseWhenIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(b.ctx, row)
+		condition, isNull, err = args[i].EvalInt(ctx, row)
 		if err != nil {
 			return 0, isNull, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalInt(b.ctx, row)
+		ret, isNull, err = args[i+1].EvalInt(ctx, row)
 		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalInt(b.ctx, row)
+		ret, isNull, err = args[l-1].EvalInt(ctx, row)
 		return ret, isNull, err
 	}
 	return ret, true, nil
@@ -374,21 +374,21 @@ func (b *builtinCaseWhenRealSig) evalReal(ctx sessionctx.Context, row chunk.Row)
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(b.ctx, row)
+		condition, isNull, err = args[i].EvalInt(ctx, row)
 		if err != nil {
 			return 0, isNull, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalReal(b.ctx, row)
+		ret, isNull, err = args[i+1].EvalReal(ctx, row)
 		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalReal(b.ctx, row)
+		ret, isNull, err = args[l-1].EvalReal(ctx, row)
 		return ret, isNull, err
 	}
 	return ret, true, nil
@@ -410,21 +410,21 @@ func (b *builtinCaseWhenDecimalSig) evalDecimal(ctx sessionctx.Context, row chun
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(b.ctx, row)
+		condition, isNull, err = args[i].EvalInt(ctx, row)
 		if err != nil {
 			return nil, isNull, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalDecimal(b.ctx, row)
+		ret, isNull, err = args[i+1].EvalDecimal(ctx, row)
 		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalDecimal(b.ctx, row)
+		ret, isNull, err = args[l-1].EvalDecimal(ctx, row)
 		return ret, isNull, err
 	}
 	return ret, true, nil
@@ -446,21 +446,21 @@ func (b *builtinCaseWhenStringSig) evalString(ctx sessionctx.Context, row chunk.
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(b.ctx, row)
+		condition, isNull, err = args[i].EvalInt(ctx, row)
 		if err != nil {
 			return "", isNull, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalString(b.ctx, row)
+		ret, isNull, err = args[i+1].EvalString(ctx, row)
 		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalString(b.ctx, row)
+		ret, isNull, err = args[l-1].EvalString(ctx, row)
 		return ret, isNull, err
 	}
 	return ret, true, nil
@@ -482,21 +482,21 @@ func (b *builtinCaseWhenTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row)
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(b.ctx, row)
+		condition, isNull, err = args[i].EvalInt(ctx, row)
 		if err != nil {
 			return ret, isNull, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalTime(b.ctx, row)
+		ret, isNull, err = args[i+1].EvalTime(ctx, row)
 		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalTime(b.ctx, row)
+		ret, isNull, err = args[l-1].EvalTime(ctx, row)
 		return ret, isNull, err
 	}
 	return ret, true, nil
@@ -518,21 +518,21 @@ func (b *builtinCaseWhenDurationSig) evalDuration(ctx sessionctx.Context, row ch
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(b.ctx, row)
+		condition, isNull, err = args[i].EvalInt(ctx, row)
 		if err != nil {
 			return ret, true, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalDuration(b.ctx, row)
+		ret, isNull, err = args[i+1].EvalDuration(ctx, row)
 		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalDuration(b.ctx, row)
+		ret, isNull, err = args[l-1].EvalDuration(ctx, row)
 		return ret, isNull, err
 	}
 	return ret, true, nil
@@ -554,20 +554,20 @@ func (b *builtinCaseWhenJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row)
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(b.ctx, row)
+		condition, isNull, err = args[i].EvalInt(ctx, row)
 		if err != nil {
 			return
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		return args[i+1].EvalJSON(b.ctx, row)
+		return args[i+1].EvalJSON(ctx, row)
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		return args[l-1].EvalJSON(b.ctx, row)
+		return args[l-1].EvalJSON(ctx, row)
 	}
 	return ret, true, nil
 }
@@ -634,14 +634,14 @@ func (b *builtinIfIntSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
 	if !isNull0 && arg0 != 0 {
-		return b.args[1].EvalInt(b.ctx, row)
+		return b.args[1].EvalInt(ctx, row)
 	}
-	return b.args[2].EvalInt(b.ctx, row)
+	return b.args[2].EvalInt(ctx, row)
 }
 
 type builtinIfRealSig struct {
@@ -655,14 +655,14 @@ func (b *builtinIfRealSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (val float64, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
 	if !isNull0 && arg0 != 0 {
-		return b.args[1].EvalReal(b.ctx, row)
+		return b.args[1].EvalReal(ctx, row)
 	}
-	return b.args[2].EvalReal(b.ctx, row)
+	return b.args[2].EvalReal(ctx, row)
 }
 
 type builtinIfDecimalSig struct {
@@ -676,14 +676,14 @@ func (b *builtinIfDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (val *types.MyDecimal, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return nil, true, err
 	}
 	if !isNull0 && arg0 != 0 {
-		return b.args[1].EvalDecimal(b.ctx, row)
+		return b.args[1].EvalDecimal(ctx, row)
 	}
-	return b.args[2].EvalDecimal(b.ctx, row)
+	return b.args[2].EvalDecimal(ctx, row)
 }
 
 type builtinIfStringSig struct {
@@ -697,14 +697,14 @@ func (b *builtinIfStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (val string, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return "", true, err
 	}
 	if !isNull0 && arg0 != 0 {
-		return b.args[1].EvalString(b.ctx, row)
+		return b.args[1].EvalString(ctx, row)
 	}
-	return b.args[2].EvalString(b.ctx, row)
+	return b.args[2].EvalString(ctx, row)
 }
 
 type builtinIfTimeSig struct {
@@ -718,14 +718,14 @@ func (b *builtinIfTimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (ret types.Time, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return ret, true, err
 	}
 	if !isNull0 && arg0 != 0 {
-		return b.args[1].EvalTime(b.ctx, row)
+		return b.args[1].EvalTime(ctx, row)
 	}
-	return b.args[2].EvalTime(b.ctx, row)
+	return b.args[2].EvalTime(ctx, row)
 }
 
 type builtinIfDurationSig struct {
@@ -739,14 +739,14 @@ func (b *builtinIfDurationSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (ret types.Duration, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return ret, true, err
 	}
 	if !isNull0 && arg0 != 0 {
-		return b.args[1].EvalDuration(b.ctx, row)
+		return b.args[1].EvalDuration(ctx, row)
 	}
-	return b.args[2].EvalDuration(b.ctx, row)
+	return b.args[2].EvalDuration(ctx, row)
 }
 
 type builtinIfJSONSig struct {
@@ -760,14 +760,14 @@ func (b *builtinIfJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (ret types.BinaryJSON, isNull bool, err error) {
-	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return ret, true, err
 	}
 	if !isNull0 && arg0 != 0 {
-		return b.args[1].EvalJSON(b.ctx, row)
+		return b.args[1].EvalJSON(ctx, row)
 	}
-	return b.args[2].EvalJSON(b.ctx, row)
+	return b.args[2].EvalJSON(ctx, row)
 }
 
 type ifNullFunctionClass struct {
@@ -834,11 +834,11 @@ func (b *builtinIfNullIntSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfNullIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalInt(ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, err
 	}
-	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalInt(ctx, row)
 	return arg1, isNull || err != nil, err
 }
 
@@ -853,11 +853,11 @@ func (b *builtinIfNullRealSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfNullRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	arg0, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalReal(ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, err
 	}
-	arg1, isNull, err := b.args[1].EvalReal(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalReal(ctx, row)
 	return arg1, isNull || err != nil, err
 }
 
@@ -872,11 +872,11 @@ func (b *builtinIfNullDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfNullDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	arg0, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, err
 	}
-	arg1, isNull, err := b.args[1].EvalDecimal(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalDecimal(ctx, row)
 	return arg1, isNull || err != nil, err
 }
 
@@ -891,11 +891,11 @@ func (b *builtinIfNullStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfNullStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	arg0, isNull, err := b.args[0].EvalString(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalString(ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, err
 	}
-	arg1, isNull, err := b.args[1].EvalString(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalString(ctx, row)
 	return arg1, isNull || err != nil, err
 }
 
@@ -910,11 +910,11 @@ func (b *builtinIfNullTimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfNullTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalTime(ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, err
 	}
-	arg1, isNull, err := b.args[1].EvalTime(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalTime(ctx, row)
 	return arg1, isNull || err != nil, err
 }
 
@@ -929,11 +929,11 @@ func (b *builtinIfNullDurationSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfNullDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, err
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalDuration(ctx, row)
 	return arg1, isNull || err != nil, err
 }
 
@@ -948,10 +948,10 @@ func (b *builtinIfNullJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinIfNullJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (types.BinaryJSON, bool, error) {
-	arg0, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if !isNull {
 		return arg0, err != nil, err
 	}
-	arg1, isNull, err := b.args[1].EvalJSON(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalJSON(ctx, row)
 	return arg1, isNull || err != nil, err
 }

--- a/pkg/expression/builtin_control_vec_generated.go
+++ b/pkg/expression/builtin_control_vec_generated.go
@@ -57,7 +57,7 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 	var eLse *chunk.Column
 	thensSlice := make([][]int64, l/2)
 	var eLseSlice []int64
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 
 	for j := 0; j < l-1; j += 2 {
@@ -66,7 +66,7 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 			return err
 		}
 		defer b.bufAllocator.put(bufWhen)
-		err = args[j].VecEvalInt(b.ctx, input, bufWhen)
+		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -82,7 +82,7 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 			return err
 		}
 		defer b.bufAllocator.put(bufThen)
-		err = args[j+1].VecEvalInt(b.ctx, input, bufThen)
+		err = args[j+1].VecEvalInt(ctx, input, bufThen)
 		afterWarns = sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -102,7 +102,7 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 			return err
 		}
 		defer b.bufAllocator.put(bufElse)
-		err = args[l-1].VecEvalInt(b.ctx, input, bufElse)
+		err = args[l-1].VecEvalInt(ctx, input, bufElse)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -168,7 +168,7 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx sessionctx.Context, input *chun
 	var eLse *chunk.Column
 	thensSlice := make([][]float64, l/2)
 	var eLseSlice []float64
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 
 	for j := 0; j < l-1; j += 2 {
@@ -177,7 +177,7 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx sessionctx.Context, input *chun
 			return err
 		}
 		defer b.bufAllocator.put(bufWhen)
-		err = args[j].VecEvalInt(b.ctx, input, bufWhen)
+		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -193,7 +193,7 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx sessionctx.Context, input *chun
 			return err
 		}
 		defer b.bufAllocator.put(bufThen)
-		err = args[j+1].VecEvalReal(b.ctx, input, bufThen)
+		err = args[j+1].VecEvalReal(ctx, input, bufThen)
 		afterWarns = sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -213,7 +213,7 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx sessionctx.Context, input *chun
 			return err
 		}
 		defer b.bufAllocator.put(bufElse)
-		err = args[l-1].VecEvalReal(b.ctx, input, bufElse)
+		err = args[l-1].VecEvalReal(ctx, input, bufElse)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -279,7 +279,7 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input
 	var eLse *chunk.Column
 	thensSlice := make([][]types.MyDecimal, l/2)
 	var eLseSlice []types.MyDecimal
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 
 	for j := 0; j < l-1; j += 2 {
@@ -288,7 +288,7 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input
 			return err
 		}
 		defer b.bufAllocator.put(bufWhen)
-		err = args[j].VecEvalInt(b.ctx, input, bufWhen)
+		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -304,7 +304,7 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input
 			return err
 		}
 		defer b.bufAllocator.put(bufThen)
-		err = args[j+1].VecEvalDecimal(b.ctx, input, bufThen)
+		err = args[j+1].VecEvalDecimal(ctx, input, bufThen)
 		afterWarns = sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -324,7 +324,7 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input
 			return err
 		}
 		defer b.bufAllocator.put(bufElse)
-		err = args[l-1].VecEvalDecimal(b.ctx, input, bufElse)
+		err = args[l-1].VecEvalDecimal(ctx, input, bufElse)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -385,7 +385,7 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx sessionctx.Context, input *
 	whensSlice := make([][]int64, l/2)
 	thens := make([]*chunk.Column, l/2)
 	var eLse *chunk.Column
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 
 	for j := 0; j < l-1; j += 2 {
@@ -394,7 +394,7 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx sessionctx.Context, input *
 			return err
 		}
 		defer b.bufAllocator.put(bufWhen)
-		err = args[j].VecEvalInt(b.ctx, input, bufWhen)
+		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -410,7 +410,7 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx sessionctx.Context, input *
 			return err
 		}
 		defer b.bufAllocator.put(bufThen)
-		err = args[j+1].VecEvalString(b.ctx, input, bufThen)
+		err = args[j+1].VecEvalString(ctx, input, bufThen)
 		afterWarns = sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -429,7 +429,7 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx sessionctx.Context, input *
 			return err
 		}
 		defer b.bufAllocator.put(bufElse)
-		err = args[l-1].VecEvalString(b.ctx, input, bufElse)
+		err = args[l-1].VecEvalString(ctx, input, bufElse)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -499,7 +499,7 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx sessionctx.Context, input *chun
 	var eLse *chunk.Column
 	thensSlice := make([][]types.Time, l/2)
 	var eLseSlice []types.Time
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 
 	for j := 0; j < l-1; j += 2 {
@@ -508,7 +508,7 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx sessionctx.Context, input *chun
 			return err
 		}
 		defer b.bufAllocator.put(bufWhen)
-		err = args[j].VecEvalInt(b.ctx, input, bufWhen)
+		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -524,7 +524,7 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx sessionctx.Context, input *chun
 			return err
 		}
 		defer b.bufAllocator.put(bufThen)
-		err = args[j+1].VecEvalTime(b.ctx, input, bufThen)
+		err = args[j+1].VecEvalTime(ctx, input, bufThen)
 		afterWarns = sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -544,7 +544,7 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx sessionctx.Context, input *chun
 			return err
 		}
 		defer b.bufAllocator.put(bufElse)
-		err = args[l-1].VecEvalTime(b.ctx, input, bufElse)
+		err = args[l-1].VecEvalTime(ctx, input, bufElse)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -610,7 +610,7 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx sessionctx.Context, inp
 	var eLse *chunk.Column
 	thensSlice := make([][]time.Duration, l/2)
 	var eLseSlice []time.Duration
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 
 	for j := 0; j < l-1; j += 2 {
@@ -619,7 +619,7 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx sessionctx.Context, inp
 			return err
 		}
 		defer b.bufAllocator.put(bufWhen)
-		err = args[j].VecEvalInt(b.ctx, input, bufWhen)
+		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -635,7 +635,7 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx sessionctx.Context, inp
 			return err
 		}
 		defer b.bufAllocator.put(bufThen)
-		err = args[j+1].VecEvalDuration(b.ctx, input, bufThen)
+		err = args[j+1].VecEvalDuration(ctx, input, bufThen)
 		afterWarns = sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -655,7 +655,7 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx sessionctx.Context, inp
 			return err
 		}
 		defer b.bufAllocator.put(bufElse)
-		err = args[l-1].VecEvalDuration(b.ctx, input, bufElse)
+		err = args[l-1].VecEvalDuration(ctx, input, bufElse)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -716,7 +716,7 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chun
 	whensSlice := make([][]int64, l/2)
 	thens := make([]*chunk.Column, l/2)
 	var eLse *chunk.Column
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 
 	for j := 0; j < l-1; j += 2 {
@@ -725,7 +725,7 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chun
 			return err
 		}
 		defer b.bufAllocator.put(bufWhen)
-		err = args[j].VecEvalInt(b.ctx, input, bufWhen)
+		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -741,7 +741,7 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chun
 			return err
 		}
 		defer b.bufAllocator.put(bufThen)
-		err = args[j+1].VecEvalJSON(b.ctx, input, bufThen)
+		err = args[j+1].VecEvalJSON(ctx, input, bufThen)
 		afterWarns = sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -760,7 +760,7 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chun
 			return err
 		}
 		defer b.bufAllocator.put(bufElse)
-		err = args[l-1].VecEvalJSON(b.ctx, input, bufElse)
+		err = args[l-1].VecEvalJSON(ctx, input, bufElse)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -823,7 +823,7 @@ func (b *builtinIfNullIntSig) fallbackEvalInt(ctx sessionctx.Context, input *chu
 
 func (b *builtinIfNullIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -831,9 +831,9 @@ func (b *builtinIfNullIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalInt(b.ctx, input, buf1)
+	err = b.args[1].VecEvalInt(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -878,7 +878,7 @@ func (b *builtinIfNullRealSig) fallbackEvalReal(ctx sessionctx.Context, input *c
 
 func (b *builtinIfNullRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -886,9 +886,9 @@ func (b *builtinIfNullRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalReal(b.ctx, input, buf1)
+	err = b.args[1].VecEvalReal(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -933,7 +933,7 @@ func (b *builtinIfNullDecimalSig) fallbackEvalDecimal(ctx sessionctx.Context, in
 
 func (b *builtinIfNullDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -941,9 +941,9 @@ func (b *builtinIfNullDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalDecimal(b.ctx, input, buf1)
+	err = b.args[1].VecEvalDecimal(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -990,7 +990,7 @@ func (b *builtinIfNullStringSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -998,9 +998,9 @@ func (b *builtinIfNullStringSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalString(b.ctx, input, buf1)
+	err = b.args[1].VecEvalString(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1048,7 +1048,7 @@ func (b *builtinIfNullTimeSig) fallbackEvalTime(ctx sessionctx.Context, input *c
 
 func (b *builtinIfNullTimeSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, result); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1056,9 +1056,9 @@ func (b *builtinIfNullTimeSig) vecEvalTime(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalTime(b.ctx, input, buf1)
+	err = b.args[1].VecEvalTime(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1103,7 +1103,7 @@ func (b *builtinIfNullDurationSig) fallbackEvalDuration(ctx sessionctx.Context, 
 
 func (b *builtinIfNullDurationSig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, result); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1111,9 +1111,9 @@ func (b *builtinIfNullDurationSig) vecEvalDuration(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalDuration(b.ctx, input, buf1)
+	err = b.args[1].VecEvalDuration(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1160,7 +1160,7 @@ func (b *builtinIfNullJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1168,9 +1168,9 @@ func (b *builtinIfNullJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalJSON(b.ctx, input, buf1)
+	err = b.args[1].VecEvalJSON(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1223,12 +1223,12 @@ func (b *builtinIfIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalInt(b.ctx, input, result)
+	err = b.args[1].VecEvalInt(ctx, input, result)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1242,7 +1242,7 @@ func (b *builtinIfIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	err = b.args[2].VecEvalInt(b.ctx, input, buf2)
+	err = b.args[2].VecEvalInt(ctx, input, buf2)
 	afterWarns = sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1302,12 +1302,12 @@ func (b *builtinIfRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalReal(b.ctx, input, result)
+	err = b.args[1].VecEvalReal(ctx, input, result)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1321,7 +1321,7 @@ func (b *builtinIfRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	err = b.args[2].VecEvalReal(b.ctx, input, buf2)
+	err = b.args[2].VecEvalReal(ctx, input, buf2)
 	afterWarns = sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1381,12 +1381,12 @@ func (b *builtinIfDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalDecimal(b.ctx, input, result)
+	err = b.args[1].VecEvalDecimal(ctx, input, result)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1400,7 +1400,7 @@ func (b *builtinIfDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	err = b.args[2].VecEvalDecimal(b.ctx, input, buf2)
+	err = b.args[2].VecEvalDecimal(ctx, input, buf2)
 	afterWarns = sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1457,17 +1457,17 @@ func (b *builtinIfStringSig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 	buf1, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	err = b.args[1].VecEvalString(b.ctx, input, buf1)
+	err = b.args[1].VecEvalString(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1481,7 +1481,7 @@ func (b *builtinIfStringSig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	err = b.args[2].VecEvalString(b.ctx, input, buf2)
+	err = b.args[2].VecEvalString(ctx, input, buf2)
 	afterWarns = sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1544,12 +1544,12 @@ func (b *builtinIfTimeSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalTime(b.ctx, input, result)
+	err = b.args[1].VecEvalTime(ctx, input, result)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1563,7 +1563,7 @@ func (b *builtinIfTimeSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	err = b.args[2].VecEvalTime(b.ctx, input, buf2)
+	err = b.args[2].VecEvalTime(ctx, input, buf2)
 	afterWarns = sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1623,12 +1623,12 @@ func (b *builtinIfDurationSig) vecEvalDuration(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalDuration(b.ctx, input, result)
+	err = b.args[1].VecEvalDuration(ctx, input, result)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1642,7 +1642,7 @@ func (b *builtinIfDurationSig) vecEvalDuration(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	err = b.args[2].VecEvalDuration(b.ctx, input, buf2)
+	err = b.args[2].VecEvalDuration(ctx, input, buf2)
 	afterWarns = sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1699,17 +1699,17 @@ func (b *builtinIfJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 	buf1, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	err = b.args[1].VecEvalJSON(b.ctx, input, buf1)
+	err = b.args[1].VecEvalJSON(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -1723,7 +1723,7 @@ func (b *builtinIfJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	err = b.args[2].VecEvalJSON(b.ctx, input, buf2)
+	err = b.args[2].VecEvalJSON(ctx, input, buf2)
 	afterWarns = sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {

--- a/pkg/expression/builtin_convert_charset.go
+++ b/pkg/expression/builtin_convert_charset.go
@@ -91,7 +91,7 @@ func (b *builtinInternalToBinarySig) Clone() builtinFunc {
 }
 
 func (b *builtinInternalToBinarySig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -112,7 +112,7 @@ func (b *builtinInternalToBinarySig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	enc := charset.FindEncoding(b.args[0].GetType().GetCharset())
@@ -170,7 +170,7 @@ func (b *builtinInternalFromBinarySig) Clone() builtinFunc {
 }
 
 func (b *builtinInternalFromBinarySig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return val, isNull, err
 	}
@@ -195,7 +195,7 @@ func (b *builtinInternalFromBinarySig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	enc := charset.FindEncoding(b.tp.GetCharset())
@@ -228,6 +228,7 @@ func BuildToBinaryFunction(ctx sessionctx.Context, expr Expression) (res Express
 		FuncName: model.NewCIStr(InternalFuncToBinary),
 		RetType:  f.getRetTp(),
 		Function: f,
+		ctx:      ctx,
 	}
 	return FoldConstant(res)
 }
@@ -243,6 +244,7 @@ func BuildFromBinaryFunction(ctx sessionctx.Context, expr Expression, tp *types.
 		FuncName: model.NewCIStr(InternalFuncFromBinary),
 		RetType:  tp,
 		Function: f,
+		ctx:      ctx,
 	}
 	return FoldConstant(res)
 }

--- a/pkg/expression/builtin_encryption.go
+++ b/pkg/expression/builtin_encryption.go
@@ -156,17 +156,17 @@ func (b *builtinAesDecryptSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_aes-decrypt
 func (b *builtinAesDecryptSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
 	// According to doc: If either function argument is NULL, the function returns NULL.
-	cryptStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	cryptStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	keyStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	keyStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 	if !b.ivRequired && len(b.args) == 3 {
 		// For modes that do not require init_vector, it is ignored and a warning is generated if it is specified.
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errWarnOptionIgnored.GenWithStackByArgs("IV"))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errWarnOptionIgnored.GenWithStackByArgs("IV"))
 	}
 
 	key := encrypt.DeriveKeyMySQL([]byte(keyStr), b.keySize)
@@ -199,17 +199,17 @@ func (b *builtinAesDecryptIVSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_aes-decrypt
 func (b *builtinAesDecryptIVSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
 	// According to doc: If either function argument is NULL, the function returns NULL.
-	cryptStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	cryptStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	keyStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	keyStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	iv, isNull, err := b.args[2].EvalString(b.ctx, row)
+	iv, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -290,17 +290,17 @@ func (b *builtinAesEncryptSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_aes-decrypt
 func (b *builtinAesEncryptSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
 	// According to doc: If either function argument is NULL, the function returns NULL.
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	keyStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	keyStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 	if !b.ivRequired && len(b.args) == 3 {
 		// For modes that do not require init_vector, it is ignored and a warning is generated if it is specified.
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errWarnOptionIgnored.GenWithStackByArgs("IV"))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errWarnOptionIgnored.GenWithStackByArgs("IV"))
 	}
 
 	key := encrypt.DeriveKeyMySQL([]byte(keyStr), b.keySize)
@@ -333,17 +333,17 @@ func (b *builtinAesEncryptIVSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_aes-decrypt
 func (b *builtinAesEncryptIVSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
 	// According to doc: If either function argument is NULL, the function returns NULL.
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	keyStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	keyStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	iv, isNull, err := b.args[2].EvalString(b.ctx, row)
+	iv, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -404,12 +404,12 @@ func (b *builtinDecodeSig) Clone() builtinFunc {
 // evalString evals DECODE(str, password_str).
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_decode
 func (b *builtinDecodeSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	dataStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	dataStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	passwordStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	passwordStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -467,12 +467,12 @@ func (b *builtinEncodeSig) Clone() builtinFunc {
 // evalString evals ENCODE(crypt_str, password_str).
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_encode
 func (b *builtinEncodeSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	decodeStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	decodeStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	passwordStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	passwordStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -528,7 +528,7 @@ func (b *builtinPasswordSig) Clone() builtinFunc {
 // evalString evals a builtinPasswordSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
 func (b *builtinPasswordSig) evalString(ctx sessionctx.Context, row chunk.Row) (val string, isNull bool, err error) {
-	pass, isNull, err := b.args[0].EvalString(b.ctx, row)
+	pass, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -539,7 +539,7 @@ func (b *builtinPasswordSig) evalString(ctx sessionctx.Context, row chunk.Row) (
 
 	// We should append a warning here because function "PASSWORD" is deprecated since MySQL 5.7.6.
 	// See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
-	b.ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("PASSWORD"))
+	ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("PASSWORD"))
 
 	return auth.EncodePassword(pass), false, nil
 }
@@ -575,7 +575,7 @@ func (b *builtinRandomBytesSig) Clone() builtinFunc {
 // evalString evals RANDOM_BYTES(len).
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_random-bytes
 func (b *builtinRandomBytesSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -626,7 +626,7 @@ func (b *builtinMD5Sig) Clone() builtinFunc {
 // evalString evals a builtinMD5Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_md5
 func (b *builtinMD5Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	arg, isNull, err := b.args[0].EvalString(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -670,7 +670,7 @@ func (b *builtinSHA1Sig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_sha1
 // The value is returned as a string of 40 hexadecimal digits, or NULL if the argument was NULL.
 func (b *builtinSHA1Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -746,7 +746,7 @@ func (b *builtinSM3Sig) Clone() builtinFunc {
 // evalString evals Sm3Hash(str).
 // The value is returned as a string of 70 hexadecimal digits, or NULL if the argument was NULL.
 func (b *builtinSM3Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -770,11 +770,11 @@ const (
 // evalString evals SHA2(str, hash_length).
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_sha2
 func (b *builtinSHA2Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	hashLength, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	hashLength, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -867,7 +867,7 @@ func (b *builtinCompressSig) Clone() builtinFunc {
 // evalString evals COMPRESS(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_compress
 func (b *builtinCompressSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -933,8 +933,8 @@ func (b *builtinUncompressSig) Clone() builtinFunc {
 // evalString evals UNCOMPRESS(compressed_string).
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_uncompress
 func (b *builtinUncompressSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	payload, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sc := ctx.GetSessionVars().StmtCtx
+	payload, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -990,8 +990,8 @@ func (b *builtinUncompressedLengthSig) Clone() builtinFunc {
 // evalInt evals UNCOMPRESSED_LENGTH(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_uncompressed-length
 func (b *builtinUncompressedLengthSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	payload, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sc := ctx.GetSessionVars().StmtCtx
+	payload, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, true, err
 	}
@@ -1036,8 +1036,8 @@ func (b *builtinValidatePasswordStrengthSig) Clone() builtinFunc {
 // evalInt evals VALIDATE_PASSWORD_STRENGTH(str).
 // See https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_validate-password-strength
 func (b *builtinValidatePasswordStrengthSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	globalVars := b.ctx.GetSessionVars().GlobalVarsAccessor
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	globalVars := ctx.GetSessionVars().GlobalVarsAccessor
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil || isNull {
 		return 0, true, err
 	} else if len([]rune(str)) < 4 {
@@ -1048,11 +1048,11 @@ func (b *builtinValidatePasswordStrengthSig) evalInt(ctx sessionctx.Context, row
 	} else if !variable.TiDBOptOn(validation) {
 		return 0, false, nil
 	}
-	return b.validateStr(str, &globalVars)
+	return b.validateStr(ctx, str, &globalVars)
 }
 
-func (b *builtinValidatePasswordStrengthSig) validateStr(str string, globalVars *variable.GlobalVarAccessor) (int64, bool, error) {
-	if warn, err := pwdValidator.ValidateUserNameInPassword(str, b.ctx.GetSessionVars()); err != nil {
+func (b *builtinValidatePasswordStrengthSig) validateStr(ctx sessionctx.Context, str string, globalVars *variable.GlobalVarAccessor) (int64, bool, error) {
+	if warn, err := pwdValidator.ValidateUserNameInPassword(str, ctx.GetSessionVars()); err != nil {
 		return 0, true, err
 	} else if len(warn) > 0 {
 		return 0, false, nil

--- a/pkg/expression/builtin_encryption_vec.go
+++ b/pkg/expression/builtin_encryption_vec.go
@@ -55,7 +55,7 @@ func (b *builtinAesDecryptSig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(strBuf)
-	if err := b.args[0].VecEvalString(b.ctx, input, strBuf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
 
@@ -64,7 +64,7 @@ func (b *builtinAesDecryptSig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(keyBuf)
-	if err := b.args[1].VecEvalString(b.ctx, input, keyBuf); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
 
@@ -73,7 +73,7 @@ func (b *builtinAesDecryptSig) vecEvalString(ctx sessionctx.Context, input *chun
 	}
 
 	isWarning := !b.ivRequired && len(b.args) == 3
-	isConstKey := b.args[1].ConstItem(b.ctx.GetSessionVars().StmtCtx)
+	isConstKey := b.args[1].ConstItem(ctx.GetSessionVars().StmtCtx)
 
 	var key []byte
 	if isConstKey {
@@ -81,7 +81,7 @@ func (b *builtinAesDecryptSig) vecEvalString(ctx sessionctx.Context, input *chun
 	}
 
 	result.ReserveString(n)
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		// According to doc: If either function argument is NULL, the function returns NULL.
 		if strBuf.IsNull(i) || keyBuf.IsNull(i) {
@@ -123,7 +123,7 @@ func (b *builtinAesEncryptIVSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(strBuf)
-	if err := b.args[0].VecEvalString(b.ctx, input, strBuf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
 
@@ -132,7 +132,7 @@ func (b *builtinAesEncryptIVSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(keyBuf)
-	if err := b.args[1].VecEvalString(b.ctx, input, keyBuf); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
 
@@ -141,7 +141,7 @@ func (b *builtinAesEncryptIVSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(ivBuf)
-	if err := b.args[2].VecEvalString(b.ctx, input, ivBuf); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, ivBuf); err != nil {
 		return err
 	}
 
@@ -159,7 +159,7 @@ func (b *builtinAesEncryptIVSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return errors.Errorf("unsupported block encryption mode - %v", b.modeName)
 	}
 
-	isConst := b.args[1].ConstItem(b.ctx.GetSessionVars().StmtCtx)
+	isConst := b.args[1].ConstItem(ctx.GetSessionVars().StmtCtx)
 	var key []byte
 	if isConst {
 		key = encrypt.DeriveKeyMySQL(keyBuf.GetBytes(0), b.keySize)
@@ -216,7 +216,7 @@ func (b *builtinDecodeSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf1, err1 := b.bufAllocator.get()
@@ -224,7 +224,7 @@ func (b *builtinDecodeSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err1
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -255,7 +255,7 @@ func (b *builtinEncodeSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf1, err1 := b.bufAllocator.get()
@@ -263,7 +263,7 @@ func (b *builtinEncodeSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err1
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -296,7 +296,7 @@ func (b *builtinAesDecryptIVSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(strBuf)
-	if err := b.args[0].VecEvalString(b.ctx, input, strBuf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
 
@@ -305,7 +305,7 @@ func (b *builtinAesDecryptIVSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(keyBuf)
-	if err := b.args[1].VecEvalString(b.ctx, input, keyBuf); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
 
@@ -314,7 +314,7 @@ func (b *builtinAesDecryptIVSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(ivBuf)
-	if err := b.args[2].VecEvalString(b.ctx, input, ivBuf); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, ivBuf); err != nil {
 		return err
 	}
 
@@ -332,7 +332,7 @@ func (b *builtinAesDecryptIVSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return errors.Errorf("unsupported block encryption mode - %v", b.modeName)
 	}
 
-	isConst := b.args[1].ConstItem(b.ctx.GetSessionVars().StmtCtx)
+	isConst := b.args[1].ConstItem(ctx.GetSessionVars().StmtCtx)
 	var key []byte
 	if isConst {
 		key = encrypt.DeriveKeyMySQL(keyBuf.GetBytes(0), b.keySize)
@@ -389,7 +389,7 @@ func (b *builtinRandomBytesSig) vecEvalString(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -426,7 +426,7 @@ func (b *builtinMD5Sig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -461,7 +461,7 @@ func (b *builtinSHA2Sig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -469,7 +469,7 @@ func (b *builtinSHA2Sig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -537,7 +537,7 @@ func (b *builtinSM3Sig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return errors.Trace(err)
 	}
 	result.ReserveString(n)
@@ -591,7 +591,7 @@ func (b *builtinCompressSig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -654,7 +654,7 @@ func (b *builtinAesEncryptSig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(strBuf)
-	if err := b.args[0].VecEvalString(b.ctx, input, strBuf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
 
@@ -663,7 +663,7 @@ func (b *builtinAesEncryptSig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(keyBuf)
-	if err := b.args[1].VecEvalString(b.ctx, input, keyBuf); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
 
@@ -673,13 +673,13 @@ func (b *builtinAesEncryptSig) vecEvalString(ctx sessionctx.Context, input *chun
 	}
 
 	isWarning := !b.ivRequired && len(b.args) == 3
-	isConst := b.args[1].ConstItem(b.ctx.GetSessionVars().StmtCtx)
+	isConst := b.args[1].ConstItem(ctx.GetSessionVars().StmtCtx)
 	var key []byte
 	if isConst {
 		key = encrypt.DeriveKeyMySQL(keyBuf.GetBytes(0), b.keySize)
 	}
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	result.ReserveString(n)
 	for i := 0; i < n; i++ {
 		// According to doc: If either function argument is NULL, the function returns NULL.
@@ -719,7 +719,7 @@ func (b *builtinPasswordSig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -737,7 +737,7 @@ func (b *builtinPasswordSig) vecEvalString(ctx sessionctx.Context, input *chunk.
 
 		// We should append a warning here because function "PASSWORD" is deprecated since MySQL 5.7.6.
 		// See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("PASSWORD"))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("PASSWORD"))
 
 		result.AppendString(auth.EncodePasswordBytes(passBytes))
 	}
@@ -755,7 +755,7 @@ func (b *builtinSHA1Sig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -789,12 +789,12 @@ func (b *builtinUncompressSig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
 	result.ReserveString(n)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			result.AppendNull()
@@ -837,14 +837,14 @@ func (b *builtinUncompressedLengthSig) vectorized() bool {
 }
 
 func (b *builtinUncompressedLengthSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	nr := input.NumRows()
 	payloadBuf, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(payloadBuf)
-	if err := b.args[0].VecEvalString(b.ctx, input, payloadBuf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, payloadBuf); err != nil {
 		return err
 	}
 
@@ -881,14 +881,14 @@ func (b *builtinValidatePasswordStrengthSig) vecEvalInt(ctx sessionctx.Context, 
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
 	result.ResizeInt64(n, false)
 	result.MergeNulls(buf)
 	i64s := result.Int64s()
-	globalVars := b.ctx.GetSessionVars().GlobalVarsAccessor
+	globalVars := ctx.GetSessionVars().GlobalVarsAccessor
 	enableValidation := false
 	validation, err := globalVars.GetGlobalSysVar(variable.ValidatePasswordEnable)
 	if err != nil {
@@ -901,7 +901,7 @@ func (b *builtinValidatePasswordStrengthSig) vecEvalInt(ctx sessionctx.Context, 
 		}
 		if !enableValidation {
 			i64s[i] = 0
-		} else if score, isNull, err := b.validateStr(buf.GetString(i), &globalVars); err != nil {
+		} else if score, isNull, err := b.validateStr(ctx, buf.GetString(i), &globalVars); err != nil {
 			return err
 		} else if !isNull {
 			i64s[i] = score

--- a/pkg/expression/builtin_func_param.go
+++ b/pkg/expression/builtin_func_param.go
@@ -15,6 +15,7 @@
 package expression
 
 import (
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 )
 
@@ -69,7 +70,7 @@ func (re *funcParam) getIntVal(id int) int64 {
 }
 
 // bool return value: return true when we get a const null parameter
-func buildStringParam(bf *baseBuiltinFunc, idx int, input *chunk.Chunk, notProvided bool) (*funcParam, bool, error) {
+func buildStringParam(ctx sessionctx.Context, bf *baseBuiltinFunc, idx int, input *chunk.Chunk, notProvided bool) (*funcParam, bool, error) {
 	var pa funcParam
 	var err error
 
@@ -79,10 +80,10 @@ func buildStringParam(bf *baseBuiltinFunc, idx int, input *chunk.Chunk, notProvi
 	}
 
 	// Check if this is a const value
-	if bf.args[idx].ConstItem(bf.ctx.GetSessionVars().StmtCtx) {
+	if bf.args[idx].ConstItem(ctx.GetSessionVars().StmtCtx) {
 		// Initialize the const
 		var isConstNull bool
-		pa.defaultStrVal, isConstNull, err = bf.args[idx].EvalString(bf.ctx, chunk.Row{})
+		pa.defaultStrVal, isConstNull, err = bf.args[idx].EvalString(ctx, chunk.Row{})
 		if isConstNull || err != nil {
 			return nil, isConstNull, err
 		}
@@ -95,13 +96,13 @@ func buildStringParam(bf *baseBuiltinFunc, idx int, input *chunk.Chunk, notProvi
 	}
 
 	// Get values from input
-	err = bf.args[idx].VecEvalString(bf.ctx, input, pa.getCol())
+	err = bf.args[idx].VecEvalString(ctx, input, pa.getCol())
 
 	return &pa, false, err
 }
 
 // bool return value: return true when we get a const null parameter
-func buildIntParam(bf *baseBuiltinFunc, idx int, input *chunk.Chunk, notProvided bool, defaultIntVal int64) (*funcParam, bool, error) {
+func buildIntParam(ctx sessionctx.Context, bf *baseBuiltinFunc, idx int, input *chunk.Chunk, notProvided bool, defaultIntVal int64) (*funcParam, bool, error) {
 	var pa funcParam
 	var err error
 
@@ -111,10 +112,10 @@ func buildIntParam(bf *baseBuiltinFunc, idx int, input *chunk.Chunk, notProvided
 	}
 
 	// Check if this is a const value
-	if bf.args[idx].ConstItem(bf.ctx.GetSessionVars().StmtCtx) {
+	if bf.args[idx].ConstItem(ctx.GetSessionVars().StmtCtx) {
 		// Initialize the const
 		var isConstNull bool
-		pa.defaultIntVal, isConstNull, err = bf.args[idx].EvalInt(bf.ctx, chunk.Row{})
+		pa.defaultIntVal, isConstNull, err = bf.args[idx].EvalInt(ctx, chunk.Row{})
 		if isConstNull || err != nil {
 			return nil, isConstNull, err
 		}
@@ -127,7 +128,7 @@ func buildIntParam(bf *baseBuiltinFunc, idx int, input *chunk.Chunk, notProvided
 	}
 
 	// Get values from input
-	err = bf.args[idx].VecEvalInt(bf.ctx, input, pa.getCol())
+	err = bf.args[idx].VecEvalInt(ctx, input, pa.getCol())
 
 	return &pa, false, err
 }

--- a/pkg/expression/builtin_grouping.go
+++ b/pkg/expression/builtin_grouping.go
@@ -232,7 +232,7 @@ func (b *BuiltinGroupingImplSig) evalInt(ctx sessionctx.Context, row chunk.Row) 
 		return 0, false, errors.Errorf("Meta data is not initialized")
 	}
 	// grouping function should be rewritten from raw column ref to built gid column and groupingMarks meta.
-	groupingID, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	groupingID, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -270,7 +270,7 @@ func (b *BuiltinGroupingImplSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(bufVal)
-	if err = b.args[0].VecEvalInt(b.ctx, input, bufVal); err != nil {
+	if err = b.args[0].VecEvalInt(ctx, input, bufVal); err != nil {
 		return err
 	}
 

--- a/pkg/expression/builtin_ilike.go
+++ b/pkg/expression/builtin_ilike.go
@@ -71,17 +71,17 @@ func (b *builtinIlikeSig) Clone() builtinFunc {
 
 // evalInt evals a builtinIlikeSig.
 func (b *builtinIlikeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	valStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	valStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
-	patternStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	patternStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
-	escape, isNull, err := b.args[2].EvalInt(b.ctx, row)
+	escape, isNull, err := b.args[2].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -102,7 +102,7 @@ func (b *builtinIlikeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64,
 	memorization := func() {
 		if b.pattern == nil {
 			b.pattern = collate.ConvertAndGetBinCollation(b.collation).Pattern()
-			if b.args[1].ConstItem(b.ctx.GetSessionVars().StmtCtx) && b.args[2].ConstItem(b.ctx.GetSessionVars().StmtCtx) {
+			if b.args[1].ConstItem(ctx.GetSessionVars().StmtCtx) && b.args[2].ConstItem(ctx.GetSessionVars().StmtCtx) {
 				b.pattern.Compile(patternStr, byte(escape))
 				b.isMemorizedPattern = true
 			}

--- a/pkg/expression/builtin_ilike_vec.go
+++ b/pkg/expression/builtin_ilike_vec.go
@@ -70,15 +70,15 @@ func (b *builtinIlikeSig) tryToMemorize(param *funcParam, escape int64) {
 	b.once.Do(memorization)
 }
 
-func (b *builtinIlikeSig) getEscape(input *chunk.Chunk, result *chunk.Column) (int64, bool, error) {
+func (b *builtinIlikeSig) getEscape(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) (int64, bool, error) {
 	rowNum := input.NumRows()
 	escape := int64('\\')
 
-	if !b.args[2].ConstItem(b.ctx.GetSessionVars().StmtCtx) {
+	if !b.args[2].ConstItem(ctx.GetSessionVars().StmtCtx) {
 		return escape, true, errors.Errorf("escape should be const")
 	}
 
-	escape, isConstNull, err := b.args[2].EvalInt(b.ctx, chunk.Row{})
+	escape, isConstNull, err := b.args[2].EvalInt(ctx, chunk.Row{})
 	if isConstNull {
 		fillNullStringIntoResult(result, rowNum)
 		return escape, true, nil
@@ -178,7 +178,7 @@ func (b *builtinIlikeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 	defer releaseBuffers(&b.baseBuiltinFunc, params)
 
 	for i := 0; i < 2; i++ {
-		param, isConstNull, err := buildStringParam(&b.baseBuiltinFunc, i, input, false)
+		param, isConstNull, err := buildStringParam(ctx, &b.baseBuiltinFunc, i, input, false)
 		if err != nil {
 			return ErrRegexp.GenWithStackByArgs(err)
 		}
@@ -189,7 +189,7 @@ func (b *builtinIlikeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		params = append(params, param)
 	}
 
-	escape, ret, err := b.getEscape(input, result)
+	escape, ret, err := b.getEscape(ctx, input, result)
 	if err != nil || ret {
 		return err
 	}

--- a/pkg/expression/builtin_info.go
+++ b/pkg/expression/builtin_info.go
@@ -118,7 +118,7 @@ func (b *builtinDatabaseSig) Clone() builtinFunc {
 // evalString evals a builtinDatabaseSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html
 func (b *builtinDatabaseSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	currentDB := b.ctx.GetSessionVars().CurrentDB
+	currentDB := ctx.GetSessionVars().CurrentDB
 	return currentDB, currentDB == "", nil
 }
 
@@ -153,7 +153,7 @@ func (b *builtinFoundRowsSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_found-rows
 // TODO: SQL_CALC_FOUND_ROWS and LIMIT not support for now, We will finish in another PR.
 func (b *builtinFoundRowsSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	if data == nil {
 		return 0, true, errors.Errorf("Missing session variable when eval builtin")
 	}
@@ -190,7 +190,7 @@ func (b *builtinCurrentUserSig) Clone() builtinFunc {
 // evalString evals a builtinCurrentUserSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_current-user
 func (b *builtinCurrentUserSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	if data == nil || data.User == nil {
 		return "", true, errors.Errorf("Missing session variable when eval builtin")
 	}
@@ -227,7 +227,7 @@ func (b *builtinCurrentRoleSig) Clone() builtinFunc {
 // evalString evals a builtinCurrentUserSig.
 // See https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_current-role
 func (b *builtinCurrentRoleSig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	if data == nil || data.ActiveRoles == nil {
 		return "", true, errors.Errorf("Missing session variable when eval builtin")
 	}
@@ -276,7 +276,7 @@ func (b *builtinCurrentResourceGroupSig) Clone() builtinFunc {
 }
 
 func (b *builtinCurrentResourceGroupSig) evalString(ctx sessionctx.Context, row chunk.Row) (val string, isNull bool, err error) {
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	if data == nil {
 		return "", true, errors.Errorf("Missing session variable when eval builtin")
 	}
@@ -313,7 +313,7 @@ func (b *builtinUserSig) Clone() builtinFunc {
 // evalString evals a builtinUserSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_user
 func (b *builtinUserSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	if data == nil || data.User == nil {
 		return "", true, errors.Errorf("Missing session variable when eval builtin")
 	}
@@ -348,7 +348,7 @@ func (b *builtinConnectionIDSig) Clone() builtinFunc {
 }
 
 func (b *builtinConnectionIDSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	if data == nil {
 		return 0, true, errors.Errorf("Missing session variable `builtinConnectionIDSig.evalInt`")
 	}
@@ -397,7 +397,7 @@ func (b *builtinLastInsertIDSig) Clone() builtinFunc {
 // evalInt evals LAST_INSERT_ID().
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_last-insert-id.
 func (b *builtinLastInsertIDSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	res = int64(b.ctx.GetSessionVars().StmtCtx.PrevLastInsertID)
+	res = int64(ctx.GetSessionVars().StmtCtx.PrevLastInsertID)
 	return res, false, nil
 }
 
@@ -414,12 +414,12 @@ func (b *builtinLastInsertIDWithIDSig) Clone() builtinFunc {
 // evalInt evals LAST_INSERT_ID(expr).
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_last-insert-id.
 func (b *builtinLastInsertIDWithIDSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalInt(b.ctx, row)
+	res, isNull, err = b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 
-	b.ctx.GetSessionVars().SetLastInsertID(uint64(res))
+	ctx.GetSessionVars().SetLastInsertID(uint64(res))
 	return res, false, nil
 }
 
@@ -517,7 +517,7 @@ func (b *builtinTiDBIsDDLOwnerSig) Clone() builtinFunc {
 
 // evalInt evals a builtinTiDBIsDDLOwnerSig.
 func (b *builtinTiDBIsDDLOwnerSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	if b.ctx.IsDDLOwner() {
+	if ctx.IsDDLOwner() {
 		res = 1
 	}
 
@@ -566,7 +566,7 @@ func (b *builtinBenchmarkSig) Clone() builtinFunc {
 
 // evalInt evals a builtinBenchmarkSig. It will execute expression repeatedly count times.
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_benchmark
-func (b *builtinBenchmarkSig) evalInt(_ sessionctx.Context, row chunk.Row) (int64, bool, error) {
+func (b *builtinBenchmarkSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
 	// Get loop count.
 	var loopCount int64
 	var isNull bool
@@ -574,7 +574,7 @@ func (b *builtinBenchmarkSig) evalInt(_ sessionctx.Context, row chunk.Row) (int6
 	if b.constLoopCount > 0 {
 		loopCount = b.constLoopCount
 	} else {
-		loopCount, isNull, err = b.args[0].EvalInt(b.ctx, row)
+		loopCount, isNull, err = b.args[0].EvalInt(ctx, row)
 		if isNull || err != nil {
 			return 0, isNull, err
 		}
@@ -590,7 +590,7 @@ func (b *builtinBenchmarkSig) evalInt(_ sessionctx.Context, row chunk.Row) (int6
 	// BENCHMARK() will pass-through the eval error,
 	// behavior observed on MySQL 5.7.24.
 	var i int64
-	arg, ctx := b.args[1], b.ctx
+	arg := b.args[1]
 	switch evalType := arg.GetType().EvalType(); evalType {
 	case types.ETInt:
 		for ; i < loopCount; i++ {
@@ -786,7 +786,7 @@ func (b *builtinRowCountSig) Clone() builtinFunc {
 // evalInt evals ROW_COUNT().
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_row-count.
 func (b *builtinRowCountSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	res = b.ctx.GetSessionVars().StmtCtx.PrevAffectedRows
+	res = ctx.GetSessionVars().StmtCtx.PrevAffectedRows
 	return res, false, nil
 }
 
@@ -818,15 +818,15 @@ func (b *builtinTiDBDecodeKeySig) Clone() builtinFunc {
 
 // evalInt evals a builtinTiDBDecodeKeySig.
 func (b *builtinTiDBDecodeKeySig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	s, isNull, err := b.args[0].EvalString(b.ctx, row)
+	s, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
 	decode := func(ctx sessionctx.Context, s string) string { return s }
-	if fn := b.ctx.Value(TiDBDecodeKeyFunctionKey); fn != nil {
+	if fn := ctx.Value(TiDBDecodeKeyFunctionKey); fn != nil {
 		decode = fn.(func(ctx sessionctx.Context, s string) string)
 	}
-	return decode(b.ctx, s), false, nil
+	return decode(ctx, s), false, nil
 }
 
 // TiDBDecodeKeyFunctionKeyType is used to identify the decoder function in context.
@@ -880,7 +880,7 @@ func (b *builtinTiDBDecodeSQLDigestsSig) Clone() builtinFunc {
 
 func (b *builtinTiDBDecodeSQLDigestsSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
 	args := b.getArgs()
-	digestsStr, isNull, err := args[0].EvalString(b.ctx, row)
+	digestsStr, isNull, err := args[0].EvalString(ctx, row)
 	if err != nil {
 		return "", true, err
 	}
@@ -890,7 +890,7 @@ func (b *builtinTiDBDecodeSQLDigestsSig) evalString(ctx sessionctx.Context, row 
 
 	stmtTruncateLength := int64(0)
 	if len(args) > 1 {
-		stmtTruncateLength, isNull, err = args[1].EvalInt(b.ctx, row)
+		stmtTruncateLength, isNull, err = args[1].EvalInt(ctx, row)
 		if err != nil {
 			return "", true, err
 		}
@@ -906,7 +906,7 @@ func (b *builtinTiDBDecodeSQLDigestsSig) evalString(ctx sessionctx.Context, row 
 		if len(digestsStr) > errMsgMaxLength {
 			digestsStr = digestsStr[:errMsgMaxLength] + "..."
 		}
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errIncorrectArgs.GenWithStack("The argument can't be unmarshalled as JSON array: '%s'", digestsStr))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errIncorrectArgs.GenWithStack("The argument can't be unmarshalled as JSON array: '%s'", digestsStr))
 		return "", true, nil
 	}
 
@@ -923,19 +923,19 @@ func (b *builtinTiDBDecodeSQLDigestsSig) evalString(ctx sessionctx.Context, row 
 
 	// Querying may take some time and it takes a context.Context as argument, which is not available here.
 	// We simply create a context with a timeout here.
-	timeout := time.Duration(b.ctx.GetSessionVars().MaxExecutionTime) * time.Millisecond
+	timeout := time.Duration(ctx.GetSessionVars().MaxExecutionTime) * time.Millisecond
 	if timeout == 0 || timeout > 20*time.Second {
 		timeout = 20 * time.Second
 	}
 	goCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	err = retriever.RetrieveGlobal(goCtx, b.ctx)
+	err = retriever.RetrieveGlobal(goCtx, ctx)
 	if err != nil {
 		if errors.Cause(err) == context.DeadlineExceeded || errors.Cause(err) == context.Canceled {
 			return "", true, errUnknown.GenWithStack("Retrieving cancelled internally with error: %v", err)
 		}
 
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknown.GenWithStack("Retrieving statements information failed with error: %v", err))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknown.GenWithStack("Retrieving statements information failed with error: %v", err))
 		return "", true, nil
 	}
 
@@ -958,7 +958,7 @@ func (b *builtinTiDBDecodeSQLDigestsSig) evalString(ctx sessionctx.Context, row 
 
 	resultStr, err := json.Marshal(result)
 	if err != nil {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknown.GenWithStack("Marshalling result as JSON failed with error: %v", err))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknown.GenWithStack("Marshalling result as JSON failed with error: %v", err))
 		return "", true, nil
 	}
 
@@ -994,7 +994,7 @@ func (b *builtinTiDBEncodeSQLDigestSig) Clone() builtinFunc {
 }
 
 func (b *builtinTiDBEncodeSQLDigestSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	orgSQLStr, isNull, err := b.getArgs()[0].EvalString(b.ctx, row)
+	orgSQLStr, isNull, err := b.getArgs()[0].EvalString(ctx, row)
 	if err != nil {
 		return "", true, err
 	}
@@ -1035,7 +1035,7 @@ func (b *builtinTiDBDecodePlanSig) Clone() builtinFunc {
 }
 
 func (b *builtinTiDBDecodePlanSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	planString, isNull, err := b.args[0].EvalString(b.ctx, row)
+	planString, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -1057,13 +1057,13 @@ func (b *builtinTiDBDecodeBinaryPlanSig) Clone() builtinFunc {
 }
 
 func (b *builtinTiDBDecodeBinaryPlanSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	planString, isNull, err := b.args[0].EvalString(b.ctx, row)
+	planString, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
 	planTree, err := plancodec.DecodeBinaryPlan(planString)
 	if err != nil {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
+		ctx.GetSessionVars().StmtCtx.AppendWarning(err)
 		return "", false, nil
 	}
 	return planTree, false, nil
@@ -1097,31 +1097,31 @@ func (b *builtinNextValSig) Clone() builtinFunc {
 }
 
 func (b *builtinNextValSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	sequenceName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sequenceName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	db, seq := getSchemaAndSequence(sequenceName)
 	if len(db) == 0 {
-		db = b.ctx.GetSessionVars().CurrentDB
+		db = ctx.GetSessionVars().CurrentDB
 	}
 	// Check the tableName valid.
-	sequence, err := util.GetSequenceByName(b.ctx.GetInfoSchema(), model.NewCIStr(db), model.NewCIStr(seq))
+	sequence, err := util.GetSequenceByName(ctx.GetInfoSchema(), model.NewCIStr(db), model.NewCIStr(seq))
 	if err != nil {
 		return 0, false, err
 	}
 	// Do the privilege check.
-	checker := privilege.GetPrivilegeManager(b.ctx)
-	user := b.ctx.GetSessionVars().User
-	if checker != nil && !checker.RequestVerification(b.ctx.GetSessionVars().ActiveRoles, db, seq, "", mysql.InsertPriv) {
+	checker := privilege.GetPrivilegeManager(ctx)
+	user := ctx.GetSessionVars().User
+	if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, db, seq, "", mysql.InsertPriv) {
 		return 0, false, errSequenceAccessDenied.GenWithStackByArgs("INSERT", user.AuthUsername, user.AuthHostname, seq)
 	}
-	nextVal, err := sequence.GetSequenceNextVal(b.ctx, db, seq)
+	nextVal, err := sequence.GetSequenceNextVal(ctx, db, seq)
 	if err != nil {
 		return 0, false, err
 	}
 	// update the sequenceState.
-	b.ctx.GetSessionVars().SequenceState.UpdateState(sequence.GetSequenceID(), nextVal)
+	ctx.GetSessionVars().SequenceState.UpdateState(sequence.GetSequenceID(), nextVal)
 	return nextVal, false, nil
 }
 
@@ -1153,26 +1153,26 @@ func (b *builtinLastValSig) Clone() builtinFunc {
 }
 
 func (b *builtinLastValSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	sequenceName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sequenceName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	db, seq := getSchemaAndSequence(sequenceName)
 	if len(db) == 0 {
-		db = b.ctx.GetSessionVars().CurrentDB
+		db = ctx.GetSessionVars().CurrentDB
 	}
 	// Check the tableName valid.
-	sequence, err := util.GetSequenceByName(b.ctx.GetInfoSchema(), model.NewCIStr(db), model.NewCIStr(seq))
+	sequence, err := util.GetSequenceByName(ctx.GetInfoSchema(), model.NewCIStr(db), model.NewCIStr(seq))
 	if err != nil {
 		return 0, false, err
 	}
 	// Do the privilege check.
-	checker := privilege.GetPrivilegeManager(b.ctx)
-	user := b.ctx.GetSessionVars().User
-	if checker != nil && !checker.RequestVerification(b.ctx.GetSessionVars().ActiveRoles, db, seq, "", mysql.SelectPriv) {
+	checker := privilege.GetPrivilegeManager(ctx)
+	user := ctx.GetSessionVars().User
+	if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, db, seq, "", mysql.SelectPriv) {
 		return 0, false, errSequenceAccessDenied.GenWithStackByArgs("SELECT", user.AuthUsername, user.AuthHostname, seq)
 	}
-	return b.ctx.GetSessionVars().SequenceState.GetLastValue(sequence.GetSequenceID())
+	return ctx.GetSessionVars().SequenceState.GetLastValue(sequence.GetSequenceID())
 }
 
 type setValFunctionClass struct {
@@ -1203,30 +1203,30 @@ func (b *builtinSetValSig) Clone() builtinFunc {
 }
 
 func (b *builtinSetValSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	sequenceName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sequenceName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	db, seq := getSchemaAndSequence(sequenceName)
 	if len(db) == 0 {
-		db = b.ctx.GetSessionVars().CurrentDB
+		db = ctx.GetSessionVars().CurrentDB
 	}
 	// Check the tableName valid.
-	sequence, err := util.GetSequenceByName(b.ctx.GetInfoSchema(), model.NewCIStr(db), model.NewCIStr(seq))
+	sequence, err := util.GetSequenceByName(ctx.GetInfoSchema(), model.NewCIStr(db), model.NewCIStr(seq))
 	if err != nil {
 		return 0, false, err
 	}
 	// Do the privilege check.
-	checker := privilege.GetPrivilegeManager(b.ctx)
-	user := b.ctx.GetSessionVars().User
-	if checker != nil && !checker.RequestVerification(b.ctx.GetSessionVars().ActiveRoles, db, seq, "", mysql.InsertPriv) {
+	checker := privilege.GetPrivilegeManager(ctx)
+	user := ctx.GetSessionVars().User
+	if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, db, seq, "", mysql.InsertPriv) {
 		return 0, false, errSequenceAccessDenied.GenWithStackByArgs("INSERT", user.AuthUsername, user.AuthHostname, seq)
 	}
-	setValue, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	setValue, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	return sequence.SetSequenceVal(b.ctx, setValue, db, seq)
+	return sequence.SetSequenceVal(ctx, setValue, db, seq)
 }
 
 func getSchemaAndSequence(sequenceName string) (string, string) {
@@ -1269,7 +1269,7 @@ func (b *builtinFormatBytesSig) Clone() builtinFunc {
 // formatBytes evals a builtinFormatBytesSig.
 // See https://dev.mysql.com/doc/refman/8.0/en/performance-schema-functions.html#function_format-bytes
 func (b *builtinFormatBytesSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -1308,7 +1308,7 @@ func (b *builtinFormatNanoTimeSig) Clone() builtinFunc {
 // formatNanoTime evals a builtinFormatNanoTimeSig, as time unit in TiDB is always nanosecond, not picosecond.
 // See https://dev.mysql.com/doc/refman/8.0/en/performance-schema-functions.html#function_format-pico-time
 func (b *builtinFormatNanoTimeSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}

--- a/pkg/expression/builtin_info_vec.go
+++ b/pkg/expression/builtin_info_vec.go
@@ -35,7 +35,7 @@ func (b *builtinDatabaseSig) vectorized() bool {
 func (b *builtinDatabaseSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	currentDB := b.ctx.GetSessionVars().CurrentDB
+	currentDB := ctx.GetSessionVars().CurrentDB
 	result.ReserveString(n)
 	if currentDB == "" {
 		for i := 0; i < n; i++ {
@@ -55,7 +55,7 @@ func (b *builtinConnectionIDSig) vectorized() bool {
 
 func (b *builtinConnectionIDSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	if data == nil {
 		return errors.Errorf("Missing session variable in `builtinConnectionIDSig.vecEvalInt`")
 	}
@@ -92,7 +92,7 @@ func (b *builtinRowCountSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 	n := input.NumRows()
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
-	res := b.ctx.GetSessionVars().StmtCtx.PrevAffectedRows
+	res := ctx.GetSessionVars().StmtCtx.PrevAffectedRows
 	for i := 0; i < n; i++ {
 		i64s[i] = res
 	}
@@ -108,7 +108,7 @@ func (b *builtinCurrentUserSig) vectorized() bool {
 func (b *builtinCurrentUserSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	result.ReserveString(n)
 	if data == nil || data.User == nil {
 		return errors.Errorf("Missing session variable when eval builtin")
@@ -124,7 +124,7 @@ func (b *builtinCurrentResourceGroupSig) vectorized() bool {
 }
 
 func (b *builtinCurrentResourceGroupSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	if data == nil {
 		return errors.Errorf("Missing session variable when eval builtin")
 	}
@@ -145,7 +145,7 @@ func (b *builtinCurrentRoleSig) vectorized() bool {
 func (b *builtinCurrentRoleSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	if data == nil || data.ActiveRoles == nil {
 		return errors.Errorf("Missing session variable when eval builtin")
 	}
@@ -178,7 +178,7 @@ func (b *builtinUserSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_user
 func (b *builtinUserSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	if data == nil || data.User == nil {
 		return errors.Errorf("Missing session variable when eval builtin")
 	}
@@ -197,7 +197,7 @@ func (b *builtinTiDBIsDDLOwnerSig) vectorized() bool {
 func (b *builtinTiDBIsDDLOwnerSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 	var res int64
-	if b.ctx.IsDDLOwner() {
+	if ctx.IsDDLOwner() {
 		res = 1
 	}
 	result.ResizeInt64(n, false)
@@ -213,7 +213,7 @@ func (b *builtinFoundRowsSig) vectorized() bool {
 }
 
 func (b *builtinFoundRowsSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	data := b.ctx.GetSessionVars()
+	data := ctx.GetSessionVars()
 	if data == nil {
 		return errors.Errorf("Missing session variable when eval builtin")
 	}
@@ -231,10 +231,10 @@ func (b *builtinBenchmarkSig) vectorized() bool {
 	return b.constLoopCount > 0
 }
 
-func (b *builtinBenchmarkSig) vecEvalInt(_ sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+func (b *builtinBenchmarkSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 	loopCount := b.constLoopCount
-	arg, ctx := b.args[1], b.ctx
+	arg := b.args[1]
 	evalType := arg.GetType().EvalType()
 	buf, err := b.bufAllocator.get()
 	if err != nil {
@@ -305,7 +305,7 @@ func (b *builtinLastInsertIDSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 	n := input.NumRows()
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
-	res := int64(b.ctx.GetSessionVars().StmtCtx.PrevLastInsertID)
+	res := int64(ctx.GetSessionVars().StmtCtx.PrevLastInsertID)
 	for i := 0; i < n; i++ {
 		i64s[i] = res
 	}
@@ -317,13 +317,13 @@ func (b *builtinLastInsertIDWithIDSig) vectorized() bool {
 }
 
 func (b *builtinLastInsertIDWithIDSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	i64s := result.Int64s()
 	for i := len(i64s) - 1; i >= 0; i-- {
 		if !result.IsNull(i) {
-			b.ctx.GetSessionVars().SetLastInsertID(uint64(i64s[i]))
+			ctx.GetSessionVars().SetLastInsertID(uint64(i64s[i]))
 			break
 		}
 	}
@@ -354,12 +354,12 @@ func (b *builtinTiDBDecodeKeySig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ReserveString(n)
 	decode := func(ctx sessionctx.Context, s string) string { return s }
-	if fn := b.ctx.Value(TiDBDecodeKeyFunctionKey); fn != nil {
+	if fn := ctx.Value(TiDBDecodeKeyFunctionKey); fn != nil {
 		decode = fn.(func(ctx sessionctx.Context, s string) string)
 	}
 	for i := 0; i < n; i++ {
@@ -367,7 +367,7 @@ func (b *builtinTiDBDecodeKeySig) vecEvalString(ctx sessionctx.Context, input *c
 			result.AppendNull()
 			continue
 		}
-		result.AppendString(decode(b.ctx, buf.GetString(i)))
+		result.AppendString(decode(ctx, buf.GetString(i)))
 	}
 	return nil
 }

--- a/pkg/expression/builtin_json.go
+++ b/pkg/expression/builtin_json.go
@@ -121,7 +121,7 @@ func (c *jsonTypeFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 
 func (b *builtinJSONTypeSig) evalString(ctx sessionctx.Context, row chunk.Row) (val string, isNull bool, err error) {
 	var j types.BinaryJSON
-	j, isNull, err = b.args[0].EvalJSON(b.ctx, row)
+	j, isNull, err = b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -171,14 +171,14 @@ func (c *jsonExtractFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 }
 
 func (b *builtinJSONExtractSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
+	res, isNull, err = b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return
 	}
 	pathExprs := make([]types.JSONPathExpression, 0, len(b.args)-1)
 	for _, arg := range b.args[1:] {
 		var s string
-		s, isNull, err = arg.EvalString(b.ctx, row)
+		s, isNull, err = arg.EvalString(ctx, row)
 		if isNull || err != nil {
 			return res, isNull, err
 		}
@@ -236,7 +236,7 @@ func (c *jsonUnquoteFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 }
 
 func (b *builtinJSONUnquoteSig) evalString(ctx sessionctx.Context, row chunk.Row) (str string, isNull bool, err error) {
-	str, isNull, err = b.args[0].EvalString(b.ctx, row)
+	str, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -289,7 +289,7 @@ func (c *jsonSetFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 }
 
 func (b *builtinJSONSetSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	res, isNull, err = jsonModify(b.ctx, b.args, row, types.JSONModifySet)
+	res, isNull, err = jsonModify(ctx, b.args, row, types.JSONModifySet)
 	return res, isNull, err
 }
 
@@ -332,7 +332,7 @@ func (c *jsonInsertFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 }
 
 func (b *builtinJSONInsertSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	res, isNull, err = jsonModify(b.ctx, b.args, row, types.JSONModifyInsert)
+	res, isNull, err = jsonModify(ctx, b.args, row, types.JSONModifyInsert)
 	return res, isNull, err
 }
 
@@ -375,7 +375,7 @@ func (c *jsonReplaceFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 }
 
 func (b *builtinJSONReplaceSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	res, isNull, err = jsonModify(b.ctx, b.args, row, types.JSONModifyReplace)
+	res, isNull, err = jsonModify(ctx, b.args, row, types.JSONModifyReplace)
 	return res, isNull, err
 }
 
@@ -412,14 +412,14 @@ func (c *jsonRemoveFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 }
 
 func (b *builtinJSONRemoveSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
+	res, isNull, err = b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 	pathExprs := make([]types.JSONPathExpression, 0, len(b.args)-1)
 	for _, arg := range b.args[1:] {
 		var s string
-		s, isNull, err = arg.EvalString(b.ctx, row)
+		s, isNull, err = arg.EvalString(ctx, row)
 		if isNull || err != nil {
 			return res, isNull, err
 		}
@@ -484,7 +484,7 @@ func (b *builtinJSONMergeSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (r
 	values := make([]types.BinaryJSON, 0, len(b.args))
 	for _, arg := range b.args {
 		var value types.BinaryJSON
-		value, isNull, err = arg.EvalJSON(b.ctx, row)
+		value, isNull, err = arg.EvalJSON(ctx, row)
 		if isNull || err != nil {
 			return res, isNull, err
 		}
@@ -494,7 +494,7 @@ func (b *builtinJSONMergeSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (r
 	// function "JSON_MERGE" is deprecated since MySQL 5.7.22. Synonym for function "JSON_MERGE_PRESERVE".
 	// See https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-merge
 	if b.pbCode == tipb.ScalarFuncSig_JsonMergeSig {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("JSON_MERGE"))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("JSON_MERGE"))
 	}
 	return res, false, nil
 }
@@ -549,7 +549,7 @@ func (b *builtinJSONObjectSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (
 	var value types.BinaryJSON
 	for i, arg := range b.args {
 		if i&1 == 0 {
-			key, isNull, err = arg.EvalString(b.ctx, row)
+			key, isNull, err = arg.EvalString(ctx, row)
 			if err != nil {
 				return res, true, err
 			}
@@ -558,7 +558,7 @@ func (b *builtinJSONObjectSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (
 				return res, true, err
 			}
 		} else {
-			value, isNull, err = arg.EvalJSON(b.ctx, row)
+			value, isNull, err = arg.EvalJSON(ctx, row)
 			if err != nil {
 				return res, true, err
 			}
@@ -612,7 +612,7 @@ func (c *jsonArrayFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 func (b *builtinJSONArraySig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
 	jsons := make([]interface{}, 0, len(b.args))
 	for _, arg := range b.args {
-		j, isNull, err := arg.EvalJSON(b.ctx, row)
+		j, isNull, err := arg.EvalJSON(ctx, row)
 		if err != nil {
 			return res, true, err
 		}
@@ -670,11 +670,11 @@ func (c *jsonContainsPathFunctionClass) getFunction(ctx sessionctx.Context, args
 }
 
 func (b *builtinJSONContainsPathSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	obj, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	containType, isNull, err := b.args[1].EvalString(b.ctx, row)
+	containType, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -685,7 +685,7 @@ func (b *builtinJSONContainsPathSig) evalInt(ctx sessionctx.Context, row chunk.R
 	var pathExpr types.JSONPathExpression
 	contains := int64(1)
 	for i := 2; i < len(b.args); i++ {
-		path, isNull, err := b.args[i].EvalString(b.ctx, row)
+		path, isNull, err := b.args[i].EvalString(ctx, row)
 		if isNull || err != nil {
 			return res, isNull, err
 		}
@@ -784,11 +784,11 @@ func (c *jsonMemberOfFunctionClass) getFunction(ctx sessionctx.Context, args []E
 }
 
 func (b *builtinJSONMemberOfSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	target, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	target, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	obj, isNull, err := b.args[1].EvalJSON(b.ctx, row)
+	obj, isNull, err := b.args[1].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -853,17 +853,17 @@ func (c *jsonContainsFunctionClass) getFunction(ctx sessionctx.Context, args []E
 }
 
 func (b *builtinJSONContainsSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	obj, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	target, isNull, err := b.args[1].EvalJSON(b.ctx, row)
+	target, isNull, err := b.args[1].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 	var pathExpr types.JSONPathExpression
 	if len(b.args) == 3 {
-		path, isNull, err := b.args[2].EvalString(b.ctx, row)
+		path, isNull, err := b.args[2].EvalString(ctx, row)
 		if isNull || err != nil {
 			return res, isNull, err
 		}
@@ -929,11 +929,11 @@ func (c *jsonOverlapsFunctionClass) getFunction(ctx sessionctx.Context, args []E
 }
 
 func (b *builtinJSONOverlapsSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	obj, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	target, isNull, err := b.args[1].EvalJSON(b.ctx, row)
+	target, isNull, err := b.args[1].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -993,7 +993,7 @@ func (b *builtinJSONValidJSONSig) Clone() builtinFunc {
 // evalInt evals a builtinJSONValidJSONSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/json-attribute-functions.html#function_json-valid
 func (b *builtinJSONValidJSONSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	_, isNull, err = b.args[0].EvalJSON(b.ctx, row)
+	_, isNull, err = b.args[0].EvalJSON(ctx, row)
 	return 1, isNull, err
 }
 
@@ -1010,7 +1010,7 @@ func (b *builtinJSONValidStringSig) Clone() builtinFunc {
 // evalInt evals a builtinJSONValidStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/json-attribute-functions.html#function_json-valid
 func (b *builtinJSONValidStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil || isNull {
 		return 0, isNull, err
 	}
@@ -1081,18 +1081,18 @@ func (b *builtinJSONArrayAppendSig) Clone() builtinFunc {
 }
 
 func (b *builtinJSONArrayAppendSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
+	res, isNull, err = b.args[0].EvalJSON(ctx, row)
 	if err != nil || isNull {
 		return res, true, err
 	}
 
 	for i := 1; i < len(b.args)-1; i += 2 {
 		// If JSON path is NULL, MySQL breaks and returns NULL.
-		s, sNull, err := b.args[i].EvalString(b.ctx, row)
+		s, sNull, err := b.args[i].EvalString(ctx, row)
 		if sNull || err != nil {
 			return res, true, err
 		}
-		value, vNull, err := b.args[i+1].EvalJSON(b.ctx, row)
+		value, vNull, err := b.args[i+1].EvalJSON(ctx, row)
 		if err != nil {
 			return res, true, err
 		}
@@ -1178,14 +1178,14 @@ func (b *builtinJSONArrayInsertSig) Clone() builtinFunc {
 }
 
 func (b *builtinJSONArrayInsertSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
+	res, isNull, err = b.args[0].EvalJSON(ctx, row)
 	if err != nil || isNull {
 		return res, true, err
 	}
 
 	for i := 1; i < len(b.args)-1; i += 2 {
 		// If JSON path is NULL, MySQL breaks and returns NULL.
-		s, isNull, err := b.args[i].EvalString(b.ctx, row)
+		s, isNull, err := b.args[i].EvalString(ctx, row)
 		if err != nil || isNull {
 			return res, true, err
 		}
@@ -1198,7 +1198,7 @@ func (b *builtinJSONArrayInsertSig) evalJSON(ctx sessionctx.Context, row chunk.R
 			return res, true, types.ErrInvalidJSONPathMultipleSelection
 		}
 
-		value, isnull, err := b.args[i+1].EvalJSON(b.ctx, row)
+		value, isnull, err := b.args[i+1].EvalJSON(ctx, row)
 		if err != nil {
 			return res, true, err
 		}
@@ -1262,7 +1262,7 @@ func (b *builtinJSONMergePatchSig) evalJSON(ctx sessionctx.Context, row chunk.Ro
 	values := make([]*types.BinaryJSON, 0, len(b.args))
 	for _, arg := range b.args {
 		var value types.BinaryJSON
-		value, isNull, err = arg.EvalJSON(b.ctx, row)
+		value, isNull, err = arg.EvalJSON(ctx, row)
 		if err != nil {
 			return
 		}
@@ -1348,7 +1348,7 @@ func (c *jsonPrettyFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 }
 
 func (b *builtinJSONSPrettySig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	obj, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1405,7 +1405,7 @@ func (c *jsonQuoteFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 }
 
 func (b *builtinJSONQuoteSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -1458,14 +1458,14 @@ func (c *jsonSearchFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 func (b *builtinJSONSearchSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
 	// json_doc
 	var obj types.BinaryJSON
-	obj, isNull, err = b.args[0].EvalJSON(b.ctx, row)
+	obj, isNull, err = b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 
 	// one_or_all
 	var containType string
-	containType, isNull, err = b.args[1].EvalString(b.ctx, row)
+	containType, isNull, err = b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1476,14 +1476,14 @@ func (b *builtinJSONSearchSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (
 
 	// search_str & escape_char
 	var searchStr string
-	searchStr, isNull, err = b.args[2].EvalString(b.ctx, row)
+	searchStr, isNull, err = b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 	escape := byte('\\')
 	if len(b.args) >= 4 {
 		var escapeStr string
-		escapeStr, isNull, err = b.args[3].EvalString(b.ctx, row)
+		escapeStr, isNull, err = b.args[3].EvalString(ctx, row)
 		if err != nil {
 			return res, isNull, err
 		}
@@ -1499,7 +1499,7 @@ func (b *builtinJSONSearchSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (
 		pathExprs := make([]types.JSONPathExpression, 0, len(b.args)-4)
 		for i := 4; i < len(b.args); i++ {
 			var s string
-			s, isNull, err = b.args[i].EvalString(b.ctx, row)
+			s, isNull, err = b.args[i].EvalString(ctx, row)
 			if isNull || err != nil {
 				return res, isNull, err
 			}
@@ -1544,7 +1544,7 @@ func (c *jsonStorageFreeFunctionClass) getFunction(ctx sessionctx.Context, args 
 }
 
 func (b *builtinJSONStorageFreeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	_, isNull, err = b.args[0].EvalJSON(b.ctx, row)
+	_, isNull, err = b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1581,7 +1581,7 @@ func (c *jsonStorageSizeFunctionClass) getFunction(ctx sessionctx.Context, args 
 }
 
 func (b *builtinJSONStorageSizeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	obj, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1623,7 +1623,7 @@ func (b *builtinJSONDepthSig) evalInt(ctx sessionctx.Context, row chunk.Row) (re
 	// json format and whether it's NULL. For NULL return NULL, for invalid json, return
 	// an error, otherwise return 0
 
-	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	obj, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1680,7 +1680,7 @@ func (b *builtinJSONKeysSig) Clone() builtinFunc {
 }
 
 func (b *builtinJSONKeysSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
+	res, isNull, err = b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1701,12 +1701,12 @@ func (b *builtinJSONKeys2ArgsSig) Clone() builtinFunc {
 }
 
 func (b *builtinJSONKeys2ArgsSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
+	res, isNull, err = b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 
-	path, isNull, err := b.args[1].EvalString(b.ctx, row)
+	path, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1765,7 +1765,7 @@ func (c *jsonLengthFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 }
 
 func (b *builtinJSONLengthSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
-	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	obj, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -1775,7 +1775,7 @@ func (b *builtinJSONLengthSig) evalInt(ctx sessionctx.Context, row chunk.Row) (r
 	}
 
 	if len(b.args) == 2 {
-		path, isNull, err := b.args[1].EvalString(b.ctx, row)
+		path, isNull, err := b.args[1].EvalString(ctx, row)
 		if isNull || err != nil {
 			return res, isNull, err
 		}

--- a/pkg/expression/builtin_json_vec.go
+++ b/pkg/expression/builtin_json_vec.go
@@ -114,7 +114,7 @@ func (b *builtinJSONStorageFreeSig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -141,7 +141,7 @@ func (b *builtinJSONStorageSizeSig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -169,7 +169,7 @@ func (b *builtinJSONDepthSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -196,7 +196,7 @@ func (b *builtinJSONKeysSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -223,7 +223,7 @@ func (b *builtinJSONInsertSig) vectorized() bool {
 }
 
 func (b *builtinJSONInsertSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	err := vecJSONModify(b.ctx, b.args, b.bufAllocator, input, result, types.JSONModifyInsert)
+	err := vecJSONModify(ctx, b.args, b.bufAllocator, input, result, types.JSONModifyInsert)
 	return err
 }
 
@@ -232,7 +232,7 @@ func (b *builtinJSONReplaceSig) vectorized() bool {
 }
 
 func (b *builtinJSONReplaceSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	err := vecJSONModify(b.ctx, b.args, b.bufAllocator, input, result, types.JSONModifyReplace)
+	err := vecJSONModify(ctx, b.args, b.bufAllocator, input, result, types.JSONModifyReplace)
 	return err
 }
 
@@ -252,7 +252,7 @@ func (b *builtinJSONArraySig) vecEvalJSON(ctx sessionctx.Context, input *chunk.C
 			return err
 		}
 		defer b.bufAllocator.put(j)
-		if err = arg.VecEvalJSON(b.ctx, input, j); err != nil {
+		if err = arg.VecEvalJSON(ctx, input, j); err != nil {
 			return err
 		}
 		for i := 0; i < nr; i++ {
@@ -287,7 +287,7 @@ func (b *builtinJSONMemberOfSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 	}
 	defer b.bufAllocator.put(targetCol)
 
-	if err := b.args[0].VecEvalJSON(b.ctx, input, targetCol); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, targetCol); err != nil {
 		return err
 	}
 
@@ -297,7 +297,7 @@ func (b *builtinJSONMemberOfSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 	}
 	defer b.bufAllocator.put(objCol)
 
-	if err := b.args[1].VecEvalJSON(b.ctx, input, objCol); err != nil {
+	if err := b.args[1].VecEvalJSON(ctx, input, objCol); err != nil {
 		return err
 	}
 
@@ -340,7 +340,7 @@ func (b *builtinJSONContainsSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 	}
 	defer b.bufAllocator.put(objCol)
 
-	if err := b.args[0].VecEvalJSON(b.ctx, input, objCol); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, objCol); err != nil {
 		return err
 	}
 
@@ -350,7 +350,7 @@ func (b *builtinJSONContainsSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 	}
 	defer b.bufAllocator.put(targetCol)
 
-	if err := b.args[1].VecEvalJSON(b.ctx, input, targetCol); err != nil {
+	if err := b.args[1].VecEvalJSON(ctx, input, targetCol); err != nil {
 		return err
 	}
 
@@ -364,7 +364,7 @@ func (b *builtinJSONContainsSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 		}
 		defer b.bufAllocator.put(pathCol)
 
-		if err := b.args[2].VecEvalString(b.ctx, input, pathCol); err != nil {
+		if err := b.args[2].VecEvalString(ctx, input, pathCol); err != nil {
 			return err
 		}
 
@@ -425,7 +425,7 @@ func (b *builtinJSONOverlapsSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 	}
 	defer b.bufAllocator.put(objCol)
 
-	if err := b.args[0].VecEvalJSON(b.ctx, input, objCol); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, objCol); err != nil {
 		return err
 	}
 
@@ -435,7 +435,7 @@ func (b *builtinJSONOverlapsSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 	}
 	defer b.bufAllocator.put(targetCol)
 
-	if err := b.args[1].VecEvalJSON(b.ctx, input, targetCol); err != nil {
+	if err := b.args[1].VecEvalJSON(ctx, input, targetCol); err != nil {
 		return err
 	}
 
@@ -468,7 +468,7 @@ func (b *builtinJSONQuoteSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -494,7 +494,7 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(jsonBuf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, jsonBuf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
 	typeBuf, err := b.bufAllocator.get()
@@ -502,7 +502,7 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(typeBuf)
-	if err := b.args[1].VecEvalString(b.ctx, input, typeBuf); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, typeBuf); err != nil {
 		return err
 	}
 	searchBuf, err := b.bufAllocator.get()
@@ -510,7 +510,7 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(searchBuf)
-	if err := b.args[2].VecEvalString(b.ctx, input, searchBuf); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, searchBuf); err != nil {
 		return err
 	}
 
@@ -521,7 +521,7 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.
 			return err
 		}
 		defer b.bufAllocator.put(escapeBuf)
-		if err := b.args[3].VecEvalString(b.ctx, input, escapeBuf); err != nil {
+		if err := b.args[3].VecEvalString(ctx, input, escapeBuf); err != nil {
 			return err
 		}
 	}
@@ -536,7 +536,7 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.
 				return err
 			}
 			defer b.bufAllocator.put(pathBufs[index])
-			if err := b.args[i].VecEvalString(b.ctx, input, pathBufs[index]); err != nil {
+			if err := b.args[i].VecEvalString(ctx, input, pathBufs[index]); err != nil {
 				return err
 			}
 		}
@@ -593,7 +593,7 @@ func (b *builtinJSONSetSig) vectorized() bool {
 }
 
 func (b *builtinJSONSetSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	err := vecJSONModify(b.ctx, b.args, b.bufAllocator, input, result, types.JSONModifySet)
+	err := vecJSONModify(ctx, b.args, b.bufAllocator, input, result, types.JSONModifySet)
 	return err
 }
 
@@ -624,7 +624,7 @@ func (b *builtinJSONObjectSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.
 				b.bufAllocator.put(buf)
 			}(argBuffers[i])
 
-			if err = b.args[i].VecEvalString(b.ctx, input, argBuffers[i]); err != nil {
+			if err = b.args[i].VecEvalString(ctx, input, argBuffers[i]); err != nil {
 				return err
 			}
 		} else {
@@ -635,7 +635,7 @@ func (b *builtinJSONObjectSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.
 				b.bufAllocator.put(buf)
 			}(argBuffers[i])
 
-			if err = b.args[i].VecEvalJSON(b.ctx, input, argBuffers[i]); err != nil {
+			if err = b.args[i].VecEvalJSON(ctx, input, argBuffers[i]); err != nil {
 				return err
 			}
 		}
@@ -686,7 +686,7 @@ func (b *builtinJSONArrayInsertSig) vecEvalJSON(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 	pathBufs := make([]*chunk.Column, (len(b.args)-1)/2)
@@ -698,7 +698,7 @@ func (b *builtinJSONArrayInsertSig) vecEvalJSON(ctx sessionctx.Context, input *c
 				return err
 			}
 			defer b.bufAllocator.put(valueBufs[i/2-1])
-			if err := b.args[i].VecEvalJSON(b.ctx, input, valueBufs[i/2-1]); err != nil {
+			if err := b.args[i].VecEvalJSON(ctx, input, valueBufs[i/2-1]); err != nil {
 				return err
 			}
 		} else {
@@ -707,7 +707,7 @@ func (b *builtinJSONArrayInsertSig) vecEvalJSON(ctx sessionctx.Context, input *c
 				return err
 			}
 			defer b.bufAllocator.put(pathBufs[(i-1)/2])
-			if err := b.args[i].VecEvalString(b.ctx, input, pathBufs[(i-1)/2]); err != nil {
+			if err := b.args[i].VecEvalString(ctx, input, pathBufs[(i-1)/2]); err != nil {
 				return err
 			}
 		}
@@ -765,7 +765,7 @@ func (b *builtinJSONKeys2ArgsSig) vecEvalJSON(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(jsonBuf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, jsonBuf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
 	pathBuf, err := b.bufAllocator.get()
@@ -773,7 +773,7 @@ func (b *builtinJSONKeys2ArgsSig) vecEvalJSON(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(pathBuf)
-	if err := b.args[1].VecEvalString(b.ctx, input, pathBuf); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, pathBuf); err != nil {
 		return err
 	}
 
@@ -820,7 +820,7 @@ func (b *builtinJSONLengthSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(jsonBuf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, jsonBuf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
 	result.ResizeInt64(nr, false)
@@ -832,7 +832,7 @@ func (b *builtinJSONLengthSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 			return err
 		}
 		defer b.bufAllocator.put(pathBuf)
-		if err := b.args[1].VecEvalString(b.ctx, input, pathBuf); err != nil {
+		if err := b.args[1].VecEvalString(ctx, input, pathBuf); err != nil {
 			return err
 		}
 
@@ -902,7 +902,7 @@ func (b *builtinJSONTypeSig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -930,7 +930,7 @@ func (b *builtinJSONExtractSig) vecEvalJSON(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(jsonBuf)
-	if err = b.args[0].VecEvalJSON(b.ctx, input, jsonBuf); err != nil {
+	if err = b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
 
@@ -944,7 +944,7 @@ func (b *builtinJSONExtractSig) vecEvalJSON(ctx sessionctx.Context, input *chunk
 			b.bufAllocator.put(buf)
 		}(pathBuffers[k])
 
-		if err := pathArgs[k].VecEvalString(b.ctx, input, pathBuffers[k]); err != nil {
+		if err := pathArgs[k].VecEvalString(ctx, input, pathBuffers[k]); err != nil {
 			return err
 		}
 	}
@@ -995,7 +995,7 @@ func (b *builtinJSONRemoveSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(jsonBuf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, jsonBuf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
 
@@ -1006,7 +1006,7 @@ func (b *builtinJSONRemoveSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.
 			return err
 		}
 		defer b.bufAllocator.put(strBufs[i-1])
-		if err := b.args[i].VecEvalString(b.ctx, input, strBufs[i-1]); err != nil {
+		if err := b.args[i].VecEvalString(ctx, input, strBufs[i-1]); err != nil {
 			return err
 		}
 	}
@@ -1063,7 +1063,7 @@ func (b *builtinJSONMergeSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.C
 			b.bufAllocator.put(buf)
 		}(argBuffers[i])
 
-		if err := arg.VecEvalJSON(b.ctx, input, argBuffers[i]); err != nil {
+		if err := arg.VecEvalJSON(ctx, input, argBuffers[i]); err != nil {
 			return err
 		}
 	}
@@ -1104,7 +1104,7 @@ func (b *builtinJSONMergeSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.C
 			if result.IsNull(i) {
 				continue
 			}
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("JSON_MERGE"))
+			ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("JSON_MERGE"))
 		}
 	}
 
@@ -1122,7 +1122,7 @@ func (b *builtinJSONContainsPathSig) vecEvalInt(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(jsonBuf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, jsonBuf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
 	typeBuf, err := b.bufAllocator.get()
@@ -1130,7 +1130,7 @@ func (b *builtinJSONContainsPathSig) vecEvalInt(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(typeBuf)
-	if err := b.args[1].VecEvalString(b.ctx, input, typeBuf); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, typeBuf); err != nil {
 		return err
 	}
 	pathBufs := make([]*chunk.Column, len(b.args)-2)
@@ -1147,7 +1147,7 @@ func (b *builtinJSONContainsPathSig) vecEvalInt(ctx sessionctx.Context, input *c
 			return err
 		}
 		pathBufs[i] = pathBuf
-		if err := b.args[2+i].VecEvalString(b.ctx, input, pathBuf); err != nil {
+		if err := b.args[2+i].VecEvalString(ctx, input, pathBuf); err != nil {
 			return err
 		}
 	}
@@ -1207,7 +1207,7 @@ func (b *builtinJSONArrayAppendSig) vecEvalJSON(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(jsonBufs)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, jsonBufs); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, jsonBufs); err != nil {
 		return err
 	}
 
@@ -1227,14 +1227,14 @@ func (b *builtinJSONArrayAppendSig) vecEvalJSON(ctx sessionctx.Context, input *c
 			return err
 		}
 		pathBufs = append(pathBufs, pathBuf)
-		if err := b.args[i].VecEvalString(b.ctx, input, pathBuf); err != nil {
+		if err := b.args[i].VecEvalString(ctx, input, pathBuf); err != nil {
 			return err
 		}
 		valBuf, err := b.bufAllocator.get()
 		if err != nil {
 			return err
 		}
-		if err := b.args[i+1].VecEvalJSON(b.ctx, input, valBuf); err != nil {
+		if err := b.args[i+1].VecEvalJSON(ctx, input, valBuf); err != nil {
 			return err
 		}
 		valBufs = append(valBufs, valBuf)
@@ -1289,7 +1289,7 @@ func (b *builtinJSONUnquoteSig) vecEvalString(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1323,7 +1323,7 @@ func (b *builtinJSONSPrettySig) vecEvalString(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -1364,7 +1364,7 @@ func (b *builtinJSONMergePatchSig) vecEvalJSON(ctx sessionctx.Context, input *ch
 			b.bufAllocator.put(buf)
 		}(argBuffers[i])
 
-		if err := arg.VecEvalJSON(b.ctx, input, argBuffers[i]); err != nil {
+		if err := arg.VecEvalJSON(ctx, input, argBuffers[i]); err != nil {
 			return err
 		}
 	}

--- a/pkg/expression/builtin_like.go
+++ b/pkg/expression/builtin_like.go
@@ -71,23 +71,23 @@ func (b *builtinLikeSig) Clone() builtinFunc {
 // evalInt evals a builtinLikeSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-comparison-functions.html#operator_like
 func (b *builtinLikeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	valStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	valStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
-	patternStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	patternStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	escape, isNull, err := b.args[2].EvalInt(b.ctx, row)
+	escape, isNull, err := b.args[2].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	memorization := func() {
 		if b.pattern == nil {
 			b.pattern = b.collator().Pattern()
-			if b.args[1].ConstItem(b.ctx.GetSessionVars().StmtCtx) && b.args[2].ConstItem(b.ctx.GetSessionVars().StmtCtx) {
+			if b.args[1].ConstItem(ctx.GetSessionVars().StmtCtx) && b.args[2].ConstItem(ctx.GetSessionVars().StmtCtx) {
 				b.pattern.Compile(patternStr, byte(escape))
 				b.isMemorizedPattern = true
 			}

--- a/pkg/expression/builtin_like_vec.go
+++ b/pkg/expression/builtin_like_vec.go
@@ -30,7 +30,7 @@ func (b *builtinLikeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, 
 		return err
 	}
 	defer b.bufAllocator.put(bufVal)
-	if err = b.args[0].VecEvalString(b.ctx, input, bufVal); err != nil {
+	if err = b.args[0].VecEvalString(ctx, input, bufVal); err != nil {
 		return err
 	}
 	bufPattern, err := b.bufAllocator.get()
@@ -38,7 +38,7 @@ func (b *builtinLikeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, 
 		return err
 	}
 	defer b.bufAllocator.put(bufPattern)
-	if err = b.args[1].VecEvalString(b.ctx, input, bufPattern); err != nil {
+	if err = b.args[1].VecEvalString(ctx, input, bufPattern); err != nil {
 		return err
 	}
 
@@ -47,7 +47,7 @@ func (b *builtinLikeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, 
 		return err
 	}
 	defer b.bufAllocator.put(bufEscape)
-	if err = b.args[2].VecEvalInt(b.ctx, input, bufEscape); err != nil {
+	if err = b.args[2].VecEvalInt(ctx, input, bufEscape); err != nil {
 		return err
 	}
 	escapes := bufEscape.Int64s()

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -176,7 +176,7 @@ func (b *builtinAbsRealSig) Clone() builtinFunc {
 // evalReal evals ABS(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_abs
 func (b *builtinAbsRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -196,7 +196,7 @@ func (b *builtinAbsIntSig) Clone() builtinFunc {
 // evalInt evals ABS(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_abs
 func (b *builtinAbsIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -222,7 +222,7 @@ func (b *builtinAbsUIntSig) Clone() builtinFunc {
 // evalInt evals ABS(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_abs
 func (b *builtinAbsUIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	return b.args[0].EvalInt(b.ctx, row)
+	return b.args[0].EvalInt(ctx, row)
 }
 
 type builtinAbsDecSig struct {
@@ -238,7 +238,7 @@ func (b *builtinAbsDecSig) Clone() builtinFunc {
 // evalDecimal evals ABS(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_abs
 func (b *builtinAbsDecSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
@@ -353,7 +353,7 @@ func (b *builtinRoundRealSig) Clone() builtinFunc {
 // evalReal evals ROUND(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -373,7 +373,7 @@ func (b *builtinRoundIntSig) Clone() builtinFunc {
 // evalInt evals ROUND(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	return b.args[0].EvalInt(b.ctx, row)
+	return b.args[0].EvalInt(ctx, row)
 }
 
 type builtinRoundDecSig struct {
@@ -389,7 +389,7 @@ func (b *builtinRoundDecSig) Clone() builtinFunc {
 // evalDecimal evals ROUND(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundDecSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
@@ -413,11 +413,11 @@ func (b *builtinRoundWithFracRealSig) Clone() builtinFunc {
 // evalReal evals ROUND(value, frac).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundWithFracRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	frac, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	frac, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -437,11 +437,11 @@ func (b *builtinRoundWithFracIntSig) Clone() builtinFunc {
 // evalInt evals ROUND(value, frac).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundWithFracIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	frac, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	frac, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -461,11 +461,11 @@ func (b *builtinRoundWithFracDecSig) Clone() builtinFunc {
 // evalDecimal evals ROUND(value, frac).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundWithFracDecSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
-	frac, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	frac, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
@@ -534,7 +534,7 @@ func (b *builtinCeilRealSig) Clone() builtinFunc {
 // evalReal evals a builtinCeilRealSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_ceil
 func (b *builtinCeilRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -554,7 +554,7 @@ func (b *builtinCeilIntToIntSig) Clone() builtinFunc {
 // evalInt evals a builtinCeilIntToIntSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_ceil
 func (b *builtinCeilIntToIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	return b.args[0].EvalInt(b.ctx, row)
+	return b.args[0].EvalInt(ctx, row)
 }
 
 type builtinCeilIntToDecSig struct {
@@ -570,7 +570,7 @@ func (b *builtinCeilIntToDecSig) Clone() builtinFunc {
 // evalDecimal evals a builtinCeilIntToDecSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_Ceil
 func (b *builtinCeilIntToDecSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return nil, true, err
 	}
@@ -594,7 +594,7 @@ func (b *builtinCeilDecToIntSig) Clone() builtinFunc {
 // evalInt evals a builtinCeilDecToIntSig.
 // Ceil receives
 func (b *builtinCeilDecToIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -621,7 +621,7 @@ func (b *builtinCeilDecToDecSig) Clone() builtinFunc {
 
 // evalDecimal evals a builtinCeilDecToDecSig.
 func (b *builtinCeilDecToDecSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
@@ -725,7 +725,7 @@ func (b *builtinFloorRealSig) Clone() builtinFunc {
 // evalReal evals a builtinFloorRealSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_floor
 func (b *builtinFloorRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -745,7 +745,7 @@ func (b *builtinFloorIntToIntSig) Clone() builtinFunc {
 // evalInt evals a builtinFloorIntToIntSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_floor
 func (b *builtinFloorIntToIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	return b.args[0].EvalInt(b.ctx, row)
+	return b.args[0].EvalInt(ctx, row)
 }
 
 type builtinFloorIntToDecSig struct {
@@ -761,7 +761,7 @@ func (b *builtinFloorIntToDecSig) Clone() builtinFunc {
 // evalDecimal evals a builtinFloorIntToDecSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_floor
 func (b *builtinFloorIntToDecSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return nil, true, err
 	}
@@ -785,7 +785,7 @@ func (b *builtinFloorDecToIntSig) Clone() builtinFunc {
 // evalInt evals a builtinFloorDecToIntSig.
 // floor receives
 func (b *builtinFloorDecToIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -812,7 +812,7 @@ func (b *builtinFloorDecToDecSig) Clone() builtinFunc {
 
 // evalDecimal evals a builtinFloorDecToDecSig.
 func (b *builtinFloorDecToDecSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, true, err
 	}
@@ -883,12 +883,12 @@ func (b *builtinLog1ArgSig) Clone() builtinFunc {
 // evalReal evals a builtinLog1ArgSig, corresponding to log(x).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_log
 func (b *builtinLog1ArgSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	if val <= 0 {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+		ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
 		return 0, true, nil
 	}
 	return math.Log(val), false, nil
@@ -907,18 +907,18 @@ func (b *builtinLog2ArgsSig) Clone() builtinFunc {
 // evalReal evals a builtinLog2ArgsSig, corresponding to log(b, x).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_log
 func (b *builtinLog2ArgsSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val1, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val1, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
-	val2, isNull, err := b.args[1].EvalReal(b.ctx, row)
+	val2, isNull, err := b.args[1].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
 	if val1 <= 0 || val1 == 1 || val2 <= 0 {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+		ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
 		return 0, true, nil
 	}
 
@@ -955,12 +955,12 @@ func (b *builtinLog2Sig) Clone() builtinFunc {
 // evalReal evals a builtinLog2Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_log2
 func (b *builtinLog2Sig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	if val <= 0 {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+		ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
 		return 0, true, nil
 	}
 	return math.Log2(val), false, nil
@@ -996,12 +996,12 @@ func (b *builtinLog10Sig) Clone() builtinFunc {
 // evalReal evals a builtinLog10Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_log10
 func (b *builtinLog10Sig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	if val <= 0 {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+		ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
 		return 0, true, nil
 	}
 	return math.Log10(val), false, nil
@@ -1082,7 +1082,7 @@ func (b *builtinRandWithSeedFirstGenSig) Clone() builtinFunc {
 // evalReal evals RAND(N).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_rand
 func (b *builtinRandWithSeedFirstGenSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	seed, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	seed, isNull, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -1128,11 +1128,11 @@ func (b *builtinPowSig) Clone() builtinFunc {
 // evalReal evals POW(x, y).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_pow
 func (b *builtinPowSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	x, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	x, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	y, isNull, err := b.args[1].EvalReal(b.ctx, row)
+	y, isNull, err := b.args[1].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1192,7 +1192,7 @@ func (b *builtinConvSig) evalString(ctx sessionctx.Context, row chunk.Row) (res 
 		if x.FuncName.L == ast.Cast {
 			arg0 := x.GetArgs()[0]
 			if arg0.GetType().Hybrid() || IsBinaryLiteral(arg0) {
-				str, isNull, err = arg0.EvalString(b.ctx, row)
+				str, isNull, err = arg0.EvalString(ctx, row)
 				if isNull || err != nil {
 					return str, isNull, err
 				}
@@ -1201,17 +1201,17 @@ func (b *builtinConvSig) evalString(ctx sessionctx.Context, row chunk.Row) (res 
 			}
 		}
 	}
-	fromBase, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	fromBase, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 
-	toBase, isNull, err := b.args[2].EvalInt(b.ctx, row)
+	toBase, isNull, err := b.args[2].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
 	if len(str) == 0 {
-		str, isNull, err = b.args[0].EvalString(b.ctx, row)
+		str, isNull, err = b.args[0].EvalString(ctx, row)
 		if isNull || err != nil {
 			return res, isNull, err
 		}
@@ -1318,7 +1318,7 @@ func (b *builtinCRC32Sig) Clone() builtinFunc {
 // evalInt evals a CRC32(expr).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_crc32
 func (b *builtinCRC32Sig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	x, isNull, err := b.args[0].EvalString(b.ctx, row)
+	x, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1356,7 +1356,7 @@ func (b *builtinSignSig) Clone() builtinFunc {
 // evalInt evals SIGN(v).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_sign
 func (b *builtinSignSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1398,7 +1398,7 @@ func (b *builtinSqrtSig) Clone() builtinFunc {
 // evalReal evals a SQRT(x).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_sqrt
 func (b *builtinSqrtSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1438,7 +1438,7 @@ func (b *builtinAcosSig) Clone() builtinFunc {
 // evalReal evals a builtinAcosSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_acos
 func (b *builtinAcosSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1479,7 +1479,7 @@ func (b *builtinAsinSig) Clone() builtinFunc {
 // evalReal evals a builtinAsinSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_asin
 func (b *builtinAsinSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1542,7 +1542,7 @@ func (b *builtinAtan1ArgSig) Clone() builtinFunc {
 // evalReal evals a builtinAtan1ArgSig, corresponding to atan(x).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_atan
 func (b *builtinAtan1ArgSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1563,12 +1563,12 @@ func (b *builtinAtan2ArgsSig) Clone() builtinFunc {
 // evalReal evals a builtinAtan1ArgSig, corresponding to atan(y, x).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_atan
 func (b *builtinAtan2ArgsSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val1, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val1, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
-	val2, isNull, err := b.args[1].EvalReal(b.ctx, row)
+	val2, isNull, err := b.args[1].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1606,7 +1606,7 @@ func (b *builtinCosSig) Clone() builtinFunc {
 // evalReal evals a builtinCosSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_cos
 func (b *builtinCosSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1643,7 +1643,7 @@ func (b *builtinCotSig) Clone() builtinFunc {
 // evalReal evals a builtinCotSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_cot
 func (b *builtinCotSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1688,7 +1688,7 @@ func (b *builtinDegreesSig) Clone() builtinFunc {
 // evalReal evals a builtinDegreesSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_degrees
 func (b *builtinDegreesSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1726,7 +1726,7 @@ func (b *builtinExpSig) Clone() builtinFunc {
 // evalReal evals a builtinExpSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_exp
 func (b *builtinExpSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1809,7 +1809,7 @@ func (b *builtinRadiansSig) Clone() builtinFunc {
 // evalReal evals RADIANS(X).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_radians
 func (b *builtinRadiansSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	x, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	x, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1846,7 +1846,7 @@ func (b *builtinSinSig) Clone() builtinFunc {
 // evalReal evals a builtinSinSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_sin
 func (b *builtinSinSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1883,7 +1883,7 @@ func (b *builtinTanSig) Clone() builtinFunc {
 // evalReal evals a builtinTanSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_tan
 func (b *builtinTanSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1951,12 +1951,12 @@ func (b *builtinTruncateDecimalSig) Clone() builtinFunc {
 // evalDecimal evals a TRUNCATE(X,D).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_truncate
 func (b *builtinTruncateDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	x, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	x, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
 
-	d, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	d, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
@@ -1981,12 +1981,12 @@ func (b *builtinTruncateRealSig) Clone() builtinFunc {
 // evalReal evals a TRUNCATE(X,D).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_truncate
 func (b *builtinTruncateRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	x, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	x, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
-	d, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	d, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -2007,7 +2007,7 @@ func (b *builtinTruncateIntSig) Clone() builtinFunc {
 // evalInt evals a TRUNCATE(X,D).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_truncate
 func (b *builtinTruncateIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	x, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	x, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -2015,7 +2015,7 @@ func (b *builtinTruncateIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (
 		return x, false, nil
 	}
 
-	d, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	d, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -2044,7 +2044,7 @@ type builtinTruncateUintSig struct {
 // evalInt evals a TRUNCATE(X,D).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_truncate
 func (b *builtinTruncateUintSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	x, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	x, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -2053,7 +2053,7 @@ func (b *builtinTruncateUintSig) evalInt(ctx sessionctx.Context, row chunk.Row) 
 	}
 	uintx := uint64(x)
 
-	d, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	d, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}

--- a/pkg/expression/builtin_math_vec.go
+++ b/pkg/expression/builtin_math_vec.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (b *builtinLog1ArgSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -37,7 +37,7 @@ func (b *builtinLog1ArgSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chu
 			continue
 		}
 		if f64s[i] <= 0 {
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+			ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
 			result.SetNull(i, true)
 		} else {
 			f64s[i] = math.Log(f64s[i])
@@ -51,7 +51,7 @@ func (b *builtinLog1ArgSig) vectorized() bool {
 }
 
 func (b *builtinLog2Sig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -60,7 +60,7 @@ func (b *builtinLog2Sig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk,
 			continue
 		}
 		if f64s[i] <= 0 {
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+			ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
 			result.SetNull(i, true)
 		} else {
 			f64s[i] = math.Log2(f64s[i])
@@ -74,7 +74,7 @@ func (b *builtinLog2Sig) vectorized() bool {
 }
 
 func (b *builtinLog10Sig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -83,7 +83,7 @@ func (b *builtinLog10Sig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk
 			continue
 		}
 		if f64s[i] <= 0 {
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+			ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
 			result.SetNull(i, true)
 		} else {
 			f64s[i] = math.Log10(f64s[i])
@@ -97,7 +97,7 @@ func (b *builtinLog10Sig) vectorized() bool {
 }
 
 func (b *builtinSqrtSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -119,7 +119,7 @@ func (b *builtinSqrtSig) vectorized() bool {
 }
 
 func (b *builtinAcosSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -141,7 +141,7 @@ func (b *builtinAcosSig) vectorized() bool {
 }
 
 func (b *builtinAsinSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -163,7 +163,7 @@ func (b *builtinAsinSig) vectorized() bool {
 }
 
 func (b *builtinAtan1ArgSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -182,7 +182,7 @@ func (b *builtinAtan1ArgSig) vectorized() bool {
 
 func (b *builtinAtan2ArgsSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -191,7 +191,7 @@ func (b *builtinAtan2ArgsSig) vecEvalReal(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -214,7 +214,7 @@ func (b *builtinAtan2ArgsSig) vectorized() bool {
 }
 
 func (b *builtinCosSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -232,7 +232,7 @@ func (b *builtinCosSig) vectorized() bool {
 }
 
 func (b *builtinCotSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -260,7 +260,7 @@ func (b *builtinCotSig) vectorized() bool {
 }
 
 func (b *builtinDegreesSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -278,7 +278,7 @@ func (b *builtinDegreesSig) vectorized() bool {
 }
 
 func (b *builtinExpSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -303,7 +303,7 @@ func (b *builtinExpSig) vectorized() bool {
 }
 
 func (b *builtinRadiansSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -321,7 +321,7 @@ func (b *builtinRadiansSig) vectorized() bool {
 }
 
 func (b *builtinSinSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -339,7 +339,7 @@ func (b *builtinSinSig) vectorized() bool {
 }
 
 func (b *builtinTanSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -357,7 +357,7 @@ func (b *builtinTanSig) vectorized() bool {
 }
 
 func (b *builtinAbsDecSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	zero := new(types.MyDecimal)
@@ -382,7 +382,7 @@ func (b *builtinAbsDecSig) vectorized() bool {
 }
 
 func (b *builtinRoundDecSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	d64s := result.Decimals()
@@ -410,11 +410,11 @@ func (b *builtinPowSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, 
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 
-	if err := b.args[1].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -440,7 +440,7 @@ func (b *builtinPowSig) vectorized() bool {
 }
 
 func (b *builtinFloorRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -458,7 +458,7 @@ func (b *builtinFloorRealSig) vectorized() bool {
 }
 
 func (b *builtinLog2ArgsSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -467,7 +467,7 @@ func (b *builtinLog2ArgsSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -479,7 +479,7 @@ func (b *builtinLog2ArgsSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Ch
 			continue
 		}
 		if d[i] <= 0 || d[i] == 1 || x[i] <= 0 {
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+			ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
 			result.SetNull(i, true)
 		}
 		d[i] = math.Log(x[i]) / math.Log(d[i])
@@ -492,7 +492,7 @@ func (b *builtinLog2ArgsSig) vectorized() bool {
 }
 
 func (b *builtinCeilRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -510,7 +510,7 @@ func (b *builtinCeilRealSig) vectorized() bool {
 }
 
 func (b *builtinRoundRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -528,7 +528,7 @@ func (b *builtinRoundRealSig) vectorized() bool {
 }
 
 func (b *builtinRoundWithFracRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -537,7 +537,7 @@ func (b *builtinRoundWithFracRealSig) vecEvalReal(ctx sessionctx.Context, input 
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -558,7 +558,7 @@ func (b *builtinRoundWithFracRealSig) vectorized() bool {
 }
 
 func (b *builtinTruncateRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -567,7 +567,7 @@ func (b *builtinTruncateRealSig) vecEvalReal(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -588,7 +588,7 @@ func (b *builtinTruncateRealSig) vectorized() bool {
 }
 
 func (b *builtinAbsRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 	f64s := result.Float64s()
@@ -603,7 +603,7 @@ func (b *builtinAbsRealSig) vectorized() bool {
 }
 
 func (b *builtinAbsIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	i64s := result.Int64s()
@@ -626,7 +626,7 @@ func (b *builtinAbsIntSig) vectorized() bool {
 }
 
 func (b *builtinRoundIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalInt(b.ctx, input, result)
+	return b.args[0].VecEvalInt(ctx, input, result)
 }
 
 func (b *builtinRoundIntSig) vectorized() bool {
@@ -634,7 +634,7 @@ func (b *builtinRoundIntSig) vectorized() bool {
 }
 
 func (b *builtinRoundWithFracIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -644,7 +644,7 @@ func (b *builtinRoundWithFracIntSig) vecEvalInt(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -674,7 +674,7 @@ func (b *builtinCRC32Sig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -727,7 +727,7 @@ func (b *builtinRandWithSeedFirstGenSig) vecEvalReal(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -757,7 +757,7 @@ func (b *builtinCeilIntToDecSig) vecEvalDecimal(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -785,7 +785,7 @@ func (b *builtinTruncateIntSig) vectorized() bool {
 }
 
 func (b *builtinTruncateIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -795,7 +795,7 @@ func (b *builtinTruncateIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 	}
 	defer b.bufAllocator.put(buf)
 
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	result.MergeNulls(buf)
@@ -828,7 +828,7 @@ func (b *builtinTruncateUintSig) vectorized() bool {
 }
 
 func (b *builtinTruncateUintSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -839,7 +839,7 @@ func (b *builtinTruncateUintSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 	}
 	defer b.bufAllocator.put(buf)
 
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	result.MergeNulls(buf)
@@ -874,7 +874,7 @@ func (b *builtinCeilDecToDecSig) vectorized() bool {
 
 func (b *builtinCeilDecToDecSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	ds := result.Decimals()
@@ -903,7 +903,7 @@ func (b *builtinFloorDecToDecSig) vectorized() bool {
 
 func (b *builtinFloorDecToDecSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	ds := result.Decimals()
@@ -938,7 +938,7 @@ func (b *builtinTruncateDecimalSig) vectorized() bool {
 
 func (b *builtinTruncateDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	buf, err := b.bufAllocator.get()
@@ -946,7 +946,7 @@ func (b *builtinTruncateDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	result.MergeNulls(buf)
@@ -972,7 +972,7 @@ func (b *builtinRoundWithFracDecSig) vectorized() bool {
 
 func (b *builtinRoundWithFracDecSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 	buf, err := b.bufAllocator.get()
@@ -980,7 +980,7 @@ func (b *builtinRoundWithFracDecSig) vecEvalDecimal(ctx sessionctx.Context, inpu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1012,7 +1012,7 @@ func (b *builtinFloorIntToDecSig) vecEvalDecimal(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1046,7 +1046,7 @@ func (b *builtinSignSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, 
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 	args := buf.Float64s()
@@ -1090,13 +1090,13 @@ func (b *builtinConvSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf3)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
-	if err := b.args[2].VecEvalInt(b.ctx, input, buf3); err != nil {
+	if err := b.args[2].VecEvalInt(ctx, input, buf3); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -1125,7 +1125,7 @@ func (b *builtinAbsUIntSig) vectorized() bool {
 }
 
 func (b *builtinAbsUIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalInt(b.ctx, input, result)
+	return b.args[0].VecEvalInt(ctx, input, result)
 }
 
 func (b *builtinCeilDecToIntSig) vectorized() bool {
@@ -1139,7 +1139,7 @@ func (b *builtinCeilDecToIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -1171,7 +1171,7 @@ func (b *builtinCeilIntToIntSig) vectorized() bool {
 }
 
 func (b *builtinCeilIntToIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalInt(b.ctx, input, result)
+	return b.args[0].VecEvalInt(ctx, input, result)
 }
 
 func (b *builtinFloorIntToIntSig) vectorized() bool {
@@ -1179,7 +1179,7 @@ func (b *builtinFloorIntToIntSig) vectorized() bool {
 }
 
 func (b *builtinFloorIntToIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalInt(b.ctx, input, result)
+	return b.args[0].VecEvalInt(ctx, input, result)
 }
 
 func (b *builtinFloorDecToIntSig) vectorized() bool {
@@ -1193,7 +1193,7 @@ func (b *builtinFloorDecToIntSig) vecEvalInt(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)

--- a/pkg/expression/builtin_miscellaneous.go
+++ b/pkg/expression/builtin_miscellaneous.go
@@ -135,12 +135,12 @@ func (b *builtinSleepSig) Clone() builtinFunc {
 // evalInt evals a builtinSleepSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_sleep
 func (b *builtinSleepSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	if err != nil {
 		return 0, isNull, err
 	}
 
-	sessVars := b.ctx.GetSessionVars()
+	sessVars := ctx.GetSessionVars()
 	if isNull || val < 0 {
 		// for insert ignore stmt, the StrictSQLMode and ignoreErr should both be considered.
 		if !sessVars.StmtCtx.BadNullAsWarning {
@@ -192,7 +192,7 @@ func (b *builtinLockSig) Clone() builtinFunc {
 // evalInt evals a builtinLockSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock
 func (b *builtinLockSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	lockName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	lockName, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil {
 		return 0, isNull, err
 	}
@@ -204,7 +204,7 @@ func (b *builtinLockSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, 
 		return 0, false, errUserLockWrongName.GenWithStackByArgs(lockName)
 	}
 	maxTimeout := int64(variable.GetSysVar(variable.InnodbLockWaitTimeout).MaxValue)
-	timeout, isNullTimeout, err := b.args[1].EvalInt(b.ctx, row)
+	timeout, isNullTimeout, err := b.args[1].EvalInt(ctx, row)
 	if err != nil {
 		return 0, false, err
 	}
@@ -217,7 +217,7 @@ func (b *builtinLockSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, 
 	// So users are aware, we also attach a warning.
 	if timeout < 0 || timeout > maxTimeout {
 		err := errTruncatedWrongValue.GenWithStackByArgs("get_lock", strconv.FormatInt(timeout, 10))
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
+		ctx.GetSessionVars().StmtCtx.AppendWarning(err)
 		timeout = maxTimeout
 	}
 
@@ -227,7 +227,7 @@ func (b *builtinLockSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, 
 	if utf8.RuneCountInString(lockName) > 64 {
 		return 0, false, errIncorrectArgs.GenWithStackByArgs("get_lock")
 	}
-	err = b.ctx.GetAdvisoryLock(lockName, timeout)
+	err = ctx.GetAdvisoryLock(lockName, timeout)
 	if err != nil {
 		if terr, ok := errors.Cause(err).(*terror.Error); ok {
 			switch terr.Code() {
@@ -275,7 +275,7 @@ func (b *builtinReleaseLockSig) Clone() builtinFunc {
 // evalInt evals a builtinReleaseLockSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_release-lock
 func (b *builtinReleaseLockSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	lockName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	lockName, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil {
 		return 0, isNull, err
 	}
@@ -293,7 +293,7 @@ func (b *builtinReleaseLockSig) evalInt(ctx sessionctx.Context, row chunk.Row) (
 		return 0, false, errIncorrectArgs.GenWithStackByArgs("release_lock")
 	}
 	released := int64(0)
-	if b.ctx.ReleaseAdvisoryLock(lockName) {
+	if ctx.ReleaseAdvisoryLock(lockName) {
 		released = 1
 	}
 	return released, false, nil
@@ -362,7 +362,7 @@ func (b *builtinDecimalAnyValueSig) Clone() builtinFunc {
 // evalDecimal evals a builtinDecimalAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinDecimalAnyValueSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	return b.args[0].EvalDecimal(b.ctx, row)
+	return b.args[0].EvalDecimal(ctx, row)
 }
 
 type builtinDurationAnyValueSig struct {
@@ -378,7 +378,7 @@ func (b *builtinDurationAnyValueSig) Clone() builtinFunc {
 // evalDuration evals a builtinDurationAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinDurationAnyValueSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	return b.args[0].EvalDuration(b.ctx, row)
+	return b.args[0].EvalDuration(ctx, row)
 }
 
 type builtinIntAnyValueSig struct {
@@ -394,7 +394,7 @@ func (b *builtinIntAnyValueSig) Clone() builtinFunc {
 // evalInt evals a builtinIntAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinIntAnyValueSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	return b.args[0].EvalInt(b.ctx, row)
+	return b.args[0].EvalInt(ctx, row)
 }
 
 type builtinJSONAnyValueSig struct {
@@ -410,7 +410,7 @@ func (b *builtinJSONAnyValueSig) Clone() builtinFunc {
 // evalJSON evals a builtinJSONAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinJSONAnyValueSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (types.BinaryJSON, bool, error) {
-	return b.args[0].EvalJSON(b.ctx, row)
+	return b.args[0].EvalJSON(ctx, row)
 }
 
 type builtinRealAnyValueSig struct {
@@ -426,7 +426,7 @@ func (b *builtinRealAnyValueSig) Clone() builtinFunc {
 // evalReal evals a builtinRealAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinRealAnyValueSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	return b.args[0].EvalReal(b.ctx, row)
+	return b.args[0].EvalReal(ctx, row)
 }
 
 type builtinStringAnyValueSig struct {
@@ -442,7 +442,7 @@ func (b *builtinStringAnyValueSig) Clone() builtinFunc {
 // evalString evals a builtinStringAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinStringAnyValueSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	return b.args[0].EvalString(b.ctx, row)
+	return b.args[0].EvalString(ctx, row)
 }
 
 type builtinTimeAnyValueSig struct {
@@ -458,7 +458,7 @@ func (b *builtinTimeAnyValueSig) Clone() builtinFunc {
 // evalTime evals a builtinTimeAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinTimeAnyValueSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	return b.args[0].EvalTime(b.ctx, row)
+	return b.args[0].EvalTime(ctx, row)
 }
 
 type defaultFunctionClass struct {
@@ -501,7 +501,7 @@ func (b *builtinInetAtonSig) Clone() builtinFunc {
 // evalInt evals a builtinInetAtonSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet-aton
 func (b *builtinInetAtonSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil || isNull {
 		return 0, true, err
 	}
@@ -581,7 +581,7 @@ func (b *builtinInetNtoaSig) Clone() builtinFunc {
 // evalString evals a builtinInetNtoaSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet-ntoa
 func (b *builtinInetNtoaSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if err != nil || isNull {
 		return "", true, err
 	}
@@ -634,7 +634,7 @@ func (b *builtinInet6AtonSig) Clone() builtinFunc {
 // evalString evals a builtinInet6AtonSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet6-aton
 func (b *builtinInet6AtonSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil || isNull {
 		return "", true, err
 	}
@@ -709,7 +709,7 @@ func (b *builtinInet6NtoaSig) Clone() builtinFunc {
 // evalString evals a builtinInet6NtoaSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet6-ntoa
 func (b *builtinInet6NtoaSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil || isNull {
 		return "", true, err
 	}
@@ -754,7 +754,7 @@ func (b *builtinFreeLockSig) Clone() builtinFunc {
 
 // See https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html#function_is-free-lock
 func (b *builtinFreeLockSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	lockName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	lockName, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -772,7 +772,7 @@ func (b *builtinFreeLockSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int
 	if utf8.RuneCountInString(lockName) > 64 {
 		return 0, true, errIncorrectArgs.GenWithStackByArgs("is_free_lock")
 	}
-	lock := b.ctx.IsUsedAdvisoryLock(lockName)
+	lock := ctx.IsUsedAdvisoryLock(lockName)
 	if lock > 0 {
 		return 0, false, nil
 	}
@@ -810,7 +810,7 @@ func (b *builtinIsIPv4Sig) Clone() builtinFunc {
 // evalInt evals a builtinIsIPv4Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_is-ipv4
 func (b *builtinIsIPv4Sig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil || isNull {
 		return 0, err != nil, err
 	}
@@ -878,7 +878,7 @@ func (b *builtinIsIPv4CompatSig) Clone() builtinFunc {
 // evalInt evals Is_IPv4_Compat
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_is-ipv4-compat
 func (b *builtinIsIPv4CompatSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil || isNull {
 		return 0, err != nil, err
 	}
@@ -927,7 +927,7 @@ func (b *builtinIsIPv4MappedSig) Clone() builtinFunc {
 // evalInt evals Is_IPv4_Mapped
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_is-ipv4-mapped
 func (b *builtinIsIPv4MappedSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil || isNull {
 		return 0, err != nil, err
 	}
@@ -976,7 +976,7 @@ func (b *builtinIsIPv6Sig) Clone() builtinFunc {
 // evalInt evals a builtinIsIPv6Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_is-ipv6
 func (b *builtinIsIPv6Sig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil || isNull {
 		return 0, err != nil, err
 	}
@@ -1016,7 +1016,7 @@ func (b *builtinUsedLockSig) Clone() builtinFunc {
 
 // See https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html#function_is-used-lock
 func (b *builtinUsedLockSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	lockName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	lockName, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil {
 		return 0, isNull, err
 	}
@@ -1034,7 +1034,7 @@ func (b *builtinUsedLockSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int
 	if utf8.RuneCountInString(lockName) > 64 {
 		return 0, false, errIncorrectArgs.GenWithStackByArgs("is_used_lock")
 	}
-	lock := b.ctx.IsUsedAdvisoryLock(lockName)
+	lock := ctx.IsUsedAdvisoryLock(lockName)
 	return int64(lock), lock == 0, nil // TODO, uint64
 }
 
@@ -1069,7 +1069,7 @@ func (b *builtinIsUUIDSig) Clone() builtinFunc {
 // evalInt evals a builtinIsUUIDSig.
 // See https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_is-uuid
 func (b *builtinIsUUIDSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil || isNull {
 		return 0, isNull, err
 	}
@@ -1139,7 +1139,7 @@ func (b *builtinNameConstDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinNameConstDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	return b.args[1].EvalDecimal(b.ctx, row)
+	return b.args[1].EvalDecimal(ctx, row)
 }
 
 type builtinNameConstIntSig struct {
@@ -1153,7 +1153,7 @@ func (b *builtinNameConstIntSig) Clone() builtinFunc {
 }
 
 func (b *builtinNameConstIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	return b.args[1].EvalInt(b.ctx, row)
+	return b.args[1].EvalInt(ctx, row)
 }
 
 type builtinNameConstRealSig struct {
@@ -1167,7 +1167,7 @@ func (b *builtinNameConstRealSig) Clone() builtinFunc {
 }
 
 func (b *builtinNameConstRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	return b.args[1].EvalReal(b.ctx, row)
+	return b.args[1].EvalReal(ctx, row)
 }
 
 type builtinNameConstStringSig struct {
@@ -1181,7 +1181,7 @@ func (b *builtinNameConstStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinNameConstStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	return b.args[1].EvalString(b.ctx, row)
+	return b.args[1].EvalString(ctx, row)
 }
 
 type builtinNameConstJSONSig struct {
@@ -1195,7 +1195,7 @@ func (b *builtinNameConstJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinNameConstJSONSig) evalJSON(ctx sessionctx.Context, row chunk.Row) (types.BinaryJSON, bool, error) {
-	return b.args[1].EvalJSON(b.ctx, row)
+	return b.args[1].EvalJSON(ctx, row)
 }
 
 type builtinNameConstDurationSig struct {
@@ -1209,7 +1209,7 @@ func (b *builtinNameConstDurationSig) Clone() builtinFunc {
 }
 
 func (b *builtinNameConstDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	return b.args[1].EvalDuration(b.ctx, row)
+	return b.args[1].EvalDuration(ctx, row)
 }
 
 type builtinNameConstTimeSig struct {
@@ -1223,7 +1223,7 @@ func (b *builtinNameConstTimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinNameConstTimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	return b.args[1].EvalTime(b.ctx, row)
+	return b.args[1].EvalTime(ctx, row)
 }
 
 type releaseAllLocksFunctionClass struct {
@@ -1256,7 +1256,7 @@ func (b *builtinReleaseAllLocksSig) Clone() builtinFunc {
 // evalInt evals a builtinReleaseAllLocksSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_release-all-locks
 func (b *builtinReleaseAllLocksSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	count := b.ctx.ReleaseAllAdvisoryLocks()
+	count := ctx.ReleaseAllAdvisoryLocks()
 	return int64(count), false, nil
 }
 
@@ -1345,7 +1345,7 @@ func (b *builtinVitessHashSig) Clone() builtinFunc {
 
 // evalInt evals VITESS_HASH(int64).
 func (b *builtinVitessHashSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	shardKeyInt, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	shardKeyInt, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, true, err
 	}
@@ -1393,7 +1393,7 @@ func (b *builtinUUIDToBinSig) Clone() builtinFunc {
 // evalString evals UUID_TO_BIN(string_uuid, swap_flag).
 // See https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_uuid-to-bin
 func (b *builtinUUIDToBinSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -1409,7 +1409,7 @@ func (b *builtinUUIDToBinSig) evalString(ctx sessionctx.Context, row chunk.Row) 
 
 	flag := int64(0)
 	if len(b.args) == 2 {
-		flag, isNull, err = b.args[1].EvalInt(b.ctx, row)
+		flag, isNull, err = b.args[1].EvalInt(ctx, row)
 		if isNull {
 			flag = 0
 		}
@@ -1462,7 +1462,7 @@ func (b *builtinBinToUUIDSig) Clone() builtinFunc {
 // evalString evals BIN_TO_UUID(binary_uuid, swap_flag).
 // See https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_bin-to-uuid
 func (b *builtinBinToUUIDSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -1476,7 +1476,7 @@ func (b *builtinBinToUUIDSig) evalString(ctx sessionctx.Context, row chunk.Row) 
 	str := u.String()
 	flag := int64(0)
 	if len(b.args) == 2 {
-		flag, isNull, err = b.args[1].EvalInt(b.ctx, row)
+		flag, isNull, err = b.args[1].EvalInt(ctx, row)
 		if isNull {
 			flag = 0
 		}
@@ -1545,7 +1545,7 @@ func (b *builtinTidbShardSig) Clone() builtinFunc {
 
 // evalInt evals tidb_shard(int64).
 func (b *builtinTidbShardSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	shardKeyInt, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	shardKeyInt, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, true, err
 	}

--- a/pkg/expression/builtin_miscellaneous_vec.go
+++ b/pkg/expression/builtin_miscellaneous_vec.go
@@ -37,7 +37,7 @@ func (b *builtinInetNtoaSig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -73,7 +73,7 @@ func (b *builtinIsIPv4Sig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -100,7 +100,7 @@ func (b *builtinJSONAnyValueSig) vectorized() bool {
 }
 
 func (b *builtinJSONAnyValueSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalJSON(b.ctx, input, result)
+	return b.args[0].VecEvalJSON(ctx, input, result)
 }
 
 func (b *builtinRealAnyValueSig) vectorized() bool {
@@ -108,7 +108,7 @@ func (b *builtinRealAnyValueSig) vectorized() bool {
 }
 
 func (b *builtinRealAnyValueSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalReal(b.ctx, input, result)
+	return b.args[0].VecEvalReal(ctx, input, result)
 }
 
 func (b *builtinStringAnyValueSig) vectorized() bool {
@@ -116,7 +116,7 @@ func (b *builtinStringAnyValueSig) vectorized() bool {
 }
 
 func (b *builtinStringAnyValueSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalString(b.ctx, input, result)
+	return b.args[0].VecEvalString(ctx, input, result)
 }
 
 func (b *builtinIsIPv6Sig) vectorized() bool {
@@ -130,7 +130,7 @@ func (b *builtinIsIPv6Sig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -165,7 +165,7 @@ func (b *builtinIsUUIDSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -189,7 +189,7 @@ func (b *builtinNameConstStringSig) vectorized() bool {
 }
 
 func (b *builtinNameConstStringSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[1].VecEvalString(b.ctx, input, result)
+	return b.args[1].VecEvalString(ctx, input, result)
 }
 
 func (b *builtinDecimalAnyValueSig) vectorized() bool {
@@ -197,7 +197,7 @@ func (b *builtinDecimalAnyValueSig) vectorized() bool {
 }
 
 func (b *builtinDecimalAnyValueSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalDecimal(b.ctx, input, result)
+	return b.args[0].VecEvalDecimal(ctx, input, result)
 }
 
 func (b *builtinUUIDSig) vectorized() bool {
@@ -224,7 +224,7 @@ func (b *builtinNameConstDurationSig) vectorized() bool {
 }
 
 func (b *builtinNameConstDurationSig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[1].VecEvalDuration(b.ctx, input, result)
+	return b.args[1].VecEvalDuration(ctx, input, result)
 }
 
 func (b *builtinDurationAnyValueSig) vectorized() bool {
@@ -232,7 +232,7 @@ func (b *builtinDurationAnyValueSig) vectorized() bool {
 }
 
 func (b *builtinDurationAnyValueSig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalDuration(b.ctx, input, result)
+	return b.args[0].VecEvalDuration(ctx, input, result)
 }
 
 func (b *builtinIntAnyValueSig) vectorized() bool {
@@ -240,7 +240,7 @@ func (b *builtinIntAnyValueSig) vectorized() bool {
 }
 
 func (b *builtinIntAnyValueSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalInt(b.ctx, input, result)
+	return b.args[0].VecEvalInt(ctx, input, result)
 }
 
 func (b *builtinIsIPv4CompatSig) vectorized() bool {
@@ -254,7 +254,7 @@ func (b *builtinIsIPv4CompatSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -285,7 +285,7 @@ func (b *builtinNameConstIntSig) vectorized() bool {
 }
 
 func (b *builtinNameConstIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[1].VecEvalInt(b.ctx, input, result)
+	return b.args[1].VecEvalInt(ctx, input, result)
 }
 
 func (b *builtinNameConstTimeSig) vectorized() bool {
@@ -293,7 +293,7 @@ func (b *builtinNameConstTimeSig) vectorized() bool {
 }
 
 func (b *builtinNameConstTimeSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[1].VecEvalTime(b.ctx, input, result)
+	return b.args[1].VecEvalTime(ctx, input, result)
 }
 
 func (b *builtinSleepSig) vectorized() bool {
@@ -310,7 +310,7 @@ func (b *builtinSleepSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 	}
 	defer b.bufAllocator.put(buf)
 
-	err = b.args[0].VecEvalReal(b.ctx, input, buf)
+	err = b.args[0].VecEvalReal(ctx, input, buf)
 	if err != nil {
 		return err
 	}
@@ -322,7 +322,7 @@ func (b *builtinSleepSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		isNull := buf.IsNull(i)
 		val := buf.GetFloat64(i)
 
-		sessVars := b.ctx.GetSessionVars()
+		sessVars := ctx.GetSessionVars()
 		if isNull || val < 0 {
 			// for insert ignore stmt, the StrictSQLMode and ignoreErr should both be considered.
 			if !sessVars.StmtCtx.BadNullAsWarning {
@@ -385,7 +385,7 @@ func (b *builtinIsIPv4MappedSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -416,7 +416,7 @@ func (b *builtinNameConstDecimalSig) vectorized() bool {
 }
 
 func (b *builtinNameConstDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[1].VecEvalDecimal(b.ctx, input, result)
+	return b.args[1].VecEvalDecimal(ctx, input, result)
 }
 
 func (b *builtinNameConstJSONSig) vectorized() bool {
@@ -424,7 +424,7 @@ func (b *builtinNameConstJSONSig) vectorized() bool {
 }
 
 func (b *builtinNameConstJSONSig) vecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[1].VecEvalJSON(b.ctx, input, result)
+	return b.args[1].VecEvalJSON(ctx, input, result)
 }
 
 func (b *builtinInet6AtonSig) vectorized() bool {
@@ -440,7 +440,7 @@ func (b *builtinInet6AtonSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -503,7 +503,7 @@ func (b *builtinTimeAnyValueSig) vectorized() bool {
 }
 
 func (b *builtinTimeAnyValueSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalTime(b.ctx, input, result)
+	return b.args[0].VecEvalTime(ctx, input, result)
 }
 
 func (b *builtinInetAtonSig) vectorized() bool {
@@ -517,7 +517,7 @@ func (b *builtinInetAtonSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	var (
@@ -590,7 +590,7 @@ func (b *builtinInet6NtoaSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(val)
-	if err := b.args[0].VecEvalString(b.ctx, input, val); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, val); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -618,7 +618,7 @@ func (b *builtinNameConstRealSig) vectorized() bool {
 }
 
 func (b *builtinNameConstRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[1].VecEvalReal(b.ctx, input, result)
+	return b.args[1].VecEvalReal(ctx, input, result)
 }
 
 func (b *builtinVitessHashSig) vectorized() bool {
@@ -633,7 +633,7 @@ func (b *builtinVitessHashSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 	}
 	defer b.bufAllocator.put(column)
 
-	if err := b.args[0].VecEvalInt(b.ctx, input, column); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, column); err != nil {
 		return err
 	}
 
@@ -669,7 +669,7 @@ func (b *builtinUUIDToBinSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(valBuf)
-	if err := b.args[0].VecEvalString(b.ctx, input, valBuf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, valBuf); err != nil {
 		return err
 	}
 
@@ -681,7 +681,7 @@ func (b *builtinUUIDToBinSig) vecEvalString(ctx sessionctx.Context, input *chunk
 			return err
 		}
 		defer b.bufAllocator.put(flagBuf)
-		if err := b.args[1].VecEvalInt(b.ctx, input, flagBuf); err != nil {
+		if err := b.args[1].VecEvalInt(ctx, input, flagBuf); err != nil {
 			return err
 		}
 		i64s = flagBuf.Int64s()
@@ -727,7 +727,7 @@ func (b *builtinBinToUUIDSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(valBuf)
-	if err := b.args[0].VecEvalString(b.ctx, input, valBuf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, valBuf); err != nil {
 		return err
 	}
 
@@ -739,7 +739,7 @@ func (b *builtinBinToUUIDSig) vecEvalString(ctx sessionctx.Context, input *chunk
 			return err
 		}
 		defer b.bufAllocator.put(flagBuf)
-		if err := b.args[1].VecEvalInt(b.ctx, input, flagBuf); err != nil {
+		if err := b.args[1].VecEvalInt(ctx, input, flagBuf); err != nil {
 			return err
 		}
 		i64s = flagBuf.Int64s()

--- a/pkg/expression/builtin_op.go
+++ b/pkg/expression/builtin_op.go
@@ -99,11 +99,11 @@ func (b *builtinLogicAndSig) Clone() builtinFunc {
 }
 
 func (b *builtinLogicAndSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalInt(ctx, row)
 	if err != nil || (!isNull0 && arg0 == 0) {
 		return 0, err != nil, err
 	}
-	arg1, isNull1, err := b.args[1].EvalInt(b.ctx, row)
+	arg1, isNull1, err := b.args[1].EvalInt(ctx, row)
 	if err != nil || (!isNull1 && arg1 == 0) {
 		return 0, err != nil, err
 	}
@@ -152,14 +152,14 @@ func (b *builtinLogicOrSig) Clone() builtinFunc {
 }
 
 func (b *builtinLogicOrSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
 	if !isNull0 && arg0 != 0 {
 		return 1, false, nil
 	}
-	arg1, isNull1, err := b.args[1].EvalInt(b.ctx, row)
+	arg1, isNull1, err := b.args[1].EvalInt(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -211,11 +211,11 @@ func (b *builtinLogicXorSig) Clone() builtinFunc {
 }
 
 func (b *builtinLogicXorSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -255,11 +255,11 @@ func (b *builtinBitAndSig) Clone() builtinFunc {
 }
 
 func (b *builtinBitAndSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -296,11 +296,11 @@ func (b *builtinBitOrSig) Clone() builtinFunc {
 }
 
 func (b *builtinBitOrSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -337,11 +337,11 @@ func (b *builtinBitXorSig) Clone() builtinFunc {
 }
 
 func (b *builtinBitXorSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -378,11 +378,11 @@ func (b *builtinLeftShiftSig) Clone() builtinFunc {
 }
 
 func (b *builtinLeftShiftSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -419,11 +419,11 @@ func (b *builtinRightShiftSig) Clone() builtinFunc {
 }
 
 func (b *builtinRightShiftSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -532,7 +532,7 @@ func (b *builtinRealIsTrueSig) Clone() builtinFunc {
 }
 
 func (b *builtinRealIsTrueSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	input, isNull, err := b.args[0].EvalReal(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -557,7 +557,7 @@ func (b *builtinDecimalIsTrueSig) Clone() builtinFunc {
 }
 
 func (b *builtinDecimalIsTrueSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	input, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -582,7 +582,7 @@ func (b *builtinIntIsTrueSig) Clone() builtinFunc {
 }
 
 func (b *builtinIntIsTrueSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	input, isNull, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -607,7 +607,7 @@ func (b *builtinRealIsFalseSig) Clone() builtinFunc {
 }
 
 func (b *builtinRealIsFalseSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	input, isNull, err := b.args[0].EvalReal(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -632,7 +632,7 @@ func (b *builtinDecimalIsFalseSig) Clone() builtinFunc {
 }
 
 func (b *builtinDecimalIsFalseSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	input, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -657,7 +657,7 @@ func (b *builtinIntIsFalseSig) Clone() builtinFunc {
 }
 
 func (b *builtinIntIsFalseSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	input, isNull, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -699,7 +699,7 @@ func (b *builtinBitNegSig) Clone() builtinFunc {
 }
 
 func (b *builtinBitNegSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -760,7 +760,7 @@ func (b *builtinUnaryNotRealSig) Clone() builtinFunc {
 }
 
 func (b *builtinUnaryNotRealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, true, err
 	}
@@ -781,7 +781,7 @@ func (b *builtinUnaryNotDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinUnaryNotDecimalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull || err != nil {
 		return 0, true, err
 	}
@@ -802,7 +802,7 @@ func (b *builtinUnaryNotIntSig) Clone() builtinFunc {
 }
 
 func (b *builtinUnaryNotIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, true, err
 	}
@@ -823,7 +823,7 @@ func (b *builtinUnaryNotJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinUnaryNotJSONSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return 0, true, err
 	}
@@ -952,7 +952,7 @@ func (b *builtinUnaryMinusIntSig) Clone() builtinFunc {
 
 func (b *builtinUnaryMinusIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (res int64, isNull bool, err error) {
 	var val int64
-	val, isNull, err = b.args[0].EvalInt(b.ctx, row)
+	val, isNull, err = b.args[0].EvalInt(ctx, row)
 	if err != nil || isNull {
 		return val, isNull, err
 	}
@@ -983,7 +983,7 @@ func (b *builtinUnaryMinusDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinUnaryMinusDecimalSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	dec, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	dec, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if err != nil || isNull {
 		return dec, isNull, err
 	}
@@ -1001,7 +1001,7 @@ func (b *builtinUnaryMinusRealSig) Clone() builtinFunc {
 }
 
 func (b *builtinUnaryMinusRealSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	val, isNull, err := b.args[0].EvalReal(ctx, row)
 	return -val, isNull, err
 }
 
@@ -1071,7 +1071,7 @@ func evalIsNull(isNull bool, err error) (int64, bool, error) {
 }
 
 func (b *builtinDecimalIsNullSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	_, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	return evalIsNull(isNull, err)
 }
 
@@ -1086,7 +1086,7 @@ func (b *builtinDurationIsNullSig) Clone() builtinFunc {
 }
 
 func (b *builtinDurationIsNullSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	_, isNull, err := b.args[0].EvalDuration(ctx, row)
 	return evalIsNull(isNull, err)
 }
 
@@ -1101,7 +1101,7 @@ func (b *builtinIntIsNullSig) Clone() builtinFunc {
 }
 
 func (b *builtinIntIsNullSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	_, isNull, err := b.args[0].EvalInt(ctx, row)
 	return evalIsNull(isNull, err)
 }
 
@@ -1116,7 +1116,7 @@ func (b *builtinRealIsNullSig) Clone() builtinFunc {
 }
 
 func (b *builtinRealIsNullSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	_, isNull, err := b.args[0].EvalReal(ctx, row)
 	return evalIsNull(isNull, err)
 }
 
@@ -1131,7 +1131,7 @@ func (b *builtinStringIsNullSig) Clone() builtinFunc {
 }
 
 func (b *builtinStringIsNullSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalString(b.ctx, row)
+	_, isNull, err := b.args[0].EvalString(ctx, row)
 	return evalIsNull(isNull, err)
 }
 
@@ -1146,6 +1146,6 @@ func (b *builtinTimeIsNullSig) Clone() builtinFunc {
 }
 
 func (b *builtinTimeIsNullSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	_, isNull, err := b.args[0].EvalTime(ctx, row)
 	return evalIsNull(isNull, err)
 }

--- a/pkg/expression/builtin_op_vec.go
+++ b/pkg/expression/builtin_op_vec.go
@@ -36,7 +36,7 @@ func (b *builtinTimeIsNullSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 	}
 	defer b.bufAllocator.put(buf)
 
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -75,7 +75,7 @@ func (b *builtinLogicOrSig) fallbackEvalInt(ctx sessionctx.Context, input *chunk
 }
 
 func (b *builtinLogicOrSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -86,9 +86,9 @@ func (b *builtinLogicOrSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chun
 	}
 	defer b.bufAllocator.put(buf)
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalInt(b.ctx, input, buf)
+	err = b.args[1].VecEvalInt(ctx, input, buf)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -128,7 +128,7 @@ func (b *builtinBitOrSig) vectorized() bool {
 }
 
 func (b *builtinBitOrSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	numRows := input.NumRows()
@@ -137,7 +137,7 @@ func (b *builtinBitOrSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	arg0s := result.Int64s()
@@ -161,7 +161,7 @@ func (b *builtinDecimalIsFalseSig) vecEvalInt(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -190,7 +190,7 @@ func (b *builtinIntIsFalseSig) vectorized() bool {
 
 func (b *builtinIntIsFalseSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	i64s := result.Int64s()
@@ -217,7 +217,7 @@ func (b *builtinUnaryMinusRealSig) vectorized() bool {
 
 func (b *builtinUnaryMinusRealSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	var err error
-	if err = b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+	if err = b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -234,7 +234,7 @@ func (b *builtinBitNegSig) vectorized() bool {
 }
 
 func (b *builtinBitNegSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -250,7 +250,7 @@ func (b *builtinUnaryMinusDecimalSig) vectorized() bool {
 }
 
 func (b *builtinUnaryMinusDecimalSig) vecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -270,7 +270,7 @@ func (b *builtinIntIsNullSig) vectorized() bool {
 }
 
 func (b *builtinIntIsNullSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -298,7 +298,7 @@ func (b *builtinRealIsNullSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 	}
 	defer b.bufAllocator.put(buf)
 
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -325,7 +325,7 @@ func (b *builtinUnaryNotRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 	f64s := buf.Float64s()
@@ -371,7 +371,7 @@ func (b *builtinLogicAndSig) fallbackEvalInt(ctx sessionctx.Context, input *chun
 func (b *builtinLogicAndSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -381,9 +381,9 @@ func (b *builtinLogicAndSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 	}
 	defer b.bufAllocator.put(buf1)
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEvalInt(b.ctx, input, buf1)
+	err = b.args[1].VecEvalInt(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -425,7 +425,7 @@ func (b *builtinBitXorSig) vectorized() bool {
 }
 
 func (b *builtinBitXorSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	numRows := input.NumRows()
@@ -434,7 +434,7 @@ func (b *builtinBitXorSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	arg0s := result.Int64s()
@@ -451,7 +451,7 @@ func (b *builtinLogicXorSig) vectorized() bool {
 }
 
 func (b *builtinLogicXorSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -461,7 +461,7 @@ func (b *builtinLogicXorSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -490,7 +490,7 @@ func (b *builtinBitAndSig) vectorized() bool {
 }
 
 func (b *builtinBitAndSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	numRows := input.NumRows()
@@ -499,7 +499,7 @@ func (b *builtinBitAndSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	arg0s := result.Int64s()
@@ -522,7 +522,7 @@ func (b *builtinRealIsFalseSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -549,7 +549,7 @@ func (b *builtinUnaryMinusIntSig) vectorized() bool {
 }
 
 func (b *builtinUnaryMinusIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	n := input.NumRows()
@@ -589,7 +589,7 @@ func (b *builtinUnaryNotDecimalSig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 	decs := buf.Decimals()
@@ -616,7 +616,7 @@ func (b *builtinUnaryNotIntSig) vectorized() bool {
 
 func (b *builtinUnaryNotIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -646,7 +646,7 @@ func (b *builtinDecimalIsNullSig) vecEvalInt(ctx sessionctx.Context, input *chun
 	}
 	defer b.bufAllocator.put(buf)
 
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -667,7 +667,7 @@ func (b *builtinLeftShiftSig) vectorized() bool {
 }
 
 func (b *builtinLeftShiftSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	numRows := input.NumRows()
@@ -676,7 +676,7 @@ func (b *builtinLeftShiftSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	arg0s := result.Int64s()
@@ -693,7 +693,7 @@ func (b *builtinRightShiftSig) vectorized() bool {
 }
 
 func (b *builtinRightShiftSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	numRows := input.NumRows()
@@ -702,7 +702,7 @@ func (b *builtinRightShiftSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	arg0s := result.Int64s()
@@ -726,7 +726,7 @@ func (b *builtinRealIsTrueSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 	}
 	defer b.bufAllocator.put(buf)
 
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(numRows, false)
@@ -758,7 +758,7 @@ func (b *builtinDecimalIsTrueSig) vecEvalInt(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -787,7 +787,7 @@ func (b *builtinIntIsTrueSig) vectorized() bool {
 
 func (b *builtinIntIsTrueSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 	i64s := result.Int64s()
@@ -818,7 +818,7 @@ func (b *builtinDurationIsNullSig) vecEvalInt(ctx sessionctx.Context, input *chu
 	}
 	defer b.bufAllocator.put(buf)
 
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
 

--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -197,7 +197,7 @@ func (b *builtinInIntSig) buildHashMapForConstArgs(ctx sessionctx.Context) error
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = make(map[int64]bool, len(b.args)-1)
 	for i := 1; i < len(b.args); i++ {
-		if b.args[i].ConstItem(b.ctx.GetSessionVars().StmtCtx) {
+		if b.args[i].ConstItem(ctx.GetSessionVars().StmtCtx) {
 			val, isNull, err := b.args[i].EvalInt(ctx, chunk.Row{})
 			if err != nil {
 				return err
@@ -225,7 +225,7 @@ func (b *builtinInIntSig) Clone() builtinFunc {
 }
 
 func (b *builtinInIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalInt(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, err
 	}
@@ -249,7 +249,7 @@ func (b *builtinInIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64,
 
 	hasNull := b.hasNull
 	for _, arg := range args {
-		evaledArg, isNull, err := arg.EvalInt(b.ctx, row)
+		evaledArg, isNull, err := arg.EvalInt(ctx, row)
 		if err != nil {
 			return 0, true, err
 		}
@@ -290,7 +290,7 @@ func (b *builtinInStringSig) buildHashMapForConstArgs(ctx sessionctx.Context) er
 	b.hashSet = set.NewStringSet()
 	collator := collate.GetCollator(b.collation)
 	for i := 1; i < len(b.args); i++ {
-		if b.args[i].ConstItem(b.ctx.GetSessionVars().StmtCtx) {
+		if b.args[i].ConstItem(ctx.GetSessionVars().StmtCtx) {
 			val, isNull, err := b.args[i].EvalString(ctx, chunk.Row{})
 			if err != nil {
 				return err
@@ -319,7 +319,7 @@ func (b *builtinInStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinInStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull0, err := b.args[0].EvalString(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalString(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, err
 	}
@@ -338,7 +338,7 @@ func (b *builtinInStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int
 
 	hasNull := b.hasNull
 	for _, arg := range args {
-		evaledArg, isNull, err := arg.EvalString(b.ctx, row)
+		evaledArg, isNull, err := arg.EvalString(ctx, row)
 		if err != nil {
 			return 0, true, err
 		}
@@ -363,7 +363,7 @@ func (b *builtinInRealSig) buildHashMapForConstArgs(ctx sessionctx.Context) erro
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = set.NewFloat64Set()
 	for i := 1; i < len(b.args); i++ {
-		if b.args[i].ConstItem(b.ctx.GetSessionVars().StmtCtx) {
+		if b.args[i].ConstItem(ctx.GetSessionVars().StmtCtx) {
 			val, isNull, err := b.args[i].EvalReal(ctx, chunk.Row{})
 			if err != nil {
 				return err
@@ -392,7 +392,7 @@ func (b *builtinInRealSig) Clone() builtinFunc {
 }
 
 func (b *builtinInRealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull0, err := b.args[0].EvalReal(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalReal(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, err
 	}
@@ -409,7 +409,7 @@ func (b *builtinInRealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64
 
 	hasNull := b.hasNull
 	for _, arg := range args {
-		evaledArg, isNull, err := arg.EvalReal(b.ctx, row)
+		evaledArg, isNull, err := arg.EvalReal(ctx, row)
 		if err != nil {
 			return 0, true, err
 		}
@@ -434,7 +434,7 @@ func (b *builtinInDecimalSig) buildHashMapForConstArgs(ctx sessionctx.Context) e
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = set.NewStringSet()
 	for i := 1; i < len(b.args); i++ {
-		if b.args[i].ConstItem(b.ctx.GetSessionVars().StmtCtx) {
+		if b.args[i].ConstItem(ctx.GetSessionVars().StmtCtx) {
 			val, isNull, err := b.args[i].EvalDecimal(ctx, chunk.Row{})
 			if err != nil {
 				return err
@@ -467,7 +467,7 @@ func (b *builtinInDecimalSig) Clone() builtinFunc {
 }
 
 func (b *builtinInDecimalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull0, err := b.args[0].EvalDecimal(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalDecimal(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, err
 	}
@@ -489,7 +489,7 @@ func (b *builtinInDecimalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (in
 
 	hasNull := b.hasNull
 	for _, arg := range args {
-		evaledArg, isNull, err := arg.EvalDecimal(b.ctx, row)
+		evaledArg, isNull, err := arg.EvalDecimal(ctx, row)
 		if err != nil {
 			return 0, true, err
 		}
@@ -514,7 +514,7 @@ func (b *builtinInTimeSig) buildHashMapForConstArgs(ctx sessionctx.Context) erro
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = make(map[types.CoreTime]struct{}, len(b.args)-1)
 	for i := 1; i < len(b.args); i++ {
-		if b.args[i].ConstItem(b.ctx.GetSessionVars().StmtCtx) {
+		if b.args[i].ConstItem(ctx.GetSessionVars().StmtCtx) {
 			val, isNull, err := b.args[i].EvalTime(ctx, chunk.Row{})
 			if err != nil {
 				return err
@@ -543,7 +543,7 @@ func (b *builtinInTimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinInTimeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull0, err := b.args[0].EvalTime(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalTime(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, err
 	}
@@ -560,7 +560,7 @@ func (b *builtinInTimeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64
 
 	hasNull := b.hasNull
 	for _, arg := range args {
-		evaledArg, isNull, err := arg.EvalTime(b.ctx, row)
+		evaledArg, isNull, err := arg.EvalTime(ctx, row)
 		if err != nil {
 			return 0, true, err
 		}
@@ -585,7 +585,7 @@ func (b *builtinInDurationSig) buildHashMapForConstArgs(ctx sessionctx.Context) 
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = make(map[time.Duration]struct{}, len(b.args)-1)
 	for i := 1; i < len(b.args); i++ {
-		if b.args[i].ConstItem(b.ctx.GetSessionVars().StmtCtx) {
+		if b.args[i].ConstItem(ctx.GetSessionVars().StmtCtx) {
 			val, isNull, err := b.args[i].EvalDuration(ctx, chunk.Row{})
 			if err != nil {
 				return err
@@ -614,7 +614,7 @@ func (b *builtinInDurationSig) Clone() builtinFunc {
 }
 
 func (b *builtinInDurationSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull0, err := b.args[0].EvalDuration(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalDuration(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, err
 	}
@@ -631,7 +631,7 @@ func (b *builtinInDurationSig) evalInt(ctx sessionctx.Context, row chunk.Row) (i
 
 	hasNull := b.hasNull
 	for _, arg := range args {
-		evaledArg, isNull, err := arg.EvalDuration(b.ctx, row)
+		evaledArg, isNull, err := arg.EvalDuration(ctx, row)
 		if err != nil {
 			return 0, true, err
 		}
@@ -658,13 +658,13 @@ func (b *builtinInJSONSig) Clone() builtinFunc {
 }
 
 func (b *builtinInJSONSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg0, isNull0, err := b.args[0].EvalJSON(b.ctx, row)
+	arg0, isNull0, err := b.args[0].EvalJSON(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, err
 	}
 	var hasNull bool
 	for _, arg := range b.args[1:] {
-		evaledArg, isNull, err := arg.EvalJSON(b.ctx, row)
+		evaledArg, isNull, err := arg.EvalJSON(ctx, row)
 		if err != nil {
 			return 0, true, err
 		}
@@ -761,8 +761,8 @@ func (b *builtinSetStringVarSig) Clone() builtinFunc {
 
 func (b *builtinSetStringVarSig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
 	var varName string
-	sessionVars := b.ctx.GetSessionVars()
-	varName, isNull, err = b.args[0].EvalString(b.ctx, row)
+	sessionVars := ctx.GetSessionVars()
+	varName, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -791,8 +791,8 @@ func (b *builtinSetRealVarSig) Clone() builtinFunc {
 
 func (b *builtinSetRealVarSig) evalReal(ctx sessionctx.Context, row chunk.Row) (res float64, isNull bool, err error) {
 	var varName string
-	sessionVars := b.ctx.GetSessionVars()
-	varName, isNull, err = b.args[0].EvalString(b.ctx, row)
+	sessionVars := ctx.GetSessionVars()
+	varName, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -818,8 +818,8 @@ func (b *builtinSetDecimalVarSig) Clone() builtinFunc {
 }
 
 func (b *builtinSetDecimalVarSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	sessionVars := b.ctx.GetSessionVars()
-	varName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sessionVars := ctx.GetSessionVars()
+	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
@@ -845,8 +845,8 @@ func (b *builtinSetIntVarSig) Clone() builtinFunc {
 }
 
 func (b *builtinSetIntVarSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	sessionVars := b.ctx.GetSessionVars()
-	varName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sessionVars := ctx.GetSessionVars()
+	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -872,14 +872,14 @@ func (b *builtinSetTimeVarSig) Clone() builtinFunc {
 }
 
 func (b *builtinSetTimeVarSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	sessionVars := b.ctx.GetSessionVars()
-	varName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sessionVars := ctx.GetSessionVars()
+	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, isNull, err
 	}
 	datum, err := b.args[1].Eval(row)
 	if err != nil || datum.IsNull() {
-		return types.ZeroTime, datum.IsNull(), handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, datum.IsNull(), handleInvalidTimeError(ctx, err)
 	}
 	res := datum.GetMysqlTime()
 	varName = strings.ToLower(varName)
@@ -913,6 +913,7 @@ func BuildGetVarFunction(ctx sessionctx.Context, expr Expression, retType *types
 		FuncName: model.NewCIStr(ast.GetVar),
 		RetType:  retType,
 		Function: f,
+		ctx:      ctx,
 	}, nil
 }
 
@@ -954,8 +955,8 @@ func (b *builtinGetStringVarSig) Clone() builtinFunc {
 }
 
 func (b *builtinGetStringVarSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	sessionVars := b.ctx.GetSessionVars()
-	varName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sessionVars := ctx.GetSessionVars()
+	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -1006,8 +1007,8 @@ func (b *builtinGetIntVarSig) Clone() builtinFunc {
 }
 
 func (b *builtinGetIntVarSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	sessionVars := b.ctx.GetSessionVars()
-	varName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sessionVars := ctx.GetSessionVars()
+	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1046,8 +1047,8 @@ func (b *builtinGetRealVarSig) Clone() builtinFunc {
 }
 
 func (b *builtinGetRealVarSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	sessionVars := b.ctx.GetSessionVars()
-	varName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sessionVars := ctx.GetSessionVars()
+	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1086,8 +1087,8 @@ func (b *builtinGetDecimalVarSig) Clone() builtinFunc {
 }
 
 func (b *builtinGetDecimalVarSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	sessionVars := b.ctx.GetSessionVars()
-	varName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sessionVars := ctx.GetSessionVars()
+	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
@@ -1134,8 +1135,8 @@ func (b *builtinGetTimeVarSig) Clone() builtinFunc {
 }
 
 func (b *builtinGetTimeVarSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	sessionVars := b.ctx.GetSessionVars()
-	varName, isNull, err := b.args[0].EvalString(b.ctx, row)
+	sessionVars := ctx.GetSessionVars()
+	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, isNull, err
 	}
@@ -1195,7 +1196,7 @@ func (b *builtinValuesIntSig) Clone() builtinFunc {
 // evalInt evals a builtinValuesIntSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_values
 func (b *builtinValuesIntSig) evalInt(ctx sessionctx.Context, _ chunk.Row) (int64, bool, error) {
-	row := b.ctx.GetSessionVars().CurrInsertValues
+	row := ctx.GetSessionVars().CurrInsertValues
 	if row.IsEmpty() {
 		return 0, true, nil
 	}
@@ -1210,7 +1211,7 @@ func (b *builtinValuesIntSig) evalInt(ctx sessionctx.Context, _ chunk.Row) (int6
 		}
 		if len(val) < 8 {
 			var binary types.BinaryLiteral = val
-			v, err := binary.ToInt(b.ctx.GetSessionVars().StmtCtx.TypeCtx())
+			v, err := binary.ToInt(ctx.GetSessionVars().StmtCtx.TypeCtx())
 			if err != nil {
 				return 0, true, errors.Trace(err)
 			}
@@ -1236,7 +1237,7 @@ func (b *builtinValuesRealSig) Clone() builtinFunc {
 // evalReal evals a builtinValuesRealSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_values
 func (b *builtinValuesRealSig) evalReal(ctx sessionctx.Context, _ chunk.Row) (float64, bool, error) {
-	row := b.ctx.GetSessionVars().CurrInsertValues
+	row := ctx.GetSessionVars().CurrInsertValues
 	if row.IsEmpty() {
 		return 0, true, nil
 	}
@@ -1267,7 +1268,7 @@ func (b *builtinValuesDecimalSig) Clone() builtinFunc {
 // evalDecimal evals a builtinValuesDecimalSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_values
 func (b *builtinValuesDecimalSig) evalDecimal(ctx sessionctx.Context, _ chunk.Row) (*types.MyDecimal, bool, error) {
-	row := b.ctx.GetSessionVars().CurrInsertValues
+	row := ctx.GetSessionVars().CurrInsertValues
 	if row.IsEmpty() {
 		return &types.MyDecimal{}, true, nil
 	}
@@ -1295,7 +1296,7 @@ func (b *builtinValuesStringSig) Clone() builtinFunc {
 // evalString evals a builtinValuesStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_values
 func (b *builtinValuesStringSig) evalString(ctx sessionctx.Context, _ chunk.Row) (string, bool, error) {
-	row := b.ctx.GetSessionVars().CurrInsertValues
+	row := ctx.GetSessionVars().CurrInsertValues
 	if row.IsEmpty() {
 		return "", true, nil
 	}
@@ -1332,7 +1333,7 @@ func (b *builtinValuesTimeSig) Clone() builtinFunc {
 // evalTime evals a builtinValuesTimeSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_values
 func (b *builtinValuesTimeSig) evalTime(ctx sessionctx.Context, _ chunk.Row) (types.Time, bool, error) {
-	row := b.ctx.GetSessionVars().CurrInsertValues
+	row := ctx.GetSessionVars().CurrInsertValues
 	if row.IsEmpty() {
 		return types.ZeroTime, true, nil
 	}
@@ -1360,7 +1361,7 @@ func (b *builtinValuesDurationSig) Clone() builtinFunc {
 // evalDuration evals a builtinValuesDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_values
 func (b *builtinValuesDurationSig) evalDuration(ctx sessionctx.Context, _ chunk.Row) (types.Duration, bool, error) {
-	row := b.ctx.GetSessionVars().CurrInsertValues
+	row := ctx.GetSessionVars().CurrInsertValues
 	if row.IsEmpty() {
 		return types.Duration{}, true, nil
 	}
@@ -1389,7 +1390,7 @@ func (b *builtinValuesJSONSig) Clone() builtinFunc {
 // evalJSON evals a builtinValuesJSONSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_values
 func (b *builtinValuesJSONSig) evalJSON(ctx sessionctx.Context, _ chunk.Row) (types.BinaryJSON, bool, error) {
-	row := b.ctx.GetSessionVars().CurrInsertValues
+	row := ctx.GetSessionVars().CurrInsertValues
 	if row.IsEmpty() {
 		return types.BinaryJSON{}, true, nil
 	}
@@ -1432,7 +1433,7 @@ func (b *builtinBitCountSig) Clone() builtinFunc {
 // evalInt evals BIT_COUNT(N).
 // See https://dev.mysql.com/doc/refman/5.7/en/bit-functions.html#function_bit-count
 func (b *builtinBitCountSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	n, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	n, isNull, err := b.args[0].EvalInt(ctx, row)
 	if err != nil || isNull {
 		if err != nil && types.ErrOverflow.Equal(err) {
 			return 64, false, nil
@@ -1473,8 +1474,8 @@ func (b *builtinGetParamStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinGetParamStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	sessionVars := b.ctx.GetSessionVars()
-	idx, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	sessionVars := ctx.GetSessionVars()
+	idx, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}

--- a/pkg/expression/builtin_other_vec.go
+++ b/pkg/expression/builtin_other_vec.go
@@ -96,7 +96,7 @@ func (b *builtinBitCountSig) vectorized() bool {
 }
 func (b *builtinBitCountSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		if types.ErrOverflow.Equal(err) {
 			result.ResizeInt64(n, false)
 			i64s := result.Int64s()
@@ -127,14 +127,14 @@ func (b *builtinGetParamStringSig) vectorized() bool {
 }
 
 func (b *builtinGetParamStringSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := ctx.GetSessionVars()
 	n := input.NumRows()
 	idx, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(idx)
-	if err := b.args[0].VecEvalInt(b.ctx, input, idx); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, idx); err != nil {
 		return err
 	}
 	idxIs := idx.Int64s()
@@ -167,7 +167,7 @@ func (b *builtinSetStringVarSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -175,11 +175,11 @@ func (b *builtinSetStringVarSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 	result.ReserveString(n)
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := ctx.GetSessionVars()
 	_, collation := sessionVars.GetCharsetInfo()
 	for i := 0; i < n; i++ {
 		if buf0.IsNull(i) || buf1.IsNull(i) {
@@ -205,7 +205,7 @@ func (b *builtinSetIntVarSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -213,12 +213,12 @@ func (b *builtinSetIntVarSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := ctx.GetSessionVars()
 	for i := 0; i < n; i++ {
 		if buf0.IsNull(i) || buf1.IsNull(i) {
 			result.SetNull(i, true)
@@ -243,7 +243,7 @@ func (b *builtinSetRealVarSig) vecEvalReal(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -251,12 +251,12 @@ func (b *builtinSetRealVarSig) vecEvalReal(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 	result.ResizeFloat64(n, false)
 	f64s := result.Float64s()
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := ctx.GetSessionVars()
 	for i := 0; i < n; i++ {
 		if buf0.IsNull(i) || buf1.IsNull(i) {
 			result.SetNull(i, true)
@@ -281,7 +281,7 @@ func (b *builtinSetDecimalVarSig) vecEvalDecimal(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -289,12 +289,12 @@ func (b *builtinSetDecimalVarSig) vecEvalDecimal(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
 	result.ResizeDecimal(n, false)
 	decs := result.Decimals()
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := ctx.GetSessionVars()
 	for i := 0; i < n; i++ {
 		if buf0.IsNull(i) || buf1.IsNull(i) {
 			result.SetNull(i, true)
@@ -327,11 +327,11 @@ func (b *builtinGetStringVarSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	result.ReserveString(n)
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := ctx.GetSessionVars()
 	for i := 0; i < n; i++ {
 		if buf0.IsNull(i) {
 			result.AppendNull()
@@ -362,13 +362,13 @@ func (b *builtinGetIntVarSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
 	result.MergeNulls(buf0)
 	i64s := result.Int64s()
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := ctx.GetSessionVars()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -394,13 +394,13 @@ func (b *builtinGetRealVarSig) vecEvalReal(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	result.ResizeFloat64(n, false)
 	result.MergeNulls(buf0)
 	f64s := result.Float64s()
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := ctx.GetSessionVars()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -426,13 +426,13 @@ func (b *builtinGetDecimalVarSig) vecEvalDecimal(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	result.ResizeDecimal(n, false)
 	result.MergeNulls(buf0)
 	decs := result.Decimals()
-	sessionVars := b.ctx.GetSessionVars()
+	sessionVars := ctx.GetSessionVars()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue

--- a/pkg/expression/builtin_other_vec_generated.go
+++ b/pkg/expression/builtin_other_vec_generated.go
@@ -33,7 +33,7 @@ func (b *builtinInIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -82,7 +82,7 @@ func (b *builtinInIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 	}
 
 	for j := 0; j < len(args); j++ {
-		if err := args[j].VecEvalInt(b.ctx, input, buf1); err != nil {
+		if err := args[j].VecEvalInt(ctx, input, buf1); err != nil {
 			return err
 		}
 		isUnsigned := mysql.HasUnsignedFlag(args[j].GetType().GetFlag())
@@ -138,7 +138,7 @@ func (b *builtinInStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -180,7 +180,7 @@ func (b *builtinInStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 	}
 
 	for j := 0; j < len(args); j++ {
-		if err := args[j].VecEvalString(b.ctx, input, buf1); err != nil {
+		if err := args[j].VecEvalString(ctx, input, buf1); err != nil {
 			return err
 		}
 		for i := 0; i < n; i++ {
@@ -219,7 +219,7 @@ func (b *builtinInDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -265,7 +265,7 @@ func (b *builtinInDecimalSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 	}
 
 	for j := 0; j < len(args); j++ {
-		if err := args[j].VecEvalDecimal(b.ctx, input, buf1); err != nil {
+		if err := args[j].VecEvalDecimal(ctx, input, buf1); err != nil {
 			return err
 		}
 		args1 := buf1.Decimals()
@@ -309,7 +309,7 @@ func (b *builtinInRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -351,7 +351,7 @@ func (b *builtinInRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 	}
 
 	for j := 0; j < len(args); j++ {
-		if err := args[j].VecEvalReal(b.ctx, input, buf1); err != nil {
+		if err := args[j].VecEvalReal(ctx, input, buf1); err != nil {
 			return err
 		}
 		args1 := buf1.Float64s()
@@ -392,7 +392,7 @@ func (b *builtinInTimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -434,7 +434,7 @@ func (b *builtinInTimeSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 	}
 
 	for j := 0; j < len(args); j++ {
-		if err := args[j].VecEvalTime(b.ctx, input, buf1); err != nil {
+		if err := args[j].VecEvalTime(ctx, input, buf1); err != nil {
 			return err
 		}
 		args1 := buf1.Times()
@@ -475,7 +475,7 @@ func (b *builtinInDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -517,7 +517,7 @@ func (b *builtinInDurationSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 	}
 
 	for j := 0; j < len(args); j++ {
-		if err := args[j].VecEvalDuration(b.ctx, input, buf1); err != nil {
+		if err := args[j].VecEvalDuration(ctx, input, buf1); err != nil {
 			return err
 		}
 		args1 := buf1.GoDurations()
@@ -558,7 +558,7 @@ func (b *builtinInJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalJSON(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -577,7 +577,7 @@ func (b *builtinInJSONSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 	args := b.args[1:]
 
 	for j := 0; j < len(args); j++ {
-		if err := args[j].VecEvalJSON(b.ctx, input, buf1); err != nil {
+		if err := args[j].VecEvalJSON(ctx, input, buf1); err != nil {
 			return err
 		}
 		for i := 0; i < n; i++ {

--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -219,7 +219,7 @@ func (b *builtinLengthSig) Clone() builtinFunc {
 // evalInt evaluates a builtinLengthSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html
 func (b *builtinLengthSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -257,7 +257,7 @@ func (b *builtinASCIISig) Clone() builtinFunc {
 // evalInt evals a builtinASCIISig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_ascii
 func (b *builtinASCIISig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -327,12 +327,12 @@ func (b *builtinConcatSig) evalString(ctx sessionctx.Context, row chunk.Row) (d 
 	//nolint: prealloc
 	var s []byte
 	for _, a := range b.getArgs() {
-		d, isNull, err = a.EvalString(b.ctx, row)
+		d, isNull, err = a.EvalString(ctx, row)
 		if isNull || err != nil {
 			return d, isNull, err
 		}
 		if uint64(len(s)+len(d)) > b.maxAllowedPacket {
-			return "", true, handleAllowedPacketOverflowed(b.ctx, "concat", b.maxAllowedPacket)
+			return "", true, handleAllowedPacketOverflowed(ctx, "concat", b.maxAllowedPacket)
 		}
 		s = append(s, []byte(d)...)
 	}
@@ -413,7 +413,7 @@ func (b *builtinConcatWSSig) evalString(ctx sessionctx.Context, row chunk.Row) (
 
 	N := len(args)
 	if N > 0 {
-		val, isNull, err := args[0].EvalString(b.ctx, row)
+		val, isNull, err := args[0].EvalString(ctx, row)
 		if err != nil || isNull {
 			// If the separator is NULL, the result is NULL.
 			return val, isNull, err
@@ -421,7 +421,7 @@ func (b *builtinConcatWSSig) evalString(ctx sessionctx.Context, row chunk.Row) (
 		sep = val
 	}
 	for i := 1; i < N; i++ {
-		val, isNull, err := args[i].EvalString(b.ctx, row)
+		val, isNull, err := args[i].EvalString(ctx, row)
 		if err != nil {
 			return val, isNull, err
 		}
@@ -436,7 +436,7 @@ func (b *builtinConcatWSSig) evalString(ctx sessionctx.Context, row chunk.Row) (
 			targetLength += len(sep)
 		}
 		if uint64(targetLength) > b.maxAllowedPacket {
-			return "", true, handleAllowedPacketOverflowed(b.ctx, "concat_ws", b.maxAllowedPacket)
+			return "", true, handleAllowedPacketOverflowed(ctx, "concat_ws", b.maxAllowedPacket)
 		}
 		strs = append(strs, val)
 	}
@@ -487,11 +487,11 @@ func (b *builtinLeftSig) Clone() builtinFunc {
 // evalString evals LEFT(str,len).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_left
 func (b *builtinLeftSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	left, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	left, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -517,11 +517,11 @@ func (b *builtinLeftUTF8Sig) Clone() builtinFunc {
 // evalString evals LEFT(str,len).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_left
 func (b *builtinLeftUTF8Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	left, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	left, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -572,11 +572,11 @@ func (b *builtinRightSig) Clone() builtinFunc {
 // evalString evals RIGHT(str,len).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_right
 func (b *builtinRightSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	right, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	right, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -602,11 +602,11 @@ func (b *builtinRightUTF8Sig) Clone() builtinFunc {
 // evalString evals RIGHT(str,len).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_right
 func (b *builtinRightUTF8Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	right, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	right, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -659,13 +659,13 @@ func (b *builtinRepeatSig) Clone() builtinFunc {
 // evalString evals a builtinRepeatSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_repeat
 func (b *builtinRepeatSig) evalString(ctx sessionctx.Context, row chunk.Row) (val string, isNull bool, err error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
 	byteLength := len(str)
 
-	num, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	num, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -677,7 +677,7 @@ func (b *builtinRepeatSig) evalString(ctx sessionctx.Context, row chunk.Row) (va
 	}
 
 	if uint64(byteLength)*uint64(num) > b.maxAllowedPacket {
-		return "", true, handleAllowedPacketOverflowed(b.ctx, "repeat", b.maxAllowedPacket)
+		return "", true, handleAllowedPacketOverflowed(ctx, "repeat", b.maxAllowedPacket)
 	}
 
 	return strings.Repeat(str, int(num)), false, nil
@@ -722,7 +722,7 @@ func (b *builtinLowerUTF8Sig) Clone() builtinFunc {
 // evalString evals a builtinLowerUTF8Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_lower
 func (b *builtinLowerUTF8Sig) evalString(ctx sessionctx.Context, row chunk.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(b.ctx, row)
+	d, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -743,7 +743,7 @@ func (b *builtinLowerSig) Clone() builtinFunc {
 // evalString evals a builtinLowerSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_lower
 func (b *builtinLowerSig) evalString(ctx sessionctx.Context, row chunk.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(b.ctx, row)
+	d, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -791,7 +791,7 @@ func (b *builtinReverseSig) Clone() builtinFunc {
 // evalString evals a REVERSE(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_reverse
 func (b *builtinReverseSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -812,7 +812,7 @@ func (b *builtinReverseUTF8Sig) Clone() builtinFunc {
 // evalString evals a REVERSE(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_reverse
 func (b *builtinReverseUTF8Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -863,7 +863,7 @@ func (b *builtinSpaceSig) Clone() builtinFunc {
 func (b *builtinSpaceSig) evalString(ctx sessionctx.Context, row chunk.Row) (d string, isNull bool, err error) {
 	var x int64
 
-	x, isNull, err = b.args[0].EvalInt(b.ctx, row)
+	x, isNull, err = b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -871,7 +871,7 @@ func (b *builtinSpaceSig) evalString(ctx sessionctx.Context, row chunk.Row) (d s
 		x = 0
 	}
 	if uint64(x) > b.maxAllowedPacket {
-		return d, true, handleAllowedPacketOverflowed(b.ctx, "space", b.maxAllowedPacket)
+		return d, true, handleAllowedPacketOverflowed(ctx, "space", b.maxAllowedPacket)
 	}
 	if x > mysql.MaxBlobWidth {
 		return d, true, nil
@@ -918,7 +918,7 @@ func (b *builtinUpperUTF8Sig) Clone() builtinFunc {
 // evalString evals a builtinUpperUTF8Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_upper
 func (b *builtinUpperUTF8Sig) evalString(ctx sessionctx.Context, row chunk.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(b.ctx, row)
+	d, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -939,7 +939,7 @@ func (b *builtinUpperSig) Clone() builtinFunc {
 // evalString evals a builtinUpperSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_upper
 func (b *builtinUpperSig) evalString(ctx sessionctx.Context, row chunk.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(b.ctx, row)
+	d, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -985,11 +985,11 @@ func (b *builtinStrcmpSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64
 		err         error
 	)
 
-	left, isNull, err = b.args[0].EvalString(b.ctx, row)
+	left, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	right, isNull, err = b.args[1].EvalString(b.ctx, row)
+	right, isNull, err = b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1044,15 +1044,15 @@ func (b *builtinReplaceSig) Clone() builtinFunc {
 func (b *builtinReplaceSig) evalString(ctx sessionctx.Context, row chunk.Row) (d string, isNull bool, err error) {
 	var str, oldStr, newStr string
 
-	str, isNull, err = b.args[0].EvalString(b.ctx, row)
+	str, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
-	oldStr, isNull, err = b.args[1].EvalString(b.ctx, row)
+	oldStr, isNull, err = b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
-	newStr, isNull, err = b.args[2].EvalString(b.ctx, row)
+	newStr, isNull, err = b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -1128,7 +1128,7 @@ func (b *builtinConvertSig) Clone() builtinFunc {
 // Syntax CONVERT(expr, type) is parsed as cast expr so not handled here.
 // See https://dev.mysql.com/doc/refman/5.7/en/cast-functions.html#function_convert
 func (b *builtinConvertSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	expr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	expr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -1210,11 +1210,11 @@ func (b *builtinSubstring2ArgsSig) Clone() builtinFunc {
 // evalString evals SUBSTR(str,pos), SUBSTR(str FROM pos), SUBSTR() is a synonym for SUBSTRING().
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
 func (b *builtinSubstring2ArgsSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	pos, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -1243,11 +1243,11 @@ func (b *builtinSubstring2ArgsUTF8Sig) Clone() builtinFunc {
 // evalString evals SUBSTR(str,pos), SUBSTR(str FROM pos), SUBSTR() is a synonym for SUBSTRING().
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
 func (b *builtinSubstring2ArgsUTF8Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	pos, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -1277,15 +1277,15 @@ func (b *builtinSubstring3ArgsSig) Clone() builtinFunc {
 // evalString evals SUBSTR(str,pos,len), SUBSTR(str FROM pos FOR len), SUBSTR() is a synonym for SUBSTRING().
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
 func (b *builtinSubstring3ArgsSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	pos, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
+	length, isNull, err := b.args[2].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -1320,15 +1320,15 @@ func (b *builtinSubstring3ArgsUTF8Sig) Clone() builtinFunc {
 // evalString evals SUBSTR(str,pos,len), SUBSTR(str FROM pos FOR len), SUBSTR() is a synonym for SUBSTRING().
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
 func (b *builtinSubstring3ArgsUTF8Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	pos, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
+	length, isNull, err := b.args[2].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -1388,15 +1388,15 @@ func (b *builtinSubstringIndexSig) evalString(ctx sessionctx.Context, row chunk.
 		str, delim string
 		count      int64
 	)
-	str, isNull, err = b.args[0].EvalString(b.ctx, row)
+	str, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
-	delim, isNull, err = b.args[1].EvalString(b.ctx, row)
+	delim, isNull, err = b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
-	count, isNull, err = b.args[2].EvalInt(b.ctx, row)
+	count, isNull, err = b.args[2].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -1480,11 +1480,11 @@ func (b *builtinLocate2ArgsSig) Clone() builtinFunc {
 // evalInt evals LOCATE(substr,str), case-sensitive.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocate2ArgsSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	subStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	str, isNull, err := b.args[1].EvalString(b.ctx, row)
+	str, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1512,11 +1512,11 @@ func (b *builtinLocate2ArgsUTF8Sig) Clone() builtinFunc {
 // evalInt evals LOCATE(substr,str).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocate2ArgsUTF8Sig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	subStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	str, isNull, err := b.args[1].EvalString(b.ctx, row)
+	str, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1540,15 +1540,15 @@ func (b *builtinLocate3ArgsSig) Clone() builtinFunc {
 // evalInt evals LOCATE(substr,str,pos), case-sensitive.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocate3ArgsSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	subStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	str, isNull, err := b.args[1].EvalString(b.ctx, row)
+	str, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	pos, isNull, err := b.args[2].EvalInt(b.ctx, row)
+	pos, isNull, err := b.args[2].EvalInt(ctx, row)
 	// Transfer the argument which starts from 1 to real index which starts from 0.
 	pos--
 	if isNull || err != nil {
@@ -1581,11 +1581,11 @@ func (b *builtinLocate3ArgsUTF8Sig) Clone() builtinFunc {
 // evalInt evals LOCATE(substr,str,pos).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocate3ArgsUTF8Sig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	subStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	str, isNull, err := b.args[1].EvalString(b.ctx, row)
+	str, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1593,7 +1593,7 @@ func (b *builtinLocate3ArgsUTF8Sig) evalInt(ctx sessionctx.Context, row chunk.Ro
 		subStr = strings.ToLower(subStr)
 		str = strings.ToLower(str)
 	}
-	pos, isNull, err := b.args[2].EvalInt(b.ctx, row)
+	pos, isNull, err := b.args[2].EvalInt(ctx, row)
 	// Transfer the argument which starts from 1 to real index which starts from 0.
 	pos--
 	if isNull || err != nil {
@@ -1666,7 +1666,7 @@ func (b *builtinHexStrArgSig) Clone() builtinFunc {
 // evalString evals a builtinHexStrArgSig, corresponding to hex(str)
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_hex
 func (b *builtinHexStrArgSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	d, isNull, err := b.args[0].EvalString(b.ctx, row)
+	d, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -1686,7 +1686,7 @@ func (b *builtinHexIntArgSig) Clone() builtinFunc {
 // evalString evals a builtinHexIntArgSig, corresponding to hex(N)
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_hex
 func (b *builtinHexIntArgSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	x, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	x, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -1748,7 +1748,7 @@ func (b *builtinUnHexSig) Clone() builtinFunc {
 func (b *builtinUnHexSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
 	var bs []byte
 
-	d, isNull, err := b.args[0].EvalString(b.ctx, row)
+	d, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -1831,7 +1831,7 @@ func (b *builtinTrim1ArgSig) Clone() builtinFunc {
 // evalString evals a builtinTrim1ArgSig, corresponding to trim(str)
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_trim
 func (b *builtinTrim1ArgSig) evalString(ctx sessionctx.Context, row chunk.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(b.ctx, row)
+	d, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -1853,11 +1853,11 @@ func (b *builtinTrim2ArgsSig) Clone() builtinFunc {
 func (b *builtinTrim2ArgsSig) evalString(ctx sessionctx.Context, row chunk.Row) (d string, isNull bool, err error) {
 	var str, remstr string
 
-	str, isNull, err = b.args[0].EvalString(b.ctx, row)
+	str, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
-	remstr, isNull, err = b.args[1].EvalString(b.ctx, row)
+	remstr, isNull, err = b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -1885,15 +1885,15 @@ func (b *builtinTrim3ArgsSig) evalString(ctx sessionctx.Context, row chunk.Row) 
 		direction    ast.TrimDirectionType
 		isRemStrNull bool
 	)
-	str, isNull, err = b.args[0].EvalString(b.ctx, row)
+	str, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
-	remstr, isRemStrNull, err = b.args[1].EvalString(b.ctx, row)
+	remstr, isRemStrNull, err = b.args[1].EvalString(ctx, row)
 	if err != nil || isRemStrNull {
 		return d, isRemStrNull, err
 	}
-	x, isNull, err = b.args[2].EvalInt(b.ctx, row)
+	x, isNull, err = b.args[2].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -1943,7 +1943,7 @@ func (b *builtinLTrimSig) Clone() builtinFunc {
 // evalString evals a builtinLTrimSig
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_ltrim
 func (b *builtinLTrimSig) evalString(ctx sessionctx.Context, row chunk.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(b.ctx, row)
+	d, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -1983,7 +1983,7 @@ func (b *builtinRTrimSig) Clone() builtinFunc {
 // evalString evals a builtinRTrimSig
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_rtrim
 func (b *builtinRTrimSig) evalString(ctx sessionctx.Context, row chunk.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(b.ctx, row)
+	d, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -2036,7 +2036,7 @@ func (c *lpadFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	bf.tp.SetFlen(getFlen4LpadAndRpad(bf.ctx, args[1]))
+	bf.tp.SetFlen(getFlen4LpadAndRpad(ctx, args[1]))
 	addBinFlag(bf.tp)
 
 	valStr, _ := ctx.GetSessionVars().GetSystemVar(variable.MaxAllowedPacket)
@@ -2073,23 +2073,23 @@ func (b *builtinLpadSig) Clone() builtinFunc {
 // evalString evals LPAD(str,len,padstr).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_lpad
 func (b *builtinLpadSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 	byteLength := len(str)
 
-	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	length, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 	targetLength := int(length)
 
 	if uint64(targetLength) > b.maxAllowedPacket {
-		return "", true, handleAllowedPacketOverflowed(b.ctx, "lpad", b.maxAllowedPacket)
+		return "", true, handleAllowedPacketOverflowed(ctx, "lpad", b.maxAllowedPacket)
 	}
 
-	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
+	padStr, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -2121,23 +2121,23 @@ func (b *builtinLpadUTF8Sig) Clone() builtinFunc {
 // evalString evals LPAD(str,len,padstr).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_lpad
 func (b *builtinLpadUTF8Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 	runeLength := len([]rune(str))
 
-	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	length, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 	targetLength := int(length)
 
 	if uint64(targetLength)*uint64(mysql.MaxBytesOfCharacter) > b.maxAllowedPacket {
-		return "", true, handleAllowedPacketOverflowed(b.ctx, "lpad", b.maxAllowedPacket)
+		return "", true, handleAllowedPacketOverflowed(ctx, "lpad", b.maxAllowedPacket)
 	}
 
-	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
+	padStr, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -2166,7 +2166,7 @@ func (c *rpadFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	bf.tp.SetFlen(getFlen4LpadAndRpad(bf.ctx, args[1]))
+	bf.tp.SetFlen(getFlen4LpadAndRpad(ctx, args[1]))
 	addBinFlag(bf.tp)
 
 	valStr, _ := ctx.GetSessionVars().GetSystemVar(variable.MaxAllowedPacket)
@@ -2203,22 +2203,22 @@ func (b *builtinRpadSig) Clone() builtinFunc {
 // evalString evals RPAD(str,len,padstr).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_rpad
 func (b *builtinRpadSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 	byteLength := len(str)
 
-	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	length, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 	targetLength := int(length)
 	if uint64(targetLength) > b.maxAllowedPacket {
-		return "", true, handleAllowedPacketOverflowed(b.ctx, "rpad", b.maxAllowedPacket)
+		return "", true, handleAllowedPacketOverflowed(ctx, "rpad", b.maxAllowedPacket)
 	}
 
-	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
+	padStr, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -2250,23 +2250,23 @@ func (b *builtinRpadUTF8Sig) Clone() builtinFunc {
 // evalString evals RPAD(str,len,padstr).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_rpad
 func (b *builtinRpadUTF8Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 	runeLength := len([]rune(str))
 
-	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	length, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 	targetLength := int(length)
 
 	if uint64(targetLength)*uint64(mysql.MaxBytesOfCharacter) > b.maxAllowedPacket {
-		return "", true, handleAllowedPacketOverflowed(b.ctx, "rpad", b.maxAllowedPacket)
+		return "", true, handleAllowedPacketOverflowed(ctx, "rpad", b.maxAllowedPacket)
 	}
 
-	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
+	padStr, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -2314,7 +2314,7 @@ func (b *builtinBitLengthSig) Clone() builtinFunc {
 // evalInt evaluates a builtinBitLengthSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_bit-length
 func (b *builtinBitLengthSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -2397,7 +2397,7 @@ func (b *builtinCharSig) evalString(ctx sessionctx.Context, row chunk.Row) (stri
 	bigints := make([]int64, 0, len(b.args)-1)
 
 	for i := 0; i < len(b.args)-1; i++ {
-		val, IsNull, err := b.args[i].EvalInt(b.ctx, row)
+		val, IsNull, err := b.args[i].EvalInt(ctx, row)
 		if err != nil {
 			return "", true, err
 		}
@@ -2411,8 +2411,8 @@ func (b *builtinCharSig) evalString(ctx sessionctx.Context, row chunk.Row) (stri
 	enc := charset.FindEncoding(b.tp.GetCharset())
 	res, err := enc.Transform(nil, dBytes, charset.OpDecode)
 	if err != nil {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
-		if b.ctx.GetSessionVars().StrictSQLMode {
+		ctx.GetSessionVars().StmtCtx.AppendWarning(err)
+		if ctx.GetSessionVars().StrictSQLMode {
 			return "", true, nil
 		}
 	}
@@ -2454,7 +2454,7 @@ func (b *builtinCharLengthBinarySig) Clone() builtinFunc {
 // evalInt evals a builtinCharLengthUTF8Sig for binary string type.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_char-length
 func (b *builtinCharLengthBinarySig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -2474,7 +2474,7 @@ func (b *builtinCharLengthUTF8Sig) Clone() builtinFunc {
 // evalInt evals a builtinCharLengthUTF8Sig for non-binary string type.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_char-length
 func (b *builtinCharLengthUTF8Sig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -2514,12 +2514,12 @@ func (b *builtinFindInSetSig) Clone() builtinFunc {
 // TODO: This function can be optimized by using bit arithmetic when the first argument is
 // a constant string and the second is a column of type SET.
 func (b *builtinFindInSetSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
-	strlist, isNull, err := b.args[1].EvalString(b.ctx, row)
+	strlist, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -2594,12 +2594,12 @@ func (b *builtinFieldIntSig) Clone() builtinFunc {
 // evalInt evals FIELD(str,str1,str2,str3,...).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_field
 func (b *builtinFieldIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	str, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	str, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, err != nil, err
 	}
 	for i, length := 1, len(b.args); i < length; i++ {
-		stri, isNull, err := b.args[i].EvalInt(b.ctx, row)
+		stri, isNull, err := b.args[i].EvalInt(ctx, row)
 		if err != nil {
 			return 0, true, err
 		}
@@ -2623,12 +2623,12 @@ func (b *builtinFieldRealSig) Clone() builtinFunc {
 // evalInt evals FIELD(str,str1,str2,str3,...).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_field
 func (b *builtinFieldRealSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	str, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	str, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return 0, err != nil, err
 	}
 	for i, length := 1, len(b.args); i < length; i++ {
-		stri, isNull, err := b.args[i].EvalReal(b.ctx, row)
+		stri, isNull, err := b.args[i].EvalReal(ctx, row)
 		if err != nil {
 			return 0, true, err
 		}
@@ -2652,12 +2652,12 @@ func (b *builtinFieldStringSig) Clone() builtinFunc {
 // evalInt evals FIELD(str,str1,str2,str3,...).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_field
 func (b *builtinFieldStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, err != nil, err
 	}
 	for i, length := 1, len(b.args); i < length; i++ {
-		stri, isNull, err := b.args[i].EvalString(b.ctx, row)
+		stri, isNull, err := b.args[i].EvalString(ctx, row)
 		if err != nil {
 			return 0, true, err
 		}
@@ -2709,7 +2709,7 @@ func (c *makeSetFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 		return nil, err
 	}
 	addBinFlag(bf.tp)
-	bf.tp.SetFlen(c.getFlen(bf.ctx, args))
+	bf.tp.SetFlen(c.getFlen(ctx, args))
 	if bf.tp.GetFlen() > mysql.MaxBlobWidth {
 		bf.tp.SetFlen(mysql.MaxBlobWidth)
 	}
@@ -2731,7 +2731,7 @@ func (b *builtinMakeSetSig) Clone() builtinFunc {
 // evalString evals MAKE_SET(bits,str1,str2,...).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_make-set
 func (b *builtinMakeSetSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	bits, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -2741,7 +2741,7 @@ func (b *builtinMakeSetSig) evalString(ctx sessionctx.Context, row chunk.Row) (s
 		if (bits & (1 << uint(i-1))) == 0 {
 			continue
 		}
-		str, isNull, err := b.args[i].EvalString(b.ctx, row)
+		str, isNull, err := b.args[i].EvalString(ctx, row)
 		if err != nil {
 			return "", true, err
 		}
@@ -2805,7 +2805,7 @@ func (b *builtinOctIntSig) Clone() builtinFunc {
 // evalString evals OCT(N).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_oct
 func (b *builtinOctIntSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -2826,7 +2826,7 @@ func (b *builtinOctStringSig) Clone() builtinFunc {
 // evalString evals OCT(N).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_oct
 func (b *builtinOctStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalString(b.ctx, row)
+	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -2885,7 +2885,7 @@ func (b *builtinOrdSig) Clone() builtinFunc {
 // evalInt evals a builtinOrdSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_ord
 func (b *builtinOrdSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -2947,7 +2947,7 @@ func (b *builtinQuoteSig) Clone() builtinFunc {
 // evalString evals QUOTE(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_quote
 func (b *builtinQuoteSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil {
 		return "", true, err
 	} else if isNull {
@@ -3017,7 +3017,7 @@ func (b *builtinBinSig) Clone() builtinFunc {
 // evalString evals BIN(N).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_bin
 func (b *builtinBinSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	val, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -3068,14 +3068,14 @@ func (b *builtinEltSig) Clone() builtinFunc {
 // evalString evals a ELT(N,str1,str2,str3,...).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_elt
 func (b *builtinEltSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	idx, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	idx, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 	if idx < 1 || idx >= int64(len(b.args)) {
 		return "", true, nil
 	}
-	arg, isNull, err := b.args[idx].EvalString(b.ctx, row)
+	arg, isNull, err := b.args[idx].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -3156,17 +3156,17 @@ func (b *builtinExportSet3ArgSig) Clone() builtinFunc {
 // evalString evals EXPORT_SET(bits,on,off).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_export-set
 func (b *builtinExportSet3ArgSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	bits, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	on, isNull, err := b.args[1].EvalString(b.ctx, row)
+	on, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	off, isNull, err := b.args[2].EvalString(b.ctx, row)
+	off, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -3187,22 +3187,22 @@ func (b *builtinExportSet4ArgSig) Clone() builtinFunc {
 // evalString evals EXPORT_SET(bits,on,off,separator).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_export-set
 func (b *builtinExportSet4ArgSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	bits, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	on, isNull, err := b.args[1].EvalString(b.ctx, row)
+	on, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	off, isNull, err := b.args[2].EvalString(b.ctx, row)
+	off, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	separator, isNull, err := b.args[3].EvalString(b.ctx, row)
+	separator, isNull, err := b.args[3].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -3223,27 +3223,27 @@ func (b *builtinExportSet5ArgSig) Clone() builtinFunc {
 // evalString evals EXPORT_SET(bits,on,off,separator,number_of_bits).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_export-set
 func (b *builtinExportSet5ArgSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	bits, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	on, isNull, err := b.args[1].EvalString(b.ctx, row)
+	on, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	off, isNull, err := b.args[2].EvalString(b.ctx, row)
+	off, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	separator, isNull, err := b.args[3].EvalString(b.ctx, row)
+	separator, isNull, err := b.args[3].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	numberOfBits, isNull, err := b.args[4].EvalInt(b.ctx, row)
+	numberOfBits, isNull, err := b.args[4].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -3297,10 +3297,9 @@ func (c *formatFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 const formatMaxDecimals int64 = 30
 
 // evalNumDecArgsForFormat evaluates first 2 arguments, i.e, x and d, for function `format`.
-func evalNumDecArgsForFormat(f builtinFunc, row chunk.Row) (string, string, bool, error) {
+func evalNumDecArgsForFormat(ctx sessionctx.Context, f builtinFunc, row chunk.Row) (string, string, bool, error) {
 	var xStr string
 	arg0, arg1 := f.getArgs()[0], f.getArgs()[1]
-	ctx := f.getCtx()
 	if arg0.GetType().EvalType() == types.ETDecimal {
 		x, isNull, err := arg0.EvalDecimal(ctx, row)
 		if isNull || err != nil {
@@ -3396,18 +3395,18 @@ func (b *builtinFormatWithLocaleSig) Clone() builtinFunc {
 // evalString evals FORMAT(X,D,locale).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_format
 func (b *builtinFormatWithLocaleSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	x, d, isNull, err := evalNumDecArgsForFormat(b, row)
+	x, d, isNull, err := evalNumDecArgsForFormat(ctx, b, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	locale, isNull, err := b.args[2].EvalString(b.ctx, row)
+	locale, isNull, err := b.args[2].EvalString(ctx, row)
 	if err != nil {
 		return "", false, err
 	}
 	if isNull {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.GenWithStackByArgs("NULL"))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.GenWithStackByArgs("NULL"))
 	} else if !strings.EqualFold(locale, "en_US") { // TODO: support other locales.
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.GenWithStackByArgs(locale))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.GenWithStackByArgs(locale))
 	}
 	locale = "en_US"
 	formatString, err := mysql.GetLocaleFormatFunction(locale)(x, d)
@@ -3427,7 +3426,7 @@ func (b *builtinFormatSig) Clone() builtinFunc {
 // evalString evals FORMAT(X,D).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_format
 func (b *builtinFormatSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	x, d, isNull, err := evalNumDecArgsForFormat(b, row)
+	x, d, isNull, err := evalNumDecArgsForFormat(ctx, b, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -3496,7 +3495,7 @@ func (b *builtinFromBase64Sig) Clone() builtinFunc {
 // evalString evals FROM_BASE64(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_from-base64
 func (b *builtinFromBase64Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -3506,7 +3505,7 @@ func (b *builtinFromBase64Sig) evalString(ctx sessionctx.Context, row chunk.Row)
 		return "", true, nil
 	}
 	if needDecodeLen > int(b.maxAllowedPacket) {
-		return "", true, handleAllowedPacketOverflowed(b.ctx, "from_base64", b.maxAllowedPacket)
+		return "", true, handleAllowedPacketOverflowed(ctx, "from_base64", b.maxAllowedPacket)
 	}
 
 	str = strings.ReplaceAll(str, "\t", "")
@@ -3590,7 +3589,7 @@ func base64NeededEncodedLength(n int) int {
 // evalString evals a builtinToBase64Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_to-base64
 func (b *builtinToBase64Sig) evalString(ctx sessionctx.Context, row chunk.Row) (val string, isNull bool, err error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -3599,7 +3598,7 @@ func (b *builtinToBase64Sig) evalString(ctx sessionctx.Context, row chunk.Row) (
 		return "", true, nil
 	}
 	if needEncodeLen > int(b.maxAllowedPacket) {
-		return "", true, handleAllowedPacketOverflowed(b.ctx, "to_base64", b.maxAllowedPacket)
+		return "", true, handleAllowedPacketOverflowed(ctx, "to_base64", b.maxAllowedPacket)
 	}
 	if b.tp.GetFlen() == -1 || b.tp.GetFlen() > mysql.MaxBlobWidth {
 		b.tp.SetFlen(mysql.MaxBlobWidth)
@@ -3675,22 +3674,22 @@ func (b *builtinInsertSig) Clone() builtinFunc {
 // evalString evals INSERT(str,pos,len,newstr).
 // See https://dev.mysql.com/doc/refman/5.6/en/string-functions.html#function_insert
 func (b *builtinInsertSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	pos, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
+	length, isNull, err := b.args[2].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	newstr, isNull, err := b.args[3].EvalString(b.ctx, row)
+	newstr, isNull, err := b.args[3].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -3704,7 +3703,7 @@ func (b *builtinInsertSig) evalString(ctx sessionctx.Context, row chunk.Row) (st
 	}
 
 	if uint64(strLength-length+int64(len(newstr))) > b.maxAllowedPacket {
-		return "", true, handleAllowedPacketOverflowed(b.ctx, "insert", b.maxAllowedPacket)
+		return "", true, handleAllowedPacketOverflowed(ctx, "insert", b.maxAllowedPacket)
 	}
 
 	return str[0:pos-1] + newstr + str[pos+length-1:], false, nil
@@ -3725,22 +3724,22 @@ func (b *builtinInsertUTF8Sig) Clone() builtinFunc {
 // evalString evals INSERT(str,pos,len,newstr).
 // See https://dev.mysql.com/doc/refman/5.6/en/string-functions.html#function_insert
 func (b *builtinInsertUTF8Sig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	pos, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
+	length, isNull, err := b.args[2].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
 
-	newstr, isNull, err := b.args[3].EvalString(b.ctx, row)
+	newstr, isNull, err := b.args[3].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
@@ -3757,7 +3756,7 @@ func (b *builtinInsertUTF8Sig) evalString(ctx sessionctx.Context, row chunk.Row)
 	strHead := string(runes[0 : pos-1])
 	strTail := string(runes[pos+length-1:])
 	if uint64(len(strHead)+len(newstr)+len(strTail)) > b.maxAllowedPacket {
-		return "", true, handleAllowedPacketOverflowed(b.ctx, "insert", b.maxAllowedPacket)
+		return "", true, handleAllowedPacketOverflowed(ctx, "insert", b.maxAllowedPacket)
 	}
 	return strHead + newstr + strTail, false, nil
 }
@@ -3804,11 +3803,11 @@ func (b *builtinInstrSig) Clone() builtinFunc {
 // evalInt evals INSTR(str,substr).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_instr
 func (b *builtinInstrUTF8Sig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	str, IsNull, err := b.args[0].EvalString(b.ctx, row)
+	str, IsNull, err := b.args[0].EvalString(ctx, row)
 	if IsNull || err != nil {
 		return 0, true, err
 	}
-	substr, IsNull, err := b.args[1].EvalString(b.ctx, row)
+	substr, IsNull, err := b.args[1].EvalString(ctx, row)
 	if IsNull || err != nil {
 		return 0, true, err
 	}
@@ -3827,12 +3826,12 @@ func (b *builtinInstrUTF8Sig) evalInt(ctx sessionctx.Context, row chunk.Row) (in
 // evalInt evals INSTR(str,substr), case sensitive.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_instr
 func (b *builtinInstrSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	str, IsNull, err := b.args[0].EvalString(b.ctx, row)
+	str, IsNull, err := b.args[0].EvalString(ctx, row)
 	if IsNull || err != nil {
 		return 0, true, err
 	}
 
-	substr, IsNull, err := b.args[1].EvalString(b.ctx, row)
+	substr, IsNull, err := b.args[1].EvalString(ctx, row)
 	if IsNull || err != nil {
 		return 0, true, err
 	}
@@ -3869,7 +3868,7 @@ type builtinLoadFileSig struct {
 }
 
 func (b *builtinLoadFileSig) evalString(ctx sessionctx.Context, row chunk.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(b.ctx, row)
+	d, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
@@ -4010,7 +4009,7 @@ func (b *builtinWeightStringSig) Clone() builtinFunc {
 // evalString evals a WEIGHT_STRING(expr [AS (CHAR|BINARY)]) when the expr is non-numeric types.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_weight-string
 func (b *builtinWeightStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(b.ctx, row)
+	str, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil {
 		return "", false, err
 	}
@@ -4028,7 +4027,7 @@ func (b *builtinWeightStringSig) evalString(ctx sessionctx.Context, row chunk.Ro
 			str = string(runes[:b.length])
 		} else if b.length > lenRunes {
 			if uint64(b.length-lenRunes) > b.maxAllowedPacket {
-				return "", true, handleAllowedPacketOverflowed(b.ctx, "weight_string", b.maxAllowedPacket)
+				return "", true, handleAllowedPacketOverflowed(ctx, "weight_string", b.maxAllowedPacket)
 			}
 			str += strings.Repeat(" ", b.length-lenRunes)
 		}
@@ -4037,11 +4036,11 @@ func (b *builtinWeightStringSig) evalString(ctx sessionctx.Context, row chunk.Ro
 		lenStr := len(str)
 		if b.length < lenStr {
 			tpInfo := fmt.Sprintf("BINARY(%d)", b.length)
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(errTruncatedWrongValue.GenWithStackByArgs(tpInfo, str))
+			ctx.GetSessionVars().StmtCtx.AppendWarning(errTruncatedWrongValue.GenWithStackByArgs(tpInfo, str))
 			str = str[:b.length]
 		} else if b.length > lenStr {
 			if uint64(b.length-lenStr) > b.maxAllowedPacket {
-				return "", true, handleAllowedPacketOverflowed(b.ctx, "cast_as_binary", b.maxAllowedPacket)
+				return "", true, handleAllowedPacketOverflowed(ctx, "cast_as_binary", b.maxAllowedPacket)
 			}
 			str += strings.Repeat("\x00", b.length-lenStr)
 		}
@@ -4102,15 +4101,15 @@ func (b *builtinTranslateBinarySig) evalString(ctx sessionctx.Context, row chunk
 		isFromStrNull, isToStrNull bool
 		tgt                        []byte
 	)
-	srcStr, isNull, err = b.args[0].EvalString(b.ctx, row)
+	srcStr, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
-	fromStr, isFromStrNull, err = b.args[1].EvalString(b.ctx, row)
+	fromStr, isFromStrNull, err = b.args[1].EvalString(ctx, row)
 	if isFromStrNull || err != nil {
 		return d, isFromStrNull, err
 	}
-	toStr, isToStrNull, err = b.args[2].EvalString(b.ctx, row)
+	toStr, isToStrNull, err = b.args[2].EvalString(ctx, row)
 	if isToStrNull || err != nil {
 		return d, isToStrNull, err
 	}
@@ -4145,15 +4144,15 @@ func (b *builtinTranslateUTF8Sig) evalString(ctx sessionctx.Context, row chunk.R
 		isFromStrNull, isToStrNull bool
 		tgt                        strings.Builder
 	)
-	srcStr, isNull, err = b.args[0].EvalString(b.ctx, row)
+	srcStr, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
-	fromStr, isFromStrNull, err = b.args[1].EvalString(b.ctx, row)
+	fromStr, isFromStrNull, err = b.args[1].EvalString(ctx, row)
 	if isFromStrNull || err != nil {
 		return d, isFromStrNull, err
 	}
-	toStr, isToStrNull, err = b.args[2].EvalString(b.ctx, row)
+	toStr, isToStrNull, err = b.args[2].EvalString(ctx, row)
 	if isToStrNull || err != nil {
 		return d, isToStrNull, err
 	}

--- a/pkg/expression/builtin_string_test.go
+++ b/pkg/expression/builtin_string_test.go
@@ -234,7 +234,7 @@ func TestConcatSig(t *testing.T) {
 		&Column{Index: 0, RetType: colTypes[0]},
 		&Column{Index: 1, RetType: colTypes[1]},
 	}
-	base := baseBuiltinFunc{args: args, ctx: ctx, tp: resultType}
+	base := baseBuiltinFunc{args: args, tp: resultType}
 	concat := &builtinConcatSig{base, 5}
 
 	cases := []struct {
@@ -355,7 +355,7 @@ func TestConcatWSSig(t *testing.T) {
 		&Column{Index: 1, RetType: colTypes[1]},
 		&Column{Index: 2, RetType: colTypes[2]},
 	}
-	base := baseBuiltinFunc{args: args, ctx: ctx, tp: resultType}
+	base := baseBuiltinFunc{args: args, tp: resultType}
 	concat := &builtinConcatWSSig{base, 6}
 
 	cases := []struct {
@@ -532,7 +532,7 @@ func TestRepeatSig(t *testing.T) {
 		&Column{Index: 0, RetType: colTypes[0]},
 		&Column{Index: 1, RetType: colTypes[1]},
 	}
-	base := baseBuiltinFunc{args: args, ctx: ctx, tp: resultType}
+	base := baseBuiltinFunc{args: args, tp: resultType}
 	repeat := &builtinRepeatSig{base, 1000}
 
 	cases := []struct {
@@ -1010,7 +1010,7 @@ func TestSpaceSig(t *testing.T) {
 	args := []Expression{
 		&Column{Index: 0, RetType: colTypes[0]},
 	}
-	base := baseBuiltinFunc{args: args, ctx: ctx, tp: resultType}
+	base := baseBuiltinFunc{args: args, tp: resultType}
 	space := &builtinSpaceSig{base, 1000}
 	input := chunk.NewChunkWithCapacity(colTypes, 10)
 	input.AppendInt64(0, 6)
@@ -1639,7 +1639,7 @@ func TestRpadSig(t *testing.T) {
 		&Column{Index: 2, RetType: colTypes[2]},
 	}
 
-	base := baseBuiltinFunc{args: args, ctx: ctx, tp: resultType}
+	base := baseBuiltinFunc{args: args, tp: resultType}
 	rpad := &builtinRpadUTF8Sig{base, 1000}
 
 	input := chunk.NewChunkWithCapacity(colTypes, 10)
@@ -1685,7 +1685,7 @@ func TestInsertBinarySig(t *testing.T) {
 		&Column{Index: 3, RetType: colTypes[3]},
 	}
 
-	base := baseBuiltinFunc{args: args, ctx: ctx, tp: resultType}
+	base := baseBuiltinFunc{args: args, tp: resultType}
 	insert := &builtinInsertSig{base, 3}
 
 	input := chunk.NewChunkWithCapacity(colTypes, 2)
@@ -2121,7 +2121,7 @@ func TestFromBase64Sig(t *testing.T) {
 		resultType := &types.FieldType{}
 		resultType.SetType(mysql.TypeVarchar)
 		resultType.SetFlen(mysql.MaxBlobWidth)
-		base := baseBuiltinFunc{args: args, ctx: ctx, tp: resultType}
+		base := baseBuiltinFunc{args: args, tp: resultType}
 		fromBase64 := &builtinFromBase64Sig{base, test.maxAllowPacket}
 
 		input := chunk.NewChunkWithCapacity(colTypes, 1)
@@ -2488,7 +2488,7 @@ func TestToBase64Sig(t *testing.T) {
 		resultType := &types.FieldType{}
 		resultType.SetType(mysql.TypeVarchar)
 		resultType.SetFlen(base64NeededEncodedLength(len(test.args)))
-		base := baseBuiltinFunc{args: args, ctx: ctx, tp: resultType}
+		base := baseBuiltinFunc{args: args, tp: resultType}
 		toBase64 := &builtinToBase64Sig{base, test.maxAllowPacket}
 
 		input := chunk.NewChunkWithCapacity(colTypes, 1)

--- a/pkg/expression/builtin_string_vec.go
+++ b/pkg/expression/builtin_string_vec.go
@@ -36,7 +36,7 @@ import (
 //revive:disable:defer
 func (b *builtinLowerSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	// if error is not nil return error, or builtinLowerSig is for binary strings (do nothing)
-	return b.args[0].VecEvalString(b.ctx, input, result)
+	return b.args[0].VecEvalString(ctx, input, result)
 }
 
 func (b *builtinLowerSig) vectorized() bool {
@@ -50,7 +50,7 @@ func (b *builtinLowerUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -76,7 +76,7 @@ func (b *builtinRepeatSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -85,7 +85,7 @@ func (b *builtinRepeatSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -109,7 +109,7 @@ func (b *builtinRepeatSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		str := buf.GetString(i)
 		byteLength := len(str)
 		if uint64(byteLength)*uint64(num) > b.maxAllowedPacket {
-			if err := handleAllowedPacketOverflowed(b.ctx, "repeat", b.maxAllowedPacket); err != nil {
+			if err := handleAllowedPacketOverflowed(ctx, "repeat", b.maxAllowedPacket); err != nil {
 				return err
 			}
 			result.AppendNull()
@@ -135,7 +135,7 @@ func (b *builtinStringIsNullSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -162,7 +162,7 @@ func (b *builtinUpperUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -182,7 +182,7 @@ func (b *builtinUpperUTF8Sig) vectorized() bool {
 }
 
 func (b *builtinUpperSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return b.args[0].VecEvalString(b.ctx, input, result)
+	return b.args[0].VecEvalString(ctx, input, result)
 }
 
 func (b *builtinUpperSig) vectorized() bool {
@@ -196,7 +196,7 @@ func (b *builtinLeftUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -205,7 +205,7 @@ func (b *builtinLeftUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -241,7 +241,7 @@ func (b *builtinRightUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -250,7 +250,7 @@ func (b *builtinRightUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -289,7 +289,7 @@ func (b *builtinSpaceSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -305,7 +305,7 @@ func (b *builtinSpaceSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chu
 			num = 0
 		}
 		if uint64(num) > b.maxAllowedPacket {
-			if err := handleAllowedPacketOverflowed(b.ctx, "space", b.maxAllowedPacket); err != nil {
+			if err := handleAllowedPacketOverflowed(ctx, "space", b.maxAllowedPacket); err != nil {
 				return err
 			}
 
@@ -328,7 +328,7 @@ func (b *builtinSpaceSig) vectorized() bool {
 // vecEvalString evals a REVERSE(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_reverse
 func (b *builtinReverseUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalString(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, result); err != nil {
 		return err
 	}
 	for i := 0; i < input.NumRows(); i++ {
@@ -365,7 +365,7 @@ func (b *builtinConcatSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 	result.ReserveString(n)
 	var byteBuf []byte
 	for j := 0; j < len(b.args); j++ {
-		if err := b.args[j].VecEvalString(b.ctx, input, buf); err != nil {
+		if err := b.args[j].VecEvalString(ctx, input, buf); err != nil {
 			return err
 		}
 		for i := 0; i < n; i++ {
@@ -378,7 +378,7 @@ func (b *builtinConcatSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 			}
 			byteBuf = buf.GetBytes(i)
 			if uint64(len(strs[i])+len(byteBuf)) > b.maxAllowedPacket {
-				if err := handleAllowedPacketOverflowed(b.ctx, "concat", b.maxAllowedPacket); err != nil {
+				if err := handleAllowedPacketOverflowed(ctx, "concat", b.maxAllowedPacket); err != nil {
 					return err
 				}
 
@@ -411,7 +411,7 @@ func (b *builtinLocate3ArgsUTF8Sig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -419,11 +419,11 @@ func (b *builtinLocate3ArgsUTF8Sig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 	// store positions in result
-	if err := b.args[2].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[2].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -477,7 +477,7 @@ func (b *builtinHexStrArgSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -504,7 +504,7 @@ func (b *builtinLTrimSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -533,7 +533,7 @@ func (b *builtinQuoteSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -560,7 +560,7 @@ func (b *builtinInsertSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(str)
-	if err := b.args[0].VecEvalString(b.ctx, input, str); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
 	pos, err := b.bufAllocator.get()
@@ -568,7 +568,7 @@ func (b *builtinInsertSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(pos)
-	if err := b.args[1].VecEvalInt(b.ctx, input, pos); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, pos); err != nil {
 		return err
 	}
 	length, err := b.bufAllocator.get()
@@ -576,7 +576,7 @@ func (b *builtinInsertSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(length)
-	if err := b.args[2].VecEvalInt(b.ctx, input, length); err != nil {
+	if err := b.args[2].VecEvalInt(ctx, input, length); err != nil {
 		return err
 	}
 	newstr, err := b.bufAllocator.get()
@@ -584,7 +584,7 @@ func (b *builtinInsertSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(newstr)
-	if err := b.args[3].VecEvalString(b.ctx, input, newstr); err != nil {
+	if err := b.args[3].VecEvalString(ctx, input, newstr); err != nil {
 		return err
 	}
 	posIs := pos.Int64s()
@@ -608,7 +608,7 @@ func (b *builtinInsertSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		}
 		newstrI := newstr.GetString(i)
 		if uint64(strLength-lengthI+int64(len(newstrI))) > b.maxAllowedPacket {
-			if err := handleAllowedPacketOverflowed(b.ctx, "insert", b.maxAllowedPacket); err != nil {
+			if err := handleAllowedPacketOverflowed(ctx, "insert", b.maxAllowedPacket); err != nil {
 				return err
 			}
 
@@ -638,7 +638,7 @@ func (b *builtinConcatWSSig) vecEvalString(ctx sessionctx.Context, input *chunk.
 			return err
 		}
 		defer b.bufAllocator.put(bufs[i])
-		if err := b.args[i].VecEvalString(b.ctx, input, bufs[i]); err != nil {
+		if err := b.args[i].VecEvalString(ctx, input, bufs[i]); err != nil {
 			return err
 		}
 	}
@@ -672,7 +672,7 @@ func (b *builtinConcatWSSig) vecEvalString(ctx sessionctx.Context, input *chunk.
 				targetLengths[i] += len(seps[i])
 			}
 			if uint64(targetLengths[i]) > b.maxAllowedPacket {
-				if err := handleAllowedPacketOverflowed(b.ctx, "concat_ws", b.maxAllowedPacket); err != nil {
+				if err := handleAllowedPacketOverflowed(ctx, "concat_ws", b.maxAllowedPacket); err != nil {
 					return err
 				}
 
@@ -710,7 +710,7 @@ func (b *builtinConvertSig) vecEvalString(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(expr)
-	if err := b.args[0].VecEvalString(b.ctx, input, expr); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, expr); err != nil {
 		return err
 	}
 	argTp, resultTp := b.args[0].GetType(), b.tp
@@ -781,7 +781,7 @@ func (b *builtinSubstringIndexSig) vecEvalString(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -790,7 +790,7 @@ func (b *builtinSubstringIndexSig) vecEvalString(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -799,7 +799,7 @@ func (b *builtinSubstringIndexSig) vecEvalString(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[2].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -864,7 +864,7 @@ func (b *builtinUnHexSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -901,7 +901,7 @@ func (b *builtinExportSet3ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(bits)
-	if err := b.args[0].VecEvalInt(b.ctx, input, bits); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, bits); err != nil {
 		return err
 	}
 	on, err := b.bufAllocator.get()
@@ -909,7 +909,7 @@ func (b *builtinExportSet3ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(on)
-	if err := b.args[1].VecEvalString(b.ctx, input, on); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, on); err != nil {
 		return err
 	}
 	off, err := b.bufAllocator.get()
@@ -917,7 +917,7 @@ func (b *builtinExportSet3ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(off)
-	if err := b.args[2].VecEvalString(b.ctx, input, off); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, off); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -946,7 +946,7 @@ func (b *builtinASCIISig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -979,7 +979,7 @@ func (b *builtinLpadSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(strBuf)
-	if err := b.args[0].VecEvalString(b.ctx, input, strBuf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
 	lenBuf, err := b.bufAllocator.get()
@@ -987,7 +987,7 @@ func (b *builtinLpadSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(lenBuf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, lenBuf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, lenBuf); err != nil {
 		return err
 	}
 	padBuf, err := b.bufAllocator.get()
@@ -995,7 +995,7 @@ func (b *builtinLpadSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(padBuf)
-	if err := b.args[2].VecEvalString(b.ctx, input, padBuf); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, padBuf); err != nil {
 		return err
 	}
 
@@ -1009,7 +1009,7 @@ func (b *builtinLpadSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		}
 		targetLength := int(i64s[i])
 		if uint64(targetLength) > b.maxAllowedPacket {
-			if err := handleAllowedPacketOverflowed(b.ctx, "lpad", b.maxAllowedPacket); err != nil {
+			if err := handleAllowedPacketOverflowed(ctx, "lpad", b.maxAllowedPacket); err != nil {
 				return err
 			}
 
@@ -1051,7 +1051,7 @@ func (b *builtinLpadUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1059,7 +1059,7 @@ func (b *builtinLpadUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 	buf2, err := b.bufAllocator.get()
@@ -1067,7 +1067,7 @@ func (b *builtinLpadUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[2].VecEvalString(b.ctx, input, buf2); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -1080,7 +1080,7 @@ func (b *builtinLpadUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		}
 		targetLength := int(i64s[i])
 		if uint64(targetLength)*uint64(mysql.MaxBytesOfCharacter) > b.maxAllowedPacket {
-			if err := handleAllowedPacketOverflowed(b.ctx, "lpad", b.maxAllowedPacket); err != nil {
+			if err := handleAllowedPacketOverflowed(ctx, "lpad", b.maxAllowedPacket); err != nil {
 				return err
 			}
 
@@ -1120,7 +1120,7 @@ func (b *builtinFindInSetSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(str)
-	if err := b.args[0].VecEvalString(b.ctx, input, str); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
 	strlist, err := b.bufAllocator.get()
@@ -1128,7 +1128,7 @@ func (b *builtinFindInSetSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(strlist)
-	if err := b.args[1].VecEvalString(b.ctx, input, strlist); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, strlist); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -1163,7 +1163,7 @@ func (b *builtinLeftSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf2, err := b.bufAllocator.get()
@@ -1171,7 +1171,7 @@ func (b *builtinLeftSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 	left := buf2.Int64s()
@@ -1197,7 +1197,7 @@ func (b *builtinReverseSig) vectorized() bool {
 }
 
 func (b *builtinReverseSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalString(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, result); err != nil {
 		return err
 	}
 	for i := 0; i < input.NumRows(); i++ {
@@ -1223,7 +1223,7 @@ func (b *builtinRTrimSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1252,7 +1252,7 @@ func (b *builtinStrcmpSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(leftBuf)
-	if err := b.args[0].VecEvalString(b.ctx, input, leftBuf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, leftBuf); err != nil {
 		return err
 	}
 	rightBuf, err := b.bufAllocator.get()
@@ -1260,7 +1260,7 @@ func (b *builtinStrcmpSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(rightBuf)
-	if err := b.args[1].VecEvalString(b.ctx, input, rightBuf); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, rightBuf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -1292,10 +1292,10 @@ func (b *builtinLocate2ArgsSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -1328,7 +1328,7 @@ func (b *builtinLocate3ArgsSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1336,11 +1336,11 @@ func (b *builtinLocate3ArgsSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 	// store positions in result
-	if err := b.args[2].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[2].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -1387,7 +1387,7 @@ func (b *builtinExportSet4ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(bits)
-	if err := b.args[0].VecEvalInt(b.ctx, input, bits); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, bits); err != nil {
 		return err
 	}
 	on, err := b.bufAllocator.get()
@@ -1395,7 +1395,7 @@ func (b *builtinExportSet4ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(on)
-	if err := b.args[1].VecEvalString(b.ctx, input, on); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, on); err != nil {
 		return err
 	}
 	off, err := b.bufAllocator.get()
@@ -1403,7 +1403,7 @@ func (b *builtinExportSet4ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(off)
-	if err := b.args[2].VecEvalString(b.ctx, input, off); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, off); err != nil {
 		return err
 	}
 	separator, err := b.bufAllocator.get()
@@ -1411,7 +1411,7 @@ func (b *builtinExportSet4ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(separator)
-	if err := b.args[3].VecEvalString(b.ctx, input, separator); err != nil {
+	if err := b.args[3].VecEvalString(ctx, input, separator); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -1440,7 +1440,7 @@ func (b *builtinRpadSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(strBuf)
-	if err := b.args[0].VecEvalString(b.ctx, input, strBuf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
 	lenBuf, err := b.bufAllocator.get()
@@ -1448,7 +1448,7 @@ func (b *builtinRpadSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(lenBuf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, lenBuf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, lenBuf); err != nil {
 		return err
 	}
 	padBuf, err := b.bufAllocator.get()
@@ -1456,7 +1456,7 @@ func (b *builtinRpadSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(padBuf)
-	if err := b.args[2].VecEvalString(b.ctx, input, padBuf); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, padBuf); err != nil {
 		return err
 	}
 
@@ -1470,7 +1470,7 @@ func (b *builtinRpadSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		}
 		targetLength := int(i64s[i])
 		if uint64(targetLength) > b.maxAllowedPacket {
-			if err := handleAllowedPacketOverflowed(b.ctx, "rpad", b.maxAllowedPacket); err != nil {
+			if err := handleAllowedPacketOverflowed(ctx, "rpad", b.maxAllowedPacket); err != nil {
 				return err
 			}
 
@@ -1511,7 +1511,7 @@ func (b *builtinFormatWithLocaleSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(dBuf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, dBuf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, dBuf); err != nil {
 		return err
 	}
 	dInt64s := dBuf.Int64s()
@@ -1521,7 +1521,7 @@ func (b *builtinFormatWithLocaleSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(localeBuf)
-	if err := b.args[2].VecEvalString(b.ctx, input, localeBuf); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, localeBuf); err != nil {
 		return err
 	}
 
@@ -1532,13 +1532,13 @@ func (b *builtinFormatWithLocaleSig) vecEvalString(ctx sessionctx.Context, input
 			return err
 		}
 		defer b.bufAllocator.put(xBuf)
-		if err := b.args[0].VecEvalDecimal(b.ctx, input, xBuf); err != nil {
+		if err := b.args[0].VecEvalDecimal(ctx, input, xBuf); err != nil {
 			return err
 		}
 
 		result.ReserveString(n)
 		xBuf.MergeNulls(dBuf)
-		return formatDecimal(b.ctx, xBuf, dInt64s, result, localeBuf)
+		return formatDecimal(ctx, xBuf, dInt64s, result, localeBuf)
 	}
 
 	// real x
@@ -1547,13 +1547,13 @@ func (b *builtinFormatWithLocaleSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(xBuf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, xBuf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, xBuf); err != nil {
 		return err
 	}
 
 	result.ReserveString(n)
 	xBuf.MergeNulls(dBuf)
-	return formatReal(b.ctx, xBuf, dInt64s, result, localeBuf)
+	return formatReal(ctx, xBuf, dInt64s, result, localeBuf)
 }
 
 func (b *builtinSubstring2ArgsSig) vectorized() bool {
@@ -1567,7 +1567,7 @@ func (b *builtinSubstring2ArgsSig) vecEvalString(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf2, err := b.bufAllocator.get()
@@ -1575,7 +1575,7 @@ func (b *builtinSubstring2ArgsSig) vecEvalString(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -1616,7 +1616,7 @@ func (b *builtinSubstring2ArgsUTF8Sig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1625,7 +1625,7 @@ func (b *builtinSubstring2ArgsUTF8Sig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -1669,7 +1669,7 @@ func (b *builtinTrim2ArgsSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1677,7 +1677,7 @@ func (b *builtinTrim2ArgsSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1707,7 +1707,7 @@ func (b *builtinInstrUTF8Sig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(str)
-	if err := b.args[0].VecEvalString(b.ctx, input, str); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
 	substr, err := b.bufAllocator.get()
@@ -1715,7 +1715,7 @@ func (b *builtinInstrUTF8Sig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(substr)
-	if err := b.args[1].VecEvalString(b.ctx, input, substr); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, substr); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -1756,7 +1756,7 @@ func (b *builtinOctStringSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1805,7 +1805,7 @@ func (b *builtinEltSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 
@@ -1829,7 +1829,7 @@ func (b *builtinEltSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk
 				return err
 			}
 			defer b.bufAllocator.put(bufs[j])
-			if err := b.args[j].VecEvalString(b.ctx, input, bufs[j]); err != nil {
+			if err := b.args[j].VecEvalString(ctx, input, bufs[j]); err != nil {
 				return err
 			}
 		}
@@ -1855,7 +1855,7 @@ func (b *builtinInsertUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1863,7 +1863,7 @@ func (b *builtinInsertUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 	buf2, err := b.bufAllocator.get()
@@ -1871,7 +1871,7 @@ func (b *builtinInsertUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[2].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 	buf3, err := b.bufAllocator.get()
@@ -1879,7 +1879,7 @@ func (b *builtinInsertUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf3)
-	if err := b.args[3].VecEvalString(b.ctx, input, buf3); err != nil {
+	if err := b.args[3].VecEvalString(ctx, input, buf3); err != nil {
 		return err
 	}
 
@@ -1910,7 +1910,7 @@ func (b *builtinInsertUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chun
 		strHead := string(runes[0 : pos-1])
 		strTail := string(runes[pos+length-1:])
 		if uint64(len(strHead)+len(newstr)+len(strTail)) > b.maxAllowedPacket {
-			if err := handleAllowedPacketOverflowed(b.ctx, "insert", b.maxAllowedPacket); err != nil {
+			if err := handleAllowedPacketOverflowed(ctx, "insert", b.maxAllowedPacket); err != nil {
 				return err
 			}
 
@@ -1935,7 +1935,7 @@ func (b *builtinExportSet5ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(bits)
-	if err := b.args[0].VecEvalInt(b.ctx, input, bits); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, bits); err != nil {
 		return err
 	}
 	on, err := b.bufAllocator.get()
@@ -1943,7 +1943,7 @@ func (b *builtinExportSet5ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(on)
-	if err := b.args[1].VecEvalString(b.ctx, input, on); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, on); err != nil {
 		return err
 	}
 	off, err := b.bufAllocator.get()
@@ -1951,7 +1951,7 @@ func (b *builtinExportSet5ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(off)
-	if err := b.args[2].VecEvalString(b.ctx, input, off); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, off); err != nil {
 		return err
 	}
 	separator, err := b.bufAllocator.get()
@@ -1959,7 +1959,7 @@ func (b *builtinExportSet5ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(separator)
-	if err := b.args[3].VecEvalString(b.ctx, input, separator); err != nil {
+	if err := b.args[3].VecEvalString(ctx, input, separator); err != nil {
 		return err
 	}
 	numberOfBits, err := b.bufAllocator.get()
@@ -1967,7 +1967,7 @@ func (b *builtinExportSet5ArgSig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(numberOfBits)
-	if err := b.args[4].VecEvalInt(b.ctx, input, numberOfBits); err != nil {
+	if err := b.args[4].VecEvalInt(ctx, input, numberOfBits); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -2001,7 +2001,7 @@ func (b *builtinSubstring3ArgsUTF8Sig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -2010,7 +2010,7 @@ func (b *builtinSubstring3ArgsUTF8Sig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -2019,7 +2019,7 @@ func (b *builtinSubstring3ArgsUTF8Sig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[2].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -2080,13 +2080,13 @@ func (b *builtinTrim3ArgsSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
-	if err := b.args[2].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -2122,7 +2122,7 @@ func (b *builtinOrdSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, r
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -2160,7 +2160,7 @@ func (b *builtinInstrSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(str)
-	if err := b.args[0].VecEvalString(b.ctx, input, str); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
 	substr, err := b.bufAllocator.get()
@@ -2168,7 +2168,7 @@ func (b *builtinInstrSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(substr)
-	if err := b.args[1].VecEvalString(b.ctx, input, substr); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, substr); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -2199,7 +2199,7 @@ func (b *builtinLengthSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -2229,7 +2229,7 @@ func (b *builtinLocate2ArgsUTF8Sig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -2237,7 +2237,7 @@ func (b *builtinLocate2ArgsUTF8Sig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -2282,7 +2282,7 @@ func (b *builtinBitLengthSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -2314,7 +2314,7 @@ func (b *builtinCharSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		}
 		buf[i] = te
 		defer b.bufAllocator.put(buf[i])
-		if err := b.args[i].VecEvalInt(b.ctx, input, buf[i]); err != nil {
+		if err := b.args[i].VecEvalInt(ctx, input, buf[i]); err != nil {
 			return err
 		}
 	}
@@ -2331,7 +2331,7 @@ func (b *builtinCharSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 	}
 	encBuf := &bytes.Buffer{}
 	enc := charset.FindEncoding(b.tp.GetCharset())
-	hasStrictMode := b.ctx.GetSessionVars().StrictSQLMode
+	hasStrictMode := ctx.GetSessionVars().StrictSQLMode
 	for i := 0; i < n; i++ {
 		bigints = bigints[0:0]
 		for j := 0; j < l-1; j++ {
@@ -2343,7 +2343,7 @@ func (b *builtinCharSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chun
 		dBytes := b.convertToBytes(bigints)
 		resultBytes, err := enc.Transform(encBuf, dBytes, charset.OpDecode)
 		if err != nil {
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
+			ctx.GetSessionVars().StmtCtx.AppendWarning(err)
 			if hasStrictMode {
 				result.AppendNull()
 				continue
@@ -2367,7 +2367,7 @@ func (b *builtinReplaceSig) vecEvalString(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -2375,7 +2375,7 @@ func (b *builtinReplaceSig) vecEvalString(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 	buf2, err := b.bufAllocator.get()
@@ -2383,7 +2383,7 @@ func (b *builtinReplaceSig) vecEvalString(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[2].VecEvalString(b.ctx, input, buf2); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -2419,7 +2419,7 @@ func (b *builtinMakeSetSig) vecEvalString(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(bitsBuf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, bitsBuf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, bitsBuf); err != nil {
 		return err
 	}
 
@@ -2430,7 +2430,7 @@ func (b *builtinMakeSetSig) vecEvalString(ctx sessionctx.Context, input *chunk.C
 			return err
 		}
 		defer b.bufAllocator.put(strBuf[i-1])
-		if err := b.args[i].VecEvalString(b.ctx, input, strBuf[i-1]); err != nil {
+		if err := b.args[i].VecEvalString(ctx, input, strBuf[i-1]); err != nil {
 			return err
 		}
 	}
@@ -2467,7 +2467,7 @@ func (b *builtinOctIntSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -2496,7 +2496,7 @@ func (b *builtinToBase64Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -2511,7 +2511,7 @@ func (b *builtinToBase64Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 			result.AppendNull()
 			continue
 		} else if needEncodeLen > int(b.maxAllowedPacket) {
-			if err := handleAllowedPacketOverflowed(b.ctx, "to_base64", b.maxAllowedPacket); err != nil {
+			if err := handleAllowedPacketOverflowed(ctx, "to_base64", b.maxAllowedPacket); err != nil {
 				return err
 			}
 
@@ -2543,7 +2543,7 @@ func (b *builtinTrim1ArgSig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -2574,7 +2574,7 @@ func (b *builtinRpadUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -2582,7 +2582,7 @@ func (b *builtinRpadUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 	buf2, err := b.bufAllocator.get()
@@ -2590,7 +2590,7 @@ func (b *builtinRpadUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[2].VecEvalString(b.ctx, input, buf2); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -2603,7 +2603,7 @@ func (b *builtinRpadUTF8Sig) vecEvalString(ctx sessionctx.Context, input *chunk.
 		}
 		targetLength := int(i64s[i])
 		if uint64(targetLength)*uint64(mysql.MaxBytesOfCharacter) > b.maxAllowedPacket {
-			if err := handleAllowedPacketOverflowed(b.ctx, "rpad", b.maxAllowedPacket); err != nil {
+			if err := handleAllowedPacketOverflowed(ctx, "rpad", b.maxAllowedPacket); err != nil {
 				return err
 			}
 
@@ -2643,7 +2643,7 @@ func (b *builtinCharLengthBinarySig) vecEvalInt(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -2670,7 +2670,7 @@ func (b *builtinBinSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -2700,7 +2700,7 @@ func (b *builtinFormatSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(dBuf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, dBuf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, dBuf); err != nil {
 		return err
 	}
 	dInt64s := dBuf.Int64s()
@@ -2712,13 +2712,13 @@ func (b *builtinFormatSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 			return err
 		}
 		defer b.bufAllocator.put(xBuf)
-		if err := b.args[0].VecEvalDecimal(b.ctx, input, xBuf); err != nil {
+		if err := b.args[0].VecEvalDecimal(ctx, input, xBuf); err != nil {
 			return err
 		}
 
 		result.ReserveString(n)
 		xBuf.MergeNulls(dBuf)
-		return formatDecimal(b.ctx, xBuf, dInt64s, result, nil)
+		return formatDecimal(ctx, xBuf, dInt64s, result, nil)
 	}
 
 	// real x
@@ -2727,13 +2727,13 @@ func (b *builtinFormatSig) vecEvalString(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(xBuf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, xBuf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, xBuf); err != nil {
 		return err
 	}
 
 	result.ReserveString(n)
 	xBuf.MergeNulls(dBuf)
-	return formatReal(b.ctx, xBuf, dInt64s, result, nil)
+	return formatReal(ctx, xBuf, dInt64s, result, nil)
 }
 
 func (b *builtinRightSig) vectorized() bool {
@@ -2747,7 +2747,7 @@ func (b *builtinRightSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 	buf2, err := b.bufAllocator.get()
@@ -2755,7 +2755,7 @@ func (b *builtinRightSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 	right := buf2.Int64s()
@@ -2790,7 +2790,7 @@ func (b *builtinSubstring3ArgsSig) vecEvalString(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -2799,7 +2799,7 @@ func (b *builtinSubstring3ArgsSig) vecEvalString(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -2808,7 +2808,7 @@ func (b *builtinSubstring3ArgsSig) vecEvalString(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[2].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -2859,7 +2859,7 @@ func (b *builtinHexIntArgSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -2887,7 +2887,7 @@ func (b *builtinFromBase64Sig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -2903,7 +2903,7 @@ func (b *builtinFromBase64Sig) vecEvalString(ctx sessionctx.Context, input *chun
 			result.AppendNull()
 			continue
 		} else if needDecodeLen > int(b.maxAllowedPacket) {
-			if err := handleAllowedPacketOverflowed(b.ctx, "from_base64", b.maxAllowedPacket); err != nil {
+			if err := handleAllowedPacketOverflowed(ctx, "from_base64", b.maxAllowedPacket); err != nil {
 				return err
 			}
 
@@ -2935,7 +2935,7 @@ func (b *builtinCharLengthUTF8Sig) vecEvalInt(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -3049,13 +3049,13 @@ func (b *builtinTranslateBinarySig) vecEvalString(ctx sessionctx.Context, input 
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
-	if err := b.args[2].VecEvalString(b.ctx, input, buf2); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
 	result.ReserveString(n)
@@ -3122,13 +3122,13 @@ func (b *builtinTranslateUTF8Sig) vecEvalString(ctx sessionctx.Context, input *c
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
-	if err := b.args[2].VecEvalString(b.ctx, input, buf2); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
 	result.ReserveString(n)

--- a/pkg/expression/builtin_string_vec_generated.go
+++ b/pkg/expression/builtin_string_vec_generated.go
@@ -30,7 +30,7 @@ func (b *builtinFieldIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -47,7 +47,7 @@ func (b *builtinFieldIntSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		i64s[i] = 0
 	}
 	for i := 1; i < len(b.args); i++ {
-		if err := b.args[i].VecEvalInt(b.ctx, input, buf1); err != nil {
+		if err := b.args[i].VecEvalInt(ctx, input, buf1); err != nil {
 			return err
 		}
 
@@ -80,7 +80,7 @@ func (b *builtinFieldRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -97,7 +97,7 @@ func (b *builtinFieldRealSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		i64s[i] = 0
 	}
 	for i := 1; i < len(b.args); i++ {
-		if err := b.args[i].VecEvalReal(b.ctx, input, buf1); err != nil {
+		if err := b.args[i].VecEvalReal(ctx, input, buf1); err != nil {
 			return err
 		}
 
@@ -130,7 +130,7 @@ func (b *builtinFieldStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -145,7 +145,7 @@ func (b *builtinFieldStringSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 		i64s[i] = 0
 	}
 	for i := 1; i < len(b.args); i++ {
-		if err := b.args[i].VecEvalString(b.ctx, input, buf1); err != nil {
+		if err := b.args[i].VecEvalString(ctx, input, buf1); err != nil {
 			return err
 		}
 

--- a/pkg/expression/builtin_test.go
+++ b/pkg/expression/builtin_test.go
@@ -178,6 +178,7 @@ func newFunctionForTest(ctx sessionctx.Context, funcName string, args ...Express
 		FuncName: model.NewCIStr(funcName),
 		RetType:  f.getRetTp(),
 		Function: f,
+		ctx:      ctx,
 	}, nil
 }
 

--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -128,10 +128,6 @@ var (
 )
 
 var (
-	_ builtinFuncNew = &builtinUnixTimestampIntSig{}
-)
-
-var (
 	_ builtinFunc = &builtinDateSig{}
 	_ builtinFunc = &builtinDateLiteralSig{}
 	_ builtinFunc = &builtinDateDiffSig{}
@@ -275,13 +271,13 @@ func (b *builtinDateSig) Clone() builtinFunc {
 // evalTime evals DATE(expr).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date
 func (b *builtinDateSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	expr, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	expr, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 
-	if expr.IsZero() && b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, expr.String()))
+	if expr.IsZero() && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, expr.String()))
 	}
 
 	expr.SetCoreTime(types.FromDate(expr.Year(), expr.Month(), expr.Day(), 0, 0, 0, 0))
@@ -336,7 +332,7 @@ func (b *builtinDateLiteralSig) Clone() builtinFunc {
 // evalTime evals DATE 'stringLit'.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-literals.html
 func (b *builtinDateLiteralSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	mode := b.ctx.GetSessionVars().SQLMode
+	mode := ctx.GetSessionVars().SQLMode
 	if mode.HasNoZeroDateMode() && b.literal.IsZero() {
 		return b.literal, true, types.ErrWrongValue.GenWithStackByArgs(types.DateStr, b.literal.String())
 	}
@@ -376,20 +372,20 @@ func (b *builtinDateDiffSig) Clone() builtinFunc {
 // evalInt evals a builtinDateDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_datediff
 func (b *builtinDateDiffSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	lhs, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	lhs, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
-	rhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
+	rhs, isNull, err := b.args[1].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 	if invalidLHS, invalidRHS := lhs.InvalidZero(), rhs.InvalidZero(); invalidLHS || invalidRHS {
 		if invalidLHS {
-			err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, lhs.String()))
+			err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, lhs.String()))
 		}
 		if invalidRHS {
-			err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, rhs.String()))
+			err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, rhs.String()))
 		}
 		return 0, true, err
 	}
@@ -487,17 +483,17 @@ func (b *builtinDurationDurationTimeDiffSig) Clone() builtinFunc {
 // evalDuration evals a builtinDurationDurationTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinDurationDurationTimeDiffSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (d types.Duration, isNull bool, err error) {
-	lhs, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	lhs, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	rhs, isNull, err := b.args[1].EvalDuration(b.ctx, row)
+	rhs, isNull, err := b.args[1].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	d, isNull, err = calculateDurationTimeDiff(b.ctx, lhs, rhs)
+	d, isNull, err = calculateDurationTimeDiff(ctx, lhs, rhs)
 	return d, isNull, err
 }
 
@@ -514,17 +510,17 @@ func (b *builtinTimeTimeTimeDiffSig) Clone() builtinFunc {
 // evalDuration evals a builtinTimeTimeTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinTimeTimeTimeDiffSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (d types.Duration, isNull bool, err error) {
-	lhs, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	lhs, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	rhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
+	rhs, isNull, err := b.args[1].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	d, isNull, err = calculateTimeDiff(sc, lhs, rhs)
 	return d, isNull, err
 }
@@ -542,23 +538,23 @@ func (b *builtinDurationStringTimeDiffSig) Clone() builtinFunc {
 // evalDuration evals a builtinDurationStringTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinDurationStringTimeDiffSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (d types.Duration, isNull bool, err error) {
-	lhs, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	lhs, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	rhsStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	rhsStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	rhs, _, isDuration, err := convertStringToDuration(sc, rhsStr, b.tp.GetDecimal())
 	if err != nil || !isDuration {
 		return d, true, err
 	}
 
-	d, isNull, err = calculateDurationTimeDiff(b.ctx, lhs, rhs)
+	d, isNull, err = calculateDurationTimeDiff(ctx, lhs, rhs)
 	return d, isNull, err
 }
 
@@ -575,23 +571,23 @@ func (b *builtinStringDurationTimeDiffSig) Clone() builtinFunc {
 // evalDuration evals a builtinStringDurationTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinStringDurationTimeDiffSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (d types.Duration, isNull bool, err error) {
-	lhsStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	lhsStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	rhs, isNull, err := b.args[1].EvalDuration(b.ctx, row)
+	rhs, isNull, err := b.args[1].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	lhs, _, isDuration, err := convertStringToDuration(sc, lhsStr, b.tp.GetDecimal())
 	if err != nil || !isDuration {
 		return d, true, err
 	}
 
-	d, isNull, err = calculateDurationTimeDiff(b.ctx, lhs, rhs)
+	d, isNull, err = calculateDurationTimeDiff(ctx, lhs, rhs)
 	return d, isNull, err
 }
 
@@ -633,17 +629,17 @@ func (b *builtinTimeStringTimeDiffSig) Clone() builtinFunc {
 // evalDuration evals a builtinTimeStringTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinTimeStringTimeDiffSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (d types.Duration, isNull bool, err error) {
-	lhs, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	lhs, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	rhsStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	rhsStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	_, rhs, isDuration, err := convertStringToDuration(sc, rhsStr, b.tp.GetDecimal())
 	if err != nil || isDuration {
 		return d, true, err
@@ -666,17 +662,17 @@ func (b *builtinStringTimeTimeDiffSig) Clone() builtinFunc {
 // evalDuration evals a builtinStringTimeTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinStringTimeTimeDiffSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (d types.Duration, isNull bool, err error) {
-	lhsStr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	lhsStr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	rhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
+	rhs, isNull, err := b.args[1].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	_, lhs, isDuration, err := convertStringToDuration(sc, lhsStr, b.tp.GetDecimal())
 	if err != nil || isDuration {
 		return d, true, err
@@ -699,17 +695,17 @@ func (b *builtinStringStringTimeDiffSig) Clone() builtinFunc {
 // evalDuration evals a builtinStringStringTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinStringStringTimeDiffSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (d types.Duration, isNull bool, err error) {
-	lhs, isNull, err := b.args[0].EvalString(b.ctx, row)
+	lhs, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	rhs, isNull, err := b.args[1].EvalString(b.ctx, row)
+	rhs, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return d, isNull, err
 	}
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	fsp := b.tp.GetDecimal()
 	lhsDur, lhsTime, lhsIsDuration, err := convertStringToDuration(sc, lhs, fsp)
 	if err != nil {
@@ -726,7 +722,7 @@ func (b *builtinStringStringTimeDiffSig) evalDuration(ctx sessionctx.Context, ro
 	}
 
 	if lhsIsDuration {
-		d, isNull, err = calculateDurationTimeDiff(b.ctx, lhsDur, rhsDur)
+		d, isNull, err = calculateDurationTimeDiff(ctx, lhsDur, rhsDur)
 	} else {
 		d, isNull, err = calculateTimeDiff(sc, lhsTime, rhsTime)
 	}
@@ -795,11 +791,11 @@ func (b *builtinDateFormatSig) Clone() builtinFunc {
 // evalString evals a builtinDateFormatSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-format
 func (b *builtinDateFormatSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	t, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	t, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return "", isNull, handleInvalidTimeError(b.ctx, err)
+		return "", isNull, handleInvalidTimeError(ctx, err)
 	}
-	formatMask, isNull, err := b.args[1].EvalString(b.ctx, row)
+	formatMask, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -819,7 +815,7 @@ func (b *builtinDateFormatSig) evalString(ctx sessionctx.Context, row chunk.Row)
 		if isOriginalIntOrDecimalZero && !isOriginalStringZero {
 			return "", true, nil
 		}
-		return "", true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String()))
+		return "", true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String()))
 	}
 
 	res, err := t.DateFormat(formatMask)
@@ -857,7 +853,7 @@ func (b *builtinFromDaysSig) Clone() builtinFunc {
 // evalTime evals FROM_DAYS(N).
 // See https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_from-days
 func (b *builtinFromDaysSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	n, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	n, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, true, err
 	}
@@ -901,7 +897,7 @@ func (b *builtinHourSig) Clone() builtinFunc {
 // evalInt evals HOUR(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_hour
 func (b *builtinHourSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	dur, isNull, err := b.args[0].EvalDuration(ctx, row)
 	// ignore error and return NULL
 	if isNull || err != nil {
 		return 0, true, nil
@@ -941,7 +937,7 @@ func (b *builtinMinuteSig) Clone() builtinFunc {
 // evalInt evals MINUTE(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_minute
 func (b *builtinMinuteSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	dur, isNull, err := b.args[0].EvalDuration(ctx, row)
 	// ignore error and return NULL
 	if isNull || err != nil {
 		return 0, true, nil
@@ -981,7 +977,7 @@ func (b *builtinSecondSig) Clone() builtinFunc {
 // evalInt evals SECOND(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_second
 func (b *builtinSecondSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	dur, isNull, err := b.args[0].EvalDuration(ctx, row)
 	// ignore error and return NULL
 	if isNull || err != nil {
 		return 0, true, nil
@@ -1021,7 +1017,7 @@ func (b *builtinMicroSecondSig) Clone() builtinFunc {
 // evalInt evals MICROSECOND(expr).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_microsecond
 func (b *builtinMicroSecondSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	dur, isNull, err := b.args[0].EvalDuration(ctx, row)
 	// ignore error and return NULL
 	if isNull || err != nil {
 		return 0, true, nil
@@ -1061,10 +1057,10 @@ func (b *builtinMonthSig) Clone() builtinFunc {
 // evalInt evals MONTH(date).
 // see: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_month
 func (b *builtinMonthSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	date, isNull, err := b.args[0].EvalTime(ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 
 	return int64(date.Month()), false, nil
@@ -1103,13 +1099,13 @@ func (b *builtinMonthNameSig) Clone() builtinFunc {
 }
 
 func (b *builtinMonthNameSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return "", true, handleInvalidTimeError(b.ctx, err)
+		return "", true, handleInvalidTimeError(ctx, err)
 	}
 	mon := arg.Month()
-	if (arg.IsZero() && b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()) || mon < 0 || mon > len(types.MonthNames) {
-		return "", true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
+	if (arg.IsZero() && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()) || mon < 0 || mon > len(types.MonthNames) {
+		return "", true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
 	} else if mon == 0 || arg.IsZero() {
 		return "", true, nil
 	}
@@ -1147,13 +1143,13 @@ func (b *builtinDayNameSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinDayNameSig) evalIndex(row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
+func (b *builtinDayNameSig) evalIndex(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
+	arg, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	if arg.InvalidZero() {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
 	}
 	// Monday is 0, ... Sunday = 6 in MySQL
 	// but in go, Sunday is 0, ... Saturday is 6
@@ -1165,7 +1161,7 @@ func (b *builtinDayNameSig) evalIndex(row chunk.Row) (int64, bool, error) {
 // evalString evals a builtinDayNameSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_dayname
 func (b *builtinDayNameSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	idx, isNull, err := b.evalIndex(row)
+	idx, isNull, err := b.evalIndex(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -1173,7 +1169,7 @@ func (b *builtinDayNameSig) evalString(ctx sessionctx.Context, row chunk.Row) (s
 }
 
 func (b *builtinDayNameSig) evalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
-	idx, isNull, err := b.evalIndex(row)
+	idx, isNull, err := b.evalIndex(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1181,7 +1177,7 @@ func (b *builtinDayNameSig) evalReal(ctx sessionctx.Context, row chunk.Row) (flo
 }
 
 func (b *builtinDayNameSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	idx, isNull, err := b.evalIndex(row)
+	idx, isNull, err := b.evalIndex(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1219,9 +1215,9 @@ func (b *builtinDayOfMonthSig) Clone() builtinFunc {
 // evalInt evals a builtinDayOfMonthSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_dayofmonth
 func (b *builtinDayOfMonthSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 	return int64(arg.Day()), false, nil
 }
@@ -1257,12 +1253,12 @@ func (b *builtinDayOfWeekSig) Clone() builtinFunc {
 // evalInt evals a builtinDayOfWeekSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_dayofweek
 func (b *builtinDayOfWeekSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 	if arg.InvalidZero() {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
 	}
 	// 1 is Sunday, 2 is Monday, .... 7 is Saturday
 	return int64(arg.Weekday() + 1), false, nil
@@ -1299,12 +1295,12 @@ func (b *builtinDayOfYearSig) Clone() builtinFunc {
 // evalInt evals a builtinDayOfYearSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_dayofyear
 func (b *builtinDayOfYearSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, handleInvalidTimeError(b.ctx, err)
+		return 0, isNull, handleInvalidTimeError(ctx, err)
 	}
 	if arg.InvalidZero() {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
 	}
 
 	return int64(arg.YearDay()), false, nil
@@ -1355,17 +1351,17 @@ func (b *builtinWeekWithModeSig) Clone() builtinFunc {
 // evalInt evals WEEK(date, mode).
 // see: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_week
 func (b *builtinWeekWithModeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	date, isNull, err := b.args[0].EvalTime(ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 
 	if date.IsZero() || date.InvalidZero() {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
 	}
 
-	mode, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	mode, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -1387,22 +1383,22 @@ func (b *builtinWeekWithoutModeSig) Clone() builtinFunc {
 // evalInt evals WEEK(date).
 // see: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_week
 func (b *builtinWeekWithoutModeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	date, isNull, err := b.args[0].EvalTime(ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 
 	if date.IsZero() || date.InvalidZero() {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
 	}
 
 	mode := 0
-	modeStr, ok := b.ctx.GetSessionVars().GetSystemVar(variable.DefaultWeekFormat)
+	modeStr, ok := ctx.GetSessionVars().GetSystemVar(variable.DefaultWeekFormat)
 	if ok && modeStr != "" {
 		mode, err = strconv.Atoi(modeStr)
 		if err != nil {
-			return 0, true, handleInvalidTimeError(b.ctx, types.ErrInvalidWeekModeFormat.GenWithStackByArgs(modeStr))
+			return 0, true, handleInvalidTimeError(ctx, types.ErrInvalidWeekModeFormat.GenWithStackByArgs(modeStr))
 		}
 	}
 
@@ -1442,13 +1438,13 @@ func (b *builtinWeekDaySig) Clone() builtinFunc {
 
 // evalInt evals WEEKDAY(date).
 func (b *builtinWeekDaySig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	date, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 
 	if date.IsZero() || date.InvalidZero() {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
 	}
 
 	return int64(date.Weekday()+6) % 7, false, nil
@@ -1486,14 +1482,14 @@ func (b *builtinWeekOfYearSig) Clone() builtinFunc {
 // evalInt evals WEEKOFYEAR(date).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_weekofyear
 func (b *builtinWeekOfYearSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	date, isNull, err := b.args[0].EvalTime(ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 
 	if date.IsZero() || date.InvalidZero() {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
 	}
 
 	week := date.Week(3)
@@ -1532,10 +1528,10 @@ func (b *builtinYearSig) Clone() builtinFunc {
 // evalInt evals YEAR(date).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_year
 func (b *builtinYearSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	date, isNull, err := b.args[0].EvalTime(ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 	return int64(date.Year()), false, nil
 }
@@ -1585,15 +1581,15 @@ func (b *builtinYearWeekWithModeSig) Clone() builtinFunc {
 // evalInt evals YEARWEEK(date,mode).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_yearweek
 func (b *builtinYearWeekWithModeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	date, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, handleInvalidTimeError(b.ctx, err)
+		return 0, isNull, handleInvalidTimeError(ctx, err)
 	}
 	if date.IsZero() || date.InvalidZero() {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
 	}
 
-	mode, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	mode, isNull, err := b.args[1].EvalInt(ctx, row)
 	if err != nil {
 		return 0, true, err
 	}
@@ -1622,13 +1618,13 @@ func (b *builtinYearWeekWithoutModeSig) Clone() builtinFunc {
 // evalInt evals YEARWEEK(date).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_yearweek
 func (b *builtinYearWeekWithoutModeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	date, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 
 	if date.InvalidZero() {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
 	}
 
 	year, week := date.YearWeek(0)
@@ -1768,11 +1764,11 @@ func (b *builtinFromUnixTime1ArgSig) Clone() builtinFunc {
 // evalTime evals a builtinFromUnixTime1ArgSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_from-unixtime
 func (b *builtinFromUnixTime1ArgSig) evalTime(ctx sessionctx.Context, row chunk.Row) (res types.Time, isNull bool, err error) {
-	unixTimeStamp, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	unixTimeStamp, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if err != nil || isNull {
 		return res, isNull, err
 	}
-	return evalFromUnixTime(b.ctx, b.tp.GetDecimal(), unixTimeStamp)
+	return evalFromUnixTime(ctx, b.tp.GetDecimal(), unixTimeStamp)
 }
 
 type builtinFromUnixTime2ArgSig struct {
@@ -1788,15 +1784,15 @@ func (b *builtinFromUnixTime2ArgSig) Clone() builtinFunc {
 // evalString evals a builtinFromUnixTime2ArgSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_from-unixtime
 func (b *builtinFromUnixTime2ArgSig) evalString(ctx sessionctx.Context, row chunk.Row) (res string, isNull bool, err error) {
-	format, isNull, err := b.args[1].EvalString(b.ctx, row)
+	format, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, err
 	}
-	unixTimeStamp, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
+	unixTimeStamp, isNull, err := b.args[0].EvalDecimal(ctx, row)
 	if err != nil || isNull {
 		return "", isNull, err
 	}
-	t, isNull, err := evalFromUnixTime(b.ctx, b.tp.GetDecimal(), unixTimeStamp)
+	t, isNull, err := evalFromUnixTime(ctx, b.tp.GetDecimal(), unixTimeStamp)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -1835,11 +1831,11 @@ func (b *builtinGetFormatSig) Clone() builtinFunc {
 // evalString evals a builtinGetFormatSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_get-format
 func (b *builtinGetFormatSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	t, isNull, err := b.args[0].EvalString(b.ctx, row)
+	t, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	l, isNull, err := b.args[1].EvalString(b.ctx, row)
+	l, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -1921,22 +1917,22 @@ func (b *builtinStrToDateDateSig) Clone() builtinFunc {
 }
 
 func (b *builtinStrToDateDateSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	date, isNull, err := b.args[0].EvalString(b.ctx, row)
+	date, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, isNull, err
 	}
-	format, isNull, err := b.args[1].EvalString(b.ctx, row)
+	format, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, isNull, err
 	}
 	var t types.Time
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	succ := t.StrToDate(sc.TypeCtx(), date, format)
 	if !succ {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String()))
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String()))
 	}
-	if b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() && (t.Year() == 0 || t.Month() == 0 || t.Day() == 0) {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, types.ErrWrongValueForType.GenWithStackByArgs(types.DateTimeStr, date, ast.StrToDate))
+	if ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() && (t.Year() == 0 || t.Month() == 0 || t.Day() == 0) {
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, types.ErrWrongValueForType.GenWithStackByArgs(types.DateTimeStr, date, ast.StrToDate))
 	}
 	t.SetType(mysql.TypeDate)
 	t.SetFsp(types.MinFsp)
@@ -1954,22 +1950,22 @@ func (b *builtinStrToDateDatetimeSig) Clone() builtinFunc {
 }
 
 func (b *builtinStrToDateDatetimeSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	date, isNull, err := b.args[0].EvalString(b.ctx, row)
+	date, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, isNull, err
 	}
-	format, isNull, err := b.args[1].EvalString(b.ctx, row)
+	format, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, isNull, err
 	}
 	var t types.Time
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	succ := t.StrToDate(sc.TypeCtx(), date, format)
 	if !succ {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String()))
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String()))
 	}
-	if b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() && (t.Year() == 0 || t.Month() == 0 || t.Day() == 0) {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String()))
+	if ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() && (t.Year() == 0 || t.Month() == 0 || t.Day() == 0) {
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String()))
 	}
 	t.SetType(mysql.TypeDatetime)
 	t.SetFsp(b.tp.GetDecimal())
@@ -1990,19 +1986,19 @@ func (b *builtinStrToDateDurationSig) Clone() builtinFunc {
 // TODO: If the NO_ZERO_DATE or NO_ZERO_IN_DATE SQL mode is enabled, zero dates or part of dates are disallowed.
 // In that case, STR_TO_DATE() returns NULL and generates a warning.
 func (b *builtinStrToDateDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	date, isNull, err := b.args[0].EvalString(b.ctx, row)
+	date, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.Duration{}, isNull, err
 	}
-	format, isNull, err := b.args[1].EvalString(b.ctx, row)
+	format, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.Duration{}, isNull, err
 	}
 	var t types.Time
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	succ := t.StrToDate(sc.TypeCtx(), date, format)
 	if !succ {
-		return types.Duration{}, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String()))
+		return types.Duration{}, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String()))
 	}
 	t.SetFsp(b.tp.GetDecimal())
 	dur, err := t.ConvertToDuration()
@@ -2057,12 +2053,12 @@ func (b *builtinSysDateWithFspSig) Clone() builtinFunc {
 // evalTime evals SYSDATE(fsp).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_sysdate
 func (b *builtinSysDateWithFspSig) evalTime(ctx sessionctx.Context, row chunk.Row) (val types.Time, isNull bool, err error) {
-	fsp, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	fsp, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, isNull, err
 	}
 
-	loc := b.ctx.GetSessionVars().Location()
+	loc := ctx.GetSessionVars().Location()
 	now := time.Now().In(loc)
 	result, err := convertTimeToMysqlTime(now, int(fsp), types.ModeHalfUp)
 	if err != nil {
@@ -2084,7 +2080,7 @@ func (b *builtinSysDateWithoutFspSig) Clone() builtinFunc {
 // evalTime evals SYSDATE().
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_sysdate
 func (b *builtinSysDateWithoutFspSig) evalTime(ctx sessionctx.Context, row chunk.Row) (val types.Time, isNull bool, err error) {
-	tz := b.ctx.GetSessionVars().Location()
+	tz := ctx.GetSessionVars().Location()
 	now := time.Now().In(tz)
 	result, err := convertTimeToMysqlTime(now, 0, types.ModeHalfUp)
 	if err != nil {
@@ -2123,8 +2119,8 @@ func (b *builtinCurrentDateSig) Clone() builtinFunc {
 // evalTime evals CURDATE().
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_curdate
 func (b *builtinCurrentDateSig) evalTime(ctx sessionctx.Context, row chunk.Row) (val types.Time, isNull bool, err error) {
-	tz := b.ctx.GetSessionVars().Location()
-	nowTs, err := getStmtTimestamp(b.ctx)
+	tz := ctx.GetSessionVars().Location()
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return types.ZeroTime, true, err
 	}
@@ -2179,13 +2175,13 @@ func (b *builtinCurrentTime0ArgSig) Clone() builtinFunc {
 }
 
 func (b *builtinCurrentTime0ArgSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	tz := b.ctx.GetSessionVars().Location()
-	nowTs, err := getStmtTimestamp(b.ctx)
+	tz := ctx.GetSessionVars().Location()
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return types.Duration{}, true, err
 	}
 	dur := nowTs.In(tz).Format(types.TimeFormat)
-	res, _, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), dur, types.MinFsp)
+	res, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), dur, types.MinFsp)
 	if err != nil {
 		return types.Duration{}, true, err
 	}
@@ -2203,17 +2199,17 @@ func (b *builtinCurrentTime1ArgSig) Clone() builtinFunc {
 }
 
 func (b *builtinCurrentTime1ArgSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	fsp, _, err := b.args[0].EvalInt(b.ctx, row)
+	fsp, _, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return types.Duration{}, true, err
 	}
-	tz := b.ctx.GetSessionVars().Location()
-	nowTs, err := getStmtTimestamp(b.ctx)
+	tz := ctx.GetSessionVars().Location()
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return types.Duration{}, true, err
 	}
 	dur := nowTs.In(tz).Format(types.TimeFSPFormat)
-	res, _, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), dur, int(fsp))
+	res, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), dur, int(fsp))
 	if err != nil {
 		return types.Duration{}, true, err
 	}
@@ -2256,7 +2252,7 @@ func (b *builtinTimeSig) Clone() builtinFunc {
 // evalDuration evals a builtinTimeSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_time.
 func (b *builtinTimeSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (res types.Duration, isNull bool, err error) {
-	expr, isNull, err := b.args[0].EvalString(b.ctx, row)
+	expr, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
 	}
@@ -2272,7 +2268,7 @@ func (b *builtinTimeSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (re
 	}
 	fsp = tmpFsp
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	res, _, err = types.ParseDuration(sc.TypeCtx(), expr, fsp)
 	if types.ErrTruncatedWrongVal.Equal(err) {
 		err = sc.HandleTruncate(err)
@@ -2360,7 +2356,7 @@ func (b *builtinUTCDateSig) Clone() builtinFunc {
 // evalTime evals UTC_DATE, UTC_DATE().
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-date
 func (b *builtinUTCDateSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	nowTs, err := getStmtTimestamp(b.ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return types.ZeroTime, true, err
 	}
@@ -2386,7 +2382,7 @@ func (c *utcTimestampFunctionClass) getFunction(ctx sessionctx.Context, args []E
 		return nil, err
 	}
 
-	fsp, err := getFspByIntArg(bf.ctx, args)
+	fsp, err := getFspByIntArg(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -2427,7 +2423,7 @@ func (b *builtinUTCTimestampWithArgSig) Clone() builtinFunc {
 // evalTime evals UTC_TIMESTAMP(fsp).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-timestamp
 func (b *builtinUTCTimestampWithArgSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	num, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	num, isNull, err := b.args[0].EvalInt(ctx, row)
 	if err != nil {
 		return types.ZeroTime, true, err
 	}
@@ -2439,7 +2435,7 @@ func (b *builtinUTCTimestampWithArgSig) evalTime(ctx sessionctx.Context, row chu
 		return types.ZeroTime, true, errors.Errorf("Invalid negative %d specified, must in [0, 6]", num)
 	}
 
-	result, isNull, err := evalUTCTimestampWithFsp(b.ctx, int(num))
+	result, isNull, err := evalUTCTimestampWithFsp(ctx, int(num))
 	return result, isNull, err
 }
 
@@ -2456,7 +2452,7 @@ func (b *builtinUTCTimestampWithoutArgSig) Clone() builtinFunc {
 // evalTime evals UTC_TIMESTAMP().
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-timestamp
 func (b *builtinUTCTimestampWithoutArgSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	result, isNull, err := evalUTCTimestampWithFsp(b.ctx, 0)
+	result, isNull, err := evalUTCTimestampWithFsp(ctx, 0)
 	return result, isNull, err
 }
 
@@ -2477,7 +2473,7 @@ func (c *nowFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 		return nil, err
 	}
 
-	fsp, err := getFspByIntArg(bf.ctx, args)
+	fsp, err := getFspByIntArg(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -2548,7 +2544,7 @@ func (b *builtinNowWithArgSig) Clone() builtinFunc {
 // evalTime evals NOW(fsp)
 // see: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_now
 func (b *builtinNowWithArgSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	fsp, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	fsp, isNull, err := b.args[0].EvalInt(ctx, row)
 
 	if err != nil {
 		return types.ZeroTime, true, err
@@ -2562,7 +2558,7 @@ func (b *builtinNowWithArgSig) evalTime(ctx sessionctx.Context, row chunk.Row) (
 		return types.ZeroTime, true, errors.Errorf("Invalid negative %d specified, must in [0, 6]", fsp)
 	}
 
-	result, isNull, err := evalNowWithFsp(b.ctx, int(fsp))
+	result, isNull, err := evalNowWithFsp(ctx, int(fsp))
 	return result, isNull, err
 }
 
@@ -2579,7 +2575,7 @@ func (b *builtinNowWithoutArgSig) Clone() builtinFunc {
 // evalTime evals NOW()
 // see: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_now
 func (b *builtinNowWithoutArgSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	result, isNull, err := evalNowWithFsp(b.ctx, 0)
+	result, isNull, err := evalNowWithFsp(ctx, 0)
 	return result, isNull, err
 }
 
@@ -2668,15 +2664,15 @@ func (b *builtinExtractDatetimeFromStringSig) Clone() builtinFunc {
 // evalInt evals a builtinExtractDatetimeFromStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_extract
 func (b *builtinExtractDatetimeFromStringSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
+	unit, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	dtStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	dtStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	if types.IsClockUnit(unit) && types.IsDateUnit(unit) {
 		dur, _, err := types.ParseDuration(sc.TypeCtx(), dtStr, types.GetFsp(dtStr))
 		if err != nil {
@@ -2712,11 +2708,11 @@ func (b *builtinExtractDatetimeSig) Clone() builtinFunc {
 // evalInt evals a builtinExtractDatetimeSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_extract
 func (b *builtinExtractDatetimeSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
+	unit, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	dt, isNull, err := b.args[1].EvalTime(b.ctx, row)
+	dt, isNull, err := b.args[1].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -2737,11 +2733,11 @@ func (b *builtinExtractDurationSig) Clone() builtinFunc {
 // evalInt evals a builtinExtractDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_extract
 func (b *builtinExtractDurationSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
+	unit, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	dur, isNull, err := b.args[1].EvalDuration(b.ctx, row)
+	dur, isNull, err := b.args[1].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -3031,14 +3027,14 @@ func (du *baseDateArithmetical) sub(ctx sessionctx.Context, date types.Time, int
 	return du.addDate(ctx, date, -year, -month, -day, -nano, resultFsp)
 }
 
-func (du *baseDateArithmetical) vecGetDateFromInt(b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+func (du *baseDateArithmetical) vecGetDateFromInt(b *baseBuiltinFunc, ctx sessionctx.Context, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -3046,7 +3042,7 @@ func (du *baseDateArithmetical) vecGetDateFromInt(b *baseBuiltinFunc, input *chu
 	result.MergeNulls(buf)
 	dates := result.Times()
 	i64s := buf.Int64s()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	isClockUnit := types.IsClockUnit(unit)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -3055,7 +3051,7 @@ func (du *baseDateArithmetical) vecGetDateFromInt(b *baseBuiltinFunc, input *chu
 
 		date, err := types.ParseTimeFromInt64(sc.TypeCtx(), i64s[i])
 		if err != nil {
-			err = handleInvalidTimeError(b.ctx, err)
+			err = handleInvalidTimeError(ctx, err)
 			if err != nil {
 				return err
 			}
@@ -3073,14 +3069,14 @@ func (du *baseDateArithmetical) vecGetDateFromInt(b *baseBuiltinFunc, input *chu
 	return nil
 }
 
-func (du *baseDateArithmetical) vecGetDateFromReal(b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+func (du *baseDateArithmetical) vecGetDateFromReal(b *baseBuiltinFunc, ctx sessionctx.Context, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -3088,7 +3084,7 @@ func (du *baseDateArithmetical) vecGetDateFromReal(b *baseBuiltinFunc, input *ch
 	result.MergeNulls(buf)
 	dates := result.Times()
 	f64s := buf.Float64s()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	isClockUnit := types.IsClockUnit(unit)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -3097,7 +3093,7 @@ func (du *baseDateArithmetical) vecGetDateFromReal(b *baseBuiltinFunc, input *ch
 
 		date, err := types.ParseTimeFromFloat64(sc.TypeCtx(), f64s[i])
 		if err != nil {
-			err = handleInvalidTimeError(b.ctx, err)
+			err = handleInvalidTimeError(ctx, err)
 			if err != nil {
 				return err
 			}
@@ -3115,21 +3111,21 @@ func (du *baseDateArithmetical) vecGetDateFromReal(b *baseBuiltinFunc, input *ch
 	return nil
 }
 
-func (du *baseDateArithmetical) vecGetDateFromDecimal(b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+func (du *baseDateArithmetical) vecGetDateFromDecimal(b *baseBuiltinFunc, ctx sessionctx.Context, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
 	result.MergeNulls(buf)
 	dates := result.Times()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	isClockUnit := types.IsClockUnit(unit)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -3139,7 +3135,7 @@ func (du *baseDateArithmetical) vecGetDateFromDecimal(b *baseBuiltinFunc, input 
 		dec := buf.GetDecimal(i)
 		date, err := types.ParseTimeFromDecimal(sc.TypeCtx(), dec)
 		if err != nil {
-			err = handleInvalidTimeError(b.ctx, err)
+			err = handleInvalidTimeError(ctx, err)
 			if err != nil {
 				return err
 			}
@@ -3157,21 +3153,21 @@ func (du *baseDateArithmetical) vecGetDateFromDecimal(b *baseBuiltinFunc, input 
 	return nil
 }
 
-func (du *baseDateArithmetical) vecGetDateFromString(b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+func (du *baseDateArithmetical) vecGetDateFromString(b *baseBuiltinFunc, ctx sessionctx.Context, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
 	result.MergeNulls(buf)
 	dates := result.Times()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	isClockUnit := types.IsClockUnit(unit)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -3186,13 +3182,13 @@ func (du *baseDateArithmetical) vecGetDateFromString(b *baseBuiltinFunc, input *
 
 		date, err := types.ParseTime(sc.TypeCtx(), dateStr, dateTp, types.MaxFsp, nil)
 		if err != nil {
-			err = handleInvalidTimeError(b.ctx, err)
+			err = handleInvalidTimeError(ctx, err)
 			if err != nil {
 				return err
 			}
 			result.SetNull(i, true)
-		} else if b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() && (date.Year() == 0 || date.Month() == 0 || date.Day() == 0) {
-			err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, dateStr))
+		} else if ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() && (date.Year() == 0 || date.Month() == 0 || date.Day() == 0) {
+			err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, dateStr))
 			if err != nil {
 				return err
 			}
@@ -3204,10 +3200,10 @@ func (du *baseDateArithmetical) vecGetDateFromString(b *baseBuiltinFunc, input *
 	return nil
 }
 
-func (du *baseDateArithmetical) vecGetDateFromDatetime(b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+func (du *baseDateArithmetical) vecGetDateFromDatetime(b *baseBuiltinFunc, ctx sessionctx.Context, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
 	result.ResizeTime(n, false)
-	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -3229,14 +3225,14 @@ func (du *baseDateArithmetical) vecGetDateFromDatetime(b *baseBuiltinFunc, input
 	return nil
 }
 
-func (du *baseDateArithmetical) vecGetIntervalFromString(b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+func (du *baseDateArithmetical) vecGetIntervalFromString(b *baseBuiltinFunc, ctx sessionctx.Context, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -3266,14 +3262,14 @@ func (du *baseDateArithmetical) vecGetIntervalFromString(b *baseBuiltinFunc, inp
 	return nil
 }
 
-func (du *baseDateArithmetical) vecGetIntervalFromDecimal(b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+func (du *baseDateArithmetical) vecGetIntervalFromDecimal(b *baseBuiltinFunc, ctx sessionctx.Context, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -3329,9 +3325,9 @@ func (du *baseDateArithmetical) vecGetIntervalFromDecimal(b *baseBuiltinFunc, in
 		/* keep interval as original decimal */
 	default:
 		// YEAR, QUARTER, MONTH, WEEK, DAY, HOUR, MINUTE, MICROSECOND
-		castExpr := WrapWithCastAsString(b.ctx, WrapWithCastAsInt(b.ctx, b.args[1]))
+		castExpr := WrapWithCastAsString(ctx, WrapWithCastAsInt(ctx, b.args[1]))
 		amendInterval = func(_ string, row *chunk.Row) (string, bool, error) {
-			interval, isNull, err := castExpr.EvalString(b.ctx, *row)
+			interval, isNull, err := castExpr.EvalString(ctx, *row)
 			return interval, isNull || err != nil, err
 		}
 	}
@@ -3367,14 +3363,14 @@ func (du *baseDateArithmetical) vecGetIntervalFromDecimal(b *baseBuiltinFunc, in
 	return nil
 }
 
-func (du *baseDateArithmetical) vecGetIntervalFromInt(b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+func (du *baseDateArithmetical) vecGetIntervalFromInt(b *baseBuiltinFunc, ctx sessionctx.Context, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -3390,14 +3386,14 @@ func (du *baseDateArithmetical) vecGetIntervalFromInt(b *baseBuiltinFunc, input 
 	return nil
 }
 
-func (du *baseDateArithmetical) vecGetIntervalFromReal(b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+func (du *baseDateArithmetical) vecGetIntervalFromReal(b *baseBuiltinFunc, ctx sessionctx.Context, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -3462,22 +3458,22 @@ func getDateFromDecimal(da *baseDateArithmetical, ctx sessionctx.Context, args [
 	return da.getDateFromDecimal(ctx, args, row, unit)
 }
 
-type funcVecGetDateForDateAddSub func(da *baseDateArithmetical, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error
+type funcVecGetDateForDateAddSub func(da *baseDateArithmetical, ctx sessionctx.Context, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error
 
-func vecGetDateFromString(da *baseDateArithmetical, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
-	return da.vecGetDateFromString(b, input, unit, result)
+func vecGetDateFromString(da *baseDateArithmetical, ctx sessionctx.Context, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+	return da.vecGetDateFromString(b, ctx, input, unit, result)
 }
 
-func vecGetDateFromInt(da *baseDateArithmetical, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
-	return da.vecGetDateFromInt(b, input, unit, result)
+func vecGetDateFromInt(da *baseDateArithmetical, ctx sessionctx.Context, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+	return da.vecGetDateFromInt(b, ctx, input, unit, result)
 }
 
-func vecGetDateFromReal(da *baseDateArithmetical, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
-	return da.vecGetDateFromReal(b, input, unit, result)
+func vecGetDateFromReal(da *baseDateArithmetical, ctx sessionctx.Context, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+	return da.vecGetDateFromReal(b, ctx, input, unit, result)
 }
 
-func vecGetDateFromDecimal(da *baseDateArithmetical, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
-	return da.vecGetDateFromDecimal(b, input, unit, result)
+func vecGetDateFromDecimal(da *baseDateArithmetical, ctx sessionctx.Context, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+	return da.vecGetDateFromDecimal(b, ctx, input, unit, result)
 }
 
 type funcGetIntervalForDateAddSub func(da *baseDateArithmetical, ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (string, bool, error)
@@ -3498,22 +3494,22 @@ func getIntervalFromDecimal(da *baseDateArithmetical, ctx sessionctx.Context, ar
 	return da.getIntervalFromDecimal(ctx, args, row, unit)
 }
 
-type funcVecGetIntervalForDateAddSub func(da *baseDateArithmetical, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error
+type funcVecGetIntervalForDateAddSub func(da *baseDateArithmetical, ctx sessionctx.Context, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error
 
-func vecGetIntervalFromString(da *baseDateArithmetical, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
-	return da.vecGetIntervalFromString(b, input, unit, result)
+func vecGetIntervalFromString(da *baseDateArithmetical, ctx sessionctx.Context, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+	return da.vecGetIntervalFromString(b, ctx, input, unit, result)
 }
 
-func vecGetIntervalFromInt(da *baseDateArithmetical, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
-	return da.vecGetIntervalFromInt(b, input, unit, result)
+func vecGetIntervalFromInt(da *baseDateArithmetical, ctx sessionctx.Context, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+	return da.vecGetIntervalFromInt(b, ctx, input, unit, result)
 }
 
-func vecGetIntervalFromReal(da *baseDateArithmetical, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
-	return da.vecGetIntervalFromReal(b, input, unit, result)
+func vecGetIntervalFromReal(da *baseDateArithmetical, ctx sessionctx.Context, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+	return da.vecGetIntervalFromReal(b, ctx, input, unit, result)
 }
 
-func vecGetIntervalFromDecimal(da *baseDateArithmetical, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
-	return da.vecGetIntervalFromDecimal(b, input, unit, result)
+func vecGetIntervalFromDecimal(da *baseDateArithmetical, ctx sessionctx.Context, b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
+	return da.vecGetIntervalFromDecimal(b, ctx, input, unit, result)
 }
 
 type addSubDateFunctionClass struct {
@@ -3897,25 +3893,25 @@ func (b *builtinAddSubDateAsStringSig) Clone() builtinFunc {
 }
 
 func (b *builtinAddSubDateAsStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
+	unit, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime.String(), true, err
 	}
 
-	date, isNull, err := b.getDate(&b.baseDateArithmetical, b.ctx, b.args, row, unit)
+	date, isNull, err := b.getDate(&b.baseDateArithmetical, ctx, b.args, row, unit)
 	if isNull || err != nil {
 		return types.ZeroTime.String(), true, err
 	}
 	if date.InvalidZero() {
-		return types.ZeroTime.String(), true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
+		return types.ZeroTime.String(), true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String()))
 	}
 
-	interval, isNull, err := b.getInterval(&b.baseDateArithmetical, b.ctx, b.args, row, unit)
+	interval, isNull, err := b.getInterval(&b.baseDateArithmetical, ctx, b.args, row, unit)
 	if isNull || err != nil {
 		return types.ZeroTime.String(), true, err
 	}
 
-	result, isNull, err := b.timeOp(&b.baseDateArithmetical, b.ctx, date, interval, unit, b.tp.GetDecimal())
+	result, isNull, err := b.timeOp(&b.baseDateArithmetical, ctx, date, interval, unit, b.tp.GetDecimal())
 	if result.Microsecond() == 0 {
 		result.SetFsp(types.MinFsp)
 	} else {
@@ -3945,22 +3941,22 @@ func (b *builtinAddSubDateDatetimeAnySig) Clone() builtinFunc {
 }
 
 func (b *builtinAddSubDateDatetimeAnySig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
+	unit, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, true, err
 	}
 
-	date, isNull, err := b.getDateFromDatetime(b.ctx, b.args, row, unit)
+	date, isNull, err := b.getDateFromDatetime(ctx, b.args, row, unit)
 	if isNull || err != nil {
 		return types.ZeroTime, true, err
 	}
 
-	interval, isNull, err := b.getInterval(&b.baseDateArithmetical, b.ctx, b.args, row, unit)
+	interval, isNull, err := b.getInterval(&b.baseDateArithmetical, ctx, b.args, row, unit)
 	if isNull || err != nil {
 		return types.ZeroTime, true, err
 	}
 
-	result, isNull, err := b.timeOp(&b.baseDateArithmetical, b.ctx, date, interval, unit, b.tp.GetDecimal())
+	result, isNull, err := b.timeOp(&b.baseDateArithmetical, ctx, date, interval, unit, b.tp.GetDecimal())
 	return result, isNull || err != nil, err
 }
 
@@ -3986,47 +3982,47 @@ func (b *builtinAddSubDateDurationAnySig) Clone() builtinFunc {
 }
 
 func (b *builtinAddSubDateDurationAnySig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
+	unit, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, true, err
 	}
 
-	d, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	d, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, true, err
 	}
 
-	interval, isNull, err := b.getInterval(&b.baseDateArithmetical, b.ctx, b.args, row, unit)
+	interval, isNull, err := b.getInterval(&b.baseDateArithmetical, ctx, b.args, row, unit)
 	if isNull || err != nil {
 		return types.ZeroTime, true, err
 	}
 
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	t, err := d.ConvertToTime(sc.TypeCtx(), mysql.TypeDatetime)
 	if err != nil {
 		return types.ZeroTime, true, err
 	}
-	result, isNull, err := b.timeOp(&b.baseDateArithmetical, b.ctx, t, interval, unit, b.tp.GetDecimal())
+	result, isNull, err := b.timeOp(&b.baseDateArithmetical, ctx, t, interval, unit, b.tp.GetDecimal())
 	return result, isNull || err != nil, err
 }
 
 func (b *builtinAddSubDateDurationAnySig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
+	unit, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, true, err
 	}
 
-	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	dur, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, true, err
 	}
 
-	interval, isNull, err := b.getInterval(&b.baseDateArithmetical, b.ctx, b.args, row, unit)
+	interval, isNull, err := b.getInterval(&b.baseDateArithmetical, ctx, b.args, row, unit)
 	if isNull || err != nil {
 		return types.ZeroDuration, true, err
 	}
 
-	result, isNull, err := b.durationOp(&b.baseDateArithmetical, b.ctx, dur, interval, unit, b.tp.GetDecimal())
+	result, isNull, err := b.durationOp(&b.baseDateArithmetical, ctx, dur, interval, unit, b.tp.GetDecimal())
 	return result, isNull || err != nil, err
 }
 
@@ -4060,24 +4056,24 @@ func (b *builtinTimestampDiffSig) Clone() builtinFunc {
 // evalInt evals a builtinTimestampDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timestampdiff
 func (b *builtinTimestampDiffSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
+	unit, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	lhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
+	lhs, isNull, err := b.args[1].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, handleInvalidTimeError(b.ctx, err)
+		return 0, isNull, handleInvalidTimeError(ctx, err)
 	}
-	rhs, isNull, err := b.args[2].EvalTime(b.ctx, row)
+	rhs, isNull, err := b.args[2].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, handleInvalidTimeError(b.ctx, err)
+		return 0, isNull, handleInvalidTimeError(ctx, err)
 	}
 	if invalidLHS, invalidRHS := lhs.InvalidZero(), rhs.InvalidZero(); invalidLHS || invalidRHS {
 		if invalidLHS {
-			err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, lhs.String()))
+			err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, lhs.String()))
 		}
 		if invalidRHS {
-			err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, rhs.String()))
+			err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, rhs.String()))
 		}
 		return 0, true, err
 	}
@@ -4204,7 +4200,7 @@ func (b *builtinUnixTimestampCurrentSig) Clone() builtinFunc {
 // evalInt evals a UNIX_TIMESTAMP().
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_unix-timestamp
 func (b *builtinUnixTimestampCurrentSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	nowTs, err := getStmtTimestamp(b.ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return 0, true, err
 	}
@@ -4232,10 +4228,6 @@ func (b *builtinUnixTimestampIntSig) Clone() builtinFunc {
 // evalInt evals a UNIX_TIMESTAMP(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_unix-timestamp
 func (b *builtinUnixTimestampIntSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	return b.evalIntWithCtx(b.ctx, row)
-}
-
-func (b *builtinUnixTimestampIntSig) evalIntWithCtx(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalTime(ctx, row)
 	if err != nil && terror.ErrorEqual(types.ErrWrongValue.GenWithStackByArgs(types.TimeStr, val), err) {
 		// Return 0 for invalid date time.
@@ -4274,12 +4266,12 @@ func (b *builtinUnixTimestampDecSig) Clone() builtinFunc {
 // evalDecimal evals a UNIX_TIMESTAMP(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_unix-timestamp
 func (b *builtinUnixTimestampDecSig) evalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	val, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		// Return 0 for invalid date time.
 		return new(types.MyDecimal), isNull, nil
 	}
-	t, err := val.GoTime(getTimeZone(b.ctx))
+	t, err := val.GoTime(getTimeZone(ctx))
 	if err != nil {
 		return new(types.MyDecimal), false, nil
 	}
@@ -4348,19 +4340,19 @@ func (b *builtinTimestamp1ArgSig) Clone() builtinFunc {
 // evalTime evals a builtinTimestamp1ArgSig.
 // See https://dev.mysql.com/doc/refman/5.5/en/date-and-time-functions.html#function_timestamp
 func (b *builtinTimestamp1ArgSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	s, isNull, err := b.args[0].EvalString(b.ctx, row)
+	s, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, isNull, err
 	}
 	var tm types.Time
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	if b.isFloat {
 		tm, err = types.ParseTimeFromFloatString(sc.TypeCtx(), s, mysql.TypeDatetime, types.GetFsp(s))
 	} else {
 		tm, err = types.ParseTime(sc.TypeCtx(), s, mysql.TypeDatetime, types.GetFsp(s), nil)
 	}
 	if err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	return tm, false, nil
 }
@@ -4380,26 +4372,26 @@ func (b *builtinTimestamp2ArgsSig) Clone() builtinFunc {
 // evalTime evals a builtinTimestamp2ArgsSig.
 // See https://dev.mysql.com/doc/refman/5.5/en/date-and-time-functions.html#function_timestamp
 func (b *builtinTimestamp2ArgsSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	arg0, isNull, err := b.args[0].EvalString(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, isNull, err
 	}
 	var tm types.Time
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	if b.isFloat {
 		tm, err = types.ParseTimeFromFloatString(sc.TypeCtx(), arg0, mysql.TypeDatetime, types.GetFsp(arg0))
 	} else {
 		tm, err = types.ParseTime(sc.TypeCtx(), arg0, mysql.TypeDatetime, types.GetFsp(arg0), nil)
 	}
 	if err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	if tm.Year() == 0 {
 		// MySQL won't evaluate add for date with zero year.
 		// See https://github.com/mysql/mysql-server/blob/5.7/sql/item_timefunc.cc#L2805
 		return types.ZeroTime, true, nil
 	}
-	arg1, isNull, err := b.args[1].EvalString(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, isNull, err
 	}
@@ -4408,7 +4400,7 @@ func (b *builtinTimestamp2ArgsSig) evalTime(ctx sessionctx.Context, row chunk.Ro
 	}
 	duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
 	if err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	tmp, err := tm.Add(sc.TypeCtx(), duration)
 	if err != nil {
@@ -4717,15 +4709,15 @@ func (b *builtinAddDatetimeAndDurationSig) Clone() builtinFunc {
 // evalTime evals a builtinAddDatetimeAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDatetimeAndDurationSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, err
 	}
-	result, err := arg0.Add(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), arg1)
+	result, err := arg0.Add(ctx.GetSessionVars().StmtCtx.TypeCtx(), arg1)
 	return result, err != nil, err
 }
 
@@ -4742,18 +4734,18 @@ func (b *builtinAddDatetimeAndStringSig) Clone() builtinFunc {
 // evalTime evals a builtinAddDatetimeAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDatetimeAndStringSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, err
 	}
-	s, isNull, err := b.args[1].EvalString(b.ctx, row)
+	s, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, err
 	}
 	if !isDuration(s) {
 		return types.ZeroDatetime, true, nil
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	arg1, _, err := types.ParseDuration(sc.TypeCtx(), s, types.GetFsp(s))
 	if err != nil {
 		if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -4795,11 +4787,11 @@ func (b *builtinAddDurationAndDurationSig) Clone() builtinFunc {
 // evalDuration evals a builtinAddDurationAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDurationAndDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, err
 	}
@@ -4823,18 +4815,18 @@ func (b *builtinAddDurationAndStringSig) Clone() builtinFunc {
 // evalDuration evals a builtinAddDurationAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDurationAndStringSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, err
 	}
-	s, isNull, err := b.args[1].EvalString(b.ctx, row)
+	s, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, err
 	}
 	if !isDuration(s) {
 		return types.ZeroDuration, true, nil
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	arg1, _, err := types.ParseDuration(sc.TypeCtx(), s, types.GetFsp(s))
 	if err != nil {
 		if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -4883,15 +4875,15 @@ func (b *builtinAddStringAndDurationSig) evalString(ctx sessionctx.Context, row 
 		arg0 string
 		arg1 types.Duration
 	)
-	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
+	arg0, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	arg1, isNull, err = b.args[1].EvalDuration(b.ctx, row)
+	arg1, isNull, err = b.args[1].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	if isDuration(arg0) {
 		result, err = strDurationAddDuration(sc, arg0, arg1)
 		if err != nil {
@@ -4924,7 +4916,7 @@ func (b *builtinAddStringAndStringSig) evalString(ctx sessionctx.Context, row ch
 		arg0, arg1Str string
 		arg1          types.Duration
 	)
-	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
+	arg0, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -4932,11 +4924,11 @@ func (b *builtinAddStringAndStringSig) evalString(ctx sessionctx.Context, row ch
 	if mysql.HasBinaryFlag(arg1Type.GetFlag()) {
 		return "", true, nil
 	}
-	arg1Str, isNull, err = b.args[1].EvalString(b.ctx, row)
+	arg1Str, isNull, err = b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	arg1, _, err = types.ParseDuration(sc.TypeCtx(), arg1Str, getFsp4TimeAddSub(arg1Str))
 	if err != nil {
 		if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -4983,11 +4975,11 @@ func (b *builtinAddDateAndDurationSig) Clone() builtinFunc {
 // evalString evals a builtinAddDurationAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDateAndDurationSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -5008,18 +5000,18 @@ func (b *builtinAddDateAndStringSig) Clone() builtinFunc {
 // evalString evals a builtinAddDateAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDateAndStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	s, isNull, err := b.args[1].EvalString(b.ctx, row)
+	s, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
 	if !isDuration(s) {
 		return "", true, nil
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	arg1, _, err := types.ParseDuration(sc.TypeCtx(), s, getFsp4TimeAddSub(s))
 	if err != nil {
 		if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -5099,19 +5091,19 @@ func (b *builtinConvertTzSig) Clone() builtinFunc {
 // `CONVERT_TZ` function returns NULL if the arguments are invalid.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_convert-tz
 func (b *builtinConvertTzSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	dt, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	dt, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, true, nil
 	}
 	if dt.InvalidZero() {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, dt.String()))
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, dt.String()))
 	}
-	fromTzStr, isNull, err := b.args[1].EvalString(b.ctx, row)
+	fromTzStr, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, true, nil
 	}
 
-	toTzStr, isNull, err := b.args[2].EvalString(b.ctx, row)
+	toTzStr, isNull, err := b.args[2].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, true, nil
 	}
@@ -5195,11 +5187,11 @@ func (b *builtinMakeDateSig) Clone() builtinFunc {
 func (b *builtinMakeDateSig) evalTime(ctx sessionctx.Context, row chunk.Row) (d types.Time, isNull bool, err error) {
 	args := b.getArgs()
 	var year, dayOfYear int64
-	year, isNull, err = args[0].EvalInt(b.ctx, row)
+	year, isNull, err = args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return d, true, err
 	}
-	dayOfYear, isNull, err = args[1].EvalInt(b.ctx, row)
+	dayOfYear, isNull, err = args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return d, true, err
 	}
@@ -5214,7 +5206,7 @@ func (b *builtinMakeDateSig) evalTime(ctx sessionctx.Context, row chunk.Row) (d 
 	startTime := types.NewTime(types.FromDate(int(year), 1, 1, 0, 0, 0, 0), mysql.TypeDate, 0)
 	retTimestamp := types.TimestampDiff("DAY", types.ZeroDate, startTime)
 	if retTimestamp == 0 {
-		return d, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, startTime.String()))
+		return d, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, startTime.String()))
 	}
 	ret := types.TimeFromDays(retTimestamp + dayOfYear - 1)
 	if ret.IsZero() || ret.Year() > 9999 {
@@ -5263,7 +5255,7 @@ func (b *builtinMakeTimeSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinMakeTimeSig) makeTime(hour int64, minute int64, second float64, hourUnsignedFlag bool) (types.Duration, error) {
+func (b *builtinMakeTimeSig) makeTime(ctx types.Context, hour int64, minute int64, second float64, hourUnsignedFlag bool) (types.Duration, error) {
 	var overflow bool
 	// MySQL TIME datatype: https://dev.mysql.com/doc/refman/5.7/en/time.html
 	// ranges from '-838:59:59.000000' to '838:59:59.000000'
@@ -5286,7 +5278,7 @@ func (b *builtinMakeTimeSig) makeTime(hour int64, minute int64, second float64, 
 		second = 59
 	}
 	fsp := b.tp.GetDecimal()
-	d, _, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), fmt.Sprintf("%02d:%02d:%v", hour, minute, second), fsp)
+	d, _, err := types.ParseDuration(ctx, fmt.Sprintf("%02d:%02d:%v", hour, minute, second), fsp)
 	return d, err
 }
 
@@ -5295,25 +5287,25 @@ func (b *builtinMakeTimeSig) makeTime(hour int64, minute int64, second float64, 
 func (b *builtinMakeTimeSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
 	dur := types.ZeroDuration
 	dur.Fsp = types.MaxFsp
-	hour, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	hour, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return dur, isNull, err
 	}
-	minute, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	minute, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return dur, isNull, err
 	}
 	if minute < 0 || minute >= 60 {
 		return dur, true, nil
 	}
-	second, isNull, err := b.args[2].EvalReal(b.ctx, row)
+	second, isNull, err := b.args[2].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return dur, isNull, err
 	}
 	if second < 0 || second >= 60 {
 		return dur, true, nil
 	}
-	dur, err = b.makeTime(hour, minute, second, mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()))
+	dur, err = b.makeTime(ctx.GetSessionVars().StmtCtx.TypeCtx(), hour, minute, second, mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()))
 	if err != nil {
 		return dur, true, err
 	}
@@ -5389,12 +5381,12 @@ func (b *builtinPeriodAddSig) Clone() builtinFunc {
 // evalInt evals PERIOD_ADD(P,N).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_period-add
 func (b *builtinPeriodAddSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	p, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	p, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, true, err
 	}
 
-	n, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	n, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, true, err
 	}
@@ -5438,12 +5430,12 @@ func (b *builtinPeriodDiffSig) Clone() builtinFunc {
 // evalInt evals PERIOD_DIFF(P1,P2).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_period-diff
 func (b *builtinPeriodDiffSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	p1, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	p1, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 
-	p2, isNull, err := b.args[1].EvalInt(b.ctx, row)
+	p2, isNull, err := b.args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -5492,9 +5484,9 @@ func (b *builtinQuarterSig) Clone() builtinFunc {
 // evalInt evals QUARTER(date).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_quarter
 func (b *builtinQuarterSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	date, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 
 	return int64((date.Month() + 2) / 3), false, nil
@@ -5544,7 +5536,7 @@ func (b *builtinSecToTimeSig) Clone() builtinFunc {
 // evalDuration evals SEC_TO_TIME(seconds).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_sec-to-time
 func (b *builtinSecToTimeSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	secondsFloat, isNull, err := b.args[0].EvalReal(b.ctx, row)
+	secondsFloat, isNull, err := b.args[0].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return types.Duration{}, isNull, err
 	}
@@ -5570,7 +5562,7 @@ func (b *builtinSecToTimeSig) evalDuration(ctx sessionctx.Context, row chunk.Row
 		minute = 59
 		second = 59
 		demical = 0
-		err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("time", strconv.FormatFloat(secondsFloat, 'f', -1, 64)))
+		err = ctx.GetSessionVars().StmtCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("time", strconv.FormatFloat(secondsFloat, 'f', -1, 64)))
 		if err != nil {
 			return types.Duration{}, err != nil, err
 		}
@@ -5581,7 +5573,7 @@ func (b *builtinSecToTimeSig) evalDuration(ctx sessionctx.Context, row chunk.Row
 	secondDemical = float64(second) + demical
 
 	var dur types.Duration
-	dur, _, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), fmt.Sprintf("%s%02d:%02d:%s", negative, hour, minute, strconv.FormatFloat(secondDemical, 'f', -1, 64)), b.tp.GetDecimal())
+	dur, _, err = types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), fmt.Sprintf("%s%02d:%02d:%s", negative, hour, minute, strconv.FormatFloat(secondDemical, 'f', -1, 64)), b.tp.GetDecimal())
 	if err != nil {
 		return types.Duration{}, err != nil, err
 	}
@@ -5669,15 +5661,15 @@ func (b *builtinSubDatetimeAndDurationSig) Clone() builtinFunc {
 // evalTime evals a builtinSubDatetimeAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDatetimeAndDurationSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	result, err := arg0.Add(sc.TypeCtx(), arg1.Neg())
 	return result, err != nil, err
 }
@@ -5695,18 +5687,18 @@ func (b *builtinSubDatetimeAndStringSig) Clone() builtinFunc {
 // evalTime evals a builtinSubDatetimeAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDatetimeAndStringSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, err
 	}
-	s, isNull, err := b.args[1].EvalString(b.ctx, row)
+	s, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, err
 	}
 	if !isDuration(s) {
 		return types.ZeroDatetime, true, nil
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	arg1, _, err := types.ParseDuration(sc.TypeCtx(), s, types.GetFsp(s))
 	if err != nil {
 		if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -5752,15 +5744,15 @@ func (b *builtinSubStringAndDurationSig) evalString(ctx sessionctx.Context, row 
 		arg0 string
 		arg1 types.Duration
 	)
-	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
+	arg0, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	arg1, isNull, err = b.args[1].EvalDuration(b.ctx, row)
+	arg1, isNull, err = b.args[1].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	if isDuration(arg0) {
 		result, err = strDurationSubDuration(sc, arg0, arg1)
 		if err != nil {
@@ -5793,7 +5785,7 @@ func (b *builtinSubStringAndStringSig) evalString(ctx sessionctx.Context, row ch
 		s, arg0 string
 		arg1    types.Duration
 	)
-	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
+	arg0, isNull, err = b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -5801,11 +5793,11 @@ func (b *builtinSubStringAndStringSig) evalString(ctx sessionctx.Context, row ch
 	if mysql.HasBinaryFlag(arg1Type.GetFlag()) {
 		return "", true, nil
 	}
-	s, isNull, err = b.args[1].EvalString(b.ctx, row)
+	s, isNull, err = b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	arg1, _, err = types.ParseDuration(sc.TypeCtx(), s, getFsp4TimeAddSub(s))
 	if err != nil {
 		if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -5858,11 +5850,11 @@ func (b *builtinSubDurationAndDurationSig) Clone() builtinFunc {
 // evalDuration evals a builtinSubDurationAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDurationAndDurationSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, err
 	}
@@ -5886,18 +5878,18 @@ func (b *builtinSubDurationAndStringSig) Clone() builtinFunc {
 // evalDuration evals a builtinSubDurationAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDurationAndStringSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, err
 	}
-	s, isNull, err := b.args[1].EvalString(b.ctx, row)
+	s, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, err
 	}
 	if !isDuration(s) {
 		return types.ZeroDuration, true, nil
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	arg1, _, err := types.ParseDuration(sc.TypeCtx(), s, types.GetFsp(s))
 	if err != nil {
 		if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -5939,11 +5931,11 @@ func (b *builtinSubDateAndDurationSig) Clone() builtinFunc {
 // evalString evals a builtinSubDateAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDateAndDurationSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
+	arg1, isNull, err := b.args[1].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
@@ -5964,18 +5956,18 @@ func (b *builtinSubDateAndStringSig) Clone() builtinFunc {
 // evalString evals a builtinSubDateAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDateAndStringSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	arg0, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	s, isNull, err := b.args[1].EvalString(b.ctx, row)
+	s, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
 	if !isDuration(s) {
 		return "", true, nil
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	arg1, _, err := types.ParseDuration(sc.TypeCtx(), s, getFsp4TimeAddSub(s))
 	if err != nil {
 		if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -6023,7 +6015,7 @@ func (b *builtinTimeFormatSig) Clone() builtinFunc {
 // evalString evals a builtinTimeFormatSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_time-format
 func (b *builtinTimeFormatSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	dur, isNull, err := b.args[0].EvalDuration(ctx, row)
 	// if err != nil, then dur is ZeroDuration, outputs 00:00:00 in this case which follows the behavior of mysql.
 	if err != nil {
 		logutil.BgLogger().Warn("time_format.args[0].EvalDuration failed", zap.Error(err))
@@ -6031,11 +6023,11 @@ func (b *builtinTimeFormatSig) evalString(ctx sessionctx.Context, row chunk.Row)
 	if isNull {
 		return "", isNull, err
 	}
-	formatMask, isNull, err := b.args[1].EvalString(b.ctx, row)
+	formatMask, isNull, err := b.args[1].EvalString(ctx, row)
 	if err != nil || isNull {
 		return "", isNull, err
 	}
-	res, err := b.formatTime(b.ctx, dur, formatMask)
+	res, err := b.formatTime(ctx, dur, formatMask)
 	return res, isNull, err
 }
 
@@ -6075,7 +6067,7 @@ func (b *builtinTimeToSecSig) Clone() builtinFunc {
 // evalInt evals TIME_TO_SEC(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_time-to-sec
 func (b *builtinTimeToSecSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	duration, isNull, err := b.args[0].EvalDuration(b.ctx, row)
+	duration, isNull, err := b.args[0].EvalDuration(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
@@ -6208,21 +6200,21 @@ func addUnitToTime(unit string, t time.Time, v float64) (time.Time, bool, error)
 // evalString evals a builtinTimestampAddSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timestampadd
 func (b *builtinTimestampAddSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
-	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
+	unit, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	v, isNull, err := b.args[1].EvalReal(b.ctx, row)
+	v, isNull, err := b.args[1].EvalReal(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	arg, isNull, err := b.args[2].EvalTime(b.ctx, row)
+	arg, isNull, err := b.args[2].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
 	tm1, err := arg.GoTime(time.Local)
 	if err != nil {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
+		ctx.GetSessionVars().StmtCtx.AppendWarning(err)
 		return "", true, nil
 	}
 	tb, overflow, err := addUnitToTime(unit, tm1, v)
@@ -6230,7 +6222,7 @@ func (b *builtinTimestampAddSig) evalString(ctx sessionctx.Context, row chunk.Ro
 		return "", true, err
 	}
 	if overflow {
-		return "", true, handleInvalidTimeError(b.ctx, types.ErrDatetimeFunctionOverflow.GenWithStackByArgs("datetime"))
+		return "", true, handleInvalidTimeError(ctx, types.ErrDatetimeFunctionOverflow.GenWithStackByArgs("datetime"))
 	}
 	fsp := types.DefaultFsp
 	// use MaxFsp when microsecond is not zero
@@ -6238,8 +6230,8 @@ func (b *builtinTimestampAddSig) evalString(ctx sessionctx.Context, row chunk.Ro
 		fsp = types.MaxFsp
 	}
 	r := types.NewTime(types.FromGoTime(tb), b.resolveType(arg.Type(), unit), fsp)
-	if err = r.Check(b.ctx.GetSessionVars().StmtCtx.TypeCtx()); err != nil {
-		return "", true, handleInvalidTimeError(b.ctx, err)
+	if err = r.Check(ctx.GetSessionVars().StmtCtx.TypeCtx()); err != nil {
+		return "", true, handleInvalidTimeError(ctx, err)
 	}
 	return r.String(), false, nil
 }
@@ -6291,17 +6283,17 @@ func (b *builtinToDaysSig) Clone() builtinFunc {
 // evalInt evals a builtinToDaysSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_to-days
 func (b *builtinToDaysSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalTime(ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 	if arg.InvalidZero() {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
 	}
 	ret := types.TimestampDiff("DAY", types.ZeroDate, arg)
 	if ret == 0 {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
 	}
 	return ret, false, nil
 }
@@ -6336,16 +6328,16 @@ func (b *builtinToSecondsSig) Clone() builtinFunc {
 // evalInt evals a builtinToSecondsSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_to-seconds
 func (b *builtinToSecondsSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return 0, true, handleInvalidTimeError(b.ctx, err)
+		return 0, true, handleInvalidTimeError(ctx, err)
 	}
 	if arg.InvalidZero() {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
 	}
 	ret := types.TimestampDiff("SECOND", types.ZeroDate, arg)
 	if ret == 0 {
-		return 0, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
+		return 0, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
 	}
 	return ret, false, nil
 }
@@ -6366,7 +6358,7 @@ func (c *utcTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	if err != nil {
 		return nil, err
 	}
-	fsp, err := getFspByIntArg(bf.ctx, args)
+	fsp, err := getFspByIntArg(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -6399,11 +6391,11 @@ func (b *builtinUTCTimeWithoutArgSig) Clone() builtinFunc {
 // evalDuration evals a builtinUTCTimeWithoutArgSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-time
 func (b *builtinUTCTimeWithoutArgSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	nowTs, err := getStmtTimestamp(b.ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return types.Duration{}, true, err
 	}
-	v, _, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), nowTs.UTC().Format(types.TimeFormat), 0)
+	v, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), nowTs.UTC().Format(types.TimeFormat), 0)
 	return v, false, err
 }
 
@@ -6420,7 +6412,7 @@ func (b *builtinUTCTimeWithArgSig) Clone() builtinFunc {
 // evalDuration evals a builtinUTCTimeWithArgSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-time
 func (b *builtinUTCTimeWithArgSig) evalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
-	fsp, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	fsp, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return types.Duration{}, isNull, err
 	}
@@ -6430,11 +6422,11 @@ func (b *builtinUTCTimeWithArgSig) evalDuration(ctx sessionctx.Context, row chun
 	if fsp < int64(types.MinFsp) {
 		return types.Duration{}, true, errors.Errorf("Invalid negative %d specified, must in [0, 6]", fsp)
 	}
-	nowTs, err := getStmtTimestamp(b.ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return types.Duration{}, true, err
 	}
-	v, _, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), nowTs.UTC().Format(types.TimeFSPFormat), int(fsp))
+	v, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), nowTs.UTC().Format(types.TimeFSPFormat), int(fsp))
 	return v, false, err
 }
 
@@ -6469,14 +6461,14 @@ func (b *builtinLastDaySig) Clone() builtinFunc {
 // evalTime evals a builtinLastDaySig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_last-day
 func (b *builtinLastDaySig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	tm := arg
 	year, month := tm.Year(), tm.Month()
-	if tm.Month() == 0 || (tm.Day() == 0 && b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()) {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
+	if tm.Month() == 0 || (tm.Day() == 0 && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()) {
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String()))
 	}
 	lastDay := types.GetLastDay(year, month)
 	ret := types.NewTime(types.FromDate(year, month, lastDay, 0, 0, 0, 0), mysql.TypeDate, types.DefaultFsp)
@@ -6532,14 +6524,14 @@ func (b *builtinTidbParseTsoSig) Clone() builtinFunc {
 
 // evalTime evals a builtinTidbParseTsoSig.
 func (b *builtinTidbParseTsoSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	arg, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil || arg <= 0 {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 
 	t := oracle.GetTimeFromTS(uint64(arg))
 	result := types.NewTime(types.FromGoTime(t), mysql.TypeDatetime, types.MaxFsp)
-	err = result.ConvertTimeZone(time.Local, b.ctx.GetSessionVars().Location())
+	err = result.ConvertTimeZone(time.Local, ctx.GetSessionVars().Location())
 	if err != nil {
 		return types.ZeroTime, true, err
 	}
@@ -6576,7 +6568,7 @@ func (b *builtinTidbParseTsoLogicalSig) Clone() builtinFunc {
 
 // evalTime evals a builtinTidbParseTsoLogicalSig.
 func (b *builtinTidbParseTsoLogicalSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalInt(b.ctx, row)
+	arg, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil || arg <= 0 {
 		return 0, true, err
 	}
@@ -6615,24 +6607,24 @@ func (b *builtinTiDBBoundedStalenessSig) Clone() builtinFunc {
 }
 
 func (b *builtinTiDBBoundedStalenessSig) evalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
-	leftTime, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	leftTime, isNull, err := b.args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
-	rightTime, isNull, err := b.args[1].EvalTime(b.ctx, row)
+	rightTime, isNull, err := b.args[1].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return types.ZeroTime, true, handleInvalidTimeError(b.ctx, err)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
 	}
 	if invalidLeftTime, invalidRightTime := leftTime.InvalidZero(), rightTime.InvalidZero(); invalidLeftTime || invalidRightTime {
 		if invalidLeftTime {
-			err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, leftTime.String()))
+			err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, leftTime.String()))
 		}
 		if invalidRightTime {
-			err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, rightTime.String()))
+			err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, rightTime.String()))
 		}
 		return types.ZeroTime, true, err
 	}
-	timeZone := getTimeZone(b.ctx)
+	timeZone := getTimeZone(ctx)
 	minTime, err := leftTime.GoTime(timeZone)
 	if err != nil {
 		return types.ZeroTime, true, err
@@ -6645,7 +6637,7 @@ func (b *builtinTiDBBoundedStalenessSig) evalTime(ctx sessionctx.Context, row ch
 		return types.ZeroTime, true, nil
 	}
 	// Because the minimum unit of a TSO is millisecond, so we only need fsp to be 3.
-	return types.NewTime(types.FromGoTime(calAppropriateTime(minTime, maxTime, getMinSafeTime(b.ctx, timeZone))), mysql.TypeDatetime, 3), false, nil
+	return types.NewTime(types.FromGoTime(calAppropriateTime(minTime, maxTime, getMinSafeTime(ctx, timeZone))), mysql.TypeDatetime, 3), false, nil
 }
 
 // GetMinSafeTime get minSafeTime
@@ -6755,7 +6747,7 @@ func (b *builtinTiDBCurrentTsoSig) Clone() builtinFunc {
 
 // evalInt evals currentTSO().
 func (b *builtinTiDBCurrentTsoSig) evalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {
-	tso, _ := b.ctx.GetSessionVars().GetSessionOrGlobalSystemVar(context.Background(), "tidb_current_ts")
+	tso, _ := ctx.GetSessionVars().GetSessionOrGlobalSystemVar(context.Background(), "tidb_current_ts")
 	itso, _ := strconv.ParseInt(tso, 10, 64)
 	return itso, false, nil
 }

--- a/pkg/expression/builtin_time_vec.go
+++ b/pkg/expression/builtin_time_vec.go
@@ -38,7 +38,7 @@ func (b *builtinMonthSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk,
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -66,7 +66,7 @@ func (b *builtinYearSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, 
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -88,7 +88,7 @@ func (b *builtinYearSig) vectorized() bool {
 }
 
 func (b *builtinDateSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, result); err != nil {
 		return err
 	}
 	times := result.Times()
@@ -96,8 +96,8 @@ func (b *builtinDateSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk,
 		if result.IsNull(i) {
 			continue
 		}
-		if times[i].IsZero() && b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, times[i].String())); err != nil {
+		if times[i].IsZero() && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, times[i].String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -124,7 +124,7 @@ func (b *builtinFromUnixTime2ArgSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err = b.args[0].VecEvalDecimal(b.ctx, input, buf1); err != nil {
+	if err = b.args[0].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -133,7 +133,7 @@ func (b *builtinFromUnixTime2ArgSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err = b.args[1].VecEvalString(b.ctx, input, buf2); err != nil {
+	if err = b.args[1].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -145,7 +145,7 @@ func (b *builtinFromUnixTime2ArgSig) vecEvalString(ctx sessionctx.Context, input
 			result.AppendNull()
 			continue
 		}
-		t, isNull, err := evalFromUnixTime(b.ctx, fsp, &ds[i])
+		t, isNull, err := evalFromUnixTime(ctx, fsp, &ds[i])
 		if err != nil {
 			return err
 		}
@@ -168,7 +168,7 @@ func (b *builtinSysDateWithoutFspSig) vectorized() bool {
 
 func (b *builtinSysDateWithoutFspSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	loc := b.ctx.GetSessionVars().Location()
+	loc := ctx.GetSessionVars().Location()
 	now := time.Now().In(loc)
 
 	result.ResizeTime(n, false)
@@ -195,7 +195,7 @@ func (b *builtinExtractDatetimeFromStringSig) vecEvalInt(ctx sessionctx.Context,
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -204,7 +204,7 @@ func (b *builtinExtractDatetimeFromStringSig) vecEvalInt(ctx sessionctx.Context,
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -229,14 +229,14 @@ func (b *builtinDayNameSig) vectorized() bool {
 	return true
 }
 
-func (b *builtinDayNameSig) vecEvalIndex(input *chunk.Chunk, apply func(i, res int), applyNull func(i int)) error {
+func (b *builtinDayNameSig) vecEvalIndex(ctx sessionctx.Context, input *chunk.Chunk, apply func(i int, res int), applyNull func(i int)) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -247,7 +247,7 @@ func (b *builtinDayNameSig) vecEvalIndex(input *chunk.Chunk, apply func(i, res i
 			continue
 		}
 		if ds[i].InvalidZero() {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
 				return err
 			}
 			applyNull(i)
@@ -268,14 +268,11 @@ func (b *builtinDayNameSig) vecEvalString(ctx sessionctx.Context, input *chunk.C
 	n := input.NumRows()
 	result.ReserveString(n)
 
-	return b.vecEvalIndex(input,
-		func(i, res int) {
-			result.AppendString(types.WeekdayNames[res])
-		},
-		func(i int) {
-			result.AppendNull()
-		},
-	)
+	return b.vecEvalIndex(ctx, input, func(i, res int) {
+		result.AppendString(types.WeekdayNames[res])
+	}, func(i int) {
+		result.AppendNull()
+	})
 }
 
 func (b *builtinDayNameSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
@@ -283,14 +280,11 @@ func (b *builtinDayNameSig) vecEvalReal(ctx sessionctx.Context, input *chunk.Chu
 	result.ResizeFloat64(n, false)
 	f64s := result.Float64s()
 
-	return b.vecEvalIndex(input,
-		func(i, res int) {
-			f64s[i] = float64(res)
-		},
-		func(i int) {
-			result.SetNull(i, true)
-		},
-	)
+	return b.vecEvalIndex(ctx, input, func(i, res int) {
+		f64s[i] = float64(res)
+	}, func(i int) {
+		result.SetNull(i, true)
+	})
 }
 
 func (b *builtinDayNameSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
@@ -298,14 +292,11 @@ func (b *builtinDayNameSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chun
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
 
-	return b.vecEvalIndex(input,
-		func(i, res int) {
-			i64s[i] = int64(res)
-		},
-		func(i int) {
-			result.SetNull(i, true)
-		},
-	)
+	return b.vecEvalIndex(ctx, input, func(i, res int) {
+		i64s[i] = int64(res)
+	}, func(i int) {
+		result.SetNull(i, true)
+	})
 }
 
 func (b *builtinWeekDaySig) vectorized() bool {
@@ -319,7 +310,7 @@ func (b *builtinWeekDaySig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -332,7 +323,7 @@ func (b *builtinWeekDaySig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chun
 			continue
 		}
 		if ds[i].IsZero() {
-			if err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
+			if err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -354,7 +345,7 @@ func (b *builtinTimeFormatSig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		// If err != nil, then dur is ZeroDuration, outputs 00:00:00
 		// in this case which follows the behavior of mysql.
 		// Use the non-vectorized method to handle this kind of error.
@@ -366,7 +357,7 @@ func (b *builtinTimeFormatSig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err1
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -376,7 +367,7 @@ func (b *builtinTimeFormatSig) vecEvalString(ctx sessionctx.Context, input *chun
 			result.AppendNull()
 			continue
 		}
-		res, err := b.formatTime(b.ctx, buf.GetDuration(i, 0), buf1.GetString(i))
+		res, err := b.formatTime(ctx, buf.GetDuration(i, 0), buf1.GetString(i))
 		if err != nil {
 			return err
 		}
@@ -398,15 +389,15 @@ func (b *builtinUTCTimeWithArgSig) vecEvalDuration(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
-	nowTs, err := getStmtTimestamp(b.ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return err
 	}
 	utc := nowTs.UTC().Format(types.TimeFSPFormat)
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 	result.ResizeGoDuration(n, false)
 	d64s := result.GoDurations()
 	i64s := buf.Int64s()
@@ -436,7 +427,7 @@ func (b *builtinUnixTimestampCurrentSig) vectorized() bool {
 }
 
 func (b *builtinUnixTimestampCurrentSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	nowTs, err := getStmtTimestamp(b.ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return err
 	}
@@ -470,7 +461,7 @@ func (b *builtinYearWeekWithoutModeSig) vecEvalInt(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -484,7 +475,7 @@ func (b *builtinYearWeekWithoutModeSig) vecEvalInt(ctx sessionctx.Context, input
 		}
 		date := ds[i]
 		if date.InvalidZero() {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String())); err != nil {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -506,7 +497,7 @@ func (b *builtinPeriodDiffSig) vectorized() bool {
 // vecEvalInt evals PERIOD_DIFF(P1,P2).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_period-diff
 func (b *builtinPeriodDiffSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -516,7 +507,7 @@ func (b *builtinPeriodDiffSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -546,7 +537,7 @@ func (b *builtinNowWithArgSig) vecEvalTime(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(bufFsp)
-	if err = b.args[0].VecEvalInt(b.ctx, input, bufFsp); err != nil {
+	if err = b.args[0].VecEvalInt(ctx, input, bufFsp); err != nil {
 		return err
 	}
 
@@ -566,7 +557,7 @@ func (b *builtinNowWithArgSig) vecEvalTime(ctx sessionctx.Context, input *chunk.
 			fsp = int(fsps[i])
 		}
 
-		t, isNull, err := evalNowWithFsp(b.ctx, fsp)
+		t, isNull, err := evalNowWithFsp(ctx, fsp)
 		if err != nil {
 			return err
 		}
@@ -593,7 +584,7 @@ func (b *builtinGetFormatSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err = b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err = b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -601,7 +592,7 @@ func (b *builtinGetFormatSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err = b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err = b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -671,7 +662,7 @@ func (b *builtinLastDaySig) vectorized() bool {
 
 func (b *builtinLastDaySig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, result); err != nil {
 		return err
 	}
 	times := result.Times()
@@ -681,8 +672,8 @@ func (b *builtinLastDaySig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chu
 		}
 		tm := times[i]
 		year, month := tm.Year(), tm.Month()
-		if tm.Month() == 0 || (tm.Day() == 0 && b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()) {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, times[i].String())); err != nil {
+		if tm.Month() == 0 || (tm.Day() == 0 && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()) {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, times[i].String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -705,7 +696,7 @@ func (b *builtinStrToDateDateSig) vecEvalTime(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(bufStrings)
-	if err := b.args[0].VecEvalString(b.ctx, input, bufStrings); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, bufStrings); err != nil {
 		return err
 	}
 
@@ -714,14 +705,14 @@ func (b *builtinStrToDateDateSig) vecEvalTime(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(bufFormats)
-	if err := b.args[1].VecEvalString(b.ctx, input, bufFormats); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, bufFormats); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
 	result.MergeNulls(bufStrings, bufFormats)
 	times := result.Times()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -729,14 +720,14 @@ func (b *builtinStrToDateDateSig) vecEvalTime(ctx sessionctx.Context, input *chu
 		var t types.Time
 		succ := t.StrToDate(sc.TypeCtx(), bufStrings.GetString(i), bufFormats.GetString(i))
 		if !succ {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
 			continue
 		}
-		if b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() && (t.Year() == 0 || t.Month() == 0 || t.Day() == 0) {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
+		if ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() && (t.Year() == 0 || t.Month() == 0 || t.Day() == 0) {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -760,11 +751,11 @@ func (b *builtinSysDateWithFspSig) vecEvalTime(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
-	loc := b.ctx.GetSessionVars().Location()
+	loc := ctx.GetSessionVars().Location()
 	now := time.Now().In(loc)
 
 	result.ResizeTime(n, false)
@@ -796,7 +787,7 @@ func (b *builtinTidbParseTsoSig) vecEvalTime(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	args := buf.Int64s()
@@ -813,7 +804,7 @@ func (b *builtinTidbParseTsoSig) vecEvalTime(ctx sessionctx.Context, input *chun
 		}
 		t := oracle.GetTimeFromTS(uint64(args[i]))
 		r := types.NewTime(types.FromGoTime(t), mysql.TypeDatetime, types.MaxFsp)
-		if err := r.ConvertTimeZone(time.Local, b.ctx.GetSessionVars().Location()); err != nil {
+		if err := r.ConvertTimeZone(time.Local, ctx.GetSessionVars().Location()); err != nil {
 			return err
 		}
 		times[i] = r
@@ -832,7 +823,7 @@ func (b *builtinTiDBBoundedStalenessSig) vecEvalTime(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err = b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err = b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -840,13 +831,13 @@ func (b *builtinTiDBBoundedStalenessSig) vecEvalTime(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err = b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err = b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 	args0 := buf0.Times()
 	args1 := buf1.Times()
-	timeZone := getTimeZone(b.ctx)
-	minSafeTime := getMinSafeTime(b.ctx, timeZone)
+	timeZone := getTimeZone(ctx)
+	minSafeTime := getMinSafeTime(ctx, timeZone)
 	result.ResizeTime(n, false)
 	result.MergeNulls(buf0, buf1)
 	times := result.Times()
@@ -856,10 +847,10 @@ func (b *builtinTiDBBoundedStalenessSig) vecEvalTime(ctx sessionctx.Context, inp
 		}
 		if invalidArg0, invalidArg1 := args0[i].InvalidZero(), args1[i].InvalidZero(); invalidArg0 || invalidArg1 {
 			if invalidArg0 {
-				err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, args0[i].String()))
+				err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, args0[i].String()))
 			}
 			if invalidArg1 {
-				err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, args1[i].String()))
+				err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, args1[i].String()))
 			}
 			if err != nil {
 				return err
@@ -896,7 +887,7 @@ func (b *builtinFromDaysSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -924,7 +915,7 @@ func (b *builtinMicroSecondSig) vecEvalInt(ctx sessionctx.Context, input *chunk.
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
 
@@ -953,7 +944,7 @@ func (b *builtinQuarterSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chun
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -981,7 +972,7 @@ func (b *builtinWeekWithModeSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 	if err != nil {
 		return err
 	}
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
@@ -990,7 +981,7 @@ func (b *builtinWeekWithModeSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 	if err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
@@ -1006,7 +997,7 @@ func (b *builtinWeekWithModeSig) vecEvalInt(ctx sessionctx.Context, input *chunk
 		}
 		date := ds[i]
 		if date.IsZero() {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String())); err != nil {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -1034,7 +1025,7 @@ func (b *builtinExtractDatetimeSig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(unit)
-	if err := b.args[0].VecEvalString(b.ctx, input, unit); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, unit); err != nil {
 		return err
 	}
 	dt, err := b.bufAllocator.get()
@@ -1042,7 +1033,7 @@ func (b *builtinExtractDatetimeSig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(dt)
-	if err = b.args[1].VecEvalTime(b.ctx, input, dt); err != nil {
+	if err = b.args[1].VecEvalTime(ctx, input, dt); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -1075,7 +1066,7 @@ func (b *builtinExtractDurationSig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(unit)
-	if err := b.args[0].VecEvalString(b.ctx, input, unit); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, unit); err != nil {
 		return err
 	}
 	dur, err := b.bufAllocator.get()
@@ -1083,7 +1074,7 @@ func (b *builtinExtractDurationSig) vecEvalInt(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(dur)
-	if err = b.args[1].VecEvalDuration(b.ctx, input, dur); err != nil {
+	if err = b.args[1].VecEvalDuration(ctx, input, dur); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -1117,7 +1108,7 @@ func (b *builtinStrToDateDurationSig) vecEvalDuration(ctx sessionctx.Context, in
 		return err
 	}
 	defer b.bufAllocator.put(bufStrings)
-	if err := b.args[0].VecEvalString(b.ctx, input, bufStrings); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, bufStrings); err != nil {
 		return err
 	}
 
@@ -1126,14 +1117,14 @@ func (b *builtinStrToDateDurationSig) vecEvalDuration(ctx sessionctx.Context, in
 		return err
 	}
 	defer b.bufAllocator.put(bufFormats)
-	if err := b.args[1].VecEvalString(b.ctx, input, bufFormats); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, bufFormats); err != nil {
 		return err
 	}
 
 	result.ResizeGoDuration(n, false)
 	result.MergeNulls(bufStrings, bufFormats)
 	d64s := result.GoDurations()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -1141,7 +1132,7 @@ func (b *builtinStrToDateDurationSig) vecEvalDuration(ctx sessionctx.Context, in
 		var t types.Time
 		succ := t.StrToDate(sc.TypeCtx(), bufStrings.GetString(i), bufFormats.GetString(i))
 		if !succ {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -1170,7 +1161,7 @@ func (b *builtinToSecondsSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1185,7 +1176,7 @@ func (b *builtinToSecondsSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		arg := ds[i]
 		ret := types.TimestampDiff("SECOND", types.ZeroDate, arg)
 		if ret == 0 {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String())); err != nil {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -1207,7 +1198,7 @@ func (b *builtinMinuteSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
 
@@ -1234,7 +1225,7 @@ func (b *builtinSecondSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
 
@@ -1256,7 +1247,7 @@ func (b *builtinNowWithoutArgSig) vectorized() bool {
 
 func (b *builtinNowWithoutArgSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	nowTs, isNull, err := evalNowWithFsp(b.ctx, 0)
+	nowTs, isNull, err := evalNowWithFsp(ctx, 0)
 	if err != nil {
 		return err
 	}
@@ -1297,7 +1288,7 @@ func (b *builtinMakeDateSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf1); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1306,7 +1297,7 @@ func (b *builtinMakeDateSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -1333,7 +1324,7 @@ func (b *builtinMakeDateSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Ch
 		startTime := types.NewTime(types.FromDate(int(years[i]), 1, 1, 0, 0, 0, 0), mysql.TypeDate, 0)
 		retTimestamp := types.TimestampDiff("DAY", types.ZeroDate, startTime)
 		if retTimestamp == 0 {
-			if err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, startTime.String())); err != nil {
+			if err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, startTime.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -1360,7 +1351,7 @@ func (b *builtinWeekOfYearSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -1372,7 +1363,7 @@ func (b *builtinWeekOfYearSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 			continue
 		}
 		if ds[i].IsZero() {
-			if err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
+			if err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -1397,7 +1388,7 @@ func (b *builtinUTCTimestampWithArgSig) vecEvalTime(ctx sessionctx.Context, inpu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeTime(n, false)
@@ -1415,7 +1406,7 @@ func (b *builtinUTCTimestampWithArgSig) vecEvalTime(ctx sessionctx.Context, inpu
 		if fsp < int64(types.MinFsp) {
 			return errors.Errorf("Invalid negative %d specified, must in [0, 6]", fsp)
 		}
-		res, isNull, err := evalUTCTimestampWithFsp(b.ctx, int(fsp))
+		res, isNull, err := evalUTCTimestampWithFsp(ctx, int(fsp))
 		if err != nil {
 			return err
 		}
@@ -1441,7 +1432,7 @@ func (b *builtinTimeToSecSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1476,7 +1467,7 @@ func (b *builtinStrToDateDatetimeSig) vecEvalTime(ctx sessionctx.Context, input 
 		return err
 	}
 	defer b.bufAllocator.put(dateBuf)
-	if err = b.args[0].VecEvalString(b.ctx, input, dateBuf); err != nil {
+	if err = b.args[0].VecEvalString(ctx, input, dateBuf); err != nil {
 		return err
 	}
 
@@ -1485,15 +1476,15 @@ func (b *builtinStrToDateDatetimeSig) vecEvalTime(ctx sessionctx.Context, input 
 		return err
 	}
 	defer b.bufAllocator.put(formatBuf)
-	if err = b.args[1].VecEvalString(b.ctx, input, formatBuf); err != nil {
+	if err = b.args[1].VecEvalString(ctx, input, formatBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
 	result.MergeNulls(dateBuf, formatBuf)
 	times := result.Times()
-	sc := b.ctx.GetSessionVars().StmtCtx
-	hasNoZeroDateMode := b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()
+	sc := ctx.GetSessionVars().StmtCtx
+	hasNoZeroDateMode := ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()
 	fsp := b.tp.GetDecimal()
 
 	for i := 0; i < n; i++ {
@@ -1503,14 +1494,14 @@ func (b *builtinStrToDateDatetimeSig) vecEvalTime(ctx sessionctx.Context, input 
 		var t types.Time
 		succ := t.StrToDate(sc.TypeCtx(), dateBuf.GetString(i), formatBuf.GetString(i))
 		if !succ {
-			if err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
+			if err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
 			continue
 		}
 		if hasNoZeroDateMode && (t.Year() == 0 || t.Month() == 0 || t.Day() == 0) {
-			if err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
+			if err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -1528,7 +1519,7 @@ func (b *builtinUTCDateSig) vectorized() bool {
 }
 
 func (b *builtinUTCDateSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	nowTs, err := getStmtTimestamp(b.ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return err
 	}
@@ -1554,7 +1545,7 @@ func (b *builtinWeekWithoutModeSig) vecEvalInt(ctx sessionctx.Context, input *ch
 	if err != nil {
 		return err
 	}
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf)
@@ -1565,11 +1556,11 @@ func (b *builtinWeekWithoutModeSig) vecEvalInt(ctx sessionctx.Context, input *ch
 	ds := buf.Times()
 
 	mode := 0
-	modeStr, ok := b.ctx.GetSessionVars().GetSystemVar(variable.DefaultWeekFormat)
+	modeStr, ok := ctx.GetSessionVars().GetSystemVar(variable.DefaultWeekFormat)
 	if ok && modeStr != "" {
 		mode, err = strconv.Atoi(modeStr)
 		if err != nil {
-			return handleInvalidTimeError(b.ctx, types.ErrInvalidWeekModeFormat.GenWithStackByArgs(modeStr))
+			return handleInvalidTimeError(ctx, types.ErrInvalidWeekModeFormat.GenWithStackByArgs(modeStr))
 		}
 	}
 	for i := 0; i < n; i++ {
@@ -1578,7 +1569,7 @@ func (b *builtinWeekWithoutModeSig) vecEvalInt(ctx sessionctx.Context, input *ch
 		}
 		date := ds[i]
 		if date.IsZero() {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String())); err != nil {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -1604,7 +1595,7 @@ func (b *builtinUnixTimestampDecSig) vecEvalDecimal(ctx sessionctx.Context, inpu
 		return err
 	}
 	defer b.bufAllocator.put(timeBuf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, timeBuf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, timeBuf); err != nil {
 		for i := 0; i < n; i++ {
 			temp, isNull, err := b.evalDecimal(ctx, input.GetRow(i))
 			if err != nil {
@@ -1621,7 +1612,7 @@ func (b *builtinUnixTimestampDecSig) vecEvalDecimal(ctx sessionctx.Context, inpu
 			if result.IsNull(i) {
 				continue
 			}
-			t, err := timeBuf.GetTime(i).GoTime(getTimeZone(b.ctx))
+			t, err := timeBuf.GetTime(i).GoTime(getTimeZone(ctx))
 			if err != nil {
 				ts[i] = *new(types.MyDecimal)
 				continue
@@ -1643,7 +1634,7 @@ func (b *builtinPeriodAddSig) vectorized() bool {
 // vecEvalInt evals PERIOD_ADD(P,N).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_period-add
 func (b *builtinPeriodAddSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -1653,7 +1644,7 @@ func (b *builtinPeriodAddSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 	i64s := result.Int64s()
@@ -1687,7 +1678,7 @@ func (b *builtinTimestampAddSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1696,7 +1687,7 @@ func (b *builtinTimestampAddSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1705,7 +1696,7 @@ func (b *builtinTimestampAddSig) vecEvalString(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	if err := b.args[2].VecEvalTime(b.ctx, input, buf2); err != nil {
+	if err := b.args[2].VecEvalTime(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -1724,7 +1715,7 @@ func (b *builtinTimestampAddSig) vecEvalString(ctx sessionctx.Context, input *ch
 
 		tm1, err := arg.GoTime(time.Local)
 		if err != nil {
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
+			ctx.GetSessionVars().StmtCtx.AppendWarning(err)
 			result.AppendNull()
 			continue
 		}
@@ -1733,7 +1724,7 @@ func (b *builtinTimestampAddSig) vecEvalString(ctx sessionctx.Context, input *ch
 			return err
 		}
 		if overflow {
-			if err = handleInvalidTimeError(b.ctx, types.ErrDatetimeFunctionOverflow.GenWithStackByArgs("datetime")); err != nil {
+			if err = handleInvalidTimeError(ctx, types.ErrDatetimeFunctionOverflow.GenWithStackByArgs("datetime")); err != nil {
 				return err
 			}
 			result.AppendNull()
@@ -1745,8 +1736,8 @@ func (b *builtinTimestampAddSig) vecEvalString(ctx sessionctx.Context, input *ch
 			fsp = types.MaxFsp
 		}
 		r := types.NewTime(types.FromGoTime(tb), b.resolveType(arg.Type(), unit), fsp)
-		if err = r.Check(b.ctx.GetSessionVars().StmtCtx.TypeCtx()); err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
+		if err = r.Check(ctx.GetSessionVars().StmtCtx.TypeCtx()); err != nil {
+			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
 			result.AppendNull()
@@ -1770,7 +1761,7 @@ func (b *builtinToDaysSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -1785,7 +1776,7 @@ func (b *builtinToDaysSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk
 		arg := ds[i]
 		ret := types.TimestampDiff("DAY", types.ZeroDate, arg)
 		if ret == 0 {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String())); err != nil {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, arg.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -1808,7 +1799,7 @@ func (b *builtinDateFormatSig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(dateBuf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, dateBuf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, dateBuf); err != nil {
 		return err
 	}
 	times := dateBuf.Times()
@@ -1818,7 +1809,7 @@ func (b *builtinDateFormatSig) vecEvalString(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(formatBuf)
-	if err := b.args[1].VecEvalString(b.ctx, input, formatBuf); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, formatBuf); err != nil {
 		return err
 	}
 
@@ -1851,7 +1842,7 @@ func (b *builtinDateFormatSig) vecEvalString(ctx sessionctx.Context, input *chun
 			if isOriginalIntOrDecimalZero && !isOriginalStringZero {
 				continue
 			}
-			if errHandled := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); errHandled != nil {
+			if errHandled := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); errHandled != nil {
 				return errHandled
 			}
 			continue
@@ -1876,7 +1867,7 @@ func (b *builtinHourSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, 
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
 
@@ -1903,7 +1894,7 @@ func (b *builtinSecToTimeSig) vecEvalDuration(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
 	args := buf.Float64s()
@@ -1929,7 +1920,7 @@ func (b *builtinSecToTimeSig) vecEvalDuration(ctx sessionctx.Context, input *chu
 			minute = 59
 			second = 59
 			demical = 0
-			err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("time", strconv.FormatFloat(secondsFloat, 'f', -1, 64)))
+			err = ctx.GetSessionVars().StmtCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("time", strconv.FormatFloat(secondsFloat, 'f', -1, 64)))
 			if err != nil {
 				return err
 			}
@@ -1938,7 +1929,7 @@ func (b *builtinSecToTimeSig) vecEvalDuration(ctx sessionctx.Context, input *chu
 			second = seconds % 60
 		}
 		secondDemical := float64(second) + demical
-		duration, _, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), fmt.Sprintf("%s%02d:%02d:%s", negative, hour, minute, strconv.FormatFloat(secondDemical, 'f', -1, 64)), b.tp.GetDecimal())
+		duration, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), fmt.Sprintf("%s%02d:%02d:%s", negative, hour, minute, strconv.FormatFloat(secondDemical, 'f', -1, 64)), b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}
@@ -1955,11 +1946,11 @@ func (b *builtinUTCTimeWithoutArgSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-time
 func (b *builtinUTCTimeWithoutArgSig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	nowTs, err := getStmtTimestamp(b.ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return err
 	}
-	res, _, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), nowTs.UTC().Format(types.TimeFormat), types.DefaultFsp)
+	res, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), nowTs.UTC().Format(types.TimeFormat), types.DefaultFsp)
 	if err != nil {
 		return err
 	}
@@ -1982,7 +1973,7 @@ func (b *builtinDateDiffSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err = b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err = b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -1990,7 +1981,7 @@ func (b *builtinDateDiffSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err = b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err = b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -2004,10 +1995,10 @@ func (b *builtinDateDiffSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Chu
 		}
 		if invalidArg0, invalidArg1 := args0[i].InvalidZero(), args1[i].InvalidZero(); invalidArg0 || invalidArg1 {
 			if invalidArg0 {
-				err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, args0[i].String()))
+				err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, args0[i].String()))
 			}
 			if invalidArg1 {
-				err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, args1[i].String()))
+				err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, args1[i].String()))
 			}
 			if err != nil {
 				return err
@@ -2025,12 +2016,12 @@ func (b *builtinCurrentDateSig) vectorized() bool {
 }
 
 func (b *builtinCurrentDateSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	nowTs, err := getStmtTimestamp(b.ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return err
 	}
 
-	tz := b.ctx.GetSessionVars().Location()
+	tz := ctx.GetSessionVars().Location()
 	year, month, day := nowTs.In(tz).Date()
 	timeValue := types.NewTime(types.FromDate(year, int(month), day, 0, 0, 0, 0), mysql.TypeDate, 0)
 
@@ -2047,9 +2038,9 @@ func (b *builtinMakeTimeSig) vectorized() bool {
 	return true
 }
 
-func (b *builtinMakeTimeSig) getVecIntParam(arg Expression, input *chunk.Chunk, col *chunk.Column) (err error) {
+func (b *builtinMakeTimeSig) getVecIntParam(ctx sessionctx.Context, arg Expression, input *chunk.Chunk, col *chunk.Column) (err error) {
 	if arg.GetType().EvalType() == types.ETReal {
-		err = arg.VecEvalReal(b.ctx, input, col)
+		err = arg.VecEvalReal(ctx, input, col)
 		if err != nil {
 			return err
 		}
@@ -2061,7 +2052,7 @@ func (b *builtinMakeTimeSig) getVecIntParam(arg Expression, input *chunk.Chunk, 
 		}
 		return nil
 	}
-	err = arg.VecEvalInt(b.ctx, input, col)
+	err = arg.VecEvalInt(ctx, input, col)
 	return err
 }
 
@@ -2070,7 +2061,7 @@ func (b *builtinMakeTimeSig) vecEvalDuration(ctx sessionctx.Context, input *chun
 	result.ResizeInt64(n, false)
 	hoursBuf := result
 	var err error
-	if err = b.getVecIntParam(b.args[0], input, hoursBuf); err != nil {
+	if err = b.getVecIntParam(ctx, b.args[0], input, hoursBuf); err != nil {
 		return err
 	}
 	minutesBuf, err := b.bufAllocator.get()
@@ -2078,7 +2069,7 @@ func (b *builtinMakeTimeSig) vecEvalDuration(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(minutesBuf)
-	if err = b.getVecIntParam(b.args[1], input, minutesBuf); err != nil {
+	if err = b.getVecIntParam(ctx, b.args[1], input, minutesBuf); err != nil {
 		return err
 	}
 	secondsBuf, err := b.bufAllocator.get()
@@ -2086,7 +2077,7 @@ func (b *builtinMakeTimeSig) vecEvalDuration(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(secondsBuf)
-	if err = b.args[2].VecEvalReal(b.ctx, input, secondsBuf); err != nil {
+	if err = b.args[2].VecEvalReal(ctx, input, secondsBuf); err != nil {
 		return err
 	}
 	hours := hoursBuf.Int64s()
@@ -2103,7 +2094,7 @@ func (b *builtinMakeTimeSig) vecEvalDuration(ctx sessionctx.Context, input *chun
 			result.SetNull(i, true)
 			continue
 		}
-		dur, err := b.makeTime(hours[i], minutes[i], seconds[i], hourUnsignedFlag)
+		dur, err := b.makeTime(ctx.GetSessionVars().StmtCtx.TypeCtx(), hours[i], minutes[i], seconds[i], hourUnsignedFlag)
 		if err != nil {
 			return err
 		}
@@ -2123,7 +2114,7 @@ func (b *builtinDayOfYearSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -2135,7 +2126,7 @@ func (b *builtinDayOfYearSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 			continue
 		}
 		if ds[i].InvalidZero() {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -2157,7 +2148,7 @@ func (b *builtinFromUnixTime1ArgSig) vecEvalTime(ctx sessionctx.Context, input *
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err = b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+	if err = b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeTime(n, false)
@@ -2169,7 +2160,7 @@ func (b *builtinFromUnixTime1ArgSig) vecEvalTime(ctx sessionctx.Context, input *
 		if result.IsNull(i) {
 			continue
 		}
-		t, isNull, err := evalFromUnixTime(b.ctx, fsp, &ds[i])
+		t, isNull, err := evalFromUnixTime(ctx, fsp, &ds[i])
 		if err != nil {
 			return err
 		}
@@ -2194,14 +2185,14 @@ func (b *builtinYearWeekWithModeSig) vecEvalInt(ctx sessionctx.Context, input *c
 	if err != nil {
 		return err
 	}
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 	buf2, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
 
@@ -2216,7 +2207,7 @@ func (b *builtinYearWeekWithModeSig) vecEvalInt(ctx sessionctx.Context, input *c
 		}
 		date := ds[i]
 		if date.IsZero() {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String())); err != nil {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, date.String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -2248,7 +2239,7 @@ func (b *builtinTimestampDiffSig) vecEvalInt(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(unitBuf)
-	if err := b.args[0].VecEvalString(b.ctx, input, unitBuf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, unitBuf); err != nil {
 		return err
 	}
 	lhsBuf, err := b.bufAllocator.get()
@@ -2256,7 +2247,7 @@ func (b *builtinTimestampDiffSig) vecEvalInt(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(lhsBuf)
-	if err := b.args[1].VecEvalTime(b.ctx, input, lhsBuf); err != nil {
+	if err := b.args[1].VecEvalTime(ctx, input, lhsBuf); err != nil {
 		return err
 	}
 	rhsBuf, err := b.bufAllocator.get()
@@ -2264,7 +2255,7 @@ func (b *builtinTimestampDiffSig) vecEvalInt(ctx sessionctx.Context, input *chun
 		return err
 	}
 	defer b.bufAllocator.put(rhsBuf)
-	if err := b.args[2].VecEvalTime(b.ctx, input, rhsBuf); err != nil {
+	if err := b.args[2].VecEvalTime(ctx, input, rhsBuf); err != nil {
 		return err
 	}
 
@@ -2279,10 +2270,10 @@ func (b *builtinTimestampDiffSig) vecEvalInt(ctx sessionctx.Context, input *chun
 		}
 		if invalidLHS, invalidRHS := lhs[i].InvalidZero(), rhs[i].InvalidZero(); invalidLHS || invalidRHS {
 			if invalidLHS {
-				err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, lhs[i].String()))
+				err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, lhs[i].String()))
 			}
 			if invalidRHS {
-				err = handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, rhs[i].String()))
+				err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, rhs[i].String()))
 			}
 			if err != nil {
 				return err
@@ -2312,7 +2303,7 @@ func (b *builtinUnixTimestampIntSig) vecEvalInt(ctx sessionctx.Context, input *c
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
 
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		var isNull bool
 		for i := 0; i < n; i++ {
 			i64s[i], isNull, err = b.evalInt(ctx, input.GetRow(i))
@@ -2330,7 +2321,7 @@ func (b *builtinUnixTimestampIntSig) vecEvalInt(ctx sessionctx.Context, input *c
 				continue
 			}
 
-			t, err := buf.GetTime(i).AdjustedGoTime(getTimeZone(b.ctx))
+			t, err := buf.GetTime(i).AdjustedGoTime(getTimeZone(ctx))
 			if err != nil {
 				i64s[i] = 0
 				continue
@@ -2356,13 +2347,13 @@ func (b *builtinCurrentTime0ArgSig) vectorized() bool {
 
 func (b *builtinCurrentTime0ArgSig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	nowTs, err := getStmtTimestamp(b.ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return err
 	}
-	tz := b.ctx.GetSessionVars().Location()
+	tz := ctx.GetSessionVars().Location()
 	dur := nowTs.In(tz).Format(types.TimeFormat)
-	res, _, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), dur, types.MinFsp)
+	res, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), dur, types.MinFsp)
 	if err != nil {
 		return err
 	}
@@ -2385,14 +2376,14 @@ func (b *builtinTimeSig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
 	result.ResizeGoDuration(n, false)
 	result.MergeNulls(buf)
 	ds := result.GoDurations()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -2428,7 +2419,7 @@ func (b *builtinDateLiteralSig) vectorized() bool {
 
 func (b *builtinDateLiteralSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	mode := b.ctx.GetSessionVars().SQLMode
+	mode := ctx.GetSessionVars().SQLMode
 	if mode.HasNoZeroDateMode() && b.literal.IsZero() {
 		return types.ErrWrongValue.GenWithStackByArgs(types.DateStr, b.literal.String())
 	}
@@ -2465,7 +2456,7 @@ func (b *builtinMonthNameSig) vecEvalString(ctx sessionctx.Context, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -2477,8 +2468,8 @@ func (b *builtinMonthNameSig) vecEvalString(ctx sessionctx.Context, input *chunk
 			continue
 		}
 		mon := ds[i].Month()
-		if (ds[i].IsZero() && b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()) || mon < 0 || mon > len(types.MonthNames) {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
+		if (ds[i].IsZero() && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()) || mon < 0 || mon > len(types.MonthNames) {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
 				return err
 			}
 			result.AppendNull()
@@ -2507,7 +2498,7 @@ func (b *builtinDayOfWeekSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -2519,7 +2510,7 @@ func (b *builtinDayOfWeekSig) vecEvalInt(ctx sessionctx.Context, input *chunk.Ch
 			continue
 		}
 		if ds[i].InvalidZero() {
-			if err := handleInvalidTimeError(b.ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
+			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -2541,17 +2532,17 @@ func (b *builtinCurrentTime1ArgSig) vecEvalDuration(ctx sessionctx.Context, inpu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
 
-	nowTs, err := getStmtTimestamp(b.ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return err
 	}
-	tz := b.ctx.GetSessionVars().Location()
+	tz := ctx.GetSessionVars().Location()
 	dur := nowTs.In(tz).Format(types.TimeFSPFormat)
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 	i64s := buf.Int64s()
 	result.ResizeGoDuration(n, false)
 	durations := result.GoDurations()
@@ -2573,7 +2564,7 @@ func (b *builtinUTCTimestampWithoutArgSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-timestamp
 func (b *builtinUTCTimestampWithoutArgSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	res, isNull, err := evalUTCTimestampWithFsp(b.ctx, types.DefaultFsp)
+	res, isNull, err := evalUTCTimestampWithFsp(ctx, types.DefaultFsp)
 	if err != nil {
 		return err
 	}
@@ -2595,7 +2586,7 @@ func (b *builtinConvertTzSig) vectorized() bool {
 
 func (b *builtinConvertTzSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -2604,7 +2595,7 @@ func (b *builtinConvertTzSig) vecEvalTime(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(fromTzBuf)
-	if err := b.args[1].VecEvalString(b.ctx, input, fromTzBuf); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, fromTzBuf); err != nil {
 		return err
 	}
 
@@ -2613,7 +2604,7 @@ func (b *builtinConvertTzSig) vecEvalTime(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(toTzBuf)
-	if err := b.args[2].VecEvalString(b.ctx, input, toTzBuf); err != nil {
+	if err := b.args[2].VecEvalString(ctx, input, toTzBuf); err != nil {
 		return err
 	}
 
@@ -2643,14 +2634,14 @@ func (b *builtinTimestamp1ArgSig) vecEvalTime(ctx sessionctx.Context, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
 	result.MergeNulls(buf)
 	times := result.Times()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	var tm types.Time
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -2664,7 +2655,7 @@ func (b *builtinTimestamp1ArgSig) vecEvalTime(ctx sessionctx.Context, input *chu
 			tm, err = types.ParseTime(sc.TypeCtx(), s, mysql.TypeDatetime, types.GetFsp(s), nil)
 		}
 		if err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
+			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -2686,7 +2677,7 @@ func (b *builtinTimestamp2ArgsSig) vecEvalTime(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 
@@ -2695,14 +2686,14 @@ func (b *builtinTimestamp2ArgsSig) vecEvalTime(ctx sessionctx.Context, input *ch
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
 	result.MergeNulls(buf0, buf1)
 	times := result.Times()
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	var tm types.Time
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -2717,7 +2708,7 @@ func (b *builtinTimestamp2ArgsSig) vecEvalTime(ctx sessionctx.Context, input *ch
 			tm, err = types.ParseTime(sc.TypeCtx(), arg0, mysql.TypeDatetime, types.GetFsp(arg0), nil)
 		}
 		if err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
+			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -2737,7 +2728,7 @@ func (b *builtinTimestamp2ArgsSig) vecEvalTime(ctx sessionctx.Context, input *ch
 
 		duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
 		if err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
+			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -2763,7 +2754,7 @@ func (b *builtinDayOfMonthSig) vecEvalInt(ctx sessionctx.Context, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf)
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)
@@ -2785,7 +2776,7 @@ func (b *builtinDayOfMonthSig) vectorized() bool {
 
 func (b *builtinAddSubDateAsStringSig) vecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
+	unit, isNull, err := b.args[2].EvalString(ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
@@ -2800,7 +2791,7 @@ func (b *builtinAddSubDateAsStringSig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
-	if err := b.vecGetInterval(&b.baseDateArithmetical, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
@@ -2809,7 +2800,7 @@ func (b *builtinAddSubDateAsStringSig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDate(&b.baseDateArithmetical, &b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDate(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -2821,7 +2812,7 @@ func (b *builtinAddSubDateAsStringSig) vecEvalString(ctx sessionctx.Context, inp
 			result.AppendNull()
 			continue
 		}
-		resDate, isNull, err := b.timeOp(&b.baseDateArithmetical, b.ctx, dateBuf.Times()[i], intervalBuf.GetString(i), unit, b.tp.GetDecimal())
+		resDate, isNull, err := b.timeOp(&b.baseDateArithmetical, ctx, dateBuf.Times()[i], intervalBuf.GetString(i), unit, b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}
@@ -2845,7 +2836,7 @@ func (b *builtinAddSubDateAsStringSig) vectorized() bool {
 
 func (b *builtinAddSubDateDatetimeAnySig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
+	unit, isNull, err := b.args[2].EvalString(ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
@@ -2859,11 +2850,11 @@ func (b *builtinAddSubDateDatetimeAnySig) vecEvalTime(ctx sessionctx.Context, in
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
-	if err := b.vecGetInterval(&b.baseDateArithmetical, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, ctx, input, unit, result); err != nil {
 		return err
 	}
 
@@ -2873,7 +2864,7 @@ func (b *builtinAddSubDateDatetimeAnySig) vecEvalTime(ctx sessionctx.Context, in
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.timeOp(&b.baseDateArithmetical, b.ctx, resDates[i], intervalBuf.GetString(i), unit, b.tp.GetDecimal())
+		resDate, isNull, err := b.timeOp(&b.baseDateArithmetical, ctx, resDates[i], intervalBuf.GetString(i), unit, b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}
@@ -2892,7 +2883,7 @@ func (b *builtinAddSubDateDatetimeAnySig) vectorized() bool {
 
 func (b *builtinAddSubDateDurationAnySig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
+	unit, isNull, err := b.args[2].EvalString(ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
@@ -2906,7 +2897,7 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalTime(ctx sessionctx.Context, in
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
-	if err := b.vecGetInterval(&b.baseDateArithmetical, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
@@ -2915,7 +2906,7 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalTime(ctx sessionctx.Context, in
 		return err
 	}
 	defer b.bufAllocator.put(durBuf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durBuf); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, durBuf); err != nil {
 		return err
 	}
 
@@ -2924,7 +2915,7 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalTime(ctx sessionctx.Context, in
 	result.MergeNulls(durBuf, intervalBuf)
 	resDates := result.Times()
 	iterDuration := types.Duration{Fsp: types.MaxFsp}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -2934,7 +2925,7 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalTime(ctx sessionctx.Context, in
 		if err != nil {
 			result.SetNull(i, true)
 		}
-		resDate, isNull, err := b.timeOp(&b.baseDateArithmetical, b.ctx, t, intervalBuf.GetString(i), unit, b.tp.GetDecimal())
+		resDate, isNull, err := b.timeOp(&b.baseDateArithmetical, ctx, t, intervalBuf.GetString(i), unit, b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}
@@ -2949,7 +2940,7 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalTime(ctx sessionctx.Context, in
 
 func (b *builtinAddSubDateDurationAnySig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
+	unit, isNull, err := b.args[2].EvalString(ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
@@ -2963,12 +2954,12 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalDuration(ctx sessionctx.Context
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
-	if err := b.vecGetInterval(&b.baseDateArithmetical, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeGoDuration(n, false)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, result); err != nil {
 		return err
 	}
 
@@ -2980,7 +2971,7 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalDuration(ctx sessionctx.Context
 			continue
 		}
 		iterDuration.Duration = resDurations[i]
-		resDuration, isNull, err := b.durationOp(&b.baseDateArithmetical, b.ctx, iterDuration, intervalBuf.GetString(i), unit, b.tp.GetDecimal())
+		resDuration, isNull, err := b.durationOp(&b.baseDateArithmetical, ctx, iterDuration, intervalBuf.GetString(i), unit, b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}

--- a/pkg/expression/builtin_time_vec_generated.go
+++ b/pkg/expression/builtin_time_vec_generated.go
@@ -27,7 +27,7 @@ import (
 func (b *builtinAddDatetimeAndDurationSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, result); err != nil {
 		return err
 	}
 	buf0 := result
@@ -37,7 +37,7 @@ func (b *builtinAddDatetimeAndDurationSig) vecEvalTime(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -63,7 +63,7 @@ func (b *builtinAddDatetimeAndDurationSig) vecEvalTime(ctx sessionctx.Context, i
 
 		// calculate
 
-		output, err := arg0.Add(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), types.Duration{Duration: arg1, Fsp: -1})
+		output, err := arg0.Add(ctx.GetSessionVars().StmtCtx.TypeCtx(), types.Duration{Duration: arg1, Fsp: -1})
 
 		if err != nil {
 			return err
@@ -84,7 +84,7 @@ func (b *builtinAddDatetimeAndDurationSig) vectorized() bool {
 func (b *builtinAddDatetimeAndStringSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, result); err != nil {
 		return err
 	}
 	buf0 := result
@@ -94,7 +94,7 @@ func (b *builtinAddDatetimeAndStringSig) vecEvalTime(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -122,7 +122,7 @@ func (b *builtinAddDatetimeAndStringSig) vecEvalTime(ctx sessionctx.Context, inp
 			result.SetNull(i, true) // fixed: true
 			continue
 		}
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -154,7 +154,7 @@ func (b *builtinAddDatetimeAndStringSig) vectorized() bool {
 func (b *builtinAddDurationAndDurationSig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, result); err != nil {
 		return err
 	}
 	buf0 := result
@@ -164,7 +164,7 @@ func (b *builtinAddDurationAndDurationSig) vecEvalDuration(ctx sessionctx.Contex
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -210,7 +210,7 @@ func (b *builtinAddDurationAndDurationSig) vectorized() bool {
 func (b *builtinAddDurationAndStringSig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, result); err != nil {
 		return err
 	}
 	buf0 := result
@@ -220,7 +220,7 @@ func (b *builtinAddDurationAndStringSig) vecEvalDuration(ctx sessionctx.Context,
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -248,7 +248,7 @@ func (b *builtinAddDurationAndStringSig) vecEvalDuration(ctx sessionctx.Context,
 			result.SetNull(i, true) // fixed: true
 			continue
 		}
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -284,7 +284,7 @@ func (b *builtinAddStringAndDurationSig) vecEvalString(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 
@@ -293,7 +293,7 @@ func (b *builtinAddStringAndDurationSig) vecEvalString(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -316,7 +316,7 @@ func (b *builtinAddStringAndDurationSig) vecEvalString(ctx sessionctx.Context, i
 
 		// calculate
 
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		fsp1 := b.args[1].GetType().GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 		var output string
@@ -367,7 +367,7 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 
@@ -385,7 +385,7 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -406,7 +406,7 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx sessionctx.Context, inp
 
 		// calculate
 
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, getFsp4TimeAddSub(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -465,7 +465,7 @@ func (b *builtinAddDateAndDurationSig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 
@@ -474,7 +474,7 @@ func (b *builtinAddDateAndDurationSig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -530,7 +530,7 @@ func (b *builtinAddDateAndStringSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 
@@ -539,7 +539,7 @@ func (b *builtinAddDateAndStringSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -566,7 +566,7 @@ func (b *builtinAddDateAndStringSig) vecEvalString(ctx sessionctx.Context, input
 			result.AppendNull() // fixed: false
 			continue
 		}
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, getFsp4TimeAddSub(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -640,7 +640,7 @@ func (b *builtinAddTimeDurationNullSig) vectorized() bool {
 func (b *builtinSubDatetimeAndDurationSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, result); err != nil {
 		return err
 	}
 	buf0 := result
@@ -650,7 +650,7 @@ func (b *builtinSubDatetimeAndDurationSig) vecEvalTime(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -676,7 +676,7 @@ func (b *builtinSubDatetimeAndDurationSig) vecEvalTime(ctx sessionctx.Context, i
 
 		// calculate
 
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration := types.Duration{Duration: arg1, Fsp: -1}
 		output, err := arg0.Add(sc.TypeCtx(), arg1Duration.Neg())
 
@@ -699,7 +699,7 @@ func (b *builtinSubDatetimeAndDurationSig) vectorized() bool {
 func (b *builtinSubDatetimeAndStringSig) vecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, result); err != nil {
 		return err
 	}
 	buf0 := result
@@ -709,7 +709,7 @@ func (b *builtinSubDatetimeAndStringSig) vecEvalTime(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -737,7 +737,7 @@ func (b *builtinSubDatetimeAndStringSig) vecEvalTime(ctx sessionctx.Context, inp
 			result.SetNull(i, true) // fixed: true
 			continue
 		}
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -768,7 +768,7 @@ func (b *builtinSubDatetimeAndStringSig) vectorized() bool {
 func (b *builtinSubDurationAndDurationSig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, result); err != nil {
 		return err
 	}
 	buf0 := result
@@ -778,7 +778,7 @@ func (b *builtinSubDurationAndDurationSig) vecEvalDuration(ctx sessionctx.Contex
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -824,7 +824,7 @@ func (b *builtinSubDurationAndDurationSig) vectorized() bool {
 func (b *builtinSubDurationAndStringSig) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, result); err != nil {
 		return err
 	}
 	buf0 := result
@@ -834,7 +834,7 @@ func (b *builtinSubDurationAndStringSig) vecEvalDuration(ctx sessionctx.Context,
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -862,7 +862,7 @@ func (b *builtinSubDurationAndStringSig) vecEvalDuration(ctx sessionctx.Context,
 			result.SetNull(i, true) // fixed: true
 			continue
 		}
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -898,7 +898,7 @@ func (b *builtinSubStringAndDurationSig) vecEvalString(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 
@@ -907,7 +907,7 @@ func (b *builtinSubStringAndDurationSig) vecEvalString(ctx sessionctx.Context, i
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -930,7 +930,7 @@ func (b *builtinSubStringAndDurationSig) vecEvalString(ctx sessionctx.Context, i
 
 		// calculate
 
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		fsp1 := b.args[1].GetType().GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 		var output string
@@ -981,7 +981,7 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 
@@ -999,7 +999,7 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1020,7 +1020,7 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx sessionctx.Context, inp
 
 		// calculate
 
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, getFsp4TimeAddSub(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -1079,7 +1079,7 @@ func (b *builtinSubDateAndDurationSig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 
@@ -1088,7 +1088,7 @@ func (b *builtinSubDateAndDurationSig) vecEvalString(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1144,7 +1144,7 @@ func (b *builtinSubDateAndStringSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
 
@@ -1153,7 +1153,7 @@ func (b *builtinSubDateAndStringSig) vecEvalString(ctx sessionctx.Context, input
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1180,7 +1180,7 @@ func (b *builtinSubDateAndStringSig) vecEvalString(ctx sessionctx.Context, input
 			result.AppendNull() // fixed: false
 			continue
 		}
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, getFsp4TimeAddSub(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -1277,16 +1277,16 @@ func (b *builtinTimeStringTimeDiffSig) vecEvalDuration(ctx sessionctx.Context, i
 	}
 	defer b.bufAllocator.put(buf1)
 
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
 	result.MergeNulls(buf0, buf1)
 	arg0 := buf0.Times()
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -1328,10 +1328,10 @@ func (b *builtinDurationStringTimeDiffSig) vecEvalDuration(ctx sessionctx.Contex
 	}
 	defer b.bufAllocator.put(buf1)
 
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1341,7 +1341,7 @@ func (b *builtinDurationStringTimeDiffSig) vecEvalDuration(ctx sessionctx.Contex
 		lhs types.Duration
 		rhs types.Duration
 	)
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -1356,7 +1356,7 @@ func (b *builtinDurationStringTimeDiffSig) vecEvalDuration(ctx sessionctx.Contex
 			continue
 		}
 		rhs = rhsDur
-		d, isNull, err := calculateDurationTimeDiff(b.ctx, lhs, rhs)
+		d, isNull, err := calculateDurationTimeDiff(ctx, lhs, rhs)
 		if err != nil {
 			return err
 		}
@@ -1384,10 +1384,10 @@ func (b *builtinDurationDurationTimeDiffSig) vecEvalDuration(ctx sessionctx.Cont
 	}
 	defer b.bufAllocator.put(buf1)
 
-	if err := b.args[0].VecEvalDuration(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1404,7 +1404,7 @@ func (b *builtinDurationDurationTimeDiffSig) vecEvalDuration(ctx sessionctx.Cont
 		}
 		lhs.Duration = arg0[i]
 		rhs.Duration = arg1[i]
-		d, isNull, err := calculateDurationTimeDiff(b.ctx, lhs, rhs)
+		d, isNull, err := calculateDurationTimeDiff(ctx, lhs, rhs)
 		if err != nil {
 			return err
 		}
@@ -1437,16 +1437,16 @@ func (b *builtinStringTimeTimeDiffSig) vecEvalDuration(ctx sessionctx.Context, i
 	}
 	defer b.bufAllocator.put(buf1)
 
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 
 	result.MergeNulls(buf0, buf1)
 	arg1 := buf1.Times()
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -1488,10 +1488,10 @@ func (b *builtinStringDurationTimeDiffSig) vecEvalDuration(ctx sessionctx.Contex
 	}
 	defer b.bufAllocator.put(buf0)
 
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalDuration(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -1501,7 +1501,7 @@ func (b *builtinStringDurationTimeDiffSig) vecEvalDuration(ctx sessionctx.Contex
 		lhs types.Duration
 		rhs types.Duration
 	)
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -1516,7 +1516,7 @@ func (b *builtinStringDurationTimeDiffSig) vecEvalDuration(ctx sessionctx.Contex
 		}
 		lhs = lhsDur
 		rhs.Duration = arg1[i]
-		d, isNull, err := calculateDurationTimeDiff(b.ctx, lhs, rhs)
+		d, isNull, err := calculateDurationTimeDiff(ctx, lhs, rhs)
 		if err != nil {
 			return err
 		}
@@ -1549,15 +1549,15 @@ func (b *builtinStringStringTimeDiffSig) vecEvalDuration(ctx sessionctx.Context,
 	}
 	defer b.bufAllocator.put(buf1)
 
-	if err := b.args[0].VecEvalString(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
 	result.MergeNulls(buf0, buf1)
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -1579,7 +1579,7 @@ func (b *builtinStringStringTimeDiffSig) vecEvalDuration(ctx sessionctx.Context,
 			isNull bool
 		)
 		if lhsIsDuration {
-			d, isNull, err = calculateDurationTimeDiff(b.ctx, lhsDur, rhsDur)
+			d, isNull, err = calculateDurationTimeDiff(ctx, lhsDur, rhsDur)
 		} else {
 			d, isNull, err = calculateTimeDiff(stmtCtx, lhsTime, rhsTime)
 		}
@@ -1615,17 +1615,17 @@ func (b *builtinTimeTimeTimeDiffSig) vecEvalDuration(ctx sessionctx.Context, inp
 	}
 	defer b.bufAllocator.put(buf1)
 
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEvalTime(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
 
 	result.MergeNulls(buf0, buf1)
 	arg0 := buf0.Times()
 	arg1 := buf1.Times()
-	stmtCtx := b.ctx.GetSessionVars().StmtCtx
+	stmtCtx := ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue

--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -75,7 +75,7 @@ func ifFoldHandler(expr *ScalarFunction) (Expression, bool) {
 	args := expr.GetArgs()
 	foldedArg0, _ := foldConstant(args[0])
 	if constArg, isConst := foldedArg0.(*Constant); isConst {
-		arg0, isNull0, err := constArg.EvalInt(expr.Function.getCtx(), chunk.Row{})
+		arg0, isNull0, err := constArg.EvalInt(expr.GetCtx(), chunk.Row{})
 		if err != nil {
 			// Failed to fold this expr to a constant, print the DEBUG log and
 			// return the original expression to let the error to be evaluated

--- a/pkg/expression/distsql_builtin.go
+++ b/pkg/expression/distsql_builtin.go
@@ -1104,6 +1104,7 @@ func newDistSQLFunctionBySig(sc *stmtctx.StatementContext, sigCode tipb.ScalarFu
 		FuncName: model.NewCIStr(fmt.Sprintf("sig_%T", f)),
 		Function: f,
 		RetType:  f.getRetTp(),
+		ctx:      ctx,
 	}, nil
 }
 

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -1035,6 +1035,7 @@ func NewValuesFunc(ctx sessionctx.Context, offset int, retTp *types.FieldType) *
 		FuncName: model.NewCIStr(ast.Values),
 		RetType:  retTp,
 		Function: bt,
+		ctx:      ctx,
 	}
 }
 
@@ -1510,6 +1511,7 @@ func wrapWithIsTrue(ctx sessionctx.Context, keepNull bool, arg Expression, wrapF
 		FuncName: model.NewCIStr(ast.IsTruthWithoutNull),
 		Function: f,
 		RetType:  f.getRetTp(),
+		ctx:      ctx,
 	}
 	if keepNull {
 		sf.FuncName = model.NewCIStr(ast.IsTruthWithNull)

--- a/pkg/expression/extension.go
+++ b/pkg/expression/extension.go
@@ -109,7 +109,7 @@ func (c *extensionFuncClass) getFunction(ctx sessionctx.Context, args []Expressi
 		return nil, err
 	}
 	bf.tp.SetFlen(c.flen)
-	sig := &extensionFuncSig{context.TODO(), bf, c.funcDef}
+	sig := &extensionFuncSig{bf, c.funcDef}
 	return sig, nil
 }
 
@@ -141,10 +141,9 @@ func (c *extensionFuncClass) checkPrivileges(ctx sessionctx.Context) error {
 	return nil
 }
 
-var _ extension.FunctionContext = &extensionFuncSig{}
+var _ extension.FunctionContext = extensionFnContext{}
 
 type extensionFuncSig struct {
-	context.Context
 	baseBuiltinFunc
 	extension.FunctionDef
 }
@@ -158,25 +157,37 @@ func (b *extensionFuncSig) Clone() builtinFunc {
 
 func (b *extensionFuncSig) evalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
 	if b.EvalTp == types.ETString {
-		return b.EvalStringFunc(b, row)
+		fnCtx := newExtensionFnContext(ctx, b)
+		return b.EvalStringFunc(fnCtx, row)
 	}
 	return b.baseBuiltinFunc.evalString(ctx, row)
 }
 
 func (b *extensionFuncSig) evalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
 	if b.EvalTp == types.ETInt {
-		return b.EvalIntFunc(b, row)
+		fnCtx := newExtensionFnContext(ctx, b)
+		return b.EvalIntFunc(fnCtx, row)
 	}
 	return b.baseBuiltinFunc.evalInt(ctx, row)
 }
 
-func (b *extensionFuncSig) EvalArgs(row chunk.Row) ([]types.Datum, error) {
-	if len(b.args) == 0 {
+type extensionFnContext struct {
+	context.Context
+	ctx sessionctx.Context
+	sig *extensionFuncSig
+}
+
+func newExtensionFnContext(ctx sessionctx.Context, sig *extensionFuncSig) extensionFnContext {
+	return extensionFnContext{Context: context.TODO(), ctx: ctx, sig: sig}
+}
+
+func (b extensionFnContext) EvalArgs(row chunk.Row) ([]types.Datum, error) {
+	if len(b.sig.args) == 0 {
 		return nil, nil
 	}
 
-	result := make([]types.Datum, 0, len(b.args))
-	for _, arg := range b.args {
+	result := make([]types.Datum, 0, len(b.sig.args))
+	for _, arg := range b.sig.args {
 		val, err := arg.Eval(row)
 		if err != nil {
 			return nil, err
@@ -187,19 +198,19 @@ func (b *extensionFuncSig) EvalArgs(row chunk.Row) ([]types.Datum, error) {
 	return result, nil
 }
 
-func (b *extensionFuncSig) ConnectionInfo() *variable.ConnectionInfo {
+func (b extensionFnContext) ConnectionInfo() *variable.ConnectionInfo {
 	return b.ctx.GetSessionVars().ConnectionInfo
 }
 
-func (b *extensionFuncSig) User() *auth.UserIdentity {
+func (b extensionFnContext) User() *auth.UserIdentity {
 	return b.ctx.GetSessionVars().User
 }
 
-func (b *extensionFuncSig) ActiveRoles() []*auth.RoleIdentity {
+func (b extensionFnContext) ActiveRoles() []*auth.RoleIdentity {
 	return b.ctx.GetSessionVars().ActiveRoles
 }
 
-func (b *extensionFuncSig) CurrentDB() string {
+func (b extensionFnContext) CurrentDB() string {
 	return b.ctx.GetSessionVars().CurrentDB
 }
 

--- a/pkg/expression/generator/compare_vec.go
+++ b/pkg/expression/generator/compare_vec.go
@@ -67,7 +67,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEval{{ .type.TypeName }}(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEval{{ .type.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -75,7 +75,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEval{{ .type.TypeName }}(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEval{{ .type.TypeName }}(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -121,7 +121,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEval{{ .type.TypeName }}(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEval{{ .type.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -129,7 +129,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEval{{ .type.TypeName }}(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEval{{ .type.TypeName }}(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -222,10 +222,10 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEval{{ .ty
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 	for j := 0; j < len(b.args); j++{
-		err := b.args[j].VecEval{{ .type.TypeName }}(b.ctx, input, buf1)
+		err := b.args[j].VecEval{{ .type.TypeName }}(ctx, input, buf1)
         {{- if eq .type.TypeName "Time" }}
         fsp := b.tp.GetDecimal()
         {{- end }}
@@ -255,7 +255,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEval{{ .ty
 	argLen := len(b.args)
 
 	bufs := make([]*chunk.Column, argLen)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 	for i := 0; i < argLen; i++ {
 		buf, err := b.bufAllocator.get()
@@ -263,7 +263,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEval{{ .ty
 			return err
 		}
 		defer b.bufAllocator.put(buf)
-		err = b.args[i].VecEval{{ .type.TypeName }}(b.ctx, input, buf)
+		err = b.args[i].VecEval{{ .type.TypeName }}(ctx, input, buf)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {

--- a/pkg/expression/generator/control_vec.go
+++ b/pkg/expression/generator/control_vec.go
@@ -112,7 +112,7 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx sessionct
 	thensSlice := make([][]{{.TypeNameGo}}, l/2)
 	var eLseSlice []{{.TypeNameGo}}
 	{{- end }}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 
 	for j := 0; j < l-1; j+=2 {
@@ -121,7 +121,7 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx sessionct
 			return err
 		}
 		defer b.bufAllocator.put(bufWhen)
-		err = args[j].VecEvalInt(b.ctx, input, bufWhen)
+		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -137,7 +137,7 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx sessionct
 			return err
 		}
 		defer b.bufAllocator.put(bufThen)
-		err = args[j+1].VecEval{{ .TypeName }}(b.ctx, input, bufThen)
+		err = args[j+1].VecEval{{ .TypeName }}(ctx, input, bufThen)
 		afterWarns = sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -159,7 +159,7 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx sessionct
 			return err
 		}
 		defer b.bufAllocator.put(bufElse)
-		err = args[l-1].VecEval{{ .TypeName }}(b.ctx, input, bufElse)
+		err = args[l-1].VecEval{{ .TypeName }}(ctx, input, bufElse)
 		afterWarns := sc.WarningCount()
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
@@ -270,7 +270,7 @@ func (b *builtinIfNull{{ .TypeName }}Sig) fallbackEval{{ .TypeName }}(ctx sessio
 func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 	{{- if .Fixed }}
-	if err := b.args[0].VecEval{{ .TypeName }}(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEval{{ .TypeName }}(ctx, input, result); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -278,9 +278,9 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx sessionctx.
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEval{{ .TypeName }}(b.ctx, input, buf1)
+	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -302,7 +302,7 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx sessionctx.
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEval{{ .TypeName }}(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEval{{ .TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -310,9 +310,9 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx sessionctx.
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
-	err = b.args[1].VecEval{{ .TypeName }}(b.ctx, input, buf1)
+	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
@@ -390,20 +390,20 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx sessionctx.Cont
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
+	sc := ctx.GetSessionVars().StmtCtx
 	beforeWarns := sc.WarningCount()
 {{- if .Fixed }}
-	err = b.args[1].VecEval{{ .TypeName }}(b.ctx, input, result)
+	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, result)
 {{- else }}
 	buf1, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	err = b.args[1].VecEval{{ .TypeName }}(b.ctx, input, buf1)
+	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
 {{- end }}
 	afterWarns := sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
@@ -418,7 +418,7 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx sessionctx.Cont
 		return err
 	}
 	defer b.bufAllocator.put(buf2)
-	err = b.args[2].VecEval{{ .TypeName }}(b.ctx, input, buf2)
+	err = b.args[2].VecEval{{ .TypeName }}(ctx, input, buf2)
 	afterWarns = sc.WarningCount()
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {

--- a/pkg/expression/generator/other_vec.go
+++ b/pkg/expression/generator/other_vec.go
@@ -67,7 +67,7 @@ var builtinInTmpl = template.Must(template.New("builtinInTmpl").Parse(`
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEval{{ .Input.TypeName }}(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEval{{ .Input.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -216,7 +216,7 @@ func (b *{{.SigName}}) vecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, re
 	{{- end }}
 
 	for j := 0; j < len(args); j++ {
-		if err := args[j].VecEval{{ .Input.TypeName }}(b.ctx, input, buf1); err != nil {
+		if err := args[j].VecEval{{ .Input.TypeName }}(ctx, input, buf1); err != nil {
 			return err
 		}
 		{{- if $InputInt }}

--- a/pkg/expression/generator/string_vec.go
+++ b/pkg/expression/generator/string_vec.go
@@ -66,7 +66,7 @@ func (b *builtinField{{ .TypeName }}Sig) vecEvalInt(ctx sessionctx.Context, inpu
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEval{{ .TypeName }}(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEval{{ .TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get()
@@ -83,7 +83,7 @@ func (b *builtinField{{ .TypeName }}Sig) vecEvalInt(ctx sessionctx.Context, inpu
 		i64s[i] = 0
 	}
 	for i := 1; i < len(b.args); i++ {
-		if err := b.args[i].VecEval{{ .TypeName }}(b.ctx, input, buf1); err != nil {
+		if err := b.args[i].VecEval{{ .TypeName }}(ctx, input, buf1); err != nil {
 			return err
 		}
 {{ if .Fixed }}

--- a/pkg/expression/generator/time_vec.go
+++ b/pkg/expression/generator/time_vec.go
@@ -63,7 +63,7 @@ import (
 			{{ template "SetNull" . }}
 			continue
 		}{{ end }}
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, {{if eq .Output.TypeName "String"}}getFsp4TimeAddSub{{else}}types.GetFsp{{end}}(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -92,7 +92,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx sessionctx.Context, inp
 	n := input.NumRows()
 {{ $reuse := (and (eq .TypeA.TypeName .Output.TypeName) .TypeA.Fixed) }}
 {{ if $reuse }}
-	if err := b.args[0].VecEval{{ .TypeA.TypeName }}(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEval{{ .TypeA.TypeName }}(ctx, input, result); err != nil {
 		return err
 	}
 	buf0 := result
@@ -102,7 +102,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEval{{ .TypeA.TypeName }}(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEval{{ .TypeA.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
 {{ end }}
@@ -123,7 +123,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx sessionctx.Context, inp
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEval{{ .TypeB.TypeName }}(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEval{{ .TypeB.TypeName }}(ctx, input, buf1); err != nil {
 		return err
 	}
 
@@ -172,9 +172,9 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx sessionctx.Context, inp
 		// calculate
 	{{ if or (eq .SigName "builtinAddDatetimeAndDurationSig") (eq .SigName "builtinSubDatetimeAndDurationSig") }}
 		{{ if eq $.FuncName "AddTime" }}
-		output, err := arg0.Add(b.ctx.GetSessionVars().StmtCtx.TypeCtx(), types.Duration{Duration: arg1, Fsp: -1})
+		output, err := arg0.Add(ctx.GetSessionVars().StmtCtx.TypeCtx(), types.Duration{Duration: arg1, Fsp: -1})
 		{{ else }}
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration := types.Duration{Duration: arg1, Fsp: -1}
 		output, err := arg0.Add(sc.TypeCtx(), arg1Duration.Neg())
 		{{ end }}
@@ -191,7 +191,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx sessionctx.Context, inp
 			result.SetNull(i, true) // fixed: true
 			continue
 		}
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
@@ -232,7 +232,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx sessionctx.Context, inp
 		}
 		{{ end }}
 	{{ else if or (eq .SigName "builtinAddStringAndDurationSig") (eq .SigName "builtinSubStringAndDurationSig") }}
-		sc := b.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		fsp1 := b.args[1].GetType().GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 		var output string
@@ -359,10 +359,10 @@ var timeDiff = template.Must(template.New("").Parse(`
 	defer b.bufAllocator.put(buf1)
 {{ end }}
 {{ define "ArgsVecEval" }}
-	if err := b.args[0].VecEval{{ .TypeA.TypeName }}(b.ctx, input, buf0); err != nil {
+	if err := b.args[0].VecEval{{ .TypeA.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
-	if err := b.args[1].VecEval{{ .TypeB.TypeName }}(b.ctx, input, buf1); err != nil {
+	if err := b.args[1].VecEval{{ .TypeB.TypeName }}(ctx, input, buf1); err != nil {
 		return err
 	}
 {{ end }}
@@ -416,7 +416,7 @@ func (b *{{.SigName}}) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chun
 			)
 		{{- end }}
 		{{- if or (or $AIsString $BIsString) (and $AIsTime $BIsTime) }}
-			stmtCtx := b.ctx.GetSessionVars().StmtCtx
+			stmtCtx := ctx.GetSessionVars().StmtCtx
 		{{- end }}
 	for i:=0; i<n ; i++{
 		if result.IsNull(i) {
@@ -485,12 +485,12 @@ func (b *{{.SigName}}) vecEvalDuration(ctx sessionctx.Context, input *chunk.Chun
 				isNull bool
 			)
 			if lhsIsDuration {
-				d, isNull, err = calculateDurationTimeDiff(b.ctx, lhsDur, rhsDur)
+				d, isNull, err = calculateDurationTimeDiff(ctx, lhsDur, rhsDur)
 			} else {
 				d, isNull, err = calculateTimeDiff(stmtCtx, lhsTime, rhsTime)
 			}
 		{{- else if or $AIsDuration $BIsDuration }}
-			d, isNull, err := calculateDurationTimeDiff(b.ctx, lhs, rhs)
+			d, isNull, err := calculateDurationTimeDiff(ctx, lhs, rhs)
 		{{- else if or $AIsTime $BIsTime }}
 			d, isNull, err := calculateTimeDiff(stmtCtx, lhsTime, rhsTime)
 		{{- end }}

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -354,6 +354,10 @@ func (sf *ScalarFunction) GetType() *types.FieldType {
 
 // Equal implements Expression interface.
 func (sf *ScalarFunction) Equal(ctx sessionctx.Context, e Expression) bool {
+	if ctx == nil {
+		ctx = sf.GetCtx()
+	}
+
 	fun, ok := e.(*ScalarFunction)
 	if !ok {
 		return false

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/hack"
+	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 // ScalarFunction is the function that returns a value.
@@ -41,42 +42,50 @@ type ScalarFunction struct {
 	// TODO: Implement type inference here, now we use ast's return type temporarily.
 	RetType           *types.FieldType
 	Function          builtinFunc
+	ctx               sessionctx.Context
 	hashcode          []byte
 	canonicalhashcode []byte
 }
 
 // VecEvalInt evaluates this expression in a vectorized manner.
 func (sf *ScalarFunction) VecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	intest.Assert(ctx != nil)
 	return sf.Function.vecEvalInt(ctx, input, result)
 }
 
 // VecEvalReal evaluates this expression in a vectorized manner.
 func (sf *ScalarFunction) VecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	intest.Assert(ctx != nil)
 	return sf.Function.vecEvalReal(ctx, input, result)
 }
 
 // VecEvalString evaluates this expression in a vectorized manner.
 func (sf *ScalarFunction) VecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	intest.Assert(ctx != nil)
 	return sf.Function.vecEvalString(ctx, input, result)
 }
 
 // VecEvalDecimal evaluates this expression in a vectorized manner.
 func (sf *ScalarFunction) VecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	intest.Assert(ctx != nil)
 	return sf.Function.vecEvalDecimal(ctx, input, result)
 }
 
 // VecEvalTime evaluates this expression in a vectorized manner.
 func (sf *ScalarFunction) VecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	intest.Assert(ctx != nil)
 	return sf.Function.vecEvalTime(ctx, input, result)
 }
 
 // VecEvalDuration evaluates this expression in a vectorized manner.
 func (sf *ScalarFunction) VecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	intest.Assert(ctx != nil)
 	return sf.Function.vecEvalDuration(ctx, input, result)
 }
 
 // VecEvalJSON evaluates this expression in a vectorized manner.
 func (sf *ScalarFunction) VecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	intest.Assert(ctx != nil)
 	return sf.Function.vecEvalJSON(ctx, input, result)
 }
 
@@ -105,9 +114,12 @@ func (sf *ScalarFunction) ReverseEval(sc *stmtctx.StatementContext, res types.Da
 	return sf.Function.reverseEval(sc, res, rType)
 }
 
-// GetCtx gets the context of function.
+// GetCtx returns the inner context
+// Deprecated: we are going to remove ctx from expression completely.
+// Do not use this method anymore.
 func (sf *ScalarFunction) GetCtx() sessionctx.Context {
-	return sf.Function.getCtx()
+	intest.Assert(sf.ctx != nil)
+	return sf.ctx
 }
 
 // String implements fmt.Stringer interface.
@@ -247,6 +259,7 @@ func newFunctionImpl(ctx sessionctx.Context, fold int, funcName string, retType 
 		FuncName: model.NewCIStr(funcName),
 		RetType:  retType,
 		Function: f,
+		ctx:      ctx,
 	}
 	if fold == 1 {
 		return FoldConstant(sf), nil
@@ -326,6 +339,7 @@ func (sf *ScalarFunction) Clone() Expression {
 		RetType:  sf.RetType,
 		Function: sf.Function.Clone(),
 		hashcode: sf.hashcode,
+		ctx:      sf.ctx,
 	}
 	c.SetCharsetAndCollation(sf.CharsetAndCollation())
 	c.SetCoercibility(sf.Coercibility())
@@ -393,28 +407,28 @@ func (sf *ScalarFunction) Eval(row chunk.Row) (d types.Datum, err error) {
 		res    interface{}
 		isNull bool
 	)
-	switch tp, evalType := sf.GetType(), sf.GetType().EvalType(); evalType {
+	switch ctx, tp, evalType := sf.GetCtx(), sf.GetType(), sf.GetType().EvalType(); evalType {
 	case types.ETInt:
 		var intRes int64
-		intRes, isNull, err = sf.EvalInt(sf.GetCtx(), row)
+		intRes, isNull, err = sf.EvalInt(ctx, row)
 		if mysql.HasUnsignedFlag(tp.GetFlag()) {
 			res = uint64(intRes)
 		} else {
 			res = intRes
 		}
 	case types.ETReal:
-		res, isNull, err = sf.EvalReal(sf.GetCtx(), row)
+		res, isNull, err = sf.EvalReal(ctx, row)
 	case types.ETDecimal:
-		res, isNull, err = sf.EvalDecimal(sf.GetCtx(), row)
+		res, isNull, err = sf.EvalDecimal(ctx, row)
 	case types.ETDatetime, types.ETTimestamp:
-		res, isNull, err = sf.EvalTime(sf.GetCtx(), row)
+		res, isNull, err = sf.EvalTime(ctx, row)
 	case types.ETDuration:
-		res, isNull, err = sf.EvalDuration(sf.GetCtx(), row)
+		res, isNull, err = sf.EvalDuration(ctx, row)
 	case types.ETJson:
-		res, isNull, err = sf.EvalJSON(sf.GetCtx(), row)
+		res, isNull, err = sf.EvalJSON(ctx, row)
 	case types.ETString:
 		var str string
-		str, isNull, err = sf.EvalString(sf.GetCtx(), row)
+		str, isNull, err = sf.EvalString(ctx, row)
 		if !isNull && err == nil && tp.GetType() == mysql.TypeEnum {
 			res, err = types.ParseEnum(tp.GetElems(), str, tp.GetCollate())
 			if ctx := sf.GetCtx(); ctx != nil {
@@ -437,39 +451,43 @@ func (sf *ScalarFunction) Eval(row chunk.Row) (d types.Datum, err error) {
 
 // EvalInt implements Expression interface.
 func (sf *ScalarFunction) EvalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
-	if f, ok := sf.Function.(builtinFuncNew); ok {
-		return f.evalIntWithCtx(ctx, row)
-	}
+	intest.Assert(ctx != nil)
 	return sf.Function.evalInt(ctx, row)
 }
 
 // EvalReal implements Expression interface.
 func (sf *ScalarFunction) EvalReal(ctx sessionctx.Context, row chunk.Row) (float64, bool, error) {
+	intest.Assert(ctx != nil)
 	return sf.Function.evalReal(ctx, row)
 }
 
 // EvalDecimal implements Expression interface.
 func (sf *ScalarFunction) EvalDecimal(ctx sessionctx.Context, row chunk.Row) (*types.MyDecimal, bool, error) {
+	intest.Assert(ctx != nil)
 	return sf.Function.evalDecimal(ctx, row)
 }
 
 // EvalString implements Expression interface.
 func (sf *ScalarFunction) EvalString(ctx sessionctx.Context, row chunk.Row) (string, bool, error) {
+	intest.Assert(ctx != nil)
 	return sf.Function.evalString(ctx, row)
 }
 
 // EvalTime implements Expression interface.
 func (sf *ScalarFunction) EvalTime(ctx sessionctx.Context, row chunk.Row) (types.Time, bool, error) {
+	intest.Assert(ctx != nil)
 	return sf.Function.evalTime(ctx, row)
 }
 
 // EvalDuration implements Expression interface.
 func (sf *ScalarFunction) EvalDuration(ctx sessionctx.Context, row chunk.Row) (types.Duration, bool, error) {
+	intest.Assert(ctx != nil)
 	return sf.Function.evalDuration(ctx, row)
 }
 
 // EvalJSON implements Expression interface.
 func (sf *ScalarFunction) EvalJSON(ctx sessionctx.Context, row chunk.Row) (types.BinaryJSON, bool, error) {
+	intest.Assert(ctx != nil)
 	return sf.Function.evalJSON(ctx, row)
 }
 

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -192,18 +192,20 @@ func TestSetExprColumnInOperand(t *testing.T) {
 	col := &Column{RetType: newIntFieldType()}
 	require.True(t, SetExprColumnInOperand(col).(*Column).InOperand)
 
-	f, err := funcs[ast.Abs].getFunction(mock.NewContext(), []Expression{col})
+	ctx := mock.NewContext()
+	f, err := funcs[ast.Abs].getFunction(ctx, []Expression{col})
 	require.NoError(t, err)
-	fun := &ScalarFunction{Function: f}
+	fun := &ScalarFunction{Function: f, ctx: ctx}
 	SetExprColumnInOperand(fun)
 	require.True(t, f.getArgs()[0].(*Column).InOperand)
 }
 
 func TestPopRowFirstArg(t *testing.T) {
+	ctx := mock.NewContext()
 	c1, c2, c3 := &Column{RetType: newIntFieldType()}, &Column{RetType: newIntFieldType()}, &Column{RetType: newIntFieldType()}
-	f, err := funcs[ast.RowFunc].getFunction(mock.NewContext(), []Expression{c1, c2, c3})
+	f, err := funcs[ast.RowFunc].getFunction(ctx, []Expression{c1, c2, c3})
 	require.NoError(t, err)
-	fun := &ScalarFunction{Function: f, FuncName: model.NewCIStr(ast.RowFunc), RetType: newIntFieldType()}
+	fun := &ScalarFunction{Function: f, FuncName: model.NewCIStr(ast.RowFunc), RetType: newIntFieldType(), ctx: ctx}
 	fun2, err := PopRowFirstArg(mock.NewContext(), fun)
 	require.NoError(t, err)
 	require.Len(t, fun2.(*ScalarFunction).GetArgs(), 2)

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1846,7 +1846,7 @@ func (er *expressionRewriter) patternLikeOrIlikeToExpression(v *ast.PatternLikeO
 	isPatternExactMatch := false
 	// Treat predicate 'like' or 'ilike' the same way as predicate '=' when it is an exact match and new collation is not enabled.
 	if patExpression, ok := er.ctxStack[l-1].(*expression.Constant); ok && !collate.NewCollationEnabled() {
-		patString, isNull, err := patExpression.EvalString(nil, chunk.Row{})
+		patString, isNull, err := patExpression.EvalString(er.sctx, chunk.Row{})
 		if err != nil {
 			er.err = err
 			return


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48408

### What is changed and how it works?

This is the second step to remove inner ctx in `ScalarFunction`, yo can see detail in: #47958

In this PR, we:

1. remove the inner `ctx` in `baseBuiltinFunc` and move it outside to `ScalarFunction` instead.
2. `builtinFuncNew` is no longer needed any more, just remove it

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
