### PR TITLE
external/test: compare the performance of external writer

### DIFF
--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
     name = "external_test",
     timeout = "short",
     srcs = [
+        "bench_test.go",
         "byte_reader_test.go",
         "codec_test.go",
         "concurrent_reader_test.go",
@@ -63,7 +64,7 @@ go_test(
     ],
     embed = [":external"],
     flaky = True,
-    shard_count = 44,
+    shard_count = 45,
     deps = [
         "//br/pkg/lightning/backend/kv",
         "//br/pkg/lightning/common",

--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
         "//br/pkg/storage",
         "//pkg/kv",
         "//pkg/util/codec",
+        "//pkg/util/intest",
         "//pkg/util/logutil",
         "//pkg/util/size",
         "@com_github_aws_aws_sdk_go//aws",

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -1,0 +1,211 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/stretchr/testify/require"
+)
+
+var testingStorageURI = "local:///tmp/external-unit-test/"
+
+func openTestingStorage(t *testing.T) storage.ExternalStorage {
+	t.Skip("This is a manual test.")
+	b, err := storage.ParseBackend(testingStorageURI, nil)
+	require.NoError(t, err)
+	s, err := storage.New(context.Background(), b, nil)
+	require.NoError(t, err)
+	return s
+}
+
+type kvSource interface {
+	next() (key, value []byte, handle kv.Handle)
+	outputSize() int
+}
+
+type ascendingKeySource struct {
+	keySize, valueSize int
+	count              int
+	kvChan             chan [2][]byte
+	curKey             []byte
+	totalSize          int
+}
+
+func newAscendingKeySource(keySize, valueSize, count int) *ascendingKeySource {
+	s := &ascendingKeySource{keySize: keySize, valueSize: valueSize, count: count}
+	s.curKey = make([]byte, keySize)
+	s.kvChan = make(chan [2][]byte, 100)
+	s.run()
+	return s
+}
+
+func (s *ascendingKeySource) run() {
+	go func() {
+		defer close(s.kvChan)
+		for i := 0; i < s.count; i++ {
+			for j := len(s.curKey) - 1; j >= 0; j-- {
+				s.curKey[j]++
+				if s.curKey[j] != 0 {
+					break
+				}
+			}
+			key := make([]byte, s.keySize)
+			copy(key, s.curKey)
+			value := make([]byte, s.valueSize)
+			s.kvChan <- [2][]byte{key, value}
+			s.totalSize += len(key) + len(value)
+		}
+	}()
+}
+
+func (s *ascendingKeySource) next() (key, value []byte, handle kv.Handle) {
+	pair, ok := <-s.kvChan
+	if !ok {
+		return nil, nil, nil
+	}
+	return pair[0], pair[1], nil
+}
+
+func (s *ascendingKeySource) outputSize() int {
+	return s.totalSize
+}
+
+type testSuite struct {
+	t                  *testing.T
+	store              storage.ExternalStorage
+	source             kvSource
+	memoryLimit        int
+	beforeCreateWriter func()
+	beforeWriterClose  func()
+	afterWriterClose   func()
+}
+
+func writePlainFile(s *testSuite) {
+	ctx := context.Background()
+	buf := make([]byte, s.memoryLimit)
+	offset := 0
+	flush := func(w storage.ExternalFileWriter) {
+		n, err := w.Write(ctx, buf[:offset])
+		require.NoError(s.t, err)
+		require.Equal(s.t, offset, n)
+		offset = 0
+	}
+
+	if s.beforeCreateWriter != nil {
+		s.beforeCreateWriter()
+	}
+	writer, err := s.store.Create(ctx, "test/plain_file", nil)
+	require.NoError(s.t, err)
+	key, val, _ := s.source.next()
+	for key != nil {
+		if offset+len(key)+len(val) > len(buf) {
+			flush(writer)
+		}
+		offset += copy(buf[offset:], key)
+		offset += copy(buf[offset:], val)
+		key, val, _ = s.source.next()
+	}
+	flush(writer)
+	if s.beforeWriterClose != nil {
+		s.beforeWriterClose()
+	}
+	require.NoError(s.t, writer.Close(ctx))
+	if s.afterWriterClose != nil {
+		s.afterWriterClose()
+	}
+}
+
+func writeExternalFile(s *testSuite) {
+	ctx := context.Background()
+	builder := NewWriterBuilder().
+		SetMemorySizeLimit(uint64(s.memoryLimit))
+
+	if s.beforeCreateWriter != nil {
+		s.beforeCreateWriter()
+	}
+	writer := builder.Build(s.store, "test/external", "writerID")
+	key, val, h := s.source.next()
+	for key != nil {
+		err := writer.WriteRow(ctx, key, val, h)
+		require.NoError(s.t, err)
+		key, val, h = s.source.next()
+	}
+	if s.beforeWriterClose != nil {
+		s.beforeWriterClose()
+	}
+	require.NoError(s.t, writer.Close(ctx))
+	if s.afterWriterClose != nil {
+		s.afterWriterClose()
+	}
+}
+
+func TestCompare(t *testing.T) {
+	store := openTestingStorage(t)
+	source := newAscendingKeySource(20, 100, 1000000)
+	memoryLimit := 64 * 1024 * 1024
+	fileIdx := 0
+	var (
+		now     time.Time
+		elapsed time.Duration
+		file    *os.File
+		err     error
+	)
+	beforeTest := func() {
+		fileIdx++
+		file, err = os.Create(fmt.Sprintf("cpu-profile-%d.prof", fileIdx))
+		require.NoError(t, err)
+		err = pprof.StartCPUProfile(file)
+		require.NoError(t, err)
+		now = time.Now()
+	}
+	beforeClose := func() {
+		file, err = os.Create(fmt.Sprintf("heap-profile-%d.prof", fileIdx))
+		require.NoError(t, err)
+		// check heap profile to see the memory usage is expected
+		err = pprof.WriteHeapProfile(file)
+		require.NoError(t, err)
+	}
+	afterClose := func() {
+		elapsed = time.Since(now)
+		pprof.StopCPUProfile()
+	}
+
+	suite := &testSuite{
+		t:                  t,
+		store:              store,
+		source:             source,
+		memoryLimit:        memoryLimit,
+		beforeCreateWriter: beforeTest,
+		beforeWriterClose:  beforeClose,
+		afterWriterClose:   afterClose,
+	}
+
+	writePlainFile(suite)
+	baseSpeed := float64(source.outputSize()) / elapsed.Seconds() / 1024 / 1024
+	t.Logf("base speed for %d bytes: %.2f MB/s", source.outputSize(), baseSpeed)
+
+	suite.source = newAscendingKeySource(20, 100, 1000000)
+	writeExternalFile(suite)
+	writerSpeed := float64(source.outputSize()) / elapsed.Seconds() / 1024 / 1024
+	t.Logf("writer speed for %d bytes: %.2f MB/s", source.outputSize(), writerSpeed)
+}

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -16,6 +16,7 @@ package external
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"runtime/pprof"
@@ -27,11 +28,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testingStorageURI = "local:///tmp/external-unit-test/"
+var testingStorageURI = flag.String("testing-storage-uri", "", "the URI of the storage used for testing")
 
 func openTestingStorage(t *testing.T) storage.ExternalStorage {
-	t.Skip("This is a manual test.")
-	b, err := storage.ParseBackend(testingStorageURI, nil)
+	if *testingStorageURI == "" {
+		t.Skip("testingStorageURI is not set")
+	}
+	b, err := storage.ParseBackend(*testingStorageURI, nil)
 	require.NoError(t, err)
 	s, err := storage.New(context.Background(), b, nil)
 	require.NoError(t, err)
@@ -161,7 +164,7 @@ func writeExternalFile(s *testSuite) {
 
 func TestCompare(t *testing.T) {
 	store := openTestingStorage(t)
-	source := newAscendingKeySource(20, 100, 1000000)
+	source := newAscendingKeySource(20, 100, 10000000)
 	memoryLimit := 64 * 1024 * 1024
 	fileIdx := 0
 	var (
@@ -204,7 +207,7 @@ func TestCompare(t *testing.T) {
 	baseSpeed := float64(source.outputSize()) / elapsed.Seconds() / 1024 / 1024
 	t.Logf("base speed for %d bytes: %.2f MB/s", source.outputSize(), baseSpeed)
 
-	suite.source = newAscendingKeySource(20, 100, 1000000)
+	suite.source = newAscendingKeySource(20, 100, 10000000)
 	writeExternalFile(suite)
 	writerSpeed := float64(source.outputSize()) / elapsed.Seconds() / 1024 / 1024
 	t.Logf("writer speed for %d bytes: %.2f MB/s", source.outputSize(), writerSpeed)

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -35,9 +35,9 @@ func openTestingStorage(t *testing.T) storage.ExternalStorage {
 		t.Skip("testingStorageURI is not set")
 	}
 	b, err := storage.ParseBackend(*testingStorageURI, nil)
-	intest.Assert(err)
+	intest.Assert(err == nil)
 	s, err := storage.New(context.Background(), b, nil)
-	intest.Assert(err)
+	intest.Assert(err == nil)
 	return s
 }
 
@@ -109,7 +109,7 @@ func writePlainFile(s *testSuite) {
 	offset := 0
 	flush := func(w storage.ExternalFileWriter) {
 		n, err := w.Write(ctx, buf[:offset])
-		intest.Assert(err)
+		intest.Assert(err == nil)
 		intest.Assert(offset == n)
 		offset = 0
 	}
@@ -118,7 +118,7 @@ func writePlainFile(s *testSuite) {
 		s.beforeCreateWriter()
 	}
 	writer, err := s.store.Create(ctx, "test/plain_file", nil)
-	intest.Assert(err)
+	intest.Assert(err == nil)
 	key, val, _ := s.source.next()
 	for key != nil {
 		if offset+len(key)+len(val) > len(buf) {
@@ -132,7 +132,8 @@ func writePlainFile(s *testSuite) {
 	if s.beforeWriterClose != nil {
 		s.beforeWriterClose()
 	}
-	intest.Assert(writer.Close(ctx))
+	err = writer.Close(ctx)
+	intest.Assert(err == nil)
 	if s.afterWriterClose != nil {
 		s.afterWriterClose()
 	}
@@ -150,13 +151,14 @@ func writeExternalFile(s *testSuite) {
 	key, val, h := s.source.next()
 	for key != nil {
 		err := writer.WriteRow(ctx, key, val, h)
-		intest.Assert(err)
+		intest.Assert(err == nil)
 		key, val, h = s.source.next()
 	}
 	if s.beforeWriterClose != nil {
 		s.beforeWriterClose()
 	}
-	intest.Assert(writer.Close(ctx))
+	err := writer.Close(ctx)
+	intest.Assert(err == nil)
 	if s.afterWriterClose != nil {
 		s.afterWriterClose()
 	}
@@ -176,17 +178,17 @@ func TestCompare(t *testing.T) {
 	beforeTest := func() {
 		fileIdx++
 		file, err = os.Create(fmt.Sprintf("cpu-profile-%d.prof", fileIdx))
-		intest.Assert(err)
+		intest.Assert(err == nil)
 		err = pprof.StartCPUProfile(file)
-		intest.Assert(err)
+		intest.Assert(err == nil)
 		now = time.Now()
 	}
 	beforeClose := func() {
 		file, err = os.Create(fmt.Sprintf("heap-profile-%d.prof", fileIdx))
-		intest.Assert(err)
+		intest.Assert(err == nil)
 		// check heap profile to see the memory usage is expected
 		err = pprof.WriteHeapProfile(file)
-		intest.Assert(err)
+		intest.Assert(err == nil)
 	}
 	afterClose := func() {
 		elapsed = time.Since(now)

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/kv"
-	"github.com/stretchr/testify/require"
+	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 var testingStorageURI = flag.String("testing-storage-uri", "", "the URI of the storage used for testing")
@@ -35,9 +35,9 @@ func openTestingStorage(t *testing.T) storage.ExternalStorage {
 		t.Skip("testingStorageURI is not set")
 	}
 	b, err := storage.ParseBackend(*testingStorageURI, nil)
-	require.NoError(t, err)
+	intest.Assert(err)
 	s, err := storage.New(context.Background(), b, nil)
-	require.NoError(t, err)
+	intest.Assert(err)
 	return s
 }
 
@@ -109,8 +109,8 @@ func writePlainFile(s *testSuite) {
 	offset := 0
 	flush := func(w storage.ExternalFileWriter) {
 		n, err := w.Write(ctx, buf[:offset])
-		require.NoError(s.t, err)
-		require.Equal(s.t, offset, n)
+		intest.Assert(err)
+		intest.Assert(offset == n)
 		offset = 0
 	}
 
@@ -118,7 +118,7 @@ func writePlainFile(s *testSuite) {
 		s.beforeCreateWriter()
 	}
 	writer, err := s.store.Create(ctx, "test/plain_file", nil)
-	require.NoError(s.t, err)
+	intest.Assert(err)
 	key, val, _ := s.source.next()
 	for key != nil {
 		if offset+len(key)+len(val) > len(buf) {
@@ -132,7 +132,7 @@ func writePlainFile(s *testSuite) {
 	if s.beforeWriterClose != nil {
 		s.beforeWriterClose()
 	}
-	require.NoError(s.t, writer.Close(ctx))
+	intest.Assert(writer.Close(ctx))
 	if s.afterWriterClose != nil {
 		s.afterWriterClose()
 	}
@@ -150,13 +150,13 @@ func writeExternalFile(s *testSuite) {
 	key, val, h := s.source.next()
 	for key != nil {
 		err := writer.WriteRow(ctx, key, val, h)
-		require.NoError(s.t, err)
+		intest.Assert(err)
 		key, val, h = s.source.next()
 	}
 	if s.beforeWriterClose != nil {
 		s.beforeWriterClose()
 	}
-	require.NoError(s.t, writer.Close(ctx))
+	intest.Assert(writer.Close(ctx))
 	if s.afterWriterClose != nil {
 		s.afterWriterClose()
 	}
@@ -176,17 +176,17 @@ func TestCompare(t *testing.T) {
 	beforeTest := func() {
 		fileIdx++
 		file, err = os.Create(fmt.Sprintf("cpu-profile-%d.prof", fileIdx))
-		require.NoError(t, err)
+		intest.Assert(err)
 		err = pprof.StartCPUProfile(file)
-		require.NoError(t, err)
+		intest.Assert(err)
 		now = time.Now()
 	}
 	beforeClose := func() {
 		file, err = os.Create(fmt.Sprintf("heap-profile-%d.prof", fileIdx))
-		require.NoError(t, err)
+		intest.Assert(err)
 		// check heap profile to see the memory usage is expected
 		err = pprof.WriteHeapProfile(file)
-		require.NoError(t, err)
+		intest.Assert(err)
 	}
 	afterClose := func() {
 		elapsed = time.Since(now)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

Add a simple unit test framework that wants to check the throughput, CPU profile and heap profile of external reader/writer and their compositions.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

```
$ go test ./br/pkg/lightning/backend/external -v --tags=intest -test.run TestCompare --testing-storage-uri "s3://nfs/tianyuan-ut?access-key=xxx&secret-access-key=xxx&endpoint=https://xxx&force-path-style=false&region=xxx&provider=ks"
...
    bench_test.go:210: base speed for 1200000000 bytes: 14.68 MB/s
...
    bench_test.go:215: writer speed for 1200000000 bytes: 54.18 MB/s
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
