### PR TITLE
statistics: avoid oom when to gc large stats_history

### DIFF
--- a/pkg/executor/historical_stats_test.go
+++ b/pkg/executor/historical_stats_test.go
@@ -238,8 +238,10 @@ func TestAssertHistoricalStatsAfterAlterTable(t *testing.T) {
 }
 
 func TestGCOutdatedHistoryStats(t *testing.T) {
-	failpoint.Enable("github.com/pingcap/tidb/pkg/domain/sendHistoricalStats", "return(true)")
-	defer failpoint.Disable("github.com/pingcap/tidb/pkg/domain/sendHistoricalStats")
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/domain/sendHistoricalStats", "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/domain/sendHistoricalStats"))
+	}()
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("set global tidb_enable_historical_stats = 1")

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1641,8 +1641,12 @@ func (s *session) ExecuteInternal(ctx context.Context, sql string, args ...inter
 	if err != nil {
 		return nil, err
 	}
+	if sq, ok := stmtNode.(*ast.NonTransactionalDMLStmt); ok {
+		rs, err = HandleNonTransactionalDML(ctx, sq, s)
+	} else {
+		rs, err = s.ExecuteStmt(ctx, stmtNode)
+	}
 
-	rs, err = s.ExecuteStmt(ctx, stmtNode)
 	if err != nil {
 		s.sessionVars.StmtCtx.AppendError(err)
 	}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2417,14 +2417,6 @@ func runStmt(ctx context.Context, se *session, s sqlexec.Statement) (rs sqlexec.
 	if err != nil {
 		return nil, err
 	}
-	if sessVars.TxnCtx.CouldRetry && !s.IsReadOnly(sessVars) {
-		// Only when the txn is could retry and the statement is not read only, need to do stmt-count-limit check,
-		// otherwise, the stmt won't be add into stmt history, and also don't need check.
-		// About `stmt-count-limit`, see more in https://docs.pingcap.com/tidb/stable/tidb-configuration-file#stmt-count-limit
-		if err := checkStmtLimit(ctx, se, false); err != nil {
-			return nil, err
-		}
-	}
 
 	rs, err = s.Exec(ctx)
 	se.updateTelemetryMetric(s.(*executor.ExecStmt))

--- a/pkg/statistics/handle/storage/gc.go
+++ b/pkg/statistics/handle/storage/gc.go
@@ -182,7 +182,7 @@ func ClearOutdatedHistoryStats(sctx sessionctx.Context) error {
 	}
 	count := rows[0].GetInt64(0)
 	if count > 0 {
-		sql = "batch on create_time limit 50 delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
+		sql = "batch on create_time limit 1000 delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
 		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 		if err != nil {
 			return err

--- a/pkg/statistics/handle/storage/gc.go
+++ b/pkg/statistics/handle/storage/gc.go
@@ -182,12 +182,12 @@ func ClearOutdatedHistoryStats(sctx sessionctx.Context) error {
 	}
 	count := rows[0].GetInt64(0)
 	if count > 0 {
-		sql = "delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
+		sql = "delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND limit 5000"
 		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 		if err != nil {
 			return err
 		}
-		sql = "delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
+		sql = "delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND limit 5000"
 		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 		logutil.BgLogger().Info("clear outdated historical stats")
 		return err

--- a/pkg/statistics/handle/storage/gc.go
+++ b/pkg/statistics/handle/storage/gc.go
@@ -182,12 +182,12 @@ func ClearOutdatedHistoryStats(sctx sessionctx.Context) error {
 	}
 	count := rows[0].GetInt64(0)
 	if count > 0 {
-		sql = "batch on create_time limit 10 delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
+		sql = "batch on create_time limit 50 delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
 		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 		if err != nil {
 			return err
 		}
-		sql = "batch on create_time limit 10 delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
+		sql = "batch on create_time limit 50 delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
 		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 		logutil.BgLogger().Info("clear outdated historical stats")
 		return err

--- a/pkg/statistics/handle/storage/gc.go
+++ b/pkg/statistics/handle/storage/gc.go
@@ -182,12 +182,12 @@ func ClearOutdatedHistoryStats(sctx sessionctx.Context) error {
 	}
 	count := rows[0].GetInt64(0)
 	if count > 0 {
-		sql = "batch on table_id limit 100 delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
+		sql = "batch on create_time limit 10 delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
 		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 		if err != nil {
 			return err
 		}
-		sql = "batch on table_id limit 100 delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
+		sql = "batch on create_time limit 10 delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
 		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 		logutil.BgLogger().Info("clear outdated historical stats")
 		return err

--- a/pkg/statistics/handle/storage/gc.go
+++ b/pkg/statistics/handle/storage/gc.go
@@ -168,7 +168,7 @@ func DeleteTableStatsFromKV(sctx sessionctx.Context, statsIDs []int64) (err erro
 func forCount(total int64, batch int64) int64 {
 	result := total / batch
 	if total%batch > 0 {
-		result += 1
+		result++
 	}
 	return result
 }

--- a/pkg/statistics/handle/storage/gc.go
+++ b/pkg/statistics/handle/storage/gc.go
@@ -165,6 +165,14 @@ func DeleteTableStatsFromKV(sctx sessionctx.Context, statsIDs []int64) (err erro
 	return nil
 }
 
+func forCount(total int64, batch int64) int64 {
+	result := total / batch
+	if total%batch > 0 {
+		result += 1
+	}
+	return result
+}
+
 // ClearOutdatedHistoryStats clear outdated historical stats
 func ClearOutdatedHistoryStats(sctx sessionctx.Context) error {
 	sql := "select count(*) from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
@@ -182,15 +190,19 @@ func ClearOutdatedHistoryStats(sctx sessionctx.Context) error {
 	}
 	count := rows[0].GetInt64(0)
 	if count > 0 {
-		sql = "batch on create_time limit 1000 delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
-		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
-		if err != nil {
+		for n := int64(0); n < forCount(count, int64(1000)); n++ {
+			sql = "delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND limit 1000 "
+			_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
+			if err != nil {
+				return err
+			}
+		}
+		for n := int64(0); n < forCount(count, int64(50)); n++ {
+			sql = "delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND limit 50 "
+			_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
+			logutil.BgLogger().Info("clear outdated historical stats")
 			return err
 		}
-		sql = "batch on create_time limit 50 delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
-		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
-		logutil.BgLogger().Info("clear outdated historical stats")
-		return err
 	}
 	return nil
 }

--- a/pkg/statistics/handle/storage/gc.go
+++ b/pkg/statistics/handle/storage/gc.go
@@ -200,9 +200,9 @@ func ClearOutdatedHistoryStats(sctx sessionctx.Context) error {
 		for n := int64(0); n < forCount(count, int64(50)); n++ {
 			sql = "delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND limit 50 "
 			_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
-			logutil.BgLogger().Info("clear outdated historical stats")
 			return err
 		}
+		logutil.BgLogger().Info("clear outdated historical stats")
 	}
 	return nil
 }

--- a/pkg/statistics/handle/storage/gc.go
+++ b/pkg/statistics/handle/storage/gc.go
@@ -182,12 +182,12 @@ func ClearOutdatedHistoryStats(sctx sessionctx.Context) error {
 	}
 	count := rows[0].GetInt64(0)
 	if count > 0 {
-		sql = "delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND limit 5000"
+		sql = "batch on table_id limit 100 delete from mysql.stats_meta_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
 		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 		if err != nil {
 			return err
 		}
-		sql = "delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND limit 5000"
+		sql = "batch on table_id limit 100 delete from mysql.stats_history use index (idx_create_time) where create_time <= NOW() - INTERVAL %? SECOND"
 		_, err = util.Exec(sctx, sql, variable.HistoricalStatsDuration.Load().Seconds())
 		logutil.BgLogger().Info("clear outdated historical stats")
 		return err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48431

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

<img width="1379" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/82c43e7a-a317-43df-b7d7-2be4be8831ed">

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
