### PR TITLE
server,session: make sure ResultSet.Close() errors return to the client

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2049,11 +2049,7 @@ func (cc *clientConn) handleStmt(ctx context.Context, stmt ast.StmtNode, warns [
 			execStmt.(*executor.ExecStmt).FinishExecuteStmt(0, err, false)
 		}
 	}
-	if err != nil {
-		return false, err
-	}
-
-	return false, nil
+	return false, err
 }
 
 func (cc *clientConn) handleFileTransInConn(ctx context.Context, status uint16) (bool, error) {
@@ -2284,6 +2280,9 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 		if stmtDetail != nil {
 			stmtDetail.WriteSQLRespDuration += time.Since(start)
 		}
+	}
+	if err := rs.Close(); err != nil {
+		return false, err
 	}
 
 	if stmtDetail != nil {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2467,16 +2467,20 @@ const ExecStmtVarKey ExecStmtVarKeyType = 0
 // RecordSet, so this struct exists and RecordSet.Close() is overrided handle that.
 type execStmtResult struct {
 	sqlexec.RecordSet
-	se  *session
-	sql sqlexec.Statement
+	se     *session
+	sql    sqlexec.Statement
+	closed bool
 }
 
 func (rs *execStmtResult) Close() error {
-	se := rs.se
-	if err := rs.RecordSet.Close(); err != nil {
-		return finishStmt(context.Background(), se, err, rs.sql)
+	if rs.closed {
+		return nil
 	}
-	return finishStmt(context.Background(), se, nil, rs.sql)
+	se := rs.se
+	err := rs.RecordSet.Close()
+	err = finishStmt(context.Background(), se, err, rs.sql)
+	rs.closed = true
+	return err
 }
 
 // rollbackOnError makes sure the next statement starts a new transaction with the latest InfoSchema.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48446, ref #48411

Problem Summary:

### What is changed and how it works?

This also fix #48411 in another way, and can prevent more bugs.

Close the result set after all rs.Next(), and before cc.writeEOF()
Avoid the case that error happen and can't be sent to the client after writeEOF.

### Check List

Tests <!-- At least one of them must be included. -->

The test code in https://github.com/pingcap/tidb/pull/48412 should also apply for this one, as the both can fix #48411, so I don't bother writer another duplicated test.

- [x] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

See https://github.com/pingcap/tidb/issues/48411

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
