### PR TITLE
flashback: support to flashback to tso syntax

### DIFF
--- a/pkg/executor/ddl.go
+++ b/pkg/executor/ddl.go
@@ -540,12 +540,16 @@ func (e *DDLExec) getRecoverTableByTableName(tableName *ast.TableName) (*model.J
 }
 
 func (e *DDLExec) executeFlashBackCluster(s *ast.FlashBackToTimestampStmt) error {
-	flashbackTS, err := staleread.CalculateAsOfTsExpr(context.Background(), e.Ctx(), s.FlashbackTS)
-	if err != nil {
-		return err
-	}
+	if s.FlashbackTSO > 0 {
+		return domain.GetDomain(e.Ctx()).DDL().FlashbackCluster(e.Ctx(), s.FlashbackTSO)
+	} else {
+		flashbackTS, err := staleread.CalculateAsOfTsExpr(context.Background(), e.Ctx(), s.FlashbackTS)
+		if err != nil {
+			return err
+		}
 
-	return domain.GetDomain(e.Ctx()).DDL().FlashbackCluster(e.Ctx(), flashbackTS)
+		return domain.GetDomain(e.Ctx()).DDL().FlashbackCluster(e.Ctx(), flashbackTS)
+	}
 }
 
 func (e *DDLExec) executeFlashbackTable(s *ast.FlashBackTableStmt) error {

--- a/pkg/executor/ddl.go
+++ b/pkg/executor/ddl.go
@@ -540,16 +540,18 @@ func (e *DDLExec) getRecoverTableByTableName(tableName *ast.TableName) (*model.J
 }
 
 func (e *DDLExec) executeFlashBackCluster(s *ast.FlashBackToTimestampStmt) error {
+	// Check `TO TSO` clause
 	if s.FlashbackTSO > 0 {
 		return domain.GetDomain(e.Ctx()).DDL().FlashbackCluster(e.Ctx(), s.FlashbackTSO)
-	} else {
-		flashbackTS, err := staleread.CalculateAsOfTsExpr(context.Background(), e.Ctx(), s.FlashbackTS)
-		if err != nil {
-			return err
-		}
-
-		return domain.GetDomain(e.Ctx()).DDL().FlashbackCluster(e.Ctx(), flashbackTS)
 	}
+
+	// Check `TO TIMESTAMP` clause
+	flashbackTS, err := staleread.CalculateAsOfTsExpr(context.Background(), e.Ctx(), s.FlashbackTS)
+	if err != nil {
+		return err
+	}
+
+	return domain.GetDomain(e.Ctx()).DDL().FlashbackCluster(e.Ctx(), flashbackTS)
 }
 
 func (e *DDLExec) executeFlashbackTable(s *ast.FlashBackTableStmt) error {

--- a/pkg/executor/recover_test.go
+++ b/pkg/executor/recover_test.go
@@ -476,19 +476,19 @@ func TestFlashbackTSOWithSafeTs(t *testing.T) {
 	}{
 		{
 			name:              "5 seconds ago to now, safeTS 5 secs ago",
-			sql:               fmt.Sprintf("flashback cluster to timestamp '%d'", ts),
+			sql:               fmt.Sprintf("flashback cluster to tso %d", ts),
 			injectSafeTS:      oracle.GoTimeToTS(flashbackTs),
 			compareWithSafeTS: 0,
 		},
 		{
 			name:              "10 seconds ago to now, safeTS 5 secs ago",
-			sql:               fmt.Sprintf("flashback cluster to timestamp '%d'", ts),
+			sql:               fmt.Sprintf("flashback cluster to tso %d", ts),
 			injectSafeTS:      oracle.GoTimeToTS(flashbackTs.Add(10 * time.Second)),
 			compareWithSafeTS: -1,
 		},
 		{
 			name:              "5 seconds ago to now, safeTS 10 secs ago",
-			sql:               fmt.Sprintf("flashback cluster to timestamp '%d'", ts),
+			sql:               fmt.Sprintf("flashback cluster to tso %d", ts),
 			injectSafeTS:      oracle.GoTimeToTS(flashbackTs.Add(-10 * time.Second)),
 			compareWithSafeTS: 1,
 		},

--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -4417,9 +4417,10 @@ func (n *RecoverTableStmt) Accept(v Visitor) (Node, bool) {
 type FlashBackToTimestampStmt struct {
 	ddlNode
 
-	FlashbackTS ExprNode
-	Tables      []*TableName
-	DBName      model.CIStr
+	FlashbackTS  ExprNode
+	FlashbackTSO uint64
+	Tables       []*TableName
+	DBName       model.CIStr
 }
 
 // Restore implements Node interface
@@ -4441,9 +4442,14 @@ func (n *FlashBackToTimestampStmt) Restore(ctx *format.RestoreCtx) error {
 	} else {
 		ctx.WriteKeyWord("CLUSTER")
 	}
-	ctx.WriteKeyWord(" TO TIMESTAMP ")
-	if err := n.FlashbackTS.Restore(ctx); err != nil {
-		return errors.Annotate(err, "An error occurred while splicing FlashBackToTimestampStmt.FlashbackTS")
+	if n.FlashbackTSO == 0 {
+		ctx.WriteKeyWord(" TO TIMESTAMP ")
+		if err := n.FlashbackTS.Restore(ctx); err != nil {
+			return errors.Annotate(err, "An error occurred while splicing FlashBackToTimestampStmt.FlashbackTS")
+		}
+	} else {
+		ctx.WriteKeyWord(" TO TSO ")
+		ctx.WritePlainf("%d", n.FlashbackTSO)
 	}
 	return nil
 }
@@ -4464,11 +4470,14 @@ func (n *FlashBackToTimestampStmt) Accept(v Visitor) (Node, bool) {
 			n.Tables[i] = node.(*TableName)
 		}
 	}
-	node, ok := n.FlashbackTS.Accept(v)
-	if !ok {
-		return n, false
+
+	if n.FlashbackTSO == 0 {
+		node, ok := n.FlashbackTS.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.FlashbackTS = node.(ExprNode)
 	}
-	n.FlashbackTS = node.(ExprNode)
 	return v.Leave(n)
 }
 

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -278,6 +278,15 @@ func (s *Scanner) Lex(v *yySymType) int {
 			v.offset = pos.Offset
 			return toTimestamp
 		}
+
+		if tok1 == tsoType && tok2 == intLit {
+			_, pos, lit = s.scan()
+			v.ident = fmt.Sprintf("%s %s", v.ident, lit)
+			s.lastKeyword = toTSO
+			s.lastScanOffset = pos.Offset
+			v.offset = pos.Offset
+			return toTSO
+		}
 	}
 	// fix shift/reduce conflict with DEFINED NULL BY xxx OPTIONALLY ENCLOSED
 	if tok == optionally {

--- a/pkg/parser/misc.go
+++ b/pkg/parser/misc.go
@@ -833,6 +833,7 @@ var tokenMap = map[string]int{
 	"TRUE":                     trueKwd,
 	"TRUNCATE":                 truncate,
 	"TRUE_CARD_COST":           trueCardCost,
+	"TSO":                      tsoType,
 	"TTL":                      ttl,
 	"TTL_ENABLE":               ttlEnable,
 	"TTL_JOB_INTERVAL":         ttlJobInterval,

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -3003,23 +3003,38 @@ FlashbackToTimestampStmt:
 	}
 |	"FLASHBACK" "CLUSTER" toTSO LengthNum
 	{
-		$$ = &ast.FlashBackToTimestampStmt{
-			FlashbackTSO: $4.(uint64),
-		}
+		if tsoValue, ok := $4.(uint64); ok && tsoValue > 0 {
+			$$ = &ast.FlashBackToTimestampStmt{
+        		FlashbackTSO: tsoValue,
+        	}
+		} else {
+    		yylex.AppendError(yylex.Errorf("Invalid TSO value provided: %d", $4))
+    		return 1
+    	}
 	}
 |	"FLASHBACK" "TABLE" TableNameList toTSO LengthNum
 	{
-		$$ = &ast.FlashBackToTimestampStmt{
-			Tables:      $3.([]*ast.TableName),
-			FlashbackTSO: $5.(uint64),
-		}
+		if tsoValue, ok := $5.(uint64); ok && tsoValue > 0 {
+			$$ = &ast.FlashBackToTimestampStmt{
+            		Tables:      $3.([]*ast.TableName),
+            		FlashbackTSO: tsoValue,
+            	}
+		} else {
+    		yylex.AppendError(yylex.Errorf("Invalid TSO value provided: %d", $5))
+    		return 1
+    	}
 	}
 |	"FLASHBACK" DatabaseSym DBName toTSO LengthNum
 	{
-		$$ = &ast.FlashBackToTimestampStmt{
-			DBName:      model.NewCIStr($3),
-			FlashbackTSO: $5.(uint64),
-		}
+		if tsoValue, ok := $5.(uint64); ok && tsoValue > 0 {
+			$$ = &ast.FlashBackToTimestampStmt{
+            	DBName:      model.NewCIStr($3),
+            	FlashbackTSO: tsoValue,
+            }
+		} else {
+    		yylex.AppendError(yylex.Errorf("Invalid TSO value provided: %d", $5))
+    		return 1
+    	}
 	}
 
 

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -6653,6 +6653,7 @@ UnReservedKeyword:
 |	"TRACE"
 |	"TRANSACTION"
 |	"TRUNCATE"
+|	"TSO"
 |	"UNBOUNDED"
 |	"UNKNOWN"
 |	"VALUE" %prec lowerThanValueKeyword

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -55,6 +55,7 @@ import (
 	identifier           "identifier"
 	asof                 "AS OF"
 	toTimestamp          "TO TIMESTAMP"
+	toTSO                "TO TSO"
 	memberof             "MEMBER OF"
 	optionallyEnclosedBy "OPTIONALLY ENCLOSED BY"
 
@@ -656,6 +657,7 @@ import (
 	transaction           "TRANSACTION"
 	triggers              "TRIGGERS"
 	truncate              "TRUNCATE"
+	tsoType               "TSO"
 	ttl                   "TTL"
 	ttlEnable             "TTL_ENABLE"
 	ttlJobInterval        "TTL_JOB_INTERVAL"
@@ -2980,6 +2982,7 @@ FlashbackToTimestampStmt:
 	{
 		$$ = &ast.FlashBackToTimestampStmt{
 			FlashbackTS: ast.NewValueExpr($4, "", ""),
+			FlashbackTSO: 0,
 		}
 	}
 |	"FLASHBACK" "TABLE" TableNameList toTimestamp stringLit
@@ -2987,6 +2990,7 @@ FlashbackToTimestampStmt:
 		$$ = &ast.FlashBackToTimestampStmt{
 			Tables:      $3.([]*ast.TableName),
 			FlashbackTS: ast.NewValueExpr($5, "", ""),
+			FlashbackTSO: 0,
 		}
 	}
 |	"FLASHBACK" DatabaseSym DBName toTimestamp stringLit
@@ -2994,8 +2998,30 @@ FlashbackToTimestampStmt:
 		$$ = &ast.FlashBackToTimestampStmt{
 			DBName:      model.NewCIStr($3),
 			FlashbackTS: ast.NewValueExpr($5, "", ""),
+			FlashbackTSO: 0,
 		}
 	}
+|	"FLASHBACK" "CLUSTER" toTSO LengthNum
+	{
+		$$ = &ast.FlashBackToTimestampStmt{
+			FlashbackTSO: $4.(uint64),
+		}
+	}
+|	"FLASHBACK" "TABLE" TableNameList toTSO LengthNum
+	{
+		$$ = &ast.FlashBackToTimestampStmt{
+			Tables:      $3.([]*ast.TableName),
+			FlashbackTSO: $5.(uint64),
+		}
+	}
+|	"FLASHBACK" DatabaseSym DBName toTSO LengthNum
+	{
+		$$ = &ast.FlashBackToTimestampStmt{
+			DBName:      model.NewCIStr($3),
+			FlashbackTSO: $5.(uint64),
+		}
+	}
+
 
 /*******************************************************************
  *

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -3010,19 +3010,19 @@ FlashbackToTimestampStmt:
 		} else {
     		yylex.AppendError(yylex.Errorf("Invalid TSO value provided: %d", $4))
     		return 1
-    	}
+		}
 	}
 |	"FLASHBACK" "TABLE" TableNameList toTSO LengthNum
 	{
 		if tsoValue, ok := $5.(uint64); ok && tsoValue > 0 {
 			$$ = &ast.FlashBackToTimestampStmt{
-            		Tables:      $3.([]*ast.TableName),
-            		FlashbackTSO: tsoValue,
-            	}
+            	Tables:      $3.([]*ast.TableName),
+            	FlashbackTSO: tsoValue,
+            }
 		} else {
-    		yylex.AppendError(yylex.Errorf("Invalid TSO value provided: %d", $5))
-    		return 1
-    	}
+			yylex.AppendError(yylex.Errorf("Invalid TSO value provided: %d", $5))
+			return 1
+		}
 	}
 |	"FLASHBACK" DatabaseSym DBName toTSO LengthNum
 	{
@@ -3030,11 +3030,11 @@ FlashbackToTimestampStmt:
 			$$ = &ast.FlashBackToTimestampStmt{
             	DBName:      model.NewCIStr($3),
             	FlashbackTSO: tsoValue,
-            }
+			}
 		} else {
-    		yylex.AppendError(yylex.Errorf("Invalid TSO value provided: %d", $5))
-    		return 1
-    	}
+			yylex.AppendError(yylex.Errorf("Invalid TSO value provided: %d", $5))
+			return 1
+		}
 	}
 
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -3413,13 +3413,15 @@ func TestDDL(t *testing.T) {
 		{"flashback database to timestamp '2021-05-26 16:45:26'", false, ""},
 
 		// for flashback to tso
-		{"flashback cluster to tso 445494955052105728", true, "FLASHBACK CLUSTER TO TSO 445494955052105728"},
-		{"flashback table t to tso 445494955052105728", true, "FLASHBACK TABLE `t` TO TSO 445494955052105728"},
-		{"flashback table t,t1 to tso 445494955052105728", true, "FLASHBACK TABLE `t`, `t1` TO TSO 445494955052105728"},
-		{"flashback database test to tso 445494955052105728", true, "FLASHBACK DATABASE `test` TO TSO 445494955052105728"},
-		{"flashback schema test to tso 445494955052105728", true, "FLASHBACK DATABASE `test` TO TSO 445494955052105728"},
-		{"flashback table to tso 445494955052105728", false, ""},
-		{"flashback database to tso 445494955052105728", false, ""},
+		{"flashback cluster to tso 445494955052105721", true, "FLASHBACK CLUSTER TO TSO 445494955052105721"},
+		{"flashback table t to tso 445494955052105722", true, "FLASHBACK TABLE `t` TO TSO 445494955052105722"},
+		{"flashback table t,t1 to tso 445494955052105723", true, "FLASHBACK TABLE `t`, `t1` TO TSO 445494955052105723"},
+		{"flashback database test to tso 445494955052105724", true, "FLASHBACK DATABASE `test` TO TSO 445494955052105724"},
+		{"flashback schema test to tso 445494955052105725", true, "FLASHBACK DATABASE `test` TO TSO 445494955052105725"},
+		{"flashback table to tso 445494955052105726", false, ""},
+		{"flashback database to tso 445494955052105727", false, ""},
+		{"flashback schema test to tso 0", false, ""},
+		{"flashback schema test to tso -100", false, ""},
 
 		// for remove partitioning
 		{"alter table t remove partitioning", true, "ALTER TABLE `t` REMOVE PARTITIONING"},

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -3412,6 +3412,15 @@ func TestDDL(t *testing.T) {
 		{"flashback table to timestamp '2021-05-26 16:45:26'", false, ""},
 		{"flashback database to timestamp '2021-05-26 16:45:26'", false, ""},
 
+		// for flashback to tso
+		{"flashback cluster to tso 445494955052105728", true, "FLASHBACK CLUSTER TO TSO 445494955052105728"},
+		{"flashback table t to tso 445494955052105728", true, "FLASHBACK TABLE `t` TO TSO 445494955052105728"},
+		{"flashback table t,t1 to tso 445494955052105728", true, "FLASHBACK TABLE `t`, `t1` TO TSO 445494955052105728"},
+		{"flashback database test to tso 445494955052105728", true, "FLASHBACK DATABASE `test` TO TSO 445494955052105728"},
+		{"flashback schema test to tso 445494955052105728", true, "FLASHBACK DATABASE `test` TO TSO 445494955052105728"},
+		{"flashback table to tso 445494955052105728", false, ""},
+		{"flashback database to tso 445494955052105728", false, ""},
+
 		// for remove partitioning
 		{"alter table t remove partitioning", true, "ALTER TABLE `t` REMOVE PARTITIONING"},
 		{"alter table db.ident remove partitioning", true, "ALTER TABLE `db`.`ident` REMOVE PARTITIONING"},

--- a/pkg/sessiontxn/staleread/util.go
+++ b/pkg/sessiontxn/staleread/util.go
@@ -16,7 +16,6 @@ package staleread
 
 import (
 	"context"
-	"strconv"
 	"time"
 
 	"github.com/pingcap/failpoint"
@@ -31,7 +30,6 @@ import (
 )
 
 // CalculateAsOfTsExpr calculates the TsExpr of AsOfClause to get a StartTS.
-// tsExpr could be an expression of TSO or a timestamp
 func CalculateAsOfTsExpr(ctx context.Context, sctx sessionctx.Context, tsExpr ast.ExprNode) (uint64, error) {
 	sctx.GetSessionVars().StmtCtx.SetStaleTSOProvider(func() (uint64, error) {
 		failpoint.Inject("mockStaleReadTSO", func(val failpoint.Value) (uint64, error) {
@@ -49,11 +47,6 @@ func CalculateAsOfTsExpr(ctx context.Context, sctx sessionctx.Context, tsExpr as
 
 	if tsVal.IsNull() {
 		return 0, errAsOf.FastGenWithCause("as of timestamp cannot be NULL")
-	}
-
-	// if tsVal is TSO already, return it directly.
-	if tso, err := strconv.ParseUint(tsVal.GetString(), 10, 64); err == nil {
-		return tso, nil
 	}
 
 	toTypeTimestamp := types.NewFieldType(mysql.TypeTimestamp)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48372

Problem Summary:

### What is changed and how it works?
This PR provide the `flashback cluster to tso` support.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [X] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
This feature provides the new syntax of `flashback` of `flashback cluster to tso xxx_int`. An example is `flashback cluster to tso 445494955052105728`.
```
