### PR TITLE
external/test: compare the performance of merge iter

### DIFF
--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -65,7 +65,7 @@ go_test(
     ],
     embed = [":external"],
     flaky = True,
-    shard_count = 45,
+    shard_count = 46,
     deps = [
         "//br/pkg/lightning/backend/kv",
         "//br/pkg/lightning/common",
@@ -89,6 +89,7 @@ go_test(
         "@com_github_pingcap_kvproto//pkg/brpb",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//rand",
+        "@org_golang_x_sync//errgroup",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -303,6 +303,13 @@ func createEvenlyDistributedFiles(
 	store := openTestingStorage(t)
 	ctx := context.Background()
 
+	files, statFiles, err := GetAllFileNames(ctx, store, "evenly_distributed")
+	intest.Assert(err == nil)
+	err = store.DeleteFiles(ctx, files)
+	intest.Assert(err == nil)
+	err = store.DeleteFiles(ctx, statFiles)
+	intest.Assert(err == nil)
+
 	value := make([]byte, 100)
 	kvCnt := 0
 	for i := 0; i < fileCount; i++ {
@@ -362,7 +369,7 @@ func readMergeIter(s *readTestSuite) {
 }
 
 func TestCompareReader(t *testing.T) {
-	fileSize := 30 * 1024 * 1024
+	fileSize := 50 * 1024 * 1024
 	fileCnt := 24
 	store, kvCnt := createEvenlyDistributedFiles(t, fileSize, fileCnt)
 	memoryLimit := 64 * 1024 * 1024

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -310,7 +310,7 @@ func createEvenlyDistributedFiles(
 			SetMemorySizeLimit(uint64(float64(fileSize) * 1.1))
 		writer := builder.Build(
 			store,
-			"test/evenly_distributed",
+			"evenly_distributed",
 			fmt.Sprintf("%d", i),
 		)
 

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -228,7 +228,7 @@ type readTestSuite struct {
 
 func readFileSequential(s *readTestSuite) {
 	ctx := context.Background()
-	files, _, err := GetAllFileNames(ctx, s.store, "")
+	files, _, err := GetAllFileNames(ctx, s.store, "evenly_distributed")
 	intest.Assert(err == nil)
 
 	buf := make([]byte, s.memoryLimit)
@@ -258,7 +258,7 @@ func readFileSequential(s *readTestSuite) {
 
 func readFileConcurrently(s *readTestSuite) {
 	ctx := context.Background()
-	files, _, err := GetAllFileNames(ctx, s.store, "")
+	files, _, err := GetAllFileNames(ctx, s.store, "evenly_distributed")
 	intest.Assert(err == nil)
 
 	conc := min(s.concurrency, len(files))
@@ -332,7 +332,7 @@ func createEvenlyDistributedFiles(
 
 func readMergeIter(s *readTestSuite) {
 	ctx := context.Background()
-	files, _, err := GetAllFileNames(ctx, s.store, "")
+	files, _, err := GetAllFileNames(ctx, s.store, "evenly_distributed")
 	intest.Assert(err == nil)
 
 	if s.beforeCreateReader != nil {

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -260,7 +260,6 @@ func readFileConcurrently(s *readTestSuite) {
 	ctx := context.Background()
 	files, _, err := GetAllFileNames(ctx, s.store, "")
 	intest.Assert(err == nil)
-	fmt.Println(files)
 
 	conc := min(s.concurrency, len(files))
 	var eg errgroup.Group

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -403,7 +403,7 @@ func TestCompareReader(t *testing.T) {
 	suite := &readTestSuite{
 		store:              store,
 		totalKVCnt:         kvCnt,
-		concurrency:        8,
+		concurrency:        100,
 		memoryLimit:        memoryLimit,
 		beforeCreateReader: beforeTest,
 		beforeReaderClose:  beforeClose,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

generate the speed, CPU/heap profile for reading from external storage. See below.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

```
$ go test ./br/pkg/lightning/backend/external -v --tags=intest -test.run TestCompareReader --testing-storage-uri "s3://nfs/tianyuan-ut?access-key=xxx&secret-access-key=xxx&endpoint=https://xxx&force-path-style=false&region=xxx&provider=ks"
    bench_test.go:413: sequential read speed for 1258291200 bytes: 52.38 MB/s
    bench_test.go:420: concurrent read speed for 1258291200 bytes: 730.08 MB/s
    bench_test.go:427: merge iter read speed for 1258291200 bytes: 103.47 MB/s
```

The data is evenly distributed in files. We can see that even in this case merge iterator is slower than concurrent reading.

and here's the CPU flame graph of merge iter. We will improve the performance in future PR.

![image](https://github.com/pingcap/tidb/assets/1689766/d085437e-200b-4ced-b063-f80ea3555506)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
