### PR TITLE
pkg/param: add correct fsp for duration

### DIFF
--- a/pkg/param/binary_params.go
+++ b/pkg/param/binary_params.go
@@ -138,6 +138,7 @@ func ExecArgs(typectx types.Context, binaryParams []BinaryParam) (params []expre
 			continue
 
 		case mysql.TypeDuration:
+			fsp := 0
 			switch len(binaryParams[i].Val) {
 			case 0:
 				tmp = "0"
@@ -155,13 +156,14 @@ func ExecArgs(typectx types.Context, binaryParams []BinaryParam) (params []expre
 					return
 				}
 				_, tmp = binaryDurationWithMS(1, binaryParams[i].Val, isNegative)
+				fsp = types.MaxFsp
 			default:
 				err = mysql.ErrMalformPacket
 				return
 			}
 			// TODO: generate the duration datum directly
 			var dur types.Duration
-			dur, _, err = types.ParseDuration(typectx, tmp.(string), types.MaxFsp)
+			dur, _, err = types.ParseDuration(typectx, tmp.(string), fsp)
 			err = typectx.HandleTruncate(err)
 			if err != nil {
 				return

--- a/pkg/server/conn_stmt_params_test.go
+++ b/pkg/server/conn_stmt_params_test.go
@@ -214,7 +214,7 @@ func TestParseExecArgs(t *testing.T) {
 			},
 			nil,
 			types.ErrTruncatedWrongVal,
-			types.Duration{Duration: types.MinTime, Fsp: types.MaxFsp},
+			types.Duration{Duration: types.MinTime, Fsp: 0},
 		},
 		{
 			args{
@@ -226,7 +226,7 @@ func TestParseExecArgs(t *testing.T) {
 			},
 			nil,
 			nil,
-			types.Duration{Duration: time.Duration(0), Fsp: types.MaxFsp},
+			types.Duration{Duration: time.Duration(0), Fsp: 0},
 		},
 		// For error test
 		{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #48563

Problem Summary:

The `TIME` parameters will always use `us` precision.

### What is changed and how it works?

Only use `us` (6) precision when the parameter length is 12.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

### Release note

```release-note
Fix the issue that the `TIME` parameters always use the `us` precision.
```
