### PR TITLE
expression, types: fix the logic of converting duration to year

### DIFF
--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -163,7 +163,8 @@ func initSessCtx(
 	typeFlags := types.StrictFlags.
 		WithTruncateAsWarning(!sqlMode.HasStrictMode()).
 		WithIgnoreInvalidDateErr(sqlMode.HasAllowInvalidDatesMode()).
-		WithIgnoreZeroInDate(!sqlMode.HasStrictMode() || sqlMode.HasAllowInvalidDatesMode())
+		WithIgnoreZeroInDate(!sqlMode.HasStrictMode() || sqlMode.HasAllowInvalidDatesMode()).
+		WithCastTimeToYearThroughConcat(true)
 	sessCtx.GetSessionVars().StmtCtx.SetTypeFlags(typeFlags)
 
 	// Prevent initializing the mock context in the workers concurrently.

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -1691,11 +1691,17 @@ func (b *builtinCastDurationAsIntSig) evalInt(ctx sessionctx.Context, row chunk.
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	dur, err := val.RoundFrac(types.DefaultFsp, ctx.GetSessionVars().Location())
-	if err != nil {
-		return res, false, err
+
+	if b.tp.GetType() == mysql.TypeYear {
+		res, err = val.ConvertToYear(ctx.GetSessionVars().StmtCtx.TypeCtx())
+	} else {
+		var dur types.Duration
+		dur, err = val.RoundFrac(types.DefaultFsp, ctx.GetSessionVars().Location())
+		if err != nil {
+			return res, false, err
+		}
+		res, err = dur.ToNumber().ToInt()
 	}
-	res, err = dur.ToNumber().ToInt()
 	return res, false, err
 }
 

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -465,47 +465,61 @@ func TestCastFuncSig(t *testing.T) {
 		before *Column
 		after  int64
 		row    chunk.MutRow
+		tp     byte
 	}{
 		// cast string as int.
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeString), Index: 0},
 			1,
 			chunk.MutRowFromDatums([]types.Datum{types.NewStringDatum("1")}),
+			mysql.TypeLonglong,
 		},
 		// cast decimal as int.
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeNewDecimal), Index: 0},
 			1,
 			chunk.MutRowFromDatums([]types.Datum{types.NewDecimalDatum(types.NewDecFromInt(1))}),
+			mysql.TypeLonglong,
 		},
 		// cast real as int.
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
 			2,
 			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(2.5)}),
+			mysql.TypeLonglong,
 		},
 		// cast Time as int.
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeDatetime), Index: 0},
 			curTimeInt,
 			chunk.MutRowFromDatums([]types.Datum{timeDatum}),
+			mysql.TypeLonglong,
 		},
 		// cast Duration as int.
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeDuration), Index: 0},
 			125959,
 			chunk.MutRowFromDatums([]types.Datum{durationDatum}),
+			mysql.TypeLonglong,
+		},
+		// cast Duration as year.
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeDuration), Index: 0},
+			int64(time.Now().Year()),
+			chunk.MutRowFromDatums([]types.Datum{durationDatum}),
+			mysql.TypeYear,
 		},
 		// cast JSON as int.
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeJSON), Index: 0},
 			3,
 			chunk.MutRowFromDatums([]types.Datum{jsonInt}),
+			mysql.TypeLonglong,
 		},
 	}
 	for i, c := range castToIntCases {
 		args := []Expression{c.before}
-		b, err := newBaseBuiltinFunc(ctx, "", args, types.NewFieldType(mysql.TypeLonglong))
+		b, err := newBaseBuiltinFunc(ctx, "", args, types.NewFieldType(c.tp))
 		require.NoError(t, err)
 		intFunc := newBaseBuiltinCastFunc(b, false)
 		switch i {
@@ -517,9 +531,9 @@ func TestCastFuncSig(t *testing.T) {
 			sig = &builtinCastRealAsIntSig{intFunc}
 		case 3:
 			sig = &builtinCastTimeAsIntSig{intFunc}
-		case 4:
+		case 4, 5:
 			sig = &builtinCastDurationAsIntSig{intFunc}
-		case 5:
+		case 6:
 			sig = &builtinCastJSONAsIntSig{intFunc}
 		}
 		res, isNull, err := sig.evalInt(ctx, c.row.ToRow())

--- a/pkg/types/context.go
+++ b/pkg/types/context.go
@@ -61,6 +61,8 @@ const (
 	FlagSkipUTF8Check
 	// FlagSkipUTF8MB4Check indicates to skip the UTF8MB4 check when converting the value to an UTF8 string.
 	FlagSkipUTF8MB4Check
+	// FlagCastTimeToYearThroughConcat indicates to cast time to year through concatenation. For example, `00:19:59` will be converted to '1959'
+	FlagCastTimeToYearThroughConcat
 )
 
 // AllowNegativeToUnsigned indicates whether the flag `FlagAllowNegativeToUnsigned` is set
@@ -178,6 +180,19 @@ func (f Flags) WithIgnoreZeroDateErr(ignore bool) Flags {
 		return f | FlagIgnoreZeroDateErr
 	}
 	return f &^ FlagIgnoreZeroDateErr
+}
+
+// CastTimeToYearThroughConcat whether `FlagCastTimeToYearThroughConcat` is set
+func (f Flags) CastTimeToYearThroughConcat() bool {
+	return f&FlagCastTimeToYearThroughConcat != 0
+}
+
+// WithCastTimeToYearThroughConcat returns a new flags with `FlagCastTimeToYearThroughConcat` set/unset according to the flag parameter
+func (f Flags) WithCastTimeToYearThroughConcat(flag bool) Flags {
+	if flag {
+		return f | FlagCastTimeToYearThroughConcat
+	}
+	return f &^ FlagCastTimeToYearThroughConcat
 }
 
 // Context provides the information when converting between different types.

--- a/pkg/types/convert_test.go
+++ b/pkg/types/convert_test.go
@@ -271,7 +271,7 @@ func TestConvertType(t *testing.T) {
 	require.Equal(t, int64(2015), v)
 	v, err = Convert(ZeroDuration, ft)
 	require.NoError(t, err)
-	require.Equal(t, int64(0), v)
+	require.Equal(t, int64(time.Now().Year()), v)
 	bj1, err := ParseBinaryJSONFromString("99")
 	require.NoError(t, err)
 	v, err = Convert(bj1, ft)

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -1550,6 +1550,8 @@ func (d *Datum) ConvertToMysqlYear(ctx Context, target *FieldType) (Datum, error
 		}
 	case KindMysqlTime:
 		y = int64(d.GetMysqlTime().Year())
+	case KindMysqlDuration:
+		y, err = d.GetMysqlDuration().ConvertToYear(ctx)
 	case KindMysqlJSON:
 		y, err = ConvertJSONToInt64(ctx, d.GetMysqlJSON(), false)
 		if err != nil {
@@ -1565,7 +1567,11 @@ func (d *Datum) ConvertToMysqlYear(ctx Context, target *FieldType) (Datum, error
 		}
 		y = ret.GetInt64()
 	}
-	y, err = AdjustYear(y, adjust)
+
+	// Duration has been adjusted in `Duration.ConvertToYear()`
+	if d.k != KindMysqlDuration {
+		y, err = AdjustYear(y, adjust)
+	}
 	ret.SetInt64(y)
 	return ret, errors.Trace(err)
 }

--- a/pkg/types/time.go
+++ b/pkg/types/time.go
@@ -1512,6 +1512,29 @@ func (d Duration) ConvertToTimeWithTimestamp(ctx Context, tp uint8, ts gotime.Ti
 	return t.Convert(ctx, tp)
 }
 
+// ConvertToYear converts duration to Year.
+func (d Duration) ConvertToYear(ctx Context) (int64, error) {
+	return d.ConvertToYearFromNow(ctx, gotime.Now())
+}
+
+// ConvertToYearFromNow converts duration to Year, with the `now` specified by the argument.
+func (d Duration) ConvertToYearFromNow(ctx Context, now gotime.Time) (int64, error) {
+	if ctx.Flags().CastTimeToYearThroughConcat() {
+		// this error will never happen, because we always give a valid FSP
+		dur, _ := d.RoundFrac(DefaultFsp, ctx.Location())
+		// the range of a duration will never exceed the range of `mysql.TypeLonglong`
+		ival, _ := dur.ToNumber().ToInt()
+
+		return AdjustYear(ival, false)
+	}
+
+	year, month, day := now.In(ctx.Location()).Date()
+	datePart := FromDate(year, int(month), day, 0, 0, 0, 0)
+	mixDateAndDuration(&datePart, d)
+
+	return AdjustYear(int64(datePart.Year()), false)
+}
+
 // RoundFrac rounds fractional seconds precision with new fsp and returns a new one.
 // We will use the “round half up” rule, e.g, >= 0.5 -> 1, < 0.5 -> 0,
 // so 10:10:10.999999 round 0 -> 10:10:11

--- a/tests/integrationtest/r/expression/cast.result
+++ b/tests/integrationtest/r/expression/cast.result
@@ -88,3 +88,12 @@ cast('61qw' as decimal)
 61
 Level	Code	Message
 Warning	1292	Truncated incorrect DECIMAL value: '61qw'
+drop table if exists t;
+create table t (y year);
+insert into t values (cast('14:15' as time));
+select 1 from t where y = YEAR(CURDATE());
+1
+1
+select cast(cast('14:15' as time) as year) = YEAR(CURDATE());
+cast(cast('14:15' as time) as year) = YEAR(CURDATE())
+1

--- a/tests/integrationtest/t/expression/cast.test
+++ b/tests/integrationtest/t/expression/cast.test
@@ -55,3 +55,10 @@ update t1 set c1 = cast('61qw' as decimal);
 --enable_warnings
 select cast('61qw' as decimal);
 --disable_warnings
+
+# TestCastTimeAsYear
+drop table if exists t;
+create table t (y year);
+insert into t values (cast('14:15' as time));
+select 1 from t where y = YEAR(CURDATE());
+select cast(cast('14:15' as time) as year) = YEAR(CURDATE());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #48557

Problem Summary:

The correct behavior of converting time to year should be mixing the `Now` and duration, and then return the year.

Actually, it has two different behaviors when converting the `TIME` to `YEAR`.

1. In DDL, e.g. modify the column type from `TIME` to `YEAR`, it follows the "concatenation" rule. The `00:19:98` will be converted to `1998`. TiDB follows this behavior in all scenario before this PR. It's more like `TIME -> CHAR() -> YEAR`. This behavior has been covered by existing tests in `ddl/column_type_change` and `ddl/modify_column`.
2. In `SELECT` (cast implicitly or explicitly) and `INSERT` (inserting a `TIME` to a `YEAR` column), it's more like `TIME -> DATETIME -> YEAR`. It will mix the duration with the current time, and return the year.

This PR makes the second one the default behavior, and use a flag to follow the first behavior in `DDL` backfilling.

### What is changed and how it works?

Modify the logic of both `CastDurationAsInt` in expression and the `ConvertTo` in `types`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

### Release note

```release-note
Fix the issue that converting the `TIME` to `YEAR` gives an integer which represents the string of the time, rather then the year part of mixing the `TIME` and current time.
```
