### PR TITLE
CI: adjust the codecov statuses to make it not affect the PR or branch commit status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -43,6 +43,7 @@ component_management:
     statuses:
       - type: project # in this case every component that doens't have a status defined will have a project type one
         target: auto
+        informational: # resulting status will pass no matter what the coverage is or what other settings are specified. 
   individual_components:
     - component_id: component_dumpling # this is an identifier that should not be changed
       name: dumpling # this is a display name, and can be changed freely
@@ -64,8 +65,10 @@ flag_management:
     statuses:
       - type: project
         target: auto
+        informational: # resulting status will pass no matter what the coverage is or what other settings are specified. 
       - type: patch
-        target: 85%
+        target: auto
+        informational: # resulting status will pass no matter what the coverage is or what other settings are specified. 
 
 ignore:
   - "LICENSES"
@@ -76,15 +79,15 @@ ignore:
   - "cmd/.*"
   - "docs/.*"
   - "vendor/.*"
-  - "ddl/failtest/.*"
-  - "ddl/testutil/.*"
-  - "executor/seqtest/.*"
-  - "metrics/.*"
-  - "expression/generator/.*"
+  - "pkg/ddl/failtest/.*"
+  - "pkg/ddl/testutil/.*"
+  - "pkg/executor/seqtest/.*"
+  - "pkg/metrics/.*"
+  - "pkg/expression/generator/.*"
   - "br/pkg/mock/.*"
-  - "testkit/.*"
-  - "server/internal/testutil/.*"
-  - "statistics/handle/cache/internal/testutil/.*"
-  - "session/testutil.go"
-  - "store/mockstore/unistore/testutil.go"
+  - "pkg/testkit/.*"
+  - "pkg/server/internal/testutil/.*"
+  - "pkg/statistics/handle/cache/internal/testutil/.*"
+  - "pkg/session/testutil.go"
+  - "pkg/store/mockstore/unistore/testutil.go"
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

- update ignore paths for coverage.
- make the codecov results just as informations in github statuses on components and flags level, will not failed the statuses.

Total project level was disabled before(ref #46232).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
