### PR TITLE
*: reuse chunk in the histogram

### DIFF
--- a/pkg/statistics/analyze.go
+++ b/pkg/statistics/analyze.go
@@ -74,6 +74,9 @@ func (a *AnalyzeResult) DestroyAndPutToPool() {
 	for _, f := range a.Fms {
 		f.DestroyAndPutToPool()
 	}
+	for _, h := range a.Hist {
+		h.DestroyAndPutToPool()
+	}
 }
 
 // AnalyzeResults represents the analyze results of a task.

--- a/pkg/statistics/handle/globalstats/global_stats_async.go
+++ b/pkg/statistics/handle/globalstats/global_stats_async.go
@@ -526,10 +526,6 @@ func (a *AsyncMergePartitionStats2GlobalStats) dealHistogramAndTopN(stmtCtx *stm
 				a.globalStats.Hg[item.idx].Buckets[j].NDV = 0
 			}
 			a.globalStats.Hg[item.idx].NDV = a.globalStatsNDV[item.idx]
-
-			for _, hg := range allhg {
-				hg.DestroyAndPutToPool()
-			}
 		case <-a.ioWorkerExitWhenErrChan:
 			return nil
 		}

--- a/pkg/statistics/handle/globalstats/global_stats_async.go
+++ b/pkg/statistics/handle/globalstats/global_stats_async.go
@@ -526,6 +526,10 @@ func (a *AsyncMergePartitionStats2GlobalStats) dealHistogramAndTopN(stmtCtx *stm
 				a.globalStats.Hg[item.idx].Buckets[j].NDV = 0
 			}
 			a.globalStats.Hg[item.idx].NDV = a.globalStatsNDV[item.idx]
+
+			for _, hg := range allhg {
+				hg.DestroyAndPutToPool()
+			}
 		case <-a.ioWorkerExitWhenErrChan:
 			return nil
 		}

--- a/pkg/statistics/handle/storage/json.go
+++ b/pkg/statistics/handle/storage/json.go
@@ -115,6 +115,7 @@ func GenJSONTableFromStats(sctx sessionctx.Context, dbName string, tableInfo *mo
 		}
 		jsonTbl.Columns[col.Info.Name.L] = proto
 		col.FMSketch.DestroyAndPutToPool()
+		hist.DestroyAndPutToPool()
 	}
 	for _, idx := range tbl.Indices {
 		proto := dumpJSONCol(&idx.Histogram, idx.CMSketch, idx.TopN, nil, &idx.StatsVer)

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -119,7 +119,7 @@ func NewHistogram(id, ndv, nullCount int64, version uint64, tp *types.FieldType,
 		NullCount:         nullCount,
 		LastUpdateVersion: version,
 		Tp:                tp,
-		Bounds:            chunk.NewChunkWithCapacity([]*types.FieldType{tp}, 2*bucketSize),
+		Bounds:            chunk.NewChunkFromPoolWithCapacity([]*types.FieldType{tp}, 2*bucketSize),
 		Buckets:           make([]Bucket, 0, bucketSize),
 		TotColSize:        totColSize,
 	}
@@ -218,6 +218,14 @@ func (hg *Histogram) ConvertTo(sc *stmtctx.StatementContext, tp *types.FieldType
 // Len is the number of buckets in the histogram.
 func (hg *Histogram) Len() int {
 	return len(hg.Buckets)
+}
+
+// DestroyAndPutToPool resets the FMSketch and puts it to the pool.
+func (hg *Histogram) DestroyAndPutToPool() {
+	if hg == nil {
+		return
+	}
+	hg.Bounds.Destory(len(hg.Buckets), []*types.FieldType{hg.Tp})
 }
 
 // HistogramEqual tests if two histograms are equal.

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -225,7 +225,7 @@ func (hg *Histogram) DestroyAndPutToPool() {
 	if hg == nil {
 		return
 	}
-	hg.Bounds.Destory(len(hg.Buckets), []*types.FieldType{hg.Tp})
+	hg.Bounds.Destroy(len(hg.Buckets), []*types.FieldType{hg.Tp})
 }
 
 // HistogramEqual tests if two histograms are equal.

--- a/pkg/util/chunk/BUILD.bazel
+++ b/pkg/util/chunk/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/util/hack",
         "//pkg/util/logutil",
         "//pkg/util/memory",
+        "//pkg/util/syncutil",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@org_golang_x_sys//cpu",

--- a/pkg/util/chunk/chunk.go
+++ b/pkg/util/chunk/chunk.go
@@ -675,6 +675,7 @@ func (c *Chunk) AppendPartialRows(colOff int, rows []Row) {
 	}
 }
 
-func (c *Chunk) Destory(initCap int, fields []*types.FieldType) {
+// Destroy is to destroy the Chunk and put Chunk into the pool
+func (c *Chunk) Destroy(initCap int, fields []*types.FieldType) {
 	putChunkFromPool(initCap, fields, c)
 }

--- a/pkg/util/chunk/chunk.go
+++ b/pkg/util/chunk/chunk.go
@@ -71,6 +71,11 @@ func NewChunkWithCapacity(fields []*types.FieldType, capacity int) *Chunk {
 	return New(fields, capacity, capacity)
 }
 
+// NewChunkFromPoolWithCapacity creates a new chunk with field types and capacity from the pool.
+func NewChunkFromPoolWithCapacity(fields []*types.FieldType, initCap int) *Chunk {
+	return getChunkFromPool(initCap, fields)
+}
+
 // New creates a new chunk.
 //
 //	cap: the limit for the max number of rows.
@@ -668,4 +673,8 @@ func (c *Chunk) AppendPartialRows(colOff int, rows []Row) {
 			appendCellByCell(dstCol, srcRow.c.columns[i], srcRow.idx)
 		}
 	}
+}
+
+func (c *Chunk) Destory(initCap int, fields []*types.FieldType) {
+	putChunkFromPool(initCap, fields, c)
 }

--- a/pkg/util/chunk/pool.go
+++ b/pkg/util/chunk/pool.go
@@ -34,7 +34,6 @@ func getChunkFromPool(initCap int, fields []*types.FieldType) *Chunk {
 	pool, ok := globalChunkPool[initCap]
 	globalChunkPoolMutex.RUnlock()
 	if ok {
-
 		return pool.GetChunk(fields)
 	}
 	globalChunkPoolMutex.Lock()

--- a/pkg/util/chunk/pool.go
+++ b/pkg/util/chunk/pool.go
@@ -30,11 +30,11 @@ var (
 func getChunkFromPool(initCap int, fields []*types.FieldType) *Chunk {
 	globalChunkPoolMutex.RLock()
 	pool, ok := globalChunkPool[initCap]
+	globalChunkPoolMutex.RUnlock()
 	if ok {
-		globalChunkPoolMutex.RUnlock()
+
 		return pool.GetChunk(fields)
 	}
-	globalChunkPoolMutex.RUnlock()
 	globalChunkPoolMutex.Lock()
 	defer globalChunkPoolMutex.Unlock()
 	globalChunkPool[initCap] = NewPool(initCap)
@@ -44,12 +44,11 @@ func getChunkFromPool(initCap int, fields []*types.FieldType) *Chunk {
 func putChunkFromPool(initCap int, fields []*types.FieldType, chk *Chunk) {
 	globalChunkPoolMutex.RLock()
 	pool, ok := globalChunkPool[initCap]
+	globalChunkPoolMutex.RUnlock()
 	if ok {
-		globalChunkPoolMutex.RUnlock()
 		pool.PutChunk(fields, chk)
 		return
 	}
-	globalChunkPoolMutex.RUnlock()
 	globalChunkPoolMutex.Lock()
 	defer globalChunkPoolMutex.Unlock()
 	globalChunkPool[initCap] = NewPool(initCap)

--- a/pkg/util/chunk/pool.go
+++ b/pkg/util/chunk/pool.go
@@ -18,10 +18,11 @@ import (
 	"sync"
 
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/syncutil"
 )
 
 var (
-	globalChunkPoolMutex sync.RWMutex
+	globalChunkPoolMutex syncutil.RWMutex
 	// globalChunkPool is a chunk pool, the key is the init capacity.
 	globalChunkPool = make(map[int]*Pool)
 )
@@ -48,6 +49,7 @@ func putChunkFromPool(initCap int, fields []*types.FieldType, chk *Chunk) {
 		pool.PutChunk(fields, chk)
 		return
 	}
+	globalChunkPoolMutex.RUnlock()
 	globalChunkPoolMutex.Lock()
 	defer globalChunkPoolMutex.Unlock()
 	globalChunkPool[initCap] = NewPool(initCap)

--- a/pkg/util/chunk/pool.go
+++ b/pkg/util/chunk/pool.go
@@ -27,6 +27,8 @@ var (
 	globalChunkPool = make(map[int]*Pool)
 )
 
+// getChunkFromPool gets a Chunk from the Pool. In fact, initCap is the size of the bucket in the histogram.
+// so it will not have too many difference value.
 func getChunkFromPool(initCap int, fields []*types.FieldType) *Chunk {
 	globalChunkPoolMutex.RLock()
 	pool, ok := globalChunkPool[initCap]

--- a/pkg/util/chunk/pool.go
+++ b/pkg/util/chunk/pool.go
@@ -105,17 +105,19 @@ func (p *Pool) GetChunk(fields []*types.FieldType) *Chunk {
 // PutChunk puts a Chunk back to the Pool.
 func (p *Pool) PutChunk(fields []*types.FieldType, chk *Chunk) {
 	for i, f := range fields {
+		c := chk.columns[i]
+		c.reset()
 		switch elemLen := getFixedLen(f); elemLen {
 		case varElemLen:
-			p.varLenColPool.Put(chk.columns[i])
+			p.varLenColPool.Put(c)
 		case 4:
-			p.fixLenColPool4.Put(chk.columns[i])
+			p.fixLenColPool4.Put(c)
 		case 8:
-			p.fixLenColPool8.Put(chk.columns[i])
+			p.fixLenColPool8.Put(c)
 		case 16:
-			p.fixLenColPool16.Put(chk.columns[i])
+			p.fixLenColPool16.Put(c)
 		case 40:
-			p.fixLenColPool40.Put(chk.columns[i])
+			p.fixLenColPool40.Put(c)
 		}
 	}
 	chk.columns = nil // release the Column references.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48584

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

analyze a table with 292 columns.

before:

spend 2517.959s

![image](https://github.com/pingcap/tidb/assets/3427324/1bddc9e0-e755-4b26-9e47-3ecb2d0ed35a)

Allocate Speed: 500MB/s

after:

spend 2422.801s

<img width="1862" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/701a36cd-8c69-47cf-afa5-c6863560c5ed">

Allocate Speed: ~400MB/s

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
