### PR TITLE
br/storage: enable async prefetch data

### DIFF
--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -407,6 +407,15 @@ func TestCompareReader(t *testing.T) {
 		beforeReaderClose:  beforeClose,
 		afterReaderClose:   afterClose,
 	}
+
+	readMergeIter(suite)
+	t.Logf(
+		"merge iter read speed for %d bytes: %.2f MB/s",
+		fileSize*fileCnt,
+		float64(fileSize*fileCnt)/elapsed.Seconds()/1024/1024,
+	)
+
+	return
 	readFileSequential(suite)
 	t.Logf(
 		"sequential read speed for %d bytes: %.2f MB/s",
@@ -417,13 +426,6 @@ func TestCompareReader(t *testing.T) {
 	readFileConcurrently(suite)
 	t.Logf(
 		"concurrent read speed for %d bytes: %.2f MB/s",
-		fileSize*fileCnt,
-		float64(fileSize*fileCnt)/elapsed.Seconds()/1024/1024,
-	)
-
-	readMergeIter(suite)
-	t.Logf(
-		"merge iter read speed for %d bytes: %.2f MB/s",
 		fileSize*fileCnt,
 		float64(fileSize*fileCnt)/elapsed.Seconds()/1024/1024,
 	)

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"runtime/pprof"
 	"sync"
@@ -38,12 +37,7 @@ func openTestingStorage(t *testing.T) storage.ExternalStorage {
 	if *testingStorageURI == "" {
 		t.Skip("testingStorageURI is not set")
 	}
-	opt := &storage.ExternalStorageOptions{}
-	tr := http.DefaultTransport.(*http.Transport).Clone()
-	tr.ReadBufferSize = 64 * 1024
-	cli := &http.Client{Transport: tr}
-	opt.HTTPClient = cli
-	s, err := storage.NewFromURL(context.Background(), *testingStorageURI, opt)
+	s, err := storage.NewFromURL(context.Background(), *testingStorageURI, nil)
 	intest.AssertNoError(err)
 	return s
 }

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -226,7 +226,7 @@ type readTestSuite struct {
 
 func readFileSequential(s *readTestSuite) {
 	ctx := context.Background()
-	files, _, err := GetAllFileNames(ctx, s.store, "evenly_distributed")
+	files, _, err := GetAllFileNames(ctx, s.store, "/evenly_distributed")
 	intest.AssertNoError(err)
 
 	buf := make([]byte, s.memoryLimit)
@@ -256,7 +256,7 @@ func readFileSequential(s *readTestSuite) {
 
 func readFileConcurrently(s *readTestSuite) {
 	ctx := context.Background()
-	files, _, err := GetAllFileNames(ctx, s.store, "evenly_distributed")
+	files, _, err := GetAllFileNames(ctx, s.store, "/evenly_distributed")
 	intest.AssertNoError(err)
 
 	conc := min(s.concurrency, len(files))
@@ -301,7 +301,7 @@ func createEvenlyDistributedFiles(
 	store := openTestingStorage(t)
 	ctx := context.Background()
 
-	files, statFiles, err := GetAllFileNames(ctx, store, "evenly_distributed")
+	files, statFiles, err := GetAllFileNames(ctx, store, "/evenly_distributed")
 	intest.AssertNoError(err)
 	err = store.DeleteFiles(ctx, files)
 	intest.AssertNoError(err)
@@ -315,7 +315,7 @@ func createEvenlyDistributedFiles(
 			SetMemorySizeLimit(uint64(float64(fileSize) * 1.1))
 		writer := builder.Build(
 			store,
-			"evenly_distributed",
+			"/evenly_distributed",
 			fmt.Sprintf("%d", i),
 		)
 
@@ -337,7 +337,7 @@ func createEvenlyDistributedFiles(
 
 func readMergeIter(s *readTestSuite) {
 	ctx := context.Background()
-	files, _, err := GetAllFileNames(ctx, s.store, "evenly_distributed")
+	files, _, err := GetAllFileNames(ctx, s.store, "/evenly_distributed")
 	intest.AssertNoError(err)
 
 	if s.beforeCreateReader != nil {

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -415,7 +415,6 @@ func TestCompareReader(t *testing.T) {
 		float64(fileSize*fileCnt)/elapsed.Seconds()/1024/1024,
 	)
 
-	return
 	readFileSequential(suite)
 	t.Logf(
 		"sequential read speed for %d bytes: %.2f MB/s",

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"runtime/pprof"
 	"sync"
@@ -37,7 +38,12 @@ func openTestingStorage(t *testing.T) storage.ExternalStorage {
 	if *testingStorageURI == "" {
 		t.Skip("testingStorageURI is not set")
 	}
-	s, err := storage.NewFromURL(context.Background(), *testingStorageURI, nil)
+	opt := &storage.ExternalStorageOptions{}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.ReadBufferSize = 64 * 1024
+	cli := &http.Client{Transport: tr}
+	opt.HTTPClient = cli
+	s, err := storage.NewFromURL(context.Background(), *testingStorageURI, opt)
 	intest.AssertNoError(err)
 	return s
 }

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -344,7 +344,7 @@ func readMergeIter(s *readTestSuite) {
 		s.beforeCreateReader()
 	}
 
-	readBufSize := 64 * 1024
+	readBufSize := s.memoryLimit / len(files)
 	zeroOffsets := make([]uint64, len(files))
 	iter, err := NewMergeKVIter(ctx, files, zeroOffsets, s.store, readBufSize, false)
 	intest.AssertNoError(err)

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -344,7 +344,7 @@ func readMergeIter(s *readTestSuite) {
 		s.beforeCreateReader()
 	}
 
-	readBufSize := s.memoryLimit / len(files)
+	readBufSize := 64 * 1024
 	zeroOffsets := make([]uint64, len(files))
 	iter, err := NewMergeKVIter(ctx, files, zeroOffsets, s.store, readBufSize, false)
 	intest.AssertNoError(err)

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -38,7 +38,7 @@ func openTestingStorage(t *testing.T) storage.ExternalStorage {
 		t.Skip("testingStorageURI is not set")
 	}
 	s, err := storage.NewFromURL(context.Background(), *testingStorageURI, nil)
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 	return s
 }
 
@@ -109,7 +109,7 @@ func writePlainFile(s *writeTestSuite) {
 	offset := 0
 	flush := func(w storage.ExternalFileWriter) {
 		n, err := w.Write(ctx, buf[:offset])
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 		intest.Assert(offset == n)
 		offset = 0
 	}
@@ -118,7 +118,7 @@ func writePlainFile(s *writeTestSuite) {
 		s.beforeCreateWriter()
 	}
 	writer, err := s.store.Create(ctx, "test/plain_file", nil)
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 	key, val, _ := s.source.next()
 	for key != nil {
 		if offset+len(key)+len(val) > len(buf) {
@@ -133,7 +133,7 @@ func writePlainFile(s *writeTestSuite) {
 		s.beforeWriterClose()
 	}
 	err = writer.Close(ctx)
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 	if s.afterWriterClose != nil {
 		s.afterWriterClose()
 	}
@@ -151,14 +151,14 @@ func writeExternalFile(s *writeTestSuite) {
 	key, val, h := s.source.next()
 	for key != nil {
 		err := writer.WriteRow(ctx, key, val, h)
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 		key, val, h = s.source.next()
 	}
 	if s.beforeWriterClose != nil {
 		s.beforeWriterClose()
 	}
 	err := writer.Close(ctx)
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 	if s.afterWriterClose != nil {
 		s.afterWriterClose()
 	}
@@ -178,17 +178,17 @@ func TestCompareWriter(t *testing.T) {
 	beforeTest := func() {
 		fileIdx++
 		file, err = os.Create(fmt.Sprintf("cpu-profile-%d.prof", fileIdx))
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 		err = pprof.StartCPUProfile(file)
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 		now = time.Now()
 	}
 	beforeClose := func() {
 		file, err = os.Create(fmt.Sprintf("heap-profile-%d.prof", fileIdx))
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 		// check heap profile to see the memory usage is expected
 		err = pprof.WriteHeapProfile(file)
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 	}
 	afterClose := func() {
 		elapsed = time.Since(now)
@@ -227,7 +227,7 @@ type readTestSuite struct {
 func readFileSequential(s *readTestSuite) {
 	ctx := context.Background()
 	files, _, err := GetAllFileNames(ctx, s.store, "evenly_distributed")
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 
 	buf := make([]byte, s.memoryLimit)
 	if s.beforeCreateReader != nil {
@@ -235,7 +235,7 @@ func readFileSequential(s *readTestSuite) {
 	}
 	for i, file := range files {
 		reader, err := s.store.Open(ctx, file, nil)
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 		_, err = reader.Read(buf)
 		for err == nil {
 			_, err = reader.Read(buf)
@@ -247,7 +247,7 @@ func readFileSequential(s *readTestSuite) {
 			}
 		}
 		err = reader.Close()
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 	}
 	if s.afterReaderClose != nil {
 		s.afterReaderClose()
@@ -257,7 +257,7 @@ func readFileSequential(s *readTestSuite) {
 func readFileConcurrently(s *readTestSuite) {
 	ctx := context.Background()
 	files, _, err := GetAllFileNames(ctx, s.store, "evenly_distributed")
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 
 	conc := min(s.concurrency, len(files))
 	var eg errgroup.Group
@@ -271,7 +271,7 @@ func readFileConcurrently(s *readTestSuite) {
 		eg.Go(func() error {
 			buf := make([]byte, s.memoryLimit/conc)
 			reader, err := s.store.Open(ctx, file, nil)
-			intest.Assert(err == nil)
+			intest.AssertNoError(err)
 			_, err = reader.Read(buf)
 			for err == nil {
 				_, err = reader.Read(buf)
@@ -283,12 +283,12 @@ func readFileConcurrently(s *readTestSuite) {
 				}
 			})
 			err = reader.Close()
-			intest.Assert(err == nil)
+			intest.AssertNoError(err)
 			return nil
 		})
 	}
 	err = eg.Wait()
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 	if s.afterReaderClose != nil {
 		s.afterReaderClose()
 	}
@@ -302,11 +302,11 @@ func createEvenlyDistributedFiles(
 	ctx := context.Background()
 
 	files, statFiles, err := GetAllFileNames(ctx, store, "evenly_distributed")
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 	err = store.DeleteFiles(ctx, files)
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 	err = store.DeleteFiles(ctx, statFiles)
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 
 	value := make([]byte, 100)
 	kvCnt := 0
@@ -324,13 +324,13 @@ func createEvenlyDistributedFiles(
 		for totalSize < fileSize {
 			key := fmt.Sprintf("key_%09d", keyIdx)
 			err := writer.WriteRow(ctx, []byte(key), value, nil)
-			intest.Assert(err == nil)
+			intest.AssertNoError(err)
 			keyIdx += fileCount
 			totalSize += len(key) + len(value)
 			kvCnt++
 		}
 		err := writer.Close(ctx)
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 	}
 	return store, kvCnt
 }
@@ -338,7 +338,7 @@ func createEvenlyDistributedFiles(
 func readMergeIter(s *readTestSuite) {
 	ctx := context.Background()
 	files, _, err := GetAllFileNames(ctx, s.store, "evenly_distributed")
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 
 	if s.beforeCreateReader != nil {
 		s.beforeCreateReader()
@@ -347,7 +347,7 @@ func readMergeIter(s *readTestSuite) {
 	readBufSize := s.memoryLimit / len(files)
 	zeroOffsets := make([]uint64, len(files))
 	iter, err := NewMergeKVIter(ctx, files, zeroOffsets, s.store, readBufSize, false)
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 
 	kvCnt := 0
 	for iter.Next() {
@@ -360,7 +360,7 @@ func readMergeIter(s *readTestSuite) {
 	}
 	intest.Assert(kvCnt == s.totalKVCnt)
 	err = iter.Close()
-	intest.Assert(err == nil)
+	intest.AssertNoError(err)
 	if s.afterReaderClose != nil {
 		s.afterReaderClose()
 	}
@@ -381,17 +381,17 @@ func TestCompareReader(t *testing.T) {
 	beforeTest := func() {
 		fileIdx++
 		file, err = os.Create(fmt.Sprintf("cpu-profile-%d.prof", fileIdx))
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 		err = pprof.StartCPUProfile(file)
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 		now = time.Now()
 	}
 	beforeClose := func() {
 		file, err = os.Create(fmt.Sprintf("heap-profile-%d.prof", fileIdx))
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 		// check heap profile to see the memory usage is expected
 		err = pprof.WriteHeapProfile(file)
-		intest.Assert(err == nil)
+		intest.AssertNoError(err)
 	}
 	afterClose := func() {
 		elapsed = time.Since(now)

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -37,9 +37,7 @@ func openTestingStorage(t *testing.T) storage.ExternalStorage {
 	if *testingStorageURI == "" {
 		t.Skip("testingStorageURI is not set")
 	}
-	b, err := storage.ParseBackend(*testingStorageURI, nil)
-	intest.Assert(err == nil)
-	s, err := storage.New(context.Background(), b, nil)
+	s, err := storage.NewFromURL(context.Background(), *testingStorageURI, nil)
 	intest.Assert(err == nil)
 	return s
 }

--- a/br/pkg/lightning/backend/external/byte_reader.go
+++ b/br/pkg/lightning/backend/external/byte_reader.go
@@ -68,8 +68,9 @@ func openStoreReaderAndSeek(
 	store storage.ExternalStorage,
 	name string,
 	initFileOffset uint64,
+	prefetchSize int,
 ) (storage.ExternalFileReader, error) {
-	storageReader, err := store.Open(ctx, name, nil)
+	storageReader, err := store.Open(ctx, name, &storage.ReaderOption{PrefetchSize: prefetchSize})
 	if err != nil {
 		return nil, err
 	}

--- a/br/pkg/lightning/backend/external/kv_reader.go
+++ b/br/pkg/lightning/backend/external/kv_reader.go
@@ -36,11 +36,11 @@ func newKVReader(
 	initFileOffset uint64,
 	bufSize int,
 ) (*kvReader, error) {
-	sr, err := openStoreReaderAndSeek(ctx, store, name, initFileOffset)
+	sr, err := openStoreReaderAndSeek(ctx, store, name, initFileOffset, bufSize/2)
 	if err != nil {
 		return nil, err
 	}
-	br, err := newByteReader(ctx, sr, bufSize)
+	br, err := newByteReader(ctx, sr, bufSize/2)
 	if err != nil {
 		return nil, err
 	}

--- a/br/pkg/lightning/backend/external/kv_reader.go
+++ b/br/pkg/lightning/backend/external/kv_reader.go
@@ -36,11 +36,12 @@ func newKVReader(
 	initFileOffset uint64,
 	bufSize int,
 ) (*kvReader, error) {
-	sr, err := openStoreReaderAndSeek(ctx, store, name, initFileOffset, bufSize/2)
+	oneThird := bufSize / 3
+	sr, err := openStoreReaderAndSeek(ctx, store, name, initFileOffset, oneThird*2)
 	if err != nil {
 		return nil, err
 	}
-	br, err := newByteReader(ctx, sr, bufSize/2)
+	br, err := newByteReader(ctx, sr, oneThird)
 	if err != nil {
 		return nil, err
 	}

--- a/br/pkg/lightning/backend/external/stat_reader.go
+++ b/br/pkg/lightning/backend/external/stat_reader.go
@@ -26,7 +26,7 @@ type statsReader struct {
 }
 
 func newStatsReader(ctx context.Context, store storage.ExternalStorage, name string, bufSize int) (*statsReader, error) {
-	sr, err := openStoreReaderAndSeek(ctx, store, name, 0)
+	sr, err := openStoreReaderAndSeek(ctx, store, name, 0, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/br/pkg/storage/BUILD.bazel
+++ b/br/pkg/storage/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//br/pkg/logutil",
         "//pkg/sessionctx/variable",
         "//pkg/util/intest",
+        "//pkg/util/prefetch",
         "@com_github_aliyun_alibaba_cloud_sdk_go//sdk/auth/credentials",
         "@com_github_aliyun_alibaba_cloud_sdk_go//sdk/auth/credentials/providers",
         "@com_github_aws_aws_sdk_go//aws",

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/log"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/logutil"
+	"github.com/pingcap/tidb/pkg/util/prefetch"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 )
@@ -735,10 +736,11 @@ func (rs *S3Storage) Open(ctx context.Context, path string, o *ReaderOption) (Ex
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	reader2 := prefetch.NewPrefetchReader(reader, 64*1024)
 	return &s3ObjectReader{
 		storage:   rs,
 		name:      path,
-		reader:    reader,
+		reader:    reader2,
 		ctx:       ctx,
 		rangeInfo: r,
 	}, nil

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -876,6 +876,9 @@ func (r *s3ObjectReader) Read(p []byte) (n int, err error) {
 	if maxCnt > int64(len(p)) {
 		maxCnt = int64(len(p))
 	}
+	if maxCnt == 0 {
+		return 0, io.EOF
+	}
 	n, err = r.reader.Read(p[:maxCnt])
 	// TODO: maybe we should use !errors.Is(err, io.EOF) here to avoid error lint, but currently, pingcap/errors
 	// doesn't implement this method yet.

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -737,7 +737,7 @@ func (rs *S3Storage) Open(ctx context.Context, path string, o *ReaderOption) (Ex
 		return nil, errors.Trace(err)
 	}
 	if o.PrefetchSize > 0 {
-		reader = prefetch.NewPrefetchReader(reader, o.PrefetchSize)
+		reader = prefetch.NewReader(reader, o.PrefetchSize)
 	}
 	return &s3ObjectReader{
 		storage:   rs,

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -736,7 +736,7 @@ func (rs *S3Storage) Open(ctx context.Context, path string, o *ReaderOption) (Ex
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if o.PrefetchSize > 0 {
+	if o != nil && o.PrefetchSize > 0 {
 		reader = prefetch.NewReader(reader, o.PrefetchSize)
 	}
 	return &s3ObjectReader{

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -736,11 +736,13 @@ func (rs *S3Storage) Open(ctx context.Context, path string, o *ReaderOption) (Ex
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	reader2 := prefetch.NewPrefetchReader(reader, 64*1024)
+	if o.PrefetchSize > 0 {
+		reader = prefetch.NewPrefetchReader(reader, o.PrefetchSize)
+	}
 	return &s3ObjectReader{
 		storage:   rs,
 		name:      path,
-		reader:    reader2,
+		reader:    reader,
 		ctx:       ctx,
 		rangeInfo: r,
 	}, nil

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -97,6 +97,8 @@ type ReaderOption struct {
 	StartOffset *int64
 	// EndOffset is exclusive. And it's incompatible with Seek.
 	EndOffset *int64
+	// PrefetchSize will switch to NewPrefetchReader if value is positive.
+	PrefetchSize int
 }
 
 // ExternalStorage represents a kind of file system storage.

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -195,6 +195,25 @@ func NewWithDefaultOpt(ctx context.Context, backend *backuppb.StorageBackend) (E
 	return New(ctx, backend, &opts)
 }
 
+// NewFromURL creates an ExternalStorage from URL.
+func NewFromURL(ctx context.Context, uri string, opts *ExternalStorageOptions) (ExternalStorage, error) {
+	if len(uri) == 0 {
+		return nil, errors.Annotate(berrors.ErrStorageInvalidConfig, "empty store is not allowed")
+	}
+	u, err := ParseRawURL(uri)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if u.Scheme == "memstore" {
+		return NewMemStorage(), nil
+	}
+	b, err := parseBackend(u, uri, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return New(ctx, b, opts)
+}
+
 // New creates an ExternalStorage with options.
 func New(ctx context.Context, backend *backuppb.StorageBackend, opts *ExternalStorageOptions) (ExternalStorage, error) {
 	if opts == nil {

--- a/br/pkg/storage/storage_test.go
+++ b/br/pkg/storage/storage_test.go
@@ -3,6 +3,7 @@
 package storage_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -23,4 +24,11 @@ func TestDefaultHttpClient(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, int(concurrency), transport.MaxIdleConnsPerHost)
 	require.Equal(t, int(concurrency), transport.MaxIdleConns)
+}
+
+func TestNewMemStorage(t *testing.T) {
+	url := "memstore://"
+	s, err := storage.NewFromURL(context.Background(), url, nil)
+	require.NoError(t, err)
+	require.IsType(t, (*storage.MemStorage)(nil), s)
 }

--- a/pkg/util/prefetch/BUILD.bazel
+++ b/pkg/util/prefetch/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "prefetch",
+    srcs = ["reader.go"],
+    importpath = "github.com/pingcap/tidb/pkg/util/prefetch",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "prefetch_test",
+    timeout = "short",
+    srcs = ["reader_test.go"],
+    embed = [":prefetch"],
+    flaky = True,
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/util/prefetch/reader.go
+++ b/pkg/util/prefetch/reader.go
@@ -22,8 +22,8 @@ func NewPrefetchReader(r io.ReadCloser, prefetchSize int) io.ReadCloser {
 		bufCh: make(chan []byte, 0),
 		err:   nil,
 	}
-	ret.buf[0] = make([]byte, prefetchSize)
-	ret.buf[1] = make([]byte, prefetchSize)
+	ret.buf[0] = make([]byte, prefetchSize/2)
+	ret.buf[1] = make([]byte, prefetchSize/2)
 	go ret.run()
 	return ret
 }

--- a/pkg/util/prefetch/reader.go
+++ b/pkg/util/prefetch/reader.go
@@ -1,4 +1,16 @@
-// Copyright 2023 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package prefetch
 

--- a/pkg/util/prefetch/reader.go
+++ b/pkg/util/prefetch/reader.go
@@ -17,6 +17,7 @@ package prefetch
 import (
 	"bytes"
 	"io"
+	"sync"
 )
 
 // Reader is a reader that prefetches data from the underlying reader.
@@ -27,28 +28,39 @@ type Reader struct {
 	bufIdx       int
 	bufCh        chan []byte
 	err          error // after bufCh is closed
+	wg           sync.WaitGroup
+
+	closeOnce sync.Once
+	closed    chan struct{}
 }
 
 // NewReader creates a new Reader.
 func NewReader(r io.ReadCloser, prefetchSize int) io.ReadCloser {
 	ret := &Reader{
-		r:     r,
-		bufCh: make(chan []byte),
-		err:   nil,
+		r:      r,
+		bufCh:  make(chan []byte),
+		err:    nil,
+		closed: make(chan struct{}),
 	}
 	ret.buf[0] = make([]byte, prefetchSize/2)
 	ret.buf[1] = make([]byte, prefetchSize/2)
+	ret.wg.Add(1)
 	go ret.run()
 	return ret
 }
 
 func (r *Reader) run() {
+	defer r.wg.Done()
 	for {
 		r.bufIdx = (r.bufIdx + 1) % 2
 		buf := r.buf[r.bufIdx]
 		n, err := r.r.Read(buf)
 		buf = buf[:n]
-		r.bufCh <- buf
+		select {
+		case <-r.closed:
+			return
+		case r.bufCh <- buf:
+		}
 		if err != nil {
 			r.err = err
 			close(r.bufCh)
@@ -57,7 +69,7 @@ func (r *Reader) run() {
 	}
 }
 
-// Read implements io.Reader.
+// Read implements io.Reader. Read should not be called concurrently with Close.
 func (r *Reader) Read(data []byte) (int, error) {
 	total := 0
 	for {
@@ -88,7 +100,12 @@ func (r *Reader) Read(data []byte) (int, error) {
 	}
 }
 
-// Close implements io.Closer.
+// Close implements io.Closer. Close should not be called concurrently with Read.
 func (r *Reader) Close() error {
-	return r.r.Close()
+	ret := r.r.Close()
+	r.closeOnce.Do(func() {
+		close(r.closed)
+	})
+	r.wg.Wait()
+	return ret
 }

--- a/pkg/util/prefetch/reader.go
+++ b/pkg/util/prefetch/reader.go
@@ -66,7 +66,7 @@ func (r *PrefetchReader) Read(data []byte) (int, error) {
 		}
 
 		data = data[n:]
-		if err == io.EOF {
+		if err == io.EOF || r.curBufReader.Len() == 0 {
 			r.curBufReader = nil
 			continue
 		}

--- a/pkg/util/prefetch/reader.go
+++ b/pkg/util/prefetch/reader.go
@@ -1,0 +1,75 @@
+// Copyright 2023 PingCAP, Inc. Licensed under Apache-2.0.
+
+package prefetch
+
+import (
+	"bytes"
+	"io"
+)
+
+type PrefetchReader struct {
+	r            io.ReadCloser
+	prefetchSize int
+	curBuf       *bytes.Reader
+	bufCh        chan []byte
+	err          error // after bufCh is closed
+}
+
+func NewPrefetchReader(r io.ReadCloser, prefetchSize int) io.ReadCloser {
+	ret := &PrefetchReader{
+		r:            r,
+		prefetchSize: prefetchSize,
+		bufCh:        make(chan []byte, 1),
+		err:          nil,
+	}
+	go ret.run()
+	return ret
+}
+
+func (r *PrefetchReader) run() {
+	for {
+		buf := make([]byte, r.prefetchSize)
+		n, err := r.r.Read(buf)
+		buf = buf[:n]
+		r.bufCh <- buf
+		if err != nil {
+			r.err = err
+			close(r.bufCh)
+			return
+		}
+	}
+}
+
+func (r *PrefetchReader) Read(data []byte) (int, error) {
+	total := 0
+	for {
+		if r.curBuf == nil {
+			b, ok := <-r.bufCh
+			if !ok {
+				if total > 0 {
+					return total, nil
+				}
+				return 0, r.err
+			}
+
+			r.curBuf = bytes.NewReader(b)
+		}
+
+		expected := len(data)
+		n, err := r.curBuf.Read(data)
+		total += n
+		if n == expected {
+			return total, nil
+		}
+
+		data = data[n:]
+		if err == io.EOF {
+			r.curBuf = nil
+			continue
+		}
+	}
+}
+
+func (r *PrefetchReader) Close() error {
+	return r.r.Close()
+}

--- a/pkg/util/prefetch/reader_test.go
+++ b/pkg/util/prefetch/reader_test.go
@@ -1,4 +1,16 @@
-// Copyright 2023 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package prefetch
 

--- a/pkg/util/prefetch/reader_test.go
+++ b/pkg/util/prefetch/reader_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestBasic(t *testing.T) {
 	source := bytes.NewReader([]byte("01234567890"))
-	r := NewPrefetchReader(io.NopCloser(source), 3)
+	r := NewReader(io.NopCloser(source), 3)
 	buf := make([]byte, 1)
 	n, err := r.Read(buf)
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestBasic(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 
 	source = bytes.NewReader([]byte("01234567890"))
-	r = NewPrefetchReader(io.NopCloser(source), 3)
+	r = NewReader(io.NopCloser(source), 3)
 	buf = make([]byte, 11)
 	n, err = r.Read(buf)
 	require.NoError(t, err)

--- a/pkg/util/prefetch/reader_test.go
+++ b/pkg/util/prefetch/reader_test.go
@@ -1,0 +1,45 @@
+// Copyright 2023 PingCAP, Inc. Licensed under Apache-2.0.
+
+package prefetch
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasic(t *testing.T) {
+	source := bytes.NewReader([]byte("01234567890"))
+	r := NewPrefetchReader(io.NopCloser(source), 3)
+	buf := make([]byte, 1)
+	n, err := r.Read(buf)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
+	require.EqualValues(t, "0", buf[:n])
+
+	buf = make([]byte, 2)
+	n, err = r.Read(buf)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, n)
+	require.EqualValues(t, "12", buf[:n])
+
+	buf = make([]byte, 3)
+	n, err = r.Read(buf)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, n)
+	require.EqualValues(t, "345", buf[:n])
+
+	buf = make([]byte, 4)
+	n, err = r.Read(buf)
+	require.NoError(t, err)
+	require.EqualValues(t, 4, n)
+	require.EqualValues(t, "6789", buf[:n])
+	n, err = r.Read(buf)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
+	require.EqualValues(t, "0", buf[:n])
+	_, err = r.Read(buf)
+	require.ErrorIs(t, err, io.EOF)
+}

--- a/pkg/util/prefetch/reader_test.go
+++ b/pkg/util/prefetch/reader_test.go
@@ -64,3 +64,10 @@ func TestBasic(t *testing.T) {
 	_, err = r.Read(buf)
 	require.ErrorIs(t, err, io.EOF)
 }
+
+func TestCloseBeforeDrainRead(t *testing.T) {
+	data := make([]byte, 1024)
+	r := NewReader(io.NopCloser(bytes.NewReader(data)), 2)
+	err := r.Close()
+	require.NoError(t, err)
+}

--- a/pkg/util/prefetch/reader_test.go
+++ b/pkg/util/prefetch/reader_test.go
@@ -42,4 +42,13 @@ func TestBasic(t *testing.T) {
 	require.EqualValues(t, "0", buf[:n])
 	_, err = r.Read(buf)
 	require.ErrorIs(t, err, io.EOF)
+
+	source = bytes.NewReader([]byte("01234567890"))
+	r = NewPrefetchReader(io.NopCloser(source), 3)
+	buf = make([]byte, 11)
+	n, err = r.Read(buf)
+	require.NoError(t, err)
+	require.EqualValues(t, 11, n)
+	_, err = r.Read(buf)
+	require.ErrorIs(t, err, io.EOF)
 }

--- a/pkg/util/prefetch/reader_test.go
+++ b/pkg/util/prefetch/reader_test.go
@@ -63,6 +63,15 @@ func TestBasic(t *testing.T) {
 	require.EqualValues(t, 11, n)
 	_, err = r.Read(buf)
 	require.ErrorIs(t, err, io.EOF)
+
+	source = bytes.NewReader([]byte("01234"))
+	r = NewReader(io.NopCloser(source), 100)
+	buf = make([]byte, 11)
+	n, err = r.Read(buf)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, n)
+	_, err = r.Read(buf)
+	require.ErrorIs(t, err, io.EOF)
 }
 
 func TestCloseBeforeDrainRead(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/48781

Problem Summary:

### What is changed and how it works?

offload the network reading from the main goroutine of merge iterator

![image](https://github.com/pingcap/tidb/assets/1689766/050d0f2c-143f-46d3-9a92-03962dc56291)

Still need to improve the performance in future.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

use this command to run the specific "benchmark" unit test

```
go test ./br/pkg/lightning/backend/external -v --tags=intest -test.run TestCompareReader --testing-storage-uri "xxx"
```

On master with ks3

```
    bench_test.go:414: merge iter read speed for 1258291200 bytes: 109.49 MB/s
```

This PR with ks3

```
    bench_test.go:412: merge iter read speed for 1258291200 bytes: 121.49 MB/s
```

This PR with memstore

```
    bench_test.go:412: merge iter read speed for 1258291200 bytes: 163.92 MB/s
```

And I checked the heap usage, I have set 64MB in the unit test, the heap does not exceed it.

![image](https://github.com/pingcap/tidb/assets/1689766/a7084d39-4812-4cc5-a592-baa21af7e93a)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
