### PR TITLE
global sort: fix set tidb_cloud_storage_uri should be redacted

### DIFF
--- a/pkg/executor/set.go
+++ b/pkg/executor/set.go
@@ -161,7 +161,11 @@ func (e *SetExecutor) setSysVariable(ctx context.Context, name string, v *expres
 			}
 			return nil
 		})
-		logutil.BgLogger().Info("set global var", zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", valStr))
+		showValStr := valStr
+		if name == variable.TiDBCloudStorageURI {
+			showValStr = ast.RedactURL(showValStr)
+		}
+		logutil.BgLogger().Info("set global var", zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", showValStr))
 		if name == variable.TiDBServiceScope {
 			dom := domain.GetDomain(e.Ctx())
 			serverID := disttaskutil.GenerateSubtaskExecID(ctx, dom.DDL().GetID())

--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -800,6 +800,8 @@ const (
 	SetNames = "SetNAMES"
 	// SetCharset is the const for set charset stmt.
 	SetCharset = "SetCharset"
+	// TiDBCloudStorageURI is the const for set tidb_cloud_storage_uri stmt.
+	TiDBCloudStorageURI = "tidb_cloud_storage_uri"
 )
 
 // VariableAssignment is a variable assignment struct.
@@ -838,7 +840,10 @@ func (n *VariableAssignment) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteName(n.Name)
 		ctx.WritePlain("=")
 	}
-	if err := n.Value.Restore(ctx); err != nil {
+	if n.Name == TiDBCloudStorageURI {
+		// need to redact the url for safety when `show processlist;`
+		ctx.WritePlain(RedactURL(n.Value.(ValueExpr).GetString()))
+	} else if err := n.Value.Restore(ctx); err != nil {
 		return errors.Annotate(err, "An error occurred while restore VariableAssignment.Value")
 	}
 	if n.ExtendValue != nil {
@@ -1107,6 +1112,15 @@ func (n *SetStmt) Accept(v Visitor) (Node, bool) {
 		n.Variables[i] = node.(*VariableAssignment)
 	}
 	return v.Leave(n)
+}
+
+// SecureText implements SensitiveStatement interface.
+// need to redact the tidb_cloud_storage_url for safety when `show processlist;`
+func (n *SetStmt) SecureText() string {
+	redactedStmt := *n
+	var sb strings.Builder
+	_ = redactedStmt.Restore(format.NewRestoreCtx(format.DefaultRestoreFlags, &sb))
+	return sb.String()
 }
 
 // SetConfigStmt is the statement to set cluster configs.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48498 

Problem Summary:
As the issue said
### What is changed and how it works?
1. Redact uri in log.
2. Redact uri in show processList.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  
1. In tidb log:
![image](https://github.com/pingcap/tidb/assets/26179892/da7ad716-7cd9-4ba4-a657-b825a02f1917)
3. show processlist;
![image](https://github.com/pingcap/tidb/assets/26179892/caf9b7b8-7191-408c-91b7-10bd5877336f)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
redact tidb_cloud_storage_uri in log
```
