### PR TITLE
expression: always use the ctx in parameter for method `Equal` in all expressions

### DIFF
--- a/pkg/executor/benchmark_test.go
+++ b/pkg/executor/benchmark_test.go
@@ -934,7 +934,7 @@ func prepare4HashJoin(testCase *hashJoinTestCase, innerExec, outerExec exec.Exec
 		},
 	}
 
-	childrenUsedSchema := markChildrenUsedColsForTest(e.Schema(), e.Children(0).Schema(), e.Children(1).Schema())
+	childrenUsedSchema := markChildrenUsedColsForTest(testCase.ctx, e.Schema(), e.Children(0).Schema(), e.Children(1).Schema())
 	defaultValues := make([]types.Datum, e.buildWorker.buildSideExec.Schema().Len())
 	lhsTypes, rhsTypes := exec.RetTypes(innerExec), exec.RetTypes(outerExec)
 	for i := uint(0); i < e.concurrency; i++ {
@@ -963,7 +963,7 @@ func prepare4HashJoin(testCase *hashJoinTestCase, innerExec, outerExec exec.Exec
 
 // markChildrenUsedColsForTest compares each child with the output schema, and mark
 // each column of the child is used by output or not.
-func markChildrenUsedColsForTest(outputSchema *expression.Schema, childSchemas ...*expression.Schema) (childrenUsed [][]bool) {
+func markChildrenUsedColsForTest(ctx sessionctx.Context, outputSchema *expression.Schema, childSchemas ...*expression.Schema) (childrenUsed [][]bool) {
 	childrenUsed = make([][]bool, 0, len(childSchemas))
 	markedOffsets := make(map[int]struct{})
 	for _, col := range outputSchema.Columns {
@@ -980,7 +980,7 @@ func markChildrenUsedColsForTest(outputSchema *expression.Schema, childSchemas .
 		childrenUsed = append(childrenUsed, used)
 	}
 	for _, child := range childSchemas {
-		used := expression.GetUsedList(outputSchema.Columns, child)
+		used := expression.GetUsedList(ctx, outputSchema.Columns, child)
 		childrenUsed = append(childrenUsed, used)
 	}
 	return

--- a/pkg/expression/column_test.go
+++ b/pkg/expression/column_test.go
@@ -31,10 +31,10 @@ func TestColumn(t *testing.T) {
 	ctx := mock.NewContext()
 	col := &Column{RetType: types.NewFieldType(mysql.TypeLonglong), UniqueID: 1}
 
-	require.True(t, col.Equal(nil, col))
-	require.False(t, col.Equal(nil, &Column{}))
+	require.True(t, col.EqualColumn(col))
+	require.False(t, col.EqualColumn(&Column{}))
 	require.False(t, col.IsCorrelated())
-	require.True(t, col.Equal(nil, col.Decorrelate(nil)))
+	require.True(t, col.EqualColumn(col.Decorrelate(nil)))
 
 	marshal, err := col.MarshalJSON()
 	require.NoError(t, err)
@@ -44,12 +44,12 @@ func TestColumn(t *testing.T) {
 	corCol := &CorrelatedColumn{Column: *col, Data: &intDatum}
 	invalidCorCol := &CorrelatedColumn{Column: Column{}}
 	schema := NewSchema(&Column{UniqueID: 1})
-	require.True(t, corCol.Equal(nil, corCol))
-	require.False(t, corCol.Equal(nil, invalidCorCol))
+	require.True(t, corCol.EqualColumn(corCol))
+	require.False(t, corCol.EqualColumn(invalidCorCol))
 	require.True(t, corCol.IsCorrelated())
 	require.False(t, corCol.ConstItem(nil))
-	require.True(t, corCol.Decorrelate(schema).Equal(nil, col))
-	require.True(t, invalidCorCol.Decorrelate(schema).Equal(nil, invalidCorCol))
+	require.True(t, col.EqualColumn(corCol.Decorrelate(schema)))
+	require.True(t, invalidCorCol.EqualColumn(invalidCorCol.Decorrelate(schema)))
 
 	intCorCol := &CorrelatedColumn{Column: Column{RetType: types.NewFieldType(mysql.TypeLonglong)},
 		Data: &intDatum}
@@ -118,7 +118,7 @@ func TestColumn2Expr(t *testing.T) {
 
 	exprs := Column2Exprs(cols)
 	for i := range exprs {
-		require.True(t, exprs[i].Equal(nil, cols[i]))
+		require.True(t, cols[i].EqualColumn(exprs[i]))
 	}
 }
 
@@ -127,7 +127,7 @@ func TestColInfo2Col(t *testing.T) {
 	cols := []*Column{col0, col1}
 	colInfo := &model.ColumnInfo{ID: 0}
 	res := ColInfo2Col(cols, colInfo)
-	require.True(t, res.Equal(nil, col1))
+	require.True(t, res.EqualColumn(col1))
 
 	colInfo.ID = 3
 	res = ColInfo2Col(cols, colInfo)
@@ -147,7 +147,7 @@ func TestIndexInfo2Cols(t *testing.T) {
 	resCols, lengths := IndexInfo2PrefixCols(colInfos, cols, indexInfo)
 	require.Len(t, resCols, 1)
 	require.Len(t, lengths, 1)
-	require.True(t, resCols[0].Equal(nil, col0))
+	require.True(t, resCols[0].EqualColumn(col0))
 
 	cols = []*Column{col1}
 	colInfos = []*model.ColumnInfo{colInfo1}
@@ -160,8 +160,8 @@ func TestIndexInfo2Cols(t *testing.T) {
 	resCols, lengths = IndexInfo2PrefixCols(colInfos, cols, indexInfo)
 	require.Len(t, resCols, 2)
 	require.Len(t, lengths, 2)
-	require.True(t, resCols[0].Equal(nil, col0))
-	require.True(t, resCols[1].Equal(nil, col1))
+	require.True(t, resCols[0].EqualColumn(col0))
+	require.True(t, resCols[1].EqualColumn(col1))
 }
 
 func TestColHybird(t *testing.T) {

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -470,11 +470,11 @@ func (c *Constant) resolveIndices(_ *Schema) error {
 }
 
 // ResolveIndicesByVirtualExpr implements Expression interface.
-func (c *Constant) ResolveIndicesByVirtualExpr(_ *Schema) (Expression, bool) {
+func (c *Constant) ResolveIndicesByVirtualExpr(_ sessionctx.Context, _ *Schema) (Expression, bool) {
 	return c, true
 }
 
-func (c *Constant) resolveIndicesByVirtualExpr(_ *Schema) bool {
+func (c *Constant) resolveIndicesByVirtualExpr(_ sessionctx.Context, _ *Schema) bool {
 	return true
 }
 

--- a/pkg/expression/constant_propagation.go
+++ b/pkg/expression/constant_propagation.go
@@ -155,7 +155,7 @@ func tryToReplaceCond(ctx sessionctx.Context, src *Column, tgt *Column, cond Exp
 		return false, true, cond
 	}
 	for idx, expr := range sf.GetArgs() {
-		if src.Equal(nil, expr) {
+		if src.EqualColumn(expr) {
 			_, coll := cond.CharsetAndCollation()
 			if tgt.GetType().GetCollate() != coll {
 				continue

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -169,10 +169,10 @@ type Expression interface {
 	resolveIndices(schema *Schema) error
 
 	// ResolveIndicesByVirtualExpr resolves indices by the given schema in terms of virual expression. It will copy the original expression and return the copied one.
-	ResolveIndicesByVirtualExpr(schema *Schema) (Expression, bool)
+	ResolveIndicesByVirtualExpr(ctx sessionctx.Context, schema *Schema) (Expression, bool)
 
 	// resolveIndicesByVirtualExpr is called inside the `ResolveIndicesByVirtualExpr` It will perform on the expression itself.
-	resolveIndicesByVirtualExpr(schema *Schema) bool
+	resolveIndicesByVirtualExpr(ctx sessionctx.Context, schema *Schema) bool
 
 	// RemapColumn remaps columns with provided mapping and returns new expression
 	RemapColumn(map[int64]*Column) (Expression, error)

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -354,10 +354,7 @@ func (sf *ScalarFunction) GetType() *types.FieldType {
 
 // Equal implements Expression interface.
 func (sf *ScalarFunction) Equal(ctx sessionctx.Context, e Expression) bool {
-	if ctx == nil {
-		ctx = sf.GetCtx()
-	}
-
+	intest.Assert(ctx != nil)
 	fun, ok := e.(*ScalarFunction)
 	if !ok {
 		return false
@@ -654,15 +651,15 @@ func (sf *ScalarFunction) resolveIndices(schema *Schema) error {
 }
 
 // ResolveIndicesByVirtualExpr implements Expression interface.
-func (sf *ScalarFunction) ResolveIndicesByVirtualExpr(schema *Schema) (Expression, bool) {
+func (sf *ScalarFunction) ResolveIndicesByVirtualExpr(ctx sessionctx.Context, schema *Schema) (Expression, bool) {
 	newSf := sf.Clone()
-	isOK := newSf.resolveIndicesByVirtualExpr(schema)
+	isOK := newSf.resolveIndicesByVirtualExpr(ctx, schema)
 	return newSf, isOK
 }
 
-func (sf *ScalarFunction) resolveIndicesByVirtualExpr(schema *Schema) bool {
+func (sf *ScalarFunction) resolveIndicesByVirtualExpr(ctx sessionctx.Context, schema *Schema) bool {
 	for _, arg := range sf.GetArgs() {
-		isOk := arg.resolveIndicesByVirtualExpr(schema)
+		isOk := arg.resolveIndicesByVirtualExpr(ctx, schema)
 		if !isOk {
 			return false
 		}

--- a/pkg/expression/schema_test.go
+++ b/pkg/expression/schema_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -151,6 +152,6 @@ func TestGetUsedList(t *testing.T) {
 	usedCols = append(usedCols, schema.Columns[1])
 	usedCols = append(usedCols, schema.Columns[3])
 
-	used := GetUsedList(usedCols, schema)
+	used := GetUsedList(mock.NewContext(), usedCols, schema)
 	require.Equal(t, []bool{false, true, false, true, false}, used)
 }

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -569,28 +569,32 @@ func (m *MockExpr) EvalJSON(ctx sessionctx.Context, row chunk.Row) (val types.Bi
 func (m *MockExpr) ReverseEval(sc *stmtctx.StatementContext, res types.Datum, rType types.RoundingType) (val types.Datum, err error) {
 	return types.Datum{}, m.err
 }
-func (m *MockExpr) GetType() *types.FieldType                                     { return m.t }
-func (m *MockExpr) Clone() Expression                                             { return nil }
-func (m *MockExpr) Equal(ctx sessionctx.Context, e Expression) bool               { return false }
-func (m *MockExpr) IsCorrelated() bool                                            { return false }
-func (m *MockExpr) ConstItem(_ *stmtctx.StatementContext) bool                    { return false }
-func (m *MockExpr) Decorrelate(schema *Schema) Expression                         { return m }
-func (m *MockExpr) ResolveIndices(schema *Schema) (Expression, error)             { return m, nil }
-func (m *MockExpr) resolveIndices(schema *Schema) error                           { return nil }
-func (m *MockExpr) ResolveIndicesByVirtualExpr(schema *Schema) (Expression, bool) { return m, true }
-func (m *MockExpr) resolveIndicesByVirtualExpr(schema *Schema) bool               { return true }
-func (m *MockExpr) RemapColumn(_ map[int64]*Column) (Expression, error)           { return m, nil }
-func (m *MockExpr) ExplainInfo() string                                           { return "" }
-func (m *MockExpr) ExplainNormalizedInfo() string                                 { return "" }
-func (m *MockExpr) ExplainNormalizedInfo4InList() string                          { return "" }
-func (m *MockExpr) HashCode(sc *stmtctx.StatementContext) []byte                  { return nil }
-func (m *MockExpr) Vectorized() bool                                              { return false }
-func (m *MockExpr) SupportReverseEval() bool                                      { return false }
-func (m *MockExpr) HasCoercibility() bool                                         { return false }
-func (m *MockExpr) Coercibility() Coercibility                                    { return 0 }
-func (m *MockExpr) SetCoercibility(Coercibility)                                  {}
-func (m *MockExpr) Repertoire() Repertoire                                        { return UNICODE }
-func (m *MockExpr) SetRepertoire(Repertoire)                                      {}
+func (m *MockExpr) GetType() *types.FieldType                         { return m.t }
+func (m *MockExpr) Clone() Expression                                 { return nil }
+func (m *MockExpr) Equal(ctx sessionctx.Context, e Expression) bool   { return false }
+func (m *MockExpr) IsCorrelated() bool                                { return false }
+func (m *MockExpr) ConstItem(_ *stmtctx.StatementContext) bool        { return false }
+func (m *MockExpr) Decorrelate(schema *Schema) Expression             { return m }
+func (m *MockExpr) ResolveIndices(schema *Schema) (Expression, error) { return m, nil }
+func (m *MockExpr) resolveIndices(schema *Schema) error               { return nil }
+func (m *MockExpr) ResolveIndicesByVirtualExpr(ctx sessionctx.Context, schema *Schema) (Expression, bool) {
+	return m, true
+}
+func (m *MockExpr) resolveIndicesByVirtualExpr(ctx sessionctx.Context, schema *Schema) bool {
+	return true
+}
+func (m *MockExpr) RemapColumn(_ map[int64]*Column) (Expression, error) { return m, nil }
+func (m *MockExpr) ExplainInfo() string                                 { return "" }
+func (m *MockExpr) ExplainNormalizedInfo() string                       { return "" }
+func (m *MockExpr) ExplainNormalizedInfo4InList() string                { return "" }
+func (m *MockExpr) HashCode(sc *stmtctx.StatementContext) []byte        { return nil }
+func (m *MockExpr) Vectorized() bool                                    { return false }
+func (m *MockExpr) SupportReverseEval() bool                            { return false }
+func (m *MockExpr) HasCoercibility() bool                               { return false }
+func (m *MockExpr) Coercibility() Coercibility                          { return 0 }
+func (m *MockExpr) SetCoercibility(Coercibility)                        {}
+func (m *MockExpr) Repertoire() Repertoire                              { return UNICODE }
+func (m *MockExpr) SetRepertoire(Repertoire)                            {}
 
 func (m *MockExpr) CharsetAndCollation() (string, string) {
 	return "", ""

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -157,7 +157,7 @@ func Selectivity(
 	slices.Sort(idxIDs)
 	for _, id := range idxIDs {
 		idxStats := coll.Indices[id]
-		idxCols := findPrefixOfIndexByCol(extractedCols, coll.Idx2ColumnIDs[id], id2Paths[idxStats.ID])
+		idxCols := findPrefixOfIndexByCol(ctx, extractedCols, coll.Idx2ColumnIDs[id], id2Paths[idxStats.ID])
 		if len(idxCols) > 0 {
 			lengths := make([]int, 0, len(idxCols))
 			for i := 0; i < len(idxCols) && i < len(idxStats.Info.Columns); i++ {
@@ -557,7 +557,7 @@ func isColEqCorCol(filter expression.Expression) *expression.Column {
 
 // findPrefixOfIndexByCol will find columns in index by checking the unique id or the virtual expression.
 // So it will return at once no matching column is found.
-func findPrefixOfIndexByCol(cols []*expression.Column, idxColIDs []int64,
+func findPrefixOfIndexByCol(ctx sessionctx.Context, cols []*expression.Column, idxColIDs []int64,
 	cachedPath *planutil.AccessPath) []*expression.Column {
 	if cachedPath != nil {
 		idxCols := cachedPath.IdxCols
@@ -565,7 +565,7 @@ func findPrefixOfIndexByCol(cols []*expression.Column, idxColIDs []int64,
 	idLoop:
 		for _, idCol := range idxCols {
 			for _, col := range cols {
-				if col.EqualByExprAndID(nil, idCol) {
+				if col.EqualByExprAndID(ctx, idCol) {
 					retCols = append(retCols, col)
 					continue idLoop
 				}

--- a/pkg/planner/cascades/implementation_rules.go
+++ b/pkg/planner/cascades/implementation_rules.go
@@ -189,7 +189,7 @@ type ImplTableScan struct {
 // Match implements ImplementationRule Match interface.
 func (*ImplTableScan) Match(expr *memo.GroupExpr, prop *property.PhysicalProperty) (matched bool) {
 	ts := expr.ExprNode.(*plannercore.LogicalTableScan)
-	return prop.IsSortItemEmpty() || (len(prop.SortItems) == 1 && ts.HandleCols != nil && prop.SortItems[0].Col.Equal(nil, ts.HandleCols.GetCol(0)))
+	return prop.IsSortItemEmpty() || (len(prop.SortItems) == 1 && ts.HandleCols != nil && prop.SortItems[0].Col.EqualColumn(ts.HandleCols.GetCol(0)))
 }
 
 // OnImplement implements ImplementationRule OnImplement interface.

--- a/pkg/planner/cascades/optimize_test.go
+++ b/pkg/planner/cascades/optimize_test.go
@@ -175,7 +175,7 @@ func TestPreparePossibleProperties(t *testing.T) {
 	aggProp := preparePossibleProperties(group, propMap)
 	// We only have one prop for Group0 : f
 	require.Len(t, aggProp, 1)
-	require.True(t, aggProp[0][0].Equal(nil, columnF))
+	require.True(t, aggProp[0][0].EqualColumn(columnF))
 
 	gatherGroup := group.Equivalents.Front().Value.(*memo.GroupExpr).Children[0]
 	gatherProp, ok := propMap[gatherGroup]
@@ -184,7 +184,7 @@ func TestPreparePossibleProperties(t *testing.T) {
 	require.Len(t, gatherProp, 2)
 	for _, prop := range gatherProp {
 		require.Len(t, prop, 1)
-		require.True(t, prop[0].Equal(nil, columnA) || prop[0].Equal(nil, columnF))
+		require.True(t, prop[0].EqualColumn(columnA) || prop[0].EqualColumn(columnF))
 	}
 }
 

--- a/pkg/planner/cascades/transformation_rules.go
+++ b/pkg/planner/cascades/transformation_rules.go
@@ -1121,7 +1121,7 @@ func (*EliminateProjection) OnTransform(old *memo.ExprIter) (newExprs []*memo.Gr
 
 	oldCols := old.GetExpr().Group.Prop.Schema.Columns
 	for i, col := range child.Group.Prop.Schema.Columns {
-		if !col.Equal(nil, oldCols[i]) {
+		if !col.EqualColumn(oldCols[i]) {
 			return nil, false, false, nil
 		}
 	}

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -81,7 +81,7 @@ func findMaxPrefixLen(candidates [][]*expression.Column, keys []*expression.Colu
 	for _, candidateKeys := range candidates {
 		matchedLen := 0
 		for i := range keys {
-			if !(i < len(candidateKeys) && keys[i].Equal(nil, candidateKeys[i])) {
+			if !(i < len(candidateKeys) && keys[i].EqualColumn(candidateKeys[i])) {
 				break
 			}
 			matchedLen++
@@ -669,7 +669,7 @@ func (p *LogicalJoin) constructIndexMergeJoin(
 		outerCompareFuncs := make([]expression.CompareFunc, 0, len(join.OuterJoinKeys))
 
 		for i := range join.KeyOff2IdxOff {
-			if isOuterKeysPrefix && !prop.SortItems[i].Col.Equal(nil, join.OuterJoinKeys[keyOff2KeyOffOrderByIdx[i]]) {
+			if isOuterKeysPrefix && !prop.SortItems[i].Col.EqualColumn(join.OuterJoinKeys[keyOff2KeyOffOrderByIdx[i]]) {
 				isOuterKeysPrefix = false
 			}
 			compareFuncs = append(compareFuncs, expression.GetCmpFunction(p.SCtx(), join.OuterJoinKeys[i], join.InnerJoinKeys[i]))
@@ -678,7 +678,7 @@ func (p *LogicalJoin) constructIndexMergeJoin(
 		// canKeepOuterOrder means whether the prop items are the prefix of the outer join keys.
 		canKeepOuterOrder := len(prop.SortItems) <= len(join.OuterJoinKeys)
 		for i := 0; canKeepOuterOrder && i < len(prop.SortItems); i++ {
-			if !prop.SortItems[i].Col.Equal(nil, join.OuterJoinKeys[keyOff2KeyOffOrderByIdx[i]]) {
+			if !prop.SortItems[i].Col.EqualColumn(join.OuterJoinKeys[keyOff2KeyOffOrderByIdx[i]]) {
 				canKeepOuterOrder = false
 			}
 		}
@@ -896,7 +896,7 @@ func (p *LogicalJoin) buildIndexJoinInner2TableScan(
 			return nil
 		}
 		for i, key := range innerJoinKeys {
-			if !key.Equal(nil, pkCol) {
+			if !key.EqualColumn(pkCol) {
 				keyOff2IdxOff[i] = -1
 				continue
 			}
@@ -1582,10 +1582,10 @@ loopOtherConds:
 		}
 		var funcName string
 		var anotherArg expression.Expression
-		if lCol, ok := sf.GetArgs()[0].(*expression.Column); ok && lCol.Equal(nil, nextCol) {
+		if lCol, ok := sf.GetArgs()[0].(*expression.Column); ok && lCol.EqualColumn(nextCol) {
 			anotherArg = sf.GetArgs()[1]
 			funcName = sf.FuncName.L
-		} else if rCol, ok := sf.GetArgs()[1].(*expression.Column); ok && rCol.Equal(nil, nextCol) {
+		} else if rCol, ok := sf.GetArgs()[1].(*expression.Column); ok && rCol.EqualColumn(nextCol) {
 			anotherArg = sf.GetArgs()[0]
 			// The column manager always build expression in the form of col op arg1.
 			// So we need use the symmetric one of the current function.
@@ -1622,7 +1622,7 @@ func (ijHelper *indexJoinBuildHelper) removeUselessEqAndInFunc(idxCols []*expres
 			ijHelper.curPossibleUsedKeys = append(ijHelper.curPossibleUsedKeys, idxCols[idxColPos])
 			continue
 		}
-		if notKeyColPos < len(notKeyEqAndIn) && ijHelper.curNotUsedIndexCols[notKeyColPos].Equal(nil, idxCols[idxColPos]) {
+		if notKeyColPos < len(notKeyEqAndIn) && ijHelper.curNotUsedIndexCols[notKeyColPos].EqualColumn(idxCols[idxColPos]) {
 			notKeyColPos++
 			continue
 		}
@@ -2740,7 +2740,7 @@ func MatchItems(p *property.PhysicalProperty, items []*util.ByItems) bool {
 	}
 	for i, col := range p.SortItems {
 		sortItem := items[i]
-		if sortItem.Desc != col.Desc || !sortItem.Expr.Equal(nil, col.Col) {
+		if sortItem.Desc != col.Desc || !col.Col.EqualColumn(sortItem.Expr) {
 			return false
 		}
 	}

--- a/pkg/planner/core/logical_plans.go
+++ b/pkg/planner/core/logical_plans.go
@@ -1585,9 +1585,10 @@ func (p *LogicalIndexScan) MatchIndexProp(prop *property.PhysicalProperty) (matc
 	if all, _ := prop.AllSameOrder(); !all {
 		return false
 	}
+	sctx := p.SCtx()
 	for i, col := range p.IdxCols {
-		if col.Equal(nil, prop.SortItems[0].Col) {
-			return matchIndicesProp(p.IdxCols[i:], p.IdxColLens[i:], prop.SortItems)
+		if col.Equal(sctx, prop.SortItems[0].Col) {
+			return matchIndicesProp(sctx, p.IdxCols[i:], p.IdxColLens[i:], prop.SortItems)
 		} else if i >= p.EqCondCount {
 			break
 		}
@@ -1821,7 +1822,7 @@ func (ds *DataSource) fillIndexPath(path *util.AccessPath, conds []expression.Ex
 		if handleCol != nil && !mysql.HasUnsignedFlag(handleCol.RetType.GetFlag()) {
 			alreadyHandle := false
 			for _, col := range path.IdxCols {
-				if col.ID == model.ExtraHandleID || col.Equal(nil, handleCol) {
+				if col.ID == model.ExtraHandleID || col.EqualColumn(handleCol) {
 					alreadyHandle = true
 				}
 			}

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -518,12 +518,12 @@ func (p *PhysicalHashJoin) extractUsedCols(parentUsedCols []*expression.Column) 
 
 func prunePhysicalColumnForHashJoinChild(sctx sessionctx.Context, hashJoin *PhysicalHashJoin, joinUsedCols []*expression.Column, sender *PhysicalExchangeSender) error {
 	var err error
-	joinUsed := expression.GetUsedList(joinUsedCols, sender.Schema())
+	joinUsed := expression.GetUsedList(sctx, joinUsedCols, sender.Schema())
 	hashCols := make([]*expression.Column, len(sender.HashCols))
 	for i, mppCol := range sender.HashCols {
 		hashCols[i] = mppCol.Col
 	}
-	hashUsed := expression.GetUsedList(hashCols, sender.Schema())
+	hashUsed := expression.GetUsedList(sctx, hashCols, sender.Schema())
 
 	needPrune := false
 	usedExprs := make([]expression.Expression, len(sender.Schema().Columns))

--- a/pkg/planner/core/resolve_indices.go
+++ b/pkg/planner/core/resolve_indices.go
@@ -147,7 +147,7 @@ func (p *PhysicalHashJoin) ResolveIndicesItself() (err error) {
 	//   e.g. The schema of child_0 is [col0, col0, col1]
 	//        ResolveIndices will only resolve all col0 reference of the current plan to the first col0.
 	for i, j := 0, 0; i < colsNeedResolving && j < len(mergedSchema.Columns); {
-		if !p.schema.Columns[i].Equal(nil, mergedSchema.Columns[j]) {
+		if !p.schema.Columns[i].EqualColumn(mergedSchema.Columns[j]) {
 			j++
 			continue
 		}
@@ -233,7 +233,7 @@ func (p *PhysicalMergeJoin) ResolveIndices() (err error) {
 	//   e.g. The schema of child_0 is [col0, col0, col1]
 	//        ResolveIndices will only resolve all col0 reference of the current plan to the first col0.
 	for i, j := 0, 0; i < colsNeedResolving && j < len(mergedSchema.Columns); {
-		if !p.schema.Columns[i].Equal(nil, mergedSchema.Columns[j]) {
+		if !p.schema.Columns[i].EqualColumn(mergedSchema.Columns[j]) {
 			j++
 			continue
 		}
@@ -329,7 +329,7 @@ func (p *PhysicalIndexJoin) ResolveIndices() (err error) {
 	//   e.g. The schema of child_0 is [col0, col0, col1]
 	//        ResolveIndices will only resolve all col0 reference of the current plan to the first col0.
 	for i, j := 0, 0; i < colsNeedResolving && j < len(mergedSchema.Columns); {
-		if !p.schema.Columns[i].Equal(nil, mergedSchema.Columns[j]) {
+		if !p.schema.Columns[i].EqualColumn(mergedSchema.Columns[j]) {
 			j++
 			continue
 		}
@@ -403,7 +403,8 @@ func (p *PhysicalIndexReader) ResolveIndices() (err error) {
 		newCol, err := col.ResolveIndices(p.indexPlan.Schema())
 		if err != nil {
 			// Check if there is duplicate virtual expression column matched.
-			newExprCol, isOK := col.ResolveIndicesByVirtualExpr(p.indexPlan.Schema())
+			sctx := p.SCtx()
+			newExprCol, isOK := col.ResolveIndicesByVirtualExpr(sctx, p.indexPlan.Schema())
 			if isOK {
 				p.OutputColumns[i] = newExprCol.(*expression.Column)
 				continue
@@ -483,7 +484,7 @@ func (p *PhysicalSelection) ResolveIndices() (err error) {
 		p.Conditions[i], err = expr.ResolveIndices(p.children[0].Schema())
 		if err != nil {
 			// Check if there is duplicate virtual expression column matched.
-			newCond, isOk := expr.ResolveIndicesByVirtualExpr(p.children[0].Schema())
+			newCond, isOk := expr.ResolveIndicesByVirtualExpr(p.SCtx(), p.children[0].Schema())
 			if isOk {
 				p.Conditions[i] = newCond
 				continue
@@ -733,7 +734,7 @@ func (p *PhysicalLimit) ResolveIndices() (err error) {
 	//   e.g. The schema of child_0 is [col0, col0, col1]
 	//        ResolveIndices will only resolve all col0 reference of the current plan to the first col0.
 	for i, j := 0, 0; i < p.schema.Len() && j < p.children[0].Schema().Len(); {
-		if !p.schema.Columns[i].Equal(nil, p.children[0].Schema().Columns[j]) {
+		if !p.schema.Columns[i].EqualColumn(p.children[0].Schema().Columns[j]) {
 			j++
 			continue
 		}

--- a/pkg/planner/core/rule_derive_topn_from_window.go
+++ b/pkg/planner/core/rule_derive_topn_from_window.go
@@ -57,7 +57,7 @@ func checkPartitionBy(p *LogicalWindow, d *DataSource) bool {
 	}
 
 	for i, col := range p.PartitionBy {
-		if !(col.Col.Equal(nil, d.handleCols.GetCol(i))) {
+		if !(col.Col.EqualColumn(d.handleCols.GetCol(i))) {
 			return false
 		}
 	}

--- a/pkg/planner/core/rule_eliminate_projection.go
+++ b/pkg/planner/core/rule_eliminate_projection.go
@@ -89,7 +89,7 @@ func canProjectionBeEliminatedStrict(p *PhysicalProjection) bool {
 	}
 	for i, expr := range p.Exprs {
 		col, ok := expr.(*expression.Column)
-		if !ok || !col.Equal(nil, child.Schema().Columns[i]) {
+		if !ok || !col.EqualColumn(child.Schema().Columns[i]) {
 			return false
 		}
 	}

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -306,7 +306,7 @@ func (s *joinReOrderSolver) optimizeRecursive(ctx sessionctx.Context, p LogicalP
 			schemaChanged = true
 		} else {
 			for i, col := range p.Schema().Columns {
-				if !col.Equal(nil, originalSchema.Columns[i]) {
+				if !col.EqualColumn(originalSchema.Columns[i]) {
 					schemaChanged = true
 					break
 				}

--- a/pkg/planner/core/rule_max_min_eliminate.go
+++ b/pkg/planner/core/rule_max_min_eliminate.go
@@ -73,7 +73,7 @@ func (a *maxMinEliminator) checkColCanUseIndex(plan LogicalPlan, col *expression
 				// Since table path can contain accessConds of at most one column,
 				// we only need to check if all of the conditions can be pushed down as accessConds
 				// and `col` is the handle column.
-				if p.handleCols != nil && col.Equal(nil, p.handleCols.GetCol(0)) {
+				if p.handleCols != nil && col.EqualColumn(p.handleCols.GetCol(0)) {
 					if _, filterConds := ranger.DetachCondsForColumn(p.SCtx(), conditions, col); len(filterConds) != 0 {
 						return false
 					}
@@ -91,7 +91,7 @@ func (a *maxMinEliminator) checkColCanUseIndex(plan LogicalPlan, col *expression
 					continue
 				}
 				for i := 0; i <= result.EqCondCount; i++ {
-					if i < len(indexCols) && col.Equal(nil, indexCols[i]) {
+					if i < len(indexCols) && col.EqualColumn(indexCols[i]) {
 						return true
 					}
 				}

--- a/pkg/planner/core/rule_result_reorder.go
+++ b/pkg/planner/core/rule_result_reorder.go
@@ -59,7 +59,7 @@ func (rs *resultReorder) completeSort(lp LogicalPlan) bool {
 		for _, col := range cols {
 			exist := false
 			for _, byItem := range sort.ByItems {
-				if col.Equal(nil, byItem.Expr) {
+				if col.EqualColumn(byItem.Expr) {
 					exist = true
 					break
 				}

--- a/pkg/planner/core/scalar_subq_expression.go
+++ b/pkg/planner/core/scalar_subq_expression.go
@@ -201,12 +201,12 @@ func (s *ScalarSubQueryExpr) ResolveIndices(_ *expression.Schema) (expression.Ex
 }
 
 // ResolveIndicesByVirtualExpr implements the Expression interface.
-func (s *ScalarSubQueryExpr) ResolveIndicesByVirtualExpr(_ *expression.Schema) (expression.Expression, bool) {
+func (s *ScalarSubQueryExpr) ResolveIndicesByVirtualExpr(_ sessionctx.Context, _ *expression.Schema) (expression.Expression, bool) {
 	return s, false
 }
 
 // resolveIndicesByVirtualExpr implements the Expression interface.
-func (*ScalarSubQueryExpr) resolveIndicesByVirtualExpr(_ *expression.Schema) bool {
+func (*ScalarSubQueryExpr) resolveIndicesByVirtualExpr(_ sessionctx.Context, _ *expression.Schema) bool {
 	return false
 }
 

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -338,7 +338,7 @@ func (ds *DataSource) derivePathStatsAndTryHeuristics() error {
 	if selected == nil && len(uniqueIdxsWithDoubleScan) > 0 {
 		uniqueIdxAccessCols := make([]util.Col2Len, 0, len(uniqueIdxsWithDoubleScan))
 		for _, uniqueIdx := range uniqueIdxsWithDoubleScan {
-			uniqueIdxAccessCols = append(uniqueIdxAccessCols, uniqueIdx.GetCol2LenFromAccessConds())
+			uniqueIdxAccessCols = append(uniqueIdxAccessCols, uniqueIdx.GetCol2LenFromAccessConds(ds.SCtx()))
 			// Find the unique index with the minimal number of ranges as `uniqueBest`.
 			if uniqueBest == nil || len(uniqueIdx.Ranges) < len(uniqueBest.Ranges) {
 				uniqueBest = uniqueIdx
@@ -353,7 +353,7 @@ func (ds *DataSource) derivePathStatsAndTryHeuristics() error {
 		// Hence, for each index in `singleScanIdxs`, we check whether it is better than some index in `uniqueIdxsWithDoubleScan`.
 		// If yes, the index is a refined one. We find the refined index with the minimal number of ranges as `refineBest`.
 		for _, singleScanIdx := range singleScanIdxs {
-			col2Len := singleScanIdx.GetCol2LenFromAccessConds()
+			col2Len := singleScanIdx.GetCol2LenFromAccessConds(ds.SCtx())
 			for _, uniqueIdxCol2Len := range uniqueIdxAccessCols {
 				accessResult, comparable1 := util.CompareCol2Len(col2Len, uniqueIdxCol2Len)
 				if comparable1 && accessResult == 1 {

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1027,7 +1027,7 @@ func (p *PhysicalLimit) sinkIntoIndexMerge(t task) bool {
 	needProj := p.schema.Len() != root.p.Schema().Len()
 	if !needProj {
 		for i := 0; i < p.schema.Len(); i++ {
-			if !p.schema.Columns[i].Equal(nil, root.p.Schema().Columns[i]) {
+			if !p.schema.Columns[i].EqualColumn(root.p.Schema().Columns[i]) {
 				needProj = true
 				break
 			}

--- a/pkg/planner/core/util.go
+++ b/pkg/planner/core/util.go
@@ -138,7 +138,7 @@ func (s *logicalSchemaProducer) setSchemaAndNames(schema *expression.Schema, nam
 // inlineProjection prunes unneeded columns inline a executor.
 func (s *logicalSchemaProducer) inlineProjection(parentUsedCols []*expression.Column, opt *logicalOptimizeOp) {
 	prunedColumns := make([]*expression.Column, 0)
-	used := expression.GetUsedList(parentUsedCols, s.Schema())
+	used := expression.GetUsedList(s.SCtx(), parentUsedCols, s.Schema())
 	for i := len(used) - 1; i >= 0; i-- {
 		if !used[i] {
 			prunedColumns = append(prunedColumns, s.Schema().Columns[i])

--- a/pkg/planner/property/physical_property.go
+++ b/pkg/planner/property/physical_property.go
@@ -113,7 +113,7 @@ func (partitionCol *MPPPartitionColumn) Equal(other *MPPPartitionColumn) bool {
 			return false
 		}
 	}
-	return partitionCol.Col.Equal(nil, other.Col)
+	return partitionCol.Col.EqualColumn(other.Col)
 }
 
 // MemoryUsage return the memory usage of MPPPartitionColumn
@@ -289,8 +289,7 @@ func (p *PhysicalProperty) IsPrefix(prop *PhysicalProperty) bool {
 		return false
 	}
 	for i := range p.SortItems {
-		if !p.SortItems[i].Col.Equal(nil,
-			prop.SortItems[i].Col) || p.SortItems[i].Desc != prop.SortItems[i].Desc {
+		if !p.SortItems[i].Col.EqualColumn(prop.SortItems[i].Col) || p.SortItems[i].Desc != prop.SortItems[i].Desc {
 			return false
 		}
 	}
@@ -303,8 +302,8 @@ func (p *PhysicalProperty) IsSortItemAllForPartition() bool {
 		return false
 	}
 	for i := range p.SortItemsForPartition {
-		if !p.SortItemsForPartition[i].Col.Equal(nil,
-			p.SortItems[i].Col) || p.SortItemsForPartition[i].Desc != p.SortItems[i].Desc {
+		if !p.SortItemsForPartition[i].Col.EqualColumn(p.SortItems[i].Col) ||
+			p.SortItemsForPartition[i].Desc != p.SortItems[i].Desc {
 			return false
 		}
 	}

--- a/pkg/util/ranger/checker.go
+++ b/pkg/util/ranger/checker.go
@@ -18,12 +18,14 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/collate"
 )
 
 // conditionChecker checks if this condition can be pushed to index planner.
 type conditionChecker struct {
+	ctx                      sessionctx.Context
 	checkerCol               *expression.Column
 	length                   int
 	optPrefixIndexSingleScan bool
@@ -209,7 +211,7 @@ func (c *conditionChecker) checkLikeFunc(scalar *expression.ScalarFunction) (isA
 func (c *conditionChecker) matchColumn(expr expression.Expression) bool {
 	// Check if virtual expression column matched
 	if c.checkerCol != nil {
-		return c.checkerCol.EqualByExprAndID(nil, expr)
+		return c.checkerCol.EqualByExprAndID(c.ctx, expr)
 	}
 	return false
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48595

### What is changed and how it works?

- Add a new method `EqualColum` to `Column` and `CorrelatedColumn` to avoid context input when determining two columns are equal.
- Always use parameter `ctx` instead of the inner context for all `Expression.Equal` methods.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
