### PR TITLE
util/codec,util/errctx,*: add error context, and use it to refactor `util/codec`

### DIFF
--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -176,9 +176,9 @@ func TestBuildTableRangeCommonHandle(t *testing.T) {
 		ids []int64
 		trs []kv.KeyRange
 	}
-	low, err_l := codec.EncodeKey(nil, nil, []types.Datum{types.MinNotNullDatum()}...)
+	low, err_l := codec.EncodeKey(time.UTC, nil, []types.Datum{types.MinNotNullDatum()}...)
 	require.NoError(t, err_l)
-	high, err_h := codec.EncodeKey(nil, nil, []types.Datum{types.MaxValueDatum()}...)
+	high, err_h := codec.EncodeKey(time.UTC, nil, []types.Datum{types.MaxValueDatum()}...)
 	require.NoError(t, err_h)
 	high = kv.Key(high).PrefixNext()
 	cases := []Case{

--- a/br/pkg/lightning/backend/local/local_test.go
+++ b/br/pkg/lightning/backend/local/local_test.go
@@ -110,12 +110,12 @@ func TestNextKey(t *testing.T) {
 
 	stmtCtx := stmtctx.NewStmtCtx()
 	for _, datums := range testDatums {
-		keyBytes, err := codec.EncodeKey(stmtCtx, nil, types.NewIntDatum(123), datums[0])
+		keyBytes, err := codec.EncodeKey(stmtCtx.TimeZone(), nil, types.NewIntDatum(123), datums[0])
 		require.NoError(t, err)
 		h, err := tidbkv.NewCommonHandle(keyBytes)
 		require.NoError(t, err)
 		key := tablecodec.EncodeRowKeyWithHandle(1, h)
-		nextKeyBytes, err := codec.EncodeKey(stmtCtx, nil, types.NewIntDatum(123), datums[1])
+		nextKeyBytes, err := codec.EncodeKey(stmtCtx.TimeZone(), nil, types.NewIntDatum(123), datums[1])
 		require.NoError(t, err)
 		nextHdl, err := tidbkv.NewCommonHandle(nextKeyBytes)
 		require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestNextKey(t *testing.T) {
 	}
 
 	// a special case that when len(string datum) % 8 == 7, nextKey twice should not panic.
-	keyBytes, err := codec.EncodeKey(stmtCtx, nil, types.NewStringDatum("1234567"))
+	keyBytes, err := codec.EncodeKey(stmtCtx.TimeZone(), nil, types.NewStringDatum("1234567"))
 	require.NoError(t, err)
 	h, err := tidbkv.NewCommonHandle(keyBytes)
 	require.NoError(t, err)

--- a/br/pkg/lightning/backend/local/localhelper_test.go
+++ b/br/pkg/lightning/backend/local/localhelper_test.go
@@ -796,7 +796,7 @@ func doTestBatchSplitByRangesWithClusteredIndex(t *testing.T, hook clientHook) {
 	keys := [][]byte{[]byte(""), tableStartKey}
 	// pre split 2 regions
 	for i := int64(0); i < 2; i++ {
-		keyBytes, err := codec.EncodeKey(stmtCtx, nil, types.NewIntDatum(i))
+		keyBytes, err := codec.EncodeKey(stmtCtx.TimeZone(), nil, types.NewIntDatum(i))
 		require.NoError(t, err)
 		h, err := kv.NewCommonHandle(keyBytes)
 		require.NoError(t, err)
@@ -818,7 +818,7 @@ func doTestBatchSplitByRangesWithClusteredIndex(t *testing.T, hook clientHook) {
 	rangeKeys := make([][]byte, 0, 20+1)
 	for i := int64(0); i < 2; i++ {
 		for j := int64(0); j < 10; j++ {
-			keyBytes, err := codec.EncodeKey(stmtCtx, nil, types.NewIntDatum(i), types.NewIntDatum(j*10000))
+			keyBytes, err := codec.EncodeKey(stmtCtx.TimeZone(), nil, types.NewIntDatum(i), types.NewIntDatum(j*10000))
 			require.NoError(t, err)
 			h, err := kv.NewCommonHandle(keyBytes)
 			require.NoError(t, err)

--- a/br/pkg/restore/merge_test.go
+++ b/br/pkg/restore/merge_test.go
@@ -47,11 +47,13 @@ func (fb *fileBulder) build(tableID, indexID, num, bytes, kv int) (files []*back
 		lowVal := types.NewIntDatum(fb.startKeyOffset - 10)
 		highVal := types.NewIntDatum(fb.startKeyOffset)
 		sc := stmtctx.NewStmtCtxWithTimeZone(time.UTC)
-		lowValue, err := codec.EncodeKey(sc, nil, lowVal)
+		lowValue, err := codec.EncodeKey(sc.TimeZone(), nil, lowVal)
+		err = sc.HandleError(err)
 		if err != nil {
 			panic(err)
 		}
-		highValue, err := codec.EncodeKey(sc, nil, highVal)
+		highValue, err := codec.EncodeKey(sc.TimeZone(), nil, highVal)
+		err = sc.HandleError(err)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/ddl/index_cop.go
+++ b/pkg/ddl/index_cop.go
@@ -376,7 +376,8 @@ func buildHandle(pkDts []types.Datum, tblInfo *model.TableInfo,
 	pkInfo *model.IndexInfo, stmtCtx *stmtctx.StatementContext) (kv.Handle, error) {
 	if tblInfo.IsCommonHandle {
 		tablecodec.TruncateIndexValues(tblInfo, pkInfo, pkDts)
-		handleBytes, err := codec.EncodeKey(stmtCtx, nil, pkDts...)
+		handleBytes, err := codec.EncodeKey(stmtCtx.TimeZone(), nil, pkDts...)
+		err = stmtCtx.HandleError(err)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ddl/index_modify_test.go
+++ b/pkg/ddl/index_modify_test.go
@@ -776,7 +776,7 @@ func checkGlobalIndexRow(
 	it.Close()
 
 	// Check global index entry.
-	encodedValue, err := codec.EncodeKey(sc, nil, idxVals...)
+	encodedValue, err := codec.EncodeKey(sc.TimeZone(), nil, idxVals...)
 	require.NoError(t, err)
 	key := tablecodec.EncodeIndexSeekKey(tblInfo.ID, indexInfo.ID, encodedValue)
 	require.NoError(t, err)

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -605,7 +605,8 @@ func buildCommonHandleFromChunkRow(sctx *stmtctx.StatementContext, tblInfo *mode
 	tablecodec.TruncateIndexValues(tblInfo, idxInfo, datumRow)
 
 	var handleBytes []byte
-	handleBytes, err := codec.EncodeKey(sctx, nil, datumRow...)
+	handleBytes, err := codec.EncodeKey(sctx.TimeZone(), nil, datumRow...)
+	err = sctx.HandleError(err)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distsql/BUILD.bazel
+++ b/pkg/distsql/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/config",
         "//pkg/ddl/placement",
+        "//pkg/errctx",
         "//pkg/errno",
         "//pkg/expression",
         "//pkg/infoschema",

--- a/pkg/distsql/distsql_test.go
+++ b/pkg/distsql/distsql_test.go
@@ -234,7 +234,7 @@ func (resp *mockResponse) Next(context.Context) (kv.ResultSubset, error) {
 	if !canUseChunkRPC(resp.ctx) {
 		datum := types.NewIntDatum(1)
 		bytes := make([]byte, 0, 100)
-		bytes, _ = codec.EncodeValue(nil, bytes, datum, datum, datum, datum)
+		bytes, _ = codec.EncodeValue(time.UTC, bytes, datum, datum, datum, datum)
 		chunks = make([]tipb.Chunk, numRows)
 		for i := range chunks {
 			chkData := make([]byte, len(bytes))

--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -19,10 +19,12 @@ import (
 	"math"
 	"sort"
 	"sync/atomic"
+	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/pkg/ddl/placement"
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -742,14 +744,23 @@ func indexRangesToKVWithoutSplit(sc *stmtctx.StatementContext, tids []int64, idx
 
 // EncodeIndexKey gets encoded keys containing low and high
 func EncodeIndexKey(sc *stmtctx.StatementContext, ran *ranger.Range) ([]byte, []byte, error) {
-	low, err := codec.EncodeKey(sc, nil, ran.LowVal...)
+	tz := time.UTC
+	errCtx := errctx.StrictNoWarningContext
+	if sc != nil {
+		tz = sc.TimeZone()
+		errCtx = sc.ErrCtx()
+	}
+
+	low, err := codec.EncodeKey(tz, nil, ran.LowVal...)
+	err = errCtx.HandleError(err)
 	if err != nil {
 		return nil, nil, err
 	}
 	if ran.LowExclude {
 		low = kv.Key(low).PrefixNext()
 	}
-	high, err := codec.EncodeKey(sc, nil, ran.HighVal...)
+	high, err := codec.EncodeKey(tz, nil, ran.HighVal...)
+	err = errCtx.HandleError(err)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/errctx/BUILD.bazel
+++ b/pkg/errctx/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "errctx",
+    srcs = ["context.go"],
+    importpath = "github.com/pingcap/tidb/pkg/errctx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/errno",
+        "//pkg/util/intest",
+        "@com_github_pingcap_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "errctx_test",
+    timeout = "short",
+    srcs = ["context_test.go"],
+    flaky = True,
+    deps = [
+        ":errctx",
+        "//pkg/types",
+        "@com_github_pingcap_errors//:errors",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/errctx/context.go
+++ b/pkg/errctx/context.go
@@ -137,8 +137,8 @@ const (
 	// ErrGroupOverflow is the group of overflow errors
 	ErrGroupOverflow
 
-	// errGroupCount is the count of all `ErrGroup`. Please leave it at the end of the list
-	errGroupCount = 2
+	// errGroupCount is the count of all `ErrGroup`. Please leave it at the end of the list.
+	errGroupCount
 )
 
 func init() {

--- a/pkg/errctx/context.go
+++ b/pkg/errctx/context.go
@@ -1,0 +1,162 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errctx
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/errno"
+	"github.com/pingcap/tidb/pkg/util/intest"
+)
+
+// Level defines the behavior for each error
+type Level uint8
+
+const (
+	// LevelError means the error will be returned
+	LevelError Level = iota
+	// LevelWarn means it will be regarded as a warning
+	LevelWarn
+	// LevelIgnore means the error will be ignored
+	LevelIgnore
+)
+
+// Context defines how to handle an error
+type Context struct {
+	levelMap        [errGroupCount]Level
+	appendWarningFn func(err error)
+}
+
+// WithStrictErrGroupLevel makes the context to return the error directly for any kinds of errors.
+func (ctx *Context) WithStrictErrGroupLevel() Context {
+	newCtx := Context{
+		appendWarningFn: ctx.appendWarningFn,
+	}
+
+	return newCtx
+}
+
+// WithErrGroupLevel sets a `Level` for an `ErrGroup`
+func (ctx *Context) WithErrGroupLevel(eg ErrGroup, l Level) Context {
+	newCtx := Context{
+		levelMap:        ctx.levelMap,
+		appendWarningFn: ctx.appendWarningFn,
+	}
+	newCtx.levelMap[eg] = l
+
+	return newCtx
+}
+
+// appendWarning appends the error to warning. If the inner `appendWarningFn` is nil, do nothing.
+func (ctx *Context) appendWarning(err error) {
+	intest.Assert(ctx.appendWarningFn != nil)
+	if fn := ctx.appendWarningFn; fn != nil {
+		// appendWarningFn should always not be nil, check fn != nil here to just make code safe.
+		fn(err)
+	}
+}
+
+// HandleError handles the error according to the context. See the comment of `HandleErrorWithAlias` for detailed logic.
+func (ctx *Context) HandleError(err error) error {
+	return ctx.HandleErrorWithAlias(err, err, err)
+}
+
+// HandleErrorWithAlias handles the error according to the context.
+//  1. If the `internalErr` is not `"pingcap/errors".Error`, or the error code is not defined in the `errGroupMap`, or the error
+//     level is set to `LevelError`(0), the `err` will be returned directly.
+//  2. If the error level is set to `LevelWarn`, the `warnErr` will be appended as a warning.
+//  3. If the error level is set to `LevelIgnore`, this function will return a `nil`.
+//
+// In most cases, these three should be the same. If there are many different kinds of error internally, but they are expected
+// to give the same error to users, the `err` can be different form `internalErr`. Also, if the warning is expected to be
+// different from the initial error, you can also use the `warnErr` argument.
+//
+// TODO: is it good to give an error code for internal only errors? Or should we use another way to distinguish different
+// group of errors?
+// TODO: both `types.Context` and `errctx.Context` can handle truncate error now. Refractor them.
+func (ctx *Context) HandleErrorWithAlias(internalErr error, err error, warnErr error) error {
+	if internalErr == nil {
+		return nil
+	}
+
+	internalErr = errors.Cause(internalErr)
+
+	e, ok := internalErr.(*errors.Error)
+	if !ok {
+		return err
+	}
+
+	eg, ok := errGroupMap[e.Code()]
+	if !ok {
+		return err
+	}
+
+	switch ctx.levelMap[eg] {
+	case LevelError:
+		return err
+	case LevelWarn:
+		ctx.appendWarning(warnErr)
+	case LevelIgnore:
+	}
+
+	return nil
+}
+
+// NewContext creates an error context to handle the errors and warnings
+func NewContext(appendWarningFn func(err error)) Context {
+	intest.Assert(appendWarningFn != nil)
+	return Context{
+		appendWarningFn: appendWarningFn,
+	}
+}
+
+// StrictNoWarningContext returns all errors directly, and ignore all errors
+var StrictNoWarningContext = NewContext(func(_ error) {
+	// the error is ignored
+})
+
+var errGroupMap = make(map[errors.ErrCode]ErrGroup)
+
+// ErrGroup groups the error according to the behavior of handling errors
+type ErrGroup int
+
+const (
+	// ErrGroupTruncate is the group of truncated errors
+	ErrGroupTruncate ErrGroup = iota
+	// ErrGroupOverflow is the group of overflow errors
+	ErrGroupOverflow
+
+	// errGroupCount is the count of all `ErrGroup`. Please leave it at the end of the list
+	errGroupCount = 2
+)
+
+func init() {
+	truncateErrCodes := []errors.ErrCode{
+		errno.ErrTruncatedWrongValue,
+		errno.ErrDataTooLong,
+		errno.ErrTruncatedWrongValueForField,
+		errno.ErrWarnDataOutOfRange,
+		errno.ErrDataOutOfRange,
+		errno.ErrBadNumber,
+		errno.ErrWrongValueForType,
+		errno.ErrDatetimeFunctionOverflow,
+		errno.WarnDataTruncated,
+		errno.ErrIncorrectDatetimeValue,
+	}
+	for _, errCode := range truncateErrCodes {
+		errGroupMap[errCode] = ErrGroupTruncate
+	}
+
+	errGroupMap[errno.ErrDataOutOfRange] = ErrGroupOverflow
+}

--- a/pkg/errctx/context_test.go
+++ b/pkg/errctx/context_test.go
@@ -1,0 +1,53 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errctx_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/errctx"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContext(t *testing.T) {
+	var warn error
+	ctx := errctx.NewContext(func(err error) {
+		warn = err
+	})
+
+	testInternalErr := types.ErrOverflow
+	testErr := errors.New("error")
+	testWarn := errors.New("warn")
+	// by default, all errors will be returned directly
+	require.Equal(t, ctx.HandleErrorWithAlias(testInternalErr, testErr, testWarn), testErr)
+
+	// set level to "warn"
+	newCtx := ctx.WithErrGroupLevel(errctx.ErrGroupOverflow, errctx.LevelWarn)
+	// ctx is not affected
+	require.Equal(t, ctx.HandleErrorWithAlias(testInternalErr, testErr, testWarn), testErr)
+	// newCtx will handle the error as a warn
+	require.NoError(t, newCtx.HandleErrorWithAlias(testInternalErr, testErr, testWarn))
+	require.Equal(t, warn, testWarn)
+
+	warn = nil
+	newCtx2 := newCtx.WithStrictErrGroupLevel()
+	// newCtx is not affected
+	require.NoError(t, newCtx.HandleErrorWithAlias(testInternalErr, testErr, testWarn))
+	require.Equal(t, warn, testWarn)
+	// newCtx2 will return all errors
+	require.Equal(t, newCtx2.HandleErrorWithAlias(testInternalErr, testErr, testWarn), testErr)
+}

--- a/pkg/executor/aggregate/agg_util.go
+++ b/pkg/executor/aggregate/agg_util.go
@@ -71,6 +71,7 @@ func GetGroupKey(ctx sessionctx.Context, input *chunk.Chunk, groupKey [][]byte, 
 		groupKey = append(groupKey, make([]byte, 0, 10*len(groupByItems)))
 	}
 
+	errCtx := ctx.GetSessionVars().StmtCtx.ErrCtx()
 	for _, item := range groupByItems {
 		tp := item.GetType()
 
@@ -102,7 +103,8 @@ func GetGroupKey(ctx sessionctx.Context, input *chunk.Chunk, groupKey [][]byte, 
 			tp = &newTp
 		}
 
-		groupKey, err = codec.HashGroupKey(ctx.GetSessionVars().StmtCtx, input.NumRows(), buf, groupKey, tp)
+		groupKey, err = codec.HashGroupKey(ctx.GetSessionVars().StmtCtx.TimeZone(), input.NumRows(), buf, groupKey, tp)
+		err = errCtx.HandleError(err)
 		if err != nil {
 			expression.PutColumn(buf)
 			return nil, err

--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -795,6 +795,7 @@ workLoop:
 				// 8 is size of reference, 8 is the size of "b := make([]byte, 0, 8)"
 				collectorMemSize := int64(sampleNum) * (8 + statistics.EmptySampleItemSize + 8)
 				e.memTracker.Consume(collectorMemSize)
+				errCtx := e.ctx.GetSessionVars().StmtCtx.ErrCtx()
 			indexSampleCollectLoop:
 				for _, row := range task.rootRowCollector.Base().Samples {
 					if len(idx.Columns) == 1 && row.Columns[idx.Columns[0].Offset].IsNull() {
@@ -809,14 +810,16 @@ workLoop:
 						if col.Length != types.UnspecifiedLength {
 							row.Columns[col.Offset].Copy(&tmpDatum)
 							ranger.CutDatumByPrefixLen(&tmpDatum, col.Length, &e.colsInfo[col.Offset].FieldType)
-							b, err = codec.EncodeKey(e.ctx.GetSessionVars().StmtCtx, b, tmpDatum)
+							b, err = codec.EncodeKey(e.ctx.GetSessionVars().StmtCtx.TimeZone(), b, tmpDatum)
+							err = errCtx.HandleError(err)
 							if err != nil {
 								resultCh <- err
 								continue workLoop
 							}
 							continue
 						}
-						b, err = codec.EncodeKey(e.ctx.GetSessionVars().StmtCtx, b, row.Columns[col.Offset])
+						b, err = codec.EncodeKey(e.ctx.GetSessionVars().StmtCtx.TimeZone(), b, row.Columns[col.Offset])
+						err = errCtx.HandleError(err)
 						if err != nil {
 							resultCh <- err
 							continue workLoop

--- a/pkg/executor/analyze_test.go
+++ b/pkg/executor/analyze_test.go
@@ -85,10 +85,10 @@ func TestAnalyzeIndexExtractTopN(t *testing.T) {
 	// Construct TopN, should be (1, 1) -> 2 and (1, 2) -> 2
 	topn := statistics.NewTopN(2)
 	{
-		key1, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx, nil, types.NewIntDatum(1), types.NewIntDatum(1))
+		key1, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx.TimeZone(), nil, types.NewIntDatum(1), types.NewIntDatum(1))
 		require.NoError(t, err)
 		topn.AppendTopN(key1, 2)
-		key2, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx, nil, types.NewIntDatum(1), types.NewIntDatum(2))
+		key2, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx.TimeZone(), nil, types.NewIntDatum(1), types.NewIntDatum(2))
 		require.NoError(t, err)
 		topn.AppendTopN(key2, 2)
 	}

--- a/pkg/executor/batch_checker.go
+++ b/pkg/executor/batch_checker.go
@@ -234,7 +234,8 @@ func buildHandleFromDatumRow(sctx *stmtctx.StatementContext, row []types.Datum, 
 		}
 		pkDts = append(pkDts, d)
 	}
-	handleBytes, err := codec.EncodeKey(sctx, nil, pkDts...)
+	handleBytes, err := codec.EncodeKey(sctx.TimeZone(), nil, pkDts...)
+	err = sctx.HandleError(err)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/chunk_size_control_test.go
+++ b/pkg/executor/chunk_size_control_test.go
@@ -179,7 +179,7 @@ func generateIndexSplitKeyForInt(tid, idx int64, splitNum []int) [][]byte {
 	for _, num := range splitNum {
 		d := new(types.Datum)
 		d.SetInt64(int64(num))
-		b, err := codec.EncodeKey(nil, nil, *d)
+		b, err := codec.EncodeKey(time.UTC, nil, *d)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/executor/coprocessor.go
+++ b/pkg/executor/coprocessor.go
@@ -277,11 +277,13 @@ func (h *CoprocessorDAGHandler) encodeDefault(chk *chunk.Chunk, tps []*types.Fie
 	stmtCtx := h.sctx.GetSessionVars().StmtCtx
 	requestedRow := make([]byte, 0)
 	chunks := []tipb.Chunk{}
+	errCtx := stmtCtx.ErrCtx()
 	for i := 0; i < chk.NumRows(); i++ {
 		requestedRow = requestedRow[:0]
 		row := chk.GetRow(i)
 		for _, ordinal := range colOrdinal {
-			data, err := codec.EncodeValue(stmtCtx, nil, row.GetDatum(int(ordinal), tps[ordinal]))
+			data, err := codec.EncodeValue(stmtCtx.TimeZone(), nil, row.GetDatum(int(ordinal), tps[ordinal]))
+			err = errCtx.HandleError(err)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/executor/cte.go
+++ b/pkg/executor/cte.go
@@ -552,7 +552,7 @@ func (p *cteProducer) computeChunkHash(chk *chunk.Chunk) (sel []int, err error) 
 	}
 
 	for i := 0; i < chk.NumCols(); i++ {
-		if err = codec.HashChunkSelected(p.ctx.GetSessionVars().StmtCtx, p.hCtx.hashVals,
+		if err = codec.HashChunkSelected(p.ctx.GetSessionVars().StmtCtx.TypeCtx(), p.hCtx.hashVals,
 			chk, p.hCtx.allTypes[i], i, p.hCtx.buf, p.hCtx.hasNull,
 			hashBitMap, false); err != nil {
 			return nil, err
@@ -647,7 +647,7 @@ func (p *cteProducer) checkHasDup(probeKey uint64,
 		if err != nil {
 			return false, err
 		}
-		isEqual, err := codec.EqualChunkRow(p.ctx.GetSessionVars().StmtCtx,
+		isEqual, err := codec.EqualChunkRow(p.ctx.GetSessionVars().StmtCtx.TypeCtx(),
 			row, p.hCtx.allTypes, p.hCtx.keyColIdx,
 			matchedRow, p.hCtx.allTypes, p.hCtx.keyColIdx)
 		if err != nil {

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -1216,7 +1216,8 @@ func (e *IndexLookUpExecutor) getHandle(row chunk.Row, handleIdx []int,
 			datums = append(datums, row.GetDatum(idx, e.handleCols[i].RetType))
 		}
 		tablecodec.TruncateIndexValues(e.table.Meta(), e.primaryKeyIndex, datums)
-		handleEncoded, err = codec.EncodeKey(e.Ctx().GetSessionVars().StmtCtx, nil, datums...)
+		handleEncoded, err = codec.EncodeKey(e.Ctx().GetSessionVars().StmtCtx.TimeZone(), nil, datums...)
+		err = e.Ctx().GetSessionVars().StmtCtx.HandleError(err)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2572,13 +2572,15 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 			return
 		}
 
+		errCtx := w.sctx.GetSessionVars().StmtCtx.ErrCtx()
 		getHandleFromRow := func(row chunk.Row) (kv.Handle, error) {
 			handleDatum := make([]types.Datum, 0)
 			for i, t := range pkTypes {
 				handleDatum = append(handleDatum, row.GetDatum(i, t))
 			}
 			if w.table.Meta().IsCommonHandle {
-				handleBytes, err := codec.EncodeKey(w.sctx.GetSessionVars().StmtCtx, nil, handleDatum...)
+				handleBytes, err := codec.EncodeKey(w.sctx.GetSessionVars().StmtCtx.TimeZone(), nil, handleDatum...)
+				err = errCtx.HandleError(err)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/executor/foreign_key.go
+++ b/pkg/executor/foreign_key.go
@@ -292,7 +292,8 @@ func (fkc *FKCheckExec) buildHandleFromFKValues(sc *stmtctx.StatementContext, va
 	if len(vals) == 1 && fkc.Idx == nil {
 		return kv.IntHandle(vals[0].GetInt64()), nil
 	}
-	handleBytes, err := codec.EncodeKey(sc, nil, vals...)
+	handleBytes, err := codec.EncodeKey(sc.TimeZone(), nil, vals...)
+	err = sc.HandleError(err)
 	if err != nil {
 		return nil, err
 	}
@@ -464,7 +465,8 @@ func (h *fkValueHelper) fetchFKValuesWithCheck(sc *stmtctx.StatementContext, row
 	if err != nil || h.hasNullValue(vals) {
 		return nil, err
 	}
-	keyBuf, err := codec.EncodeKey(sc, nil, vals...)
+	keyBuf, err := codec.EncodeKey(sc.TimeZone(), nil, vals...)
+	err = sc.HandleError(err)
 	if err != nil {
 		return nil, err
 	}
@@ -687,7 +689,8 @@ func (fkc *FKCascadeExec) onUpdateRow(sc *stmtctx.StatementContext, oldRow, newR
 	if err != nil {
 		return err
 	}
-	newValsKey, err := codec.EncodeKey(sc, nil, newVals...)
+	newValsKey, err := codec.EncodeKey(sc.TimeZone(), nil, newVals...)
+	err = sc.HandleError(err)
 	if err != nil {
 		return err
 	}

--- a/pkg/executor/hash_table.go
+++ b/pkg/executor/hash_table.go
@@ -245,7 +245,7 @@ func (c *hashRowContainer) GetAllMatchedRows(probeHCtx *hashContext, probeSideRo
 		}
 		if probeKeyNullBits != nil && len(probeHCtx.naKeyColIdx) > 1 {
 			// check the idxs-th value of the join columns.
-			ok, err = codec.EqualChunkRow(c.sc, mayMatchedRow, needCheckBuildTypes, needCheckBuildColPos, probeSideRow, needCheckProbeTypes, needCheckProbeColPos)
+			ok, err = codec.EqualChunkRow(c.sc.TypeCtx(), mayMatchedRow, needCheckBuildTypes, needCheckBuildColPos, probeSideRow, needCheckProbeTypes, needCheckProbeColPos)
 			if err != nil {
 				return nil, err
 			}
@@ -381,7 +381,7 @@ func (c *hashRowContainer) GetNullBucketRows(probeHCtx *hashContext, probeSideRo
 				needCheckProbeTypes = append(needCheckProbeTypes, probeHCtx.allTypes[i])
 			}
 			// check the idxs-th value of the join columns.
-			ok, err = codec.EqualChunkRow(c.sc, mayMatchedRow, needCheckBuildTypes, needCheckBuildColPos, probeSideRow, needCheckProbeTypes, needCheckProbeColPos)
+			ok, err = codec.EqualChunkRow(c.sc.TypeCtx(), mayMatchedRow, needCheckBuildTypes, needCheckBuildColPos, probeSideRow, needCheckProbeTypes, needCheckProbeColPos)
 			if err != nil {
 				return nil, err
 			}
@@ -404,7 +404,7 @@ func (c *hashRowContainer) GetNullBucketRows(probeHCtx *hashContext, probeSideRo
 				needCheckProbeTypes = append(needCheckProbeTypes, probeHCtx.allTypes[i])
 			}
 			// check the idxs-th value of the join columns.
-			ok, err = codec.EqualChunkRow(c.sc, mayMatchedRow, needCheckBuildTypes, needCheckBuildColPos, probeSideRow, needCheckProbeTypes, needCheckProbeColPos)
+			ok, err = codec.EqualChunkRow(c.sc.TypeCtx(), mayMatchedRow, needCheckBuildTypes, needCheckBuildColPos, probeSideRow, needCheckProbeTypes, needCheckProbeColPos)
 			if err != nil {
 				return nil, err
 			}
@@ -421,11 +421,11 @@ func (c *hashRowContainer) GetNullBucketRows(probeHCtx *hashContext, probeSideRo
 // matchJoinKey checks if join keys of buildRow and probeRow are logically equal.
 func (c *hashRowContainer) matchJoinKey(buildRow, probeRow chunk.Row, probeHCtx *hashContext) (ok bool, err error) {
 	if len(c.hCtx.naKeyColIdx) > 0 {
-		return codec.EqualChunkRow(c.sc,
+		return codec.EqualChunkRow(c.sc.TypeCtx(),
 			buildRow, c.hCtx.allTypes, c.hCtx.naKeyColIdx,
 			probeRow, probeHCtx.allTypes, probeHCtx.naKeyColIdx)
 	}
-	return codec.EqualChunkRow(c.sc,
+	return codec.EqualChunkRow(c.sc.TypeCtx(),
 		buildRow, c.hCtx.allTypes, c.hCtx.keyColIdx,
 		probeRow, probeHCtx.allTypes, probeHCtx.keyColIdx)
 }
@@ -463,7 +463,7 @@ func (c *hashRowContainer) PutChunkSelected(chk *chunk.Chunk, selected, ignoreNu
 	// 1: write the row data of join key to hashVals. (normal EQ key should ignore the null values.) null-EQ for Except statement is an exception.
 	for keyIdx, colIdx := range c.hCtx.keyColIdx {
 		ignoreNull := len(ignoreNulls) > keyIdx && ignoreNulls[keyIdx]
-		err := codec.HashChunkSelected(c.sc, hCtx.hashVals, chk, hCtx.allTypes[keyIdx], colIdx, hCtx.buf, hCtx.hasNull, selected, ignoreNull)
+		err := codec.HashChunkSelected(c.sc.TypeCtx(), hCtx.hashVals, chk, hCtx.allTypes[keyIdx], colIdx, hCtx.buf, hCtx.hasNull, selected, ignoreNull)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -473,7 +473,7 @@ func (c *hashRowContainer) PutChunkSelected(chk *chunk.Chunk, selected, ignoreNu
 	hasNullMark := make([]bool, len(hCtx.hasNull))
 	for keyIdx, colIdx := range c.hCtx.naKeyColIdx {
 		// NAAJ won't ignore any null values, but collect them as one hash bucket.
-		err := codec.HashChunkSelected(c.sc, hCtx.hashVals, chk, hCtx.allTypes[keyIdx], colIdx, hCtx.buf, hCtx.hasNull, selected, false)
+		err := codec.HashChunkSelected(c.sc.TypeCtx(), hCtx.hashVals, chk, hCtx.allTypes[keyIdx], colIdx, hCtx.buf, hCtx.hasNull, selected, false)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/pkg/executor/index_lookup_hash_join.go
+++ b/pkg/executor/index_lookup_hash_join.go
@@ -581,7 +581,7 @@ func (iw *indexHashJoinInnerWorker) buildHashTableForOuterResult(task *indexHash
 				}
 			}
 			h.Reset()
-			err := codec.HashChunkRow(iw.ctx.GetSessionVars().StmtCtx, h, row, iw.outerCtx.hashTypes, hashColIdx, buf)
+			err := codec.HashChunkRow(iw.ctx.GetSessionVars().StmtCtx.TypeCtx(), h, row, iw.outerCtx.hashTypes, hashColIdx, buf)
 			failpoint.Inject("testIndexHashJoinBuildErr", func() {
 				err = errors.New("mockIndexHashJoinBuildErr")
 			})
@@ -709,7 +709,7 @@ func (iw *indexHashJoinInnerWorker) doJoinUnordered(ctx context.Context, task *i
 
 func (iw *indexHashJoinInnerWorker) getMatchedOuterRows(innerRow chunk.Row, task *indexHashJoinTask, h hash.Hash64, buf []byte) (matchedRows []chunk.Row, matchedRowPtr []chunk.RowPtr, err error) {
 	h.Reset()
-	err = codec.HashChunkRow(iw.ctx.GetSessionVars().StmtCtx, h, innerRow, iw.hashTypes, iw.hashCols, buf)
+	err = codec.HashChunkRow(iw.ctx.GetSessionVars().StmtCtx.TypeCtx(), h, innerRow, iw.hashTypes, iw.hashCols, buf)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -722,7 +722,7 @@ func (iw *indexHashJoinInnerWorker) getMatchedOuterRows(innerRow chunk.Row, task
 	for ; matchedOuterEntry != nil; matchedOuterEntry = matchedOuterEntry.next {
 		ptr := matchedOuterEntry.ptr
 		outerRow := task.outerResult.GetRow(ptr)
-		ok, err := codec.EqualChunkRow(iw.ctx.GetSessionVars().StmtCtx, innerRow, iw.hashTypes, iw.hashCols, outerRow, iw.outerCtx.hashTypes, iw.outerCtx.hashCols)
+		ok, err := codec.EqualChunkRow(iw.ctx.GetSessionVars().StmtCtx.TypeCtx(), innerRow, iw.hashTypes, iw.hashCols, outerRow, iw.outerCtx.hashTypes, iw.outerCtx.hashCols)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/executor/index_lookup_join.go
+++ b/pkg/executor/index_lookup_join.go
@@ -576,7 +576,8 @@ func (iw *innerWorker) constructLookupContent(task *lookUpJoinTask) ([]*indexJoi
 				continue
 			}
 			keyBuf = keyBuf[:0]
-			keyBuf, err = codec.EncodeKey(iw.ctx.GetSessionVars().StmtCtx, keyBuf, dHashKey...)
+			keyBuf, err = codec.EncodeKey(iw.ctx.GetSessionVars().StmtCtx.TimeZone(), keyBuf, dHashKey...)
+			err = iw.ctx.GetSessionVars().StmtCtx.HandleError(err)
 			if err != nil {
 				if terror.ErrorEqual(err, types.ErrWrongValue) {
 					// we ignore rows with invalid datetime
@@ -747,7 +748,8 @@ func (iw *innerWorker) buildLookUpMap(task *lookUpJoinTask) error {
 			for _, keyCol := range iw.hashCols {
 				d := innerRow.GetDatum(keyCol, iw.rowTypes[keyCol])
 				var err error
-				keyBuf, err = codec.EncodeKey(iw.ctx.GetSessionVars().StmtCtx, keyBuf, d)
+				keyBuf, err = codec.EncodeKey(iw.ctx.GetSessionVars().StmtCtx.TimeZone(), keyBuf, d)
+				err = iw.ctx.GetSessionVars().StmtCtx.HandleError(err)
 				if err != nil {
 					return err
 				}

--- a/pkg/executor/internal/vecgroupchecker/vec_group_checker.go
+++ b/pkg/executor/internal/vecgroupchecker/vec_group_checker.go
@@ -93,12 +93,14 @@ func (e *VecGroupChecker) SplitIntoGroups(chk *chunk.Chunk) (isFirstGroupSameAsP
 			return false, err
 		}
 	}
-	e.firstGroupKey, err = codec.EncodeValue(e.ctx.GetSessionVars().StmtCtx, e.firstGroupKey, e.firstRowDatums...)
+	e.firstGroupKey, err = codec.EncodeValue(e.ctx.GetSessionVars().StmtCtx.TimeZone(), e.firstGroupKey, e.firstRowDatums...)
+	err = e.ctx.GetSessionVars().StmtCtx.HandleError(err)
 	if err != nil {
 		return false, err
 	}
 
-	e.lastGroupKey, err = codec.EncodeValue(e.ctx.GetSessionVars().StmtCtx, e.lastGroupKey, e.lastRowDatums...)
+	e.lastGroupKey, err = codec.EncodeValue(e.ctx.GetSessionVars().StmtCtx.TimeZone(), e.lastGroupKey, e.lastRowDatums...)
+	err = e.ctx.GetSessionVars().StmtCtx.HandleError(err)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/executor/join.go
+++ b/pkg/executor/join.go
@@ -999,7 +999,7 @@ func (w *probeWorker) join2Chunk(probeSideChk *chunk.Chunk, hCtx *hashContext, j
 	// 1: write the row data of join key to hashVals. (normal EQ key should ignore the null values.) null-EQ for Except statement is an exception.
 	for keyIdx, i := range hCtx.keyColIdx {
 		ignoreNull := len(w.hashJoinCtx.isNullEQ) > keyIdx && w.hashJoinCtx.isNullEQ[keyIdx]
-		err = codec.HashChunkSelected(w.rowContainerForProbe.sc, hCtx.hashVals, probeSideChk, hCtx.allTypes[keyIdx], i, hCtx.buf, hCtx.hasNull, selected, ignoreNull)
+		err = codec.HashChunkSelected(w.rowContainerForProbe.sc.TypeCtx(), hCtx.hashVals, probeSideChk, hCtx.allTypes[keyIdx], i, hCtx.buf, hCtx.hasNull, selected, ignoreNull)
 		if err != nil {
 			joinResult.err = err
 			return false, joinResult
@@ -1009,7 +1009,7 @@ func (w *probeWorker) join2Chunk(probeSideChk *chunk.Chunk, hCtx *hashContext, j
 	isNAAJ := len(hCtx.naKeyColIdx) > 0
 	for keyIdx, i := range hCtx.naKeyColIdx {
 		// NAAJ won't ignore any null values, but collect them up to probe.
-		err = codec.HashChunkSelected(w.rowContainerForProbe.sc, hCtx.hashVals, probeSideChk, hCtx.allTypes[keyIdx], i, hCtx.buf, hCtx.hasNull, selected, false)
+		err = codec.HashChunkSelected(w.rowContainerForProbe.sc.TypeCtx(), hCtx.hashVals, probeSideChk, hCtx.allTypes[keyIdx], i, hCtx.buf, hCtx.hasNull, selected, false)
 		if err != nil {
 			joinResult.err = err
 			return false, joinResult
@@ -1086,7 +1086,7 @@ func (w *probeWorker) join2Chunk(probeSideChk *chunk.Chunk, hCtx *hashContext, j
 func (w *probeWorker) join2ChunkForOuterHashJoin(probeSideChk *chunk.Chunk, hCtx *hashContext, joinResult *hashjoinWorkerResult) (ok bool, _ *hashjoinWorkerResult) {
 	hCtx.initHash(probeSideChk.NumRows())
 	for keyIdx, i := range hCtx.keyColIdx {
-		err := codec.HashChunkColumns(w.rowContainerForProbe.sc, hCtx.hashVals, probeSideChk, hCtx.allTypes[keyIdx], i, hCtx.buf, hCtx.hasNull)
+		err := codec.HashChunkColumns(w.rowContainerForProbe.sc.TypeCtx(), hCtx.hashVals, probeSideChk, hCtx.allTypes[keyIdx], i, hCtx.buf, hCtx.hasNull)
 		if err != nil {
 			joinResult.err = err
 			return false, joinResult
@@ -1478,7 +1478,8 @@ func (e *NestedLoopApplyExec) Next(ctx context.Context, req *chunk.Chunk) (err e
 				var key []byte
 				for _, col := range e.outerSchema {
 					*col.Data = e.outerRow.GetDatum(col.Index, col.RetType)
-					key, err = codec.EncodeKey(e.Ctx().GetSessionVars().StmtCtx, key, *col.Data)
+					key, err = codec.EncodeKey(e.Ctx().GetSessionVars().StmtCtx.TimeZone(), key, *col.Data)
+					err = e.Ctx().GetSessionVars().StmtCtx.HandleError(err)
 					if err != nil {
 						return err
 					}

--- a/pkg/executor/mem_reader.go
+++ b/pkg/executor/mem_reader.go
@@ -502,7 +502,8 @@ func (m *memTableReader) getRowData(handle kv.Handle, value []byte) ([][]byte, e
 			} else {
 				handleDatum = types.NewIntDatum(handle.IntValue())
 			}
-			handleData, err1 := codec.EncodeValue(ctx, buffer.handleBytes, handleDatum)
+			handleData, err1 := codec.EncodeValue(ctx.TimeZone(), buffer.handleBytes, handleDatum)
+			err1 = ctx.HandleError(err1)
 			if err1 != nil {
 				return nil, errors.Trace(err1)
 			}
@@ -623,7 +624,8 @@ func (m *memIndexReader) getMemRowsHandle() ([]kv.Handle, error) {
 		// For https://github.com/pingcap/tidb/issues/41827,
 		// When handle type is year, tablecodec.DecodeIndexHandle will convert it to IntHandle instead of CommonHandle
 		if m.table.IsCommonHandle && handle.IsInt() {
-			b, err := codec.EncodeKey(m.ctx.GetSessionVars().StmtCtx, nil, types.NewDatum(handle.IntValue()))
+			b, err := codec.EncodeKey(m.ctx.GetSessionVars().StmtCtx.TimeZone(), nil, types.NewDatum(handle.IntValue()))
+			err = m.ctx.GetSessionVars().StmtCtx.HandleError(err)
 			if err != nil {
 				return err
 			}

--- a/pkg/executor/parallel_apply.go
+++ b/pkg/executor/parallel_apply.go
@@ -282,7 +282,9 @@ func (e *ParallelNestedLoopApplyExec) fetchAllInners(ctx context.Context, id int
 	for _, col := range e.corCols[id] {
 		*col.Data = e.outerRow[id].GetDatum(col.Index, col.RetType)
 		if e.useCache {
-			if key, err = codec.EncodeKey(e.Ctx().GetSessionVars().StmtCtx, key, *col.Data); err != nil {
+			key, err = codec.EncodeKey(e.Ctx().GetSessionVars().StmtCtx.TimeZone(), key, *col.Data)
+			err = e.Ctx().GetSessionVars().StmtCtx.HandleError(err)
+			if err != nil {
 				return err
 			}
 		}

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -571,7 +571,8 @@ func EncodeUniqueIndexValuesForKey(ctx sessionctx.Context, tblInfo *model.TableI
 		}
 	}
 
-	encodedIdxVals, err := codec.EncodeKey(sc, nil, idxVals...)
+	encodedIdxVals, err := codec.EncodeKey(sc.TimeZone(), nil, idxVals...)
+	err = sc.HandleError(err)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/point_get_test.go
+++ b/pkg/executor/point_get_test.go
@@ -103,7 +103,7 @@ func TestReturnValues(t *testing.T) {
 	tk.MustExec("begin pessimistic")
 	tk.MustQuery("select * from t where a = 'b' for update").Check(testkit.Rows("b 2"))
 	tid := external.GetTableByName(t, tk, "test", "t").Meta().ID
-	idxVal, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx, nil, types.NewStringDatum("b"))
+	idxVal, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx.TimeZone(), nil, types.NewStringDatum("b"))
 	require.NoError(t, err)
 	pk := tablecodec.EncodeIndexSeekKey(tid, 1, idxVal)
 	txnCtx := tk.Session().GetSessionVars().TxnCtx

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -1243,7 +1243,7 @@ func TestCheckFailReport(t *testing.T) {
 
 		txn, err := store.Begin()
 		require.NoError(t, err)
-		encoded, err := codec.EncodeKey(stmtctx.NewStmtCtx(), nil, types.NewBytesDatum([]byte{1, 0, 1, 0, 0, 1, 1}))
+		encoded, err := codec.EncodeKey(time.UTC, nil, types.NewBytesDatum([]byte{1, 0, 1, 0, 0, 1, 1}))
 		require.NoError(t, err)
 		hd, err := kv.NewCommonHandle(encoded)
 		require.NoError(t, err)
@@ -1635,7 +1635,7 @@ func TestAdminCheckTableErrorLocateForClusterIndex(t *testing.T) {
 	r := regexp.MustCompile(pattern)
 
 	getCommonHandle := func(randomRow int) *kv.CommonHandle {
-		h, err := codec.EncodeKey(sc, nil, types.MakeDatums(randomRow)...)
+		h, err := codec.EncodeKey(sc.TimeZone(), nil, types.MakeDatums(randomRow)...)
 		require.NoError(t, err)
 		ch, err := kv.NewCommonHandle(h)
 		require.NoError(t, err)

--- a/pkg/expression/aggregation/util.go
+++ b/pkg/expression/aggregation/util.go
@@ -42,7 +42,8 @@ func createDistinctChecker(sc *stmtctx.StatementContext) *distinctChecker {
 func (d *distinctChecker) Check(values []types.Datum) (bool, error) {
 	d.key = d.key[:0]
 	var err error
-	d.key, err = codec.EncodeValue(d.sc, d.key, values...)
+	d.key, err = codec.EncodeValue(d.sc.TimeZone(), d.key, values...)
+	err = d.sc.HandleError(err)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/expression/distsql_builtin_test.go
+++ b/pkg/expression/distsql_builtin_test.go
@@ -904,7 +904,7 @@ func datumExpr(t *testing.T, d types.Datum) *tipb.Expr {
 		expr.Tp = tipb.ExprType_MysqlJson
 		var err error
 		expr.Val = make([]byte, 0, 1024)
-		expr.Val, err = codec.EncodeValue(nil, expr.Val, d)
+		expr.Val, err = codec.EncodeValue(time.UTC, expr.Val, d)
 		require.NoError(t, err)
 	case types.KindMysqlTime:
 		expr.Tp = tipb.ExprType_MysqlTime

--- a/pkg/expression/expr_to_pb.go
+++ b/pkg/expression/expr_to_pb.go
@@ -143,7 +143,8 @@ func (pc *PbConverter) encodeDatum(ft *types.FieldType, d types.Datum) (tipb.Exp
 	case types.KindMysqlTime:
 		if pc.client.IsRequestTypeSupported(kv.ReqTypeDAG, int64(tipb.ExprType_MysqlTime)) {
 			tp = tipb.ExprType_MysqlTime
-			val, err := codec.EncodeMySQLTime(pc.sc, d.GetMysqlTime(), ft.GetType(), nil)
+			val, err := codec.EncodeMySQLTime(pc.sc.TimeZone(), d.GetMysqlTime(), ft.GetType(), nil)
+			err = pc.sc.HandleError(err)
 			if err != nil {
 				logutil.BgLogger().Error("encode mysql time", zap.Error(err))
 				return tp, nil, false

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -466,7 +466,7 @@ func TestTiDBDecodeKeyFunc(t *testing.T) {
 		return ret
 	}
 	buildCommonKeyFromData := func(tableID int64, data []types.Datum) string {
-		k, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx, nil, data...)
+		k, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx.TimeZone(), nil, data...)
 		require.NoError(t, err)
 		h, err := kv.NewCommonHandle(k)
 		require.NoError(t, err)
@@ -493,7 +493,7 @@ func TestTiDBDecodeKeyFunc(t *testing.T) {
 	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	buildIndexKeyFromData := func(tableID, indexID int64, data []types.Datum) string {
-		k, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx, nil, data...)
+		k, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx.TimeZone(), nil, data...)
 		require.NoError(t, err)
 		k = tablecodec.EncodeIndexSeekKey(tableID, indexID, k)
 		return hex.EncodeToString(codec.EncodeBytes(nil, k))

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -354,14 +354,14 @@ func TestHashGroupKey(t *testing.T) {
 		var err error
 		err = EvalExpr(ctx, colExpr, colExpr.GetType().EvalType(), input, colBuf)
 		require.NoError(t, err)
-		bufs, err = codec.HashGroupKey(sc, 1024, colBuf, bufs, ft)
+		bufs, err = codec.HashGroupKey(sc.TimeZone(), 1024, colBuf, bufs, ft)
 		require.NoError(t, err)
 
 		var buf []byte
 		for j := 0; j < input.NumRows(); j++ {
 			d, err := colExpr.Eval(input.GetRow(j))
 			require.NoError(t, err)
-			buf, err = codec.EncodeValue(sc, buf[:0], d)
+			buf, err = codec.EncodeValue(sc.TimeZone(), buf[:0], d)
 			require.NoError(t, err)
 			require.Equal(t, string(bufs[j]), string(buf))
 		}

--- a/pkg/kv/key_test.go
+++ b/pkg/kv/key_test.go
@@ -35,13 +35,13 @@ import (
 func TestPartialNext(t *testing.T) {
 	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	// keyA represents a multi column index.
-	keyA, err := codec.EncodeValue(sc, nil, types.NewDatum("abc"), types.NewDatum("def"))
+	keyA, err := codec.EncodeValue(sc.TimeZone(), nil, types.NewDatum("abc"), types.NewDatum("def"))
 	require.NoError(t, err)
-	keyB, err := codec.EncodeValue(sc, nil, types.NewDatum("abca"), types.NewDatum("def"))
+	keyB, err := codec.EncodeValue(sc.TimeZone(), nil, types.NewDatum("abca"), types.NewDatum("def"))
 	require.NoError(t, err)
 
 	// We only use first column value to seek.
-	seekKey, err := codec.EncodeValue(sc, nil, types.NewDatum("abc"))
+	seekKey, err := codec.EncodeValue(sc.TimeZone(), nil, types.NewDatum("abc"))
 	require.NoError(t, err)
 
 	nextKey := Key(seekKey).Next()
@@ -149,7 +149,7 @@ func TestHandle(t *testing.T) {
 
 func TestPaddingHandle(t *testing.T) {
 	dec := types.NewDecFromInt(1)
-	encoded, err := codec.EncodeKey(stmtctx.NewStmtCtx(), nil, types.NewDecimalDatum(dec))
+	encoded, err := codec.EncodeKey(stmtctx.NewStmtCtx().TimeZone(), nil, types.NewDecimalDatum(dec))
 	assert.Nil(t, err)
 	assert.Less(t, len(encoded), 9)
 
@@ -229,7 +229,7 @@ func TestHandleMapWithPartialHandle(t *testing.T) {
 	m.Set(ih, 3)
 
 	dec := types.NewDecFromInt(1)
-	encoded, err := codec.EncodeKey(stmtctx.NewStmtCtx(), nil, types.NewDecimalDatum(dec))
+	encoded, err := codec.EncodeKey(stmtctx.NewStmtCtx().TimeZone(), nil, types.NewDecimalDatum(dec))
 	assert.Nil(t, err)
 	assert.Less(t, len(encoded), 9)
 
@@ -285,7 +285,7 @@ func TestMemAwareHandleMapWithPartialHandle(t *testing.T) {
 	m.Set(ih, 3)
 
 	dec := types.NewDecFromInt(1)
-	encoded, err := codec.EncodeKey(stmtctx.NewStmtCtx(), nil, types.NewDecimalDatum(dec))
+	encoded, err := codec.EncodeKey(stmtctx.NewStmtCtx().TimeZone(), nil, types.NewDecimalDatum(dec))
 	assert.Nil(t, err)
 	assert.Less(t, len(encoded), 9)
 
@@ -381,7 +381,7 @@ func BenchmarkMemAwareHandleMap(b *testing.B) {
 			if i%2 == 0 {
 				handles[i] = IntHandle(i)
 			} else {
-				handleBytes, _ := codec.EncodeKey(&sc, nil, types.NewIntDatum(int64(i)))
+				handleBytes, _ := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(int64(i)))
 				handles[i], _ = NewCommonHandle(handleBytes)
 			}
 		}
@@ -403,7 +403,7 @@ func BenchmarkNativeHandleMap(b *testing.B) {
 			if i%2 == 0 {
 				handles[i] = IntHandle(i)
 			} else {
-				handleBytes, _ := codec.EncodeKey(&sc, nil, types.NewIntDatum(int64(i)))
+				handleBytes, _ := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(int64(i)))
 				handles[i], _ = NewCommonHandle(handleBytes)
 			}
 		}

--- a/pkg/planner/cardinality/row_count_column.go
+++ b/pkg/planner/cardinality/row_count_column.go
@@ -191,11 +191,13 @@ func GetColumnRowCount(sctx sessionctx.Context, c *statistics.Column, ranges []*
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
-		lowEncoded, err := codec.EncodeKey(sc, nil, lowVal)
+		lowEncoded, err := codec.EncodeKey(sc.TimeZone(), nil, lowVal)
+		err = sc.HandleError(err)
 		if err != nil {
 			return 0, err
 		}
-		highEncoded, err := codec.EncodeKey(sc, nil, highVal)
+		highEncoded, err := codec.EncodeKey(sc.TimeZone(), nil, highVal)
+		err = sc.HandleError(err)
 		if err != nil {
 			return 0, err
 		}
@@ -336,11 +338,13 @@ func columnBetweenRowCount(sctx sessionctx.Context, t *statistics.Table, a, b ty
 	if !ok || c.IsInvalid(sctx, t.Pseudo) {
 		return float64(t.RealtimeCount) / pseudoBetweenRate, nil
 	}
-	aEncoded, err := codec.EncodeKey(sc, nil, a)
+	aEncoded, err := codec.EncodeKey(sc.TimeZone(), nil, a)
+	err = sc.HandleError(err)
 	if err != nil {
 		return 0, err
 	}
-	bEncoded, err := codec.EncodeKey(sc, nil, b)
+	bEncoded, err := codec.EncodeKey(sc.TimeZone(), nil, b)
+	err = sc.HandleError(err)
 	if err != nil {
 		return 0, err
 	}
@@ -357,7 +361,8 @@ func ColumnEqualRowCount(sctx sessionctx.Context, t *statistics.Table, value typ
 	if !ok || c.IsInvalid(sctx, t.Pseudo) {
 		return float64(t.RealtimeCount) / pseudoEqualRate, nil
 	}
-	encodedVal, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx, nil, value)
+	encodedVal, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx.TimeZone(), nil, value)
+	err = sctx.GetSessionVars().StmtCtx.HandleError(err)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -642,7 +642,7 @@ func generateIntDatum(dimension, num int) ([]types.Datum, error) {
 				data[dimension-k-1].SetInt64(int64(j % num))
 				j = j / num
 			}
-			bytes, err := codec.EncodeKey(sc, nil, data...)
+			bytes, err := codec.EncodeKey(sc.TimeZone(), nil, data...)
 			if err != nil {
 				return nil, err
 			}
@@ -1035,7 +1035,7 @@ func TestOrderingIdxSelectivityThreshold(t *testing.T) {
 	require.NoError(t, err)
 	idxValues := make([]types.Datum, 0)
 	for _, val := range colValues {
-		b, err := codec.EncodeKey(sc, nil, val)
+		b, err := codec.EncodeKey(sc.TimeZone(), nil, val)
 		require.NoError(t, err)
 		idxValues = append(idxValues, types.NewBytesDatum(b))
 	}

--- a/pkg/planner/core/handle_cols.go
+++ b/pkg/planner/core/handle_cols.go
@@ -72,7 +72,8 @@ type CommonHandleCols struct {
 
 func (cb *CommonHandleCols) buildHandleByDatumsBuffer(datumBuf []types.Datum) (kv.Handle, error) {
 	tablecodec.TruncateIndexValues(cb.tblInfo, cb.idxInfo, datumBuf)
-	handleBytes, err := codec.EncodeKey(cb.sc, nil, datumBuf...)
+	handleBytes, err := codec.EncodeKey(cb.sc.TimeZone(), nil, datumBuf...)
+	err = cb.sc.HandleError(err)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/handler/tests/http_handler_test.go
+++ b/pkg/server/handler/tests/http_handler_test.go
@@ -101,7 +101,7 @@ func TestRegionIndexRange(t *testing.T) {
 		}
 		expectIndexValues = append(expectIndexValues, str)
 	}
-	encodedValue, err := codec.EncodeKey(stmtctx.NewStmtCtxWithTimeZone(time.Local), nil, indexValues...)
+	encodedValue, err := codec.EncodeKey(stmtctx.NewStmtCtxWithTimeZone(time.Local).TimeZone(), nil, indexValues...)
 	require.NoError(t, err)
 
 	startKey := tablecodec.EncodeIndexSeekKey(sTableID, sIndex, encodedValue)
@@ -168,7 +168,7 @@ func TestRegionCommonHandleRange(t *testing.T) {
 		}
 		expectIndexValues = append(expectIndexValues, str)
 	}
-	encodedValue, err := codec.EncodeKey(stmtctx.NewStmtCtxWithTimeZone(time.Local), nil, indexValues...)
+	encodedValue, err := codec.EncodeKey(stmtctx.NewStmtCtxWithTimeZone(time.Local).TimeZone(), nil, indexValues...)
 	require.NoError(t, err)
 
 	startKey := tablecodec.EncodeRowKey(sTableID, encodedValue)

--- a/pkg/server/handler/tikv_handler.go
+++ b/pkg/server/handler/tikv_handler.go
@@ -98,7 +98,8 @@ func (t *TikvHandlerTool) GetHandle(tb table.PhysicalTable, params map[string]st
 		}
 		tablecodec.TruncateIndexValues(tblInfo, pkIdx, pkDts)
 		var handleBytes []byte
-		handleBytes, err = codec.EncodeKey(sc, nil, pkDts...)
+		handleBytes, err = codec.EncodeKey(sc.TimeZone(), nil, pkDts...)
+		err = sc.HandleError(err)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/pkg/sessionctx/stmtctx/BUILD.bazel
+++ b/pkg/sessionctx/stmtctx/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/domain/resourcegroup",
+        "//pkg/errctx",
         "//pkg/parser",
         "//pkg/parser/ast",
         "//pkg/parser/model",

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/domain/resourcegroup"
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -157,6 +158,9 @@ type StatementContext struct {
 
 	// 	typeCtx is used to indicate how to make the type conversation.
 	typeCtx types.Context
+
+	// errCtx is used to indicate how to handle the errors
+	errCtx errctx.Context
 
 	// Set the following variables before execution
 	StmtHints
@@ -458,6 +462,23 @@ func (sc *StatementContext) SetTimeZone(tz *time.Location) {
 // TypeCtx returns the type context
 func (sc *StatementContext) TypeCtx() types.Context {
 	return sc.typeCtx
+}
+
+// ErrCtx returns the error context
+// TODO: add a cache to the `ErrCtx` if needed, though it's not a big burden to generate `ErrCtx` everytime.
+func (sc *StatementContext) ErrCtx() errctx.Context {
+	ctx := errctx.NewContext(sc.AppendWarning)
+
+	if sc.TypeFlags().IgnoreTruncateErr() {
+		ctx = ctx.WithErrGroupLevel(errctx.ErrGroupTruncate, errctx.LevelIgnore)
+	} else if sc.TypeFlags().TruncateAsWarning() {
+		ctx = ctx.WithErrGroupLevel(errctx.ErrGroupTruncate, errctx.LevelWarn)
+	}
+
+	if sc.OverflowAsWarning {
+		ctx = ctx.WithErrGroupLevel(errctx.ErrGroupOverflow, errctx.LevelWarn)
+	}
+	return ctx
 }
 
 // TypeFlags returns the type flags

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -450,6 +450,11 @@ func (sc *StatementContext) Reset() {
 
 // TimeZone returns the timezone of the type context
 func (sc *StatementContext) TimeZone() *time.Location {
+	intest.AssertNotNil(sc)
+	if sc == nil {
+		return time.UTC
+	}
+
 	return sc.typeCtx.Location()
 }
 
@@ -492,8 +497,15 @@ func (sc *StatementContext) SetTypeFlags(flags types.Flags) {
 }
 
 // HandleTruncate ignores or returns the error based on the TypeContext inside.
+// TODO: replace this function with `HandleError`, for `TruncatedError` they should have the same effect.
 func (sc *StatementContext) HandleTruncate(err error) error {
 	return sc.typeCtx.HandleTruncate(err)
+}
+
+// HandleError handles the error based on `ErrCtx()`
+func (sc *StatementContext) HandleError(err error) error {
+	errCtx := sc.ErrCtx()
+	return errCtx.HandleError(err)
 }
 
 // StmtHints are SessionVars related sql hints.

--- a/pkg/statistics/builder.go
+++ b/pkg/statistics/builder.go
@@ -253,7 +253,8 @@ func BuildHistAndTopN(
 	var getComparedBytes func(datum types.Datum) ([]byte, error)
 	if isColumn {
 		getComparedBytes = func(datum types.Datum) ([]byte, error) {
-			encoded, err := codec.EncodeKey(ctx.GetSessionVars().StmtCtx, nil, datum)
+			encoded, err := codec.EncodeKey(ctx.GetSessionVars().StmtCtx.TimeZone(), nil, datum)
+			err = ctx.GetSessionVars().StmtCtx.HandleError(err)
 			if memTracker != nil {
 				// tmp memory usage
 				deltaSize := int64(cap(encoded))

--- a/pkg/statistics/cmsketch_test.go
+++ b/pkg/statistics/cmsketch_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -29,7 +30,7 @@ import (
 )
 
 func (c *CMSketch) insert(val *types.Datum) error {
-	bytes, err := codec.EncodeValue(nil, nil, *val)
+	bytes, err := codec.EncodeValue(time.UTC, nil, *val)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -40,7 +41,7 @@ func (c *CMSketch) insert(val *types.Datum) error {
 func prepareCMSAndTopN(d, w int32, vals []*types.Datum, n uint32, total uint64) (*CMSketch, *TopN, error) {
 	data := make([][]byte, 0, len(vals))
 	for _, v := range vals {
-		bytes, err := codec.EncodeValue(nil, nil, *v)
+		bytes, err := codec.EncodeValue(time.UTC, nil, *v)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/pkg/statistics/fmsketch.go
+++ b/pkg/statistics/fmsketch.go
@@ -97,7 +97,8 @@ func (s *FMSketch) insertHashValue(hashVal uint64) {
 
 // InsertValue inserts a value into the FM sketch.
 func (s *FMSketch) InsertValue(sc *stmtctx.StatementContext, value types.Datum) error {
-	bytes, err := codec.EncodeValue(sc, nil, value)
+	bytes, err := codec.EncodeValue(sc.TimeZone(), nil, value)
+	err = sc.HandleError(err)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -118,9 +119,12 @@ func (s *FMSketch) InsertRowValue(sc *stmtctx.StatementContext, values []types.D
 	hashFunc := murmur3Pool.Get().(hash.Hash64)
 	hashFunc.Reset()
 	defer murmur3Pool.Put(hashFunc)
+
+	errCtx := sc.ErrCtx()
 	for _, v := range values {
 		b = b[:0]
-		b, err := codec.EncodeValue(sc, b, v)
+		b, err := codec.EncodeValue(sc.TimeZone(), b, v)
+		err = errCtx.HandleError(err)
 		if err != nil {
 			return err
 		}

--- a/pkg/statistics/handle/globalstats/topn_bench_test.go
+++ b/pkg/statistics/handle/globalstats/topn_bench_test.go
@@ -44,7 +44,7 @@ func prepareTopNsAndHists(b *testing.B, partitions int, tz *time.Location) ([]*s
 				if i%2 == 0 && j%2 == 0 {
 					continue
 				}
-				key, err := codec.EncodeKey(sc, nil, types.NewIntDatum(int64(j)))
+				key, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(int64(j)))
 				require.NoError(b, err)
 				topN.AppendTopN(key, uint64(rand.Intn(1000)))
 			}

--- a/pkg/statistics/handle/globalstats/topn_test.go
+++ b/pkg/statistics/handle/globalstats/topn_test.go
@@ -40,13 +40,13 @@ func TestMergePartTopN2GlobalTopNWithoutHists(t *testing.T) {
 		// Construct TopN, should be key(1, 1) -> 2, key(1, 2) -> 2, key(1, 3) -> 3.
 		topN := statistics.NewTopN(3)
 		{
-			key1, err := codec.EncodeKey(sc, nil, types.NewIntDatum(1), types.NewIntDatum(1))
+			key1, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(1), types.NewIntDatum(1))
 			require.NoError(t, err)
 			topN.AppendTopN(key1, 2)
-			key2, err := codec.EncodeKey(sc, nil, types.NewIntDatum(1), types.NewIntDatum(2))
+			key2, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(1), types.NewIntDatum(2))
 			require.NoError(t, err)
 			topN.AppendTopN(key2, 2)
-			key3, err := codec.EncodeKey(sc, nil, types.NewIntDatum(1), types.NewIntDatum(3))
+			key3, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(1), types.NewIntDatum(3))
 			require.NoError(t, err)
 			topN.AppendTopN(key3, 3)
 		}
@@ -73,14 +73,14 @@ func TestMergePartTopN2GlobalTopNWithHists(t *testing.T) {
 		// Construct TopN, should be key1 -> 2, key2 -> 2, key3 -> 3.
 		topN := statistics.NewTopN(3)
 		{
-			key1, err := codec.EncodeKey(sc, nil, types.NewIntDatum(1))
+			key1, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(1))
 			require.NoError(t, err)
 			topN.AppendTopN(key1, 2)
-			key2, err := codec.EncodeKey(sc, nil, types.NewIntDatum(2))
+			key2, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(2))
 			require.NoError(t, err)
 			topN.AppendTopN(key2, 2)
 			if i%2 == 0 {
-				key3, err := codec.EncodeKey(sc, nil, types.NewIntDatum(3))
+				key3, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(3))
 				require.NoError(t, err)
 				topN.AppendTopN(key3, 3)
 			}

--- a/pkg/statistics/handle/updatetest/BUILD.bazel
+++ b/pkg/statistics/handle/updatetest/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "//pkg/parser/mysql",
         "//pkg/planner/cardinality",
         "//pkg/sessionctx",
+        "//pkg/sessionctx/stmtctx",
         "//pkg/sessionctx/variable",
         "//pkg/statistics",
         "//pkg/statistics/handle/autoanalyze",

--- a/pkg/statistics/handle/updatetest/update_test.go
+++ b/pkg/statistics/handle/updatetest/update_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/cardinality"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze"
@@ -561,6 +562,8 @@ func TestSplitRange(t *testing.T) {
 			result:  "[8,9)",
 		},
 	}
+	sc := new(stmtctx.StatementContext)
+	sc.SetTimeZone(time.UTC)
 	for _, test := range tests {
 		ranges := make([]*ranger.Range, 0, len(test.points)/2)
 		for i := 0; i < len(test.points); i += 2 {
@@ -572,7 +575,7 @@ func TestSplitRange(t *testing.T) {
 				Collators:   collate.GetBinaryCollatorSlice(1),
 			})
 		}
-		ranges, _ = h.SplitRange(nil, ranges, false)
+		ranges, _ = h.SplitRange(sc, ranges, false)
 		var ranStrs []string
 		for _, ran := range ranges {
 			ranStrs = append(ranStrs, ran.String())

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -648,11 +648,13 @@ func validRange(sc *stmtctx.StatementContext, ran *ranger.Range, encoded bool) b
 		low, high = ran.LowVal[0].GetBytes(), ran.HighVal[0].GetBytes()
 	} else {
 		var err error
-		low, err = codec.EncodeKey(sc, nil, ran.LowVal[0])
+		low, err = codec.EncodeKey(sc.TimeZone(), nil, ran.LowVal[0])
+		err = sc.HandleError(err)
 		if err != nil {
 			return false
 		}
-		high, err = codec.EncodeKey(sc, nil, ran.HighVal[0])
+		high, err = codec.EncodeKey(sc.TimeZone(), nil, ran.HighVal[0])
+		err = sc.HandleError(err)
 		if err != nil {
 			return false
 		}

--- a/pkg/statistics/histogram_bench_test.go
+++ b/pkg/statistics/histogram_bench_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
@@ -60,9 +61,9 @@ func genBucket4TestData(length int) []*bucket4Test {
 func genHist4Bench(t *testing.B, buckets []*bucket4Test, totColSize int64) *Histogram {
 	h := NewHistogram(0, 0, 0, 0, types.NewFieldType(mysql.TypeBlob), len(buckets), totColSize)
 	for _, bucket := range buckets {
-		lower, err := codec.EncodeKey(nil, nil, types.NewIntDatum(bucket.lower))
+		lower, err := codec.EncodeKey(time.UTC, nil, types.NewIntDatum(bucket.lower))
 		require.NoError(t, err)
-		upper, err := codec.EncodeKey(nil, nil, types.NewIntDatum(bucket.upper))
+		upper, err := codec.EncodeKey(time.UTC, nil, types.NewIntDatum(bucket.upper))
 		require.NoError(t, err)
 		di, du := types.NewBytesDatum(lower), types.NewBytesDatum(upper)
 		h.AppendBucketWithNDV(&di, &du, bucket.count, bucket.repeat, bucket.ndv)
@@ -81,7 +82,7 @@ func benchmarkMergePartitionHist2GlobalHist(b *testing.B, partition int) {
 	}
 	poped := make([]TopNMeta, 0, popedTopNLen)
 	for n := 0; n < popedTopNLen; n++ {
-		b, _ := codec.EncodeKey(sc, nil, types.NewIntDatum(rand.Int63n(10000)))
+		b, _ := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(rand.Int63n(10000)))
 		tmp := TopNMeta{
 			Encoded: b,
 			Count:   uint64(rand.Int63n(10000)),

--- a/pkg/statistics/histogram_test.go
+++ b/pkg/statistics/histogram_test.go
@@ -17,6 +17,7 @@ package statistics
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -37,7 +38,7 @@ func TestTruncateHistogram(t *testing.T) {
 }
 
 func TestValueToString4InvalidKey(t *testing.T) {
-	bytes, err := codec.EncodeKey(nil, nil, types.NewDatum(1), types.NewDatum(0.5))
+	bytes, err := codec.EncodeKey(time.UTC, nil, types.NewDatum(1), types.NewDatum(0.5))
 	require.NoError(t, err)
 	// Append invalid flag.
 	bytes = append(bytes, 20)
@@ -63,9 +64,9 @@ type topN4Test struct {
 func genHist4Test(t *testing.T, buckets []*bucket4Test, totColSize int64) *Histogram {
 	h := NewHistogram(0, 0, 0, 0, types.NewFieldType(mysql.TypeBlob), len(buckets), totColSize)
 	for _, bucket := range buckets {
-		lower, err := codec.EncodeKey(nil, nil, types.NewIntDatum(bucket.lower))
+		lower, err := codec.EncodeKey(time.UTC, nil, types.NewIntDatum(bucket.lower))
 		require.NoError(t, err)
-		upper, err := codec.EncodeKey(nil, nil, types.NewIntDatum(bucket.upper))
+		upper, err := codec.EncodeKey(time.UTC, nil, types.NewIntDatum(bucket.upper))
 		require.NoError(t, err)
 		di, du := types.NewBytesDatum(lower), types.NewBytesDatum(upper)
 		h.AppendBucketWithNDV(&di, &du, bucket.count, bucket.repeat, bucket.ndv)
@@ -288,7 +289,7 @@ func TestMergePartitionLevelHist(t *testing.T) {
 		sc := ctx.GetSessionVars().StmtCtx
 		poped := make([]TopNMeta, 0, len(tt.popedTopN))
 		for _, top := range tt.popedTopN {
-			b, err := codec.EncodeKey(sc, nil, types.NewIntDatum(top.data))
+			b, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(top.data))
 			require.NoError(t, err)
 			tmp := TopNMeta{
 				Encoded: b,
@@ -375,9 +376,9 @@ func TestIndexQueryBytes(t *testing.T) {
 	sc := ctx.GetSessionVars().StmtCtx
 	idx := &Index{Info: &model.IndexInfo{Columns: []*model.IndexColumn{{Name: model.NewCIStr("a"), Offset: 0}}}}
 	idx.Histogram = *NewHistogram(0, 15, 0, 0, types.NewFieldType(mysql.TypeBlob), 0, 0)
-	low, err1 := codec.EncodeKey(sc, nil, types.NewBytesDatum([]byte("0")))
+	low, err1 := codec.EncodeKey(sc.TimeZone(), nil, types.NewBytesDatum([]byte("0")))
 	require.NoError(t, err1)
-	high, err2 := codec.EncodeKey(sc, nil, types.NewBytesDatum([]byte("3")))
+	high, err2 := codec.EncodeKey(sc.TimeZone(), nil, types.NewBytesDatum([]byte("3")))
 	require.NoError(t, err2)
 	idx.Bounds.AppendBytes(0, low)
 	idx.Bounds.AppendBytes(0, high)
@@ -464,19 +465,19 @@ func TestStandardizeForV2AnalyzeIndex(t *testing.T) {
 	// 2. prepare the actual Histogram input
 	ctx := mock.NewContext()
 	sc := ctx.GetSessionVars().StmtCtx
-	val0, err := codec.EncodeKey(sc, nil, types.NewIntDatum(111))
+	val0, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(111))
 	require.NoError(t, err)
-	val1, err := codec.EncodeKey(sc, nil, types.NewIntDatum(123))
+	val1, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(123))
 	require.NoError(t, err)
-	val2, err := codec.EncodeKey(sc, nil, types.NewIntDatum(34567))
+	val2, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(34567))
 	require.NoError(t, err)
-	val3, err := codec.EncodeKey(sc, nil, types.NewIntDatum(5))
+	val3, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(5))
 	require.NoError(t, err)
-	val4, err := codec.EncodeKey(sc, nil, types.NewIntDatum(876))
+	val4, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(876))
 	require.NoError(t, err)
-	val5, err := codec.EncodeKey(sc, nil, types.NewIntDatum(990))
+	val5, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(990))
 	require.NoError(t, err)
-	val6, err := codec.EncodeKey(sc, nil, types.NewIntDatum(95))
+	val6, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(95))
 	require.NoError(t, err)
 	val0Bytes := types.NewBytesDatum(val0)
 	val1Bytes := types.NewBytesDatum(val1)
@@ -556,7 +557,7 @@ func TestVerifyHistsBinarySearchRemoveValAndRemoveVals(t *testing.T) {
 	require.Equal(t, data1, data2)
 	ctx := mock.NewContext()
 	sc := ctx.GetSessionVars().StmtCtx
-	b, err := codec.EncodeKey(sc, nil, types.NewIntDatum(150))
+	b, err := codec.EncodeKey(sc.TimeZone(), nil, types.NewIntDatum(150))
 	require.NoError(t, err)
 	tmp := TopNMeta{
 		Encoded: b,

--- a/pkg/statistics/statistics_test.go
+++ b/pkg/statistics/statistics_test.go
@@ -456,7 +456,7 @@ func SubTestIndexRanges() func(*testing.T) {
 
 func encodeKey(key types.Datum) types.Datum {
 	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
-	buf, _ := codec.EncodeKey(sc, nil, key)
+	buf, _ := codec.EncodeKey(sc.TimeZone(), nil, key)
 	return types.NewBytesDatum(buf)
 }
 
@@ -482,7 +482,7 @@ func buildIndex(sctx sessionctx.Context, numBuckets, id int64, records sqlexec.R
 		}
 		for row := it.Begin(); row != it.End(); row = it.Next() {
 			datums := RowToDatums(row, records.Fields())
-			buf, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx, nil, datums...)
+			buf, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx.TimeZone(), nil, datums...)
 			if err != nil {
 				return 0, nil, nil, errors.Trace(err)
 			}

--- a/pkg/store/mockstore/cluster_test.go
+++ b/pkg/store/mockstore/cluster_test.go
@@ -62,7 +62,7 @@ func TestClusterSplit(t *testing.T) {
 		require.NoError(t, err1)
 		txn.Set(rowKey, rowValue)
 
-		encodedIndexValue, err1 := codec.EncodeKey(sc, nil, []types.Datum{colValue, types.NewIntDatum(handle)}...)
+		encodedIndexValue, err1 := codec.EncodeKey(sc.TimeZone(), nil, []types.Datum{colValue, types.NewIntDatum(handle)}...)
 		require.NoError(t, err1)
 		idxKey := tablecodec.EncodeIndexSeekKey(tblID, idxID, encodedIndexValue)
 		txn.Set(idxKey, []byte{'0'})

--- a/pkg/store/mockstore/mockcopr/executor.go
+++ b/pkg/store/mockstore/mockcopr/executor.go
@@ -638,7 +638,7 @@ func getRowData(columns []*tipb.ColumnInfo, colIDs map[int64]int, handle int64, 
 			} else {
 				handleDatum = types.NewIntDatum(handle)
 			}
-			handleData, err1 := codec.EncodeValue(nil, nil, handleDatum)
+			handleData, err1 := codec.EncodeValue(time.UTC, nil, handleDatum)
 			if err1 != nil {
 				return nil, errors.Trace(err1)
 			}

--- a/pkg/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/closure_exec.go
@@ -675,7 +675,8 @@ func (e *countStarProcessor) Finish() error {
 // countFinish is used for `count(*)`.
 func (e *closureExecutor) countFinish() error {
 	d := types.NewIntDatum(int64(e.rowCount))
-	rowData, err := codec.EncodeValue(e.sc, nil, d)
+	rowData, err := codec.EncodeValue(e.sc.TimeZone(), nil, d)
+	err = e.sc.HandleError(err)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -946,6 +947,7 @@ func (e *closureExecutor) indexScanProcessCore(key, value []byte) error {
 
 func (e *closureExecutor) chunkToOldChunk(chk *chunk.Chunk) error {
 	var oldRow []types.Datum
+	errCtx := e.sc.ErrCtx()
 	for i := 0; i < chk.NumRows(); i++ {
 		oldRow = oldRow[:0]
 		if e.outputOff != nil {
@@ -960,7 +962,8 @@ func (e *closureExecutor) chunkToOldChunk(chk *chunk.Chunk) error {
 			}
 		}
 		var err error
-		e.oldRowBuf, err = codec.EncodeValue(e.sc, e.oldRowBuf[:0], oldRow...)
+		e.oldRowBuf, err = codec.EncodeValue(e.sc.TimeZone(), e.oldRowBuf[:0], oldRow...)
+		err = errCtx.HandleError(err)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1122,12 +1125,14 @@ func (e *hashAggProcessor) getGroupKey(row chunk.Row) ([]byte, error) {
 		return nil, nil
 	}
 	key := make([]byte, 0, 32)
+	errCtx := e.sc.ErrCtx()
 	for _, item := range e.groupByExprs {
 		v, err := item.Eval(row)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		b, err := codec.EncodeValue(e.sc, nil, v)
+		b, err := codec.EncodeValue(e.sc.TimeZone(), nil, v)
+		err = errCtx.HandleError(err)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1149,13 +1154,15 @@ func (e *hashAggProcessor) getContexts(groupKey []byte) []*aggregation.AggEvalua
 }
 
 func (e *hashAggProcessor) Finish() error {
+	errCtx := e.sc.ErrCtx()
 	for i, gk := range e.groupKeys {
 		aggCtxs := e.getContexts(gk)
 		e.oldRowBuf = e.oldRowBuf[:0]
 		for i, agg := range e.aggExprs {
 			partialResults := agg.GetPartialResult(aggCtxs[i])
 			var err error
-			e.oldRowBuf, err = codec.EncodeValue(e.sc, e.oldRowBuf, partialResults...)
+			e.oldRowBuf, err = codec.EncodeValue(e.sc.TimeZone(), e.oldRowBuf, partialResults...)
+			err = errCtx.HandleError(err)
 			if err != nil {
 				return err
 			}

--- a/pkg/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/pkg/store/mockstore/unistore/cophandler/cop_handler.go
@@ -240,6 +240,7 @@ func useDefaultEncoding(chk *chunk.Chunk, dagCtx *dagContext, dagReq *tipb.DAGRe
 	var datums []types.Datum
 	var err error
 	numRows := chk.NumRows()
+	errCtx := dagCtx.sc.ErrCtx()
 	for i := 0; i < numRows; i++ {
 		datums = datums[:0]
 		if dagReq.OutputOffsets != nil {
@@ -251,7 +252,8 @@ func useDefaultEncoding(chk *chunk.Chunk, dagCtx *dagContext, dagReq *tipb.DAGRe
 				datums = append(datums, chk.GetRow(i).GetDatum(j, ft))
 			}
 		}
-		buf, err = codec.EncodeValue(dagCtx.sc, buf[:0], datums...)
+		buf, err = codec.EncodeValue(dagCtx.sc.TimeZone(), buf[:0], datums...)
+		err = errCtx.HandleError(err)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
@@ -619,7 +619,8 @@ func (e *exchSenderExec) toTiPBChunk(chk *chunk.Chunk) ([]tipb.Chunk, error) {
 		}
 		var err error
 		var oldRowBuf []byte
-		oldRowBuf, err = codec.EncodeValue(e.sc, oldRowBuf[:0], oldRow...)
+		oldRowBuf, err = codec.EncodeValue(e.sc.TimeZone(), oldRowBuf[:0], oldRow...)
+		err = e.sc.HandleError(err)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -663,7 +664,7 @@ func (e *exchSenderExec) next() (*chunk.Chunk, error) {
 				hashVals.Reset()
 				// use hash values to get unique uint64 to mod.
 				// collect all the hash key datum.
-				err := codec.HashChunkRow(e.sc, hashVals, row, e.hashKeyTypes, e.hashKeyOffsets, payload)
+				err := codec.HashChunkRow(e.sc.TypeCtx(), hashVals, row, e.hashKeyTypes, e.hashKeyOffsets, payload)
 				if err != nil {
 					for _, tunnel := range e.tunnels {
 						tunnel.ErrCh <- err
@@ -1012,7 +1013,8 @@ func (e *aggExec) getGroupKey(row chunk.Row) (*chunk.MutRow, []byte, error) {
 			return nil, nil, errors.Trace(err)
 		}
 		gbyRow.SetDatum(i, v)
-		b, err := codec.EncodeValue(e.sc, nil, v)
+		b, err := codec.EncodeValue(e.sc.TimeZone(), nil, v)
+		err = e.sc.HandleError(err)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/pkg/table/tables/index_test.go
+++ b/pkg/table/tables/index_test.go
@@ -64,7 +64,7 @@ func TestMultiColumnCommonHandle(t *testing.T) {
 	// create index for "insert t values (3, 2, "abc", "abc")
 	idxColVals := types.MakeDatums("abc")
 	handleColVals := types.MakeDatums(3, 2)
-	encodedHandle, err := codec.EncodeKey(sc, nil, handleColVals...)
+	encodedHandle, err := codec.EncodeKey(sc.TimeZone(), nil, handleColVals...)
 	require.NoError(t, err)
 	commonHandle, err := kv.NewCommonHandle(encodedHandle)
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestSingleColumnCommonHandle(t *testing.T) {
 	// create index for "insert t values ('abc', 1, 1)"
 	idxColVals := types.MakeDatums(1)
 	handleColVals := types.MakeDatums("abc")
-	encodedHandle, err := codec.EncodeKey(sc, nil, handleColVals...)
+	encodedHandle, err := codec.EncodeKey(sc.TimeZone(), nil, handleColVals...)
 	require.NoError(t, err)
 	commonHandle, err := kv.NewCommonHandle(encodedHandle)
 	require.NoError(t, err)

--- a/pkg/table/tables/mutation_checker_test.go
+++ b/pkg/table/tables/mutation_checker_test.go
@@ -268,7 +268,7 @@ func TestCheckIndexKeysAndCheckHandleConsistency(t *testing.T) {
 				table := MockTableFromMeta(&tableInfo).(*TableCommon)
 				var handle, corruptedHandle kv.Handle
 				if isCommonHandle {
-					encoded, err := codec.EncodeKey(sessVars.StmtCtx, nil, rowToInsert[0])
+					encoded, err := codec.EncodeKey(sessVars.StmtCtx.TimeZone(), nil, rowToInsert[0])
 					require.Nil(t, err)
 					corrupted := make([]byte, len(encoded))
 					copy(corrupted, encoded)

--- a/pkg/table/tables/partition.go
+++ b/pkg/table/tables/partition.go
@@ -1107,7 +1107,8 @@ func (lp *ForListColumnPruning) genKey(sc *stmtctx.StatementContext, v types.Dat
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	valByte, err := codec.EncodeKey(sc, nil, v)
+	valByte, err := codec.EncodeKey(sc.TimeZone(), nil, v)
+	err = sc.HandleError(err)
 	return valByte, err
 }
 

--- a/pkg/tablecodec/BUILD.bazel
+++ b/pkg/tablecodec/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/tablecodec",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/errctx",
         "//pkg/errno",
         "//pkg/kv",
         "//pkg/parser/charset",

--- a/pkg/tablecodec/tablecodec_test.go
+++ b/pkg/tablecodec/tablecodec_test.go
@@ -355,7 +355,7 @@ func TestCutKeyNew(t *testing.T) {
 	handle := types.NewIntDatum(100)
 	values = append(values, handle)
 	sc := stmtctx.NewStmtCtxWithTimeZone(time.UTC)
-	encodedValue, err := codec.EncodeKey(sc, nil, values...)
+	encodedValue, err := codec.EncodeKey(sc.TimeZone(), nil, values...)
 	require.NoError(t, err)
 	tableID := int64(4)
 	indexID := int64(5)
@@ -378,7 +378,7 @@ func TestCutKey(t *testing.T) {
 	handle := types.NewIntDatum(100)
 	values = append(values, handle)
 	sc := stmtctx.NewStmtCtxWithTimeZone(time.UTC)
-	encodedValue, err := codec.EncodeKey(sc, nil, values...)
+	encodedValue, err := codec.EncodeKey(sc.TimeZone(), nil, values...)
 	require.NoError(t, err)
 	tableID := int64(4)
 	indexID := int64(5)
@@ -494,7 +494,7 @@ func TestDecodeIndexKey(t *testing.T) {
 		valueStrs = append(valueStrs, str)
 	}
 	sc := stmtctx.NewStmtCtxWithTimeZone(time.UTC)
-	encodedValue, err := codec.EncodeKey(sc, nil, values...)
+	encodedValue, err := codec.EncodeKey(sc.TimeZone(), nil, values...)
 	require.NoError(t, err)
 	indexKey := EncodeIndexSeekKey(tableID, indexID, encodedValue)
 
@@ -601,7 +601,7 @@ func TestUntouchedIndexKValue(t *testing.T) {
 
 func TestTempIndexKey(t *testing.T) {
 	values := []types.Datum{types.NewIntDatum(1), types.NewBytesDatum([]byte("abc")), types.NewFloat64Datum(5.5)}
-	encodedValue, err := codec.EncodeKey(stmtctx.NewStmtCtxWithTimeZone(time.UTC), nil, values...)
+	encodedValue, err := codec.EncodeKey(stmtctx.NewStmtCtxWithTimeZone(time.UTC).TimeZone(), nil, values...)
 	require.NoError(t, err)
 	tableID := int64(4)
 	indexID := int64(5)
@@ -628,7 +628,7 @@ func TestTempIndexKey(t *testing.T) {
 
 func TestTempIndexValueCodec(t *testing.T) {
 	// Test encode temp index value.
-	encodedValue, err := codec.EncodeValue(stmtctx.NewStmtCtxWithTimeZone(time.UTC), nil, types.NewIntDatum(1))
+	encodedValue, err := codec.EncodeValue(stmtctx.NewStmtCtxWithTimeZone(time.UTC).TimeZone(), nil, types.NewIntDatum(1))
 	require.NoError(t, err)
 	encodedValueCopy := make([]byte, len(encodedValue))
 	copy(encodedValueCopy, encodedValue)

--- a/pkg/testkit/testutil/handle.go
+++ b/pkg/testkit/testutil/handle.go
@@ -30,7 +30,7 @@ import (
 
 // MustNewCommonHandle create a common handle with given values.
 func MustNewCommonHandle(t *testing.T, values ...interface{}) kv.Handle {
-	encoded, err := codec.EncodeKey(stmtctx.NewStmtCtx(), nil, types.MakeDatums(values...)...)
+	encoded, err := codec.EncodeKey(stmtctx.NewStmtCtx().TimeZone(), nil, types.MakeDatums(values...)...)
 	require.NoError(t, err)
 	ch, err := kv.NewCommonHandle(encoded)
 	require.NoError(t, err)

--- a/pkg/ttl/cache/split_test.go
+++ b/pkg/ttl/cache/split_test.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -205,7 +206,7 @@ func (s *mockTiKVStore) GetRegionCache() *tikv.RegionCache {
 }
 
 func bytesHandle(t *testing.T, data []byte) kv.Handle {
-	encoded, err := codec.EncodeKey(nil, nil, types.NewBytesDatum(data))
+	encoded, err := codec.EncodeKey(time.UTC, nil, types.NewBytesDatum(data))
 	require.NoError(t, err)
 	h, err := kv.NewCommonHandle(encoded)
 	require.NoError(t, err)
@@ -499,7 +500,7 @@ func TestNoTTLSplitSupportTables(t *testing.T) {
 func TestGetNextBytesHandleDatum(t *testing.T) {
 	tblID := int64(7)
 	buildHandleBytes := func(data []byte) []byte {
-		handleBytes, err := codec.EncodeKey(nil, nil, types.NewBytesDatum(data))
+		handleBytes, err := codec.EncodeKey(time.UTC, nil, types.NewBytesDatum(data))
 		require.NoError(t, err)
 		return handleBytes
 	}

--- a/pkg/ttl/cache/table.go
+++ b/pkg/ttl/cache/table.go
@@ -379,7 +379,7 @@ func (t *PhysicalTable) splitRawKeyRanges(ctx context.Context, store tikv.Storag
 var emptyBytesHandleKey kv.Key
 
 func init() {
-	key, err := codec.EncodeKey(nil, nil, types.NewBytesDatum(nil))
+	key, err := codec.EncodeKey(time.UTC, nil, types.NewBytesDatum(nil))
 	terror.MustNil(err)
 	emptyBytesHandleKey = key
 }

--- a/pkg/ttl/cache/task.go
+++ b/pkg/ttl/cache/task.go
@@ -68,11 +68,11 @@ func PeekWaitingTTLTask(hbExpire time.Time) (string, []interface{}) {
 // InsertIntoTTLTask returns an SQL statement to insert a ttl task into mysql.tidb_ttl_task
 func InsertIntoTTLTask(sctx sessionctx.Context, jobID string, tableID int64, scanID int, scanRangeStart []types.Datum,
 	scanRangeEnd []types.Datum, expireTime time.Time, createdTime time.Time) (string, []interface{}, error) {
-	rangeStart, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx, []byte{}, scanRangeStart...)
+	rangeStart, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx.TimeZone(), []byte{}, scanRangeStart...)
 	if err != nil {
 		return "", nil, err
 	}
-	rangeEnd, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx, []byte{}, scanRangeEnd...)
+	rangeEnd, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx.TimeZone(), []byte{}, scanRangeEnd...)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/ttl/cache/task_test.go
+++ b/pkg/ttl/cache/task_test.go
@@ -76,10 +76,10 @@ func TestRowToTTLTask(t *testing.T) {
 	require.Equal(t, now, task.ExpireTime)
 	require.Equal(t, now, task.CreatedTime)
 
-	rangeStart, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx,
+	rangeStart, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx.TimeZone(),
 		[]byte{}, []types.Datum{types.NewDatum(1)}...)
 	require.NoError(t, err)
-	rangeEnd, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx,
+	rangeEnd, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx.TimeZone(),
 		[]byte{}, []types.Datum{types.NewDatum(2)}...)
 	require.NoError(t, err)
 	tk.MustExec(

--- a/pkg/types/context.go
+++ b/pkg/types/context.go
@@ -250,3 +250,9 @@ const DefaultStmtFlags = StrictFlags | FlagAllowNegativeToUnsigned | FlagIgnoreZ
 var DefaultStmtNoWarningContext = NewContext(DefaultStmtFlags, time.UTC, func(_ error) {
 	// the error is ignored
 })
+
+// StrictContext is the most strict context which returns every error it meets
+var StrictContext = NewContext(StrictFlags, time.UTC, func(_ error) {
+	// this context should never append warnings
+	// However, the implementation of `types` may still append some warnings. TODO: remove them in the future.
+})

--- a/pkg/util/codec/BUILD.bazel
+++ b/pkg/util/codec/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/parser/mysql",
         "//pkg/parser/terror",
-        "//pkg/sessionctx/stmtctx",
         "//pkg/types",
         "//pkg/util/chunk",
         "//pkg/util/collate",

--- a/pkg/util/codec/bench_test.go
+++ b/pkg/util/codec/bench_test.go
@@ -16,6 +16,7 @@ package codec
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
@@ -30,7 +31,7 @@ func composeEncodedData(size int) []byte {
 	for i := 0; i < size; i++ {
 		values = append(values, types.NewDatum(i))
 	}
-	bs, _ := EncodeValue(nil, nil, values...)
+	bs, _ := EncodeValue(time.UTC, nil, values...)
 	return bs
 }
 

--- a/pkg/util/codec/codec.go
+++ b/pkg/util/codec/codec.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/collate"
@@ -84,7 +83,7 @@ func preRealloc(b []byte, vals []types.Datum, comparable1 bool) []byte {
 
 // encode will encode a datum and append it to a byte slice. If comparable1 is true, the encoded bytes can be sorted as it's original order.
 // If hash is true, the encoded bytes can be checked equal as it's original value.
-func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparable1 bool) (_ []byte, err error) {
+func encode(loc *time.Location, b []byte, vals []types.Datum, comparable1 bool) (_ []byte, err error) {
 	b = preRealloc(b, vals, comparable1)
 	for i, length := 0, len(vals); i < length; i++ {
 		switch vals[i].Kind() {
@@ -101,7 +100,7 @@ func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparab
 			b = encodeBytes(b, vals[i].GetBytes(), comparable1)
 		case types.KindMysqlTime:
 			b = append(b, uintFlag)
-			b, err = EncodeMySQLTime(sc, vals[i].GetMysqlTime(), mysql.TypeUnspecified, b)
+			b, err = EncodeMySQLTime(loc, vals[i].GetMysqlTime(), mysql.TypeUnspecified, b)
 			if err != nil {
 				return b, err
 			}
@@ -112,11 +111,6 @@ func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparab
 		case types.KindMysqlDecimal:
 			b = append(b, decimalFlag)
 			b, err = EncodeDecimal(b, vals[i].GetMysqlDecimal(), vals[i].Length(), vals[i].Frac())
-			if terror.ErrorEqual(err, types.ErrTruncated) {
-				err = sc.HandleTruncate(err)
-			} else if terror.ErrorEqual(err, types.ErrOverflow) {
-				err = sc.HandleOverflow(err, err)
-			}
 		case types.KindMysqlEnum:
 			b = encodeUnsignedInt(b, vals[i].GetMysqlEnum().Value, comparable1)
 		case types.KindMysqlSet:
@@ -124,7 +118,7 @@ func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparab
 		case types.KindMysqlBit, types.KindBinaryLiteral:
 			// We don't need to handle errors here since the literal is ensured to be able to store in uint64 in convertToMysqlBit.
 			var val uint64
-			val, err = vals[i].GetBinaryLiteral().ToInt(sc.TypeCtxOrDefault())
+			val, err = vals[i].GetBinaryLiteral().ToInt(types.StrictContext)
 			terror.Log(errors.Trace(err))
 			b = encodeUnsignedInt(b, val, comparable1)
 		case types.KindMysqlJSON:
@@ -147,7 +141,7 @@ func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparab
 }
 
 // EstimateValueSize uses to estimate the value  size of the encoded values.
-func EstimateValueSize(sc *stmtctx.StatementContext, val types.Datum) (int, error) {
+func EstimateValueSize(typeCtx types.Context, val types.Datum) (int, error) {
 	l := 0
 	switch val.Kind() {
 	case types.KindInt64:
@@ -170,7 +164,7 @@ func EstimateValueSize(sc *stmtctx.StatementContext, val types.Datum) (int, erro
 	case types.KindMysqlSet:
 		l = valueSizeOfUnsignedInt(val.GetMysqlSet().Value)
 	case types.KindMysqlBit, types.KindBinaryLiteral:
-		val, err := val.GetBinaryLiteral().ToInt(sc.TypeCtxOrDefault())
+		val, err := val.GetBinaryLiteral().ToInt(typeCtx)
 		terror.Log(errors.Trace(err))
 		l = valueSizeOfUnsignedInt(val)
 	case types.KindMysqlJSON:
@@ -184,14 +178,14 @@ func EstimateValueSize(sc *stmtctx.StatementContext, val types.Datum) (int, erro
 }
 
 // EncodeMySQLTime encodes datum of `KindMysqlTime` to []byte.
-func EncodeMySQLTime(sc *stmtctx.StatementContext, t types.Time, tp byte, b []byte) (_ []byte, err error) {
+func EncodeMySQLTime(loc *time.Location, t types.Time, tp byte, b []byte) (_ []byte, err error) {
 	// Encoding timestamp need to consider timezone. If it's not in UTC, transform to UTC first.
 	// This is compatible with `PBToExpr > convertTime`, and coprocessor assumes the passed timestamp is in UTC as well.
 	if tp == mysql.TypeUnspecified {
 		tp = t.Type()
 	}
-	if tp == mysql.TypeTimestamp && sc.TimeZone() != time.UTC {
-		err = t.ConvertTimeZone(sc.TimeZone(), time.UTC)
+	if tp == mysql.TypeTimestamp && loc != time.UTC {
+		err = t.ConvertTimeZone(loc, time.UTC)
 		if err != nil {
 			return nil, err
 		}
@@ -293,17 +287,17 @@ func sizeInt(comparable1 bool) int {
 // EncodeKey appends the encoded values to byte slice b, returns the appended
 // slice. It guarantees the encoded value is in ascending order for comparison.
 // For decimal type, datum must set datum's length and frac.
-func EncodeKey(sc *stmtctx.StatementContext, b []byte, v ...types.Datum) ([]byte, error) {
-	return encode(sc, b, v, true)
+func EncodeKey(loc *time.Location, b []byte, v ...types.Datum) ([]byte, error) {
+	return encode(loc, b, v, true)
 }
 
 // EncodeValue appends the encoded values to byte slice b, returning the appended
 // slice. It does not guarantee the order for comparison.
-func EncodeValue(sc *stmtctx.StatementContext, b []byte, v ...types.Datum) ([]byte, error) {
-	return encode(sc, b, v, false)
+func EncodeValue(loc *time.Location, b []byte, v ...types.Datum) ([]byte, error) {
+	return encode(loc, b, v, false)
 }
 
-func encodeHashChunkRowIdx(sc *stmtctx.StatementContext, row chunk.Row, tp *types.FieldType, idx int) (flag byte, b []byte, err error) {
+func encodeHashChunkRowIdx(typeCtx types.Context, row chunk.Row, tp *types.FieldType, idx int) (flag byte, b []byte, err error) {
 	if row.IsNull(idx) {
 		flag = NilFlag
 		return
@@ -384,7 +378,7 @@ func encodeHashChunkRowIdx(sc *stmtctx.StatementContext, row chunk.Row, tp *type
 	case mysql.TypeBit:
 		// We don't need to handle errors here since the literal is ensured to be able to store in uint64 in convertToMysqlBit.
 		flag = uvarintFlag
-		v, err1 := types.BinaryLiteral(row.GetBytes(idx)).ToInt(sc.TypeCtxOrDefault())
+		v, err1 := types.BinaryLiteral(row.GetBytes(idx)).ToInt(typeCtx)
 		terror.Log(errors.Trace(err1))
 		b = unsafe.Slice((*byte)(unsafe.Pointer(&v)), unsafe.Sizeof(v))
 	case mysql.TypeJSON:
@@ -398,13 +392,13 @@ func encodeHashChunkRowIdx(sc *stmtctx.StatementContext, row chunk.Row, tp *type
 }
 
 // HashChunkColumns writes the encoded value of each row's column, which of index `colIdx`, to h.
-func HashChunkColumns(sc *stmtctx.StatementContext, h []hash.Hash64, chk *chunk.Chunk, tp *types.FieldType, colIdx int, buf []byte, isNull []bool) (err error) {
-	return HashChunkSelected(sc, h, chk, tp, colIdx, buf, isNull, nil, false)
+func HashChunkColumns(typeCtx types.Context, h []hash.Hash64, chk *chunk.Chunk, tp *types.FieldType, colIdx int, buf []byte, isNull []bool) (err error) {
+	return HashChunkSelected(typeCtx, h, chk, tp, colIdx, buf, isNull, nil, false)
 }
 
 // HashChunkSelected writes the encoded value of selected row's column, which of index `colIdx`, to h.
 // sel indicates which rows are selected. If it is nil, all rows are selected.
-func HashChunkSelected(sc *stmtctx.StatementContext, h []hash.Hash64, chk *chunk.Chunk, tp *types.FieldType, colIdx int, buf []byte,
+func HashChunkSelected(typeCtx types.Context, h []hash.Hash64, chk *chunk.Chunk, tp *types.FieldType, colIdx int, buf []byte,
 	isNull, sel []bool, ignoreNull bool) (err error) {
 	var b []byte
 	column := chk.Column(colIdx)
@@ -629,7 +623,7 @@ func HashChunkSelected(sc *stmtctx.StatementContext, h []hash.Hash64, chk *chunk
 			} else {
 				// We don't need to handle errors here since the literal is ensured to be able to store in uint64 in convertToMysqlBit.
 				buf[0] = uvarintFlag
-				v, err1 := types.BinaryLiteral(column.GetBytes(i)).ToInt(sc.TypeCtxOrDefault())
+				v, err1 := types.BinaryLiteral(column.GetBytes(i)).ToInt(typeCtx)
 				terror.Log(errors.Trace(err1))
 				b = unsafe.Slice((*byte)(unsafe.Pointer(&v)), sizeUint64)
 			}
@@ -676,10 +670,10 @@ func HashChunkSelected(sc *stmtctx.StatementContext, h []hash.Hash64, chk *chunk
 
 // HashChunkRow writes the encoded values to w.
 // If two rows are logically equal, it will generate the same bytes.
-func HashChunkRow(sc *stmtctx.StatementContext, w io.Writer, row chunk.Row, allTypes []*types.FieldType, colIdx []int, buf []byte) (err error) {
+func HashChunkRow(typeCtx types.Context, w io.Writer, row chunk.Row, allTypes []*types.FieldType, colIdx []int, buf []byte) (err error) {
 	var b []byte
 	for i, idx := range colIdx {
-		buf[0], b, err = encodeHashChunkRowIdx(sc, row, allTypes[i], idx)
+		buf[0], b, err = encodeHashChunkRowIdx(typeCtx, row, allTypes[i], idx)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -697,7 +691,7 @@ func HashChunkRow(sc *stmtctx.StatementContext, w io.Writer, row chunk.Row, allT
 
 // EqualChunkRow returns a boolean reporting whether row1 and row2
 // with their types and column index are logically equal.
-func EqualChunkRow(sc *stmtctx.StatementContext,
+func EqualChunkRow(typeCtx types.Context,
 	row1 chunk.Row, allTypes1 []*types.FieldType, colIdx1 []int,
 	row2 chunk.Row, allTypes2 []*types.FieldType, colIdx2 []int,
 ) (bool, error) {
@@ -706,11 +700,11 @@ func EqualChunkRow(sc *stmtctx.StatementContext,
 	}
 	for i := range colIdx1 {
 		idx1, idx2 := colIdx1[i], colIdx2[i]
-		flag1, b1, err := encodeHashChunkRowIdx(sc, row1, allTypes1[i], idx1)
+		flag1, b1, err := encodeHashChunkRowIdx(typeCtx, row1, allTypes1[i], idx1)
 		if err != nil {
 			return false, errors.Trace(err)
 		}
-		flag2, b2, err := encodeHashChunkRowIdx(sc, row2, allTypes2[i], idx2)
+		flag2, b2, err := encodeHashChunkRowIdx(typeCtx, row2, allTypes2[i], idx2)
 		if err != nil {
 			return false, errors.Trace(err)
 		}
@@ -1232,7 +1226,7 @@ func appendFloatToChunk(val float64, chk *chunk.Chunk, colIdx int, ft *types.Fie
 
 // HashGroupKey encodes each row of this column and append encoded data into buf.
 // Only use in the aggregate executor.
-func HashGroupKey(sc *stmtctx.StatementContext, n int, col *chunk.Column, buf [][]byte, ft *types.FieldType) ([][]byte, error) {
+func HashGroupKey(loc *time.Location, n int, col *chunk.Column, buf [][]byte, ft *types.FieldType) ([][]byte, error) {
 	var err error
 	switch ft.EvalType() {
 	case types.ETInt:
@@ -1262,11 +1256,6 @@ func HashGroupKey(sc *stmtctx.StatementContext, n int, col *chunk.Column, buf []
 			} else {
 				buf[i] = append(buf[i], decimalFlag)
 				buf[i], err = EncodeDecimal(buf[i], &ds[i], ft.GetFlen(), ft.GetDecimal())
-				if terror.ErrorEqual(err, types.ErrTruncated) {
-					err = sc.HandleTruncate(err)
-				} else if terror.ErrorEqual(err, types.ErrOverflow) {
-					err = sc.HandleOverflow(err, err)
-				}
 				if err != nil {
 					return nil, err
 				}
@@ -1279,7 +1268,7 @@ func HashGroupKey(sc *stmtctx.StatementContext, n int, col *chunk.Column, buf []
 				buf[i] = append(buf[i], NilFlag)
 			} else {
 				buf[i] = append(buf[i], uintFlag)
-				buf[i], err = EncodeMySQLTime(sc, ts[i], mysql.TypeUnspecified, buf[i])
+				buf[i], err = EncodeMySQLTime(loc, ts[i], mysql.TypeUnspecified, buf[i])
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/util/codec/codec_test.go
+++ b/pkg/util/codec/codec_test.go
@@ -75,14 +75,14 @@ func TestCodecKey(t *testing.T) {
 	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	for i, datums := range table {
 		comment := fmt.Sprintf("%d %v", i, datums)
-		b, err := EncodeKey(sc, nil, datums.Input...)
+		b, err := EncodeKey(sc.TimeZone(), nil, datums.Input...)
 		require.NoError(t, err, comment)
 
 		args, err := Decode(b, 1)
 		require.NoError(t, err, comment)
 		require.Equal(t, datums.Expect, args, comment)
 
-		b, err = EncodeValue(sc, nil, datums.Input...)
+		b, err = EncodeValue(sc.TimeZone(), nil, datums.Input...)
 		require.NoError(t, err, comment)
 
 		size, err := estimateValuesSize(sc, datums.Input)
@@ -96,14 +96,14 @@ func TestCodecKey(t *testing.T) {
 
 	var raw types.Datum
 	raw.SetRaw([]byte("raw"))
-	_, err := EncodeKey(sc, nil, raw)
+	_, err := EncodeKey(sc.TimeZone(), nil, raw)
 	require.Error(t, err)
 }
 
 func estimateValuesSize(sc *stmtctx.StatementContext, vals []types.Datum) (int, error) {
 	size := 0
 	for _, val := range vals {
-		length, err := EstimateValueSize(sc, val)
+		length, err := EstimateValueSize(sc.TypeCtx(), val)
 		if err != nil {
 			return 0, err
 		}
@@ -216,10 +216,10 @@ func TestCodecKeyCompare(t *testing.T) {
 	}
 	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	for _, datums := range table {
-		b1, err := EncodeKey(sc, nil, datums.Left...)
+		b1, err := EncodeKey(sc.TimeZone(), nil, datums.Left...)
 		require.NoError(t, err)
 
-		b2, err := EncodeKey(sc, nil, datums.Right...)
+		b2, err := EncodeKey(sc.TimeZone(), nil, datums.Right...)
 		require.NoError(t, err)
 
 		comparedRes := bytes.Compare(b1, b2)
@@ -541,7 +541,7 @@ func TestTime(t *testing.T) {
 	for _, timeDatum := range tbl {
 		m := types.NewDatum(parseTime(t, timeDatum))
 
-		b, err := EncodeKey(sc, nil, m)
+		b, err := EncodeKey(sc.TimeZone(), nil, m)
 		require.NoError(t, err)
 		v, err := Decode(b, 1)
 		require.NoError(t, err)
@@ -568,9 +568,9 @@ func TestTime(t *testing.T) {
 		m1 := types.NewDatum(parseTime(t, timeData.Arg1))
 		m2 := types.NewDatum(parseTime(t, timeData.Arg2))
 
-		b1, err := EncodeKey(sc, nil, m1)
+		b1, err := EncodeKey(sc.TimeZone(), nil, m1)
 		require.NoError(t, err)
-		b2, err := EncodeKey(sc, nil, m2)
+		b2, err := EncodeKey(sc.TimeZone(), nil, m2)
 		require.NoError(t, err)
 
 		ret := bytes.Compare(b1, b2)
@@ -588,7 +588,7 @@ func TestDuration(t *testing.T) {
 	for _, duration := range tbl {
 		m := parseDuration(t, duration)
 
-		b, err := EncodeKey(sc, nil, types.NewDatum(m))
+		b, err := EncodeKey(sc.TimeZone(), nil, types.NewDatum(m))
 		require.NoError(t, err)
 		v, err := Decode(b, 1)
 		require.NoError(t, err)
@@ -610,9 +610,9 @@ func TestDuration(t *testing.T) {
 		m1 := parseDuration(t, durations.Arg1)
 		m2 := parseDuration(t, durations.Arg2)
 
-		b1, err := EncodeKey(sc, nil, types.NewDatum(m1))
+		b1, err := EncodeKey(sc.TimeZone(), nil, types.NewDatum(m1))
 		require.NoError(t, err)
-		b2, err := EncodeKey(sc, nil, types.NewDatum(m2))
+		b2, err := EncodeKey(sc.TimeZone(), nil, types.NewDatum(m2))
 		require.NoError(t, err)
 
 		ret := bytes.Compare(b1, b2)
@@ -643,7 +643,7 @@ func TestDecimal(t *testing.T) {
 		err := dec.FromString([]byte(decimalNum))
 		require.NoError(t, err)
 
-		b, err := EncodeKey(sc, nil, types.NewDatum(dec))
+		b, err := EncodeKey(sc.TimeZone(), nil, types.NewDatum(dec))
 		require.NoError(t, err)
 		v, err := Decode(b, 1)
 		require.NoError(t, err)
@@ -734,17 +734,17 @@ func TestDecimal(t *testing.T) {
 		d2.SetLength(30)
 		d2.SetFrac(6)
 
-		b1, err := EncodeKey(sc, nil, d1)
+		b1, err := EncodeKey(sc.TimeZone(), nil, d1)
 		require.NoError(t, err)
-		b2, err := EncodeKey(sc, nil, d2)
+		b2, err := EncodeKey(sc.TimeZone(), nil, d2)
 		require.NoError(t, err)
 
 		ret := bytes.Compare(b1, b2)
 		require.Equalf(t, decimalNums.Ret, ret, "%v %x %x", decimalNums, b1, b2)
 
-		b1, err = EncodeValue(sc, b1[:0], d1)
+		b1, err = EncodeValue(sc.TimeZone(), b1[:0], d1)
 		require.NoError(t, err)
-		size, err := EstimateValueSize(sc, d1)
+		size, err := EstimateValueSize(sc.TypeCtx(), d1)
 		require.NoError(t, err)
 		require.Len(t, b1, size)
 	}
@@ -761,7 +761,7 @@ func TestDecimal(t *testing.T) {
 		b, err := EncodeDecimal(nil, d.GetMysqlDecimal(), d.Length(), d.Frac())
 		require.NoError(t, err)
 		decs = append(decs, b)
-		size, err := EstimateValueSize(sc, d)
+		size, err := EstimateValueSize(sc.TypeCtx(), d)
 		require.NoError(t, err)
 		// size - 1 because the flag occupy 1 bit.
 		require.Len(t, b, size-1)
@@ -782,13 +782,15 @@ func TestDecimal(t *testing.T) {
 	decimalDatum := types.NewDatum(d)
 	decimalDatum.SetLength(20)
 	decimalDatum.SetFrac(5)
-	_, err = EncodeValue(sc, nil, decimalDatum)
+	_, err = EncodeValue(sc.TimeZone(), nil, decimalDatum)
+	err = sc.HandleError(err)
 	require.NoError(t, err)
 
 	sc.OverflowAsWarning = true
 	decimalDatum.SetLength(12)
 	decimalDatum.SetFrac(10)
-	_, err = EncodeValue(sc, nil, decimalDatum)
+	_, err = EncodeValue(sc.TimeZone(), nil, decimalDatum)
+	err = sc.HandleError(err)
 	require.NoError(t, err)
 }
 
@@ -878,7 +880,7 @@ func TestCut(t *testing.T) {
 	}
 	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	for i, datums := range table {
-		b, err := EncodeKey(sc, nil, datums.Input...)
+		b, err := EncodeKey(sc.TimeZone(), nil, datums.Input...)
 		require.NoErrorf(t, err, "%d %v", i, datums)
 
 		var d []byte
@@ -887,7 +889,7 @@ func TestCut(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, d)
 
-			ed, err1 := EncodeKey(sc, nil, e)
+			ed, err1 := EncodeKey(sc.TimeZone(), nil, e)
 			require.NoError(t, err1)
 			require.Equalf(t, ed, d, "%d:%d %#v", i, j, e)
 		}
@@ -895,7 +897,7 @@ func TestCut(t *testing.T) {
 	}
 
 	for i, datums := range table {
-		b, err := EncodeValue(sc, nil, datums.Input...)
+		b, err := EncodeValue(sc.TimeZone(), nil, datums.Input...)
 		require.NoErrorf(t, err, "%d %v", i, datums)
 
 		var d []byte
@@ -904,7 +906,7 @@ func TestCut(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, d)
 
-			ed, err1 := EncodeValue(sc, nil, e)
+			ed, err1 := EncodeValue(sc.TimeZone(), nil, e)
 			require.NoError(t, err1)
 			require.Equalf(t, ed, d, "%d:%d %#v", i, j, e)
 		}
@@ -912,7 +914,7 @@ func TestCut(t *testing.T) {
 	}
 
 	input := 42
-	b, err := EncodeValue(sc, nil, types.NewDatum(input))
+	b, err := EncodeValue(sc.TimeZone(), nil, types.NewDatum(input))
 	require.NoError(t, err)
 	rem, n, err := CutColumnID(b)
 	require.NoError(t, err)
@@ -935,7 +937,7 @@ func TestCutOneError(t *testing.T) {
 func TestSetRawValues(t *testing.T) {
 	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	datums := types.MakeDatums(1, "abc", 1.1, []byte("def"))
-	rowData, err := EncodeValue(sc, nil, datums...)
+	rowData, err := EncodeValue(sc.TimeZone(), nil, datums...)
 	require.NoError(t, err)
 
 	values := make([]types.Datum, 4)
@@ -944,7 +946,7 @@ func TestSetRawValues(t *testing.T) {
 
 	for i, rawVal := range values {
 		require.IsType(t, types.KindRaw, rawVal.Kind())
-		encoded, encodedErr := EncodeValue(sc, nil, datums[i])
+		encoded, encodedErr := EncodeValue(sc.TimeZone(), nil, datums[i])
 		require.NoError(t, encodedErr)
 		require.Equal(t, rawVal.GetBytes(), encoded)
 	}
@@ -988,13 +990,13 @@ func TestHashGroup(t *testing.T) {
 	tp1 := tp
 	tp1.SetFlen(20)
 	tp1.SetDecimal(5)
-	_, err := HashGroupKey(sc, 3, chk1.Column(0), buf1, tp1)
+	_, err := HashGroupKey(sc.TimeZone(), 3, chk1.Column(0), buf1, tp1)
 	require.Error(t, err)
 
 	tp2 := tp
 	tp2.SetFlen(12)
 	tp2.SetDecimal(10)
-	_, err = HashGroupKey(sc, 3, chk1.Column(0), buf1, tp2)
+	_, err = HashGroupKey(sc.TimeZone(), 3, chk1.Column(0), buf1, tp2)
 	require.Error(t, err)
 }
 
@@ -1068,7 +1070,7 @@ func datumsForTest(_ *stmtctx.StatementContext) ([]types.Datum, []*types.FieldTy
 func chunkForTest(t *testing.T, sc *stmtctx.StatementContext, datums []types.Datum, tps []*types.FieldType, rowCount int) *chunk.Chunk {
 	decoder := NewDecoder(chunk.New(tps, 32, 32), sc.TimeZone())
 	for rowIdx := 0; rowIdx < rowCount; rowIdx++ {
-		encoded, err := EncodeValue(sc, nil, datums...)
+		encoded, err := EncodeValue(sc.TimeZone(), nil, datums...)
 		require.NoError(t, err)
 		decoder.buf = make([]byte, 0, len(encoded))
 		for colIdx, tp := range tps {
@@ -1084,7 +1086,7 @@ func TestDecodeRange(t *testing.T) {
 	require.Error(t, err)
 
 	datums := types.MakeDatums(1, "abc", 1.1, []byte("def"))
-	rowData, err := EncodeValue(nil, nil, datums...)
+	rowData, err := EncodeValue(time.UTC, nil, datums...)
 	require.NoError(t, err)
 
 	datums1, _, err := DecodeRange(rowData, len(datums), nil, nil)
@@ -1122,10 +1124,10 @@ func testHashChunkRowEqual(t *testing.T, a, b interface{}, equal bool) {
 	chk2.AppendDatum(0, &d)
 
 	h := crc32.NewIEEE()
-	err1 := HashChunkRow(sc, h, chk1.GetRow(0), []*types.FieldType{tp1}, []int{0}, buf1)
+	err1 := HashChunkRow(sc.TypeCtx(), h, chk1.GetRow(0), []*types.FieldType{tp1}, []int{0}, buf1)
 	sum1 := h.Sum32()
 	h.Reset()
-	err2 := HashChunkRow(sc, h, chk2.GetRow(0), []*types.FieldType{tp2}, []int{0}, buf2)
+	err2 := HashChunkRow(sc.TypeCtx(), h, chk2.GetRow(0), []*types.FieldType{tp2}, []int{0}, buf2)
 	sum2 := h.Sum32()
 	require.NoError(t, err1)
 	require.NoError(t, err2)
@@ -1134,7 +1136,7 @@ func testHashChunkRowEqual(t *testing.T, a, b interface{}, equal bool) {
 	} else {
 		require.NotEqual(t, sum2, sum1)
 	}
-	e, err := EqualChunkRow(sc,
+	e, err := EqualChunkRow(sc.TypeCtx(),
 		chk1.GetRow(0), []*types.FieldType{tp1}, []int{0},
 		chk2.GetRow(0), []*types.FieldType{tp2}, []int{0})
 	require.NoError(t, err)
@@ -1156,16 +1158,16 @@ func TestHashChunkRow(t *testing.T) {
 		colIdx[i] = i
 	}
 	h := crc32.NewIEEE()
-	err1 := HashChunkRow(sc, h, chk.GetRow(0), tps, colIdx, buf)
+	err1 := HashChunkRow(sc.TypeCtx(), h, chk.GetRow(0), tps, colIdx, buf)
 	sum1 := h.Sum32()
 	h.Reset()
-	err2 := HashChunkRow(sc, h, chk.GetRow(0), tps, colIdx, buf)
+	err2 := HashChunkRow(sc.TypeCtx(), h, chk.GetRow(0), tps, colIdx, buf)
 	sum2 := h.Sum32()
 
 	require.NoError(t, err1)
 	require.NoError(t, err2)
 	require.Equal(t, sum2, sum1)
-	e, err := EqualChunkRow(sc,
+	e, err := EqualChunkRow(sc.TypeCtx(),
 		chk.GetRow(0), tps, colIdx,
 		chk.GetRow(0), tps, colIdx)
 	require.NoError(t, err)
@@ -1255,10 +1257,10 @@ func TestHashChunkColumns(t *testing.T) {
 	// Test hash value of the first 12 `Null` columns
 	for i := 0; i < 12; i++ {
 		require.True(t, chk.GetRow(0).IsNull(i))
-		err1 := HashChunkSelected(sc, vecHash, chk, tps[i], i, buf, hasNull, sel, false)
-		err2 := HashChunkRow(sc, rowHash[0], chk.GetRow(0), tps[i:i+1], colIdx[i:i+1], buf)
-		err3 := HashChunkRow(sc, rowHash[1], chk.GetRow(1), tps[i:i+1], colIdx[i:i+1], buf)
-		err4 := HashChunkRow(sc, rowHash[2], chk.GetRow(2), tps[i:i+1], colIdx[i:i+1], buf)
+		err1 := HashChunkSelected(sc.TypeCtx(), vecHash, chk, tps[i], i, buf, hasNull, sel, false)
+		err2 := HashChunkRow(sc.TypeCtx(), rowHash[0], chk.GetRow(0), tps[i:i+1], colIdx[i:i+1], buf)
+		err3 := HashChunkRow(sc.TypeCtx(), rowHash[1], chk.GetRow(1), tps[i:i+1], colIdx[i:i+1], buf)
+		err4 := HashChunkRow(sc.TypeCtx(), rowHash[2], chk.GetRow(2), tps[i:i+1], colIdx[i:i+1], buf)
 		require.NoError(t, err1)
 		require.NoError(t, err2)
 		require.NoError(t, err3)
@@ -1280,10 +1282,10 @@ func TestHashChunkColumns(t *testing.T) {
 
 		require.False(t, chk.GetRow(0).IsNull(i))
 
-		err1 := HashChunkSelected(sc, vecHash, chk, tps[i], i, buf, hasNull, sel, false)
-		err2 := HashChunkRow(sc, rowHash[0], chk.GetRow(0), tps[i:i+1], colIdx[i:i+1], buf)
-		err3 := HashChunkRow(sc, rowHash[1], chk.GetRow(1), tps[i:i+1], colIdx[i:i+1], buf)
-		err4 := HashChunkRow(sc, rowHash[2], chk.GetRow(2), tps[i:i+1], colIdx[i:i+1], buf)
+		err1 := HashChunkSelected(sc.TypeCtx(), vecHash, chk, tps[i], i, buf, hasNull, sel, false)
+		err2 := HashChunkRow(sc.TypeCtx(), rowHash[0], chk.GetRow(0), tps[i:i+1], colIdx[i:i+1], buf)
+		err3 := HashChunkRow(sc.TypeCtx(), rowHash[1], chk.GetRow(1), tps[i:i+1], colIdx[i:i+1], buf)
+		err4 := HashChunkRow(sc.TypeCtx(), rowHash[2], chk.GetRow(2), tps[i:i+1], colIdx[i:i+1], buf)
 
 		require.NoError(t, err1)
 		require.NoError(t, err2)

--- a/pkg/util/codec/collation_test.go
+++ b/pkg/util/codec/collation_test.go
@@ -52,10 +52,10 @@ func TestHashGroupKeyCollation(t *testing.T) {
 	tp.SetCollate("utf8_general_ci")
 	buf1 := make([][]byte, n)
 	buf2 := make([][]byte, n)
-	buf1, err := HashGroupKey(sc, n, chk1.Column(0), buf1, tp)
+	buf1, err := HashGroupKey(sc.TimeZone(), n, chk1.Column(0), buf1, tp)
 	require.NoError(t, err)
 
-	buf2, err = HashGroupKey(sc, n, chk2.Column(0), buf2, tp)
+	buf2, err = HashGroupKey(sc.TimeZone(), n, chk2.Column(0), buf2, tp)
 	require.NoError(t, err)
 
 	for i := 0; i < n; i++ {
@@ -68,9 +68,9 @@ func TestHashGroupKeyCollation(t *testing.T) {
 	tp.SetCollate("utf8_unicode_ci")
 	buf1 = make([][]byte, n)
 	buf2 = make([][]byte, n)
-	buf1, err = HashGroupKey(sc, n, chk1.Column(0), buf1, tp)
+	buf1, err = HashGroupKey(sc.TimeZone(), n, chk1.Column(0), buf1, tp)
 	require.NoError(t, err)
-	buf2, err = HashGroupKey(sc, n, chk2.Column(0), buf2, tp)
+	buf2, err = HashGroupKey(sc.TimeZone(), n, chk2.Column(0), buf2, tp)
 	require.NoError(t, err)
 
 	for i := 0; i < n; i++ {
@@ -93,8 +93,8 @@ func TestHashChunkRowCollation(t *testing.T) {
 	for i := 0; i < n; i++ {
 		h1 := crc32.NewIEEE()
 		h2 := crc32.NewIEEE()
-		require.NoError(t, HashChunkRow(sc, h1, chk1.GetRow(i), tps, cols, buf))
-		require.NoError(t, HashChunkRow(sc, h2, chk2.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(sc.TypeCtx(), h1, chk1.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(sc.TypeCtx(), h2, chk2.GetRow(i), tps, cols, buf))
 		require.NotEqual(t, h2.Sum32(), h1.Sum32())
 		h1.Reset()
 		h2.Reset()
@@ -104,8 +104,8 @@ func TestHashChunkRowCollation(t *testing.T) {
 	for i := 0; i < n; i++ {
 		h1 := crc32.NewIEEE()
 		h2 := crc32.NewIEEE()
-		require.NoError(t, HashChunkRow(sc, h1, chk1.GetRow(i), tps, cols, buf))
-		require.NoError(t, HashChunkRow(sc, h2, chk2.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(sc.TypeCtx(), h1, chk1.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(sc.TypeCtx(), h2, chk2.GetRow(i), tps, cols, buf))
 		require.Equal(t, h2.Sum32(), h1.Sum32())
 		h1.Reset()
 		h2.Reset()
@@ -115,8 +115,8 @@ func TestHashChunkRowCollation(t *testing.T) {
 	for i := 0; i < n; i++ {
 		h1 := crc32.NewIEEE()
 		h2 := crc32.NewIEEE()
-		require.NoError(t, HashChunkRow(sc, h1, chk1.GetRow(i), tps, cols, buf))
-		require.NoError(t, HashChunkRow(sc, h2, chk2.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(sc.TypeCtx(), h1, chk1.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(sc.TypeCtx(), h2, chk2.GetRow(i), tps, cols, buf))
 		require.Equal(t, h2.Sum32(), h1.Sum32())
 		h1.Reset()
 		h2.Reset()
@@ -133,8 +133,8 @@ func TestHashChunkColumnsCollation(t *testing.T) {
 	h2s := []hash.Hash64{fnv.New64(), fnv.New64(), fnv.New64()}
 
 	tp.SetCollate("binary")
-	require.NoError(t, HashChunkColumns(sc, h1s, chk1, tp, 0, buf, hasNull))
-	require.NoError(t, HashChunkColumns(sc, h2s, chk2, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h1s, chk1, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h2s, chk2, tp, 0, buf, hasNull))
 
 	for i := 0; i < n; i++ {
 		require.NotEqual(t, h2s[i].Sum64(), h1s[i].Sum64())
@@ -143,15 +143,15 @@ func TestHashChunkColumnsCollation(t *testing.T) {
 	}
 
 	tp.SetCollate("utf8_general_ci")
-	require.NoError(t, HashChunkColumns(sc, h1s, chk1, tp, 0, buf, hasNull))
-	require.NoError(t, HashChunkColumns(sc, h2s, chk2, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h1s, chk1, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h2s, chk2, tp, 0, buf, hasNull))
 	for i := 0; i < n; i++ {
 		require.Equal(t, h2s[i].Sum64(), h1s[i].Sum64())
 	}
 
 	tp.SetCollate("utf8_unicode_ci")
-	require.NoError(t, HashChunkColumns(sc, h1s, chk1, tp, 0, buf, hasNull))
-	require.NoError(t, HashChunkColumns(sc, h2s, chk2, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h1s, chk1, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h2s, chk2, tp, 0, buf, hasNull))
 	for i := 0; i < n; i++ {
 		require.Equal(t, h2s[i].Sum64(), h1s[i].Sum64())
 	}

--- a/pkg/util/keydecoder/keydecoder_test.go
+++ b/pkg/util/keydecoder/keydecoder_test.go
@@ -117,7 +117,7 @@ func TestDecodeKey(t *testing.T) {
 
 	values := types.MakeDatums("abc", 1)
 	sc := stmtctx.NewStmtCtx()
-	encodedValue, err := codec.EncodeKey(sc, nil, values...)
+	encodedValue, err := codec.EncodeKey(sc.TimeZone(), nil, values...)
 	assert.Nil(t, err)
 	key = []byte{
 		't',
@@ -166,7 +166,7 @@ func TestDecodeKey(t *testing.T) {
 
 	// Index key in a partitioned table.
 	values = types.MakeDatums("abcde", 2)
-	encodedValue, err = codec.EncodeKey(sc, nil, values...)
+	encodedValue, err = codec.EncodeKey(sc.TimeZone(), nil, values...)
 	assert.Nil(t, err)
 	key = []byte("t\x80\x00\x00\x00\x00\x00\x00\x06_i\x80\x00\x00\x00\x00\x00\x00\x04")
 	key = append(key, encodedValue...)

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -39,14 +39,16 @@ import (
 
 func validInterval(sctx sessionctx.Context, low, high *point) (bool, error) {
 	sc := sctx.GetSessionVars().StmtCtx
-	l, err := codec.EncodeKey(sc, nil, low.value)
+	l, err := codec.EncodeKey(sc.TimeZone(), nil, low.value)
+	err = sc.HandleError(err)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
 	if low.excl {
 		l = kv.Key(l).PrefixNext()
 	}
-	r, err := codec.EncodeKey(sc, nil, high.value)
+	r, err := codec.EncodeKey(sc.TimeZone(), nil, high.value)
+	err = sc.HandleError(err)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
@@ -571,14 +573,16 @@ func UnionRanges(sctx sessionctx.Context, ranges Ranges, mergeConsecutive bool) 
 	}
 	objects := make([]*sortRange, 0, len(ranges))
 	for _, ran := range ranges {
-		left, err := codec.EncodeKey(sc, nil, ran.LowVal...)
+		left, err := codec.EncodeKey(sc.TimeZone(), nil, ran.LowVal...)
+		err = sc.HandleError(err)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		if ran.LowExclude {
 			left = kv.Key(left).PrefixNext()
 		}
-		right, err := codec.EncodeKey(sc, nil, ran.HighVal...)
+		right, err := codec.EncodeKey(sc.TimeZone(), nil, ran.HighVal...)
+		err = sc.HandleError(err)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/pkg/util/ranger/types.go
+++ b/pkg/util/ranger/types.go
@@ -195,14 +195,16 @@ func (ran *Range) String() string {
 // Encode encodes the range to its encoded value.
 func (ran *Range) Encode(sc *stmtctx.StatementContext, lowBuffer, highBuffer []byte) ([]byte, []byte, error) {
 	var err error
-	lowBuffer, err = codec.EncodeKey(sc, lowBuffer[:0], ran.LowVal...)
+	lowBuffer, err = codec.EncodeKey(sc.TimeZone(), lowBuffer[:0], ran.LowVal...)
+	err = sc.HandleError(err)
 	if err != nil {
 		return nil, nil, err
 	}
 	if ran.LowExclude {
 		lowBuffer = kv.Key(lowBuffer).PrefixNext()
 	}
-	highBuffer, err = codec.EncodeKey(sc, highBuffer[:0], ran.HighVal...)
+	highBuffer, err = codec.EncodeKey(sc.TimeZone(), highBuffer[:0], ran.HighVal...)
+	err = sc.HandleError(err)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tests/realtikvtest/pessimistictest/pessimistic_test.go
+++ b/tests/realtikvtest/pessimistictest/pessimistic_test.go
@@ -2835,7 +2835,7 @@ func TestRCPointWriteLockIfExists(t *testing.T) {
 	tk.MustQuery("show variables like 'transaction_isolation'").Check(testkit.Rows("transaction_isolation READ-COMMITTED"))
 
 	tableID := external.GetTableByName(t, tk, "test", "t1").Meta().ID
-	idxVal, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx, nil, types.NewIntDatum(1))
+	idxVal, err := codec.EncodeKey(tk.Session().GetSessionVars().StmtCtx.TimeZone(), nil, types.NewIntDatum(1))
 	require.NoError(t, err)
 	secIdxKey1 := tablecodec.EncodeIndexSeekKey(tableID, 1, idxVal)
 	key1 := tablecodec.EncodeRowKeyWithHandle(tableID, kv.IntHandle(1))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #48611

Problem Summary:

This PR adds an error context to handle the error. The function signature is:

```
func (ctx *Context) HandleError(err error) error

func (ctx *Context) HandleErrorWithAlias(internalErr error, err error, warnErr error) error
```

According to the `internalErr` and the error level, it can choose to return the `err` or append the `warnErr` to warnings. This PR also uses this context to modify the `util/codec` package to show its ability (and make this PR do have some effect). The main part of this PR is the first commit: https://github.com/YangKeao/tidb/commit/75401b5812032bf35d96afa94e14f1e7b31e60ce . 

Another thing may need to discuss is about how to combine multiple contexts. I used two separated arguments here. Would it be better to use a single one (e.g. `CodecContext`, which contains the type context and error context) and unifying them as one argument?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Other refractors are covered by existing tests.

### Release note

```release-note
None
```
