### PR TITLE
build: don't run linter on excluded files

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "nogo")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "nogo")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//build/linter/staticcheck:def.bzl", "staticcheck_analyzers")
 
@@ -180,4 +180,14 @@ nogo(
                ],
                "//conditions:default": [],
            }),
+)
+
+go_library(
+    name = "build",
+    srcs = ["config.go"],
+    embedsrcs = [
+        "nogo_config.json",
+    ],
+    importpath = "github.com/pingcap/tidb/build",
+    visibility = ["//visibility:public"],
 )

--- a/build/config.go
+++ b/build/config.go
@@ -1,0 +1,42 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	_ "embed"
+	"encoding/json"
+)
+
+//go:embed nogo_config.json
+var configFile []byte
+
+// NogoConfig is the nogo config file
+var NogoConfig NogoConfigFormat
+
+// NogoConfigFormat is the format of the nogo config file
+type NogoConfigFormat map[string]AnalysisConfig
+
+// AnalysisConfig represents the config of an analysis pass
+type AnalysisConfig struct {
+	ExcludeFiles map[string]string `json:"exclude_files"`
+	OnlyFiles    map[string]string `json:"only_files"`
+}
+
+func init() {
+	err := json.Unmarshal(configFile, &NogoConfig)
+	if err != nil {
+		panic("fail to parse nogo_config.json")
+	}
+}

--- a/build/linter/allrevive/analyzer.go
+++ b/build/linter/allrevive/analyzer.go
@@ -123,7 +123,12 @@ var allRules = append([]lint.Rule{
 func run(pass *analysis.Pass) (any, error) {
 	files := make([]string, 0, len(pass.Files))
 	for _, file := range pass.Files {
-		files = append(files, pass.Fset.PositionFor(file.Pos(), false).Filename)
+		fileName := pass.Fset.PositionFor(file.Pos(), false).Filename
+		if !util.ShouldRun("all_revive", fileName) {
+			continue
+		}
+
+		files = append(files, fileName)
 	}
 	packages := [][]string{files}
 

--- a/build/linter/allrevive/analyzer.go
+++ b/build/linter/allrevive/analyzer.go
@@ -37,6 +37,7 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }
 
@@ -123,12 +124,7 @@ var allRules = append([]lint.Rule{
 func run(pass *analysis.Pass) (any, error) {
 	files := make([]string, 0, len(pass.Files))
 	for _, file := range pass.Files {
-		fileName := pass.Fset.PositionFor(file.Pos(), false).Filename
-		if !util.ShouldRun("all_revive", fileName) {
-			continue
-		}
-
-		files = append(files, fileName)
+		files = append(files, pass.Fset.PositionFor(file.Pos(), false).Filename)
 	}
 	packages := [][]string{files}
 

--- a/build/linter/asciicheck/BUILD.bazel
+++ b/build/linter/asciicheck/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["analysis.go"],
     importpath = "github.com/pingcap/tidb/build/linter/asciicheck",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_tdakkota_asciicheck//:asciicheck"],
+    deps = [
+        "//build/linter/util",
+        "@com_github_tdakkota_asciicheck//:asciicheck",
+    ],
 )

--- a/build/linter/asciicheck/analysis.go
+++ b/build/linter/asciicheck/analysis.go
@@ -14,7 +14,14 @@
 
 package asciicheck
 
-import "github.com/tdakkota/asciicheck"
+import (
+	"github.com/pingcap/tidb/build/linter/util"
+	"github.com/tdakkota/asciicheck"
+)
 
 // Analyzer is the analyzer struct of asciicheck.
 var Analyzer = asciicheck.NewAnalyzer()
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
+}

--- a/build/linter/bootstrap/BUILD.bazel
+++ b/build/linter/bootstrap/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["analyzer.go"],
     importpath = "github.com/pingcap/tidb/build/linter/bootstrap",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_tools//go/analysis"],
+    deps = [
+        "//build/linter/util",
+        "@org_golang_x_tools//go/analysis",
+    ],
 )

--- a/build/linter/bootstrap/analyzer.go
+++ b/build/linter/bootstrap/analyzer.go
@@ -38,11 +38,7 @@ const (
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
-		fileName := pass.Fset.File(file.Pos()).Name()
-		if !strings.HasSuffix(fileName, bootstrapCodeFile) {
-			continue
-		}
-		if !util.ShouldRun("bootstrap", fileName) {
+		if !strings.HasSuffix(pass.Fset.File(file.Pos()).Name(), bootstrapCodeFile) {
 			continue
 		}
 
@@ -135,4 +131,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		pass.Reportf(curVerVariablePos, "current version variable: %d", curVerVariable)
 	}
 	return nil, nil
+}
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 }

--- a/build/linter/bootstrap/analyzer.go
+++ b/build/linter/bootstrap/analyzer.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pingcap/tidb/build/linter/util"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -39,6 +40,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
 		fileName := pass.Fset.File(file.Pos()).Name()
 		if !strings.HasSuffix(fileName, bootstrapCodeFile) {
+			continue
+		}
+		if !util.ShouldRun("bootstrap", fileName) {
 			continue
 		}
 

--- a/build/linter/constructor/BUILD.bazel
+++ b/build/linter/constructor/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/build/linter/constructor",
     visibility = ["//visibility:public"],
     deps = [
+        "//build/linter/util",
         "@com_github_fatih_structtag//:structtag",
         "@org_golang_x_tools//go/analysis",
         "@org_golang_x_tools//go/ast/inspector",

--- a/build/linter/constructor/analyzer.go
+++ b/build/linter/constructor/analyzer.go
@@ -158,11 +158,6 @@ func handleValueSpec(pass *analysis.Pass, n *ast.ValueSpec, _ bool, stack []ast.
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
-		fileName := pass.Fset.PositionFor(file.Pos(), false).Filename
-		if !util.ShouldRun("constructor", fileName) {
-			continue
-		}
-
 		i := inspector.New([]*ast.File{file})
 
 		i.WithStack([]ast.Node{&ast.CompositeLit{}, &ast.CallExpr{}, &ast.ValueSpec{}}, func(n ast.Node, push bool, stack []ast.Node) bool {
@@ -179,4 +174,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		})
 	}
 	return nil, nil
+}
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 }

--- a/build/linter/constructor/analyzer.go
+++ b/build/linter/constructor/analyzer.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/fatih/structtag"
+	"github.com/pingcap/tidb/build/linter/util"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/ast/inspector"
 )
@@ -157,6 +158,11 @@ func handleValueSpec(pass *analysis.Pass, n *ast.ValueSpec, _ bool, stack []ast.
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
+		fileName := pass.Fset.PositionFor(file.Pos(), false).Filename
+		if !util.ShouldRun("constructor", fileName) {
+			continue
+		}
+
 		i := inspector.New([]*ast.File{file})
 
 		i.WithStack([]ast.Node{&ast.CompositeLit{}, &ast.CallExpr{}, &ast.ValueSpec{}}, func(n ast.Node, push bool, stack []ast.Node) bool {

--- a/build/linter/deferrecover/analyzer.go
+++ b/build/linter/deferrecover/analyzer.go
@@ -39,11 +39,6 @@ const (
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
-		fileName := pass.Fset.PositionFor(file.Pos(), false).Filename
-		if !util.ShouldRun("recover", fileName) {
-			continue
-		}
-
 		packageName := util.GetPackageName(file.Imports, packagePath, packageName)
 		if packageName == "" {
 			continue
@@ -82,4 +77,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		})
 	}
 	return nil, nil
+}
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 }

--- a/build/linter/deferrecover/analyzer.go
+++ b/build/linter/deferrecover/analyzer.go
@@ -39,6 +39,11 @@ const (
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
+		fileName := pass.Fset.PositionFor(file.Pos(), false).Filename
+		if !util.ShouldRun("recover", fileName) {
+			continue
+		}
+
 		packageName := util.GetPackageName(file.Imports, packagePath, packageName)
 		if packageName == "" {
 			continue

--- a/build/linter/durationcheck/analyzer.go
+++ b/build/linter/durationcheck/analyzer.go
@@ -23,5 +23,6 @@ import (
 var Analyzer = durationcheck.Analyzer
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/errcheck/analyzer.go
+++ b/build/linter/errcheck/analyzer.go
@@ -34,5 +34,6 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/etcdconfig/analyzer.go
+++ b/build/linter/etcdconfig/analyzer.go
@@ -38,11 +38,6 @@ const (
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
-		fileName := pass.Fset.PositionFor(file.Pos(), false).Filename
-		if !util.ShouldRun("etcdconfig", fileName) {
-			continue
-		}
-
 		packageName := util.GetPackageName(file.Imports, configPackagePath, configPackageName)
 		if packageName == "" {
 			continue
@@ -92,4 +87,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 	}
 	return nil, nil
+}
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 }

--- a/build/linter/etcdconfig/analyzer.go
+++ b/build/linter/etcdconfig/analyzer.go
@@ -38,6 +38,11 @@ const (
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
+		fileName := pass.Fset.PositionFor(file.Pos(), false).Filename
+		if !util.ShouldRun("etcdconfig", fileName) {
+			continue
+		}
+
 		packageName := util.GetPackageName(file.Imports, configPackagePath, configPackageName)
 		if packageName == "" {
 			continue

--- a/build/linter/exportloopref/BUILD.bazel
+++ b/build/linter/exportloopref/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["analyzer.go"],
     importpath = "github.com/pingcap/tidb/build/linter/exportloopref",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_kyoh86_exportloopref//:exportloopref"],
+    deps = [
+        "//build/linter/util",
+        "@com_github_kyoh86_exportloopref//:exportloopref",
+    ],
 )

--- a/build/linter/exportloopref/analyzer.go
+++ b/build/linter/exportloopref/analyzer.go
@@ -14,7 +14,14 @@
 
 package exportloopref
 
-import "github.com/kyoh86/exportloopref"
+import (
+	"github.com/kyoh86/exportloopref"
+	"github.com/pingcap/tidb/build/linter/util"
+)
 
 // Analyzer is the analyzer struct of exportloopref.
 var Analyzer = exportloopref.Analyzer
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
+}

--- a/build/linter/filepermission/BUILD.bazel
+++ b/build/linter/filepermission/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["checker.go"],
     importpath = "github.com/pingcap/tidb/build/linter/filepermission",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_tools//go/analysis"],
+    deps = [
+        "//build/linter/util",
+        "@org_golang_x_tools//go/analysis",
+    ],
 )

--- a/build/linter/filepermission/checker.go
+++ b/build/linter/filepermission/checker.go
@@ -34,10 +34,6 @@ var Analyzer = &analysis.Analyzer{
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, f := range pass.Files {
 		fn := pass.Fset.PositionFor(f.Pos(), false).Filename
-		if !util.ShouldRun(Name, fn) {
-			continue
-		}
-
 		if fn != "" {
 			stat, err := os.Stat(fn)
 			if err != nil {
@@ -50,4 +46,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	return nil, nil
+}
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 }

--- a/build/linter/filepermission/checker.go
+++ b/build/linter/filepermission/checker.go
@@ -17,6 +17,7 @@ package filepermission
 import (
 	"os"
 
+	"github.com/pingcap/tidb/build/linter/util"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -33,6 +34,10 @@ var Analyzer = &analysis.Analyzer{
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, f := range pass.Files {
 		fn := pass.Fset.PositionFor(f.Pos(), false).Filename
+		if !util.ShouldRun(Name, fn) {
+			continue
+		}
+
 		if fn != "" {
 			stat, err := os.Stat(fn)
 			if err != nil {

--- a/build/linter/forcetypeassert/analysis.go
+++ b/build/linter/forcetypeassert/analysis.go
@@ -23,5 +23,6 @@ import (
 var Analyzer = forcetypeassert.Analyzer
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/gci/BUILD.bazel
+++ b/build/linter/gci/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/build/linter/gci",
     visibility = ["//visibility:public"],
     deps = [
+        "//build/linter/util",
         "@com_github_daixiang0_gci//pkg/config",
         "@com_github_daixiang0_gci//pkg/gci",
         "@org_golang_x_tools//go/analysis",

--- a/build/linter/gci/analysis.go
+++ b/build/linter/gci/analysis.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/daixiang0/gci/pkg/config"
 	"github.com/daixiang0/gci/pkg/gci"
+	"github.com/pingcap/tidb/build/linter/util"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -34,6 +35,10 @@ func run(pass *analysis.Pass) (any, error) {
 	fileNames := make([]string, 0, len(pass.Files))
 	for _, f := range pass.Files {
 		pos := pass.Fset.PositionFor(f.Pos(), false)
+		if !util.ShouldRun("gci", pos.Filename) {
+			continue
+		}
+
 		fileNames = append(fileNames, pos.Filename)
 	}
 	rawCfg := config.YamlConfig{

--- a/build/linter/gci/analysis.go
+++ b/build/linter/gci/analysis.go
@@ -35,10 +35,6 @@ func run(pass *analysis.Pass) (any, error) {
 	fileNames := make([]string, 0, len(pass.Files))
 	for _, f := range pass.Files {
 		pos := pass.Fset.PositionFor(f.Pos(), false)
-		if !util.ShouldRun("gci", pos.Filename) {
-			continue
-		}
-
 		fileNames = append(fileNames, pos.Filename)
 	}
 	rawCfg := config.YamlConfig{
@@ -69,4 +65,8 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 
 	return nil, nil
+}
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 }

--- a/build/linter/gofmt/BUILD.bazel
+++ b/build/linter/gofmt/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/build/linter/gofmt",
     visibility = ["//visibility:public"],
     deps = [
+        "//build/linter/util",
         "@com_github_golangci_gofmt//gofmt",
         "@org_golang_x_tools//go/analysis",
     ],

--- a/build/linter/gofmt/analyzer.go
+++ b/build/linter/gofmt/analyzer.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/golangci/gofmt/gofmt"
+	"github.com/pingcap/tidb/build/linter/util"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -46,6 +47,10 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 
 	for _, f := range fileNames {
+		if !util.ShouldRun("gofmt", f) {
+			continue
+		}
+
 		diff, err := gofmt.Run(f, needSimplify)
 		if err != nil {
 			return nil, fmt.Errorf("could not run gofmt: %w (%s)", err, f)

--- a/build/linter/gofmt/analyzer.go
+++ b/build/linter/gofmt/analyzer.go
@@ -47,10 +47,6 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 
 	for _, f := range fileNames {
-		if !util.ShouldRun("gofmt", f) {
-			continue
-		}
-
 		diff, err := gofmt.Run(f, needSimplify)
 		if err != nil {
 			return nil, fmt.Errorf("could not run gofmt: %w (%s)", err, f)
@@ -67,4 +63,8 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 
 	return nil, nil
+}
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 }

--- a/build/linter/gosec/analysis.go
+++ b/build/linter/gosec/analysis.go
@@ -41,6 +41,7 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }
 

--- a/build/linter/ineffassign/analyzer.go
+++ b/build/linter/ineffassign/analyzer.go
@@ -23,5 +23,6 @@ import (
 var Analyzer = ineffassign.Analyzer
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/lll/analyzer.go
+++ b/build/linter/lll/analyzer.go
@@ -72,10 +72,6 @@ func runLll(pass *analysis.Pass, settings *settings) error {
 	spaces := strings.Repeat(" ", settings.TabWidth)
 
 	for _, f := range fileNames {
-		if !util.ShouldRun("lll", f) {
-			continue
-		}
-
 		lintIssues, err := getLLLIssuesForFile(f, settings.LineLength, spaces)
 		if err != nil {
 			return err
@@ -162,4 +158,9 @@ func getLLLIssuesForFile(filename string, maxLineLen int, tabSpaces string) ([]r
 	}
 
 	return res, nil
+}
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
+	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/lll/analyzer.go
+++ b/build/linter/lll/analyzer.go
@@ -72,6 +72,10 @@ func runLll(pass *analysis.Pass, settings *settings) error {
 	spaces := strings.Repeat(" ", settings.TabWidth)
 
 	for _, f := range fileNames {
+		if !util.ShouldRun("lll", f) {
+			continue
+		}
+
 		lintIssues, err := getLLLIssuesForFile(f, settings.LineLength, spaces)
 		if err != nil {
 			return err

--- a/build/linter/makezero/analyzer.go
+++ b/build/linter/makezero/analyzer.go
@@ -23,5 +23,6 @@ import (
 var Analyzer = analyzer.NewAnalyzer()
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/mirror/analyzer.go
+++ b/build/linter/mirror/analyzer.go
@@ -23,5 +23,6 @@ import (
 var Analyzer = mirror.NewAnalyzer()
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/misspell/analyzer.go
+++ b/build/linter/misspell/analyzer.go
@@ -34,6 +34,7 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }
 
@@ -61,10 +62,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	files := make([]string, 0, len(pass.Files))
 	for _, file := range pass.Files {
 		pos := pass.Fset.PositionFor(file.Pos(), false)
-		if !util.ShouldRun(Name, pos.Filename) {
-			continue
-		}
-
 		files = append(files, pos.Filename)
 	}
 	for _, f := range files {

--- a/build/linter/misspell/analyzer.go
+++ b/build/linter/misspell/analyzer.go
@@ -61,6 +61,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	files := make([]string, 0, len(pass.Files))
 	for _, file := range pass.Files {
 		pos := pass.Fset.PositionFor(file.Pos(), false)
+		if !util.ShouldRun(Name, pos.Filename) {
+			continue
+		}
+
 		files = append(files, pos.Filename)
 	}
 	for _, f := range files {

--- a/build/linter/noloopclosure/analysis.go
+++ b/build/linter/noloopclosure/analysis.go
@@ -23,5 +23,6 @@ import (
 var Analyzer = nlc.Analyzer
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/prealloc/analyzer.go
+++ b/build/linter/prealloc/analyzer.go
@@ -46,6 +46,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		ForLoops:   false,
 	}
 	for _, f := range pass.Files {
+		fileName := pass.Fset.PositionFor(f.Pos(), false).Filename
+		if !util.ShouldRun(Name, fileName) {
+			continue
+		}
+
 		hints := prealloc.Check([]*ast.File{f}, s.Simple, s.RangeLoops, s.ForLoops)
 		for _, hint := range hints {
 			pass.Reportf(hint.Pos, "[%s] Consider preallocating %s", Name, util.FormatCode(hint.DeclaredSliceName))

--- a/build/linter/prealloc/analyzer.go
+++ b/build/linter/prealloc/analyzer.go
@@ -46,11 +46,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		ForLoops:   false,
 	}
 	for _, f := range pass.Files {
-		fileName := pass.Fset.PositionFor(f.Pos(), false).Filename
-		if !util.ShouldRun(Name, fileName) {
-			continue
-		}
-
 		hints := prealloc.Check([]*ast.File{f}, s.Simple, s.RangeLoops, s.ForLoops)
 		for _, hint := range hints {
 			pass.Reportf(hint.Pos, "[%s] Consider preallocating %s", Name, util.FormatCode(hint.DeclaredSliceName))
@@ -61,5 +56,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 }
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/predeclared/analysis.go
+++ b/build/linter/predeclared/analysis.go
@@ -23,5 +23,6 @@ import (
 var Analyzer = predeclared.Analyzer
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/revive/analyzer.go
+++ b/build/linter/revive/analyzer.go
@@ -92,7 +92,12 @@ var allRules = append([]lint.Rule{
 func run(pass *analysis.Pass) (any, error) {
 	files := make([]string, 0, len(pass.Files))
 	for _, file := range pass.Files {
-		files = append(files, pass.Fset.PositionFor(file.Pos(), false).Filename)
+		fileName := pass.Fset.PositionFor(file.Pos(), false).Filename
+		if !util.ShouldRun("revive", fileName) {
+			continue
+		}
+
+		files = append(files, fileName)
 	}
 	packages := [][]string{files}
 

--- a/build/linter/revive/analyzer.go
+++ b/build/linter/revive/analyzer.go
@@ -37,6 +37,7 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }
 
@@ -92,12 +93,7 @@ var allRules = append([]lint.Rule{
 func run(pass *analysis.Pass) (any, error) {
 	files := make([]string, 0, len(pass.Files))
 	for _, file := range pass.Files {
-		fileName := pass.Fset.PositionFor(file.Pos(), false).Filename
-		if !util.ShouldRun("revive", fileName) {
-			continue
-		}
-
-		files = append(files, fileName)
+		files = append(files, pass.Fset.PositionFor(file.Pos(), false).Filename)
 	}
 	packages := [][]string{files}
 

--- a/build/linter/rowserrcheck/analyzer.go
+++ b/build/linter/rowserrcheck/analyzer.go
@@ -23,5 +23,6 @@ import (
 var Analyzer = rowserr.NewAnalyzer()
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/staticcheck/analyzer.go
+++ b/build/linter/staticcheck/analyzer.go
@@ -29,5 +29,6 @@ var (
 
 func init() {
 	Analyzer = FindAnalyzerByName(name)
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/toomanytests/BUILD.bazel
+++ b/build/linter/toomanytests/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["analyze.go"],
     importpath = "github.com/pingcap/tidb/build/linter/toomanytests",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_tools//go/analysis"],
+    deps = [
+        "//build/linter/util",
+        "@org_golang_x_tools//go/analysis",
+    ],
 )

--- a/build/linter/toomanytests/analyze.go
+++ b/build/linter/toomanytests/analyze.go
@@ -19,6 +19,7 @@ import (
 	"go/token"
 	"strings"
 
+	"github.com/pingcap/tidb/build/linter/util"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -29,6 +30,11 @@ var Analyzer = &analysis.Analyzer{
 	Run: func(pass *analysis.Pass) (any, error) {
 		cnt := 0
 		for _, f := range pass.Files {
+			fileName := pass.Fset.PositionFor(f.Pos(), false).Filename
+			if !util.ShouldRun("toomanytests", fileName) {
+				continue
+			}
+
 			astFile := pass.Fset.File(f.Pos())
 			if !isTestFile(astFile) {
 				continue

--- a/build/linter/toomanytests/analyze.go
+++ b/build/linter/toomanytests/analyze.go
@@ -30,11 +30,6 @@ var Analyzer = &analysis.Analyzer{
 	Run: func(pass *analysis.Pass) (any, error) {
 		cnt := 0
 		for _, f := range pass.Files {
-			fileName := pass.Fset.PositionFor(f.Pos(), false).Filename
-			if !util.ShouldRun("toomanytests", fileName) {
-				continue
-			}
-
 			astFile := pass.Fset.File(f.Pos())
 			if !isTestFile(astFile) {
 				continue
@@ -59,4 +54,9 @@ var Analyzer = &analysis.Analyzer{
 
 func isTestFile(file *token.File) bool {
 	return strings.HasSuffix(file.Name(), "_test.go")
+}
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
+	util.SkipAnalyzer(Analyzer)
 }

--- a/build/linter/unconvert/analysis.go
+++ b/build/linter/unconvert/analysis.go
@@ -37,6 +37,7 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
 	util.SkipAnalyzer(Analyzer)
 }
 

--- a/build/linter/util/BUILD.bazel
+++ b/build/linter/util/BUILD.bazel
@@ -1,13 +1,26 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "util",
-    srcs = ["util.go"],
+    srcs = [
+        "exclude.go",
+        "util.go",
+    ],
     importpath = "github.com/pingcap/tidb/build/linter/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//build",
         "@co_honnef_go_tools//analysis/report",
         "@org_golang_x_tools//go/analysis",
         "@org_golang_x_tools//go/loader",
     ],
+)
+
+go_test(
+    name = "util_test",
+    timeout = "short",
+    srcs = ["exclude_test.go"],
+    embed = [":util"],
+    flaky = True,
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/build/linter/util/exclude.go
+++ b/build/linter/util/exclude.go
@@ -1,0 +1,62 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/pingcap/tidb/build"
+)
+
+// ShouldRun checks whether a `file` should be analyzed in the specific pass
+func ShouldRun(passName string, fileName string) bool {
+	config, ok := build.NogoConfig[passName]
+	if !ok {
+		return true
+	}
+
+	if config.OnlyFiles != nil {
+		for _, f := range config.OnlyFiles {
+			matched, err := regexp.MatchString(f, fileName)
+			if err != nil {
+				panic(fmt.Sprintf("regex is wrong: %s", f))
+			}
+
+			if matched {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	if config.ExcludeFiles != nil {
+		for f := range config.ExcludeFiles {
+			matched, err := regexp.MatchString(f, fileName)
+			if err != nil {
+				panic(fmt.Sprintf("regex is wrong: %s", f))
+			}
+
+			if matched {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	return true
+}

--- a/build/linter/util/exclude.go
+++ b/build/linter/util/exclude.go
@@ -21,8 +21,8 @@ import (
 	"github.com/pingcap/tidb/build"
 )
 
-// ShouldRun checks whether a `file` should be analyzed in the specific pass
-func ShouldRun(passName string, fileName string) bool {
+// shouldRun checks whether a `file` should be analyzed in the specific pass
+func shouldRun(passName string, fileName string) bool {
 	config, ok := build.NogoConfig[passName]
 	if !ok {
 		return true

--- a/build/linter/util/exclude_test.go
+++ b/build/linter/util/exclude_test.go
@@ -21,6 +21,6 @@ import (
 )
 
 func TestShouldRun(t *testing.T) {
-	require.True(t, ShouldRun("gofmt", "some.go"))
-	require.False(t, ShouldRun("gofmt", "uca_generated.go"))
+	require.True(t, shouldRun("gofmt", "some.go"))
+	require.False(t, shouldRun("gofmt", "uca_generated.go"))
 }

--- a/build/linter/util/exclude_test.go
+++ b/build/linter/util/exclude_test.go
@@ -1,0 +1,26 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldRun(t *testing.T) {
+	require.True(t, ShouldRun("gofmt", "some.go"))
+	require.False(t, ShouldRun("gofmt", "uca_generated.go"))
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #48624 

Problem Summary:

As I have tested, this PR makes it possible to run `make bazel_build` within 16GB ram (without cache). 

Previously, it'll need more than 40GB ram. As I only have 48GB ram for my development environment and the `bazel` processes are always OOM-killed, I'm not sure how much it'll actually take.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

### Release note

```release-note
None
```
