### PR TITLE
Fix placement policy in alter table partition by

### DIFF
--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -4376,6 +4376,10 @@ func (d *ddl) AlterTablePartitioning(ctx sessionctx.Context, ident ast.Ident, sp
 	}
 	newPartInfo := newMeta.Partition
 
+	if err = handlePartitionPlacement(ctx, newPartInfo); err != nil {
+		return errors.Trace(err)
+	}
+
 	if err = d.assignPartitionIDs(newPartInfo.Definitions); err != nil {
 		return errors.Trace(err)
 	}

--- a/tests/integrationtest/r/partition.result
+++ b/tests/integrationtest/r/partition.result
@@ -1,0 +1,3 @@
+create placement policy pp1 followers=1;
+create table t (a int);
+alter table t partition by range (a) (partition p0 values less than (1000000), partition pMax values less than (maxvalue) placement policy pp1);

--- a/tests/integrationtest/t/partition.test
+++ b/tests/integrationtest/t/partition.test
@@ -1,0 +1,3 @@
+create placement policy pp1 followers=1;
+create table t (a int);
+alter table t partition by range (a) (partition p0 values less than (1000000), partition pMax values less than (maxvalue) placement policy pp1);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48630

Problem Summary:
When specifying PLACEMENT POLICY per partitions in ALTER TABLE t PARTITION BY ... it failed, due to missed lookup of Name -> ID of the placement policy.
Workaround is to not assign placement policy and then alter the placement policy by:
https://docs.pingcap.com/tidb/dev/placement-rules-in-sql#specify-a-placement-policy-for-a-partitioned-table

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
