### PR TITLE
expression: ignore some plan cache limitations for test

### DIFF
--- a/expression/function_traits.go
+++ b/expression/function_traits.go
@@ -33,10 +33,10 @@ var UnCacheableFunctions = map[string]struct{}{
 	ast.Like:                 {},
 
 	// functions below are incompatible with (non-prep) plan cache, we'll fix them one by one later.
-	ast.JSONExtract:      {}, // cannot pass TestFuncJSON
-	ast.JSONObject:       {},
-	ast.JSONArray:        {},
-	ast.Coalesce:         {},
+	ast.JSONExtract: {}, // cannot pass TestFuncJSON
+	ast.JSONObject:  {},
+	ast.JSONArray:   {},
+	//ast.Coalesce:         {},
 	ast.Convert:          {},
 	ast.TimeLiteral:      {},
 	ast.DateLiteral:      {},

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -674,7 +674,7 @@ func ExtractEqAndInCondition(sctx sessionctx.Context, conditions []expression.Ex
 			}
 			if expression.MaybeOverOptimized4PlanCache(sctx, conditions) {
 				// `a=@x and a=@y` --> `a=@x if @x==@y`
-				sctx.GetSessionVars().StmtCtx.SetSkipPlanCache(errors.Errorf("some parameters may be overwritten"))
+				//sctx.GetSessionVars().StmtCtx.SetSkipPlanCache(errors.Errorf("some parameters may be overwritten"))
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?
```sql
mysql> create table t (a int, key (a));
Query OK, 0 rows affected (0.02 sec)

mysql> prepare st from 'select * from t where a=? and a=?';
Query OK, 0 rows affected (0.00 sec)

mysql> set @a=1,@b=1;
Query OK, 0 rows affected (0.00 sec)

mysql> execute st using @a,@b;
Empty set (0.00 sec)

mysql> execute st using @a,@b;
Empty set (0.01 sec)

mysql> select @@last_plan_from_cache;
+------------------------+
| @@last_plan_from_cache |
+------------------------+
|                      1 |
+------------------------+
1 row in set (0.00 sec)
```

and SQL with func `Coalesce` can be plan cache.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
