### PR TITLE
lightning: fix typo because lightning supports sql/parquet data files but csv. 

### DIFF
--- a/br/pkg/lightning/importer/precheck_impl.go
+++ b/br/pkg/lightning/importer/precheck_impl.go
@@ -463,7 +463,7 @@ func (ci *largeFileCheckItem) Check(_ context.Context) (*precheck.CheckResult, e
 		Item:     ci.GetCheckItemID(),
 		Severity: precheck.Warn,
 		Passed:   true,
-		Message:  "Source csv files size is proper",
+		Message:  "Source data files size is proper",
 	}
 
 	if !ci.cfg.Mydumper.StrictFormat {
@@ -471,14 +471,14 @@ func (ci *largeFileCheckItem) Check(_ context.Context) (*precheck.CheckResult, e
 			for _, t := range db.Tables {
 				for _, f := range t.DataFiles {
 					if f.FileMeta.RealSize > defaultCSVSize {
-						theResult.Message = fmt.Sprintf("large csv: %s file exists and it will slow down import performance", f.FileMeta.Path)
+						theResult.Message = fmt.Sprintf("large data file: %s file exists and it will slow down import performance", f.FileMeta.Path)
 						theResult.Passed = false
 					}
 				}
 			}
 		}
 	} else {
-		theResult.Message = "Skip the csv size check, because config.StrictFormat is true"
+		theResult.Message = "Skip the data file size check, because config.StrictFormat is true"
 	}
 	return theResult, nil
 }

--- a/br/pkg/lightning/importer/table_import_test.go
+++ b/br/pkg/lightning/importer/table_import_test.go
@@ -1388,14 +1388,14 @@ func (s *tableRestoreSuite) TestCheckHasLargeCSV() {
 	}{
 		{
 			true,
-			"(.*)Skip the csv size check, because config.StrictFormat is true(.*)",
+			"(.*)Skip the data file size check, because config.StrictFormat is true(.*)",
 			true,
 			0,
 			nil,
 		},
 		{
 			false,
-			"(.*)Source csv files size is proper(.*)",
+			"(.*)Source data files size is proper(.*)",
 			true,
 			0,
 			[]*mydump.MDDatabaseMeta{
@@ -1416,7 +1416,7 @@ func (s *tableRestoreSuite) TestCheckHasLargeCSV() {
 		},
 		{
 			false,
-			"(.*)large csv: /testPath file exists(.*)",
+			"(.*)large data file: /testPath file exists(.*)",
 			true,
 			1,
 			[]*mydump.MDDatabaseMeta{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
As title.
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/48654

Problem Summary:
- the comments is "source csv files is proper" when lightning imports the parquet data files, which could confuse the DBA.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
- [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

#### manual test
- after fix it 
```
+----+------------------------------------------------------------------------------------------------------------------------------------+-------------+--------+
|  # | CHECK ITEM                                                                                                                         | TYPE        | PASSED |
+----+------------------------------------------------------------------------------------------------------------------------------------+-------------+--------+
|  1 | Source data files size is proper                                                                                                   | performance | true   |
+----+------------------------------------------------------------------------------------------------------------------------------------+-------------+--------+
|  2 | the checkpoints are valid                                                                                                          | critical    | true   |
+----+------------------------------------------------------------------------------------------------------------------------------------+-------------+--------+
|  3 | table schemas are valid                                                                                                            | critical    | true   |
+----+------------------------------------------------------------------------------------------------------------------------------------+-------------+--------+
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
