### PR TITLE
Revert "server,session: make sure ResultSet.Close() errors return to the client (#48447)"

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2050,7 +2050,11 @@ func (cc *clientConn) handleStmt(ctx context.Context, stmt ast.StmtNode, warns [
 			execStmt.(*executor.ExecStmt).FinishExecuteStmt(0, err, false)
 		}
 	}
-	return false, err
+	if err != nil {
+		return false, err
+	}
+
+	return false, nil
 }
 
 func (cc *clientConn) handleFileTransInConn(ctx context.Context, status uint16) (bool, error) {
@@ -2277,9 +2281,6 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 		if stmtDetail != nil {
 			stmtDetail.WriteSQLRespDuration += time.Since(start)
 		}
-	}
-	if err := rs.Close(); err != nil {
-		return false, err
 	}
 
 	if stmtDetail != nil {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2475,20 +2475,16 @@ const ExecStmtVarKey ExecStmtVarKeyType = 0
 // RecordSet, so this struct exists and RecordSet.Close() is overrided handle that.
 type execStmtResult struct {
 	sqlexec.RecordSet
-	se     *session
-	sql    sqlexec.Statement
-	closed bool
+	se  *session
+	sql sqlexec.Statement
 }
 
 func (rs *execStmtResult) Close() error {
-	if rs.closed {
-		return nil
-	}
 	se := rs.se
-	err := rs.RecordSet.Close()
-	err = finishStmt(context.Background(), se, err, rs.sql)
-	rs.closed = true
-	return err
+	if err := rs.RecordSet.Close(); err != nil {
+		return finishStmt(context.Background(), se, err, rs.sql)
+	}
+	return finishStmt(context.Background(), se, nil, rs.sql)
 }
 
 // rollbackOnError makes sure the next statement starts a new transaction with the latest InfoSchema.


### PR DESCRIPTION
close #48667


Reverts pingcap/tidb#48486

The 7.5 release is frozen, and we don't have enough time to figure out why this PR could introduce a regression.
So revert it.

As for the bug this PR fixes, we have other PR that also could do that, the risk is low.