### PR TITLE
lightning: avoid copying bytes if the bytes are already non-shared

### DIFF
--- a/br/pkg/lightning/backend/external/engine.go
+++ b/br/pkg/lightning/backend/external/engine.go
@@ -494,11 +494,15 @@ func (m *memoryDataIter) Error() error {
 	return nil
 }
 
+// ReleaseBuf implements ForwardIter.
+func (m *memoryDataIter) ReleaseBuf() {}
+
 type memoryDataDupDetectIter struct {
 	iter           *memoryDataIter
 	dupDetector    *common.DupDetector
 	err            error
 	curKey, curVal []byte
+	buf            *membuf.Buffer
 }
 
 // First implements ForwardIter.
@@ -534,16 +538,17 @@ func (m *memoryDataDupDetectIter) Next() bool {
 
 // Key implements ForwardIter.
 func (m *memoryDataDupDetectIter) Key() []byte {
-	return m.curKey
+	return m.buf.AddBytes(m.curKey)
 }
 
 // Value implements ForwardIter.
 func (m *memoryDataDupDetectIter) Value() []byte {
-	return m.curVal
+	return m.buf.AddBytes(m.curVal)
 }
 
 // Close implements ForwardIter.
 func (m *memoryDataDupDetectIter) Close() error {
+	m.buf.Destroy()
 	return m.dupDetector.Close()
 }
 
@@ -552,8 +557,17 @@ func (m *memoryDataDupDetectIter) Error() error {
 	return m.err
 }
 
+// ReleaseBuf implements ForwardIter.
+func (m *memoryDataDupDetectIter) ReleaseBuf() {
+	m.buf.Reset()
+}
+
 // NewIter implements IngestData.NewIter.
-func (m *MemoryIngestData) NewIter(ctx context.Context, lowerBound, upperBound []byte) common.ForwardIter {
+func (m *MemoryIngestData) NewIter(
+	ctx context.Context,
+	lowerBound, upperBound []byte,
+	bufPool *membuf.Pool,
+) common.ForwardIter {
 	firstKeyIdx, lastKeyIdx := m.firstAndLastKeyIndex(lowerBound, upperBound)
 	iter := &memoryDataIter{
 		keys:        m.keys,
@@ -569,6 +583,7 @@ func (m *MemoryIngestData) NewIter(ctx context.Context, lowerBound, upperBound [
 	return &memoryDataDupDetectIter{
 		iter:        iter,
 		dupDetector: detector,
+		buf:         bufPool.NewBuffer(),
 	}
 }
 

--- a/br/pkg/lightning/backend/external/writer_test.go
+++ b/br/pkg/lightning/backend/external/writer_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jfcg/sorty/v2"
 	"github.com/pingcap/tidb/br/pkg/lightning/backend/kv"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
+	"github.com/pingcap/tidb/br/pkg/membuf"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	dbkv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/util/size"
@@ -224,7 +225,9 @@ func TestWriterDuplicateDetect(t *testing.T) {
 		values:             values,
 		ts:                 123,
 	}
-	iter := data.NewIter(ctx, nil, nil)
+	pool := membuf.NewPool()
+	defer pool.Destroy()
+	iter := data.NewIter(ctx, nil, nil, pool)
 
 	for iter.First(); iter.Valid(); iter.Next() {
 	}

--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -975,7 +975,7 @@ func (e *Engine) loadEngineMeta() error {
 	return nil
 }
 
-func (e *Engine) newKVIter(ctx context.Context, opts *pebble.IterOptions, buf *membuf.Buffer) LocalEngineIngestIter {
+func (e *Engine) newKVIter(ctx context.Context, opts *pebble.IterOptions, buf *membuf.Buffer) IngestLocalEngineIter {
 	if bytes.Compare(opts.LowerBound, normalIterStartKey) < 0 {
 		newOpts := *opts
 		newOpts.LowerBound = normalIterStartKey

--- a/br/pkg/lightning/backend/local/engine_test.go
+++ b/br/pkg/lightning/backend/local/engine_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/lightning/backend"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
+	"github.com/pingcap/tidb/br/pkg/membuf"
 	"github.com/stretchr/testify/require"
 )
 
@@ -170,5 +171,57 @@ func TestGetFirstAndLastKey(t *testing.T) {
 }
 
 func TestIterOutputHasUniqueMemorySpace(t *testing.T) {
+	db, tmpPath := makePebbleDB(t, nil)
+	f := &Engine{
+		sstDir: tmpPath,
+	}
+	f.db.Store(db)
+	err := db.Set([]byte("a"), []byte("a"), nil)
+	require.NoError(t, err)
+	err = db.Set([]byte("c"), []byte("c"), nil)
+	require.NoError(t, err)
+	err = db.Set([]byte("e"), []byte("e"), nil)
+	require.NoError(t, err)
+	err = db.Set([]byte("g"), []byte("g"), nil)
+	require.NoError(t, err)
 
+	pool := membuf.NewPool()
+	ctx := context.Background()
+	iter := f.NewIter(ctx, nil, nil, pool)
+	keys := make([][]byte, 0, 2)
+	values := make([][]byte, 0, 2)
+	require.True(t, iter.First())
+	keys = append(keys, iter.Key())
+	values = append(values, iter.Value())
+	require.True(t, iter.Next())
+	keys = append(keys, iter.Key())
+	values = append(values, iter.Value())
+	expectKeys := [][]byte{[]byte("a"), []byte("c")}
+	expectValues := [][]byte{[]byte("a"), []byte("c")}
+	require.Equal(t, expectKeys, keys)
+	require.Equal(t, expectValues, values)
+
+	iter.ReleaseBuf()
+
+	keys2 := make([][]byte, 0, 2)
+	values2 := make([][]byte, 0, 2)
+	require.True(t, iter.Next())
+	keys2 = append(keys2, iter.Key())
+	values2 = append(values2, iter.Value())
+	require.True(t, iter.Next())
+	keys2 = append(keys2, iter.Key())
+	values2 = append(values2, iter.Value())
+	expectKeys2 := [][]byte{[]byte("e"), []byte("g")}
+	expectValues2 := [][]byte{[]byte("e"), []byte("g")}
+	require.Equal(t, expectKeys2, keys2)
+	require.Equal(t, expectValues2, values2)
+	require.False(t, iter.Next())
+
+	// just to reveal that after iter.ReleaseBuf() keys and values are not valid anymore
+	require.Equal(t, keys2, keys)
+
+	require.Equal(t, int64(0), pool.TotalSize())
+	require.NoError(t, iter.Close())
+	// after iter closed, the memory buffer of iter goes to pool
+	require.Greater(t, pool.TotalSize(), int64(0))
 }

--- a/br/pkg/lightning/backend/local/engine_test.go
+++ b/br/pkg/lightning/backend/local/engine_test.go
@@ -168,3 +168,7 @@ func TestGetFirstAndLastKey(t *testing.T) {
 	require.Equal(t, []byte("e"), first)
 	require.Equal(t, []byte("e"), last)
 }
+
+func TestIterOutputHasUniqueMemorySpace(t *testing.T) {
+
+}

--- a/br/pkg/lightning/backend/local/iterator.go
+++ b/br/pkg/lightning/backend/local/iterator.go
@@ -22,8 +22,8 @@ import (
 	"go.uber.org/multierr"
 )
 
-// LocalEngineIngestIter abstract iterator method for iterator.
-type LocalEngineIngestIter interface {
+// IngestLocalEngineIter abstract iterator method for iterator.
+type IngestLocalEngineIter interface {
 	common.ForwardIter
 	// Last moves this iter to the last key.
 	Last() bool
@@ -58,7 +58,7 @@ func (p *pebbleIter) Value() []byte {
 	return p.buf.AddBytes(p.Iterator.Value())
 }
 
-var _ LocalEngineIngestIter = &pebbleIter{}
+var _ IngestLocalEngineIter = &pebbleIter{}
 
 type dupDetectIter struct {
 	keyAdapter  common.KeyAdapter
@@ -144,7 +144,7 @@ func (d *dupDetectIter) ReleaseBuf() {
 	d.buf.Reset()
 }
 
-var _ LocalEngineIngestIter = &dupDetectIter{}
+var _ IngestLocalEngineIter = &dupDetectIter{}
 
 func newDupDetectIter(
 	db *pebble.DB,
@@ -236,6 +236,7 @@ func (d *dupDBIter) Close() error {
 	return d.iter.Close()
 }
 
+// Iter describes an iterator.
 type Iter interface {
 	// Valid check this iter reach the end.
 	Valid() bool

--- a/br/pkg/lightning/backend/local/iterator.go
+++ b/br/pkg/lightning/backend/local/iterator.go
@@ -16,39 +16,42 @@ package local
 
 import (
 	"github.com/cockroachdb/pebble"
-	sst "github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
+	"github.com/pingcap/tidb/br/pkg/membuf"
 	"go.uber.org/multierr"
 )
 
-// Iter abstract iterator method for Ingester.
-type Iter interface {
+// LocalEngineIngestIter abstract iterator method for iterator.
+type LocalEngineIngestIter interface {
 	common.ForwardIter
-	// Seek seek to specify position.
-	// if key not found, seeks next key position in iter.
-	Seek(key []byte) bool
 	// Last moves this iter to the last key.
 	Last() bool
-	// OpType represents operations of pair. currently we have two types.
-	// 1. Put
-	// 2. Delete
-	OpType() sst.Pair_OP
 }
 
 type pebbleIter struct {
 	*pebble.Iterator
+	buf *membuf.Buffer
 }
 
-func (p pebbleIter) Seek(key []byte) bool {
-	return p.SeekGE(key)
+func (p *pebbleIter) ReleaseBuf() {
+	p.buf.Reset()
 }
 
-func (pebbleIter) OpType() sst.Pair_OP {
-	return sst.Pair_Put
+func (p *pebbleIter) Close() error {
+	p.buf.Destroy()
+	return p.Iterator.Close()
 }
 
-var _ Iter = pebbleIter{}
+func (p *pebbleIter) Key() []byte {
+	return p.buf.AddBytes(p.Iterator.Key())
+}
+
+func (p *pebbleIter) Value() []byte {
+	return p.buf.AddBytes(p.Iterator.Value())
+}
+
+var _ LocalEngineIngestIter = &pebbleIter{}
 
 type dupDetectIter struct {
 	keyAdapter  common.KeyAdapter
@@ -57,16 +60,8 @@ type dupDetectIter struct {
 	err         error
 
 	curKey, curVal []byte
+	buf            *membuf.Buffer
 	logger         log.Logger
-}
-
-func (d *dupDetectIter) Seek(key []byte) bool {
-	rawKey := d.keyAdapter.Encode(nil, key, common.ZeroRowID)
-	if d.err != nil || !d.iter.SeekGE(rawKey) {
-		return false
-	}
-	d.fill()
-	return d.err == nil
 }
 
 func (d *dupDetectIter) First() bool {
@@ -106,11 +101,11 @@ func (d *dupDetectIter) Next() bool {
 }
 
 func (d *dupDetectIter) Key() []byte {
-	return d.curKey
+	return d.buf.AddBytes(d.curKey)
 }
 
 func (d *dupDetectIter) Value() []byte {
-	return d.curVal
+	return d.buf.AddBytes(d.curVal)
 }
 
 func (d *dupDetectIter) Valid() bool {
@@ -122,6 +117,7 @@ func (d *dupDetectIter) Error() error {
 }
 
 func (d *dupDetectIter) Close() error {
+	d.buf.Destroy()
 	firstErr := d.dupDetector.Close()
 	err := d.iter.Close()
 	if firstErr != nil {
@@ -130,11 +126,11 @@ func (d *dupDetectIter) Close() error {
 	return err
 }
 
-func (*dupDetectIter) OpType() sst.Pair_OP {
-	return sst.Pair_Put
+func (d *dupDetectIter) ReleaseBuf() {
+	d.buf.Reset()
 }
 
-var _ Iter = &dupDetectIter{}
+var _ LocalEngineIngestIter = &dupDetectIter{}
 
 func newDupDetectIter(
 	db *pebble.DB,
@@ -143,6 +139,7 @@ func newDupDetectIter(
 	dupDB *pebble.DB,
 	logger log.Logger,
 	dupOpt common.DupDetectOpt,
+	buf *membuf.Buffer,
 ) *dupDetectIter {
 	newOpts := &pebble.IterOptions{TableFilter: opts.TableFilter}
 	if len(opts.LowerBound) > 0 {
@@ -156,6 +153,7 @@ func newDupDetectIter(
 	return &dupDetectIter{
 		keyAdapter:  keyAdapter,
 		iter:        db.NewIter(newOpts),
+		buf:         buf,
 		dupDetector: detector,
 		logger:      logger,
 	}
@@ -224,8 +222,22 @@ func (d *dupDBIter) Close() error {
 	return d.iter.Close()
 }
 
-func (*dupDBIter) OpType() sst.Pair_OP {
-	return sst.Pair_Put
+type Iter interface {
+	// Valid check this iter reach the end.
+	Valid() bool
+	// Next moves this iter forward.
+	Next() bool
+	// Key returns current position pair's key. The key is accessible after more
+	// Next() or Key() invocations but is invalidated by Close() or ReleaseBuf().
+	Key() []byte
+	// Value returns current position pair's Value. The value is accessible after
+	// more Next() or Value() invocations but is invalidated by Close() or
+	// ReleaseBuf().
+	Value() []byte
+	// Close close this iter.
+	Close() error
+	// Error return current error on this iter.
+	Error() error
 }
 
 var _ Iter = &dupDBIter{}

--- a/br/pkg/lightning/backend/local/iterator.go
+++ b/br/pkg/lightning/backend/local/iterator.go
@@ -39,11 +39,18 @@ func (p *pebbleIter) ReleaseBuf() {
 }
 
 func (p *pebbleIter) Close() error {
-	p.buf.Destroy()
+	// only happens for GetFirstAndLastKey
+	if p.buf != nil {
+		p.buf.Destroy()
+	}
 	return p.Iterator.Close()
 }
 
 func (p *pebbleIter) Key() []byte {
+	// only happens for GetFirstAndLastKey
+	if p.buf == nil {
+		return p.Iterator.Key()
+	}
 	return p.buf.AddBytes(p.Iterator.Key())
 }
 
@@ -101,6 +108,10 @@ func (d *dupDetectIter) Next() bool {
 }
 
 func (d *dupDetectIter) Key() []byte {
+	// only happens for GetFirstAndLastKey
+	if d.buf == nil {
+		return d.curKey
+	}
 	return d.buf.AddBytes(d.curKey)
 }
 
@@ -117,7 +128,10 @@ func (d *dupDetectIter) Error() error {
 }
 
 func (d *dupDetectIter) Close() error {
-	d.buf.Destroy()
+	// only happens for GetFirstAndLastKey
+	if d.buf != nil {
+		d.buf.Destroy()
+	}
 	firstErr := d.dupDetector.Close()
 	err := d.iter.Close()
 	if firstErr != nil {

--- a/br/pkg/lightning/backend/local/iterator_test.go
+++ b/br/pkg/lightning/backend/local/iterator_test.go
@@ -131,8 +131,7 @@ func TestDupDetectIterator(t *testing.T) {
 	require.NoError(t, err)
 	pool := membuf.NewPool()
 	defer pool.Destroy()
-	var iter IngestLocalEngineIter
-	iter = newDupDetectIter(db, keyAdapter, &pebble.IterOptions{}, dupDB, log.L(), common.DupDetectOpt{}, pool.NewBuffer())
+	iter := newDupDetectIter(db, keyAdapter, &pebble.IterOptions{}, dupDB, log.L(), common.DupDetectOpt{}, pool.NewBuffer())
 	sort.Slice(pairs, func(i, j int) bool {
 		key1 := keyAdapter.Encode(nil, pairs[i].Key, pairs[i].RowID)
 		key2 := keyAdapter.Encode(nil, pairs[j].Key, pairs[j].RowID)

--- a/br/pkg/lightning/backend/local/iterator_test.go
+++ b/br/pkg/lightning/backend/local/iterator_test.go
@@ -131,7 +131,7 @@ func TestDupDetectIterator(t *testing.T) {
 	require.NoError(t, err)
 	pool := membuf.NewPool()
 	defer pool.Destroy()
-	var iter LocalEngineIngestIter
+	var iter IngestLocalEngineIter
 	iter = newDupDetectIter(db, keyAdapter, &pebble.IterOptions{}, dupDB, log.L(), common.DupDetectOpt{}, pool.NewBuffer())
 	sort.Slice(pairs, func(i, j int) bool {
 		key1 := keyAdapter.Encode(nil, pairs[i].Key, pairs[i].RowID)

--- a/br/pkg/lightning/backend/local/iterator_test.go
+++ b/br/pkg/lightning/backend/local/iterator_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
+	"github.com/pingcap/tidb/br/pkg/membuf"
 	"github.com/stretchr/testify/require"
 )
 
@@ -128,8 +129,10 @@ func TestDupDetectIterator(t *testing.T) {
 
 	dupDB, err := pebble.Open(filepath.Join(storeDir, "duplicates"), &pebble.Options{})
 	require.NoError(t, err)
-	var iter Iter
-	iter = newDupDetectIter(db, keyAdapter, &pebble.IterOptions{}, dupDB, log.L(), common.DupDetectOpt{})
+	pool := membuf.NewPool()
+	defer pool.Destroy()
+	var iter LocalEngineIngestIter
+	iter = newDupDetectIter(db, keyAdapter, &pebble.IterOptions{}, dupDB, log.L(), common.DupDetectOpt{}, pool.NewBuffer())
 	sort.Slice(pairs, func(i, j int) bool {
 		key1 := keyAdapter.Encode(nil, pairs[i].Key, pairs[i].RowID)
 		key2 := keyAdapter.Encode(nil, pairs[j].Key, pairs[j].RowID)
@@ -159,16 +162,16 @@ func TestDupDetectIterator(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	// Check duplicates detected by dupDetectIter.
-	iter = newDupDBIter(dupDB, keyAdapter, &pebble.IterOptions{})
+	iter2 := newDupDBIter(dupDB, keyAdapter, &pebble.IterOptions{})
 	var detectedPairs []common.KvPair
-	for iter.First(); iter.Valid(); iter.Next() {
+	for iter2.First(); iter2.Valid(); iter2.Next() {
 		detectedPairs = append(detectedPairs, common.KvPair{
-			Key: append([]byte{}, iter.Key()...),
-			Val: append([]byte{}, iter.Value()...),
+			Key: append([]byte{}, iter2.Key()...),
+			Val: append([]byte{}, iter2.Value()...),
 		})
 	}
-	require.NoError(t, iter.Error())
-	require.NoError(t, iter.Close())
+	require.NoError(t, iter2.Error())
+	require.NoError(t, iter2.Close())
 	require.NoError(t, dupDB.Close())
 	require.Equal(t, len(dupPairs), len(detectedPairs))
 
@@ -184,55 +187,6 @@ func TestDupDetectIterator(t *testing.T) {
 		require.Equal(t, dupPairs[i].Key, detectedPairs[i].Key)
 		require.Equal(t, dupPairs[i].Val, detectedPairs[i].Val)
 	}
-}
-
-func TestDupDetectIterSeek(t *testing.T) {
-	pairs := []common.KvPair{
-		{
-			Key:   []byte{1, 2, 3, 0},
-			Val:   randBytes(128),
-			RowID: common.EncodeIntRowID(1),
-		},
-		{
-			Key:   []byte{1, 2, 3, 1},
-			Val:   randBytes(128),
-			RowID: common.EncodeIntRowID(2),
-		},
-		{
-			Key:   []byte{1, 2, 3, 1},
-			Val:   randBytes(128),
-			RowID: common.EncodeIntRowID(3),
-		},
-		{
-			Key:   []byte{1, 2, 3, 2},
-			Val:   randBytes(128),
-			RowID: common.EncodeIntRowID(4),
-		},
-	}
-
-	storeDir := t.TempDir()
-	db, err := pebble.Open(filepath.Join(storeDir, "kv"), &pebble.Options{})
-	require.NoError(t, err)
-
-	keyAdapter := common.DupDetectKeyAdapter{}
-	wb := db.NewBatch()
-	for _, p := range pairs {
-		key := keyAdapter.Encode(nil, p.Key, p.RowID)
-		require.NoError(t, wb.Set(key, p.Val, nil))
-	}
-	require.NoError(t, wb.Commit(pebble.Sync))
-
-	dupDB, err := pebble.Open(filepath.Join(storeDir, "duplicates"), &pebble.Options{})
-	require.NoError(t, err)
-	iter := newDupDetectIter(db, keyAdapter, &pebble.IterOptions{}, dupDB, log.L(), common.DupDetectOpt{})
-
-	require.True(t, iter.Seek([]byte{1, 2, 3, 1}))
-	require.Equal(t, pairs[1].Val, iter.Value())
-	require.True(t, iter.Next())
-	require.Equal(t, pairs[3].Val, iter.Value())
-	require.NoError(t, iter.Close())
-	require.NoError(t, db.Close())
-	require.NoError(t, dupDB.Close())
 }
 
 func TestKeyAdapterEncoding(t *testing.T) {
@@ -267,13 +221,23 @@ func BenchmarkDupDetectIter(b *testing.B) {
 	}
 	wb.Commit(pebble.Sync)
 
+	pool := membuf.NewPool()
 	dupDB, _ := pebble.Open(filepath.Join(b.TempDir(), "dup"), &pebble.Options{})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		iter := newDupDetectIter(db, keyAdapter, &pebble.IterOptions{}, dupDB, log.L(), common.DupDetectOpt{})
+		iter := newDupDetectIter(
+			db,
+			keyAdapter,
+			&pebble.IterOptions{},
+			dupDB,
+			log.L(),
+			common.DupDetectOpt{},
+			pool.NewBuffer(),
+		)
 		keyCnt := 0
 		for iter.First(); iter.Valid(); iter.Next() {
 			keyCnt++
 		}
+		iter.Close()
 	}
 }

--- a/br/pkg/lightning/backend/local/local_test.go
+++ b/br/pkg/lightning/backend/local/local_test.go
@@ -1200,7 +1200,9 @@ func (m *mockIngestIter) Close() error { return nil }
 
 func (m *mockIngestIter) Error() error { return nil }
 
-func (m mockIngestData) NewIter(ctx context.Context, lowerBound, upperBound []byte) common.ForwardIter {
+func (m *mockIngestIter) ReleaseBuf() {}
+
+func (m mockIngestData) NewIter(_ context.Context, lowerBound, upperBound []byte, _ *membuf.Pool) common.ForwardIter {
 	i, j := m.getFirstAndLastKeyIdx(lowerBound, upperBound)
 	return &mockIngestIter{data: m, startIdx: i, endIdx: j, curIdx: i}
 }
@@ -2358,7 +2360,7 @@ func TestExternalEngine(t *testing.T) {
 	kvIdx := 0
 	for i, job := range jobs {
 		require.Equal(t, expectedKeyRanges[i], job.keyRange)
-		iter := job.ingestData.NewIter(ctx, job.keyRange.Start, job.keyRange.End)
+		iter := job.ingestData.NewIter(ctx, job.keyRange.Start, job.keyRange.End, nil)
 		for iter.First(); iter.Valid(); iter.Next() {
 			require.Equal(t, keys[kvIdx], iter.Key())
 			require.Equal(t, values[kvIdx], iter.Value())

--- a/br/pkg/lightning/common/BUILD.bazel
+++ b/br/pkg/lightning/common/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//br/pkg/httputil",
         "//br/pkg/lightning/log",
         "//br/pkg/logutil",
+        "//br/pkg/membuf",
         "//br/pkg/utils",
         "//pkg/errno",
         "//pkg/meta/autoid",

--- a/br/pkg/lightning/common/ingest_data.go
+++ b/br/pkg/lightning/common/ingest_data.go
@@ -14,7 +14,11 @@
 
 package common
 
-import "context"
+import (
+	"context"
+
+	"github.com/pingcap/tidb/br/pkg/membuf"
+)
 
 // IngestData describes a common interface that is needed by TiKV write +
 // ingest RPC.
@@ -24,7 +28,12 @@ type IngestData interface {
 	// lowerBound must be less than upperBound.
 	// when there is no data in the range, it should return nil, nil, nil
 	GetFirstAndLastKey(lowerBound, upperBound []byte) ([]byte, []byte, error)
-	NewIter(ctx context.Context, lowerBound, upperBound []byte) ForwardIter
+	// NewIter creates an iterator. The only expected usage of the iterator is read
+	// batches of key-value pairs by caller. Due to the implementation of IngestData,
+	// the iterator may need to allocate memories to retain the key-value pair batch,
+	// these memories will be allocated from given bufPool and be released when the
+	// iterator is closed or ForwardIter.ReleaseBuf is called.
+	NewIter(ctx context.Context, lowerBound, upperBound []byte, bufPool *membuf.Pool) ForwardIter
 	// GetTS will be used as the start/commit TS of the data.
 	GetTS() uint64
 	// IncRef should be called every time when IngestData is referred by regionJob.
@@ -47,14 +56,21 @@ type ForwardIter interface {
 	Valid() bool
 	// Next moves this iter forward.
 	Next() bool
-	// Key represents current position pair's key.
+	// Key returns current position pair's key. The key is accessible after more
+	// Next() or Key() invocations but is invalidated by Close() or ReleaseBuf().
 	Key() []byte
-	// Value represents current position pair's Value.
+	// Value returns current position pair's Value. The value is accessible after
+	// more Next() or Value() invocations but is invalidated by Close() or
+	// ReleaseBuf().
 	Value() []byte
 	// Close close this iter.
 	Close() error
 	// Error return current error on this iter.
 	Error() error
+	// ReleaseBuf release the memory that saves the previously returned keys and
+	// values. These previously returned keys and values should not be accessed
+	// again.
+	ReleaseBuf()
 }
 
 // DataAndRange is a pair of IngestData and Range.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48677

Problem Summary:

iter.Key() and Value() should promise the returned key and value can be retained after Next(), Key(), Value(). The memory can be released by iter.RelaeseBuf()

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
