### PR TITLE
planner: quick fix the panic issue when restoring hints from a plan

### DIFF
--- a/planner/core/hints.go
+++ b/planner/core/hints.go
@@ -108,7 +108,10 @@ func getJoinHints(sctx sessionctx.Context, joinType string, parentOffset int, no
 		}
 		var dbName, tableName *model.CIStr
 		if blockOffset != parentOffset {
-			blockAsNames := *(sctx.GetSessionVars().PlannerSelectBlockAsName.Load())
+			var blockAsNames []ast.HintTable
+			if p := sctx.GetSessionVars().PlannerSelectBlockAsName.Load(); p != nil {
+				blockAsNames = *p
+			}
 			if blockOffset >= len(blockAsNames) {
 				continue
 			}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -400,11 +400,8 @@ func (b *PlanBuilder) buildResultSetNode(ctx context.Context, node ast.ResultSet
 			}
 		}
 		// `TableName` is not a select block, so we do not need to handle it.
-		var plannerSelectBlockAsName []ast.HintTable
-		if p := b.ctx.GetSessionVars().PlannerSelectBlockAsName.Load(); p != nil {
-			plannerSelectBlockAsName = *p
-		}
-		if len(plannerSelectBlockAsName) > 0 && !isTableName {
+		if !isTableName && b.ctx.GetSessionVars().PlannerSelectBlockAsName.Load() != nil {
+			plannerSelectBlockAsName := *(b.ctx.GetSessionVars().PlannerSelectBlockAsName.Load())
 			plannerSelectBlockAsName[p.SelectBlockOffset()] = ast.HintTable{DBName: p.OutputNames()[0].DBName, TableName: p.OutputNames()[0].TblName}
 		}
 		// Duplicate column name in one table is not allowed.

--- a/planner/core/rule_join_reorder.go
+++ b/planner/core/rule_join_reorder.go
@@ -394,7 +394,10 @@ func (s *baseSingleGroupJoinOrderSolver) generateLeadingJoinGroup(curJoinGroup [
 	var leadingJoinGroup []LogicalPlan
 	leftJoinGroup := make([]LogicalPlan, len(curJoinGroup))
 	copy(leftJoinGroup, curJoinGroup)
-	queryBlockNames := *(s.ctx.GetSessionVars().PlannerSelectBlockAsName.Load())
+	var queryBlockNames []ast.HintTable
+	if p := s.ctx.GetSessionVars().PlannerSelectBlockAsName.Load(); p != nil {
+		queryBlockNames = *p
+	}
 	for _, hintTbl := range hintInfo.leadingJoinOrder {
 		match := false
 		for i, joinGroup := range leftJoinGroup {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #46791

Problem Summary: planner: quick fix the panic issue when restoring hints from a plan

### What is changed and how it works?

Forget to check whether the pointer is nil before using it:

<img width="661" alt="image" src="https://github.com/pingcap/tidb/assets/7499936/7d7bcee0-fd0a-4ba3-ba6e-3c8546a1cfa3">

But this pointer shouldn't be nil anyway, the root cause still needs more investigation, this is just a quick fix for users.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
