### PR TITLE
test: fix unstable test `TestIndexMergeRuntimeStats`

### DIFF
--- a/pkg/executor/test/executor/executor_test.go
+++ b/pkg/executor/test/executor/executor_test.go
@@ -794,31 +794,6 @@ func TestHashAggRuntimeStats(t *testing.T) {
 	require.Regexp(t, pattern, explain)
 }
 
-func TestIndexMergeRuntimeStats(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("set @@tidb_enable_index_merge = 1")
-	tk.MustExec("create table t1(id int primary key, a int, b int, c int, d int)")
-	tk.MustExec("create index t1a on t1(a)")
-	tk.MustExec("create index t1b on t1(b)")
-	tk.MustExec("insert into t1 values(1,1,1,1,1),(2,2,2,2,2),(3,3,3,3,3),(4,4,4,4,4),(5,5,5,5,5)")
-	rows := tk.MustQuery("explain analyze select /*+ use_index_merge(t1, primary, t1a) */ * from t1 where id < 2 or a > 4;").Rows()
-	require.Len(t, rows, 4)
-	explain := fmt.Sprintf("%v", rows[0])
-	pattern := ".*time:.*loops:.*index_task:{fetch_handle:.*, merge:.*}.*table_task:{num.*concurrency.*fetch_row.*wait_time.*}.*"
-	require.Regexp(t, pattern, explain)
-	tableRangeExplain := fmt.Sprintf("%v", rows[1])
-	indexExplain := fmt.Sprintf("%v", rows[2])
-	tableExplain := fmt.Sprintf("%v", rows[3])
-	require.Regexp(t, ".*time:.*loops:.*cop_task:.*", tableRangeExplain)
-	require.Regexp(t, ".*time:.*loops:.*cop_task:.*", indexExplain)
-	require.Regexp(t, ".*time:.*loops:.*cop_task:.*", tableExplain)
-	tk.MustExec("set @@tidb_enable_collect_execution_info=0;")
-	tk.MustQuery("select /*+ use_index_merge(t1, primary, t1a) */ * from t1 where id < 2 or a > 4 order by a").Check(testkit.Rows("1 1 1 1 1", "5 5 5 5 5"))
-}
-
 func TestPrevStmtDesensitization(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -4390,3 +4390,18 @@ Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collatio
 select * from `executor__executor` . `testbind`	SELECT * FROM `executor__executor`.`testbind` USE INDEX FOR JOIN (`index_t`)	executor__executor	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	a2fa907992be17801e5976df09b5b3a0d205f4c4aff39a14ab3bc8642026f527	
 drop session binding for select * from testbind using select * from testbind use index for join(index_t);
 drop global binding for select * from testbind using select * from testbind use index for join(index_t);
+drop table if EXISTS t1;
+create table t1(id int primary key, a int, b int, c int, d int, index t1a(a), index t1b(b));
+insert into t1 values(1,1,1,1,1),(2,2,2,2,2),(3,3,3,3,3),(4,4,4,4,4),(5,5,5,5,5);
+explain analyze select /*+ use_index_merge(t1, primary, t1a) */ * from t1 where id < 2 or a > 4;
+id	estRows	actRows	task	access object	execution info	operator info	memory	disk
+IndexMerge_8	3334.67	2	root	NULL	.*time:.*loops:.*index_task:{fetch_handle:.*, merge:.*}.*table_task:{num.*concurrency.*fetch_row.*wait_time.*}.*	type: union	<num> KB	N/A
+├─TableRangeScan_5(Build)	3333.33	1	cop[tikv]	table:t1	.*time:.*loops:.*cop_task:.*	range:[-inf,2), keep order:false, stats:pseudo	<num> Bytes	N/A
+├─IndexRangeScan_6(Build)	3333.33	1	cop[tikv]	table:t1, index:t1a(a)	.*time:.*loops:.*cop_task:.*	range:(4,+inf], keep order:false, stats:pseudo	N/A	N/A
+└─TableRowIDScan_7(Probe)	3334.67	2	cop[tikv]	table:t1	.*time:.*loops:.*cop_task:.*	keep order:false, stats:pseudo	N/A	N/A
+set @@tidb_enable_collect_execution_info=0;
+select /*+ use_index_merge(t1, primary, t1a) */ * from t1 where id < 2 or a > 4 order by a;
+id	a	b	c	d
+1	1	1	1	1
+5	5	5	5	5
+set @@tidb_enable_collect_execution_info=default;

--- a/tests/integrationtest/r/session/variable.result
+++ b/tests/integrationtest/r/session/variable.result
@@ -240,18 +240,3 @@ set @@group_concat_max_len='hello';
 Error 1232 (42000): Incorrect argument type to variable 'group_concat_max_len'
 set global group_concat_max_len = default;
 set @@session.group_concat_max_len = default;
-drop table if EXISTS t1;
-create table t1(id int primary key, a int, b int, c int, d int, index t1a(a), index t1b(b));
-insert into t1 values(1,1,1,1,1),(2,2,2,2,2),(3,3,3,3,3),(4,4,4,4,4),(5,5,5,5,5);
-explain analyze select /*+ use_index_merge(t1, primary, t1a) */ * from t1 where id < 2 or a > 4;
-id	estRows	actRows	task	access object	execution info	operator info	memory	disk
-IndexMerge_8	3334.67	2	root	NULL	time:<num>, loops:<num>, RU:<num>, index_task:{fetch_handle:<num>, merge:<num>}, table_task:{num:<num>, concurrency:<num>, fetch_row:<num>, wait_time:<num>}	type: union	<num> KB	N/A
-├─TableRangeScan_5(Build)	3333.33	1	cop[tikv]	table:t1	time:<num>, loops:<num>, cop_task: {num:<num>, max:<num>, proc_keys:<num>, rpc_num:<num>, rpc_time:<num>, copr_cache_hit_ratio:<num>, build_task_duration:<num>, max_distsql_concurrency:<num>}, tikv_task:{time:<num>, loops:<num>}	range:[-inf,2), keep order:false, stats:pseudo	<num> Bytes	N/A
-├─IndexRangeScan_6(Build)	3333.33	1	cop[tikv]	table:t1, index:t1a(a)	time:<num>, loops:<num>, cop_task: {num:<num>, max:<num>, proc_keys:<num>, rpc_num:<num>, rpc_time:<num>, copr_cache_hit_ratio:<num>, build_task_duration:<num>, max_distsql_concurrency:<num>}, tikv_task:{time:<num>, loops:<num>}	range:(4,+inf], keep order:false, stats:pseudo	N/A	N/A
-└─TableRowIDScan_7(Probe)	3334.67	2	cop[tikv]	table:t1	time:<num>, loops:<num>, cop_task: {num:<num>, max:<num>, min:<num>, avg:<num>, p95:<num>, rpc_num:<num>, rpc_time:<num>, copr_cache_hit_ratio:<num>, build_task_duration:<num>, max_distsql_concurrency:<num>, max_extra_concurrency:<num>}, tikv_task:{proc max:<num>, min:<num>, avg:<num>, p80:<num>, p95:<num>, iters:<num>, tasks:<num>}	keep order:false, stats:pseudo	N/A	N/A
-set @@tidb_enable_collect_execution_info=0;
-select /*+ use_index_merge(t1, primary, t1a) */ * from t1 where id < 2 or a > 4 order by a;
-id	a	b	c	d
-1	1	1	1	1
-5	5	5	5	5
-set @@tidb_enable_collect_execution_info=default;

--- a/tests/integrationtest/t/executor/executor.test
+++ b/tests/integrationtest/t/executor/executor.test
@@ -2660,3 +2660,14 @@ show session bindings where default_db='executor__executor';
 
 drop session binding for select * from testbind using select * from testbind use index for join(index_t);
 drop global binding for select * from testbind using select * from testbind use index for join(index_t);
+
+# TestIndexMergeRuntimeStats
+drop table if EXISTS t1;
+create table t1(id int primary key, a int, b int, c int, d int, index t1a(a), index t1b(b));
+insert into t1 values(1,1,1,1,1),(2,2,2,2,2),(3,3,3,3,3),(4,4,4,4,4),(5,5,5,5,5);
+--replace_regex /.*time:.*loops:.*cop_task:.*/.*time:.*loops:.*cop_task:.*/ /.*time:.*loops:.*index_task:{fetch_handle:.*, merge:.*}.*table_task:{num.*concurrency.*fetch_row.*wait_time.*}.*/.*time:.*loops:.*index_task:{fetch_handle:.*, merge:.*}.*table_task:{num.*concurrency.*fetch_row.*wait_time.*}.*/ /[0-9]+ Bytes/<num> Bytes/ /[.0-9]+ KB/<num> KB/
+explain analyze select /*+ use_index_merge(t1, primary, t1a) */ * from t1 where id < 2 or a > 4;
+set @@tidb_enable_collect_execution_info=0;
+select /*+ use_index_merge(t1, primary, t1a) */ * from t1 where id < 2 or a > 4 order by a;
+set @@tidb_enable_collect_execution_info=default;
+

--- a/tests/integrationtest/t/session/variable.test
+++ b/tests/integrationtest/t/session/variable.test
@@ -178,14 +178,3 @@ set @@group_concat_max_len = 18446744073709551616;
 set @@group_concat_max_len='hello';
 set global group_concat_max_len = default;
 set @@session.group_concat_max_len = default;
-
-# TestIndexMergeRuntimeStats
-drop table if EXISTS t1;
-create table t1(id int primary key, a int, b int, c int, d int, index t1a(a), index t1b(b));
-insert into t1 values(1,1,1,1,1),(2,2,2,2,2),(3,3,3,3,3),(4,4,4,4,4),(5,5,5,5,5);
---replace_regex /:[ ]?[.0-9]+[µms]*/:<num>/ /, scan_detail: {.*}// / max_proc_keys:.*?, p95_proc_keys:.*?,// / tot_proc:.*?, tot_wait:.*?,// /[0-9]+ Bytes/<num> Bytes/ /[.0-9]+ KB/<num> KB/
-explain analyze select /*+ use_index_merge(t1, primary, t1a) */ * from t1 where id < 2 or a > 4;
-set @@tidb_enable_collect_execution_info=0;
-select /*+ use_index_merge(t1, primary, t1a) */ * from t1 where id < 2 or a > 4 order by a;
-set @@tidb_enable_collect_execution_info=default;
-


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary: https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftidb%2Fghpr_check2/detail/ghpr_check2/33657/pipeline/

The result contains `backoff{regionMiss:<num>}` which not processed correctly, so update the regex pattern. And aslo found a duplicate test case, delete it.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
