### PR TITLE
planner: don't allow 'MATCH AGAINST'. It's not supported in TiDB yet.

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -472,6 +472,10 @@ func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
 		}
 	case *ast.SetCollationExpr:
 		// Do nothing
+	case *ast.MatchAgainst:
+		// TODO: support `MATCH ... AGAINST ...` in TiDB. It's already supported in `parser`.
+		er.err = errors.New("\"MATCH ... AGAINST ...\" is not supported in TiDB")
+		return inNode, false
 	default:
 		er.asScalar = true
 	}

--- a/tests/integrationtest/r/planner/core/expression_rewriter.result
+++ b/tests/integrationtest/r/planner/core/expression_rewriter.result
@@ -433,3 +433,8 @@ select collation(_utf8mb4'@a' collate utf8mb4_general_ci);
 collation(_utf8mb4'@a' collate utf8mb4_general_ci)
 utf8mb4_general_ci
 set @@session.default_collation_for_utf8mb4=default;
+drop table if exists t;
+create table t(str varchar(40));
+insert into t values ('test');
+select * from t where match (t) against ('test');
+Error 1105 (HY000): "MATCH ... AGAINST ..." is not supported in TiDB

--- a/tests/integrationtest/t/planner/core/expression_rewriter.test
+++ b/tests/integrationtest/t/planner/core/expression_rewriter.test
@@ -272,3 +272,9 @@ select collation(_utf8mb4'@a' collate utf8mb4_general_ci);
 
 set @@session.default_collation_for_utf8mb4=default;
 
+# TestMatchAgainstNotSupported
+drop table if exists t;
+create table t(str varchar(40));
+insert into t values ('test');
+-- error 1105
+select * from t where match (t) against ('test');


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #48734 

Problem Summary:

Return error for `MATCH AGAINST`. As it's already supported in `parser`, I didn't modify the `parser` to return the error (as it's expected for `parser` to give a full MySQL compatible parser, right?)

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

### Release note

```release-note
None
```
