### PR TITLE
planner: replace `EvalWithInnerCtx` with `Eval` in `exprToString` in planner

### DIFF
--- a/pkg/planner/cardinality/trace.go
+++ b/pkg/planner/cardinality/trace.go
@@ -37,7 +37,7 @@ import (
 
 // ceTraceExpr appends an expression and related information into CE trace
 func ceTraceExpr(sctx sessionctx.Context, tableID int64, tp string, expr expression.Expression, rowCount float64) {
-	exprStr, err := exprToString(expr)
+	exprStr, err := exprToString(sctx, expr)
 	if err != nil {
 		logutil.BgLogger().Debug("Failed to trace CE of an expression", zap.String("category", "OptimizerTrace"),
 			zap.Any("expression", expr))
@@ -64,7 +64,7 @@ func ceTraceExpr(sctx sessionctx.Context, tableID int64, tp string, expr express
 // It may be more appropriate to put this in expression package. But currently we only use it for CE trace,
 //
 //	and it may not be general enough to handle all possible expressions. So we put it here for now.
-func exprToString(e expression.Expression) (string, error) {
+func exprToString(ctx sessionctx.Context, e expression.Expression) (string, error) {
 	switch expr := e.(type) {
 	case *expression.ScalarFunction:
 		var buffer bytes.Buffer
@@ -72,7 +72,7 @@ func exprToString(e expression.Expression) (string, error) {
 		switch expr.FuncName.L {
 		case ast.Cast:
 			for _, arg := range expr.GetArgs() {
-				argStr, err := exprToString(arg)
+				argStr, err := exprToString(ctx, arg)
 				if err != nil {
 					return "", err
 				}
@@ -82,7 +82,7 @@ func exprToString(e expression.Expression) (string, error) {
 			}
 		default:
 			for i, arg := range expr.GetArgs() {
-				argStr, err := exprToString(arg)
+				argStr, err := exprToString(ctx, arg)
 				if err != nil {
 					return "", err
 				}
@@ -99,7 +99,7 @@ func exprToString(e expression.Expression) (string, error) {
 	case *expression.CorrelatedColumn:
 		return "", errors.New("tracing for correlated columns not supported now")
 	case *expression.Constant:
-		value, err := expr.EvalWithInnerCtx(chunk.Row{})
+		value, err := expr.Eval(ctx, chunk.Row{})
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48787

Problem Summary:

After https://github.com/pingcap/tidb/pull/48609 , we have added a ctx parameter to Expression.Eval to use context as an input instead of using the inner one. However, we left some EvalWithInnerCtx invokes when we could not find a context around the invoke. We should replace them with Eval in the later PRs.

### What is changed and how it works?

replace `EvalWithInnerCtx` with `Eval` in `exprToString` in planner

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

just run current tests is enough

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
