### PR TITLE
ddl: fix add wrong timezone during adding index

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -648,9 +648,6 @@ func (w *indexIngestWorker) initSessCtx() {
 			return
 		}
 		w.restore = restoreSessCtx(sessCtx)
-		tz := *time.UTC
-		sessCtx.GetSessionVars().TimeZone = &tz
-		sessCtx.GetSessionVars().StmtCtx.SetTimeZone(&tz)
 		if err := initSessCtx(sessCtx,
 			w.reorgMeta.SQLMode,
 			w.reorgMeta.Location,

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -648,6 +648,9 @@ func (w *indexIngestWorker) initSessCtx() {
 			return
 		}
 		w.restore = restoreSessCtx(sessCtx)
+		tz := *time.UTC
+		sessCtx.GetSessionVars().TimeZone = &tz
+		sessCtx.GetSessionVars().StmtCtx.SetTimeZone(&tz)
 		if err := initSessCtx(sessCtx,
 			w.reorgMeta.SQLMode,
 			w.reorgMeta.Location,

--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -143,12 +143,18 @@ func newSessCtx(
 	return sessCtx, nil
 }
 
+// initSessCtx initializes the session context. Be careful to the timezone.
 func initSessCtx(
 	sessCtx sessionctx.Context,
 	sqlMode mysql.SQLMode,
 	tzLocation *model.TimeZoneLocation,
 	resGroupName string,
 ) error {
+	// Correct the initial timezone.
+	tz := *time.UTC
+	sessCtx.GetSessionVars().TimeZone = &tz
+	sessCtx.GetSessionVars().StmtCtx.SetTimeZone(&tz)
+
 	// Set the row encode format version.
 	rowFormat := variable.GetDDLReorgRowFormat()
 	sessCtx.GetSessionVars().RowEncoder.Enable = rowFormat != variable.DefTiDBRowFormatV1


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #48724

Problem Summary:
The timezone is not recovered correctly. 

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
 Pass the internal test.
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
