### PR TITLE
server: use failpoint rather than real error in test `TestCursorFetchErrorInFetch`

### DIFF
--- a/pkg/util/chunk/row_container_reader.go
+++ b/pkg/util/chunk/row_container_reader.go
@@ -19,6 +19,8 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 )
 
@@ -122,6 +124,11 @@ func (reader *rowContainerReader) startWorker() {
 
 		for chkIdx := 0; chkIdx < reader.rc.NumChunks(); chkIdx++ {
 			chk, err := reader.rc.GetChunk(chkIdx)
+			failpoint.Inject("get-chunk-error", func(val failpoint.Value) {
+				if val.(bool) {
+					err = errors.New("fail to get chunk for test")
+				}
+			})
 			if err != nil {
 				reader.err = err
 				return


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #47029

Problem Summary:

In the original test, I closed the file used by row containers, and expected it to give an error. However, it seems to be unstable, and cannot be used on Mac OS. I turned to use `failpoint` to give a more stable error.

Actually, I'm not very sure whether this PR will fix the flacky test, because I still don't know the root cause of it.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
