### PR TITLE
statistics: do not directly update global stats when dropping a partition

### DIFF
--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -116,16 +116,8 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 			}
 		}
 	case model.ActionDropTablePartition:
-		pruneMode, err := util.GetCurrentPruneMode(h.statsHandler.SPool())
-		if err != nil {
-			return err
-		}
-		globalTableInfo, droppedPartitionInfo := t.GetDropPartitionInfo()
-		if variable.PartitionPruneMode(pruneMode) == variable.Dynamic && droppedPartitionInfo != nil {
-			if err := h.globalStatsHandler.UpdateGlobalStats(globalTableInfo); err != nil {
-				return err
-			}
-		}
+		// TODO: Update the modify count and count for the global table.
+		_, droppedPartitionInfo := t.GetDropPartitionInfo()
 		for _, def := range droppedPartitionInfo.Definitions {
 			if err := h.statsWriter.ResetTableStats2KVForDrop(def.ID); err != nil {
 				return err

--- a/pkg/statistics/handle/globalstats/BUILD.bazel
+++ b/pkg/statistics/handle/globalstats/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/parser/model",
         "//pkg/sessionctx",
         "//pkg/sessionctx/stmtctx",
-        "//pkg/sessiontxn",
         "//pkg/statistics",
         "//pkg/statistics/handle/logutil",
         "//pkg/statistics/handle/storage",

--- a/pkg/statistics/handle/globalstats/global_stats.go
+++ b/pkg/statistics/handle/globalstats/global_stats.go
@@ -22,10 +22,8 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/sessiontxn"
 	"github.com/pingcap/tidb/pkg/statistics"
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
-	"github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/tiancaiamao/gp"
@@ -55,14 +53,6 @@ func (sg *statsGlobalImpl) MergePartitionStats2GlobalStatsByTableID(sc sessionct
 	histIDs []int64,
 ) (globalStats interface{}, err error) {
 	return MergePartitionStats2GlobalStatsByTableID(sc, sg.statsHandler, opts, is, physicalID, isIndex, histIDs)
-}
-
-// UpdateGlobalStats will trigger the merge of global-stats when we drop table partition
-func (sg *statsGlobalImpl) UpdateGlobalStats(tblInfo *model.TableInfo) error {
-	// We need to merge the partition-level stats to global-stats when we drop table partition in dynamic mode.
-	return util.CallWithSCtx(sg.statsHandler.SPool(), func(sctx sessionctx.Context) error {
-		return UpdateGlobalStats(sctx, sg.statsHandler, tblInfo)
-	})
 }
 
 // GlobalStats is used to store the statistics contained in the global-level stats
@@ -168,107 +158,6 @@ func MergePartitionStats2GlobalStatsByTableID(
 var analyzeOptionDefault = map[ast.AnalyzeOptionType]uint64{
 	ast.AnalyzeOptNumBuckets: 256,
 	ast.AnalyzeOptNumTopN:    20,
-}
-
-// UpdateGlobalStats update the global-level stats based on the partition-level stats.
-func UpdateGlobalStats(
-	sctx sessionctx.Context,
-	statsHandle statstypes.StatsHandle,
-	tblInfo *model.TableInfo) error {
-	tableID := tblInfo.ID
-	is := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema()
-	globalStats, err := statsHandle.TableStatsFromStorage(tblInfo, tableID, true, 0)
-	if err != nil {
-		return err
-	}
-	// If we do not currently have global-stats, no new global-stats will be generated.
-	if globalStats == nil {
-		return nil
-	}
-	opts := make(map[ast.AnalyzeOptionType]uint64, len(analyzeOptionDefault))
-	for key, val := range analyzeOptionDefault {
-		opts[key] = val
-	}
-	// Use current global-stats related information to construct the opts for `MergePartitionStats2GlobalStats` function.
-	globalColStatsTopNNum, globalColStatsBucketNum := 0, 0
-	for colID := range globalStats.Columns {
-		globalColStatsTopN := globalStats.Columns[colID].TopN
-		if globalColStatsTopN != nil && len(globalColStatsTopN.TopN) > globalColStatsTopNNum {
-			globalColStatsTopNNum = len(globalColStatsTopN.TopN)
-		}
-		globalColStats := globalStats.Columns[colID]
-		if globalColStats != nil && len(globalColStats.Buckets) > globalColStatsBucketNum {
-			globalColStatsBucketNum = len(globalColStats.Buckets)
-		}
-	}
-	if globalColStatsTopNNum != 0 {
-		opts[ast.AnalyzeOptNumTopN] = uint64(globalColStatsTopNNum)
-	}
-	if globalColStatsBucketNum != 0 {
-		opts[ast.AnalyzeOptNumBuckets] = uint64(globalColStatsBucketNum)
-	}
-	// Generate the new column global-stats
-	newColGlobalStats, err := MergePartitionStats2GlobalStats(sctx, statsHandle, opts, is, tblInfo, false, nil)
-	if err != nil {
-		return err
-	}
-	if len(newColGlobalStats.MissingPartitionStats) > 0 {
-		logutil.BgLogger().Warn("missing partition stats when merging global stats", zap.String("table", tblInfo.Name.L),
-			zap.String("item", "columns"), zap.Strings("missing", newColGlobalStats.MissingPartitionStats))
-	}
-	for i := 0; i < newColGlobalStats.Num; i++ {
-		hg, cms, topN := newColGlobalStats.Hg[i], newColGlobalStats.Cms[i], newColGlobalStats.TopN[i]
-		if hg == nil {
-			// All partitions have no stats so global stats are not created.
-			continue
-		}
-		// fms for global stats doesn't need to dump to kv.
-		err = statsHandle.SaveStatsToStorage(tableID, newColGlobalStats.Count, newColGlobalStats.ModifyCount,
-			0, hg, cms, topN, 2, 1, false, util.StatsMetaHistorySourceSchemaChange)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Generate the new index global-stats
-	globalIdxStatsTopNNum, globalIdxStatsBucketNum := 0, 0
-	for _, idx := range tblInfo.Indices {
-		globalIdxStatsTopN := globalStats.Indices[idx.ID].TopN
-		if globalIdxStatsTopN != nil && len(globalIdxStatsTopN.TopN) > globalIdxStatsTopNNum {
-			globalIdxStatsTopNNum = len(globalIdxStatsTopN.TopN)
-		}
-		globalIdxStats := globalStats.Indices[idx.ID]
-		if globalIdxStats != nil && len(globalIdxStats.Buckets) > globalIdxStatsBucketNum {
-			globalIdxStatsBucketNum = len(globalIdxStats.Buckets)
-		}
-		if globalIdxStatsTopNNum != 0 {
-			opts[ast.AnalyzeOptNumTopN] = uint64(globalIdxStatsTopNNum)
-		}
-		if globalIdxStatsBucketNum != 0 {
-			opts[ast.AnalyzeOptNumBuckets] = uint64(globalIdxStatsBucketNum)
-		}
-		newIndexGlobalStats, err := MergePartitionStats2GlobalStats(sctx, statsHandle, opts, is, tblInfo, true, []int64{idx.ID})
-		if err != nil {
-			return err
-		}
-		if len(newIndexGlobalStats.MissingPartitionStats) > 0 {
-			logutil.BgLogger().Warn("missing partition stats when merging global stats", zap.String("table", tblInfo.Name.L),
-				zap.String("item", "index "+idx.Name.L), zap.Strings("missing", newIndexGlobalStats.MissingPartitionStats))
-		}
-		for i := 0; i < newIndexGlobalStats.Num; i++ {
-			hg, cms, topN := newIndexGlobalStats.Hg[i], newIndexGlobalStats.Cms[i], newIndexGlobalStats.TopN[i]
-			if hg == nil {
-				// All partitions have no stats so global stats are not created.
-				continue
-			}
-			// fms for global stats doesn't need to dump to kv.
-			err = statsHandle.SaveStatsToStorage(tableID, newIndexGlobalStats.Count, newIndexGlobalStats.ModifyCount, 1, hg, cms, topN, 2, 1, false, util.StatsMetaHistorySourceSchemaChange)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 // blockingMergePartitionStats2GlobalStats merge the partition-level stats to global-level stats based on the tableInfo.

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -348,9 +348,6 @@ type StatsGlobal interface {
 		isIndex bool,
 		histIDs []int64,
 	) (globalStats interface{}, err error)
-
-	// UpdateGlobalStats will trigger the merge of global-stats when we drop table partition
-	UpdateGlobalStats(tblInfo *model.TableInfo) error
 }
 
 // DDL is used to handle ddl events.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/48182#issuecomment-1824091079

Problem Summary:

### What changed and how does it work?

Based on [this design doc](https://pingcap.feishu.cn/docx/OLCrdxHj2ojb9KxlUvUch60LnBe#part-PRTmdkF0doiZSxxHHmDckfeJnZf), we will only update the `count` and `modfiy_count` for it. Then it will use the `count` and `modify_count` to determine if we need to trigger an auto-analysis task.

So in this PR, I dropped the update global stats operation.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
