### PR TITLE
infosync: integrate PD HTTP client into the placement manager

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -7158,13 +7158,13 @@ def go_deps():
         name = "com_github_tikv_pd_client",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/pd/client",
-        sha256 = "38789aba9a8542056f58fa8374e794a7b0c5949531744a9962634385b717134f",
-        strip_prefix = "github.com/JmPotato/pd/client@v0.0.0-20231123144827-8fc4cf2ee7b0",
+        sha256 = "5232ba0bba677a6d4614ae2cc102554d59cd00d473d9138739508d6f25169f02",
+        strip_prefix = "github.com/tikv/pd/client@v0.0.0-20231127075044-9f4803d8bd05",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/JmPotato/pd/client/com_github_jmpotato_pd_client-v0.0.0-20231123144827-8fc4cf2ee7b0.zip",
-            "http://ats.apps.svc/gomod/github.com/JmPotato/pd/client/com_github_jmpotato_pd_client-v0.0.0-20231123144827-8fc4cf2ee7b0.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/JmPotato/pd/client/com_github_jmpotato_pd_client-v0.0.0-20231123144827-8fc4cf2ee7b0.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/JmPotato/pd/client/com_github_jmpotato_pd_client-v0.0.0-20231123144827-8fc4cf2ee7b0.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20231127075044-9f4803d8bd05.zip",
+            "http://ats.apps.svc/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20231127075044-9f4803d8bd05.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20231127075044-9f4803d8bd05.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20231127075044-9f4803d8bd05.zip",
         ],
     )
     go_repository(

--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -7158,13 +7158,13 @@ def go_deps():
         name = "com_github_tikv_pd_client",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/pd/client",
-        sha256 = "440821579da980d0405695b463da892608a59252a296cd7e52b4f97881c5fdb7",
-        strip_prefix = "github.com/tikv/pd/client@v0.0.0-20231121080541-8919bc11f770",
+        sha256 = "38789aba9a8542056f58fa8374e794a7b0c5949531744a9962634385b717134f",
+        strip_prefix = "github.com/JmPotato/pd/client@v0.0.0-20231123144827-8fc4cf2ee7b0",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20231121080541-8919bc11f770.zip",
-            "http://ats.apps.svc/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20231121080541-8919bc11f770.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20231121080541-8919bc11f770.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20231121080541-8919bc11f770.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/JmPotato/pd/client/com_github_jmpotato_pd_client-v0.0.0-20231123144827-8fc4cf2ee7b0.zip",
+            "http://ats.apps.svc/gomod/github.com/JmPotato/pd/client/com_github_jmpotato_pd_client-v0.0.0-20231123144827-8fc4cf2ee7b0.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/JmPotato/pd/client/com_github_jmpotato_pd_client-v0.0.0-20231123144827-8fc4cf2ee7b0.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/JmPotato/pd/client/com_github_jmpotato_pd_client-v0.0.0-20231123144827-8fc4cf2ee7b0.zip",
         ],
     )
     go_repository(

--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -389,7 +389,7 @@ func (p *PdController) getRegionCountWith(
 	}
 	var err error
 	for _, addr := range p.getAllPDAddrs() {
-		v, e := get(ctx, addr, pdhttp.RegionStatsByKeyRange(start, end), p.cli, http.MethodGet, nil)
+		v, e := get(ctx, addr, pdhttp.RegionStatsByKeyRange(pdhttp.NewKeyRange(start, end)), p.cli, http.MethodGet, nil)
 		if e != nil {
 			err = e
 			continue

--- a/go.mod
+++ b/go.mod
@@ -314,4 +314,5 @@ replace (
 	github.com/dgrijalva/jwt-go => github.com/form3tech-oss/jwt-go v3.2.6-0.20210809144907-32ab6a8243d7+incompatible
 	github.com/go-ldap/ldap/v3 => github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117
 	github.com/pingcap/tidb/pkg/parser => ./pkg/parser
+	github.com/tikv/pd/client v0.0.0-20231121080541-8919bc11f770 => github.com/JmPotato/pd/client v0.0.0-20231123144827-8fc4cf2ee7b0
 )

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/tdakkota/asciicheck v0.2.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
 	github.com/tikv/client-go/v2 v2.0.8-0.20231116051730-1c2351c28173
-	github.com/tikv/pd/client v0.0.0-20231121080541-8919bc11f770
+	github.com/tikv/pd/client v0.0.0-20231127075044-9f4803d8bd05
 	github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966
 	github.com/twmb/murmur3 v1.1.6
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
@@ -314,5 +314,4 @@ replace (
 	github.com/dgrijalva/jwt-go => github.com/form3tech-oss/jwt-go v3.2.6-0.20210809144907-32ab6a8243d7+incompatible
 	github.com/go-ldap/ldap/v3 => github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117
 	github.com/pingcap/tidb/pkg/parser => ./pkg/parser
-	github.com/tikv/pd/client v0.0.0-20231121080541-8919bc11f770 => github.com/JmPotato/pd/client v0.0.0-20231123144827-8fc4cf2ee7b0
 )

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,6 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/Jeffail/gabs/v2 v2.5.1 h1:ANfZYjpMlfTTKebycu4X1AgkVWumFVDYQl7JwOr4mDk=
 github.com/Jeffail/gabs/v2 v2.5.1/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
-github.com/JmPotato/pd/client v0.0.0-20231123144827-8fc4cf2ee7b0 h1:EfoujwJPhwsS0Qe/Tc60nn2e9HfJPM9w5zbspIYNI74=
-github.com/JmPotato/pd/client v0.0.0-20231123144827-8fc4cf2ee7b0/go.mod h1:cd6zBqRM9aogxf26K8NnFRPVtq9BnRE59tKEpX8IaWQ=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -994,6 +992,8 @@ github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
 github.com/tikv/client-go/v2 v2.0.8-0.20231116051730-1c2351c28173 h1:lmJzX0kqrV7kO21wrZPbtjkidzwbDCfXeQrhDWEi5dE=
 github.com/tikv/client-go/v2 v2.0.8-0.20231116051730-1c2351c28173/go.mod h1:BOGTSZtbMHEnGC4HOpbONdnTQF+E9nb2Io7c3P9sb7g=
+github.com/tikv/pd/client v0.0.0-20231127075044-9f4803d8bd05 h1:87NPUfzaVrO5MTBwVCPQ/FlJGpFnHi6WFYHDYD3n3Zc=
+github.com/tikv/pd/client v0.0.0-20231127075044-9f4803d8bd05/go.mod h1:cd6zBqRM9aogxf26K8NnFRPVtq9BnRE59tKEpX8IaWQ=
 github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966 h1:quvGphlmUVU+nhpFa4gg4yJyTRJ13reZMDHrKwYw53M=
 github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966/go.mod h1:27bSVNWSBOHm+qRp1T9qzaIpsWEP6TbUnei/43HK+PQ=
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/Jeffail/gabs/v2 v2.5.1 h1:ANfZYjpMlfTTKebycu4X1AgkVWumFVDYQl7JwOr4mDk=
 github.com/Jeffail/gabs/v2 v2.5.1/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
+github.com/JmPotato/pd/client v0.0.0-20231123144827-8fc4cf2ee7b0 h1:EfoujwJPhwsS0Qe/Tc60nn2e9HfJPM9w5zbspIYNI74=
+github.com/JmPotato/pd/client v0.0.0-20231123144827-8fc4cf2ee7b0/go.mod h1:cd6zBqRM9aogxf26K8NnFRPVtq9BnRE59tKEpX8IaWQ=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -992,8 +994,6 @@ github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
 github.com/tikv/client-go/v2 v2.0.8-0.20231116051730-1c2351c28173 h1:lmJzX0kqrV7kO21wrZPbtjkidzwbDCfXeQrhDWEi5dE=
 github.com/tikv/client-go/v2 v2.0.8-0.20231116051730-1c2351c28173/go.mod h1:BOGTSZtbMHEnGC4HOpbONdnTQF+E9nb2Io7c3P9sb7g=
-github.com/tikv/pd/client v0.0.0-20231121080541-8919bc11f770 h1:YSXDKT9+KngRSAShoSQVKD/CK1kR4X/9hutKkSK9gn0=
-github.com/tikv/pd/client v0.0.0-20231121080541-8919bc11f770/go.mod h1:cd6zBqRM9aogxf26K8NnFRPVtq9BnRE59tKEpX8IaWQ=
 github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966 h1:quvGphlmUVU+nhpFa4gg4yJyTRJ13reZMDHrKwYw53M=
 github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966/go.mod h1:27bSVNWSBOHm+qRp1T9qzaIpsWEP6TbUnei/43HK+PQ=
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=

--- a/pkg/ddl/placement/BUILD.bazel
+++ b/pkg/ddl/placement/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/tablecodec",
         "//pkg/util/codec",
         "@com_github_pingcap_failpoint//:failpoint",
+        "@com_github_tikv_pd_client//http",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )
@@ -45,5 +46,6 @@ go_test(
         "//pkg/util/codec",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
+        "@com_github_tikv_pd_client//http",
     ],
 )

--- a/pkg/ddl/placement/meta_bundle_test.go
+++ b/pkg/ddl/placement/meta_bundle_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/stretchr/testify/require"
+	pd "github.com/tikv/pd/client/http"
 )
 
 type metaBundleSuite struct {
@@ -342,9 +343,9 @@ func (s *metaBundleSuite) checkPartitionBundle(t *testing.T, def model.Partition
 	s.checkTwoJSONObjectEquals(t, expected, got)
 }
 
-func (s *metaBundleSuite) expectedRules(t *testing.T, ref *model.PolicyRefInfo) []*placement.Rule {
+func (s *metaBundleSuite) expectedRules(t *testing.T, ref *model.PolicyRefInfo) []*pd.Rule {
 	if ref == nil {
-		return []*placement.Rule{}
+		return []*pd.Rule{}
 	}
 
 	var policy *model.PolicyInfo

--- a/pkg/domain/infosync/info.go
+++ b/pkg/domain/infosync/info.go
@@ -213,7 +213,7 @@ func GlobalInfoSyncerInit(
 		pdHTTPCli = pdHTTPCli.WithRespHandler(pdResponseHandler)
 	}
 	is.labelRuleManager = initLabelRuleManager(pdHTTPCli)
-	is.placementManager = initPlacementManager(etcdCli)
+	is.placementManager = initPlacementManager(pdHTTPCli)
 	is.scheduleManager = initScheduleManager(etcdCli)
 	is.tiflashReplicaManager = initTiFlashReplicaManager(etcdCli, codec)
 	is.resourceManagerClient = initResourceManagerClient(pdCli)
@@ -254,11 +254,11 @@ func initLabelRuleManager(pdHTTPCli pdhttp.Client) LabelRuleManager {
 	return &PDLabelManager{pdHTTPCli}
 }
 
-func initPlacementManager(etcdCli *clientv3.Client) PlacementManager {
-	if etcdCli == nil {
+func initPlacementManager(pdHTTPCli pdhttp.Client) PlacementManager {
+	if pdHTTPCli == nil {
 		return &mockPlacementManager{}
 	}
-	return &PDPlacementManager{etcdCli: etcdCli}
+	return &PDPlacementManager{pdHTTPCli}
 }
 
 func initResourceManagerClient(pdCli pd.Client) (cli pd.ResourceManagerClient) {

--- a/pkg/domain/infosync/placement_manager.go
+++ b/pkg/domain/infosync/placement_manager.go
@@ -15,18 +15,11 @@
 package infosync
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"net/http"
-	"path"
 	"sync"
 
-	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/ddl/placement"
 	pd "github.com/tikv/pd/client/http"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.uber.org/zap"
 )
 
 // PlacementManager manages placement settings
@@ -41,27 +34,30 @@ type PlacementManager interface {
 
 // PDPlacementManager manages placement with pd
 type PDPlacementManager struct {
-	etcdCli *clientv3.Client
+	pdHTTPCli pd.Client
 }
 
 // GetRuleBundle is used to get one specific rule bundle from PD.
 func (m *PDPlacementManager) GetRuleBundle(ctx context.Context, name string) (*placement.Bundle, error) {
-	bundle := &placement.Bundle{ID: name}
-	res, err := doRequest(ctx, "GetPlacementRule", m.etcdCli.Endpoints(), path.Join(pd.Config, "placement-rule", name), http.MethodGet, nil)
-	if err == nil && res != nil {
-		err = json.Unmarshal(res, bundle)
+	groupBundle, err := m.pdHTTPCli.GetPlacementRuleBundleByGroup(ctx, name)
+	if err != nil {
+		return nil, err
 	}
-	return bundle, err
+	groupBundle.ID = name
+	return (*placement.Bundle)(groupBundle), err
 }
 
 // GetAllRuleBundles is used to get all rule bundles from PD. It is used to load full rules from PD while fullload infoschema.
 func (m *PDPlacementManager) GetAllRuleBundles(ctx context.Context) ([]*placement.Bundle, error) {
-	var bundles []*placement.Bundle
-	res, err := doRequest(ctx, "GetAllPlacementRules", m.etcdCli.Endpoints(), path.Join(pd.Config, "placement-rule"), http.MethodGet, nil)
-	if err == nil && res != nil {
-		err = json.Unmarshal(res, &bundles)
+	bundles, err := m.pdHTTPCli.GetAllPlacementRuleBundles(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return bundles, err
+	rules := make([]*placement.Bundle, 0, len(bundles))
+	for _, bundle := range bundles {
+		rules = append(rules, (*placement.Bundle)(bundle))
+	}
+	return rules, nil
 }
 
 // PutRuleBundles is used to post specific rule bundles to PD.
@@ -69,15 +65,11 @@ func (m *PDPlacementManager) PutRuleBundles(ctx context.Context, bundles []*plac
 	if len(bundles) == 0 {
 		return nil
 	}
-
-	b, err := json.Marshal(bundles)
-	if err != nil {
-		return err
+	ruleBundles := make([]*pd.GroupBundle, 0, len(bundles))
+	for _, bundle := range bundles {
+		ruleBundles = append(ruleBundles, (*pd.GroupBundle)(bundle))
 	}
-
-	log.Debug("Put placement rule bundles", zap.String("rules", string(b)))
-	_, err = doRequest(ctx, "PutPlacementRules", m.etcdCli.Endpoints(), path.Join(pd.Config, "placement-rule")+"?partial=true", http.MethodPost, bytes.NewReader(b))
-	return err
+	return m.pdHTTPCli.SetPlacementRuleBundles(ctx, ruleBundles, true)
 }
 
 type mockPlacementManager struct {

--- a/pkg/domain/infosync/tiflash_manager.go
+++ b/pkg/domain/infosync/tiflash_manager.go
@@ -495,7 +495,7 @@ func (m *TiFlashReplicaManagerCtx) GetRegionCountFromPD(ctx context.Context, tab
 	endKey := tablecodec.EncodeTablePrefix(tableID + 1)
 	startKey, endKey = m.codec.EncodeRegionRange(startKey, endKey)
 
-	p := fmt.Sprintf("%s&count", pd.RegionStatsByKeyRange(startKey, endKey))
+	p := fmt.Sprintf("%s&count", pd.RegionStatsByKeyRange(pd.NewKeyRange(startKey, endKey)))
 	res, err := doRequest(ctx, "GetPDRegionStats", m.etcdCli.Endpoints(), p, "GET", nil)
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/domain/infosync/tiflash_manager.go
+++ b/pkg/domain/infosync/tiflash_manager.go
@@ -314,19 +314,19 @@ var _ json.Marshaler = (*RuleOp)(nil)
 var _ json.Unmarshaler = (*RuleOp)(nil)
 
 type ruleOp struct {
-	GroupID          string                 `json:"group_id"`
-	ID               string                 `json:"id"`
-	Index            int                    `json:"index,omitempty"`
-	Override         bool                   `json:"override,omitempty"`
-	Role             placement.PeerRoleType `json:"role"`
-	Count            int                    `json:"count"`
-	Constraints      placement.Constraints  `json:"label_constraints,omitempty"`
-	LocationLabels   []string               `json:"location_labels,omitempty"`
-	IsolationLevel   string                 `json:"isolation_level,omitempty"`
-	StartKeyHex      string                 `json:"start_key"`
-	EndKeyHex        string                 `json:"end_key"`
-	Action           RuleOpType             `json:"action"`
-	DeleteByIDPrefix bool                   `json:"delete_by_id_prefix"`
+	GroupID          string               `json:"group_id"`
+	ID               string               `json:"id"`
+	Index            int                  `json:"index,omitempty"`
+	Override         bool                 `json:"override,omitempty"`
+	Role             pd.PeerRoleType      `json:"role"`
+	Count            int                  `json:"count"`
+	Constraints      []pd.LabelConstraint `json:"label_constraints,omitempty"`
+	LocationLabels   []string             `json:"location_labels,omitempty"`
+	IsolationLevel   string               `json:"isolation_level,omitempty"`
+	StartKeyHex      string               `json:"start_key"`
+	EndKeyHex        string               `json:"end_key"`
+	Action           RuleOpType           `json:"action"`
+	DeleteByIDPrefix bool                 `json:"delete_by_id_prefix"`
 }
 
 // MarshalJSON implements json.Marshaler interface for RuleOp.
@@ -544,12 +544,12 @@ func makeBaseRule() placement.TiFlashRule {
 		ID:       "",
 		Index:    placement.RuleIndexTiFlash,
 		Override: false,
-		Role:     placement.Learner,
+		Role:     pd.Learner,
 		Count:    2,
-		Constraints: []placement.Constraint{
+		Constraints: []pd.LabelConstraint{
 			{
 				Key:    "engine",
-				Op:     placement.In,
+				Op:     pd.In,
 				Values: []string{"tiflash"},
 			},
 		},
@@ -874,7 +874,7 @@ func isRuleMatch(rule placement.TiFlashRule, startKey []byte, endKey []byte, cou
 	}
 	ok := false
 	for _, c := range rule.Constraints {
-		if c.Key == "engine" && len(c.Values) == 1 && c.Values[0] == "tiflash" && c.Op == placement.In {
+		if c.Key == "engine" && len(c.Values) == 1 && c.Values[0] == "tiflash" && c.Op == pd.In {
 			ok = true
 			break
 		}
@@ -894,7 +894,7 @@ func isRuleMatch(rule placement.TiFlashRule, startKey []byte, endKey []byte, cou
 	if rule.Count != count {
 		return false
 	}
-	if rule.Role != placement.Learner {
+	if rule.Role != pd.Learner {
 		return false
 	}
 	return true

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -1730,7 +1730,7 @@ func (*memtableRetriever) getRegionsInfoForSingleTable(ctx context.Context, help
 	if err != nil {
 		return nil, err
 	}
-	return pdCli.GetRegionsByKeyRange(ctx, sk, ek, -1)
+	return pdCli.GetRegionsByKeyRange(ctx, pd.NewKeyRange(sk, ek), -1)
 }
 
 func (e *memtableRetriever) setNewTiKVRegionStatusCol(region *pd.RegionInfo, table *helper.TableInfo) {

--- a/pkg/store/helper/helper.go
+++ b/pkg/store/helper/helper.go
@@ -806,7 +806,7 @@ func (h *Helper) GetPDRegionStats(ctx context.Context, tableID int64, noIndexSta
 	startKey = codec.EncodeBytes([]byte{}, startKey)
 	endKey = codec.EncodeBytes([]byte{}, endKey)
 
-	return pdCli.GetRegionStatusByKeyRange(ctx, startKey, endKey)
+	return pdCli.GetRegionStatusByKeyRange(ctx, pd.NewKeyRange(startKey, endKey))
 }
 
 // GetTiFlashTableIDFromEndKey computes tableID from pd rule's endKey.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #35319, https://github.com/tikv/pd/issues/7300

Problem Summary:

Integrate PD HTTP client into the placement manager.

### What is changed and how it works?

- Replace the etcd client inside `PlacementManager` with PD HTTP client.
- Reuse the type definitions within the PD SDK as much as possible.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
