### PR TITLE
lightning: still update stats_meta if analyze is skipped

### DIFF
--- a/br/pkg/lightning/importer/table_import.go
+++ b/br/pkg/lightning/importer/table_import.go
@@ -1000,7 +1000,7 @@ func (tr *TableImporter) postProcess(
 			}
 		}
 		indexNum := len(tr.tableInfo.Core.Indices)
-		if !tr.tableInfo.Core.PKIsHandle && !tr.tableInfo.Core.IsCommonHandle {
+		if common.TableHasAutoRowID(tr.tableInfo.Core) {
 			indexNum++
 		}
 		estimatedModifyCnt = int(localChecksum.SumKVS()) / (1 + indexNum)

--- a/br/tests/lightning_checkpoint_chunks/file.toml
+++ b/br/tests/lightning_checkpoint_chunks/file.toml
@@ -10,3 +10,6 @@ schema = "tidb_lightning_checkpoint_test_cpch"
 driver = "file"
 dsn = "/tmp/backup_restore_test/cpch.pb"
 keep-after-success = true
+
+[post-restore]
+analyze = false

--- a/br/tests/lightning_checkpoint_chunks/run.sh
+++ b/br/tests/lightning_checkpoint_chunks/run.sh
@@ -116,7 +116,7 @@ check_contains "sum(i): $(( $ROW_COUNT*$CHUNK_COUNT*(($CHUNK_COUNT+2)*$ROW_COUNT
 [ -e "$TEST_DIR/cpch.pb.1234567890.bak" ]
 
 # default auto analyze tick is 3s
-sleep 6s
+sleep 6
 run_sql "SHOW STATS_META WHERE Table_name = 'tbl';"
 check_contains "Row_count: 5000"
 check_contains "Modify_count: 0"

--- a/br/tests/lightning_checkpoint_chunks/run.sh
+++ b/br/tests/lightning_checkpoint_chunks/run.sh
@@ -114,3 +114,5 @@ check_contains "count(i): $(($ROW_COUNT*$CHUNK_COUNT))"
 check_contains "sum(i): $(( $ROW_COUNT*$CHUNK_COUNT*(($CHUNK_COUNT+2)*$ROW_COUNT + 1)/2 ))"
 [ ! -e "$TEST_DIR/cpch.pb" ]
 [ -e "$TEST_DIR/cpch.pb.1234567890.bak" ]
+
+read -p 123

--- a/br/tests/lightning_checkpoint_chunks/run.sh
+++ b/br/tests/lightning_checkpoint_chunks/run.sh
@@ -115,4 +115,9 @@ check_contains "sum(i): $(( $ROW_COUNT*$CHUNK_COUNT*(($CHUNK_COUNT+2)*$ROW_COUNT
 [ ! -e "$TEST_DIR/cpch.pb" ]
 [ -e "$TEST_DIR/cpch.pb.1234567890.bak" ]
 
-read -p 123
+# default auto analyze tick is 3s
+sleep 6s
+run_sql "SHOW STATS_META WHERE Table_name = 'tbl';"
+check_contains "Row_count: 5000"
+check_contains "Modify_count: 0"
+


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48562

Problem Summary:

### What changed and how does it work?

update mysql.stats_meta if analyze is off

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
even if lightning didn't run analyze which is specified in task configuration, still enable TiDB server auto analyze feature for the imported table
```
