### PR TITLE
expression: replace `EvalWithInnerCtx` with `Eval` for `PbConverter` and `ExplainInfo`

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -339,7 +339,7 @@ func (e *IndexReaderExecutor) open(ctx context.Context, kvRanges []kv.KeyRange) 
 		if err != nil {
 			return err
 		}
-		pbConditions, err := expression.ExpressionsToPBList(e.Ctx().GetSessionVars().StmtCtx, []expression.Expression{inCondition}, e.Ctx().GetClient())
+		pbConditions, err := expression.ExpressionsToPBList(e.Ctx(), []expression.Expression{inCondition}, e.Ctx().GetClient())
 		if err != nil {
 			return err
 		}

--- a/pkg/expression/aggregation/agg_to_pb.go
+++ b/pkg/expression/aggregation/agg_to_pb.go
@@ -101,7 +101,7 @@ func (desc *baseFuncDesc) GetTiPBExpr(tryWindowDesc bool) (tp tipb.ExprType) {
 
 // AggFuncToPBExpr converts aggregate function to pb.
 func AggFuncToPBExpr(sctx sessionctx.Context, client kv.Client, aggFunc *AggFuncDesc, storeType kv.StoreType) (*tipb.Expr, error) {
-	pc := expression.NewPBConverter(client, sctx.GetSessionVars().StmtCtx)
+	pc := expression.NewPBConverter(client, sctx)
 	tp := aggFunc.GetTiPBExpr(false)
 	if !client.IsRequestTypeSupported(kv.ReqTypeSelect, int64(tp)) {
 		return nil, errors.New("select request is not supported by client")
@@ -122,9 +122,8 @@ func AggFuncToPBExpr(sctx sessionctx.Context, client kv.Client, aggFunc *AggFunc
 
 	if tp == tipb.ExprType_GroupConcat {
 		orderBy := make([]*tipb.ByItem, 0, len(aggFunc.OrderByItems))
-		sc := sctx.GetSessionVars().StmtCtx
 		for _, arg := range aggFunc.OrderByItems {
-			pbArg := expression.SortByItemToPB(sc, client, arg.Expr, arg.Desc)
+			pbArg := expression.SortByItemToPB(sctx, client, arg.Expr, arg.Desc)
 			if pbArg == nil {
 				return nil, errors.New(aggFunc.String() + " can't be converted to PB.")
 			}

--- a/pkg/expression/aggregation/explain.go
+++ b/pkg/expression/aggregation/explain.go
@@ -19,10 +19,11 @@ import (
 	"fmt"
 
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 )
 
 // ExplainAggFunc generates explain information for a aggregation function.
-func ExplainAggFunc(agg *AggFuncDesc, normalized bool) string {
+func ExplainAggFunc(ctx sessionctx.Context, agg *AggFuncDesc, normalized bool) string {
 	var buffer bytes.Buffer
 	fmt.Fprintf(&buffer, "%s(", agg.Name)
 	if agg.HasDistinct {
@@ -37,13 +38,13 @@ func ExplainAggFunc(agg *AggFuncDesc, normalized bool) string {
 						if normalized {
 							fmt.Fprintf(&buffer, "%s desc", item.Expr.ExplainNormalizedInfo())
 						} else {
-							fmt.Fprintf(&buffer, "%s desc", item.Expr.ExplainInfo())
+							fmt.Fprintf(&buffer, "%s desc", item.Expr.ExplainInfo(ctx))
 						}
 					} else {
 						if normalized {
 							fmt.Fprintf(&buffer, "%s", item.Expr.ExplainNormalizedInfo())
 						} else {
-							fmt.Fprintf(&buffer, "%s", item.Expr.ExplainInfo())
+							fmt.Fprintf(&buffer, "%s", item.Expr.ExplainInfo(ctx))
 						}
 					}
 
@@ -59,7 +60,7 @@ func ExplainAggFunc(agg *AggFuncDesc, normalized bool) string {
 		if normalized {
 			buffer.WriteString(arg.ExplainNormalizedInfo())
 		} else {
-			buffer.WriteString(arg.ExplainInfo())
+			buffer.WriteString(arg.ExplainInfo(ctx))
 		}
 	}
 	buffer.WriteString(")")

--- a/pkg/expression/aggregation/window_func.go
+++ b/pkg/expression/aggregation/window_func.go
@@ -125,7 +125,7 @@ func (s *WindowFuncDesc) Clone() *WindowFuncDesc {
 
 // WindowFuncToPBExpr converts aggregate function to pb.
 func WindowFuncToPBExpr(sctx sessionctx.Context, client kv.Client, desc *WindowFuncDesc) *tipb.Expr {
-	pc := expression.NewPBConverter(client, sctx.GetSessionVars().StmtCtx)
+	pc := expression.NewPBConverter(client, sctx)
 	tp := desc.GetTiPBExpr(true)
 	if !client.IsRequestTypeSupported(kv.ReqTypeSelect, int64(tp)) {
 		return nil
@@ -145,7 +145,7 @@ func WindowFuncToPBExpr(sctx sessionctx.Context, client kv.Client, desc *WindowF
 // CanPushDownToTiFlash control whether a window function desc can be push down to tiflash.
 func (s *WindowFuncDesc) CanPushDownToTiFlash(ctx sessionctx.Context) bool {
 	// args
-	if !expression.CanExprsPushDown(ctx.GetSessionVars().StmtCtx, s.Args, ctx.GetClient(), kv.TiFlash) {
+	if !expression.CanExprsPushDown(ctx, s.Args, ctx.GetClient(), kv.TiFlash) {
 		return false
 	}
 	// window functions

--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -58,7 +58,7 @@ func isNullHandler(ctx sessionctx.Context, expr *ScalarFunction) (Expression, bo
 			// Failed to fold this expr to a constant, print the DEBUG log and
 			// return the original expression to let the error to be evaluated
 			// again, in that time, the error is returned to the client.
-			logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", expr.ExplainInfo()), zap.Error(err))
+			logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", expr.ExplainInfo(ctx)), zap.Error(err))
 			return expr, isDeferredConst
 		}
 		if isDeferredConst {
@@ -81,7 +81,7 @@ func ifFoldHandler(ctx sessionctx.Context, expr *ScalarFunction) (Expression, bo
 			// Failed to fold this expr to a constant, print the DEBUG log and
 			// return the original expression to let the error to be evaluated
 			// again, in that time, the error is returned to the client.
-			logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", expr.ExplainInfo()), zap.Error(err))
+			logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", expr.ExplainInfo(ctx)), zap.Error(err))
 			return expr, false
 		}
 		if !isNull0 && arg0 != 0 {
@@ -230,7 +230,7 @@ func foldConstant(ctx sessionctx.Context, expr Expression) (Expression, bool) {
 			}
 		}
 		if err != nil {
-			logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", x.ExplainInfo()), zap.Error(err))
+			logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", x.ExplainInfo(ctx)), zap.Error(err))
 			return expr, isDeferredConst
 		}
 		if isDeferredConst {
@@ -248,7 +248,7 @@ func foldConstant(ctx sessionctx.Context, expr Expression) (Expression, bool) {
 		} else if x.DeferredExpr != nil {
 			value, err := x.DeferredExpr.Eval(ctx, chunk.Row{})
 			if err != nil {
-				logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", x.ExplainInfo()), zap.Error(err))
+				logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", x.ExplainInfo(ctx)), zap.Error(err))
 				return expr, true
 			}
 			return &Constant{Value: value, RetType: x.RetType, DeferredExpr: x.DeferredExpr}, true

--- a/pkg/expression/explain.go
+++ b/pkg/expression/explain.go
@@ -21,16 +21,20 @@ import (
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 // ExplainInfo implements the Expression interface.
-func (expr *ScalarFunction) ExplainInfo() string {
-	return expr.explainInfo(false)
+func (expr *ScalarFunction) ExplainInfo(ctx sessionctx.Context) string {
+	return expr.explainInfo(ctx, false)
 }
 
-func (expr *ScalarFunction) explainInfo(normalized bool) string {
+func (expr *ScalarFunction) explainInfo(ctx sessionctx.Context, normalized bool) string {
+	// we only need ctx for non-normalized explain info.
+	intest.Assert(normalized || ctx != nil)
 	var buffer bytes.Buffer
 	fmt.Fprintf(&buffer, "%s(", expr.FuncName.L)
 	switch expr.FuncName.L {
@@ -39,7 +43,8 @@ func (expr *ScalarFunction) explainInfo(normalized bool) string {
 			if normalized {
 				buffer.WriteString(arg.ExplainNormalizedInfo())
 			} else {
-				buffer.WriteString(arg.ExplainInfo())
+				intest.Assert(ctx != nil)
+				buffer.WriteString(arg.ExplainInfo(ctx))
 			}
 			buffer.WriteString(", ")
 			buffer.WriteString(expr.RetType.String())
@@ -49,7 +54,8 @@ func (expr *ScalarFunction) explainInfo(normalized bool) string {
 			if normalized {
 				buffer.WriteString(arg.ExplainNormalizedInfo())
 			} else {
-				buffer.WriteString(arg.ExplainInfo())
+				intest.Assert(ctx != nil)
+				buffer.WriteString(arg.ExplainInfo(ctx))
 			}
 			if i+1 < len(expr.GetArgs()) {
 				buffer.WriteString(", ")
@@ -62,7 +68,7 @@ func (expr *ScalarFunction) explainInfo(normalized bool) string {
 
 // ExplainNormalizedInfo implements the Expression interface.
 func (expr *ScalarFunction) ExplainNormalizedInfo() string {
-	return expr.explainInfo(true)
+	return expr.explainInfo(nil, true)
 }
 
 // ExplainNormalizedInfo4InList implements the Expression interface.
@@ -90,30 +96,35 @@ func (expr *ScalarFunction) ExplainNormalizedInfo4InList() string {
 	return buffer.String()
 }
 
-// ExplainInfo implements the Expression interface.
-func (col *Column) ExplainInfo() string {
+// ColumnExplainInfo returns the explained info for column.
+func (col *Column) ColumnExplainInfo(normalized bool) string {
+	if normalized {
+		if col.OrigName != "" {
+			return col.OrigName
+		}
+		return "?"
+	}
 	return col.String()
+}
+
+// ExplainInfo implements the Expression interface.
+func (col *Column) ExplainInfo(sessionctx.Context) string {
+	return col.ColumnExplainInfo(false)
 }
 
 // ExplainNormalizedInfo implements the Expression interface.
 func (col *Column) ExplainNormalizedInfo() string {
-	if col.OrigName != "" {
-		return col.OrigName
-	}
-	return "?"
+	return col.ColumnExplainInfo(true)
 }
 
 // ExplainNormalizedInfo4InList implements the Expression interface.
 func (col *Column) ExplainNormalizedInfo4InList() string {
-	if col.OrigName != "" {
-		return col.OrigName
-	}
-	return "?"
+	return col.ColumnExplainInfo(true)
 }
 
 // ExplainInfo implements the Expression interface.
-func (expr *Constant) ExplainInfo() string {
-	dt, err := expr.EvalWithInnerCtx(chunk.Row{})
+func (expr *Constant) ExplainInfo(ctx sessionctx.Context) string {
+	dt, err := expr.Eval(ctx, chunk.Row{})
 	if err != nil {
 		return "not recognized const value"
 	}
@@ -179,16 +190,17 @@ func ExplainExpressionList(exprs []Expression, schema *Schema) string {
 // SortedExplainExpressionList generates explain information for a list of expressions in order.
 // In some scenarios, the expr's order may not be stable when executing multiple times.
 // So we add a sort to make its explain result stable.
-func SortedExplainExpressionList(exprs []Expression) []byte {
-	return sortedExplainExpressionList(exprs, false, false)
+func SortedExplainExpressionList(ctx sessionctx.Context, exprs []Expression) []byte {
+	return sortedExplainExpressionList(ctx, exprs, false, false)
 }
 
 // SortedExplainExpressionListIgnoreInlist generates explain information for a list of expressions in order.
 func SortedExplainExpressionListIgnoreInlist(exprs []Expression) []byte {
-	return sortedExplainExpressionList(exprs, false, true)
+	return sortedExplainExpressionList(nil, exprs, false, true)
 }
 
-func sortedExplainExpressionList(exprs []Expression, normalized bool, ignoreInlist bool) []byte {
+func sortedExplainExpressionList(ctx sessionctx.Context, exprs []Expression, normalized bool, ignoreInlist bool) []byte {
+	intest.Assert(ignoreInlist || normalized || ctx != nil)
 	buffer := bytes.NewBufferString("")
 	exprInfos := make([]string, 0, len(exprs))
 	for _, expr := range exprs {
@@ -197,7 +209,8 @@ func sortedExplainExpressionList(exprs []Expression, normalized bool, ignoreInli
 		} else if normalized {
 			exprInfos = append(exprInfos, expr.ExplainNormalizedInfo())
 		} else {
-			exprInfos = append(exprInfos, expr.ExplainInfo())
+			intest.Assert(ctx != nil)
+			exprInfos = append(exprInfos, expr.ExplainInfo(ctx))
 		}
 	}
 	slices.Sort(exprInfos)
@@ -212,7 +225,7 @@ func sortedExplainExpressionList(exprs []Expression, normalized bool, ignoreInli
 
 // SortedExplainNormalizedExpressionList is same like SortedExplainExpressionList, but use for generating normalized information.
 func SortedExplainNormalizedExpressionList(exprs []Expression) []byte {
-	return sortedExplainExpressionList(exprs, true, false)
+	return sortedExplainExpressionList(nil, exprs, true, false)
 }
 
 // SortedExplainNormalizedScalarFuncList is same like SortedExplainExpressionList, but use for generating normalized information.
@@ -221,14 +234,14 @@ func SortedExplainNormalizedScalarFuncList(exprs []*ScalarFunction) []byte {
 	for i := range exprs {
 		expressions[i] = exprs[i]
 	}
-	return sortedExplainExpressionList(expressions, true, false)
+	return sortedExplainExpressionList(nil, expressions, true, false)
 }
 
 // ExplainColumnList generates explain information for a list of columns.
-func ExplainColumnList(cols []*Column) []byte {
+func ExplainColumnList(ctx sessionctx.Context, cols []*Column) []byte {
 	buffer := bytes.NewBufferString("")
 	for i, col := range cols {
-		buffer.WriteString(col.ExplainInfo())
+		buffer.WriteString(col.ExplainInfo(ctx))
 		if i+1 < len(cols) {
 			buffer.WriteString(", ")
 		}

--- a/pkg/expression/expr_to_pb.go
+++ b/pkg/expression/expr_to_pb.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	ast "github.com/pingcap/tidb/pkg/parser/types"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
@@ -34,8 +34,8 @@ import (
 )
 
 // ExpressionsToPBList converts expressions to tipb.Expr list for new plan.
-func ExpressionsToPBList(sc *stmtctx.StatementContext, exprs []Expression, client kv.Client) (pbExpr []*tipb.Expr, err error) {
-	pc := PbConverter{client: client, sc: sc}
+func ExpressionsToPBList(ctx sessionctx.Context, exprs []Expression, client kv.Client) (pbExpr []*tipb.Expr, err error) {
+	pc := PbConverter{client: client, ctx: ctx}
 	for _, expr := range exprs {
 		v := pc.ExprToPB(expr)
 		if v == nil {
@@ -49,12 +49,12 @@ func ExpressionsToPBList(sc *stmtctx.StatementContext, exprs []Expression, clien
 // PbConverter supplies methods to convert TiDB expressions to TiPB.
 type PbConverter struct {
 	client kv.Client
-	sc     *stmtctx.StatementContext
+	ctx    sessionctx.Context
 }
 
 // NewPBConverter creates a PbConverter.
-func NewPBConverter(client kv.Client, sc *stmtctx.StatementContext) PbConverter {
-	return PbConverter{client: client, sc: sc}
+func NewPBConverter(client kv.Client, ctx sessionctx.Context) PbConverter {
+	return PbConverter{client: client, ctx: ctx}
 }
 
 // ExprToPB converts Expression to TiPB.
@@ -78,9 +78,9 @@ func (pc PbConverter) ExprToPB(expr Expression) *tipb.Expr {
 
 func (pc PbConverter) conOrCorColToPBExpr(expr Expression) *tipb.Expr {
 	ft := expr.GetType()
-	d, err := expr.EvalWithInnerCtx(chunk.Row{})
+	d, err := expr.Eval(pc.ctx, chunk.Row{})
 	if err != nil {
-		logutil.BgLogger().Error("eval constant or correlated column", zap.String("expression", expr.ExplainInfo()), zap.Error(err))
+		logutil.BgLogger().Error("eval constant or correlated column", zap.String("expression", expr.ExplainInfo(pc.ctx)), zap.Error(err))
 		return nil
 	}
 	tp, val, ok := pc.encodeDatum(ft, d)
@@ -143,8 +143,9 @@ func (pc *PbConverter) encodeDatum(ft *types.FieldType, d types.Datum) (tipb.Exp
 	case types.KindMysqlTime:
 		if pc.client.IsRequestTypeSupported(kv.ReqTypeDAG, int64(tipb.ExprType_MysqlTime)) {
 			tp = tipb.ExprType_MysqlTime
-			val, err := codec.EncodeMySQLTime(pc.sc.TimeZone(), d.GetMysqlTime(), ft.GetType(), nil)
-			err = pc.sc.HandleError(err)
+			sc := pc.ctx.GetSessionVars().StmtCtx
+			val, err := codec.EncodeMySQLTime(sc.TimeZone(), d.GetMysqlTime(), ft.GetType(), nil)
+			err = sc.HandleError(err)
 			if err != nil {
 				logutil.BgLogger().Error("encode mysql time", zap.Error(err))
 				return tp, nil, false
@@ -277,8 +278,8 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 }
 
 // GroupByItemToPB converts group by items to pb.
-func GroupByItemToPB(sc *stmtctx.StatementContext, client kv.Client, expr Expression) *tipb.ByItem {
-	pc := PbConverter{client: client, sc: sc}
+func GroupByItemToPB(ctx sessionctx.Context, client kv.Client, expr Expression) *tipb.ByItem {
+	pc := PbConverter{client: client, ctx: ctx}
 	e := pc.ExprToPB(expr)
 	if e == nil {
 		return nil
@@ -287,8 +288,8 @@ func GroupByItemToPB(sc *stmtctx.StatementContext, client kv.Client, expr Expres
 }
 
 // SortByItemToPB converts order by items to pb.
-func SortByItemToPB(sc *stmtctx.StatementContext, client kv.Client, expr Expression, desc bool) *tipb.ByItem {
-	pc := PbConverter{client: client, sc: sc}
+func SortByItemToPB(ctx sessionctx.Context, client kv.Client, expr Expression, desc bool) *tipb.ByItem {
+	pc := PbConverter{client: client, ctx: ctx}
 	e := pc.ExprToPB(expr)
 	if e == nil {
 		return nil

--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/pingcap/tipb/go-tipb"
@@ -44,7 +43,7 @@ func genColumn(tp byte, id int64) *Column {
 func TestConstant2Pb(t *testing.T) {
 	t.Skip("constant pb has changed")
 	var constExprs []Expression
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	// can be transformed
@@ -99,11 +98,11 @@ func TestConstant2Pb(t *testing.T) {
 	require.Equal(t, types.KindMysqlEnum, constValue.Value.Kind())
 	constExprs = append(constExprs, constValue)
 
-	pushed, remained := PushDownExprs(sc, constExprs, client, kv.UnSpecified)
+	pushed, remained := PushDownExprs(ctx, constExprs, client, kv.UnSpecified)
 	require.Len(t, pushed, len(constExprs)-3)
 	require.Len(t, remained, 3)
 
-	pbExprs, err := ExpressionsToPBList(sc, constExprs, client)
+	pbExprs, err := ExpressionsToPBList(ctx, constExprs, client)
 	require.NoError(t, err)
 	jsons := []string{
 		"{\"tp\":0,\"sig\":0}",
@@ -127,19 +126,19 @@ func TestConstant2Pb(t *testing.T) {
 
 func TestColumn2Pb(t *testing.T) {
 	var colExprs []Expression
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	colExprs = append(colExprs, genColumn(mysql.TypeSet, 1))
 	colExprs = append(colExprs, genColumn(mysql.TypeGeometry, 2))
 	colExprs = append(colExprs, genColumn(mysql.TypeUnspecified, 3))
 
-	pushed, remained := PushDownExprs(sc, colExprs, client, kv.UnSpecified)
+	pushed, remained := PushDownExprs(ctx, colExprs, client, kv.UnSpecified)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(colExprs))
 
 	for _, col := range colExprs { // cannot be pushed down
-		_, err := ExpressionsToPBList(sc, []Expression{col}, client)
+		_, err := ExpressionsToPBList(ctx, []Expression{col}, client)
 		require.Error(t, err)
 	}
 
@@ -168,11 +167,11 @@ func TestColumn2Pb(t *testing.T) {
 	colExprs = append(colExprs, genColumn(mysql.TypeString, 23))
 	colExprs = append(colExprs, genColumn(mysql.TypeEnum, 24))
 	colExprs = append(colExprs, genColumn(mysql.TypeBit, 25))
-	pushed, remained = PushDownExprs(sc, colExprs, client, kv.UnSpecified)
+	pushed, remained = PushDownExprs(ctx, colExprs, client, kv.UnSpecified)
 	require.Len(t, pushed, len(colExprs))
 	require.Len(t, remained, 0)
 
-	pbExprs, err := ExpressionsToPBList(sc, colExprs, client)
+	pbExprs, err := ExpressionsToPBList(ctx, colExprs, client)
 	require.NoError(t, err)
 	jsons := []string{
 		"{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":1,\"flag\":0,\"flen\":4,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}",
@@ -212,14 +211,14 @@ func TestColumn2Pb(t *testing.T) {
 		expr.(*Column).Index = 0
 	}
 
-	pushed, remained = PushDownExprs(sc, colExprs, client, kv.UnSpecified)
+	pushed, remained = PushDownExprs(ctx, colExprs, client, kv.UnSpecified)
 	require.Len(t, pushed, len(colExprs))
 	require.Len(t, remained, 0)
 }
 
 func TestCompareFunc2Pb(t *testing.T) {
 	var compareExprs = make([]Expression, 0)
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	funcNames := []string{ast.LT, ast.LE, ast.GT, ast.GE, ast.EQ, ast.NE, ast.NullEQ}
@@ -229,11 +228,11 @@ func TestCompareFunc2Pb(t *testing.T) {
 		compareExprs = append(compareExprs, fc)
 	}
 
-	pushed, remained := PushDownExprs(sc, compareExprs, client, kv.UnSpecified)
+	pushed, remained := PushDownExprs(ctx, compareExprs, client, kv.UnSpecified)
 	require.Len(t, pushed, len(compareExprs))
 	require.Len(t, remained, 0)
 
-	pbExprs, err := ExpressionsToPBList(sc, compareExprs, client)
+	pbExprs, err := ExpressionsToPBList(ctx, compareExprs, client)
 	require.NoError(t, err)
 	require.Len(t, pbExprs, len(compareExprs))
 	jsons := []string{
@@ -255,7 +254,7 @@ func TestCompareFunc2Pb(t *testing.T) {
 
 func TestLikeFunc2Pb(t *testing.T) {
 	var likeFuncs []Expression
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	retTp := types.NewFieldType(mysql.TypeString)
@@ -268,7 +267,6 @@ func TestLikeFunc2Pb(t *testing.T) {
 		&Constant{RetType: retTp, Value: types.NewDatum(`%abc%`)},
 		&Constant{RetType: retTp, Value: types.NewDatum("\\")},
 	}
-	ctx := mock.NewContext()
 	retTp = types.NewFieldType(mysql.TypeUnspecified)
 	fc, err := NewFunction(ctx, ast.Like, retTp, args[0], args[1], args[3])
 	require.NoError(t, err)
@@ -278,7 +276,7 @@ func TestLikeFunc2Pb(t *testing.T) {
 	require.NoError(t, err)
 	likeFuncs = append(likeFuncs, fc)
 
-	pbExprs, err := ExpressionsToPBList(sc, likeFuncs, client)
+	pbExprs, err := ExpressionsToPBList(ctx, likeFuncs, client)
 	require.NoError(t, err)
 	results := []string{
 		`{"tp":10000,"children":[{"tp":5,"val":"c3RyaW5n","sig":0,"field_type":{"tp":254,"flag":1,"flen":-1,"decimal":-1,"collate":-83,"charset":"utf8","array":false},"has_distinct":false},{"tp":5,"val":"cGF0dGVybg==","sig":0,"field_type":{"tp":254,"flag":1,"flen":-1,"decimal":-1,"collate":-83,"charset":"utf8","array":false},"has_distinct":false},{"tp":10000,"val":"CAA=","children":[{"tp":5,"val":"XA==","sig":0,"field_type":{"tp":254,"flag":1,"flen":-1,"decimal":-1,"collate":-83,"charset":"utf8","array":false},"has_distinct":false}],"sig":30,"field_type":{"tp":8,"flag":129,"flen":-1,"decimal":0,"collate":-83,"charset":"binary","array":false},"has_distinct":false}],"sig":4310,"field_type":{"tp":8,"flag":524416,"flen":1,"decimal":0,"collate":-83,"charset":"binary","array":false},"has_distinct":false}`,
@@ -293,7 +291,7 @@ func TestLikeFunc2Pb(t *testing.T) {
 
 func TestArithmeticalFunc2Pb(t *testing.T) {
 	var arithmeticalFuncs = make([]Expression, 0)
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	funcNames := []string{ast.Plus, ast.Minus, ast.Mul, ast.Div}
@@ -315,7 +313,7 @@ func TestArithmeticalFunc2Pb(t *testing.T) {
 	jsons[ast.Div] = "{\"tp\":10000,\"children\":[{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},{\"tp\":201,\"val\":\"gAAAAAAAAAI=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}],\"sig\":211,\"field_type\":{\"tp\":5,\"flag\":128,\"flen\":23,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}"
 	jsons[ast.Mod] = "{\"tp\":10000,\"children\":[{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},{\"tp\":201,\"val\":\"gAAAAAAAAAI=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}],\"sig\":215,\"field_type\":{\"tp\":5,\"flag\":128,\"flen\":23,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}"
 
-	pbExprs, err := ExpressionsToPBList(sc, arithmeticalFuncs, client)
+	pbExprs, err := ExpressionsToPBList(ctx, arithmeticalFuncs, client)
 	require.NoError(t, err)
 	for i, pbExpr := range pbExprs {
 		require.NotNil(t, pbExpr)
@@ -333,13 +331,13 @@ func TestArithmeticalFunc2Pb(t *testing.T) {
 			genColumn(mysql.TypeDouble, 1),
 			genColumn(mysql.TypeDouble, 2))
 		require.NoError(t, err)
-		_, err = ExpressionsToPBList(sc, []Expression{fc}, client)
+		_, err = ExpressionsToPBList(ctx, []Expression{fc}, client)
 		require.Error(t, err)
 	}
 }
 
 func TestDateFunc2Pb(t *testing.T) {
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	fc, err := NewFunction(
@@ -350,7 +348,7 @@ func TestDateFunc2Pb(t *testing.T) {
 		genColumn(mysql.TypeString, 2))
 	require.NoError(t, err)
 	funcs := []Expression{fc}
-	pbExprs, err := ExpressionsToPBList(sc, funcs, client)
+	pbExprs, err := ExpressionsToPBList(ctx, funcs, client)
 	require.NoError(t, err)
 	require.NotNil(t, pbExprs[0])
 	js, err := json.Marshal(pbExprs[0])
@@ -360,7 +358,7 @@ func TestDateFunc2Pb(t *testing.T) {
 
 func TestLogicalFunc2Pb(t *testing.T) {
 	var logicalFuncs = make([]Expression, 0)
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	funcNames := []string{ast.LogicAnd, ast.LogicOr, ast.LogicXor, ast.UnaryNot}
@@ -379,7 +377,7 @@ func TestLogicalFunc2Pb(t *testing.T) {
 		logicalFuncs = append(logicalFuncs, fc)
 	}
 
-	pbExprs, err := ExpressionsToPBList(sc, logicalFuncs, client)
+	pbExprs, err := ExpressionsToPBList(ctx, logicalFuncs, client)
 	require.NoError(t, err)
 	jsons := []string{
 		"{\"tp\":10000,\"children\":[{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":1,\"flag\":0,\"flen\":4,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},{\"tp\":201,\"val\":\"gAAAAAAAAAI=\",\"sig\":0,\"field_type\":{\"tp\":1,\"flag\":0,\"flen\":4,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}],\"sig\":3101,\"field_type\":{\"tp\":8,\"flag\":524416,\"flen\":1,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}",
@@ -396,7 +394,7 @@ func TestLogicalFunc2Pb(t *testing.T) {
 
 func TestBitwiseFunc2Pb(t *testing.T) {
 	var bitwiseFuncs = make([]Expression, 0)
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	funcNames := []string{ast.And, ast.Or, ast.Xor, ast.LeftShift, ast.RightShift, ast.BitNeg}
@@ -415,7 +413,7 @@ func TestBitwiseFunc2Pb(t *testing.T) {
 		bitwiseFuncs = append(bitwiseFuncs, fc)
 	}
 
-	pbExprs, err := ExpressionsToPBList(sc, bitwiseFuncs, client)
+	pbExprs, err := ExpressionsToPBList(ctx, bitwiseFuncs, client)
 	require.NoError(t, err)
 	jsons := []string{
 		"{\"tp\":10000,\"children\":[{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":3,\"flag\":0,\"flen\":11,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},{\"tp\":201,\"val\":\"gAAAAAAAAAI=\",\"sig\":0,\"field_type\":{\"tp\":3,\"flag\":0,\"flen\":11,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}],\"sig\":3118,\"field_type\":{\"tp\":8,\"flag\":160,\"flen\":20,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}",
@@ -434,7 +432,7 @@ func TestBitwiseFunc2Pb(t *testing.T) {
 
 func TestControlFunc2Pb(t *testing.T) {
 	var controlFuncs = make([]Expression, 0)
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	funcNames := []string{
@@ -458,7 +456,7 @@ func TestControlFunc2Pb(t *testing.T) {
 		controlFuncs = append(controlFuncs, fc)
 	}
 
-	pbExprs, err := ExpressionsToPBList(sc, controlFuncs, client)
+	pbExprs, err := ExpressionsToPBList(ctx, controlFuncs, client)
 	require.NoError(t, err)
 	jsons := []string{
 		"{\"tp\":10000,\"children\":[{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":3,\"flag\":0,\"flen\":11,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},{\"tp\":201,\"val\":\"gAAAAAAAAAI=\",\"sig\":0,\"field_type\":{\"tp\":3,\"flag\":0,\"flen\":11,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},{\"tp\":201,\"val\":\"gAAAAAAAAAM=\",\"sig\":0,\"field_type\":{\"tp\":3,\"flag\":0,\"flen\":11,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}],\"sig\":4208,\"field_type\":{\"tp\":3,\"flag\":128,\"flen\":11,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}",
@@ -475,7 +473,6 @@ func TestControlFunc2Pb(t *testing.T) {
 
 func TestOtherFunc2Pb(t *testing.T) {
 	var otherFuncs = make([]Expression, 0)
-	sc := stmtctx.NewStmtCtx()
 	client := new(mock.Client)
 
 	funcNames := []string{ast.Coalesce, ast.IsNull}
@@ -490,7 +487,7 @@ func TestOtherFunc2Pb(t *testing.T) {
 		otherFuncs = append(otherFuncs, fc)
 	}
 
-	pbExprs, err := ExpressionsToPBList(sc, otherFuncs, client)
+	pbExprs, err := ExpressionsToPBList(mock.NewContext(), otherFuncs, client)
 	require.NoError(t, err)
 	jsons := map[string]string{
 		ast.Coalesce: "{\"tp\":10000,\"children\":[{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":3,\"flag\":0,\"flen\":11,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}],\"sig\":4201,\"field_type\":{\"tp\":3,\"flag\":0,\"flen\":11,\"decimal\":0,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false}",
@@ -504,7 +501,7 @@ func TestOtherFunc2Pb(t *testing.T) {
 }
 
 func TestExprPushDownToFlash(t *testing.T) {
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	exprs := make([]Expression, 0)
@@ -978,7 +975,7 @@ func TestExprPushDownToFlash(t *testing.T) {
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 
-	canPush := CanExprsPushDown(sc, exprs, client, kv.TiFlash)
+	canPush := CanExprsPushDown(mock.NewContext(), exprs, client, kv.TiFlash)
 	require.Equal(t, true, canPush)
 
 	exprs = exprs[:0]
@@ -1037,11 +1034,11 @@ func TestExprPushDownToFlash(t *testing.T) {
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 
-	pushed, remained := PushDownExprs(sc, exprs, client, kv.TiFlash)
+	pushed, remained := PushDownExprs(ctx, exprs, client, kv.TiFlash)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
 
-	pushed, remained = PushDownExprsWithExtraInfo(sc, exprs, client, kv.TiFlash, true)
+	pushed, remained = PushDownExprsWithExtraInfo(ctx, exprs, client, kv.TiFlash, true)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
 
@@ -1294,18 +1291,17 @@ func TestExprPushDownToFlash(t *testing.T) {
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 
-	pushed, remained = PushDownExprs(sc, exprs, client, kv.TiFlash)
+	pushed, remained = PushDownExprs(ctx, exprs, client, kv.TiFlash)
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
 
-	pushed, remained = PushDownExprsWithExtraInfo(sc, exprs, client, kv.TiFlash, true)
+	pushed, remained = PushDownExprsWithExtraInfo(ctx, exprs, client, kv.TiFlash, true)
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
 }
 
 func TestExprOnlyPushDownToFlash(t *testing.T) {
 	t.Skip("Skip this unstable test temporarily and bring it back before 2021-07-26")
-	sc := stmtctx.NewStmtCtx()
 	client := new(mock.Client)
 
 	exprs := make([]Expression, 0)
@@ -1343,26 +1339,25 @@ func TestExprOnlyPushDownToFlash(t *testing.T) {
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 
-	pushed, remained := PushDownExprs(sc, exprs, client, kv.UnSpecified)
+	pushed, remained := PushDownExprs(mock.NewContext(), exprs, client, kv.UnSpecified)
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
 
-	canPush := CanExprsPushDown(sc, exprs, client, kv.TiFlash)
+	canPush := CanExprsPushDown(mock.NewContext(), exprs, client, kv.TiFlash)
 	require.Equal(t, true, canPush)
-	canPush = CanExprsPushDown(sc, exprs, client, kv.TiKV)
+	canPush = CanExprsPushDown(mock.NewContext(), exprs, client, kv.TiKV)
 	require.Equal(t, false, canPush)
 
-	pushed, remained = PushDownExprs(sc, exprs, client, kv.TiFlash)
+	pushed, remained = PushDownExprs(mock.NewContext(), exprs, client, kv.TiFlash)
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
 
-	pushed, remained = PushDownExprs(sc, exprs, client, kv.TiKV)
+	pushed, remained = PushDownExprs(mock.NewContext(), exprs, client, kv.TiKV)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
 }
 
 func TestExprPushDownToTiKV(t *testing.T) {
-	sc := stmtctx.NewStmtCtx()
 	client := new(mock.Client)
 
 	exprs := make([]Expression, 0)
@@ -1410,7 +1405,7 @@ func TestExprPushDownToTiKV(t *testing.T) {
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 
-	pushed, remained := PushDownExprs(sc, exprs, client, kv.TiKV)
+	pushed, remained := PushDownExprs(mock.NewContext(), exprs, client, kv.TiKV)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
 
@@ -1538,78 +1533,79 @@ func TestExprPushDownToTiKV(t *testing.T) {
 		},
 	}
 
+	ctx := mock.NewContext()
 	for _, tc := range testcases {
-		function, err = NewFunction(mock.NewContext(), tc.functionName, tc.retType, tc.args...)
+		function, err = NewFunction(ctx, tc.functionName, tc.retType, tc.args...)
 		require.NoError(t, err)
 		exprs = append(exprs, function)
 	}
 
-	pushed, remained = PushDownExprs(sc, exprs, client, kv.TiKV)
+	pushed, remained = PushDownExprs(ctx, exprs, client, kv.TiKV)
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
 }
 
 func TestExprOnlyPushDownToTiKV(t *testing.T) {
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
-	function, err := NewFunction(mock.NewContext(), "uuid", types.NewFieldType(mysql.TypeLonglong))
+	function, err := NewFunction(ctx, "uuid", types.NewFieldType(mysql.TypeLonglong))
 	require.NoError(t, err)
 	var exprs = make([]Expression, 0)
 	exprs = append(exprs, function)
 
-	pushed, remained := PushDownExprs(sc, exprs, client, kv.UnSpecified)
+	pushed, remained := PushDownExprs(ctx, exprs, client, kv.UnSpecified)
 	require.Len(t, pushed, 1)
 	require.Len(t, remained, 0)
 
-	canPush := CanExprsPushDown(sc, exprs, client, kv.TiFlash)
+	canPush := CanExprsPushDown(ctx, exprs, client, kv.TiFlash)
 	require.Equal(t, false, canPush)
-	canPush = CanExprsPushDown(sc, exprs, client, kv.TiKV)
+	canPush = CanExprsPushDown(ctx, exprs, client, kv.TiKV)
 	require.Equal(t, true, canPush)
 
-	pushed, remained = PushDownExprs(sc, exprs, client, kv.TiFlash)
+	pushed, remained = PushDownExprs(ctx, exprs, client, kv.TiFlash)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, 1)
-	pushed, remained = PushDownExprs(sc, exprs, client, kv.TiKV)
+	pushed, remained = PushDownExprs(ctx, exprs, client, kv.TiKV)
 	require.Len(t, pushed, 1)
 	require.Len(t, remained, 0)
 }
 
 func TestGroupByItem2Pb(t *testing.T) {
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	item := genColumn(mysql.TypeDouble, 0)
-	pbByItem := GroupByItemToPB(sc, client, item)
+	pbByItem := GroupByItemToPB(ctx, client, item)
 	js, err := json.Marshal(pbByItem)
 	require.NoError(t, err)
 	require.Equal(t, "{\"expr\":{\"tp\":201,\"val\":\"gAAAAAAAAAA=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},\"desc\":false}", string(js))
 
 	item = genColumn(mysql.TypeDouble, 1)
-	pbByItem = GroupByItemToPB(sc, client, item)
+	pbByItem = GroupByItemToPB(ctx, client, item)
 	js, err = json.Marshal(pbByItem)
 	require.NoError(t, err)
 	require.Equal(t, "{\"expr\":{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},\"desc\":false}", string(js))
 }
 
 func TestSortByItem2Pb(t *testing.T) {
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	item := genColumn(mysql.TypeDouble, 0)
-	pbByItem := SortByItemToPB(sc, client, item, false)
+	pbByItem := SortByItemToPB(ctx, client, item, false)
 	js, err := json.Marshal(pbByItem)
 	require.NoError(t, err)
 	require.Equal(t, "{\"expr\":{\"tp\":201,\"val\":\"gAAAAAAAAAA=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},\"desc\":false}", string(js))
 
 	item = genColumn(mysql.TypeDouble, 1)
-	pbByItem = SortByItemToPB(sc, client, item, false)
+	pbByItem = SortByItemToPB(ctx, client, item, false)
 	js, err = json.Marshal(pbByItem)
 	require.NoError(t, err)
 	require.Equal(t, "{\"expr\":{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},\"desc\":false}", string(js))
 
 	item = genColumn(mysql.TypeDouble, 1)
-	pbByItem = SortByItemToPB(sc, client, item, true)
+	pbByItem = SortByItemToPB(ctx, client, item, true)
 	js, err = json.Marshal(pbByItem)
 	require.NoError(t, err)
 	require.Equal(t, "{\"expr\":{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-63,\"charset\":\"binary\",\"array\":false},\"has_distinct\":false},\"desc\":true}", string(js))
@@ -1624,7 +1620,7 @@ func TestPushCollationDown(t *testing.T) {
 	tps := []*types.FieldType{types.NewFieldType(mysql.TypeVarchar), types.NewFieldType(mysql.TypeVarchar)}
 	for _, coll := range []string{charset.CollationBin, charset.CollationLatin1, charset.CollationUTF8, charset.CollationUTF8MB4} {
 		fc.SetCharsetAndCollation("binary", coll) // only collation matters
-		pbExpr, err := ExpressionsToPBList(ctx.GetSessionVars().StmtCtx, []Expression{fc}, client)
+		pbExpr, err := ExpressionsToPBList(ctx, []Expression{fc}, client)
 		require.NoError(t, err)
 		expr, err := PBToExpr(ctx, pbExpr[0], tps)
 		require.NoError(t, err)
@@ -1641,7 +1637,7 @@ func columnCollation(c *Column, chs, coll string) *Column {
 
 func TestNewCollationsEnabled(t *testing.T) {
 	var colExprs []Expression
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	colExprs = colExprs[:0]
@@ -1652,9 +1648,9 @@ func TestNewCollationsEnabled(t *testing.T) {
 	colExprs = append(colExprs, columnCollation(genColumn(mysql.TypeVarchar, 5), "utf8", "utf8_bin"))
 	colExprs = append(colExprs, columnCollation(genColumn(mysql.TypeVarchar, 6), "utf8", "utf8_unicode_ci"))
 	colExprs = append(colExprs, columnCollation(genColumn(mysql.TypeVarchar, 7), "utf8mb4", "utf8mb4_zh_pinyin_tidb_as_cs"))
-	pushed, _ := PushDownExprs(sc, colExprs, client, kv.UnSpecified)
+	pushed, _ := PushDownExprs(ctx, colExprs, client, kv.UnSpecified)
 	require.Equal(t, len(colExprs), len(pushed))
-	pbExprs, err := ExpressionsToPBList(sc, colExprs, client)
+	pbExprs, err := ExpressionsToPBList(ctx, colExprs, client)
 	require.NoError(t, err)
 	jsons := []string{
 		"{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":15,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-46,\"charset\":\"utf8mb4\",\"array\":false},\"has_distinct\":false}",
@@ -1673,14 +1669,14 @@ func TestNewCollationsEnabled(t *testing.T) {
 	}
 
 	item := columnCollation(genColumn(mysql.TypeDouble, 0), "utf8mb4", "utf8mb4_0900_ai_ci")
-	pbByItem := GroupByItemToPB(sc, client, item)
+	pbByItem := GroupByItemToPB(ctx, client, item)
 	js, err := json.Marshal(pbByItem)
 	require.NoError(t, err)
 	require.Equal(t, "{\"expr\":{\"tp\":201,\"val\":\"gAAAAAAAAAA=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":-255,\"charset\":\"utf8mb4\",\"array\":false},\"has_distinct\":false},\"desc\":false}", string(js))
 }
 
 func TestMetadata(t *testing.T) {
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/expression/PushDownTestSwitcher", `return("all")`))
@@ -1688,7 +1684,7 @@ func TestMetadata(t *testing.T) {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/expression/PushDownTestSwitcher"))
 	}()
 
-	pc := PbConverter{client: client, sc: sc}
+	pc := PbConverter{client: client, ctx: ctx}
 
 	metadata := new(tipb.InUnionMetadata)
 	var err error
@@ -1722,7 +1718,7 @@ func TestMetadata(t *testing.T) {
 
 func TestPushDownSwitcher(t *testing.T) {
 	var funcs = make([]Expression, 0)
-	sc := stmtctx.NewStmtCtx()
+	ctx := mock.NewContext()
 	client := new(mock.Client)
 
 	cases := []struct {
@@ -1758,7 +1754,7 @@ func TestPushDownSwitcher(t *testing.T) {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/expression/PushDownTestSwitcher"))
 	}()
 
-	pbExprs, err := ExpressionsToPBList(sc, funcs, client)
+	pbExprs, err := ExpressionsToPBList(ctx, funcs, client)
 	require.NoError(t, err)
 	require.Equal(t, len(cases), len(pbExprs))
 	for i, pbExpr := range pbExprs {
@@ -1767,7 +1763,7 @@ func TestPushDownSwitcher(t *testing.T) {
 
 	// All disabled
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/expression/PushDownTestSwitcher", `return("")`))
-	pc := PbConverter{client: client, sc: sc}
+	pc := PbConverter{client: client, ctx: ctx}
 	for i := range funcs {
 		pbExpr := pc.ExprToPB(funcs[i])
 		require.Nil(t, pbExpr)
@@ -1803,6 +1799,6 @@ func TestPanicIfPbCodeUnspecified(t *testing.T) {
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/expression/PanicIfPbCodeUnspecified"))
 	}()
-	pc := PbConverter{client: new(mock.Client), sc: stmtctx.NewStmtCtx()}
+	pc := PbConverter{client: new(mock.Client), ctx: mock.NewContext()}
 	require.PanicsWithError(t, "unspecified PbCode: *expression.builtinBitAndSig", func() { pc.ExprToPB(fn) })
 }

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -183,7 +183,7 @@ type Expression interface {
 	RemapColumn(map[int64]*Column) (Expression, error)
 
 	// ExplainInfo returns operator information to be explained.
-	ExplainInfo() string
+	ExplainInfo(ctx sessionctx.Context) string
 
 	// ExplainNormalizedInfo returns operator normalized information for generating digest.
 	ExplainNormalizedInfo() string
@@ -1395,10 +1395,11 @@ func canScalarFuncPushDown(scalarFunc *ScalarFunction, pc PbConverter, storeType
 			storageName = "storage layer"
 		}
 		warnErr := errors.New("Scalar function '" + scalarFunc.FuncName.L + "'(signature: " + scalarFunc.Function.PbCode().String() + ", return type: " + scalarFunc.RetType.CompactStr() + ") is not supported to push down to " + storageName + " now.")
-		if pc.sc.InExplainStmt {
-			pc.sc.AppendWarning(warnErr)
+		sc := pc.ctx.GetSessionVars().StmtCtx
+		if sc.InExplainStmt {
+			sc.AppendWarning(warnErr)
 		} else {
-			pc.sc.AppendExtraWarning(warnErr)
+			sc.AppendExtraWarning(warnErr)
 		}
 		return false
 	}
@@ -1423,25 +1424,26 @@ func canScalarFuncPushDown(scalarFunc *ScalarFunction, pc PbConverter, storeType
 
 func canExprPushDown(expr Expression, pc PbConverter, storeType kv.StoreType, canEnumPush bool) bool {
 	if storeType == kv.TiFlash {
+		sc := pc.ctx.GetSessionVars().StmtCtx
 		switch expr.GetType().GetType() {
 		case mysql.TypeEnum, mysql.TypeBit, mysql.TypeSet, mysql.TypeGeometry, mysql.TypeUnspecified:
 			if expr.GetType().GetType() == mysql.TypeEnum && canEnumPush {
 				break
 			}
 			warnErr := errors.New("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains unsupported calculation of type '" + types.TypeStr(expr.GetType().GetType()) + "'.")
-			if pc.sc.InExplainStmt {
-				pc.sc.AppendWarning(warnErr)
+			if sc.InExplainStmt {
+				sc.AppendWarning(warnErr)
 			} else {
-				pc.sc.AppendExtraWarning(warnErr)
+				sc.AppendExtraWarning(warnErr)
 			}
 			return false
 		case mysql.TypeNewDecimal:
 			if !expr.GetType().IsDecimalValid() {
 				warnErr := errors.New("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains invalid decimal('" + strconv.Itoa(expr.GetType().GetFlen()) + "','" + strconv.Itoa(expr.GetType().GetDecimal()) + "').")
-				if pc.sc.InExplainStmt {
-					pc.sc.AppendWarning(warnErr)
+				if sc.InExplainStmt {
+					sc.AppendWarning(warnErr)
 				} else {
-					pc.sc.AppendExtraWarning(warnErr)
+					sc.AppendExtraWarning(warnErr)
 				}
 				return false
 			}
@@ -1461,8 +1463,8 @@ func canExprPushDown(expr Expression, pc PbConverter, storeType kv.StoreType, ca
 }
 
 // PushDownExprsWithExtraInfo split the input exprs into pushed and remained, pushed include all the exprs that can be pushed down
-func PushDownExprsWithExtraInfo(sc *stmtctx.StatementContext, exprs []Expression, client kv.Client, storeType kv.StoreType, canEnumPush bool) (pushed []Expression, remained []Expression) {
-	pc := PbConverter{sc: sc, client: client}
+func PushDownExprsWithExtraInfo(ctx sessionctx.Context, exprs []Expression, client kv.Client, storeType kv.StoreType, canEnumPush bool) (pushed []Expression, remained []Expression) {
+	pc := PbConverter{ctx: ctx, client: client}
 	for _, expr := range exprs {
 		if canExprPushDown(expr, pc, storeType, canEnumPush) {
 			pushed = append(pushed, expr)
@@ -1474,19 +1476,19 @@ func PushDownExprsWithExtraInfo(sc *stmtctx.StatementContext, exprs []Expression
 }
 
 // PushDownExprs split the input exprs into pushed and remained, pushed include all the exprs that can be pushed down
-func PushDownExprs(sc *stmtctx.StatementContext, exprs []Expression, client kv.Client, storeType kv.StoreType) (pushed []Expression, remained []Expression) {
-	return PushDownExprsWithExtraInfo(sc, exprs, client, storeType, false)
+func PushDownExprs(ctx sessionctx.Context, exprs []Expression, client kv.Client, storeType kv.StoreType) (pushed []Expression, remained []Expression) {
+	return PushDownExprsWithExtraInfo(ctx, exprs, client, storeType, false)
 }
 
 // CanExprsPushDownWithExtraInfo return true if all the expr in exprs can be pushed down
-func CanExprsPushDownWithExtraInfo(sc *stmtctx.StatementContext, exprs []Expression, client kv.Client, storeType kv.StoreType, canEnumPush bool) bool {
-	_, remained := PushDownExprsWithExtraInfo(sc, exprs, client, storeType, canEnumPush)
+func CanExprsPushDownWithExtraInfo(ctx sessionctx.Context, exprs []Expression, client kv.Client, storeType kv.StoreType, canEnumPush bool) bool {
+	_, remained := PushDownExprsWithExtraInfo(ctx, exprs, client, storeType, canEnumPush)
 	return len(remained) == 0
 }
 
 // CanExprsPushDown return true if all the expr in exprs can be pushed down
-func CanExprsPushDown(sc *stmtctx.StatementContext, exprs []Expression, client kv.Client, storeType kv.StoreType) bool {
-	return CanExprsPushDownWithExtraInfo(sc, exprs, client, storeType, false)
+func CanExprsPushDown(ctx sessionctx.Context, exprs []Expression, client kv.Client, storeType kv.StoreType) bool {
+	return CanExprsPushDownWithExtraInfo(ctx, exprs, client, storeType, false)
 }
 
 // wrapWithIsTrue wraps `arg` with istrue function if the return type of expr is not

--- a/pkg/expression/grouping_sets.go
+++ b/pkg/expression/grouping_sets.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/util/intset"
 	"github.com/pingcap/tidb/pkg/util/size"
 	"github.com/pingcap/tipb/go-tipb"
@@ -286,10 +286,10 @@ func (gs GroupingSet) MemoryUsage() int64 {
 }
 
 // ToPB is used to convert current grouping set to pb constructor.
-func (gs GroupingSet) ToPB(sc *stmtctx.StatementContext, client kv.Client) (*tipb.GroupingSet, error) {
+func (gs GroupingSet) ToPB(ctx sessionctx.Context, client kv.Client) (*tipb.GroupingSet, error) {
 	res := &tipb.GroupingSet{}
 	for _, gExprs := range gs {
-		gExprsPB, err := ExpressionsToPBList(sc, gExprs, client)
+		gExprsPB, err := ExpressionsToPBList(ctx, gExprs, client)
 		if err != nil {
 			return nil, err
 		}
@@ -335,10 +335,10 @@ func (gss GroupingSets) String() string {
 }
 
 // ToPB is used to convert current grouping sets to pb constructor.
-func (gss GroupingSets) ToPB(sc *stmtctx.StatementContext, client kv.Client) ([]*tipb.GroupingSet, error) {
+func (gss GroupingSets) ToPB(ctx sessionctx.Context, client kv.Client) ([]*tipb.GroupingSet, error) {
 	res := make([]*tipb.GroupingSet, 0, len(gss))
 	for _, gs := range gss {
-		one, err := gs.ToPB(sc, client)
+		one, err := gs.ToPB(ctx, client)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1394,7 +1394,7 @@ func RemoveDupExprs(exprs []Expression) []Expression {
 func GetUint64FromConstant(ctx sessionctx.Context, expr Expression) (uint64, bool, bool) {
 	con, ok := expr.(*Constant)
 	if !ok {
-		logutil.BgLogger().Warn("not a constant expression", zap.String("expression", expr.ExplainInfo()))
+		logutil.BgLogger().Warn("not a constant expression", zap.String("expression", expr.ExplainInfo(ctx)))
 		return 0, false, false
 	}
 	dt := con.Value

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -589,7 +589,7 @@ func (m *MockExpr) resolveIndicesByVirtualExpr(ctx sessionctx.Context, schema *S
 	return true
 }
 func (m *MockExpr) RemapColumn(_ map[int64]*Column) (Expression, error) { return m, nil }
-func (m *MockExpr) ExplainInfo() string                                 { return "" }
+func (m *MockExpr) ExplainInfo(sessionctx.Context) string               { return "" }
 func (m *MockExpr) ExplainNormalizedInfo() string                       { return "" }
 func (m *MockExpr) ExplainNormalizedInfo4InList() string                { return "" }
 func (m *MockExpr) HashCode() []byte                                    { return nil }

--- a/pkg/planner/cascades/transformation_rules.go
+++ b/pkg/planner/cascades/transformation_rules.go
@@ -331,7 +331,7 @@ func (*PushSelDownTiKVSingleGather) OnTransform(old *memo.ExprIter) (newExprs []
 	childGroup := old.Children[0].Children[0].Group
 	var pushed, remained []expression.Expression
 	sctx := sg.SCtx()
-	pushed, remained = expression.PushDownExprs(sctx.GetSessionVars().StmtCtx, sel.Conditions, sctx.GetClient(), kv.TiKV)
+	pushed, remained = expression.PushDownExprs(sctx, sel.Conditions, sctx.GetClient(), kv.TiKV)
 	if len(pushed) == 0 {
 		return nil, false, false, nil
 	}

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -2360,16 +2360,17 @@ func canExprsInJoinPushdown(p *LogicalJoin, storeType kv.StoreType) bool {
 		}
 		equalExprs = append(equalExprs, eqCondition)
 	}
-	if !expression.CanExprsPushDown(p.SCtx().GetSessionVars().StmtCtx, equalExprs, p.SCtx().GetClient(), storeType) {
+	ctx := p.SCtx()
+	if !expression.CanExprsPushDown(ctx, equalExprs, p.SCtx().GetClient(), storeType) {
 		return false
 	}
-	if !expression.CanExprsPushDown(p.SCtx().GetSessionVars().StmtCtx, p.LeftConditions, p.SCtx().GetClient(), storeType) {
+	if !expression.CanExprsPushDown(ctx, p.LeftConditions, p.SCtx().GetClient(), storeType) {
 		return false
 	}
-	if !expression.CanExprsPushDown(p.SCtx().GetSessionVars().StmtCtx, p.RightConditions, p.SCtx().GetClient(), storeType) {
+	if !expression.CanExprsPushDown(ctx, p.RightConditions, p.SCtx().GetClient(), storeType) {
 		return false
 	}
-	if !expression.CanExprsPushDown(p.SCtx().GetSessionVars().StmtCtx, p.OtherConditions, p.SCtx().GetClient(), storeType) {
+	if !expression.CanExprsPushDown(ctx, p.OtherConditions, p.SCtx().GetClient(), storeType) {
 		return false
 	}
 	return true
@@ -2632,14 +2633,15 @@ func (p *LogicalProjection) exhaustPhysicalPlans(prop *property.PhysicalProperty
 	}
 	newProps := []*property.PhysicalProperty{newProp}
 	// generate a mpp task candidate if mpp mode is allowed
-	if newProp.TaskTp != property.MppTaskType && p.SCtx().GetSessionVars().IsMPPAllowed() && p.canPushToCop(kv.TiFlash) &&
-		expression.CanExprsPushDown(p.SCtx().GetSessionVars().StmtCtx, p.Exprs, p.SCtx().GetClient(), kv.TiFlash) {
+	ctx := p.SCtx()
+	if newProp.TaskTp != property.MppTaskType && ctx.GetSessionVars().IsMPPAllowed() && p.canPushToCop(kv.TiFlash) &&
+		expression.CanExprsPushDown(ctx, p.Exprs, ctx.GetClient(), kv.TiFlash) {
 		mppProp := newProp.CloneEssentialFields()
 		mppProp.TaskTp = property.MppTaskType
 		newProps = append(newProps, mppProp)
 	}
-	if newProp.TaskTp != property.CopSingleReadTaskType && p.SCtx().GetSessionVars().AllowProjectionPushDown && p.canPushToCop(kv.TiKV) &&
-		expression.CanExprsPushDown(p.SCtx().GetSessionVars().StmtCtx, p.Exprs, p.SCtx().GetClient(), kv.TiKV) && !expression.ContainVirtualColumn(p.Exprs) {
+	if newProp.TaskTp != property.CopSingleReadTaskType && ctx.GetSessionVars().AllowProjectionPushDown && p.canPushToCop(kv.TiKV) &&
+		expression.CanExprsPushDown(ctx, p.Exprs, ctx.GetClient(), kv.TiKV) && !expression.ContainVirtualColumn(p.Exprs) {
 		copProp := newProp.CloneEssentialFields()
 		copProp.TaskTp = property.CopSingleReadTaskType
 		newProps = append(newProps, copProp)
@@ -2868,12 +2870,13 @@ func (lw *LogicalWindow) tryToGetMppWindows(prop *property.PhysicalProperty) []P
 		}
 
 		if lw.Frame != nil && lw.Frame.Type == ast.Ranges {
-			if _, err := expression.ExpressionsToPBList(lw.SCtx().GetSessionVars().StmtCtx, lw.Frame.Start.CalcFuncs, lw.SCtx().GetClient()); err != nil {
+			ctx := lw.SCtx()
+			if _, err := expression.ExpressionsToPBList(ctx, lw.Frame.Start.CalcFuncs, lw.SCtx().GetClient()); err != nil {
 				lw.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced(
 					"MPP mode may be blocked because window function frame can't be pushed down, because " + err.Error())
 				return nil
 			}
-			if _, err := expression.ExpressionsToPBList(lw.SCtx().GetSessionVars().StmtCtx, lw.Frame.End.CalcFuncs, lw.SCtx().GetClient()); err != nil {
+			if _, err := expression.ExpressionsToPBList(ctx, lw.Frame.End.CalcFuncs, lw.SCtx().GetClient()); err != nil {
 				lw.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced(
 					"MPP mode may be blocked because window function frame can't be pushed down, because " + err.Error())
 				return nil
@@ -3486,7 +3489,7 @@ func (p *LogicalSelection) canPushDown(storeTp kv.StoreType) bool {
 	return !expression.ContainVirtualColumn(p.Conditions) &&
 		p.canPushToCop(storeTp) &&
 		expression.CanExprsPushDown(
-			p.SCtx().GetSessionVars().StmtCtx,
+			p.SCtx(),
 			p.Conditions,
 			p.SCtx().GetClient(),
 			storeTp)

--- a/pkg/planner/core/explain.go
+++ b/pkg/planner/core/explain.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/planner/util"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/types"
@@ -221,7 +222,7 @@ func (p *PhysicalTableScan) OperatorInfo(normalized bool) string {
 			if normalized {
 				buffer.Write(expression.SortedExplainNormalizedExpressionList(p.lateMaterializationFilterCondition))
 			} else {
-				buffer.Write(expression.SortedExplainExpressionList(p.lateMaterializationFilterCondition))
+				buffer.Write(expression.SortedExplainExpressionList(p.SCtx(), p.lateMaterializationFilterCondition))
 			}
 		} else {
 			buffer.WriteString("empty")
@@ -352,12 +353,12 @@ func (p *PhysicalIndexMergeReader) ExplainInfo() string {
 
 // ExplainInfo implements Plan interface.
 func (p *PhysicalUnionScan) ExplainInfo() string {
-	return string(expression.SortedExplainExpressionList(p.Conditions))
+	return string(expression.SortedExplainExpressionList(p.SCtx(), p.Conditions))
 }
 
 // ExplainInfo implements Plan interface.
 func (p *PhysicalSelection) ExplainInfo() string {
-	exprStr := string(expression.SortedExplainExpressionList(p.Conditions))
+	exprStr := string(expression.SortedExplainExpressionList(p.SCtx(), p.Conditions))
 	if p.TiFlashFineGrainedShuffleStreamCount > 0 {
 		exprStr += fmt.Sprintf(", stream_count: %d", p.TiFlashFineGrainedShuffleStreamCount)
 	}
@@ -424,7 +425,7 @@ func (p *PhysicalTableDual) ExplainInfo() string {
 // ExplainInfo implements Plan interface.
 func (p *PhysicalSort) ExplainInfo() string {
 	buffer := bytes.NewBufferString("")
-	buffer = explainByItems(buffer, p.ByItems)
+	buffer = explainByItems(p.SCtx(), buffer, p.ByItems)
 	if p.TiFlashFineGrainedShuffleStreamCount > 0 {
 		fmt.Fprintf(buffer, ", stream_count: %d", p.TiFlashFineGrainedShuffleStreamCount)
 	}
@@ -466,13 +467,15 @@ func (p *basePhysicalAgg) ExplainInfo() string {
 func (p *basePhysicalAgg) explainInfo(normalized bool) string {
 	sortedExplainExpressionList := expression.SortedExplainExpressionList
 	if normalized {
-		sortedExplainExpressionList = expression.SortedExplainNormalizedExpressionList
+		sortedExplainExpressionList = func(_ sessionctx.Context, exprs []expression.Expression) []byte {
+			return expression.SortedExplainNormalizedExpressionList(exprs)
+		}
 	}
 
 	builder := &strings.Builder{}
 	if len(p.GroupByItems) > 0 {
 		builder.WriteString("group by:")
-		builder.Write(sortedExplainExpressionList(p.GroupByItems))
+		builder.Write(sortedExplainExpressionList(p.SCtx(), p.GroupByItems))
 		builder.WriteString(", ")
 	}
 	for i := 0; i < len(p.AggFuncs); i++ {
@@ -481,9 +484,9 @@ func (p *basePhysicalAgg) explainInfo(normalized bool) string {
 		if normalized {
 			colName = p.schema.Columns[i].ExplainNormalizedInfo()
 		} else {
-			colName = p.schema.Columns[i].ExplainInfo()
+			colName = p.schema.Columns[i].ExplainInfo(p.SCtx())
 		}
-		builder.WriteString(aggregation.ExplainAggFunc(p.AggFuncs[i], normalized))
+		builder.WriteString(aggregation.ExplainAggFunc(p.SCtx(), p.AggFuncs[i], normalized))
 		builder.WriteString("->")
 		builder.WriteString(colName)
 		if i+1 < len(p.AggFuncs) {
@@ -514,7 +517,9 @@ func (p *PhysicalIndexMergeJoin) ExplainInfo() string {
 func (p *PhysicalIndexJoin) explainInfo(normalized bool, isIndexMergeJoin bool) string {
 	sortedExplainExpressionList := expression.SortedExplainExpressionList
 	if normalized {
-		sortedExplainExpressionList = expression.SortedExplainNormalizedExpressionList
+		sortedExplainExpressionList = func(_ sessionctx.Context, exprs []expression.Expression) []byte {
+			return expression.SortedExplainNormalizedExpressionList(exprs)
+		}
 	}
 
 	buffer := bytes.NewBufferString(p.JoinType.String())
@@ -526,11 +531,11 @@ func (p *PhysicalIndexJoin) explainInfo(normalized bool, isIndexMergeJoin bool) 
 	}
 	if len(p.OuterJoinKeys) > 0 {
 		buffer.WriteString(", outer key:")
-		buffer.Write(expression.ExplainColumnList(p.OuterJoinKeys))
+		buffer.Write(expression.ExplainColumnList(p.SCtx(), p.OuterJoinKeys))
 	}
 	if len(p.InnerJoinKeys) > 0 {
 		buffer.WriteString(", inner key:")
-		buffer.Write(expression.ExplainColumnList(p.InnerJoinKeys))
+		buffer.Write(expression.ExplainColumnList(p.SCtx(), p.InnerJoinKeys))
 	}
 
 	if len(p.OuterHashKeys) > 0 && !isIndexMergeJoin {
@@ -543,19 +548,19 @@ func (p *PhysicalIndexJoin) explainInfo(normalized bool, isIndexMergeJoin bool) 
 			exprs = append(exprs, expr)
 		}
 		buffer.WriteString(", equal cond:")
-		buffer.Write(sortedExplainExpressionList(exprs))
+		buffer.Write(sortedExplainExpressionList(p.SCtx(), exprs))
 	}
 	if len(p.LeftConditions) > 0 {
 		buffer.WriteString(", left cond:")
-		buffer.Write(sortedExplainExpressionList(p.LeftConditions))
+		buffer.Write(sortedExplainExpressionList(p.SCtx(), p.LeftConditions))
 	}
 	if len(p.RightConditions) > 0 {
 		buffer.WriteString(", right cond:")
-		buffer.Write(sortedExplainExpressionList(p.RightConditions))
+		buffer.Write(sortedExplainExpressionList(p.SCtx(), p.RightConditions))
 	}
 	if len(p.OtherConditions) > 0 {
 		buffer.WriteString(", other cond:")
-		buffer.Write(sortedExplainExpressionList(p.OtherConditions))
+		buffer.Write(sortedExplainExpressionList(p.SCtx(), p.OtherConditions))
 	}
 	return buffer.String()
 }
@@ -583,7 +588,9 @@ func (p *PhysicalHashJoin) ExplainNormalizedInfo() string {
 func (p *PhysicalHashJoin) explainInfo(normalized bool) string {
 	sortedExplainExpressionList := expression.SortedExplainExpressionList
 	if normalized {
-		sortedExplainExpressionList = expression.SortedExplainNormalizedExpressionList
+		sortedExplainExpressionList = func(_ sessionctx.Context, exprs []expression.Expression) []byte {
+			return expression.SortedExplainNormalizedExpressionList(exprs)
+		}
 	}
 
 	buffer := new(strings.Builder)
@@ -645,11 +652,11 @@ func (p *PhysicalHashJoin) explainInfo(normalized bool) string {
 	}
 	if len(p.RightConditions) > 0 {
 		buffer.WriteString(", right cond:")
-		buffer.Write(sortedExplainExpressionList(p.RightConditions))
+		buffer.Write(sortedExplainExpressionList(p.SCtx(), p.RightConditions))
 	}
 	if len(p.OtherConditions) > 0 {
 		buffer.WriteString(", other cond:")
-		buffer.Write(sortedExplainExpressionList(p.OtherConditions))
+		buffer.Write(sortedExplainExpressionList(p.SCtx(), p.OtherConditions))
 	}
 	if p.TiFlashFineGrainedShuffleStreamCount > 0 {
 		fmt.Fprintf(buffer, ", stream_count: %d", p.TiFlashFineGrainedShuffleStreamCount)
@@ -676,17 +683,19 @@ func (p *PhysicalMergeJoin) ExplainInfo() string {
 func (p *PhysicalMergeJoin) explainInfo(normalized bool) string {
 	sortedExplainExpressionList := expression.SortedExplainExpressionList
 	if normalized {
-		sortedExplainExpressionList = expression.SortedExplainNormalizedExpressionList
+		sortedExplainExpressionList = func(_ sessionctx.Context, exprs []expression.Expression) []byte {
+			return expression.SortedExplainNormalizedExpressionList(exprs)
+		}
 	}
 
 	buffer := bytes.NewBufferString(p.JoinType.String())
 	if len(p.LeftJoinKeys) > 0 {
 		fmt.Fprintf(buffer, ", left key:%s",
-			expression.ExplainColumnList(p.LeftJoinKeys))
+			expression.ExplainColumnList(p.SCtx(), p.LeftJoinKeys))
 	}
 	if len(p.RightJoinKeys) > 0 {
 		fmt.Fprintf(buffer, ", right key:%s",
-			expression.ExplainColumnList(p.RightJoinKeys))
+			expression.ExplainColumnList(p.SCtx(), p.RightJoinKeys))
 	}
 	if len(p.LeftConditions) > 0 {
 		if normalized {
@@ -697,11 +706,11 @@ func (p *PhysicalMergeJoin) explainInfo(normalized bool) string {
 	}
 	if len(p.RightConditions) > 0 {
 		fmt.Fprintf(buffer, ", right cond:%s",
-			sortedExplainExpressionList(p.RightConditions))
+			sortedExplainExpressionList(p.SCtx(), p.RightConditions))
 	}
 	if len(p.OtherConditions) > 0 {
 		fmt.Fprintf(buffer, ", other cond:%s",
-			sortedExplainExpressionList(p.OtherConditions))
+			sortedExplainExpressionList(p.SCtx(), p.OtherConditions))
 	}
 	return buffer.String()
 }
@@ -716,11 +725,7 @@ func explainPartitionBy(buffer *bytes.Buffer, partitionBy []property.SortItem, n
 	if len(partitionBy) > 0 {
 		buffer.WriteString("partition by ")
 		for i, item := range partitionBy {
-			if normalized {
-				fmt.Fprintf(buffer, "%s", item.Col.ExplainNormalizedInfo())
-			} else {
-				fmt.Fprintf(buffer, "%s", item.Col.ExplainInfo())
-			}
+			fmt.Fprintf(buffer, "%s", item.Col.ColumnExplainInfo(normalized))
 			if i+1 < len(partitionBy) {
 				buffer.WriteString(", ")
 			}
@@ -742,7 +747,7 @@ func (p *PhysicalTopN) ExplainInfo() string {
 		if len(p.GetPartitionBy()) > 0 {
 			buffer.WriteString("order by ")
 		}
-		buffer = explainByItems(buffer, p.ByItems)
+		buffer = explainByItems(p.SCtx(), buffer, p.ByItems)
 	}
 	fmt.Fprintf(buffer, ", offset:%v, count:%v", p.Offset, p.Count)
 	return buffer.String()
@@ -766,7 +771,7 @@ func (p *PhysicalTopN) ExplainNormalizedInfo() string {
 	return buffer.String()
 }
 
-func (*PhysicalWindow) formatFrameBound(buffer *bytes.Buffer, bound *FrameBound) {
+func (p *PhysicalWindow) formatFrameBound(buffer *bytes.Buffer, bound *FrameBound) {
 	if bound.Type == ast.CurrentRow {
 		buffer.WriteString("current row")
 		return
@@ -774,14 +779,15 @@ func (*PhysicalWindow) formatFrameBound(buffer *bytes.Buffer, bound *FrameBound)
 	if bound.UnBounded {
 		buffer.WriteString("unbounded")
 	} else if len(bound.CalcFuncs) > 0 {
+		ctx := p.SCtx()
 		sf := bound.CalcFuncs[0].(*expression.ScalarFunction)
 		switch sf.FuncName.L {
 		case ast.DateAdd, ast.DateSub:
 			// For `interval '2:30' minute_second`.
-			fmt.Fprintf(buffer, "interval %s %s", sf.GetArgs()[1].ExplainInfo(), sf.GetArgs()[2].ExplainInfo())
+			fmt.Fprintf(buffer, "interval %s %s", sf.GetArgs()[1].ExplainInfo(ctx), sf.GetArgs()[2].ExplainInfo(ctx))
 		case ast.Plus, ast.Minus:
 			// For `1 preceding` of range frame.
-			fmt.Fprintf(buffer, "%s", sf.GetArgs()[1].ExplainInfo())
+			fmt.Fprintf(buffer, "%s", sf.GetArgs()[1].ExplainInfo(ctx))
 		}
 	} else {
 		fmt.Fprintf(buffer, "%d", bound.Num)
@@ -808,11 +814,12 @@ func (p *PhysicalWindow) ExplainInfo() string {
 			buffer.WriteString(" ")
 		}
 		buffer.WriteString("order by ")
+		ctx := p.SCtx()
 		for i, item := range p.OrderBy {
 			if item.Desc {
-				fmt.Fprintf(buffer, "%s desc", item.Col.ExplainInfo())
+				fmt.Fprintf(buffer, "%s desc", item.Col.ExplainInfo(ctx))
 			} else {
-				fmt.Fprintf(buffer, "%s", item.Col.ExplainInfo())
+				fmt.Fprintf(buffer, "%s", item.Col.ExplainInfo(ctx))
 			}
 
 			if i+1 < len(p.OrderBy) {
@@ -873,15 +880,15 @@ func (p *LogicalJoin) ExplainInfo() string {
 	}
 	if len(p.LeftConditions) > 0 {
 		fmt.Fprintf(buffer, ", left cond:%s",
-			expression.SortedExplainExpressionList(p.LeftConditions))
+			expression.SortedExplainExpressionList(p.SCtx(), p.LeftConditions))
 	}
 	if len(p.RightConditions) > 0 {
 		fmt.Fprintf(buffer, ", right cond:%s",
-			expression.SortedExplainExpressionList(p.RightConditions))
+			expression.SortedExplainExpressionList(p.SCtx(), p.RightConditions))
 	}
 	if len(p.OtherConditions) > 0 {
 		fmt.Fprintf(buffer, ", other cond:%s",
-			expression.SortedExplainExpressionList(p.OtherConditions))
+			expression.SortedExplainExpressionList(p.SCtx(), p.OtherConditions))
 	}
 	return buffer.String()
 }
@@ -891,12 +898,12 @@ func (p *LogicalAggregation) ExplainInfo() string {
 	buffer := bytes.NewBufferString("")
 	if len(p.GroupByItems) > 0 {
 		fmt.Fprintf(buffer, "group by:%s, ",
-			expression.SortedExplainExpressionList(p.GroupByItems))
+			expression.SortedExplainExpressionList(p.SCtx(), p.GroupByItems))
 	}
 	if len(p.AggFuncs) > 0 {
 		buffer.WriteString("funcs:")
 		for i, agg := range p.AggFuncs {
-			buffer.WriteString(aggregation.ExplainAggFunc(agg, false))
+			buffer.WriteString(aggregation.ExplainAggFunc(p.SCtx(), agg, false))
 			if i+1 < len(p.AggFuncs) {
 				buffer.WriteString(", ")
 			}
@@ -912,7 +919,7 @@ func (p *LogicalProjection) ExplainInfo() string {
 
 // ExplainInfo implements Plan interface.
 func (p *LogicalSelection) ExplainInfo() string {
-	return string(expression.SortedExplainExpressionList(p.Conditions))
+	return string(expression.SortedExplainExpressionList(p.SCtx(), p.Conditions))
 }
 
 // ExplainInfo implements Plan interface.
@@ -960,7 +967,7 @@ func (p *PhysicalExchangeSender) ExplainInfo() string {
 		fmt.Fprintf(buffer, ", Compression: %s", p.CompressionMode.Name())
 	}
 	if p.ExchangeType == tipb.ExchangeType_Hash {
-		fmt.Fprintf(buffer, ", Hash Cols: %s", property.ExplainColumnList(p.HashCols))
+		fmt.Fprintf(buffer, ", Hash Cols: %s", property.ExplainColumnList(p.SCtx(), p.HashCols))
 	}
 	if len(p.Tasks) > 0 {
 		fmt.Fprintf(buffer, ", tasks: [")
@@ -990,17 +997,17 @@ func (p *PhysicalExchangeReceiver) ExplainInfo() (res string) {
 func (p *LogicalUnionScan) ExplainInfo() string {
 	buffer := bytes.NewBufferString("")
 	fmt.Fprintf(buffer, "conds:%s",
-		expression.SortedExplainExpressionList(p.conditions))
+		expression.SortedExplainExpressionList(p.SCtx(), p.conditions))
 	fmt.Fprintf(buffer, ", handle:%s", p.handleCols)
 	return buffer.String()
 }
 
-func explainByItems(buffer *bytes.Buffer, byItems []*util.ByItems) *bytes.Buffer {
+func explainByItems(ctx sessionctx.Context, buffer *bytes.Buffer, byItems []*util.ByItems) *bytes.Buffer {
 	for i, item := range byItems {
 		if item.Desc {
-			fmt.Fprintf(buffer, "%s:desc", item.Expr.ExplainInfo())
+			fmt.Fprintf(buffer, "%s:desc", item.Expr.ExplainInfo(ctx))
 		} else {
-			fmt.Fprintf(buffer, "%s", item.Expr.ExplainInfo())
+			fmt.Fprintf(buffer, "%s", item.Expr.ExplainInfo(ctx))
 		}
 
 		if i+1 < len(byItems) {
@@ -1028,7 +1035,7 @@ func explainNormalizedByItems(buffer *bytes.Buffer, byItems []*util.ByItems) *by
 // ExplainInfo implements Plan interface.
 func (p *LogicalSort) ExplainInfo() string {
 	buffer := bytes.NewBufferString("")
-	return explainByItems(buffer, p.ByItems).String()
+	return explainByItems(p.SCtx(), buffer, p.ByItems).String()
 }
 
 // ExplainInfo implements Plan interface.
@@ -1038,7 +1045,7 @@ func (lt *LogicalTopN) ExplainInfo() string {
 	if len(lt.GetPartitionBy()) > 0 && len(lt.ByItems) > 0 {
 		buffer.WriteString("order by ")
 	}
-	buffer = explainByItems(buffer, lt.ByItems)
+	buffer = explainByItems(lt.SCtx(), buffer, lt.ByItems)
 	fmt.Fprintf(buffer, ", offset:%v, count:%v", lt.Offset, lt.Count)
 	return buffer.String()
 }

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/fixcontrol"
 	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/types"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
@@ -1523,7 +1522,6 @@ func setIndexMergeTableScanHandleCols(ds *DataSource, ts *PhysicalTableScan) (er
 // Filters that cannot be pushed to TiKV are also returned, and an extra Selection above IndexMergeReader will be constructed later.
 func (ds *DataSource) buildIndexMergeTableScan(tableFilters []expression.Expression,
 	totalRowCount float64, matchProp bool) (PhysicalPlan, []expression.Expression, bool, error) {
-	sessVars := ds.SCtx().GetSessionVars()
 	ts := PhysicalTableScan{
 		Table:           ds.tableInfo,
 		Columns:         slices.Clone(ds.Columns),
@@ -1550,7 +1548,7 @@ func (ds *DataSource) buildIndexMergeTableScan(tableFilters []expression.Express
 	}
 	var currentTopPlan PhysicalPlan = ts
 	if len(tableFilters) > 0 {
-		pushedFilters, remainingFilters := extractFiltersForIndexMerge(sessVars.StmtCtx, ds.SCtx().GetClient(), tableFilters)
+		pushedFilters, remainingFilters := extractFiltersForIndexMerge(ds.SCtx(), ds.SCtx().GetClient(), tableFilters)
 		pushedFilters1, remainingFilters1 := SplitSelCondsWithVirtualColumn(pushedFilters)
 		pushedFilters = pushedFilters1
 		remainingFilters = append(remainingFilters, remainingFilters1...)
@@ -1616,13 +1614,13 @@ func (ds *DataSource) buildIndexMergeTableScan(tableFilters []expression.Express
 //
 //	But the new Selection should exclude the exprs that can NOT be pushed to ALL the storage engines.
 //	Because these exprs have already been put in another Selection(check rule_predicate_push_down).
-func extractFiltersForIndexMerge(sc *stmtctx.StatementContext, client kv.Client, filters []expression.Expression) (pushed []expression.Expression, remaining []expression.Expression) {
+func extractFiltersForIndexMerge(ctx sessionctx.Context, client kv.Client, filters []expression.Expression) (pushed []expression.Expression, remaining []expression.Expression) {
 	for _, expr := range filters {
-		if expression.CanExprsPushDown(sc, []expression.Expression{expr}, client, kv.TiKV) {
+		if expression.CanExprsPushDown(ctx, []expression.Expression{expr}, client, kv.TiKV) {
 			pushed = append(pushed, expr)
 			continue
 		}
-		if expression.CanExprsPushDown(sc, []expression.Expression{expr}, client, kv.UnSpecified) {
+		if expression.CanExprsPushDown(ctx, []expression.Expression{expr}, client, kv.UnSpecified) {
 			remaining = append(remaining, expr)
 		}
 	}
@@ -1944,10 +1942,10 @@ func (is *PhysicalIndexScan) addPushedDownSelection(copTask *copTask, p *DataSou
 	tableConds, copTask.rootTaskConds = SplitSelCondsWithVirtualColumn(tableConds)
 
 	var newRootConds []expression.Expression
-	indexConds, newRootConds = expression.PushDownExprs(is.SCtx().GetSessionVars().StmtCtx, indexConds, is.SCtx().GetClient(), kv.TiKV)
+	indexConds, newRootConds = expression.PushDownExprs(is.SCtx(), indexConds, is.SCtx().GetClient(), kv.TiKV)
 	copTask.rootTaskConds = append(copTask.rootTaskConds, newRootConds...)
 
-	tableConds, newRootConds = expression.PushDownExprs(is.SCtx().GetSessionVars().StmtCtx, tableConds, is.SCtx().GetClient(), kv.TiKV)
+	tableConds, newRootConds = expression.PushDownExprs(is.SCtx(), tableConds, is.SCtx().GetClient(), kv.TiKV)
 	copTask.rootTaskConds = append(copTask.rootTaskConds, newRootConds...)
 
 	if indexConds != nil {
@@ -2446,7 +2444,7 @@ func (ds *DataSource) convertToBatchPointGet(prop *property.PhysicalProperty, ca
 func (ts *PhysicalTableScan) addPushedDownSelectionToMppTask(mpp *mppTask, stats *property.StatsInfo) *mppTask {
 	filterCondition, rootTaskConds := SplitSelCondsWithVirtualColumn(ts.filterCondition)
 	var newRootConds []expression.Expression
-	filterCondition, newRootConds = expression.PushDownExprs(ts.SCtx().GetSessionVars().StmtCtx, filterCondition, ts.SCtx().GetClient(), ts.StoreType)
+	filterCondition, newRootConds = expression.PushDownExprs(ts.SCtx(), filterCondition, ts.SCtx().GetClient(), ts.StoreType)
 	mpp.rootTaskConds = append(rootTaskConds, newRootConds...)
 
 	ts.filterCondition = filterCondition
@@ -2462,7 +2460,7 @@ func (ts *PhysicalTableScan) addPushedDownSelectionToMppTask(mpp *mppTask, stats
 func (ts *PhysicalTableScan) addPushedDownSelection(copTask *copTask, stats *property.StatsInfo) {
 	ts.filterCondition, copTask.rootTaskConds = SplitSelCondsWithVirtualColumn(ts.filterCondition)
 	var newRootConds []expression.Expression
-	ts.filterCondition, newRootConds = expression.PushDownExprs(ts.SCtx().GetSessionVars().StmtCtx, ts.filterCondition, ts.SCtx().GetClient(), ts.StoreType)
+	ts.filterCondition, newRootConds = expression.PushDownExprs(ts.SCtx(), ts.filterCondition, ts.SCtx().GetClient(), ts.StoreType)
 	copTask.rootTaskConds = append(copTask.rootTaskConds, newRootConds...)
 
 	// Add filter condition to table plan now.

--- a/pkg/planner/core/handle_cols.go
+++ b/pkg/planner/core/handle_cols.go
@@ -164,7 +164,7 @@ func (cb *CommonHandleCols) String() string {
 		if i != 0 {
 			b.WriteByte(',')
 		}
-		b.WriteString(col.ExplainInfo())
+		b.WriteString(col.ColumnExplainInfo(false))
 	}
 	b.WriteByte(']')
 	return b.String()
@@ -269,7 +269,7 @@ func (*IntHandleCols) IsInt() bool {
 
 // String implements the kv.HandleCols interface.
 func (ib *IntHandleCols) String() string {
-	return ib.col.ExplainInfo()
+	return ib.col.ColumnExplainInfo(false)
 }
 
 // GetCol implements the kv.HandleCols interface.

--- a/pkg/planner/core/plan_to_pb.go
+++ b/pkg/planner/core/plan_to_pb.go
@@ -38,9 +38,8 @@ func (p *PhysicalExpand) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*
 	if len(p.LevelExprs) > 0 {
 		return p.toPBV2(ctx, storeType)
 	}
-	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
-	groupingSetsPB, err := p.GroupingSets.ToPB(sc, client)
+	groupingSetsPB, err := p.GroupingSets.ToPB(ctx, client)
 	if err != nil {
 		return nil, err
 	}
@@ -60,11 +59,10 @@ func (p *PhysicalExpand) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*
 }
 
 func (p *PhysicalExpand) toPBV2(ctx sessionctx.Context, storeType kv.StoreType) (*tipb.Executor, error) {
-	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
 	projExprsPB := make([]*tipb.ExprSlice, 0, len(p.LevelExprs))
 	for _, exprs := range p.LevelExprs {
-		expressionsPB, err := expression.ExpressionsToPBList(sc, exprs, client)
+		expressionsPB, err := expression.ExpressionsToPBList(ctx, exprs, client)
 		if err != nil {
 			return nil, err
 		}
@@ -88,9 +86,8 @@ func (p *PhysicalExpand) toPBV2(ctx sessionctx.Context, storeType kv.StoreType) 
 
 // ToPB implements PhysicalPlan ToPB interface.
 func (p *PhysicalHashAgg) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*tipb.Executor, error) {
-	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
-	groupByExprs, err := expression.ExpressionsToPBList(sc, p.GroupByItems, client)
+	groupByExprs, err := expression.ExpressionsToPBList(ctx, p.GroupByItems, client)
 	if err != nil {
 		return nil, err
 	}
@@ -124,9 +121,8 @@ func (p *PhysicalHashAgg) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (
 
 // ToPB implements PhysicalPlan ToPB interface.
 func (p *PhysicalStreamAgg) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*tipb.Executor, error) {
-	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
-	groupByExprs, err := expression.ExpressionsToPBList(sc, p.GroupByItems, client)
+	groupByExprs, err := expression.ExpressionsToPBList(ctx, p.GroupByItems, client)
 	if err != nil {
 		return nil, err
 	}
@@ -154,9 +150,8 @@ func (p *PhysicalStreamAgg) ToPB(ctx sessionctx.Context, storeType kv.StoreType)
 
 // ToPB implements PhysicalPlan ToPB interface.
 func (p *PhysicalSelection) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*tipb.Executor, error) {
-	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
-	conditions, err := expression.ExpressionsToPBList(sc, p.Conditions, client)
+	conditions, err := expression.ExpressionsToPBList(ctx, p.Conditions, client)
 	if err != nil {
 		return nil, err
 	}
@@ -177,9 +172,8 @@ func (p *PhysicalSelection) ToPB(ctx sessionctx.Context, storeType kv.StoreType)
 
 // ToPB implements PhysicalPlan ToPB interface.
 func (p *PhysicalProjection) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*tipb.Executor, error) {
-	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
-	exprs, err := expression.ExpressionsToPBList(sc, p.Exprs, client)
+	exprs, err := expression.ExpressionsToPBList(ctx, p.Exprs, client)
 	if err != nil {
 		return nil, err
 	}
@@ -200,16 +194,15 @@ func (p *PhysicalProjection) ToPB(ctx sessionctx.Context, storeType kv.StoreType
 
 // ToPB implements PhysicalPlan ToPB interface.
 func (p *PhysicalTopN) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*tipb.Executor, error) {
-	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
 	topNExec := &tipb.TopN{
 		Limit: p.Count,
 	}
 	for _, item := range p.ByItems {
-		topNExec.OrderBy = append(topNExec.OrderBy, expression.SortByItemToPB(sc, client, item.Expr, item.Desc))
+		topNExec.OrderBy = append(topNExec.OrderBy, expression.SortByItemToPB(ctx, client, item.Expr, item.Desc))
 	}
 	for _, item := range p.PartitionBy {
-		topNExec.PartitionBy = append(topNExec.PartitionBy, expression.SortByItemToPB(sc, client, item.Col.Clone(), item.Desc))
+		topNExec.PartitionBy = append(topNExec.PartitionBy, expression.SortByItemToPB(ctx, client, item.Col.Clone(), item.Desc))
 	}
 	executorID := ""
 	if storeType == kv.TiFlash {
@@ -225,14 +218,13 @@ func (p *PhysicalTopN) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*ti
 
 // ToPB implements PhysicalPlan ToPB interface.
 func (p *PhysicalLimit) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*tipb.Executor, error) {
-	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
 	limitExec := &tipb.Limit{
 		Limit: p.Count,
 	}
 	executorID := ""
 	for _, item := range p.PartitionBy {
-		limitExec.PartitionBy = append(limitExec.PartitionBy, expression.SortByItemToPB(sc, client, item.Col.Clone(), item.Desc))
+		limitExec.PartitionBy = append(limitExec.PartitionBy, expression.SortByItemToPB(ctx, client, item.Col.Clone(), item.Desc))
 	}
 	if storeType == kv.TiFlash {
 		var err error
@@ -257,9 +249,8 @@ func (p *PhysicalTableScan) ToPB(ctx sessionctx.Context, storeType kv.StoreType)
 	tsExec.IsFastScan = &(ctx.GetSessionVars().TiFlashFastScan)
 
 	if len(p.lateMaterializationFilterCondition) > 0 {
-		sc := ctx.GetSessionVars().StmtCtx
 		client := ctx.GetClient()
-		conditions, err := expression.ExpressionsToPBList(sc, p.lateMaterializationFilterCondition, client)
+		conditions, err := expression.ExpressionsToPBList(ctx, p.lateMaterializationFilterCondition, client)
 		if err != nil {
 			return nil, err
 		}
@@ -267,7 +258,7 @@ func (p *PhysicalTableScan) ToPB(ctx sessionctx.Context, storeType kv.StoreType)
 	}
 
 	var err error
-	tsExec.RuntimeFilterList, err = RuntimeFilterListToPB(p.runtimeFilterList, ctx.GetSessionVars().StmtCtx, ctx.GetClient())
+	tsExec.RuntimeFilterList, err = RuntimeFilterListToPB(ctx, p.runtimeFilterList, ctx.GetClient())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -297,9 +288,8 @@ func (p *PhysicalTableScan) partitionTableScanToPBForFlash(ctx sessionctx.Contex
 	}
 
 	if len(p.lateMaterializationFilterCondition) > 0 {
-		sc := ctx.GetSessionVars().StmtCtx
 		client := ctx.GetClient()
-		conditions, err := expression.ExpressionsToPBList(sc, p.lateMaterializationFilterCondition, client)
+		conditions, err := expression.ExpressionsToPBList(ctx, p.lateMaterializationFilterCondition, client)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +298,7 @@ func (p *PhysicalTableScan) partitionTableScanToPBForFlash(ctx sessionctx.Contex
 
 	// set runtime filter
 	var err error
-	ptsExec.RuntimeFilterList, err = RuntimeFilterListToPB(p.runtimeFilterList, ctx.GetSessionVars().StmtCtx, ctx.GetClient())
+	ptsExec.RuntimeFilterList, err = RuntimeFilterListToPB(ctx, p.runtimeFilterList, ctx.GetClient())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -408,7 +398,7 @@ func (e *PhysicalExchangeSender) ToPB(ctx sessionctx.Context, storeType kv.Store
 		}
 		allFieldTypes = append(allFieldTypes, pbType)
 	}
-	hashColPb, err := expression.ExpressionsToPBList(ctx.GetSessionVars().StmtCtx, hashCols, ctx.GetClient())
+	hashColPb, err := expression.ExpressionsToPBList(ctx, hashCols, ctx.GetClient())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -507,7 +497,6 @@ func (p *PhysicalIndexScan) ToPB(_ sessionctx.Context, _ kv.StoreType) (*tipb.Ex
 
 // ToPB implements PhysicalPlan ToPB interface.
 func (p *PhysicalHashJoin) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*tipb.Executor, error) {
-	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
 
 	if len(p.LeftJoinKeys) > 0 && len(p.LeftNAJoinKeys) > 0 {
@@ -542,20 +531,20 @@ func (p *PhysicalHashJoin) ToPB(ctx sessionctx.Context, storeType kv.StoreType) 
 		return nil, errors.Trace(err)
 	}
 
-	left, err := expression.ExpressionsToPBList(sc, leftKeys, client)
+	left, err := expression.ExpressionsToPBList(ctx, leftKeys, client)
 	if err != nil {
 		return nil, err
 	}
-	right, err := expression.ExpressionsToPBList(sc, rightKeys, client)
+	right, err := expression.ExpressionsToPBList(ctx, rightKeys, client)
 	if err != nil {
 		return nil, err
 	}
 
-	leftConditions, err := expression.ExpressionsToPBList(sc, p.LeftConditions, client)
+	leftConditions, err := expression.ExpressionsToPBList(ctx, p.LeftConditions, client)
 	if err != nil {
 		return nil, err
 	}
-	rightConditions, err := expression.ExpressionsToPBList(sc, p.RightConditions, client)
+	rightConditions, err := expression.ExpressionsToPBList(ctx, p.RightConditions, client)
 	if err != nil {
 		return nil, err
 	}
@@ -575,11 +564,11 @@ func (p *PhysicalHashJoin) ToPB(ctx sessionctx.Context, storeType kv.StoreType) 
 	} else {
 		otherConditionsInJoin = p.OtherConditions
 	}
-	otherConditions, err := expression.ExpressionsToPBList(sc, otherConditionsInJoin, client)
+	otherConditions, err := expression.ExpressionsToPBList(ctx, otherConditionsInJoin, client)
 	if err != nil {
 		return nil, err
 	}
-	otherEqConditions, err := expression.ExpressionsToPBList(sc, otherEqConditionsFromIn, client)
+	otherEqConditions, err := expression.ExpressionsToPBList(ctx, otherEqConditionsFromIn, client)
 	if err != nil {
 		return nil, err
 	}
@@ -622,7 +611,7 @@ func (p *PhysicalHashJoin) ToPB(ctx sessionctx.Context, storeType kv.StoreType) 
 	}
 
 	// runtime filter
-	rfListPB, err := RuntimeFilterListToPB(p.runtimeFilterList, sc, client)
+	rfListPB, err := RuntimeFilterListToPB(ctx, p.runtimeFilterList, client)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -663,7 +652,7 @@ func (fb *FrameBound) ToPB(ctx sessionctx.Context) (*tipb.WindowFrameBound, erro
 	pbBound.Offset = &offset
 
 	if fb.IsExplicitRange {
-		rangeFrame, err := expression.ExpressionsToPBList(ctx.GetSessionVars().StmtCtx, fb.CalcFuncs, ctx.GetClient())
+		rangeFrame, err := expression.ExpressionsToPBList(ctx, fb.CalcFuncs, ctx.GetClient())
 		if err != nil {
 			return nil, err
 		}
@@ -677,7 +666,6 @@ func (fb *FrameBound) ToPB(ctx sessionctx.Context) (*tipb.WindowFrameBound, erro
 
 // ToPB implements PhysicalPlan ToPB interface.
 func (p *PhysicalWindow) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*tipb.Executor, error) {
-	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
 
 	windowExec := &tipb.Window{}
@@ -687,10 +675,10 @@ func (p *PhysicalWindow) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*
 		windowExec.FuncDesc = append(windowExec.FuncDesc, aggregation.WindowFuncToPBExpr(ctx, client, desc))
 	}
 	for _, item := range p.PartitionBy {
-		windowExec.PartitionBy = append(windowExec.PartitionBy, expression.SortByItemToPB(sc, client, item.Col.Clone(), item.Desc))
+		windowExec.PartitionBy = append(windowExec.PartitionBy, expression.SortByItemToPB(ctx, client, item.Col.Clone(), item.Desc))
 	}
 	for _, item := range p.OrderBy {
-		windowExec.OrderBy = append(windowExec.OrderBy, expression.SortByItemToPB(sc, client, item.Col.Clone(), item.Desc))
+		windowExec.OrderBy = append(windowExec.OrderBy, expression.SortByItemToPB(ctx, client, item.Col.Clone(), item.Desc))
 	}
 
 	if p.Frame != nil {
@@ -734,12 +722,11 @@ func (p *PhysicalSort) ToPB(ctx sessionctx.Context, storeType kv.StoreType) (*ti
 		return nil, errors.Errorf("sort %s can't convert to pb, because it isn't a partial sort", p.Plan.ExplainID())
 	}
 
-	sc := ctx.GetSessionVars().StmtCtx
 	client := ctx.GetClient()
 
 	sortExec := &tipb.Sort{}
 	for _, item := range p.ByItems {
-		sortExec.ByItems = append(sortExec.ByItems, expression.SortByItemToPB(sc, client, item.Expr, item.Desc))
+		sortExec.ByItems = append(sortExec.ByItems, expression.SortByItemToPB(ctx, client, item.Expr, item.Desc))
 	}
 	isPartialSort := p.IsPartialSort
 	sortExec.IsPartialSort = &isPartialSort

--- a/pkg/planner/core/rule_predicate_push_down.go
+++ b/pkg/planner/core/rule_predicate_push_down.go
@@ -139,7 +139,7 @@ func (ds *DataSource) PredicatePushDown(predicates []expression.Expression, opt 
 	// TODO: remove it to the place building logical plan
 	predicates = ds.AddPrefix4ShardIndexes(ds.SCtx(), predicates)
 	ds.allConds = predicates
-	ds.pushedDownConds, predicates = expression.PushDownExprs(ds.SCtx().GetSessionVars().StmtCtx, predicates, ds.SCtx().GetClient(), kv.UnSpecified)
+	ds.pushedDownConds, predicates = expression.PushDownExprs(ds.SCtx(), predicates, ds.SCtx().GetClient(), kv.UnSpecified)
 	appendDataSourcePredicatePushDownTraceStep(ds, opt)
 	return predicates, ds
 }

--- a/pkg/planner/core/runtime_filter.go
+++ b/pkg/planner/core/runtime_filter.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -201,10 +201,10 @@ func (rf *RuntimeFilter) Clone() *RuntimeFilter {
 }
 
 // RuntimeFilterListToPB convert runtime filter list to PB list
-func RuntimeFilterListToPB(runtimeFilterList []*RuntimeFilter, sc *stmtctx.StatementContext, client kv.Client) ([]*tipb.RuntimeFilter, error) {
+func RuntimeFilterListToPB(ctx sessionctx.Context, runtimeFilterList []*RuntimeFilter, client kv.Client) ([]*tipb.RuntimeFilter, error) {
 	result := make([]*tipb.RuntimeFilter, 0, len(runtimeFilterList))
 	for _, runtimeFilter := range runtimeFilterList {
-		rfPB, err := runtimeFilter.ToPB(sc, client)
+		rfPB, err := runtimeFilter.ToPB(ctx, client)
 		if err != nil {
 			return nil, err
 		}
@@ -214,8 +214,8 @@ func RuntimeFilterListToPB(runtimeFilterList []*RuntimeFilter, sc *stmtctx.State
 }
 
 // ToPB convert runtime filter to PB
-func (rf *RuntimeFilter) ToPB(sc *stmtctx.StatementContext, client kv.Client) (*tipb.RuntimeFilter, error) {
-	pc := expression.NewPBConverter(client, sc)
+func (rf *RuntimeFilter) ToPB(ctx sessionctx.Context, client kv.Client) (*tipb.RuntimeFilter, error) {
+	pc := expression.NewPBConverter(client, ctx)
 	srcExprListPB := make([]*tipb.Expr, 0, len(rf.srcExprList))
 	for _, srcExpr := range rf.srcExprList {
 		srcExprPB := pc.ExprToPB(srcExpr)

--- a/pkg/planner/core/scalar_subq_expression.go
+++ b/pkg/planner/core/scalar_subq_expression.go
@@ -223,7 +223,7 @@ func (s *ScalarSubQueryExpr) RemapColumn(_ map[int64]*expression.Column) (expres
 }
 
 // ExplainInfo implements the Expression interface.
-func (s *ScalarSubQueryExpr) ExplainInfo() string {
+func (s *ScalarSubQueryExpr) ExplainInfo(sessionctx.Context) string {
 	return s.String()
 }
 

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1111,7 +1111,7 @@ func (p *PhysicalTopN) canExpressionConvertedToPB(storeTp kv.StoreType) bool {
 	for _, item := range p.ByItems {
 		exprs = append(exprs, item.Expr)
 	}
-	return expression.CanExprsPushDown(p.SCtx().GetSessionVars().StmtCtx, exprs, p.SCtx().GetClient(), storeTp)
+	return expression.CanExprsPushDown(p.SCtx(), exprs, p.SCtx().GetClient(), storeTp)
 }
 
 // containVirtualColumn checks whether TopN.ByItems contains virtual generated columns.
@@ -1212,12 +1212,12 @@ func (p *PhysicalExpand) attach2Task(tasks ...task) task {
 func (p *PhysicalProjection) attach2Task(tasks ...task) task {
 	t := tasks[0].copy()
 	if cop, ok := t.(*copTask); ok {
-		if (len(cop.rootTaskConds) == 0 && len(cop.idxMergePartPlans) == 0) && expression.CanExprsPushDown(p.SCtx().GetSessionVars().StmtCtx, p.Exprs, p.SCtx().GetClient(), cop.getStoreType()) {
+		if (len(cop.rootTaskConds) == 0 && len(cop.idxMergePartPlans) == 0) && expression.CanExprsPushDown(p.SCtx(), p.Exprs, p.SCtx().GetClient(), cop.getStoreType()) {
 			copTask := attachPlan2Task(p, cop)
 			return copTask
 		}
 	} else if mpp, ok := t.(*mppTask); ok {
-		if expression.CanExprsPushDown(p.SCtx().GetSessionVars().StmtCtx, p.Exprs, p.SCtx().GetClient(), kv.TiFlash) {
+		if expression.CanExprsPushDown(p.SCtx(), p.Exprs, p.SCtx().GetClient(), kv.TiFlash) {
 			p.SetChildren(mpp.p)
 			mpp.p = p
 			return mpp
@@ -1274,8 +1274,7 @@ func (p *PhysicalUnionAll) attach2Task(tasks ...task) task {
 
 func (sel *PhysicalSelection) attach2Task(tasks ...task) task {
 	if mppTask, _ := tasks[0].(*mppTask); mppTask != nil { // always push to mpp task.
-		sc := sel.SCtx().GetSessionVars().StmtCtx
-		if expression.CanExprsPushDown(sc, sel.Conditions, sel.SCtx().GetClient(), kv.TiFlash) {
+		if expression.CanExprsPushDown(sel.SCtx(), sel.Conditions, sel.SCtx().GetClient(), kv.TiFlash) {
 			return attachPlan2Task(sel, mppTask.copy())
 		}
 	}
@@ -1302,7 +1301,7 @@ func CheckAggCanPushCop(sctx sessionctx.Context, aggFuncs []*aggregation.AggFunc
 			ret = false
 			break
 		}
-		if !expression.CanExprsPushDownWithExtraInfo(sc, aggFunc.Args, client, storeType, aggFunc.Name == ast.AggFuncSum) {
+		if !expression.CanExprsPushDownWithExtraInfo(sctx, aggFunc.Args, client, storeType, aggFunc.Name == ast.AggFuncSum) {
 			reason = "arguments of AggFunc `" + aggFunc.Name + "` contains unsupported exprs"
 			ret = false
 			break
@@ -1313,7 +1312,7 @@ func CheckAggCanPushCop(sctx sessionctx.Context, aggFuncs []*aggregation.AggFunc
 			for _, item := range aggFunc.OrderByItems {
 				exprs = append(exprs, item.Expr)
 			}
-			if !expression.CanExprsPushDownWithExtraInfo(sc, exprs, client, storeType, false) {
+			if !expression.CanExprsPushDownWithExtraInfo(sctx, exprs, client, storeType, false) {
 				reason = "arguments of AggFunc `" + aggFunc.Name + "` contains unsupported exprs in order-by clause"
 				ret = false
 				break
@@ -1330,7 +1329,7 @@ func CheckAggCanPushCop(sctx sessionctx.Context, aggFuncs []*aggregation.AggFunc
 		reason = "groupByItems contain virtual columns, which is not supported now"
 		ret = false
 	}
-	if ret && !expression.CanExprsPushDown(sc, groupByItems, client, storeType) {
+	if ret && !expression.CanExprsPushDown(sctx, groupByItems, client, storeType) {
 		reason = "groupByItems contain unsupported exprs"
 		ret = false
 	}

--- a/pkg/planner/core/tiflash_selection_late_materialization.go
+++ b/pkg/planner/core/tiflash_selection_late_materialization.go
@@ -251,7 +251,7 @@ func predicatePushDownToTableScanImpl(sctx sessionctx.Context, physicalSelection
 	if len(selectedConds) == 0 {
 		return
 	}
-	logutil.BgLogger().Debug("planner: push down conditions to table scan", zap.String("table", physicalTableScan.Table.Name.L), zap.String("conditions", string(expression.SortedExplainExpressionList(selectedConds))))
+	logutil.BgLogger().Debug("planner: push down conditions to table scan", zap.String("table", physicalTableScan.Table.Name.L), zap.String("conditions", string(expression.SortedExplainExpressionList(sctx, selectedConds))))
 	// remove the pushed down conditions from selection
 	removeSpecificExprsFromSelection(physicalSelection, selectedConds)
 	// add the pushed down conditions to table scan

--- a/pkg/planner/property/BUILD.bazel
+++ b/pkg/planner/property/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/expression",
+        "//pkg/sessionctx",
         "//pkg/sessionctx/stmtctx",
         "//pkg/statistics",
         "//pkg/util/codec",

--- a/pkg/planner/property/physical_property.go
+++ b/pkg/planner/property/physical_property.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/collate"
@@ -130,11 +131,11 @@ func (partitionCol *MPPPartitionColumn) MemoryUsage() (sum int64) {
 }
 
 // ExplainColumnList generates explain information for a list of columns.
-func ExplainColumnList(cols []*MPPPartitionColumn) []byte {
+func ExplainColumnList(ctx sessionctx.Context, cols []*MPPPartitionColumn) []byte {
 	buffer := bytes.NewBufferString("")
 	for i, col := range cols {
 		buffer.WriteString("[name: ")
-		buffer.WriteString(col.Col.ExplainInfo())
+		buffer.WriteString(col.Col.ExplainInfo(ctx))
 		buffer.WriteString(", collate: ")
 		if collate.NewCollationEnabled() {
 			buffer.WriteString(GetCollateNameByIDForPartition(col.CollateID))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48914

### What changed and how does it work?

To make sure some `Eval` methods can have a outside input of the context, we did below two refactors

1. Replace inner context type from `StatementContext` to `sessionctx.Context` for `PbConverter`
2. Add a new parameter `ctx` for method `Expression.ExplainInfo`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
