### PR TITLE
pkg/errctx, *: remove `OverflowAsWarning` field from `stmtctx`

### DIFF
--- a/br/pkg/lightning/backend/kv/BUILD.bazel
+++ b/br/pkg/lightning/backend/kv/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//br/pkg/logutil",
         "//br/pkg/redact",
         "//br/pkg/utils",
+        "//pkg/errctx",
         "//pkg/expression",
         "//pkg/kv",
         "//pkg/meta/autoid",

--- a/br/pkg/lightning/backend/kv/session.go
+++ b/br/pkg/lightning/backend/kv/session.go
@@ -29,11 +29,11 @@ import (
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
 	"github.com/pingcap/tidb/br/pkg/lightning/manual"
 	"github.com/pingcap/tidb/br/pkg/utils"
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
-	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/topsql/stmtstats"
 	"go.uber.org/zap"
 )
@@ -287,7 +287,6 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 	vars.StmtCtx.InInsertStmt = true
 	vars.StmtCtx.BatchCheck = true
 	vars.StmtCtx.BadNullAsWarning = !sqlMode.HasStrictMode()
-	vars.StmtCtx.OverflowAsWarning = !sqlMode.HasStrictMode()
 	vars.SQLMode = sqlMode
 
 	typeFlags := vars.StmtCtx.TypeFlags().
@@ -315,7 +314,11 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 		}
 	}
 	vars.StmtCtx.SetTimeZone(vars.Location())
-	vars.StmtCtx.SetTypeFlags(types.StrictFlags)
+
+	if !sqlMode.HasStrictMode() {
+		vars.StmtCtx.SetErrGroupLevel(errctx.ErrGroupOverflow, errctx.LevelWarn)
+	}
+
 	if err := vars.SetSystemVar("timestamp", strconv.FormatInt(options.Timestamp, 10)); err != nil {
 		logger.Warn("new session: failed to set timestamp",
 			log.ShortError(err))

--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -87,6 +87,7 @@ go_library(
         "//pkg/disttask/operator",
         "//pkg/domain/infosync",
         "//pkg/domain/resourcegroup",
+        "//pkg/errctx",
         "//pkg/expression",
         "//pkg/infoschema",
         "//pkg/kv",

--- a/pkg/errctx/context.go
+++ b/pkg/errctx/context.go
@@ -34,7 +34,7 @@ const (
 
 // Context defines how to handle an error
 type Context struct {
-	levelMap        [errGroupCount]Level
+	levelMap        [ErrGroupCount]Level
 	appendWarningFn func(err error)
 }
 
@@ -133,6 +133,11 @@ func (ctx *Context) HandleErrorWithAlias(internalErr error, err error, warnErr e
 	return nil
 }
 
+// GetLevel returns a level of the given `ErrGroup`
+func (ctx *Context) GetLevel(eg ErrGroup) Level {
+	return ctx.levelMap[eg]
+}
+
 // NewContext creates an error context to handle the errors and warnings
 func NewContext(appendWarningFn func(err error)) Context {
 	intest.Assert(appendWarningFn != nil)
@@ -157,8 +162,8 @@ const (
 	// ErrGroupOverflow is the group of overflow errors
 	ErrGroupOverflow
 
-	// errGroupCount is the count of all `ErrGroup`. Please leave it at the end of the list.
-	errGroupCount
+	// ErrGroupCount is the count of all `ErrGroup`. Please leave it at the end of the list.
+	ErrGroupCount
 )
 
 func init() {

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -109,6 +109,7 @@ go_library(
         "//pkg/domain",
         "//pkg/domain/infosync",
         "//pkg/domain/resourcegroup",
+        "//pkg/errctx",
         "//pkg/errno",
         "//pkg/executor/aggfuncs",
         "//pkg/executor/aggregate",

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl/schematracker"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/executor/aggregate"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/executor/internal/pdhelper"
@@ -2146,7 +2147,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		// said "For statements such as SELECT that do not change data, invalid values
 		// generate a warning in strict mode, not an error."
 		// and https://dev.mysql.com/doc/refman/5.7/en/out-of-range-and-overflow.html
-		sc.OverflowAsWarning = true
+		sc.SetErrGroupLevel(errctx.ErrGroupOverflow, errctx.LevelWarn)
 
 		// Return warning for truncate error in selection.
 		sc.SetTypeFlags(sc.TypeFlags().
@@ -2160,7 +2161,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.WeakConsistency = isWeakConsistencyRead(ctx, stmt)
 	case *ast.SetOprStmt:
 		sc.InSelectStmt = true
-		sc.OverflowAsWarning = true
+		sc.SetErrGroupLevel(errctx.ErrGroupOverflow, errctx.LevelWarn)
 		sc.SetTypeFlags(sc.TypeFlags().
 			WithTruncateAsWarning(true).
 			WithIgnoreZeroInDate(true).

--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -191,6 +191,7 @@ go_test(
     shard_count = 50,
     deps = [
         "//pkg/config",
+        "//pkg/errctx",
         "//pkg/errno",
         "//pkg/kv",
         "//pkg/parser",

--- a/pkg/expression/builtin_arithmetic.go
+++ b/pkg/expression/builtin_arithmetic.go
@@ -843,7 +843,7 @@ func (s *builtinArithmeticIntDivideDecimalSig) evalInt(ctx sessionctx.Context, r
 	}
 	if err == types.ErrOverflow {
 		newErr := errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c)
-		err = sc.HandleOverflow(newErr, newErr)
+		err = sc.HandleError(newErr)
 	}
 	if err != nil {
 		return 0, true, err

--- a/pkg/expression/builtin_arithmetic_vec.go
+++ b/pkg/expression/builtin_arithmetic_vec.go
@@ -621,7 +621,7 @@ func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(ctx sessionctx.Context
 			err = sc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
 		} else if err == types.ErrOverflow {
 			newErr := errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c)
-			err = sc.HandleOverflow(newErr, newErr)
+			err = sc.HandleError(newErr)
 		}
 		if err != nil {
 			return err

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -542,7 +542,7 @@ func convertJSON2Tp(evalType types.EvalType) func(*stmtctx.StatementContext, typ
 				return nil, ErrInvalidJSONForFuncIndex
 			}
 			jsonToInt, err := types.ConvertJSONToInt(sc.TypeCtx(), item, mysql.HasUnsignedFlag(tp.GetFlag()), tp.GetType())
-			err = sc.HandleOverflow(err, err)
+			err = sc.HandleError(err)
 			if mysql.HasUnsignedFlag(tp.GetFlag()) {
 				return uint64(jsonToInt), err
 			}
@@ -705,7 +705,7 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(ctx sessionctx.Context, row chu
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, isNull, err
 }
 
@@ -790,7 +790,7 @@ func (b *builtinCastIntAsDurationSig) evalDuration(ctx sessionctx.Context, row c
 	dur, err := types.NumberToDuration(val, b.tp.GetDecimal())
 	if err != nil {
 		if types.ErrOverflow.Equal(err) {
-			err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
+			err = ctx.GetSessionVars().StmtCtx.HandleError(err)
 		}
 		if types.ErrTruncatedWrongVal.Equal(err) {
 			err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
@@ -987,7 +987,7 @@ func (b *builtinCastRealAsIntSig) evalInt(ctx sessionctx.Context, row chunk.Row)
 		res = int64(uintVal)
 	}
 	if types.ErrOverflow.Equal(err) {
-		err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
+		err = ctx.GetSessionVars().StmtCtx.HandleError(err)
 	}
 	return res, isNull, err
 }
@@ -1012,7 +1012,7 @@ func (b *builtinCastRealAsDecimalSig) evalDecimal(ctx sessionctx.Context, row ch
 		err = res.FromFloat64(val)
 		if types.ErrOverflow.Equal(err) {
 			warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0])
-			err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
+			err = ctx.GetSessionVars().StmtCtx.HandleErrorWithAlias(err, err, warnErr)
 		} else if types.ErrTruncated.Equal(err) {
 			// This behavior is consistent with MySQL.
 			err = nil
@@ -1023,7 +1023,7 @@ func (b *builtinCastRealAsDecimalSig) evalDecimal(ctx sessionctx.Context, row ch
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 
@@ -1136,7 +1136,7 @@ func (b *builtinCastDecimalAsDecimalSig) evalDecimal(ctx sessionctx.Context, row
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 
@@ -1175,7 +1175,7 @@ func (b *builtinCastDecimalAsIntSig) evalInt(ctx sessionctx.Context, row chunk.R
 
 	if types.ErrOverflow.Equal(err) {
 		warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", val)
-		err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
+		err = ctx.GetSessionVars().StmtCtx.HandleErrorWithAlias(err, err, warnErr)
 	}
 
 	return res, false, err
@@ -1343,7 +1343,7 @@ func (*builtinCastStringAsIntSig) handleOverflow(ctx sessionctx.Context, origRes
 			res = int64(uval)
 		}
 		warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("INTEGER", origStr)
-		err = sc.HandleOverflow(origErr, warnErr)
+		err = sc.HandleErrorWithAlias(origErr, origErr, warnErr)
 	}
 	return
 }
@@ -1461,7 +1461,7 @@ func (b *builtinCastStringAsDecimalSig) evalDecimal(ctx sessionctx.Context, row 
 		}
 	}
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 
@@ -1607,7 +1607,7 @@ func (b *builtinCastTimeAsDecimalSig) evalDecimal(ctx sessionctx.Context, row ch
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), val.ToNumber(), b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 
@@ -1747,7 +1747,7 @@ func (b *builtinCastDurationAsDecimalSig) evalDecimal(ctx sessionctx.Context, ro
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), val.ToNumber(), b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 
@@ -1850,7 +1850,7 @@ func (b *builtinCastJSONAsIntSig) evalInt(ctx sessionctx.Context, row chunk.Row)
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ConvertJSONToInt64(sc.TypeCtx(), val, mysql.HasUnsignedFlag(b.tp.GetFlag()))
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return
 }
 
@@ -1895,7 +1895,7 @@ func (b *builtinCastJSONAsDecimalSig) evalDecimal(ctx sessionctx.Context, row ch
 		return res, false, err
 	}
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
@@ -98,8 +99,7 @@ func TestCastFunctions(t *testing.T) {
 	defer func() {
 		sc.InSelectStmt = oldInSelectStmt
 	}()
-	sc.OverflowAsWarning = true
-
+	sc.SetErrGroupLevel(errctx.ErrGroupOverflow, errctx.LevelWarn)
 	// cast('18446744073709551616' as unsigned);
 	tp1 := types.NewFieldTypeBuilder().SetType(mysql.TypeLonglong).SetFlag(mysql.BinaryFlag).SetFlen(mysql.MaxIntWidth).SetCharset(charset.CharsetBin).SetCollate(charset.CollationBin).BuildP()
 	f = BuildCastFunction(ctx, &Constant{Value: types.NewDatum("18446744073709551616"), RetType: types.NewFieldType(mysql.TypeString)}, tp1)

--- a/pkg/sessionctx/stmtctx/BUILD.bazel
+++ b/pkg/sessionctx/stmtctx/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     flaky = True,
     shard_count = 10,
     deps = [
+        "//pkg/errctx",
         "//pkg/kv",
         "//pkg/sessionctx/variable",
         "//pkg/testkit",

--- a/pkg/sessionctx/stmtctx/stmtctx_test.go
+++ b/pkg/sessionctx/stmtctx/stmtctx_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
@@ -95,7 +96,7 @@ func TestStatementContextPushDownFLags(t *testing.T) {
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.InSelectStmt = true }), 32},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true)) }), 1},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true)) }), 2},
-		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.OverflowAsWarning = true }), 64},
+		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetErrGroupLevel(errctx.ErrGroupOverflow, errctx.LevelWarn) }), 64},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithIgnoreZeroInDate(true)) }), 128},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.DividedByZeroAsWarning = true }), 256},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.InLoadDataStmt = true }), 1024},

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -322,8 +322,7 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 			zap.Uint64("conn", ctx.GetSessionVars().ConnectionID), zap.Error(err))
 	}
 
-	err = sc.HandleTruncate(err)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 
 	if forceIgnoreTruncate {
 		err = nil

--- a/pkg/util/codec/BUILD.bazel
+++ b/pkg/util/codec/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     embed = [":codec"],
     flaky = True,
     deps = [
+        "//pkg/errctx",
         "//pkg/parser/mysql",
         "//pkg/parser/terror",
         "//pkg/sessionctx/stmtctx",

--- a/pkg/util/codec/codec_test.go
+++ b/pkg/util/codec/codec_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
@@ -786,7 +787,7 @@ func TestDecimal(t *testing.T) {
 	err = sc.HandleError(err)
 	require.NoError(t, err)
 
-	sc.OverflowAsWarning = true
+	sc.SetErrGroupLevel(errctx.ErrGroupOverflow, errctx.LevelWarn)
 	decimalDatum.SetLength(12)
 	decimalDatum.SetFrac(10)
 	_, err = EncodeValue(sc.TimeZone(), nil, decimalDatum)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #48920 

Now, all error handling could be migrated to use `errctx`. This PR modifies the original code related with `OverflowAsWarning`. It stores the states in the `errctx` and handle error according to it.=

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > No logic change. This refractor should be covered by existing tests.

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
