### PR TITLE
statistics: Update stats meta count and modify count for dropped table partitions

### DIFF
--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/statistics/handle/types",
         "//pkg/statistics/handle/util",
+        "//pkg/util/logutil",
+        "@org_uber_go_zap//:zap",
     ],
 )
 
@@ -18,10 +20,11 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",
+        "//pkg/statistics/handle/util",
         "//pkg/testkit",
         "//pkg/types",
         "//pkg/util/mock",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -8,9 +8,9 @@ go_library(
     deps = [
         "//pkg/parser/model",
         "//pkg/sessionctx/variable",
+        "//pkg/statistics/handle/logutil",
         "//pkg/statistics/handle/types",
         "//pkg/statistics/handle/util",
-        "//pkg/util/logutil",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -17,9 +17,9 @@ package ddl
 import (
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	"github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
-	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
 )
 
@@ -126,7 +126,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 			// Get the count and modify count of the partition.
 			stats := h.statsHandler.GetPartitionStats(globalTableInfo, def.ID)
 			if stats.Pseudo {
-				logutil.BgLogger().Warn(
+				logutil.StatsLogger.Warn(
 					"drop partition with pseudo stats, "+
 						"usually it won't happen because we always load stats when initializing the handle",
 					zap.String("table", globalTableInfo.Name.O),

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -141,7 +141,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 			}
 		}
 		if err := h.statsWriter.UpdateStatsMetaDelta(
-			globalTableInfo.ID, delta, count,
+			globalTableInfo.ID, count, delta,
 		); err != nil {
 			return err
 		}

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -307,7 +307,7 @@ func TestDropAPartition(t *testing.T) {
 			partition p3 values less than (21)
 		)
 	`)
-	testKit.MustExec("insert into t values (1,2),(6,2),(11,2),(16,2)")
+	testKit.MustExec("insert into t values (1,2),(2,2),(6,2),(11,2),(16,2)")
 	testKit.MustExec("analyze table t")
 	is := do.InfoSchema()
 	tbl, err := is.TableByName(
@@ -336,9 +336,10 @@ func TestDropAPartition(t *testing.T) {
 	err = h.HandleDDLEvent(dropPartitionEvent)
 	require.NoError(t, err)
 	// Check the global stats meta.
+	// Because we have dropped a partition, the count should be 3 and the modify count should be 2.
 	testKit.MustQuery(
 		fmt.Sprintf("select count, modify_count from mysql.stats_meta where table_id = %d", tableInfo.ID),
 	).Check(
-		testkit.Rows("3 1"),
+		testkit.Rows("3 2"),
 	)
 }

--- a/pkg/statistics/handle/storage/save.go
+++ b/pkg/statistics/handle/storage/save.go
@@ -325,9 +325,18 @@ func SaveTableStatsToStorage(sctx sessionctx.Context,
 // If count is negative, both count and modify count would not be used and not be written to the table. Unless, corresponding
 // fields in the stats_meta table will be updated.
 // TODO: refactor to reduce the number of parameters
-func SaveStatsToStorage(sctx sessionctx.Context,
-	tableID int64, count, modifyCount int64, isIndex int, hg *statistics.Histogram,
-	cms *statistics.CMSketch, topN *statistics.TopN, statsVersion int, isAnalyzed int64, updateAnalyzeTime bool) (statsVer uint64, err error) {
+func SaveStatsToStorage(
+	sctx sessionctx.Context,
+	tableID int64,
+	count, modifyCount int64,
+	isIndex int,
+	hg *statistics.Histogram,
+	cms *statistics.CMSketch,
+	topN *statistics.TopN,
+	statsVersion int,
+	isAnalyzed int64,
+	updateAnalyzeTime bool,
+) (statsVer uint64, err error) {
 	version, err := util.GetStartTS(sctx)
 	if err != nil {
 		return 0, errors.Trace(err)

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -216,7 +216,7 @@ func (s *statsReadWriter) StatsMetaCountAndModifyCount(tableID int64) (count, mo
 }
 
 // UpdateStatsMetaDelta updates the count and modify_count for the given table in mysql.stats_meta.
-func (s *statsReadWriter) UpdateStatsMetaDelta(tableID int64, count, modifyCount int64) (err error) {
+func (s *statsReadWriter) UpdateStatsMetaDelta(tableID int64, count, delta int64) (err error) {
 	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		lockedTables, err := s.statsHandler.GetLockedTables(tableID)
 		if err != nil {
@@ -233,7 +233,7 @@ func (s *statsReadWriter) UpdateStatsMetaDelta(tableID int64, count, modifyCount
 		err = UpdateStatsMeta(
 			sctx,
 			startTS,
-			variable.TableDelta{Count: count, Delta: modifyCount},
+			variable.TableDelta{Count: count, Delta: delta},
 			tableID,
 			isLocked,
 		)

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -215,19 +215,20 @@ func (s *statsReadWriter) StatsMetaCountAndModifyCount(tableID int64) (count, mo
 	return
 }
 
+// UpdateStatsMetaDelta updates the count and modify_count for the given table in mysql.stats_meta.
 func (s *statsReadWriter) UpdateStatsMetaDelta(tableID int64, count, modifyCount int64) (err error) {
 	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
-		startTS, err := util.GetStartTS(sctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
 		lockedTables, err := s.statsHandler.GetLockedTables(tableID)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		var isLocked bool
+		isLocked := false
 		if len(lockedTables) > 0 {
 			isLocked = true
+		}
+		startTS, err := util.GetStartTS(sctx)
+		if err != nil {
+			return errors.Trace(err)
 		}
 		err = UpdateStatsMeta(
 			sctx,

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -233,8 +233,18 @@ func (s *statsReadWriter) TableStatsFromStorage(tableInfo *model.TableInfo, phys
 // If count is negative, both count and modify count would not be used and not be written to the table. Unless, corresponding
 // fields in the stats_meta table will be updated.
 // TODO: refactor to reduce the number of parameters
-func (s *statsReadWriter) SaveStatsToStorage(tableID int64, count, modifyCount int64, isIndex int, hg *statistics.Histogram,
-	cms *statistics.CMSketch, topN *statistics.TopN, statsVersion int, isAnalyzed int64, updateAnalyzeTime bool, source string) (err error) {
+func (s *statsReadWriter) SaveStatsToStorage(
+	tableID int64,
+	count, modifyCount int64,
+	isIndex int,
+	hg *statistics.Histogram,
+	cms *statistics.CMSketch,
+	topN *statistics.TopN,
+	statsVersion int,
+	isAnalyzed int64,
+	updateAnalyzeTime bool,
+	source string,
+) (err error) {
 	var statsVer uint64
 	err = util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		statsVer, err = SaveStatsToStorage(sctx, tableID,

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -228,6 +228,10 @@ type StatsReadWriter interface {
 	// StatsMetaCountAndModifyCount reads count and modify_count for the given table from mysql.stats_meta.
 	StatsMetaCountAndModifyCount(tableID int64) (count, modifyCount int64, err error)
 
+	// UpdateStatsMetaDelta updates the count and modify_count for the given table in mysql.stats_meta.
+	// It will add the delta to the original count and modify_count. The delta can be positive or negative.
+	UpdateStatsMetaDelta(tableID int64, count, modifyCount int64) (err error)
+
 	// LoadNeededHistograms will load histograms for those needed columns/indices and put them into the cache.
 	LoadNeededHistograms() (err error)
 

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -230,7 +230,7 @@ type StatsReadWriter interface {
 
 	// UpdateStatsMetaDelta updates the count and modify_count for the given table in mysql.stats_meta.
 	// It will add the delta to the original count and modify_count. The delta can be positive or negative.
-	UpdateStatsMetaDelta(tableID int64, count, modifyCount int64) (err error)
+	UpdateStatsMetaDelta(tableID int64, count, delta int64) (err error)
 
 	// LoadNeededHistograms will load histograms for those needed columns/indices and put them into the cache.
 	LoadNeededHistograms() (err error)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/48182

Problem Summary:

### What changed and how does it work?

Based on [this design doc](https://pingcap.feishu.cn/docx/OLCrdxHj2ojb9KxlUvUch60LnBe#part-PRTmdkF0doiZSxxHHmDckfeJnZf), we will only update the count and modfiy_count for it. Then it will use the count and modify_count to determine if we need to trigger an auto-analysis task.

So in this PR, I updated the count and modify count of the global table.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] [Manual test](https://pingcap.feishu.cn/docx/XPYIdC4Ihoc7jNxuPficBbOgn8g)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
