### PR TITLE
expression: remove inner context cache in `expression.ScalarFunction`

### DIFF
--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -2147,7 +2147,6 @@ func BuildCastFunctionWithCheck(ctx sessionctx.Context, expr Expression, tp *typ
 		FuncName: model.NewCIStr(ast.Cast),
 		RetType:  tp,
 		Function: f,
-		ctx:      ctx,
 	}
 	// We do not fold CAST if the eval type of this scalar function is ETJson
 	// since we may reset the flag of the field type of CastAsJson later which
@@ -2394,7 +2393,7 @@ func TryPushCastIntoControlFunctionForHybridType(ctx sessionctx.Context, expr Ex
 			if err != nil {
 				return expr
 			}
-			sf.RetType, sf.Function, sf.ctx = f.getRetTp(), f, ctx
+			sf.RetType, sf.Function = f.getRetTp(), f
 			return sf
 		}
 	case ast.Case:
@@ -2419,7 +2418,7 @@ func TryPushCastIntoControlFunctionForHybridType(ctx sessionctx.Context, expr Ex
 		if err != nil {
 			return expr
 		}
-		sf.RetType, sf.Function, sf.ctx = f.getRetTp(), f, ctx
+		sf.RetType, sf.Function = f.getRetTp(), f
 		return sf
 	case ast.Elt:
 		hasHybrid := false
@@ -2437,7 +2436,7 @@ func TryPushCastIntoControlFunctionForHybridType(ctx sessionctx.Context, expr Ex
 		if err != nil {
 			return expr
 		}
-		sf.RetType, sf.Function, sf.ctx = f.getRetTp(), f, ctx
+		sf.RetType, sf.Function = f.getRetTp(), f
 		return sf
 	default:
 		return expr

--- a/pkg/expression/builtin_convert_charset.go
+++ b/pkg/expression/builtin_convert_charset.go
@@ -228,7 +228,6 @@ func BuildToBinaryFunction(ctx sessionctx.Context, expr Expression) (res Express
 		FuncName: model.NewCIStr(InternalFuncToBinary),
 		RetType:  f.getRetTp(),
 		Function: f,
-		ctx:      ctx,
 	}
 	return FoldConstant(ctx, res)
 }
@@ -244,7 +243,6 @@ func BuildFromBinaryFunction(ctx sessionctx.Context, expr Expression, tp *types.
 		FuncName: model.NewCIStr(InternalFuncFromBinary),
 		RetType:  tp,
 		Function: f,
-		ctx:      ctx,
 	}
 	return FoldConstant(ctx, res)
 }

--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -913,7 +913,6 @@ func BuildGetVarFunction(ctx sessionctx.Context, expr Expression, retType *types
 		FuncName: model.NewCIStr(ast.GetVar),
 		RetType:  retType,
 		Function: f,
-		ctx:      ctx,
 	}, nil
 }
 

--- a/pkg/expression/builtin_test.go
+++ b/pkg/expression/builtin_test.go
@@ -178,7 +178,6 @@ func newFunctionForTest(ctx sessionctx.Context, funcName string, args ...Express
 		FuncName: model.NewCIStr(funcName),
 		RetType:  f.getRetTp(),
 		Function: f,
-		ctx:      ctx,
 	}, nil
 }
 

--- a/pkg/expression/builtin_vectorized_test.go
+++ b/pkg/expression/builtin_vectorized_test.go
@@ -775,11 +775,11 @@ func TestVectorizedCheck(t *testing.T) {
 
 	ctx := mock.NewContext()
 	vecF, _, _, _ := genMockRowDouble(ctx, types.ETInt, true)
-	sf := &ScalarFunction{Function: vecF, ctx: ctx}
+	sf := &ScalarFunction{Function: vecF}
 	require.True(t, sf.Vectorized())
 
 	rowF, _, _, _ := genMockRowDouble(ctx, types.ETInt, false)
-	sf = &ScalarFunction{Function: rowF, ctx: ctx}
+	sf = &ScalarFunction{Function: rowF}
 	require.False(t, sf.Vectorized())
 }
 

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -94,13 +94,6 @@ func (col *CorrelatedColumn) Eval(_ sessionctx.Context, _ chunk.Row) (types.Datu
 	return *col.Data, nil
 }
 
-// EvalWithInnerCtx evaluates expression with inner ctx.
-// Deprecated: This function is only used during refactoring, please do not use it in new code.
-// TODO: remove this method after refactoring.
-func (col *CorrelatedColumn) EvalWithInnerCtx(_ chunk.Row) (types.Datum, error) {
-	return *col.Data, nil
-}
-
 // EvalInt returns int representation of CorrelatedColumn.
 func (col *CorrelatedColumn) EvalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, error) {
 	if col.Data.IsNull() {
@@ -428,13 +421,6 @@ func (col *Column) Traverse(action TraverseAction) Expression {
 
 // Eval implements Expression interface.
 func (col *Column) Eval(_ sessionctx.Context, row chunk.Row) (types.Datum, error) {
-	return row.GetDatum(col.Index, col.RetType), nil
-}
-
-// EvalWithInnerCtx evaluates expression with inner ctx.
-// Deprecated: This function is only used during refactoring, please do not use it in new code.
-// TODO: remove this method after refactoring.
-func (col *Column) EvalWithInnerCtx(row chunk.Row) (types.Datum, error) {
 	return row.GetDatum(col.Index, col.RetType), nil
 }
 

--- a/pkg/expression/distsql_builtin.go
+++ b/pkg/expression/distsql_builtin.go
@@ -1100,7 +1100,6 @@ func newDistSQLFunctionBySig(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig,
 		FuncName: model.NewCIStr(fmt.Sprintf("sig_%T", f)),
 		Function: f,
 		RetType:  f.getRetTp(),
-		ctx:      ctx,
 	}, nil
 }
 

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -113,11 +113,6 @@ type Expression interface {
 
 	Traverse(TraverseAction) Expression
 
-	// EvalWithInnerCtx evaluates expression with inner ctx.
-	// Deprecated: This function is only used during refactoring, please do not use it in new code.
-	// TODO: remove this method after refactoring.
-	EvalWithInnerCtx(row chunk.Row) (types.Datum, error)
-
 	// Eval evaluates an expression through a row.
 	Eval(ctx sessionctx.Context, row chunk.Row) (types.Datum, error)
 
@@ -1045,7 +1040,6 @@ func NewValuesFunc(ctx sessionctx.Context, offset int, retTp *types.FieldType) *
 		FuncName: model.NewCIStr(ast.Values),
 		RetType:  retTp,
 		Function: bt,
-		ctx:      ctx,
 	}
 }
 
@@ -1523,7 +1517,6 @@ func wrapWithIsTrue(ctx sessionctx.Context, keepNull bool, arg Expression, wrapF
 		FuncName: model.NewCIStr(ast.IsTruthWithoutNull),
 		Function: f,
 		RetType:  f.getRetTp(),
-		ctx:      ctx,
 	}
 	if keepNull {
 		sf.FuncName = model.NewCIStr(ast.IsTruthWithNull)

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -195,7 +195,7 @@ func TestSetExprColumnInOperand(t *testing.T) {
 	ctx := mock.NewContext()
 	f, err := funcs[ast.Abs].getFunction(ctx, []Expression{col})
 	require.NoError(t, err)
-	fun := &ScalarFunction{Function: f, ctx: ctx}
+	fun := &ScalarFunction{Function: f}
 	SetExprColumnInOperand(fun)
 	require.True(t, f.getArgs()[0].(*Column).InOperand)
 }
@@ -205,7 +205,7 @@ func TestPopRowFirstArg(t *testing.T) {
 	c1, c2, c3 := &Column{RetType: newIntFieldType()}, &Column{RetType: newIntFieldType()}, &Column{RetType: newIntFieldType()}
 	f, err := funcs[ast.RowFunc].getFunction(ctx, []Expression{c1, c2, c3})
 	require.NoError(t, err)
-	fun := &ScalarFunction{Function: f, FuncName: model.NewCIStr(ast.RowFunc), RetType: newIntFieldType(), ctx: ctx}
+	fun := &ScalarFunction{Function: f, FuncName: model.NewCIStr(ast.RowFunc), RetType: newIntFieldType()}
 	fun2, err := PopRowFirstArg(mock.NewContext(), fun)
 	require.NoError(t, err)
 	require.Len(t, fun2.(*ScalarFunction).GetArgs(), 2)
@@ -524,9 +524,6 @@ func (m *MockExpr) VecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, resul
 func (m *MockExpr) String() string               { return "" }
 func (m *MockExpr) MarshalJSON() ([]byte, error) { return nil, nil }
 func (m *MockExpr) Eval(ctx sessionctx.Context, row chunk.Row) (types.Datum, error) {
-	return types.NewDatum(m.i), m.err
-}
-func (m *MockExpr) EvalWithInnerCtx(row chunk.Row) (types.Datum, error) {
 	return types.NewDatum(m.i), m.err
 }
 func (m *MockExpr) EvalInt(ctx sessionctx.Context, row chunk.Row) (val int64, isNull bool, err error) {

--- a/pkg/planner/core/scalar_subq_expression.go
+++ b/pkg/planner/core/scalar_subq_expression.go
@@ -104,13 +104,6 @@ func (s *ScalarSubQueryExpr) selfEvaluate() error {
 	return nil
 }
 
-// EvalWithInnerCtx evaluates expression with inner ctx.
-// Deprecated: This function is only used during refactoring, please do not use it in new code.
-// TODO: remove this method after refactoring.
-func (s *ScalarSubQueryExpr) EvalWithInnerCtx(row chunk.Row) (types.Datum, error) {
-	return s.Eval(nil, row)
-}
-
 // Eval implements the Expression interface.
 func (s *ScalarSubQueryExpr) Eval(_ sessionctx.Context, _ chunk.Row) (types.Datum, error) {
 	if s.evaled {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48916

After some previous works in #47958, the context cache in `ScalarFunction` is not used anymore, we should remove it.

### What changed and how does it work?

Remove inner context cache in `expression.ScalarFunction`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
