### PR TITLE
meta/autoid: change to exponental backoff and add a reset count metric

### DIFF
--- a/pkg/meta/autoid/autoid_service.go
+++ b/pkg/meta/autoid/autoid_service.go
@@ -129,6 +129,8 @@ func (sp *singlePointAlloc) Alloc(ctx context.Context, n uint64, increment, offs
 		return 0, 0, errInvalidIncrementAndOffset.GenWithStackByArgs(increment, offset)
 	}
 
+	var bo backoffer
+	bo.Reset()
 retry:
 	cli, err := sp.GetClient(ctx)
 	if err != nil {
@@ -148,12 +150,13 @@ retry:
 	metrics.AutoIDHistogram.WithLabelValues(metrics.TableAutoIDAlloc, metrics.RetLabel(err)).Observe(time.Since(start).Seconds())
 	if err != nil {
 		if strings.Contains(err.Error(), "rpc error") {
-			time.Sleep(backoffDuration)
 			sp.ResetConn(err)
+			bo.Backoff()
 			goto retry
 		}
 		return 0, 0, errors.Trace(err)
 	}
+	bo.Reset()
 	if len(resp.Errmsg) != 0 {
 		return 0, 0, errors.Trace(errors.New(string(resp.Errmsg)))
 	}
@@ -164,7 +167,23 @@ retry:
 	return resp.Min, resp.Max, err
 }
 
-const backoffDuration = 200 * time.Millisecond
+const backoffMin = 200 * time.Millisecond
+const backoffMax = 5 * time.Second
+
+type backoffer struct {
+	time.Duration
+}
+
+func (b *backoffer) Reset() {
+	b.Duration = backoffMin
+}
+
+func (b *backoffer) Backoff() {
+	b.Duration *= 2
+	if b.Duration > backoffMax {
+		b.Duration = backoffMax
+	}
+}
 
 // ResetConn reset the AutoIDAllocClient and underlying grpc connection.
 // The next GetClient() call will recreate the client connecting to the correct leader by querying etcd.
@@ -173,6 +192,8 @@ func (d *ClientDiscover) ResetConn(reason error) {
 		logutil.BgLogger().Info("reset grpc connection", zap.String("category", "autoid client"),
 			zap.String("reason", reason.Error()))
 	}
+
+	metrics.ResetAutoIDConnCounter.Add(1)
 	var grpcConn *grpc.ClientConn
 	d.mu.Lock()
 	grpcConn = d.mu.ClientConn
@@ -209,6 +230,8 @@ func (sp *singlePointAlloc) Rebase(ctx context.Context, newBase int64, _ bool) e
 }
 
 func (sp *singlePointAlloc) rebase(ctx context.Context, newBase int64, force bool) error {
+	var bo backoffer
+	bo.Reset()
 retry:
 	cli, err := sp.GetClient(ctx)
 	if err != nil {
@@ -224,12 +247,13 @@ retry:
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "rpc error") {
-			time.Sleep(backoffDuration)
 			sp.ResetConn(err)
+			bo.Backoff()
 			goto retry
 		}
 		return errors.Trace(err)
 	}
+	bo.Reset()
 	if len(resp.Errmsg) != 0 {
 		return errors.Trace(errors.New(string(resp.Errmsg)))
 	}

--- a/pkg/meta/autoid/autoid_service.go
+++ b/pkg/meta/autoid/autoid_service.go
@@ -130,7 +130,6 @@ func (sp *singlePointAlloc) Alloc(ctx context.Context, n uint64, increment, offs
 	}
 
 	var bo backoffer
-	bo.Reset()
 retry:
 	cli, err := sp.GetClient(ctx)
 	if err != nil {
@@ -179,10 +178,14 @@ func (b *backoffer) Reset() {
 }
 
 func (b *backoffer) Backoff() {
+	if b.Duration == 0 {
+		b.Duration = backoffMin
+	}
 	b.Duration *= 2
 	if b.Duration > backoffMax {
 		b.Duration = backoffMax
 	}
+	time.Sleep(b.Duration)
 }
 
 // ResetConn reset the AutoIDAllocClient and underlying grpc connection.
@@ -231,7 +234,6 @@ func (sp *singlePointAlloc) Rebase(ctx context.Context, newBase int64, _ bool) e
 
 func (sp *singlePointAlloc) rebase(ctx context.Context, newBase int64, force bool) error {
 	var bo backoffer
-	bo.Reset()
 retry:
 	cli, err := sp.GetClient(ctx)
 	if err != nil {

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -16604,6 +16604,10 @@
           "dashLength": 10,
           "datasource": "${DS_TEST-CLUSTER}",
           "description": "TiDB auto id client connection reset counter",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -16627,13 +16631,17 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.5.11",
           "pointradius": 5,
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
           "targets": [
             {
-              "expr": "sum(tidb_meta_autoid_client_conn_reset_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "expr": "increase(tidb_meta_autoid_client_conn_reset_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[2m])",
               "legendFormat": "",
               "interval": "",
               "exemplar": true,
@@ -16660,44 +16668,39 @@
           },
           "yaxes": [
             {
-              "format": "s",
+              "format": "short",
               "label": null,
-              "logBase": 2,
+              "logBase": 1,
               "max": null,
-              "min": "0.001",
-              "show": true
+              "min": "1",
+              "show": true,
+              "$$hashKey": "object:259",
+              "decimals": null
             },
             {
               "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
-              "show": true
+              "min": "1",
+              "show": true,
+              "$$hashKey": "object:260"
             }
           ],
           "yaxis": {
             "align": false,
             "alignLevel": null
           },
-          "options": {
-            "alertThreshold": true
-          },
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "pluginVersion": "7.5.11",
           "bars": false,
           "dashes": false,
+          "fillGradient": 0,
+          "hiddenSeries": false,
           "percentage": false,
           "points": false,
           "stack": false,
           "steppedLine": false,
           "timeFrom": null,
-          "timeShift": null,
-          "fillGradient": 0,
-          "hiddenSeries": false
+          "timeShift": null
         }
       ],
       "repeat": null,

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -16598,6 +16598,106 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "dashLength": 10,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "TiDB auto id client connection reset counter",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 22
+          },
+          "id": 23763571994,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "pointradius": 5,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "targets": [
+            {
+              "expr": "sum(tidb_meta_autoid_client_conn_reset_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
+              "legendFormat": "",
+              "interval": "",
+              "exemplar": true,
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "AutoID Client Conn Reset Counter",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 2,
+              "max": null,
+              "min": "0.001",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          },
+          "options": {
+            "alertThreshold": true
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "pluginVersion": "7.5.11",
+          "bars": false,
+          "dashes": false,
+          "percentage": false,
+          "points": false,
+          "stack": false,
+          "steppedLine": false,
+          "timeFrom": null,
+          "timeShift": null,
+          "fillGradient": 0,
+          "hiddenSeries": false
         }
       ],
       "repeat": null,

--- a/pkg/metrics/meta.go
+++ b/pkg/metrics/meta.go
@@ -29,7 +29,8 @@ var (
 	SetSchemaDiff    = "set_schema_diff"
 	GetHistoryDDLJob = "get_history_ddl_job"
 
-	MetaHistogram *prometheus.HistogramVec
+	MetaHistogram          *prometheus.HistogramVec
+	ResetAutoIDConnCounter prometheus.Counter
 )
 
 // InitMetaMetrics initializes meta metrics.
@@ -51,4 +52,12 @@ func InitMetaMetrics() {
 			Help:      "Bucketed histogram of processing time (s) of tidb meta data operations.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 29), // 0.5ms ~ 1.5days
 		}, []string{LblType, LblResult})
+
+	ResetAutoIDConnCounter = NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "meta",
+			Name:      "autoid_client_conn_reset_total",
+			Help:      "Counter of resetting autoid client connection.",
+		})
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -231,6 +231,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(LoadTableCacheDurationHistogram)
 	prometheus.MustRegister(NonTransactionalDMLCount)
 	prometheus.MustRegister(PessimisticDMLDurationByAttempt)
+	prometheus.MustRegister(ResetAutoIDConnCounter)
 	prometheus.MustRegister(ResourceGroupQueryTotalCounter)
 	prometheus.MustRegister(MemoryUsage)
 	prometheus.MustRegister(StatsCacheCounter)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48942

Problem Summary:

### What changed and how does it work?

From time.Sleep(200ms) to bo.Backoff() and the duration increase every time.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

start tidb 4000, 4001, where 4001 is the autoid service leader
Run some workload connect to tidb 4000
kill -9 to kill the tidb 4001 instance
Watch the autoid client connection retry behaviour:

![image](https://github.com/pingcap/tidb/assets/1420062/eaabac72-6d3b-4303-80b0-4ec0eec89918)


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
