### PR TITLE
planner: fix DATA RACE caused by TestTiDBBindingInListToVer175

### DIFF
--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -2833,7 +2833,8 @@ func upgradeToVer175(s sessiontypes.Session, ver int64) {
 			if originalNormalizedSQL == newNormalizedSQL {
 				continue // no need to update
 			}
-			// must run those update statements outside this loop, otherwise may cause some concurrency problems.
+			// must run those update statements outside this loop, otherwise may cause some concurrency problems,
+			// since the current statement over this session has not been finished yet.
 			updateStmts = append(updateStmts, fmt.Sprintf("UPDATE mysql.bind_info SET original_sql='%s' WHERE original_sql='%s'", newNormalizedSQL, originalNormalizedSQL))
 		}
 		req.Reset()

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -2816,6 +2816,7 @@ func upgradeToVer175(s sessiontypes.Session, ver int64) {
 		return
 	}
 	req := rs.NewChunk(nil)
+	updateStmts := make([]string, 0, 4)
 	for {
 		err = rs.Next(ctx, req)
 		if err != nil {
@@ -2832,12 +2833,16 @@ func upgradeToVer175(s sessiontypes.Session, ver int64) {
 			if originalNormalizedSQL == newNormalizedSQL {
 				continue // no need to update
 			}
-			mustExecute(s, fmt.Sprintf("UPDATE mysql.bind_info SET original_sql='%s' WHERE original_sql='%s'", newNormalizedSQL, originalNormalizedSQL))
+			// must run those update statements outside this loop, otherwise may cause some concurrency problems.
+			updateStmts = append(updateStmts, fmt.Sprintf("UPDATE mysql.bind_info SET original_sql='%s' WHERE original_sql='%s'", newNormalizedSQL, originalNormalizedSQL))
 		}
 		req.Reset()
 	}
 	if err := rs.Close(); err != nil {
 		logutil.BgLogger().Fatal("upgradeToVer175 error", zap.Error(err))
+	}
+	for _, updateStmt := range updateStmts {
+		mustExecute(s, updateStmt)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48953

Problem Summary: planner: fix DATA RACE caused by TestTiDBBindingInListToVer175

### What changed and how does it work?

planner: fix DATA RACE caused by TestTiDBBindingInListToVer175

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
