### PR TITLE
*: create the predicate_stats and add the interfaces of write/read/delete the records in this table(no caching implementation)

### DIFF
--- a/pkg/session/bootstraptest/BUILD.bazel
+++ b/pkg/session/bootstraptest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2708,6 +2708,14 @@ type TableDelta struct {
 	TableID  int64
 }
 
+// ReadTableDelta stands for the changed count for one table or partition after reading.
+type ReadTableDelta struct {
+	TableID              int64
+	Count                int64
+	StepHash             uint64
+	PredicateSelectivity float32
+}
+
 // Clone returns a cloned TableDelta.
 func (td TableDelta) Clone() TableDelta {
 	colSize := make(map[int64]int64, len(td.ColSize))

--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -54,7 +54,7 @@ go_test(
         "read_test.go",
     ],
     flaky = True,
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         ":storage",
         "//pkg/domain",

--- a/pkg/statistics/handle/storage/gc.go
+++ b/pkg/statistics/handle/storage/gc.go
@@ -114,6 +114,9 @@ func GCStats(sctx sessionctx.Context,
 			if err := gcHistoryStatsFromKV(sctx, row.GetInt64(0)); err != nil {
 				return errors.Trace(err)
 			}
+			if err := gcPredicateStatsFromKV(sctx, row.GetInt64(0)); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 
@@ -216,6 +219,13 @@ func gcHistoryStatsFromKV(sctx sessionctx.Context, physicalID int64) (err error)
 		return errors.Trace(err)
 	}
 	sql = "delete from mysql.stats_meta_history where table_id = %?"
+	_, err = util.Exec(sctx, sql, physicalID)
+	return err
+}
+
+// gcPredicateStatsFromKV delete predicate stats from kv.
+func gcPredicateStatsFromKV(sctx sessionctx.Context, physicalID int64) (err error) {
+	sql := "delete from mysql.predicate_stats where table_id = %?"
 	_, err = util.Exec(sctx, sql, physicalID)
 	return err
 }

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -476,13 +476,10 @@ func TablePredicateStatsFromStorage(sctx sessionctx.Context, tableID int64, step
 	table := &statistics.TablePredicateItem{}
 	table.TableID = tableID
 	table.StepHash = stepHash
-	for _, row := range rows {
-		table.Count = row.GetInt64(0)
-		table.PredicateSelectivity = row.GetFloat32(1)
-		table.Version = row.GetUint64(2)
-		return table, nil
-	}
-	return nil, nil
+	table.Count = rows[0].GetInt64(0)
+	table.PredicateSelectivity = rows[0].GetFloat32(1)
+	table.Version = rows[0].GetUint64(2)
+	return table, nil
 }
 
 // LoadHistogram will load histogram from storage.

--- a/pkg/statistics/handle/storage/save.go
+++ b/pkg/statistics/handle/storage/save.go
@@ -400,3 +400,17 @@ func SaveMetaToStorage(
 	cache.TableRowStatsCache.Invalidate(tableID)
 	return
 }
+
+// SaveHistoryToStorage will save predicate_stats to storage.
+func SaveHistoryToStorage(
+	sctx sessionctx.Context,
+	tableID, count, stepHash int64, predicateSelectivity float32) (statsVer uint64, err error) {
+	version, err := util.GetStartTS(sctx)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	_, err = util.Exec(sctx, "replace into mysql.predicate_stats (table_id, count, step_hash, predicate_selectivity, version) values (%?, %?, %?, %?, %?)", tableID, count, stepHash, predicateSelectivity, version)
+	statsVer = version
+	// cache.TableRowStatsCache.Invalidate(tableID)
+	return
+}

--- a/pkg/statistics/handle/storage/update.go
+++ b/pkg/statistics/handle/storage/update.go
@@ -80,6 +80,17 @@ func UpdateStatsMeta(
 	return err
 }
 
+// UpdatePredicateStatsMeta update the predicate stats meta for this Table.
+func UpdatePredicateStatsMeta(
+	sctx sessionctx.Context,
+	startTS uint64,
+	delta variable.ReadTableDelta,
+) (err error) {
+	_, err = statsutil.Exec(sctx, "replace into mysql.predicate_stats (table_id, count, step_hash, predicate_selectivity, version) values (%?, %?, %?, %?, %?)",
+		delta.TableID, delta.Count, delta.StepHash, delta.PredicateSelectivity, startTS)
+	return err
+}
+
 // DumpTableStatColSizeToKV dumps the column size stats to storage.
 func DumpTableStatColSizeToKV(sctx sessionctx.Context, id int64, delta variable.TableDelta) error {
 	if len(delta.ColSize) == 0 {

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 	"go.uber.org/atomic"
@@ -115,6 +116,12 @@ type HistColl struct {
 	// The physical id is used when try to load column stats from storage.
 	HavePhysicalID bool
 	Pseudo         bool
+}
+
+// TablePredicateItem is the cached item of a mysql.predicate_stats record.
+type TablePredicateItem struct {
+	variable.ReadTableDelta
+	Version uint64
 }
 
 // TableMemoryUsage records tbl memory usage


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/46773

Problem Summary:
* Create `mysql.predicate_stats` table
* Add the interfaces of write/read/delete the records in this table
    * `func UpdatePredicateStatsMeta(sctx sessionctx.Context,startTS uint64,delta variable.ReadTableDelta) (err error)`
    * `func LoadHistogram(sctx sessionctx.Context, tableID int64, isIndex int, histID int64, tableInfo *model.TableInfo) (*statistics.Histogram, error) `
    * `gcPredicateStatsFromKV(sctx sessionctx.Context, physicalID int64) (err error)`

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
