### PR TITLE
tools/check: increase the parallelism for building test binaries

### DIFF
--- a/tools/check/ut.go
+++ b/tools/check/ut.go
@@ -29,6 +29,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -97,6 +98,7 @@ func (t *task) String() string {
 }
 
 var p int
+var buildParallel int
 var workDir string
 
 func cmdList(args ...string) bool {
@@ -309,7 +311,7 @@ func cmdRun(args ...string) bool {
 		tasks = tmp
 	}
 
-	fmt.Printf("building task finish, maxproc=%d, count=%d, takes=%v\n", p, len(tasks), time.Since(start))
+	fmt.Printf("building task finish, parallelism=%d, count=%d, takes=%v\n", buildParallel, len(tasks), time.Since(start))
 
 	taskCh := make(chan task, 100)
 	works := make([]numa, p)
@@ -448,6 +450,8 @@ func main() {
 
 	// Get the correct count of CPU if it's in docker.
 	p = runtime.GOMAXPROCS(0)
+	// We use 2 * p for `go build` to make it faster.
+	buildParallel = p * 2
 	var err error
 	workDir, err = os.Getwd()
 	if err != nil {
@@ -870,7 +874,7 @@ func buildTestBinaryMulti(pkgs []string) error {
 	}
 
 	var cmd *exec.Cmd
-	cmd = exec.Command("go", "test", "--tags=intest", "--exec", xprogPath, "-vet", "off", "-count", "0")
+	cmd = exec.Command("go", "test", "--tags=intest", "-p", strconv.Itoa(buildParallel), "--exec", xprogPath, "-vet", "off", "-count", "0")
 	if coverprofile != "" {
 		cmd.Args = append(cmd.Args, "-cover")
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #31880

Problem Summary:

### What changed and how does it work?

Increase the parallelism when building the test binaries, by default it is the number of cores(https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies): 

> 
>-p n
>	the number of programs, such as build commands or
>	test binaries, that can be run in parallel.
>	The default is GOMAXPROCS, normally the number of CPUs available.
> 

I found that when running the 'building binaries stage' of `make ut`, the CPU usage is not high with the default value. So I think it's a better idea to increase the parallelism. In this PR, I doubled it.

The result of `make ut` time in my Macbook M2 Pro:

(Before this PR)
```
bash> make ut
...
building task finish, maxproc=10, count=4822, takes=12m32.547299958s 
...
```
(After this PR)
```
bash> make ut
...
building task finish, parallelism=20, count=4822, takes=6m45.4092545s
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > This is a change of the test framework, it does not change any behavior of the release, and it is trivial enough.

Side effects

- None

Documentation

- None

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
