### PR TITLE
 build/linter/util: exclude files according to the key of `only_files`

### DIFF
--- a/br/pkg/lightning/log/log.go
+++ b/br/pkg/lightning/log/log.go
@@ -187,7 +187,7 @@ func IsContextCanceledError(err error) bool {
 		return true
 	}
 
-	// see https://github.com/aws/aws-sdk-go/blob/9d1f49ba63bdac44a5b9f4d736e79d792e389e8a/aws/credentials/credentials.go#L246-L249
+	// see https://github.com/aws/aws-sdk-go/blob/9d1f49ba/aws/credentials/credentials.go#L246-L249
 	if v, ok := err.(awserr.Error); ok {
 		return v.Code() == request.CanceledErrorCode
 	}

--- a/build/linter/util/exclude.go
+++ b/build/linter/util/exclude.go
@@ -29,7 +29,7 @@ func shouldRun(passName string, fileName string) bool {
 	}
 
 	if config.OnlyFiles != nil {
-		for _, f := range config.OnlyFiles {
+		for f := range config.OnlyFiles {
 			matched, err := regexp.MatchString(f, fileName)
 			if err != nil {
 				panic(fmt.Sprintf("regex is wrong: %s", f))

--- a/build/linter/util/exclude_test.go
+++ b/build/linter/util/exclude_test.go
@@ -23,4 +23,5 @@ import (
 func TestShouldRun(t *testing.T) {
 	require.True(t, shouldRun("gofmt", "some.go"))
 	require.False(t, shouldRun("gofmt", "uca_generated.go"))
+	require.True(t, shouldRun("revive", "/pkg/meta/distributed_lock.go"))
 }

--- a/build/nogo_config.json
+++ b/build/nogo_config.json
@@ -4,6 +4,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "/rules_go_work-*": "ignore generated code",
       ".*_/testmain\\.go$": "ignore code",
       "pkg/extension/enterprise/audit/entry.go": "pkg/extension/enterprise/audit/entry.go",
@@ -15,6 +16,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "br/pkg/lightning/web/res_vfsdata.go": "ignore code"
     }
   },
@@ -86,6 +88,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "br/pkg/glue/console_glue_test.go": "ignore code",
       "br/pkg/restore/db_test.go": "ignore code",
       ".*_/testmain\\.go$": "ignore code"
@@ -96,6 +99,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "/cgo/": "ignore cgo code"
     }
   },
@@ -139,6 +143,7 @@
     "exclude_files": {
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       ".*_test\\.go$": "ignore generated code",
       "pkg/util/logutil": "ignore util/logutil code",
       "tools/": "ignore tools code",
@@ -163,6 +168,7 @@
       "external/": "no need to vet third party code",
       ".cgo/": "no need to cgo code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       ".*_/testmain\\.go$": "ignore code"
     }
   },
@@ -171,6 +177,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       ".*_/testmain\\.go$": "ignore code",
       ".*_test\\.go$": "ignore test code"
     },
@@ -254,6 +261,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "/cgo/": "ignore cgo code",
       "/rules_go_work-*": "ignore generated code",
       ".*test_/testmain\\.go$": "ignore generated code",
@@ -264,6 +272,7 @@
     "exclude_files": {
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "/cgo/": "ignore cgo code",
       ".*\\.pb\\.go$": "generated code",
       "/rules_go_work-*": "ignore generated code",
@@ -312,6 +321,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "/cgo/": "no need to vet cgo code"
     }
   },
@@ -342,6 +352,7 @@
       "/cgo/": "ignore cgo code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       ".*pb\\.go$": "ignore generated code",
       "br/pkg/streamhelper/.*_test\\.go$": "ignore test code",
       "br/pkg/errors/errors.go": "ignore error",
@@ -464,6 +475,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "/cgo/": "ignore cgo"
     }
   },
@@ -503,6 +515,7 @@
       "dumpling/export/sql_type.go": "please fix it",
       ".*_test\\.go$": "ignore generated code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "pkg/plugin/conn_ip_example/": "plugin/conn_ip_example/"
     },
     "only_files": {
@@ -592,6 +605,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "/cgo/": "ignore cgo code",
       "/rules_go_work-*": "ignore generated code",
       ".*test_/testmain\\.go$": "ignore generated code",
@@ -699,6 +713,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "pkg/parser/digester.go": "ignore code"
     }
   },
@@ -707,6 +722,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "pkg/parser/digester_test.go": "ignore code"
     }
   },
@@ -715,6 +731,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "pkg/server/tidb_test.go": "ignore test code",
       "pkg/server/tests/tidb_test.go": "ignore test code",
       "pkg/server/tests/tidb_serial_test.go": "ignore test code",
@@ -866,6 +883,7 @@
     "exclude_files": {
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "pkg/parser/parser.go": "ignore code"
     }
   },
@@ -881,6 +899,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "tools/check/ut.go": "ignore code"
     }
   },
@@ -895,6 +914,7 @@
     "exclude_files": {
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "pkg/parser/parser.go": "ignore code"
     }
   },
@@ -1014,6 +1034,7 @@
     "exclude_files": {
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "pkg/parser/parser.go": "ignore generated code"
     }
   },
@@ -1023,6 +1044,7 @@
       "/build/": "no need to linter code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       ".*_test\\.go$": "ignore test code",
       "br/pkg/restore/split/client.go": "github.com/golang/protobuf deprecated",
       "br/pkg/streamhelper/advancer_cliext.go": "github.com/golang/protobuf deprecated",
@@ -1058,6 +1080,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       "/external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       ".*_test\\.go$": "ignore test code"
     }
   },
@@ -1237,6 +1260,7 @@
       "cmd/mirror": "cmd/mirror code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "pkg/parser/yy_parser.go": "ignore generated code",
       "/cgo/": "no need to vet third party code for cgo"
     }
@@ -1246,6 +1270,7 @@
       "external/": "no need to vet third party code",
       "cmd/mirror": "no need to mirror",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "pkg/parser/yy_parser.go": "ignore generated code",
       "pkg/parser/parser.go": "ignore generated code",
       "/cgo/": "no need to vet third party code for cgo"
@@ -1263,6 +1288,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       ".*_test.go": "ignore test code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "external/": "no need to vet third party code"
     }
   },
@@ -1270,6 +1296,7 @@
     "exclude_files": {
       "parser/parser.go": "parser/parser.go code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "external/": "no need to vet third party code",
       "build/linter/constructor/testdata/": "no need to vet the test inside the linter"
     }
@@ -1279,6 +1306,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       ".*_test.go": "ignore test code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "external/": "no need to vet third party code"
     }
   },
@@ -1287,6 +1315,7 @@
       "pkg/parser/parser.go": "parser/parser.go code",
       ".*_test.go": "ignore test code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "external/": "no need to vet third party code"
     }
   },
@@ -1296,6 +1325,7 @@
       ".*_test.go": "ignore test code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "/cgo/": "no need to vet third party code for cgo"
     }
   },
@@ -1305,6 +1335,7 @@
       ".*_test.go": "ignore test code",
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
+      ".*mock.go$": "ignore generated code",
       "/cgo/": "no need to vet third party code for cgo"
     }
   },

--- a/pkg/disttask/framework/storage/task_table.go
+++ b/pkg/disttask/framework/storage/task_table.go
@@ -195,7 +195,7 @@ func (stm *TaskManager) AddNewGlobalTask(ctx context.Context, key string, tp pro
 }
 
 // AddGlobalTaskWithSession adds a new task to global task table with session.
-func (stm *TaskManager) AddGlobalTaskWithSession(ctx context.Context, se sessionctx.Context, key string, tp proto.TaskType, concurrency int, meta []byte) (taskID int64, err error) {
+func (*TaskManager) AddGlobalTaskWithSession(ctx context.Context, se sessionctx.Context, key string, tp proto.TaskType, concurrency int, meta []byte) (taskID int64, err error) {
 	_, err = ExecSQL(ctx, se,
 		`insert into mysql.tidb_global_task(task_key, type, state, concurrency, step, meta, start_time, state_update_time)
 		values (%?, %?, %?, %?, %?, %?, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())`,
@@ -813,7 +813,7 @@ func (stm *TaskManager) CancelGlobalTask(ctx context.Context, taskID int64) erro
 }
 
 // CancelGlobalTaskByKeySession cancels global task by key using input session.
-func (stm *TaskManager) CancelGlobalTaskByKeySession(ctx context.Context, se sessionctx.Context, taskKey string) error {
+func (*TaskManager) CancelGlobalTaskByKeySession(ctx context.Context, se sessionctx.Context, taskKey string) error {
 	_, err := ExecSQL(ctx, se,
 		"update mysql.tidb_global_task set state=%?, state_update_time = CURRENT_TIMESTAMP() "+
 			"where task_key=%? and state in (%?, %?)",

--- a/pkg/planner/property/BUILD.bazel
+++ b/pkg/planner/property/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     deps = [
         "//pkg/expression",
         "//pkg/sessionctx",
-        "//pkg/sessionctx/stmtctx",
         "//pkg/statistics",
         "//pkg/util/codec",
         "//pkg/util/collate",

--- a/pkg/planner/property/physical_property.go
+++ b/pkg/planner/property/physical_property.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/size"
@@ -95,7 +94,7 @@ type MPPPartitionColumn struct {
 	CollateID int32
 }
 
-func (partitionCol *MPPPartitionColumn) hashCode(ctx *stmtctx.StatementContext) []byte {
+func (partitionCol *MPPPartitionColumn) hashCode() []byte {
 	hashcode := partitionCol.Col.HashCode()
 	if partitionCol.CollateID < 0 {
 		// collateId < 0 means new collation is not enabled
@@ -341,7 +340,7 @@ func (p *PhysicalProperty) HashCode() []byte {
 	if p.TaskTp == MppTaskType {
 		p.hashcode = codec.EncodeInt(p.hashcode, int64(p.MPPPartitionTp))
 		for _, col := range p.MPPPartitionCols {
-			p.hashcode = append(p.hashcode, col.hashCode(nil)...)
+			p.hashcode = append(p.hashcode, col.hashCode()...)
 		}
 	}
 	p.hashcode = append(p.hashcode, codec.EncodeInt(nil, int64(p.CTEProducerStatus))...)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #48998

Problem Summary:

The config use `key` to represent the pattern, but not value. I copied the code from [`nogo_main.go`](https://github.com/bazelbuild/rules_go/blob/master/go/tools/builders/nogo_main.go), but in `nogo_main` it's an array :facepalm: .

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
