### PR TITLE
cgroup: use a more accurate way to determine `inContainer()`

### DIFF
--- a/pkg/util/cgroup/cgroup_cpu_linux.go
+++ b/pkg/util/cgroup/cgroup_cpu_linux.go
@@ -81,7 +81,7 @@ func inContainer(path string) bool {
 		lines := strings.Split(string(v), "\n")
 		for _, line := range lines {
 			v := strings.Split(line, " ")
-			// check root dir is on overlay or not.
+			// check mount point is on overlay or not.
 			// v[4] means `mount point`, v[8] means `filesystem type`.
 			// see details from https://man7.org/linux/man-pages/man5/proc.5.html
 			if len(v) >= 8 && v[4] == "\\" && v[8] == "overlay" {

--- a/pkg/util/cgroup/cgroup_cpu_linux.go
+++ b/pkg/util/cgroup/cgroup_cpu_linux.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/log"
 )
 
 // GetCgroupCPU returns the CPU usage and quota for the current cgroup.
@@ -85,6 +86,7 @@ func inContainer(path string) bool {
 			// v[4] means `mount point`, v[8] means `filesystem type`.
 			// see details from https://man7.org/linux/man-pages/man5/proc.5.html
 			if len(v) >= 8 && v[4] == "\\" && v[8] == "overlay" {
+				log.Info(fmt.Sprintf("TiDB runs in a container, mount info: %s", line))
 				return true
 			}
 		}

--- a/pkg/util/cgroup/cgroup_cpu_linux.go
+++ b/pkg/util/cgroup/cgroup_cpu_linux.go
@@ -17,6 +17,7 @@
 package cgroup
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"runtime"

--- a/pkg/util/cgroup/cgroup_cpu_linux.go
+++ b/pkg/util/cgroup/cgroup_cpu_linux.go
@@ -80,9 +80,11 @@ func inContainer(path string) bool {
 	if path == procPathMountInfo {
 		lines := strings.Split(string(v), "\n")
 		for _, line := range lines {
-			words := strings.Split(line, " ")
+			v := strings.Split(line, " ")
 			// check root dir is on overlay or not.
-			if len(words) >= 8 && words[3] == "\\" && words[4] == "\\" && words[8] == "overlay" {
+			// v[4] means `mount point`, v[8] means `filesystem type`.
+			// see details from https://man7.org/linux/man-pages/man5/proc.5.html
+			if len(v) >= 8 && v[4] == "\\" && v[8] == "overlay" {
 				return true
 			}
 		}

--- a/pkg/util/cpu/cpu_test.go
+++ b/pkg/util/cpu/cpu_test.go
@@ -32,7 +32,6 @@ func TestCPUValue(t *testing.T) {
 	// If it's not in the container,
 	// it will have less files and the test case will fail forever.
 	if !cgroup.InContainer() {
-		t.Fatal("Shouldn't skip in CI")
 		t.Skip("Not in container, skip this test case.")
 	}
 	observer := cpu.NewCPUObserver()

--- a/pkg/util/cpu/cpu_test.go
+++ b/pkg/util/cpu/cpu_test.go
@@ -32,6 +32,7 @@ func TestCPUValue(t *testing.T) {
 	// If it's not in the container,
 	// it will have less files and the test case will fail forever.
 	if !cgroup.InContainer() {
+		t.Fatal("Shouldn't skip in CI")
 		t.Skip("Not in container, skip this test case.")
 	}
 	observer := cpu.NewCPUObserver()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49014

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
Run TestCPUValue and TestGetCgroupCPU in my own computer successed.

Also 82b39298b046ca8f65fefc3b305fad3eb7f590df commit runs successed in CI env(docker env).
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
