### PR TITLE
statistics: log the db name

### DIFF
--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/statistics/handle/logutil",
         "//pkg/statistics/handle/types",
         "//pkg/statistics/handle/util",
+        "@com_github_pingcap_errors//:errors",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -6,7 +6,9 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/statistics/handle/ddl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/infoschema",
         "//pkg/parser/model",
+        "//pkg/sessionctx",
         "//pkg/sessionctx/variable",
         "//pkg/statistics/handle/logutil",
         "//pkg/statistics/handle/types",

--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -53,7 +53,10 @@ type Handle struct {
 	// LeaseGetter is used to get stats lease.
 	util.LeaseGetter
 
-	// initStatsCtx is the ctx only used for initStats
+	// initStatsCtx is a context specifically used for initStats.
+	// It's not designed for concurrent use, so avoid using it in such scenarios.
+	// Currently, it's only utilized within initStats, which is exclusively used during bootstrap.
+	// Since bootstrap is a one-time operation, using this context remains safe.
 	initStatsCtx sessionctx.Context
 
 	// TableInfoGetter is used to fetch table meta info.

--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -133,7 +133,6 @@ func NewHandle(
 	handle.StatsSyncLoad = syncload.NewStatsSyncLoad(handle)
 	handle.StatsGlobal = globalstats.NewStatsGlobal(handle)
 	handle.DDL = ddl.NewDDLHandler(
-		initStatsCtx,
 		handle.StatsReadWriter,
 		handle,
 		handle.StatsGlobal,

--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -132,7 +132,12 @@ func NewHandle(
 	handle.StatsAnalyze = autoanalyze.NewStatsAnalyze(handle, tracker)
 	handle.StatsSyncLoad = syncload.NewStatsSyncLoad(handle)
 	handle.StatsGlobal = globalstats.NewStatsGlobal(handle)
-	handle.DDL = ddl.NewDDLHandler(handle.StatsReadWriter, handle, handle.StatsGlobal)
+	handle.DDL = ddl.NewDDLHandler(
+		initStatsCtx,
+		handle.StatsReadWriter,
+		handle,
+		handle.StatsGlobal,
+	)
 	return handle, nil
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/pull/48929#discussion_r1407975768

Problem Summary:

### What changed and how does it work?

Printed the DB name in the logs.

Because changing the interface would have a significant invasive impact, the ctx was attached to the DDL handler. Otherwise, not only all the tests but also the handle's flush operation would have to query the schema by themselves.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
