### PR TITLE
planner: Adjust index scan estimate for order with limit

### DIFF
--- a/pkg/planner/cardinality/cross_estimation.go
+++ b/pkg/planner/cardinality/cross_estimation.go
@@ -92,6 +92,10 @@ func AdjustRowCountForIndexScanByLimit(sctx sessionctx.Context,
 		correlationFactor := math.Pow(1-abs, float64(sctx.GetSessionVars().CorrelationExpFactor))
 		selectivity := dsStatsInfo.RowCount / rowCount
 		rowCount = min(expectedCnt/selectivity/correlationFactor, rowCount)
+		orderRatio := sctx.GetSessionVars().OptOrderingIdxSelRatio
+		if dsStatsInfo.RowCount < path.CountAfterAccess && orderRatio > 0 {
+			rowCount = max(rowCount, (path.CountAfterAccess-dsStatsInfo.RowCount)*orderRatio)
+		}
 	}
 	return rowCount
 }

--- a/pkg/planner/cardinality/cross_estimation.go
+++ b/pkg/planner/cardinality/cross_estimation.go
@@ -89,12 +89,21 @@ func AdjustRowCountForIndexScanByLimit(sctx sessionctx.Context,
 	if ok {
 		rowCount = count
 	} else if abs := math.Abs(corr); abs < 1 {
-		correlationFactor := math.Pow(1-abs, float64(sctx.GetSessionVars().CorrelationExpFactor))
-		selectivity := dsStatsInfo.RowCount / rowCount
-		rowCount = min(expectedCnt/selectivity/correlationFactor, rowCount)
+		// If OptOrderingIdxSelRatio is enabled - estimate the difference between index and table filtering, as this represents
+		// the possible scan range when LIMIT rows will be found. orderRatio is the estimated percentage of that range when the first
+		// row isexpected to be found. Index filtering applies orderRatio twice. Once found - rows are estimated to be clustered (expectedCnt).
+		// This formula is to bias away from non-filtering (or poorly filtering) indexes that provide order due, where filtering exists
+		// outside of that index. Such plans have high risk since we cannot estimate when rows will be found.
 		orderRatio := sctx.GetSessionVars().OptOrderingIdxSelRatio
-		if dsStatsInfo.RowCount < path.CountAfterAccess && orderRatio > 0 {
-			rowCount = max(rowCount, (path.CountAfterAccess-dsStatsInfo.RowCount)*orderRatio)
+		if dsStatsInfo.RowCount < path.CountAfterAccess && orderRatio > -1 {
+			rowsToMeetFirst := (((path.CountAfterAccess - path.CountAfterIndex) * orderRatio) + (path.CountAfterIndex - dsStatsInfo.RowCount)) * orderRatio
+			rowCount = rowsToMeetFirst + expectedCnt
+		} else {
+			// Assume rows are linearly distributed throughout the range - for example: selectivity 0.1 assumes that a
+			// qualified row is found every 10th row.
+			correlationFactor := math.Pow(1-abs, float64(sctx.GetSessionVars().CorrelationExpFactor))
+			selectivity := dsStatsInfo.RowCount / rowCount
+			rowCount = min(expectedCnt/selectivity/correlationFactor, rowCount)
 		}
 	}
 	return rowCount

--- a/pkg/planner/cardinality/testdata/cardinality_suite_in.json
+++ b/pkg/planner/cardinality/testdata/cardinality_suite_in.json
@@ -269,6 +269,7 @@
   {
     "name": "TestOrderingIdxSelectivityThreshold",
     "cases": [
+      "set @@tidb_opt_ordering_index_selectivity_ratio = -1",
       "set @@tidb_opt_ordering_index_selectivity_threshold = 0",
       "explain format = 'brief' select * from t where b >= 9950 order by c limit 1",
       "explain format = 'brief' select * from t where b >= 9950 order by c desc limit 1",
@@ -291,6 +292,24 @@
       "explain format = 'brief' select * from t where b >= 0 and b <= 50 or c >= 0 and c <= 50 order by c limit 1",
       "explain format = 'brief' select * from t where b >= 9950 and c >= 9950 order by c limit 1",
       "explain format = 'brief' select * from t where b >= 9950 and c >= 9900 order by c limit 1"
+    ]
+  },
+  {
+    "name": "TestOrderingIdxSelectivityRatio",
+    "cases": [
+      "set @@tidb_opt_ordering_index_selectivity_threshold = 0",
+      "set @@tidb_opt_ordering_index_selectivity_ratio = -1",
+      "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 1",
+      "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 100",
+      "set @@tidb_opt_ordering_index_selectivity_ratio = 0",
+      "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 1",
+      "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 100",
+      "set @@tidb_opt_ordering_index_selectivity_ratio = 0.1",
+      "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 1",
+      "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 100",
+      "set @@tidb_opt_ordering_index_selectivity_ratio = 0.5",
+      "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 1",
+      "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 100"
     ]
   },
   {

--- a/pkg/planner/cardinality/testdata/cardinality_suite_out.json
+++ b/pkg/planner/cardinality/testdata/cardinality_suite_out.json
@@ -24,7 +24,7 @@
       {
         "Start": 800,
         "End": 900,
-        "Count": 752.004166655054
+        "Count": 764.004166655054
       },
       {
         "Start": 900,
@@ -74,12 +74,12 @@
       {
         "Start": 300,
         "End": 899,
-        "Count": 4498.5
+        "Count": 4500
       },
       {
         "Start": 800,
         "End": 1000,
-        "Count": 1201.196869573942
+        "Count": 1222.196869573942
       },
       {
         "Start": 900,
@@ -104,7 +104,7 @@
       {
         "Start": 200,
         "End": 400,
-        "Count": 1211.5288209899081
+        "Count": 1215.0288209899081
       },
       {
         "Start": 200,
@@ -964,6 +964,10 @@
     "Name": "TestOrderingIdxSelectivityThreshold",
     "Cases": [
       {
+        "Query": "set @@tidb_opt_ordering_index_selectivity_ratio = -1",
+        "Result": null
+      },
+      {
         "Query": "set @@tidb_opt_ordering_index_selectivity_threshold = 0",
         "Result": null
       },
@@ -1170,6 +1174,111 @@
           "  └─TopN(Probe) 1.00 cop[tikv]  test.t.c, offset:0, count:1",
           "    └─Selection 5.00 cop[tikv]  ge(test.t.c, 9900)",
           "      └─TableRowIDScan 500.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "TestOrderingIdxSelectivityRatio",
+    "Cases": [
+      {
+        "Query": "set @@tidb_opt_ordering_index_selectivity_threshold = 0",
+        "Result": null
+      },
+      {
+        "Query": "set @@tidb_opt_ordering_index_selectivity_ratio = -1",
+        "Result": null
+      },
+      {
+        "Query": "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 1",
+        "Result": [
+          "Limit 1.00 root  offset:0, count:1",
+          "└─IndexLookUp 1.00 root  ",
+          "  ├─IndexFullScan(Build) 10.00 cop[tikv] table:t, index:ic(c) keep order:true",
+          "  └─Selection(Probe) 1.00 cop[tikv]  ge(test.t.b, 9000)",
+          "    └─TableRowIDScan 10.00 cop[tikv] table:t keep order:false"
+        ]
+      },
+      {
+        "Query": "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 100",
+        "Result": [
+          "Limit 100.00 root  offset:0, count:100",
+          "└─IndexLookUp 100.00 root  ",
+          "  ├─IndexFullScan(Build) 1000.00 cop[tikv] table:t, index:ic(c) keep order:true",
+          "  └─Selection(Probe) 100.00 cop[tikv]  ge(test.t.b, 9000)",
+          "    └─TableRowIDScan 1000.00 cop[tikv] table:t keep order:false"
+        ]
+      },
+      {
+        "Query": "set @@tidb_opt_ordering_index_selectivity_ratio = 0",
+        "Result": null
+      },
+      {
+        "Query": "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 1",
+        "Result": [
+          "Limit 1.00 root  offset:0, count:1",
+          "└─IndexLookUp 1.00 root  ",
+          "  ├─IndexFullScan(Build) 1.00 cop[tikv] table:t, index:ic(c) keep order:true",
+          "  └─Selection(Probe) 1.00 cop[tikv]  ge(test.t.b, 9000)",
+          "    └─TableRowIDScan 1.00 cop[tikv] table:t keep order:false"
+        ]
+      },
+      {
+        "Query": "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 100",
+        "Result": [
+          "Limit 100.00 root  offset:0, count:100",
+          "└─IndexLookUp 100.00 root  ",
+          "  ├─IndexFullScan(Build) 100.00 cop[tikv] table:t, index:ic(c) keep order:true",
+          "  └─Selection(Probe) 100.00 cop[tikv]  ge(test.t.b, 9000)",
+          "    └─TableRowIDScan 100.00 cop[tikv] table:t keep order:false"
+        ]
+      },
+      {
+        "Query": "set @@tidb_opt_ordering_index_selectivity_ratio = 0.1",
+        "Result": null
+      },
+      {
+        "Query": "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 1",
+        "Result": [
+          "Limit 1.00 root  offset:0, count:1",
+          "└─IndexLookUp 1.00 root  ",
+          "  ├─IndexFullScan(Build) 901.00 cop[tikv] table:t, index:ic(c) keep order:true",
+          "  └─Selection(Probe) 1.00 cop[tikv]  ge(test.t.b, 9000)",
+          "    └─TableRowIDScan 901.00 cop[tikv] table:t keep order:false"
+        ]
+      },
+      {
+        "Query": "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 100",
+        "Result": [
+          "Limit 100.00 root  offset:0, count:100",
+          "└─IndexLookUp 100.00 root  ",
+          "  ├─IndexFullScan(Build) 1000.00 cop[tikv] table:t, index:ic(c) keep order:true",
+          "  └─Selection(Probe) 100.00 cop[tikv]  ge(test.t.b, 9000)",
+          "    └─TableRowIDScan 1000.00 cop[tikv] table:t keep order:false"
+        ]
+      },
+      {
+        "Query": "set @@tidb_opt_ordering_index_selectivity_ratio = 0.5",
+        "Result": null
+      },
+      {
+        "Query": "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 1",
+        "Result": [
+          "Limit 1.00 root  offset:0, count:1",
+          "└─IndexLookUp 1.00 root  ",
+          "  ├─IndexFullScan(Build) 4501.00 cop[tikv] table:t, index:ic(c) keep order:true",
+          "  └─Selection(Probe) 1.00 cop[tikv]  ge(test.t.b, 9000)",
+          "    └─TableRowIDScan 4501.00 cop[tikv] table:t keep order:false"
+        ]
+      },
+      {
+        "Query": "explain format = 'brief' select * from t use index (ic) where b >= 9000 order by c limit 100",
+        "Result": [
+          "Limit 100.00 root  offset:0, count:100",
+          "└─IndexLookUp 100.00 root  ",
+          "  ├─IndexFullScan(Build) 4600.00 cop[tikv] table:t, index:ic(c) keep order:true",
+          "  └─Selection(Probe) 100.00 cop[tikv]  ge(test.t.b, 9000)",
+          "    └─TableRowIDScan 4600.00 cop[tikv] table:t keep order:false"
         ]
       }
     ]

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1514,6 +1514,11 @@ type SessionVars struct {
 	// use the ExpectedCnt to adjust the estimated row count for index scan.
 	OptOrderingIdxSelThresh float64
 
+	// OptOrderingIdxSelRatio is the ratio for optimizer to determine when qualified rows from filtering outside
+	// of the index will be found during the scan of an ordering index.
+	// If all filtering is applied as matching on the ordering index, this ratio will have no impact.
+	OptOrderingIdxSelRatio float64
+
 	// EnableMPPSharedCTEExecution indicates whether we enable the shared CTE execution strategy on MPP side.
 	EnableMPPSharedCTEExecution bool
 

--- a/pkg/sessionctx/variable/setvar_affect.go
+++ b/pkg/sessionctx/variable/setvar_affect.go
@@ -93,6 +93,7 @@ var isHintUpdatableVerified = map[string]struct{}{
 	"tidb_enable_inl_join_inner_multi_pattern":        {},
 	"tidb_opt_enable_late_materialization":            {},
 	"tidb_opt_ordering_index_selectivity_threshold":   {},
+	"tidb_opt_ordering_index_selectivity_ratio":       {},
 	"tidb_opt_enable_mpp_shared_cte_execution":        {},
 	"tidb_opt_fix_control":                            {},
 	"tidb_runtime_filter_type":                        {},

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2615,6 +2615,11 @@ var defaultSysVars = []*SysVar{
 			s.OptOrderingIdxSelThresh = tidbOptFloat64(val, DefTiDBOptOrderingIdxSelThresh)
 			return nil
 		}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBOptOrderingIdxSelRatio, Value: strconv.FormatFloat(DefTiDBOptOrderingIdxSelRatio, 'f', -1, 64), Type: TypeFloat, MinValue: 0, MaxValue: 1,
+		SetSession: func(s *SessionVars, val string) error {
+			s.OptOrderingIdxSelRatio = tidbOptFloat64(val, DefTiDBOptOrderingIdxSelRatio)
+			return nil
+		}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBOptEnableMPPSharedCTEExecution, Value: BoolToOnOff(DefTiDBOptEnableMPPSharedCTEExecution), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
 		s.EnableMPPSharedCTEExecution = TiDBOptOn(val)
 		return nil

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2615,7 +2615,7 @@ var defaultSysVars = []*SysVar{
 			s.OptOrderingIdxSelThresh = tidbOptFloat64(val, DefTiDBOptOrderingIdxSelThresh)
 			return nil
 		}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBOptOrderingIdxSelRatio, Value: strconv.FormatFloat(DefTiDBOptOrderingIdxSelRatio, 'f', -1, 64), Type: TypeFloat, MinValue: 0, MaxValue: 1,
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBOptOrderingIdxSelRatio, Value: strconv.FormatFloat(DefTiDBOptOrderingIdxSelRatio, 'f', -1, 64), Type: TypeFloat, MinValue: -1, MaxValue: 1,
 		SetSession: func(s *SessionVars, val string) error {
 			s.OptOrderingIdxSelRatio = tidbOptFloat64(val, DefTiDBOptOrderingIdxSelRatio)
 			return nil

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -893,6 +893,10 @@ const (
 	// TiDBOptOrderingIdxSelThresh is the threshold for optimizer to consider the ordering index.
 	TiDBOptOrderingIdxSelThresh = "tidb_opt_ordering_index_selectivity_threshold"
 
+	// TiDBOptOrderingIdxSelRatio is the ratio the optimizer will assume applies when non indexed filtering rows are found
+	// via the ordering index.
+	TiDBOptOrderingIdxSelRatio = "tidb_opt_ordering_index_selectivity_ratio"
+
 	// TiDBOptEnableMPPSharedCTEExecution indicates whether the optimizer try to build shared CTE scan during MPP execution.
 	TiDBOptEnableMPPSharedCTEExecution = "tidb_opt_enable_mpp_shared_cte_execution"
 	// TiDBOptFixControl makes the user able to control some details of the optimizer behavior.
@@ -1403,6 +1407,7 @@ const (
 	DefTiDBLoadBasedReplicaReadThreshold              = time.Second
 	DefTiDBOptEnableLateMaterialization               = true
 	DefTiDBOptOrderingIdxSelThresh                    = 0.0
+	DefTiDBOptOrderingIdxSelRatio                     = 0.0
 	DefTiDBOptEnableMPPSharedCTEExecution             = false
 	DefTiDBPlanCacheInvalidationOnFreshStats          = true
 	DefTiDBEnableRowLevelChecksum                     = false

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1407,7 +1407,7 @@ const (
 	DefTiDBLoadBasedReplicaReadThreshold              = time.Second
 	DefTiDBOptEnableLateMaterialization               = true
 	DefTiDBOptOrderingIdxSelThresh                    = 0.0
-	DefTiDBOptOrderingIdxSelRatio                     = 0.0
+	DefTiDBOptOrderingIdxSelRatio                     = -1
 	DefTiDBOptEnableMPPSharedCTEExecution             = false
 	DefTiDBPlanCacheInvalidationOnFreshStats          = true
 	DefTiDBEnableRowLevelChecksum                     = false

--- a/tests/integrationtest/r/sessionctx/setvar.result
+++ b/tests/integrationtest/r/sessionctx/setvar.result
@@ -1597,6 +1597,26 @@ set @@tidb_opt_ordering_index_selectivity_threshold=default;
 select @@tidb_opt_ordering_index_selectivity_threshold;
 @@tidb_opt_ordering_index_selectivity_threshold
 0
+select /*+ set_var(tidb_opt_ordering_index_selectivity_ratio=-1) */ @@tidb_opt_ordering_index_selectivity_ratio;
+@@tidb_opt_ordering_index_selectivity_ratio
+-1
+select @@tidb_opt_ordering_index_selectivity_ratio;
+@@tidb_opt_ordering_index_selectivity_ratio
+-1
+set @@tidb_opt_ordering_index_selectivity_ratio=default;
+select @@tidb_opt_ordering_index_selectivity_ratio;
+@@tidb_opt_ordering_index_selectivity_ratio
+-1
+select /*+ set_var(tidb_opt_ordering_index_selectivity_ratio=1) */ @@tidb_opt_ordering_index_selectivity_ratio;
+@@tidb_opt_ordering_index_selectivity_ratio
+1
+select @@tidb_opt_ordering_index_selectivity_ratio;
+@@tidb_opt_ordering_index_selectivity_ratio
+-1
+set @@tidb_opt_ordering_index_selectivity_ratio=default;
+select @@tidb_opt_ordering_index_selectivity_ratio;
+@@tidb_opt_ordering_index_selectivity_ratio
+-1
 select /*+ set_var(tidb_opt_enable_mpp_shared_cte_execution=0) */ @@tidb_opt_enable_mpp_shared_cte_execution;
 @@tidb_opt_enable_mpp_shared_cte_execution
 0

--- a/tests/integrationtest/t/sessionctx/setvar.test
+++ b/tests/integrationtest/t/sessionctx/setvar.test
@@ -652,6 +652,14 @@ select /*+ set_var(tidb_opt_ordering_index_selectivity_threshold=1) */ @@tidb_op
 select @@tidb_opt_ordering_index_selectivity_threshold;
 set @@tidb_opt_ordering_index_selectivity_threshold=default;
 select @@tidb_opt_ordering_index_selectivity_threshold;
+select /*+ set_var(tidb_opt_ordering_index_selectivity_ratio=-1) */ @@tidb_opt_ordering_index_selectivity_ratio;
+select @@tidb_opt_ordering_index_selectivity_ratio;
+set @@tidb_opt_ordering_index_selectivity_ratio=default;
+select @@tidb_opt_ordering_index_selectivity_ratio;
+select /*+ set_var(tidb_opt_ordering_index_selectivity_ratio=1) */ @@tidb_opt_ordering_index_selectivity_ratio;
+select @@tidb_opt_ordering_index_selectivity_ratio;
+set @@tidb_opt_ordering_index_selectivity_ratio=default;
+select @@tidb_opt_ordering_index_selectivity_ratio;
 select /*+ set_var(tidb_opt_enable_mpp_shared_cte_execution=0) */ @@tidb_opt_enable_mpp_shared_cte_execution;
 select @@tidb_opt_enable_mpp_shared_cte_execution;
 set @@tidb_opt_enable_mpp_shared_cte_execution=default;


### PR DESCRIPTION
Issue Number: close #50237

Add penalty to index scan for limit with order by when filtering exists outside of the ordering index. Add session variable to adjust ratio.

### What problem does this PR solve?

For a query that has filtering (WHERE clause), ordering (ORDER BY) and LIMIT - if there is an index that provides order, but filtering resides outside of that index, the optimizer currently has a very optimistic estimate as to when the qualified row(s) will be found.

For example in issue #50237, the query estimate is that the LIMIT 1 row will be found within 9.85 rows, when the actual is that 915,000 rows are scanned.

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
 
Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

This enhancement will improve the bias towards a query plan that provides filtering vs a plan that provides ordering, but the filtering is in not in the chosen index. This can improve the stability of plans chosen by the optimizer. Given that the optimizer cannot estimate when a qualified row will be found (this is not a statistic that is available to the optimizer) - then being too optimistic creates risk.

The default is that this enhancement is disabled, but users can control the optimism/pessimism associated with this estimation with variable tidb_opt_ordering_index_selectivity_ratio.
1. Default = -1 : new estimation is disabled.
2. Value 0 : rows are estimated to be found immediately within the scan range.
3. Value >=0 and < 1 : a percentage of the scan range when a row will be found. 0.1 means 10% of the scan range. 0.5 means 50%. 1 means 100%.
