### PR TITLE
statistics: move the previous auto-analyze selection into a func

### DIFF
--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -196,7 +196,6 @@ func HandleAutoAnalyze(
 		sysProcTracker,
 		is,
 		autoAnalyzeRatio,
-		start, end,
 		pruneMode,
 	)
 }
@@ -212,7 +211,6 @@ func randomPickOneTableAndTryAutoAnalyze(
 	sysProcTracker sessionctx.SysProcTracker,
 	is infoschema.InfoSchema,
 	autoAnalyzeRatio float64,
-	start, end time.Time,
 	pruneMode variable.PartitionPruneMode,
 ) bool {
 	dbs := is.AllSchemaNames()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: None

Problem Summary:

### What changed and how does it work?

Before proceeding with the implementation of a new auto-analysis queue, we can first consolidate the existing logic into one function. This way, it will be easier to revert to the old method if necessary. We don't have to remove the old logic right away. Instead, we can use a deprecation and opt-in process to gradually introduce this change to users.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
