### PR TITLE
sessionctx: move default_password_lifetime out of noop

### DIFF
--- a/pkg/sessionctx/variable/noop.go
+++ b/pkg/sessionctx/variable/noop.go
@@ -170,7 +170,6 @@ var noopSysVars = []*SysVar{
 	{Scope: ScopeNone, Name: "performance_schema_max_file_classes", Value: "50"},
 	{Scope: ScopeGlobal, Name: "expire_logs_days", Value: "0"},
 	{Scope: ScopeGlobal | ScopeSession, Name: BinlogRowQueryLogEvents, Value: Off, Type: TypeBool},
-	{Scope: ScopeGlobal, Name: DefaultPasswordLifetime, Value: "0", Type: TypeInt, MinValue: 0, MaxValue: math.MaxUint16},
 	{Scope: ScopeNone, Name: "pid_file", Value: "/usr/local/mysql/data/localhost.pid"},
 	{Scope: ScopeNone, Name: "innodb_undo_tablespaces", Value: "0"},
 	{Scope: ScopeGlobal, Name: InnodbStatusOutputLocks, Value: Off, Type: TypeBool, AutoConvertNegativeBool: true},

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -686,6 +686,7 @@ var defaultSysVars = []*SysVar{
 		},
 	},
 	{Scope: ScopeGlobal, Name: ValidatePasswordDictionary, Value: "", Type: TypeStr},
+	{Scope: ScopeGlobal, Name: DefaultPasswordLifetime, Value: "0", Type: TypeInt, MinValue: 0, MaxValue: math.MaxUint16},
 	{Scope: ScopeGlobal, Name: DisconnectOnExpiredPassword, Value: On, Type: TypeBool, ReadOnly: true, GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 		return BoolToOnOff(!IsSandBoxModeEnabled.Load()), nil
 	}},

--- a/pkg/sessionctx/variable/variable_test.go
+++ b/pkg/sessionctx/variable/variable_test.go
@@ -431,6 +431,9 @@ func TestIsNoop(t *testing.T) {
 
 	sv = GetSysVar(ReadOnly)
 	require.True(t, sv.IsNoop)
+
+	sv = GetSysVar(DefaultPasswordLifetime)
+	require.False(t, sv.IsNoop)
 }
 
 // TestDefaultValuesAreSettable that sysvars defaults are logically valid. i.e.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48910

Problem Summary:
default_password_lifetime should not be noop.

### What changed and how does it work?
Move default_password_lifetime from noop to sysvar.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```
mysql> select * from information_schema.VARIABLES_INFO where VARIABLE_NAME='default_password_lifetime'\G
*************************** 1. row ***************************
  VARIABLE_NAME: default_password_lifetime
 VARIABLE_SCOPE: GLOBAL
  DEFAULT_VALUE: 0
  CURRENT_VALUE: 0
      MIN_VALUE: 0
      MAX_VALUE: 65535
POSSIBLE_VALUES: NULL
        IS_NOOP: NO
1 row in set (0.02 sec)

mysql> set global default_password_lifetime=2;
Query OK, 0 rows affected (0.01 sec)

mysql> select @@global.default_password_lifetime;
+------------------------------------+
| @@global.default_password_lifetime |
+------------------------------------+
| 2                                  |
+------------------------------------+
1 row in set (0.00 sec)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
