### PR TITLE
executor, codec: hash join build wrong hash key for ENUM value

### DIFF
--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -2925,3 +2925,24 @@ func TestTiDBNAAJ(t *testing.T) {
 	tk.MustQuery("select ( table1 . a , table1 . b ) NOT IN ( SELECT 3 , 2 UNION  SELECT 9, 2 ) AS field2 from t as table1 order by field2;").Check(testkit.Rows(
 		"0", "0", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1"))
 }
+
+func TestIssue48991(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists tbl_3")
+	tk.MustExec("create table tbl_3 ( col_11 mediumint  unsigned not null default 8346281 ,col_12 enum ( 'Alice','Bob','Charlie','David' ) ,col_13 time   not null default '07:10:30.00' ,col_14 timestamp ,col_15 varbinary ( 194 )   not null default '-ZpCzjqdl4hsyo' , key idx_5 ( col_14 ,col_11 ,col_12 ) ,primary key  ( col_11 ,col_15 ) /*T![clustered_index] clustered */ ) charset utf8mb4 collate utf8mb4_bin partition by range ( col_11 ) ( partition p0 values less than (530262), partition p1 values less than (9415740), partition p2 values less than (11007444), partition p3 values less than (maxvalue) );")
+	tk.MustExec("insert into tbl_3 values ( 8838143,'David','23:41:27.00','1993-02-23','g0q~Z0b*PpMPKJxYbIE' );")
+	tk.MustExec("insert into tbl_3 values ( 9082223,'Alice','02:25:16.00','2035-11-08','i' );")
+	tk.MustExec("insert into tbl_3 values ( 2483729,'Charlie','14:43:13.00','1970-09-10','w6o6WFYyL5' );")
+	tk.MustExec("insert into tbl_3 values ( 4135401,'Charlie','19:30:34.00','2017-06-07','2FZmy9lanL8' );")
+	tk.MustExec("insert into tbl_3 values ( 1479390,'Alice','20:40:08.00','1984-06-10','LeoVONgN~iJz&inj' );")
+	tk.MustExec("insert into tbl_3 values ( 10427825,'Charlie','15:27:35.00','1986-12-25','tWJ' );")
+	tk.MustExec("insert into tbl_3 values ( 12794792,'Charlie','04:10:08.00','2034-08-08','hvpXVQyuP' );")
+	tk.MustExec("insert into tbl_3 values ( 4696775,'Charlie','05:07:43.00','1984-07-31','SKOW9I^sM$4xNk' );")
+	tk.MustExec("insert into tbl_3 values ( 8963236,'Alice','08:18:31.00','2022-04-17','v4DsE' );")
+	tk.MustExec("insert into tbl_3 values ( 9048951,'Alice','05:19:47.00','2018-09-22','sJ!vs' );")
+
+	res := tk.MustQuery("SELECT `col_14` FROM `test`.`tbl_3` WHERE ((`tbl_3`.`col_15` < 'dV') AND `tbl_3`.`col_12` IN (SELECT `col_12` FROM `test`.`tbl_3` WHERE NOT (ISNULL(`tbl_3`.`col_12`)))) ORDER BY IF(ISNULL(`col_14`),0,1),`col_14`;")
+	res.Check(testkit.Rows("1984-06-10 00:00:00", "1984-07-31 00:00:00", "2017-06-07 00:00:00"))
+}

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -363,14 +363,11 @@ func encodeHashChunkRowIdx(sc *stmtctx.StatementContext, row chunk.Row, tp *type
 			b = unsafe.Slice((*byte)(unsafe.Pointer(&v)), sizeUint64)
 		} else {
 			flag = compactBytesFlag
-			enumVal := row.GetEnum(idx)
-			str := enumVal.Name
-			if str == "" {
-				enum, err := types.ParseEnumValue(tp.GetElems(), enumVal.Value)
-				if err == nil {
-					// str will be empty string if v out of definition of enum.
-					str = enum.Name
-				}
+			v := row.GetEnum(idx).Value
+			str := ""
+			if enum, err := types.ParseEnumValue(tp.GetElems(), v); err == nil {
+				// str will be empty string if v out of definition of enum.
+				str = enum.Name
 			}
 			b = ConvertByCollation(hack.Slice(str), tp)
 		}
@@ -582,14 +579,11 @@ func HashChunkSelected(sc *stmtctx.StatementContext, h []hash.Hash64, chk *chunk
 				b = unsafe.Slice((*byte)(unsafe.Pointer(&v)), sizeUint64)
 			} else {
 				buf[0] = compactBytesFlag
-				enumVal := column.GetEnum(i)
-				str := enumVal.Name
-				if str == "" {
-					enum, err := types.ParseEnumValue(tp.GetElems(), enumVal.Value)
-					if err == nil {
-						// str will be empty string if v out of definition of enum.
-						str = enum.Name
-					}
+				v := column.GetEnum(i).Value
+				str := ""
+				if enum, err := types.ParseEnumValue(tp.GetElems(), v); err == nil {
+					// str will be empty string if v out of definition of enum.
+					str = enum.Name
 				}
 				b = ConvertByCollation(hack.Slice(str), tp)
 			}

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -363,11 +363,14 @@ func encodeHashChunkRowIdx(sc *stmtctx.StatementContext, row chunk.Row, tp *type
 			b = unsafe.Slice((*byte)(unsafe.Pointer(&v)), sizeUint64)
 		} else {
 			flag = compactBytesFlag
-			v := row.GetEnum(idx).Value
-			str := ""
-			if enum, err := types.ParseEnumValue(tp.GetElems(), v); err == nil {
-				// str will be empty string if v out of definition of enum.
-				str = enum.Name
+			enumVal := row.GetEnum(idx)
+			str := enumVal.Name
+			if str == "" {
+				enum, err := types.ParseEnumValue(tp.GetElems(), enumVal.Value)
+				if err == nil {
+					// str will be empty string if v out of definition of enum.
+					str = enum.Name
+				}
 			}
 			b = ConvertByCollation(hack.Slice(str), tp)
 		}
@@ -579,11 +582,14 @@ func HashChunkSelected(sc *stmtctx.StatementContext, h []hash.Hash64, chk *chunk
 				b = unsafe.Slice((*byte)(unsafe.Pointer(&v)), sizeUint64)
 			} else {
 				buf[0] = compactBytesFlag
-				v := column.GetEnum(i).Value
-				str := ""
-				if enum, err := types.ParseEnumValue(tp.GetElems(), v); err == nil {
-					// str will be empty string if v out of definition of enum.
-					str = enum.Name
+				enumVal := column.GetEnum(i)
+				str := enumVal.Name
+				if str == "" {
+					enum, err := types.ParseEnumValue(tp.GetElems(), enumVal.Value)
+					if err == nil {
+						// str will be empty string if v out of definition of enum.
+						str = enum.Name
+					}
 				}
 				b = ConvertByCollation(hack.Slice(str), tp)
 			}


### PR DESCRIPTION
### This is a manual cherry-pick for https://github.com/pingcap/tidb/pull/49031
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48991 

Problem Summary:

### What changed and how does it work?

When the projection disables the ColumnEvaluator, it will eval the ENUM and parse a new ENUM. But the new ENUM value's value index will be set to 0.

But when we construct the hash value for the join key, we use the value index to seek the string value. So a wrong hash key is constructed.

This pull aims to solve the case.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that hash join will construct wrong join key for ENUM type
```
