### PR TITLE
statistics: handle exchange partition event

### DIFF
--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -2594,7 +2594,7 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 
 	// exchange table meta id
 	pt.ExchangePartitionInfo = nil
-	// Used below to update the partition table stats.
+	// Used below to update the partitioned table's stats meta.
 	orginalPartitionDef := partDef.Clone()
 	originalNt := nt.Clone()
 	partDef.ID, nt.ID = nt.ID, partDef.ID

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -2594,6 +2594,7 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 
 	// exchange table meta id
 	pt.ExchangePartitionInfo = nil
+	// Used below to update the partition table stats.
 	orginalPartitionDef := partDef.Clone()
 	originalNt := nt.Clone()
 	partDef.ID, nt.ID = nt.ID, partDef.ID

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -2594,6 +2594,8 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 
 	// exchange table meta id
 	pt.ExchangePartitionInfo = nil
+	orginalPartitionDef := partDef.Clone()
+	originalNt := nt.Clone()
 	partDef.ID, nt.ID = nt.ID, partDef.ID
 
 	err = t.UpdateTable(ptSchemaID, pt)
@@ -2697,6 +2699,12 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 	}
 
 	job.FinishTableJob(model.JobStateDone, model.StateNone, ver, pt)
+	exchangePartitionEvent := statsutil.NewExchangePartitionEvent(
+		pt,
+		&model.PartitionInfo{Definitions: []model.PartitionDefinition{orginalPartitionDef}},
+		originalNt,
+	)
+	asyncNotifyEvent(d, exchangePartitionEvent)
 	return ver, nil
 }
 

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -2595,7 +2595,7 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 	// exchange table meta id
 	pt.ExchangePartitionInfo = nil
 	// Used below to update the partitioned table's stats meta.
-	orginalPartitionDef := partDef.Clone()
+	originalPartitionDef := partDef.Clone()
 	originalNt := nt.Clone()
 	partDef.ID, nt.ID = nt.ID, partDef.ID
 
@@ -2702,7 +2702,7 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 	job.FinishTableJob(model.JobStateDone, model.StateNone, ver, pt)
 	exchangePartitionEvent := statsutil.NewExchangePartitionEvent(
 		pt,
-		&model.PartitionInfo{Definitions: []model.PartitionDefinition{orginalPartitionDef}},
+		&model.PartitionInfo{Definitions: []model.PartitionDefinition{originalPartitionDef}},
 		originalNt,
 	)
 	asyncNotifyEvent(d, exchangePartitionEvent)

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/parser/model",
         "//pkg/sessionctx",
         "//pkg/sessionctx/variable",
+        "//pkg/statistics/handle/lockstats",
         "//pkg/statistics/handle/logutil",
         "//pkg/statistics/handle/storage",
         "//pkg/statistics/handle/types",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "ddl",
-    srcs = ["ddl.go"],
+    srcs = [
+        "ddl.go",
+        "exchange_partition.go",
+    ],
     importpath = "github.com/pingcap/tidb/pkg/statistics/handle/ddl",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -23,7 +23,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/sessionctx",
         "//pkg/sessionctx/variable",
         "//pkg/statistics/handle/logutil",
+        "//pkg/statistics/handle/storage",
         "//pkg/statistics/handle/types",
         "//pkg/statistics/handle/util",
         "@com_github_pingcap_errors//:errors",

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -15,6 +15,8 @@
 package ddl
 
 import (
+	"math"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -226,10 +228,10 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 	// If the original partition has substantial changes (contributing a large delta to global stats),
 	// it will help us trigger auto-analyze quickly.
 	// If the changes are minor, it won't have a significant effect.
-	count := tableCount - partCount
+	delta := tableCount - partCount
+	count := int64(math.Abs(float64(delta)))
 	// Update the global stats.
 	if count != 0 {
-		delta := -count
 		if err := h.statsWriter.UpdateStatsMetaDelta(
 			globalTableInfo.ID, count, delta,
 		); err != nil {

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -227,7 +227,7 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 	// Next, since the old partition no longer belongs to the table,
 	// the modify count of the partition should be subtracted.
 	// The modify count of the table should be added as we are adding the table as a partition.
-	modifyCountDelta := (tableCount + partCount) - (partModifyCount + tableModifyCount)
+	modifyCountDelta := (tableCount + partCount) - partModifyCount + tableModifyCount
 
 	// Update the global stats.
 	if modifyCountDelta != 0 || countDelta != 0 {

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -345,25 +345,23 @@ func (h *ddlHandlerImpl) updateStatsWithCountDeltaAndModifyCountDelta(
 				tableID,
 			)
 			return err
-		} else {
-			// For count and modify_count, we should use GREATEST(0, x) to avoid negative values.
-			_, err = util.Exec(
-				sctx,
-				"INSERT INTO mysql.stats_meta "+
-					"(version, count, modify_count, table_id) "+
-					"VALUES (%?, GREATEST(0, %?), GREATEST(0, %?), %?) "+
-					"ON DUPLICATE KEY UPDATE "+
-					"version = VALUES(version), "+
-					"count = GREATEST(0, count + VALUES(count)), "+
-					"modify_count = GREATEST(0, modify_count + VALUES(modify_count))",
-				startTS,
-				countDelta,
-				modifyCountDelta,
-				tableID,
-			)
-			return err
 		}
-
+		// For count and modify_count, we should use GREATEST(0, x) to avoid negative values.
+		_, err = util.Exec(
+			sctx,
+			"INSERT INTO mysql.stats_meta "+
+				"(version, count, modify_count, table_id) "+
+				"VALUES (%?, GREATEST(0, %?), GREATEST(0, %?), %?) "+
+				"ON DUPLICATE KEY UPDATE "+
+				"version = VALUES(version), "+
+				"count = GREATEST(0, count + VALUES(count)), "+
+				"modify_count = GREATEST(0, modify_count + VALUES(modify_count))",
+			startTS,
+			countDelta,
+			modifyCountDelta,
+			tableID,
+		)
+		return err
 	}, util.FlagWrapTxn); err != nil {
 		return err
 	}

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -246,7 +246,6 @@ func updateStatsWithCountDeltaAndModifyCountDelta(
 		return err
 	}
 	if isNull {
-		// Insert
 		_, err = util.Exec(
 			sctx,
 			"INSERT INTO mysql.stats_meta "+
@@ -258,7 +257,6 @@ func updateStatsWithCountDeltaAndModifyCountDelta(
 			tableID,
 		)
 	} else {
-		// Update
 		_, err = util.Exec(
 			sctx,
 			"UPDATE mysql.stats_meta SET "+

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -217,6 +217,9 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 		return err
 	}
 
+	// The count of the partition should be added to the table.
+	// The formula is: total_count = original_table_count - original_partition_count + new_table_count.
+	// So the delta is : new_table_count - original_partition_count.
 	countDelta := tableCount - partCount
 	// Initially, the sum of tableCount and partCount represents
 	// the operation of deleting the partition and adding the table.

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -237,7 +237,10 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 		}
 		sctx := se.(sessionctx.Context)
 		is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-		schema, _ := is.SchemaByTable(globalTableInfo)
+		schema, ok := is.SchemaByTable(globalTableInfo)
+		if !ok {
+			return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
+		}
 		if err := h.updateStatsWithCountDeltaAndModifyCountDelta(
 			globalTableInfo.ID, countDelta, modifyCountDelta,
 		); err != nil {

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -244,11 +244,6 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 			if !ok {
 				return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
 			}
-			// Note: It is OK to exchange one table from different schemas.
-			tableSchema, ok := is.SchemaByTable(originalTableInfo)
-			if !ok {
-				return errors.Errorf("schema not found for table %s", originalTableInfo.Name.O)
-			}
 			if err := updateStatsWithCountDeltaAndModifyCountDelta(
 				sctx,
 				globalTableInfo.ID, countDelta, modifyCountDelta,
@@ -257,7 +252,6 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 					golbalTableSchema.Name.O,
 					globalTableInfo,
 					originalPartInfo.Definitions[0],
-					tableSchema.Name.O,
 					originalTableInfo,
 					countDelta, modifyCountDelta,
 					partCount,
@@ -278,7 +272,6 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 					golbalTableSchema.Name.O,
 					globalTableInfo,
 					originalPartInfo.Definitions[0],
-					tableSchema.Name.O,
 					originalTableInfo,
 					countDelta, modifyCountDelta,
 					partCount,
@@ -300,7 +293,6 @@ func exchangePartitionLogFields(
 	globalTableSchemaName string,
 	globalTableInfo *model.TableInfo,
 	originalPartInfo model.PartitionDefinition,
-	tableSchemaName string,
 	originalTableInfo *model.TableInfo,
 	countDelta, modifyCountDelta,
 	partCount, partModifyCount,
@@ -316,7 +308,6 @@ func exchangePartitionLogFields(
 		zap.String("partitionName", originalPartInfo.Name.O),
 		zap.Int64("partitionCount", partCount),
 		zap.Int64("partitionModifyCount", partModifyCount),
-		zap.String("tableSchema", tableSchemaName),
 		zap.Int64("tableID", originalTableInfo.ID),
 		zap.String("tableName", originalTableInfo.Name.O),
 		zap.Int64("tableCount", tableCount),

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -203,6 +203,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 	globalTableInfo, originalPartInfo,
 		originalTableInfo := t.GetExchangePartitionInfo()
+	// Note: Put all the operations in a transaction.
 	if err := util.CallWithSCtx(h.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		// Get the count of the partition.
 		partCount, partModifyCount, _, err := storage.StatsMetaCountAndModifyCount(
@@ -247,6 +248,7 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 			if !ok {
 				return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
 			}
+			// Note: It is OK to exchange one table from different schemas.
 			tableSchema, ok := is.SchemaByTable(originalTableInfo)
 			if !ok {
 				return errors.Errorf("schema not found for table %s", originalTableInfo.Name.O)

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics/handle/lockstats"
 	"github.com/pingcap/tidb/pkg/statistics/handle/logutil"
-	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
 	"github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"go.uber.org/zap"
@@ -199,120 +198,6 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 		return h.statsWriter.UpdateStatsVersion()
 	}
 	return nil
-}
-
-func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
-	globalTableInfo, originalPartInfo,
-		originalTableInfo := t.GetExchangePartitionInfo()
-	// Note: Put all the operations in a transaction.
-	if err := util.CallWithSCtx(h.statsHandler.SPool(), func(sctx sessionctx.Context) error {
-		// Get the count of the partition.
-		partCount, partModifyCount, _, err := storage.StatsMetaCountAndModifyCount(
-			sctx,
-			// You only can exchange one partition at a time.
-			originalPartInfo.Definitions[0].ID,
-		)
-		if err != nil {
-			return err
-		}
-
-		// Get the count of the table.
-		tableCount, tableModifyCount, _, err := storage.StatsMetaCountAndModifyCount(
-			sctx,
-			originalTableInfo.ID,
-		)
-		if err != nil {
-			return err
-		}
-
-		// The count of the partition should be added to the table.
-		// The formula is: total_count = original_table_count - original_partition_count + new_table_count.
-		// So the delta is : new_table_count - original_partition_count.
-		countDelta := tableCount - partCount
-		// Initially, the sum of tableCount and partCount represents
-		// the operation of deleting the partition and adding the table.
-		// Therefore, they are considered as modifyCountDelta.
-		// Next, since the old partition no longer belongs to the table,
-		// the modify count of the partition should be subtracted.
-		// The modify count of the table should be added as we are adding the table as a partition.
-		modifyCountDelta := (tableCount + partCount) - partModifyCount + tableModifyCount
-
-		// Update the global stats.
-		if modifyCountDelta != 0 || countDelta != 0 {
-			is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-			globalTableSchema, ok := is.SchemaByTable(globalTableInfo)
-			if !ok {
-				return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
-			}
-			if err := updateStatsWithCountDeltaAndModifyCountDelta(
-				sctx,
-				globalTableInfo.ID, countDelta, modifyCountDelta,
-			); err != nil {
-				fields := exchangePartitionLogFields(
-					globalTableSchema.Name.O,
-					globalTableInfo,
-					originalPartInfo.Definitions[0],
-					originalTableInfo,
-					countDelta, modifyCountDelta,
-					partCount,
-					partModifyCount,
-					tableCount,
-					tableModifyCount,
-				)
-				fields = append(fields, zap.Error(err))
-				logutil.StatsLogger.Error(
-					"Update global stats after exchange partition failed",
-					fields...,
-				)
-				return err
-			}
-			logutil.StatsLogger.Info(
-				"Update global stats after exchange partition",
-				exchangePartitionLogFields(
-					globalTableSchema.Name.O,
-					globalTableInfo,
-					originalPartInfo.Definitions[0],
-					originalTableInfo,
-					countDelta, modifyCountDelta,
-					partCount,
-					partModifyCount,
-					tableCount,
-					tableModifyCount,
-				)...,
-			)
-		}
-		return nil
-	}, util.FlagWrapTxn); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func exchangePartitionLogFields(
-	globalTableSchemaName string,
-	globalTableInfo *model.TableInfo,
-	originalPartInfo model.PartitionDefinition,
-	originalTableInfo *model.TableInfo,
-	countDelta, modifyCountDelta,
-	partCount, partModifyCount,
-	tableCount, tableModifyCount int64,
-) []zap.Field {
-	return []zap.Field{
-		zap.String("globalTableSchema", globalTableSchemaName),
-		zap.Int64("globalTableID", globalTableInfo.ID),
-		zap.String("globalTableName", globalTableInfo.Name.O),
-		zap.Int64("countDelta", countDelta),
-		zap.Int64("modifyCountDelta", modifyCountDelta),
-		zap.Int64("partitionID", originalPartInfo.ID),
-		zap.String("partitionName", originalPartInfo.Name.O),
-		zap.Int64("partitionCount", partCount),
-		zap.Int64("partitionModifyCount", partModifyCount),
-		zap.Int64("tableID", originalTableInfo.ID),
-		zap.String("tableName", originalTableInfo.Name.O),
-		zap.Int64("tableCount", tableCount),
-		zap.Int64("tableModifyCount", tableModifyCount),
-	}
 }
 
 // updateStatsWithCountDeltaAndModifyCountDelta updates

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -240,7 +240,7 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 		// Update the global stats.
 		if modifyCountDelta != 0 || countDelta != 0 {
 			is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-			golbalTableSchema, ok := is.SchemaByTable(globalTableInfo)
+			globalTableSchema, ok := is.SchemaByTable(globalTableInfo)
 			if !ok {
 				return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
 			}
@@ -249,7 +249,7 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 				globalTableInfo.ID, countDelta, modifyCountDelta,
 			); err != nil {
 				fields := exchangePartitionLogFields(
-					golbalTableSchema.Name.O,
+					globalTableSchema.Name.O,
 					globalTableInfo,
 					originalPartInfo.Definitions[0],
 					originalTableInfo,
@@ -269,7 +269,7 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 			logutil.StatsLogger.Info(
 				"Update global stats after exchange partition",
 				exchangePartitionLogFields(
-					golbalTableSchema.Name.O,
+					globalTableSchema.Name.O,
 					globalTableInfo,
 					originalPartInfo.Definitions[0],
 					originalTableInfo,

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -239,11 +239,6 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 
 		// Update the global stats.
 		if modifyCountDelta != 0 || countDelta != 0 {
-			se, err := h.statsHandler.SPool().Get()
-			if err != nil {
-				return errors.Trace(err)
-			}
-			sctx := se.(sessionctx.Context)
 			is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
 			golbalTableSchema, ok := is.SchemaByTable(globalTableInfo)
 			if !ok {

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -274,7 +274,6 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 	}
 	// Update the global stats.
 	if modifyCountDelta != 0 || countDelta != 0 {
-
 		if err := h.updateStatsWithCountDeltaAndModifyCountDelta(
 			globalTableInfo.ID, countDelta, modifyCountDelta,
 		); err != nil {
@@ -329,7 +328,6 @@ func (h *ddlHandlerImpl) updateStatsWithCountDeltaAndModifyCountDelta(
 		if err != nil {
 			return errors.Trace(err)
 		}
-
 		if isLocked {
 			// For locked tables, it is possible that the record gets deleted. So it can be negative.
 			_, err = util.Exec(
@@ -347,7 +345,6 @@ func (h *ddlHandlerImpl) updateStatsWithCountDeltaAndModifyCountDelta(
 				tableID,
 			)
 			return err
-
 		} else {
 			// For count and modify_count, we should use GREATEST(0, x) to avoid negative values.
 			_, err = util.Exec(

--- a/pkg/statistics/handle/ddl/exchange_partition.go
+++ b/pkg/statistics/handle/ddl/exchange_partition.go
@@ -103,7 +103,10 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 	return nil
 }
 
-func getCountsAndModifyCounts(sctx sessionctx.Context, partitionID, tableID int64) (partCount, partModifyCount, tableCount, tableModifyCount int64, err error) {
+func getCountsAndModifyCounts(
+	sctx sessionctx.Context,
+	partitionID, tableID int64,
+) (partCount, partModifyCount, tableCount, tableModifyCount int64, err error) {
 	partCount, partModifyCount, _, err = storage.StatsMetaCountAndModifyCount(sctx, partitionID)
 	if err != nil {
 		return

--- a/pkg/statistics/handle/ddl/exchange_partition.go
+++ b/pkg/statistics/handle/ddl/exchange_partition.go
@@ -74,13 +74,13 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
 					tableModifyCount,
 				)
 				fields = append(fields, zap.Error(err))
-				logutil.StatsLogger.Error(
+				logutil.StatsLogger().Error(
 					"Update global stats after exchange partition failed",
 					fields...,
 				)
 				return err
 			}
-			logutil.StatsLogger.Info(
+			logutil.StatsLogger().Info(
 				"Update global stats after exchange partition",
 				exchangePartitionLogFields(
 					globalTableSchema.Name.O,

--- a/pkg/statistics/handle/ddl/exchange_partition.go
+++ b/pkg/statistics/handle/ddl/exchange_partition.go
@@ -1,0 +1,144 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/statistics/handle/logutil"
+	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
+	"github.com/pingcap/tidb/pkg/statistics/handle/util"
+	"go.uber.org/zap"
+)
+
+func (h *ddlHandlerImpl) onExchangeAPartition(t *util.DDLEvent) error {
+	globalTableInfo, originalPartInfo,
+		originalTableInfo := t.GetExchangePartitionInfo()
+	// Note: Put all the operations in a transaction.
+	if err := util.CallWithSCtx(h.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		partCount, partModifyCount, tableCount, tableModifyCount, err := getCountsAndModifyCounts(
+			sctx,
+			originalPartInfo.Definitions[0].ID,
+			originalTableInfo.ID,
+		)
+		if err != nil {
+			return err
+		}
+
+		// The count of the partition should be added to the table.
+		// The formula is: total_count = original_table_count - original_partition_count + new_table_count.
+		// So the delta is : new_table_count - original_partition_count.
+		countDelta := tableCount - partCount
+		// Initially, the sum of tableCount and partCount represents
+		// the operation of deleting the partition and adding the table.
+		// Therefore, they are considered as modifyCountDelta.
+		// Next, since the old partition no longer belongs to the table,
+		// the modify count of the partition should be subtracted.
+		// The modify count of the table should be added as we are adding the table as a partition.
+		modifyCountDelta := (tableCount + partCount) - partModifyCount + tableModifyCount
+
+		// Update the global stats.
+		if modifyCountDelta != 0 || countDelta != 0 {
+			is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+			globalTableSchema, ok := is.SchemaByTable(globalTableInfo)
+			if !ok {
+				return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
+			}
+			if err := updateStatsWithCountDeltaAndModifyCountDelta(
+				sctx,
+				globalTableInfo.ID, countDelta, modifyCountDelta,
+			); err != nil {
+				fields := exchangePartitionLogFields(
+					globalTableSchema.Name.O,
+					globalTableInfo,
+					originalPartInfo.Definitions[0],
+					originalTableInfo,
+					countDelta, modifyCountDelta,
+					partCount,
+					partModifyCount,
+					tableCount,
+					tableModifyCount,
+				)
+				fields = append(fields, zap.Error(err))
+				logutil.StatsLogger.Error(
+					"Update global stats after exchange partition failed",
+					fields...,
+				)
+				return err
+			}
+			logutil.StatsLogger.Info(
+				"Update global stats after exchange partition",
+				exchangePartitionLogFields(
+					globalTableSchema.Name.O,
+					globalTableInfo,
+					originalPartInfo.Definitions[0],
+					originalTableInfo,
+					countDelta, modifyCountDelta,
+					partCount,
+					partModifyCount,
+					tableCount,
+					tableModifyCount,
+				)...,
+			)
+		}
+		return nil
+	}, util.FlagWrapTxn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getCountsAndModifyCounts(sctx sessionctx.Context, partitionID, tableID int64) (partCount, partModifyCount, tableCount, tableModifyCount int64, err error) {
+	partCount, partModifyCount, _, err = storage.StatsMetaCountAndModifyCount(sctx, partitionID)
+	if err != nil {
+		return
+	}
+
+	tableCount, tableModifyCount, _, err = storage.StatsMetaCountAndModifyCount(sctx, tableID)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func exchangePartitionLogFields(
+	globalTableSchemaName string,
+	globalTableInfo *model.TableInfo,
+	originalPartInfo model.PartitionDefinition,
+	originalTableInfo *model.TableInfo,
+	countDelta, modifyCountDelta,
+	partCount, partModifyCount,
+	tableCount, tableModifyCount int64,
+) []zap.Field {
+	return []zap.Field{
+		zap.String("globalTableSchema", globalTableSchemaName),
+		zap.Int64("globalTableID", globalTableInfo.ID),
+		zap.String("globalTableName", globalTableInfo.Name.O),
+		zap.Int64("countDelta", countDelta),
+		zap.Int64("modifyCountDelta", modifyCountDelta),
+		zap.Int64("partitionID", originalPartInfo.ID),
+		zap.String("partitionName", originalPartInfo.Name.O),
+		zap.Int64("partitionCount", partCount),
+		zap.Int64("partitionModifyCount", partModifyCount),
+		zap.Int64("tableID", originalTableInfo.ID),
+		zap.String("tableName", originalTableInfo.Name.O),
+		zap.Int64("tableCount", tableCount),
+		zap.Int64("tableModifyCount", tableModifyCount),
+	}
+}

--- a/pkg/statistics/handle/util/BUILD.bazel
+++ b/pkg/statistics/handle/util/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/parser/terror",
         "//pkg/sessionctx",
         "//pkg/sessionctx/variable",
+        "//pkg/statistics/handle/logutil",
         "//pkg/table",
         "//pkg/util/chunk",
         "//pkg/util/intest",
@@ -31,6 +32,7 @@ go_library(
         "@com_github_tiancaiamao_gp//:gp",
         "@com_github_tikv_client_go_v2//oracle",
         "@org_uber_go_atomic//:atomic",
+        "@org_uber_go_zap//:zap",
     ],
 )
 

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/statistics/handle/logutil"
+	"go.uber.org/zap"
 )
 
 // DDLEvent contains the information of a ddl event that is used to update stats.
@@ -152,23 +154,42 @@ func (e *DDLEvent) GetDropPartitionInfo() (globalTableInfo *model.TableInfo, dro
 }
 
 // NewExchangePartitionEvent creates a new ddl event that exchanges a partition.
+// Please make sure pass the information before the exchange.
 func NewExchangePartitionEvent(
 	globalTableInfo *model.TableInfo,
-	exchangedPartInfo *model.PartitionInfo,
-	exchangedTableInfo *model.TableInfo,
+	originalPartInfo *model.PartitionInfo,
+	originalTableInfo *model.TableInfo,
 ) *DDLEvent {
+	if len(originalPartInfo.Definitions) != 1 {
+		allIDs := make([]int64, 0, len(originalPartInfo.Definitions))
+		allNames := make([]string, 0, len(originalPartInfo.Definitions))
+		for _, def := range originalPartInfo.Definitions {
+			allIDs = append(allIDs, def.ID)
+			allNames = append(allNames, def.Name.O)
+		}
+		logutil.StatsLogger.Error("Exchange partition should only have one partition to exchange",
+			zap.Int64("globalTableID", globalTableInfo.ID),
+			zap.String("globalTableName", globalTableInfo.Name.O),
+			zap.Int64("tableID", originalTableInfo.ID),
+			zap.String("tableName", originalTableInfo.Name.O),
+			zap.Int64s("allPartitionIDs", allIDs),
+			zap.Strings("allPartitionNames", allNames),
+		)
+	}
 	return &DDLEvent{
 		tp:           model.ActionExchangeTablePartition,
 		tableInfo:    globalTableInfo,
-		partInfo:     exchangedPartInfo,
-		oldTableInfo: exchangedTableInfo,
+		partInfo:     originalPartInfo,
+		oldTableInfo: originalTableInfo,
 	}
 }
 
-func (e *DDLEvent) getExchangePartitionInfo() (
+// GetExchangePartitionInfo gets the table info of the table that is exchanged a partition.\
+// Note: All information pertains to the state before the exchange.
+func (e *DDLEvent) GetExchangePartitionInfo() (
 	globalTableInfo *model.TableInfo,
-	exchangedPartInfo *model.PartitionInfo,
-	exchangedTableInfo *model.TableInfo,
+	originalPartInfo *model.PartitionInfo,
+	originalTableInfo *model.TableInfo,
 ) {
 	return e.tableInfo, e.partInfo, e.oldTableInfo
 }

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -167,7 +167,7 @@ func NewExchangePartitionEvent(
 			allIDs = append(allIDs, def.ID)
 			allNames = append(allNames, def.Name.O)
 		}
-		logutil.StatsLogger.Error("Exchange partition should only have one partition to exchange",
+		logutil.StatsLogger().Error("Exchange partition should only have one partition to exchange",
 			zap.Int64("globalTableID", globalTableInfo.ID),
 			zap.String("globalTableName", globalTableInfo.Name.O),
 			zap.Int64("tableID", originalTableInfo.ID),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/47354

Problem Summary:

### What changed and how does it work?

Based on [this design doc](https://pingcap.feishu.cn/docx/OLCrdxHj2ojb9KxlUvUch60LnBe#part-PRTmdkF0doiZSxxHHmDckfeJnZf), we will only update the count and modfiy_count for it. Then it will use the count and modify_count to determine if we need to trigger an auto-analysis task.

So in this PR, I updated the global stats with the old partition info and table info.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
