### PR TITLE
ddl/ingest: add failpoint to change flush local interval

### DIFF
--- a/pkg/ddl/ingest/backend.go
+++ b/pkg/ddl/ingest/backend.go
@@ -270,6 +270,7 @@ func (bc *litBackendCtx) ShouldSync(mode FlushMode) (shouldFlush bool, shouldImp
 		shouldFlush = true
 	} else {
 		interval := bc.updateInterval
+		// This failpoint will be manually set through HTTP status port.
 		failpoint.Inject("mockSyncIntervalMs", func(val failpoint.Value) {
 			if v, ok := val.(int); ok {
 				interval = time.Duration(v) * time.Millisecond

--- a/pkg/ddl/ingest/backend.go
+++ b/pkg/ddl/ingest/backend.go
@@ -269,8 +269,14 @@ func (bc *litBackendCtx) ShouldSync(mode FlushMode) (shouldFlush bool, shouldImp
 	if mode == FlushModeForceLocalAndCheckDiskQuota {
 		shouldFlush = true
 	} else {
+		interval := bc.updateInterval
+		failpoint.Inject("mockSyncInterval", func(val failpoint.Value) {
+			if v, ok := val.(int); ok {
+				interval = time.Duration(v) * time.Millisecond
+			}
+		})
 		shouldFlush = shouldImport ||
-			time.Since(bc.timeOfLastFlush.Load()) >= bc.updateInterval
+			time.Since(bc.timeOfLastFlush.Load()) >= interval
 	}
 	return shouldFlush, shouldImport
 }

--- a/pkg/ddl/ingest/backend.go
+++ b/pkg/ddl/ingest/backend.go
@@ -270,7 +270,7 @@ func (bc *litBackendCtx) ShouldSync(mode FlushMode) (shouldFlush bool, shouldImp
 		shouldFlush = true
 	} else {
 		interval := bc.updateInterval
-		failpoint.Inject("mockSyncInterval", func(val failpoint.Value) {
+		failpoint.Inject("mockSyncIntervalMs", func(val failpoint.Value) {
 			if v, ok := val.(int); ok {
 				interval = time.Duration(v) * time.Millisecond
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Problem Summary:

This PR adds a failpoint to change flush local interval, thus we can change this in test environment.

### What changed and how does it work?

See code changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
