### PR TITLE
server: log expensive scan query in slow log

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -492,6 +492,7 @@ type Instance struct {
 
 	EnableSlowLog         AtomicBool `toml:"tidb_enable_slow_log" json:"tidb_enable_slow_log"`
 	SlowThreshold         uint64     `toml:"tidb_slow_log_threshold" json:"tidb_slow_log_threshold"`
+	ExpensiveScanRatio    uint64     `toml:"tidb_expensive_scan_ratio" json:"tidb_expensive_scan_ratio"`
 	RecordPlanInSlowLog   uint32     `toml:"tidb_record_plan_in_slow_log" json:"tidb_record_plan_in_slow_log"`
 	CheckMb4ValueInUTF8   AtomicBool `toml:"tidb_check_mb4_value_in_utf8" json:"tidb_check_mb4_value_in_utf8"`
 	ForcePriority         string     `toml:"tidb_force_priority" json:"tidb_force_priority"`
@@ -889,6 +890,7 @@ var defaultConf = Config{
 		ExpensiveQueryTimeThreshold: DefExpensiveQueryTimeThreshold,
 		EnableSlowLog:               *NewAtomicBool(logutil.DefaultTiDBEnableSlowLog),
 		SlowThreshold:               logutil.DefaultSlowThreshold,
+		ExpensiveScanRatio:          logutil.DefaultExpensiveScanRatio,
 		RecordPlanInSlowLog:         logutil.DefaultRecordPlanInSlowLog,
 		CheckMb4ValueInUTF8:         *NewAtomicBool(true),
 		ForcePriority:               "NO_PRIORITY",

--- a/config/config.go
+++ b/config/config.go
@@ -892,6 +892,7 @@ var defaultConf = Config{
 		EnableSlowLog:               *NewAtomicBool(logutil.DefaultTiDBEnableSlowLog),
 		SlowThreshold:               logutil.DefaultSlowThreshold,
 		InefficientScanRatio:        logutil.DefaultInefficientScanRatio,
+		InefficientScanNum:          logutil.DefaultInefficientScanNum,
 		RecordPlanInSlowLog:         logutil.DefaultRecordPlanInSlowLog,
 		CheckMb4ValueInUTF8:         *NewAtomicBool(true),
 		ForcePriority:               "NO_PRIORITY",

--- a/config/config.go
+++ b/config/config.go
@@ -492,7 +492,8 @@ type Instance struct {
 
 	EnableSlowLog         AtomicBool `toml:"tidb_enable_slow_log" json:"tidb_enable_slow_log"`
 	SlowThreshold         uint64     `toml:"tidb_slow_log_threshold" json:"tidb_slow_log_threshold"`
-	ExpensiveScanRatio    uint64     `toml:"tidb_expensive_scan_ratio" json:"tidb_expensive_scan_ratio"`
+	InefficientScanRatio  uint64     `toml:"tidb_expensive_scan_ratio" json:"tidb_expensive_scan_ratio"`
+	InefficientScanNum    uint64     `toml:"tidb_expensive_scan_num" json:"tidb_expensive_scan_num"`
 	RecordPlanInSlowLog   uint32     `toml:"tidb_record_plan_in_slow_log" json:"tidb_record_plan_in_slow_log"`
 	CheckMb4ValueInUTF8   AtomicBool `toml:"tidb_check_mb4_value_in_utf8" json:"tidb_check_mb4_value_in_utf8"`
 	ForcePriority         string     `toml:"tidb_force_priority" json:"tidb_force_priority"`
@@ -890,7 +891,7 @@ var defaultConf = Config{
 		ExpensiveQueryTimeThreshold: DefExpensiveQueryTimeThreshold,
 		EnableSlowLog:               *NewAtomicBool(logutil.DefaultTiDBEnableSlowLog),
 		SlowThreshold:               logutil.DefaultSlowThreshold,
-		ExpensiveScanRatio:          logutil.DefaultExpensiveScanRatio,
+		InefficientScanRatio:        logutil.DefaultInefficientScanRatio,
 		RecordPlanInSlowLog:         logutil.DefaultRecordPlanInSlowLog,
 		CheckMb4ValueInUTF8:         *NewAtomicBool(true),
 		ForcePriority:               "NO_PRIORITY",

--- a/config/config.go
+++ b/config/config.go
@@ -492,8 +492,8 @@ type Instance struct {
 
 	EnableSlowLog         AtomicBool `toml:"tidb_enable_slow_log" json:"tidb_enable_slow_log"`
 	SlowThreshold         uint64     `toml:"tidb_slow_log_threshold" json:"tidb_slow_log_threshold"`
-	InefficientScanRatio  uint64     `toml:"tidb_expensive_scan_ratio" json:"tidb_expensive_scan_ratio"`
-	InefficientScanNum    uint64     `toml:"tidb_expensive_scan_num" json:"tidb_expensive_scan_num"`
+	InefficientScanRatio  uint64     `toml:"tidb_inefficient_scan_ratio" json:"tidb_inefficient_scan_ratio"`
+	InefficientScanNum    uint64     `toml:"tidb_inefficient_scan_num" json:"tidb_inefficient_scan_num"`
 	RecordPlanInSlowLog   uint32     `toml:"tidb_record_plan_in_slow_log" json:"tidb_record_plan_in_slow_log"`
 	CheckMb4ValueInUTF8   AtomicBool `toml:"tidb_check_mb4_value_in_utf8" json:"tidb_check_mb4_value_in_utf8"`
 	ForcePriority         string     `toml:"tidb_force_priority" json:"tidb_force_priority"`

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -207,9 +207,6 @@ func (r *selectResult) fetchResp(ctx context.Context) error {
 				}
 				r.durationReported = true
 			}
-			if r.ctx.GetSessionVars().ConnectionID > 0 {
-				return errors.Trace(errQueryInterrupted)
-			}
 			return nil
 		}
 		r.selectResp = new(tipb.SelectResponse)

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -207,6 +207,9 @@ func (r *selectResult) fetchResp(ctx context.Context) error {
 				}
 				r.durationReported = true
 			}
+			if r.ctx.GetSessionVars().ConnectionID > 0 {
+				return errors.Trace(errQueryInterrupted)
+			}
 			return nil
 		}
 		r.selectResp = new(tipb.SelectResponse)

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -1503,7 +1503,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 			processedKeys = 1
 		}
 		currentScanRatio := execDetail.ScanDetail.RocksdbKeySkippedCount / uint64(processedKeys)
-		if currentScanRatio > expensiveRatio {
+		if currentScanRatio >= expensiveRatio {
 			isExpensiveScan = true
 			execDetail.ScanExpensiveRatio = currentScanRatio
 		}

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -1480,6 +1480,10 @@ func resetCTEStorageMap(se sessionctx.Context) error {
 // LogSlowQuery is used to print the slow query in the log files.
 func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 	sessVars := a.Ctx.GetSessionVars()
+	// Disable recording the internal queries.
+	if sessVars.ConnectionID == 0 {
+		return
+	}
 	stmtCtx := sessVars.StmtCtx
 	level := log.GetLevel()
 	cfg := config.GetGlobalConfig()

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -386,6 +386,12 @@ var defaultSysVars = []*SysVar{
 	}, GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Instance.SlowThreshold), 10), nil
 	}},
+	{Scope: ScopeInstance, Name: TiDBExpensiveScanRatio, Value: strconv.Itoa(logutil.DefaultExpensiveScanRatio), Type: TypeInt, MinValue: -1, MaxValue: math.MaxInt64, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+		atomic.StoreUint64(&config.GetGlobalConfig().Instance.ExpensiveScanRatio, uint64(TidbOptInt64(val, logutil.DefaultExpensiveScanRatio)))
+		return nil
+	}, GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Instance.ExpensiveQueryTimeThreshold), 10), nil
+	}},
 	{Scope: ScopeInstance, Name: TiDBRecordPlanInSlowLog, Value: int32ToBoolStr(logutil.DefaultRecordPlanInSlowLog), Type: TypeBool, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		atomic.StoreUint32(&config.GetGlobalConfig().Instance.RecordPlanInSlowLog, uint32(TidbOptInt64(val, logutil.DefaultRecordPlanInSlowLog)))
 		return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -386,11 +386,17 @@ var defaultSysVars = []*SysVar{
 	}, GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Instance.SlowThreshold), 10), nil
 	}},
-	{Scope: ScopeInstance, Name: TiDBExpensiveScanRatio, Value: strconv.Itoa(logutil.DefaultExpensiveScanRatio), Type: TypeInt, MinValue: -1, MaxValue: math.MaxInt64, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
-		atomic.StoreUint64(&config.GetGlobalConfig().Instance.ExpensiveScanRatio, uint64(TidbOptInt64(val, logutil.DefaultExpensiveScanRatio)))
+	{Scope: ScopeInstance, Name: TiDBInefficientScanRatio, Value: strconv.Itoa(logutil.DefaultInefficientScanRatio), Type: TypeInt, MinValue: -1, MaxValue: math.MaxInt64, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+		atomic.StoreUint64(&config.GetGlobalConfig().Instance.InefficientScanRatio, uint64(TidbOptInt64(val, logutil.DefaultInefficientScanRatio)))
 		return nil
 	}, GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
-		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Instance.ExpensiveQueryTimeThreshold), 10), nil
+		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Instance.InefficientScanRatio), 10), nil
+	}},
+	{Scope: ScopeInstance, Name: TiDBInefficientScanNum, Value: strconv.Itoa(logutil.DefaultInefficientScanNum), Type: TypeInt, MinValue: -1, MaxValue: math.MaxInt64, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+		atomic.StoreUint64(&config.GetGlobalConfig().Instance.InefficientScanNum, uint64(TidbOptInt64(val, logutil.DefaultInefficientScanNum)))
+		return nil
+	}, GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Instance.InefficientScanNum), 10), nil
 	}},
 	{Scope: ScopeInstance, Name: TiDBRecordPlanInSlowLog, Value: int32ToBoolStr(logutil.DefaultRecordPlanInSlowLog), Type: TypeBool, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		atomic.StoreUint32(&config.GetGlobalConfig().Instance.RecordPlanInSlowLog, uint32(TidbOptInt64(val, logutil.DefaultRecordPlanInSlowLog)))

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -258,11 +258,11 @@ const (
 	// TiDBUseAlloc indicates whether the last statement used chunk alloc
 	TiDBUseAlloc = "last_sql_use_alloc"
 
-	// TiDBInefficientScanRatio indicates whether to print the query as slow query if mvcc scanned versions/
+	// TiDBInefficientScanRatio indicates to print the query as slow query if mvcc scanned versions/
 	// processed version is larger than the ratio value.
 	TiDBInefficientScanRatio = "tidb_inefficient_scan_ratio"
 
-	// TiDBInefficientScanNum indicates whether to print the query as slow query if mvcc scanned versions
+	// TiDBInefficientScanNum indicates to print the query as slow query if mvcc scanned versions
 	// is larger than the threshold number.
 	TiDBInefficientScanNum = "tidb_inefficient_scan_num"
 )

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -258,9 +258,13 @@ const (
 	// TiDBUseAlloc indicates whether the last statement used chunk alloc
 	TiDBUseAlloc = "last_sql_use_alloc"
 
-	// TiDBExpensiveScanRatio indicates whether to print the query as slow query if mvcc scanned versions/
+	// TiDBInefficientScanRatio indicates whether to print the query as slow query if mvcc scanned versions/
 	// processed version is larger than the ratio value.
-	TiDBExpensiveScanRatio = "tidb_expensive_scan_ratio"
+	TiDBInefficientScanRatio = "tidb_inefficient_scan_ratio"
+
+	// TiDBInefficientScanNum indicates whether to print the query as slow query if mvcc scanned versions
+	// is larger than the threshold number.
+	TiDBInefficientScanNum = "tidb_inefficient_scan_num"
 )
 
 // TiDB system variable names that both in session and global scope.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -257,6 +257,10 @@ const (
 
 	// TiDBUseAlloc indicates whether the last statement used chunk alloc
 	TiDBUseAlloc = "last_sql_use_alloc"
+
+	// TiDBExpensiveScanRatio indicates whether to print the query as slow query if mvcc scanned versions/
+	// processed version is larger than the ratio value.
+	TiDBExpensiveScanRatio = "tidb_expensive_scan_ratio"
 )
 
 // TiDB system variable names that both in session and global scope.

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -35,13 +35,14 @@ import (
 // ExecDetails contains execution detail information.
 type ExecDetails struct {
 	DetailsNeedP90
-	CommitDetail         *util.CommitDetails
-	LockKeysDetail       *util.LockKeysDetails
-	ScanDetail           *util.ScanDetail
-	CopTime              time.Duration
-	BackoffTime          time.Duration
-	LockKeysDuration     time.Duration
-	RequestCount         int
+	CommitDetail     *util.CommitDetails
+	LockKeysDetail   *util.LockKeysDetails
+	ScanDetail       *util.ScanDetail
+	CopTime          time.Duration
+	BackoffTime      time.Duration
+	LockKeysDuration time.Duration
+	RequestCount     int
+	// InEfficientScanRatio is initialized in `LogSlowQuery` function.
 	InEfficientScanRatio uint64
 }
 

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -35,13 +35,14 @@ import (
 // ExecDetails contains execution detail information.
 type ExecDetails struct {
 	DetailsNeedP90
-	CommitDetail     *util.CommitDetails
-	LockKeysDetail   *util.LockKeysDetails
-	ScanDetail       *util.ScanDetail
-	CopTime          time.Duration
-	BackoffTime      time.Duration
-	LockKeysDuration time.Duration
-	RequestCount     int
+	CommitDetail       *util.CommitDetails
+	LockKeysDetail     *util.LockKeysDetails
+	ScanDetail         *util.ScanDetail
+	CopTime            time.Duration
+	BackoffTime        time.Duration
+	LockKeysDuration   time.Duration
+	RequestCount       int
+	ScanExpensiveRatio uint64
 }
 
 // DetailsNeedP90 contains execution detail information which need calculate P90.
@@ -177,6 +178,8 @@ const (
 	RocksdbBlockReadByteStr = "Rocksdb_block_read_byte"
 	// RocksdbBlockReadTimeStr means the time spent on rocksdb block read.
 	RocksdbBlockReadTimeStr = "Rocksdb_block_read_time"
+	// ScanExpensiveRatio is the ratio of total iterated keys and processed keys.
+	ScanExpensiveRatio = "Scan_expensive_ratio"
 )
 
 // String implements the fmt.Stringer interface.
@@ -291,6 +294,9 @@ func (d ExecDetails) String() string {
 		if scanDetail.RocksdbBlockReadDuration > 0 {
 			parts = append(parts, RocksdbBlockReadTimeStr+": "+strconv.FormatFloat(scanDetail.RocksdbBlockReadDuration.Seconds(), 'f', 3, 64))
 		}
+	}
+	if d.ScanExpensiveRatio > 0 {
+		parts = append(parts, ScanExpensiveRatio+": "+strconv.FormatUint(d.ScanExpensiveRatio, 10))
 	}
 	return strings.Join(parts, " ")
 }

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -35,14 +35,14 @@ import (
 // ExecDetails contains execution detail information.
 type ExecDetails struct {
 	DetailsNeedP90
-	CommitDetail       *util.CommitDetails
-	LockKeysDetail     *util.LockKeysDetails
-	ScanDetail         *util.ScanDetail
-	CopTime            time.Duration
-	BackoffTime        time.Duration
-	LockKeysDuration   time.Duration
-	RequestCount       int
-	ScanExpensiveRatio uint64
+	CommitDetail         *util.CommitDetails
+	LockKeysDetail       *util.LockKeysDetails
+	ScanDetail           *util.ScanDetail
+	CopTime              time.Duration
+	BackoffTime          time.Duration
+	LockKeysDuration     time.Duration
+	RequestCount         int
+	InEfficientScanRatio uint64
 }
 
 // DetailsNeedP90 contains execution detail information which need calculate P90.
@@ -295,8 +295,8 @@ func (d ExecDetails) String() string {
 			parts = append(parts, RocksdbBlockReadTimeStr+": "+strconv.FormatFloat(scanDetail.RocksdbBlockReadDuration.Seconds(), 'f', 3, 64))
 		}
 	}
-	if d.ScanExpensiveRatio > 0 {
-		parts = append(parts, ScanExpensiveRatio+": "+strconv.FormatUint(d.ScanExpensiveRatio, 10))
+	if d.InEfficientScanRatio > 0 {
+		parts = append(parts, ScanExpensiveRatio+": "+strconv.FormatUint(d.InEfficientScanRatio, 10))
 	}
 	return strings.Join(parts, " ")
 }

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -178,8 +178,8 @@ const (
 	RocksdbBlockReadByteStr = "Rocksdb_block_read_byte"
 	// RocksdbBlockReadTimeStr means the time spent on rocksdb block read.
 	RocksdbBlockReadTimeStr = "Rocksdb_block_read_time"
-	// ScanExpensiveRatio is the ratio of total iterated keys and processed keys.
-	ScanExpensiveRatio = "Scan_expensive_ratio"
+	// InEfficientScanRatio is the ratio of total iterated keys and processed keys.
+	InEfficientScanRatio = "Inefficient_scan_ratio"
 )
 
 // String implements the fmt.Stringer interface.
@@ -296,7 +296,7 @@ func (d ExecDetails) String() string {
 		}
 	}
 	if d.InEfficientScanRatio > 0 {
-		parts = append(parts, ScanExpensiveRatio+": "+strconv.FormatUint(d.InEfficientScanRatio, 10))
+		parts = append(parts, InEfficientScanRatio+": "+strconv.FormatUint(d.InEfficientScanRatio, 10))
 	}
 	return strings.Join(parts, " ")
 }

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -45,7 +45,7 @@ const (
 	// DefaultTiDBEnableSlowLog enables TiDB to log slow queries.
 	DefaultTiDBEnableSlowLog = true
 	// DefaultExpensiveScanRatio is the ratio of iterated keys and processed keys.
-	DefaultExpensiveScanRatio = 20
+	DefaultExpensiveScanRatio = 100
 )
 
 // EmptyFileLogConfig is an empty FileLogConfig.

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -43,7 +43,8 @@ const (
 	// DefaultRecordPlanInSlowLog is the default value for whether enable log query plan in the slow log.
 	DefaultRecordPlanInSlowLog = 1
 	// DefaultTiDBEnableSlowLog enables TiDB to log slow queries.
-	DefaultTiDBEnableSlowLog = true
+	DefaultTiDBEnableSlowLog  = true
+	DefaultExpensiveScanRatio = 20
 )
 
 // EmptyFileLogConfig is an empty FileLogConfig.

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -44,8 +44,10 @@ const (
 	DefaultRecordPlanInSlowLog = 1
 	// DefaultTiDBEnableSlowLog enables TiDB to log slow queries.
 	DefaultTiDBEnableSlowLog = true
-	// DefaultExpensiveScanRatio is the ratio of iterated keys and processed keys.
-	DefaultExpensiveScanRatio = 100
+	// DefaultInefficientScanRatio is the ratio of iterated keys and processed keys when a scan is regarded as inefficient.
+	DefaultInefficientScanRatio = 100
+	// DefaultInefficientScanNum is the number of mvcc keys scanned when a scan is regarded as inefficient.
+	DefaultInefficientScanNum = 10000
 )
 
 // EmptyFileLogConfig is an empty FileLogConfig.

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -47,7 +47,7 @@ const (
 	// DefaultInefficientScanRatio is the ratio of iterated keys and processed keys when a scan is regarded as inefficient.
 	DefaultInefficientScanRatio = 100
 	// DefaultInefficientScanNum is the number of mvcc keys scanned when a scan is regarded as inefficient.
-	DefaultInefficientScanNum = 10000
+	DefaultInefficientScanNum = 100000
 )
 
 // EmptyFileLogConfig is an empty FileLogConfig.

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -43,7 +43,8 @@ const (
 	// DefaultRecordPlanInSlowLog is the default value for whether enable log query plan in the slow log.
 	DefaultRecordPlanInSlowLog = 1
 	// DefaultTiDBEnableSlowLog enables TiDB to log slow queries.
-	DefaultTiDBEnableSlowLog  = true
+	DefaultTiDBEnableSlowLog = true
+	// DefaultExpensiveScanRatio is the ratio of iterated keys and processed keys.
 	DefaultExpensiveScanRatio = 20
 )
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #48947


Problem Summary:
Record the expensive scan queries in the slow log. Adding a new system varible `tidb_expensive_scan_ratio` to config the expensive scan ratio. It works seperately with the slow log theshold.

For example
```
...
# Query_time: 0.007010543  // The threshold is 300ms
...
# Cop_time: 0.004936477 Wait_time: 0.001 Request_count: 1 Process_keys: 4 Total_keys: 20 Get_snapshot_time: 0.001 Rocksdb_delete_skipped_count: 1 Rocksdb_key_skipped_count: 25 Rocksdb_block_cache_hit_count: 1 Scan_expensive_ratio: 6
...
select * from t;
```
When set to `6`, the `select * from t` is regarded as expensive scan.
Here the `Rocksdb_key_skipped_count` is `25` and  `Process_keys` is `4`.

Note it works for `SELECT` statments with coprocessor tasks only in this PR by now, the `point get` and `batch point get` expensive scan could not be recorded yet.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->


- [ ] Manual test (add detailed scripts or steps below)


Side effects



Documentation

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
