### PR TITLE
*: fix return 1 topn when to set 0 topn in analyzeOption

### DIFF
--- a/pkg/planner/cardinality/testdata/cardinality_suite_out.json
+++ b/pkg/planner/cardinality/testdata/cardinality_suite_out.json
@@ -198,8 +198,8 @@
       {
         "SQL": "explain format = 'brief' select * from t where a > 800 and a < 1000",
         "Result": [
-          "TableReader 793.13 root  data:Selection",
-          "└─Selection 793.13 cop[tikv]  gt(test.t.a, 800), lt(test.t.a, 1000)",
+          "TableReader 793.20 root  data:Selection",
+          "└─Selection 793.20 cop[tikv]  gt(test.t.a, 800), lt(test.t.a, 1000)",
           "  └─TableFullScan 2000.00 cop[tikv] table:t keep order:false"
         ]
       },

--- a/pkg/planner/cardinality/testdata/cardinality_suite_out.json
+++ b/pkg/planner/cardinality/testdata/cardinality_suite_out.json
@@ -206,8 +206,8 @@
       {
         "SQL": "explain format = 'brief' select * from t where a > 900 and a < 1000",
         "Result": [
-          "TableReader 458.12 root  data:Selection",
-          "└─Selection 458.12 cop[tikv]  gt(test.t.a, 900), lt(test.t.a, 1000)",
+          "TableReader 458.19 root  data:Selection",
+          "└─Selection 458.19 cop[tikv]  gt(test.t.a, 900), lt(test.t.a, 1000)",
           "  └─TableFullScan 2000.00 cop[tikv] table:t keep order:false"
         ]
       },

--- a/pkg/planner/cardinality/testdata/cardinality_suite_out.json
+++ b/pkg/planner/cardinality/testdata/cardinality_suite_out.json
@@ -230,8 +230,8 @@
       {
         "SQL": "explain format = 'brief' select * from t where a > 100 and a < 300",
         "Result": [
-          "TableReader 832.77 root  data:Selection",
-          "└─Selection 832.77 cop[tikv]  gt(test.t.a, 100), lt(test.t.a, 300)",
+          "TableReader 834.45 root  data:Selection",
+          "└─Selection 834.45 cop[tikv]  gt(test.t.a, 100), lt(test.t.a, 300)",
           "  └─TableFullScan 2000.00 cop[tikv] table:t keep order:false"
         ]
       },

--- a/pkg/planner/cardinality/testdata/cardinality_suite_out.json
+++ b/pkg/planner/cardinality/testdata/cardinality_suite_out.json
@@ -222,8 +222,8 @@
       {
         "SQL": "explain format = 'brief' select * from t where a > 200 and a < 300",
         "Result": [
-          "TableReader 458.12 root  data:Selection",
-          "└─Selection 458.12 cop[tikv]  gt(test.t.a, 200), lt(test.t.a, 300)",
+          "TableReader 459.03 root  data:Selection",
+          "└─Selection 459.03 cop[tikv]  gt(test.t.a, 200), lt(test.t.a, 300)",
           "  └─TableFullScan 2000.00 cop[tikv] table:t keep order:false"
         ]
       },

--- a/pkg/planner/cardinality/testdata/cardinality_suite_out.json
+++ b/pkg/planner/cardinality/testdata/cardinality_suite_out.json
@@ -214,8 +214,8 @@
       {
         "SQL": "explain format = 'brief' select * from t where a > 900 and a < 1100",
         "Result": [
-          "TableReader 832.49 root  data:Selection",
-          "└─Selection 832.49 cop[tikv]  gt(test.t.a, 900), lt(test.t.a, 1100)",
+          "TableReader 832.77 root  data:Selection",
+          "└─Selection 832.77 cop[tikv]  gt(test.t.a, 900), lt(test.t.a, 1100)",
           "  └─TableFullScan 2000.00 cop[tikv] table:t keep order:false"
         ]
       },
@@ -230,8 +230,8 @@
       {
         "SQL": "explain format = 'brief' select * from t where a > 100 and a < 300",
         "Result": [
-          "TableReader 832.49 root  data:Selection",
-          "└─Selection 832.49 cop[tikv]  gt(test.t.a, 100), lt(test.t.a, 300)",
+          "TableReader 832.77 root  data:Selection",
+          "└─Selection 832.77 cop[tikv]  gt(test.t.a, 100), lt(test.t.a, 300)",
           "  └─TableFullScan 2000.00 cop[tikv] table:t keep order:false"
         ]
       },

--- a/pkg/statistics/builder.go
+++ b/pkg/statistics/builder.go
@@ -313,7 +313,9 @@ func BuildHistAndTopN(
 		if isColumn {
 			corrXYSum += float64(i) * float64(samples[i].Ordinal)
 		}
-
+		if numTopN == 0 {
+			continue
+		}
 		sampleBytes, err := getComparedBytes(samples[i].Value)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
@@ -358,7 +360,7 @@ func BuildHistAndTopN(
 
 	// Handle the counting for the last value. Basically equal to the case 2 above.
 	// now topn is empty: append the "current" count directly
-	if len(topNList) == 0 {
+	if len(topNList) == 0 && numTopN != 0 {
 		topNList = append(topNList, TopNMeta{Encoded: cur, Count: uint64(curCnt)})
 	} else if len(topNList) < numTopN || uint64(curCnt) > topNList[len(topNList)-1].Count {
 		// now topn is not full, or the "current" count is larger than the least count in the topn: need to find a slot to insert the "current"
@@ -379,55 +381,57 @@ func BuildHistAndTopN(
 	topNList = pruneTopNItem(topNList, ndv, nullCount, sampleNum, count)
 
 	// Step2: exclude topn from samples
-	for i := int64(0); i < int64(len(samples)); i++ {
-		sampleBytes, err := getComparedBytes(samples[i].Value)
-		if err != nil {
-			return nil, nil, errors.Trace(err)
-		}
-		// For debugging invalid sample data.
-		var (
-			foundTwice      bool
-			firstTimeSample types.Datum
-		)
-		for j := 0; j < len(topNList); j++ {
-			if bytes.Equal(sampleBytes, topNList[j].Encoded) {
-				// This should never happen, but we met this panic before, so we add this check here.
-				// See: https://github.com/pingcap/tidb/issues/35948
-				if foundTwice {
-					datumString, err := firstTimeSample.ToString()
-					if err != nil {
-						statslogutil.StatsLogger.Error("try to convert datum to string failed", zap.Error(err))
-					}
+	if numTopN != 0 {
+		for i := int64(0); i < int64(len(samples)); i++ {
+			sampleBytes, err := getComparedBytes(samples[i].Value)
+			if err != nil {
+				return nil, nil, errors.Trace(err)
+			}
+			// For debugging invalid sample data.
+			var (
+				foundTwice      bool
+				firstTimeSample types.Datum
+			)
+			for j := 0; j < len(topNList); j++ {
+				if bytes.Equal(sampleBytes, topNList[j].Encoded) {
+					// This should never happen, but we met this panic before, so we add this check here.
+					// See: https://github.com/pingcap/tidb/issues/35948
+					if foundTwice {
+						datumString, err := firstTimeSample.ToString()
+						if err != nil {
+							statslogutil.StatsLogger.Error("try to convert datum to string failed", zap.Error(err))
+						}
 
-					statslogutil.StatsLogger.Warn(
-						"invalid sample data",
-						zap.Bool("isColumn", isColumn),
-						zap.Int64("columnID", id),
-						zap.String("datum", datumString),
-						zap.Binary("sampleBytes", sampleBytes),
-						zap.Binary("topNBytes", topNList[j].Encoded),
-					)
-					// NOTE: if we don't return here, we may meet panic in the following code.
-					// The i may decrease to a negative value.
-					// We haven't fix the issue here, because we don't know how to
-					// remove the invalid sample data from the samples.
-					break
+						statslogutil.StatsLogger.Warn(
+							"invalid sample data",
+							zap.Bool("isColumn", isColumn),
+							zap.Int64("columnID", id),
+							zap.String("datum", datumString),
+							zap.Binary("sampleBytes", sampleBytes),
+							zap.Binary("topNBytes", topNList[j].Encoded),
+						)
+						// NOTE: if we don't return here, we may meet panic in the following code.
+						// The i may decrease to a negative value.
+						// We haven't fix the issue here, because we don't know how to
+						// remove the invalid sample data from the samples.
+						break
+					}
+					// First time to find the same value in topN: need to record the sample data for debugging.
+					firstTimeSample = samples[i].Value
+					// Found the same value in topn: need to skip over this value in samples.
+					copy(samples[i:], samples[uint64(i)+topNList[j].Count:])
+					samples = samples[:uint64(len(samples))-topNList[j].Count]
+					i--
+					foundTwice = true
+					continue
 				}
-				// First time to find the same value in topN: need to record the sample data for debugging.
-				firstTimeSample = samples[i].Value
-				// Found the same value in topn: need to skip over this value in samples.
-				copy(samples[i:], samples[uint64(i)+topNList[j].Count:])
-				samples = samples[:uint64(len(samples))-topNList[j].Count]
-				i--
-				foundTwice = true
-				continue
 			}
 		}
+		for i := 0; i < len(topNList); i++ {
+			topNList[i].Count *= uint64(sampleFactor)
+		}
 	}
 
-	for i := 0; i < len(topNList); i++ {
-		topNList[i].Count *= uint64(sampleFactor)
-	}
 	topn := &TopN{TopN: topNList}
 
 	if uint64(count) <= topn.TotalCount() || int(hg.NDV) <= len(topn.TopN) {
@@ -451,7 +455,7 @@ func BuildHistAndTopN(
 //	We assume that the ones not in the top-n list's selectivity is 1/remained_ndv which is the internal implementation of EqualRowCount
 func pruneTopNItem(topns []TopNMeta, ndv, nullCount, sampleRows, totalRows int64) []TopNMeta {
 	// If the sampleRows holds all rows, or NDV of samples equals to actual NDV, we just return the TopN directly.
-	if sampleRows == totalRows || totalRows <= 1 || int64(len(topns)) >= ndv {
+	if sampleRows == totalRows || totalRows <= 1 || int64(len(topns)) >= ndv || len(topns) == 0 {
 		return topns
 	}
 	// Sum the occurrence except the least common one from the top-n list. To check whether the lest common one is worth

--- a/pkg/statistics/builder.go
+++ b/pkg/statistics/builder.go
@@ -360,21 +360,23 @@ func BuildHistAndTopN(
 
 	// Handle the counting for the last value. Basically equal to the case 2 above.
 	// now topn is empty: append the "current" count directly
-	if len(topNList) == 0 && numTopN != 0 {
-		topNList = append(topNList, TopNMeta{Encoded: cur, Count: uint64(curCnt)})
-	} else if len(topNList) < numTopN || uint64(curCnt) > topNList[len(topNList)-1].Count {
-		// now topn is not full, or the "current" count is larger than the least count in the topn: need to find a slot to insert the "current"
-		j := len(topNList)
-		for ; j > 0; j-- {
-			if uint64(curCnt) < topNList[j-1].Count {
-				break
+	if numTopN != 0 {
+		if len(topNList) == 0 {
+			topNList = append(topNList, TopNMeta{Encoded: cur, Count: uint64(curCnt)})
+		} else if len(topNList) < numTopN || uint64(curCnt) > topNList[len(topNList)-1].Count {
+			// now topn is not full, or the "current" count is larger than the least count in the topn: need to find a slot to insert the "current"
+			j := len(topNList)
+			for ; j > 0; j-- {
+				if uint64(curCnt) < topNList[j-1].Count {
+					break
+				}
 			}
-		}
-		topNList = append(topNList, TopNMeta{})
-		copy(topNList[j+1:], topNList[j:])
-		topNList[j] = TopNMeta{Encoded: cur, Count: uint64(curCnt)}
-		if len(topNList) > numTopN {
-			topNList = topNList[:numTopN]
+			topNList = append(topNList, TopNMeta{})
+			copy(topNList[j+1:], topNList[j:])
+			topNList[j] = TopNMeta{Encoded: cur, Count: uint64(curCnt)}
+			if len(topNList) > numTopN {
+				topNList = topNList[:numTopN]
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/49080

Problem Summary:

### What changed and how does it work?

as described in the issue. we make 0 topn to return empty topn.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
