### PR TITLE
util/memory: use atomic.Pointer instead of atomic.Value for byteLimits

### DIFF
--- a/pkg/util/memory/tracker.go
+++ b/pkg/util/memory/tracker.go
@@ -72,7 +72,7 @@ var (
 // The actions that could be triggered are: SpillDiskAction, SortAndSpillDiskAction, rateLimitAction,
 // PanicOnExceed, globalPanicOnExceed, LogOnExceed.
 type Tracker struct {
-	bytesLimit           atomic.Value
+	bytesLimit           atomic.Pointer[bytesLimits]
 	actionMuForHardLimit actionMu
 	actionMuForSoftLimit actionMu
 	Killer               *sqlkiller.SQLKiller
@@ -177,7 +177,7 @@ func NewGlobalTracker(label int, bytesLimit int64) *Tracker {
 // CheckBytesLimit check whether the bytes limit of the tracker is equal to a value.
 // Only used in test.
 func (t *Tracker) CheckBytesLimit(val int64) bool {
-	return t.bytesLimit.Load().(*bytesLimits).bytesHardLimit == val
+	return t.bytesLimit.Load().bytesHardLimit == val
 }
 
 // SetBytesLimit sets the bytes limit for this tracker.
@@ -192,12 +192,12 @@ func (t *Tracker) SetBytesLimit(bytesLimit int64) {
 // GetBytesLimit gets the bytes limit for this tracker.
 // "bytesHardLimit <= 0" means no limit.
 func (t *Tracker) GetBytesLimit() int64 {
-	return t.bytesLimit.Load().(*bytesLimits).bytesHardLimit
+	return t.bytesLimit.Load().bytesHardLimit
 }
 
 // CheckExceed checks whether the consumed bytes is exceed for this tracker.
 func (t *Tracker) CheckExceed() bool {
-	bytesHardLimit := t.bytesLimit.Load().(*bytesLimits).bytesHardLimit
+	bytesHardLimit := t.bytesLimit.Load().bytesHardLimit
 	return atomic.LoadInt64(&t.bytesConsumed) >= bytesHardLimit && bytesHardLimit > 0
 }
 
@@ -406,7 +406,7 @@ func (t *Tracker) Consume(bs int64) {
 		}
 		bytesConsumed := atomic.AddInt64(&tracker.bytesConsumed, bs)
 		bytesReleased := atomic.LoadInt64(&tracker.bytesReleased)
-		limits := tracker.bytesLimit.Load().(*bytesLimits)
+		limits := tracker.bytesLimit.Load()
 		if bytesConsumed+bytesReleased >= limits.bytesHardLimit && limits.bytesHardLimit > 0 {
 			rootExceed = tracker
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tidb/issues/44736

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > Current Tests have already covered, so no need to add more tests.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
