### PR TITLE
server: make `clientConn()` thread-safe

### DIFF
--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -2091,5 +2091,4 @@ func TestCloseConn(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	require.Equalf(t, int32(1), cc.isClosed, "Expected isClosed to be 1, got 0")
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #48224, #36793 and #32110

Problem Summary:

### What changed and how does it work?

Please check https://github.com/pingcap/tidb/issues/36793#issuecomment-1823563911 for more details and context:

> But for further enhancement, we cloud still try to make [closeConn](https://github.com/pingcap/tidb/blob/3f94666b4bafd903886b89206ac603d26d9a9e87/pkg/server/conn.go#L352-L354) thread-safe.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- None

Documentation

- None

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
