### PR TITLE
Revert "server: Set default drainClientWait as 15s (#42134) (#48944)"

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1111,8 +1111,6 @@ func (cc *clientConn) Run(ctx context.Context) {
 	// by CAS operation, it would then take some actions accordingly.
 	for {
 		// Close connection between txn when we are going to shutdown server.
-		// Note the current implementation when shutting down, for an idle connection, the connection may block at readPacket()
-		// consider provider a way to close the connection directly after sometime if we can not read any data.
 		if cc.server.inShutdownMode.Load() {
 			if !cc.ctx.GetSessionVars().InTxn() {
 				return

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -836,15 +836,17 @@ func closeDomainAndStorage(storage kv.Storage, dom *domain.Domain) {
 	terror.Log(errors.Trace(err))
 }
 
-// The amount of time we wait for the ongoing txt to finished.
-// We should better provider a dynamic way to set this value.
 var gracefulCloseConnectionsTimeout = 15 * time.Second
 
-func cleanup(svr *server.Server, storage kv.Storage, dom *domain.Domain, _ bool) {
+func cleanup(svr *server.Server, storage kv.Storage, dom *domain.Domain, graceful bool) {
 	dom.StopAutoAnalyze()
 
-	drainClientWait := gracefulCloseConnectionsTimeout
-
+	var drainClientWait time.Duration
+	if graceful {
+		drainClientWait = 1<<63 - 1
+	} else {
+		drainClientWait = gracefulCloseConnectionsTimeout
+	}
 	cancelClientWait := time.Second * 1
 	svr.DrainClients(drainClientWait, cancelClientWait)
 


### PR DESCRIPTION
This reverts commit 877198dde22010e428be26aa0d7bdc5aab75d629.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/49098

Problem Summary:
https://github.com/pingcap/tidb/pull/32111 causes too many problems, so we decided to revert it in v6.5.6 and merge https://github.com/pingcap/tidb/pull/49073 to v6.5.6.

### What changed and how does it work?
Revert PR.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
