### PR TITLE
stmtctx: remove OverflowAsWarning flag

### DIFF
--- a/br/pkg/lightning/backend/kv/session.go
+++ b/br/pkg/lightning/backend/kv/session.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
-	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/topsql/stmtstats"
 	"go.uber.org/zap"
 )
@@ -287,7 +286,6 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 	vars.StmtCtx.InInsertStmt = true
 	vars.StmtCtx.BatchCheck = true
 	vars.StmtCtx.BadNullAsWarning = !sqlMode.HasStrictMode()
-	vars.StmtCtx.OverflowAsWarning = !sqlMode.HasStrictMode()
 	vars.SQLMode = sqlMode
 
 	typeFlags := vars.StmtCtx.TypeFlags().
@@ -315,7 +313,6 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 		}
 	}
 	vars.StmtCtx.SetTimeZone(vars.Location())
-	vars.StmtCtx.SetTypeFlags(types.StrictFlags)
 	if err := vars.SetSystemVar("timestamp", strconv.FormatInt(options.Timestamp, 10)); err != nil {
 		logger.Warn("new session: failed to set timestamp",
 			log.ShortError(err))

--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -165,7 +165,6 @@ func initSessCtx(
 	}
 	sessCtx.GetSessionVars().StmtCtx.SetTimeZone(sessCtx.GetSessionVars().Location())
 	sessCtx.GetSessionVars().StmtCtx.BadNullAsWarning = !sqlMode.HasStrictMode()
-	sessCtx.GetSessionVars().StmtCtx.OverflowAsWarning = !sqlMode.HasStrictMode()
 	sessCtx.GetSessionVars().StmtCtx.DividedByZeroAsWarning = !sqlMode.HasStrictMode()
 
 	typeFlags := types.StrictFlags.
@@ -196,7 +195,6 @@ func restoreSessCtx(sessCtx sessionctx.Context) func(sessCtx sessionctx.Context)
 		timezone = &tz
 	}
 	badNullAsWarn := sv.StmtCtx.BadNullAsWarning
-	overflowAsWarn := sv.StmtCtx.OverflowAsWarning
 	dividedZeroAsWarn := sv.StmtCtx.DividedByZeroAsWarning
 	typeFlags := sv.StmtCtx.TypeFlags()
 	resGroupName := sv.ResourceGroupName
@@ -206,7 +204,6 @@ func restoreSessCtx(sessCtx sessionctx.Context) func(sessCtx sessionctx.Context)
 		uv.SQLMode = sqlMode
 		uv.TimeZone = timezone
 		uv.StmtCtx.BadNullAsWarning = badNullAsWarn
-		uv.StmtCtx.OverflowAsWarning = overflowAsWarn
 		uv.StmtCtx.DividedByZeroAsWarning = dividedZeroAsWarn
 		uv.StmtCtx.SetTypeFlags(typeFlags)
 		uv.ResourceGroupName = resGroupName

--- a/pkg/errctx/context.go
+++ b/pkg/errctx/context.go
@@ -176,6 +176,4 @@ func init() {
 	for _, errCode := range truncateErrCodes {
 		errGroupMap[errCode] = ErrGroupTruncate
 	}
-
-	errGroupMap[errno.ErrDataOutOfRange] = ErrGroupOverflow
 }

--- a/pkg/errctx/context_test.go
+++ b/pkg/errctx/context_test.go
@@ -38,7 +38,7 @@ func TestContext(t *testing.T) {
 	require.Equal(t, ctx.HandleErrorWithAlias(testInternalErr, testErr, testWarn), testErr)
 
 	// set level to "warn"
-	newCtx := ctx.WithErrGroupLevel(errctx.ErrGroupOverflow, errctx.LevelWarn)
+	newCtx := ctx.WithErrGroupLevel(errctx.ErrGroupTruncate, errctx.LevelWarn)
 	// ctx is not affected
 	require.Equal(t, ctx.HandleErrorWithAlias(testInternalErr, testErr, testWarn), testErr)
 	// newCtx will handle the error as a warn

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2116,8 +2116,6 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		// but should not make DupKeyAsWarning.
 		sc.DupKeyAsWarning = stmt.IgnoreErr
 		sc.BadNullAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
-		// see https://dev.mysql.com/doc/refman/8.0/en/out-of-range-and-overflow.html
-		sc.OverflowAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 		sc.IgnoreNoPartition = stmt.IgnoreErr
 		sc.ErrAutoincReadFailedAsWarning = stmt.IgnoreErr
 		sc.DividedByZeroAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
@@ -2144,12 +2142,6 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	case *ast.SelectStmt:
 		sc.InSelectStmt = true
 
-		// see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-strict
-		// said "For statements such as SELECT that do not change data, invalid values
-		// generate a warning in strict mode, not an error."
-		// and https://dev.mysql.com/doc/refman/5.7/en/out-of-range-and-overflow.html
-		sc.OverflowAsWarning = true
-
 		// Return warning for truncate error in selection.
 		sc.SetTypeFlags(sc.TypeFlags().
 			WithTruncateAsWarning(true).
@@ -2162,7 +2154,6 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.WeakConsistency = isWeakConsistencyRead(ctx, stmt)
 	case *ast.SetOprStmt:
 		sc.InSelectStmt = true
-		sc.OverflowAsWarning = true
 		sc.SetTypeFlags(sc.TypeFlags().
 			WithTruncateAsWarning(true).
 			WithIgnoreZeroInDate(true).

--- a/pkg/expression/builtin_arithmetic.go
+++ b/pkg/expression/builtin_arithmetic.go
@@ -843,7 +843,7 @@ func (s *builtinArithmeticIntDivideDecimalSig) evalInt(ctx EvalContext, row chun
 	}
 	if err == types.ErrOverflow {
 		newErr := errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c)
-		err = sc.HandleOverflow(newErr, newErr)
+		err = sc.HandleError(newErr)
 	}
 	if err != nil {
 		return 0, true, err

--- a/pkg/expression/builtin_arithmetic_vec.go
+++ b/pkg/expression/builtin_arithmetic_vec.go
@@ -620,7 +620,7 @@ func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(ctx EvalContext, input
 			err = sc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
 		} else if err == types.ErrOverflow {
 			newErr := errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c)
-			err = sc.HandleOverflow(newErr, newErr)
+			err = sc.HandleError(newErr)
 		}
 		if err != nil {
 			return err

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -542,7 +542,7 @@ func convertJSON2Tp(evalType types.EvalType) func(*stmtctx.StatementContext, typ
 				return nil, ErrInvalidJSONForFuncIndex
 			}
 			jsonToInt, err := types.ConvertJSONToInt(sc.TypeCtx(), item, mysql.HasUnsignedFlag(tp.GetFlag()), tp.GetType())
-			err = sc.HandleOverflow(err, err)
+			err = sc.HandleError(err)
 			if mysql.HasUnsignedFlag(tp.GetFlag()) {
 				return uint64(jsonToInt), err
 			}
@@ -705,7 +705,7 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row)
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, isNull, err
 }
 
@@ -790,7 +790,7 @@ func (b *builtinCastIntAsDurationSig) evalDuration(ctx EvalContext, row chunk.Ro
 	dur, err := types.NumberToDuration(val, b.tp.GetDecimal())
 	if err != nil {
 		if types.ErrOverflow.Equal(err) {
-			err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
+			err = ctx.GetSessionVars().StmtCtx.HandleError(err)
 		}
 		if types.ErrTruncatedWrongVal.Equal(err) {
 			err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
@@ -987,7 +987,7 @@ func (b *builtinCastRealAsIntSig) evalInt(ctx EvalContext, row chunk.Row) (res i
 		res = int64(uintVal)
 	}
 	if types.ErrOverflow.Equal(err) {
-		err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
+		err = ctx.GetSessionVars().StmtCtx.HandleError(err)
 	}
 	return res, isNull, err
 }
@@ -1012,7 +1012,7 @@ func (b *builtinCastRealAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row
 		err = res.FromFloat64(val)
 		if types.ErrOverflow.Equal(err) {
 			warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0])
-			err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
+			err = ctx.GetSessionVars().StmtCtx.HandleErrorWithAlias(err, err, warnErr)
 		} else if types.ErrTruncated.Equal(err) {
 			// This behavior is consistent with MySQL.
 			err = nil
@@ -1023,7 +1023,7 @@ func (b *builtinCastRealAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 
@@ -1136,7 +1136,7 @@ func (b *builtinCastDecimalAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 
@@ -1175,7 +1175,7 @@ func (b *builtinCastDecimalAsIntSig) evalInt(ctx EvalContext, row chunk.Row) (re
 
 	if types.ErrOverflow.Equal(err) {
 		warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", val)
-		err = ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
+		err = ctx.GetSessionVars().StmtCtx.HandleErrorWithAlias(err, err, warnErr)
 	}
 
 	return res, false, err
@@ -1343,7 +1343,7 @@ func (*builtinCastStringAsIntSig) handleOverflow(ctx EvalContext, origRes int64,
 			res = int64(uval)
 		}
 		warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("INTEGER", origStr)
-		err = sc.HandleOverflow(origErr, warnErr)
+		err = sc.HandleErrorWithAlias(origErr, origErr, warnErr)
 	}
 	return
 }
@@ -1461,7 +1461,7 @@ func (b *builtinCastStringAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.R
 		}
 	}
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 
@@ -1607,7 +1607,7 @@ func (b *builtinCastTimeAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), val.ToNumber(), b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 
@@ -1747,7 +1747,7 @@ func (b *builtinCastDurationAsDecimalSig) evalDecimal(ctx EvalContext, row chunk
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), val.ToNumber(), b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 
@@ -1850,7 +1850,7 @@ func (b *builtinCastJSONAsIntSig) evalInt(ctx EvalContext, row chunk.Row) (res i
 	}
 	sc := ctx.GetSessionVars().StmtCtx
 	res, err = types.ConvertJSONToInt64(sc.TypeCtx(), val, mysql.HasUnsignedFlag(b.tp.GetFlag()))
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return
 }
 
@@ -1895,7 +1895,7 @@ func (b *builtinCastJSONAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row
 		return res, false, err
 	}
 	res, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), res, b.tp)
-	err = sc.HandleOverflow(err, err)
+	err = sc.HandleError(err)
 	return res, false, err
 }
 

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -98,7 +98,6 @@ func TestCastFunctions(t *testing.T) {
 	defer func() {
 		sc.InSelectStmt = oldInSelectStmt
 	}()
-	sc.OverflowAsWarning = true
 
 	// cast('18446744073709551616' as unsigned);
 	tp1 := types.NewFieldTypeBuilder().SetType(mysql.TypeLonglong).SetFlag(mysql.BinaryFlag).SetFlen(mysql.MaxIntWidth).SetCharset(charset.CharsetBin).SetCollate(charset.CollationBin).BuildP()

--- a/pkg/expression/typeinfer_test.go
+++ b/pkg/expression/typeinfer_test.go
@@ -205,11 +205,11 @@ func (s *InferTypeSuite) createTestCase4Cast() []typeInferTestCase {
 		{"CAST(c_varchar AS DECIMAL)", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag, 10, 0},
 		{"CAST(\"123456789.0123456789\" AS DECIMAL)", mysql.TypeNewDecimal, charset.CharsetBin, mysql.NotNullFlag | mysql.BinaryFlag, 10, 0},          // TODO: flen should be 11.
 		{"CAST(\"123456789.0123456789\" AS DECIMAL(10,0))", mysql.TypeNewDecimal, charset.CharsetBin, mysql.NotNullFlag | mysql.BinaryFlag, 10, 0},    // TODO: flen should be 11.
-		{"CAST(\"123456789.0123456789\" AS DECIMAL(5,5))", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag, 5, 5},                          // TODO: flen should be 7. flag should be mysql.NotNullFlag | mysql.BinaryFlag.
-		{"CAST(\"123456789.0123456789\" AS DECIMAL(6,5))", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag, 6, 5},                          // TODO: flen should be 8. flag should be mysql.NotNullFlag | mysql.BinaryFlag.
+		{"CAST(\"123456789.0123456789\" AS DECIMAL(5,5))", mysql.TypeNewDecimal, charset.CharsetBin, mysql.NotNullFlag | mysql.BinaryFlag, 5, 5},      // TODO: flen should be 7.
+		{"CAST(\"123456789.0123456789\" AS DECIMAL(6,5))", mysql.TypeNewDecimal, charset.CharsetBin, mysql.NotNullFlag | mysql.BinaryFlag, 6, 5},      // TODO: flen should be 8.
 		{"CAST(\"-123456789.0123456789\" AS DECIMAL(64,30))", mysql.TypeNewDecimal, charset.CharsetBin, mysql.NotNullFlag | mysql.BinaryFlag, 64, 30}, // TODO: flen should be 66.
 		{"CAST(\"-123456789.0123456789\" AS DECIMAL(10,0))", mysql.TypeNewDecimal, charset.CharsetBin, mysql.NotNullFlag | mysql.BinaryFlag, 10, 0},   // TODO: flen should be 11.
-		{"CAST(\"-123456789.0123456789\" AS DECIMAL(5,5))", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag, 5, 5},                         // TODO: flen should be 7. flag should be mysql.NotNullFlag | mysql.BinaryFlag.
+		{"CAST(\"-123456789.0123456789\" AS DECIMAL(5,5))", mysql.TypeNewDecimal, charset.CharsetBin, mysql.NotNullFlag | mysql.BinaryFlag, 5, 5},     // TODO: flen should be 7.
 		{"CAST(c_int_d AS JSON)", mysql.TypeJSON, charset.CharsetUTF8MB4, mysql.BinaryFlag | mysql.ParseToJSONFlag, 12582912 / 3, 0},
 		{"CAST(c_int_d AS SIGNED)", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag, 22, 0},         // TODO: flen should be 11.
 		{"CAST(c_int_d AS SIGNED INTEGER)", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag, 22, 0}, // TODO: flen should be 11.

--- a/pkg/sessionctx/stmtctx/stmtctx_test.go
+++ b/pkg/sessionctx/stmtctx/stmtctx_test.go
@@ -94,15 +94,14 @@ func TestStatementContextPushDownFLags(t *testing.T) {
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.InDeleteStmt = true }), 16},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.InSelectStmt = true }), 32},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true)) }), 1},
-		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true)) }), 2},
-		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.OverflowAsWarning = true }), 64},
+		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true)) }), 66},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.SetTypeFlags(sc.TypeFlags().WithIgnoreZeroInDate(true)) }), 128},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.DividedByZeroAsWarning = true }), 256},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) { sc.InLoadDataStmt = true }), 1024},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) {
 			sc.InSelectStmt = true
 			sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true))
-		}), 34},
+		}), 98},
 		{newStmtCtx(func(sc *stmtctx.StatementContext) {
 			sc.DividedByZeroAsWarning = true
 			sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true))

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -353,7 +353,6 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 	}
 
 	err = sc.HandleTruncate(err)
-	err = sc.HandleOverflow(err, err)
 
 	if forceIgnoreTruncate {
 		err = nil

--- a/pkg/util/codec/codec_test.go
+++ b/pkg/util/codec/codec_test.go
@@ -786,7 +786,7 @@ func TestDecimal(t *testing.T) {
 	err = sc.HandleError(err)
 	require.NoError(t, err)
 
-	sc.OverflowAsWarning = true
+	sc.SetTypeFlags(types.DefaultStmtFlags.WithTruncateAsWarning(true))
 	decimalDatum.SetLength(12)
 	decimalDatum.SetFrac(10)
 	_, err = EncodeValue(sc.TimeZone(), nil, decimalDatum)

--- a/tests/integrationtest/r/ddl/integration.result
+++ b/tests/integrationtest/r/ddl/integration.result
@@ -91,3 +91,11 @@ rename table t to t1;
 Error 8242 (HY000): 'Rename Table' is unsupported on cache tables.
 alter table t nocache;
 drop table if exists t;
+drop table if exists t;
+create table t (d int default '18446744073709551616' );
+Error 1067 (42000): Invalid default value for 'd'
+set sql_mode='';
+create table t (d int default '18446744073709551616' );
+Level	Code	Message
+Warning	1690	BIGINT value is out of range in '18446744073709551616'
+set sql_mode=DEFAULT;

--- a/tests/integrationtest/r/executor/delete.result
+++ b/tests/integrationtest/r/executor/delete.result
@@ -107,3 +107,18 @@ id	data
 11	321
 22	322
 23	323
+drop table if exists t;
+create table t (id char(255));
+insert into t values ('18446744073709551616');
+delete from t where cast(id as unsigned) = 1;
+Error 1690 (22003): BIGINT value is out of range in '18446744073709551616'
+update t set id = '1' where cast(id as unsigned) = 1;
+Error 1690 (22003): BIGINT value is out of range in '18446744073709551616'
+set sql_mode=''
+delete from t where cast(id as unsigned) = 1;
+Level	Code	Message
+Warning	1292	Truncated incorrect INTEGER value: '18446744073709551616'
+update t set id = '1' where cast(id as unsigned) = 1;
+Level	Code	Message
+Warning	1292	Truncated incorrect INTEGER value: '18446744073709551616'
+set sql_mode=DEFAULT

--- a/tests/integrationtest/r/executor/insert.result
+++ b/tests/integrationtest/r/executor/insert.result
@@ -2131,3 +2131,13 @@ insert into t1 set c1 = 0.1 on duplicate key update c1 = 1;
 select * from t1 use index(primary);
 c1
 1.0000
+drop table if exists t;
+create table t (d int);
+insert into t values (cast('18446744073709551616' as unsigned));
+Error 1690 (22003): BIGINT UNSIGNED value is out of range in '18446744073709551616'
+set sql_mode='';
+insert into t values (cast('18446744073709551616' as unsigned));
+Level	Code	Message
+Warning	1264	Out of range value for column 'd' at row 1
+Warning	1292	Truncated incorrect INTEGER value: '18446744073709551616'
+set sql_mode=DEFAULT;

--- a/tests/integrationtest/t/ddl/integration.test
+++ b/tests/integrationtest/t/ddl/integration.test
@@ -73,3 +73,12 @@ rename table t to t1;
 alter table t nocache;
 drop table if exists t;
 
+# TestNonStrictCreateTableOverflowError
+drop table if exists t;
+-- error 1067
+create table t (d int default '18446744073709551616' );
+set sql_mode='';
+-- enable_warnings
+create table t (d int default '18446744073709551616' );
+-- disable_warnings
+set sql_mode=DEFAULT;

--- a/tests/integrationtest/t/executor/delete.test
+++ b/tests/integrationtest/t/executor/delete.test
@@ -97,4 +97,23 @@ delete t1, t2 from t1 inner join t2 inner join t3 where t1.id=t2.id and t2.id=t3
 --sorted_result
 select * from t3;
 
+# TestNonStrictDeleteUpdateOverflowExpression
+drop table if exists t;
+create table t (id char(255));
+insert into t values ('18446744073709551616');
+# TODO: the error and warning message is different between TiDB and TiKV. Fix it.
+-- replace_regex /BIGINT UNSIGNED/BIGINT/
+-- error 1690
+delete from t where cast(id as unsigned) = 1;
+-- replace_regex /BIGINT UNSIGNED/BIGINT/
+-- error 1690
+update t set id = '1' where cast(id as unsigned) = 1;
+set sql_mode=''
+-- enable_warnings
+-- replace_regex /evaluation failed: //
+delete from t where cast(id as unsigned) = 1;
+-- replace_regex /evaluation failed: //
+update t set id = '1' where cast(id as unsigned) = 1;
+-- disable_warnings
+set sql_mode=DEFAULT
 

--- a/tests/integrationtest/t/executor/insert.test
+++ b/tests/integrationtest/t/executor/insert.test
@@ -1615,3 +1615,14 @@ create table t1(c1 decimal(6,4), primary key(c1));
 insert into t1 set c1 = 0.1;
 insert into t1 set c1 = 0.1 on duplicate key update c1 = 1;
 select * from t1 use index(primary);
+
+# TestNonStrictInsertOverflowValue
+drop table if exists t;
+create table t (d int);
+-- error 1690
+insert into t values (cast('18446744073709551616' as unsigned));
+set sql_mode='';
+--enable_warnings
+insert into t values (cast('18446744073709551616' as unsigned));
+--disable_warnings
+set sql_mode=DEFAULT;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #49143, close #49137

Problem Summary:

The difference between `OverflowAsWarning` and `TruncatedAsWarning` doesn't actually exist. The existing difference are all incompatible with MySQL.

**I suggest to read https://github.com/pingcap/tidb/issues/49141#issuecomment-1838583457. It gives a clearer explanation on why this PR is right.**

### What changed and how does it work?

This PR removes `OverflowAsWarning` and handle them through `HandleError`. Actually `HandleError` and `HandleTruncate` are the same (and `HandleTruncate` will be removed in this or next week). As we provided `HandleErrorWithAlias`, it's more appropriate for this PR.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that in non-strict SQL_MODE, overflow error is not regarded as warning in UPDATE, DELETE and INSERT statement.
```
