### PR TITLE
disttask: ensure no subtasks generated on done step

### DIFF
--- a/pkg/ddl/backfilling_dispatcher.go
+++ b/pkg/ddl/backfilling_dispatcher.go
@@ -189,8 +189,8 @@ func (*BackfillingDispatcherExt) GetEligibleInstances(ctx context.Context, _ *pr
 	return serverInfos, true, nil
 }
 
-// IsRetryableErr implements dispatcher.Extension.IsRetryableErr interface.
-func (*BackfillingDispatcherExt) IsRetryableErr(error) bool {
+// IsRetryableError implements dispatcher.Extension.IsRetryableError interface.
+func (*BackfillingDispatcherExt) IsRetryableError(error) bool {
 	return true
 }
 

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -155,7 +155,7 @@ func (s *backfillDistExecutor) Init(ctx context.Context) error {
 
 func (s *backfillDistExecutor) GetSubtaskExecutor(ctx context.Context, task *proto.Task, summary *execute.Summary) (execute.SubtaskExecutor, error) {
 	switch task.Step {
-	case proto.StepOne, proto.StepTwo, proto.StepThree:
+	case StepReadIndex, StepMergeSort, StepWriteAndIngest:
 		return NewBackfillSubtaskExecutor(ctx, task.Meta, s.d, s.backendCtx, task.Step, summary)
 	default:
 		return nil, errors.Errorf("unknown backfill step %d for task %d", task.Step, task.ID)

--- a/pkg/disttask/framework/BUILD.bazel
+++ b/pkg/disttask/framework/BUILD.bazel
@@ -5,15 +5,15 @@ go_test(
     timeout = "short",
     srcs = [
         "framework_dynamic_dispatch_test.go",
-        "framework_err_handling_test.go",
         "framework_ha_test.go",
         "framework_pause_and_resume_test.go",
+        "framework_plan_err_handling_test.go",
         "framework_rollback_test.go",
         "framework_test.go",
     ],
     flaky = True,
     race = "off",
-    shard_count = 32,
+    shard_count = 33,
     deps = [
         "//pkg/disttask/framework/dispatcher",
         "//pkg/disttask/framework/handle",

--- a/pkg/disttask/framework/dispatcher/dispatcher_test.go
+++ b/pkg/disttask/framework/dispatcher/dispatcher_test.go
@@ -52,7 +52,7 @@ func getTestDispatcherExt(ctrl *gomock.Controller) dispatcher.Extension {
 			return mockedAllServerInfos, true, nil
 		},
 	).AnyTimes()
-	mockDispatcher.EXPECT().IsRetryableErr(gomock.Any()).Return(true).AnyTimes()
+	mockDispatcher.EXPECT().IsRetryableError(gomock.Any()).Return(true).AnyTimes()
 	mockDispatcher.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
 		func(task *proto.Task) proto.Step {
 			return proto.StepDone
@@ -77,7 +77,7 @@ func getNumberExampleDispatcherExt(ctrl *gomock.Controller) dispatcher.Extension
 			return serverInfo, true, err
 		},
 	).AnyTimes()
-	mockDispatcher.EXPECT().IsRetryableErr(gomock.Any()).Return(true).AnyTimes()
+	mockDispatcher.EXPECT().IsRetryableError(gomock.Any()).Return(true).AnyTimes()
 	mockDispatcher.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
 		func(task *proto.Task) proto.Step {
 			switch task.Step {

--- a/pkg/disttask/framework/dispatcher/interface.go
+++ b/pkg/disttask/framework/dispatcher/interface.go
@@ -78,8 +78,8 @@ type Extension interface {
 	// The bool return value indicates whether filter instances by role.
 	GetEligibleInstances(ctx context.Context, task *proto.Task) ([]*infosync.ServerInfo, bool, error)
 
-	// IsRetryableErr is used to check whether the error occurred in dispatcher is retryable.
-	IsRetryableErr(err error) bool
+	// IsRetryableError is used to check whether the error occurred in dispatcher is retryable.
+	IsRetryableError(err error) bool
 
 	// GetNextStep is used to get the next step for the task.
 	// if task runs successfully, it should go from StepInit to business steps,

--- a/pkg/disttask/framework/dispatcher/mock/dispatcher_mock.go
+++ b/pkg/disttask/framework/dispatcher/mock/dispatcher_mock.go
@@ -71,7 +71,7 @@ func (mr *MockExtensionMockRecorder) GetNextStep(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextStep", reflect.TypeOf((*MockExtension)(nil).GetNextStep), arg0)
 }
 
-// IsRetryableErroror mocks base method.
+// IsRetryableError mocks base method.
 func (m *MockExtension) IsRetryableError(arg0 error) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsRetryableError", arg0)

--- a/pkg/disttask/framework/dispatcher/mock/dispatcher_mock.go
+++ b/pkg/disttask/framework/dispatcher/mock/dispatcher_mock.go
@@ -71,18 +71,18 @@ func (mr *MockExtensionMockRecorder) GetNextStep(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextStep", reflect.TypeOf((*MockExtension)(nil).GetNextStep), arg0)
 }
 
-// IsRetryableErr mocks base method.
-func (m *MockExtension) IsRetryableErr(arg0 error) bool {
+// IsRetryableErroror mocks base method.
+func (m *MockExtension) IsRetryableError(arg0 error) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsRetryableErr", arg0)
+	ret := m.ctrl.Call(m, "IsRetryableError", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// IsRetryableErr indicates an expected call of IsRetryableErr.
-func (mr *MockExtensionMockRecorder) IsRetryableErr(arg0 any) *gomock.Call {
+// IsRetryableError indicates an expected call of IsRetryableError.
+func (mr *MockExtensionMockRecorder) IsRetryableError(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRetryableErr", reflect.TypeOf((*MockExtension)(nil).IsRetryableErr), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRetryableError", reflect.TypeOf((*MockExtension)(nil).IsRetryableError), arg0)
 }
 
 // OnDone mocks base method.

--- a/pkg/disttask/framework/framework_plan_err_handling_test.go
+++ b/pkg/disttask/framework/framework_plan_err_handling_test.go
@@ -47,3 +47,11 @@ func TestPlanNotRetryableErr(t *testing.T) {
 	testutil.DispatchTaskAndCheckState(ctx, t, "key1", testContext, proto.TaskStateFailed)
 	distContext.Close()
 }
+
+func TestPlanHaveSubtasksInDoneStep(t *testing.T) {
+	ctx, ctrl, testContext, distContext := testutil.InitTestContext(t, 2)
+	defer ctrl.Finish()
+	testutil.RegisterTaskMeta(t, ctrl, testutil.GetHasSubtasksOnDoneStepDispatcherExt(ctrl), testContext, nil)
+	testutil.DispatchTaskAndCheckState(ctx, t, "key1", testContext, proto.TaskStateFailed)
+	distContext.Close()
+}

--- a/pkg/disttask/framework/testutil/dispatcher_util.go
+++ b/pkg/disttask/framework/testutil/dispatcher_util.go
@@ -34,7 +34,7 @@ func GetMockBasicDispatcherExt(ctrl *gomock.Controller) dispatcher.Extension {
 			return generateTaskExecutorNodes4Test()
 		},
 	).AnyTimes()
-	mockDispatcher.EXPECT().IsRetryableErr(gomock.Any()).Return(true).AnyTimes()
+	mockDispatcher.EXPECT().IsRetryableError(gomock.Any()).Return(true).AnyTimes()
 	mockDispatcher.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
 		func(task *proto.Task) proto.Step {
 			switch task.Step {
@@ -78,7 +78,7 @@ func GetMockHATestDispatcherExt(ctrl *gomock.Controller) dispatcher.Extension {
 			return generateTaskExecutorNodes4Test()
 		},
 	).AnyTimes()
-	mockDispatcher.EXPECT().IsRetryableErr(gomock.Any()).Return(true).AnyTimes()
+	mockDispatcher.EXPECT().IsRetryableError(gomock.Any()).Return(true).AnyTimes()
 	mockDispatcher.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
 		func(task *proto.Task) proto.Step {
 			switch task.Step {
@@ -147,7 +147,7 @@ func GetPlanNotRetryableErrDispatcherExt(ctrl *gomock.Controller) dispatcher.Ext
 			return generateTaskExecutorNodes4Test()
 		},
 	).AnyTimes()
-	mockDispatcher.EXPECT().IsRetryableErr(gomock.Any()).Return(false).AnyTimes()
+	mockDispatcher.EXPECT().IsRetryableError(gomock.Any()).Return(false).AnyTimes()
 	mockDispatcher.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
 		func(task *proto.Task) proto.Step {
 			return proto.StepDone
@@ -172,7 +172,7 @@ func GetPlanErrDispatcherExt(ctrl *gomock.Controller, testContext *TestContext) 
 			return generateTaskExecutorNodes4Test()
 		},
 	).AnyTimes()
-	mockDispatcher.EXPECT().IsRetryableErr(gomock.Any()).Return(true).AnyTimes()
+	mockDispatcher.EXPECT().IsRetryableError(gomock.Any()).Return(true).AnyTimes()
 	mockDispatcher.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
 		func(task *proto.Task) proto.Step {
 			switch task.Step {
@@ -214,6 +214,48 @@ func GetPlanErrDispatcherExt(ctrl *gomock.Controller, testContext *TestContext) 
 	return mockDispatcher
 }
 
+// GetHasSubtasksOnDoneStepDispatcherExt returns mock dispatcher.Extension with subtasks on Done step.
+func GetHasSubtasksOnDoneStepDispatcherExt(ctrl *gomock.Controller) dispatcher.Extension {
+	mockDispatcher := mockDispatch.NewMockExtension(ctrl)
+	mockDispatcher.EXPECT().OnTick(gomock.Any(), gomock.Any()).Return().AnyTimes()
+	mockDispatcher.EXPECT().GetEligibleInstances(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *proto.Task) ([]*infosync.ServerInfo, bool, error) {
+			return generateTaskExecutorNodes4Test()
+		},
+	).AnyTimes()
+	mockDispatcher.EXPECT().IsRetryableError(gomock.Any()).Return(true).AnyTimes()
+	mockDispatcher.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
+		func(task *proto.Task) proto.Step {
+			switch task.Step {
+			case proto.StepInit:
+				return proto.StepOne
+			default:
+				return proto.StepDone
+			}
+		},
+	).AnyTimes()
+	mockDispatcher.EXPECT().OnNextSubtasksBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ dispatcher.TaskHandle, task *proto.Task, _ []*infosync.ServerInfo, nextStep proto.Step) (metas [][]byte, err error) {
+			if nextStep == proto.StepOne {
+				return [][]byte{
+					[]byte("task1"),
+					[]byte("task2"),
+					[]byte("task3"),
+				}, nil
+			}
+			if nextStep == proto.StepDone {
+				return [][]byte{
+					[]byte("task4"),
+				}, nil
+			}
+			return nil, nil
+		},
+	).AnyTimes()
+
+	mockDispatcher.EXPECT().OnDone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	return mockDispatcher
+}
+
 // GetMockRollbackDispatcherExt returns mock dispatcher.Extension which will generate rollback subtasks.
 func GetMockRollbackDispatcherExt(ctrl *gomock.Controller) dispatcher.Extension {
 	mockDispatcher := mockDispatch.NewMockExtension(ctrl)
@@ -223,7 +265,7 @@ func GetMockRollbackDispatcherExt(ctrl *gomock.Controller) dispatcher.Extension 
 			return generateTaskExecutorNodes4Test()
 		},
 	).AnyTimes()
-	mockDispatcher.EXPECT().IsRetryableErr(gomock.Any()).Return(true).AnyTimes()
+	mockDispatcher.EXPECT().IsRetryableError(gomock.Any()).Return(true).AnyTimes()
 	mockDispatcher.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
 		func(task *proto.Task) proto.Step {
 			switch task.Step {
@@ -260,7 +302,7 @@ func GetMockDynamicDispatchExt(ctrl *gomock.Controller) dispatcher.Extension {
 			return generateTaskExecutorNodes4Test()
 		},
 	).AnyTimes()
-	mockDispatcher.EXPECT().IsRetryableErr(gomock.Any()).Return(true).AnyTimes()
+	mockDispatcher.EXPECT().IsRetryableError(gomock.Any()).Return(true).AnyTimes()
 	mockDispatcher.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
 		func(task *proto.Task) proto.Step {
 			switch task.Step {

--- a/pkg/disttask/importinto/dispatcher.go
+++ b/pkg/disttask/importinto/dispatcher.go
@@ -344,8 +344,8 @@ func (*ImportDispatcherExt) GetEligibleInstances(ctx context.Context, task *prot
 	return serverInfo, true, err
 }
 
-// IsRetryableErr implements dispatcher.Extension interface.
-func (*ImportDispatcherExt) IsRetryableErr(error) bool {
+// IsRetryableError implements dispatcher.Extension interface.
+func (*ImportDispatcherExt) IsRetryableError(error) bool {
 	// TODO: check whether the error is retryable.
 	return false
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #48795

Problem Summary:
It's possible that business implementation add subtasks for done step.
Then subtasks for done step will not processed which will make the user confused.
### What changed and how does it work?
1. Make sure no subtasks dispatched on done step.
2. rename dispatcher.Extension.IsRetryableErr to IsRetryableError
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
