### PR TITLE
test: fix goroutine leak in network related funcs

### DIFF
--- a/pkg/store/helper/helper_test.go
+++ b/pkg/store/helper/helper_test.go
@@ -87,10 +87,7 @@ func TestGetRegionsTableInfo(t *testing.T) {
 func TestTiKVRegionsInfo(t *testing.T) {
 	store := createMockStore(t)
 
-	h := helper.Helper{
-		Store:       store,
-		RegionCache: store.GetRegionCache(),
-	}
+	h := helper.NewHelper(store)
 	pdCli, err := h.TryGetPDHTTPClient()
 	require.NoError(t, err)
 	regionsInfo, err := pdCli.GetRegions(context.Background())
@@ -101,11 +98,7 @@ func TestTiKVRegionsInfo(t *testing.T) {
 func TestTiKVStoresStat(t *testing.T) {
 	store := createMockStore(t)
 
-	h := helper.Helper{
-		Store:       store,
-		RegionCache: store.GetRegionCache(),
-	}
-
+	h := helper.NewHelper(store)
 	pdCli, err := h.TryGetPDHTTPClient()
 	require.NoError(t, err)
 

--- a/pkg/store/helper/main_test.go
+++ b/pkg/store/helper/main_test.go
@@ -28,6 +28,9 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/lestrrat-go/httprc.runFetchWorker"),
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop"),
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreTopFunction("net.(*Resolver).lookupIPAddr.func2"),
+		goleak.IgnoreTopFunction("net.(*Resolver).goLookupIPCNAMEOrder.func4"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
 	}
 	goleak.VerifyTestMain(m, opts...)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:
Fix the goroutine leak below,

```
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 131 in state chan receive, with net.(*Resolver).lookupIPAddr.func2 on top of the stack:
net.(*Resolver).lookupIPAddr.func2(0xf42d25?, 0x1efc148)
    /usr/local/go/src/net/lookup.go:328 +0x1a
created by net.(*Resolver).lookupIPAddr in goroutine 125
    /usr/local/go/src/net/lookup.go:343 +0x6f6
 Goroutine 126 in state chan receive, with net.(*Resolver).goLookupIPCNAMEOrder.func4 on top of the stack:
net.(*Resolver).goLookupIPCNAMEOrder.func4({_, _}, _)
    /usr/local/go/src/net/dnsclient_unix.go:659 +0x7f
net.(*Resolver).goLookupIPCNAMEOrder(_, {_, _}, {_, _}, {_, _}, _, _)
    /usr/local/go/src/net/dnsclient_unix.go:669 +0xd49
net.(*Resolver).lookupIP(0x3c23b40, {0x2180db0, 0xc000119770}, {0x1e2f8de, 0x3}, {0xc00013ce70, 0x12})
    /usr/local/go/src/net/lookup_unix.go:72 +0x166
net.glob..func1({0x2180db0?, 0xc000119770?}, 0x0?, {0x1e2f8de?, 0x4?}, {0xc00013ce70?, 0x15?})
    /usr/local/go/src/net/hook.go:23 +0x37
net.(*Resolver).lookupIPAddr.func1()
    /usr/local/go/src/net/lookup.go:324 +0x3a
internal/singleflight.(*Group).doCall(0x3c23b50, 0xc0001197c0, {0xc00013ce88, 0x16}, 0xc0003369a0?)
    /usr/local/go/src/internal/singleflight/singleflight.go:93 +0x35
created by internal/singleflight.(*Group).DoChan in goroutine 125
    /usr/local/go/src/internal/singleflight/singleflight.go:86 +0x2e9
 Goroutine 127 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
internal/poll.runtime_pollWait(0x7fb4df1411f0, 0x72)
    /usr/local/go/src/runtime/netpoll.go:343 +0x85
internal/poll.(*pollDesc).wait(0xc000628400?, 0xc000334000?, 0x0)
    /usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
    /usr/local/go/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc000628400, {0xc000334000, 0x4d0, 0x4d0})                                                                                                                                      /usr/local/go/src/internal/poll/fd_unix.go:164 +0x27a
net.(*netFD).Read(0xc000628400, {0xc000334000?, 0x7fb4d6f0e060?, 0x7fb525e1c108?})
    /usr/local/go/src/net/fd_posix.go:55 +0x25
net.(*conn).Read(0xc000507f48, {0xc000334000?, 0x1a869a0?, 0x1?})
    /usr/local/go/src/net/net.go:179 +0x45
net.dnsPacketRoundTrip({_, _}, _, {{{0x69, 0x6e, 0x76, 0x61, 0x6c, 0x69, 0x64, ...}, ...}, ...}, ...)
    /usr/local/go/src/net/dnsclient_unix.go:108 +0x143
net.(*Resolver).exchange(_, {_, _}, {_, _}, {{{0x69, 0x6e, 0x76, 0x61, 0x6c, ...}, ...}, ...}, ...)
    /usr/local/go/src/net/dnsclient_unix.go:187 +0x528
net.(*Resolver).tryOneName(_, {_, _}, _, {_, _}, _)
    /usr/local/go/src/net/dnsclient_unix.go:277 +0x466
net.(*Resolver).goLookupIPCNAMEOrder.func3.1(0x1?)
    /usr/local/go/src/net/dnsclient_unix.go:653 +0x85
created by net.(*Resolver).goLookupIPCNAMEOrder.func3 in goroutine 126
    /usr/local/go/src/net/dnsclient_unix.go:652 +0x158
 Goroutine 128 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
internal/poll.runtime_pollWait(0x7fb4df1412e8, 0x72)
    /usr/local/go/src/runtime/netpoll.go:343 +0x85
internal/poll.(*pollDesc).wait(0xc000622880?, 0xc00021f900?, 0x0)
    /usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
    /usr/local/go/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc000622880, {0xc00021f900, 0x4d0, 0x4d0})
    /usr/local/go/src/internal/poll/fd_unix.go:164 +0x27a
net.(*netFD).Read(0xc000622880, {0xc00021f900?, 0x7fb4df143a08?, 0x7fb525e1c108?})
    /usr/local/go/src/net/fd_posix.go:55 +0x25
net.(*conn).Read(0xc000507e20, {0xc00021f900?, 0x1a869a0?, 0x1?})
    /usr/local/go/src/net/net.go:179 +0x45
net.dnsPacketRoundTrip({_, _}, _, {{{0x69, 0x6e, 0x76, 0x61, 0x6c, 0x69, 0x64, ...}, ...}, ...}, ...)
    /usr/local/go/src/net/dnsclient_unix.go:108 +0x143
net.(*Resolver).exchange(_, {_, _}, {_, _}, {{{0x69, 0x6e, 0x76, 0x61, 0x6c, ...}, ...}, ...}, ...)
    /usr/local/go/src/net/dnsclient_unix.go:187 +0x528
net.(*Resolver).tryOneName(_, {_, _}, _, {_, _}, _)
    /usr/local/go/src/net/dnsclient_unix.go:277 +0x466
net.(*Resolver).goLookupIPCNAMEOrder.func3.1(0x1c?)
    /usr/local/go/src/net/dnsclient_unix.go:653 +0x85
created by net.(*Resolver).goLookupIPCNAMEOrder.func3 in goroutine 126
    /usr/local/go/src/net/dnsclient_unix.go:652 +0x158
]
```

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
