### PR TITLE
test: remove test files (`extract` and `replayer`) after running tests

### DIFF
--- a/pkg/domain/extract_test.go
+++ b/pkg/domain/extract_test.go
@@ -35,6 +35,7 @@ func TestExtractPlanWithoutHistoryView(t *testing.T) {
 	task := domain.NewExtractPlanTask(time.Now(), time.Now())
 	task.UseHistoryView = false
 	_, err := extractHandler.ExtractTask(context.Background(), task)
+	defer os.RemoveAll(domain.GetExtractTaskDirName())
 	require.NoError(t, err)
 }
 
@@ -46,6 +47,7 @@ func TestExtractWithoutStmtSummaryPersistedEnabled(t *testing.T) {
 	task := domain.NewExtractPlanTask(time.Now(), time.Now())
 	task.UseHistoryView = true
 	_, err := extractHandler.ExtractTask(context.Background(), task)
+	defer os.RemoveAll(domain.GetExtractTaskDirName())
 	require.Error(t, err)
 }
 
@@ -75,6 +77,7 @@ func TestExtractHandlePlanTask(t *testing.T) {
 	task := domain.NewExtractPlanTask(startTime, end)
 	task.UseHistoryView = true
 	name, err := extractHandler.ExtractTask(context.Background(), task)
+	defer os.RemoveAll(domain.GetExtractTaskDirName())
 	require.NoError(t, err)
 	require.True(t, len(name) > 0)
 }

--- a/pkg/domain/plan_replayer_test.go
+++ b/pkg/domain/plan_replayer_test.go
@@ -16,6 +16,7 @@ package domain
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -31,6 +32,7 @@ func TestPlanReplayerDifferentGC(t *testing.T) {
 	time1 := time.Now().Add(-7 * 25 * time.Hour).UnixNano()
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/util/replayer/InjectPlanReplayerFileNameTimeField", fmt.Sprintf("return(%d)", time1)))
 	file1, fileName1, err := replayer.GeneratePlanReplayerFile(true, false, false)
+	defer os.RemoveAll(replayer.GetPlanReplayerDirName())
 	require.NoError(t, err)
 	require.NoError(t, file1.Close())
 	filePath1 := filepath.Join(dirName, fileName1)

--- a/pkg/executor/test/executor/executor_test.go
+++ b/pkg/executor/test/executor/executor_test.go
@@ -18,6 +18,7 @@ import (
 	"archive/zip"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -108,6 +109,7 @@ func TestPlanReplayer(t *testing.T) {
 	tk.MustExec("create table t(a int, b int, index idx_a(a))")
 	tk.MustExec("alter table t set tiflash replica 1")
 	tk.MustQuery("plan replayer dump explain select * from t where a=10")
+	defer os.RemoveAll(replayer.GetPlanReplayerDirName())
 	tk.MustQuery("plan replayer dump explain select /*+ read_from_storage(tiflash[t]) */ * from t")
 
 	tk.MustExec("create table t1 (a int)")
@@ -139,6 +141,7 @@ func TestPlanReplayerCaptureSEM(t *testing.T) {
 	tk.MustExec("plan replayer capture '123' '123';")
 	tk.MustExec("create table t(id int)")
 	tk.MustQuery("plan replayer dump explain select * from t")
+	defer os.RemoveAll(replayer.GetPlanReplayerDirName())
 	tk.MustQuery("select count(*) from mysql.plan_replayer_status").Check(testkit.Rows("1"))
 }
 
@@ -202,6 +205,7 @@ func TestPlanReplayerDumpSingle(t *testing.T) {
 	tk.MustExec("drop table if exists t_dump_single")
 	tk.MustExec("create table t_dump_single(a int)")
 	res := tk.MustQuery("plan replayer dump explain select * from t_dump_single")
+	defer os.RemoveAll(replayer.GetPlanReplayerDirName())
 	path := testdata.ConvertRowsToStrings(res.Rows())
 
 	reader, err := zip.OpenReader(filepath.Join(replayer.GetPlanReplayerDirName(), path[0]))

--- a/pkg/server/handler/extractorhandler/BUILD.bazel
+++ b/pkg/server/handler/extractorhandler/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     deps = [
         ":extractorhandler",
         "//pkg/config",
+        "//pkg/domain",
         "//pkg/metrics",
         "//pkg/server",
         "//pkg/server/internal/testserverclient",

--- a/pkg/server/handler/extractorhandler/extract_test.go
+++ b/pkg/server/handler/extractorhandler/extract_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/domain"
 	server2 "github.com/pingcap/tidb/pkg/server"
 	"github.com/pingcap/tidb/pkg/server/handler/extractorhandler"
 	"github.com/pingcap/tidb/pkg/server/internal/testserverclient"
@@ -80,6 +81,7 @@ func TestExtractHandler(t *testing.T) {
 	}()
 	resp0, err := client.FetchStatus(fmt.Sprintf("/extract_task/dump?type=plan&begin=%s&end=%s",
 		url.QueryEscape(startTime.Format(types.TimeFormat)), url.QueryEscape(endTime.Format(types.TimeFormat))))
+	defer os.RemoveAll(domain.GetExtractTaskDirName())
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, resp0.Body.Close())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #49127

Problem Summary:

### What changed and how does it work?

Remove the `extract` and `replayer` folder after running tests related with them.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > This PR is modifying tests

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility


### Release note


```release-note
None
```
