### PR TITLE
planner: fix prepare select into outfile fail

### DIFF
--- a/pkg/executor/select_into_test.go
+++ b/pkg/executor/select_into_test.go
@@ -290,3 +290,27 @@ func TestYearType(t *testing.T) {
 	tk.MustExec(fmt.Sprintf("select * from t into outfile '%v' fields terminated by ',' optionally enclosed by '\"' lines terminated by '\\n';", outfile))
 	cmpAndRm("2010\n2011\n2012\n2030\n", outfile, t)
 }
+
+func TestPrepareSelectIntoOutfile(t *testing.T) {
+	outfile := randomSelectFilePath("TestPrepareSelectInto")
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t (
+		a int,
+		b double,
+		c varchar(10),
+		d blob,
+		e json,
+		f set('1', '2', '3'),
+		g enum('1', '2', '3'))`)
+	tk.MustExec(`insert into t values (1, 1, "1", "1", '{"key": 1}', "1", "1")`)
+
+	tk.MustExec(fmt.Sprintf("prepare stmt from \"select * from t into outfile '%v' fields terminated by ',' escaped by '1'\"", outfile))
+	tk.MustExec("execute stmt")
+	cmpAndRm(`1,1,11,11,{"key": 11},11,11
+`, outfile, t)
+	tk.MustExec("execute stmt")
+	cmpAndRm(`1,1,11,11,{"key": 11},11,11
+`, outfile, t)
+}

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5287,6 +5287,7 @@ func (b *PlanBuilder) buildSelectInto(ctx context.Context, sel *ast.SelectStmt) 
 	}
 	selectIntoInfo := sel.SelectIntoOpt
 	sel.SelectIntoOpt = nil
+	defer func() { sel.SelectIntoOpt = selectIntoInfo }()
 	targetPlan, _, err := OptimizeAstNode(ctx, b.ctx, sel, b.is)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49166 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the into clause is missing in prepare into outfile (https://github.com/pingcap/tidb/issues/49166)
```
