### PR TITLE
server: register compression statistics and fix the memory leak

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -122,7 +122,7 @@ var (
 
 // newClientConn creates a *clientConn object.
 func newClientConn(s *Server) *clientConn {
-	cc := &clientConn{
+	return &clientConn{
 		server:       s,
 		connectionID: s.dom.NextConnID(),
 		collation:    mysql.DefaultCollationID,
@@ -134,8 +134,6 @@ func newClientConn(s *Server) *clientConn {
 		quit:         make(chan struct{}),
 		ppEnabled:    s.cfg.ProxyProtocol.Networks != "",
 	}
-	variable.RegisterStatistics(cc)
-	return cc
 }
 
 // clientConn represents a connection between server and client, it maintains connection specific state,
@@ -2606,8 +2604,10 @@ func (cc *clientConn) Flush(ctx context.Context) error {
 	return cc.flush(ctx)
 }
 
+type compressionStats struct{}
+
 // Stats returns the connection statistics.
-func (*clientConn) Stats(vars *variable.SessionVars) (map[string]interface{}, error) {
+func (*compressionStats) Stats(vars *variable.SessionVars) (map[string]interface{}, error) {
 	m := make(map[string]interface{}, 3)
 
 	switch vars.CompressionAlgorithm {
@@ -2637,6 +2637,10 @@ func (*clientConn) Stats(vars *variable.SessionVars) (map[string]interface{}, er
 }
 
 // GetScope gets the status variables scope.
-func (*clientConn) GetScope(_ string) variable.ScopeFlag {
+func (*compressionStats) GetScope(_ string) variable.ScopeFlag {
 	return variable.ScopeSession
+}
+
+func init() {
+	variable.RegisterStatistics(&compressionStats{})
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #49190

Problem Summary:

The `conn` shouldn't be registered as a statistics. The `RegisterStatistics` should be called for each **kind** of statistics. Registering every connection on it will cause memory leak.

### What changed and how does it work?

Create a new struct `compressionStats` to register the status variables.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
None
```
