### PR TITLE
ddl: update checkpoint manager's min task id when complete

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -496,7 +496,9 @@ func handleOneResult(result *backfillResult, scheduler backfillScheduler, consum
 	}
 	if !consumer.distribute {
 		reorgCtx := consumer.dc.getReorgCtx(reorgInfo.Job.ID)
-		reorgCtx.setRowCount(*totalAddedCount)
+		if reorgCtx != nil {
+			reorgCtx.setRowCount(*totalAddedCount)
+		}
 	}
 	keeper.updateNextKey(result.taskID, result.nextKey)
 	if taskSeq%(scheduler.currentWorkerSize()*4) == 0 {

--- a/pkg/ddl/index_cop.go
+++ b/pkg/ddl/index_cop.go
@@ -115,7 +115,7 @@ func (c *copReqSender) run() {
 		if !ok {
 			return
 		}
-		if p.checkpointMgr != nil && p.checkpointMgr.IsComplete(task.endKey) {
+		if p.checkpointMgr != nil && p.checkpointMgr.CheckComplete(task.id, task.endKey) {
 			logutil.Logger(p.ctx).Info("checkpoint detected, skip a cop-request task",
 				zap.Int("task ID", task.id),
 				zap.String("task end key", hex.EncodeToString(task.endKey)))

--- a/pkg/ddl/ingest/checkpoint.go
+++ b/pkg/ddl/ingest/checkpoint.go
@@ -243,7 +243,7 @@ func (s *CheckpointManager) Reset(newPhysicalID int64, start, end kv.Key) {
 	logutil.BgLogger().Info("reset checkpoint manager", zap.String("category", "ddl-ingest"),
 		zap.Int64("newPhysicalID", newPhysicalID), zap.Int64("oldPhysicalID", s.pidLocal),
 		zap.Int64("indexID", s.indexID), zap.Int64("jobID", s.jobID), zap.Int("localCnt", s.localCnt))
-	if s.pidLocal != newPhysicalID {
+	if s.pidLocal != 0 && s.pidLocal != newPhysicalID {
 		s.minKeySyncLocal = nil
 		s.minKeySyncGlobal = nil
 		s.minTaskIDSynced = 0

--- a/pkg/ddl/ingest/checkpoint.go
+++ b/pkg/ddl/ingest/checkpoint.go
@@ -247,10 +247,10 @@ func (s *CheckpointManager) Reset(newPhysicalID int64, start, end kv.Key) {
 		s.minKeySyncLocal = nil
 		s.minKeySyncGlobal = nil
 		s.minTaskIDSynced = 0
-		s.pidLocal = newPhysicalID
 		s.startLocal = start
 		s.endLocal = end
 	}
+	s.pidLocal = newPhysicalID
 }
 
 // JobReorgMeta is the metadata for a reorg job.

--- a/pkg/ddl/ingest/checkpoint_test.go
+++ b/pkg/ddl/ingest/checkpoint_test.go
@@ -45,26 +45,26 @@ func TestCheckpointManager(t *testing.T) {
 	mgr.Register(1, []byte{'1', '9'})
 	mgr.Register(2, []byte{'2', '9'})
 	mgr.UpdateTotal(1, 100, false)
-	require.False(t, mgr.IsComplete([]byte{'1', '9'}))
+	require.False(t, mgr.CheckComplete(1, []byte{'1', '9'}))
 	require.NoError(t, mgr.UpdateCurrent(1, 100))
-	require.False(t, mgr.IsComplete([]byte{'1', '9'}))
+	require.False(t, mgr.CheckComplete(1, []byte{'1', '9'}))
 	mgr.UpdateTotal(1, 100, true)
 	require.NoError(t, mgr.UpdateCurrent(1, 100))
 	// The data is not imported to the storage yet.
-	require.False(t, mgr.IsComplete([]byte{'1', '9'}))
+	require.False(t, mgr.CheckComplete(1, []byte{'1', '9'}))
 	flushCtrl.imported = true // Mock the data is imported to the storage.
 	require.NoError(t, mgr.UpdateCurrent(2, 0))
-	require.True(t, mgr.IsComplete([]byte{'1', '9'}))
+	require.True(t, mgr.CheckComplete(1, []byte{'1', '9'}))
 
 	// Only when the last batch is completed, the job can be completed.
 	mgr.UpdateTotal(2, 50, false)
 	mgr.UpdateTotal(2, 50, true)
 	require.NoError(t, mgr.UpdateCurrent(2, 50))
-	require.True(t, mgr.IsComplete([]byte{'1', '9'}))
-	require.False(t, mgr.IsComplete([]byte{'2', '9'}))
+	require.True(t, mgr.CheckComplete(1, []byte{'1', '9'}))
+	require.False(t, mgr.CheckComplete(1, []byte{'2', '9'}))
 	require.NoError(t, mgr.UpdateCurrent(2, 50))
-	require.True(t, mgr.IsComplete([]byte{'1', '9'}))
-	require.True(t, mgr.IsComplete([]byte{'2', '9'}))
+	require.True(t, mgr.CheckComplete(1, []byte{'1', '9'}))
+	require.True(t, mgr.CheckComplete(2, []byte{'2', '9'}))
 
 	// Only when the subsequent job is completed, the previous job can be completed.
 	mgr.Register(3, []byte{'3', '9'})
@@ -75,8 +75,8 @@ func TestCheckpointManager(t *testing.T) {
 	mgr.UpdateTotal(5, 100, true)
 	require.NoError(t, mgr.UpdateCurrent(5, 100))
 	require.NoError(t, mgr.UpdateCurrent(4, 100))
-	require.False(t, mgr.IsComplete([]byte{'3', '9'}))
-	require.False(t, mgr.IsComplete([]byte{'4', '9'}))
+	require.False(t, mgr.CheckComplete(3, []byte{'3', '9'}))
+	require.False(t, mgr.CheckComplete(4, []byte{'4', '9'}))
 }
 
 func TestCheckpointManagerUpdateReorg(t *testing.T) {
@@ -143,11 +143,18 @@ func TestCheckpointManagerResumeReorg(t *testing.T) {
 	mgr, err := ingest.NewCheckpointManager(ctx, flushCtrl, sessPool, 1, 1)
 	require.NoError(t, err)
 	defer mgr.Close()
-	require.True(t, mgr.IsComplete([]byte{'1', '9'}))
-	require.True(t, mgr.IsComplete([]byte{'2', '9'}))
+	require.True(t, mgr.CheckComplete(1, []byte{'1', '9'}))
+	require.True(t, mgr.CheckComplete(2, []byte{'2', '9'}))
 	localCnt, globalNextKey := mgr.Status()
 	require.Equal(t, 100, localCnt)
 	require.EqualValues(t, []byte{'2', '9'}, globalNextKey)
+
+	mgr.Register(3, []byte{'3', '9'})
+	mgr.Register(4, []byte{'4', '9'})
+	mgr.UpdateTotal(3, 100, true)
+	mgr.UpdateTotal(4, 100, true)
+	require.NoError(t, mgr.UpdateCurrent(3, 100))
+	require.True(t, mgr.CheckComplete(3, []byte{'3', '9'}))
 }
 
 type dummyFlushCtrl struct {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49252

Problem Summary:

https://github.com/pingcap/tidb/blob/be62f754fb4182a544b52b2f58a5f867136e7695/pkg/ddl/ingest/checkpoint.go#L238-L241

`Reset()` unsets `minKeySyncLocal` when the local physical ID does not match the current new one. However, when TiDB restarts local physical ID is always `0`. As a result, the minimal sync key is always reset, local checkpoint cannot be used.

### What changed and how does it work?

- When local physical ID is `0`, we don't reset and let checkpoint manager use the information from checkpoint.
- Let `IsComplete()` update local min task ID, otherwise it will not progress when TiDB restarts(see `progressLocalSyncMinKey()`).

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  Change the default update inverval:
  ```
  -const checkpointUpdateInterval = 10 * time.Minute
  +const checkpointUpdateInterval = 10 * time.Second
  ```
    Before this PR:
  ```
  [2023/12/07 15:16:30.883 +08:00] [INFO] [checkpoint.go:378] ["update checkpoint"] [category=ddl-ingest] ["job ID"=105] ["index ID"=2] ["local checkpoint"=7480000000000000665f72800000000077934d00] ["global checkpoint"=] ["global   physical ID"=102] []
  [2023/12/07 15:16:40.885 +08:00] [INFO] [checkpoint.go:378] ["update checkpoint"] [category=ddl-ingest] ["job ID"=105] ["index ID"=2] ["local checkpoint"=7480000000000000665f728000000000dc13b800] ["global checkpoint"=] ["global   physical ID"=102] []
  // kill TiDB and restart...
  [2023/12/07 15:18:12.895 +08:00] [INFO] [checkpoint.go:312] ["resume checkpoint"] [category=ddl-ingest] ["job ID"=105] ["index ID"=2] ["local checkpoint"=7480000000000000665f728000000000dc13b800] ["global checkpoint"=] ["physical   table ID"=102] ["previous instance"=127.0.0.1:4000:/tmp/tidb] ["current instance"=127.0.0.1:4000:/tmp/tidb]
  [2023/12/07 15:18:12.895 +08:00] [INFO] [checkpoint.go:116] ["create checkpoint manager"] [category=ddl-ingest] [jobID=105] [indexID=2]
  [2023/12/07 15:18:12.896 +08:00] [INFO] [job_table.go:639] ["resume physical table ID from checkpoint"] [category=ddl-ingest] [jobID=105] [start=7480000000000000665f728000000000000001]   [end=7480000000000000665f728000000005fb27df00] ["checkpoint physical ID"=102]
  [2023/12/07 15:18:12.896 +08:00] [INFO] [index.go:1960] ["start to add table index"] [category=ddl] [job="ID:105, Type:add index, State:running, SchemaState:write reorganization, SchemaID:2, TableID:102, RowCount:16075130,   ArgLen:6, start time: 2023-12-07 15:16:10.456 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:446151621543723015, UniqueWarnings:0"] [reorgInfo="CurrElementType:_idx_,CurrElementID:2,  StartKey:7480000000000000665f728000000000000001,EndKey:7480000000000000665f728000000005fb27df00,First:false,PhysicalTableID:102,Ingest mode:true"]
  [2023/12/07 15:18:12.896 +08:00] [INFO] [checkpoint.go:238] ["reset checkpoint manager"] [category=ddl-ingest] [newPhysicalID=102] [oldPhysicalID=0] [indexID=2] [jobID=105] [localCnt=14380450]
  [2023/12/07 15:18:32.903 +08:00] [INFO] [checkpoint.go:378] ["update checkpoint"] [category=ddl-ingest] ["job ID"=105] ["index ID"=2] ["local checkpoint"=7480000000000000665f728000000000eeed9700] ["global checkpoint"=] ["global   physical ID"=102] []
  [2023/12/07 15:18:42.903 +08:00] [INFO] [checkpoint.go:378] ["update checkpoint"] [category=ddl-ingest] ["job ID"=105] ["index ID"=2] ["local checkpoint"=7480000000000000665f7280000000018c514f00] ["global checkpoint"=] ["global   physical ID"=102] []
  [2023/12/07 15:19:02.907 +08:00] [INFO] [checkpoint.go:378] ["update checkpoint"] [category=ddl-ingest] ["job ID"=105] ["index ID"=2] ["local checkpoint"=7480000000000000665f72800000000248f4f800] ["global checkpoint"=] ["global   physical ID"=102] []
  ```
  
  After this PR:
  ```
  [2023/12/07 15:26:06.538 +08:00] [INFO] [checkpoint.go:312] ["resume checkpoint"] [category=ddl-ingest] ["job ID"=107] ["index ID"=3] ["local checkpoint"=] ["global checkpoint"=] ["physical table ID"=102] ["previous instance"=]   ["current instance"=127.0.0.1:4000:/tmp/tidb]
  [2023/12/07 15:26:06.538 +08:00] [INFO] [checkpoint.go:116] ["create checkpoint manager"] [category=ddl-ingest] [jobID=107] [indexID=3]
  [2023/12/07 15:26:06.540 +08:00] [INFO] [job_table.go:639] ["resume physical table ID from checkpoint"] [category=ddl-ingest] [jobID=107] [start=7480000000000000665f728000000000000001]   [end=7480000000000000665f728000000005fb27df00] ["checkpoint physical ID"=102]
  [2023/12/07 15:26:06.540 +08:00] [INFO] [checkpoint.go:238] ["reset checkpoint manager"] [category=ddl-ingest] [newPhysicalID=102] [oldPhysicalID=0] [indexID=3] [jobID=107] [localCnt=0]
  [2023/12/07 15:26:26.573 +08:00] [INFO] [checkpoint.go:378] ["update checkpoint"] [category=ddl-ingest] ["job ID"=107] ["index ID"=3] ["local checkpoint"=7480000000000000665f72800000000090ad9b00] ["global checkpoint"=] ["global   physical ID"=102] []
  [2023/12/07 15:26:36.582 +08:00] [INFO] [checkpoint.go:378] ["update checkpoint"] [category=ddl-ingest] ["job ID"=107] ["index ID"=3] ["local checkpoint"=7480000000000000665f72800000000140b9a900] ["global checkpoint"=] ["global   physical ID"=102] []
  // kill TiDB and restart...
  [2023/12/07 15:30:20.088 +08:00] [INFO] [checkpoint.go:238] ["reset checkpoint manager"] [category=ddl-ingest] [newPhysicalID=102] [oldPhysicalID=0] [indexID=3] [jobID=107] [localCnt=20954370]
  [2023/12/07 15:30:20.271 +08:00] [INFO] [backfilling.go:387] ["split table range from PD"] [category=ddl] [physicalTableID=102] ["start key"=7480000000000000665f728000000003251587] ["end   key"=7480000000000000665f728000000005fb27df00]
  [2023/12/07 15:30:20.271 +08:00] [INFO] [index_cop.go:119] ["checkpoint detected, skip a cop-request task"] [category=ddl-ingest] ["task ID"=1] ["task end key"=7480000000000000665f72800000000006482800]
  [2023/12/07 15:30:20.271 +08:00] [INFO] [index_cop.go:119] ["checkpoint detected, skip a cop-request task"] [category=ddl-ingest] ["task ID"=3] ["task end key"=7480000000000000665f72800000000012d41e00]
  [2023/12/07 15:30:20.271 +08:00] [INFO] [index_cop.go:119] ["checkpoint detected, skip a cop-request task"] [category=ddl-ingest] ["task ID"=4] ["task end key"=7480000000000000665f728000000000191ba400]
  [2023/12/07 15:30:20.271 +08:00] [INFO] [index_cop.go:119] ["checkpoint detected, skip a cop-request task"] [category=ddl-ingest] ["task ID"=5] ["task end key"=7480000000000000665f7280000000001f60e900]
  ```
  ```
  mysql> admin check table sbtest1;
  Query OK, 0 rows affected (1 min 17.82 sec)
  ```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
