### PR TITLE
server,executor: split ResultSet Close() to Finish() and Close()

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1470,10 +1470,9 @@ func (a *ExecStmt) checkPlanReplayerCapture(txnTS uint64) {
 
 // CloseRecordSet will finish the execution of current statement and do some record work
 func (a *ExecStmt) CloseRecordSet(txnStartTS uint64, lastErr error) {
-	a.FinishExecuteStmt(txnStartTS, nil, false)
+	a.FinishExecuteStmt(txnStartTS, lastErr, false)
 	a.logAudit()
 	a.Ctx.GetSessionVars().StmtCtx.DetachMemDiskTracker()
-	return
 }
 
 // Clean CTE storage shared by different CTEFullScan executor within a SQL stmt.

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -22,6 +22,7 @@ import (
 	"runtime/trace"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -90,6 +91,7 @@ type recordSet struct {
 	stmt       *ExecStmt
 	lastErr    error
 	txnStartTS uint64
+	once       sync.Once
 }
 
 func (a *recordSet) Fields() []*ast.ResultField {
@@ -179,13 +181,31 @@ func (a *recordSet) NewChunk(alloc chunk.Allocator) *chunk.Chunk {
 	return alloc.Alloc(base.RetFieldTypes(), base.InitCap(), base.MaxChunkSize())
 }
 
-func (a *recordSet) Close() error {
-	err := a.executor.Close()
-	err1 := a.stmt.CloseRecordSet(a.txnStartTS, a.lastErr)
+func (a *recordSet) Finish() error {
+	var err error
+	a.once.Do(func() {
+		err = a.executor.Close()
+		cteErr := resetCTEStorageMap(a.stmt.Ctx)
+		if cteErr != nil {
+			logutil.BgLogger().Error("got error when reset cte storage, should check if the spill disk file deleted or not", zap.Error(cteErr))
+		}
+		if err == nil {
+			err = cteErr
+		}
+	})
 	if err != nil {
-		return err
+		a.lastErr = err
 	}
-	return err1
+	return err
+}
+
+func (a *recordSet) Close() error {
+	err := a.Finish()
+	if err != nil {
+		logutil.BgLogger().Error("close recordSet error", zap.Error(err))
+	}
+	a.stmt.CloseRecordSet(a.txnStartTS, a.lastErr)
+	return err
 }
 
 // OnFetchReturned implements commandLifeCycle#OnFetchReturned
@@ -871,7 +891,8 @@ func (c *chunkRowRecordSet) NewChunk(alloc chunk.Allocator) *chunk.Chunk {
 }
 
 func (c *chunkRowRecordSet) Close() error {
-	return c.execStmt.CloseRecordSet(c.execStmt.Ctx.GetSessionVars().TxnCtx.StartTS, nil)
+	c.execStmt.CloseRecordSet(c.execStmt.Ctx.GetSessionVars().TxnCtx.StartTS, nil)
+	return nil
 }
 
 func (a *ExecStmt) handlePessimisticSelectForUpdate(ctx context.Context, e exec.Executor) (_ sqlexec.RecordSet, retErr error) {
@@ -1448,19 +1469,11 @@ func (a *ExecStmt) checkPlanReplayerCapture(txnTS uint64) {
 }
 
 // CloseRecordSet will finish the execution of current statement and do some record work
-func (a *ExecStmt) CloseRecordSet(txnStartTS uint64, lastErr error) error {
-	cteErr := resetCTEStorageMap(a.Ctx)
-	if cteErr != nil {
-		logutil.BgLogger().Error("got error when reset cte storage, should check if the spill disk file deleted or not", zap.Error(cteErr))
-	}
-	if lastErr == nil {
-		// Only overwrite err when it's nil.
-		lastErr = cteErr
-	}
-	a.FinishExecuteStmt(txnStartTS, lastErr, false)
+func (a *ExecStmt) CloseRecordSet(txnStartTS uint64, lastErr error) {
+	a.FinishExecuteStmt(txnStartTS, nil, false)
 	a.logAudit()
 	a.Ctx.GetSessionVars().StmtCtx.DetachMemDiskTracker()
-	return cteErr
+	return
 }
 
 // Clean CTE storage shared by different CTEFullScan executor within a SQL stmt.

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -968,9 +968,7 @@ func (cc *clientConn) initConnect(ctx context.Context) error {
 					break
 				}
 			}
-			if err := rs.Close(); err != nil {
-				return err
-			}
+			rs.Close()
 		}
 	}
 	logutil.Logger(ctx).Debug("init_connect complete")
@@ -2035,7 +2033,7 @@ func (cc *clientConn) handleStmt(ctx context.Context, stmt ast.StmtNode, warns [
 	// - If the rs is nil and err is not nil, the detachment will be done in
 	//   the `handleNoDelay`.
 	if rs != nil {
-		defer terror.Call(rs.Close)
+		defer rs.Close()
 	}
 	if err != nil {
 		// If error is returned during the planner phase or the executor.Open
@@ -2303,7 +2301,7 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 			stmtDetail.WriteSQLRespDuration += time.Since(start)
 		}
 	}
-	if err := rs.Close(); err != nil {
+	if err := rs.Finish(); err != nil {
 		return false, err
 	}
 

--- a/pkg/server/conn_stmt.go
+++ b/pkg/server/conn_stmt.go
@@ -50,7 +50,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/parser/terror"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/server/internal/dump"
 	"github.com/pingcap/tidb/pkg/server/internal/parse"
@@ -304,7 +303,7 @@ func (cc *clientConn) executePreparedStmtAndWriteResult(ctx context.Context, stm
 	execStmt.SetText(charset.EncodingUTF8Impl, sql)
 	rs, err := (&cc.ctx).ExecuteStmt(ctx, execStmt)
 	if rs != nil {
-		defer terror.Call(rs.Close)
+		defer rs.Close()
 	}
 	if err != nil {
 		// If error is returned during the planner phase or the executor.Open

--- a/pkg/server/internal/resultset/BUILD.bazel
+++ b/pkg/server/internal/resultset/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/server/internal/resultset",
     visibility = ["//pkg/server:__subpackages__"],
     deps = [
+        "//pkg/parser/terror",
         "//pkg/planner/core",
         "//pkg/server/internal/column",
         "//pkg/types",

--- a/pkg/server/internal/resultset/resultset.go
+++ b/pkg/server/internal/resultset/resultset.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync/atomic"
 
+	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/server/internal/column"
 	"github.com/pingcap/tidb/pkg/types"
@@ -74,7 +75,7 @@ func (trs *tidbResultSet) Close() {
 	if !atomic.CompareAndSwapInt32(&trs.closed, 0, 1) {
 		return
 	}
-	trs.recordSet.Close()
+	terror.Call(trs.recordSet.Close)
 	trs.recordSet = nil
 	return
 }

--- a/pkg/server/internal/resultset/resultset.go
+++ b/pkg/server/internal/resultset/resultset.go
@@ -77,7 +77,6 @@ func (trs *tidbResultSet) Close() {
 	}
 	terror.Call(trs.recordSet.Close)
 	trs.recordSet = nil
-	return
 }
 
 // IsClosed implements ResultSet.IsClosed interface.

--- a/pkg/server/internal/resultset/resultset.go
+++ b/pkg/server/internal/resultset/resultset.go
@@ -30,11 +30,12 @@ type ResultSet interface {
 	Columns() []*column.Info
 	NewChunk(chunk.Allocator) *chunk.Chunk
 	Next(context.Context, *chunk.Chunk) error
-	Close() error
+	Close()
 	// IsClosed checks whether the result set is closed.
 	IsClosed() bool
 	FieldTypes() []*types.FieldType
 	SetPreparedStmt(stmt *core.PlanCacheStmt)
+	Finish() error
 }
 
 var _ ResultSet = &tidbResultSet{}
@@ -62,13 +63,20 @@ func (trs *tidbResultSet) Next(ctx context.Context, req *chunk.Chunk) error {
 	return trs.recordSet.Next(ctx, req)
 }
 
-func (trs *tidbResultSet) Close() error {
-	if !atomic.CompareAndSwapInt32(&trs.closed, 0, 1) {
-		return nil
+func (trs *tidbResultSet) Finish() error {
+	if x, ok := trs.recordSet.(interface{ Finish() error }); ok {
+		return x.Finish()
 	}
-	err := trs.recordSet.Close()
+	return nil
+}
+
+func (trs *tidbResultSet) Close() {
+	if !atomic.CompareAndSwapInt32(&trs.closed, 0, 1) {
+		return
+	}
+	trs.recordSet.Close()
 	trs.recordSet = nil
-	return err
+	return
 }
 
 // IsClosed implements ResultSet.IsClosed interface.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48667

Problem Summary:

### What changed and how does it work?

In the old interface design, `ResultSet.Close()`  may return error, and we must make sure the error is returned to the client, otherwise we get this issue https://github.com/pingcap/tidb/issues/48446

In the previous https://github.com/pingcap/tidb/pull/48447 I make sure the error is returned, but that cause peformance regression #48667

So the idea is split the work of Close() into two: the part that may return error and the part that may not return error.

```
	Finish() error
	Close()
```

We call Finish() first and writeEOF(), then call Close().

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

Run sysbench and get the flamegraph:

![image](https://github.com/pingcap/tidb/assets/1420062/e69a4f19-8eaf-45d0-abe8-2004169b669f)

![image](https://github.com/pingcap/tidb/assets/1420062/958dc237-a7c2-4431-be72-38ec5a4cdc10)

Now Close() will be after writeChunks() and there is a Finish() call inside writeChunks().


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
