### PR TITLE
ddl: fix partition definition for literal with non-utf8 charsets + binary column | tidb-test=pr/2262

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -991,6 +991,11 @@ error = '''
 This partition function is not allowed
 '''
 
+["ddl:1566"]
+error = '''
+Not allowed to use NULL value in VALUES LESS THAN
+'''
+
 ["ddl:1567"]
 error = '''
 Incorrect partition name

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/format"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -1309,13 +1310,14 @@ func buildListPartitionDefinitions(ctx expression.BuildContext, defs []*ast.Part
 			return nil, err
 		}
 		clause := def.Clause.(*ast.PartitionDefinitionClauseIn)
+		partVals := make([][]types.Datum, 0, len(clause.Values))
 		if len(tbInfo.Partition.Columns) > 0 {
 			for _, vs := range clause.Values {
-				// TODO: use the generated strings / normalized partition values
-				_, err := checkAndGetColumnsTypeAndValuesMatch(ctx, colTypes, vs)
+				vals, err := checkAndGetColumnsTypeAndValuesMatch(ctx, colTypes, vs)
 				if err != nil {
 					return nil, err
 				}
+				partVals = append(partVals, vals)
 			}
 		} else {
 			for _, vs := range clause.Values {
@@ -1339,16 +1341,32 @@ func buildListPartitionDefinitions(ctx expression.BuildContext, defs []*ast.Part
 		}
 
 		buf := new(bytes.Buffer)
-		for _, vs := range clause.Values {
+		for valIdx, vs := range clause.Values {
 			inValue := make([]string, 0, len(vs))
-			for i := range vs {
-				vs[i].Accept(exprChecker)
-				if exprChecker.err != nil {
-					return nil, exprChecker.err
+			isDefault := false
+			if len(vs) == 1 {
+				if _, ok := vs[0].(*ast.DefaultExpr); ok {
+					isDefault = true
 				}
-				buf.Reset()
-				vs[i].Format(buf)
-				inValue = append(inValue, buf.String())
+			}
+			if len(partVals) > valIdx && !isDefault {
+				for colIdx := range partVals[valIdx] {
+					partVal, err := generatePartValuesWithTp(partVals[valIdx][colIdx], colTypes[colIdx])
+					if err != nil {
+						return nil, err
+					}
+					inValue = append(inValue, partVal)
+				}
+			} else {
+				for i := range vs {
+					vs[i].Accept(exprChecker)
+					if exprChecker.err != nil {
+						return nil, exprChecker.err
+					}
+					buf.Reset()
+					vs[i].Format(buf)
+					inValue = append(inValue, buf.String())
+				}
 			}
 			piDef.InValues = append(piDef.InValues, inValue)
 			buf.Reset()
@@ -1387,10 +1405,10 @@ func buildRangePartitionDefinitions(ctx expression.BuildContext, defs []*ast.Par
 			return nil, err
 		}
 		clause := def.Clause.(*ast.PartitionDefinitionClauseLessThan)
-		var partValStrings []string
+		var partValDatums []types.Datum
 		if len(tbInfo.Partition.Columns) > 0 {
 			var err error
-			if partValStrings, err = checkAndGetColumnsTypeAndValuesMatch(ctx, colTypes, clause.Exprs); err != nil {
+			if partValDatums, err = checkAndGetColumnsTypeAndValuesMatch(ctx, colTypes, clause.Exprs); err != nil {
 				return nil, err
 			}
 		} else {
@@ -1424,19 +1442,23 @@ func buildRangePartitionDefinitions(ctx expression.BuildContext, defs []*ast.Par
 				return nil, exprChecker.err
 			}
 			// If multi-column use new evaluated+normalized output, instead of just formatted expression
-			if len(partValStrings) > i && len(colTypes) > 1 {
-				partVal := partValStrings[i]
-				switch colTypes[i].EvalType() {
-				case types.ETInt:
-					// no wrapping
-				case types.ETDatetime, types.ETString, types.ETDuration:
-					if _, ok := clause.Exprs[i].(*ast.MaxValueExpr); !ok {
-						// Don't wrap MAXVALUE
-						partVal = driver.WrapInSingleQuotes(partVal)
-					}
-				default:
-					return nil, dbterror.ErrWrongTypeColumnValue.GenWithStackByArgs()
+			if len(partValDatums) > i {
+				var partVal string
+				if partValDatums[i].Kind() == types.KindNull {
+					return nil, dbterror.ErrNullInValuesLessThan
 				}
+				if _, ok := clause.Exprs[i].(*ast.MaxValueExpr); ok {
+					partVal, err = partValDatums[i].ToString()
+					if err != nil {
+						return nil, err
+					}
+				} else {
+					partVal, err = generatePartValuesWithTp(partValDatums[i], colTypes[i])
+					if err != nil {
+						return nil, err
+					}
+				}
+
 				piDef.LessThan = append(piDef.LessThan, partVal)
 			} else {
 				expr.Format(buf)
@@ -4383,4 +4405,31 @@ func AppendPartitionDefs(partitionInfo *model.PartitionInfo, buf *bytes.Buffer, 
 			fmt.Fprintf(buf, " /*T![placement] PLACEMENT POLICY=%s */", stringutil.Escape(def.PlacementPolicyRef.Name.O, sqlMode))
 		}
 	}
+}
+
+func generatePartValuesWithTp(partVal types.Datum, tp types.FieldType) (string, error) {
+	if partVal.Kind() == types.KindNull {
+		return "NULL", nil
+	}
+
+	s, err := partVal.ToString()
+	if err != nil {
+		return "", err
+	}
+
+	switch tp.EvalType() {
+	case types.ETInt:
+		return s, nil
+	case types.ETString:
+		// The `partVal` can be an invalid utf8 string if it's converted to BINARY, then the content will be lost after
+		// marshaling and storing in the schema. In this case, we use a hex literal to work around this issue.
+		if tp.GetCharset() == charset.CharsetBin {
+			return fmt.Sprintf("_binary 0x%x", s), nil
+		}
+		return driver.WrapInSingleQuotes(s), nil
+	case types.ETDatetime, types.ETDuration:
+		return driver.WrapInSingleQuotes(s), nil
+	}
+
+	return "", dbterror.ErrWrongTypeColumnValue.GenWithStackByArgs()
 }

--- a/pkg/ddl/tests/partition/db_partition_test.go
+++ b/pkg/ddl/tests/partition/db_partition_test.go
@@ -736,7 +736,7 @@ create table log_message_1 (
 			"  `a` time DEFAULT NULL\n" +
 			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin\n" +
 			"PARTITION BY RANGE COLUMNS(`a`)\n" +
-			"(PARTITION `p1` VALUES LESS THAN ('2020'))"))
+			"(PARTITION `p1` VALUES LESS THAN ('00:20:20'))"))
 	tk.MustExec(`drop table t`)
 	tk.MustExec(`create table t (a time, b time) partition by range columns (a) (partition p1 values less than ('2020'), partition p2 values less than ('20:20:10'))`)
 	tk.MustQuery(`show create table t`).Check(testkit.Rows(
@@ -745,7 +745,7 @@ create table log_message_1 (
 			"  `b` time DEFAULT NULL\n" +
 			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin\n" +
 			"PARTITION BY RANGE COLUMNS(`a`)\n" +
-			"(PARTITION `p1` VALUES LESS THAN ('2020'),\n" +
+			"(PARTITION `p1` VALUES LESS THAN ('00:20:20'),\n" +
 			" PARTITION `p2` VALUES LESS THAN ('20:20:10'))"))
 	tk.MustExec(`insert into t values ('2019','2019'),('20:20:09','20:20:09')`)
 	tk.MustExec(`drop table t`)
@@ -3406,8 +3406,8 @@ func TestAlterLastIntervalPartition(t *testing.T) {
 		"  `create_time` datetime DEFAULT NULL\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin\n" +
 		"PARTITION BY RANGE COLUMNS(`create_time`)\n" +
-		"(PARTITION `P_LT_2023-01-01` VALUES LESS THAN ('2023-01-01'),\n" +
-		" PARTITION `P_LT_2023-01-02` VALUES LESS THAN ('2023-01-02'),\n" +
+		"(PARTITION `P_LT_2023-01-01` VALUES LESS THAN ('2023-01-01 00:00:00'),\n" +
+		" PARTITION `P_LT_2023-01-02` VALUES LESS THAN ('2023-01-02 00:00:00'),\n" +
 		" PARTITION `P_LT_2023-01-03 00:00:00` VALUES LESS THAN ('2023-01-03 00:00:00'),\n" +
 		" PARTITION `P_LT_2023-01-04 00:00:00` VALUES LESS THAN ('2023-01-04 00:00:00'))"))
 }

--- a/pkg/util/dbterror/ddl_terror.go
+++ b/pkg/util/dbterror/ddl_terror.go
@@ -288,6 +288,8 @@ var (
 	ErrUnsupportedConstraintCheck = ClassDDL.NewStd(mysql.ErrUnsupportedConstraintCheck)
 	// ErrDerivedMustHaveAlias returns when a sub select statement does not have a table alias.
 	ErrDerivedMustHaveAlias = ClassDDL.NewStd(mysql.ErrDerivedMustHaveAlias)
+	// ErrNullInValuesLessThan returns when a range partition LESS THAN expression includes a NULL
+	ErrNullInValuesLessThan = ClassDDL.NewStd(mysql.ErrNullInValuesLessThan)
 
 	// ErrSequenceRunOut returns when the sequence has been run out.
 	ErrSequenceRunOut = ClassDDL.NewStd(mysql.ErrSequenceRunOut)

--- a/tests/integrationtest/r/ddl/db_partition.result
+++ b/tests/integrationtest/r/ddl/db_partition.result
@@ -584,9 +584,9 @@ t	CREATE TABLE `t` (
   `a` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 PARTITION BY LIST COLUMNS(`a`)
-(PARTITION `p0` VALUES IN (0,4),
- PARTITION `p1` VALUES IN (1,NULL,DEFAULT),
- PARTITION `p2` VALUES IN (2,7,10))
+(PARTITION `p0` VALUES IN ('0','4'),
+ PARTITION `p1` VALUES IN ('1',NULL,DEFAULT),
+ PARTITION `p2` VALUES IN ('2','7','10'))
 insert into t values (1, "1"), (2, "2"), (3,'3'), (null, null), (4, "4"), (11, "11");
 analyze table t;
 select * from t partition(p0);
@@ -600,9 +600,9 @@ NULL	NULL
 3	3
 select partition_name, partition_method, partition_expression, partition_description, table_rows from information_schema.partitions where table_schema = 'ddl__db_partition' and table_name = 't';
 partition_name	partition_method	partition_expression	partition_description	table_rows
-p0	LIST COLUMNS	`a`	0,4	1
-p1	LIST COLUMNS	`a`	1,NULL,DEFAULT	4
-p2	LIST COLUMNS	`a`	2,7,10	1
+p0	LIST COLUMNS	`a`	'0','4'	1
+p1	LIST COLUMNS	`a`	'1',NULL,DEFAULT	4
+p2	LIST COLUMNS	`a`	'2','7','10'	1
 set @@tidb_partition_prune_mode = 'dynamic';
 explain format = 'brief' select * from t where a is null;
 id	estRows	task	access object	operator info
@@ -2805,7 +2805,7 @@ t	CREATE TABLE "t" (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 PARTITION BY LIST COLUMNS("a")
 (PARTITION "p0" VALUES IN ('''','''''',''''''''),
- PARTITION "p1" VALUES IN ('""','\\',x'5c27090a'))
+ PARTITION "p1" VALUES IN ('""','\\','\\''\t\n'))
 drop table t;
 CREATE TABLE t (a varchar(255) DEFAULT NULL) PARTITION BY LIST COLUMNS(a) (
 PARTITION p0 VALUES IN ('\'','\'\'',''''''''),
@@ -2818,7 +2818,7 @@ t	CREATE TABLE "t" (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 PARTITION BY LIST COLUMNS("a")
 (PARTITION "p0" VALUES IN ('''','''''',''''''''),
- PARTITION "p1" VALUES IN ('""','\\',x'5c27090a'))
+ PARTITION "p1" VALUES IN ('""','\\','\\''\t\n'))
 drop table t;
 CREATE TABLE t (a varchar(255)) PARTITION BY RANGE COLUMNS(a) (
 PARTITION p0 VALUES LESS THAN ('"'),
@@ -2859,7 +2859,7 @@ PARTITION BY RANGE COLUMNS("a")
  PARTITION "p1" VALUES LESS THAN ('""'),
  PARTITION "p2" VALUES LESS THAN (''''),
  PARTITION "p3" VALUES LESS THAN (''''''),
- PARTITION "p4" VALUES LESS THAN (x'5c27090a'),
+ PARTITION "p4" VALUES LESS THAN ('\\''\t\n'),
  PARTITION "pMax" VALUES LESS THAN (MAXVALUE))
 drop table t;
 CREATE TABLE t (a varchar(255), b varchar(255)) PARTITION BY RANGE COLUMNS(a,b) (

--- a/tests/integrationtest/r/ddl/partition.result
+++ b/tests/integrationtest/r/ddl/partition.result
@@ -280,3 +280,180 @@ UNIQUE KEY (id, id1))
 PARTITION BY KEY()
 PARTITIONS 2;
 Error 1105 (HY000): Table partition metadata not correct, neither partition expression or list of partition columns
+set character_set_connection=gbk;
+drop table if exists t;
+create table t (col1 varbinary(16) unique key) partition by list columns(col1)
+(partition p0 values in ('你好', '我好'), partition p1 values in ('大家好'), partition p2 DEFAULT);
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `col1` varbinary(16) DEFAULT NULL,
+  UNIQUE KEY `col1` (`col1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY LIST COLUMNS(`col1`)
+(PARTITION `p0` VALUES IN (_binary 0xc4e3bac3,_binary 0xced2bac3),
+ PARTITION `p1` VALUES IN (_binary 0xb4f3bcd2bac3),
+ PARTITION `p2` DEFAULT)
+insert into t values ("你好");
+select hex(col1) from t partition(p0);
+hex(col1)
+C4E3BAC3
+select hex(col1) from t partition(p1);
+hex(col1)
+select hex(col1) from t partition(p2);
+hex(col1)
+drop table t;
+create table t (col1 varbinary(16) unique key) partition by range columns(col1)
+(partition p0 values less than ('你好'), partition p1 values less than ('我好'), partition p2 values less than MAXVALUE);
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `col1` varbinary(16) DEFAULT NULL,
+  UNIQUE KEY `col1` (`col1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE COLUMNS(`col1`)
+(PARTITION `p0` VALUES LESS THAN (_binary 0xc4e3bac3),
+ PARTITION `p1` VALUES LESS THAN (_binary 0xced2bac3),
+ PARTITION `p2` VALUES LESS THAN (MAXVALUE))
+insert into t values ("你好");
+select hex(col1) from t partition(p0);
+hex(col1)
+select hex(col1) from t partition(p1);
+hex(col1)
+C4E3BAC3
+select hex(col1) from t partition(p2);
+hex(col1)
+drop table t;
+create table t (col1 varchar(16) collate gbk_chinese_ci unique key) partition by list columns(col1)
+(partition p0 values in ('你好', '我好'), partition p1 values in ('大家好'), partition p2 DEFAULT);
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `col1` varchar(16) CHARACTER SET gbk COLLATE gbk_chinese_ci DEFAULT NULL,
+  UNIQUE KEY `col1` (`col1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY LIST COLUMNS(`col1`)
+(PARTITION `p0` VALUES IN ('你好','我好'),
+ PARTITION `p1` VALUES IN ('大家好'),
+ PARTITION `p2` DEFAULT)
+insert into t values ("你好");
+select hex(col1) from t partition(p0);
+hex(col1)
+C4E3BAC3
+select hex(col1) from t partition(p1);
+hex(col1)
+select hex(col1) from t partition(p2);
+hex(col1)
+drop table t;
+create table t (col1 varchar(16) collate gbk_chinese_ci unique key) partition by range columns(col1)
+(partition p0 values less than ('你好'), partition p1 values less than ('我好'), partition p2 values less than MAXVALUE);
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `col1` varchar(16) CHARACTER SET gbk COLLATE gbk_chinese_ci DEFAULT NULL,
+  UNIQUE KEY `col1` (`col1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE COLUMNS(`col1`)
+(PARTITION `p0` VALUES LESS THAN ('你好'),
+ PARTITION `p1` VALUES LESS THAN ('我好'),
+ PARTITION `p2` VALUES LESS THAN (MAXVALUE))
+insert into t values ("你好");
+select hex(col1) from t partition(p0);
+hex(col1)
+select hex(col1) from t partition(p1);
+hex(col1)
+C4E3BAC3
+select hex(col1) from t partition(p2);
+hex(col1)
+drop table t;
+create table t (col1 varbinary(16), col2 varbinary(16), unique key (col1, col2)) partition by list columns(col1, col2)
+(partition p0 values in (('你好','你好'), ('我好','我好')), partition p1 values in (('大家好','大家好')), partition p2 DEFAULT);
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `col1` varbinary(16) DEFAULT NULL,
+  `col2` varbinary(16) DEFAULT NULL,
+  UNIQUE KEY `col1` (`col1`,`col2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY LIST COLUMNS(`col1`,`col2`)
+(PARTITION `p0` VALUES IN ((_binary 0xc4e3bac3,_binary 0xc4e3bac3),(_binary 0xced2bac3,_binary 0xced2bac3)),
+ PARTITION `p1` VALUES IN ((_binary 0xb4f3bcd2bac3,_binary 0xb4f3bcd2bac3)),
+ PARTITION `p2` DEFAULT)
+insert into t values ("你好","你好");
+select hex(col1),hex(col2) from t partition(p0);
+hex(col1)	hex(col2)
+C4E3BAC3	C4E3BAC3
+select hex(col1),hex(col2) from t partition(p1);
+hex(col1)	hex(col2)
+select hex(col1),hex(col2) from t partition(p2);
+hex(col1)	hex(col2)
+drop table t;
+create table t (col1 varbinary(16), col2 varbinary(16), unique key (col1, col2)) partition by range columns(col1, col2)
+(partition p0 values less than ('你好','你好'), partition p1 values less than ('我好','我好'), partition p2 values less than (MAXVALUE, MAXVALUE));
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `col1` varbinary(16) DEFAULT NULL,
+  `col2` varbinary(16) DEFAULT NULL,
+  UNIQUE KEY `col1` (`col1`,`col2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE COLUMNS(`col1`,`col2`)
+(PARTITION `p0` VALUES LESS THAN (_binary 0xc4e3bac3,_binary 0xc4e3bac3),
+ PARTITION `p1` VALUES LESS THAN (_binary 0xced2bac3,_binary 0xced2bac3),
+ PARTITION `p2` VALUES LESS THAN (MAXVALUE,MAXVALUE))
+insert into t values ("你好","你好");
+select hex(col1),hex(col2) from t partition(p0);
+hex(col1)	hex(col2)
+select hex(col1),hex(col2) from t partition(p1);
+hex(col1)	hex(col2)
+C4E3BAC3	C4E3BAC3
+select hex(col1),hex(col2) from t partition(p2);
+hex(col1)	hex(col2)
+drop table t;
+create table t (col1 varchar(16) collate gbk_chinese_ci, col2 varchar(16) collate gbk_chinese_ci, unique key (col1, col2)) partition by list columns(col1, col2)
+(partition p0 values in (('你好','你好'), ('我好','我好')), partition p1 values in (('大家好','大家好')), partition p2 DEFAULT);
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `col1` varchar(16) CHARACTER SET gbk COLLATE gbk_chinese_ci DEFAULT NULL,
+  `col2` varchar(16) CHARACTER SET gbk COLLATE gbk_chinese_ci DEFAULT NULL,
+  UNIQUE KEY `col1` (`col1`,`col2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY LIST COLUMNS(`col1`,`col2`)
+(PARTITION `p0` VALUES IN (('你好','你好'),('我好','我好')),
+ PARTITION `p1` VALUES IN (('大家好','大家好')),
+ PARTITION `p2` DEFAULT)
+insert into t values ("你好","你好");
+select hex(col1),hex(col2) from t partition(p0);
+hex(col1)	hex(col2)
+C4E3BAC3	C4E3BAC3
+select hex(col1),hex(col2) from t partition(p1);
+hex(col1)	hex(col2)
+select hex(col1),hex(col2) from t partition(p2);
+hex(col1)	hex(col2)
+drop table t;
+create table t (col1 varchar(16) collate gbk_chinese_ci, col2 varchar(16) collate gbk_chinese_ci, unique key (col1, col2)) partition by range columns(col1, col2)
+(partition p0 values less than ('你好','你好'), partition p1 values less than ('我好','我好'), partition p2 values less than (MAXVALUE, MAXVALUE) );
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `col1` varchar(16) CHARACTER SET gbk COLLATE gbk_chinese_ci DEFAULT NULL,
+  `col2` varchar(16) CHARACTER SET gbk COLLATE gbk_chinese_ci DEFAULT NULL,
+  UNIQUE KEY `col1` (`col1`,`col2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE COLUMNS(`col1`,`col2`)
+(PARTITION `p0` VALUES LESS THAN ('你好','你好'),
+ PARTITION `p1` VALUES LESS THAN ('我好','我好'),
+ PARTITION `p2` VALUES LESS THAN (MAXVALUE,MAXVALUE))
+insert into t values ("你好","你好");
+select hex(col1),hex(col2) from t partition(p0);
+hex(col1)	hex(col2)
+select hex(col1),hex(col2) from t partition(p1);
+hex(col1)	hex(col2)
+C4E3BAC3	C4E3BAC3
+select hex(col1),hex(col2) from t partition(p2);
+hex(col1)	hex(col2)
+drop table t;
+set character_set_connection=DEFAULT;
+create table a (col1 int, col2 int, unique key (col1, col2)) partition by range  columns (col1, col2) (partition p0 values less than (NULL, 1 ));
+Error 1566 (HY000): Not allowed to use NULL value in VALUES LESS THAN

--- a/tests/integrationtest/r/executor/show.result
+++ b/tests/integrationtest/r/executor/show.result
@@ -542,7 +542,7 @@ t	CREATE TABLE `t` (
   `a` varchar(255) CHARACTER SET ascii COLLATE ascii_bin DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 PARTITION BY RANGE COLUMNS(`a`)
-(PARTITION `p` VALUES LESS THAN (x'7f'))
+(PARTITION `p` VALUES LESS THAN (0x7f))
 set @@session.tidb_enable_list_partition = default;
 set @@foreign_key_checks=default;
 create table if not exists show_errors (a int);

--- a/tests/integrationtest/r/planner/core/integration_partition.result
+++ b/tests/integrationtest/r/planner/core/integration_partition.result
@@ -678,7 +678,7 @@ drop table t1;
 create database RangeColumnsMulti;
 use RangeColumnsMulti;
 create table t (a int, b datetime, c varchar(255)) partition by range columns (a,b,c)(partition p0 values less than (NULL,NULL,NULL));
-Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 26 near ",'',''))" 
+Error 1566 (HY000): Not allowed to use NULL value in VALUES LESS THAN
 create table t (a int, b datetime, c varchar(255)) partition by range columns (a,b,c)(partition p1 values less than (-2147483649,'0000-00-00',""));
 Error 1654 (HY000): Partition column values of incorrect type
 create table t (a int, b datetime, c varchar(255)) partition by range columns (a,b,c)(partition p1 values less than (-2147483648,'0000-00-00',""),partition p2 values less than (10,'2022-01-01',"Wow"),partition p3 values less than (11,'2022-01-01',MAXVALUE),partition p4 values less than (MAXVALUE,'2022-01-01',"Wow"));
@@ -1161,11 +1161,11 @@ t	CREATE TABLE `t` (
   `a` date DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 PARTITION BY RANGE COLUMNS(`a`)
-(PARTITION `p0` VALUES LESS THAN ('19990601'),
+(PARTITION `p0` VALUES LESS THAN ('1999-06-01'),
  PARTITION `p1` VALUES LESS THAN ('2000-05-01'),
- PARTITION `p2` VALUES LESS THAN ('20080401'),
+ PARTITION `p2` VALUES LESS THAN ('2008-04-01'),
  PARTITION `p3` VALUES LESS THAN ('2010-03-01'),
- PARTITION `p4` VALUES LESS THAN ('20160201'),
+ PARTITION `p4` VALUES LESS THAN ('2016-02-01'),
  PARTITION `p5` VALUES LESS THAN ('2020-01-01'),
  PARTITION `p6` VALUES LESS THAN (MAXVALUE))
 insert into t values ('19990101'),('1999-06-01'),('2000-05-01'),('20080401'),('2010-03-01'),('2016-02-01'),('2020-01-01');

--- a/tests/integrationtest/t/ddl/partition.test
+++ b/tests/integrationtest/t/ddl/partition.test
@@ -185,3 +185,77 @@ CREATE TABLE k4(
     UNIQUE KEY (id, id1))
 PARTITION BY KEY()
 PARTITIONS 2;
+
+# TestPartitionInNonUTF8Charset
+set character_set_connection=gbk;
+drop table if exists t;
+create table t (col1 varbinary(16) unique key) partition by list columns(col1)
+    (partition p0 values in ('你好', '我好'), partition p1 values in ('大家好'), partition p2 DEFAULT);
+show create table t;
+insert into t values ("你好");
+select hex(col1) from t partition(p0);
+select hex(col1) from t partition(p1);
+select hex(col1) from t partition(p2);
+drop table t;
+create table t (col1 varbinary(16) unique key) partition by range columns(col1)
+    (partition p0 values less than ('你好'), partition p1 values less than ('我好'), partition p2 values less than MAXVALUE);
+show create table t;
+insert into t values ("你好");
+select hex(col1) from t partition(p0);
+select hex(col1) from t partition(p1);
+select hex(col1) from t partition(p2);
+drop table t;
+create table t (col1 varchar(16) collate gbk_chinese_ci unique key) partition by list columns(col1)
+    (partition p0 values in ('你好', '我好'), partition p1 values in ('大家好'), partition p2 DEFAULT);
+show create table t;
+insert into t values ("你好");
+select hex(col1) from t partition(p0);
+select hex(col1) from t partition(p1);
+select hex(col1) from t partition(p2);
+drop table t;
+create table t (col1 varchar(16) collate gbk_chinese_ci unique key) partition by range columns(col1)
+    (partition p0 values less than ('你好'), partition p1 values less than ('我好'), partition p2 values less than MAXVALUE);
+show create table t;
+insert into t values ("你好");
+select hex(col1) from t partition(p0);
+select hex(col1) from t partition(p1);
+select hex(col1) from t partition(p2);
+drop table t;
+create table t (col1 varbinary(16), col2 varbinary(16), unique key (col1, col2)) partition by list columns(col1, col2)
+    (partition p0 values in (('你好','你好'), ('我好','我好')), partition p1 values in (('大家好','大家好')), partition p2 DEFAULT);
+show create table t;
+insert into t values ("你好","你好");
+select hex(col1),hex(col2) from t partition(p0);
+select hex(col1),hex(col2) from t partition(p1);
+select hex(col1),hex(col2) from t partition(p2);
+drop table t;
+create table t (col1 varbinary(16), col2 varbinary(16), unique key (col1, col2)) partition by range columns(col1, col2)
+    (partition p0 values less than ('你好','你好'), partition p1 values less than ('我好','我好'), partition p2 values less than (MAXVALUE, MAXVALUE));
+show create table t;
+insert into t values ("你好","你好");
+select hex(col1),hex(col2) from t partition(p0);
+select hex(col1),hex(col2) from t partition(p1);
+select hex(col1),hex(col2) from t partition(p2);
+drop table t;
+create table t (col1 varchar(16) collate gbk_chinese_ci, col2 varchar(16) collate gbk_chinese_ci, unique key (col1, col2)) partition by list columns(col1, col2)
+    (partition p0 values in (('你好','你好'), ('我好','我好')), partition p1 values in (('大家好','大家好')), partition p2 DEFAULT);
+show create table t;
+insert into t values ("你好","你好");
+select hex(col1),hex(col2) from t partition(p0);
+select hex(col1),hex(col2) from t partition(p1);
+select hex(col1),hex(col2) from t partition(p2);
+drop table t;
+create table t (col1 varchar(16) collate gbk_chinese_ci, col2 varchar(16) collate gbk_chinese_ci, unique key (col1, col2)) partition by range columns(col1, col2)
+    (partition p0 values less than ('你好','你好'), partition p1 values less than ('我好','我好'), partition p2 values less than (MAXVALUE, MAXVALUE) );
+show create table t;
+insert into t values ("你好","你好");
+select hex(col1),hex(col2) from t partition(p0);
+select hex(col1),hex(col2) from t partition(p1);
+select hex(col1),hex(col2) from t partition(p2);
+drop table t;
+set character_set_connection=DEFAULT;
+
+# TestNULLInRangeParitionLessThanExpression
+-- error 1566
+create table a (col1 int, col2 int, unique key (col1, col2)) partition by range  columns (col1, col2) (partition p0 values less than (NULL, 1 ));
+

--- a/tests/integrationtest/t/planner/core/integration_partition.test
+++ b/tests/integrationtest/t/planner/core/integration_partition.test
@@ -565,7 +565,7 @@ drop table t1;
 # TestRangeColumnsMultiColumn
 create database RangeColumnsMulti;
 use RangeColumnsMulti;
--- error 1064
+-- error 1566
 create table t (a int, b datetime, c varchar(255)) partition by range columns (a,b,c)(partition p0 values less than (NULL,NULL,NULL));
 -- error 1654
 create table t (a int, b datetime, c varchar(255)) partition by range columns (a,b,c)(partition p1 values less than (-2147483649,'0000-00-00',""));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #36433, close #49251

Problem Summary:

The string literal in the partition clause is stored as a formated string literal. For example, the `'你好'` will be kept as `'你好'` in the schema, and the collation information is lost. However, when running the `getRangeLocateExprs`, the expression is constructed with the DDL session, which always use `utf8mb4` collation.

When inserting the row, the string (after converted to the collation corresponding to the column) will be compared with the `utf8mb4` literal string, which may cause unexpected behavior. In the issue #36433, the insert value `你好` is converted to binary encoding GBK `\xc4\xe3\xba\xc3`, and compare it with the utf8 string `'你好'` through binary collation directly, then former is smaller than the later one.

MySQL records the binary representation in table schema. If we run `show create table a` in MySQL, it'll give a hex literal  with `_binary` prefix in the partition clause.

### What changed and how does it work?

If the target is binary charset, use the hex literal to represent the string. Actually this PR does two change:

1. Always use the evaluated string to represent the partition clause.
2. If the target column collation is binary, use the `_binary` + hex literal to represent the definition, as it may be an invalid utf8 string.

As TiDB always use utf8 to represent a string internally (except binary), it's fine to not consider other charset like GBK.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
Fix the issue that the partition clause is compared through the collation of `utf8` charset, but not the column charset.
```
