### PR TITLE
tests: enable `check-error` for integrationtest

### DIFF
--- a/tests/integrationtest/r/collation_agg_func_disabled.result
+++ b/tests/integrationtest/r/collation_agg_func_disabled.result
@@ -131,13 +131,10 @@ approx_count_distinct(value collate utf8mb4_bin, value1)
 create table tt(a char(10), b enum('a', 'B', 'c'), c set('a', 'B', 'c'), d json) collate utf8mb4_general_ci;
 insert into tt values ("a", "a", "a", JSON_OBJECT("a", "a"));
 insert into tt values ("A", "A", "A", JSON_OBJECT("A", "A"));
-Error 1265 (01000): Data truncated for column 'b' at row 1
 insert into tt values ("b", "b", "b", JSON_OBJECT("b", "b"));
-Error 1265 (01000): Data truncated for column 'b' at row 1
 insert into tt values ("B", "B", "B", JSON_OBJECT("B", "B"));
 insert into tt values ("c", "c", "c", JSON_OBJECT("c", "c"));
 insert into tt values ("C", "C", "C", JSON_OBJECT("C", "C"));
-Error 1265 (01000): Data truncated for column 'b' at row 1
 split table tt by (0), (1), (2), (3), (4), (5);
 TOTAL_SPLIT_REGION	SCATTER_FINISH_RATIO
 6	1

--- a/tests/integrationtest/r/collation_check_use_collation_disabled.result
+++ b/tests/integrationtest/r/collation_check_use_collation_disabled.result
@@ -30,7 +30,6 @@ drop table if exists t;
 create table t(a enum('a', 'b') charset utf8mb4 collate utf8mb4_general_ci, b varchar(20));
 insert into t values ("b", "c");
 insert into t values ("B", "b");
-Error 1265 (01000): Data truncated for column 'a' at row 1
 select * from t where 'B' collate utf8mb4_general_ci in (a);
 a	b
 select * from t where 'B' collate utf8mb4_bin in (a);
@@ -80,7 +79,6 @@ drop table if exists t;
 create table t(a set('a', 'b') charset utf8mb4 collate utf8mb4_general_ci, b varchar(20));
 insert into t values ("b", "c");
 insert into t values ("B", "b");
-Error 1265 (01000): Data truncated for column 'a' at row 1
 select * from t where 'B' collate utf8mb4_general_ci in (a);
 a	b
 select * from t where 'B' collate utf8mb4_bin in (a);

--- a/tests/integrationtest/r/collation_misc_disabled.result
+++ b/tests/integrationtest/r/collation_misc_disabled.result
@@ -38,9 +38,9 @@ Error 8200 (HY000): Unsupported modify charset from latin1 to utf8
 alter table t modify column a varchar(20) charset utf8mb4 collate utf8bin;
 Error 1273 (HY000): Unknown collation: 'utf8bin'
 alter table t collate LATIN1_GENERAL_CI charset utf8 collate utf8_bin;
-Error 1302 (HY000): Conflicting declarations: 'CHARACTER SET latin1' and 'CHARACTER SET utf8'
+Got one of the listed errors
 alter table t collate LATIN1_GENERAL_CI collate UTF8MB4_UNICODE_ci collate utf8_bin;
-Error 1253 (42000): COLLATION 'utf8mb4_unicode_ci' is not valid for CHARACTER SET 'latin1'
+Got one of the listed errors
 drop table t;
 create table t(a varchar(20) charset latin1);
 insert into t values ("t_value");

--- a/tests/integrationtest/r/collation_misc_enabled.result
+++ b/tests/integrationtest/r/collation_misc_enabled.result
@@ -38,9 +38,9 @@ Error 8200 (HY000): Unsupported modify charset from latin1 to utf8
 alter table t modify column a varchar(20) charset utf8mb4 collate utf8bin;
 Error 1273 (HY000): Unknown collation: 'utf8bin'
 alter table t collate LATIN1_GENERAL_CI charset utf8 collate utf8_bin;
-Error 1273 (HY000): Unsupported collation when new collation is enabled: 'latin1_general_ci'
+Got one of the listed errors
 alter table t collate LATIN1_GENERAL_CI collate UTF8MB4_UNICODE_ci collate utf8_bin;
-Error 1273 (HY000): Unsupported collation when new collation is enabled: 'latin1_general_ci'
+Got one of the listed errors
 drop table t;
 create table t(a varchar(20) charset latin1);
 insert into t values ("t_value");
@@ -51,7 +51,6 @@ a
 t_value
 create database if not exists cd_test_utf8 CHARACTER SET utf8 COLLATE utf8_bin;
 create database if not exists cd_test_latin1 CHARACTER SET latin1 COLLATE latin1_swedish_ci;
-Error 1273 (HY000): Unsupported collation when new collation is enabled: 'latin1_swedish_ci'
 use cd_test_utf8;
 select @@character_set_database;
 @@character_set_database
@@ -60,7 +59,6 @@ select @@collation_database;
 @@collation_database
 utf8_bin
 use cd_test_latin1;
-Error 1049 (42000): Unknown database 'cd_test_latin1'
 select @@character_set_database;
 @@character_set_database
 utf8
@@ -68,7 +66,6 @@ select @@collation_database;
 @@collation_database
 utf8_bin
 create database if not exists test_db CHARACTER SET latin1 COLLATE latin1_swedish_ci;
-Error 1273 (HY000): Unsupported collation when new collation is enabled: 'latin1_swedish_ci'
 with cte as (select cast('2010-09-09' as date) a union select  '2010-09-09  ') select count(*) from cte;
 count(*)
 1

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -3933,8 +3933,8 @@ a
 1
 2
 3
-SELECT `s`.`count(a)` FROM (SELECT COUNT(`a`) FROM `test`.`t`) AS `s`;
-Error 1146 (42S02): Table 'test.t' doesn't exist
+SELECT `s`.`count(a)` FROM (SELECT COUNT(`a`) FROM `executor__executor`.`t`) AS `s`;
+Error 1054 (42S22): Unknown column 's.count(a)' in 'field list'
 drop view v;
 create definer='root'@'localhost' view v as select * from (select count(a) from t) s;
 select * from v;

--- a/tests/integrationtest/r/executor/write.result
+++ b/tests/integrationtest/r/executor/write.result
@@ -2012,8 +2012,8 @@ replace replace_test_1 select id, c1 from replace_test;
 affected rows: 4
 info: Records: 4  Duplicates: 0  Warnings: 0
 begin;
-replace replace_test_0 select c1 from replace_test;
-Error 1146 (42S02): Table 'executor__write.replace_test_0' doesn't exist
+replace replace_test_1 select c1 from replace_test;
+Error 1136 (21S01): Column count doesn't match value count at row 1
 rollback;
 create table replace_test_2 (id int, c1 int);
 replace replace_test_1 select id, c1 from replace_test union select id * 10, c1 * 10 from replace_test;

--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -133,15 +133,14 @@ set global innodb_commit_concurrency=16;
 Error 1227 (42000): Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
 # TestCheckPointGetDBPrivilege
 CREATE USER 'tester'@'localhost';
-GRANT SELECT,UPDATE ON privilege__privileges.* TO  'tester'@'localhost';
+GRANT SELECT,UPDATE ON privilege__privileges2.* TO  'tester'@'localhost';
 create database if not exists privilege__privileges;
 create table privilege__privileges.t(id int, v int, primary key(id));
 insert into privilege__privileges.t(id, v) values(1, 1);
-use privilege__privileges;
 select * from privilege__privileges.t where id = 1;
-id	v
-1	1
+Error 1142 (42000): SELECT command denied to user 'tester'@'localhost' for table 't'
 update privilege__privileges.t set v = 2 where id = 1;
+Error 1142 (42000): SELECT command denied to user 'tester'@'localhost' for table 't'
 DROP USER 'tester'@'localhost';
 CREATE DATABASE if not exists privilege__privileges;
 USE privilege__privileges;
@@ -328,8 +327,8 @@ GRANT USAGE ON *.* TO 'column'@'%'
 GRANT SELECT(a), INSERT(c), UPDATE(a, b) ON `privilege__privileges`.`column_table` TO 'column'@'%'
 CREATE USER 'tableaccess'@'localhost';
 CREATE TABLE fieldlistt1 (a int);
-desc fieldlistt1;
-Error 1046 (3D000): No database selected
+desc privilege__privileges.fieldlistt1;
+Error 1142 (42000): SELECT command denied to user 'tableaccess'@'localhost' for table 'fieldlistt1'
 CREATE USER tr_insert;
 CREATE USER tr_update;
 CREATE USER tr_delete;

--- a/tests/integrationtest/run-tests.sh
+++ b/tests/integrationtest/run-tests.sh
@@ -235,10 +235,10 @@ function run_mysql_tester()
     if [ $record -eq 1 ]; then
       if [ "$record_case" = 'all' ]; then
           echo "record all cases"
-          $mysql_tester -port "$port" --collation-disable=$coll_disabled --record
+          $mysql_tester -port "$port" --check-error=true --collation-disable=$coll_disabled --record
       else
           echo "record result for case: \"$record_case\""
-          $mysql_tester -port "$port" --collation-disable=$coll_disabled --record $record_case
+          $mysql_tester -port "$port" --check-error=true --collation-disable=$coll_disabled --record $record_case
       fi
     else
       if [ -z "$tests" ]; then
@@ -246,7 +246,7 @@ function run_mysql_tester()
       else
           echo "run integration test cases($coll_msg): $tests"
       fi
-      $mysql_tester -port "$port" --collation-disable=$coll_disabled $tests
+      $mysql_tester -port "$port" --check-error=true --collation-disable=$coll_disabled $tests
     fi
 }
 

--- a/tests/integrationtest/t/collation_agg_func.test
+++ b/tests/integrationtest/t/collation_agg_func.test
@@ -44,13 +44,13 @@ select approx_count_distinct(value collate utf8mb4_bin, value1) from t;
 # minMax
 create table tt(a char(10), b enum('a', 'B', 'c'), c set('a', 'B', 'c'), d json) collate utf8mb4_general_ci;
 insert into tt values ("a", "a", "a", JSON_OBJECT("a", "a"));
---error 1265
+--error 0,1265
 insert into tt values ("A", "A", "A", JSON_OBJECT("A", "A"));
---error 1265
+--error 0,1265
 insert into tt values ("b", "b", "b", JSON_OBJECT("b", "b"));
 insert into tt values ("B", "B", "B", JSON_OBJECT("B", "B"));
 insert into tt values ("c", "c", "c", JSON_OBJECT("c", "c"));
---error 1265
+--error 0,1265
 insert into tt values ("C", "C", "C", JSON_OBJECT("C", "C"));
 split table tt by (0), (1), (2), (3), (4), (5);
 desc format='brief' select min(a) from tt;
@@ -88,14 +88,10 @@ desc format='brief' select max(c collate utf8mb4_bin) from tt;
 select max(c collate utf8mb4_bin) from tt;
 desc format='brief' select min(d) from tt;
 select min(d) from tt;
---error 1253
 desc format='brief' select min(d collate utf8mb4_bin) from tt;
---error 1253
 select min(d collate utf8mb4_bin) from tt;
 desc format='brief' select max(d) from tt;
 select max(d) from tt;
---error 1253
 desc format='brief' select max(d collate utf8mb4_bin) from tt;
---error 1253
 select max(d collate utf8mb4_bin) from tt;
 

--- a/tests/integrationtest/t/collation_check_use_collation.test
+++ b/tests/integrationtest/t/collation_check_use_collation.test
@@ -10,7 +10,6 @@ CREATE TABLE `t1` (
 );
 insert into t values ("A");
 # Ignore error for the disabled new-collation case.
---error 1265
 insert into t1 values ("a");
 select a as a_col from t where t.a = all (select a collate utf8mb4_general_ci from t1);
 select a as a_col from t where t.a != any (select a collate utf8mb4_general_ci from t1);
@@ -29,7 +28,7 @@ drop table if exists t;
 create table t(a enum('a', 'b') charset utf8mb4 collate utf8mb4_general_ci, b varchar(20));
 insert into t values ("b", "c");
 # Ignore error for the disabled new-collation case.
---error 1265
+--error 0,1265
 insert into t values ("B", "b");
 select * from t where 'B' collate utf8mb4_general_ci in (a);
 select * from t where 'B' collate utf8mb4_bin in (a);
@@ -57,7 +56,7 @@ drop table if exists t;
 create table t(a set('a', 'b') charset utf8mb4 collate utf8mb4_general_ci, b varchar(20));
 insert into t values ("b", "c");
 # Ignore error for the disabled new-collation case.
---error 1265
+--error 0,1265
 insert into t values ("B", "b");
 select * from t where 'B' collate utf8mb4_general_ci in (a);
 select * from t where 'B' collate utf8mb4_bin in (a);

--- a/tests/integrationtest/t/collation_misc.test
+++ b/tests/integrationtest/t/collation_misc.test
@@ -50,18 +50,18 @@ select * from t;
 
 # TestCharsetDatabase
 create database if not exists cd_test_utf8 CHARACTER SET utf8 COLLATE utf8_bin;
---error 1273
+--error 0,1273
 create database if not exists cd_test_latin1 CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 use cd_test_utf8;
 select @@character_set_database;
 select @@collation_database;
---error 1049
+--error 0,1049
 use cd_test_latin1;
 select @@character_set_database;
 select @@collation_database;
 
 # DefaultDBAfterDropCurDB
---error 1273
+--error 0,1273
 create database if not exists test_db CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 
 # CollationUnion

--- a/tests/integrationtest/t/ddl/constraint.test
+++ b/tests/integrationtest/t/ddl/constraint.test
@@ -619,7 +619,6 @@ create table t(a int);
 insert into t values(1), (2), (3);
 -- error 3819
 alter table t add constraint check(a < 2);
--- error 3819
 alter table t add constraint check(a < 2) not enforced;
 
 # TestAlterTableDropCheckConstraints
@@ -666,12 +665,12 @@ CREATE TABLE `t` (`a` int(11) DEFAULT NULL);
 show create table t;
 insert t values(1);
 select * from t;
--- error 3940
+-- error 3819
 alter table t ADD CONSTRAINT chk CHECK (a > 1) ENFORCED;
--- error 3940
+-- error 3819
 alter table t ADD CONSTRAINT chk CHECK (a > 1) ENFORCED;
 alter table t ADD CONSTRAINT chk CHECK (a > 1) NOT ENFORCED;
--- error 3940
+-- error 3819
 ALTER TABLE t ALTER CONSTRAINT chk ENFORCED;
 show create table t;
 alter table t drop CONSTRAINT chk;

--- a/tests/integrationtest/t/ddl/db_partition.test
+++ b/tests/integrationtest/t/ddl/db_partition.test
@@ -307,7 +307,7 @@ explain format = 'brief' select * from t where a is null;
 explain format = 'brief' select * from t where a = 3;
 # TODO: check ranges with 1,2 and 3 matching values, including 'holes' matching DEFAULT
 # DEFAULT partition will not be used in reorganize partition if not included in the source/destination
--- error 8112
+-- error 1526
 alter table t reorganize partition p0 into (partition p0 values in (0));
 drop table t;
 CREATE TABLE t (a VARCHAR(100),b INT) PARTITION BY LIST COLUMNS (a) (PARTITION p1 VALUES IN ('a', 'b', 'DEFAULT'),PARTITION pDef DEFAULT);
@@ -369,7 +369,7 @@ explain format = 'brief' select * from t where a >= "3" and a <= "4";
 --sorted_result
 select * from t where a >= "3" and a <= "4";
 # DEFAULT partition will not be used in reorganize partition if not included in the source/destination
--- error 8112
+-- error 1526
 alter table t reorganize partition p0 into (partition p0 values in (0));
 set @@tidb_partition_prune_mode = default;
 

--- a/tests/integrationtest/t/ddl/table_modify.test
+++ b/tests/integrationtest/t/ddl/table_modify.test
@@ -20,45 +20,45 @@ create table dbCollateTest (a varchar(10));
 show create table dbCollateTest;
 -- error 1291
 create table t_enum (a enum('e','e'));
--- error 1290
+-- error 1115
 create table t_enum (a enum('e','E')) charset=utf7 collate=utf8_general_ci;
--- error 1290
+-- error 1115
 create table t_enum (a enum('abc','Abc')) charset=utf7 collate=utf8_general_ci;
--- error 1290
+-- error 1115
 create table t_enum (a enum('e','E')) charset=utf7 collate=utf8_unicode_ci;
--- error 1290
+-- error 1115
 create table t_enum (a enum('ss','ß')) charset=utf7 collate=utf8_unicode_ci;
--- error 1290
+-- error 1115
 create table t_enum (a enum('æ','ae')) charset=utf7mb4 collate=utf8mb4_0900_ai_ci;
--- error 1290
+-- error 1291
 create table t_enum (a set('e','e'));
--- error 1290
+-- error 1115
 create table t_enum (a set('e','E')) charset=utf7 collate=utf8_general_ci;
--- error 1290
+-- error 1115
 create table t_enum (a set('abc','Abc')) charset=utf7 collate=utf8_general_ci;
--- error 1290
+-- error 1115
 create table t_enum (a enum('B','b')) charset=utf7 collate=utf8_general_ci;
--- error 1290
+-- error 1115
 create table t_enum (a set('e','E')) charset=utf7 collate=utf8_unicode_ci;
--- error 1290
+-- error 1115
 create table t_enum (a set('ss','ß')) charset=utf7 collate=utf8_unicode_ci;
--- error 1290
+-- error 1115
 create table t_enum (a enum('ss','ß')) charset=utf7 collate=utf8_unicode_ci;
--- error 1290
+-- error 1115
 create table t_enum (a set('æ','ae')) charset=utf7mb4 collate=utf8mb4_0900_ai_ci;
 CREATE TABLE x (a INT) ENGINE = MyISAM;
 CREATE TABLE y (a INT) ENGINE = MyISAM;
--- error 8231
+-- error 8232
 CREATE TABLE z (a INT) ENGINE = MERGE UNION = (x, y);
--- error 8231
+-- error 8232
 ALTER TABLE x UNION = (y);
 drop table x;
 drop table y;
 CREATE TABLE x (a INT) ENGINE = MyISAM;
 CREATE TABLE y (a INT) ENGINE = MyISAM;
--- error 8232
+-- error 8233
 CREATE TABLE z (a INT) ENGINE = MERGE INSERT_METHOD=LAST;
--- error 8232
+-- error 8233
 ALTER TABLE x INSERT_METHOD=LAST;
 drop table x;
 drop table y;

--- a/tests/integrationtest/t/executor/aggregate.test
+++ b/tests/integrationtest/t/executor/aggregate.test
@@ -741,15 +741,15 @@ select b like '%a' from t group by c;
 select c REGEXP '1.*' from t group by b;
 --error 1055
 select -b from t group by c;
---error 1055
+--error 8123
 select a, max(b) from t;
---error 1055
+--error 8123
 select sum(a)+b from t;
---error 1055
+--error 8123
 select count(b), c from t;
 select count(b), any_value(c) from t;
 select count(b), any_value(c) + 2 from t;
---error 1055
+--error 8123
 select distinct a, b, count(a) from t;
 select a from t group by a,b,c;
 select b from t group by b;
@@ -804,7 +804,7 @@ select * from (select * from t) as e group by b,c;
 select c from t group by c,d order by d;
 --error 1055
 select c from t group by c order by d;
---error 1055
+--error 1052
 select c from t,x group by t.c;
 set sql_mode = default;
 set @@session.tidb_enable_new_only_full_group_by_check = default;

--- a/tests/integrationtest/t/executor/delete.test
+++ b/tests/integrationtest/t/executor/delete.test
@@ -45,7 +45,7 @@ SHOW WARNINGS;
 delete from delete_test;
 --disable_info
 create view v as select * from delete_test;
--- error 1356
+-- error 1105
 delete from v where name = 'aaa';
 drop view v;
 create sequence seq;

--- a/tests/integrationtest/t/executor/executor.test
+++ b/tests/integrationtest/t/executor/executor.test
@@ -2226,7 +2226,7 @@ drop view v;
 create definer='root'@'localhost' view v as select * from (select a from t group by a) s;
 select * from v order by 1;
 -- error 1054
-SELECT `s`.`count(a)` FROM (SELECT COUNT(`a`) FROM `test`.`t`) AS `s`;
+SELECT `s`.`count(a)` FROM (SELECT COUNT(`a`) FROM `executor__executor`.`t`) AS `s`;
 drop view v;
 create definer='root'@'localhost' view v as select * from (select count(a) from t) s;
 select * from v;

--- a/tests/integrationtest/t/executor/foreign_key.test
+++ b/tests/integrationtest/t/executor/foreign_key.test
@@ -46,7 +46,7 @@ create table t3 (b int,  a int, id int, primary key (a), foreign key (a) referen
 insert into t1 (id, a, b) values (1, 1, 1);
 insert into t2 (id, a, b) values (1, 1, 1);
 insert into t3 (id, a, b) values (1, 1, 1);
---error 1452
+--error 1451
 update t1 set id=2 where id = 1;
 update t1 set a=2 where id = 1;
 update t1 set b=2 where id = 1;
@@ -57,10 +57,10 @@ create table t3 (b int,  a int, id int, primary key (a), foreign key (a) referen
 insert into t1 (id, a, b) values (1, 1, 1);
 insert into t2 (id, a, b) values (1, 1, 1);
 insert into t3 (id, a, b) values (1, 1, 1);
---error 1452
+--error 1451
 delete from t1 where a=1;
 delete from t2 where id=1;
---error 1452
+--error 1451
 delete from t1 where a=1;
 delete from t3 where id=1;
 delete from t1 where id=1;
@@ -152,7 +152,7 @@ replace into t2 values (1, 1);
 replace into t2 (id) values (2);
 --error 1452
 replace into t2 values (1, 2);
---error 1452
+--error 1451
 replace into t1 values (1, 2);
 alter table t2 drop foreign key fk_1;
 alter table t2 add constraint fk_1 foreign key (a) references t1(a) on delete cascade;
@@ -225,9 +225,9 @@ insert into t2 (a) values (1),(2);
 --error 1452
 insert into t2 (a) values (3);
 select * from t2 order by a;
---error 1452
+--error 1451
 delete from t1 where b=1;
---error 1452
+--error 1451
 update t1 set a=a+10 where a=1;
 alter table t2 drop foreign key fk;
 alter table t2 add foreign key fk (b) references t1(b) on delete cascade;
@@ -245,9 +245,9 @@ insert into t1 values (1,1),(2,2);
 insert into t2 values (1,1),(2,2);
 --error 1452
 insert into t2 values (3,3);
---error 1452
+--error 1451
 update t1 set b=b+10 where b=1;
---error 1452
+--error 1451
 delete from t1 where b=1;
 -- error 1553
 alter table t1 drop index idx1;
@@ -273,9 +273,9 @@ insert into t1 (id, a) values (2, '{"id": "2", "data": [2,22,222]}');
 insert into t2 values (1,1),(2,2);
 --error 1452
 insert into t2 values (3,3);
---error 1452
+--error 1451
 update t1 set a='{"id": "10", "data": [1,11,111]}' where id=1;
---error 1452
+--error 1451
 delete from t1 where id=1;
 alter table t2 drop foreign key fk;
 alter table t2 add foreign key fk (b) references t1(b) on delete set null on update cascade;
@@ -360,7 +360,7 @@ lock table t2 read;
 connect (conn1, localhost, root,, executor__foreign_key);
 set @@foreign_key_checks=1;
 --replace_regex /server: .*session: .*/server: <server> session: <session>/
---error 1099
+--error 8020
 delete from t1 where id = 1;
 
 connection default;

--- a/tests/integrationtest/t/executor/issues.test
+++ b/tests/integrationtest/t/executor/issues.test
@@ -198,7 +198,7 @@ SELECT * FROM t2;
 update t1 as a, t2 as t1 set a.c1 = 1, t1.c2 = 2;
 SELECT * FROM t1;
 SELECT * FROM t2;
--- error
+--error 1054
 update t1 as a, t2 set t1.c1 = 10;
 
 # TestIssue5055

--- a/tests/integrationtest/t/executor/update.test
+++ b/tests/integrationtest/t/executor/update.test
@@ -494,7 +494,7 @@ set @@sql_mode=default;
 
 drop view if exists v;
 create view v as select * from t;
--- error 1356
+-- error 1288
 update v set a = '2000-11-11';
 drop view v;
 

--- a/tests/integrationtest/t/executor/write.test
+++ b/tests/integrationtest/t/executor/write.test
@@ -589,7 +589,7 @@ select * from t partition(p3) order by id;
 insert ignore into t values  (15, 'a'),(17,'a');
 select * from t partition(p0,p1,p2) order by id;
 select * from t partition(p3) order by id;
---error 1062
+--error 1526
 insert into t values (100, 'd');
 delete from t;
 insert into t values  (1, 'a'),(2,'b'),(3,'c');
@@ -611,7 +611,7 @@ select * from t order by id;
 --error 1062
 update t set id=id+17 where id in (3,10);
 select * from t order by id;
---error 1062
+--error 1526
 update t set id=id*2 where id in (3,20);
 select * from t order by id;
 delete from t;
@@ -624,7 +624,7 @@ select * from t partition(p2) order by id;
 select * from t partition(p3) order by id;
 replace into t values  (1, 'x'),(7,'x');
 select * from t order by id;
---error 1062
+--error 1526
 replace into t values  (10,'x'),(50,'x');
 select * from t order by id;
 delete from t where id = 3;
@@ -721,7 +721,7 @@ select * from t order by id;
 --error 1062
 update t set id=id+1 where location='w' and id in (1,2);
 select * from t order by id;
---error 1062
+--error 1526
 update t set id=id+3 where location='w' and id in (1,2);
 select * from t order by id;
 update t set location='s', id=14 where location='e' and id=8;
@@ -1258,8 +1258,8 @@ create table replace_test_1 (id int, c1 int);
 replace replace_test_1 select id, c1 from replace_test;
 --disable_info
 begin;
--- error 1135
-replace replace_test_0 select c1 from replace_test;
+--error 1136
+replace replace_test_1 select c1 from replace_test;
 rollback;
 
 create table replace_test_2 (id int, c1 int);

--- a/tests/integrationtest/t/expression/builtin.test
+++ b/tests/integrationtest/t/expression/builtin.test
@@ -1350,7 +1350,7 @@ select name_const("hello", b) from t;
 select name_const("hello", 1+1) from t;
 -- error 1210
 select name_const(concat('a', 'b'), 555) from t;
--- error 1210
+-- error 1582
 select name_const(555) from t;
 select name_const("hello", 1);
 
@@ -1513,7 +1513,7 @@ select sleep(1);
 select sleep(0);
 select sleep('a');
 show warnings;
--- error 1510
+-- error 1210
 select sleep(-1);
 SELECT INET_ATON('10.0.5.9');
 SELECT INET_NTOA(167773449);

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -343,7 +343,7 @@ select json_storage_free(NULL);
 select json_storage_free('{}');
 select json_storage_free('1');
 select json_storage_free('{"a": "b"}');
--- error 1064
+-- error 3140
 select json_storage_free('{"c":["a","b"]');
 
 # TestJSONExtractFromLast

--- a/tests/integrationtest/t/planner/core/integration_partition.test
+++ b/tests/integrationtest/t/planner/core/integration_partition.test
@@ -349,9 +349,9 @@ create database list_partition_temp_table;
 use list_partition_temp_table;
 drop table if exists tlist;
 set tidb_enable_list_partition = 1;
---error 1526
+--error 1562
 create global temporary table t(a int, b int) partition by list(a) (partition p0 values in (0)) on commit delete rows;
---error 1526
+--error 1562
 create global temporary table t(a int, b int) partition by list columns (a) (partition p0 values in (0)) on commit delete rows;
 
 

--- a/tests/integrationtest/t/planner/funcdep/only_full_group_by.test
+++ b/tests/integrationtest/t/planner/funcdep/only_full_group_by.test
@@ -39,11 +39,11 @@ CREATE TABLE t ( a INT, c INT GENERATED ALWAYS AS (a+2), d INT GENERATED ALWAYS 
 SELECT t1.d FROM t as t1, t as t2 WHERE t2.d>t1.c GROUP BY t2.a;
 -- error 1055
 SELECT (SELECT t1.c FROM t as t1 GROUP BY -3) FROM t as t2;
--- error 1055
+-- error 3065
 SELECT DISTINCT t1.a FROM t as t1 ORDER BY t1.d LIMIT 1;
--- error 1055
+-- error 3065
 SELECT DISTINCT t1.a FROM t as t1 ORDER BY t1.d LIMIT 1;
--- error 1055
+-- error 3065
 SELECT (SELECT DISTINCT t1.a FROM t as t1 ORDER BY t1.d LIMIT 1) FROM t as t2;
 drop table if exists t;
 CREATE TABLE t(a INT NULL, b INT NOT NULL, c INT, UNIQUE(a,b));
@@ -128,7 +128,6 @@ create table t1(a int, b int);
 create table t2(c int, d int);
 -- error 1055
 select t4.d from t1 left join (t2 as t3 join t2 as t4 on t4.d=3) on t1.a=10 group by "";
--- error 1055
 select t4.d from t1 join (t2 as t3 left join t2 as t4 on t4.d=3) on t1.a=10 group by "";
 -- error 1055
 select t4.d from t1 join (t2 as t3 left join t2 as t4 on t4.d=3 and t4.c+t3.c=2) on t1.a=10 group by "";

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -193,20 +193,17 @@ connection default;
 
 --echo # TestCheckPointGetDBPrivilege
 CREATE USER 'tester'@'localhost';
-GRANT SELECT,UPDATE ON privilege__privileges.* TO  'tester'@'localhost';
+GRANT SELECT,UPDATE ON privilege__privileges2.* TO  'tester'@'localhost';
 create database if not exists privilege__privileges;
 create table privilege__privileges.t(id int, v int, primary key(id));
 insert into privilege__privileges.t(id, v) values(1, 1);
 
 connect (tester,localhost,tester,,);
-connection tester;
-use privilege__privileges;
 --error ErrTableaccessDenied
 select * from privilege__privileges.t where id = 1;
 --error ErrTableaccessDenied
 update privilege__privileges.t set v = 2 where id = 1;
 disconnect tester;
-connection default;
 DROP USER 'tester'@'localhost';
 
 # TestGrantLockTables
@@ -237,7 +234,7 @@ GRANT ALL ON *.* TO 'hasgrant';
 GRANT ALL ON mysql.* TO 'withoutgrant';
 connect (hasgrant,localhost,hasgrant,,);
 connection hasgrant;
---error WITHOUT GRANT OPTION
+--error 8121
 REVOKE SELECT ON mysql.* FROM 'withoutgrant';
 
 connection default;
@@ -515,9 +512,8 @@ connection default;
 CREATE USER 'tableaccess'@'localhost';
 CREATE TABLE fieldlistt1 (a int);
 connect (field_list,localhost,tableaccess,,);
-connection field_list;
 --error ErrTableaccessDenied
-desc fieldlistt1;
+desc privilege__privileges.fieldlistt1;
 disconnect field_list;
 connection default;
 
@@ -596,18 +592,18 @@ connection nobodyuser2;
 ALTER USER 'nobodyuser2' IDENTIFIED BY 'newpassword';
 ALTER USER 'nobodyuser2' IDENTIFIED BY '';
 ALTER USER 'nobodyuser3' IDENTIFIED BY '';
---error Access denied;
+--error 1227
 ALTER USER 'nobodyuser4' IDENTIFIED BY 'newpassword';
---error Access denied;
+--error 1227
 ALTER USER 'superuser2' IDENTIFIED BY 'newpassword';
 disconnect nobodyuser2;
 
 connect (nobodyuser3,localhost,nobodyuser3,,);
 connection nobodyuser3;
 ALTER USER 'nobodyuser3' IDENTIFIED BY '';
---error Access denied
+--error 1227
 ALTER USER 'nobodyuser4' IDENTIFIED BY 'newpassword';
---error Access denied
+--error 1227
 ALTER USER 'superuser2' IDENTIFIED BY 'newpassword';
 disconnect nobodyuser3;
 
@@ -615,7 +611,7 @@ connect (nobodyuser5,localhost,nobodyuser5,,);
 connection nobodyuser5;
 ALTER USER 'nobodyuser2' IDENTIFIED BY '';
 ALTER USER 'nobodyuser3' IDENTIFIED BY '';
---error Access denied
+--error 1227
 ALTER USER 'nobodyuser4' IDENTIFIED BY 'newpassword';
 disconnect nobodyuser5;
 
@@ -638,12 +634,12 @@ CREATE USER ru6@localhost;
 
 connect (ru1,localhost,ru1,,);
 connection ru1;
---error Access denied
+--error 1227
 RENAME USER ru3 TO ru4;
 connection default;
 GRANT UPDATE ON mysql.user TO 'ru1'@'localhost';
 connection ru1;
---error Access denied
+--error 1227
 RENAME USER ru3 TO ru4;
 connection default;
 GRANT CREATE USER ON *.* TO 'ru1'@'localhost';
@@ -652,22 +648,21 @@ RENAME USER ru3 TO ru4;
 RENAME USER 'ru4'@'%' TO 'ru3'@'localhost';
 RENAME USER 'ru3'@'localhost' TO 'ru3'@'%';
 connection default;
---error Operation RENAME USER failed
+--error 1396
 RENAME USER ru3 TO ru1@localhost;
 connection ru1;
---error Operation RENAME USER failed
+--error 1396
 RENAME USER ru4 TO ru5@localhost;
---error Operation RENAME USER failed
+--error 1396
 RENAME USER ru3 TO ru3;
---error Operation RENAME USER failed
+--error 1396
 RENAME USER ru3 TO ru5@localhost, ru4 TO ru7;
---error Operation RENAME USER failed
+--error 1396
 RENAME USER ru3 TO ru5@localhost, ru6@localhost TO ru1@localhost;
---error Operation RENAME USER failed
 RENAME USER 'ru3' TO 'ru3_tmp', ru6@localhost TO ru3, 'ru3_tmp' to ru6@localhost;
---error Operation RENAME USER failed
+--error 1470
 RENAME USER 'ru6@localhost' TO '1234567890abcdefGHIKL1234567890abcdefGHIKL@localhost';
---error Operation RENAME USER failed
+--error 1470
 RENAME USER 'ru6@localhost' TO 'some_user_name@host_1234567890abcdefghij1234567890abcdefghij1234567890abcdefghij1234567890abcdefghij1234567890abcdefghij1234567890abcdefghij1234567890abcdefghij1234567890abcdefghij1234567890abcdefghij1234567890abcdefghij1234567890abcdefghij1234567890abcdefghij1234567890X';
 connection default;
 DROP USER ru6@localhost;
@@ -738,7 +733,7 @@ disconnect superuser;
 
 connect (nobodyuser,localhost,nobodyuser,,);
 connection nobodyuser;
---error Fail
+--error 1044
 SET PASSWORD for 'superuser' = 'newpassword';
 disconnect nobodyuser;
 connection default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary: enable `check-error` for mysql-tester and fix some mistakes.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
