### PR TITLE
executor: inherit memory quota from user session for admin check

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2359,7 +2359,7 @@ func getCheckSum(ctx context.Context, se sessionctx.Context, sql string) ([]grou
 	return checksums, nil
 }
 
-func (w *checkIndexWorker) initSessCtx(ctx context.Context, se sessionctx.Context) (restore func()) {
+func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
 	sessVars := se.GetSessionVars()
 	originOptUseInvisibleIdx := sessVars.OptimizerUseInvisibleIndexes
 	originMemQuotaQuery := sessVars.MemQuotaQuery
@@ -2389,7 +2389,7 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		trySaveErr(err)
 		return
 	}
-	restoreCtx := w.initSessCtx(ctx, se)
+	restoreCtx := w.initSessCtx(se)
 	defer func() {
 		restoreCtx()
 		w.e.Base().ReleaseSysSession(ctx, se)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49258

Problem Summary:

`ADMIN CHECK` is implemented with running queries with internal sessions. `tidb_mem_quota_query` is not initialized for internal session.

### What changed and how does it work?

Inherit `ADMIN CHECK` session variable `tidb_mem_quota_query` for internal session.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  ```
  mysql> admin check index sbtest1 idx;
  ERROR 8175 (HY000): Your query has been cancelled due to exceeding the allowed memory limit for a single SQL query. Please try narrowing your query scope or increase the tidb_mem_quota_query limit and try again.[conn=0]
  mysql> set session tidb_mem_quota_query = -1;
  Query OK, 0 rows affected (0.00 sec)
  
  mysql> admin check index sbtest1 idx;
  Query OK, 0 rows affected (1 min 23.84 sec)
  ```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
