### PR TITLE
planner: encapsulate binding operations behind 2 interfaces

### DIFF
--- a/pkg/bindinfo/BUILD.bazel
+++ b/pkg/bindinfo/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "bind_cache.go",
         "bind_record.go",
         "capture.go",
-        "handle.go",
+        "global_handle.go",
         "session_handle.go",
         "util.go",
     ],
@@ -51,7 +51,7 @@ go_test(
     srcs = [
         "bind_cache_test.go",
         "capture_test.go",
-        "handle_test.go",
+        "global_handle_test.go",
         "main_test.go",
         "optimize_test.go",
         "session_handle_test.go",

--- a/pkg/bindinfo/capture.go
+++ b/pkg/bindinfo/capture.go
@@ -84,7 +84,7 @@ func ParseCaptureTableFilter(tableFilter string) (f tablefilter.Filter, valid bo
 	return f, true
 }
 
-func (h *BindHandle) extractCaptureFilterFromStorage() (filter *captureFilter) {
+func (h *globalBindingHandle) extractCaptureFilterFromStorage() (filter *captureFilter) {
 	filter = &captureFilter{
 		frequency: 1,
 		users:     make(map[string]struct{}),
@@ -134,7 +134,7 @@ func (h *BindHandle) extractCaptureFilterFromStorage() (filter *captureFilter) {
 }
 
 // CaptureBaselines is used to automatically capture plan baselines.
-func (h *BindHandle) CaptureBaselines() {
+func (h *globalBindingHandle) CaptureBaselines() {
 	parser4Capture := parser.New()
 	captureFilter := h.extractCaptureFilterFromStorage()
 	emptyCaptureFilter := captureFilter.isEmpty()

--- a/pkg/bindinfo/global_handle_test.go
+++ b/pkg/bindinfo/global_handle_test.go
@@ -51,7 +51,7 @@ func TestBindingCache(t *testing.T) {
 
 	tk.MustExec("drop global binding for select * from t;")
 	require.Nil(t, dom.BindHandle().Update(false))
-	require.Equal(t, 1, len(dom.BindHandle().GetAllGlobalBinding()))
+	require.Equal(t, 1, len(dom.BindHandle().GetAllGlobalBindings()))
 }
 
 func TestBindingLastUpdateTime(t *testing.T) {
@@ -65,7 +65,7 @@ func TestBindingLastUpdateTime(t *testing.T) {
 	tk.MustExec("create global binding for select * from t0 using select * from t0 use index(a);")
 	tk.MustExec("admin reload bindings;")
 
-	bindHandle := bindinfo.NewBindHandle(&mockSessionPool{tk.Session()})
+	bindHandle := bindinfo.NewGlobalBindingHandle(&mockSessionPool{tk.Session()})
 	err := bindHandle.Update(true)
 	require.NoError(t, err)
 	sql, sqlDigest := parser.NormalizeDigest("select * from test . t0")
@@ -128,7 +128,7 @@ func TestBindParse(t *testing.T) {
 	sql := fmt.Sprintf(`INSERT INTO mysql.bind_info(original_sql,bind_sql,default_db,status,create_time,update_time,charset,collation,source, sql_digest, plan_digest) VALUES ('%s', '%s', '%s', '%s', NOW(), NOW(),'%s', '%s', '%s', '%s', '%s')`,
 		originSQL, bindSQL, defaultDb, status, charset, collation, source, mockDigest, mockDigest)
 	tk.MustExec(sql)
-	bindHandle := bindinfo.NewBindHandle(&mockSessionPool{tk.Session()})
+	bindHandle := bindinfo.NewGlobalBindingHandle(&mockSessionPool{tk.Session()})
 	err := bindHandle.Update(true)
 	require.NoError(t, err)
 	require.Equal(t, 1, bindHandle.Size())
@@ -477,7 +477,7 @@ func TestGlobalBinding(t *testing.T) {
 		require.NotNil(t, row.GetString(6))
 		require.NotNil(t, row.GetString(7))
 
-		bindHandle := bindinfo.NewBindHandle(&mockSessionPool{tk.Session()})
+		bindHandle := bindinfo.NewGlobalBindingHandle(&mockSessionPool{tk.Session()})
 		err = bindHandle.Update(true)
 		require.NoError(t, err)
 		require.Equal(t, 1, bindHandle.Size())
@@ -508,7 +508,7 @@ func TestGlobalBinding(t *testing.T) {
 		// From newly created global bind handle.
 		require.Equal(t, testSQL.memoryUsage, pb.GetGauge().GetValue())
 
-		bindHandle = bindinfo.NewBindHandle(&mockSessionPool{tk.Session()})
+		bindHandle = bindinfo.NewGlobalBindingHandle(&mockSessionPool{tk.Session()})
 		err = bindHandle.Update(true)
 		require.NoError(t, err)
 		require.Equal(t, 0, bindHandle.Size())

--- a/pkg/bindinfo/session_handle_test.go
+++ b/pkg/bindinfo/session_handle_test.go
@@ -116,7 +116,7 @@ func TestSessionBinding(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, testSQL.memoryUsage, pb.GetGauge().GetValue())
 
-		handle := tk.Session().Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
+		handle := tk.Session().Value(bindinfo.SessionBindInfoKeyType).(bindinfo.SessionBindingHandle)
 		sqlDigest := parser.DigestNormalized(testSQL.originSQL).String()
 		bindData := handle.GetSessionBinding(sqlDigest, testSQL.originSQL, "test")
 		require.NotNil(t, bindData)

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1833,7 +1833,11 @@ func (do *Domain) PrivilegeHandle() *privileges.Handle {
 
 // BindHandle returns domain's bindHandle.
 func (do *Domain) BindHandle() bindinfo.GlobalBindingHandle {
-	return do.bindHandle.Load().(bindinfo.GlobalBindingHandle)
+	v := do.bindHandle.Load()
+	if v == nil {
+		return nil
+	}
+	return v.(bindinfo.GlobalBindingHandle)
 }
 
 // LoadBindInfoLoop create a goroutine loads BindInfo in a loop, it should

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -2094,12 +2094,12 @@ func checkPlanReplayerContinuesCapture(sctx sessionctx.Context, stmtNode ast.Stm
 func sendPlanReplayerDumpTask(key replayer.PlanReplayerTaskKey, sctx sessionctx.Context, stmtNode ast.StmtNode,
 	startTS uint64, isContinuesCapture bool) {
 	stmtCtx := sctx.GetSessionVars().StmtCtx
-	handle := sctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
+	handle := sctx.Value(bindinfo.SessionBindInfoKeyType).(bindinfo.SessionBindingHandle)
 	dumpTask := &domain.PlanReplayerDumpTask{
 		PlanReplayerTaskKey: key,
 		StartTS:             startTS,
 		TblStats:            stmtCtx.TableStats,
-		SessionBindings:     handle.GetAllSessionBindRecord(),
+		SessionBindings:     handle.GetAllSessionBindings(),
 		SessionVars:         sctx.GetSessionVars(),
 		ExecStmts:           []ast.StmtNode{stmtNode},
 		DebugTrace:          []interface{}{stmtCtx.OptimizerDebugTrace},

--- a/pkg/executor/bind.go
+++ b/pkg/executor/bind.go
@@ -82,7 +82,7 @@ func (e *SQLBindExec) dropSQLBind() error {
 		}
 	}
 	if !e.isGlobal {
-		handle := e.Ctx().Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
+		handle := e.Ctx().Value(bindinfo.SessionBindInfoKeyType).(bindinfo.SessionBindingHandle)
 		err := handle.DropSessionBinding(e.normdOrigSQL, e.db, bindInfo)
 		return err
 	}
@@ -96,7 +96,7 @@ func (e *SQLBindExec) dropSQLBindByDigest() error {
 		return errors.New("sql digest is empty")
 	}
 	if !e.isGlobal {
-		handle := e.Ctx().Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
+		handle := e.Ctx().Value(bindinfo.SessionBindInfoKeyType).(bindinfo.SessionBindingHandle)
 		err := handle.DropSessionBindingByDigest(e.sqlDigest)
 		return err
 	}
@@ -158,7 +158,7 @@ func (e *SQLBindExec) createSQLBind() error {
 		Bindings:    []bindinfo.Binding{bindInfo},
 	}
 	if !e.isGlobal {
-		handle := e.Ctx().Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
+		handle := e.Ctx().Value(bindinfo.SessionBindInfoKeyType).(bindinfo.SessionBindingHandle)
 		return handle.CreateSessionBinding(e.Ctx(), record)
 	}
 	return domain.GetDomain(e.Ctx()).BindHandle().CreateGlobalBinding(e.Ctx(), record)

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -323,10 +323,10 @@ func (*visibleChecker) Leave(in ast.Node) (out ast.Node, ok bool) {
 func (e *ShowExec) fetchShowBind() error {
 	var tmp []*bindinfo.BindRecord
 	if !e.GlobalScope {
-		handle := e.Ctx().Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
-		tmp = handle.GetAllSessionBindRecord()
+		handle := e.Ctx().Value(bindinfo.SessionBindInfoKeyType).(bindinfo.SessionBindingHandle)
+		tmp = handle.GetAllSessionBindings()
 	} else {
-		tmp = domain.GetDomain(e.Ctx()).BindHandle().GetAllGlobalBinding()
+		tmp = domain.GetDomain(e.Ctx()).BindHandle().GetAllGlobalBindings()
 	}
 	bindRecords := make([]*bindinfo.BindRecord, 0)
 	for _, bindRecord := range tmp {
@@ -408,7 +408,7 @@ func (e *ShowExec) fetchShowBindingCacheStatus(ctx context.Context) error {
 
 	handle := domain.GetDomain(e.Ctx()).BindHandle()
 
-	bindRecords := handle.GetAllGlobalBinding()
+	bindRecords := handle.GetAllGlobalBindings()
 	numBindings := 0
 	for _, bindRecord := range bindRecords {
 		for _, binding := range bindRecord.Bindings {

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -796,7 +796,7 @@ func GetBindSQL4PlanCache(sctx sessionctx.Context, stmt *PlanCacheStmt) (string,
 	if sctx.Value(bindinfo.SessionBindInfoKeyType) == nil {
 		return "", ignore
 	}
-	sessionHandle := sctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
+	sessionHandle := sctx.Value(bindinfo.SessionBindInfoKeyType).(bindinfo.SessionBindingHandle)
 	bindRecord := sessionHandle.GetSessionBinding(stmt.SQLDigest4PC, stmt.NormalizedSQL4PC, "")
 	if bindRecord != nil {
 		enabledBinding := bindRecord.FindEnabledBinding()

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -665,7 +665,7 @@ func getBindRecord(ctx sessionctx.Context, stmt ast.StmtNode) (*bindinfo.BindRec
 	if err != nil || stmtNode == nil {
 		return nil, "", err
 	}
-	sessionHandle := ctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
+	sessionHandle := ctx.Value(bindinfo.SessionBindInfoKeyType).(bindinfo.SessionBindingHandle)
 	bindRecord := sessionHandle.GetSessionBinding(sqlDigest, normalizedSQL, "")
 	if bindRecord != nil {
 		if bindRecord.HasEnabledBinding() {
@@ -682,7 +682,7 @@ func getBindRecord(ctx sessionctx.Context, stmt ast.StmtNode) (*bindinfo.BindRec
 }
 
 func handleInvalidBinding(ctx context.Context, sctx sessionctx.Context, level string, bindRecord bindinfo.BindRecord) {
-	sessionHandle := sctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
+	sessionHandle := sctx.Value(bindinfo.SessionBindInfoKeyType).(bindinfo.SessionBindingHandle)
 	err := sessionHandle.DropSessionBinding(bindRecord.OriginalSQL, bindRecord.Db, &bindRecord.Bindings[0])
 	if err != nil {
 		logutil.Logger(ctx).Info("drop session bindings failed")

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -2021,7 +2021,7 @@ func upgradeToVer67(s sessiontypes.Session, ver int64) {
 		return
 	}
 	bindMap := make(map[string]bindInfo)
-	h := &bindinfo.BindHandle{}
+	h := bindinfo.NewGlobalBindingHandle(nil)
 	var err error
 	mustExecute(s, "BEGIN PESSIMISTIC")
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2587,7 +2587,7 @@ func (s *session) Close() {
 	telemetry.GlobalBuiltinFunctionsUsage.Collect(s.GetBuiltinFunctionUsage())
 	bindValue := s.Value(bindinfo.SessionBindInfoKeyType)
 	if bindValue != nil {
-		bindValue.(*bindinfo.SessionHandle).Close()
+		bindValue.(bindinfo.SessionBindingHandle).Close()
 	}
 	ctx := context.WithValue(context.TODO(), inCloseSession{}, struct{}{})
 	s.RollbackTxn(ctx)
@@ -3590,7 +3590,7 @@ func createSessionWithOpt(store kv.Storage, opt *Opt) (*session, error) {
 	s.sessionVars.BinlogClient = binloginfo.GetPumpsClient()
 	s.txn.init()
 
-	sessionBindHandle := bindinfo.NewSessionBindHandle()
+	sessionBindHandle := bindinfo.NewSessionBindingHandle()
 	s.SetValue(bindinfo.SessionBindInfoKeyType, sessionBindHandle)
 	s.SetSessionStatesHandler(sessionstates.StateBinding, sessionBindHandle)
 	return s, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #48875

Problem Summary: planner: encapsulate binding operations behind 2 interfaces

### What changed and how does it work?

planner: encapsulate binding operations behind 2 interfaces

NO LOGICAL CHANGE, JUST REFACTOR

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
