### PR TITLE
statistics: fix illegal bucket order when to merge global stats

### DIFF
--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -1382,6 +1382,7 @@ func mergePartitionBuckets(sc *stmtctx.StatementContext, buckets []*bucket4Mergi
 		if compare == 0 {
 			res.Repeat += buckets[i].Repeat
 		}
+		intest.Assert(compare > 0, "illegal bucket order")
 		if i != len(buckets)-1 {
 			tmp, err := mergeBucketNDV(sc, buckets[i], &right)
 			if err != nil {

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -1473,7 +1473,7 @@ func MergePartitionHist2GlobalHist(sc *stmtctx.StatementContext, hists []*Histog
 	// Remove empty buckets
 	tail := 0
 	for i := range buckets {
-		if buckets[i].Count != 0 && i != tail {
+		if buckets[i].Count != 0 {
 			buckets[tail], buckets[i] = buckets[i], buckets[tail]
 			tail++
 		}

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -1473,7 +1473,7 @@ func MergePartitionHist2GlobalHist(sc *stmtctx.StatementContext, hists []*Histog
 	// Remove empty buckets
 	tail := 0
 	for i := range buckets {
-		if buckets[i].Count != 0 {
+		if buckets[i].Count != 0 && i != tail {
 			buckets[tail], buckets[i] = buckets[i], buckets[tail]
 			tail++
 		}

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -1381,8 +1381,10 @@ func mergePartitionBuckets(sc *stmtctx.StatementContext, buckets []*bucket4Mergi
 		}
 		if compare == 0 {
 			res.Repeat += buckets[i].Repeat
+		} else {
+			intest.Assert(compare < 0, "illegal bucket order")
 		}
-		intest.Assert(compare > 0, "illegal bucket order")
+
 		if i != len(buckets)-1 {
 			tmp, err := mergeBucketNDV(sc, buckets[i], &right)
 			if err != nil {

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -1474,7 +1474,9 @@ func MergePartitionHist2GlobalHist(sc *stmtctx.StatementContext, hists []*Histog
 	tail := 0
 	for i := range buckets {
 		if buckets[i].Count != 0 {
+			tmp := buckets[tail]
 			buckets[tail] = buckets[i]
+			buckets[i] = tmp
 			tail++
 		}
 	}

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -1382,7 +1382,6 @@ func mergePartitionBuckets(sc *stmtctx.StatementContext, buckets []*bucket4Mergi
 		if compare == 0 {
 			res.Repeat += buckets[i].Repeat
 		}
-
 		if i != len(buckets)-1 {
 			tmp, err := mergeBucketNDV(sc, buckets[i], &right)
 			if err != nil {

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -1381,8 +1381,6 @@ func mergePartitionBuckets(sc *stmtctx.StatementContext, buckets []*bucket4Mergi
 		}
 		if compare == 0 {
 			res.Repeat += buckets[i].Repeat
-		} else {
-			intest.Assert(compare < 0, "illegal bucket order")
 		}
 
 		if i != len(buckets)-1 {
@@ -1477,9 +1475,7 @@ func MergePartitionHist2GlobalHist(sc *stmtctx.StatementContext, hists []*Histog
 	tail := 0
 	for i := range buckets {
 		if buckets[i].Count != 0 {
-			tmp := buckets[tail]
-			buckets[tail] = buckets[i]
-			buckets[i] = tmp
+			buckets[tail], buckets[i] = buckets[i], buckets[tail]
 			tail++
 		}
 	}

--- a/pkg/statistics/histogram_test.go
+++ b/pkg/statistics/histogram_test.go
@@ -276,6 +276,170 @@ func TestMergePartitionLevelHist(t *testing.T) {
 			},
 			expBucketNumber: 3,
 		},
+		{
+			// issue#49023
+			partitionHists: [][]*bucket4Test{
+				{
+					// Col(1) = [1, 4,|| 6, 9, 9,|| 12, 12, 12,|| 13, 14, 15]
+					{
+						lower:  1,
+						upper:  4,
+						count:  2,
+						repeat: 1,
+						ndv:    2,
+					},
+					{
+						lower:  6,
+						upper:  9,
+						count:  5,
+						repeat: 2,
+						ndv:    2,
+					},
+					{
+						lower:  12,
+						upper:  12,
+						count:  5,
+						repeat: 3,
+						ndv:    1,
+					},
+					{
+						lower:  13,
+						upper:  15,
+						count:  11,
+						repeat: 1,
+						ndv:    3,
+					},
+				},
+				// Col(2) = [2, 5,|| 6, 7, 7,|| 11, 11, 11,|| 13, 14, 17]
+				{
+					{
+						lower:  2,
+						upper:  5,
+						count:  2,
+						repeat: 1,
+						ndv:    2,
+					},
+					{
+						lower:  6,
+						upper:  7,
+						count:  2,
+						repeat: 2,
+						ndv:    2,
+					},
+					{
+						lower:  11,
+						upper:  11,
+						count:  8,
+						repeat: 3,
+						ndv:    1,
+					},
+					{
+						lower:  13,
+						upper:  17,
+						count:  11,
+						repeat: 1,
+						ndv:    3,
+					},
+				},
+				// Col(3) = [2, 5,|| 6, 7, 7,|| 11, 11, 11,|| 13, 14, 17]
+				{
+					{
+						lower:  2,
+						upper:  5,
+						count:  2,
+						repeat: 1,
+						ndv:    2,
+					},
+					{
+						lower:  6,
+						upper:  7,
+						count:  2,
+						repeat: 2,
+						ndv:    2,
+					},
+					{
+						lower:  11,
+						upper:  11,
+						count:  8,
+						repeat: 3,
+						ndv:    1,
+					},
+					{
+						lower:  13,
+						upper:  17,
+						count:  11,
+						repeat: 1,
+						ndv:    3,
+					},
+				},
+				// Col(4) = [2, 5,|| 6, 7, 7,|| 11, 11, 11,|| 13, 14, 17]
+				{
+					{
+						lower:  2,
+						upper:  5,
+						count:  2,
+						repeat: 1,
+						ndv:    2,
+					},
+					{
+						lower:  6,
+						upper:  7,
+						count:  2,
+						repeat: 2,
+						ndv:    2,
+					},
+					{
+						lower:  11,
+						upper:  11,
+						count:  8,
+						repeat: 3,
+						ndv:    1,
+					},
+					{
+						lower:  13,
+						upper:  17,
+						count:  11,
+						repeat: 1,
+						ndv:    3,
+					},
+				},
+			},
+			totColSize: []int64{11, 11, 11, 11},
+			popedTopN: []topN4Test{
+				{
+					data:  18,
+					count: 5,
+				},
+				{
+					data:  4,
+					count: 6,
+				},
+			},
+			expHist: []*bucket4Test{
+				{
+					lower:  1,
+					upper:  9,
+					count:  17,
+					repeat: 2,
+					ndv:    10,
+				},
+				{
+					lower:  11,
+					upper:  11,
+					count:  35,
+					repeat: 9,
+					ndv:    1,
+				},
+				{
+					lower:  11,
+					upper:  18,
+					count:  55,
+					repeat: 5,
+					ndv:    8,
+				},
+			},
+			expBucketNumber: 3,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49023

Problem Summary:

### What changed and how does it work?

for better performance, we reuse memory to avoid allocating memory frequently. but bug will happen here. when we remove the empty bucket, use the non-empty bucket to overwrite it. but we cannot use the empty bucket to put into the pool. we wrongly put the non-empty bucket into the pool. it will lead to problems.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

We have tested with problem data. it will not raise this error.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
