### PR TITLE
executor, planner: Server side help, powered by OpenAI ChatGPT

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -163,6 +163,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231030173426-d783a09b4405 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
+	gopkg.in/resty.v1 v1.12.0 // indirect
 	k8s.io/utils v0.0.0-20230711102312-30195339c3c7 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1427,6 +1427,8 @@ gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3M
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
+gopkg.in/resty.v1 v1.12.0 h1:CuXP0Pjfw9rOuY6EP+UvtNvt5DSqHpIxILZKT/quCZI=
+gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -892,6 +892,8 @@ func (b *executorBuilder) buildSimple(v *plannercore.Simple) exec.Executor {
 		return b.buildRevoke(s)
 	case *ast.BRIEStmt:
 		return b.buildBRIE(s, v.Schema())
+	case *ast.HelpStmt:
+		return b.buildHelp(s, v.Schema())
 	case *ast.CreateUserStmt, *ast.AlterUserStmt:
 		var lockOptions []*ast.PasswordOrLockOption
 		if b.Ti.AccountLockTelemetry == nil {
@@ -5501,4 +5503,8 @@ func (b *executorBuilder) buildCompactTable(v *plannercore.CompactTable) exec.Ex
 
 func (b *executorBuilder) buildAdminShowBDRRole(v *plannercore.AdminShowBDRRole) exec.Executor {
 	return &AdminShowBDRRoleExec{BaseExecutor: exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID())}
+}
+
+func (b *executorBuilder) buildHelp(help *ast.HelpStmt, schema *expression.Schema) exec.Executor {
+	return &HelpExec{BaseExecutor: exec.NewBaseExecutor(b.ctx, schema, 0), topic: help.Topic}
 }

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2820,9 +2820,13 @@ func (e *HelpExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	apiEndpoint := "https://api.openai.com/v1/chat/completions"
 	reqBody := map[string]interface{}{
 		"model": "gpt-3.5-turbo",
-		"messages": []interface{}{map[string]interface{}{
-			"role":    "system",
-			"content": "Please give me a short description with an example about how to use " + e.topic + " in TiDB SQL."}},
+		"messages": []interface{}{
+			map[string]interface{}{
+				"role":    "system",
+				"content": "You will be provide with text. Your task is to give a short description with an example about how to use it in TiDB SQL."},
+			map[string]interface{}{
+				"role":    "user",
+				"content": e.topic}},
 		"max_tokens": 250,
 	}
 	client := resty.New()


### PR DESCRIPTION
This requires the user to set a `OPENAI_API_KEY` environment variable.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33609

Problem Summary:

This adds support for server side help: e.g. `HELP 'select'`. This make it easier to lookup documentation for statements, etc. This uses ChatGPT.

- https://dev.mysql.com/doc/refman/8.0/en/mysql-server-side-help.html
- https://dev.mysql.com/doc/refman/8.0/en/help.html

A more classical implementation is in #25485

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Server side powered by ChatGPT was added.
```
