### PR TITLE
tests: wait services to be healthy before executing test cases in GlobalKill e2e tests

### DIFF
--- a/tests/globalkilltest/BUILD.bazel
+++ b/tests/globalkilltest/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "globalkilltest_test",
@@ -7,6 +7,7 @@ go_test(
         "global_kill_test.go",
         "main_test.go",
     ],
+    embed = [":globalkilltest"],
     flaky = True,
     deps = [
         "//pkg/testkit/testsetup",
@@ -18,6 +19,20 @@ go_test(
         "@io_etcd_go_etcd_client_v3//:client",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//backoff",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_library(
+    name = "globalkilltest",
+    srcs = ["util.go"],
+    importpath = "github.com/pingcap/tidb/tests/globalkilltest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/server",
+        "//pkg/util",
+        "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_log//:log",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/tests/globalkilltest/global_kill_test.go
+++ b/tests/globalkilltest/global_kill_test.go
@@ -170,8 +170,7 @@ func (s *GlobalKillSuite) startTiKV(dataDir string) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	time.Sleep(500 * time.Millisecond)
-	return nil
+	return errors.Trace(CheckTiKVStatus())
 }
 
 func (s *GlobalKillSuite) startPD(dataDir string) (err error) {
@@ -185,8 +184,7 @@ func (s *GlobalKillSuite) startPD(dataDir string) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	time.Sleep(500 * time.Millisecond)
-	return nil
+	return errors.Trace(CheckPDHealth(*pdClientPath))
 }
 
 func (s *GlobalKillSuite) startCluster() (err error) {
@@ -199,7 +197,6 @@ func (s *GlobalKillSuite) startCluster() (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	time.Sleep(10 * time.Second)
 	return nil
 }
 
@@ -266,8 +263,7 @@ func (s *GlobalKillSuite) startTiDBWithoutPD(port int, statusPort int) (cmd *exe
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	time.Sleep(500 * time.Millisecond)
-	return cmd, nil
+	return cmd, errors.Trace(CheckTiDBStatus(statusPort))
 }
 
 func (s *GlobalKillSuite) startTiDBWithPD(port int, statusPort int, pdPath string) (cmd *exec.Cmd, err error) {
@@ -285,8 +281,7 @@ func (s *GlobalKillSuite) startTiDBWithPD(port int, statusPort int, pdPath strin
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	time.Sleep(500 * time.Millisecond)
-	return cmd, nil
+	return cmd, errors.Trace(CheckTiDBStatus(statusPort))
 }
 
 func (s *GlobalKillSuite) mustStartTiDBWithPD(t *testing.T, port int, statusPort int, pdPath string) *exec.Cmd {
@@ -335,9 +330,8 @@ func (s *GlobalKillSuite) connectTiDB(port int) (db *sql.DB, err error) {
 	dsn := fmt.Sprintf("root@(%s)/test", addr)
 	sleepTime := 250 * time.Millisecond
 	sleepTimeLimit := 1 * time.Second
-	maxRetryDuration := 20 * time.Second
 	startTime := time.Now()
-	for i := 0; time.Since(startTime) < maxRetryDuration; i++ {
+	for i := 0; time.Since(startTime) < timeoutConnectDB; i++ {
 		db, err = sql.Open("mysql", dsn)
 		if err != nil {
 			log.Warn("open addr failed",

--- a/tests/globalkilltest/global_kill_test.go
+++ b/tests/globalkilltest/global_kill_test.go
@@ -170,7 +170,7 @@ func (s *GlobalKillSuite) startTiKV(dataDir string) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return errors.Trace(CheckTiKVStatus())
+	return errors.Trace(checkTiKVStatus())
 }
 
 func (s *GlobalKillSuite) startPD(dataDir string) (err error) {
@@ -184,7 +184,7 @@ func (s *GlobalKillSuite) startPD(dataDir string) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return errors.Trace(CheckPDHealth(*pdClientPath))
+	return errors.Trace(checkPDHealth(*pdClientPath))
 }
 
 func (s *GlobalKillSuite) startCluster() (err error) {
@@ -263,7 +263,7 @@ func (s *GlobalKillSuite) startTiDBWithoutPD(port int, statusPort int) (cmd *exe
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return cmd, errors.Trace(CheckTiDBStatus(statusPort))
+	return cmd, errors.Trace(checkTiDBStatus(statusPort))
 }
 
 func (s *GlobalKillSuite) startTiDBWithPD(port int, statusPort int, pdPath string) (cmd *exec.Cmd, err error) {
@@ -281,7 +281,7 @@ func (s *GlobalKillSuite) startTiDBWithPD(port int, statusPort int, pdPath strin
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return cmd, errors.Trace(CheckTiDBStatus(statusPort))
+	return cmd, errors.Trace(checkTiDBStatus(statusPort))
 }
 
 func (s *GlobalKillSuite) mustStartTiDBWithPD(t *testing.T, port int, statusPort int, pdPath string) *exec.Cmd {

--- a/tests/globalkilltest/global_kill_test.go
+++ b/tests/globalkilltest/global_kill_test.go
@@ -58,8 +58,9 @@ var (
 )
 
 const (
-	waitToStartup   = 500 * time.Millisecond
-	msgErrConnectPD = "connect PD err: %v. Establish a cluster with PD & TiKV, and provide PD client path by `--pd=<ip:port>[,<ip:port>]"
+	waitToStartup    = 500 * time.Millisecond
+	msgErrConnectPD  = "connect PD err: %v. Establish a cluster with PD & TiKV, and provide PD client path by `--pd=<ip:port>[,<ip:port>]"
+	timeoutConnectDB = 20 * time.Second
 )
 
 // GlobalKillSuite is used for automated test of "Global Kill" feature.

--- a/tests/globalkilltest/util.go
+++ b/tests/globalkilltest/util.go
@@ -1,0 +1,135 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalkilltest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/server"
+	"github.com/pingcap/tidb/pkg/util"
+	"go.uber.org/zap"
+)
+
+const (
+	timeoutCheckPDStatus   = 10 * time.Second
+	timeoutCheckTiKVStatus = 30 * time.Second
+	timeoutCheckTiDBStatus = 30 * time.Second
+	timeoutConnectDB       = 20 * time.Second
+
+	retryInterval = 500 * time.Millisecond
+)
+
+func WithRetry[T any](fn func() (T, error), timeout time.Duration) (resp T, err error) {
+	startTime := time.Now()
+	retry := 0
+	for time.Since(startTime) < timeout {
+		retry += 1
+		resp, err = fn()
+		if err == nil {
+			break
+		}
+		log.Debug("withRetry", zap.Error(err), zap.Int("retry", retry))
+		time.Sleep(retryInterval)
+	}
+	return resp, errors.Trace(err)
+}
+
+func CheckPDHealth(host string) error {
+	url := util.ComposeURL(host, "/health")
+
+	request := func() (interface{}, error) {
+		resp, err := util.InternalHTTPClient().Get(url)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("PD health status code %d", resp.StatusCode)
+		}
+		defer resp.Body.Close()
+		var health struct {
+			Health string `json:"health"`
+		}
+		dec := json.NewDecoder(resp.Body)
+		err = dec.Decode(&health)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		log.Info("PD health", zap.Any("health", health))
+		if health.Health != "true" {
+			return nil, fmt.Errorf("PD not healthy %v", health.Health)
+		}
+		return nil, nil
+	}
+
+	_, err := WithRetry(request, timeoutCheckPDStatus)
+	return errors.Trace(err)
+}
+
+func CheckTiKVStatus() error {
+	url := util.ComposeURL("127.0.0.1:20180", "/status")
+
+	request := func() (interface{}, error) {
+		resp, err := util.InternalHTTPClient().Get(url)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		log.Info("TiKV status", zap.Any("status", resp.StatusCode))
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("TiKV status code %d", resp.StatusCode)
+		}
+		resp.Body.Close()
+		return nil, nil
+	}
+
+	_, err := WithRetry(request, timeoutCheckTiKVStatus)
+	return errors.Trace(err)
+}
+
+func CheckTiDBStatus(statusPort int) error {
+	host := fmt.Sprintf("127.0.0.1:%d", statusPort)
+	url := util.ComposeURL(host, "/status")
+
+	request := func() (interface{}, error) {
+		resp, err := util.InternalHTTPClient().Get(url)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("TiDB status code %d", resp.StatusCode)
+		}
+		defer resp.Body.Close()
+		var status server.Status
+		dec := json.NewDecoder(resp.Body)
+		err = dec.Decode(&status)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		log.Info("TiDB status", zap.Any("status", status))
+		return nil, nil
+	}
+
+	_, err := WithRetry(request, timeoutCheckTiDBStatus)
+	return errors.Trace(err)
+}

--- a/tests/globalkilltest/util.go
+++ b/tests/globalkilltest/util.go
@@ -31,7 +31,6 @@ const (
 	timeoutCheckPDStatus   = 10 * time.Second
 	timeoutCheckTiKVStatus = 30 * time.Second
 	timeoutCheckTiDBStatus = 60 * time.Second // First start up of TiDB would take a long time.
-	timeoutConnectDB       = 20 * time.Second
 
 	retryInterval = 500 * time.Millisecond
 )


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49316 

Problem Summary: **test: Global Kill e2e test is flaky**

### What changed and how does it work?

- Wait services (PD, TiKV & TiDB) to be healthy before executing test cases.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
