### PR TITLE
test: ignore some expected goroutine leak

### DIFF
--- a/br/pkg/lightning/common/main_test.go
+++ b/br/pkg/lightning/common/main_test.go
@@ -27,6 +27,9 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
 		goleak.IgnoreTopFunction("github.com/lestrrat-go/httprc.runFetchWorker"),
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreTopFunction("net.(*Resolver).lookupIPAddr.func2"),
+		goleak.IgnoreTopFunction("net.(*Resolver).goLookupIPCNAMEOrder.func4"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
 	}
 	goleak.VerifyTestMain(m, opts...)
 }

--- a/pkg/store/helper/main_test.go
+++ b/pkg/store/helper/main_test.go
@@ -28,6 +28,9 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/lestrrat-go/httprc.runFetchWorker"),
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop"),
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreTopFunction("net.(*Resolver).lookupIPAddr.func2"),
+		goleak.IgnoreTopFunction("net.(*Resolver).goLookupIPCNAMEOrder.func4"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
 	}
 	goleak.VerifyTestMain(m, opts...)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43430

Problem Summary:

Ignore some expected goroutine leak when DNS server is slow, like 

```
[2023/12/11 10:24:20.846 +08:00] [ERROR] [client.go:256] ["[pd] do http request failed"] [name=GetMinResolvedTSByStoresIDs] [url=http://invalid_pd_address/pd/api/v1/min-resolved-ts] [error="Get \"http://invalid_pd_address/pd/api/v1/min-resolved-ts\": dial tcp: lookup invalid_pd_address on [fe80::1%enp34s0]:53: no such host"] [stack="github.com/tikv/pd/client/http.(*client).request\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:256\ngithub.com/tikv/pd/client/http.(*client).requestWithRetry\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:223\ngithub.com/tikv/pd/client/http.(*client).GetMinResolvedTSByStoresIDs\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:689\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).getMinResolvedTSByStoresIDs\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:698\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).updateGlobalTxnScopeTSFromPD\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:732\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).updateSafeTS\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:601\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).safeTSUpdater\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:594"]
[2023/12/11 10:24:20.846 +08:00] [ERROR] [client.go:256] ["[pd] do http request failed"] [name=GetStores] [url=http://invalid_pd_address/pd/api/v1/stores] [error="Get \"http://invalid_pd_address/pd/api/v1/stores\": dial tcp: lookup invalid_pd_address on [fe80::1%enp34s0]:53: no such host"] [stack="github.com/tikv/pd/client/http.(*client).request\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:256\ngithub.com/tikv/pd/client/http.(*client).requestWithRetry\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:223\ngithub.com/tikv/pd/client/http.(*client).GetStores\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:455\ngithub.com/pingcap/tidb/pkg/store/helper_test.TestTiKVStoresStat\n\t/home/jasonmo/tidb/pkg/store/helper/helper_test.go:112\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1595"]
[2023/12/11 10:24:20.847 +08:00] [ERROR] [client.go:284] ["[pd] request failed with a non-200 status"] [name=GetMinResolvedTSByStoresIDs] [url=http://127.0.0.1:44769/pd/api/v1/min-resolved-ts] [status="404 Not Found"] [body="404 page not found\n"] [stack="github.com/tikv/pd/client/http.(*client).request\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:284\ngithub.com/tikv/pd/client/http.(*client).requestWithRetry\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:223\ngithub.com/tikv/pd/client/http.(*client).GetMinResolvedTSByStoresIDs\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:689\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).getMinResolvedTSByStoresIDs\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:698\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).updateGlobalTxnScopeTSFromPD\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:732\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).updateSafeTS\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:601\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).safeTSUpdater\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:594"]
[2023/12/11 10:24:20.848 +08:00] [ERROR] [client.go:256] ["[pd] do http request failed"] [name=GetMinResolvedTSByStoresIDs] [url=http://invalid_pd_address/pd/api/v1/min-resolved-ts] [error="Get \"http://invalid_pd_address/pd/api/v1/min-resolved-ts\": context canceled"] [stack="github.com/tikv/pd/client/http.(*client).request\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:256\ngithub.com/tikv/pd/client/http.(*client).requestWithRetry\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:223\ngithub.com/tikv/pd/client/http.(*client).GetMinResolvedTSByStoresIDs\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:689\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).getMinResolvedTSByStoresIDs\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:698\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).updateSafeTS\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:620\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).safeTSUpdater\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:594"]
[2023/12/11 10:24:20.848 +08:00] [ERROR] [client.go:256] ["[pd] do http request failed"] [name=GetMinResolvedTSByStoresIDs] [url=http://127.0.0.1:44769/pd/api/v1/min-resolved-ts] [error="Get \"http://127.0.0.1:44769/pd/api/v1/min-resolved-ts\": context canceled"] [stack="github.com/tikv/pd/client/http.(*client).request\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:256\ngithub.com/tikv/pd/client/http.(*client).requestWithRetry\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:223\ngithub.com/tikv/pd/client/http.(*client).GetMinResolvedTSByStoresIDs\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20231130081618-862eee18738e/http/client.go:689\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).getMinResolvedTSByStoresIDs\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:698\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).updateSafeTS\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:620\ngithub.com/tikv/client-go/v2/tikv.(*KVStore).safeTSUpdater\n\t/home/jasonmo/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20231201024404-0ff16620f6c0/tikv/kv.go:594"]
[2023/12/11 10:24:20.848 +08:00] [INFO] [client.go:173] ["[pd] http client closed"]
[2023/12/11 10:24:20.849 +08:00] [INFO] [db.go:567] ["Closing database"]
[2023/12/11 10:24:20.849 +08:00] [INFO] [db.go:592] ["Memtable flushed"]
[2023/12/11 10:24:20.849 +08:00] [INFO] [db.go:596] ["Compaction finished"]
[2023/12/11 10:24:20.849 +08:00] [INFO] [db.go:615] ["BlobManager finished"]
[2023/12/11 10:24:20.849 +08:00] [INFO] [db.go:619] ["ResourceManager finished"]
[2023/12/11 10:24:20.849 +08:00] [INFO] [db.go:625] ["Waiting for closer"]
PASS
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 132 in state chan receive, with net.(*Resolver).lookupIPAddr.func2 on top of the stack:
net.(*Resolver).lookupIPAddr.func2(0xf42d65?, 0x1efd588)
	/usr/local/go/src/net/lookup.go:328 +0x1a
created by net.(*Resolver).lookupIPAddr in goroutine 126
	/usr/local/go/src/net/lookup.go:343 +0x6f6
 Goroutine 127 in state chan receive, with net.(*Resolver).goLookupIPCNAMEOrder.func4 on top of the stack:
net.(*Resolver).goLookupIPCNAMEOrder.func4({_, _}, _)
	/usr/local/go/src/net/dnsclient_unix.go:659 +0x7f
net.(*Resolver).goLookupIPCNAMEOrder(_, {_, _}, {_, _}, {_, _}, _, _)
	/usr/local/go/src/net/dnsclient_unix.go:669 +0xd49
net.(*Resolver).lookupIP(0x3c27840, {0x2182290, 0xc000181770}, {0x1e30c1e, 0x3}, {0xc000058a08, 0x12})
	/usr/local/go/src/net/lookup_unix.go:72 +0x166
net.glob..func1({0x2182290?, 0xc000181770?}, 0x0?, {0x1e30c1e?, 0x4?}, {0xc000058a08?, 0x15?})
	/usr/local/go/src/net/hook.go:23 +0x37
net.(*Resolver).lookupIPAddr.func1()
	/usr/local/go/src/net/lookup.go:324 +0x3a
internal/singleflight.(*Group).doCall(0x3c27850, 0xc0001817c0, {0xc000058a20, 0x16}, 0xc0004cb810?)
	/usr/local/go/src/internal/singleflight/singleflight.go:93 +0x35
created by internal/singleflight.(*Group).DoChan in goroutine 126
	/usr/local/go/src/internal/singleflight/singleflight.go:86 +0x2e9
 Goroutine 128 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
internal/poll.runtime_pollWait(0x7f8ce46c90b0, 0x72)
	/usr/local/go/src/runtime/netpoll.go:343 +0x85
internal/poll.(*pollDesc).wait(0xc00087ea80?, 0xc000352000?, 0x0)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc00087ea80, {0xc000352000, 0x4d0, 0x4d0})
	/usr/local/go/src/internal/poll/fd_unix.go:164 +0x27a
net.(*netFD).Read(0xc00087ea80, {0xc000352000?, 0x7f8ce46c08f8?, 0x7f8d2cc27108?})
	/usr/local/go/src/net/fd_posix.go:55 +0x25
net.(*conn).Read(0xc00077c3f8, {0xc000352000?, 0x1a87a80?, 0x1?})
	/usr/local/go/src/net/net.go:179 +0x45
net.dnsPacketRoundTrip({_, _}, _, {{{0x69, 0x6e, 0x76, 0x61, 0x6c, 0x69, 0x64, ...}, ...}, ...}, ...)
	/usr/local/go/src/net/dnsclient_unix.go:108 +0x143
net.(*Resolver).exchange(_, {_, _}, {_, _}, {{{0x69, 0x6e, 0x76, 0x61, 0x6c, ...}, ...}, ...}, ...)
	/usr/local/go/src/net/dnsclient_unix.go:187 +0x528
net.(*Resolver).tryOneName(_, {_, _}, _, {_, _}, _)
	/usr/local/go/src/net/dnsclient_unix.go:277 +0x466
net.(*Resolver).goLookupIPCNAMEOrder.func3.1(0x1?)
	/usr/local/go/src/net/dnsclient_unix.go:653 +0x85
created by net.(*Resolver).goLookupIPCNAMEOrder.func3 in goroutine 127
	/usr/local/go/src/net/dnsclient_unix.go:652 +0x158
 Goroutine 129 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
internal/poll.runtime_pollWait(0x7f8ce46c91a8, 0x72)
	/usr/local/go/src/runtime/netpoll.go:343 +0x85
internal/poll.(*pollDesc).wait(0xc00087e880?, 0xc000293900?, 0x0)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc00087e880, {0xc000293900, 0x4d0, 0x4d0})
	/usr/local/go/src/internal/poll/fd_unix.go:164 +0x27a
net.(*netFD).Read(0xc00087e880, {0xc000293900?, 0x7f8ce46c1d50?, 0x7f8d2cc27108?})
	/usr/local/go/src/net/fd_posix.go:55 +0x25
net.(*conn).Read(0xc0001c3fc8, {0xc000293900?, 0x1a87a80?, 0x1?})
	/usr/local/go/src/net/net.go:179 +0x45
net.dnsPacketRoundTrip({_, _}, _, {{{0x69, 0x6e, 0x76, 0x61, 0x6c, 0x69, 0x64, ...}, ...}, ...}, ...)
	/usr/local/go/src/net/dnsclient_unix.go:108 +0x143
net.(*Resolver).exchange(_, {_, _}, {_, _}, {{{0x69, 0x6e, 0x76, 0x61, 0x6c, ...}, ...}, ...}, ...)
	/usr/local/go/src/net/dnsclient_unix.go:187 +0x528
net.(*Resolver).tryOneName(_, {_, _}, _, {_, _}, _)
	/usr/local/go/src/net/dnsclient_unix.go:277 +0x466
net.(*Resolver).goLookupIPCNAMEOrder.func3.1(0x1c?)
	/usr/local/go/src/net/dnsclient_unix.go:653 +0x85
created by net.(*Resolver).goLookupIPCNAMEOrder.func3 in goroutine 127
	/usr/local/go/src/net/dnsclient_unix.go:652 +0x158
]
``` 

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
