### PR TITLE
statistics: do not get stats meta from cache when handling drop partition DDL event

### DIFF
--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "ddl",
     srcs = [
         "ddl.go",
+        "drop_partition.go",
         "exchange_partition.go",
     ],
     importpath = "github.com/pingcap/tidb/pkg/statistics/handle/ddl",

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -16,16 +16,13 @@ package ddl
 
 import (
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics/handle/lockstats"
-	"github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
 	"github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
-	"go.uber.org/zap"
 )
 
 type ddlHandlerImpl struct {
@@ -123,43 +120,8 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 			}
 		}
 	case model.ActionDropTablePartition:
-		globalTableInfo, droppedPartitionInfo := t.GetDropPartitionInfo()
-
-		count := int64(0)
-		for _, def := range droppedPartitionInfo.Definitions {
-			// Get the count and modify count of the partition.
-			stats := h.statsHandler.GetPartitionStats(globalTableInfo, def.ID)
-			if stats.Pseudo {
-				se, err := h.statsHandler.SPool().Get()
-				if err != nil {
-					return errors.Trace(err)
-				}
-				sctx := se.(sessionctx.Context)
-				is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-				schema, _ := is.SchemaByTable(globalTableInfo)
-				logutil.StatsLogger().Warn(
-					"drop partition with pseudo stats, "+
-						"usually it won't happen because we always load stats when initializing the handle",
-					zap.String("schema", schema.Name.O),
-					zap.String("table", globalTableInfo.Name.O),
-					zap.String("partition", def.Name.O),
-				)
-			} else {
-				count += stats.RealtimeCount
-			}
-			// Always reset the partition stats.
-			if err := h.statsWriter.ResetTableStats2KVForDrop(def.ID); err != nil {
-				return err
-			}
-		}
-		if count != 0 {
-			// Because we drop the partition, we should subtract the count from the global stats.
-			delta := -count
-			if err := h.statsWriter.UpdateStatsMetaDelta(
-				globalTableInfo.ID, count, delta,
-			); err != nil {
-				return err
-			}
+		if err := h.onDropPartitions(t); err != nil {
+			return err
 		}
 	case model.ActionExchangeTablePartition:
 		if err := h.onExchangeAPartition(t); err != nil {

--- a/pkg/statistics/handle/ddl/drop_partition.go
+++ b/pkg/statistics/handle/ddl/drop_partition.go
@@ -1,0 +1,72 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/statistics/handle/lockstats"
+	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
+	"github.com/pingcap/tidb/pkg/statistics/handle/util"
+)
+
+func (h *ddlHandlerImpl) onDropPartitions(t *util.DDLEvent) error {
+	globalTableInfo, droppedPartitionInfo := t.GetDropPartitionInfo()
+	// Note: Put all the operations in a transaction.
+	return util.CallWithSCtx(h.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		count := int64(0)
+		for _, def := range droppedPartitionInfo.Definitions {
+			// Get the count and modify count of the partition.
+			tableCount, _, _, err := storage.StatsMetaCountAndModifyCount(sctx, def.ID)
+			if err != nil {
+				return err
+			}
+			count += tableCount
+			// Always reset the partition stats.
+			// TODO: Technically, we should not reset it in different transactions.
+			if err := h.statsWriter.ResetTableStats2KVForDrop(def.ID); err != nil {
+				return err
+			}
+		}
+		if count != 0 {
+			lockedTables, err := lockstats.QueryLockedTables(sctx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			isLocked := false
+			if _, ok := lockedTables[globalTableInfo.ID]; ok {
+				isLocked = true
+			}
+			startTS, err := util.GetStartTS(sctx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			// Because we drop the partition, we should subtract the count from the global stats.
+			delta := -count
+			err = storage.UpdateStatsMeta(
+				sctx,
+				startTS,
+				variable.TableDelta{Count: count, Delta: delta},
+				globalTableInfo.ID,
+				isLocked,
+			)
+			return err
+		}
+
+		return nil
+	}, util.FlagWrapTxn)
+}


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/48126

Problem Summary:

### What changed and how does it work?

1. Moved the code to a separate file to have better readability.
2. Do not use the stats meta from the cache, maybe it is outdated.
3. ~~Added a TODO item. There are some bugs in ResetTableStats2KVForDrop which prevent it from storing history correctly. I will fix it in my next PR, and then I will complete this TODO.~~ After offline discussion with @time-and-fate, it's OK to put them in the different txns.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
