### PR TITLE
statistics: fix can not record meta history issue

### DIFF
--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -52,9 +52,10 @@ go_test(
         "dump_test.go",
         "gc_test.go",
         "read_test.go",
+        "stats_read_writer_test.go",
     ],
     flaky = True,
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         ":storage",
         "//pkg/domain",

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -173,15 +173,30 @@ func (s *statsReadWriter) ResetTableStats2KVForDrop(physicalID int64) (err error
 	}()
 
 	return util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
-		startTS, err := util.GetStartTS(sctx)
+		startTS, err := ResetTableStats2KVForDrop(sctx, physicalID)
 		if err != nil {
-			return errors.Trace(err)
-		}
-		if _, err := util.Exec(sctx, "update mysql.stats_meta set version=%? where table_id =%?", startTS, physicalID); err != nil {
 			return err
 		}
+		statsVer = startTS
 		return nil
 	}, util.FlagWrapTxn)
+}
+
+// ResetTableStats2KVForDrop update the version of mysql.stats_meta.
+// Then GC worker will delete the old version of stats.
+// Exported for scenarios where it's necessary to encapsulate operations within a single transaction.
+func ResetTableStats2KVForDrop(
+	sctx sessionctx.Context,
+	physicalID int64,
+) (uint64, error) {
+	startTS, err := util.GetStartTS(sctx)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	if _, err := util.Exec(sctx, "update mysql.stats_meta set version=%? where table_id =%?", startTS, physicalID); err != nil {
+		return 0, err
+	}
+	return startTS, nil
 }
 
 // UpdateStatsVersion will set statistics version to the newest TS,

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -173,30 +173,20 @@ func (s *statsReadWriter) ResetTableStats2KVForDrop(physicalID int64) (err error
 	}()
 
 	return util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
-		startTS, err := ResetTableStats2KVForDrop(sctx, physicalID)
+		startTS, err := util.GetStartTS(sctx)
 		if err != nil {
+			return errors.Trace(err)
+		}
+		if _, err := util.Exec(
+			sctx,
+			"update mysql.stats_meta set version=%? where table_id =%?",
+			startTS, physicalID,
+		); err != nil {
 			return err
 		}
 		statsVer = startTS
 		return nil
 	}, util.FlagWrapTxn)
-}
-
-// ResetTableStats2KVForDrop update the version of mysql.stats_meta.
-// Then GC worker will delete the old version of stats.
-// Exported for scenarios where it's necessary to encapsulate operations within a single transaction.
-func ResetTableStats2KVForDrop(
-	sctx sessionctx.Context,
-	physicalID int64,
-) (uint64, error) {
-	startTS, err := util.GetStartTS(sctx)
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-	if _, err := util.Exec(sctx, "update mysql.stats_meta set version=%? where table_id =%?", startTS, physicalID); err != nil {
-		return 0, err
-	}
-	return startTS, nil
 }
 
 // UpdateStatsVersion will set statistics version to the newest TS,

--- a/pkg/statistics/handle/storage/stats_read_writer_test.go
+++ b/pkg/statistics/handle/storage/stats_read_writer_test.go
@@ -1,0 +1,82 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResetTableStats2KVForDrop(t *testing.T) {
+	store, do := testkit.CreateMockStoreAndDomain(t)
+	testKit := testkit.NewTestKit(t, store)
+	h := do.StatsHandle()
+	testKit.MustExec("use test")
+	testKit.MustExec("drop table if exists t")
+	testKit.MustExec(`
+		create table t (
+			a int,
+			b int,
+			primary key(a),
+			index idx(b)
+		)
+		partition by range (a) (
+			partition p0 values less than (6),
+			partition p1 values less than (11),
+			partition p2 values less than (16),
+			partition p3 values less than (21)
+		)
+	`)
+	testKit.MustExec("insert into t values (1,2),(2,2),(6,2),(11,2),(16,2)")
+	testKit.MustExec("analyze table t")
+	is := do.InfoSchema()
+	tbl, err := is.TableByName(
+		model.NewCIStr("test"), model.NewCIStr("t"),
+	)
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	pi := tableInfo.GetPartitionInfo()
+	for _, def := range pi.Definitions {
+		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
+		require.False(t, statsTbl.Pseudo)
+	}
+	err = h.Update(is)
+	require.NoError(t, err)
+
+	// Reset one partition stats.
+	p0 := pi.Definitions[0]
+	err = h.ResetTableStats2KVForDrop(p0.ID)
+	require.NoError(t, err)
+
+	// Get partition stats from stats_meta table.
+	rows := testKit.MustQuery(
+		"select version from mysql.stats_meta where table_id = ?",
+		p0.ID,
+	).Rows()
+	require.Equal(t, 1, len(rows))
+	// Parse version from stats_meta.
+	version := rows[0][0].(string)
+
+	// Check stats_meta_history again. The version should be the same.
+	rows = testKit.MustQuery(
+		"select count(*) from mysql.stats_meta_history where table_id = ? and version = ?",
+		p0.ID,
+		version,
+	).Rows()
+	require.Equal(t, 1, len(rows))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/49334

Problem Summary:

### What changed and how does it work?

1. Set the statsVer correctly.
2. Added a unit test for this behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix dropped partition stats meta can not record issue
```
