### PR TITLE
br/storage: disable keep alive for GCS on default to speed up request

### DIFF
--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -64,7 +64,7 @@ go_test(
     ],
     embed = [":external"],
     flaky = True,
-    shard_count = 48,
+    shard_count = 50,
     deps = [
         "//br/pkg/lightning/backend/kv",
         "//br/pkg/lightning/common",
@@ -80,6 +80,7 @@ go_test(
         "@com_github_aws_aws_sdk_go//aws/session",
         "@com_github_aws_aws_sdk_go//service/s3",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_jfcg_sorty_v2//:sorty",
         "@com_github_johannesboyne_gofakes3//:gofakes3",
         "@com_github_johannesboyne_gofakes3//backend/s3mem",

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/util/intest"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 )
@@ -44,7 +45,7 @@ func openTestingStorage(t *testing.T) storage.ExternalStorage {
 		t.Skip("testingStorageURI is not set")
 	}
 	s, err := storage.NewFromURL(context.Background(), *testingStorageURI, nil)
-	intest.AssertNoError(err)
+	require.NoError(t, err)
 	return s
 }
 

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -634,7 +634,7 @@ func readMergeIter(t *testing.T, s *readTestSuite) {
 				s.beforeReaderClose()
 			}
 		}
-		totalSize += len(iter.Key()) + len(iter.Value())
+		totalSize += len(iter.Key()) + len(iter.Value()) + lengthBytes*2
 	}
 	intest.Assert(kvCnt == s.totalKVCnt)
 	err = iter.Close()

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/util/intest"
@@ -473,7 +474,7 @@ type readTestSuite struct {
 	afterReaderClose   func()
 }
 
-func readFileSequential(s *readTestSuite) {
+func readFileSequential(t *testing.T, s *readTestSuite) {
 	ctx := context.Background()
 	files, _, err := GetAllFileNames(ctx, s.store, "/"+s.subDir)
 	intest.AssertNoError(err)
@@ -482,14 +483,21 @@ func readFileSequential(s *readTestSuite) {
 	if s.beforeCreateReader != nil {
 		s.beforeCreateReader()
 	}
+	var totalFileSize atomic.Int64
+	startTime := time.Now()
 	for i, file := range files {
 		reader, err := s.store.Open(ctx, file, nil)
 		intest.AssertNoError(err)
-		_, err = reader.Read(buf)
-		for err == nil {
-			_, err = reader.Read(buf)
+		var size int
+		for {
+			n, err := reader.Read(buf)
+			size += n
+			if err != nil {
+				break
+			}
 		}
 		intest.Assert(err == io.EOF)
+		totalFileSize.Add(int64(size))
 		if i == len(files)-1 {
 			if s.beforeReaderClose != nil {
 				s.beforeReaderClose()
@@ -501,9 +509,15 @@ func readFileSequential(s *readTestSuite) {
 	if s.afterReaderClose != nil {
 		s.afterReaderClose()
 	}
+	t.Logf(
+		"sequential read speed for %s bytes(%d files): %s/s",
+		units.BytesSize(float64(totalFileSize.Load())),
+		len(files),
+		units.BytesSize(float64(totalFileSize.Load())/time.Since(startTime).Seconds()),
+	)
 }
 
-func readFileConcurrently(s *readTestSuite) {
+func readFileConcurrently(t *testing.T, s *readTestSuite) {
 	ctx := context.Background()
 	files, _, err := GetAllFileNames(ctx, s.store, "/"+s.subDir)
 	intest.AssertNoError(err)
@@ -516,16 +530,24 @@ func readFileConcurrently(s *readTestSuite) {
 	if s.beforeCreateReader != nil {
 		s.beforeCreateReader()
 	}
-	for _, file := range files {
+	var totalFileSize atomic.Int64
+	startTime := time.Now()
+	for i := range files {
+		file := files[i]
 		eg.Go(func() error {
 			buf := make([]byte, s.memoryLimit/conc)
 			reader, err := s.store.Open(ctx, file, nil)
 			intest.AssertNoError(err)
-			_, err = reader.Read(buf)
-			for err == nil {
-				_, err = reader.Read(buf)
+			var size int
+			for {
+				n, err := reader.Read(buf)
+				size += n
+				if err != nil {
+					break
+				}
 			}
 			intest.Assert(err == io.EOF)
+			totalFileSize.Add(int64(size))
 			once.Do(func() {
 				if s.beforeReaderClose != nil {
 					s.beforeReaderClose()
@@ -541,6 +563,13 @@ func readFileConcurrently(s *readTestSuite) {
 	if s.afterReaderClose != nil {
 		s.afterReaderClose()
 	}
+	totalDur := time.Since(startTime)
+	t.Logf(
+		"concurrent read speed for %s bytes(%d files): %s/s, total-dur=%s",
+		units.BytesSize(float64(totalFileSize.Load())),
+		len(files),
+		units.BytesSize(float64(totalFileSize.Load())/totalDur.Seconds()), totalDur,
+	)
 }
 
 func createEvenlyDistributedFiles(
@@ -581,7 +610,7 @@ func createEvenlyDistributedFiles(
 	return store, kvCnt
 }
 
-func readMergeIter(s *readTestSuite) {
+func readMergeIter(t *testing.T, s *readTestSuite) {
 	ctx := context.Background()
 	files, _, err := GetAllFileNames(ctx, s.store, "/"+s.subDir)
 	intest.AssertNoError(err)
@@ -590,6 +619,8 @@ func readMergeIter(s *readTestSuite) {
 		s.beforeCreateReader()
 	}
 
+	startTime := time.Now()
+	var totalSize int
 	readBufSize := s.memoryLimit / len(files)
 	zeroOffsets := make([]uint64, len(files))
 	iter, err := NewMergeKVIter(ctx, files, zeroOffsets, s.store, readBufSize, s.mergeIterHotspot, 0)
@@ -603,6 +634,7 @@ func readMergeIter(s *readTestSuite) {
 				s.beforeReaderClose()
 			}
 		}
+		totalSize += len(iter.Key()) + len(iter.Value())
 	}
 	intest.Assert(kvCnt == s.totalKVCnt)
 	err = iter.Close()
@@ -610,6 +642,12 @@ func readMergeIter(s *readTestSuite) {
 	if s.afterReaderClose != nil {
 		s.afterReaderClose()
 	}
+	t.Logf(
+		"merge iter read (hotspot=%t) speed for %s bytes: %s/s",
+		s.mergeIterHotspot,
+		units.BytesSize(float64(totalSize)),
+		units.BytesSize(float64(totalSize)/time.Since(startTime).Seconds()),
+	)
 }
 
 func TestCompareReaderEvenlyDistributedContent(t *testing.T) {
@@ -656,21 +694,21 @@ func TestCompareReaderEvenlyDistributedContent(t *testing.T) {
 		subDir:             subDir,
 	}
 
-	readFileSequential(suite)
+	readFileSequential(t, suite)
 	t.Logf(
 		"sequential read speed for %d bytes: %.2f MB/s",
 		fileSize*fileCnt,
 		float64(fileSize*fileCnt)/elapsed.Seconds()/1024/1024,
 	)
 
-	readFileConcurrently(suite)
+	readFileConcurrently(t, suite)
 	t.Logf(
 		"concurrent read speed for %d bytes: %.2f MB/s",
 		fileSize*fileCnt,
 		float64(fileSize*fileCnt)/elapsed.Seconds()/1024/1024,
 	)
 
-	readMergeIter(suite)
+	readMergeIter(t, suite)
 	t.Logf(
 		"merge iter read speed for %d bytes: %.2f MB/s",
 		fileSize*fileCnt,
@@ -679,11 +717,10 @@ func TestCompareReaderEvenlyDistributedContent(t *testing.T) {
 }
 
 func createAscendingFiles(
-	t *testing.T,
+	store storage.ExternalStorage,
 	fileSize, fileCount int,
 	subDir string,
-) (storage.ExternalStorage, int) {
-	store := openTestingStorage(t)
+) int {
 	ctx := context.Background()
 
 	cleanOldFiles(ctx, store, "/"+subDir)
@@ -712,21 +749,47 @@ func createAscendingFiles(
 		err := writer.Close(ctx)
 		intest.AssertNoError(err)
 	}
-	return store, kvCnt
+	return kvCnt
 }
 
-func TestCompareReaderAscendingContent(t *testing.T) {
-	fileSize := 50 * 1024 * 1024
-	fileCnt := 24
-	subDir := "ascending"
-	store, kvCnt := createAscendingFiles(t, fileSize, fileCnt, subDir)
-	memoryLimit := 64 * 1024 * 1024
+var (
+	objectPrefix = flag.String("object-prefix", "ascending", "object prefix")
+	fileSize     = flag.Int("file-size", 50*units.MiB, "file size")
+	fileCount    = flag.Int("file-count", 24, "file count")
+	concurrency  = flag.Int("concurrency", 100, "concurrency")
+	memoryLimit  = flag.Int("memory-limit", 64*units.MiB, "memory limit")
+	skipCreate   = flag.Bool("skip-create", false, "skip create files")
+)
+
+func TestReadFileConcurrently(t *testing.T) {
+	testCompareReaderAscendingContent(t, readFileConcurrently)
+}
+
+func TestReadFileSequential(t *testing.T) {
+	testCompareReaderAscendingContent(t, readFileSequential)
+}
+
+func TestReadMergeIterCheckHotspot(t *testing.T) {
+	testCompareReaderAscendingContent(t, func(t *testing.T, suite *readTestSuite) {
+		suite.mergeIterHotspot = true
+		readMergeIter(t, suite)
+	})
+}
+
+func TestReadMergeIterWithoutCheckHotspot(t *testing.T) {
+	testCompareReaderAscendingContent(t, readMergeIter)
+}
+
+func testCompareReaderAscendingContent(t *testing.T, fn func(t *testing.T, suite *readTestSuite)) {
+	store := openTestingStorage(t)
+	kvCnt := 0
+	if !*skipCreate {
+		kvCnt = createAscendingFiles(store, *fileSize, *fileCount, *objectPrefix)
+	}
 	fileIdx := 0
 	var (
-		now     time.Time
-		elapsed time.Duration
-		file    *os.File
-		err     error
+		file *os.File
+		err  error
 	)
 	beforeTest := func() {
 		fileIdx++
@@ -734,7 +797,6 @@ func TestCompareReaderAscendingContent(t *testing.T) {
 		intest.AssertNoError(err)
 		err = pprof.StartCPUProfile(file)
 		intest.AssertNoError(err)
-		now = time.Now()
 	}
 	beforeClose := func() {
 		file, err = os.Create(fmt.Sprintf("heap-profile-%d.prof", fileIdx))
@@ -744,49 +806,21 @@ func TestCompareReaderAscendingContent(t *testing.T) {
 		intest.AssertNoError(err)
 	}
 	afterClose := func() {
-		elapsed = time.Since(now)
 		pprof.StopCPUProfile()
 	}
 
 	suite := &readTestSuite{
 		store:              store,
 		totalKVCnt:         kvCnt,
-		concurrency:        100,
-		memoryLimit:        memoryLimit,
+		concurrency:        *concurrency,
+		memoryLimit:        *memoryLimit,
 		beforeCreateReader: beforeTest,
 		beforeReaderClose:  beforeClose,
 		afterReaderClose:   afterClose,
-		subDir:             subDir,
+		subDir:             *objectPrefix,
 	}
 
-	readFileSequential(suite)
-	t.Logf(
-		"sequential read speed for %d bytes: %.2f MB/s",
-		fileSize*fileCnt,
-		float64(fileSize*fileCnt)/elapsed.Seconds()/1024/1024,
-	)
-
-	readFileConcurrently(suite)
-	t.Logf(
-		"concurrent read speed for %d bytes: %.2f MB/s",
-		fileSize*fileCnt,
-		float64(fileSize*fileCnt)/elapsed.Seconds()/1024/1024,
-	)
-
-	readMergeIter(suite)
-	t.Logf(
-		"merge iter read (hotspot=false) speed for %d bytes: %.2f MB/s",
-		fileSize*fileCnt,
-		float64(fileSize*fileCnt)/elapsed.Seconds()/1024/1024,
-	)
-
-	suite.mergeIterHotspot = true
-	readMergeIter(suite)
-	t.Logf(
-		"merge iter read (hotspot=true) speed for %d bytes: %.2f MB/s",
-		fileSize*fileCnt,
-		float64(fileSize*fileCnt)/elapsed.Seconds()/1024/1024,
-	)
+	fn(t, suite)
 }
 
 const largeAscendingDataPath = "large_ascending_data"

--- a/br/pkg/storage/BUILD.bazel
+++ b/br/pkg/storage/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "@com_google_cloud_go_storage//:storage",
         "@org_golang_google_api//iterator",
         "@org_golang_google_api//option",
+        "@org_golang_google_api//transport/http",
         "@org_golang_x_oauth2//google",
         "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -324,7 +324,7 @@ func NewGCSStorage(ctx context.Context, gcs *backuppb.GCS, opts *ExternalStorage
 
 	httpClient := opts.HTTPClient
 	if httpClient == nil {
-		// http2 will to reuse the connection to read multiple files, which is
+		// http2 will reuse the connection to read multiple files, which is
 		// very slow, the speed is about the same speed as reading a single file.
 		// So we disable keepalive here to use multiple connections to read files.
 		// open a new connection takes about 20~50ms, which is acceptable.

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -334,8 +334,7 @@ func NewGCSStorage(ctx context.Context, gcs *backuppb.GCS, opts *ExternalStorage
 	}
 	// see https://github.com/pingcap/tidb/issues/47022#issuecomment-1722913455
 	var err error
-	httpClient.Transport, err = htransport.NewTransport(ctx, httpClient.Transport,
-		append(clientOps, option.WithScopes(storage.ScopeFullControl, "https://www.googleapis.com/auth/cloud-platform"))...)
+	httpClient.Transport, err = htransport.NewTransport(ctx, httpClient.Transport)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -331,12 +331,12 @@ func NewGCSStorage(ctx context.Context, gcs *backuppb.GCS, opts *ExternalStorage
 		transport, _ := CloneDefaultHttpTransport()
 		transport.DisableKeepAlives = true
 		httpClient = &http.Client{Transport: transport}
-	}
-	// see https://github.com/pingcap/tidb/issues/47022#issuecomment-1722913455
-	var err error
-	httpClient.Transport, err = htransport.NewTransport(ctx, httpClient.Transport)
-	if err != nil {
-		return nil, errors.Trace(err)
+		// see https://github.com/pingcap/tidb/issues/47022#issuecomment-1722913455
+		var err error
+		httpClient.Transport, err = htransport.NewTransport(ctx, httpClient.Transport, clientOps...)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	clientOps = append(clientOps, option.WithHTTPClient(httpClient))
 

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+	htransport "google.golang.org/api/transport/http"
 )
 
 const (
@@ -319,12 +321,26 @@ func NewGCSStorage(ctx context.Context, gcs *backuppb.GCS, opts *ExternalStorage
 	if gcs.Endpoint != "" {
 		clientOps = append(clientOps, option.WithEndpoint(gcs.Endpoint))
 	}
-	// the HTTPClient should has credential, currently the HTTPClient only has the http.Transport.
-	// So we remove the HTTPClient in the storage.New().
-	// Issue: https: //github.com/pingcap/tidb/issues/47022
-	if opts.HTTPClient != nil {
-		clientOps = append(clientOps, option.WithHTTPClient(opts.HTTPClient))
+
+	httpClient := opts.HTTPClient
+	if httpClient == nil {
+		// http2 will to reuse the connection to read multiple files, which is
+		// very slow, the speed is about the same speed as reading a single file.
+		// So we disable keepalive here to use multiple connections to read files.
+		// open a new connection takes about 20~50ms, which is acceptable.
+		transport, _ := CloneDefaultHttpTransport()
+		transport.DisableKeepAlives = true
+		httpClient = &http.Client{Transport: transport}
 	}
+	// see https://github.com/pingcap/tidb/issues/47022#issuecomment-1722913455
+	var err error
+	httpClient.Transport, err = htransport.NewTransport(ctx, httpClient.Transport,
+		append(clientOps, option.WithScopes(storage.ScopeFullControl, "https://www.googleapis.com/auth/cloud-platform"))...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	clientOps = append(clientOps, option.WithHTTPClient(httpClient))
+
 	client, err := storage.NewClient(ctx, clientOps...)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/br/pkg/storage/gcs_test.go
+++ b/br/pkg/storage/gcs_test.go
@@ -272,7 +272,7 @@ func TestNewGCSStorage(t *testing.T) {
 			Prefix:          "a/b/",
 			StorageClass:    "NEARLINE",
 			PredefinedAcl:   "private",
-			CredentialsBlob: "FakeCredentials",
+			CredentialsBlob: `{"type": "service_account"}`,
 		}
 		_, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  true,
@@ -280,7 +280,7 @@ func TestNewGCSStorage(t *testing.T) {
 			HTTPClient:       server.HTTPClient(),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "FakeCredentials", gcs.CredentialsBlob)
+		require.Equal(t, `{"type": "service_account"}`, gcs.CredentialsBlob)
 	}
 
 	{
@@ -289,7 +289,7 @@ func TestNewGCSStorage(t *testing.T) {
 			Prefix:          "a/b/",
 			StorageClass:    "NEARLINE",
 			PredefinedAcl:   "private",
-			CredentialsBlob: "FakeCredentials",
+			CredentialsBlob: `{"type": "service_account"}`,
 		}
 		_, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  false,
@@ -386,7 +386,7 @@ func TestNewGCSStorage(t *testing.T) {
 			Prefix:          "a/b",
 			StorageClass:    "NEARLINE",
 			PredefinedAcl:   "private",
-			CredentialsBlob: "FakeCredentials",
+			CredentialsBlob: `{"type": "service_account"}`,
 		}
 		s, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  false,

--- a/br/pkg/storage/gcs_test.go
+++ b/br/pkg/storage/gcs_test.go
@@ -272,7 +272,7 @@ func TestNewGCSStorage(t *testing.T) {
 			Prefix:          "a/b/",
 			StorageClass:    "NEARLINE",
 			PredefinedAcl:   "private",
-			CredentialsBlob: `{"type": "service_account"}`,
+			CredentialsBlob: "FakeCredentials",
 		}
 		_, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  true,
@@ -280,7 +280,7 @@ func TestNewGCSStorage(t *testing.T) {
 			HTTPClient:       server.HTTPClient(),
 		})
 		require.NoError(t, err)
-		require.Equal(t, `{"type": "service_account"}`, gcs.CredentialsBlob)
+		require.Equal(t, "FakeCredentials", gcs.CredentialsBlob)
 	}
 
 	{
@@ -289,7 +289,7 @@ func TestNewGCSStorage(t *testing.T) {
 			Prefix:          "a/b/",
 			StorageClass:    "NEARLINE",
 			PredefinedAcl:   "private",
-			CredentialsBlob: `{"type": "service_account"}`,
+			CredentialsBlob: "FakeCredentials",
 		}
 		_, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  false,
@@ -386,7 +386,7 @@ func TestNewGCSStorage(t *testing.T) {
 			Prefix:          "a/b",
 			StorageClass:    "NEARLINE",
 			PredefinedAcl:   "private",
-			CredentialsBlob: `{"type": "service_account"}`,
+			CredentialsBlob: "FakeCredentials",
 		}
 		s, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
 			SendCredentials:  false,
@@ -396,6 +396,22 @@ func TestNewGCSStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "", gcs.CredentialsBlob)
 		require.Equal(t, "a/b/x", s.objectName("x"))
+	}
+
+	// without http client
+	{
+		gcs := &backuppb.GCS{
+			Bucket:          bucketName,
+			Prefix:          "a/b",
+			StorageClass:    "NEARLINE",
+			PredefinedAcl:   "private",
+			CredentialsBlob: `{"type": "service_account"}`,
+		}
+		_, err := NewGCSStorage(ctx, gcs, &ExternalStorageOptions{
+			SendCredentials:  false,
+			CheckPermissions: []Permission{AccessBuckets},
+		})
+		require.NoError(t, err)
 	}
 }
 

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -163,7 +163,7 @@ type ExternalStorageOptions struct {
 	// HTTPClient to use. The created storage may ignore this field if it is not
 	// directly using HTTP (e.g. the local storage) or use self-design HTTP client
 	// with credential (e.g. the gcs).
-	// NOTICE: the HTTPClient is only used by s3 storage and azure blob storage.
+	// NOTICE: the HTTPClient is only used by s3/azure/gcs.
 	HTTPClient *http.Client
 
 	// CheckPermissions check the given permission in New() function.
@@ -247,9 +247,6 @@ func New(ctx context.Context, backend *backuppb.StorageBackend, opts *ExternalSt
 		if backend.Gcs == nil {
 			return nil, errors.Annotate(berrors.ErrStorageInvalidConfig, "GCS config not found")
 		}
-		// the HTTPClient should has credential, currently the HTTPClient only has the http.Transport.
-		// Issue: https: //github.com/pingcap/tidb/issues/47022
-		opts.HTTPClient = nil
 		return NewGCSStorage(ctx, backend.Gcs, opts)
 	case *backuppb.StorageBackend_AzureBlobStorage:
 		return newAzureBlobStorage(ctx, backend.AzureBlobStorage, opts)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49340

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  run TestReadFileConcurrently and check speed can use all network bandwidth
before
```
    bench_test.go:575: concurrent read speed for 2.136GiB bytes(20 files): 234.9MiB/s, total-dur=9.309418879s
```
after
```
    bench_test.go:568: concurrent read speed for 2.136GiB bytes(20 files): 2.353GiB/s, total-dur=907.624007ms
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
