### PR TITLE
br: skip when rewrite rule not found

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -3481,8 +3481,12 @@ func (rc *Client) InsertGCRows(ctx context.Context) error {
 			// (job_id, elem_id, start_key, end_key, ts)
 			paramsList = append(paramsList, newJobID, params.ElemID, params.StartKey, params.EndKey, ts)
 		}
-		if err := rc.db.se.ExecuteInternal(ctx, query.Sql, paramsList...); err != nil {
-			return errors.Trace(err)
+		if len(paramsList) > 0 {
+			// trim the ',' behind the query.Sql if exists
+			sql := strings.TrimSuffix(query.Sql, ",")
+			if err := rc.db.se.ExecuteInternal(ctx, sql, paramsList...); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 	return nil

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -3483,6 +3483,7 @@ func (rc *Client) InsertGCRows(ctx context.Context) error {
 		}
 		if len(paramsList) > 0 {
 			// trim the ',' behind the query.Sql if exists
+			// that's when the rewrite rule of the last table id is not exist
 			sql := strings.TrimSuffix(query.Sql, ",")
 			if err := rc.db.se.ExecuteInternal(ctx, sql, paramsList...); err != nil {
 				return errors.Trace(err)

--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -668,9 +668,7 @@ func TestDeleteRangeQuery(t *testing.T) {
 		for j := range expected_query.ParamsList {
 			require.Equal(t, expected_query.ParamsList[j], query.ParamsList[j])
 		}
-
 	}
-
 }
 
 func TestDeleteRangeQueryExec(t *testing.T) {

--- a/br/pkg/stream/BUILD.bazel
+++ b/br/pkg/stream/BUILD.bazel
@@ -55,7 +55,7 @@ go_test(
     ],
     embed = [":stream"],
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//br/pkg/storage",
         "//br/pkg/streamhelper",

--- a/br/pkg/stream/rewrite_meta_rawkv.go
+++ b/br/pkg/stream/rewrite_meta_rawkv.go
@@ -748,7 +748,7 @@ func (bdr *brDelRangeExecWrapper) PrepareParamsList(sz int) {
 func (bdr *brDelRangeExecWrapper) RewriteTableID(tableID int64) (int64, bool) {
 	newTableID, exists := bdr.globalTableIdMap[tableID]
 	if !exists {
-		log.Warn("failed to find the downstream id when rewrite delete range", zap.Int64("tableID", newTableID))
+		log.Warn("failed to find the downstream id when rewrite delete range", zap.Int64("old tableID", tableID))
 	}
 	return newTableID, exists
 }

--- a/br/pkg/stream/rewrite_meta_rawkv.go
+++ b/br/pkg/stream/rewrite_meta_rawkv.go
@@ -746,11 +746,11 @@ func (bdr *brDelRangeExecWrapper) PrepareParamsList(sz int) {
 }
 
 func (bdr *brDelRangeExecWrapper) RewriteTableID(tableID int64) (int64, bool) {
-	tableID, exists := bdr.globalTableIdMap[tableID]
+	newTableID, exists := bdr.globalTableIdMap[tableID]
 	if !exists {
-		log.Warn("failed to find the downstream id when rewrite delete range", zap.Int64("tableID", tableID))
+		log.Warn("failed to find the downstream id when rewrite delete range", zap.Int64("tableID", newTableID))
 	}
-	return tableID, exists
+	return newTableID, exists
 }
 
 func (bdr *brDelRangeExecWrapper) AppendParamsList(jobID, elemID int64, startKey, endKey string) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49346

Problem Summary:
When there is no rewrite rule, need to skip trying to insert SQL to `gc_delete_range`
### What changed and how does it work?
skip and add unit test
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
