### PR TITLE
statistics: update the global stats correctly after truncate a partition

### DIFF
--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 6,
+    shard_count = 7,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "ddl.go",
         "exchange_partition.go",
+        "truncate_partition.go",
     ],
     importpath = "github.com/pingcap/tidb/pkg/statistics/handle/ddl",
     visibility = ["//visibility:public"],

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -116,11 +116,8 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 			}
 		}
 	case model.ActionTruncateTablePartition:
-		globalTableInfo, addedPartInfo, _ := t.GetTruncatePartitionInfo()
-		for _, def := range addedPartInfo.Definitions {
-			if err := h.statsWriter.InsertTableStats2KV(globalTableInfo, def.ID); err != nil {
-				return err
-			}
+		if err := h.onTruncatePartitions(t); err != nil {
+			return err
 		}
 	case model.ActionDropTablePartition:
 		globalTableInfo, droppedPartitionInfo := t.GetDropPartitionInfo()

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -407,7 +407,7 @@ func TestTruncatePartitions(t *testing.T) {
 	err = h.HandleDDLEvent(truncatePartitionEvent)
 	require.NoError(t, err)
 	// Check global stats meta.
-	// Because we have truncated a partition, the count should be 5 - 2 - 1  = 2 and the modify count should be 3.
+	// Because we have truncated two partitions, the count should be 5 - 2 - 1  = 2 and the modify count should be 3.
 	testKit.MustQuery(
 		"select count, modify_count from mysql.stats_meta where table_id = ?", tableInfo.ID,
 	).Check(

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -272,6 +272,69 @@ PARTITION BY RANGE ( a ) (
 	}
 }
 
+func TestTruncateAPartition(t *testing.T) {
+	store, do := testkit.CreateMockStoreAndDomain(t)
+	testKit := testkit.NewTestKit(t, store)
+	h := do.StatsHandle()
+	testKit.MustExec("use test")
+	testKit.MustExec("drop table if exists t")
+	testKit.MustExec(`
+		create table t (
+			a int,
+			b int,
+			primary key(a),
+			index idx(b)
+		)
+		partition by range (a) (
+			partition p0 values less than (6),
+			partition p1 values less than (11),
+			partition p2 values less than (16),
+			partition p3 values less than (21)
+		)
+	`)
+	testKit.MustExec("insert into t values (1,2),(2,2),(6,2),(11,2),(16,2)")
+	testKit.MustExec("analyze table t")
+	is := do.InfoSchema()
+	tbl, err := is.TableByName(
+		model.NewCIStr("test"), model.NewCIStr("t"),
+	)
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	pi := tableInfo.GetPartitionInfo()
+	for _, def := range pi.Definitions {
+		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
+		require.False(t, statsTbl.Pseudo)
+	}
+	err = h.Update(is)
+	require.NoError(t, err)
+
+	// Get partition p0's stats update version.
+	partitionId := pi.Definitions[0].ID
+	// Get it from stats_meat first.
+	rows := testKit.MustQuery(
+		fmt.Sprintf("select version from mysql.stats_meta where table_id = %d", partitionId),
+	).Rows()
+	require.Len(t, rows, 1)
+	version := rows[0][0].(string)
+
+	testKit.MustExec("alter table t truncate partition p0")
+	// Check global stats meta.
+	// FIXME: we should update the global stats meta after truncating a partition.
+	testKit.MustQuery(
+		fmt.Sprintf("select count, modify_count from mysql.stats_meta where table_id = %d", tableInfo.ID),
+	).Check(
+		testkit.Rows("5 0"),
+	)
+
+	// Check the version again.
+	rows = testKit.MustQuery(
+		fmt.Sprintf("select version from mysql.stats_meta where table_id = %d", partitionId),
+	).Rows()
+	require.Len(t, rows, 1)
+	// FIXME: we should update the version after truncating a partition.
+	require.Equal(t, version, rows[0][0].(string))
+}
+
 func TestDropAPartition(t *testing.T) {
 	store, do := testkit.CreateMockStoreAndDomain(t)
 	testKit := testkit.NewTestKit(t, store)

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -330,11 +330,11 @@ func TestTruncateAPartition(t *testing.T) {
 	err = h.HandleDDLEvent(truncatePartitionEvent)
 	require.NoError(t, err)
 	// Check global stats meta.
-	// FIXME: we should update the global stats meta after truncating a partition.
+	// Because we have truncated a partition, the count should be 5 - 2 = 3 and the modify count should be 2.
 	testKit.MustQuery(
 		fmt.Sprintf("select count, modify_count from mysql.stats_meta where table_id = %d", tableInfo.ID),
 	).Check(
-		testkit.Rows("5 0"),
+		testkit.Rows("3 2"),
 	)
 
 	// Check the version again.

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -318,6 +318,17 @@ func TestTruncateAPartition(t *testing.T) {
 	version := rows[0][0].(string)
 
 	testKit.MustExec("alter table t truncate partition p0")
+	// Find the truncate partition event.
+	var truncatePartitionEvent *util.DDLEvent
+	for {
+		event := <-h.DDLEventCh()
+		if event.GetType() == model.ActionTruncateTablePartition {
+			truncatePartitionEvent = event
+			break
+		}
+	}
+	err = h.HandleDDLEvent(truncatePartitionEvent)
+	require.NoError(t, err)
 	// Check global stats meta.
 	// FIXME: we should update the global stats meta after truncating a partition.
 	testKit.MustQuery(

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -342,8 +342,8 @@ func TestTruncateAPartition(t *testing.T) {
 		"select version from mysql.stats_meta where table_id = ?", partitionID,
 	).Rows()
 	require.Len(t, rows, 1)
-	// FIXME: we should update the version after truncating a partition.
-	require.Equal(t, version, rows[0][0].(string))
+	// Version gets updated after truncate the partition.
+	require.NotEqual(t, version, rows[0][0].(string))
 }
 
 func TestDropAPartition(t *testing.T) {

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -319,14 +319,7 @@ func TestTruncateAPartition(t *testing.T) {
 
 	testKit.MustExec("alter table t truncate partition p0")
 	// Find the truncate partition event.
-	var truncatePartitionEvent *util.DDLEvent
-	for {
-		event := <-h.DDLEventCh()
-		if event.GetType() == model.ActionTruncateTablePartition {
-			truncatePartitionEvent = event
-			break
-		}
-	}
+	truncatePartitionEvent := findEvent(h.DDLEventCh(), model.ActionTruncateTablePartition)
 	err = h.HandleDDLEvent(truncatePartitionEvent)
 	require.NoError(t, err)
 	// Check global stats meta.
@@ -396,14 +389,7 @@ func TestTruncatePartitions(t *testing.T) {
 	// Truncate two partitions.
 	testKit.MustExec("alter table t truncate partition p0, p1")
 	// Find the truncate partition event.
-	var truncatePartitionEvent *util.DDLEvent
-	for {
-		event := <-h.DDLEventCh()
-		if event.GetType() == model.ActionTruncateTablePartition {
-			truncatePartitionEvent = event
-			break
-		}
-	}
+	truncatePartitionEvent := findEvent(h.DDLEventCh(), model.ActionTruncateTablePartition)
 	err = h.HandleDDLEvent(truncatePartitionEvent)
 	require.NoError(t, err)
 	// Check global stats meta.

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -380,7 +380,7 @@ func TestTruncatePartitions(t *testing.T) {
 	partitionP1ID := pi.Definitions[1].ID
 	// Get it from stats_meat first.
 	rows := testKit.MustQuery(
-		"select version from mysql.stats_meta where table_id in (?, ?)", partitionP0ID, partitionP1ID,
+		"select version from mysql.stats_meta where table_id in (?, ?) order by table_id", partitionP0ID, partitionP1ID,
 	).Rows()
 	require.Len(t, rows, 2)
 	versionP0 := rows[0][0].(string)
@@ -402,7 +402,7 @@ func TestTruncatePartitions(t *testing.T) {
 
 	// Check the version again.
 	rows = testKit.MustQuery(
-		"select version from mysql.stats_meta where table_id in (?, ?)", partitionP0ID, partitionP1ID,
+		"select version from mysql.stats_meta where table_id in (?, ?) order by table_id", partitionP0ID, partitionP1ID,
 	).Rows()
 	require.Len(t, rows, 2)
 	// Version gets updated after truncate the partition.

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -255,21 +255,6 @@ PARTITION BY RANGE ( a ) (
 			require.False(t, statsTbl.Pseudo)
 		}
 
-		truncatePartition := "alter table t truncate partition p4"
-		testKit.MustExec(truncatePartition)
-		is = do.InfoSchema()
-		tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
-		require.NoError(t, err)
-		tableInfo = tbl.Meta()
-		err = h.HandleDDLEvent(<-h.DDLEventCh())
-		require.NoError(t, err)
-		require.Nil(t, h.Update(is))
-		pi = tableInfo.GetPartitionInfo()
-		for _, def := range pi.Definitions {
-			statsTbl := h.GetPartitionStats(tableInfo, def.ID)
-			require.False(t, statsTbl.Pseudo)
-		}
-
 		reorganizePartition := "alter table t reorganize partition p0,p1 into (partition p0 values less than (11))"
 		testKit.MustExec(reorganizePartition)
 		is = do.InfoSchema()

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -309,10 +309,10 @@ func TestTruncateAPartition(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get partition p0's stats update version.
-	partitionId := pi.Definitions[0].ID
+	partitionID := pi.Definitions[0].ID
 	// Get it from stats_meat first.
 	rows := testKit.MustQuery(
-		fmt.Sprintf("select version from mysql.stats_meta where table_id = %d", partitionId),
+		"select version from mysql.stats_meta where table_id = ?", partitionID,
 	).Rows()
 	require.Len(t, rows, 1)
 	version := rows[0][0].(string)
@@ -332,14 +332,14 @@ func TestTruncateAPartition(t *testing.T) {
 	// Check global stats meta.
 	// Because we have truncated a partition, the count should be 5 - 2 = 3 and the modify count should be 2.
 	testKit.MustQuery(
-		fmt.Sprintf("select count, modify_count from mysql.stats_meta where table_id = %d", tableInfo.ID),
+		"select count, modify_count from mysql.stats_meta where table_id = ?", tableInfo.ID,
 	).Check(
 		testkit.Rows("3 2"),
 	)
 
 	// Check the version again.
 	rows = testKit.MustQuery(
-		fmt.Sprintf("select version from mysql.stats_meta where table_id = %d", partitionId),
+		"select version from mysql.stats_meta where table_id = ?", partitionID,
 	).Rows()
 	require.Len(t, rows, 1)
 	// FIXME: we should update the version after truncating a partition.

--- a/pkg/statistics/handle/ddl/truncate_partition.go
+++ b/pkg/statistics/handle/ddl/truncate_partition.go
@@ -1,0 +1,27 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+import "github.com/pingcap/tidb/pkg/statistics/handle/util"
+
+func (h *ddlHandlerImpl) onTruncatePartitions(t *util.DDLEvent) error {
+	globalTableInfo, addedPartInfo, _ := t.GetTruncatePartitionInfo()
+	for _, def := range addedPartInfo.Definitions {
+		if err := h.statsWriter.InsertTableStats2KV(globalTableInfo, def.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/statistics/handle/ddl/truncate_partition.go
+++ b/pkg/statistics/handle/ddl/truncate_partition.go
@@ -60,6 +60,13 @@ func (h *ddlHandlerImpl) onTruncatePartitions(t *util.DDLEvent) error {
 			}
 
 			// Because we drop the partition, we should subtract the count from the global stats.
+			// Note: We don't need to subtract the modify count from the global stats.
+			// For example:
+			// 1. The partition has 100 rows.
+			// 2. We deleted 100 rows from the partition.
+			// 3. The global stats has `count - 100 rows` and 100 modify count.
+			// 4. We drop the partition.
+			// 5. The global stats should not be `count` and 0 modify count. We need to keep the modify count.
 			delta := -count
 			err = storage.UpdateStatsMeta(
 				sctx,

--- a/pkg/statistics/handle/ddl/truncate_partition.go
+++ b/pkg/statistics/handle/ddl/truncate_partition.go
@@ -14,14 +14,63 @@
 
 package ddl
 
-import "github.com/pingcap/tidb/pkg/statistics/handle/util"
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/statistics/handle/lockstats"
+	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
+	"github.com/pingcap/tidb/pkg/statistics/handle/util"
+)
 
 func (h *ddlHandlerImpl) onTruncatePartitions(t *util.DDLEvent) error {
-	globalTableInfo, addedPartInfo, _ := t.GetTruncatePartitionInfo()
+	globalTableInfo, addedPartInfo, droppedPartInfo := t.GetTruncatePartitionInfo()
+	// First, add the new stats meta record for the new partitions.
 	for _, def := range addedPartInfo.Definitions {
 		if err := h.statsWriter.InsertTableStats2KV(globalTableInfo, def.ID); err != nil {
 			return err
 		}
 	}
-	return nil
+
+	// Second, clean up the old stats meta from global stats meta for the dropped partitions.
+	// Do not forget to put those operations in one transaction.
+	return util.CallWithSCtx(h.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+		count := int64(0)
+		for _, def := range droppedPartInfo.Definitions {
+			// Get the count and modify count of the partition.
+			tableCount, _, _, err := storage.StatsMetaCountAndModifyCount(sctx, def.ID)
+			if err != nil {
+				return err
+			}
+			count += tableCount
+		}
+
+		if count != 0 {
+			lockedTables, err := lockstats.QueryLockedTables(sctx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			isLocked := false
+			if _, ok := lockedTables[globalTableInfo.ID]; ok {
+				isLocked = true
+			}
+			startTS, err := util.GetStartTS(sctx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			// Because we drop the partition, we should subtract the count from the global stats.
+			delta := -count
+			err = storage.UpdateStatsMeta(
+				sctx,
+				startTS,
+				variable.TableDelta{Count: count, Delta: delta},
+				globalTableInfo.ID,
+				isLocked,
+			)
+			return err
+		}
+
+		return nil
+	}, util.FlagWrapTxn)
 }

--- a/pkg/statistics/handle/ddl/truncate_partition.go
+++ b/pkg/statistics/handle/ddl/truncate_partition.go
@@ -40,8 +40,8 @@ func (h *ddlHandlerImpl) onTruncatePartitions(t *util.DDLEvent) error {
 	// Do not forget to put those operations in one transaction.
 	if err := util.CallWithSCtx(h.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		count := int64(0)
-		var partitionIDs []int64
-		var partitionNames []string
+		partitionIDs := make([]int64, 0, len(droppedPartInfo.Definitions))
+		partitionNames := make([]string, 0, len(droppedPartInfo.Definitions))
 		for _, def := range droppedPartInfo.Definitions {
 			// Get the count and modify count of the partition.
 			tableCount, _, _, err := storage.StatsMetaCountAndModifyCount(sctx, def.ID)

--- a/pkg/statistics/handle/globalstats/global_stats_test.go
+++ b/pkg/statistics/handle/globalstats/global_stats_test.go
@@ -598,10 +598,9 @@ func TestDDLPartition4GlobalStats(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
 	require.NoError(t, h.Update(is))
-	// The value of global.count will not be updated automatically when we truncate the table partition.
-	// Because the partition-stats in the partition table which have been truncated has not been updated.
+	// We will update the global-stats after the truncate operation.
 	globalStats = h.GetTableStats(tableInfo)
-	require.Equal(t, int64(15), globalStats.RealtimeCount)
+	require.Equal(t, int64(11), globalStats.RealtimeCount)
 
 	tk.MustExec("analyze table t;")
 	result = tk.MustQuery("show stats_meta where table_name = 't';").Rows()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/39681

Problem Summary:

### What changed and how does it work?

- Relocated truncate partition logic to truncate_partition.go.
- Updated the global stats correctly, updated the count, and modify_count for the global table.
- Added test case for truncating one partition and multiple partitions.
- Fixed the broken old test case for global stats.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix TiDB global stats meta update issue after truncating tables
```
