### PR TITLE
br/storage: add scope to support service_account type of credential file & remove default GCS httpclient

### DIFF
--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -44,7 +44,7 @@ func openTestingStorage(t *testing.T) storage.ExternalStorage {
 	if *testingStorageURI == "" {
 		t.Skip("testingStorageURI is not set")
 	}
-	s, err := storage.NewFromURL(context.Background(), *testingStorageURI, nil)
+	s, err := storage.NewFromURL(context.Background(), *testingStorageURI)
 	require.NoError(t, err)
 	return s
 }

--- a/br/pkg/restore/BUILD.bazel
+++ b/br/pkg/restore/BUILD.bazel
@@ -162,6 +162,7 @@ go_test(
         "//pkg/testkit/testsetup",
         "//pkg/types",
         "//pkg/util/codec",
+        "//pkg/util/intest",
         "//pkg/util/table-filter",
         "@com_github_fsouza_fake_gcs_server//fakestorage",
         "@com_github_golang_protobuf//proto",

--- a/br/pkg/restore/stream_metas_test.go
+++ b/br/pkg/restore/stream_metas_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/restore"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/br/pkg/stream"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
@@ -302,6 +303,7 @@ func TestTruncateSafepoint(t *testing.T) {
 }
 
 func TestTruncateSafepointForGCS(t *testing.T) {
+	require.True(t, intest.InTest)
 	ctx := context.Background()
 	opts := fakestorage.Options{
 		NoListener: true,

--- a/br/pkg/storage/BUILD.bazel
+++ b/br/pkg/storage/BUILD.bazel
@@ -92,6 +92,7 @@ go_test(
     shard_count = 50,
     deps = [
         "//br/pkg/mock",
+        "//pkg/util/intest",
         "@com_github_aws_aws_sdk_go//aws",
         "@com_github_aws_aws_sdk_go//aws/awserr",
         "@com_github_aws_aws_sdk_go//aws/request",

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -332,8 +332,11 @@ func NewGCSStorage(ctx context.Context, gcs *backuppb.GCS, opts *ExternalStorage
 		transport.DisableKeepAlives = true
 		httpClient = &http.Client{Transport: transport}
 		// see https://github.com/pingcap/tidb/issues/47022#issuecomment-1722913455
+		// https://www.googleapis.com/auth/cloud-platform must be set to use service_account
+		// type of credential-file.
 		var err error
-		httpClient.Transport, err = htransport.NewTransport(ctx, httpClient.Transport, clientOps...)
+		httpClient.Transport, err = htransport.NewTransport(ctx, httpClient.Transport,
+			append(clientOps, option.WithScopes(storage.ScopeFullControl, "https://www.googleapis.com/auth/cloud-platform"))...)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/br/pkg/storage/gcs_test.go
+++ b/br/pkg/storage/gcs_test.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGCS(t *testing.T) {
+	require.True(t, intest.InTest)
 	ctx := context.Background()
 
 	opts := fakestorage.Options{
@@ -255,6 +257,7 @@ func TestGCS(t *testing.T) {
 }
 
 func TestNewGCSStorage(t *testing.T) {
+	require.True(t, intest.InTest)
 	ctx := context.Background()
 
 	opts := fakestorage.Options{
@@ -416,6 +419,7 @@ func TestNewGCSStorage(t *testing.T) {
 }
 
 func TestReadRange(t *testing.T) {
+	require.True(t, intest.InTest)
 	ctx := context.Background()
 
 	opts := fakestorage.Options{

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -161,9 +161,9 @@ type ExternalStorageOptions struct {
 	NoCredentials bool
 
 	// HTTPClient to use. The created storage may ignore this field if it is not
-	// directly using HTTP (e.g. the local storage) or use self-design HTTP client
-	// with credential (e.g. the gcs).
+	// directly using HTTP (e.g. the local storage).
 	// NOTICE: the HTTPClient is only used by s3/azure/gcs.
+	// For GCS, we will use this as base client to init a client with credentials.
 	HTTPClient *http.Client
 
 	// CheckPermissions check the given permission in New() function.
@@ -195,11 +195,14 @@ func NewWithDefaultOpt(ctx context.Context, backend *backuppb.StorageBackend) (E
 	if intest.InTest {
 		opts.NoCredentials = true
 	}
+	if backend.GetGcs() != nil {
+		opts.HTTPClient = gcsHttpClientForThroughput()
+	}
 	return New(ctx, backend, &opts)
 }
 
 // NewFromURL creates an ExternalStorage from URL.
-func NewFromURL(ctx context.Context, uri string, opts *ExternalStorageOptions) (ExternalStorage, error) {
+func NewFromURL(ctx context.Context, uri string) (ExternalStorage, error) {
 	if len(uri) == 0 {
 		return nil, errors.Annotate(berrors.ErrStorageInvalidConfig, "empty store is not allowed")
 	}
@@ -214,7 +217,7 @@ func NewFromURL(ctx context.Context, uri string, opts *ExternalStorageOptions) (
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return New(ctx, b, opts)
+	return NewWithDefaultOpt(ctx, b)
 }
 
 // New creates an ExternalStorage with options.

--- a/br/pkg/storage/storage_test.go
+++ b/br/pkg/storage/storage_test.go
@@ -28,7 +28,7 @@ func TestDefaultHttpClient(t *testing.T) {
 
 func TestNewMemStorage(t *testing.T) {
 	url := "memstore://"
-	s, err := storage.NewFromURL(context.Background(), url, nil)
+	s, err := storage.NewFromURL(context.Background(), url)
 	require.NoError(t, err)
 	require.IsType(t, (*storage.MemStorage)(nil), s)
 }

--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -99,7 +99,7 @@ go_test(
     ],
     embed = [":task"],
     flaky = True,
-    shard_count = 21,
+    shard_count = 22,
     deps = [
         "//br/pkg/conn",
         "//br/pkg/errors",

--- a/br/pkg/task/stream_test.go
+++ b/br/pkg/task/stream_test.go
@@ -248,3 +248,16 @@ func TestGetLogRangeWithLogBackupDir(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, logInfo.logMinTS, startLogBackupTS)
 }
+
+func TestGetExternalStorageOptions(t *testing.T) {
+	cfg := Config{}
+	u, err := storage.ParseBackend("s3://bucket/path", nil)
+	require.NoError(t, err)
+	options := getExternalStorageOptions(&cfg, u)
+	require.NotNil(t, options.HTTPClient)
+
+	u, err = storage.ParseBackend("gs://bucket/path", nil)
+	require.NoError(t, err)
+	options = getExternalStorageOptions(&cfg, u)
+	require.Nil(t, options.HTTPClient)
+}

--- a/pkg/ddl/backfilling_merge_sort.go
+++ b/pkg/ddl/backfilling_merge_sort.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
-	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/size"
 	"go.uber.org/zap"
@@ -88,11 +87,7 @@ func (m *mergeSortExecutor) RunSubtask(ctx context.Context, subtask *proto.Subta
 	if err != nil {
 		return err
 	}
-	opt := &storage.ExternalStorageOptions{}
-	if intest.InTest {
-		opt.NoCredentials = true
-	}
-	store, err := storage.New(ctx, storeBackend, opt)
+	store, err := storage.NewWithDefaultOpt(ctx, storeBackend)
 	if err != nil {
 		return err
 	}

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -57,7 +57,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/filter"
-	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/stringutil"
 	kvconfig "github.com/tikv/client-go/v2/config"
@@ -942,11 +941,7 @@ func (*LoadDataController) initExternalStore(ctx context.Context, u *url.URL, ta
 		return nil, exeerrors.ErrLoadDataInvalidURI.GenWithStackByArgs(target, GetMsgFromBRError(err2))
 	}
 
-	opt := &storage.ExternalStorageOptions{}
-	if intest.InTest {
-		opt.NoCredentials = true
-	}
-	s, err := storage.New(ctx, b, opt)
+	s, err := storage.NewWithDefaultOpt(ctx, b)
 	if err != nil {
 		return nil, exeerrors.ErrLoadDataCantAccess.GenWithStackByArgs(target, GetMsgFromBRError(err))
 	}

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -57,8 +57,7 @@ func genStorageURI(t *testing.T) (host string, port uint16, uri string) {
 func checkFileCleaned(t *testing.T, jobID int64, sortStorageURI string) {
 	storeBackend, err := storage.ParseBackend(sortStorageURI, nil)
 	require.NoError(t, err)
-	opts := &storage.ExternalStorageOptions{NoCredentials: true}
-	extStore, err := storage.New(context.Background(), storeBackend, opts)
+	extStore, err := storage.NewWithDefaultOpt(context.Background(), storeBackend)
 	require.NoError(t, err)
 	prefix := strconv.Itoa(int(jobID))
 	dataFiles, statFiles, err := external.GetAllFileNames(context.Background(), extStore, prefix)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #49340

Problem Summary:

### What changed and how does it work?
- remove default GCS httpclient and init httpclient on need, as BR might cause some issue when reading many metadata
- `https://www.googleapis.com/auth/cloud-platform` must be add to scope to use `service_account` type of credential-file, else it report:
```
oauth2: cannot fetch token: 400 Bad Request\nResponse: {\"error\":\"invalid_scope\",\"error_description\":\"Invalid OAuth scope or ID token audience provided.\"}"
```
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
run `TestReadFileConcurrently` with a service_account type of credential file
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
