### PR TITLE
*: speed up `create table` when the number of tables is relatively large

### DIFF
--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -1545,7 +1545,7 @@ func checkTableNotExistsFromInfoSchema(is infoschema.InfoSchema, schemaID int64,
 
 func checkTableNotExistsFromStore(t *meta.Meta, schemaID int64, tableName string) error {
 	// Check this table's database.
-	tbls, err := t.ListTables(schemaID)
+	tbls, err := t.ListSimpleTables(schemaID)
 	if err != nil {
 		if meta.ErrDBNotExists.Equal(err) {
 			return infoschema.ErrDatabaseNotExists.GenWithStackByArgs("")

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -269,6 +269,9 @@ func TestMeta(t *testing.T) {
 	err = m.CreateTableOrView(1, tbInfo2)
 	require.NoError(t, err)
 
+	tableNames, err := m.ListSimpleTables(1)
+	require.NoError(t, err)
+	require.Equal(t, []*model.TableNameInfo{{tbInfo.ID, tbInfo.Name}, {tbInfo2.ID, tbInfo2.Name}}, tableNames)
 	tables, err := m.ListTables(1)
 	require.NoError(t, err)
 	require.Equal(t, []*model.TableInfo{tbInfo, tbInfo2}, tables)
@@ -304,6 +307,9 @@ func TestMeta(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(0), n)
 
+	tableNames, err = m.ListSimpleTables(1)
+	require.NoError(t, err)
+	require.Equal(t, []*model.TableNameInfo{{tbInfo.ID, tbInfo.Name}}, tableNames)
 	tables, err = m.ListTables(1)
 	require.NoError(t, err)
 	require.Equal(t, []*model.TableInfo{tbInfo}, tables)

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -269,9 +269,11 @@ func TestMeta(t *testing.T) {
 	err = m.CreateTableOrView(1, tbInfo2)
 	require.NoError(t, err)
 
+	tblName := &model.TableNameInfo{ID: tbInfo.ID, Name: tbInfo.Name}
+	tblName2 := &model.TableNameInfo{ID: tbInfo2.ID, Name: tbInfo2.Name}
 	tableNames, err := m.ListSimpleTables(1)
 	require.NoError(t, err)
-	require.Equal(t, []*model.TableNameInfo{{tbInfo.ID, tbInfo.Name}, {tbInfo2.ID, tbInfo2.Name}}, tableNames)
+	require.Equal(t, []*model.TableNameInfo{tblName, tblName2}, tableNames)
 	tables, err := m.ListTables(1)
 	require.NoError(t, err)
 	require.Equal(t, []*model.TableInfo{tbInfo, tbInfo2}, tables)
@@ -309,7 +311,7 @@ func TestMeta(t *testing.T) {
 
 	tableNames, err = m.ListSimpleTables(1)
 	require.NoError(t, err)
-	require.Equal(t, []*model.TableNameInfo{{tbInfo.ID, tbInfo.Name}}, tableNames)
+	require.Equal(t, []*model.TableNameInfo{tblName}, tableNames)
 	tables, err = m.ListTables(1)
 	require.NoError(t, err)
 	require.Equal(t, []*model.TableInfo{tbInfo}, tables)

--- a/pkg/parser/model/model.go
+++ b/pkg/parser/model/model.go
@@ -543,6 +543,12 @@ type TableInfo struct {
 	TTLInfo *TTLInfo `json:"ttl_info"`
 }
 
+// TableNameInfo provides meta data describing a table name info.
+type TableNameInfo struct {
+	ID   int64 `json:"id"`
+	Name CIStr `json:"name"`
+}
+
 // SepAutoInc decides whether _rowid and auto_increment id use separate allocator.
 func (t *TableInfo) SepAutoInc() bool {
 	return t.Version >= TableInfoVersion5 && t.AutoIdCache == 1


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/49370

Problem Summary:
`ListTables` took a lot of time when the number of tables was relatively large

### What changed and how does it work?
Because the unmarshal of the `TableInfo` structure takes a large proportion of time, we only needn't all structures of the `TableInfo`. So we use `TableNameInfo` instead of it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Execute `checkTableNotExistsFromStore` function consumption of time.

| Total Table Count 	| Current DB Table Count 	| Master Branch Take Time 	| After this PR Table Time 	|
|-------------------	|------------------------	|-------------------------	|--------------------------	|
| 437k              	| 215k                   	| 23-26s                  	| 12-14s                   	|

Master branch info:
<img width="857" alt="截屏2023-12-12 14 56 09" src="https://github.com/pingcap/tidb/assets/4242506/87617f4d-4764-4602-9b10-dca5bc58d4fc">

<img width="1623" alt="截屏2023-12-12 15 15 27" src="https://github.com/pingcap/tidb/assets/4242506/9f3a6957-e055-488e-b50c-f966d66ebca1">


After this PR info(The middle area is particularly high because the owner of another service is transferred):
<img width="856" alt="截屏2023-12-12 14 56 16" src="https://github.com/pingcap/tidb/assets/4242506/4c975a4a-4777-4248-9dc9-6cf7d2f5dc91">

<img width="1666" alt="截屏2023-12-12 15 15 19" src="https://github.com/pingcap/tidb/assets/4242506/56cdfcb6-5817-478d-981d-b51ad320d0a2">


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
