### PR TITLE
statistics: fix `LoadStatsFromJSONNoUpdate` func for `CPUNum = 1`

### DIFF
--- a/pkg/statistics/handle/storage/dump_test.go
+++ b/pkg/statistics/handle/storage/dump_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -226,6 +227,10 @@ func TestLoadPartitionStats(t *testing.T) {
 func TestLoadPartitionStatsErrPanic(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
+	val := runtime.GOMAXPROCS(1)
+	defer func() {
+		runtime.GOMAXPROCS(val)
+	}()
 	tk.MustExec("use test")
 	tk.MustExec("set @@tidb_analyze_version = 2")
 	tk.MustExec("set @@tidb_partition_prune_mode = 'dynamic'")

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -594,7 +594,7 @@ func (s *statsReadWriter) LoadStatsFromJSONNoUpdate(ctx context.Context, is info
 		close(taskCh)
 		var wg sync.WaitGroup
 		e := new(atomic.Pointer[error])
-		for i := 0; i < int(concurrencyForPartition); i++ {
+		for i := 0; i < concurrencyForPartition; i++ {
 			wg.Add(1)
 			s.statsHandler.GPool().Go(func() {
 				defer func() {

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -558,7 +558,7 @@ type TestLoadStatsErr struct{}
 // LoadStatsFromJSON will load statistic from JSONTable, and save it to the storage.
 // In final, it will also udpate the stats cache.
 func (s *statsReadWriter) LoadStatsFromJSON(ctx context.Context, is infoschema.InfoSchema,
-	jsonTbl *util.JSONTable, concurrencyForPartition uint8) error {
+	jsonTbl *util.JSONTable, concurrencyForPartition int) error {
 	if err := s.LoadStatsFromJSONNoUpdate(ctx, is, jsonTbl, concurrencyForPartition); err != nil {
 		return errors.Trace(err)
 	}
@@ -567,14 +567,12 @@ func (s *statsReadWriter) LoadStatsFromJSON(ctx context.Context, is infoschema.I
 
 // LoadStatsFromJSONNoUpdate will load statistic from JSONTable, and save it to the storage.
 func (s *statsReadWriter) LoadStatsFromJSONNoUpdate(ctx context.Context, is infoschema.InfoSchema,
-	jsonTbl *util.JSONTable, concurrencyForPartition uint8) error {
-	nCPU := uint8(runtime.GOMAXPROCS(0))
+	jsonTbl *util.JSONTable, concurrencyForPartition int) error {
+	nCPU := runtime.GOMAXPROCS(0)
 	if concurrencyForPartition == 0 {
-		concurrencyForPartition = nCPU / 2 // default
+		concurrencyForPartition = (nCPU + 1) / 2 // default
 	}
-	if concurrencyForPartition > nCPU {
-		concurrencyForPartition = nCPU // for safety
-	}
+	concurrencyForPartition = min(concurrencyForPartition, nCPU) // for safety
 
 	table, err := is.TableByName(model.NewCIStr(jsonTbl.DatabaseName), model.NewCIStr(jsonTbl.TableName))
 	if err != nil {

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -299,10 +299,10 @@ type StatsReadWriter interface {
 
 	// LoadStatsFromJSON will load statistic from JSONTable, and save it to the storage.
 	// In final, it will also udpate the stats cache.
-	LoadStatsFromJSON(ctx context.Context, is infoschema.InfoSchema, jsonTbl *statsutil.JSONTable, concurrencyForPartition uint8) error
+	LoadStatsFromJSON(ctx context.Context, is infoschema.InfoSchema, jsonTbl *statsutil.JSONTable, concurrencyForPartition int) error
 
 	// LoadStatsFromJSONNoUpdate will load statistic from JSONTable, and save it to the storage.
-	LoadStatsFromJSONNoUpdate(ctx context.Context, is infoschema.InfoSchema, jsonTbl *statsutil.JSONTable, concurrencyForPartition uint8) error
+	LoadStatsFromJSONNoUpdate(ctx context.Context, is infoschema.InfoSchema, jsonTbl *statsutil.JSONTable, concurrencyForPartition int) error
 
 	// Methods for extended stast.
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49374

Problem Summary: When `runtime.GOMAXPROCS(0)` return 1, the `concurrencyForPartition` will be set to 0.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
