### PR TITLE
statsitics: clear the fmsketch's map correctly

### DIFF
--- a/pkg/statistics/fmsketch.go
+++ b/pkg/statistics/fmsketch.go
@@ -217,16 +217,7 @@ func (s *FMSketch) MemoryUsage() (sum int64) {
 }
 
 func (s *FMSketch) reset() {
-	// not use hashset.Clear, it will release all memory and Not conducive to memory reuse.
-	// the size of set is not more than 10000.
-	set := make([]uint64, 0, s.hashset.Count())
-	s.hashset.Iter(func(k uint64, v bool) (stop bool) {
-		set = append(set, k)
-		return false
-	})
-	for _, k := range set {
-		s.hashset.Delete(k)
-	}
+	s.hashset.Clear()
 	s.mask = 0
 	s.maxSize = 0
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49381

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

before

<img width="1348" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/53e496aa-993f-4755-802a-cc251308894c">

after:

<img width="1346" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/a6b482e2-6e1a-4ba4-b96c-ef83de5df58d">


The new one has better CPU usage.

<img width="1862" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/f674f0a0-892a-474b-865b-973ceaf64c40">

the left one is the old, the right one is the new.


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
