### PR TITLE
executor: set OverflowAsWarning for insert statement in non-strict sql mode

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2116,6 +2116,8 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		// but should not make DupKeyAsWarning.
 		sc.DupKeyAsWarning = stmt.IgnoreErr
 		sc.BadNullAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
+		// see https://dev.mysql.com/doc/refman/8.0/en/out-of-range-and-overflow.html
+		sc.OverflowAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 		sc.IgnoreNoPartition = stmt.IgnoreErr
 		sc.ErrAutoincReadFailedAsWarning = stmt.IgnoreErr
 		sc.DividedByZeroAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr

--- a/tests/integrationtest/r/executor/issues.result
+++ b/tests/integrationtest/r/executor/issues.result
@@ -831,3 +831,22 @@ explain select ps_partkey, sum(ps_supplycost * ps_availqty) as value from partsu
 Error 8175 (HY000): Your query has been cancelled due to exceeding the allowed memory limit for a single SQL query. Please try narrowing your query scope or increase the tidb_mem_quota_query limit and try again.[conn=<num>]
 SET GLOBAL tidb_mem_oom_action = DEFAULT;
 set @@tidb_mem_quota_query=default;
+drop table if exists issue49369;
+CREATE TABLE `issue49369` (
+`x` varchar(32) COLLATE utf8mb4_bin DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+insert into t   select round(cast('88888899999999999888888888888888888888888888888888888.11111111111111111111' as decimal(18,12)) * cast('88888899999999999888888888888888888888888888888888888.11111111111111111111' as decimal(42,18)) );
+Error 1690 (22003): DECIMAL value is out of range in '(18, 12)'
+set @@sql_mode = '';
+insert into t   select round(cast('88888899999999999888888888888888888888888888888888888.11111111111111111111' as decimal(18,12)) * cast('88888899999999999888888888888888888888888888888888888.11111111111111111111' as decimal(42,18)) );
+show warnings;
+Level	Code	Message
+Warning	1690	DECIMAL value is out of range in '(18, 12)'
+Warning	1690	DECIMAL value is out of range in '(42, 18)'
+Warning	1690	%s value is out of range in '%s'
+select * from t;
+c
+1
+2
+2147483647
+set @@sql_mode = default;

--- a/tests/integrationtest/t/executor/issues.test
+++ b/tests/integrationtest/t/executor/issues.test
@@ -633,3 +633,17 @@ set @@tidb_mem_quota_query=128;
 explain select ps_partkey, sum(ps_supplycost * ps_availqty) as value from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'MOZAMBIQUE' group by ps_partkey having sum(ps_supplycost * ps_availqty) > ( select sum(ps_supplycost * ps_availqty) * 0.0001000000 from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'MOZAMBIQUE' ) order by value desc;
 SET GLOBAL tidb_mem_oom_action = DEFAULT;
 set @@tidb_mem_quota_query=default;
+
+
+# TestIssue49369
+drop table if exists issue49369;
+CREATE TABLE `issue49369` (
+  `x` varchar(32) COLLATE utf8mb4_bin DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+--error 1690
+insert into t   select round(cast('88888899999999999888888888888888888888888888888888888.11111111111111111111' as decimal(18,12)) * cast('88888899999999999888888888888888888888888888888888888.11111111111111111111' as decimal(42,18)) );
+set @@sql_mode = '';
+insert into t   select round(cast('88888899999999999888888888888888888888888888888888888.11111111111111111111' as decimal(18,12)) * cast('88888899999999999888888888888888888888888888888888888.11111111111111111111' as decimal(42,18)) );
+show warnings;
+select * from t;
+set @@sql_mode = default;


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49369

Problem Summary:

### What changed and how does it work?

Fix the compatibility issue.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
In non-strict SQL mode, treat the overflow error as warning in insert statement.
```
