### PR TITLE
ebs br: avoid unconditional wait for fsr enablement

### DIFF
--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -329,35 +329,12 @@ func (e *EC2Session) EnableDataFSR(meta *config.EBSBasedBRMeta, targetAZ string)
 
 // waitDataFSREnabled waits FSR for data volume snapshots are all enabled and also have enough credit balance
 func (e *EC2Session) waitDataFSREnabled(snapShotIDs []*string, targetAZ string) error {
-	// Record current time
-	start := time.Now()
-
-	//  get the maximum size of volumes, in GiB
-	var maxVolumeSize int64 = 0
 	resp, err := e.ec2.DescribeSnapshots(&ec2.DescribeSnapshotsInput{SnapshotIds: snapShotIDs})
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if len(resp.Snapshots) <= 0 {
 		return errors.Errorf("specified snapshot [%s] is not found", *snapShotIDs[0])
-	}
-
-	for _, s := range resp.Snapshots {
-		if *s.VolumeSize > maxVolumeSize {
-			maxVolumeSize = *s.VolumeSize
-		}
-	}
-
-	// Calculate the time in minutes to fill 1.0 credit according to
-	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-fast-snapshot-restore.html#volume-creation-credits
-	// 5 minutes more is just for safe
-	fillElapsedTime := 60.0/(min(10, 1024.0/(float64)(maxVolumeSize))) + 5
-
-	// We have to sleep for at least fillElapsedTime minutes in order to make credits are filled to 1.0
-	// Let's heartbeat every 5 minutes
-	for time.Since(start) <= time.Duration(fillElapsedTime)*time.Minute {
-		log.Info("FSR enablement is ongoing, going to sleep for 5 minutes...")
-		time.Sleep(5 * time.Minute)
 	}
 
 	// Wait that all snapshot has enough fsr credit balance, it's very likely true since we have wait for long enough
@@ -378,9 +355,8 @@ func (e *EC2Session) waitDataFSREnabled(snapShotIDs []*string, targetAZ string) 
 				}
 				retryCount++
 			}
-			// Retry for both invalid calling and not enough fsr credit
-			// Cloudwatch by default flushes every 5 seconds. So, 20 seconds wait should be enough
-			time.Sleep(20 * time.Second)
+			// Retry for both invalid calling and not enough fsr credit at 3 minute intervals
+			time.Sleep(3 * time.Minute)
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49398

Problem Summary:

### What changed and how does it work?

This PR will call cloudwatch API to check fsr credit balance every 5 minutes once fsr enablement requests are issued.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
