### PR TITLE
planner: the recursive cte will make UPDATE's result wrong

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -7731,6 +7731,10 @@ func (b *PlanBuilder) buildRecursiveCTE(ctx context.Context, cte ast.ResultSetNo
 					// Build seed part plan.
 					saveSelect := x.SelectList.Selects
 					x.SelectList.Selects = x.SelectList.Selects[:i]
+					// We're rebuilding the seed part, so we pop the result we built previously.
+					for _i := 0; _i < i; _i++ {
+						b.handleHelper.popMap()
+					}
 					p, err = b.buildSetOpr(ctx, x)
 					if err != nil {
 						return err

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -313,3 +313,22 @@ a	length(a)
 select *,length(a) from t2 where a like '测试';
 a	length(a)
 测试	4
+drop view if exists v1;
+create view v1(id) as
+with recursive cte(a) as (select 1 union select a+1 from cte where a<3)
+select * from cte;
+create table test2(id int,value int);
+insert into test2 values(1,1),(2,2),(3,3),(4,4),(5,5);
+update test2
+set value=0
+where test2.id in
+(
+select * from v1
+);
+select * from test2;
+id	value
+1	0
+2	0
+3	0
+4	4
+5	5

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -169,3 +169,20 @@ explain format = brief select *,length(a) from t2 where a like '测试 %';
 explain format = brief select *,length(a) from t2 where a like '测试';
 select *,length(a) from t2 where a like '测试 %';
 select *,length(a) from t2 where a like '测试';
+
+# https://github.com/pingcap/tidb/issues/48969
+drop view if exists v1;
+create view v1(id) as
+with recursive cte(a) as (select 1 union select a+1 from cte where a<3)
+select * from cte;
+
+create table test2(id int,value int);
+insert into test2 values(1,1),(2,2),(3,3),(4,4),(5,5);
+
+update test2
+set value=0
+where test2.id in
+(
+  select * from v1
+);
+select * from test2;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48969 

Problem Summary:

### What changed and how does it work?

When we build the recursive CTE, we'll first try to build it as a non-recursive one. And going to treat it as a real recursive one when we actually meet the recursive part.

So the non-recursive part is built twice, but we don't pop the rowid information correctly, causing the UPDATE's result wrong.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the possible wrong result when the UPDATE/DELETE contains the Recursive CTE.
```
