### PR TITLE
expression: remove useless ctx input in `newBaseBuiltinFuncWithFieldType`

### DIFF
--- a/pkg/expression/builtin.go
+++ b/pkg/expression/builtin.go
@@ -286,10 +286,7 @@ func newBaseBuiltinFuncWithFieldTypes(ctx sessionctx.Context, funcName string, a
 
 // newBaseBuiltinFuncWithFieldType create BaseBuiltinFunc with FieldType charset and collation.
 // do not check and compute collation.
-func newBaseBuiltinFuncWithFieldType(ctx sessionctx.Context, tp *types.FieldType, args []Expression) (baseBuiltinFunc, error) {
-	if ctx == nil {
-		return baseBuiltinFunc{}, errors.New("unexpected nil session ctx")
-	}
+func newBaseBuiltinFuncWithFieldType(tp *types.FieldType, args []Expression) (baseBuiltinFunc, error) {
 	bf := baseBuiltinFunc{
 		bufAllocator:           newLocalColumnPool(),
 		childrenVectorizedOnce: new(sync.Once),

--- a/pkg/expression/builtin_grouping_test.go
+++ b/pkg/expression/builtin_grouping_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/testkit/testutil"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -39,12 +38,12 @@ func constructFieldType() types.FieldType {
 	return tp
 }
 
-func createGroupingFunc(ctx sessionctx.Context, args []Expression) (*BuiltinGroupingImplSig, error) {
+func createGroupingFunc(args []Expression) (*BuiltinGroupingImplSig, error) {
 	// TODO We should use the commented codes after the completion of rollup
 	// argTp := []types.EvalType{types.ETInt}
 	tp := constructFieldType()
 	// bf, err := newBaseBuiltinFuncWithTp(ctx, groupingImplName, args, types.ETInt, argTp...)
-	bf, err := newBaseBuiltinFuncWithFieldType(ctx, &tp, args)
+	bf, err := newBaseBuiltinFuncWithFieldType(&tp, args)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +91,7 @@ func TestGrouping(t *testing.T) {
 		comment := fmt.Sprintf(`for grouping = "%d", version = "%d", groupingIDs = "%v", expectRes = "%d"`, testCase.groupingID, testCase.mode, testCase.groupingIDs, testCase.expectResult)
 		args := datumsToConstants(types.MakeDatums(testCase.groupingID))
 
-		groupingFunc, err := createGroupingFunc(ctx, args)
+		groupingFunc, err := createGroupingFunc(args)
 		require.NoError(t, err, comment)
 
 		err = groupingFunc.SetMetadata(testCase.mode, []map[uint64]struct{}{testCase.groupingIDs})

--- a/pkg/expression/distsql_builtin.go
+++ b/pkg/expression/distsql_builtin.go
@@ -41,7 +41,7 @@ func PbTypeToFieldType(tp *tipb.FieldType) *types.FieldType {
 
 func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *tipb.FieldType, args []Expression) (f builtinFunc, e error) {
 	fieldTp := PbTypeToFieldType(tp)
-	base, err := newBaseBuiltinFuncWithFieldType(ctx, fieldTp, args)
+	base, err := newBaseBuiltinFuncWithFieldType(fieldTp, args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #47958

Problem Summary:

After we removed ctx cache inner `ScalarFunction`. The `ctx` parameter in `newBaseBuiltinFuncWithFieldType` is useless, just remove it.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > Simple code, no need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
