### PR TITLE
*: delete '.test.bin' files for 'make clean'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ coverage.out
 *.iml
 *.swp
 *.log
-*.test.bin
 tags
 profile.coverprofile
 mysql_tester

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ license:
 		--run_under="cd $(CURDIR) && " \
 		 @com_github_apache_skywalking_eyes//cmd/license-eye:license-eye --run_under="cd $(CURDIR) && "  -- -c ./.github/licenserc.yml  header check
 
-
 tidy:
 	@echo "go mod tidy"
 	./tools/check/check-tidy.sh
@@ -87,10 +86,13 @@ check-parallel:
 		xargs -0 grep -F -n "t.Parallel()" || \
 		! echo "Error: all the go tests should be run in serial."
 
+CLEAN_UT_BINARY := find . -name '*.test.bin'| xargs rm
+
 clean: failpoint-disable
 	$(GO) clean -i ./...
 	rm -rf $(TEST_COVERAGE_DIR)
-	
+	@$(CLEAN_UT_BINARY)
+
 # Split tests for CI to run `make test` in parallel.
 test: test_part_1 test_part_2
 	@>&2 echo "Great, all tests passed."
@@ -126,8 +128,6 @@ integrationtest: server_check
 
 ddltest:
 	@cd cmd/ddltest && $(GO) test --tags=deadllock,intest -o ../../bin/ddltest -c
-
-CLEAN_UT_BINARY := find . -name '*.test.bin'| xargs rm
 
 ut: tools/bin/ut tools/bin/xprog failpoint-enable
 	tools/bin/ut $(X) || { $(FAILPOINT_DISABLE); exit 1; }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #49070

Problem Summary:

### What changed and how does it work?

After #30822, `make ut` will build the `.test.bin` files for each of the `_test.go` file and run them in parallel and clean `.test.bin` files. However, when `make ut` failed because of any reason, the cleanup will not happen and leave a large number of `.test.bin` files:

```
➜  tidb git:(bb7133/make_clean) ✗ find . -name '*.test.bin' -print0 | xargs -0 du -hsc
 56M	./pkg/statistics/handle/lockstats/lockstats.test.bin
136M	./pkg/statistics/handle/handletest/lockstats/lockstats.test.bin
136M	./pkg/statistics/handle/handletest/handletest.test.bin
...
136M	./pkg/session/resourcegrouptest/resourcegrouptest.test.bin
136M	./pkg/session/temporarytabletest/temporarytabletest.test.bin
 25G	total
```

IMO it's better to make `.test.bin` files cleanable by `make clean` and remove them from `.gitignore` files so that developers will be aware of them(when they're there) and the large amount of size.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- None

Documentation

- None

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
