### PR TITLE
executor: fix `IndexNestedLoopHashJoin` missed panicErr

### DIFF
--- a/pkg/executor/index_lookup_hash_join.go
+++ b/pkg/executor/index_lookup_hash_join.go
@@ -235,7 +235,7 @@ func (e *IndexNestedLoopHashJoin) Next(ctx context.Context, req *chunk.Chunk) er
 func (e *IndexNestedLoopHashJoin) runInOrder(ctx context.Context, req *chunk.Chunk) error {
 	for {
 		if e.isDryUpTasks(ctx) {
-			return nil
+			return e.panicErr
 		}
 		if e.curTask.err != nil {
 			return e.curTask.err

--- a/pkg/executor/test/jointest/join_test.go
+++ b/pkg/executor/test/jointest/join_test.go
@@ -17,6 +17,7 @@ package jointest
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -863,6 +864,10 @@ func TestIssue37932(t *testing.T) {
 }
 
 func TestIssue49033(t *testing.T) {
+	val := runtime.GOMAXPROCS(0)
+	defer func() {
+		runtime.GOMAXPROCS(val)
+	}()
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test;")

--- a/pkg/executor/test/jointest/join_test.go
+++ b/pkg/executor/test/jointest/join_test.go
@@ -864,7 +864,7 @@ func TestIssue37932(t *testing.T) {
 }
 
 func TestIssue49033(t *testing.T) {
-	val := runtime.GOMAXPROCS(0)
+	val := runtime.GOMAXPROCS(1)
 	defer func() {
 		runtime.GOMAXPROCS(val)
 	}()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49453

Problem Summary: `IndexNestedLoopHashJoin.isDryUpTasks` sometimes will return true when ctx be canceled instead of get a task from `e.taskCh`. This can lead to missed panic errors.
This situation is easier to trigger when `GOMAXPROCS = 1`, so change the test case.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
