### PR TITLE
executor: Fix issue that in expression with null constant produces unexpected cast warnings

### DIFF
--- a/pkg/executor/test/issuetest/BUILD.bazel
+++ b/pkg/executor/test/issuetest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 15,
+    shard_count = 16,
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",

--- a/pkg/expression/builtin_compare_test.go
+++ b/pkg/expression/builtin_compare_test.go
@@ -116,7 +116,7 @@ func TestCompare(t *testing.T) {
 		{durationVal, durationVal, ast.NE, mysql.TypeDuration, 0},
 		{durationVal, durationVal, ast.NullEQ, mysql.TypeDuration, 1},
 		{nil, nil, ast.NullEQ, mysql.TypeNull, 1},
-		{nil, intVal, ast.NullEQ, mysql.TypeDouble, 0},
+		{nil, intVal, ast.NullEQ, mysql.TypeLonglong, 0},
 		{uintVal, intVal, ast.NullEQ, mysql.TypeLonglong, 1},
 		{uintVal, intVal, ast.EQ, mysql.TypeLonglong, 1},
 		{intVal, uintVal, ast.NullEQ, mysql.TypeLonglong, 1},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49015 

Problem Summary:

### What changed and how does it work?
For comparisons which contains constant null as parameter, if field types are not the same, set null constant's field type as the other one's to avoid useless cast.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
