### PR TITLE
expression: remove interface `expression.ReverseExpr`

### DIFF
--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -705,21 +705,6 @@ func (col *Column) EvalVirtualColumn(ctx EvalContext, row chunk.Row) (types.Datu
 	return col.VirtualExpr.Eval(ctx, row)
 }
 
-// SupportReverseEval checks whether the builtinFunc support reverse evaluation.
-func (col *Column) SupportReverseEval() bool {
-	switch col.RetType.GetType() {
-	case mysql.TypeShort, mysql.TypeLong, mysql.TypeLonglong,
-		mysql.TypeFloat, mysql.TypeDouble, mysql.TypeNewDecimal:
-		return true
-	}
-	return false
-}
-
-// ReverseEval evaluates the only one column value with given function result.
-func (col *Column) ReverseEval(sc *stmtctx.StatementContext, res types.Datum, rType types.RoundingType) (val types.Datum, err error) {
-	return types.ChangeReverseResultByUpperLowerBound(sc.TypeCtx(), col.RetType, res, rType)
-}
-
 // Coercibility returns the coercibility value which is used to check collations.
 func (col *Column) Coercibility() Coercibility {
 	if !col.HasCoercibility() {

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -499,19 +499,6 @@ func (c *Constant) Vectorized() bool {
 	return true
 }
 
-// SupportReverseEval checks whether the builtinFunc support reverse evaluation.
-func (c *Constant) SupportReverseEval() bool {
-	if c.DeferredExpr != nil {
-		return c.DeferredExpr.SupportReverseEval()
-	}
-	return true
-}
-
-// ReverseEval evaluates the only one column value with given function result.
-func (c *Constant) ReverseEval(sc *stmtctx.StatementContext, res types.Datum, rType types.RoundingType) (val types.Datum, err error) {
-	return c.Value, nil
-}
-
 // Coercibility returns the coercibility value which is used to check collations.
 func (c *Constant) Coercibility() Coercibility {
 	if !c.HasCoercibility() {

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -89,15 +89,6 @@ type VecExpr interface {
 	VecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error
 }
 
-// ReverseExpr contains all resersed evaluation methods.
-type ReverseExpr interface {
-	// SupportReverseEval checks whether the builtinFunc support reverse evaluation.
-	SupportReverseEval() bool
-
-	// ReverseEval evaluates the only one column value with given function result.
-	ReverseEval(sc *stmtctx.StatementContext, res types.Datum, rType types.RoundingType) (val types.Datum, err error)
-}
-
 // TraverseAction define the interface for action when traversing down an expression.
 type TraverseAction interface {
 	Transform(Expression) Expression
@@ -108,7 +99,6 @@ type Expression interface {
 	fmt.Stringer
 	goJSON.Marshaler
 	VecExpr
-	ReverseExpr
 	CollationInfo
 
 	Traverse(TraverseAction) Expression

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -98,21 +98,6 @@ func (sf *ScalarFunction) Vectorized() bool {
 	return sf.Function.vectorized() && sf.Function.isChildrenVectorized()
 }
 
-// SupportReverseEval returns if this expression supports reversed evaluation.
-func (sf *ScalarFunction) SupportReverseEval() bool {
-	switch sf.RetType.GetType() {
-	case mysql.TypeShort, mysql.TypeLong, mysql.TypeLonglong,
-		mysql.TypeFloat, mysql.TypeDouble, mysql.TypeNewDecimal:
-		return sf.Function.supportReverseEval() && sf.Function.isChildrenReversed()
-	}
-	return false
-}
-
-// ReverseEval evaluates the only one column value with given function result.
-func (sf *ScalarFunction) ReverseEval(sc *stmtctx.StatementContext, res types.Datum, rType types.RoundingType) (val types.Datum, err error) {
-	return sf.Function.reverseEval(sc, res, rType)
-}
-
 // String implements fmt.Stringer interface.
 func (sf *ScalarFunction) String() string {
 	var buffer bytes.Buffer

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -567,9 +567,6 @@ func (m *MockExpr) EvalJSON(ctx EvalContext, row chunk.Row) (val types.BinaryJSO
 	}
 	return types.BinaryJSON{}, m.i == nil, m.err
 }
-func (m *MockExpr) ReverseEval(sc *stmtctx.StatementContext, res types.Datum, rType types.RoundingType) (val types.Datum, err error) {
-	return types.Datum{}, m.err
-}
 func (m *MockExpr) GetType() *types.FieldType                         { return m.t }
 func (m *MockExpr) Clone() Expression                                 { return nil }
 func (m *MockExpr) Equal(ctx EvalContext, e Expression) bool          { return false }
@@ -591,7 +588,6 @@ func (m *MockExpr) ExplainNormalizedInfo4InList() string                { return
 func (m *MockExpr) HashCode() []byte                                    { return nil }
 func (m *MockExpr) CanonicalHashCode() []byte                           { return nil }
 func (m *MockExpr) Vectorized() bool                                    { return false }
-func (m *MockExpr) SupportReverseEval() bool                            { return false }
 func (m *MockExpr) HasCoercibility() bool                               { return false }
 func (m *MockExpr) Coercibility() Coercibility                          { return 0 }
 func (m *MockExpr) SetCoercibility(Coercibility)                        {}

--- a/pkg/planner/core/scalar_subq_expression.go
+++ b/pkg/planner/core/scalar_subq_expression.go
@@ -271,26 +271,6 @@ func (s *ScalarSubQueryExpr) MarshalJSON() ([]byte, error) {
 	return s.Constant.MarshalJSON()
 }
 
-// ReverseEval evaluates the only one column value with given function result.
-func (s *ScalarSubQueryExpr) ReverseEval(_ *stmtctx.StatementContext, _ types.Datum, _ types.RoundingType) (val types.Datum, err error) {
-	if s.evalErr != nil {
-		return s.Value, s.evalErr
-	}
-	if s.evaled {
-		return s.Value, nil
-	}
-	err = s.selfEvaluate()
-	if err != nil {
-		return s.Value, err
-	}
-	return s.Value, nil
-}
-
-// SupportReverseEval implements the Expression interface.
-func (*ScalarSubQueryExpr) SupportReverseEval() bool {
-	return true
-}
-
 // VecEvalInt evaluates this expression in a vectorized manner.
 func (*ScalarSubQueryExpr) VecEvalInt(_ expression.EvalContext, _ *chunk.Chunk, _ *chunk.Column) error {
 	return errors.Errorf("ScalarSubQueryExpr doesn't implement the vec eval yet")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49467

### What changed and how does it work?

Just remove `expression.ReverseExpr` because it is useless now.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > simple code, just make sure build pass is enough

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
