### PR TITLE
global sort: new merge with 1 writer

### DIFF
--- a/br/pkg/lightning/backend/external/BUILD.bazel
+++ b/br/pkg/lightning/backend/external/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "iter.go",
         "kv_reader.go",
         "merge.go",
+        "merge_v2.go",
         "onefile_writer.go",
         "reader.go",
         "split.go",
@@ -73,6 +74,7 @@ go_test(
     deps = [
         "//br/pkg/lightning/backend/kv",
         "//br/pkg/lightning/common",
+        "//br/pkg/lightning/log",
         "//br/pkg/membuf",
         "//br/pkg/storage",
         "//pkg/kv",
@@ -91,10 +93,12 @@ go_test(
         "@com_github_johannesboyne_gofakes3//:gofakes3",
         "@com_github_johannesboyne_gofakes3//backend/s3mem",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/brpb",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//rand",
         "@org_golang_x_sync//errgroup",
         "@org_uber_go_atomic//:atomic",
+        "@org_uber_go_zap//:zap",
     ],
 )

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -361,7 +361,7 @@ func writeExternalOneFile(s *writeTestSuite) {
 	}
 	writer := builder.BuildOneFile(
 		s.store, filePath, "writerID")
-	_ = writer.Init(ctx, 20*1024*1024)
+	intest.AssertNoError(writer.Init(ctx, 20*1024*1024))
 	key, val, _ := s.source.next()
 	for key != nil {
 		err := writer.WriteRow(ctx, key, val)
@@ -371,8 +371,7 @@ func writeExternalOneFile(s *writeTestSuite) {
 	if s.beforeWriterClose != nil {
 		s.beforeWriterClose()
 	}
-	err := writer.Close(ctx)
-	intest.AssertNoError(err)
+	intest.AssertNoError(writer.Close(ctx))
 	if s.afterWriterClose != nil {
 		s.afterWriterClose()
 	}

--- a/br/pkg/lightning/backend/external/engine.go
+++ b/br/pkg/lightning/backend/external/engine.go
@@ -193,12 +193,12 @@ func getFilesReadConcurrency(
 	for i := range statsFiles {
 		result[i] = (endOffs[i] - startOffs[i]) / uint64(ConcurrentReaderBufferSizePerConc)
 		result[i] = max(result[i], 1)
-		// logutil.Logger(ctx).Info("found hotspot file in getFilesReadConcurrency",
-		// 	zap.String("filename", statsFiles[i]),
-		// 	zap.Uint64("startOffset", startOffs[i]),
-		// 	zap.Uint64("endOffset", endOffs[i]),
-		// 	zap.Uint64("expected concurrency", result[i]),
-		// )
+		logutil.Logger(ctx).Debug("found hotspot file in getFilesReadConcurrency",
+			zap.String("filename", statsFiles[i]),
+			zap.Uint64("startOffset", startOffs[i]),
+			zap.Uint64("endOffset", endOffs[i]),
+			zap.Uint64("expected concurrency", result[i]),
+		)
 	}
 	return result, startOffs, nil
 }

--- a/br/pkg/lightning/backend/external/engine.go
+++ b/br/pkg/lightning/backend/external/engine.go
@@ -193,12 +193,12 @@ func getFilesReadConcurrency(
 	for i := range statsFiles {
 		result[i] = (endOffs[i] - startOffs[i]) / uint64(ConcurrentReaderBufferSizePerConc)
 		result[i] = max(result[i], 1)
-		logutil.Logger(ctx).Info("found hotspot file in getFilesReadConcurrency",
-			zap.String("filename", statsFiles[i]),
-			zap.Uint64("startOffset", startOffs[i]),
-			zap.Uint64("endOffset", endOffs[i]),
-			zap.Uint64("expected concurrency", result[i]),
-		)
+		// logutil.Logger(ctx).Info("found hotspot file in getFilesReadConcurrency",
+		// 	zap.String("filename", statsFiles[i]),
+		// 	zap.Uint64("startOffset", startOffs[i]),
+		// 	zap.Uint64("endOffset", endOffs[i]),
+		// 	zap.Uint64("expected concurrency", result[i]),
+		// )
 	}
 	return result, startOffs, nil
 }

--- a/br/pkg/lightning/backend/external/merge.go
+++ b/br/pkg/lightning/backend/external/merge.go
@@ -118,7 +118,6 @@ func mergeOverlappingFilesInternal(
 		SetWriterBatchCount(writeBatchCount).
 		SetPropKeysDistance(propKeysDist).
 		SetPropSizeDistance(propSizeDist).
-		SetOnCloseFunc(onClose).
 		BuildOneFile(store, newFilePrefix, writerID)
 	err = writer.Init(ctx, partSize)
 	if err != nil {

--- a/br/pkg/lightning/backend/external/merge.go
+++ b/br/pkg/lightning/backend/external/merge.go
@@ -53,7 +53,7 @@ func MergeOverlappingFiles(
 	for _, files := range dataFilesSlice {
 		files := files
 		eg.Go(func() error {
-			return mergeOverlappingFilesV2(
+			return mergeOverlappingFilesInternal(
 				egCtx,
 				files,
 				store,
@@ -74,68 +74,9 @@ func MergeOverlappingFiles(
 	return eg.Wait()
 }
 
-// unused for now.
-func mergeOverlappingFilesImpl(ctx context.Context,
-	paths []string,
-	store storage.ExternalStorage,
-	readBufferSize int,
-	newFilePrefix string,
-	writerID string,
-	memSizeLimit uint64,
-	blockSize int,
-	writeBatchCount uint64,
-	propSizeDist uint64,
-	propKeysDist uint64,
-	onClose OnCloseFunc,
-	checkHotspot bool,
-) (err error) {
-	task := log.BeginTask(logutil.Logger(ctx).With(
-		zap.String("writer-id", writerID),
-		zap.Int("file-count", len(paths)),
-	), "merge overlapping files")
-	defer func() {
-		task.End(zap.ErrorLevel, err)
-	}()
-
-	zeroOffsets := make([]uint64, len(paths))
-	iter, err := NewMergeKVIter(ctx, paths, zeroOffsets, store, readBufferSize, checkHotspot, 0)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err := iter.Close()
-		if err != nil {
-			logutil.Logger(ctx).Warn("close iterator failed", zap.Error(err))
-		}
-	}()
-
-	writer := NewWriterBuilder().
-		SetMemorySizeLimit(memSizeLimit).
-		SetBlockSize(blockSize).
-		SetOnCloseFunc(onClose).
-		SetWriterBatchCount(writeBatchCount).
-		SetPropSizeDistance(propSizeDist).
-		SetPropKeysDistance(propKeysDist).
-		Build(store, newFilePrefix, writerID)
-
-	// currently use same goroutine to do read and write. The main advantage is
-	// there's no KV copy and iter can reuse the buffer.
-	for iter.Next() {
-		err = writer.WriteRow(ctx, iter.Key(), iter.Value(), nil)
-		if err != nil {
-			return err
-		}
-	}
-	err = iter.Error()
-	if err != nil {
-		return err
-	}
-	return writer.Close(ctx)
-}
-
-// mergeOverlappingFilesV2 reads from given files whose key range may overlap
+// mergeOverlappingFilesInternal reads from given files whose key range may overlap
 // and writes to one new sorted, nonoverlapping files.
-func mergeOverlappingFilesV2(
+func mergeOverlappingFilesInternal(
 	ctx context.Context,
 	paths []string,
 	store storage.ExternalStorage,

--- a/br/pkg/lightning/backend/external/merge_v2.go
+++ b/br/pkg/lightning/backend/external/merge_v2.go
@@ -3,19 +3,16 @@ package external
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math"
 	"time"
 
 	"github.com/jfcg/sorty/v2"
 	"github.com/pingcap/tidb/br/pkg/membuf"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/kv"
 	tidbkv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/util/logutil"
-	"github.com/pingcap/tidb/pkg/util/size"
 	"go.uber.org/zap"
 )
 
@@ -49,12 +46,20 @@ func MergeOverlappingFilesV2(
 		zap.Int("concurrency", concurrency),
 	)
 
+	// seed := time.Now().Unix()
+	// rand.Seed(uint64(seed))
+	// memSizeLimit := (rand.Intn(10) + 1) * 400
+
+	rangeGroupSize := 4 * 1024 * 1024 * 1024
+	// if intest.InTest {
+	// 	rangeGroupSize = memSizeLimit
+	// }
 	splitter, err := NewRangeSplitter(
 		ctx,
 		dataFiles,
 		statFiles,
 		store,
-		4*1024*1024*1024,
+		int64(rangeGroupSize),
 		math.MaxInt64,
 		4*1024*1024*1024,
 		math.MaxInt64,
@@ -74,7 +79,7 @@ func MergeOverlappingFilesV2(
 			store,
 			newFilePrefix,
 			writerID)
-	// todo consider writer conc.
+	// ywq todo consider writer conc.
 	err = writer.Init(ctx, partSize)
 	if err != nil {
 		return nil
@@ -84,6 +89,7 @@ func MergeOverlappingFilesV2(
 	loaded := &memKVsAndBuffers{}
 	curStart := kv.Key(startKey).Clone()
 	var curEnd kv.Key
+	var maxKey kv.Key
 
 	for {
 		endKeyOfGroup, dataFilesOfGroup, statFilesOfGroup, _, err := splitter.SplitOneRangesGroup()
@@ -92,6 +98,7 @@ func MergeOverlappingFilesV2(
 		}
 		curEnd = kv.Key(endKeyOfGroup).Clone()
 		if len(endKeyOfGroup) == 0 {
+			logutil.BgLogger().Info("ywq test len endkeyofgroup = 0")
 			curEnd = kv.Key(endKey).Clone()
 		}
 		now := time.Now()
@@ -135,211 +142,32 @@ func MergeOverlappingFilesV2(
 		logutil.Logger(ctx).Info("writing in MergeOverlappingFiles",
 			zap.Duration("cost time", time.Since(now)),
 			zap.Any("key len", len(loaded.keys)))
+		// should release or not?
+		// ywq todo why?
+		maxKey = kv.Key(loaded.keys[len(loaded.keys)-1]).Clone()
+		// loaded.keys = nil
+		// loaded.values = nil
+		// loaded.memKVBuffers = nil
 		curStart = curEnd.Clone()
+
 		if len(endKeyOfGroup) == 0 {
+			logutil.BgLogger().Info("ywq test break the loop")
 			break
 		}
 	}
 
+	// ywq todo why loaded data len = 0.
 	var stat MultipleFilesStat
 	stat.Filenames = append(stat.Filenames,
 		[2]string{writer.dataFile, writer.statFile})
-	// ywq todo what if no key readed... in read all data
+
 	stat.build([]tidbkv.Key{startKey}, []tidbkv.Key{curEnd})
 	if onClose != nil {
 		onClose(&WriterSummary{
 			WriterID:           writer.writerID,
 			Seq:                0,
 			Min:                startKey,
-			Max:                curEnd, // ywq todo ... with bug.....
-			TotalSize:          writer.totalSize,
-			MultipleFilesStats: []MultipleFilesStat{stat},
-		})
-	}
-	err = writer.Close(ctx)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type readerGroup struct {
-	dataFiles []string
-	statFiles []string
-	startKey  kv.Key
-	endKey    kv.Key
-}
-
-func getGroups(ctx context.Context, splitter *RangeSplitter, startKey kv.Key, endKey kv.Key) ([]readerGroup, error) {
-	readerGroups := make([]readerGroup, 0, 10)
-	curStart := startKey
-
-	for {
-		endKeyOfGroup, dataFilesOfGroup, statFilesOfGroup, _, err := splitter.SplitOneRangesGroup()
-		if err != nil {
-			return nil, err
-		}
-		curEnd := kv.Key(endKeyOfGroup).Clone()
-		if len(endKeyOfGroup) == 0 {
-			curEnd = kv.Key(endKey).Clone()
-		}
-		readerGroups = append(readerGroups, readerGroup{
-			dataFiles: dataFilesOfGroup,
-			statFiles: statFilesOfGroup,
-			startKey:  curStart,
-			endKey:    curEnd,
-		})
-
-		curStart = curEnd.Clone()
-		if len(endKeyOfGroup) == 0 {
-			break
-		}
-	}
-	return readerGroups, nil
-}
-
-// Using concurrency * (readAllData and writer).
-func MergeOverlappingFilesOpt(
-	ctx context.Context,
-	dataFiles []string,
-	statFiles []string,
-	store storage.ExternalStorage,
-	startKey []byte,
-	endKey []byte,
-	partSize int64,
-	newFilePrefix string,
-	writerID string,
-	blockSize int,
-	writeBatchCount uint64,
-	propSizeDist uint64,
-	propKeysDist uint64,
-	onClose OnCloseFunc,
-	concurrency int,
-	checkHotspot bool,
-) error {
-	logutil.Logger(ctx).Info("enter MergeOverlappingFiles opt",
-		zap.Int("data-file-count", len(dataFiles)),
-		zap.Int("stat-file-count", len(statFiles)),
-		zap.Binary("start-key", startKey),
-		zap.Binary("end-key", endKey),
-		zap.String("new-file-prefix", newFilePrefix),
-		zap.Int("concurrency", concurrency),
-	)
-
-	splitter, err := NewRangeSplitter(
-		ctx,
-		dataFiles,
-		statFiles,
-		store,
-		1*1024*1024*1024,
-		math.MaxInt64,
-		4*1024*1024*1024,
-		math.MaxInt64,
-		checkHotspot,
-	)
-	if err != nil {
-		return err
-	}
-
-	groups, err := getGroups(ctx, splitter, startKey, endKey)
-	if err != nil {
-		return err
-	}
-	logutil.Logger(ctx).Info("get groups", zap.Int("len", len(groups)))
-	eg, egCtx := errgroup.WithContext(ctx)
-	eg.SetLimit(concurrency)
-	partSize = max(int64(5*size.MB), partSize+int64(1*size.MB))
-	for i, group := range groups {
-		group := group
-		i := i
-		eg.Go(func() error {
-			return runOneGroup(egCtx, store, group, partSize, newFilePrefix, fmt.Sprintf("%s%d", writerID, i), blockSize, propSizeDist, propKeysDist, onClose)
-		})
-	}
-	return eg.Wait()
-}
-
-func runOneGroup(
-	ctx context.Context,
-	store storage.ExternalStorage,
-	rdGroup readerGroup,
-	partSize int64,
-	newFilePrefix string,
-	wrireID string,
-	blockSize int,
-	propSizeDist uint64,
-	propKeysDist uint64,
-	onClose OnCloseFunc) error {
-	logutil.BgLogger().Info("data files", zap.Int("len", len(rdGroup.dataFiles)))
-	writer := NewWriterBuilder().
-		SetMemorySizeLimit(DefaultMemSizeLimit*2).
-		SetBlockSize(blockSize).
-		SetPropKeysDistance(propKeysDist).
-		SetPropSizeDistance(propSizeDist).
-		SetOnCloseFunc(onClose).
-		BuildOneFile(store, newFilePrefix, wrireID)
-
-	err := writer.Init(ctx, partSize)
-	if err != nil {
-		return nil
-	}
-
-	bufPool := membuf.NewPool()
-	loaded := &memKVsAndBuffers{}
-	now := time.Now()
-	err = readAllData(
-		ctx,
-		store,
-		rdGroup.dataFiles,
-		rdGroup.statFiles,
-		rdGroup.startKey,
-		rdGroup.endKey,
-		bufPool,
-		loaded,
-	)
-	if err != nil {
-		return err
-	}
-	logutil.Logger(ctx).Info("reading external storage in MergeOverlappingFiles",
-		zap.Duration("cost time", time.Since(now)))
-
-	now = time.Now()
-	sorty.MaxGor = uint64(8)
-	sorty.Sort(len(loaded.keys), func(i, k, r, s int) bool {
-		if bytes.Compare(loaded.keys[i], loaded.keys[k]) < 0 { // strict comparator like < or >
-			if r != s {
-				loaded.keys[r], loaded.keys[s] = loaded.keys[s], loaded.keys[r]
-				loaded.values[r], loaded.values[s] = loaded.values[s], loaded.values[r]
-			}
-			return true
-		}
-		return false
-	})
-
-	logutil.Logger(ctx).Info("sorting in MergeOverlappingFiles",
-		zap.Duration("cost time", time.Since(now)),
-		zap.Any("key len", len(loaded.keys)))
-	now = time.Now()
-	for i, key := range loaded.keys {
-		err = writer.WriteRow(ctx, key, loaded.values[i])
-		if err != nil {
-			return err
-		}
-	}
-	logutil.Logger(ctx).Info("writing in MergeOverlappingFiles",
-		zap.Duration("cost time", time.Since(now)),
-		zap.Any("key len", len(loaded.keys)))
-
-	var stat MultipleFilesStat
-	stat.Filenames = append(stat.Filenames,
-		[2]string{writer.dataFile, writer.statFile})
-	stat.build([]tidbkv.Key{rdGroup.startKey}, []tidbkv.Key{loaded.keys[len(loaded.keys)-1]})
-	if onClose != nil {
-		onClose(&WriterSummary{
-			WriterID:           writer.writerID,
-			Seq:                0,
-			Min:                rdGroup.startKey,
-			Max:                loaded.keys[len(loaded.keys)-1],
+			Max:                maxKey,
 			TotalSize:          writer.totalSize,
 			MultipleFilesStats: []MultipleFilesStat{stat},
 		})

--- a/br/pkg/lightning/backend/external/merge_v2.go
+++ b/br/pkg/lightning/backend/external/merge_v2.go
@@ -52,7 +52,7 @@ func MergeOverlappingFilesV2(
 
 	rangeGroupSize := 4 * size.GB
 	failpoint.Inject("mockRangeGroupSize", func(val failpoint.Value) {
-		rangeGroupSize = val.(uint64)
+		rangeGroupSize = uint64(val.(int))
 	})
 
 	splitter, err := NewRangeSplitter(

--- a/br/pkg/lightning/backend/external/merge_v2.go
+++ b/br/pkg/lightning/backend/external/merge_v2.go
@@ -1,0 +1,351 @@
+package external
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/jfcg/sorty/v2"
+	"github.com/pingcap/tidb/br/pkg/membuf"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tidb/pkg/kv"
+	tidbkv "github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/pingcap/tidb/pkg/util/size"
+	"go.uber.org/zap"
+)
+
+// MergeOverlappingFilesV2 reads from given files whose key range may overlap
+// and writes to new sorted, nonoverlapping files.
+// Using 1 readAllData and 1 writer.
+func MergeOverlappingFilesV2(
+	ctx context.Context,
+	dataFiles []string,
+	statFiles []string,
+	store storage.ExternalStorage,
+	startKey []byte,
+	endKey []byte,
+	partSize int64,
+	newFilePrefix string,
+	writerID string,
+	blockSize int,
+	writeBatchCount uint64,
+	propSizeDist uint64,
+	propKeysDist uint64,
+	onClose OnCloseFunc,
+	concurrency int,
+	checkHotspot bool,
+) error {
+	logutil.Logger(ctx).Info("enter MergeOverlappingFiles",
+		zap.Int("data-file-count", len(dataFiles)),
+		zap.Int("stat-file-count", len(statFiles)),
+		zap.Binary("start-key", startKey),
+		zap.Binary("end-key", endKey),
+		zap.String("new-file-prefix", newFilePrefix),
+		zap.Int("concurrency", concurrency),
+	)
+
+	splitter, err := NewRangeSplitter(
+		ctx,
+		dataFiles,
+		statFiles,
+		store,
+		4*1024*1024*1024,
+		math.MaxInt64,
+		4*1024*1024*1024,
+		math.MaxInt64,
+		checkHotspot,
+	)
+	if err != nil {
+		return err
+	}
+
+	writer := NewWriterBuilder().
+		SetMemorySizeLimit(DefaultMemSizeLimit).
+		SetBlockSize(blockSize).
+		SetPropKeysDistance(propKeysDist).
+		SetPropSizeDistance(propSizeDist).
+		SetOnCloseFunc(onClose).
+		BuildOneFile(
+			store,
+			newFilePrefix,
+			writerID)
+	// todo consider writer conc.
+	err = writer.Init(ctx, partSize)
+	if err != nil {
+		return nil
+	}
+
+	bufPool := membuf.NewPool()
+	loaded := &memKVsAndBuffers{}
+	curStart := kv.Key(startKey).Clone()
+	var curEnd kv.Key
+
+	for {
+		endKeyOfGroup, dataFilesOfGroup, statFilesOfGroup, _, err := splitter.SplitOneRangesGroup()
+		if err != nil {
+			return err
+		}
+		curEnd = kv.Key(endKeyOfGroup).Clone()
+		if len(endKeyOfGroup) == 0 {
+			curEnd = kv.Key(endKey).Clone()
+		}
+		now := time.Now()
+		err = readAllData(
+			ctx,
+			store,
+			dataFilesOfGroup,
+			statFilesOfGroup,
+			curStart,
+			curEnd,
+			bufPool,
+			loaded,
+		)
+		if err != nil {
+			return err
+		}
+		logutil.Logger(ctx).Info("reading external storage in MergeOverlappingFiles",
+			zap.Duration("cost time", time.Since(now)))
+		now = time.Now()
+		sorty.MaxGor = uint64(concurrency)
+		sorty.Sort(len(loaded.keys), func(i, k, r, s int) bool {
+			if bytes.Compare(loaded.keys[i], loaded.keys[k]) < 0 { // strict comparator like < or >
+				if r != s {
+					loaded.keys[r], loaded.keys[s] = loaded.keys[s], loaded.keys[r]
+					loaded.values[r], loaded.values[s] = loaded.values[s], loaded.values[r]
+				}
+				return true
+			}
+			return false
+		})
+		logutil.Logger(ctx).Info("sorting in MergeOverlappingFiles",
+			zap.Duration("cost time", time.Since(now)),
+			zap.Any("key len", len(loaded.keys)))
+		now = time.Now()
+		for i, key := range loaded.keys {
+			err = writer.WriteRow(ctx, key, loaded.values[i])
+			if err != nil {
+				return err
+			}
+		}
+		logutil.Logger(ctx).Info("writing in MergeOverlappingFiles",
+			zap.Duration("cost time", time.Since(now)),
+			zap.Any("key len", len(loaded.keys)))
+		curStart = curEnd.Clone()
+		if len(endKeyOfGroup) == 0 {
+			break
+		}
+	}
+
+	var stat MultipleFilesStat
+	stat.Filenames = append(stat.Filenames,
+		[2]string{writer.dataFile, writer.statFile})
+	stat.build([]tidbkv.Key{startKey}, []tidbkv.Key{curEnd})
+	if onClose != nil {
+		onClose(&WriterSummary{
+			WriterID:           writer.writerID,
+			Seq:                0,
+			Min:                startKey,
+			Max:                curEnd, // ywq todo ... with bug.....
+			TotalSize:          writer.totalSize,
+			MultipleFilesStats: []MultipleFilesStat{stat},
+		})
+	}
+	err = writer.Close(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type readerGroup struct {
+	dataFiles []string
+	statFiles []string
+	startKey  kv.Key
+	endKey    kv.Key
+}
+
+func getGroups(ctx context.Context, splitter *RangeSplitter, startKey kv.Key, endKey kv.Key) ([]readerGroup, error) {
+	readerGroups := make([]readerGroup, 0, 10)
+	curStart := startKey
+
+	for {
+		endKeyOfGroup, dataFilesOfGroup, statFilesOfGroup, _, err := splitter.SplitOneRangesGroup()
+		if err != nil {
+			return nil, err
+		}
+		curEnd := kv.Key(endKeyOfGroup).Clone()
+		if len(endKeyOfGroup) == 0 {
+			curEnd = kv.Key(endKey).Clone()
+		}
+		readerGroups = append(readerGroups, readerGroup{
+			dataFiles: dataFilesOfGroup,
+			statFiles: statFilesOfGroup,
+			startKey:  curStart,
+			endKey:    curEnd,
+		})
+
+		curStart = curEnd.Clone()
+		if len(endKeyOfGroup) == 0 {
+			break
+		}
+	}
+	return readerGroups, nil
+}
+
+// Using concurrency * (readAllData and writer).
+func MergeOverlappingFilesOpt(
+	ctx context.Context,
+	dataFiles []string,
+	statFiles []string,
+	store storage.ExternalStorage,
+	startKey []byte,
+	endKey []byte,
+	partSize int64,
+	newFilePrefix string,
+	writerID string,
+	blockSize int,
+	writeBatchCount uint64,
+	propSizeDist uint64,
+	propKeysDist uint64,
+	onClose OnCloseFunc,
+	concurrency int,
+	checkHotspot bool,
+) error {
+	logutil.Logger(ctx).Info("enter MergeOverlappingFiles opt",
+		zap.Int("data-file-count", len(dataFiles)),
+		zap.Int("stat-file-count", len(statFiles)),
+		zap.Binary("start-key", startKey),
+		zap.Binary("end-key", endKey),
+		zap.String("new-file-prefix", newFilePrefix),
+		zap.Int("concurrency", concurrency),
+	)
+
+	splitter, err := NewRangeSplitter(
+		ctx,
+		dataFiles,
+		statFiles,
+		store,
+		1*1024*1024*1024,
+		math.MaxInt64,
+		4*1024*1024*1024,
+		math.MaxInt64,
+		checkHotspot,
+	)
+	if err != nil {
+		return err
+	}
+
+	groups, err := getGroups(ctx, splitter, startKey, endKey)
+	if err != nil {
+		return err
+	}
+	logutil.Logger(ctx).Info("get groups", zap.Int("len", len(groups)))
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(concurrency)
+	partSize = max(int64(5*size.MB), partSize+int64(1*size.MB))
+	for i, group := range groups {
+		group := group
+		i := i
+		eg.Go(func() error {
+			return runOneGroup(egCtx, store, group, partSize, newFilePrefix, fmt.Sprintf("%s%d", writerID, i), blockSize, propSizeDist, propKeysDist, onClose)
+		})
+	}
+	return eg.Wait()
+}
+
+func runOneGroup(
+	ctx context.Context,
+	store storage.ExternalStorage,
+	rdGroup readerGroup,
+	partSize int64,
+	newFilePrefix string,
+	wrireID string,
+	blockSize int,
+	propSizeDist uint64,
+	propKeysDist uint64,
+	onClose OnCloseFunc) error {
+	logutil.BgLogger().Info("data files", zap.Int("len", len(rdGroup.dataFiles)))
+	writer := NewWriterBuilder().
+		SetMemorySizeLimit(DefaultMemSizeLimit*2).
+		SetBlockSize(blockSize).
+		SetPropKeysDistance(propKeysDist).
+		SetPropSizeDistance(propSizeDist).
+		SetOnCloseFunc(onClose).
+		BuildOneFile(store, newFilePrefix, wrireID)
+
+	err := writer.Init(ctx, partSize)
+	if err != nil {
+		return nil
+	}
+
+	bufPool := membuf.NewPool()
+	loaded := &memKVsAndBuffers{}
+	now := time.Now()
+	err = readAllData(
+		ctx,
+		store,
+		rdGroup.dataFiles,
+		rdGroup.statFiles,
+		rdGroup.startKey,
+		rdGroup.endKey,
+		bufPool,
+		loaded,
+	)
+	if err != nil {
+		return err
+	}
+	logutil.Logger(ctx).Info("reading external storage in MergeOverlappingFiles",
+		zap.Duration("cost time", time.Since(now)))
+
+	now = time.Now()
+	sorty.MaxGor = uint64(8)
+	sorty.Sort(len(loaded.keys), func(i, k, r, s int) bool {
+		if bytes.Compare(loaded.keys[i], loaded.keys[k]) < 0 { // strict comparator like < or >
+			if r != s {
+				loaded.keys[r], loaded.keys[s] = loaded.keys[s], loaded.keys[r]
+				loaded.values[r], loaded.values[s] = loaded.values[s], loaded.values[r]
+			}
+			return true
+		}
+		return false
+	})
+
+	logutil.Logger(ctx).Info("sorting in MergeOverlappingFiles",
+		zap.Duration("cost time", time.Since(now)),
+		zap.Any("key len", len(loaded.keys)))
+	now = time.Now()
+	for i, key := range loaded.keys {
+		err = writer.WriteRow(ctx, key, loaded.values[i])
+		if err != nil {
+			return err
+		}
+	}
+	logutil.Logger(ctx).Info("writing in MergeOverlappingFiles",
+		zap.Duration("cost time", time.Since(now)),
+		zap.Any("key len", len(loaded.keys)))
+
+	var stat MultipleFilesStat
+	stat.Filenames = append(stat.Filenames,
+		[2]string{writer.dataFile, writer.statFile})
+	stat.build([]tidbkv.Key{rdGroup.startKey}, []tidbkv.Key{loaded.keys[len(loaded.keys)-1]})
+	if onClose != nil {
+		onClose(&WriterSummary{
+			WriterID:           writer.writerID,
+			Seq:                0,
+			Min:                rdGroup.startKey,
+			Max:                loaded.keys[len(loaded.keys)-1],
+			TotalSize:          writer.totalSize,
+			MultipleFilesStats: []MultipleFilesStat{stat},
+		})
+	}
+	err = writer.Close(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/br/pkg/lightning/backend/external/merge_v2.go
+++ b/br/pkg/lightning/backend/external/merge_v2.go
@@ -144,6 +144,7 @@ func MergeOverlappingFilesV2(
 	var stat MultipleFilesStat
 	stat.Filenames = append(stat.Filenames,
 		[2]string{writer.dataFile, writer.statFile})
+	// ywq todo what if no key readed... in read all data
 	stat.build([]tidbkv.Key{startKey}, []tidbkv.Key{curEnd})
 	if onClose != nil {
 		onClose(&WriterSummary{

--- a/br/pkg/lightning/backend/external/merge_v2.go
+++ b/br/pkg/lightning/backend/external/merge_v2.go
@@ -10,10 +10,8 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
 	"github.com/pingcap/tidb/br/pkg/membuf"
-
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/kv"
-	tidbkv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/size"
 	"go.uber.org/zap"
@@ -159,7 +157,7 @@ func MergeOverlappingFilesV2(
 	stat.Filenames = append(stat.Filenames,
 		[2]string{writer.dataFile, writer.statFile})
 
-	stat.build([]tidbkv.Key{startKey}, []tidbkv.Key{curEnd})
+	stat.build([]kv.Key{startKey}, []kv.Key{curEnd})
 	if onClose != nil {
 		onClose(&WriterSummary{
 			WriterID:           writer.writerID,

--- a/br/pkg/lightning/backend/external/onefile_writer.go
+++ b/br/pkg/lightning/backend/external/onefile_writer.go
@@ -47,8 +47,7 @@ type OneFileWriter struct {
 	dataWriter     storage.ExternalFileWriter
 	statWriter     storage.ExternalFileWriter
 
-	onClose OnCloseFunc
-	closed  bool
+	closed bool
 
 	logger *zap.Logger
 }

--- a/br/pkg/lightning/backend/external/onefile_writer_test.go
+++ b/br/pkg/lightning/backend/external/onefile_writer_test.go
@@ -50,8 +50,7 @@ func TestOnefileWriterBasic(t *testing.T) {
 		SetPropKeysDistance(2).
 		BuildOneFile(memStore, "/test", "0")
 
-	err := writer.Init(ctx, 5*1024*1024)
-	require.NoError(t, err)
+	require.NoError(t, writer.Init(ctx, 5*1024*1024))
 
 	kvCnt := 100
 	kvs := make([]common.KvPair, kvCnt)
@@ -67,12 +66,10 @@ func TestOnefileWriterBasic(t *testing.T) {
 	}
 
 	for _, item := range kvs {
-		err := writer.WriteRow(ctx, item.Key, item.Val)
-		require.NoError(t, err)
+		require.Error(t, writer.WriteRow(ctx, item.Key, item.Val))
 	}
 
-	err = writer.Close(ctx)
-	require.NoError(t, err)
+	require.NoError(t, writer.Close(ctx))
 
 	bufSize := rand.Intn(100) + 1
 	kvReader, err := newKVReader(ctx, "/test/0/one-file", memStore, 0, bufSize)
@@ -124,8 +121,7 @@ func checkOneFileWriterStatWithDistance(t *testing.T, kvCnt int, keysDistance ui
 		SetPropKeysDistance(keysDistance).
 		BuildOneFile(memStore, "/"+prefix, "0")
 
-	err := writer.Init(ctx, 5*1024*1024)
-	require.NoError(t, err)
+	require.NoError(t, writer.Init(ctx, 5*1024*1024))
 	kvs := make([]common.KvPair, 0, kvCnt)
 	for i := 0; i < kvCnt; i++ {
 		kvs = append(kvs, common.KvPair{
@@ -134,11 +130,9 @@ func checkOneFileWriterStatWithDistance(t *testing.T, kvCnt int, keysDistance ui
 		})
 	}
 	for _, item := range kvs {
-		err := writer.WriteRow(ctx, item.Key, item.Val)
-		require.NoError(t, err)
+		require.NoError(t, writer.WriteRow(ctx, item.Key, item.Val))
 	}
-	err = writer.Close(ctx)
-	require.NoError(t, err)
+	require.NoError(t, writer.Close(ctx))
 
 	bufSize := rand.Intn(100) + 1
 	kvReader, err := newKVReader(ctx, "/"+prefix+"/0/one-file", memStore, 0, bufSize)
@@ -197,13 +191,11 @@ func TestMergeOverlappingFilesInternal(t *testing.T) {
 			v-- // insert a duplicate key.
 		}
 		key, val := []byte{byte(v)}, []byte{byte(v)}
-		err := writer.WriteRow(ctx, key, val, dbkv.IntHandle(i))
-		require.NoError(t, err)
+		require.NoError(t, writer.WriteRow(ctx, key, val, dbkv.IntHandle(i)))
 	}
-	err := writer.Close(ctx)
-	require.NoError(t, err)
+	require.NoError(t, writer.Close(ctx))
 
-	err = mergeOverlappingFilesInternal(
+	require.NoError(t, mergeOverlappingFilesInternal(
 		ctx,
 		[]string{"/test/0/0", "/test/0/1", "/test/0/2", "/test/0/3", "/test/0/4"},
 		memStore,
@@ -218,8 +210,7 @@ func TestMergeOverlappingFilesInternal(t *testing.T) {
 		2,
 		nil,
 		true,
-	)
-	require.NoError(t, err)
+	))
 
 	keys := make([][]byte, 0, kvCount)
 	values := make([][]byte, 0, kvCount)
@@ -276,8 +267,7 @@ func TestOnefileWriterManyRows(t *testing.T) {
 		SetMemorySizeLimit(1000).
 		BuildOneFile(memStore, "/test", "0")
 
-	err := writer.Init(ctx, 5*1024*1024)
-	require.NoError(t, err)
+	require.NoError(t, writer.Init(ctx, 5*1024*1024))
 
 	kvCnt := 100000
 	expectedTotalSize := 0
@@ -301,17 +291,15 @@ func TestOnefileWriterManyRows(t *testing.T) {
 	})
 
 	for _, item := range kvs {
-		err := writer.WriteRow(ctx, item.Key, item.Val)
-		require.NoError(t, err)
+		require.NoError(t, writer.WriteRow(ctx, item.Key, item.Val))
 	}
-	err = writer.Close(ctx)
-	require.NoError(t, err)
+	require.NoError(t, writer.Close(ctx))
 
 	var resSummary *WriterSummary
 	onClose := func(summary *WriterSummary) {
 		resSummary = summary
 	}
-	err = mergeOverlappingFilesInternal(
+	require.NoError(t, mergeOverlappingFilesInternal(
 		ctx,
 		[]string{"/test/0/one-file"},
 		memStore,
@@ -326,8 +314,7 @@ func TestOnefileWriterManyRows(t *testing.T) {
 		2,
 		onClose,
 		true,
-	)
-	require.NoError(t, err)
+	))
 
 	bufSize := rand.Intn(100) + 1
 	kvReader, err := newKVReader(ctx, "/test2/mergeID/one-file", memStore, 0, bufSize)

--- a/br/pkg/lightning/backend/external/onefile_writer_test.go
+++ b/br/pkg/lightning/backend/external/onefile_writer_test.go
@@ -66,7 +66,7 @@ func TestOnefileWriterBasic(t *testing.T) {
 	}
 
 	for _, item := range kvs {
-		require.Error(t, writer.WriteRow(ctx, item.Key, item.Val))
+		require.NoError(t, writer.WriteRow(ctx, item.Key, item.Val))
 	}
 
 	require.NoError(t, writer.Close(ctx))

--- a/br/pkg/lightning/backend/external/onefile_writer_test.go
+++ b/br/pkg/lightning/backend/external/onefile_writer_test.go
@@ -177,7 +177,7 @@ func checkOneFileWriterStatWithDistance(t *testing.T, kvCnt int, keysDistance ui
 	require.NoError(t, statReader.Close())
 }
 
-func TestMergeOverlappingFilesV2(t *testing.T) {
+func TestMergeOverlappingFilesInternal(t *testing.T) {
 	// 1. Write to 5 files.
 	// 2. merge 5 files into one file.
 	// 3. read one file and check result.
@@ -203,7 +203,7 @@ func TestMergeOverlappingFilesV2(t *testing.T) {
 	err := writer.Close(ctx)
 	require.NoError(t, err)
 
-	err = mergeOverlappingFilesV2(
+	err = mergeOverlappingFilesInternal(
 		ctx,
 		[]string{"/test/0/0", "/test/0/1", "/test/0/2", "/test/0/3", "/test/0/4"},
 		memStore,
@@ -311,7 +311,7 @@ func TestOnefileWriterManyRows(t *testing.T) {
 	onClose := func(summary *WriterSummary) {
 		resSummary = summary
 	}
-	err = mergeOverlappingFilesV2(
+	err = mergeOverlappingFilesInternal(
 		ctx,
 		[]string{"/test/0/one-file"},
 		memStore,

--- a/br/pkg/lightning/backend/external/reader_test.go
+++ b/br/pkg/lightning/backend/external/reader_test.go
@@ -95,8 +95,7 @@ func TestReadAllOneFile(t *testing.T) {
 		require.NoError(t, w.WriteRow(ctx, kvs[i].Key, kvs[i].Val))
 	}
 
-	err := w.Close(ctx)
-	require.NoError(t, err)
+	require.NoError(t, w.Close(ctx))
 
 	slices.SortFunc(kvs, func(i, j common.KvPair) int {
 		return bytes.Compare(i.Key, j.Key)

--- a/br/pkg/lightning/backend/external/sort_test.go
+++ b/br/pkg/lightning/backend/external/sort_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/size"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"golang.org/x/exp/rand"
 )
 
@@ -210,7 +211,9 @@ func TestGlobalSortLocalWithMergeV2(t *testing.T) {
 	t.Logf("seed: %d", seed)
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
-	memSizeLimit := (rand.Intn(10) + 1) * 400
+	// memSizeLimit := (rand.Intn(10) + 1) * 400
+	memSizeLimit := 400
+
 	multiStats := make([]MultipleFilesStat, 0, 100)
 	closeFn := func(s *WriterSummary) {
 		multiStats = append(multiStats, s.MultipleFilesStats...)
@@ -246,12 +249,27 @@ func TestGlobalSortLocalWithMergeV2(t *testing.T) {
 	datas, stats, err := GetAllFileNames(ctx, memStore, "")
 	require.NoError(t, err)
 
+	// ywq todo check it.
 	dataGroup, statGroup, startKeys, endKeys := splitDataStatAndKeys(datas, stats, multiStats)
+
+	for _, stat := range multiStats {
+		logutil.BgLogger().Info("ywq test stat", zap.Binary("minKey", stat.MinKey), zap.Binary("maxKey", stat.MaxKey))
+	}
+
+	logutil.BgLogger().Info("ywq test actual min max", zap.Any("min", kvs[0].Key), zap.Any("max", kvs[len(kvs)-1].Key))
+
+	// startKeys "000a94e1-edc7-4583-893c-4598bee2cde4" "b4a5ed60-16f5-4981-9b9c-3c4b7a5a1232"
+	// endkeys "b49f03c6-4b0e-4788-808d-2e546e906fac\x00" "fff1a2c3-277e-444b-9a94-fa3d841fce21\x00"
+
+	// multistats
+	// min "000a94e1-edc7-4583-893c-4598bee2cde4" max "587ee8e5-7725-4353-91df-d8cbdd4672dc"
+	//     "58846994-849b-4844-bf9f-8578590a5cab"     "b49f03c6-4b0e-4788-808d-2e546e906fac"
+	//     "b4a5ed60-16f5-4981-9b9c-3c4b7a5a1232"     "fff1a2c3-277e-444b-9a94-fa3d841fce21"
 
 	lastStepDatas := make([]string, 0, 10)
 	lastStepStats := make([]string, 0, 10)
 	var startKey, endKey dbkv.Key
-
+	// prepare meta for last step.
 	closeFn1 := func(s *WriterSummary) {
 		for _, stat := range s.MultipleFilesStats {
 			for i := range stat.Filenames {
@@ -268,6 +286,7 @@ func TestGlobalSortLocalWithMergeV2(t *testing.T) {
 		endKey = BytesMax(endKey, s.Max.Clone().Next())
 	}
 	logutil.BgLogger().Info("ywq test start merge step")
+	logutil.BgLogger().Info("ywq test see meta", zap.Any("startKeys", startKeys), zap.Any("endKeys", endKeys))
 
 	for i, group := range dataGroup {
 		MergeOverlappingFilesV2(

--- a/br/pkg/lightning/backend/external/sort_test.go
+++ b/br/pkg/lightning/backend/external/sort_test.go
@@ -96,7 +96,7 @@ func TestGlobalSortLocalWithMerge(t *testing.T) {
 	t.Logf("seed: %d", seed)
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
-	memSizeLimit := 400
+	memSizeLimit := (rand.Intn(10) + 1) * 400
 
 	w := NewWriterBuilder().
 		SetPropSizeDistance(100).

--- a/br/pkg/lightning/backend/external/sort_test.go
+++ b/br/pkg/lightning/backend/external/sort_test.go
@@ -150,7 +150,7 @@ func TestGlobalSortLocalWithMerge(t *testing.T) {
 	}
 
 	for _, group := range dataGroup {
-		MergeOverlappingFiles(
+		require.NoError(t, MergeOverlappingFiles(
 			ctx,
 			group,
 			memStore,
@@ -164,7 +164,7 @@ func TestGlobalSortLocalWithMerge(t *testing.T) {
 			closeFn,
 			1,
 			true,
-		)
+		))
 	}
 
 	// 3. read and sort step
@@ -182,10 +182,10 @@ func TestGlobalSortLocalWithMergeV2(t *testing.T) {
 	multiStats := make([]MultipleFilesStat, 0, 100)
 	randomSize := (rand.Intn(500) + 1) * 1000
 
-	failpoint.Enable("github.com/pingcap/tidb/br/pkg/lightning/backend/external/mockRangeGroupSize",
+	failpoint.Enable("github.com/pingcap/tidb/br/pkg/lightning/backend/external/mockRangesGroupSize",
 		"return("+strconv.Itoa(randomSize)+")")
 	t.Cleanup(func() {
-		failpoint.Disable("github.com/pingcap/tidb/br/pkg/lightning/backend/external/mockRangeGroupSize")
+		failpoint.Disable("github.com/pingcap/tidb/br/pkg/lightning/backend/external/mockRangesGroupSize")
 	})
 	datas := make([]string, 0, 100)
 	stats := make([]string, 0, 100)
@@ -248,7 +248,7 @@ func TestGlobalSortLocalWithMergeV2(t *testing.T) {
 	}
 
 	for i, group := range dataGroup {
-		MergeOverlappingFilesV2(
+		require.NoError(t, MergeOverlappingFilesV2(
 			ctx,
 			group,
 			statGroup[i],
@@ -264,7 +264,7 @@ func TestGlobalSortLocalWithMergeV2(t *testing.T) {
 			2,
 			closeFn1,
 			1,
-			true)
+			true))
 	}
 
 	// 3. read and sort step

--- a/br/pkg/lightning/backend/external/sort_test.go
+++ b/br/pkg/lightning/backend/external/sort_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	dbkv "github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/size"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
@@ -166,5 +167,115 @@ func TestGlobalSortLocalWithMerge(t *testing.T) {
 	}
 
 	// 3. read and sort step
+	testReadAndCompare(ctx, t, kvs, memStore, lastStepDatas, lastStepStats, startKey, memSizeLimit)
+}
+
+func splitDataStatAndKeys(datas []string, stats []string, multiStats []MultipleFilesStat) ([][]string, [][]string, []dbkv.Key, []dbkv.Key) {
+	startKeys := make([]dbkv.Key, 0, 10)
+	endKeys := make([]dbkv.Key, 0, 10)
+	i := 0
+	for ; i < len(multiStats)-1; i += 2 {
+		startKey := BytesMin(multiStats[i].MinKey, multiStats[i+1].MinKey)
+		endKey := BytesMax(multiStats[i].MaxKey, multiStats[i+1].MaxKey)
+		endKey = dbkv.Key(endKey).Next().Clone()
+		startKeys = append(startKeys, startKey)
+		endKeys = append(endKeys, endKey)
+	}
+	if i == len(multiStats)-1 {
+		startKeys = append(startKeys, multiStats[i].MinKey.Clone())
+		endKeys = append(endKeys, dbkv.Key(multiStats[i].MaxKey).Next().Clone())
+	}
+
+	dataGroup := make([][]string, 0, 10)
+	statGroup := make([][]string, 0, 10)
+
+	start := 0
+	step := 1000
+	for start < len(datas) {
+		end := start + step
+		if end > len(datas) {
+			end = len(datas)
+		}
+		dataGroup = append(dataGroup, datas[start:end])
+		statGroup = append(statGroup, stats[start:end])
+		start = end
+	}
+	return dataGroup, statGroup, startKeys, endKeys
+}
+
+func TestGlobalSortLocalWithMergeV2(t *testing.T) {
+	// 1. write data step
+	seed := time.Now().Unix()
+	rand.Seed(uint64(seed))
+	t.Logf("seed: %d", seed)
+	ctx := context.Background()
+	memStore := storage.NewMemStorage()
+	memSizeLimit := (rand.Intn(10) + 1) * 400
+	multiStats := make([]MultipleFilesStat, 0, 100)
+	closeFn := func(s *WriterSummary) {
+		multiStats = append(multiStats, s.MultipleFilesStats...)
+	}
+
+	w := NewWriterBuilder().
+		SetPropSizeDistance(100).
+		SetPropKeysDistance(2).
+		SetMemorySizeLimit(uint64(memSizeLimit)).
+		SetBlockSize(memSizeLimit).
+		SetOnCloseFunc(closeFn).
+		Build(memStore, "/test", "0")
+
+	writer := NewEngineWriter(w)
+	kvCnt := rand.Intn(10) + 10000
+	kvs := make([]common.KvPair, kvCnt)
+	for i := 0; i < kvCnt; i++ {
+		kvs[i] = common.KvPair{
+			Key: []byte(uuid.New().String()),
+			Val: []byte("56789"),
+		}
+	}
+
+	slices.SortFunc(kvs, func(i, j common.KvPair) int {
+		return bytes.Compare(i.Key, j.Key)
+	})
+
+	require.NoError(t, writer.AppendRows(ctx, nil, kv.MakeRowsFromKvPairs(kvs)))
+	_, err := writer.Close(ctx)
+	require.NoError(t, err)
+
+	// 2. merge step
+	datas, stats, err := GetAllFileNames(ctx, memStore, "")
+	require.NoError(t, err)
+
+	dataGroup, statGroup, startKeys, endKeys := splitDataStatAndKeys(datas, stats, multiStats)
+
+	lastStepDatas := make([]string, 0, 10)
+	lastStepStats := make([]string, 0, 10)
+	var startKey, endKey dbkv.Key
+
+	closeFn1 := func(s *WriterSummary) {
+		for _, stat := range s.MultipleFilesStats {
+			for i := range stat.Filenames {
+				lastStepDatas = append(lastStepDatas, stat.Filenames[i][0])
+				lastStepStats = append(lastStepStats, stat.Filenames[i][1])
+			}
+
+		}
+		if len(startKey) == 0 && len(endKey) == 0 {
+			startKey = s.Min.Clone()
+			endKey = s.Max.Clone().Next()
+		}
+		startKey = BytesMin(startKey, s.Min.Clone())
+		endKey = BytesMax(endKey, s.Max.Clone().Next())
+	}
+	logutil.BgLogger().Info("ywq test start merge step")
+
+	for i, group := range dataGroup {
+		MergeOverlappingFilesV2(
+			ctx, group, statGroup[i], memStore, startKeys[i], endKeys[i], int64(5*size.MB), "/test2", uuid.NewString(), 100,
+			8*1024, 100, 2, closeFn1, 1, true)
+	}
+
+	// 3. read and sort step
+	logutil.BgLogger().Info("ywq test start last step")
 	testReadAndCompare(ctx, t, kvs, memStore, lastStepDatas, lastStepStats, startKey, memSizeLimit)
 }

--- a/br/pkg/lightning/backend/external/sort_test.go
+++ b/br/pkg/lightning/backend/external/sort_test.go
@@ -171,40 +171,6 @@ func TestGlobalSortLocalWithMerge(t *testing.T) {
 	testReadAndCompare(ctx, t, kvs, memStore, lastStepDatas, lastStepStats, startKey, memSizeLimit)
 }
 
-// split subtasks for merge step.
-func splitDataStatAndKeys(datas []string, stats []string, multiStats []MultipleFilesStat) ([][]string, [][]string, []dbkv.Key, []dbkv.Key) {
-	startKeys := make([]dbkv.Key, 0, 10)
-	endKeys := make([]dbkv.Key, 0, 10)
-	i := 0
-	for ; i < len(multiStats)-1; i += 2 {
-		startKey := BytesMin(multiStats[i].MinKey, multiStats[i+1].MinKey)
-		endKey := BytesMax(multiStats[i].MaxKey, multiStats[i+1].MaxKey)
-		endKey = dbkv.Key(endKey).Next().Clone()
-		startKeys = append(startKeys, startKey)
-		endKeys = append(endKeys, endKey)
-	}
-	if i == len(multiStats)-1 {
-		startKeys = append(startKeys, multiStats[i].MinKey.Clone())
-		endKeys = append(endKeys, dbkv.Key(multiStats[i].MaxKey).Next().Clone())
-	}
-
-	dataGroup := make([][]string, 0, 10)
-	statGroup := make([][]string, 0, 10)
-
-	start := 0
-	step := 1000
-	for start < len(datas) {
-		end := start + step
-		if end > len(datas) {
-			end = len(datas)
-		}
-		dataGroup = append(dataGroup, datas[start:end])
-		statGroup = append(statGroup, stats[start:end])
-		start = end
-	}
-	return dataGroup, statGroup, startKeys, endKeys
-}
-
 func TestGlobalSortLocalWithMergeV2(t *testing.T) {
 	// 1. write data step
 	seed := time.Now().Unix()

--- a/br/pkg/lightning/backend/external/testutil.go
+++ b/br/pkg/lightning/backend/external/testutil.go
@@ -127,3 +127,37 @@ func splitDataAndStatFiles(datas []string, stats []string) ([][]string, [][]stri
 	}
 	return dataGroup, statGroup
 }
+
+// split data&stat files, startKeys and endKeys into groups for new merge step.
+func splitDataStatAndKeys(datas []string, stats []string, multiStats []MultipleFilesStat) ([][]string, [][]string, []dbkv.Key, []dbkv.Key) {
+	startKeys := make([]dbkv.Key, 0, 10)
+	endKeys := make([]dbkv.Key, 0, 10)
+	i := 0
+	for ; i < len(multiStats)-1; i += 2 {
+		startKey := BytesMin(multiStats[i].MinKey, multiStats[i+1].MinKey)
+		endKey := BytesMax(multiStats[i].MaxKey, multiStats[i+1].MaxKey)
+		endKey = dbkv.Key(endKey).Next().Clone()
+		startKeys = append(startKeys, startKey)
+		endKeys = append(endKeys, endKey)
+	}
+	if i == len(multiStats)-1 {
+		startKeys = append(startKeys, multiStats[i].MinKey.Clone())
+		endKeys = append(endKeys, dbkv.Key(multiStats[i].MaxKey).Next().Clone())
+	}
+
+	dataGroup := make([][]string, 0, 10)
+	statGroup := make([][]string, 0, 10)
+
+	start := 0
+	step := 1000
+	for start < len(datas) {
+		end := start + step
+		if end > len(datas) {
+			end = len(datas)
+		}
+		dataGroup = append(dataGroup, datas[start:end])
+		statGroup = append(statGroup, stats[start:end])
+		start = end
+	}
+	return dataGroup, statGroup, startKeys, endKeys
+}

--- a/br/pkg/lightning/backend/external/testutil.go
+++ b/br/pkg/lightning/backend/external/testutil.go
@@ -149,7 +149,7 @@ func splitDataStatAndKeys(datas []string, stats []string, multiStats []MultipleF
 	statGroup := make([][]string, 0, 10)
 
 	start := 0
-	step := 1000
+	step := 2 * multiFileStatNum
 	for start < len(datas) {
 		end := start + step
 		if end > len(datas) {

--- a/br/pkg/lightning/backend/external/testutil.go
+++ b/br/pkg/lightning/backend/external/testutil.go
@@ -93,12 +93,12 @@ func testReadAndCompare(
 			require.EqualValues(t, kvs[kvIdx].Val, loaded.values[i])
 			kvIdx++
 		}
+		curStart = curEnd.Clone()
 
 		// release
 		loaded.keys = nil
 		loaded.values = nil
 		loaded.memKVBuffers = nil
-		curStart = curEnd.Clone()
 
 		if len(endKeyOfGroup) == 0 {
 			break

--- a/br/pkg/lightning/backend/external/util.go
+++ b/br/pkg/lightning/backend/external/util.go
@@ -24,11 +24,13 @@ import (
 	"strings"
 
 	"github.com/docker/go-units"
+	"github.com/pingcap/tidb/br/pkg/lightning/log"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // seekPropsOffsets seeks the statistic files to find the largest offset of
@@ -42,10 +44,10 @@ func seekPropsOffsets(
 	checkHotSpot bool,
 ) (_ []uint64, err error) {
 	logger := logutil.Logger(ctx)
-	// task := log.BeginTask(logger, "seek props offsets")
-	// defer func() {
-	// 	task.End(zapcore.ErrorLevel, err)
-	// }()
+	task := log.BeginTask(logger, "seek props offsets")
+	defer func() {
+		task.End(zapcore.ErrorLevel, err)
+	}()
 	iter, err := NewMergePropIter(ctx, paths, exStorage, checkHotSpot)
 	if err != nil {
 		return nil, err

--- a/br/pkg/lightning/backend/external/util.go
+++ b/br/pkg/lightning/backend/external/util.go
@@ -24,13 +24,11 @@ import (
 	"strings"
 
 	"github.com/docker/go-units"
-	"github.com/pingcap/tidb/br/pkg/lightning/log"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // seekPropsOffsets seeks the statistic files to find the largest offset of
@@ -44,10 +42,10 @@ func seekPropsOffsets(
 	checkHotSpot bool,
 ) (_ []uint64, err error) {
 	logger := logutil.Logger(ctx)
-	task := log.BeginTask(logger, "seek props offsets")
-	defer func() {
-		task.End(zapcore.ErrorLevel, err)
-	}()
+	// task := log.BeginTask(logger, "seek props offsets")
+	// defer func() {
+	// 	task.End(zapcore.ErrorLevel, err)
+	// }()
 	iter, err := NewMergePropIter(ctx, paths, exStorage, checkHotSpot)
 	if err != nil {
 		return nil, err

--- a/br/pkg/lightning/backend/external/writer.go
+++ b/br/pkg/lightning/backend/external/writer.go
@@ -231,7 +231,6 @@ func (b *WriterBuilder) BuildOneFile(
 		filenamePrefix: filenamePrefix,
 		writerID:       writerID,
 		kvStore:        nil,
-		onClose:        b.onClose,
 		closed:         false,
 	}
 	return ret

--- a/br/pkg/lightning/backend/external/writer.go
+++ b/br/pkg/lightning/backend/external/writer.go
@@ -377,7 +377,9 @@ func (w *Writer) Close(ctx context.Context) error {
 		zap.String("writerID", w.writerID),
 		zap.Int("kv-cnt-cap", cap(w.kvLocations)),
 		zap.String("minKey", hex.EncodeToString(w.minKey)),
-		zap.String("maxKey", hex.EncodeToString(w.maxKey)))
+		zap.String("maxKey", hex.EncodeToString(w.maxKey)),
+		zap.Binary("minKey", w.minKey),
+		zap.Binary("maxKey", w.maxKey))
 
 	w.kvLocations = nil
 	w.onClose(&WriterSummary{
@@ -488,7 +490,6 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 	w.recordMinMax(minKey, maxKey, uint64(w.kvSize))
 
 	// maintain 500-batch statistics
-
 	l := len(w.multiFileStats)
 	w.multiFileStats[l-1].Filenames = append(w.multiFileStats[l-1].Filenames,
 		[2]string{dataFile, statFile},

--- a/br/pkg/lightning/backend/external/writer.go
+++ b/br/pkg/lightning/backend/external/writer.go
@@ -377,9 +377,7 @@ func (w *Writer) Close(ctx context.Context) error {
 		zap.String("writerID", w.writerID),
 		zap.Int("kv-cnt-cap", cap(w.kvLocations)),
 		zap.String("minKey", hex.EncodeToString(w.minKey)),
-		zap.String("maxKey", hex.EncodeToString(w.maxKey)),
-		zap.Binary("minKey", w.minKey),
-		zap.Binary("maxKey", w.maxKey))
+		zap.String("maxKey", hex.EncodeToString(w.maxKey)))
 
 	w.kvLocations = nil
 	w.onClose(&WriterSummary{

--- a/br/pkg/lightning/backend/external/writer_test.go
+++ b/br/pkg/lightning/backend/external/writer_test.go
@@ -30,13 +30,75 @@ import (
 	"github.com/jfcg/sorty/v2"
 	"github.com/pingcap/tidb/br/pkg/lightning/backend/kv"
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
+	"github.com/pingcap/tidb/br/pkg/lightning/log"
 	"github.com/pingcap/tidb/br/pkg/membuf"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	dbkv "github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/size"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"golang.org/x/exp/rand"
 )
+
+// only used in testing for now.
+func mergeOverlappingFilesImpl(ctx context.Context,
+	paths []string,
+	store storage.ExternalStorage,
+	readBufferSize int,
+	newFilePrefix string,
+	writerID string,
+	memSizeLimit uint64,
+	blockSize int,
+	writeBatchCount uint64,
+	propSizeDist uint64,
+	propKeysDist uint64,
+	onClose OnCloseFunc,
+	checkHotspot bool,
+) (err error) {
+	task := log.BeginTask(logutil.Logger(ctx).With(
+		zap.String("writer-id", writerID),
+		zap.Int("file-count", len(paths)),
+	), "merge overlapping files")
+	defer func() {
+		task.End(zap.ErrorLevel, err)
+	}()
+
+	zeroOffsets := make([]uint64, len(paths))
+	iter, err := NewMergeKVIter(ctx, paths, zeroOffsets, store, readBufferSize, checkHotspot, 0)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := iter.Close()
+		if err != nil {
+			logutil.Logger(ctx).Warn("close iterator failed", zap.Error(err))
+		}
+	}()
+
+	writer := NewWriterBuilder().
+		SetMemorySizeLimit(memSizeLimit).
+		SetBlockSize(blockSize).
+		SetOnCloseFunc(onClose).
+		SetWriterBatchCount(writeBatchCount).
+		SetPropSizeDistance(propSizeDist).
+		SetPropKeysDistance(propKeysDist).
+		Build(store, newFilePrefix, writerID)
+
+	// currently use same goroutine to do read and write. The main advantage is
+	// there's no KV copy and iter can reuse the buffer.
+	for iter.Next() {
+		err = writer.WriteRow(ctx, iter.Key(), iter.Value(), nil)
+		if err != nil {
+			return err
+		}
+	}
+	err = iter.Error()
+	if err != nil {
+		return err
+	}
+	return writer.Close(ctx)
+}
 
 func TestWriter(t *testing.T) {
 	seed := time.Now().Unix()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #48779

Problem Summary:

### What changed and how does it work?
Implement new merge step. In new implementation, mergeIter is abandoned.
The new merge step process data from startKey to endKey, using datas and stats.
1. use rangeSplitter to split range groups to read data.
2. read range data then sort them.
3. write all data to only one file.

Currently, the new merge step use only 1 writer.

TODO:
1. We can speed up the process using multiple worker doing the merge process later.
2. Add more bench test after gcs parallel writer stable.
3. integrate with add index and import into.
4. See if the new merge step can handle more files.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
