### PR TITLE
*: fix upgrade error for version 181

### DIFF
--- a/build/linter/bootstrap/analyzer.go
+++ b/build/linter/bootstrap/analyzer.go
@@ -15,7 +15,6 @@
 package bootstrap
 
 import (
-	"fmt"
 	"go/ast"
 	"go/token"
 	"strconv"
@@ -108,25 +107,30 @@ func run(pass *analysis.Pass) (interface{}, error) {
 							continue
 						}
 
+						if valInName < maxVerVariable {
+							pass.Reportf(spec.Pos(), "version variable %q is not valid, we should have a increment list of version variables", name)
+							continue
+						}
+
+						maxVerVariable = valInName
+						maxVerVariablePos = v2.Names[0].Pos()
+
 						if len(v2.Values) != 1 {
-							panic(fmt.Sprintf("bootstrap.go: the value of version variable '%s' must be specified explicitly", name))
+							pass.Reportf(spec.Pos(), "the value of version variable %q must be specified explicitly", name)
+							continue
 						}
 
 						valStr := v2.Values[0].(*ast.BasicLit).Value
 						val, err := strconv.Atoi(valStr)
 						if err != nil {
-							panic(fmt.Sprintf("bootstrap.go: unexpected value of version variable '%s': '%s'", name, valStr))
+							pass.Reportf(spec.Pos(), "unexpected value of version variable %q: %q", name, valStr)
+							continue
 						}
 
 						if val != valInName {
-							panic(fmt.Sprintf("bootstrap.go: the value of version variable '%s' must be '%d'", name, valInName))
+							pass.Reportf(spec.Pos(), "the value of version variable %q must be '%d', but now is '%d'", name, valInName, val)
+							continue
 						}
-
-						if val <= maxVerVariable {
-							panic(fmt.Sprintf("bootstrap.go: '%s' is not valid, we should have a increment list of version variables", name))
-						}
-						maxVerVariable = val
-						maxVerVariablePos = v2.Names[0].Pos()
 					}
 				}
 			case *ast.FuncDecl:

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1042,7 +1042,7 @@ const (
 
 	// version 181
 	//   add a new `type` column on mysql.bind_info, which is for universal binding #48875.
-	version181
+	version181 = 181
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49485

Problem Summary:

We did not assig a explicitly version to `version181`, see: https://github.com/pingcap/tidb/pull/49426/files#diff-2fde3341e0231e7b162880b36f07d23b7949ca512c5536b50706ac5aa9072b25R1045

Seems golang will not increase the last const value when the list not started with iota, see: https://go.dev/play/p/dCORpY3lJP7

```
const (
	v1 = 1
	v2
)

func main() {
	fmt.Println(v1)
	fmt.Println(v2)
}
```

result is

```
1
1
```


### What changed and how does it work?

See PR

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
