### PR TITLE
Lightning : make pebbleDB block size configurable

### DIFF
--- a/br/pkg/lightning/backend/backend.go
+++ b/br/pkg/lightning/backend/backend.go
@@ -99,6 +99,9 @@ type LocalEngineConfig struct {
 	CompactThreshold int64
 	// compact routine concurrency
 	CompactConcurrency int
+
+	// blocksize
+	BlockSize int
 }
 
 // ExternalEngineConfig is the configuration used for local backend external engine.

--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -1349,7 +1349,7 @@ func (w *Writer) addSST(ctx context.Context, meta *sstMeta) error {
 
 func (w *Writer) createSSTWriter() (*sstWriter, error) {
 	path := filepath.Join(w.engine.sstDir, uuid.New().String()+".sst")
-	writer, err := newSSTWriter(path)
+	writer, err := newSSTWriter(path, w.engine.config.BlockSize)
 	if err != nil {
 		return nil, err
 	}
@@ -1365,7 +1365,7 @@ type sstWriter struct {
 	logger log.Logger
 }
 
-func newSSTWriter(path string) (*sstable.Writer, error) {
+func newSSTWriter(path string, blockSize int) (*sstable.Writer, error) {
 	f, err := os.Create(path)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1374,7 +1374,7 @@ func newSSTWriter(path string) (*sstable.Writer, error) {
 		TablePropertyCollectors: []func() pebble.TablePropertyCollector{
 			newRangePropertiesCollector,
 		},
-		BlockSize: 16 * 1024,
+		BlockSize: blockSize,
 	})
 	return writer, nil
 }
@@ -1561,7 +1561,7 @@ func (i dbSSTIngester) mergeSSTs(metas []*sstMeta, dir string) (*sstMeta, error)
 	heap.Init(mergeIter)
 
 	name := filepath.Join(dir, fmt.Sprintf("%s.sst", uuid.New()))
-	writer, err := newSSTWriter(name)
+	writer, err := newSSTWriter(name, 16*1024)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/br/pkg/lightning/backend/local/engine.go
+++ b/br/pkg/lightning/backend/local/engine.go
@@ -642,7 +642,7 @@ func (e *Engine) ingestSSTLoop() {
 					}
 					ingestMetas := metas.metas
 					if e.config.Compact {
-						newMeta, err := e.sstIngester.mergeSSTs(metas.metas, e.sstDir)
+						newMeta, err := e.sstIngester.mergeSSTs(metas.metas, e.sstDir, e.config.BlockSize)
 						if err != nil {
 							e.setError(err)
 							return
@@ -1504,7 +1504,7 @@ func (h *sstIterHeap) Next() ([]byte, []byte, error) {
 // sstIngester is a interface used to merge and ingest SST files.
 // it's a interface mainly used for test convenience
 type sstIngester interface {
-	mergeSSTs(metas []*sstMeta, dir string) (*sstMeta, error)
+	mergeSSTs(metas []*sstMeta, dir string, blockSize int) (*sstMeta, error)
 	ingest([]*sstMeta) error
 }
 
@@ -1512,7 +1512,7 @@ type dbSSTIngester struct {
 	e *Engine
 }
 
-func (i dbSSTIngester) mergeSSTs(metas []*sstMeta, dir string) (*sstMeta, error) {
+func (i dbSSTIngester) mergeSSTs(metas []*sstMeta, dir string, blockSize int) (*sstMeta, error) {
 	if len(metas) == 0 {
 		return nil, errors.New("sst metas is empty")
 	} else if len(metas) == 1 {
@@ -1561,7 +1561,7 @@ func (i dbSSTIngester) mergeSSTs(metas []*sstMeta, dir string) (*sstMeta, error)
 	heap.Init(mergeIter)
 
 	name := filepath.Join(dir, fmt.Sprintf("%s.sst", uuid.New()))
-	writer, err := newSSTWriter(name, 16*1024)
+	writer, err := newSSTWriter(name, blockSize)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/br/pkg/lightning/backend/local/engine_mgr.go
+++ b/br/pkg/lightning/backend/local/engine_mgr.go
@@ -207,7 +207,7 @@ func (em *engineManager) openEngineDB(engineUUID uuid.UUID, readOnly bool) (*peb
 	opt.Levels = []pebble.LevelOptions{
 		{
 			TargetFileSize: 16 * units.GiB,
-			BlockSize:      local.BackendConfig.BlockSize,
+			BlockSize:      int(local.BackendConfig.BlockSize),
 		},
 	}
 

--- a/br/pkg/lightning/backend/local/engine_mgr.go
+++ b/br/pkg/lightning/backend/local/engine_mgr.go
@@ -207,6 +207,7 @@ func (em *engineManager) openEngineDB(engineUUID uuid.UUID, readOnly bool) (*peb
 	opt.Levels = []pebble.LevelOptions{
 		{
 			TargetFileSize: 16 * units.GiB,
+			BlockSize:      local.BackendConfig.BlockSize
 		},
 	}
 

--- a/br/pkg/lightning/backend/local/engine_mgr.go
+++ b/br/pkg/lightning/backend/local/engine_mgr.go
@@ -207,7 +207,7 @@ func (em *engineManager) openEngineDB(engineUUID uuid.UUID, readOnly bool) (*peb
 	opt.Levels = []pebble.LevelOptions{
 		{
 			TargetFileSize: 16 * units.GiB,
-			BlockSize:      int(local.BackendConfig.BlockSize),
+			BlockSize:      em.BlockSize,
 		},
 	}
 

--- a/br/pkg/lightning/backend/local/engine_mgr.go
+++ b/br/pkg/lightning/backend/local/engine_mgr.go
@@ -207,7 +207,7 @@ func (em *engineManager) openEngineDB(engineUUID uuid.UUID, readOnly bool) (*peb
 	opt.Levels = []pebble.LevelOptions{
 		{
 			TargetFileSize: 16 * units.GiB,
-			BlockSize:      local.BackendConfig.BlockSize
+			BlockSize:      local.BackendConfig.BlockSize,
 		},
 	}
 

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -703,40 +703,6 @@ func (*Backend) ShouldPostProcess() bool {
 	return true
 }
 
-<<<<<<< HEAD
-=======
-func (local *Backend) openEngineDB(engineUUID uuid.UUID, readOnly bool) (*pebble.DB, error) {
-	opt := &pebble.Options{
-		MemTableSize: local.MemTableSize,
-		// the default threshold value may cause write stall.
-		MemTableStopWritesThreshold: 8,
-		MaxConcurrentCompactions:    16,
-		// set threshold to half of the max open files to avoid trigger compaction
-		L0CompactionThreshold: math.MaxInt32,
-		L0StopWritesThreshold: math.MaxInt32,
-		LBaseMaxBytes:         16 * units.TiB,
-		MaxOpenFiles:          local.MaxOpenFiles,
-		DisableWAL:            true,
-		ReadOnly:              readOnly,
-		TablePropertyCollectors: []func() pebble.TablePropertyCollector{
-			newRangePropertiesCollector,
-		},
-		DisableAutomaticCompactions: local.DisableAutomaticCompactions,
-	}
-	// set level target file size to avoid pebble auto triggering compaction that split ingest SST files into small SST.
-	opt.Levels = []pebble.LevelOptions{
-		{
-			TargetFileSize: 16 * units.GiB,
-			BlockSize:      local.BackendConfig.BlockSize,
-		},
-	}
-
-	dbPath := filepath.Join(local.LocalStoreDir, engineUUID.String())
-	db, err := pebble.Open(dbPath, opt)
-	return db, errors.Trace(err)
-}
-
->>>>>>> 524397d07 (change type to bytesize)
 // OpenEngine must be called with holding mutex of Engine.
 func (local *Backend) OpenEngine(ctx context.Context, cfg *backend.EngineConfig, engineUUID uuid.UUID) error {
 	return local.engineMgr.openEngine(ctx, cfg, engineUUID)

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -431,7 +431,7 @@ func NewBackendConfig(cfg *config.Config, maxOpenFiles int, keyspaceName, resour
 		MaxConnPerStore:             cfg.TikvImporter.RangeConcurrency,
 		ConnCompressType:            cfg.TikvImporter.CompressKVPairs,
 		WorkerConcurrency:           cfg.TikvImporter.RangeConcurrency * 2,
-		BlockSize:                   cfg.TikvImporter.BlockSize,
+		BlockSize:                   int(cfg.TikvImporter.BlockSize),
 		KVWriteBatchSize:            int64(cfg.TikvImporter.SendKVSize),
 		RegionSplitBatchSize:        cfg.TikvImporter.RegionSplitBatchSize,
 		RegionSplitConcurrency:      cfg.TikvImporter.RegionSplitConcurrency,

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -703,6 +703,40 @@ func (*Backend) ShouldPostProcess() bool {
 	return true
 }
 
+<<<<<<< HEAD
+=======
+func (local *Backend) openEngineDB(engineUUID uuid.UUID, readOnly bool) (*pebble.DB, error) {
+	opt := &pebble.Options{
+		MemTableSize: local.MemTableSize,
+		// the default threshold value may cause write stall.
+		MemTableStopWritesThreshold: 8,
+		MaxConcurrentCompactions:    16,
+		// set threshold to half of the max open files to avoid trigger compaction
+		L0CompactionThreshold: math.MaxInt32,
+		L0StopWritesThreshold: math.MaxInt32,
+		LBaseMaxBytes:         16 * units.TiB,
+		MaxOpenFiles:          local.MaxOpenFiles,
+		DisableWAL:            true,
+		ReadOnly:              readOnly,
+		TablePropertyCollectors: []func() pebble.TablePropertyCollector{
+			newRangePropertiesCollector,
+		},
+		DisableAutomaticCompactions: local.DisableAutomaticCompactions,
+	}
+	// set level target file size to avoid pebble auto triggering compaction that split ingest SST files into small SST.
+	opt.Levels = []pebble.LevelOptions{
+		{
+			TargetFileSize: 16 * units.GiB,
+			BlockSize:      local.BackendConfig.BlockSize,
+		},
+	}
+
+	dbPath := filepath.Join(local.LocalStoreDir, engineUUID.String())
+	db, err := pebble.Open(dbPath, opt)
+	return db, errors.Trace(err)
+}
+
+>>>>>>> 524397d07 (change type to bytesize)
 // OpenEngine must be called with holding mutex of Engine.
 func (local *Backend) OpenEngine(ctx context.Context, cfg *backend.EngineConfig, engineUUID uuid.UUID) error {
 	return local.engineMgr.openEngine(ctx, cfg, engineUUID)

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -420,6 +420,7 @@ type BackendConfig struct {
 	// see DisableAutomaticCompactions of pebble.Options for more details.
 	// default true.
 	DisableAutomaticCompactions bool
+	BlockSize                   int
 }
 
 // NewBackendConfig creates a new BackendConfig.
@@ -430,6 +431,7 @@ func NewBackendConfig(cfg *config.Config, maxOpenFiles int, keyspaceName, resour
 		MaxConnPerStore:             cfg.TikvImporter.RangeConcurrency,
 		ConnCompressType:            cfg.TikvImporter.CompressKVPairs,
 		WorkerConcurrency:           cfg.TikvImporter.RangeConcurrency * 2,
+		BlockSize:                   cfg.TikvImporter.BlockSize,
 		KVWriteBatchSize:            int64(cfg.TikvImporter.SendKVSize),
 		RegionSplitBatchSize:        cfg.TikvImporter.RegionSplitBatchSize,
 		RegionSplitConcurrency:      cfg.TikvImporter.RegionSplitConcurrency,

--- a/br/pkg/lightning/backend/local/local_test.go
+++ b/br/pkg/lightning/backend/local/local_test.go
@@ -448,7 +448,7 @@ func (c *mockSplitClient) GetRegion(ctx context.Context, key []byte) (*split.Reg
 
 type testIngester struct{}
 
-func (i testIngester) mergeSSTs(metas []*sstMeta, dir string) (*sstMeta, error) {
+func (i testIngester) mergeSSTs(metas []*sstMeta, dir string, blockSize int) (*sstMeta, error) {
 	if len(metas) == 0 {
 		return nil, errors.New("sst metas is empty")
 	} else if len(metas) == 1 {
@@ -614,7 +614,7 @@ func testMergeSSTs(t *testing.T, kvs [][]common.KvPair, meta *sstMeta) {
 	}
 
 	i := dbSSTIngester{e: f}
-	newMeta, err := i.mergeSSTs(metas, tmpPath)
+	newMeta, err := i.mergeSSTs(metas, tmpPath, 16*1024)
 	require.NoError(t, err)
 
 	require.Equal(t, meta.totalCount, newMeta.totalCount)

--- a/br/pkg/lightning/backend/local/local_test.go
+++ b/br/pkg/lightning/backend/local/local_test.go
@@ -592,7 +592,7 @@ func testMergeSSTs(t *testing.T, kvs [][]common.KvPair, meta *sstMeta) {
 
 	createSSTWriter := func() (*sstWriter, error) {
 		path := filepath.Join(f.sstDir, uuid.New().String()+".sst")
-		writer, err := newSSTWriter(path)
+		writer, err := newSSTWriter(path, 16*1024)
 		if err != nil {
 			return nil, err
 		}

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -1070,6 +1070,7 @@ type TikvImporter struct {
 	StoreWriteBWLimit       ByteSize `toml:"store-write-bwlimit" json:"store-write-bwlimit"`
 	// default is PausePDSchedulerScopeTable to compatible with previous version(>= 6.1)
 	PausePDSchedulerScope PausePDSchedulerScope `toml:"pause-pd-scheduler-scope" json:"pause-pd-scheduler-scope"`
+	BlockSize             int                   `toml:"block-size" json:"block-size"`
 }
 
 func (t *TikvImporter) adjust() error {
@@ -1457,6 +1458,7 @@ func NewConfig() *Config {
 			DiskQuota:               ByteSize(math.MaxInt64),
 			DuplicateResolution:     DupeResAlgNone,
 			PausePDSchedulerScope:   PausePDSchedulerScopeTable,
+			BlockSize:               8192,
 		},
 		PostRestore: PostRestore{
 			Checksum:          OpLevelRequired,

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -1071,7 +1071,7 @@ type TikvImporter struct {
 	// default is PausePDSchedulerScopeTable to compatible with previous version(>= 6.1)
 	PausePDSchedulerScope PausePDSchedulerScope `toml:"pause-pd-scheduler-scope" json:"pause-pd-scheduler-scope"`
 	// block size is in KiB
-	BlockSize int `toml:"block-size" json:"block-size"`
+	BlockSize ByteSize `toml:"block-size" json:"block-size"`
 }
 
 func (t *TikvImporter) adjust() error {

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -1070,7 +1070,7 @@ type TikvImporter struct {
 	StoreWriteBWLimit       ByteSize `toml:"store-write-bwlimit" json:"store-write-bwlimit"`
 	// default is PausePDSchedulerScopeTable to compatible with previous version(>= 6.1)
 	PausePDSchedulerScope PausePDSchedulerScope `toml:"pause-pd-scheduler-scope" json:"pause-pd-scheduler-scope"`
-	BlockSize ByteSize `toml:"block-size" json:"block-size"`
+	BlockSize             ByteSize              `toml:"block-size" json:"block-size"`
 }
 
 func (t *TikvImporter) adjust() error {

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -1459,7 +1459,7 @@ func NewConfig() *Config {
 			DiskQuota:               ByteSize(math.MaxInt64),
 			DuplicateResolution:     DupeResAlgNone,
 			PausePDSchedulerScope:   PausePDSchedulerScopeTable,
-			BlockSize:               8192,
+			BlockSize:               16 * 1024,
 		},
 		PostRestore: PostRestore{
 			Checksum:          OpLevelRequired,

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -1070,7 +1070,8 @@ type TikvImporter struct {
 	StoreWriteBWLimit       ByteSize `toml:"store-write-bwlimit" json:"store-write-bwlimit"`
 	// default is PausePDSchedulerScopeTable to compatible with previous version(>= 6.1)
 	PausePDSchedulerScope PausePDSchedulerScope `toml:"pause-pd-scheduler-scope" json:"pause-pd-scheduler-scope"`
-	BlockSize             int                   `toml:"block-size" json:"block-size"`
+	// block size is in KiB
+	BlockSize int `toml:"block-size" json:"block-size"`
 }
 
 func (t *TikvImporter) adjust() error {

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -1070,7 +1070,6 @@ type TikvImporter struct {
 	StoreWriteBWLimit       ByteSize `toml:"store-write-bwlimit" json:"store-write-bwlimit"`
 	// default is PausePDSchedulerScopeTable to compatible with previous version(>= 6.1)
 	PausePDSchedulerScope PausePDSchedulerScope `toml:"pause-pd-scheduler-scope" json:"pause-pd-scheduler-scope"`
-	// block size is in KiB
 	BlockSize ByteSize `toml:"block-size" json:"block-size"`
 }
 

--- a/br/pkg/lightning/importer/table_import.go
+++ b/br/pkg/lightning/importer/table_import.go
@@ -449,6 +449,7 @@ func (tr *TableImporter) importEngines(pCtx context.Context, rc *Controller, cp 
 				Compact:            threshold > 0,
 				CompactConcurrency: 4,
 				CompactThreshold:   threshold,
+				BlockSize:          rc.cfg.TikvImporter.BlockSize,
 			}
 		}
 		// import backend can't reopen engine if engine is closed, so

--- a/br/pkg/lightning/importer/table_import.go
+++ b/br/pkg/lightning/importer/table_import.go
@@ -449,7 +449,7 @@ func (tr *TableImporter) importEngines(pCtx context.Context, rc *Controller, cp 
 				Compact:            threshold > 0,
 				CompactConcurrency: 4,
 				CompactThreshold:   threshold,
-				BlockSize:          rc.cfg.TikvImporter.BlockSize,
+				BlockSize:          int(rc.cfg.TikvImporter.BlockSize),
 			}
 		}
 		// import backend can't reopen engine if engine is closed, so

--- a/pkg/ddl/ingest/config.go
+++ b/pkg/ddl/ingest/config.go
@@ -91,7 +91,7 @@ func generateLocalEngineConfig(id int64, dbName, tbName string) *backend.EngineC
 			Compact:            true,
 			CompactThreshold:   int64(compactMemory),
 			CompactConcurrency: compactConcurrency,
-			BlockSize:          8192, // using default for DDL
+			BlockSize:          16 * 1024, // using default for DDL
 		},
 		TableInfo: &checkpoints.TidbTableInfo{
 			ID:   id,

--- a/pkg/ddl/ingest/config.go
+++ b/pkg/ddl/ingest/config.go
@@ -91,6 +91,7 @@ func generateLocalEngineConfig(id int64, dbName, tbName string) *backend.EngineC
 			Compact:            true,
 			CompactThreshold:   int64(compactMemory),
 			CompactConcurrency: compactConcurrency,
+			BlockSize:          8192, // using default for DDL
 		},
 		TableInfo: &checkpoints.TidbTableInfo{
 			ID:   id,

--- a/pkg/executor/importer/table_import.go
+++ b/pkg/executor/importer/table_import.go
@@ -461,6 +461,7 @@ func (ti *TableImporter) OpenIndexEngine(ctx context.Context, engineID int32) (*
 		Compact:            threshold > 0,
 		CompactConcurrency: 4,
 		CompactThreshold:   threshold,
+		BlockSize:          8192,
 	}
 	fullTableName := ti.fullTableName()
 	// todo: cleanup all engine data on any error since we don't support checkpoint for now

--- a/pkg/executor/importer/table_import.go
+++ b/pkg/executor/importer/table_import.go
@@ -461,7 +461,7 @@ func (ti *TableImporter) OpenIndexEngine(ctx context.Context, engineID int32) (*
 		Compact:            threshold > 0,
 		CompactConcurrency: 4,
 		CompactThreshold:   threshold,
-		BlockSize:          8192,
+		BlockSize:          16 * 1024,
 	}
 	fullTableName := ti.fullTableName()
 	// todo: cleanup all engine data on any error since we don't support checkpoint for now


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45037

Problem Summary:
We have seen that lightning is bounded by EBS IOPS which is 16k and is taking more than 3 hours to transfer 7 TB of data. 
### What changed and how does it work?

I have made the block size configurable through lightning config. We are setting it 128k internally. 
### Check List

Tests <!-- At least one of them must be included. -->
- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Its running in production with 128k size. However, i haven't tested the master code. I am relying on pingcap CI to test it. 
Side effects


I haven't seen much increase in memory and CPU after increasing the block size. 
Documentation

- [X] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
