### PR TITLE
Lightning: support multiple PD addresses

### DIFF
--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -218,8 +218,12 @@ func (d *DBStore) adjust(
 			// verify that it is not a empty string
 			pdAddrs := strings.Split(settings.Path, ",")
 			for _, ip := range pdAddrs {
-				if ip == "" {
-					return common.ErrInvalidConfig.GenWithStack("invalid `pd address` setting")
+				ipPort := strings.Split(ip, ":")
+				if len(ipPort[0]) == 0 {
+					return common.ErrInvalidConfig.GenWithStack("invalid `tidb.pd-addr` setting")
+				}
+				if len(ipPort[1]) == 0 || ipPort[1] == "0" {
+					return common.ErrInvalidConfig.GenWithStack("invalid `tidb.port` setting")
 				}
 			}
 			d.PdAddr = settings.Path

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -218,7 +218,7 @@ func (d *DBStore) adjust(
 			// verify that it is not a empty string
 			pdAddrs := strings.Split(settings.Path, ",")
 			for _, ip := range pdAddrs {
-				if net.ParseIP(ip) == nil {
+				if ip == "" {
 					return common.ErrInvalidConfig.GenWithStack("invalid `pd address` setting")
 				}
 			}

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -215,6 +215,13 @@ func (d *DBStore) adjust(
 			d.Port = int(settings.Port)
 		}
 		if len(d.PdAddr) == 0 {
+			// verify that it is not a empty string
+			pdAddrs := strings.Split(settings.Path, ",")
+			for _, ip := range pdAddrs {
+				if net.ParseIP(ip) == nil {
+					return common.ErrInvalidConfig.GenWithStack("invalid `pd address` setting")
+				}
+			}
 			d.PdAddr = settings.Path
 		}
 	}

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -214,10 +214,7 @@ func (d *DBStore) adjust(
 		if d.Port <= 0 {
 			d.Port = int(settings.Port)
 		}
-		if len(d.PdAddr) == 0 {
-			pdAddrs := strings.Split(settings.Path, ",")
-			d.PdAddr = pdAddrs[0] // FIXME support multiple PDs once importer can.
-		}
+		d.PdAddr = settings.Path
 	}
 
 	if d.Port <= 0 {

--- a/br/pkg/lightning/config/config.go
+++ b/br/pkg/lightning/config/config.go
@@ -214,7 +214,9 @@ func (d *DBStore) adjust(
 		if d.Port <= 0 {
 			d.Port = int(settings.Port)
 		}
-		d.PdAddr = settings.Path
+		if len(d.PdAddr) == 0 {
+			d.PdAddr = settings.Path
+		}
 	}
 
 	if d.Port <= 0 {

--- a/br/pkg/lightning/config/config_test.go
+++ b/br/pkg/lightning/config/config_test.go
@@ -273,7 +273,6 @@ func TestInvalidSetting(t *testing.T) {
 	cfg.TikvImporter.SortedKVDir = "."
 	cfg.TiDB.DistSQLScanConcurrency = 1
 	cfg.Mydumper.SourceDir = "."
-	cfg.TiDB.PdAddr = "234.56.78.90:12345"
 
 	err := cfg.Adjust(context.Background())
 	require.EqualError(t, err, "[Lightning:Config:ErrInvalidConfig]invalid `tidb.port` setting")

--- a/br/pkg/lightning/config/config_test.go
+++ b/br/pkg/lightning/config/config_test.go
@@ -273,6 +273,7 @@ func TestInvalidSetting(t *testing.T) {
 	cfg.TikvImporter.SortedKVDir = "."
 	cfg.TiDB.DistSQLScanConcurrency = 1
 	cfg.Mydumper.SourceDir = "."
+	cfg.TiDB.PdAddr = "234.56.78.90:12345"
 
 	err := cfg.Adjust(context.Background())
 	require.EqualError(t, err, "[Lightning:Config:ErrInvalidConfig]invalid `tidb.port` setting")

--- a/br/pkg/lightning/config/config_test.go
+++ b/br/pkg/lightning/config/config_test.go
@@ -79,7 +79,7 @@ func TestAdjustPdAddrAndPort(t *testing.T) {
 	err := cfg.Adjust(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 4444, cfg.TiDB.Port)
-	require.Equal(t, "123.45.67.89:1234", cfg.TiDB.PdAddr)
+	require.Equal(t, "123.45.67.89:1234,56.78.90.12:3456", cfg.TiDB.PdAddr)
 }
 
 func TestPausePDSchedulerScope(t *testing.T) {

--- a/br/pkg/lightning/importer/import.go
+++ b/br/pkg/lightning/importer/import.go
@@ -357,7 +357,9 @@ func NewImportControllerWithPauser(
 		if maxOpenFiles < 0 {
 			maxOpenFiles = math.MaxInt32
 		}
-		pdCli, err = pd.NewClientWithContext(ctx, []string{cfg.TiDB.PdAddr}, tls.ToPDSecurityOption())
+
+		addrs := strings.Split(cfg.TiDB.PdAddr, ",")
+		pdCli, err = pd.NewClientWithContext(ctx, addrs, tls.ToPDSecurityOption())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1437,7 +1439,8 @@ const (
 
 func (rc *Controller) keepPauseGCForDupeRes(ctx context.Context) (<-chan struct{}, error) {
 	tlsOpt := rc.tls.ToPDSecurityOption()
-	pdCli, err := pd.NewClientWithContext(ctx, []string{rc.pdCli.GetLeaderAddr()}, tlsOpt)
+	addrs := strings.Split(rc.cfg.TiDB.PdAddr, ",")
+	pdCli, err := pd.NewClientWithContext(ctx, addrs, tlsOpt)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/br/tests/lightning_pd_leader_switch/run.sh
+++ b/br/tests/lightning_pd_leader_switch/run.sh
@@ -48,7 +48,7 @@ sleep 5
 start_tidb
 
 export GO_FAILPOINTS='github.com/pingcap/tidb/br/pkg/lightning/importer/beforeRun=sleep(60000)'
-run_lightning --backend local --enable-checkpoint=0 &
+run_lightning --backend local --enable-checkpoint=0 --pd-urls '127.0.0.1:9999,127.0.0.1:2379' &
 lightning_pid=$!
 # in many libraries, etcd client's auto-sync-interval is 30s, so we need to wait at least 30s before kill PD leader
 sleep 45

--- a/br/tests/lightning_pd_leader_switch/run.sh
+++ b/br/tests/lightning_pd_leader_switch/run.sh
@@ -48,7 +48,7 @@ sleep 5
 start_tidb
 
 export GO_FAILPOINTS='github.com/pingcap/tidb/br/pkg/lightning/importer/beforeRun=sleep(60000)'
-run_lightning --backend local --enable-checkpoint=0 --pd-urls '127.0.0.1:9999,127.0.0.1:2379' &
+run_lightning --backend local --enable-checkpoint=0 &
 lightning_pid=$!
 # in many libraries, etcd client's auto-sync-interval is 30s, so we need to wait at least 30s before kill PD leader
 sleep 45

--- a/pkg/executor/importer/table_import.go
+++ b/pkg/executor/importer/table_import.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -134,7 +135,8 @@ func GetTiKVModeSwitcherWithPDClient(ctx context.Context, logger *zap.Logger) (p
 		return nil, nil, err
 	}
 	tlsOpt := tls.ToPDSecurityOption()
-	pdCli, err := pd.NewClientWithContext(ctx, []string{tidbCfg.Path}, tlsOpt)
+	addrs := strings.Split(tidbCfg.Path, ",")
+	pdCli, err := pd.NewClientWithContext(ctx, addrs, tlsOpt)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -169,7 +171,8 @@ func GetRegionSplitSizeKeys(ctx context.Context) (regionSplitSize int64, regionS
 		return 0, 0, err
 	}
 	tlsOpt := tls.ToPDSecurityOption()
-	pdCli, err := pd.NewClientWithContext(ctx, []string{tidbCfg.Path}, tlsOpt)
+	addrs := strings.Split(tidbCfg.Path, ",")
+	pdCli, err := pd.NewClientWithContext(ctx, addrs, tlsOpt)
 	if err != nil {
 		return 0, 0, errors.Trace(err)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49515

Problem Summary:
Lightning doesn't support multiple PD addresses in config file. It made to lightning to fail if that PD address is down before import is started.
### What changed and how does it work?
It is a simple fix as PD client already supports multiple PD addresses. We only need to parse it correctly and give to list of PD addresses while creating the PD client. 
### Check List

Tests <!-- At least one of them must be included. -->
- [X] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

It is tested in 6.5 and already deployed to production cluster

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [X] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
