### PR TITLE
parser: raise error for empty db name | tidb-test=pr/2275

### DIFF
--- a/pkg/parser/misc.go
+++ b/pkg/parser/misc.go
@@ -29,6 +29,17 @@ func isIdentExtend(ch byte) bool {
 	return ch >= 0x80
 }
 
+// See https://dev.mysql.com/doc/refman/5.7/en/identifiers.html
+func isInCorrectIdentifierName(name string) bool {
+	if len(name) == 0 {
+		return true
+	}
+	if name[len(name)-1] == ' ' {
+		return true
+	}
+	return false
+}
+
 // Initialize a lookup table for isUserVarChar
 var isUserVarCharTable [256]bool
 

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -8788,7 +8788,7 @@ TableName:
 |	Identifier '.' Identifier
 	{
 		schema := $1
-		if schema == "" {
+		if isInCorrectIdentifierName(schema) {
 			yylex.AppendError(ErrWrongDBName.GenWithStackByArgs(schema))
 			return 1
 		}

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -8787,7 +8787,12 @@ TableName:
 	}
 |	Identifier '.' Identifier
 	{
-		$$ = &ast.TableName{Schema: model.NewCIStr($1), Name: model.NewCIStr($3)}
+		schema := $1
+		if schema == "" {
+			yylex.AppendError(ErrWrongDBName.GenWithStackByArgs(schema))
+			return 1
+		}
+		$$ = &ast.TableName{Schema: model.NewCIStr(schema), Name: model.NewCIStr($3)}
 	}
 |	'*' '.' Identifier
 	{

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -3961,6 +3961,9 @@ func TestErrorMsg(t *testing.T) {
 	_, _, err = p.Parse("create table ``.t (id int);", "", "")
 	require.EqualError(t, err, "[parser:1102]Incorrect database name ''")
 
+	_, _, err = p.Parse("create table ` `.t (id int);", "", "")
+	require.EqualError(t, err, "[parser:1102]Incorrect database name ' '")
+
 	_, _, err = p.Parse("select ifnull(a,0) & ifnull(a,0) like '55' ESCAPE '\\\\a' from t;", "", "")
 	require.EqualError(t, err, "[parser:1210]Incorrect arguments to ESCAPE")
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -3958,6 +3958,9 @@ func TestErrorMsg(t *testing.T) {
 	_, _, err = p.Parse("create table t(f_year year(5))ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;", "", "")
 	require.EqualError(t, err, "[parser:1818]Supports only YEAR or YEAR(4) column")
 
+	_, _, err = p.Parse("create table ``.t (id int);", "", "")
+	require.EqualError(t, err, "[parser:1102]Incorrect database name ''")
+
 	_, _, err = p.Parse("select ifnull(a,0) & ifnull(a,0) like '55' ESCAPE '\\\\a' from t;", "", "")
 	require.EqualError(t, err, "[parser:1210]Incorrect arguments to ESCAPE")
 

--- a/pkg/parser/yy_parser.go
+++ b/pkg/parser/yy_parser.go
@@ -58,6 +58,8 @@ var (
 	ErrWarnDeprecatedSyntaxNoReplacement = terror.ClassParser.NewStd(mysql.ErrWarnDeprecatedSyntaxNoReplacement)
 	// ErrWrongUsage returns for incorrect usages.
 	ErrWrongUsage = terror.ClassParser.NewStd(mysql.ErrWrongUsage)
+	// ErrWrongDBName returns for incorrect DB name.
+	ErrWrongDBName = terror.ClassParser.NewStd(mysql.ErrWrongDBName)
 	// SpecFieldPattern special result field pattern
 	SpecFieldPattern = regexp.MustCompile(`(\/\*!(M?[0-9]{5,6})?|\*\/)`)
 	specCodeStart    = regexp.MustCompile(`^\/\*!(M?[0-9]{5,6})?[ \t]*`)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45873

Problem Summary:
as-is
```
tidb> create table ``.t(id int);
Query OK, 0 rows affected (0.02 sec)
```

to-be (same as mysql)
```
tidb> create table ``.t(id int);
ERROR 1102 (42000): Incorrect database name ''
```

### What changed and how does it work?
When schema is empty string in {schema}.{table}, return error ("Incorrect database name ''").
```
# case 1: {schema}.{table} && schema is not empty -> no change
tidb> create table test.t(id int);
Query OK, 0 rows affected (0.02 sec)

# case 2: {table}  -> no change
tidb> create table t(id int);
Query OK, 0 rows affected (0.02 sec)

# case 3:  {schema}.{table} && schema is empty  -> change from ok to error
tidb> create table ``.t(id int);
ERROR 1102 (42000): Incorrect database name ''
```

The validation for case 3 will be done in parser layer.

The reason is that it's impossible to differenciate case 2 and case 3 in preprocessor layer.
Currently, in both case 2 and case 3, schema name is `""` before preprocessor layer and is filled with `currentDB` of the session  in processor layer.  
https://github.com/yoshikipom/tidb/blob/61e20358b2572f34b9f1832db28760845e496c66/pkg/planner/core/preprocess.go#L1531

So, I decided to filter out case 3 in parser layer.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
