### PR TITLE
global sort: enable concurrent read test

### DIFF
--- a/br/pkg/lightning/backend/external/byte_reader.go
+++ b/br/pkg/lightning/backend/external/byte_reader.go
@@ -313,7 +313,7 @@ func (r *byteReader) reload() error {
 func (r *byteReader) closeConcurrentReader() (reloadCnt, offsetInOldBuffer int) {
 	r.logger.Info("drop data in closeConcurrentReader",
 		zap.Int("reloadCnt", r.concurrentReader.reloadCnt),
-		zap.Int("dropBytes", len(r.curBuf)-r.curBufOffset),
+		zap.Int("dropBytes", len(r.curBuf[r.curBufIdx])-r.curBufOffset),
 	)
 	r.concurrentReader.largeBufferPool.Destroy()
 	r.concurrentReader.largeBuf = nil

--- a/br/pkg/lightning/backend/external/byte_reader.go
+++ b/br/pkg/lightning/backend/external/byte_reader.go
@@ -317,7 +317,7 @@ func (r *byteReader) reload() error {
 func (r *byteReader) closeConcurrentReader() (reloadCnt, offsetInOldBuffer int) {
 	r.logger.Info("drop data in closeConcurrentReader",
 		zap.Int("reloadCnt", r.concurrentReader.reloadCnt),
-		zap.Int("dropBytes", len(r.curBuf[r.curBufIdx])-r.curBufOffset),
+		zap.Int("dropBytes", r.concurrentReader.bufSizePerConc*(len(r.curBuf)-r.curBufIdx)-r.curBufOffset),
 		zap.Int("curBufIdx", r.curBufIdx),
 	)
 	r.concurrentReader.largeBufferPool.Destroy()

--- a/br/pkg/lightning/backend/external/byte_reader.go
+++ b/br/pkg/lightning/backend/external/byte_reader.go
@@ -212,8 +212,8 @@ func (r *byteReader) readNBytes(n int) ([]byte, error) {
 	if n > int(size.GB) {
 		return nil, errors.Errorf("read %d bytes from external storage, exceed max limit %d", n, size.GB)
 	}
-	if n < 0 {
-		return nil, errors.Errorf("read %d bytes from external storage", n)
+	if n <= 0 {
+		return nil, errors.Errorf("illegal n (%d) when reading from external storage", n)
 	}
 	auxBuf := make([]byte, n)
 	for _, b := range bs {

--- a/br/pkg/lightning/backend/external/byte_reader.go
+++ b/br/pkg/lightning/backend/external/byte_reader.go
@@ -147,7 +147,7 @@ func (r *byteReader) switchConcurrentMode(useConcurrent bool) error {
 	// is it's the end of file. When it's the end of the file, caller will see EOF
 	// and no further switchConcurrentMode should be called.
 	largeBufSize := readerFields.bufSizePerConc * readerFields.concurrency
-	delta := int64(offsetInOldBuf + (reloadCnt-1)*largeBufSize + (r.curBufIdx)*readerFields.bufSizePerConc)
+	delta := int64(offsetInOldBuf + (reloadCnt-1)*largeBufSize)
 
 	if _, err := r.storageReader.Seek(delta, io.SeekCurrent); err != nil {
 		return err
@@ -326,7 +326,7 @@ func (r *byteReader) closeConcurrentReader() (reloadCnt, offsetInOldBuffer int) 
 	reloadCnt = r.concurrentReader.reloadCnt
 	r.concurrentReader.reloadCnt = 0
 	r.curBuf = [][]byte{r.smallBuf}
-	offsetInOldBuffer = r.curBufOffset
+	offsetInOldBuffer = r.curBufOffset + r.curBufIdx*r.concurrentReader.bufSizePerConc
 	r.curBufOffset = 0
 	return
 }

--- a/br/pkg/lightning/backend/external/byte_reader_test.go
+++ b/br/pkg/lightning/backend/external/byte_reader_test.go
@@ -209,7 +209,7 @@ func TestEmptyContent(t *testing.T) {
 func TestSwitchMode(t *testing.T) {
 	st := storage.NewMemStorage()
 	// Prepare
-	fileSize := 1024 * 1024
+	fileSize := 1024 * 1024 * 40
 	err := st.WriteFile(context.Background(), "/testfile", make([]byte, fileSize))
 	require.NoError(t, err)
 
@@ -219,14 +219,14 @@ func TestSwitchMode(t *testing.T) {
 		return rsc
 	}
 	pool := membuf.NewPool()
-	ConcurrentReaderBufferSizePerConc = 100
-	br, err := newByteReader(context.Background(), newRsc(), 100)
-	require.NoError(t, err)
-	br.enableConcurrentRead(st, "/testfile", 100, 100, pool.NewBuffer())
-
+	// ConcurrentReaderBufferSizePerConc = rand.Intn(300) + 1
 	seed := time.Now().Unix()
 	rand.Seed(uint64(seed))
 	t.Logf("seed: %d", seed)
+	br, err := newByteReader(context.Background(), newRsc(), 64*1024)
+	require.NoError(t, err)
+	br.enableConcurrentRead(st, "/testfile", 100, ConcurrentReaderBufferSizePerConc, pool.NewBuffer())
+
 	totalCnt := 0
 	modeUseCon := false
 	for totalCnt < fileSize {
@@ -239,7 +239,7 @@ func TestSwitchMode(t *testing.T) {
 				modeUseCon = true
 			}
 		}
-		n := rand.Intn(100)
+		n := rand.Intn(300)
 		if n == 0 {
 			n = 1
 		}

--- a/br/pkg/lightning/backend/external/byte_reader_test.go
+++ b/br/pkg/lightning/backend/external/byte_reader_test.go
@@ -209,6 +209,7 @@ func TestEmptyContent(t *testing.T) {
 
 func TestSwitchMode(t *testing.T) {
 	seed := time.Now().Unix()
+	// seed := 1702880814
 	rand.Seed(uint64(seed))
 	t.Logf("seed: %d", seed)
 	st := storage.NewMemStorage()
@@ -243,7 +244,7 @@ func TestSwitchMode(t *testing.T) {
 	err = writer.Close(ctx)
 	require.NoError(t, err)
 	pool := membuf.NewPool()
-	ConcurrentReaderBufferSizePerConc = rand.Intn(300) + 1
+	ConcurrentReaderBufferSizePerConc = rand.Intn(100) + 1
 	kvReader, err := newKVReader(context.Background(), "/test/0/one-file", st, 0, 64*1024)
 	require.NoError(t, err)
 	kvReader.byteReader.enableConcurrentRead(st, "/test/0/one-file", 100, ConcurrentReaderBufferSizePerConc, pool.NewBuffer())

--- a/br/pkg/lightning/backend/external/byte_reader_test.go
+++ b/br/pkg/lightning/backend/external/byte_reader_test.go
@@ -209,7 +209,6 @@ func TestEmptyContent(t *testing.T) {
 
 func TestSwitchMode(t *testing.T) {
 	seed := time.Now().Unix()
-	// seed := 1702880814
 	rand.Seed(uint64(seed))
 	t.Logf("seed: %d", seed)
 	st := storage.NewMemStorage()

--- a/br/pkg/lightning/backend/external/byte_reader_test.go
+++ b/br/pkg/lightning/backend/external/byte_reader_test.go
@@ -248,8 +248,9 @@ func TestSwitchMode(t *testing.T) {
 	require.NoError(t, err)
 	kvReader.byteReader.enableConcurrentRead(st, "/test/0/one-file", 100, ConcurrentReaderBufferSizePerConc, pool.NewBuffer())
 	modeUseCon := false
+	i := 0
 	for {
-		if rand.Intn(2) == 0 {
+		if rand.Intn(5) == 0 {
 			if modeUseCon {
 				kvReader.byteReader.switchConcurrentMode(false)
 				modeUseCon = false
@@ -258,11 +259,14 @@ func TestSwitchMode(t *testing.T) {
 				modeUseCon = true
 			}
 		}
-		_, _, err := kvReader.nextKV()
+		key, val, err := kvReader.nextKV()
 		if err == io.EOF {
 			break
 		}
 		require.NoError(t, err)
+		require.Equal(t, kvs[i].Key, key)
+		require.Equal(t, kvs[i].Val, val)
+		i++
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #48952 close #49537

Problem Summary:

### What changed and how does it work?
1. enable switch concurrent mode in byte reader test
2. fix a bug when switch mode.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
