### PR TITLE
expression: enum/set could be invalid during evaluation

### DIFF
--- a/pkg/expression/chunk_executor.go
+++ b/pkg/expression/chunk_executor.go
@@ -183,7 +183,11 @@ func evalOneVec(ctx sessionctx.Context, expr Expression, input *chunk.Chunk, out
 				} else {
 					enum, err := types.ParseEnumName(ft.GetElems(), result.GetString(i), ft.GetCollate())
 					if err != nil {
-						logutil.BgLogger().Debug("Wrong enum value parsed during evaluation", zap.Error(err))
+						logutil.BgLogger().Debug("Wrong enum name parsed during evaluation",
+							zap.String("The name to be parsed in the ENUM", result.GetString(i)),
+							zap.Strings("The valid names in the ENUM", ft.GetElems()),
+							zap.Error(err),
+						)
 					}
 					buf.AppendEnum(enum)
 				}
@@ -199,7 +203,11 @@ func evalOneVec(ctx sessionctx.Context, expr Expression, input *chunk.Chunk, out
 				} else {
 					set, err := types.ParseSetName(ft.GetElems(), result.GetString(i), ft.GetCollate())
 					if err != nil {
-						logutil.BgLogger().Debug("Wrong set value parsed during evaluation", zap.Error(err))
+						logutil.BgLogger().Debug("Wrong set name parsed during evaluation",
+							zap.String("The name to be parsed in the SET", result.GetString(i)),
+							zap.Strings("The valid names in the SET", ft.GetElems()),
+							zap.Error(err),
+						)
 					}
 					buf.AppendSet(set)
 				}

--- a/pkg/expression/chunk_executor.go
+++ b/pkg/expression/chunk_executor.go
@@ -15,12 +15,13 @@
 package expression
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"go.uber.org/zap"
 )
 
 // Vectorizable checks whether a list of expressions can employ vectorized execution.
@@ -182,7 +183,7 @@ func evalOneVec(ctx sessionctx.Context, expr Expression, input *chunk.Chunk, out
 				} else {
 					enum, err := types.ParseEnumName(ft.GetElems(), result.GetString(i), ft.GetCollate())
 					if err != nil {
-						return errors.Errorf("Wrong enum value parsed during evaluation")
+						logutil.BgLogger().Debug("Wrong enum value parsed during evaluation", zap.Error(err))
 					}
 					buf.AppendEnum(enum)
 				}
@@ -198,7 +199,7 @@ func evalOneVec(ctx sessionctx.Context, expr Expression, input *chunk.Chunk, out
 				} else {
 					set, err := types.ParseSetName(ft.GetElems(), result.GetString(i), ft.GetCollate())
 					if err != nil {
-						return errors.Errorf("Wrong set value parsed during evaluation")
+						logutil.BgLogger().Debug("Wrong set value parsed during evaluation", zap.Error(err))
 					}
 					buf.AppendSet(set)
 				}

--- a/tests/integrationtest/r/expression/enum_set.result
+++ b/tests/integrationtest/r/expression/enum_set.result
@@ -1,0 +1,13 @@
+drop table if exists t01;
+CREATE TABLE `t01` (
+`6524d87a` timestamp DEFAULT '2024-10-02 01:54:55',
+`744e4d52` int(11) NOT NULL DEFAULT '2023959529',
+`087de3b2` varchar(122) DEFAULT '36h0hvfpylz0f0iv9h0ownfcg3rehi4',
+`26cbbf2a` enum('l7i9','3sdz3','83','4','92p','4g','8y5rn','7gp','7','1','e') NOT NULL DEFAULT '4',
+PRIMARY KEY (`744e4d52`,`26cbbf2a`) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=gbk COLLATE=gbk_chinese_ci COMMENT='7ad99128'
+PARTITION BY HASH (`744e4d52`) PARTITIONS 9;
+insert ignore into t01 values ("2023-01-01 20:01:02", 123, 'abcd', '');
+select `t01`.`26cbbf2a` as r0 from `t01` where `t01`.`6524d87a` in ( '2010-05-25') or not( `t01`.`26cbbf2a` > '1' ) ;
+r0
+

--- a/tests/integrationtest/t/expression/enum_set.test
+++ b/tests/integrationtest/t/expression/enum_set.test
@@ -1,0 +1,12 @@
+# https://github.com/pingcap/tidb/issues/49487
+drop table if exists t01;
+CREATE TABLE `t01` (
+  `6524d87a` timestamp DEFAULT '2024-10-02 01:54:55',
+  `744e4d52` int(11) NOT NULL DEFAULT '2023959529',
+  `087de3b2` varchar(122) DEFAULT '36h0hvfpylz0f0iv9h0ownfcg3rehi4',
+  `26cbbf2a` enum('l7i9','3sdz3','83','4','92p','4g','8y5rn','7gp','7','1','e') NOT NULL DEFAULT '4',
+  PRIMARY KEY (`744e4d52`,`26cbbf2a`) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=gbk COLLATE=gbk_chinese_ci COMMENT='7ad99128'
+PARTITION BY HASH (`744e4d52`) PARTITIONS 9;
+insert ignore into t01 values ("2023-01-01 20:01:02", 123, 'abcd', '');
+select `t01`.`26cbbf2a` as r0 from `t01` where `t01`.`6524d87a` in ( '2010-05-25') or not( `t01`.`26cbbf2a` > '1' ) ;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49487 

Problem Summary:

### What changed and how does it work?

The invalid enum/set value can exist during evaluation. So we should not throw error here.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
