### PR TITLE
executor: refactor executor pkg's warning and note generation

### DIFF
--- a/pkg/executor/aggfuncs/func_group_concat.go
+++ b/pkg/executor/aggfuncs/func_group_concat.go
@@ -75,7 +75,7 @@ func (e *baseGroupConcat4String) handleTruncateError(sctx sessionctx.Context) (e
 		if !sctx.GetSessionVars().StmtCtx.TypeFlags().TruncateAsWarning() {
 			return expression.ErrCutValueGroupConcat.GenWithStackByArgs(e.args[0].String())
 		}
-		sctx.GetSessionVars().StmtCtx.AppendWarning(expression.ErrCutValueGroupConcat.GenWithStackByArgs(e.args[0].String()))
+		sctx.GetSessionVars().StmtCtx.AppendWarning(expression.ErrCutValueGroupConcat.FastGenByArgs(e.args[0].String()))
 	}
 	return nil
 }

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -292,7 +292,7 @@ func warnLockedTableMsg(sessionVars *variable.SessionVars, needAnalyzeTableCnt u
 		} else {
 			msg = "skip analyze locked table: %s"
 		}
-		sessionVars.StmtCtx.AppendWarning(errors.Errorf(msg, tables))
+		sessionVars.StmtCtx.AppendWarning(errors.NewNoStackErrorf(msg, tables))
 	}
 }
 

--- a/pkg/executor/bind.go
+++ b/pkg/executor/bind.go
@@ -117,7 +117,7 @@ func (e *SQLBindExec) setBindingStatus() error {
 	}
 	ok, err := domain.GetDomain(e.Ctx()).BindHandle().SetGlobalBindingStatus(e.normdOrigSQL, bindInfo, e.newStatus)
 	if err == nil && !ok {
-		warningMess := errors.New("There are no bindings can be set the status. Please check the SQL text")
+		warningMess := errors.NewNoStackError("There are no bindings can be set the status. Please check the SQL text")
 		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(warningMess)
 	}
 	return err
@@ -126,7 +126,7 @@ func (e *SQLBindExec) setBindingStatus() error {
 func (e *SQLBindExec) setBindingStatusByDigest() error {
 	ok, err := domain.GetDomain(e.Ctx()).BindHandle().SetGlobalBindingStatusByDigest(e.newStatus, e.sqlDigest)
 	if err == nil && !ok {
-		warningMess := errors.New("There are no bindings can be set the status. Please check the SQL text")
+		warningMess := errors.NewNoStackError("There are no bindings can be set the status. Please check the SQL text")
 		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(warningMess)
 	}
 	return err

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -2651,7 +2651,7 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 		if *sampleRate < 0 {
 			*sampleRate, sampleRateReason = b.getAdjustedSampleRate(task)
 			if task.PartitionName != "" {
-				sc.AppendNote(errors.Errorf(
+				sc.AppendNote(errors.NewNoStackErrorf(
 					`Analyze use auto adjusted sample rate %f for table %s.%s's partition %s, reason to use this rate is "%s"`,
 					*sampleRate,
 					task.DBName,
@@ -2660,7 +2660,7 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 					sampleRateReason,
 				))
 			} else {
-				sc.AppendNote(errors.Errorf(
+				sc.AppendNote(errors.NewNoStackErrorf(
 					`Analyze use auto adjusted sample rate %f for table %s.%s, reason to use this rate is "%s"`,
 					*sampleRate,
 					task.DBName,
@@ -3409,7 +3409,7 @@ func (b *executorBuilder) buildTableReader(v *plannercore.PhysicalTableReader) e
 	useTiFlash := useMPP || useTiFlashBatchCop
 	if useTiFlash {
 		if _, isTiDBZoneLabelSet := config.GetGlobalConfig().Labels[placement.DCLabelKey]; b.ctx.GetSessionVars().TiFlashReplicaRead != tiflash.AllReplicas && !isTiDBZoneLabelSet {
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("the variable tiflash_replica_read is ignored, because the entry TiDB[%s] does not set the zone attribute and tiflash_replica_read is '%s'", config.GetGlobalConfig().AdvertiseAddress, tiflash.GetTiFlashReplicaRead(b.ctx.GetSessionVars().TiFlashReplicaRead)))
+			b.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf("the variable tiflash_replica_read is ignored, because the entry TiDB[%s] does not set the zone attribute and tiflash_replica_read is '%s'", config.GetGlobalConfig().AdvertiseAddress, tiflash.GetTiFlashReplicaRead(b.ctx.GetSessionVars().TiFlashReplicaRead)))
 		}
 	}
 	if useMPP {

--- a/pkg/executor/compact_table.go
+++ b/pkg/executor/compact_table.go
@@ -87,7 +87,7 @@ func (e *CompactTableTiFlashExec) Next(ctx context.Context, chk *chunk.Chunk) er
 func (e *CompactTableTiFlashExec) doCompact(execCtx context.Context) error {
 	vars := e.Ctx().GetSessionVars()
 	if e.tableInfo.TiFlashReplica == nil || e.tableInfo.TiFlashReplica.Count == 0 {
-		vars.StmtCtx.AppendWarning(errors.Errorf("compact skipped: no tiflash replica in the table"))
+		vars.StmtCtx.AppendWarning(errors.NewNoStackErrorf("compact skipped: no tiflash replica in the table"))
 		return nil
 	}
 
@@ -257,33 +257,38 @@ func (task *storeCompactTask) compactOnePhysicalTable(physicalTableID int64) (bo
 		if err != nil {
 			// Even after backoff, the request is still failed.., or the request is cancelled or timed out
 			// For example, the store is down. Let's simply don't compact other partitions.
-			warn := errors.Errorf("compact on store %s failed: %v", task.targetStore.Address, err)
+			warn := errors.NewNoStackErrorf("compact on store %s failed: %v", task.targetStore.Address, err)
 			task.parentExec.Ctx().GetSessionVars().StmtCtx.AppendWarning(warn)
+			newErr := errors.Trace(warn)
 			task.logFailure(
 				zap.Int64("physical-table-id", physicalTableID),
 				zap.Error(err))
-			return false, warn
+			return false, newErr
 		}
 		if resp.GetError() != nil {
 			switch resp.GetError().GetError().(type) {
 			case *kvrpcpb.CompactError_ErrCompactInProgress:
-				warn := errors.Errorf("compact on store %s failed: table is compacting in progress", task.targetStore.Address)
+				// warn is light stackless.
+				warn := errors.NewNoStackErrorf("compact on store %s failed: table is compacting in progress", task.targetStore.Address)
 				task.parentExec.Ctx().GetSessionVars().StmtCtx.AppendWarning(warn)
+				err := errors.Trace(warn)
 				task.logFailure(
 					zap.Int64("physical-table-id", physicalTableID),
-					zap.Error(warn))
+					zap.Error(err))
 				// TiFlash reported that there are existing compacting for the same table.
 				// We should stop the whole SQL execution, including compacting requests to other stores, as repeatedly
 				// compacting the same table is a waste of resource.
-				return true, warn
+				return true, err
 			case *kvrpcpb.CompactError_ErrTooManyPendingTasks:
 				// The store is already very busy, don't retry and don't compact other partitions.
-				warn := errors.Errorf("compact on store %s failed: store is too busy", task.targetStore.Address)
+				// warn is light stackless.
+				warn := errors.NewNoStackErrorf("compact on store %s failed: store is too busy", task.targetStore.Address)
 				task.parentExec.Ctx().GetSessionVars().StmtCtx.AppendWarning(warn)
+				err := errors.Trace(warn)
 				task.logFailure(
 					zap.Int64("physical-table-id", physicalTableID),
-					zap.Error(warn))
-				return false, warn
+					zap.Error(err))
+				return false, err
 			case *kvrpcpb.CompactError_ErrPhysicalTableNotExist:
 				// The physical table does not exist, don't retry this partition, but other partitions should still be compacted.
 				// This may happen when partition or table is dropped during the long compaction.
@@ -296,12 +301,13 @@ func (task *storeCompactTask) compactOnePhysicalTable(physicalTableID int64) (bo
 				return false, nil
 			default:
 				// Others are unexpected errors, don't retry and don't compact other partitions.
-				warn := errors.Errorf("compact on store %s failed: internal error (check logs for details)", task.targetStore.Address)
+				warn := errors.NewNoStackErrorf("compact on store %s failed: internal error (check logs for details)", task.targetStore.Address)
 				task.parentExec.Ctx().GetSessionVars().StmtCtx.AppendWarning(warn)
+				err := errors.Trace(warn)
 				task.logFailure(
 					zap.Int64("physical-table-id", physicalTableID),
 					zap.Any("response-error", resp.GetError().GetError()))
-				return false, warn
+				return false, err
 			}
 		}
 
@@ -314,14 +320,15 @@ func (task *storeCompactTask) compactOnePhysicalTable(physicalTableID int64) (bo
 		if len(lastEndKey) == 0 || bytes.Compare(lastEndKey, startKey) <= 0 {
 			// The TiFlash server returned an invalid compacted end key.
 			// This is unexpected...
-			warn := errors.Errorf("compact on store %s failed: internal error (check logs for details)", task.targetStore.Address)
+			warn := errors.NewNoStackErrorf("compact on store %s failed: internal error (check logs for details)", task.targetStore.Address)
 			task.parentExec.Ctx().GetSessionVars().StmtCtx.AppendWarning(warn)
+			err := errors.Trace(warn)
 			task.logFailure(
 				zap.Int64("physical-table-id", physicalTableID),
 				zap.String("compacted-start-key", hex.EncodeToString(resp.GetCompactedStartKey())),
 				zap.String("compacted-end-key", hex.EncodeToString(resp.GetCompactedEndKey())),
 			)
-			return false, warn
+			return false, err
 		}
 		startKey = lastEndKey
 	}

--- a/pkg/executor/lockstats/lock_stats_executor.go
+++ b/pkg/executor/lockstats/lock_stats_executor.go
@@ -65,7 +65,7 @@ func (e *LockExec) Next(_ context.Context, _ *chunk.Chunk) error {
 			return err
 		}
 		if msg != "" {
-			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.New(msg))
+			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError(msg))
 		}
 	} else {
 		tableWithPartitions, err := populateTableAndPartitionIDs(e.Tables, is)
@@ -78,7 +78,7 @@ func (e *LockExec) Next(_ context.Context, _ *chunk.Chunk) error {
 			return err
 		}
 		if msg != "" {
-			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.New(msg))
+			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError(msg))
 		}
 	}
 

--- a/pkg/executor/lockstats/unlock_stats_executor.go
+++ b/pkg/executor/lockstats/unlock_stats_executor.go
@@ -60,7 +60,7 @@ func (e *UnlockExec) Next(context.Context, *chunk.Chunk) error {
 			return err
 		}
 		if msg != "" {
-			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.New(msg))
+			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError(msg))
 		}
 	} else {
 		tableWithPartitions, err := populateTableAndPartitionIDs(e.Tables, is)
@@ -72,7 +72,7 @@ func (e *UnlockExec) Next(context.Context, *chunk.Chunk) error {
 			return err
 		}
 		if msg != "" {
-			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.New(msg))
+			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError(msg))
 		}
 	}
 

--- a/pkg/executor/memtable_reader.go
+++ b/pkg/executor/memtable_reader.go
@@ -188,7 +188,7 @@ func fetchClusterConfig(sctx sessionctx.Context, nodeTypes, nodeAddrs set.String
 		address := srv.Address
 		statusAddr := srv.StatusAddr
 		if len(statusAddr) == 0 {
-			sctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("%s node %s does not contain status address", typ, address))
+			sctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf("%s node %s does not contain status address", typ, address))
 			continue
 		}
 		wg.Add(1)
@@ -456,7 +456,7 @@ func (e *clusterLogRetriever) startRetrieving(
 		address := srv.Address
 		statusAddr := srv.StatusAddr
 		if len(statusAddr) == 0 {
-			sctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("%s node %s does not contain status address", typ, address))
+			sctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf("%s node %s does not contain status address", typ, address))
 			continue
 		}
 		ch := make(chan logStreamResult)

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -401,7 +401,7 @@ func loadVariables(ctx sessionctx.Context, z *zip.Reader) error {
 		}
 	}
 	if len(unLoadVars) > 0 {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("variables set failed:%s", strings.Join(unLoadVars, ",")))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackErrorf("variables set failed:%s", strings.Join(unLoadVars, ",")))
 	}
 	return nil
 }

--- a/pkg/executor/revoke.go
+++ b/pkg/executor/revoke.go
@@ -203,7 +203,7 @@ func (e *RevokeExec) revokePriv(internalSession sessionctx.Context, priv *ast.Pr
 func (e *RevokeExec) revokeDynamicPriv(internalSession sessionctx.Context, privName string, user, host string) error {
 	privName = strings.ToUpper(privName)
 	if !privilege.GetPrivilegeManager(e.Ctx()).IsDynamicPrivilege(privName) { // for MySQL compatibility
-		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(exeerrors.ErrDynamicPrivilegeNotRegistered.GenWithStackByArgs(privName))
+		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(exeerrors.ErrDynamicPrivilegeNotRegistered.FastGenByArgs(privName))
 	}
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnPrivilege)
 	_, err := internalSession.(sqlexec.SQLExecutor).ExecuteInternal(ctx, "DELETE FROM mysql.global_grants WHERE user = %? AND host = %? AND priv = %?", user, host, privName)

--- a/pkg/executor/set.go
+++ b/pkg/executor/set.go
@@ -138,13 +138,13 @@ func (e *SetExecutor) setSysVariable(ctx context.Context, name string, v *expres
 		// The variable is a noop. For compatibility we allow it to still
 		// be changed, but we append a warning since users might be expecting
 		// something that's not going to happen.
-		sessionVars.StmtCtx.AppendWarning(exeerrors.ErrSettingNoopVariable.GenWithStackByArgs(sysVar.Name))
+		sessionVars.StmtCtx.AppendWarning(exeerrors.ErrSettingNoopVariable.FastGenByArgs(sysVar.Name))
 	}
 	if sysVar.HasInstanceScope() && !v.IsGlobal && sessionVars.EnableLegacyInstanceScope {
 		// For backward compatibility we will change the v.IsGlobal to true,
 		// and append a warning saying this will not be supported in future.
 		v.IsGlobal = true
-		sessionVars.StmtCtx.AppendWarning(exeerrors.ErrInstanceScope.GenWithStackByArgs(sysVar.Name))
+		sessionVars.StmtCtx.AppendWarning(exeerrors.ErrInstanceScope.FastGenByArgs(sysVar.Name))
 	}
 
 	if v.IsGlobal {

--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -615,9 +615,9 @@ func (e *SimpleExec) executeBegin(ctx context.Context, s *ast.BeginStmt) error {
 	if s.ReadOnly {
 		noopFuncsMode := e.Ctx().GetSessionVars().NoopFuncsMode
 		if s.AsOf == nil && noopFuncsMode != variable.OnInt {
-			err := expression.ErrFunctionsNoopImpl.GenWithStackByArgs("READ ONLY")
+			err := expression.ErrFunctionsNoopImpl.FastGenByArgs("READ ONLY")
 			if noopFuncsMode == variable.OffInt {
-				return err
+				return errors.Trace(err)
 			}
 			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(err)
 		}
@@ -1144,7 +1144,7 @@ func (e *SimpleExec) executeCreateUser(ctx context.Context, s *ast.CreateUserStm
 				}
 				return exeerrors.ErrCannotUser.GenWithStackByArgs("CREATE USER", user)
 			}
-			err := infoschema.ErrUserAlreadyExists.GenWithStackByArgs(user)
+			err := infoschema.ErrUserAlreadyExists.FastGenByArgs(user)
 			e.Ctx().GetSessionVars().StmtCtx.AppendNote(err)
 			continue
 		}
@@ -1916,7 +1916,7 @@ func (e *SimpleExec) executeAlterUser(ctx context.Context, s *ast.AlterUserStmt)
 		switch authTokenOptionHandler {
 		case noNeedAuthTokenOptions:
 			if len(authTokenOptions) > 0 {
-				err := errors.New("TOKEN_ISSUER is not needed for the auth plugin")
+				err := errors.NewNoStackError("TOKEN_ISSUER is not needed for the auth plugin")
 				e.Ctx().GetSessionVars().StmtCtx.AppendWarning(err)
 			}
 		case OptionalAuthTokenOptions:
@@ -1931,7 +1931,7 @@ func (e *SimpleExec) executeAlterUser(ctx context.Context, s *ast.AlterUserStmt)
 					fields = append(fields, alterField{authTokenOption.Type.String() + "=%?", authTokenOption.Value})
 				}
 			} else {
-				err := errors.New("Auth plugin 'tidb_auth_plugin' needs TOKEN_ISSUER")
+				err := errors.NewNoStackError("Auth plugin 'tidb_auth_plugin' needs TOKEN_ISSUER")
 				e.Ctx().GetSessionVars().StmtCtx.AppendWarning(err)
 			}
 		}
@@ -1978,7 +1978,7 @@ func (e *SimpleExec) executeAlterUser(ctx context.Context, s *ast.AlterUserStmt)
 			return exeerrors.ErrCannotUser.GenWithStackByArgs("ALTER USER", strings.Join(failedUsers, ","))
 		}
 		for _, user := range failedUsers {
-			err := infoschema.ErrUserDropExists.GenWithStackByArgs(user)
+			err := infoschema.ErrUserDropExists.FastGenByArgs(user)
 			e.Ctx().GetSessionVars().StmtCtx.AppendNote(err)
 		}
 	}
@@ -2239,7 +2239,7 @@ func (e *SimpleExec) executeDropUser(ctx context.Context, s *ast.DropUserStmt) e
 				failedUsers = append(failedUsers, user.String())
 				break
 			}
-			e.Ctx().GetSessionVars().StmtCtx.AppendNote(infoschema.ErrUserDropExists.GenWithStackByArgs(user))
+			e.Ctx().GetSessionVars().StmtCtx.AppendNote(infoschema.ErrUserDropExists.FastGenByArgs(user))
 		}
 
 		// Certain users require additional privileges in order to be modified.
@@ -2474,7 +2474,7 @@ func (e *SimpleExec) executeSetPwd(ctx context.Context, s *ast.SetPwdStmt) error
 	case mysql.AuthCachingSha2Password, mysql.AuthTiDBSM3Password:
 		pwd = auth.NewHashPassword(s.Password, authplugin)
 	case mysql.AuthSocket:
-		e.Ctx().GetSessionVars().StmtCtx.AppendNote(exeerrors.ErrSetPasswordAuthPlugin.GenWithStackByArgs(u, h))
+		e.Ctx().GetSessionVars().StmtCtx.AppendNote(exeerrors.ErrSetPasswordAuthPlugin.FastGenByArgs(u, h))
 		pwd = ""
 	default:
 		pwd = auth.EncodePassword(s.Password)
@@ -2541,7 +2541,7 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 			}
 			sm.Kill(s.ConnectionID, s.Query, false)
 		} else {
-			err := errors.New("Invalid operation. Please use 'KILL TIDB [CONNECTION | QUERY] [connectionID | CONNECTION_ID()]' instead")
+			err := errors.NewNoStackError("Invalid operation. Please use 'KILL TIDB [CONNECTION | QUERY] [connectionID | CONNECTION_ID()]' instead")
 			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(err)
 		}
 		return nil
@@ -2560,7 +2560,7 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 
 	gcid, isTruncated, err := globalconn.ParseConnID(s.ConnectionID)
 	if err != nil {
-		err1 := errors.New("Parse ConnectionID failed: " + err.Error())
+		err1 := errors.NewNoStackError("Parse ConnectionID failed: " + err.Error())
 		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(err1)
 		return nil
 	}
@@ -2569,14 +2569,14 @@ func (e *SimpleExec) executeKillStmt(ctx context.Context, s *ast.KillStmt) error
 		logutil.BgLogger().Warn(message, zap.Uint64("conn", s.ConnectionID))
 		// Notice that this warning cannot be seen if KILL is triggered by "CTRL-C" of mysql client,
 		//   as the KILL is sent by a new connection.
-		err := errors.New(message)
+		err := errors.NewNoStackError(message)
 		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(err)
 		return nil
 	}
 
 	if gcid.ServerID != sm.ServerID() {
 		if err := killRemoteConn(ctx, e.Ctx(), &gcid, s.Query); err != nil {
-			err1 := errors.New("KILL remote connection failed: " + err.Error())
+			err1 := errors.NewNoStackError("KILL remote connection failed: " + err.Error())
 			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(err1)
 		}
 	} else {
@@ -2811,7 +2811,7 @@ func (e *SimpleExec) executeAdminFlushPlanCache(s *ast.AdminStmt) error {
 		return errors.New("Do not support the 'admin flush global scope.'")
 	}
 	if !e.Ctx().GetSessionVars().EnablePreparedPlanCache {
-		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.New("The plan cache is disable. So there no need to flush the plan cache"))
+		e.Ctx().GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError("The plan cache is disable. So there no need to flush the plan cache"))
 		return nil
 	}
 	now := types.NewTime(types.FromGoTime(time.Now().In(e.Ctx().GetSessionVars().StmtCtx.TimeZone())), mysql.TypeTimestamp, 3)

--- a/pkg/expression/simple_rewriter.go
+++ b/pkg/expression/simple_rewriter.go
@@ -94,7 +94,7 @@ func ParseSimpleExprsWithNames(ctx sessionctx.Context, exprStr string, schema *S
 		stmts, warns, err = parser.New().ParseSQL(exprStr)
 	}
 	if err != nil {
-		return nil, util.SyntaxWarn(err)
+		return nil, errors.Trace(util.SyntaxWarn(err))
 	}
 	for _, warn := range warns {
 		ctx.GetSessionVars().StmtCtx.AppendWarning(util.SyntaxWarn(warn))

--- a/pkg/table/tables/partition.go
+++ b/pkg/table/tables/partition.go
@@ -1862,7 +1862,8 @@ func parseExpr(p *parser.Parser, exprStr string) (ast.ExprNode, error) {
 	exprStr = "select " + exprStr
 	stmts, _, err := p.ParseSQL(exprStr)
 	if err != nil {
-		return nil, util.SyntaxWarn(err)
+		// if you want to use warn like an error, trace the stack info by yourself.
+		return nil, errors.Trace(util.SyntaxWarn(err))
 	}
 	fields := stmts[0].(*ast.SelectStmt).Fields.Fields
 	return fields[0].Expr, nil

--- a/pkg/util/misc.go
+++ b/pkg/util/misc.go
@@ -174,7 +174,7 @@ func SyntaxWarn(err error) error {
 		}
 	}
 
-	return parser.ErrParse.GenWithStackByArgs(syntaxErrorPrefix, err.Error())
+	return parser.ErrParse.FastGenByArgs(syntaxErrorPrefix, err.Error())
 }
 
 var (


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/49291

Problem Summary:

### What changed and how does it work?
* if a error is only generated and used like warning and note, don't bind unnecessary stack info with it. Because showExec (show warning logic) only fetch errCode and errMsg to show.
* if a error is generated in deep call chain, by now, always generating it with stack, because you couldn't know whether it will be used like error/warning/note later and outer.
* if a error is treated several ways according sqlMode/var/hint/ticker and some thing, eg: like the code below, the error can be possibly treated like an error, we couldn't control generating logic with it. 
* if this error is generated in current level, like the second case below, generating it without stack info, and wrapping stack with it when warn is returned like error, because of stack info is quite same.
```go
if err != nil {
    // deep call chain for generation of ERROR here.
    stmtCtx.IsSyncStatsFailed = true
    if variable.StatsLoadPseudoTimeout.Load() {
	logutil.BgLogger().Warn("SyncWaitStatsLoad failed", zap.Error(err))
        // treated like warning
	stmtCtx.AppendWarning(err)
	return nil
    }
    logutil.BgLogger().Error("SyncWaitStatsLoad failed", zap.Error(err))
    // treated like user error
    return err
}


if exists {
    err := infoschema.ErrTableExists.FastGenByArgs(ast.Ident{Schema: s.Table.Schema, Name: s.Table.Name})
    if s.IfNotExists {
  	e.Ctx().GetSessionVars().StmtCtx.AppendNote(err)
	return nil
    }
    return errors.Trace(err)
}
```
* error's stack info will be useful, because it can be used to quickly locate where the error comes from.
```go
func (cc *clientConn) Run(ctx context.Context) {
    // ...
    logutil.Logger(ctx).Info("command dispatched failed",
	zap.String("connInfo", cc.String()),
	zap.String("command", mysql.Command2Str[data[0]]),
	zap.String("status", cc.SessionStatusToString()),
	zap.Stringer("sql", getLastStmtInConn{cc}),
	zap.String("txn_mode", txnMode),
	zap.Uint64("timestamp", startTS),
	zap.String("err", errStrForLog(err, cc.ctx.GetSessionVars().EnableRedactLog)),  // fetch stack info here
}
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
