### PR TITLE
ddl: fix the optimization for the empty table(speed up)

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -388,6 +388,11 @@ func splitTableRanges(t table.PhysicalTable, store kv.Storage, startKey, endKey 
 		zap.Int64("physicalTableID", t.GetPhysicalID()),
 		zap.String("start key", hex.EncodeToString(startKey)),
 		zap.String("end key", hex.EncodeToString(endKey)))
+	if len(startKey) == 0 && len(endKey) == 0 {
+		logutil.BgLogger().Info("split table range from PD, get noop table range", zap.String("category", "ddl"), zap.Int64("physicalTableID", t.GetPhysicalID()))
+		return []kv.KeyRange{}, nil
+	}
+
 	kvRange := kv.KeyRange{StartKey: startKey, EndKey: endKey}
 	s, ok := store.(tikv.Storage)
 	if !ok {
@@ -672,9 +677,6 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sess.Pool, t table.Physical
 
 	if err := dc.isReorgRunnable(reorgInfo.Job.ID, false); err != nil {
 		return errors.Trace(err)
-	}
-	if startKey == nil && endKey == nil {
-		return nil
 	}
 
 	failpoint.Inject("MockCaseWhenParseFailure", func(val failpoint.Value) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/49679, close https://github.com/pingcap/tidb/issues/49682

Problem Summary:
The optimization for the empty table(`startKey == nil && endKey == nil)` doesn't work.
The following case is obvious (because split regions take so long).
#49679 
```
[2023/12/20 11:23:10.873 +08:00] [INFO] [backfilling.go:712] ["start backfill workers to reorg record"] [category=ddl] [type="add index"] [workerCnt=4] [regionCnt=1] [startKey=] [endKey=]
...
[2023/12/20 11:25:14.752 +08:00] [INFO] [backfilling.go:559] ["get backfill range task, get reverse key failed"] [category=ddl] [error="[tikv:9005]Region is unavailable"]
...
...
```


### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
Before this PR, took time: 2min+
![image](https://github.com/pingcap/tidb/assets/4242506/443f58fb-17b0-48a2-83cc-9f5a441e8b93)

After this PR, took time: 40s+
![img_v3_026b_4698de00-e023-4c0a-990d-8cdb530e67bg](https://github.com/pingcap/tidb/assets/4242506/2eb67614-428f-4318-bca8-ba2835388a92)

- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
