### PR TITLE
statistics: add some key info in sync load timeout log

### DIFF
--- a/pkg/statistics/column.go
+++ b/pkg/statistics/column.go
@@ -15,8 +15,6 @@
 package statistics
 
 import (
-	"strconv"
-
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/util/debugtrace"
@@ -168,8 +166,8 @@ func (c *Column) IsInvalid(
 		if (!c.IsStatsInitialized() || c.IsLoadNeeded()) && stmtctx != nil {
 			if stmtctx.StatsLoad.Timeout > 0 {
 				logutil.BgLogger().Warn("Hist for column should already be loaded as sync but not found.",
-					zap.String("table_id", strconv.FormatInt(c.PhysicalID, 10)),
-					zap.String("column_id", strconv.FormatInt(c.Info.ID, 10)),
+					zap.Int64("table_id", c.PhysicalID),
+					zap.Int64("column_id", c.Info.ID),
 					zap.String("column_name", c.Info.Name.O))
 			}
 			// In some tests, the c.Info is not set, so we add this check here.

--- a/pkg/statistics/column.go
+++ b/pkg/statistics/column.go
@@ -168,7 +168,9 @@ func (c *Column) IsInvalid(
 		if (!c.IsStatsInitialized() || c.IsLoadNeeded()) && stmtctx != nil {
 			if stmtctx.StatsLoad.Timeout > 0 {
 				logutil.BgLogger().Warn("Hist for column should already be loaded as sync but not found.",
-					zap.String(strconv.FormatInt(c.Info.ID, 10), c.Info.Name.O))
+					zap.String("table_id", strconv.FormatInt(c.PhysicalID, 10)),
+					zap.String("column_id", strconv.FormatInt(c.Info.ID, 10)),
+					zap.String("column_name", c.Info.Name.O))
 			}
 			// In some tests, the c.Info is not set, so we add this check here.
 			// When we are using stats from PseudoTable(), the table ID will possibly be -1.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49631

Problem Summary:

### What changed and how does it work?

Add table id in timeout sync load log

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
