### PR TITLE
parser: truncate keywords.go when re-creating it

### DIFF
--- a/pkg/parser/generate_keyword/genkeyword.go
+++ b/pkg/parser/generate_keyword/genkeyword.go
@@ -97,6 +97,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create keywords.go: %s", err)
 	}
+	err = keywordsFile.Truncate(0)
+	if err != nil {
+		log.Fatalf("Failed to create keywords.go: %s", err)
+	}
 	_, err = keywordsFile.WriteString(fileStart)
 	if err != nil {
 		log.Fatalf("Failed to write fileStart to keywords.go: %s", err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #48801

Problem Summary:

The code added in #48807 doesn't truncate the file when re-creating it. This might lead to left over bits of previous versions if the new file is shorter.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
