### PR TITLE
metrics: change background resource group label name

### DIFF
--- a/pkg/metrics/grafana/tidb_resource_control.json
+++ b/pkg/metrics/grafana/tidb_resource_control.json
@@ -3073,7 +3073,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{name}}-{{instance}}",
+              "legendFormat": "{{resource_group}}-{{instance}}",
               "metric": "scan_details",
               "refId": "B",
               "step": 4
@@ -3184,7 +3184,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{name}}-{{instance}}",
+              "legendFormat": "{{resource_group}}-{{instance}}",
               "metric": "scan_details",
               "refId": "B",
               "step": 4
@@ -3295,7 +3295,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{name}}-{{instance}}",
+              "legendFormat": "{{resource_group}}-{{instance}}",
               "metric": "scan_details",
               "refId": "B",
               "step": 4
@@ -3406,7 +3406,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{name}}-{{instance}}",
+              "legendFormat": "{{resource_group}}-{{instance}}",
               "metric": "scan_details",
               "refId": "B",
               "step": 4
@@ -3517,7 +3517,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{name}}-{{instance}}",
+              "legendFormat": "{{resource_group}}-{{instance}}",
               "metric": "scan_details",
               "refId": "B",
               "step": 4


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #49318

Problem Summary:

### What changed and how does it work?
Change the resource group name from "name" to "resource_group" so we can add a global label selector later. Related tikv side change is https://github.com/tikv/tikv/pull/16192.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
