### PR TITLE
session: fix wrong test logic of tidb_super_read_only

### DIFF
--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -150,7 +150,7 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 		defer debugtrace.LeaveContextCommon(sctx)
 	}
 
-	if !sctx.GetSessionVars().InRestrictedSQL && variable.RestrictedReadOnly.Load() || variable.VarTiDBSuperReadOnly.Load() {
+	if !sctx.GetSessionVars().InRestrictedSQL && (variable.RestrictedReadOnly.Load() || variable.VarTiDBSuperReadOnly.Load()) {
 		allowed, err := allowInReadOnlyMode(sctx, node)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -507,7 +507,7 @@ func (s *session) doCommit(ctx context.Context) error {
 		return nil
 	}
 	// check if the cluster is read-only
-	if !s.sessionVars.InRestrictedSQL && variable.RestrictedReadOnly.Load() || variable.VarTiDBSuperReadOnly.Load() {
+	if !s.sessionVars.InRestrictedSQL && (variable.RestrictedReadOnly.Load() || variable.VarTiDBSuperReadOnly.Load()) {
 		// It is not internal SQL, and the cluster has one of RestrictedReadOnly or SuperReadOnly
 		// We need to privilege check again: a privilege check occurred during planning, but we need
 		// to prevent the case that a long running auto-commit statement is now trying to commit.

--- a/tests/readonlytest/BUILD.bazel
+++ b/tests/readonlytest/BUILD.bazel
@@ -9,6 +9,8 @@ go_test(
     ],
     flaky = True,
     deps = [
+        "//pkg/kv",
+        "//pkg/testkit",
         "//pkg/testkit/testsetup",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_stretchr_testify//require",

--- a/tests/readonlytest/readonly_test.go
+++ b/tests/readonlytest/readonly_test.go
@@ -279,13 +279,10 @@ func TestInternalSQL(t *testing.T) {
 		tk.MustExec("set global tidb_super_read_only=default")
 	}()
 
-	runSQL := func() {
-		sql := "insert into mysql.stats_top_n (table_id, is_index, hist_id, value, count) values (874, 0, 1, 'a', 3)"
-		_, err := tk.Session().ExecuteInternal(ctx, sql)
-		require.NoError(t, err)
-	}
-
 	tk.MustExec("set global tidb_restricted_read_only=On")
 	tk.MustExec("set global tidb_super_read_only=On")
-	runSQL()
+
+	sql := "insert into mysql.stats_top_n (table_id, is_index, hist_id, value, count) values (874, 0, 1, 'a', 3)"
+	_, err := tk.Session().ExecuteInternal(ctx, sql)
+	require.NoError(t, err)
 }

--- a/tests/readonlytest/readonly_test.go
+++ b/tests/readonlytest/readonly_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/stats/view"
 )

--- a/tests/readonlytest/readonly_test.go
+++ b/tests/readonlytest/readonly_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/testkit"
-	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/stats/view"
 )
@@ -237,8 +237,8 @@ func TestInternalSQL(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 
 	defer func() {
-		tk.MustExec("set global tidb_restricted_read_only=default");
-		tk.MustExec("set global tidb_super_read_only=default");
+		tk.MustExec("set global tidb_restricted_read_only=default")
+		tk.MustExec("set global tidb_super_read_only=default")
 	}()
 
 	runSQL := func() {
@@ -247,7 +247,7 @@ func TestInternalSQL(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	tk.MustExec("set global tidb_restricted_read_only=On");
-	tk.MustExec("set global tidb_super_read_only=On");
+	tk.MustExec("set global tidb_restricted_read_only=On")
+	tk.MustExec("set global tidb_super_read_only=On")
 	runSQL()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49659

Problem Summary: I think the [original code ](https://github.com/pingcap/tidb/pull/31746/files#diff-0a0c95887230cee4dde6537c6be06ea308529b392c4c3303c242509f53bb8f1aR354) is unexpected.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
