### PR TITLE
statistics: drop old stats meta after truncate a table 

### DIFF
--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 16,
+    shard_count = 17,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 15,
+    shard_count = 16,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -61,7 +61,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 			}
 		}
 	case model.ActionTruncateTable:
-		newTableInfo, _ := t.GetTruncateTableInfo()
+		newTableInfo, droppedTableInfo := t.GetTruncateTableInfo()
 		ids, err := h.getInitStateTableIDs(newTableInfo)
 		if err != nil {
 			return err
@@ -70,6 +70,11 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 			if err := h.statsWriter.InsertTableStats2KV(newTableInfo, id); err != nil {
 				return err
 			}
+		}
+
+		// Remove the old table stats.
+		if err := h.statsWriter.ResetTableStats2KVForDrop(droppedTableInfo.ID); err != nil {
+			return err
 		}
 	case model.ActionDropTable:
 		droppedTableInfo := t.GetDropTableInfo()

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -51,7 +51,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 	switch t.GetType() {
 	case model.ActionCreateTable:
 		newTableInfo := t.GetCreateTableInfo()
-		ids, err := h.getInitStateTableIDs(newTableInfo)
+		ids, err := h.getTableIDs(newTableInfo)
 		if err != nil {
 			return err
 		}
@@ -62,7 +62,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 		}
 	case model.ActionTruncateTable:
 		newTableInfo, droppedTableInfo := t.GetTruncateTableInfo()
-		ids, err := h.getInitStateTableIDs(newTableInfo)
+		ids, err := h.getTableIDs(newTableInfo)
 		if err != nil {
 			return err
 		}
@@ -73,12 +73,18 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 		}
 
 		// Remove the old table stats.
-		if err := h.statsWriter.ResetTableStats2KVForDrop(droppedTableInfo.ID); err != nil {
+		droppedIDs, err := h.getTableIDs(droppedTableInfo)
+		if err != nil {
 			return err
+		}
+		for _, id := range droppedIDs {
+			if err := h.statsWriter.ResetTableStats2KVForDrop(id); err != nil {
+				return err
+			}
 		}
 	case model.ActionDropTable:
 		droppedTableInfo := t.GetDropTableInfo()
-		ids, err := h.getInitStateTableIDs(droppedTableInfo)
+		ids, err := h.getTableIDs(droppedTableInfo)
 		if err != nil {
 			return err
 		}
@@ -89,7 +95,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 		}
 	case model.ActionAddColumn:
 		newTableInfo, newColumnInfo := t.GetAddColumnInfo()
-		ids, err := h.getInitStateTableIDs(newTableInfo)
+		ids, err := h.getTableIDs(newTableInfo)
 		if err != nil {
 			return err
 		}
@@ -101,7 +107,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 	case model.ActionModifyColumn:
 		newTableInfo, modifiedColumnInfo := t.GetModifyColumnInfo()
 
-		ids, err := h.getInitStateTableIDs(newTableInfo)
+		ids, err := h.getTableIDs(newTableInfo)
 		if err != nil {
 			return err
 		}
@@ -239,7 +245,7 @@ func updateStatsWithCountDeltaAndModifyCountDelta(
 	return err
 }
 
-func (h *ddlHandlerImpl) getInitStateTableIDs(tblInfo *model.TableInfo) (ids []int64, err error) {
+func (h *ddlHandlerImpl) getTableIDs(tblInfo *model.TableInfo) (ids []int64, err error) {
 	pi := tblInfo.GetPartitionInfo()
 	if pi == nil {
 		return []int64{tblInfo.ID}, nil

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -138,8 +138,8 @@ func TestTruncateTablePartition(t *testing.T) {
 		"select version from mysql.stats_meta where table_id = ?", tableInfo.ID,
 	).Rows()
 	require.Len(t, rows, 1)
-	// FIXME: Version gets updated after truncate the table.
-	require.Equal(t, version, rows[0][0].(string))
+	// Version gets updated after truncate the table.
+	require.NotEqual(t, version, rows[0][0].(string))
 }
 
 func TestDDLHistogram(t *testing.T) {

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -88,7 +88,7 @@ func TestDDLTable(t *testing.T) {
 	require.False(t, statsTbl.Pseudo)
 }
 
-func TestTruncateTablePartition(t *testing.T) {
+func TestTruncateTable(t *testing.T) {
 	store, do := testkit.CreateMockStoreAndDomain(t)
 	testKit := testkit.NewTestKit(t, store)
 	testKit.MustExec("use test")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB! 

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/49663

Problem Summary:

### What changed and how does it work?

- Added a test case to cover this problem.
- Drop the old stats meta after truncating a table.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix TiDB can not drop old stats meta after truncating a table issue
```
