### PR TITLE
expression: remove old `regexpBaseFuncSig` and rename `regexpNewBaseFuncSig` to `regexpBaseFuncSig`

### DIFF
--- a/pkg/expression/builtin_regexp_test.go
+++ b/pkg/expression/builtin_regexp_test.go
@@ -1229,7 +1229,7 @@ func TestRegexpCache(t *testing.T) {
 	ctx := createContext(t)
 
 	// if the pattern or match type is not constant, it should not be cached
-	sig := regexpNewBaseFuncSig{}
+	sig := regexpBaseFuncSig{}
 	sig.args = []Expression{&Column{}, &Column{}, &Constant{}}
 	reg, err := sig.getRegexp(ctx, "abc", "", 2)
 	require.NoError(t, err)
@@ -1269,7 +1269,7 @@ func TestRegexpCache(t *testing.T) {
 	require.False(t, ok)
 
 	// if pattern and match type are both constant, it should be cached
-	sig = regexpNewBaseFuncSig{}
+	sig = regexpBaseFuncSig{}
 	sig.args = []Expression{&Column{}, &Constant{ParamMarker: &ParamMarker{}}, &Constant{ParamMarker: &ParamMarker{}}}
 	reg, err = sig.getRegexp(ctx, "ccc", "", 2)
 	require.NoError(t, err)
@@ -1280,7 +1280,7 @@ func TestRegexpCache(t *testing.T) {
 	require.Same(t, reg, reg2)
 	require.Equal(t, "ccc", reg2.String())
 
-	sig = regexpNewBaseFuncSig{}
+	sig = regexpBaseFuncSig{}
 	sig.args = []Expression{&Column{}, &Constant{ParamMarker: &ParamMarker{}}, &Constant{ParamMarker: &ParamMarker{}}}
 	reg, ok, err = sig.tryVecMemorizedRegexp(ctx, []*funcParam{
 		{defaultStrVal: "x"},

--- a/pkg/expression/distsql_builtin.go
+++ b/pkg/expression/distsql_builtin.go
@@ -663,17 +663,17 @@ func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *ti
 	case tipb.ScalarFuncSig_IlikeSig:
 		f = &builtinIlikeSig{base, nil, false, sync.Once{}}
 	case tipb.ScalarFuncSig_RegexpSig:
-		f = &builtinRegexpLikeFuncSig{regexpNewBaseFuncSig{baseBuiltinFunc: base}}
+		f = &builtinRegexpLikeFuncSig{regexpBaseFuncSig{baseBuiltinFunc: base}}
 	case tipb.ScalarFuncSig_RegexpUTF8Sig:
-		f = &builtinRegexpLikeFuncSig{regexpNewBaseFuncSig{baseBuiltinFunc: base}}
+		f = &builtinRegexpLikeFuncSig{regexpBaseFuncSig{baseBuiltinFunc: base}}
 	case tipb.ScalarFuncSig_RegexpLikeSig:
-		f = &builtinRegexpLikeFuncSig{regexpNewBaseFuncSig{baseBuiltinFunc: base}}
+		f = &builtinRegexpLikeFuncSig{regexpBaseFuncSig{baseBuiltinFunc: base}}
 	case tipb.ScalarFuncSig_RegexpSubstrSig:
-		f = &builtinRegexpSubstrFuncSig{regexpNewBaseFuncSig{baseBuiltinFunc: base}}
+		f = &builtinRegexpSubstrFuncSig{regexpBaseFuncSig{baseBuiltinFunc: base}}
 	case tipb.ScalarFuncSig_RegexpInStrSig:
-		f = &builtinRegexpInStrFuncSig{regexpNewBaseFuncSig{baseBuiltinFunc: base}}
+		f = &builtinRegexpInStrFuncSig{regexpBaseFuncSig{baseBuiltinFunc: base}}
 	case tipb.ScalarFuncSig_RegexpReplaceSig:
-		f = &builtinRegexpReplaceFuncSig{regexpNewBaseFuncSig: regexpNewBaseFuncSig{baseBuiltinFunc: base}}
+		f = &builtinRegexpReplaceFuncSig{regexpBaseFuncSig: regexpBaseFuncSig{baseBuiltinFunc: base}}
 	case tipb.ScalarFuncSig_JsonExtractSig:
 		f = &builtinJSONExtractSig{base}
 	case tipb.ScalarFuncSig_JsonUnquoteSig:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49684

Problem Summary:

After #49584 and #49642 the old `regexpBaseFuncSig` is useless. Now, we can remove it and rename `regexpNewBaseFuncSig` to `regexpBaseFuncSig` now.

### What changed and how does it work?

remove old `regexpBaseFuncSig` and rename `regexpNewBaseFuncSig` to `regexpBaseFuncSig`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
