### PR TITLE
expression: refactor expression pkg's warning and note generation logic

### DIFF
--- a/pkg/expression/aggregation/concat.go
+++ b/pkg/expression/aggregation/concat.go
@@ -104,7 +104,7 @@ func (cf *concatFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 		}
 		evalCtx.Buffer.Truncate(i)
 		if !cf.truncated {
-			sc.AppendWarning(expression.ErrCutValueGroupConcat.GenWithStackByArgs(cf.Args[0].String()))
+			sc.AppendWarning(expression.ErrCutValueGroupConcat.FastGenByArgs(cf.Args[0].String()))
 		}
 		cf.truncated = true
 	}

--- a/pkg/expression/builtin_encryption.go
+++ b/pkg/expression/builtin_encryption.go
@@ -166,7 +166,7 @@ func (b *builtinAesDecryptSig) evalString(ctx EvalContext, row chunk.Row) (strin
 	}
 	if !b.ivRequired && len(b.args) == 3 {
 		// For modes that do not require init_vector, it is ignored and a warning is generated if it is specified.
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errWarnOptionIgnored.GenWithStackByArgs("IV"))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errWarnOptionIgnored.FastGenByArgs("IV"))
 	}
 
 	key := encrypt.DeriveKeyMySQL([]byte(keyStr), b.keySize)
@@ -300,7 +300,7 @@ func (b *builtinAesEncryptSig) evalString(ctx EvalContext, row chunk.Row) (strin
 	}
 	if !b.ivRequired && len(b.args) == 3 {
 		// For modes that do not require init_vector, it is ignored and a warning is generated if it is specified.
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errWarnOptionIgnored.GenWithStackByArgs("IV"))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errWarnOptionIgnored.FastGenByArgs("IV"))
 	}
 
 	key := encrypt.DeriveKeyMySQL([]byte(keyStr), b.keySize)
@@ -539,7 +539,7 @@ func (b *builtinPasswordSig) evalString(ctx EvalContext, row chunk.Row) (val str
 
 	// We should append a warning here because function "PASSWORD" is deprecated since MySQL 5.7.6.
 	// See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
-	ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("PASSWORD"))
+	ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.FastGenByArgs("PASSWORD"))
 
 	return auth.EncodePassword(pass), false, nil
 }

--- a/pkg/expression/builtin_encryption_vec.go
+++ b/pkg/expression/builtin_encryption_vec.go
@@ -89,7 +89,7 @@ func (b *builtinAesDecryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 		}
 		if isWarning {
 			// For modes that do not require init_vector, it is ignored and a warning is generated if it is specified.
-			stmtCtx.AppendWarning(errWarnOptionIgnored.GenWithStackByArgs("IV"))
+			stmtCtx.AppendWarning(errWarnOptionIgnored.FastGenByArgs("IV"))
 		}
 		if !isConstKey {
 			key = encrypt.DeriveKeyMySQL(keyBuf.GetBytes(i), b.keySize)
@@ -687,7 +687,7 @@ func (b *builtinAesEncryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 			continue
 		}
 		if isWarning {
-			sc.AppendWarning(errWarnOptionIgnored.GenWithStackByArgs("IV"))
+			sc.AppendWarning(errWarnOptionIgnored.FastGenByArgs("IV"))
 		}
 		if !isConst {
 			key = encrypt.DeriveKeyMySQL(keyBuf.GetBytes(i), b.keySize)
@@ -736,7 +736,7 @@ func (b *builtinPasswordSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 
 		// We should append a warning here because function "PASSWORD" is deprecated since MySQL 5.7.6.
 		// See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("PASSWORD"))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.FastGenByArgs("PASSWORD"))
 
 		result.AppendString(auth.EncodePasswordBytes(passBytes))
 	}

--- a/pkg/expression/builtin_info.go
+++ b/pkg/expression/builtin_info.go
@@ -906,7 +906,7 @@ func (b *builtinTiDBDecodeSQLDigestsSig) evalString(ctx EvalContext, row chunk.R
 		if len(digestsStr) > errMsgMaxLength {
 			digestsStr = digestsStr[:errMsgMaxLength] + "..."
 		}
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errIncorrectArgs.GenWithStack("The argument can't be unmarshalled as JSON array: '%s'", digestsStr))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errIncorrectArgs.FastGen("The argument can't be unmarshalled as JSON array: '%s'", digestsStr))
 		return "", true, nil
 	}
 
@@ -935,7 +935,7 @@ func (b *builtinTiDBDecodeSQLDigestsSig) evalString(ctx EvalContext, row chunk.R
 			return "", true, errUnknown.GenWithStack("Retrieving cancelled internally with error: %v", err)
 		}
 
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknown.GenWithStack("Retrieving statements information failed with error: %v", err))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknown.FastGen("Retrieving statements information failed with error: %v", err))
 		return "", true, nil
 	}
 
@@ -958,7 +958,7 @@ func (b *builtinTiDBDecodeSQLDigestsSig) evalString(ctx EvalContext, row chunk.R
 
 	resultStr, err := json.Marshal(result)
 	if err != nil {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknown.GenWithStack("Marshalling result as JSON failed with error: %v", err))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknown.FastGen("Marshalling result as JSON failed with error: %v", err))
 		return "", true, nil
 	}
 

--- a/pkg/expression/builtin_json.go
+++ b/pkg/expression/builtin_json.go
@@ -494,7 +494,7 @@ func (b *builtinJSONMergeSig) evalJSON(ctx EvalContext, row chunk.Row) (res type
 	// function "JSON_MERGE" is deprecated since MySQL 5.7.22. Synonym for function "JSON_MERGE_PRESERVE".
 	// See https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-merge
 	if b.pbCode == tipb.ScalarFuncSig_JsonMergeSig {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("JSON_MERGE"))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.FastGenByArgs("JSON_MERGE"))
 	}
 	return res, false, nil
 }

--- a/pkg/expression/builtin_json_vec.go
+++ b/pkg/expression/builtin_json_vec.go
@@ -1103,7 +1103,7 @@ func (b *builtinJSONMergeSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, r
 			if result.IsNull(i) {
 				continue
 			}
-			ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenWithStackByArgs("JSON_MERGE"))
+			ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.FastGenByArgs("JSON_MERGE"))
 		}
 	}
 

--- a/pkg/expression/builtin_miscellaneous.go
+++ b/pkg/expression/builtin_miscellaneous.go
@@ -146,7 +146,7 @@ func (b *builtinSleepSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, 
 		if !sessVars.StmtCtx.BadNullAsWarning {
 			return 0, false, errIncorrectArgs.GenWithStackByArgs("sleep")
 		}
-		err := errIncorrectArgs.GenWithStackByArgs("sleep")
+		err := errIncorrectArgs.FastGenByArgs("sleep")
 		sessVars.StmtCtx.AppendWarning(err)
 		return 0, false, nil
 	}
@@ -216,7 +216,7 @@ func (b *builtinLockSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, e
 	// We can't have a timeout greater than innodb_lock_wait_timeout.
 	// So users are aware, we also attach a warning.
 	if timeout < 0 || timeout > maxTimeout {
-		err := errTruncatedWrongValue.GenWithStackByArgs("get_lock", strconv.FormatInt(timeout, 10))
+		err := errTruncatedWrongValue.FastGenByArgs("get_lock", strconv.FormatInt(timeout, 10))
 		ctx.GetSessionVars().StmtCtx.AppendWarning(err)
 		timeout = maxTimeout
 	}

--- a/pkg/expression/builtin_miscellaneous_vec.go
+++ b/pkg/expression/builtin_miscellaneous_vec.go
@@ -327,7 +327,7 @@ func (b *builtinSleepSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 			if !sessVars.StmtCtx.BadNullAsWarning {
 				return errIncorrectArgs.GenWithStackByArgs("sleep")
 			}
-			err := errIncorrectArgs.GenWithStackByArgs("sleep")
+			err := errIncorrectArgs.FastGenByArgs("sleep")
 			sessVars.StmtCtx.AppendWarning(err)
 			continue
 		}

--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -3404,9 +3404,9 @@ func (b *builtinFormatWithLocaleSig) evalString(ctx EvalContext, row chunk.Row) 
 		return "", false, err
 	}
 	if isNull {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.GenWithStackByArgs("NULL"))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.FastGenByArgs("NULL"))
 	} else if !strings.EqualFold(locale, "en_US") { // TODO: support other locales.
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.GenWithStackByArgs(locale))
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.FastGenByArgs(locale))
 	}
 	locale = "en_US"
 	formatString, err := mysql.GetLocaleFormatFunction(locale)(x, d)
@@ -4036,7 +4036,7 @@ func (b *builtinWeightStringSig) evalString(ctx EvalContext, row chunk.Row) (str
 		lenStr := len(str)
 		if b.length < lenStr {
 			tpInfo := fmt.Sprintf("BINARY(%d)", b.length)
-			ctx.GetSessionVars().StmtCtx.AppendWarning(errTruncatedWrongValue.GenWithStackByArgs(tpInfo, str))
+			ctx.GetSessionVars().StmtCtx.AppendWarning(errTruncatedWrongValue.FastGenByArgs(tpInfo, str))
 			str = str[:b.length]
 		} else if b.length > lenStr {
 			if uint64(b.length-lenStr) > b.maxAllowedPacket {

--- a/pkg/expression/builtin_string_vec.go
+++ b/pkg/expression/builtin_string_vec.go
@@ -2972,10 +2972,10 @@ func formatDecimal(sctx EvalContext, xBuf *chunk.Column, dInt64s []int64, result
 			// FORMAT(x, d)
 		} else if localeBuf.IsNull(i) {
 			// FORMAT(x, d, NULL)
-			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.GenWithStackByArgs("NULL"))
+			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.FastGenByArgs("NULL"))
 		} else if !strings.EqualFold(localeBuf.GetString(i), "en_US") {
 			// TODO: support other locales.
-			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.GenWithStackByArgs(localeBuf.GetString(i)))
+			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.FastGenByArgs(localeBuf.GetString(i)))
 		}
 
 		xStr := roundFormatArgs(x.String(), int(d))
@@ -3012,10 +3012,10 @@ func formatReal(sctx EvalContext, xBuf *chunk.Column, dInt64s []int64, result *c
 			// FORMAT(x, d)
 		} else if localeBuf.IsNull(i) {
 			// FORMAT(x, d, NULL)
-			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.GenWithStackByArgs("NULL"))
+			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.FastGenByArgs("NULL"))
 		} else if !strings.EqualFold(localeBuf.GetString(i), "en_US") {
 			// TODO: support other locales.
-			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.GenWithStackByArgs(localeBuf.GetString(i)))
+			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.FastGenByArgs(localeBuf.GetString(i)))
 		}
 
 		xStr := roundFormatArgs(strconv.FormatFloat(x, 'f', -1, 64), int(d))

--- a/pkg/expression/errors.go
+++ b/pkg/expression/errors.go
@@ -15,6 +15,7 @@
 package expression
 
 import (
+	"github.com/pingcap/errors"
 	mysql "github.com/pingcap/tidb/pkg/errno"
 	pmysql "github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
@@ -99,7 +100,7 @@ func handleDivisionByZeroError(ctx EvalContext) error {
 
 // handleAllowedPacketOverflowed reports error or warning depend on the context.
 func handleAllowedPacketOverflowed(ctx EvalContext, exprName string, maxAllowedPacketSize uint64) error {
-	err := errWarnAllowedPacketOverflowed.GenWithStackByArgs(exprName, maxAllowedPacketSize)
+	err := errWarnAllowedPacketOverflowed.FastGenByArgs(exprName, maxAllowedPacketSize)
 	sc := ctx.GetSessionVars().StmtCtx
 
 	// insert|update|delete ignore ...
@@ -109,7 +110,7 @@ func handleAllowedPacketOverflowed(ctx EvalContext, exprName string, maxAllowedP
 	}
 
 	if ctx.GetSessionVars().StrictSQLMode && (sc.InInsertStmt || sc.InUpdateStmt || sc.InDeleteStmt) {
-		return err
+		return errors.Trace(err)
 	}
 	sc.AppendWarning(err)
 	return nil

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -1380,7 +1380,7 @@ func canScalarFuncPushDown(scalarFunc *ScalarFunction, pc PbConverter, storeType
 		if storeType == kv.UnSpecified {
 			storageName = "storage layer"
 		}
-		warnErr := errors.New("Scalar function '" + scalarFunc.FuncName.L + "'(signature: " + scalarFunc.Function.PbCode().String() + ", return type: " + scalarFunc.RetType.CompactStr() + ") is not supported to push down to " + storageName + " now.")
+		warnErr := errors.NewNoStackError("Scalar function '" + scalarFunc.FuncName.L + "'(signature: " + scalarFunc.Function.PbCode().String() + ", return type: " + scalarFunc.RetType.CompactStr() + ") is not supported to push down to " + storageName + " now.")
 		sc := pc.ctx.GetSessionVars().StmtCtx
 		if sc.InExplainStmt {
 			sc.AppendWarning(warnErr)
@@ -1416,7 +1416,7 @@ func canExprPushDown(expr Expression, pc PbConverter, storeType kv.StoreType, ca
 			if expr.GetType().GetType() == mysql.TypeEnum && canEnumPush {
 				break
 			}
-			warnErr := errors.New("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains unsupported calculation of type '" + types.TypeStr(expr.GetType().GetType()) + "'.")
+			warnErr := errors.NewNoStackError("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains unsupported calculation of type '" + types.TypeStr(expr.GetType().GetType()) + "'.")
 			if sc.InExplainStmt {
 				sc.AppendWarning(warnErr)
 			} else {
@@ -1425,7 +1425,7 @@ func canExprPushDown(expr Expression, pc PbConverter, storeType kv.StoreType, ca
 			return false
 		case mysql.TypeNewDecimal:
 			if !expr.GetType().IsDecimalValid() {
-				warnErr := errors.New("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains invalid decimal('" + strconv.Itoa(expr.GetType().GetFlen()) + "','" + strconv.Itoa(expr.GetType().GetDecimal()) + "').")
+				warnErr := errors.NewNoStackError("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains invalid decimal('" + strconv.Itoa(expr.GetType().GetFlen()) + "','" + strconv.Itoa(expr.GetType().GetDecimal()) + "').")
 				if sc.InExplainStmt {
 					sc.AppendWarning(warnErr)
 				} else {

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -206,9 +206,9 @@ func newFunctionImpl(ctx sessionctx.Context, fold int, funcName string, retType 
 	noopFuncsMode := ctx.GetSessionVars().NoopFuncsMode
 	if noopFuncsMode != variable.OnInt {
 		if _, ok := noopFuncs[funcName]; ok {
-			err := ErrFunctionsNoopImpl.GenWithStackByArgs(funcName)
+			err := ErrFunctionsNoopImpl.FastGenByArgs(funcName)
 			if noopFuncsMode == variable.OffInt {
-				return nil, err
+				return nil, errors.Trace(err)
 			}
 			// NoopFuncsMode is Warn, append an error
 			ctx.GetSessionVars().StmtCtx.AppendWarning(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/49291

Problem Summary:

### What changed and how does it work?
* if a error is only generated and used like warning and note, don't bind unnecessary stack info with it. Because showExec (show warning logic) only fetch errCode and errMsg to show.
* if a error is generated in deep call chain, by now, always generating it with stack, because you couldn't know whether it will be used like error/warning/note later and outer.
* if a error is treated several ways according sqlMode/var/hint/ticker and some thing, eg: like the code below, the error can be possibly treated like an error, we couldn't control generating logic with it. 
* if this error is generated in current level, like the second case below, generating it without stack info, and wrapping stack with it when warn is returned like error, because of stack info is quite same.
```go
if err != nil {
    // deep call chain for generation of ERROR here.
    stmtCtx.IsSyncStatsFailed = true
    if variable.StatsLoadPseudoTimeout.Load() {
	logutil.BgLogger().Warn("SyncWaitStatsLoad failed", zap.Error(err))
        // treated like warning
	stmtCtx.AppendWarning(err)
	return nil
    }
    logutil.BgLogger().Error("SyncWaitStatsLoad failed", zap.Error(err))
    // treated like user error
    return err
}


if exists {
    err := infoschema.ErrTableExists.FastGenByArgs(ast.Ident{Schema: s.Table.Schema, Name: s.Table.Name})
    if s.IfNotExists {
  	e.Ctx().GetSessionVars().StmtCtx.AppendNote(err)
	return nil
    }
    return errors.Trace(err)
}
```
* error's stack info will be useful, because it can be used to quickly locate where the error comes from.
```go
func (cc *clientConn) Run(ctx context.Context) {
    // ...
    logutil.Logger(ctx).Info("command dispatched failed",
	zap.String("connInfo", cc.String()),
	zap.String("command", mysql.Command2Str[data[0]]),
	zap.String("status", cc.SessionStatusToString()),
	zap.Stringer("sql", getLastStmtInConn{cc}),
	zap.String("txn_mode", txnMode),
	zap.Uint64("timestamp", startTS),
	zap.String("err", errStrForLog(err, cc.ctx.GetSessionVars().EnableRedactLog)),  // fetch stack info here
}
```


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
