### PR TITLE
errctx, stmtctx: add cache to the errctx

### DIFF
--- a/pkg/sessionctx/stmtctx/BUILD.bazel
+++ b/pkg/sessionctx/stmtctx/BUILD.bazel
@@ -41,7 +41,7 @@ go_test(
     ],
     embed = [":stmtctx"],
     flaky = True,
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//pkg/kv",
         "//pkg/sessionctx/variable",

--- a/pkg/sessionctx/stmtctx/stmtctx_test.go
+++ b/pkg/sessionctx/stmtctx/stmtctx_test.go
@@ -408,6 +408,17 @@ func TestStmtCtxID(t *testing.T) {
 	}
 }
 
+func TestErrCtx(t *testing.T) {
+	sc := stmtctx.NewStmtCtx()
+	// the default errCtx
+	err := types.ErrTruncated
+	require.Error(t, sc.HandleError(err))
+
+	// reset the types flags will re-initialize the error flag
+	sc.SetTypeFlags(types.DefaultStmtFlags | types.FlagTruncateAsWarning)
+	require.NoError(t, sc.HandleError(err))
+}
+
 func BenchmarkErrCtx(b *testing.B) {
 	sc := stmtctx.NewStmtCtx()
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #49688

Problem Summary:

We are going to add more and more complex logic to the initialization of errctx, so we'd better add a cache for it.

### What changed and how does it work?

Use the `sync.Once` to achieve a lazy initialization.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

The existing performance gain is also significant:

Before:

```
BenchmarkErrCtx
BenchmarkErrCtx-8   	552535581	         2.166 ns/op
```

After:

```
BenchmarkErrCtx
BenchmarkErrCtx-8   	1000000000	         0.7046 ns/op
```

### Release note


```release-note
None
```
