### PR TITLE
bazel, mirror: print exit err in mirror/mirror.go

### DIFF
--- a/cmd/mirror/mirror.go
+++ b/cmd/mirror/mirror.go
@@ -481,6 +481,10 @@ func mirror() error {
 func main() {
 	flag.Parse()
 	if err := mirror(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			panic("subprocess exited with stderr:\n" + string(exitErr.Stderr))
+		}
 		panic(err)
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #49690

Problem Summary:

Print the stderr of `ExitErr` in `cmd/mirror` command. It now prints:

```
panic: subprocess exited with stderr: 
go: github.com/twmb/murmur3@v1.1.6: missing go.sum entry for go.mod file; to add it:
        go mod download github.com/twmb/murmur3


goroutine 1 [running]:
main.main()
        cmd/mirror/mirror.go:486 +0x105
```

If your `go.sum` somehow lost some rows.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > Not important change. Only take effect for CI / dev environment.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
