### PR TITLE
disttask: Refactor taskExecutor slotManager to handle task occupation

### DIFF
--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -967,7 +967,13 @@ func PauseSchedulersByKeyRange(
 	pdHTTPCli pdhttp.Client,
 	startKey, endKey []byte,
 ) (done <-chan struct{}, err error) {
-	return pauseSchedulerByKeyRangeWithTTL(ctx, pdHTTPCli, startKey, endKey, pauseTimeout)
+	done, err = pauseSchedulerByKeyRangeWithTTL(ctx, pdHTTPCli, startKey, endKey, pauseTimeout)
+	// Wait for the rule to take effect because the PD operator is processed asynchronously.
+	// To synchronize this, checking the operator status may not be enough. For details, see
+	// https://github.com/pingcap/tidb/issues/49477.
+	// Let's use two times default value of `patrol-region-interval` from PD configuration.
+	<-time.After(20 * time.Millisecond)
+	return
 }
 
 func pauseSchedulerByKeyRangeWithTTL(

--- a/pkg/disttask/framework/proto/task.go
+++ b/pkg/disttask/framework/proto/task.go
@@ -165,6 +165,7 @@ var (
 )
 
 // Compare compares two tasks by task order.
+// returns < 0 represents priority of t is higher than other.
 func (t *Task) Compare(other *Task) int {
 	if t.Priority != other.Priority {
 		return t.Priority - other.Priority

--- a/pkg/disttask/framework/taskexecutor/manager.go
+++ b/pkg/disttask/framework/taskexecutor/manager.go
@@ -229,7 +229,7 @@ func (m *Manager) onRunnableTasks(tasks []*proto.Task) {
 		}
 
 		if !canAlloc {
-			logutil.Logger(m.logCtx).Debug("subtask has been rejected", zap.Int64("task-id", task.ID))
+			logutil.Logger(m.logCtx).Debug("no enough slots to run task", zap.Int64("task-id", task.ID))
 			continue
 		}
 		m.addHandlingTask(task.ID)
@@ -421,8 +421,6 @@ func (m *Manager) onRunnableTask(task *proto.Task) {
 		switch task.State {
 		case proto.TaskStateRunning:
 			if taskCtx.Err() != nil {
-				logutil.Logger(m.logCtx).Debug("onRunnableTask exit for taskCtx.Done",
-					zap.Int64("task-id", task.ID), zap.Stringer("type", task.Type), zap.Error(taskCtx.Err()))
 				return
 			}
 			// use taskCtx for canceling.

--- a/pkg/disttask/framework/taskexecutor/manager.go
+++ b/pkg/disttask/framework/taskexecutor/manager.go
@@ -421,7 +421,7 @@ func (m *Manager) onRunnableTask(task *proto.Task) {
 		switch task.State {
 		case proto.TaskStateRunning:
 			if taskCtx.Err() != nil {
-				logutil.Logger(m.logCtx).Info("onRunnableTask exit for taskCtx.Done",
+				logutil.Logger(m.logCtx).Debug("onRunnableTask exit for taskCtx.Done",
 					zap.Int64("task-id", task.ID), zap.Stringer("type", task.Type), zap.Error(taskCtx.Err()))
 				return
 			}

--- a/pkg/disttask/framework/taskexecutor/manager_test.go
+++ b/pkg/disttask/framework/taskexecutor/manager_test.go
@@ -323,8 +323,8 @@ func TestSlotManagerInManager(t *testing.T) {
 
 	// task1 alloc resource success
 	require.Equal(t, 0, m.slotManager.available)
-	require.Equal(t, map[int64]*slotInfo{
-		taskID1: {taskID: int(taskID1), slotCount: 10},
+	require.Equal(t, map[int64]*proto.Task{
+		taskID1: task1,
 	}, m.slotManager.executorSlotInfos)
 	ch <- struct{}{}
 

--- a/pkg/disttask/framework/taskexecutor/manager_test.go
+++ b/pkg/disttask/framework/taskexecutor/manager_test.go
@@ -383,7 +383,7 @@ func TestSlotManagerInManager(t *testing.T) {
 		return ctrl.Satisfied()
 	}, 2*time.Second, 300*time.Millisecond)
 
-	// 2. task1 is occupied by task3, task1 start to pausing
+	// 2. task1 is preempted by task3, task1 start to pausing
 	// 3. task3 is waiting for task1 to be released, and task2 can't be allocated
 	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID3, proto.StepOne,
 		unfinishedSubtaskStates...).

--- a/pkg/disttask/framework/taskexecutor/manager_test.go
+++ b/pkg/disttask/framework/taskexecutor/manager_test.go
@@ -76,7 +76,7 @@ func TestManageTask(t *testing.T) {
 	m.addHandlingTask(2)
 	ctx1, cancel1 = context.WithCancelCause(context.Background())
 	m.registerCancelFunc(2, cancel1)
-	m.cancelTasks([]*proto.Task{{ID: 2}})
+	m.cancelTaskExecutors([]*proto.Task{{ID: 2}})
 	require.Equal(t, context.Canceled, ctx1.Err())
 
 	// test cancel.
@@ -325,7 +325,7 @@ func TestSlotManagerInManager(t *testing.T) {
 
 	// task1 alloc resource success
 	require.Equal(t, 0, m.slotManager.available)
-	require.Equal(t, []*proto.Task{task1}, m.slotManager.executorSlotInfos)
+	require.Equal(t, []*proto.Task{task1}, m.slotManager.executorTasks)
 	ch <- nil
 
 	// task1 succeed
@@ -334,7 +334,7 @@ func TestSlotManagerInManager(t *testing.T) {
 	mockInternalExecutor.EXPECT().Close()
 	wg.Wait()
 	require.Equal(t, 10, m.slotManager.available)
-	require.Equal(t, 0, len(m.slotManager.executorSlotInfos))
+	require.Equal(t, 0, len(m.slotManager.executorTasks))
 	require.True(t, ctrl.Satisfied())
 
 	// ******** Test task occupation ********
@@ -374,7 +374,7 @@ func TestSlotManagerInManager(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	// task1 alloc resource success
 	require.Equal(t, 0, m.slotManager.available)
-	require.Equal(t, []*proto.Task{task1}, m.slotManager.executorSlotInfos)
+	require.Equal(t, []*proto.Task{task1}, m.slotManager.executorTasks)
 	require.True(t, ctrl.Satisfied())
 
 	// 2. task1 is occupied by task3, task1 start to pausing
@@ -387,7 +387,7 @@ func TestSlotManagerInManager(t *testing.T) {
 	m.onRunnableTasks([]*proto.Task{task3, task2})
 	time.Sleep(2 * time.Second)
 	require.Equal(t, 0, m.slotManager.available)
-	require.Equal(t, []*proto.Task{task1}, m.slotManager.executorSlotInfos)
+	require.Equal(t, []*proto.Task{task1}, m.slotManager.executorTasks)
 	require.True(t, ctrl.Satisfied())
 
 	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID1).Return(task1, nil)
@@ -400,7 +400,7 @@ func TestSlotManagerInManager(t *testing.T) {
 	ch <- context.Canceled
 	time.Sleep(time.Second)
 	require.Equal(t, 10, m.slotManager.available)
-	require.Len(t, m.slotManager.executorSlotInfos, 0)
+	require.Len(t, m.slotManager.executorTasks, 0)
 	require.True(t, ctrl.Satisfied())
 
 	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID3, proto.StepOne,
@@ -438,7 +438,7 @@ func TestSlotManagerInManager(t *testing.T) {
 	m.onRunnableTasks([]*proto.Task{task3, task1, task2})
 	time.Sleep(2 * time.Second)
 	require.Equal(t, 8, m.slotManager.available)
-	require.Equal(t, 2, len(m.slotManager.executorSlotInfos))
+	require.Equal(t, 2, len(m.slotManager.executorTasks))
 	require.True(t, ctrl.Satisfied())
 
 	// 6. task3/task2 run success
@@ -452,6 +452,6 @@ func TestSlotManagerInManager(t *testing.T) {
 	ch <- nil
 	wg.Wait()
 	require.Equal(t, 10, m.slotManager.available)
-	require.Equal(t, 0, len(m.slotManager.executorSlotInfos))
+	require.Equal(t, 0, len(m.slotManager.executorTasks))
 	require.True(t, ctrl.Satisfied())
 }

--- a/pkg/disttask/framework/taskexecutor/manager_test.go
+++ b/pkg/disttask/framework/taskexecutor/manager_test.go
@@ -29,11 +29,6 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-var unfinishedSubtaskStates = []interface{}{
-	proto.TaskStatePending, proto.TaskStateRevertPending,
-	proto.TaskStateRunning, proto.TaskStateReverting,
-}
-
 func getPoolRunFn() (*sync.WaitGroup, func(f func()) error) {
 	wg := &sync.WaitGroup{}
 	return wg, func(f func()) error {
@@ -76,6 +71,12 @@ func TestManageTask(t *testing.T) {
 	ctx1, cancel1 := context.WithCancelCause(context.Background())
 	m.registerCancelFunc(2, cancel1)
 	m.cancelAllRunningTasks()
+	require.Equal(t, context.Canceled, ctx1.Err())
+
+	m.addHandlingTask(2)
+	ctx1, cancel1 = context.WithCancelCause(context.Background())
+	m.registerCancelFunc(2, cancel1)
+	m.cancelTasks([]*proto.Task{{ID: 2}})
 	require.Equal(t, context.Canceled, ctx1.Err())
 
 	// test cancel.
@@ -272,32 +273,34 @@ func TestSlotManagerInManager(t *testing.T) {
 	require.NoError(t, err)
 	m.slotManager.available = 10
 
-	taskID1 := int64(1)
-	taskID2 := int64(2)
+	var (
+		taskID1 = int64(1)
+		taskID2 = int64(2)
 
-	now := time.Now()
+		task1 = &proto.Task{
+			ID:          taskID1,
+			State:       proto.TaskStateRunning,
+			Concurrency: 10,
+			Step:        proto.StepOne,
+			Type:        "type",
+		}
+		task2 = &proto.Task{
+			ID:          taskID2,
+			State:       proto.TaskStateRunning,
+			Concurrency: 1,
+			Step:        proto.StepOne,
+			Type:        "type",
+		}
+	)
 
-	task1 := &proto.Task{
-		ID:          taskID1,
-		State:       proto.TaskStateRunning,
-		CreateTime:  now,
-		Concurrency: 10,
-		Step:        proto.StepOne,
-		Type:        "type",
-	}
-	task2 := &proto.Task{
-		ID:          taskID2,
-		State:       proto.TaskStateRunning,
-		CreateTime:  now,
-		Concurrency: 1,
-		Step:        proto.StepOne,
-		Type:        "type",
-	}
-
-	ch := make(chan struct{})
-
+	ch := make(chan error)
+	defer close(ch)
 	wg, runFn := getPoolRunFn()
 
+	// ******** Test task1 alloc success ********
+	// 1. task1 alloc success
+	// 2. task2 alloc failed
+	// 3. task1 run success
 	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
 		unfinishedSubtaskStates...).
 		Return(true, nil)
@@ -314,8 +317,7 @@ func TestSlotManagerInManager(t *testing.T) {
 		Return(true, nil)
 	// task1 start running
 	mockInternalExecutor.EXPECT().Run(gomock.Any(), task1).DoAndReturn(func(_ context.Context, _ *proto.Task) error {
-		<-ch
-		return nil
+		return <-ch
 	})
 
 	m.onRunnableTasks([]*proto.Task{task1, task2})
@@ -323,17 +325,133 @@ func TestSlotManagerInManager(t *testing.T) {
 
 	// task1 alloc resource success
 	require.Equal(t, 0, m.slotManager.available)
-	require.Equal(t, map[int64]*proto.Task{
-		taskID1: task1,
-	}, m.slotManager.executorSlotInfos)
-	ch <- struct{}{}
+	require.Equal(t, []*proto.Task{task1}, m.slotManager.executorSlotInfos)
+	ch <- nil
 
 	// task1 succeed
 	task1.State = proto.TaskStateSucceed
 	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID1).Return(task1, nil)
 	mockInternalExecutor.EXPECT().Close()
-
 	wg.Wait()
 	require.Equal(t, 10, m.slotManager.available)
 	require.Equal(t, 0, len(m.slotManager.executorSlotInfos))
+	require.True(t, ctrl.Satisfied())
+
+	// ******** Test task occupation ********
+	task1.State = proto.TaskStateRunning
+	var (
+		taskID3 = int64(3)
+		task3   = &proto.Task{
+			ID:          taskID3,
+			State:       proto.TaskStateRunning,
+			Concurrency: 1,
+			Priority:    -1,
+			Step:        proto.StepOne,
+			Type:        "type",
+		}
+	)
+	// 1. task1 alloc success
+	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
+		unfinishedSubtaskStates...).
+		Return(true, nil)
+	mockPool.EXPECT().Run(gomock.Any()).DoAndReturn(runFn)
+	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID2, proto.StepOne,
+		unfinishedSubtaskStates...).
+		Return(true, nil)
+
+	// mock inside onRunnableTask
+	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
+	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID1).Return(task1, nil)
+	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
+		unfinishedSubtaskStates...).
+		Return(true, nil)
+	// task1 start running
+	mockInternalExecutor.EXPECT().Run(gomock.Any(), task1).DoAndReturn(func(_ context.Context, _ *proto.Task) error {
+		return <-ch
+	})
+
+	m.onRunnableTasks([]*proto.Task{task1, task2})
+	time.Sleep(2 * time.Second)
+	// task1 alloc resource success
+	require.Equal(t, 0, m.slotManager.available)
+	require.Equal(t, []*proto.Task{task1}, m.slotManager.executorSlotInfos)
+	require.True(t, ctrl.Satisfied())
+
+	// 2. task1 is occupied by task3, task1 start to pausing
+	// 3. task3 is waiting for task1 to be released, and task2 can't be allocated
+	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID3, proto.StepOne,
+		unfinishedSubtaskStates...).
+		Return(true, nil)
+
+	// the priority of task3 is higher than task2, so task3 is in front of task2
+	m.onRunnableTasks([]*proto.Task{task3, task2})
+	time.Sleep(2 * time.Second)
+	require.Equal(t, 0, m.slotManager.available)
+	require.Equal(t, []*proto.Task{task1}, m.slotManager.executorSlotInfos)
+	require.True(t, ctrl.Satisfied())
+
+	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID1).Return(task1, nil)
+	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
+		unfinishedSubtaskStates...).
+		Return(true, nil)
+	mockInternalExecutor.EXPECT().Close()
+
+	// 4. task1 is released, task3 alloc success, start to run
+	ch <- context.Canceled
+	time.Sleep(time.Second)
+	require.Equal(t, 10, m.slotManager.available)
+	require.Len(t, m.slotManager.executorSlotInfos, 0)
+	require.True(t, ctrl.Satisfied())
+
+	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID3, proto.StepOne,
+		unfinishedSubtaskStates...).
+		Return(true, nil)
+	mockPool.EXPECT().Run(gomock.Any()).DoAndReturn(runFn)
+	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
+		unfinishedSubtaskStates...).
+		Return(true, nil)
+	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID2, proto.StepOne,
+		unfinishedSubtaskStates...).
+		Return(true, nil)
+	mockPool.EXPECT().Run(gomock.Any()).DoAndReturn(runFn)
+
+	// mock inside onRunnableTask
+	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
+	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID3).Return(task3, nil)
+	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID3, proto.StepOne,
+		unfinishedSubtaskStates...).
+		Return(true, nil)
+	mockInternalExecutor.EXPECT().Run(gomock.Any(), task3).DoAndReturn(func(_ context.Context, _ *proto.Task) error {
+		return <-ch
+	})
+
+	// 5. available is enough, task2 alloc success,
+	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
+	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID2).Return(task2, nil)
+	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID2, proto.StepOne,
+		unfinishedSubtaskStates...).
+		Return(true, nil)
+	mockInternalExecutor.EXPECT().Run(gomock.Any(), task2).DoAndReturn(func(_ context.Context, _ *proto.Task) error {
+		return <-ch
+	})
+
+	m.onRunnableTasks([]*proto.Task{task3, task1, task2})
+	time.Sleep(2 * time.Second)
+	require.Equal(t, 8, m.slotManager.available)
+	require.Equal(t, 2, len(m.slotManager.executorSlotInfos))
+	require.True(t, ctrl.Satisfied())
+
+	// 6. task3/task2 run success
+	task3.State = proto.TaskStateSucceed
+	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID3).Return(task3, nil)
+	mockInternalExecutor.EXPECT().Close()
+	task2.State = proto.TaskStateSucceed
+	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID2).Return(task2, nil)
+	mockInternalExecutor.EXPECT().Close()
+	ch <- nil
+	ch <- nil
+	wg.Wait()
+	require.Equal(t, 10, m.slotManager.available)
+	require.Equal(t, 0, len(m.slotManager.executorSlotInfos))
+	require.True(t, ctrl.Satisfied())
 }

--- a/pkg/disttask/framework/taskexecutor/slot_test.go
+++ b/pkg/disttask/framework/taskexecutor/slot_test.go
@@ -23,32 +23,99 @@ import (
 
 func TestSlotManager(t *testing.T) {
 	sm := slotManager{
-		executorSlotInfos: make(map[int64]*slotInfo),
+		executorSlotInfos: make(map[int64]*proto.Task),
 		available:         10,
 	}
 
 	var (
 		taskID  = int64(1)
 		taskID2 = int64(2)
+		taskID3 = int64(3)
+		taskID4 = int64(4)
+		task    = &proto.Task{
+			ID:          taskID,
+			Priority:    1,
+			Concurrency: 1,
+		}
+		task2 = &proto.Task{
+			ID:          taskID2,
+			Priority:    2,
+			Concurrency: 10,
+		}
 	)
 
-	task := &proto.Task{
-		ID:          taskID,
-		Priority:    1,
-		Concurrency: 1,
-	}
-	require.True(t, sm.canAlloc(task))
+	canAlloc, tasksNeedFree := sm.canAlloc(task)
+	require.True(t, canAlloc)
+	require.Nil(t, tasksNeedFree)
 	sm.alloc(task)
-	require.Equal(t, 1, sm.executorSlotInfos[taskID].priority)
-	require.Equal(t, 1, sm.executorSlotInfos[taskID].slotCount)
+	require.Len(t, sm.executorSlotInfos, 1)
+	require.Equal(t, task, sm.executorSlotInfos[taskID])
 	require.Equal(t, 9, sm.available)
 
-	require.False(t, sm.canAlloc(&proto.Task{
-		ID:          taskID2,
-		Priority:    2,
+	// the available slots is not enough for task2
+	canAlloc, tasksNeedFree = sm.canAlloc(task2)
+	require.False(t, canAlloc)
+	require.Nil(t, tasksNeedFree)
+
+	// increase the priority of task2, task2 is waiting for allocation
+	task2.Priority = 0
+	canAlloc, tasksNeedFree = sm.canAlloc(task2)
+	require.False(t, canAlloc)
+	require.Equal(t, []*proto.Task{task}, tasksNeedFree)
+	require.Equal(t, task2, sm.taskWaitAlloc)
+
+	// task with lower priority is restricted
+	task3 := &proto.Task{
+		ID:          taskID3,
+		Priority:    3,
+		Concurrency: 1,
+	}
+	canAlloc, tasksNeedFree = sm.canAlloc(task3)
+	require.False(t, canAlloc)
+	require.Nil(t, tasksNeedFree)
+
+	// increase the priority of task3, it can be allocated now
+	task3.Priority = -1
+	canAlloc, tasksNeedFree = sm.canAlloc(task3)
+	require.True(t, canAlloc)
+	require.Nil(t, tasksNeedFree)
+	// task2 is occupied by task3
+	require.Nil(t, sm.taskWaitAlloc)
+	sm.alloc(task3)
+	require.Len(t, sm.executorSlotInfos, 2)
+	require.Equal(t, task3, sm.executorSlotInfos[taskID3])
+	require.Equal(t, 8, sm.available)
+	sm.free(taskID3)
+	require.Len(t, sm.executorSlotInfos, 1)
+	require.Nil(t, sm.executorSlotInfos[taskID3])
+
+	// task2 is waiting for allocation again
+	canAlloc, tasksNeedFree = sm.canAlloc(task2)
+	require.False(t, canAlloc)
+	require.Equal(t, []*proto.Task{task}, tasksNeedFree)
+	require.Equal(t, task2, sm.taskWaitAlloc)
+
+	// task2 is occupied by task4
+	task4 := &proto.Task{
+		ID:          taskID4,
+		Priority:    -1,
 		Concurrency: 10,
-	}))
+	}
+	canAlloc, tasksNeedFree = sm.canAlloc(task4)
+	require.False(t, canAlloc)
+	require.Equal(t, []*proto.Task{task}, tasksNeedFree)
+	// task 4 is waiting for allocation
+	require.Equal(t, task4, sm.taskWaitAlloc)
 
 	sm.free(taskID)
+	require.Len(t, sm.executorSlotInfos, 0)
 	require.Nil(t, sm.executorSlotInfos[taskID])
+
+	sm.alloc(task4)
+	require.Len(t, sm.executorSlotInfos, 1)
+	require.Equal(t, task4, sm.executorSlotInfos[taskID4])
+	require.Equal(t, 0, sm.available)
+	sm.free(taskID4)
+	require.Len(t, sm.executorSlotInfos, 0)
+	require.Nil(t, sm.executorSlotInfos[taskID4])
 }

--- a/pkg/disttask/framework/taskexecutor/slot_test.go
+++ b/pkg/disttask/framework/taskexecutor/slot_test.go
@@ -98,6 +98,19 @@ func TestSlotManager(t *testing.T) {
 	// test the order of executorTasks
 	require.Equal(t, []*proto.Task{task4, task, task5, task3}, sm.executorTasks)
 	require.Equal(t, 6, sm.available)
+
+	task6 := &proto.Task{
+		ID:          6,
+		Priority:    0,
+		Concurrency: 8,
+	}
+	canAlloc, tasksNeedFree = sm.canAlloc(task6)
+	require.True(t, canAlloc)
+	require.Equal(t, []*proto.Task{task4, task}, tasksNeedFree)
+	task6.Concurrency++
+	canAlloc, tasksNeedFree = sm.canAlloc(task6)
+	require.False(t, canAlloc)
+	require.Nil(t, tasksNeedFree)
 	sm.free(task4.ID)
 	sm.free(task5.ID)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/49008

Problem Summary: we need free slots(resource) when higher task comes.

### What changed and how does it work?

- cancel the lower priority task when higher task comes, higher task is waiting slots
- alloc slot to waiting task after lower task cancelled
- can't alloc lower task when a task is waiting
- higher task will occupy slots that the waiting task reserved, and waiting task reset

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
