### PR TITLE
rowcodec: use array type to decode index value

### DIFF
--- a/pkg/util/rowcodec/decoder.go
+++ b/pkg/util/rowcodec/decoder.go
@@ -389,7 +389,7 @@ func (decoder *BytesDecoder) decodeToBytesInternal(outputOffset map[int64]int, h
 	values := make([][]byte, len(outputOffset))
 	for i := range decoder.columns {
 		col := &decoder.columns[i]
-		tp := fieldType2Flag(col.Ft.GetType(), col.Ft.GetFlag()&mysql.UnsignedFlag == 0)
+		tp := fieldType2Flag(col.Ft.ArrayType().GetType(), col.Ft.GetFlag()&mysql.UnsignedFlag == 0)
 		colID := col.ID
 		offset := outputOffset[colID]
 		idx, isNil, notFound := r.findColID(colID)

--- a/tests/integrationtest/r/expression/multi_valued_index.result
+++ b/tests/integrationtest/r/expression/multi_valued_index.result
@@ -506,3 +506,13 @@ Error 3903 (HY000): Invalid JSON value for CAST for expression index 'idx'
 insert into t values (json_array(cast('{"a":1}' as json)));
 Error 3903 (HY000): Invalid JSON value for CAST for expression index 'idx'
 set sql_mode=default;
+drop table if exists t;
+create table t (j json not null, str varchar(5),  KEY `idx` ((cast(`j` as unsigned array)),`str`));
+insert into t values ('1', 'abcde');
+drop table t;
+create table t (j json not null, str varchar(5) collate utf8mb4_unicode_ci,  KEY `idx` ((cast(`j` as unsigned array)),`str`));
+insert into t values ('1', 'abcde');
+drop table t;
+create table t (j json not null, str varchar(5) collate gbk_chinese_ci,  KEY `idx` ((cast(`j` as unsigned array)),`str`));
+insert into t values ('1', 'abcde');
+drop table t;

--- a/tests/integrationtest/t/expression/multi_valued_index.test
+++ b/tests/integrationtest/t/expression/multi_valued_index.test
@@ -511,3 +511,15 @@ insert into t values (json_array(cast("2022-02-02 11:00:00" as datetime)));
 insert into t values (json_array(cast('{"a":1}' as json)));
 
 set sql_mode=default;
+
+# TestMultiValuedIndexInCompoundIndex
+drop table if exists t;
+create table t (j json not null, str varchar(5),  KEY `idx` ((cast(`j` as unsigned array)),`str`));
+insert into t values ('1', 'abcde');
+drop table t;
+create table t (j json not null, str varchar(5) collate utf8mb4_unicode_ci,  KEY `idx` ((cast(`j` as unsigned array)),`str`));
+insert into t values ('1', 'abcde');
+drop table t;
+create table t (j json not null, str varchar(5) collate gbk_chinese_ci,  KEY `idx` ((cast(`j` as unsigned array)),`str`));
+insert into t values ('1', 'abcde');
+drop table t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #49680

Problem Summary:

For multi-valued index, we should use the `ArrayType` to decode the restore data.

### What changed and how does it work?

Use the `ArrayType` rather the direct `GetType` to decode the restore data. The `GetType` will give `JSON`, but we expect the internal type (e.g. unsigned integer, string...).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
Fix the issue that the compound index of multi-valued index and any other non-binary string cannot be inserted.
```
