### PR TITLE
statistics: add better comments to UpdateStatsMetaVersionForGC

### DIFF
--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -78,7 +78,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 			return err
 		}
 		for _, id := range droppedIDs {
-			if err := h.statsWriter.ResetTableStats2KVForDrop(id); err != nil {
+			if err := h.statsWriter.UpdateStatsMetaVersionForGC(id); err != nil {
 				return err
 			}
 		}
@@ -89,7 +89,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 			return err
 		}
 		for _, id := range ids {
-			if err := h.statsWriter.ResetTableStats2KVForDrop(id); err != nil {
+			if err := h.statsWriter.UpdateStatsMetaVersionForGC(id); err != nil {
 				return err
 			}
 		}
@@ -162,7 +162,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 
 		// Remove partition stats.
 		for _, def := range droppedPartInfo.Definitions {
-			if err := h.statsWriter.ResetTableStats2KVForDrop(def.ID); err != nil {
+			if err := h.statsWriter.UpdateStatsMetaVersionForGC(def.ID); err != nil {
 				return err
 			}
 		}

--- a/pkg/statistics/handle/ddl/drop_partition.go
+++ b/pkg/statistics/handle/ddl/drop_partition.go
@@ -70,7 +70,7 @@ func (h *ddlHandlerImpl) onDropPartitions(t *util.DDLEvent) error {
 	// Reset the partition stats.
 	// It's OK to put those operations in different transactions. Because it will not affect the correctness.
 	for _, def := range droppedPartitionInfo.Definitions {
-		if err := h.statsWriter.ResetTableStats2KVForDrop(def.ID); err != nil {
+		if err := h.statsWriter.UpdateStatsMetaVersionForGC(def.ID); err != nil {
 			return err
 		}
 	}

--- a/pkg/statistics/handle/ddl/reorganize_partition.go
+++ b/pkg/statistics/handle/ddl/reorganize_partition.go
@@ -38,7 +38,7 @@ func (h *ddlHandlerImpl) onReorganizePartitions(t *util.DDLEvent) error {
 	// Reset the partition stats.
 	// It's OK to put those operations in different transactions. Because it will not affect the correctness.
 	for _, def := range droppedPartitionInfo.Definitions {
-		if err := h.statsWriter.ResetTableStats2KVForDrop(def.ID); err != nil {
+		if err := h.statsWriter.UpdateStatsMetaVersionForGC(def.ID); err != nil {
 			return err
 		}
 	}

--- a/pkg/statistics/handle/ddl/truncate_partition.go
+++ b/pkg/statistics/handle/ddl/truncate_partition.go
@@ -129,7 +129,7 @@ func (h *ddlHandlerImpl) onTruncatePartitions(t *util.DDLEvent) error {
 	// Third, clean up the old stats meta from partition stats meta for the dropped partitions.
 	// It's OK to put those operations in different transactions. Because it will not affect the correctness.
 	for _, def := range droppedPartInfo.Definitions {
-		if err := h.statsWriter.ResetTableStats2KVForDrop(def.ID); err != nil {
+		if err := h.statsWriter.UpdateStatsMetaVersionForGC(def.ID); err != nil {
 			return err
 		}
 	}

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -162,9 +162,9 @@ func (s *statsReadWriter) ChangeGlobalStatsID(from, to int64) (err error) {
 	}, util.FlagWrapTxn)
 }
 
-// ResetTableStats2KVForDrop update the version of mysql.stats_meta.
-// Then GC worker will delete the old version of stats.
-func (s *statsReadWriter) ResetTableStats2KVForDrop(physicalID int64) (err error) {
+// UpdateStatsMetaVersionForGC update the version of mysql.stats_meta.
+// See more details in the interface definition.
+func (s *statsReadWriter) UpdateStatsMetaVersionForGC(physicalID int64) (err error) {
 	statsVer := uint64(0)
 	defer func() {
 		if err == nil && statsVer != 0 {

--- a/pkg/statistics/handle/storage/stats_read_writer_test.go
+++ b/pkg/statistics/handle/storage/stats_read_writer_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResetTableStats2KVForDrop(t *testing.T) {
+func TestUpdateStatsMetaVersionForGC(t *testing.T) {
 	store, do := testkit.CreateMockStoreAndDomain(t)
 	testKit := testkit.NewTestKit(t, store)
 	h := do.StatsHandle()
@@ -60,7 +60,7 @@ func TestResetTableStats2KVForDrop(t *testing.T) {
 
 	// Reset one partition stats.
 	p0 := pi.Definitions[0]
-	err = h.ResetTableStats2KVForDrop(p0.ID)
+	err = h.UpdateStatsMetaVersionForGC(p0.ID)
 	require.NoError(t, err)
 
 	// Get partition stats from stats_meta table.

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -271,6 +271,9 @@ type StatsReadWriter interface {
 	// ensuring it is greater than the last garbage collection (GC) time.
 	// The GC worker deletes old stats based on a safe time point,
 	// calculated as now() - 10 * max(stats lease, ddl lease).
+	// The range [last GC time, safe time point) is chosen to prevent
+	// the simultaneous deletion of numerous stats, minimizing potential
+	// performance issues.
 	// This function ensures the version is updated beyond the last GC time,
 	// allowing the GC worker to delete outdated stats.
 	//

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -267,7 +267,7 @@ type StatsReadWriter interface {
 	// then tidb-server will reload automatic.
 	UpdateStatsVersion() error
 
-	// ResetTableStats2KVForDrop updates the version of mysql.stats_meta,
+	// UpdateStatsMetaVersionForGC updates the version of mysql.stats_meta,
 	// ensuring it is greater than the last garbage collection (GC) time.
 	// The GC worker deletes old stats based on a safe time point,
 	// calculated as now() - 10 * max(stats lease, ddl lease).
@@ -287,7 +287,7 @@ type StatsReadWriter interface {
 	// For instance, if a table was created at time 90, and it's now time 200,
 	// with the last GC time at 95 and the safe time point at 100,
 	// updating the version beyond 95 ensures eventual deletion of stats.
-	ResetTableStats2KVForDrop(physicalID int64) (err error)
+	UpdateStatsMetaVersionForGC(physicalID int64) (err error)
 
 	// ChangeGlobalStatsID changes the global stats ID.
 	ChangeGlobalStatsID(from, to int64) (err error)

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -267,8 +267,26 @@ type StatsReadWriter interface {
 	// then tidb-server will reload automatic.
 	UpdateStatsVersion() error
 
-	// ResetTableStats2KVForDrop update the version of mysql.stats_meta.
-	// Then GC worker will delete the old version of stats.
+	// ResetTableStats2KVForDrop updates the version of mysql.stats_meta,
+	// ensuring it is greater than the last garbage collection (GC) time.
+	// The GC worker deletes old stats based on a safe time point,
+	// calculated as now() - 10 * max(stats lease, ddl lease).
+	// This function ensures the version is updated beyond the last GC time,
+	// allowing the GC worker to delete outdated stats.
+	//
+	// Explanation:
+	// - ddl lease: 10
+	// - stats lease: 3
+	// - safe time point: now() - 10 * 10 = now() - 100
+	// - now: 200
+	// - last GC time: 90
+	// - [last GC time, safe time point) = [90, 100)
+	// - To trigger stats deletion, the version must be updated beyond 90.
+	//
+	// This safeguards scenarios where a table remains unchanged for an extended period.
+	// For instance, if a table was created at time 90, and it's now time 200,
+	// with the last GC time at 95 and the safe time point at 100,
+	// updating the version beyond 95 ensures eventual deletion of stats.
 	ResetTableStats2KVForDrop(physicalID int64) (err error)
 
 	// ChangeGlobalStatsID changes the global stats ID.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary:

### What changed and how does it work?

- Added better comments to `ResetTableStats2KVForDrop` to get better readability.
- Renamed to `UpdateStatsMetaVersionForGC`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
