### PR TITLE
statistics: BCE for the histogram

### DIFF
--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -176,11 +176,12 @@ func (hg *Histogram) updateLastBucket(upper *types.Datum, count, repeat int64, n
 	hg.Bounds.TruncateTo(2*l - 1)
 	hg.Bounds.AppendDatum(0, upper)
 	// The sampling case doesn't hold NDV since the low sampling rate. So check the NDV here.
-	if needBucketNDV && hg.Buckets[l-1].NDV > 0 {
-		hg.Buckets[l-1].NDV++
+	bucket := &hg.Buckets[l-1]
+	if needBucketNDV && bucket.NDV > 0 {
+		bucket.NDV++
 	}
-	hg.Buckets[l-1].Count = count
-	hg.Buckets[l-1].Repeat = repeat
+	bucket.Count = count
+	bucket.Repeat = repeat
 }
 
 // DecodeTo decodes the histogram bucket values into `tp`.
@@ -321,15 +322,17 @@ func (hg *Histogram) BinarySearchRemoveVal(valCntPairs TopNMeta) {
 			lowIdx = midIdx + 1
 			continue
 		}
-		if hg.Buckets[midIdx].NDV > 0 {
-			hg.Buckets[midIdx].NDV--
+		midbucket := &hg.Buckets[midIdx]
+
+		if midbucket.NDV > 0 {
+			midbucket.NDV--
 		}
 		if cmpResult == 0 {
-			hg.Buckets[midIdx].Repeat = 0
+			midbucket.Repeat = 0
 		}
-		hg.Buckets[midIdx].Count -= int64(valCntPairs.Count)
-		if hg.Buckets[midIdx].Count < 0 {
-			hg.Buckets[midIdx].Count = 0
+		midbucket.Count -= int64(valCntPairs.Count)
+		if midbucket.Count < 0 {
+			midbucket.Count = 0
 		}
 		found = true
 		break

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -16,10 +16,10 @@ package statistics
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"math"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1163,7 +1163,7 @@ func (hg *Histogram) ExtractTopN(cms *CMSketch, topN *TopN, numCols int, numTopN
 			}
 		}
 	}
-	sort.SliceStable(dataCnts, func(i, j int) bool { return dataCnts[i].cnt >= dataCnts[j].cnt })
+	slices.SortStableFunc(dataCnts, func(a, b dataCnt) int { return -cmp.Compare(a.cnt, b.cnt) })
 	if len(dataCnts) > int(numTopN) {
 		dataCnts = dataCnts[:numTopN]
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49750

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)


before

```
➜  tidb git:(master) go test -run=^$ -bench=BenchmarkMergePartTopN2GlobalTopNWithHists -benchmem github.com/pingcap/tidb/pkg/statistics/handle/globalstats
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/pkg/statistics/handle/globalstats
cpu: AMD Ryzen 7 7735HS with Radeon Graphics
BenchmarkMergePartTopN2GlobalTopNWithHists/Size100-16         	     200	   5901398 ns/op	  177652 B/op	      30 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size1000-16        	      12	  89938452 ns/op	  178092 B/op	      32 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size2000-16        	       4	 254384526 ns/op	  178248 B/op	      30 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size5000-16        	       1	1078682107 ns/op	  179640 B/op	      34 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size10000-16       	       1	2604364596 ns/op	  176360 B/op	      29 allocs/op
PASS
ok  	github.com/pingcap/tidb/pkg/statistics/handle/globalstats	12.227s
```

after
```
go test -run=^$ -bench=BenchmarkMergePartTopN2GlobalTopNWithHists -benchmem github.com/pingcap/tidb/pkg/statistics/handle/globalstats
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/pkg/statistics/handle/globalstats
cpu: AMD Ryzen 7 7735HS with Radeon Graphics
BenchmarkMergePartTopN2GlobalTopNWithHists/Size100-16         	     205	   5869891 ns/op	  177727 B/op	      30 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size1000-16        	      12	  90053269 ns/op	  177553 B/op	      30 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size2000-16        	       4	 255820154 ns/op	  177476 B/op	      31 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size5000-16        	       1	1060368605 ns/op	  177480 B/op	      29 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size10000-16       	       1	2586619643 ns/op	  175592 B/op	      28 allocs/op
PASS
ok  	github.com/pingcap/tidb/pkg/statistics/handle/globalstats	13.211s
```



- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
