### PR TITLE
sessionctx: refactor sessionctx pkg's warning and note generation

### DIFF
--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -1275,10 +1275,10 @@ func (sc *StatementContext) RecordRangeFallback(rangeMaxSize int64) {
 	// If range fallback happens, it means ether the query is unreasonable(for example, several long IN lists) or tidb_opt_range_max_size is too small
 	// and the generated plan is probably suboptimal. In that case we don't put it into plan cache.
 	if sc.UseCache {
-		sc.SetSkipPlanCache(errors.Errorf("in-list is too long"))
+		sc.SetSkipPlanCache(errors.NewNoStackError("in-list is too long"))
 	}
 	if !sc.RangeFallback {
-		sc.AppendWarning(errors.Errorf("Memory capacity of %v bytes for 'tidb_opt_range_max_size' exceeded when building ranges. Less accurate ranges such as full range are chosen", rangeMaxSize))
+		sc.AppendWarning(errors.NewNoStackErrorf("Memory capacity of %v bytes for 'tidb_opt_range_max_size' exceeded when building ranges. Less accurate ranges such as full range are chosen", rangeMaxSize))
 		sc.RangeFallback = true
 	}
 }

--- a/pkg/sessionctx/stmtctx/stmtctx_test.go
+++ b/pkg/sessionctx/stmtctx/stmtctx_test.go
@@ -317,7 +317,7 @@ func TestNewStmtCtx(t *testing.T) {
 	require.Equal(t, types.DefaultStmtFlags, sc.TypeFlags())
 	require.Same(t, time.UTC, sc.TimeZone())
 	require.Same(t, time.UTC, sc.TimeZone())
-	sc.AppendWarning(errors.New("err1"))
+	sc.AppendWarning(errors.NewNoStackError("err1"))
 	warnings := sc.GetWarnings()
 	require.Equal(t, 1, len(warnings))
 	require.Equal(t, stmtctx.WarnLevelWarning, warnings[0].Level)
@@ -328,7 +328,7 @@ func TestNewStmtCtx(t *testing.T) {
 	require.Equal(t, types.DefaultStmtFlags, sc.TypeFlags())
 	require.Same(t, tz, sc.TimeZone())
 	require.Same(t, tz, sc.TimeZone())
-	sc.AppendWarning(errors.New("err2"))
+	sc.AppendWarning(errors.NewNoStackError("err2"))
 	warnings = sc.GetWarnings()
 	require.Equal(t, 1, len(warnings))
 	require.Equal(t, stmtctx.WarnLevelWarning, warnings[0].Level)
@@ -363,7 +363,7 @@ func TestResetStmtCtx(t *testing.T) {
 	tz := time.FixedZone("UTC+1", 2*60*60)
 	sc.SetTimeZone(tz)
 	sc.SetTypeFlags(types.FlagAllowNegativeToUnsigned | types.FlagSkipASCIICheck)
-	sc.AppendWarning(errors.New("err1"))
+	sc.AppendWarning(errors.NewNoStackError("err1"))
 	sc.InRestrictedSQL = true
 	sc.StmtType = "Insert"
 
@@ -379,7 +379,7 @@ func TestResetStmtCtx(t *testing.T) {
 	require.False(t, sc.InRestrictedSQL)
 	require.Empty(t, sc.StmtType)
 	require.Equal(t, 0, len(sc.GetWarnings()))
-	sc.AppendWarning(errors.New("err2"))
+	sc.AppendWarning(errors.NewNoStackError("err2"))
 	warnings := sc.GetWarnings()
 	require.Equal(t, 1, len(warnings))
 	require.Equal(t, stmtctx.WarnLevelWarning, warnings[0].Level)

--- a/pkg/sessionctx/variable/noop.go
+++ b/pkg/sessionctx/variable/noop.go
@@ -15,8 +15,9 @@
 package variable
 
 import (
-	"github.com/pingcap/errors"
 	"math"
+
+	"github.com/pingcap/errors"
 )
 
 // The following sysVars are noops.

--- a/pkg/sessionctx/variable/noop.go
+++ b/pkg/sessionctx/variable/noop.go
@@ -15,6 +15,7 @@
 package variable
 
 import (
+	"github.com/pingcap/errors"
 	"math"
 )
 
@@ -196,11 +197,11 @@ var noopSysVars = []*SysVar{
 	{Scope: ScopeGlobal | ScopeSession, Name: SQLAutoIsNull, Value: Off, Type: TypeBool, IsHintUpdatableVerfied: true, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
 		// checkSQLAutoIsNull requires TiDBEnableNoopFuncs != OFF for the same scope otherwise an error will be returned.
 		// See also https://github.com/pingcap/tidb/issues/28230
-		errMsg := ErrFunctionsNoopImpl.GenWithStackByArgs("sql_auto_is_null")
+		errMsg := ErrFunctionsNoopImpl.FastGenByArgs("sql_auto_is_null")
 		if TiDBOptOn(normalizedValue) {
 			if scope == ScopeSession && vars.NoopFuncsMode != OnInt {
 				if vars.NoopFuncsMode == OffInt {
-					return Off, errMsg
+					return Off, errors.Trace(errMsg)
 				}
 				vars.StmtCtx.AppendWarning(errMsg)
 			}
@@ -210,7 +211,7 @@ var noopSysVars = []*SysVar{
 					return originalValue, errUnknownSystemVariable.GenWithStackByArgs(TiDBEnableNoopFuncs)
 				}
 				if val == Off {
-					return Off, errMsg
+					return Off, errors.Trace(errMsg)
 				}
 				if val == Warn {
 					vars.StmtCtx.AppendWarning(errMsg)

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1739,9 +1739,9 @@ func (s *SessionVars) RaiseWarningWhenMPPEnforced(warning string) {
 		return
 	}
 	if s.StmtCtx.InExplainStmt {
-		s.StmtCtx.AppendWarning(errors.New(warning))
+		s.StmtCtx.AppendWarning(errors.NewNoStackError(warning))
 	} else {
-		s.StmtCtx.AppendExtraWarning(errors.New(warning))
+		s.StmtCtx.AppendExtraWarning(errors.NewNoStackError(warning))
 	}
 }
 

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1044,7 +1044,7 @@ var defaultSysVars = []*SysVar{
 				intVal = bt
 			}
 			if intVal > 0 && intVal < 128 { // 128 Bytes
-				s.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(TiDBServerMemoryLimitSessMinSize, originalValue))
+				s.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(TiDBServerMemoryLimitSessMinSize, originalValue))
 				intVal = 128
 			}
 			return strconv.FormatUint(intVal, 10), nil
@@ -1566,7 +1566,7 @@ var defaultSysVars = []*SysVar{
 		if mathutil.IntBits == 32 {
 			if val, err := strconv.ParseUint(normalizedValue, 10, 64); err == nil {
 				if val > uint64(math.MaxUint32) {
-					vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(GroupConcatMaxLen, originalValue))
+					vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(GroupConcatMaxLen, originalValue))
 					return strconv.FormatInt(int64(math.MaxUint32), 10), nil
 				}
 			}
@@ -1603,7 +1603,7 @@ var defaultSysVars = []*SysVar{
 			}
 			remainder := u % 1024
 			if remainder != 0 {
-				vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(MaxAllowedPacket, normalizedValue))
+				vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(MaxAllowedPacket, normalizedValue))
 				u -= remainder
 			}
 			return strconv.FormatUint(u, 10), nil
@@ -1924,7 +1924,7 @@ var defaultSysVars = []*SysVar{
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableFastAnalyze, Value: BoolToOnOff(DefTiDBUseFastAnalyze), Type: TypeBool,
 		Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
 			if TiDBOptOn(normalizedValue) {
-				vars.StmtCtx.AppendWarning(errors.New("the fast analyze feature has already been removed in TiDB v7.5.0, so this will have no effect"))
+				vars.StmtCtx.AppendWarning(errors.NewNoStackError("the fast analyze feature has already been removed in TiDB v7.5.0, so this will have no effect"))
 			}
 			return normalizedValue, nil
 		},
@@ -2076,15 +2076,15 @@ var defaultSysVars = []*SysVar{
 	}, SetSession: func(s *SessionVars, val string) error {
 		newMode := strings.ToLower(strings.TrimSpace(val))
 		if PartitionPruneMode(s.PartitionPruneMode.Load()) == Static && PartitionPruneMode(newMode) == Dynamic {
-			s.StmtCtx.AppendWarning(errors.New("Please analyze all partition tables again for consistency between partition and global stats"))
-			s.StmtCtx.AppendWarning(errors.New("Please avoid setting partition prune mode to dynamic at session level and set partition prune mode to dynamic at global level"))
+			s.StmtCtx.AppendWarning(errors.NewNoStackError("Please analyze all partition tables again for consistency between partition and global stats"))
+			s.StmtCtx.AppendWarning(errors.NewNoStackError("Please avoid setting partition prune mode to dynamic at session level and set partition prune mode to dynamic at global level"))
 		}
 		s.PartitionPruneMode.Store(newMode)
 		return nil
 	}, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		newMode := strings.ToLower(strings.TrimSpace(val))
 		if PartitionPruneMode(newMode) == Dynamic {
-			s.StmtCtx.AppendWarning(errors.New("Please analyze all partition tables again for consistency between partition and global stats"))
+			s.StmtCtx.AppendWarning(errors.NewNoStackError("Please analyze all partition tables again for consistency between partition and global stats"))
 		}
 		return nil
 	}},
@@ -2132,7 +2132,7 @@ var defaultSysVars = []*SysVar{
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableExchangePartition, Value: On, Type: TypeBool,
 		Validation: func(vars *SessionVars, s string, s2 string, flag ScopeFlag) (string, error) {
 			if s == Off {
-				vars.StmtCtx.AppendWarning(errors.New("tidb_enable_exchange_partition is always turned on. This variable has been deprecated and will be removed in the future releases"))
+				vars.StmtCtx.AppendWarning(errors.NewNoStackError("tidb_enable_exchange_partition is always turned on. This variable has been deprecated and will be removed in the future releases"))
 			}
 			return On, nil
 		},
@@ -2251,7 +2251,7 @@ var defaultSysVars = []*SysVar{
 	}, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
 		intVal := TidbOptInt64(normalizedValue, DefTiDBMemQuotaQuery)
 		if intVal > 0 && intVal < 128 {
-			vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(TiDBMemQuotaQuery, originalValue))
+			vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(TiDBMemQuotaQuery, originalValue))
 			normalizedValue = "128"
 		}
 		return normalizedValue, nil
@@ -2350,7 +2350,7 @@ var defaultSysVars = []*SysVar{
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableTiFlashReadForWriteStmt, Value: On, Type: TypeBool,
 		Validation: func(vars *SessionVars, s string, s2 string, flag ScopeFlag) (string, error) {
 			if s == Off {
-				vars.StmtCtx.AppendWarning(errors.New("tidb_enable_tiflash_read_for_write_stmt is always turned on. This variable has been deprecated and will be removed in the future releases"))
+				vars.StmtCtx.AppendWarning(errors.NewNoStackError("tidb_enable_tiflash_read_for_write_stmt is always turned on. This variable has been deprecated and will be removed in the future releases"))
 			}
 			return On, nil
 		},
@@ -2641,7 +2641,7 @@ var defaultSysVars = []*SysVar{
 				return err
 			}
 			for _, warning := range warnings {
-				vars.StmtCtx.AppendWarning(errors.New(warning))
+				vars.StmtCtx.AppendWarning(errors.NewNoStackError(warning))
 			}
 			return nil
 		},
@@ -2651,7 +2651,7 @@ var defaultSysVars = []*SysVar{
 				return err
 			}
 			for _, warning := range warnings {
-				s.StmtCtx.AppendWarning(errors.New(warning))
+				s.StmtCtx.AppendWarning(errors.NewNoStackError(warning))
 			}
 			s.OptimizerFixControl = newMap
 			return nil
@@ -2905,7 +2905,7 @@ var defaultSysVars = []*SysVar{
 			chars := []rune(normalizedValue)
 			warningAdded := false
 			if len(chars) > 64 {
-				s.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(TiDBSessionAlias, originalValue))
+				s.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(TiDBSessionAlias, originalValue))
 				warningAdded = true
 				chars = chars[:64]
 				normalizedValue = string(chars)
@@ -2914,7 +2914,7 @@ var defaultSysVars = []*SysVar{
 			// truncate to a valid identifier
 			for normalizedValue != "" && util.IsInCorrectIdentifierName(normalizedValue) {
 				if !warningAdded {
-					s.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(TiDBSessionAlias, originalValue))
+					s.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(TiDBSessionAlias, originalValue))
 					warningAdded = true
 				}
 				chars = chars[:len(chars)-1]

--- a/pkg/sessionctx/variable/variable.go
+++ b/pkg/sessionctx/variable/variable.go
@@ -402,11 +402,11 @@ func (sv *SysVar) checkDurationSystemVar(value string, vars *SessionVars) (strin
 	}
 	// Check for min/max violations
 	if int64(d) < sv.MinValue {
-		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(sv.Name, value))
+		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(sv.Name, value))
 		return time.Duration(sv.MinValue).String(), nil
 	}
 	if uint64(d) > sv.MaxValue {
-		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(sv.Name, value))
+		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(sv.Name, value))
 		return time.Duration(sv.MaxValue).String(), nil
 	}
 	// return a string representation of the duration
@@ -425,7 +425,7 @@ func (sv *SysVar) checkUInt64SystemVar(value string, vars *SessionVars) (string,
 		if err != nil {
 			return value, ErrWrongTypeForVar.GenWithStackByArgs(sv.Name)
 		}
-		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(sv.Name, value))
+		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(sv.Name, value))
 		return strconv.FormatInt(sv.MinValue, 10), nil
 	}
 	val, err := strconv.ParseUint(value, 10, 64)
@@ -433,11 +433,11 @@ func (sv *SysVar) checkUInt64SystemVar(value string, vars *SessionVars) (string,
 		return value, ErrWrongTypeForVar.GenWithStackByArgs(sv.Name)
 	}
 	if val < uint64(sv.MinValue) {
-		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(sv.Name, value))
+		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(sv.Name, value))
 		return strconv.FormatInt(sv.MinValue, 10), nil
 	}
 	if val > sv.MaxValue {
-		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(sv.Name, value))
+		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(sv.Name, value))
 		return strconv.FormatUint(sv.MaxValue, 10), nil
 	}
 	return value, nil
@@ -452,11 +452,11 @@ func (sv *SysVar) checkInt64SystemVar(value string, vars *SessionVars) (string, 
 		return value, ErrWrongTypeForVar.GenWithStackByArgs(sv.Name)
 	}
 	if val < sv.MinValue {
-		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(sv.Name, value))
+		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(sv.Name, value))
 		return strconv.FormatInt(sv.MinValue, 10), nil
 	}
 	if val > int64(sv.MaxValue) {
-		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(sv.Name, value))
+		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(sv.Name, value))
 		return strconv.FormatUint(sv.MaxValue, 10), nil
 	}
 	return value, nil
@@ -484,11 +484,11 @@ func (sv *SysVar) checkFloatSystemVar(value string, vars *SessionVars) (string, 
 		return value, ErrWrongTypeForVar.GenWithStackByArgs(sv.Name)
 	}
 	if val < float64(sv.MinValue) {
-		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(sv.Name, value))
+		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(sv.Name, value))
 		return strconv.FormatInt(sv.MinValue, 10), nil
 	}
 	if val > float64(sv.MaxValue) {
-		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.GenWithStackByArgs(sv.Name, value))
+		vars.StmtCtx.AppendWarning(ErrTruncatedWrongValue.FastGenByArgs(sv.Name, value))
 		return strconv.FormatUint(sv.MaxValue, 10), nil
 	}
 	return value, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/49291

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
sessionctx: refactor sessionctx pkg's warning and note generation
```
