### PR TITLE
global sort: add 2-level iterator for merge property and range splitter

### DIFF
--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -996,8 +996,7 @@ func newMergeStep(t *testing.T, s *mergeTestSuite) {
 	now := time.Now()
 	err = MergeOverlappingFilesV2(
 		ctx,
-		datas,
-		stats,
+		mockOneMultiFileStat(datas, stats),
 		s.store,
 		s.minKey,
 		s.maxKey.Next(),

--- a/br/pkg/lightning/backend/external/iter.go
+++ b/br/pkg/lightning/backend/external/iter.go
@@ -640,6 +640,10 @@ func (m mergePropBaseIter) path() string {
 func (m mergePropBaseIter) next() (*rangeProperty, error) {
 	ok, _ := m.iter.next()
 	if !ok {
+		// TODO(lance6716): explain it?
+		if m.iter.err == nil {
+			return nil, io.EOF
+		}
 		return nil, m.iter.err
 	}
 	return m.iter.curr, nil

--- a/br/pkg/lightning/backend/external/iter_test.go
+++ b/br/pkg/lightning/backend/external/iter_test.go
@@ -525,7 +525,8 @@ func (m myInt) cloneInnerFields() {}
 func (m myInt) len() int { return 1 }
 
 type intReader struct {
-	ints []int
+	ints   []int
+	refCnt *atomic.Int64
 }
 
 const errInt = -1
@@ -546,39 +547,48 @@ func (i *intReader) next() (myInt, error) {
 
 func (i *intReader) switchConcurrentMode(bool) error { return nil }
 
-func (i *intReader) close() error { return nil }
+func (i *intReader) close() error {
+	i.refCnt.Dec()
+	return nil
+}
+
+func buildOpener(in [][]int, refCnt *atomic.Int64) []readerOpenerFn[myInt, *intReader] {
+	ret := make([]readerOpenerFn[myInt, *intReader], 0, len(in))
+	for _, ints := range in {
+		ints := ints
+		ret = append(ret, func() (**intReader, error) {
+			refCnt.Inc()
+			r := &intReader{ints, refCnt}
+			return &r, nil
+		})
+	}
+	return ret
+}
 
 func TestLimitSizeMergeIter(t *testing.T) {
 	ctx := context.Background()
-	buildOpener := func(in [][]int) []readerOpenerFn[myInt, *intReader] {
-		ret := make([]readerOpenerFn[myInt, *intReader], 0, len(in))
-		for _, ints := range in {
-			ints := ints
-			ret = append(ret, func() (**intReader, error) {
-				r := &intReader{ints}
-				return &r, nil
-			})
-		}
-		return ret
-	}
+	refCnt := atomic.NewInt64(0)
 	readerOpeners := buildOpener([][]int{
 		{1, 2, 3}, {4, 5, 6}, {7, 8, 9},
-	})
+	}, refCnt)
 	weight := []int64{1, 1, 1}
 
 	oneToNine := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
 	for limit := int64(1); limit <= 4; limit++ {
+		refCnt.Store(0)
 		i, err := newLimitSizeMergeIter(ctx, readerOpeners, weight, limit)
 		require.NoError(t, err)
 		var got []int
 		ok, _ := i.next()
 		for ok {
 			got = append(got, int(i.curr))
+			require.LessOrEqual(t, refCnt.Load(), limit)
 			ok, _ = i.next()
 		}
 		require.NoError(t, i.err)
 		require.Equal(t, oneToNine, got)
 
+		// check it can return error
 		for errIdx := 1; errIdx <= 9; errIdx++ {
 			nums := make([]int, 9)
 			for i := range nums {
@@ -587,7 +597,7 @@ func TestLimitSizeMergeIter(t *testing.T) {
 					nums[i] = errInt
 				}
 			}
-			readerOpeners := buildOpener([][]int{nums[:3], nums[3:6], nums[6:]})
+			readerOpeners := buildOpener([][]int{nums[:3], nums[3:6], nums[6:]}, refCnt)
 			i, err = newLimitSizeMergeIter(ctx, readerOpeners, weight, limit)
 			if err != nil {
 				require.EqualError(t, err, "mock error")
@@ -605,4 +615,34 @@ func TestLimitSizeMergeIter(t *testing.T) {
 	}
 }
 
-// TODO(lance6716): test about non-even weights
+func TestLimitSizeMergeIterDiffWeight(t *testing.T) {
+	ctx := context.Background()
+	refCnt := atomic.NewInt64(0)
+	readerOpeners := buildOpener([][]int{
+		{1, 4, 7}, {2, 5}, {3},
+		{10},
+		{11, 14, 17}, {12, 15}, {13},
+	}, refCnt)
+	weight := []int64{
+		1, 1, 1,
+		3,
+		1, 1, 1,
+	}
+	limit := int64(3)
+
+	expected := []int{1, 2, 3, 4, 5, 7, 10, 11, 12, 13, 14, 15, 17}
+	expectedRefCnt := []int64{3, 3, 3, 2, 2, 1, 1, 3, 3, 3, 2, 2, 1}
+	iter, err := newLimitSizeMergeIter(ctx, readerOpeners, weight, limit)
+	require.NoError(t, err)
+	for i, exp := range expected {
+		ok, _ := iter.next()
+		require.True(t, ok)
+		require.Equal(t, exp, int(iter.curr), "i: %d", i)
+		require.Equal(t, expectedRefCnt[i], refCnt.Load(), "i: %d", i)
+	}
+
+	ok, _ := iter.next()
+	require.False(t, ok)
+	require.NoError(t, iter.err)
+	require.Equal(t, int64(0), refCnt.Load())
+}

--- a/br/pkg/lightning/backend/external/merge_v2.go
+++ b/br/pkg/lightning/backend/external/merge_v2.go
@@ -22,8 +22,7 @@ import (
 // Using 1 readAllData and 1 writer.
 func MergeOverlappingFilesV2(
 	ctx context.Context,
-	dataFiles []string,
-	statFiles []string,
+	multiFileStat []MultipleFilesStat,
 	store storage.ExternalStorage,
 	startKey []byte,
 	endKey []byte,
@@ -38,9 +37,12 @@ func MergeOverlappingFilesV2(
 	concurrency int,
 	checkHotspot bool,
 ) (err error) {
+	fileCnt := 0
+	for _, m := range multiFileStat {
+		fileCnt += len(m.Filenames)
+	}
 	task := log.BeginTask(logutil.Logger(ctx).With(
-		zap.Int("data-file-count", len(dataFiles)),
-		zap.Int("stat-file-count", len(statFiles)),
+		zap.Int("file-count", fileCnt),
 		zap.Binary("start-key", startKey),
 		zap.Binary("end-key", endKey),
 		zap.String("new-file-prefix", newFilePrefix),
@@ -57,8 +59,7 @@ func MergeOverlappingFilesV2(
 
 	splitter, err := NewRangeSplitter(
 		ctx,
-		dataFiles,
-		statFiles,
+		multiFileStat,
 		store,
 		int64(rangesGroupSize),
 		math.MaxInt64,

--- a/br/pkg/lightning/backend/external/sort_test.go
+++ b/br/pkg/lightning/backend/external/sort_test.go
@@ -251,11 +251,9 @@ func TestGlobalSortLocalWithMergeV2(t *testing.T) {
 	}
 
 	for i, group := range dataGroup {
-		_ = group
-		_ = statGroup
 		require.NoError(t, MergeOverlappingFilesV2(
 			ctx,
-			nil, // FIXME
+			mockOneMultiFileStat(group, statGroup[i]),
 			memStore,
 			startKeys[i],
 			endKeys[i],

--- a/br/pkg/lightning/backend/external/sort_test.go
+++ b/br/pkg/lightning/backend/external/sort_test.go
@@ -251,10 +251,11 @@ func TestGlobalSortLocalWithMergeV2(t *testing.T) {
 	}
 
 	for i, group := range dataGroup {
+		_ = group
+		_ = statGroup
 		require.NoError(t, MergeOverlappingFilesV2(
 			ctx,
-			group,
-			statGroup[i],
+			nil, // FIXME
 			memStore,
 			startKeys[i],
 			endKeys[i],

--- a/br/pkg/lightning/backend/external/split.go
+++ b/br/pkg/lightning/backend/external/split.go
@@ -100,11 +100,14 @@ func NewRangeSplitter(
 ) (*RangeSplitter, error) {
 	logger := logutil.Logger(ctx)
 	overlaps := make([]int64, 0, len(multiFileStat))
+	fileNums := make([]int, 0, len(multiFileStat))
 	for _, m := range multiFileStat {
 		overlaps = append(overlaps, m.MaxOverlappingNum)
+		fileNums = append(fileNums, len(m.Filenames))
 	}
 	logger.Info("create range splitter",
 		zap.Int64s("overlaps", overlaps),
+		zap.Ints("fileNums", fileNums),
 		zap.Int64("rangesGroupSize", rangesGroupSize),
 		zap.Int64("rangesGroupKeys", rangesGroupKeys),
 		zap.Int64("maxRangeSize", maxRangeSize),

--- a/br/pkg/lightning/backend/external/split.go
+++ b/br/pkg/lightning/backend/external/split.go
@@ -76,7 +76,6 @@ type RangeSplitter struct {
 	recordSplitKeyAfterNextProp bool
 	lastDataFile                string
 	lastStatFile                string
-	lastHeapSize                int
 	lastRangeProperty           *rangeProperty
 	willExhaustHeap             exhaustedHeap
 
@@ -152,9 +151,8 @@ func (r *RangeSplitter) SplitOneRangesGroup() (
 		r.curGroupKeys += int64(prop.keys)
 		r.curRangeKeys += int64(prop.keys)
 
-		// a tricky way to detect source file will exhaust
-		heapSize := r.propIter.iter.h.Len()
-		if heapSize < r.lastHeapSize {
+		// if this Next call will close the last reader
+		if *r.propIter.baseCloseReaderFlag {
 			heap.Push(&r.willExhaustHeap, exhaustedHeapElem{
 				key:      r.lastRangeProperty.lastKey,
 				dataFile: r.lastDataFile,
@@ -170,7 +168,6 @@ func (r *RangeSplitter) SplitOneRangesGroup() (
 		r.activeStatFiles[statFilePath] = [2]int{idx, idx2}
 		r.lastDataFile = dataFilePath
 		r.lastStatFile = statFilePath
-		r.lastHeapSize = heapSize
 		r.lastRangeProperty = prop
 
 		for r.willExhaustHeap.Len() > 0 &&

--- a/br/pkg/lightning/backend/external/split_test.go
+++ b/br/pkg/lightning/backend/external/split_test.go
@@ -241,7 +241,9 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 		"/mock-test/3/0", "/mock-test/3/1",
 	}, dataFiles123)
 
-	multiFileStat := mockOneMultiFileStat(dataFiles123, statFiles123)
+	multi := mockOneMultiFileStat(dataFiles123[:4], statFiles123[:4])
+	multi2 := mockOneMultiFileStat(dataFiles123[4:], statFiles123[4:])
+	multiFileStat := []MultipleFilesStat{multi[0], multi2[0]}
 	// group keys = 2, region keys = 1
 	splitter, err := NewRangeSplitter(
 		ctx, multiFileStat, memStore, 1000, 2, 1000, 1, true,

--- a/br/pkg/lightning/backend/external/split_test.go
+++ b/br/pkg/lightning/backend/external/split_test.go
@@ -241,7 +241,7 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 		"/mock-test/3/0", "/mock-test/3/1",
 	}, dataFiles123)
 
-	multiFileStat := mockOneMultiFileStat(statFiles123, statFiles123)
+	multiFileStat := mockOneMultiFileStat(dataFiles123, statFiles123)
 	// group keys = 2, region keys = 1
 	splitter, err := NewRangeSplitter(
 		ctx, multiFileStat, memStore, 1000, 2, 1000, 1, true,

--- a/br/pkg/lightning/backend/external/split_test.go
+++ b/br/pkg/lightning/backend/external/split_test.go
@@ -54,8 +54,9 @@ func TestGeneralProperties(t *testing.T) {
 
 	dataFiles, statFiles, err := MockExternalEngine(memStore, keys, values)
 	require.NoError(t, err)
+	multiFileStat := mockOneMultiFileStat(dataFiles, statFiles)
 	splitter, err := NewRangeSplitter(
-		ctx, dataFiles, statFiles, memStore, 1000, 30, 1000, 1, true,
+		ctx, multiFileStat, memStore, 1000, 30, 1000, 1, true,
 	)
 	var lastEndKey []byte
 notExhausted:
@@ -112,8 +113,10 @@ func TestOnlyOneGroup(t *testing.T) {
 	require.Len(t, dataFiles, 1)
 	require.Len(t, statFiles, 1)
 
+	multiFileStat := mockOneMultiFileStat(dataFiles, statFiles)
+
 	splitter, err := NewRangeSplitter(
-		ctx, dataFiles, statFiles, memStore, 1000, 30, 1000, 10, true,
+		ctx, multiFileStat, memStore, 1000, 30, 1000, 10, true,
 	)
 	require.NoError(t, err)
 	endKey, dataFiles, statFiles, splitKeys, err := splitter.SplitOneRangesGroup()
@@ -125,7 +128,7 @@ func TestOnlyOneGroup(t *testing.T) {
 	require.NoError(t, splitter.Close())
 
 	splitter, err = NewRangeSplitter(
-		ctx, dataFiles, statFiles, memStore, 1000, 30, 1000, 1, true,
+		ctx, multiFileStat, memStore, 1000, 30, 1000, 1, true,
 	)
 	require.NoError(t, err)
 	endKey, dataFiles, statFiles, splitKeys, err = splitter.SplitOneRangesGroup()
@@ -157,8 +160,9 @@ func TestSortedData(t *testing.T) {
 	rangesGroupKV := 30
 	groupFileNumUpperBound := int(math.Ceil(float64(rangesGroupKV-1)/avgKVPerFile)) + 1
 
+	multiFileStat := mockOneMultiFileStat(dataFiles, statFiles)
 	splitter, err := NewRangeSplitter(
-		ctx, dataFiles, statFiles, memStore, 1000, int64(rangesGroupKV), 1000, 10, true,
+		ctx, multiFileStat, memStore, 1000, int64(rangesGroupKV), 1000, 10, true,
 	)
 	require.NoError(t, err)
 
@@ -237,9 +241,10 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 		"/mock-test/3/0", "/mock-test/3/1",
 	}, dataFiles123)
 
+	multiFileStat := mockOneMultiFileStat(statFiles123, statFiles123)
 	// group keys = 2, region keys = 1
 	splitter, err := NewRangeSplitter(
-		ctx, dataFiles123, statFiles123, memStore, 1000, 2, 1000, 1, true,
+		ctx, multiFileStat, memStore, 1000, 2, 1000, 1, true,
 	)
 	require.NoError(t, err)
 
@@ -318,10 +323,11 @@ func TestExactlyKeyNum(t *testing.T) {
 
 	dataFiles, statFiles, err := MockExternalEngineWithWriter(memStore, writer, subDir, keys, values)
 	require.NoError(t, err)
+	multiFileStat := mockOneMultiFileStat(dataFiles, statFiles)
 
 	// maxRangeKeys = 3
 	splitter, err := NewRangeSplitter(
-		ctx, dataFiles, statFiles, memStore, 1000, 100, 1000, 3, true,
+		ctx, multiFileStat, memStore, 1000, 100, 1000, 3, true,
 	)
 	require.NoError(t, err)
 	endKey, splitDataFiles, splitStatFiles, splitKeys, err := splitter.SplitOneRangesGroup()
@@ -333,7 +339,7 @@ func TestExactlyKeyNum(t *testing.T) {
 
 	// rangesGroupKeys = 3
 	splitter, err = NewRangeSplitter(
-		ctx, dataFiles, statFiles, memStore, 1000, 3, 1000, 1, true,
+		ctx, multiFileStat, memStore, 1000, 3, 1000, 1, true,
 	)
 	require.NoError(t, err)
 	endKey, splitDataFiles, splitStatFiles, splitKeys, err = splitter.SplitOneRangesGroup()

--- a/br/pkg/lightning/backend/external/testutil.go
+++ b/br/pkg/lightning/backend/external/testutil.go
@@ -28,6 +28,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func mockOneMultiFileStat(data, stat []string) []MultipleFilesStat {
+	m := MultipleFilesStat{}
+	for i := range data {
+		m.Filenames = append(m.Filenames, [2]string{data[i], stat[i]})
+	}
+	return []MultipleFilesStat{m}
+}
+
 func testReadAndCompare(
 	ctx context.Context,
 	t *testing.T,
@@ -40,8 +48,7 @@ func testReadAndCompare(
 
 	splitter, err := NewRangeSplitter(
 		ctx,
-		datas,
-		stats,
+		mockOneMultiFileStat(datas, stats),
 		store,
 		int64(memSizeLimit), // make the group small for testing
 		math.MaxInt64,
@@ -142,7 +149,7 @@ func splitDataStatAndKeys(datas []string, stats []string, multiStats []MultipleF
 	}
 	if i == len(multiStats)-1 {
 		startKeys = append(startKeys, multiStats[i].MinKey.Clone())
-		endKeys = append(endKeys, dbkv.Key(multiStats[i].MaxKey).Next().Clone())
+		endKeys = append(endKeys, multiStats[i].MaxKey.Next().Clone())
 	}
 
 	dataGroup := make([][]string, 0, 10)

--- a/br/pkg/lightning/backend/external/util.go
+++ b/br/pkg/lightning/backend/external/util.go
@@ -79,7 +79,8 @@ func seekPropsOffsets(
 			return offsets, nil
 		}
 		moved = true
-		offsets[iter.readerIndex()] = p.offset
+		_, idx := iter.readerIndex()
+		offsets[idx] = p.offset
 	}
 	if iter.Error() != nil {
 		return nil, iter.Error()

--- a/br/pkg/lightning/backend/external/util.go
+++ b/br/pkg/lightning/backend/external/util.go
@@ -48,7 +48,13 @@ func seekPropsOffsets(
 	defer func() {
 		task.End(zapcore.ErrorLevel, err)
 	}()
-	iter, err := NewMergePropIter(ctx, paths, exStorage, checkHotSpot)
+
+	// adapt the NewMergePropIter argument types
+	multiFileStat := MultipleFilesStat{Filenames: make([][2]string, 0, len(paths))}
+	for _, path := range paths {
+		multiFileStat.Filenames = append(multiFileStat.Filenames, [2]string{"", path})
+	}
+	iter, err := NewMergePropIter(ctx, []MultipleFilesStat{multiFileStat}, exStorage, checkHotSpot)
 	if err != nil {
 		return nil, err
 	}

--- a/br/pkg/lightning/backend/external/writer_test.go
+++ b/br/pkg/lightning/backend/external/writer_test.go
@@ -298,7 +298,11 @@ func TestWriterDuplicateDetect(t *testing.T) {
 }
 
 func TestMultiFileStat(t *testing.T) {
-	s := &MultipleFilesStat{}
+	s := &MultipleFilesStat{
+		Filenames: [][2]string{
+			{"3", "5"}, {"1", "3"}, {"2", "4"},
+		},
+	}
 	// [3, 5], [1, 3], [2, 4]
 	startKeys := []dbkv.Key{{3}, {1}, {2}}
 	endKeys := []dbkv.Key{{5}, {3}, {4}}
@@ -306,6 +310,7 @@ func TestMultiFileStat(t *testing.T) {
 	require.EqualValues(t, []byte{1}, s.MinKey)
 	require.EqualValues(t, []byte{5}, s.MaxKey)
 	require.EqualValues(t, 3, s.MaxOverlappingNum)
+	require.Equal(t, [][2]string{{"1", "3"}, {"2", "4"}, {"3", "5"}}, s.Filenames)
 }
 
 func TestMultiFileStatOverlap(t *testing.T) {

--- a/pkg/disttask/importinto/planner.go
+++ b/pkg/disttask/importinto/planner.go
@@ -503,8 +503,7 @@ func getRangeSplitter(ctx context.Context, store storage.ExternalStorage, kvMeta
 
 	return external.NewRangeSplitter(
 		ctx,
-		kvMeta.GetDataFiles(),
-		kvMeta.GetStatFiles(),
+		kvMeta.MultipleFilesStats,
 		store,
 		int64(config.DefaultBatchSize),
 		int64(math.MaxInt64),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/49717

Problem Summary:

### What changed and how does it work?

- For `MultipleFilesStat`, it's maintained every 500 files, and `MultipleFilesStat.MaxOverlappingNum` is the number of the key range maximum overlaping of the 500 files. In this PR, `MultipleFilesStat.Filenames` is also sorted by start key of each file, so that we only need to keep number of `MultipleFilesStat.MaxOverlappingNum` files open from left to right, and get the minimum key among the opened files.
- We introduced a `limitSizeMergeIter`, which can have reader openers, their weights, and maximum weight limit as arguments. `limitSizeMergeIter` will automatically open readers in given order and keep readers' weight sum under the limit.
- For `RangeSplitter`, now it takes `[]MultipleFilesStat` as arguments. It has two levels of `limitSizeMergeIter`. The upper level is a whole `MultipleFilesStat` with weight `MultipleFilesStat.MaxOverlappingNum`, and the limit for this level is `MergeSortOverlapThreshold`. The second level is intra-`MultipleFilesStat` which means the 500 files, with weight `1`, and the limit is `MultipleFilesStat.MaxOverlappingNum`. In this way `RangeSplitter` can still output ordered key but won't open all files.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
