### PR TITLE
errno: add test to check every errcode has its message

### DIFF
--- a/pkg/domain/infosync/error.go
+++ b/pkg/domain/infosync/error.go
@@ -16,13 +16,10 @@ package infosync
 
 import (
 	"github.com/pingcap/tidb/pkg/errno"
-	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 )
 
 var (
 	// ErrHTTPServiceError means we got a http response with a status code which is not '2xx'
-	ErrHTTPServiceError = dbterror.ClassDomain.NewStdErr(
-		errno.ErrHTTPServiceError, mysql.Message("HTTP request failed with status %s", nil),
-	)
+	ErrHTTPServiceError = dbterror.ClassDomain.NewStd(errno.ErrHTTPServiceError)
 )

--- a/pkg/errno/BUILD.bazel
+++ b/pkg/errno/BUILD.bazel
@@ -16,10 +16,12 @@ go_test(
     name = "errno_test",
     timeout = "short",
     srcs = [
+        "errname_test.go",
         "infoschema_test.go",
         "main_test.go",
     ],
     embed = [":errno"],
+    embedsrcs = ["errcode.go"],
     flaky = True,
     deps = [
         "//pkg/testkit/testsetup",

--- a/pkg/errno/errcode.go
+++ b/pkg/errno/errcode.go
@@ -1068,7 +1068,6 @@ const (
 	ErrLoadDataInvalidURI                  = 8158
 	ErrLoadDataCantAccess                  = 8159
 	ErrLoadDataCantRead                    = 8160
-	ErrLoadDataPhysicalImportTableNotEmpty = 8161
 	ErrLoadDataWrongFormatConfig           = 8162
 	ErrUnknownOption                       = 8163
 	ErrInvalidOptionVal                    = 8164

--- a/pkg/errno/errname.go
+++ b/pkg/errno/errname.go
@@ -1073,6 +1073,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrLoadDataPreCheckFailed:           mysql.Message("PreCheck failed: %s", nil),
 	ErrMemoryExceedForQuery:             mysql.Message("Your query has been cancelled due to exceeding the allowed memory limit for a single SQL query. Please try narrowing your query scope or increase the tidb_mem_quota_query limit and try again.[conn=%d]", nil),
 	ErrMemoryExceedForInstance:          mysql.Message("Your query has been cancelled due to exceeding the allowed memory limit for the tidb-server instance and this query is currently using the most memory. Please try narrowing your query scope or increase the tidb_server_memory_limit and try again.[conn=%d]", nil),
+	ErrHTTPServiceError:                 mysql.Message("HTTP request failed with status %s", nil),
 
 	ErrWarnOptimizerHintInvalidInteger:  mysql.Message("integer value is out of range in '%s'", nil),
 	ErrWarnOptimizerHintUnsupportedHint: mysql.Message("Optimizer hint %s is not supported by TiDB and is ignored", nil),

--- a/pkg/errno/errname_test.go
+++ b/pkg/errno/errname_test.go
@@ -1,0 +1,47 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errno
+
+import (
+	_ "embed"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed errcode.go
+var errCodeSrc string
+
+func TestAllErrCodeHasMsg(t *testing.T) {
+	lines := strings.Split(errCodeSrc, "\n")
+	errCodes := make([]uint16, 0, len(lines))
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if !strings.HasPrefix(l, "Err") {
+			continue
+		}
+		codeStr := strings.TrimSpace(strings.Split(l, "=")[1])
+		code, err := strconv.Atoi(codeStr)
+		assert.NoErrorf(t, err, "parse code definition: %s", codeStr)
+		errCodes = append(errCodes, uint16(code))
+	}
+
+	for _, code := range errCodes {
+		_, ok := MySQLErrName[code]
+		assert.Truef(t, ok, "ErrCode: %d is unknown", code)
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #49546

Problem Summary:

Two err codes don't have corresponding error messages. They may be the reason of #49546, but actually I'm not 100% sure. A possible routine is that the connection to PD HTTP Server somehow failed, and the user uses `show ...` like `show placement`, then the `ErrHTTPServiceError` will be recorded.

### What changed and how does it work?

This PR adds a test to make sure every err code has its corresponding message.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
