### PR TITLE
plan replayer: fix  cannot load bindings when the statement contains in (...)

### DIFF
--- a/pkg/bindinfo/tests/BUILD.bazel
+++ b/pkg/bindinfo/tests/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 14,
+    shard_count = 15,
     deps = [
         "//pkg/bindinfo",
         "//pkg/bindinfo/internal",

--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -441,7 +441,7 @@ func TestBestPlanInBaselines(t *testing.T) {
 	_, fuzzyDigest := norm.NormalizeStmtForBinding(stmt, norm.WithFuzz(true))
 	binding, matched := dom.BindHandle().MatchGlobalBinding(tk.Session(), fuzzyDigest, bindinfo.CollectTableNames(stmt))
 	require.True(t, matched)
-	require.Equal(t, "select `a` , `b` from `test` . `t` where `a` = ? limit ...", binding.OriginalSQL)
+	require.Equal(t, "select `a` , `b` from `test` . `t` where `a` = ? limit ?,?,?", binding.OriginalSQL)
 	require.Equal(t, "SELECT /*+ use_index(@`sel_1` `test`.`t` `ia`)*/ `a`,`b` FROM `test`.`t` WHERE `a` = 1 LIMIT 0,1", binding.BindSQL)
 	require.Equal(t, "test", binding.Db)
 	require.Equal(t, bindinfo.Enabled, binding.Status)

--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -324,7 +324,7 @@ func TestBindingSymbolList(t *testing.T) {
 	_, fuzzyDigest := norm.NormalizeStmtForBinding(stmt, norm.WithFuzz(true))
 	binding, matched := dom.BindHandle().MatchGlobalBinding(tk.Session(), fuzzyDigest, bindinfo.CollectTableNames(stmt))
 	require.True(t, matched)
-	require.Equal(t, "select `a` , `b` from `test` . `t` where `a` = ? limit ...", binding.OriginalSQL)
+	require.Equal(t, "select `a` , `b` from `test` . `t` where `a` = ? limit ?,?,?", binding.OriginalSQL)
 	require.Equal(t, "SELECT `a`,`b` FROM `test`.`t` USE INDEX (`ib`) WHERE `a` = 1 LIMIT 0,1", binding.BindSQL)
 	require.Equal(t, "test", binding.Db)
 	require.Equal(t, bindinfo.Enabled, binding.Status)

--- a/pkg/executor/test/executor/executor_test.go
+++ b/pkg/executor/test/executor/executor_test.go
@@ -666,7 +666,7 @@ func TestPrevStmtDesensitization(t *testing.T) {
 	tk.MustExec("create table t (a int, unique key (a))")
 	tk.MustExec("begin")
 	tk.MustExec("insert into t values (1),(2)")
-	require.Equal(t, "insert into `t` values ( ... )", tk.Session().GetSessionVars().PrevStmt.String())
+	require.Equal(t, "insert into `t` values ( ?,?,? )", tk.Session().GetSessionVars().PrevStmt.String())
 	tk.MustGetErrMsg("insert into t values (1)", `[kv:1062]Duplicate entry '?' for key 't.a'`)
 }
 

--- a/pkg/extension/event_listener_test.go
+++ b/pkg/extension/event_listener_test.go
@@ -269,7 +269,7 @@ func TestExtensionStmtEvents(t *testing.T) {
 		},
 		{
 			sql:          "insert into t1 values(1, 10), (2, 20)",
-			redactText:   "insert into `t1` values ( ... )",
+			redactText:   "insert into `t1` values ( ?,?,? )",
 			affectedRows: 2,
 			tables: []stmtctx.TableEntry{
 				{DB: "test", Table: "t1"},

--- a/pkg/parser/digester.go
+++ b/pkg/parser/digester.go
@@ -333,7 +333,7 @@ func (d *sqlDigester) reduceLit(currTok *token) {
 	if d.isGenericList(last2) {
 		d.tokens.popBack(2)
 		currTok.tok = genericSymbolList
-		currTok.lit = "..."
+		currTok.lit = "?,?,?"
 		return
 	}
 
@@ -342,7 +342,7 @@ func (d *sqlDigester) reduceLit(currTok *token) {
 	if d.isGenericLists(last4) {
 		d.tokens.popBack(4)
 		currTok.tok = genericSymbolList
-		currTok.lit = "..."
+		currTok.lit = "?,?,?"
 		return
 	}
 
@@ -386,7 +386,7 @@ func (d *sqlDigester) reduceInListWithSingleLiteral(currTok *token) {
 		last3[2].tok == genericSymbol &&
 		d.isRightParen(*currTok) {
 		d.tokens.popBack(1)
-		d.tokens.pushBack(token{genericSymbolList, "..."})
+		d.tokens.pushBack(token{genericSymbolList, "?,?,?"})
 		return
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -72,7 +72,7 @@ func TestOptimizerDebugTrace(t *testing.T) {
 
 	tk.MustExec("plan replayer capture '0595c79f25d183319d0830ff8ca538c9054cbf407e5e27488b5dc40e4738a7c8' '*'")
 	tk.MustExec("plan replayer capture 'c0fcc0abbaaffcaafe21115a3c67ae5d96a188cc197559953d2865ea6852d3cc' '*'")
-	tk.MustExec("plan replayer capture '58fcbdd56a722c02225488c89a782cd2d626f8219c8ef8f57cd3bcdb6eb7c1b2' '*'")
+	tk.MustExec("plan replayer capture '230df11e6806860186ce77413df67413a26a149fd24214b239ec6500ae323c24' '*'")
 	require.NoError(t, cc.HandleStmtPrepare(ctx, "select sum(col1) from t where col1 < ? and col1 > 100"))
 	tk.MustExec("prepare stmt from 'select * from t where col1 in (?, 2, 3)'")
 	tk.MustExec("set @a = 1")

--- a/tests/integrationtest/r/bindinfo/bind.result
+++ b/tests/integrationtest/r/bindinfo/bind.result
@@ -337,44 +337,44 @@ create binding for select * from t where a in(1) using select * from t where a i
 create binding for select * from t where a in(1,2) using select * from t where a in(1,2);
 create binding for select * from t where a in(1,2,3) using select * from t where a in(1,2,3);
 show bindings where default_db='bindinfo__bind';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ... )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1,2,3)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	b67d59db636eefe4353553308079b13a6e0ea71235906ab3ce0c7f9e99c06ed8	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1,2,3)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop binding for select * from t where a in(1);
 show bindings where default_db='bindinfo__bind';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
 create binding for select * from t where a in(1,2,3) using select * from t where a in(1);
 show bindings where default_db='bindinfo__bind';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ... )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	b67d59db636eefe4353553308079b13a6e0ea71235906ab3ce0c7f9e99c06ed8	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop binding for select * from t where a in(1);
 show bindings where default_db='bindinfo__bind';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
 create binding for select * from t where a in(1) using select * from t where a in(1);
 show bindings where default_db='bindinfo__bind';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ... )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	b67d59db636eefe4353553308079b13a6e0ea71235906ab3ce0c7f9e99c06ed8	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop binding for select * from t where a in(1,2,3);
 show bindings where default_db='bindinfo__bind';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
 create binding for select * from t where a in(1) using select * from t where a in(1);
 show bindings where default_db='bindinfo__bind';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ... )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	b67d59db636eefe4353553308079b13a6e0ea71235906ab3ce0c7f9e99c06ed8	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop binding for select * from t where a in(1,2,3,4,5,6,7,8,9,0,11,12);
 show bindings where default_db='bindinfo__bind';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
 create global binding for select * from t where a in(1,2,3) using select * from t where a in(1);
 show global bindings where original_sql like '%bindinfo__bind%';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ... )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	b67d59db636eefe4353553308079b13a6e0ea71235906ab3ce0c7f9e99c06ed8	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 set binding disabled for select * from t where a in(1);
 show global bindings where original_sql like '%bindinfo__bind%';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ... )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	b67d59db636eefe4353553308079b13a6e0ea71235906ab3ce0c7f9e99c06ed8	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)		disabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 set binding enabled for select * from t where a in(1,2,3,4,5);
 show global bindings where original_sql like '%bindinfo__bind%';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ... )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	b67d59db636eefe4353553308079b13a6e0ea71235906ab3ce0c7f9e99c06ed8	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)		enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop global binding for select * from t where a in(1,2,3);
 drop table if exists t;
 create table t (a varchar(10) CHARACTER SET utf8);

--- a/tests/integrationtest/r/bindinfo/bind.result
+++ b/tests/integrationtest/r/bindinfo/bind.result
@@ -338,7 +338,7 @@ create binding for select * from t where a in(1,2) using select * from t where a
 create binding for select * from t where a in(1,2,3) using select * from t where a in(1,2,3);
 show bindings where default_db='bindinfo__bind';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1,2,3)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1,2,3)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop binding for select * from t where a in(1);
 show bindings where default_db='bindinfo__bind';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest

--- a/tests/integrationtest/r/bindinfo/bind.result
+++ b/tests/integrationtest/r/bindinfo/bind.result
@@ -337,44 +337,44 @@ create binding for select * from t where a in(1) using select * from t where a i
 create binding for select * from t where a in(1,2) using select * from t where a in(1,2);
 create binding for select * from t where a in(1,2,3) using select * from t where a in(1,2,3);
 show bindings where default_db='bindinfo__bind';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
 select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1,2,3)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop binding for select * from t where a in(1);
 show bindings where default_db='bindinfo__bind';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
 create binding for select * from t where a in(1,2,3) using select * from t where a in(1);
 show bindings where default_db='bindinfo__bind';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop binding for select * from t where a in(1);
 show bindings where default_db='bindinfo__bind';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
 create binding for select * from t where a in(1) using select * from t where a in(1);
 show bindings where default_db='bindinfo__bind';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop binding for select * from t where a in(1,2,3);
 show bindings where default_db='bindinfo__bind';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
 create binding for select * from t where a in(1) using select * from t where a in(1);
 show bindings where default_db='bindinfo__bind';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop binding for select * from t where a in(1,2,3,4,5,6,7,8,9,0,11,12);
 show bindings where default_db='bindinfo__bind';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
 create global binding for select * from t where a in(1,2,3) using select * from t where a in(1);
 show global bindings where original_sql like '%bindinfo__bind%';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 set binding disabled for select * from t where a in(1);
 show global bindings where original_sql like '%bindinfo__bind%';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)		disabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)		disabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 set binding enabled for select * from t where a in(1,2,3,4,5);
 show global bindings where original_sql like '%bindinfo__bind%';
-Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Type	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)		enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual		7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
+Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)		enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop global binding for select * from t where a in(1,2,3);
 drop table if exists t;
 create table t (a varchar(10) CHARACTER SET utf8);

--- a/tests/integrationtest/r/bindinfo/bind.result
+++ b/tests/integrationtest/r/bindinfo/bind.result
@@ -370,11 +370,11 @@ select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindi
 set binding disabled for select * from t where a in(1);
 show global bindings where original_sql like '%bindinfo__bind%';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)		disabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	disabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 set binding enabled for select * from t where a in(1,2,3,4,5);
 show global bindings where original_sql like '%bindinfo__bind%';
 Original_sql	Bind_sql	Default_db	Status	Create_time	Update_time	Charset	Collation	Source	Sql_digest	Plan_digest
-select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)		enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
+select * from `bindinfo__bind` . `t` where `a` in ( ?,?,? )	SELECT * FROM `bindinfo__bind`.`t` WHERE `a` IN (1)	bindinfo__bind	enabled	<create_time>	<update_time>	utf8mb4	utf8mb4_general_ci	manual	7de35506acc15abc831113a6b9e6fc7a5d83bf1a83e0737eba82cd39edf7dab1	
 drop global binding for select * from t where a in(1,2,3);
 drop table if exists t;
 create table t (a varchar(10) CHARACTER SET utf8);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #43192

Problem Summary:
plan replayer cannot load bindings when the statement contains in (...).

### What changed and how does it work?
This PR is to change the way of normalizing in-list from (…) to (?,?,?).

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
