### PR TITLE
planner: when column collation is consistent, constant propagation is required | tidb-test=pr/2271

### DIFF
--- a/pkg/expression/constant_propagation.go
+++ b/pkg/expression/constant_propagation.go
@@ -91,9 +91,6 @@ func ValidCompareConstantPredicateHelper(eq *ScalarFunction, colIsLeft bool) (*C
 	if !conOk {
 		return nil, nil
 	}
-	if col.GetType().GetCollate() != con.GetType().GetCollate() {
-		return nil, nil
-	}
 	return col, con
 }
 

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -494,7 +494,10 @@ func ColumnSubstituteImpl(ctx sessionctx.Context, expr Expression, schema *Schem
 					logutil.BgLogger().Error("Unexpected error happened during ColumnSubstitution", zap.Stack("stack"))
 					return false, failed, v
 				}
-				if oldCollEt.Collation == newCollEt.Collation {
+				// When column collations are consistent, constant propagation can proceed without checking the collation of the constants.
+				if len(v.GetArgs()) == 2 && v.GetArgs()[0].GetType().GetCollate() == v.GetArgs()[1].GetType().GetCollate() {
+					changed = true
+				} else if oldCollEt.Collation == newCollEt.Collation {
 					if newFuncExpr.GetType().GetCollate() == arg.GetType().GetCollate() && newFuncExpr.Coercibility() == arg.Coercibility() {
 						// It's safe to use the new expression, otherwise some cases in projection push-down will be wrong.
 						changed = true

--- a/tests/integrationtest/r/executor/index_advise.result
+++ b/tests/integrationtest/r/executor/index_advise.result
@@ -34,7 +34,7 @@ Update	N/A	root		N/A
   │ └─Selection	0.01	cop[tikv]		eq(executor__index_advise.t2.pnbrn_cnaps, "40001"), eq(executor__index_advise.t2.txn_dt, 2022-12-01)
   │   └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo
   └─IndexReader(Probe)	0.01	root		index:IndexRangeScan
-    └─IndexRangeScan	0.01	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno)	range: decided by [eq(executor__index_advise.t1.new_accno, executor__index_advise.t2.txn_accno) eq(executor__index_advise.t1.pnbrn_cnaps, 40001)], keep order:false, stats:pseudo
+    └─IndexRangeScan	0.01	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno)	range: decided by [eq(executor__index_advise.t1.new_accno, executor__index_advise.t2.txn_accno) eq(executor__index_advise.t1.pnbrn_cnaps, 40001)], keep order:false, stats:pseudo	
 set @@session.tidb_enable_inl_join_inner_multi_pattern='OFF';
 explain format='brief' update
 /*+ inl_join(a) */

--- a/tests/integrationtest/r/executor/index_advise.result
+++ b/tests/integrationtest/r/executor/index_advise.result
@@ -34,7 +34,7 @@ Update	N/A	root		N/A
   │ └─Selection	0.01	cop[tikv]		eq(executor__index_advise.t2.pnbrn_cnaps, "40001"), eq(executor__index_advise.t2.txn_dt, 2022-12-01)
   │   └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo
   └─IndexReader(Probe)	0.01	root		index:IndexRangeScan
-    └─IndexRangeScan	0.01	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno) range: decided by [eq(executor__index_advise.t1.new_accno, executor__index_advise.t2.txn_accno) eq(executor__index_advise.t1.pnbrn_cnaps, 40001)], keep order:false, stats:pseudo
+    └─IndexRangeScan	0.01	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno)	range: decided by [eq(executor__index_advise.t1.new_accno, executor__index_advise.t2.txn_accno) eq(executor__index_advise.t1.pnbrn_cnaps, 40001)], keep order:false, stats:pseudo
 set @@session.tidb_enable_inl_join_inner_multi_pattern='OFF';
 explain format='brief' update
 /*+ inl_join(a) */

--- a/tests/integrationtest/r/executor/index_advise.result
+++ b/tests/integrationtest/r/executor/index_advise.result
@@ -51,12 +51,12 @@ and b.pnbrn_cnaps = a.pnbrn_cnaps
 and b.txn_accno = a.new_accno;
 id	estRows	task	access object	operator info
 Update	N/A	root		N/A
-└─HashJoin	12.50	root		inner join, equal:[eq(executor__index_advise.t2.pnbrn_cnaps, executor__index_advise.t1.pnbrn_cnaps) eq(executor__index_advise.t2.txn_accno, executor__index_advise.t1.new_accno)]
-  ├─IndexReader(Build)	10.00	root		index:IndexRangeScan
-  │ └─IndexRangeScan	10.00	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno)	range:["40001","40001"], keep order:false, stats:pseudo
-  └─TableReader(Probe)	10.00	root		data:Selection
-    └─Selection	10.00	cop[tikv]		eq(executor__index_advise.t2.txn_dt, 2022-12-01)
-      └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo
+└─HashJoin	0.01	root		inner join, equal:[eq(executor__index_advise.t2.txn_accno, executor__index_advise.t1.new_accno)]
+  ├─TableReader(Build)	0.01	root		data:Selection
+  │ └─Selection	0.01	cop[tikv]		eq(executor__index_advise.t2.pnbrn_cnaps, "40001"), eq(executor__index_advise.t2.txn_dt, 2022-12-01)
+  │   └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo	
+  └─IndexReader(Probe)	10.00	root		index:IndexRangeScan
+    └─IndexRangeScan	10.00	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno)	range:["40001","40001"], keep order:false, stats:pseudo	
 set @@session.tidb_enable_inl_join_inner_multi_pattern='ON';
 update
 /*+ inl_join(a) */

--- a/tests/integrationtest/r/executor/index_advise.result
+++ b/tests/integrationtest/r/executor/index_advise.result
@@ -34,7 +34,7 @@ Update	N/A	root		N/A
   │ └─Selection	0.01	cop[tikv]		eq(executor__index_advise.t2.pnbrn_cnaps, "40001"), eq(executor__index_advise.t2.txn_dt, 2022-12-01)
   │   └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo
   └─IndexReader(Probe)	0.01	root		index:IndexRangeScan
-    └─IndexRangeScan	0.01	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno)	range: decided by [eq(executor__index_advise.t1.new_accno, executor__index_advise.t2.txn_accno) eq(executor__index_advise.t1.pnbrn_cnaps, 40001)], keep order:false, stats:pseudo	
+    └─IndexRangeScan	0.01	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno)	range: decided by [eq(executor__index_advise.t1.new_accno, executor__index_advise.t2.txn_accno) eq(executor__index_advise.t1.pnbrn_cnaps, 40001)], keep order:false, stats:pseudo
 set @@session.tidb_enable_inl_join_inner_multi_pattern='OFF';
 explain format='brief' update
 /*+ inl_join(a) */
@@ -54,9 +54,9 @@ Update	N/A	root		N/A
 └─HashJoin	0.01	root		inner join, equal:[eq(executor__index_advise.t2.txn_accno, executor__index_advise.t1.new_accno)]
   ├─TableReader(Build)	0.01	root		data:Selection
   │ └─Selection	0.01	cop[tikv]		eq(executor__index_advise.t2.pnbrn_cnaps, "40001"), eq(executor__index_advise.t2.txn_dt, 2022-12-01)
-  │   └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo	
+  │   └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo
   └─IndexReader(Probe)	10.00	root		index:IndexRangeScan
-    └─IndexRangeScan	10.00	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno)	range:["40001","40001"], keep order:false, stats:pseudo	
+    └─IndexRangeScan	10.00	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno)	range:["40001","40001"], keep order:false, stats:pseudo
 set @@session.tidb_enable_inl_join_inner_multi_pattern='ON';
 update
 /*+ inl_join(a) */

--- a/tests/integrationtest/r/executor/index_advise.result
+++ b/tests/integrationtest/r/executor/index_advise.result
@@ -29,13 +29,12 @@ and b.pnbrn_cnaps = a.pnbrn_cnaps
 and b.txn_accno = a.new_accno;
 id	estRows	task	access object	operator info
 Update	N/A	root		N/A
-└─IndexJoin	12.50	root		inner join, inner:IndexReader, outer key:executor__index_advise.t2.pnbrn_cnaps, executor__index_advise.t2.txn_accno, inner key:executor__index_advise.t1.pnbrn_cnaps, executor__index_advise.t1.new_accno, equal cond:eq(executor__index_advise.t2.pnbrn_cnaps, executor__index_advise.t1.pnbrn_cnaps), eq(executor__index_advise.t2.txn_accno, executor__index_advise.t1.new_accno)
-  ├─TableReader(Build)	10.00	root		data:Selection
-  │ └─Selection	10.00	cop[tikv]		eq(executor__index_advise.t2.txn_dt, 2022-12-01)
+└─IndexJoin	0.01	root		inner join, inner:IndexReader, outer key:executor__index_advise.t2.txn_accno, inner key:executor__index_advise.t1.new_accno, equal cond:eq(executor__index_advise.t2.txn_accno, executor__index_advise.t1.new_accno)
+  ├─TableReader(Build)	0.01	root		data:Selection
+  │ └─Selection	0.01	cop[tikv]		eq(executor__index_advise.t2.pnbrn_cnaps, "40001"), eq(executor__index_advise.t2.txn_dt, 2022-12-01)
   │   └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo
-  └─IndexReader(Probe)	10.00	root		index:Selection
-    └─Selection	10.00	cop[tikv]		eq(executor__index_advise.t1.pnbrn_cnaps, "40001")
-      └─IndexRangeScan	10.00	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno)	range: decided by [eq(executor__index_advise.t1.pnbrn_cnaps, executor__index_advise.t2.pnbrn_cnaps) eq(executor__index_advise.t1.new_accno, executor__index_advise.t2.txn_accno)], keep order:false, stats:pseudo
+  └─IndexReader(Probe)	0.01	root		index:IndexRangeScan
+    └─IndexRangeScan	0.01	cop[tikv]	table:t1, index:PRIMARY(pnbrn_cnaps, new_accno) range: decided by [eq(executor__index_advise.t1.new_accno, executor__index_advise.t2.txn_accno) eq(executor__index_advise.t1.pnbrn_cnaps, 40001)], keep order:false, stats:pseudo
 set @@session.tidb_enable_inl_join_inner_multi_pattern='OFF';
 explain format='brief' update
 /*+ inl_join(a) */

--- a/tests/integrationtest/r/expression/charset_and_collation.result
+++ b/tests/integrationtest/r/expression/charset_and_collation.result
@@ -883,7 +883,7 @@ CREATE TABLE t (`COL1` tinyblob NOT NULL,  `COL2` binary(1) NOT NULL,  `COL3` bi
 insert into t values(0x1E,0xEC,6966939640596047133);
 select * from t where col1 not in (0x1B,0x20) order by col1;
 COL1	COL2	COL3
-	�	6966939640596047133
+	�	6966939640596047133
 drop table if exists t;
 create table t(a varchar(10));
 insert into t values('aaaaaaaaa'),('天王盖地虎宝塔镇河妖');

--- a/tests/integrationtest/r/expression/charset_and_collation.result
+++ b/tests/integrationtest/r/expression/charset_and_collation.result
@@ -883,7 +883,7 @@ CREATE TABLE t (`COL1` tinyblob NOT NULL,  `COL2` binary(1) NOT NULL,  `COL3` bi
 insert into t values(0x1E,0xEC,6966939640596047133);
 select * from t where col1 not in (0x1B,0x20) order by col1;
 COL1	COL2	COL3
-	�	6966939640596047133
+	�	6966939640596047133
 drop table if exists t;
 create table t(a varchar(10));
 insert into t values('aaaaaaaaa'),('天王盖地虎宝塔镇河妖');
@@ -919,7 +919,6 @@ create table t (a char(10) collate utf8mb4_general_ci, b char(10) collate utf8mb
 insert into t values ('A', 'a');
 select * from t t1, t t2 where t1.a=t2.b and t2.b='a' collate utf8mb4_bin;
 a	b	a	b
-A	a	A	a
 select * from t t1, t t2 where t1.a=t2.b and t2.b>='a' collate utf8mb4_bin;
 a	b	a	b
 A	a	A	a

--- a/tests/integrationtest/r/expression/charset_and_collation.result
+++ b/tests/integrationtest/r/expression/charset_and_collation.result
@@ -883,7 +883,7 @@ CREATE TABLE t (`COL1` tinyblob NOT NULL,  `COL2` binary(1) NOT NULL,  `COL3` bi
 insert into t values(0x1E,0xEC,6966939640596047133);
 select * from t where col1 not in (0x1B,0x20) order by col1;
 COL1	COL2	COL3
-	�	6966939640596047133
+	�	6966939640596047133
 drop table if exists t;
 create table t(a varchar(10));
 insert into t values('aaaaaaaaa'),('天王盖地虎宝塔镇河妖');

--- a/tests/integrationtest/r/expression/charset_and_collation.result
+++ b/tests/integrationtest/r/expression/charset_and_collation.result
@@ -883,7 +883,7 @@ CREATE TABLE t (`COL1` tinyblob NOT NULL,  `COL2` binary(1) NOT NULL,  `COL3` bi
 insert into t values(0x1E,0xEC,6966939640596047133);
 select * from t where col1 not in (0x1B,0x20) order by col1;
 COL1	COL2	COL3
-	�	6966939640596047133
+	�	6966939640596047133
 drop table if exists t;
 create table t(a varchar(10));
 insert into t values('aaaaaaaaa'),('天王盖地虎宝塔镇河妖');
@@ -919,6 +919,7 @@ create table t (a char(10) collate utf8mb4_general_ci, b char(10) collate utf8mb
 insert into t values ('A', 'a');
 select * from t t1, t t2 where t1.a=t2.b and t2.b='a' collate utf8mb4_bin;
 a	b	a	b
+A	a	A	a
 select * from t t1, t t2 where t1.a=t2.b and t2.b>='a' collate utf8mb4_bin;
 a	b	a	b
 A	a	A	a

--- a/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
@@ -1213,31 +1213,34 @@ create table t2 (a char(10));
 create table t3 (a char(10) COLLATE utf8mb4_general_ci);
 set session collation_connection=utf8_general_ci;
 explain format='brief' select * from t1, t2 where t1.a=t2.a and t2.a = 'a';
-HashJoin 100.00 root  CARTESIAN inner join
-├─TableReader(Build) 10.00 root  data:Selection
-│ └─Selection 10.00 cop[tikv]  eq(test.t2.a, \"a\")
-│   └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo
-└─TableReader(Probe) 10.00 root  data:Selection
-  └─Selection 10.00 cop[tikv]  eq(test.t1.a, \"a\")
-    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo
+id	estRows	task	access object	operator info
+HashJoin	100.00	root		CARTESIAN inner join
+├─TableReader(Build)	10.00	root		data:Selection
+│ └─Selection	10.00	cop[tikv]		eq(planner__core__casetest__physicalplantest__physical_plan.t2.a, "a")
+│   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+└─TableReader(Probe)	10.00	root		data:Selection
+  └─Selection	10.00	cop[tikv]		eq(planner__core__casetest__physicalplantest__physical_plan.t1.a, "a")
+    └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format='brief' select * from t1, t3 where t1.a=t3.a and t3.a = 'a';
-Projection 12.50 root  test.t1.a, test.t3.a
-└─HashJoin 12.50 root  inner join, equal:[eq(test.t3.a, test.t1.a)]
-  ├─TableReader(Build) 10.00 root  data:Selection
-  │ └─Selection 10.00 cop[tikv]  eq(test.t3.a, \"a\"), not(isnull(test.t3.a))
-  │   └─TableFullScan 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo
-  └─TableReader(Probe) 9990.00 root  data:Selection
-    └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.a))
-      └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo
+id	estRows	task	access object	operator info
+Projection	12.50	root		planner__core__casetest__physicalplantest__physical_plan.t1.a, planner__core__casetest__physicalplantest__physical_plan.t3.a
+└─HashJoin	12.50	root		inner join, equal:[eq(planner__core__casetest__physicalplantest__physical_plan.t3.a, planner__core__casetest__physicalplantest__physical_plan.t1.a)]
+  ├─TableReader(Build)	10.00	root		data:Selection
+  │ └─Selection	10.00	cop[tikv]		eq(planner__core__casetest__physicalplantest__physical_plan.t3.a, "a"), not(isnull(planner__core__casetest__physicalplantest__physical_plan.t3.a))
+  │   └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+  └─TableReader(Probe)	9990.00	root		data:Selection
+    └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__physicalplantest__physical_plan.t1.a))
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format='brief' select * from t1 where t1.a in (select a from t2 where a = 'a');
-HashJoin 10.00 root  inner join, equal:[eq(test.t2.a, test.t1.a)]
-├─HashAgg(Build) 8.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a
-│ └─TableReader 10.00 root  data:Selection
-│   └─Selection 10.00 cop[tikv]  eq(test.t2.a, \"a\"), not(isnull(test.t2.a))
-│     └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo
-└─TableReader(Probe) 9990.00 root  data:Selection
-  └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.a))
-    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo
+id	estRows	task	access object	operator info
+HashJoin	10.00	root		inner join, equal:[eq(planner__core__casetest__physicalplantest__physical_plan.t2.a, planner__core__casetest__physicalplantest__physical_plan.t1.a)]
+├─HashAgg(Build)	8.00	root		group by:planner__core__casetest__physicalplantest__physical_plan.t2.a, funcs:firstrow(planner__core__casetest__physicalplantest__physical_plan.t2.a)->planner__core__casetest__physicalplantest__physical_plan.t2.a
+│ └─TableReader	10.00	root		data:Selection
+│   └─Selection	10.00	cop[tikv]		eq(planner__core__casetest__physicalplantest__physical_plan.t2.a, "a"), not(isnull(planner__core__casetest__physicalplantest__physical_plan.t2.a))
+│     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+└─TableReader(Probe)	9990.00	root		data:Selection
+  └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__physicalplantest__physical_plan.t1.a))
+    └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int);
 explain format='brief' select * from t where t.a < 3 and t.a < 3;

--- a/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
@@ -1207,6 +1207,37 @@ Selection	370.37	root		gt(planner__core__casetest__physicalplantest__physical_pl
   ├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:t2, index:idx_a(a)	range:(1,+inf], keep order:false, stats:pseudo
   └─Selection(Probe)	1111.11	cop[tikv]		gt(planner__core__casetest__physicalplantest__physical_plan.t2.c, 1)
     └─TableRowIDScan	3333.33	cop[tikv]	table:t2	keep order:false, stats:pseudo
+drop table if exists t1, t2, t3
+create table t1 (a char(10))
+create table t2 (a char(10))
+create table t3 (a char(10) COLLATE utf8mb4_general_ci)
+set session collation_connection=utf8_general_ci;
+explain format='brief' select * from t1, t2 where t1.a=t2.a and t2.a = 'a';
+HashJoin 100.00 root  CARTESIAN inner join
+├─TableReader(Build) 10.00 root  data:Selection
+│ └─Selection 10.00 cop[tikv]  eq(test.t2.a, \"a\")
+│   └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo
+└─TableReader(Probe) 10.00 root  data:Selection
+  └─Selection 10.00 cop[tikv]  eq(test.t1.a, \"a\")
+    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo
+explain format='brief' select * from t1, t3 where t1.a=t3.a and t3.a = 'a';
+Projection 12.50 root  test.t1.a, test.t3.a
+└─HashJoin 12.50 root  inner join, equal:[eq(test.t3.a, test.t1.a)]
+  ├─TableReader(Build) 10.00 root  data:Selection
+  │ └─Selection 10.00 cop[tikv]  eq(test.t3.a, \"a\"), not(isnull(test.t3.a))
+  │   └─TableFullScan 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo
+  └─TableReader(Probe) 9990.00 root  data:Selection
+    └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.a))
+      └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo
+explain format='brief' select * from t1 where t1.a in (select a from t2 where a = 'a');
+HashJoin 10.00 root  inner join, equal:[eq(test.t2.a, test.t1.a)]
+├─HashAgg(Build) 8.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a
+│ └─TableReader 10.00 root  data:Selection
+│   └─Selection 10.00 cop[tikv]  eq(test.t2.a, \"a\"), not(isnull(test.t2.a))
+│     └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo
+└─TableReader(Probe) 9990.00 root  data:Selection
+  └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.a))
+    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int);
 explain format='brief' select * from t where t.a < 3 and t.a < 3;

--- a/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
@@ -1207,10 +1207,10 @@ Selection	370.37	root		gt(planner__core__casetest__physicalplantest__physical_pl
   ├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:t2, index:idx_a(a)	range:(1,+inf], keep order:false, stats:pseudo
   └─Selection(Probe)	1111.11	cop[tikv]		gt(planner__core__casetest__physicalplantest__physical_plan.t2.c, 1)
     └─TableRowIDScan	3333.33	cop[tikv]	table:t2	keep order:false, stats:pseudo
-drop table if exists t1, t2, t3
-create table t1 (a char(10))
-create table t2 (a char(10))
-create table t3 (a char(10) COLLATE utf8mb4_general_ci)
+drop table if exists t1, t2, t3;
+create table t1 (a char(10));
+create table t2 (a char(10));
+create table t3 (a char(10) COLLATE utf8mb4_general_ci);
 set session collation_connection=utf8_general_ci;
 explain format='brief' select * from t1, t2 where t1.a=t2.a and t2.a = 'a';
 HashJoin 100.00 root  CARTESIAN inner join

--- a/tests/integrationtest/r/planner/core/casetest/point_get_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/point_get_plan.result
@@ -34,8 +34,8 @@ id	estRows	task	access object	operator info
 Projection	0.00	root		planner__core__casetest__point_get_plan.t.a, planner__core__casetest__point_get_plan.t.b, planner__core__casetest__point_get_plan.t.c, planner__core__casetest__point_get_plan.t.d, planner__core__casetest__point_get_plan.t.a, planner__core__casetest__point_get_plan.t.b, planner__core__casetest__point_get_plan.t.c, planner__core__casetest__point_get_plan.t.d
 └─HashJoin	0.00	root		CARTESIAN inner join
   ├─Selection(Build)	0.00	root		or(and(eq(planner__core__casetest__point_get_plan.t.b, 1), eq(planner__core__casetest__point_get_plan.t.c, 1)), and(eq(planner__core__casetest__point_get_plan.t.b, 2), eq(planner__core__casetest__point_get_plan.t.c, 2)))
-  │ └─Point_Get 1.00	root	table:t, index:PRIMARY(a)	
-  └─Point_Get(Probe)	1.00	root	table:t, index:PRIMARY(a)
+  │ └─Point_Get 1.00	root	table:t, index:PRIMARY(a)
+  └─Point_Get(Probe)	1.00	root	table:t, index:PRIMARY(a)	
 select * from t t1 join t t2 on t1.a = t2.a where t1.a = '4' and (t2.b, t2.c) in ((1,1),(2,2));
 a	b	c	d	a	b	c	d
 4	1	1	4	4	1	1	4

--- a/tests/integrationtest/r/planner/core/casetest/point_get_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/point_get_plan.result
@@ -32,10 +32,10 @@ a	b	c	d
 explain format = 'brief' select * from t t1 join t t2 on t1.a = t2.a where t1.a = '4' and (t2.b, t2.c) in ((1,1),(2,2));
 id	estRows	task	access object	operator info
 Projection	0.00	root		planner__core__casetest__point_get_plan.t.a, planner__core__casetest__point_get_plan.t.b, planner__core__casetest__point_get_plan.t.c, planner__core__casetest__point_get_plan.t.d, planner__core__casetest__point_get_plan.t.a, planner__core__casetest__point_get_plan.t.b, planner__core__casetest__point_get_plan.t.c, planner__core__casetest__point_get_plan.t.d
-└─MergeJoin	0.00	root		inner join, left key:planner__core__casetest__point_get_plan.t.a, right key:planner__core__casetest__point_get_plan.t.a
-  ├─Point_Get(Build)	1.00	root	table:t, index:PRIMARY(a)	
-  └─Selection(Probe)	0.00	root		or(and(eq(planner__core__casetest__point_get_plan.t.b, 1), eq(planner__core__casetest__point_get_plan.t.c, 1)), and(eq(planner__core__casetest__point_get_plan.t.b, 2), eq(planner__core__casetest__point_get_plan.t.c, 2)))
-    └─Point_Get	1.00	root	table:t, index:PRIMARY(a)	
+└─HashJoin	0.00	root		CARTESIAN inner join
+  ├─Selection(Build)	0.00	root		or(and(eq(planner__core__casetest__point_get_plan.t.b, 1), eq(planner__core__casetest__point_get_plan.t.c, 1)), and(eq(planner__core__casetest__point_get_plan.t.b, 2), eq(planner__core__casetest__point_get_plan.t.c, 2)))
+  │ └─Point_Get 1.00	root	table:t, index:PRIMARY(a)	
+  └─Point_Get(Probe)	1.00	root	table:t, index:PRIMARY(a)
 select * from t t1 join t t2 on t1.a = t2.a where t1.a = '4' and (t2.b, t2.c) in ((1,1),(2,2));
 a	b	c	d	a	b	c	d
 4	1	1	4	4	1	1	4

--- a/tests/integrationtest/r/planner/core/casetest/point_get_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/point_get_plan.result
@@ -34,8 +34,9 @@ id	estRows	task	access object	operator info
 Projection	0.00	root		planner__core__casetest__point_get_plan.t.a, planner__core__casetest__point_get_plan.t.b, planner__core__casetest__point_get_plan.t.c, planner__core__casetest__point_get_plan.t.d, planner__core__casetest__point_get_plan.t.a, planner__core__casetest__point_get_plan.t.b, planner__core__casetest__point_get_plan.t.c, planner__core__casetest__point_get_plan.t.d
 └─HashJoin	0.00	root		CARTESIAN inner join
   ├─Selection(Build)	0.00	root		or(and(eq(planner__core__casetest__point_get_plan.t.b, 1), eq(planner__core__casetest__point_get_plan.t.c, 1)), and(eq(planner__core__casetest__point_get_plan.t.b, 2), eq(planner__core__casetest__point_get_plan.t.c, 2)))
-  │ └─Point_Get 1.00	root	table:t, index:PRIMARY(a)
+  │ └─Point_Get	1.00	root	table:t, index:PRIMARY(a)	
   └─Point_Get(Probe)	1.00	root	table:t, index:PRIMARY(a)	
+
 select * from t t1 join t t2 on t1.a = t2.a where t1.a = '4' and (t2.b, t2.c) in ((1,1),(2,2));
 a	b	c	d	a	b	c	d
 4	1	1	4	4	1	1	4

--- a/tests/integrationtest/r/planner/core/casetest/point_get_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/point_get_plan.result
@@ -36,7 +36,6 @@ Projection	0.00	root		planner__core__casetest__point_get_plan.t.a, planner__core
   ├─Selection(Build)	0.00	root		or(and(eq(planner__core__casetest__point_get_plan.t.b, 1), eq(planner__core__casetest__point_get_plan.t.c, 1)), and(eq(planner__core__casetest__point_get_plan.t.b, 2), eq(planner__core__casetest__point_get_plan.t.c, 2)))
   │ └─Point_Get	1.00	root	table:t, index:PRIMARY(a)	
   └─Point_Get(Probe)	1.00	root	table:t, index:PRIMARY(a)	
-
 select * from t t1 join t t2 on t1.a = t2.a where t1.a = '4' and (t2.b, t2.c) in ((1,1),(2,2));
 a	b	c	d	a	b	c	d
 4	1	1	4	4	1	1	4

--- a/tests/integrationtest/t/planner/core/casetest/physicalplantest/physical_plan.test
+++ b/tests/integrationtest/t/planner/core/casetest/physicalplantest/physical_plan.test
@@ -373,6 +373,16 @@ explain format='brief' select * from t1 where a > 1 and b > 1;
 -- echo ## Make sure row_count(tikv_selection) == row_count(index_lookup) and row_count(index_lookup) > row_count(tidb_selection)
 explain format='brief' select * from t2 use index(idx_a) where a > 1 and b > 1 and c > 1;
 
+# TestIssue47629
+drop table if exists t1, t2, t3
+create table t1 (a char(10))
+create table t2 (a char(10))
+create table t3 (a char(10) COLLATE utf8mb4_general_ci)
+set session collation_connection=utf8_general_ci;
+explain format='brief' select * from t1, t2 where t1.a=t2.a and t2.a = 'a';
+explain format='brief' select * from t1, t3 where t1.a=t3.a and t3.a = 'a';
+explain format='brief' select * from t1 where t1.a in (select a from t2 where a = 'a');
+
 # TestIssue28316
 drop table if exists t;
 create table t(a int);

--- a/tests/integrationtest/t/planner/core/casetest/physicalplantest/physical_plan.test
+++ b/tests/integrationtest/t/planner/core/casetest/physicalplantest/physical_plan.test
@@ -374,10 +374,10 @@ explain format='brief' select * from t1 where a > 1 and b > 1;
 explain format='brief' select * from t2 use index(idx_a) where a > 1 and b > 1 and c > 1;
 
 # TestIssue47629
-drop table if exists t1, t2, t3
-create table t1 (a char(10))
-create table t2 (a char(10))
-create table t3 (a char(10) COLLATE utf8mb4_general_ci)
+drop table if exists t1, t2, t3;
+create table t1 (a char(10));
+create table t2 (a char(10));
+create table t3 (a char(10) COLLATE utf8mb4_general_ci);
 set session collation_connection=utf8_general_ci;
 explain format='brief' select * from t1, t2 where t1.a=t2.a and t2.a = 'a';
 explain format='brief' select * from t1, t3 where t1.a=t3.a and t3.a = 'a';


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #47629   
Problem Summary:
When the collation set by collation_connection is inconsistent with the column collation, it may affect the normal propagation of constants.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->  

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
When the collation_connection setting conflicts with column collation, this release ensures consistent handling for proper constant propagation and introduces compatibility improvements, aligning with MySQL 8.0 standards.
```
