### PR TITLE
gcs: fix a deadlock in gs parallel writer

### DIFF
--- a/br/pkg/storage/gcs_extra.go
+++ b/br/pkg/storage/gcs_extra.go
@@ -144,7 +144,7 @@ func (w *GCSWriter) readChunk(ch chan chunk) {
 		select {
 		case <-w.ctx.Done():
 			data.cleanup()
-			return
+			w.err.CompareAndSwap(nil, w.ctx.Err())
 		default:
 			part := &xmlMPUPart{
 				uploadBase: w.uploadBase,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #48443

Problem Summary:

### What changed and how does it work?

The error is introduced when port https://github.com/liqiuqing/gcsmpu/blob/fffbb8a9ad154cfe8a9621f091973954d0146d7c/upload.go#L466-L479.

When use channel to send task in producer/consumer pattern, we'd better have only one way to nofity consumer exit, which is closing the channel

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > easy fix

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
