### PR TITLE
statistics: do not get partition stats again and again

### DIFF
--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -426,7 +426,7 @@ func RandomPickOneTableAndTryAutoAnalyze(
 				continue
 			}
 			// Only analyze the partition that has not been locked.
-			var partitionDefs []model.PartitionDefinition
+			partitionDefs := make([]model.PartitionDefinition, 0, len(pi.Definitions))
 			for _, def := range pi.Definitions {
 				if _, ok := lockedTables[def.ID]; !ok {
 					partitionDefs = append(partitionDefs, def)

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -432,8 +432,18 @@ func RandomPickOneTableAndTryAutoAnalyze(
 					partitionDefs = append(partitionDefs, def)
 				}
 			}
+			partitionStats := getPartitionStats(statsHandle, tblInfo, partitionDefs)
 			if pruneMode == variable.Dynamic {
-				analyzed := tryAutoAnalyzePartitionTableInDynamicMode(sctx, statsHandle, sysProcTracker, tblInfo, partitionDefs, db, autoAnalyzeRatio)
+				analyzed := tryAutoAnalyzePartitionTableInDynamicMode(
+					sctx,
+					statsHandle,
+					sysProcTracker,
+					tblInfo,
+					partitionDefs,
+					partitionStats,
+					db,
+					autoAnalyzeRatio,
+				)
 				if analyzed {
 					return true
 				}
@@ -441,7 +451,7 @@ func RandomPickOneTableAndTryAutoAnalyze(
 			}
 			for _, def := range partitionDefs {
 				sql := "analyze table %n.%n partition %n"
-				statsTbl := statsHandle.GetPartitionStats(tblInfo, def.ID)
+				statsTbl := partitionStats[def.ID]
 				analyzed := tryAutoAnalyzeTable(sctx, statsHandle, sysProcTracker, tblInfo, statsTbl, autoAnalyzeRatio, sql, db, tblInfo.Name.O, def.Name.O)
 				if analyzed {
 					return true
@@ -451,6 +461,20 @@ func RandomPickOneTableAndTryAutoAnalyze(
 	}
 
 	return false
+}
+
+func getPartitionStats(
+	statsHandle statstypes.StatsHandle,
+	tblInfo *model.TableInfo,
+	defs []model.PartitionDefinition,
+) map[int64]*statistics.Table {
+	partitionStats := make(map[int64]*statistics.Table, len(defs))
+
+	for _, def := range defs {
+		partitionStats[def.ID] = statsHandle.GetPartitionStats(tblInfo, def.ID)
+	}
+
+	return partitionStats
 }
 
 // AutoAnalyzeMinCnt means if the count of table is less than this value, we don't need to do auto analyze.
@@ -569,6 +593,7 @@ func tryAutoAnalyzePartitionTableInDynamicMode(
 	sysProcTracker sessionctx.SysProcTracker,
 	tblInfo *model.TableInfo,
 	partitionDefs []model.PartitionDefinition,
+	partitionStats map[int64]*statistics.Table,
 	db string,
 	ratio float64,
 ) bool {
@@ -577,7 +602,7 @@ func tryAutoAnalyzePartitionTableInDynamicMode(
 	needAnalyzePartitionNames := make([]interface{}, 0, len(partitionDefs))
 
 	for _, def := range partitionDefs {
-		partitionStatsTbl := statsHandle.GetPartitionStats(tblInfo, def.ID)
+		partitionStatsTbl := partitionStats[def.ID]
 		// 1. If the stats are not loaded, we don't need to analyze it.
 		// 2. If the table is too small, we don't want to waste time to analyze it.
 		//    Leave the opportunity to other bigger tables.
@@ -652,7 +677,7 @@ func tryAutoAnalyzePartitionTableInDynamicMode(
 		}
 		// Collect all the partition names that need to analyze.
 		for _, def := range partitionDefs {
-			partitionStatsTbl := statsHandle.GetPartitionStats(tblInfo, def.ID)
+			partitionStatsTbl := partitionStats[def.ID]
 			if _, ok := partitionStatsTbl.Indices[idx.ID]; !ok {
 				needAnalyzePartitionNames = append(needAnalyzePartitionNames, def.Name.O)
 				statistics.CheckAnalyzeVerOnTable(partitionStatsTbl, &tableStatsVer)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary:

### What changed and how does it work?

- Only get the partition's stats meta once.

Before:
<img width="1669" alt="image" src="https://github.com/pingcap/tidb/assets/29879298/1c56a1fc-e8b3-4f28-bf2a-4e91ffaf1a09">
After:
<img width="1675" alt="image" src="https://github.com/pingcap/tidb/assets/29879298/31830f03-b63c-45ef-b007-258aa805d297">


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
