### PR TITLE
ddl: allow altering integer with foreign key and deny altering decimal with foreign key

### DIFF
--- a/pkg/ddl/foreign_key.go
+++ b/pkg/ddl/foreign_key.go
@@ -398,7 +398,7 @@ func isAcceptableRefferedKeyColumnChange(newCol, originalCol, childCol *model.Co
 		return false
 	}
 	if newCol.GetType() == mysql.TypeNewDecimal {
-		if newCol.GetFlen() != childCol.GetFlen() || newCol.GetDecimal() != childCol.GetDecimal() {
+		if newCol.GetFlen() != originalCol.GetFlen() || newCol.GetDecimal() != originalCol.GetDecimal() {
 			return false
 		}
 	}

--- a/pkg/ddl/foreign_key.go
+++ b/pkg/ddl/foreign_key.go
@@ -350,7 +350,7 @@ func checkModifyColumnWithForeignKeyConstraint(is infoschema.InfoSchema, dbName 
 				if newCol.GetType() != childCol.GetType() {
 					return dbterror.ErrFKIncompatibleColumns.GenWithStackByArgs(childCol.Name, originalCol.Name, referredFK.ChildFKName)
 				}
-				if !isAcceptableRefferedKeyColumnChange(newCol, originalCol, childCol) {
+				if !isAcceptableForeignKeyColumnChange(newCol, originalCol, childCol) {
 					return dbterror.ErrForeignKeyColumnCannotChangeChild.GenWithStackByArgs(originalCol.Name, referredFK.ChildFKName, referredFK.ChildSchema.L+"."+referredFK.ChildTable.L)
 				}
 			}
@@ -360,7 +360,7 @@ func checkModifyColumnWithForeignKeyConstraint(is infoschema.InfoSchema, dbName 
 	return nil
 }
 
-func isAcceptableForeignKeyColumnChange(newCol, originalCol, referCol *model.ColumnInfo) bool {
+func isAcceptableForeignKeyColumnChange(newCol, originalCol, relatedCol *model.ColumnInfo) bool {
 	switch newCol.GetType() {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 		// For integer data types, value from GetFlen indicates the minimum display width and is unrelated to the range of values a type can store.
@@ -368,30 +368,7 @@ func isAcceptableForeignKeyColumnChange(newCol, originalCol, referCol *model.Col
 		return true
 	}
 
-	if newCol.GetFlen() < referCol.GetFlen() {
-		return false
-	}
-	if newCol.GetFlen() < originalCol.GetFlen() {
-		return false
-	}
-	if newCol.GetType() == mysql.TypeNewDecimal {
-		if newCol.GetFlen() != originalCol.GetFlen() || newCol.GetDecimal() != originalCol.GetDecimal() {
-			return false
-		}
-	}
-
-	return true
-}
-
-func isAcceptableRefferedKeyColumnChange(newCol, originalCol, childCol *model.ColumnInfo) bool {
-	switch newCol.GetType() {
-	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
-		// For integer data types, value from GetFlen indicates the minimum display width and is unrelated to the range of values a type can store.
-		// We don't have to prevent the length change. See: https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html
-		return true
-	}
-
-	if newCol.GetFlen() < childCol.GetFlen() {
+	if newCol.GetFlen() < relatedCol.GetFlen() {
 		return false
 	}
 	if newCol.GetFlen() < originalCol.GetFlen() {

--- a/tests/integrationtest/r/ddl/foreign_key.result
+++ b/tests/integrationtest/r/ddl/foreign_key.result
@@ -48,6 +48,11 @@ create table t1 (a bigint(10) key);
 create table t2 (a bigint(10), constraint fk foreign key (a) references t1(a));
 alter table t2 modify column a bigint(5);
 alter table t1 modify column a bigint(1);
+drop table t1, t2;
+create table t1 (id int key, b decimal(8, 5), index(b));
+create table t2 (a decimal(10, 5), constraint fk foreign key (a) references t1(b));
+alter table t1 modify column b decimal(10, 5);
+Error 1833 (HY000): Cannot change column 'b': used in a foreign key constraint 'fk' of table 'ddl__foreign_key.t2'
 set @@global.tidb_enable_foreign_key=default;
 set @@foreign_key_checks=default;
 set @@global.tidb_enable_foreign_key=1;

--- a/tests/integrationtest/r/ddl/foreign_key.result
+++ b/tests/integrationtest/r/ddl/foreign_key.result
@@ -47,6 +47,7 @@ drop table t1, t2;
 create table t1 (a bigint(10) key);
 create table t2 (a bigint(10), constraint fk foreign key (a) references t1(a));
 alter table t2 modify column a bigint(5);
+alter table t1 modify column a bigint(1);
 set @@global.tidb_enable_foreign_key=default;
 set @@foreign_key_checks=default;
 set @@global.tidb_enable_foreign_key=1;

--- a/tests/integrationtest/r/ddl/foreign_key.result
+++ b/tests/integrationtest/r/ddl/foreign_key.result
@@ -43,6 +43,10 @@ alter table t2 modify column a decimal(30, 15);
 Error 1832 (HY000): Cannot change column 'a': used in a foreign key constraint 'fk'
 alter table t2 modify column a decimal(5, 2);
 Error 1832 (HY000): Cannot change column 'a': used in a foreign key constraint 'fk'
+drop table t1, t2;
+create table t1 (a bigint(10) key);
+create table t2 (a bigint(10), constraint fk foreign key (a) references t1(a));
+alter table t2 modify column a bigint(5);
 set @@global.tidb_enable_foreign_key=default;
 set @@foreign_key_checks=default;
 set @@global.tidb_enable_foreign_key=1;

--- a/tests/integrationtest/t/ddl/foreign_key.test
+++ b/tests/integrationtest/t/ddl/foreign_key.test
@@ -56,6 +56,7 @@ drop table t1, t2;
 create table t1 (a bigint(10) key);
 create table t2 (a bigint(10), constraint fk foreign key (a) references t1(a));
 alter table t2 modify column a bigint(5);
+alter table t1 modify column a bigint(1);
 
 set @@global.tidb_enable_foreign_key=default;
 set @@foreign_key_checks=default;

--- a/tests/integrationtest/t/ddl/foreign_key.test
+++ b/tests/integrationtest/t/ddl/foreign_key.test
@@ -58,6 +58,12 @@ create table t2 (a bigint(10), constraint fk foreign key (a) references t1(a));
 alter table t2 modify column a bigint(5);
 alter table t1 modify column a bigint(1);
 
+drop table t1, t2;
+create table t1 (id int key, b decimal(8, 5), index(b));
+create table t2 (a decimal(10, 5), constraint fk foreign key (a) references t1(b));
+-- error 1833
+alter table t1 modify column b decimal(10, 5);
+
 set @@global.tidb_enable_foreign_key=default;
 set @@foreign_key_checks=default;
 

--- a/tests/integrationtest/t/ddl/foreign_key.test
+++ b/tests/integrationtest/t/ddl/foreign_key.test
@@ -52,6 +52,11 @@ alter table t2 modify column a decimal(30, 15);
 -- error 1832
 alter table t2 modify column a decimal(5, 2);
 
+drop table t1, t2;
+create table t1 (a bigint(10) key);
+create table t2 (a bigint(10), constraint fk foreign key (a) references t1(a));
+alter table t2 modify column a bigint(5);
+
 set @@global.tidb_enable_foreign_key=default;
 set @@foreign_key_checks=default;
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47702
Issue Number: close #49836

Problem Summary:
This pull request is for the compatibility with MySQL regarding altering columns with foreign key constraint.

### What changed and how does it work?
#### Allow altering integer length
#47702

As @YangKeao said,  the length of integer does nothing on the data. MySQL document also said so.


> For integer data types, M indicates the minimum display width. The maximum display width is 255. Display width is unrelated to the range of values a type can store
https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html

You can confirm the behavior on TiDB as well.
```
tidb> CREATE TABLE bigint_test (
    ->     bigIntColumn1 bigint(10),
    ->     bigIntColumn2 bigint(1)
    -> );
Query OK, 0 rows affected (0.07 sec)

tidb> INSERT INTO bigint_test (bigIntColumn1, bigIntColumn2) VALUES (1234567890, 1234567890);
Query OK, 1 row affected (0.01 sec)

tidb> INSERT INTO bigint_test (bigIntColumn1, bigIntColumn2) VALUES (-1234567890, -1234567890);
Query OK, 1 row affected (0.00 sec)

tidb> SELECT * FROM bigint_test;
+---------------+---------------+
| bigIntColumn1 | bigIntColumn2 |
+---------------+---------------+
|    1234567890 |    1234567890 |
|   -1234567890 |   -1234567890 |
+---------------+---------------+
2 rows in set (0.01 sec)
```

Because of that, MySQL doesn't raise error when altering length of integer and TiDB will follow that by this change.

#### Denying altering decimal length
#49836
In refactoring phase of above issue, I found this compatibility issue. 
By fixing this issue on 2564f05edf0ebea11b4c2a5af40c80f4b1bbe825 ,  I could unify 2 methods to one on 69448dfff5ad39aede1b164371f389b4badafbe0. That's why I would like to fix this issue in this pull request too.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
