### PR TITLE
util: fix recover log doesn't contains stack

### DIFF
--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "//pkg/testkit/testsetup",
         "//pkg/types",
         "//pkg/util/fastrand",
+        "//pkg/util/logutil",
         "//pkg/util/memory",
         "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//assert",

--- a/pkg/util/cpuprofile/cpuprofile.go
+++ b/pkg/util/cpuprofile/cpuprofile.go
@@ -211,7 +211,7 @@ func (p *parallelCPUProfiler) sendToConsumers() {
 	defer func() {
 		p.Unlock()
 		if r := recover(); r != nil {
-			logutil.BgLogger().Error("parallel cpu profiler panic", zap.Any("recover", r))
+			logutil.BgLogger().Error("parallel cpu profiler panic", zap.Any("recover", r), zap.Stack("stack"))
 		}
 	}()
 

--- a/pkg/util/wait_group_wrapper.go
+++ b/pkg/util/wait_group_wrapper.go
@@ -229,8 +229,7 @@ func (g *ErrorGroupWithRecover) Go(fn func() error) {
 	g.Group.Go(func() (err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				// stack is automatically printed
-				logutil.BgLogger().Error("panic in error group", zap.Any("recover", r))
+				logutil.BgLogger().Error("panic in error group", zap.Any("recover", r), zap.Stack("stack"))
 				err = GetRecoverError(r)
 			}
 		}()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49867

Problem Summary:

### What changed and how does it work?
InitLogger contains zap.AddStacktrace(zapcore.FatalLevel), so log level below fatal will not contain stack automatically.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
