### PR TITLE
statistics: BCE for BinarySearchRemoveVal

### DIFF
--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -299,12 +299,13 @@ func (hg *Histogram) BucketToString(bktID, idxCols int) string {
 // BinarySearchRemoveVal removes the value from the TopN using binary search.
 func (hg *Histogram) BinarySearchRemoveVal(valCntPairs TopNMeta) {
 	lowIdx, highIdx := 0, hg.Len()-1
+	column := hg.Bounds.Column(0)
 	// if hg is too small, we don't need to check the branch. because the cost is more than binary search.
 	if hg.Len() > 4 {
-		if cmpResult := bytes.Compare(hg.Bounds.Column(0).GetRaw(highIdx*2+1), valCntPairs.Encoded); cmpResult < 0 {
+		if cmpResult := bytes.Compare(column.GetRaw(highIdx*2+1), valCntPairs.Encoded); cmpResult < 0 {
 			return
 		}
-		if cmpResult := bytes.Compare(hg.Bounds.Column(0).GetRaw(lowIdx), valCntPairs.Encoded); cmpResult > 0 {
+		if cmpResult := bytes.Compare(column.GetRaw(lowIdx), valCntPairs.Encoded); cmpResult > 0 {
 			return
 		}
 	}

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -313,12 +313,12 @@ func (hg *Histogram) BinarySearchRemoveVal(valCntPairs TopNMeta) {
 	var found bool
 	for lowIdx <= highIdx {
 		midIdx = (lowIdx + highIdx) / 2
-		cmpResult := bytes.Compare(hg.Bounds.Column(0).GetRaw(midIdx*2), valCntPairs.Encoded)
+		cmpResult := bytes.Compare(column.GetRaw(midIdx*2), valCntPairs.Encoded)
 		if cmpResult > 0 {
 			highIdx = midIdx - 1
 			continue
 		}
-		cmpResult = bytes.Compare(hg.Bounds.Column(0).GetRaw(midIdx*2+1), valCntPairs.Encoded)
+		cmpResult = bytes.Compare(column.GetRaw(midIdx*2+1), valCntPairs.Encoded)
 		if cmpResult < 0 {
 			lowIdx = midIdx + 1
 			continue


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49876

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

before

```
pkg/statistics/histogram.go:304:49: Found IsInBounds
pkg/statistics/histogram.go:304:59: Found IsSliceInBounds
pkg/statistics/histogram.go:304:59: Found IsInBounds
pkg/statistics/histogram.go:307:49: Found IsInBounds
pkg/statistics/histogram.go:307:59: Found IsSliceInBounds
pkg/statistics/histogram.go:307:59: Found IsInBounds
pkg/statistics/histogram.go:315:46: Found IsInBounds
pkg/statistics/histogram.go:315:56: Found IsSliceInBounds
pkg/statistics/histogram.go:315:56: Found IsInBounds
pkg/statistics/histogram.go:320:45: Found IsInBounds
```

after 

```
pkg/statistics/histogram.go:302:28: Found IsInBounds
pkg/statistics/histogram.go:305:46: Found IsSliceInBounds
pkg/statistics/histogram.go:305:46: Found IsInBounds
pkg/statistics/histogram.go:308:46: Found IsSliceInBounds
pkg/statistics/histogram.go:308:46: Found IsInBounds
pkg/statistics/histogram.go:316:43: Found IsSliceInBounds
pkg/statistics/histogram.go:316:43: Found IsInBounds
pkg/statistics/histogram.go:321:42: Found IsSliceInBounds
pkg/statistics/histogram.go:321:42: Found IsInBounds

```

# gobench

```
go test -run=^$ -bench=BenchmarkMergePartTopN2GlobalTopNWithHists -benchmem github.com/pingcap/tidb/pkg/statistics/handle/globalstats
```

before

```
goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/pkg/statistics/handle/globalstats
BenchmarkMergePartTopN2GlobalTopNWithHists/Size100-8                 231           5237536 ns/op          177657 B/op         30 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size1000-8                 14          74706851 ns/op          177771 B/op         30 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size2000-8                  6         187332771 ns/op          176674 B/op         29 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size5000-8                  2         872378271 ns/op          179360 B/op         34 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size10000-8                 1        2077151917 ns/op          176776 B/op         31 allocs/op
PASS
ok      github.com/pingcap/tidb/pkg/statistics/handle/globalstats       14.021s

```

after 

```
goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/pkg/statistics/handle/globalstats
BenchmarkMergePartTopN2GlobalTopNWithHists/Size100-8                 230           5141669 ns/op          177722 B/op         30 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size1000-8                 16          63135646 ns/op          177431 B/op         29 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size2000-8                  6         182425965 ns/op          178802 B/op         32 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size5000-8                  2         988736625 ns/op          177200 B/op         29 allocs/op
BenchmarkMergePartTopN2GlobalTopNWithHists/Size10000-8                 1        2049309958 ns/op          179432 B/op         33 allocs/op
PASS
ok      github.com/pingcap/tidb/pkg/statistics/handle/globalstats       13.125s

```


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
