### PR TITLE
test: fix not-stable test about ExchangePartition when wait for ddl enter next state

### DIFF
--- a/pkg/table/tables/test/partition/BUILD.bazel
+++ b/pkg/table/tables/test/partition/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "//pkg/table",
         "//pkg/table/tables",
         "//pkg/testkit",
+        "//pkg/testkit/external",
         "//pkg/testkit/testsetup",
         "//pkg/types",
         "//pkg/util",

--- a/pkg/table/tables/test/partition/BUILD.bazel
+++ b/pkg/table/tables/test/partition/BUILD.bazel
@@ -18,7 +18,6 @@ go_test(
         "//pkg/table",
         "//pkg/table/tables",
         "//pkg/testkit",
-        "//pkg/testkit/external",
         "//pkg/testkit/testsetup",
         "//pkg/types",
         "//pkg/util",

--- a/pkg/table/tables/test/partition/partition_test.go
+++ b/pkg/table/tables/test/partition/partition_test.go
@@ -408,10 +408,11 @@ func TestExchangePartitionStates(t *testing.T) {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
 				break
 			}
-			gotime.Sleep(50 * gotime.Millisecond)
+			gotime.Sleep(10 * gotime.Millisecond)
 		}
-		// Sleep 50ms to wait load InforSchema finish, issue #46815.
-		gotime.Sleep(50 * gotime.Millisecond)
+		dom := domain.GetDomain(tk.Session())
+		// Make sure the table schema is the new schema.
+		require.NoError(t, dom.Reload())
 	}
 	waitFor("t", "write only", 4)
 	tk3.MustExec(`BEGIN`)
@@ -519,10 +520,11 @@ func TestExchangePartitionCheckConstraintStates(t *testing.T) {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
 				break
 			}
-			gotime.Sleep(50 * gotime.Millisecond)
+			gotime.Sleep(10 * gotime.Millisecond)
 		}
-		// Sleep 50ms to wait load InforSchema finish.
-		gotime.Sleep(50 * gotime.Millisecond)
+		dom := domain.GetDomain(tk.Session())
+		// Make sure the table schema is the new schema.
+		require.NoError(t, dom.Reload())
 	}
 	waitFor("nt", "write only", 4)
 
@@ -630,10 +632,11 @@ func TestExchangePartitionCheckConstraintStatesTwo(t *testing.T) {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
 				break
 			}
-			gotime.Sleep(50 * gotime.Millisecond)
+			gotime.Sleep(10 * gotime.Millisecond)
 		}
-		// Sleep 50ms to wait load InforSchema finish.
-		gotime.Sleep(50 * gotime.Millisecond)
+		dom := domain.GetDomain(tk.Session())
+		// Make sure the table schema is the new schema.
+		require.NoError(t, dom.Reload())
 	}
 	waitFor("nt", "write only", 4)
 
@@ -691,8 +694,9 @@ func TestAddKeyPartitionStates(t *testing.T) {
 			}
 			gotime.Sleep(10 * gotime.Millisecond)
 		}
-		// Sleep 50ms to wait load InforSchema finish.
-		gotime.Sleep(50 * gotime.Millisecond)
+		dom := domain.GetDomain(tk.Session())
+		// Make sure the table schema is the new schema.
+		require.NoError(t, dom.Reload())
 	}
 	waitFor(4, "delete only")
 	tk3.MustExec(`BEGIN`)

--- a/pkg/table/tables/test/partition/partition_test.go
+++ b/pkg/table/tables/test/partition/partition_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/external"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -403,10 +404,7 @@ func TestExchangePartitionStates(t *testing.T) {
 			default:
 				// Alter still running
 			}
-			ctx := tk.Session()
-			is := domain.GetDomain(ctx).InfoSchema()
-			tbl, err := is.TableByName(model.NewCIStr(dbName), model.NewCIStr(tableName))
-			require.NoError(t, err)
+			tbl := external.GetTableByName(t, tk, dbName, tableName)
 			nullExchangeInfo := tbl.Meta().ExchangePartitionInfo == nil
 			if s == "write only" && !nullExchangeInfo || s == "rollback done" && nullExchangeInfo {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
@@ -516,10 +514,7 @@ func TestExchangePartitionCheckConstraintStates(t *testing.T) {
 			default:
 				// Alter still running
 			}
-			ctx := tk.Session()
-			is := domain.GetDomain(ctx).InfoSchema()
-			tbl, err := is.TableByName(model.NewCIStr("check_constraint"), model.NewCIStr(tableName))
-			require.NoError(t, err)
+			tbl := external.GetTableByName(t, tk, "check_constraint", tableName)
 			nullExchangeInfo := tbl.Meta().ExchangePartitionInfo == nil
 			if s == "write only" && !nullExchangeInfo || s == "none" && nullExchangeInfo {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
@@ -629,10 +624,7 @@ func TestExchangePartitionCheckConstraintStatesTwo(t *testing.T) {
 			default:
 				// Alter still running
 			}
-			ctx := tk.Session()
-			is := domain.GetDomain(ctx).InfoSchema()
-			tbl, err := is.TableByName(model.NewCIStr("check_constraint"), model.NewCIStr(tableName))
-			require.NoError(t, err)
+			tbl := external.GetTableByName(t, tk, "check_constraint", tableName)
 			nullExchangeInfo := tbl.Meta().ExchangePartitionInfo == nil
 			if s == "write only" && !nullExchangeInfo {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))

--- a/pkg/table/tables/test/partition/partition_test.go
+++ b/pkg/table/tables/test/partition/partition_test.go
@@ -395,7 +395,7 @@ func TestExchangePartitionStates(t *testing.T) {
 		err := tk2.ExecToErr(`alter table tp exchange partition p0 with table t`)
 		alterChan <- err
 	}()
-	waitFor := func(tableName, s string) {
+	waitFor := func(tableName, s string, pos int) {
 		for {
 			select {
 			case alterErr := <-alterChan:
@@ -403,19 +403,17 @@ func TestExchangePartitionStates(t *testing.T) {
 			default:
 				// Alter still running
 			}
-			ctx := tk.Session()
-			is := domain.GetDomain(ctx).InfoSchema()
-			tbl, err := is.TableByName(model.NewCIStr(dbName), model.NewCIStr(tableName))
-			require.NoError(t, err)
-			nullExchangeInfo := tbl.Meta().ExchangePartitionInfo == nil
-			if s == "write only" && !nullExchangeInfo || s == "rollback done" && nullExchangeInfo {
+			res := tk4.MustQuery(`admin show ddl jobs where db_name = '` + strings.ToLower(dbName) + `' and table_name = '` + tableName + `' and job_type = 'exchange partition'`).Rows()
+			if len(res) == 1 && res[0][pos] == s {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
 				break
 			}
-			gotime.Sleep(10 * gotime.Millisecond)
+			gotime.Sleep(50 * gotime.Millisecond)
 		}
+		// Sleep 50ms to wait load InforSchema finish, issue #46815.
+		gotime.Sleep(50 * gotime.Millisecond)
 	}
-	waitFor("t", "write only")
+	waitFor("t", "write only", 4)
 	tk3.MustExec(`BEGIN`)
 	tk3.MustExec(`insert into t values (4,"4")`)
 	tk3.MustContainErrMsg(`insert into t values (1000004,"1000004")`, "[table:1748]Found a row not matching the given partition set")
@@ -426,7 +424,7 @@ func TestExchangePartitionStates(t *testing.T) {
 	// MDL will block the alter to not continue until all clients
 	// are in StateWriteOnly, which tk is blocking until it commits
 	tk.MustExec(`COMMIT`)
-	waitFor("t", "rollback done")
+	waitFor("t", "rollback done", 11)
 	// MDL will block the alter from finish, tk is in 'rollbacked' schema version
 	// but the alter is still waiting for tk3 to commit, before continuing
 	tk.MustExec("BEGIN")
@@ -508,7 +506,7 @@ func TestExchangePartitionCheckConstraintStates(t *testing.T) {
 		err := tk3.ExecToErr(`alter table pt exchange partition p1 with table nt`)
 		alterChan <- err
 	}()
-	waitFor := func(tableName, s string) {
+	waitFor := func(tableName, s string, pos int) {
 		for {
 			select {
 			case alterErr := <-alterChan:
@@ -516,19 +514,17 @@ func TestExchangePartitionCheckConstraintStates(t *testing.T) {
 			default:
 				// Alter still running
 			}
-			ctx := tk.Session()
-			is := domain.GetDomain(ctx).InfoSchema()
-			tbl, err := is.TableByName(model.NewCIStr("check_constraint"), model.NewCIStr(tableName))
-			require.NoError(t, err)
-			nullExchangeInfo := tbl.Meta().ExchangePartitionInfo == nil
-			if s == "write only" && !nullExchangeInfo || s == "none" && nullExchangeInfo {
+			res := tk4.MustQuery(`admin show ddl jobs where db_name = 'check_constraint' and table_name = '` + tableName + `' and job_type = 'exchange partition'`).Rows()
+			if len(res) == 1 && res[0][pos] == s {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
 				break
 			}
-			gotime.Sleep(10 * gotime.Millisecond)
+			gotime.Sleep(50 * gotime.Millisecond)
 		}
+		// Sleep 50ms to wait load InforSchema finish.
+		gotime.Sleep(50 * gotime.Millisecond)
 	}
-	waitFor("nt", "write only")
+	waitFor("nt", "write only", 4)
 
 	tk.MustExec(`insert into nt values (60, 60)`)
 	// violate pt (a < 75)
@@ -562,7 +558,7 @@ func TestExchangePartitionCheckConstraintStates(t *testing.T) {
 
 	// Release tk2 mdl, wait ddl enter next state.
 	tk2.MustExec("commit")
-	waitFor("nt", "none")
+	waitFor("pt", "none", 4)
 
 	// violate nt (b > 50)
 	// Now tk5 handle the sql with MDL: pt version state is write-only, nt version state is none.
@@ -621,7 +617,7 @@ func TestExchangePartitionCheckConstraintStatesTwo(t *testing.T) {
 		err := tk3.ExecToErr(`alter table pt exchange partition p1 with table nt`)
 		alterChan <- err
 	}()
-	waitFor := func(tableName, s string) {
+	waitFor := func(tableName, s string, pos int) {
 		for {
 			select {
 			case alterErr := <-alterChan:
@@ -629,19 +625,17 @@ func TestExchangePartitionCheckConstraintStatesTwo(t *testing.T) {
 			default:
 				// Alter still running
 			}
-			ctx := tk.Session()
-			is := domain.GetDomain(ctx).InfoSchema()
-			tbl, err := is.TableByName(model.NewCIStr("check_constraint"), model.NewCIStr(tableName))
-			require.NoError(t, err)
-			nullExchangeInfo := tbl.Meta().ExchangePartitionInfo == nil
-			if s == "write only" && !nullExchangeInfo {
+			res := tk4.MustQuery(`admin show ddl jobs where db_name = 'check_constraint' and table_name = '` + tableName + `' and job_type = 'exchange partition'`).Rows()
+			if len(res) == 1 && res[0][pos] == s {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
 				break
 			}
-			gotime.Sleep(10 * gotime.Millisecond)
+			gotime.Sleep(50 * gotime.Millisecond)
 		}
+		// Sleep 50ms to wait load InforSchema finish.
+		gotime.Sleep(50 * gotime.Millisecond)
 	}
-	waitFor("nt", "write only")
+	waitFor("nt", "write only", 4)
 
 	tk.MustExec(`insert into nt values (60, 60)`)
 	// violate pt (a < 75)

--- a/pkg/table/tables/test/partition/partition_test.go
+++ b/pkg/table/tables/test/partition/partition_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/testkit"
-	"github.com/pingcap/tidb/pkg/testkit/external"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -404,7 +403,10 @@ func TestExchangePartitionStates(t *testing.T) {
 			default:
 				// Alter still running
 			}
-			tbl := external.GetTableByName(t, tk, dbName, tableName)
+			ctx := tk.Session()
+			is := domain.GetDomain(ctx).InfoSchema()
+			tbl, err := is.TableByName(model.NewCIStr(dbName), model.NewCIStr(tableName))
+			require.NoError(t, err)
 			nullExchangeInfo := tbl.Meta().ExchangePartitionInfo == nil
 			if s == "write only" && !nullExchangeInfo || s == "rollback done" && nullExchangeInfo {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
@@ -514,7 +516,10 @@ func TestExchangePartitionCheckConstraintStates(t *testing.T) {
 			default:
 				// Alter still running
 			}
-			tbl := external.GetTableByName(t, tk, "check_constraint", tableName)
+			ctx := tk.Session()
+			is := domain.GetDomain(ctx).InfoSchema()
+			tbl, err := is.TableByName(model.NewCIStr("check_constraint"), model.NewCIStr(tableName))
+			require.NoError(t, err)
 			nullExchangeInfo := tbl.Meta().ExchangePartitionInfo == nil
 			if s == "write only" && !nullExchangeInfo || s == "none" && nullExchangeInfo {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))
@@ -624,7 +629,10 @@ func TestExchangePartitionCheckConstraintStatesTwo(t *testing.T) {
 			default:
 				// Alter still running
 			}
-			tbl := external.GetTableByName(t, tk, "check_constraint", tableName)
+			ctx := tk.Session()
+			is := domain.GetDomain(ctx).InfoSchema()
+			tbl, err := is.TableByName(model.NewCIStr("check_constraint"), model.NewCIStr(tableName))
+			require.NoError(t, err)
 			nullExchangeInfo := tbl.Meta().ExchangePartitionInfo == nil
 			if s == "write only" && !nullExchangeInfo {
 				logutil.BgLogger().Info("Got state", zap.String("State", s))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49777

Problem Summary:

### What changed and how does it work?

Same problem with #46815,  the pr #46816 solve it by sleeping 50ms to wait domain load the new schemaVersion.
In most case it works, but it is only an `improvement`, it did not make it stable, the tests can also fails by some times.
This pr solve it by check the new tableInfo, so it should be possible to handle it fundamentally.

This pr check the non-partition table `ExchangePartitionInfo` part, it will be not-null if it is in write-only state.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
