### PR TITLE
disttask: do not retry meta initialization if context done

### DIFF
--- a/pkg/disttask/framework/scheduler/scheduler.go
+++ b/pkg/disttask/framework/scheduler/scheduler.go
@@ -491,8 +491,8 @@ func (s *BaseScheduler) updateTask(taskState proto.TaskState, newSubTasks []*pro
 		if err == nil || !retryable {
 			break
 		}
-		if err := s.ctx.Err(); err != nil {
-			return err
+		if err1 := s.ctx.Err(); err1 != nil {
+			return err1
 		}
 		if i%10 == 0 {
 			logutil.Logger(s.logCtx).Warn("updateTask first failed", zap.Stringer("from", prevState), zap.Stringer("to", s.Task.State),

--- a/pkg/disttask/framework/scheduler/scheduler.go
+++ b/pkg/disttask/framework/scheduler/scheduler.go
@@ -494,6 +494,9 @@ func (s *BaseScheduler) updateTask(taskState proto.TaskState, newSubTasks []*pro
 		select {
 		case <-s.ctx.Done():
 			// We don't retry if the context is canceled.
+			if err1 := s.ctx.Err(); err1 != nil {
+				return err1
+			}
 			return err
 		default:
 		}

--- a/pkg/disttask/framework/scheduler/scheduler.go
+++ b/pkg/disttask/framework/scheduler/scheduler.go
@@ -491,14 +491,8 @@ func (s *BaseScheduler) updateTask(taskState proto.TaskState, newSubTasks []*pro
 		if err == nil || !retryable {
 			break
 		}
-		select {
-		case <-s.ctx.Done():
-			// We don't retry if the context is canceled.
-			if err1 := s.ctx.Err(); err1 != nil {
-				return err1
-			}
+		if err := s.ctx.Err(); err != nil {
 			return err
-		default:
 		}
 		if i%10 == 0 {
 			logutil.Logger(s.logCtx).Warn("updateTask first failed", zap.Stringer("from", prevState), zap.Stringer("to", s.Task.State),

--- a/pkg/disttask/framework/scheduler/scheduler.go
+++ b/pkg/disttask/framework/scheduler/scheduler.go
@@ -491,6 +491,12 @@ func (s *BaseScheduler) updateTask(taskState proto.TaskState, newSubTasks []*pro
 		if err == nil || !retryable {
 			break
 		}
+		select {
+		case <-s.ctx.Done():
+			// We don't retry if the context is canceled.
+			return err
+		default:
+		}
 		if i%10 == 0 {
 			logutil.Logger(s.logCtx).Warn("updateTask first failed", zap.Stringer("from", prevState), zap.Stringer("to", s.Task.State),
 				zap.Int("retry times", i), zap.Error(err))

--- a/pkg/disttask/framework/taskexecutor/manager.go
+++ b/pkg/disttask/framework/taskexecutor/manager.go
@@ -115,6 +115,9 @@ func (m *Manager) initMeta() (err error) {
 		select {
 		case <-m.ctx.Done():
 			// We don't retry if the context is canceled.
+			if err1 := m.ctx.Err(); err1 != nil {
+				return err1
+			}
 			return err
 		default:
 		}

--- a/pkg/disttask/framework/taskexecutor/manager.go
+++ b/pkg/disttask/framework/taskexecutor/manager.go
@@ -112,14 +112,8 @@ func (m *Manager) initMeta() (err error) {
 		if err == nil {
 			break
 		}
-		select {
-		case <-m.ctx.Done():
-			// We don't retry if the context is canceled.
-			if err1 := m.ctx.Err(); err1 != nil {
-				return err1
-			}
+		if err = m.ctx.Err(); err != nil {
 			return err
-		default:
 		}
 		if i%10 == 0 {
 			logutil.Logger(m.logCtx).Warn("start manager failed",

--- a/pkg/disttask/framework/taskexecutor/manager.go
+++ b/pkg/disttask/framework/taskexecutor/manager.go
@@ -114,7 +114,7 @@ func (m *Manager) initMeta() (err error) {
 		}
 		select {
 		case <-m.ctx.Done():
-			// We don't retry if outer context is canceled.
+			// We don't retry if the context is canceled.
 			return err
 		default:
 		}

--- a/pkg/disttask/framework/taskexecutor/manager.go
+++ b/pkg/disttask/framework/taskexecutor/manager.go
@@ -112,8 +112,8 @@ func (m *Manager) initMeta() (err error) {
 		if err == nil {
 			break
 		}
-		if err = m.ctx.Err(); err != nil {
-			return err
+		if err1 := m.ctx.Err(); err1 != nil {
+			return err1
 		}
 		if i%10 == 0 {
 			logutil.Logger(m.logCtx).Warn("start manager failed",

--- a/pkg/disttask/framework/taskexecutor/manager.go
+++ b/pkg/disttask/framework/taskexecutor/manager.go
@@ -112,6 +112,12 @@ func (m *Manager) initMeta() (err error) {
 		if err == nil {
 			break
 		}
+		select {
+		case <-m.ctx.Done():
+			// We don't retry if outer context is canceled.
+			return err
+		default:
+		}
 		if i%10 == 0 {
 			logutil.Logger(m.logCtx).Warn("start manager failed",
 				zap.String("scope", config.GetGlobalConfig().Instance.TiDBServiceScope),

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1459,7 +1459,7 @@ func (do *Domain) checkReplicaRead(ctx context.Context, pdClient pd.Client) erro
 
 // InitDistTaskLoop initializes the distributed task framework.
 func (do *Domain) InitDistTaskLoop() error {
-	ctx := context.Background()
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalDistTask)
 	failpoint.Inject("MockDisableDistTask", func(val failpoint.Value) {
 		if val.(bool) {
 			failpoint.Return(nil)

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -159,7 +159,7 @@ type Domain struct {
 	// TODO: use Run for each process in future pr
 	wg                  *util.WaitGroupEnhancedWrapper
 	statsUpdating       atomicutil.Int32
-	cancel              context.CancelFunc
+	cancelFns           []context.CancelFunc
 	indexUsageSyncLease time.Duration
 	dumpFileGcChecker   *dumpFileGcChecker
 	planReplayerHandle  *planReplayerHandle
@@ -1036,8 +1036,8 @@ func (do *Domain) Close() {
 	}
 
 	do.slowQuery.Close()
-	if do.cancel != nil {
-		do.cancel()
+	for _, f := range do.cancelFns {
+		f()
 	}
 	do.wg.Wait()
 	do.sysSessionPool.Close()
@@ -1164,7 +1164,7 @@ func (do *Domain) Init(
 	}
 	sysCtxPool := pools.NewResourcePool(sysFac, 128, 128, resourceIdleTimeout)
 	ctx, cancelFunc := context.WithCancel(context.Background())
-	do.cancel = cancelFunc
+	do.cancelFns = append(do.cancelFns, cancelFunc)
 	var callback ddl.Callback
 	newCallbackFunc, err := ddl.GetCustomizedHook("default_hook")
 	if err != nil {
@@ -1458,7 +1458,8 @@ func (do *Domain) checkReplicaRead(ctx context.Context, pdClient pd.Client) erro
 }
 
 // InitDistTaskLoop initializes the distributed task framework.
-func (do *Domain) InitDistTaskLoop(ctx context.Context) error {
+func (do *Domain) InitDistTaskLoop() error {
+	ctx := context.Background()
 	failpoint.Inject("MockDisableDistTask", func(val failpoint.Value) {
 		if val.(bool) {
 			failpoint.Return(nil)
@@ -1478,7 +1479,9 @@ func (do *Domain) InitDistTaskLoop(ctx context.Context) error {
 		errMsg := fmt.Sprintf("TiDB node ID( = %s ) not found in available TiDB nodes list", do.ddl.GetID())
 		return errors.New(errMsg)
 	}
-	executorManager, err := taskexecutor.NewManagerBuilder().BuildManager(ctx, serverID, taskManager)
+	managerCtx, cancel := context.WithCancel(ctx)
+	do.cancelFns = append(do.cancelFns, cancel)
+	executorManager, err := taskexecutor.NewManagerBuilder().BuildManager(managerCtx, serverID, taskManager)
 	if err != nil {
 		return err
 	}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3493,7 +3493,7 @@ func bootstrapSessionImpl(store kv.Storage, createSessionsImpl func(store kv.Sto
 		dom.Close()
 		return nil, errors.New("Fail to load or parse sql file")
 	}
-	err = dom.InitDistTaskLoop(ctx)
+	err = dom.InitDistTaskLoop()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49753

Problem Summary:

```
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=loadPrivilegeInLoop]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=topNSlowQueryLoop]
[INFO] [mock.go:105] ["owner manager is canceled"] [category=ddl] [ID=4d0f1deb-2066-4e6f-b6bd-b7cd26a25837] [ownerKey=/tidb/bindinfo/owner]
[INFO] [domain.go:1346] ["closestReplicaReadCheckLoop exited."]
[INFO] [domain.go:1866] ["globalBindHandleWorkerLoop exited."]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=closestReplicaReadCheckLoop]
[INFO] [domain.go:725] ["globalConfigSyncerKeeper exited."]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=globalBindHandleWorkerLoop]
[INFO] [domain.go:2106] ["dumpFileGcChecker exited."]
[INFO] [domain.go:699] ["infoSyncerKeeper exited."]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=loadSigningCertLoop]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=dumpFileGcChecker]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=runawayWatchSyncLoop]
[INFO] [stats_syncload.go:187] ["SubLoadWorker exited."]
[INFO] [stats_syncload.go:187] ["SubLoadWorker exited."]
[INFO] [stats_syncload.go:187] ["SubLoadWorker exited."]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=runawayRecordFlushLoop]
[INFO] [stats_syncload.go:187] ["SubLoadWorker exited."]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=mdlCheckLoop]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=infoSyncerKeeper]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=topologySyncerKeeper]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=globalConfigSyncerKeeper]
[INFO] [domain.go:892] ["loadSchemaInLoop exited."]
[INFO] [domain.go:1727] ["LoadSysVarCacheLoop exited."]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=loadSchemaInLoop]
[INFO] [mock.go:105] ["owner manager is canceled"] [category=ddl] [ID=4d0f1deb-2066-4e6f-b6bd-b7cd26a25837] [ownerKey=/tidb/stats/owner]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=LoadSysVarCacheLoop]
[INFO] [wait_group_wrapper.go:140] ["background process exited"] [source=domain] [process=quitStatsOwner]
[INFO] [stats_syncload.go:187] ["SubLoadWorker exited."]
[WARN] [session.go:900] ["can not retry txn"] [label=internal] [error="[domain:8027]Information schema is out of date: schema failed to update in 1 lease, please make sure TiDB can connect to TiKV"] [errorVerbose="[domain:8027]Information schema is out of date: schema failed to update in 1 lease, please make sure TiDB can connect to TiKV
github.com/tikv/client-go/v2/txnkv/transaction.(*twoPhaseCommitter).checkSchemaValid
    external/com_github_tikv_client_go_v2/txnkv/transaction/2pc.go:1791
github.com/tikv/client-go/v2/txnkv/transaction.(*twoPhaseCommitter).execute
    external/com_github_tikv_client_go_v2/txnkv/transaction/2pc.go:1616
github.com/tikv/client-go/v2/txnkv/transaction.(*KVTxn).Commit
    external/com_github_tikv_client_go_v2/txnkv/transaction/txn.go:508
github.com/pingcap/tidb/pkg/store/driver/txn.(*tikvTxn).Commit
    pkg/store/driver/txn/txn_driver.go:99
github.com/pingcap/tidb/pkg/session.(*LazyTxn).Commit
    pkg/session/txn.go:428
github.com/pingcap/tidb/pkg/session.(*session).commitTxnWithTemporaryData
    pkg/session/session.go:740
github.com/pingcap/tidb/pkg/session.(*session).doCommit
    pkg/session/session.go:621
github.com/pingcap/tidb/pkg/session.(*session).doCommitWithRetry
    pkg/session/session.go:874
github.com/pingcap/tidb/pkg/session.(*session).CommitTxn
    pkg/session/session.go:1001
github.com/pingcap/tidb/pkg/session.autoCommitAfterStmt
    pkg/session/tidb.go:298
github.com/pingcap/tidb/pkg/session.finishStmt
    pkg/session/tidb.go:260
github.com/pingcap/tidb/pkg/session.runStmt
    pkg/session/session.go:2405
github.com/pingcap/tidb/pkg/session.(*session).ExecuteStmt
    pkg/session/session.go:2228
github.com/pingcap/tidb/pkg/session.(*session).ExecuteInternal
    pkg/session/session.go:1600
github.com/pingcap/tidb/pkg/disttask/framework/storage.ExecSQL
    pkg/disttask/framework/storage/task_table.go:119
github.com/pingcap/tidb/pkg/disttask/framework/storage.(*TaskManager).executeSQLWithNewSession.func1
    pkg/disttask/framework/storage/task_table.go:214
github.com/pingcap/tidb/pkg/disttask/framework/storage.(*TaskManager).WithNewSession
    pkg/disttask/framework/storage/task_table.go:179
github.com/pingcap/tidb/pkg/disttask/framework/storage.(*TaskManager).executeSQLWithNewSession
    pkg/disttask/framework/storage/task_table.go:213
github.com/pingcap/tidb/pkg/disttask/framework/storage.(*TaskManager).StartManager
    pkg/disttask/framework/storage/task_table.go:702
github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor.(*Manager).initMeta
    pkg/disttask/framework/taskexecutor/manager.go:111
github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor.(*Manager).Start
    pkg/disttask/framework/taskexecutor/manager.go:129
github.com/pingcap/tidb/pkg/domain.(*Domain).distTaskFrameworkLoop
    pkg/domain/domain.go:1497
github.com/pingcap/tidb/pkg/domain.(*Domain).InitDistTaskLoop.func1
    pkg/domain/domain.go:1491
github.com/pingcap/tidb/pkg/util.(*WaitGroupEnhancedWrapper).Run.func1
    pkg/util/wait_group_wrapper.go:99
...
```

`initMeta` should not retry if the context is canceled. Otherwise, it will keep retry until timeout in the scenario of `domain.Close()`.

### What changed and how does it work?

Check if context is done before retrying.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
