### PR TITLE
planner: fix show stats_bucket couldn't decode index boundary out

### DIFF
--- a/pkg/executor/show_stats_test.go
+++ b/pkg/executor/show_stats_test.go
@@ -142,6 +142,25 @@ func TestShowStatsBuckets(t *testing.T) {
 	result.Check(testkit.Rows("test t  idx 1 0 1 1 (2020-01-01 00:00:00, 1) (2020-01-01 00:00:00, 1) 0"))
 }
 
+func TestShowStatsBucketWithDateNullValue(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a datetime, b int, index ia(a,b));")
+	tk.MustExec("insert into t value('2023-12-27',1),(null, 2),('2023-12-28',3),(null,4);")
+	tk.MustExec("analyze table t with 0 topn;")
+	tk.MustQuery("explain format=\"brief\" select * from t where a > 1;").Check(testkit.Rows(
+		"IndexReader 3.20 root  index:Selection",
+		"└─Selection 3.20 cop[tikv]  gt(cast(test.t.a, double BINARY), 1)",
+		"  └─IndexFullScan 4.00 cop[tikv] table:t, index:ia(a, b) keep order:false"))
+	tk.MustQuery("show stats_buckets where db_name = 'test' and Column_name = 'ia';").Check(testkit.Rows(
+		"test t  ia 1 0 1 1 (NULL, 2) (NULL, 2) 0",
+		"test t  ia 1 1 2 1 (NULL, 4) (NULL, 4) 0",
+		"test t  ia 1 2 3 1 (2023-12-27 00:00:00, 1) (2023-12-27 00:00:00, 1) 0",
+		"test t  ia 1 3 4 1 (2023-12-28 00:00:00, 3) (2023-12-28 00:00:00, 3) 0"))
+}
+
 func TestShowStatsHasNullValue(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 

--- a/pkg/util/codec/codec.go
+++ b/pkg/util/codec/codec.go
@@ -883,6 +883,9 @@ func DecodeAsDateTime(b []byte, tp byte, loc *time.Location) (remain []byte, d t
 	case uvarintFlag:
 		// Datetime can be encoded as Uvarint
 		b, v, err = DecodeUvarint(b)
+	case NilFlag:
+		// null value should also be decoded out.
+		return b, d, nil
 
 	default:
 		return b, d, errors.Errorf("invalid encoded key flag %v", flag)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/49823

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix show stats_bucket couldn't decode index boundary out
```
