### PR TITLE
statistic: support fine-grained dump/load statistics

### DIFF
--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -55,7 +55,7 @@ go_test(
         "stats_read_writer_test.go",
     ],
     flaky = True,
-    shard_count = 21,
+    shard_count = 22,
     deps = [
         ":storage",
         "//pkg/domain",
@@ -64,6 +64,7 @@ go_test(
         "//pkg/sessionctx/variable",
         "//pkg/statistics",
         "//pkg/statistics/handle/internal",
+        "//pkg/statistics/handle/types",
         "//pkg/statistics/handle/util",
         "//pkg/testkit",
         "//pkg/types",

--- a/pkg/statistics/handle/storage/dump_test.go
+++ b/pkg/statistics/handle/storage/dump_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"runtime"
 	"strings"
 	"testing"
@@ -28,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/internal"
 	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
+	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
 	handleutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util"
@@ -124,6 +126,17 @@ func getStatsJSON(t *testing.T, dom *domain.Domain, db, tableName string) *handl
 	jsonTbl, err := h.DumpStatsToJSON("test", tableInfo, nil, true)
 	require.NoError(t, err)
 	return jsonTbl
+}
+
+func persistStats(t *testing.T, ctx context.Context, dom *domain.Domain, db, tableName string, persist statstypes.PersistFunc) {
+	is := dom.InfoSchema()
+	h := dom.StatsHandle()
+	require.Nil(t, h.Update(is))
+	table, err := is.TableByName(model.NewCIStr(db), model.NewCIStr(tableName))
+	require.NoError(t, err)
+	tableInfo := table.Meta()
+	err = h.PersistStatsBySnapshot(ctx, "test", tableInfo, math.MaxUint64, persist)
+	require.NoError(t, err)
 }
 
 func TestDumpGlobalStats(t *testing.T) {
@@ -620,4 +633,44 @@ func TestLoadStatsFromOldVersion(t *testing.T) {
 	for _, idx := range statsTbl.Indices {
 		require.False(t, idx.IsStatsInitialized())
 	}
+}
+
+func TestPersistStats(t *testing.T) {
+	ctx := context.Background()
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	createTable := `CREATE TABLE t (a int, b int, primary key(a), index idx(b))
+PARTITION BY RANGE ( a ) (
+		PARTITION p0 VALUES LESS THAN (6),
+		PARTITION p1 VALUES LESS THAN (11),
+		PARTITION p2 VALUES LESS THAN (16),
+		PARTITION p3 VALUES LESS THAN (21)
+)`
+	tk.MustExec(createTable)
+	tk.MustExec("CREATE TABLE t2 (a int, b int, primary key(a), index idx(b))")
+	for i := 1; i < 21; i++ {
+		tk.MustExec(fmt.Sprintf(`insert into t values (%d, %d)`, i, i))
+		tk.MustExec(fmt.Sprintf(`insert into t2 values (%d, %d)`, i, i))
+	}
+	tk.MustExec("analyze table t")
+	tk.MustExec("analyze table t2")
+
+	statsCnt := 0
+	persistStats(t, ctx, dom, "test", "t", func(ctx context.Context, jsonTable *handleutil.JSONTable, physicalID int64) error {
+		require.True(t, physicalID > 0)
+		require.NotNil(t, jsonTable)
+		statsCnt += 1
+		return nil
+	})
+	require.Equal(t, statsCnt, 5)
+	statsCnt = 0
+	persistStats(t, ctx, dom, "test", "t2", func(ctx context.Context, jsonTable *handleutil.JSONTable, physicalID int64) error {
+		require.True(t, physicalID > 0)
+		require.NotNil(t, jsonTable)
+		statsCnt += 1
+		return nil
+	})
+	require.Equal(t, statsCnt, 1)
 }

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -635,7 +635,7 @@ func (s *statsReadWriter) LoadStatsFromJSONConcurrency(
 					loadFunc = ctx.Value(TestLoadStatsErr{}).(func(*model.TableInfo, int64, *util.JSONTable) error)
 				}
 
-				err := loadFunc(tableInfo, tbl.PhysicalID, tbl.JsonTable)
+				err := loadFunc(tableInfo, tbl.PhysicalID, tbl.JSONTable)
 				if err != nil {
 					e.CompareAndSwap(nil, &err)
 					return
@@ -676,7 +676,7 @@ func (s *statsReadWriter) LoadStatsFromJSONNoUpdate(ctx context.Context, is info
 			if tbl != nil {
 				taskCh <- &statstypes.PartitionStatisticLoadTask{
 					PhysicalID: def.ID,
-					JsonTable:  tbl,
+					JSONTable:  tbl,
 				}
 			}
 		}
@@ -685,7 +685,7 @@ func (s *statsReadWriter) LoadStatsFromJSONNoUpdate(ctx context.Context, is info
 		if globalStats, ok := jsonTbl.Partitions[util.TiDBGlobalStats]; ok {
 			taskCh <- &statstypes.PartitionStatisticLoadTask{
 				PhysicalID: tableInfo.ID,
-				JsonTable:  globalStats,
+				JSONTable:  globalStats,
 			}
 		}
 		close(taskCh)

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -460,6 +460,8 @@ func (s *statsReadWriter) DumpHistoricalStatsBySnapshot(
 // Notice:
 //  1. It might call the function `persist` with nil jsontable.
 //  2. It is only used by BR, so partitions' statistic are always dumped.
+//
+// TODO: once we support column-level statistic dump, it should replace the `PersistStatsBySnapshot` and `DumpStatsToJSON`.
 func (s *statsReadWriter) PersistStatsBySnapshot(
 	ctx context.Context,
 	dbName string,

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -33,7 +33,6 @@ import (
 	handle_metrics "github.com/pingcap/tidb/pkg/statistics/handle/metrics"
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
-	statsutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
@@ -466,7 +465,7 @@ func (s *statsReadWriter) PersistStatsBySnapshot(
 	dbName string,
 	tableInfo *model.TableInfo,
 	snapshot uint64,
-	persist func(ctx context.Context, jsonTable *statsutil.JSONTable, physicalID int64) error,
+	persist func(ctx context.Context, jsonTable *util.JSONTable, physicalID int64) error,
 ) error {
 	pi := tableInfo.GetPartitionInfo()
 	if pi == nil {

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -33,6 +33,7 @@ import (
 	handle_metrics "github.com/pingcap/tidb/pkg/statistics/handle/metrics"
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
+	statsutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
@@ -456,6 +457,49 @@ func (s *statsReadWriter) DumpHistoricalStatsBySnapshot(
 	return jsonTbl, fallbackTbls, nil
 }
 
+// PersistStatsBySnapshot dumps statistic to json and call the function for each partition statistic to persist.
+// Notice:
+//  1. It might call the function `persist` with nil jsontable.
+//  2. It is only used by BR, so partitions' statistic are always dumped.
+func (s *statsReadWriter) PersistStatsBySnapshot(
+	ctx context.Context,
+	dbName string,
+	tableInfo *model.TableInfo,
+	snapshot uint64,
+	persist func(ctx context.Context, jsonTable *statsutil.JSONTable, physicalID int64) error,
+) error {
+	pi := tableInfo.GetPartitionInfo()
+	if pi == nil {
+		jsonTable, err := s.TableStatsToJSON(dbName, tableInfo, tableInfo.ID, snapshot)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		return persist(ctx, jsonTable, tableInfo.ID)
+	}
+
+	for _, def := range pi.Definitions {
+		tbl, err := s.TableStatsToJSON(dbName, tableInfo, def.ID, snapshot)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if tbl == nil {
+			continue
+		}
+		if err := persist(ctx, tbl, def.ID); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	// dump its global-stats if existed
+	tbl, err := s.TableStatsToJSON(dbName, tableInfo, tableInfo.ID, snapshot)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if tbl != nil {
+		return persist(ctx, tbl, tableInfo.ID)
+	}
+	return nil
+}
+
 // DumpStatsToJSONBySnapshot dumps statistic to json.
 func (s *statsReadWriter) DumpStatsToJSONBySnapshot(dbName string, tableInfo *model.TableInfo, snapshot uint64, dumpPartitionStats bool) (*util.JSONTable, error) {
 	pruneMode, err := util.GetCurrentPruneMode(s.statsHandler.SPool())
@@ -555,25 +599,64 @@ func (s *statsReadWriter) TableStatsToJSON(dbName string, tableInfo *model.Table
 // TestLoadStatsErr is only for test.
 type TestLoadStatsErr struct{}
 
-// LoadStatsFromJSON will load statistic from JSONTable, and save it to the storage.
-// In final, it will also udpate the stats cache.
-func (s *statsReadWriter) LoadStatsFromJSON(ctx context.Context, is infoschema.InfoSchema,
-	jsonTbl *util.JSONTable, concurrencyForPartition int) error {
-	if err := s.LoadStatsFromJSONNoUpdate(ctx, is, jsonTbl, concurrencyForPartition); err != nil {
-		return errors.Trace(err)
-	}
-	return errors.Trace(s.statsHandler.Update(is))
-}
-
-// LoadStatsFromJSONNoUpdate will load statistic from JSONTable, and save it to the storage.
-func (s *statsReadWriter) LoadStatsFromJSONNoUpdate(ctx context.Context, is infoschema.InfoSchema,
-	jsonTbl *util.JSONTable, concurrencyForPartition int) error {
+// LoadStatsFromJSONConcurrency consumes concurrently the statistic task from `taskCh`.
+func (s *statsReadWriter) LoadStatsFromJSONConcurrency(
+	ctx context.Context,
+	tableInfo *model.TableInfo,
+	taskCh chan *statstypes.PartitionStatisticLoadTask,
+	concurrencyForPartition int,
+) error {
 	nCPU := runtime.GOMAXPROCS(0)
 	if concurrencyForPartition == 0 {
 		concurrencyForPartition = (nCPU + 1) / 2 // default
 	}
 	concurrencyForPartition = min(concurrencyForPartition, nCPU) // for safety
 
+	var wg sync.WaitGroup
+	e := new(atomic.Pointer[error])
+	for i := 0; i < concurrencyForPartition; i++ {
+		wg.Add(1)
+		s.statsHandler.GPool().Go(func() {
+			defer func() {
+				if r := recover(); r != nil {
+					err := fmt.Errorf("%v", r)
+					e.CompareAndSwap(nil, &err)
+				}
+				wg.Done()
+			}()
+
+			for tbl := range taskCh {
+				if tbl == nil {
+					continue
+				}
+
+				loadFunc := s.loadStatsFromJSON
+				if intest.InTest && ctx.Value(TestLoadStatsErr{}) != nil {
+					loadFunc = ctx.Value(TestLoadStatsErr{}).(func(*model.TableInfo, int64, *util.JSONTable) error)
+				}
+
+				err := loadFunc(tableInfo, tbl.PhysicalID, tbl.JsonTable)
+				if err != nil {
+					e.CompareAndSwap(nil, &err)
+					return
+				}
+				if e.Load() != nil {
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+	if e.Load() != nil {
+		return *e.Load()
+	}
+
+	return nil
+}
+
+// LoadStatsFromJSONNoUpdate will load statistic from JSONTable, and save it to the storage.
+func (s *statsReadWriter) LoadStatsFromJSONNoUpdate(ctx context.Context, is infoschema.InfoSchema,
+	jsonTbl *util.JSONTable, concurrencyForPartition int) error {
 	table, err := is.TableByName(model.NewCIStr(jsonTbl.DatabaseName), model.NewCIStr(jsonTbl.TableName))
 	if err != nil {
 		return errors.Trace(err)
@@ -587,59 +670,40 @@ func (s *statsReadWriter) LoadStatsFromJSONNoUpdate(ctx context.Context, is info
 		}
 	} else {
 		// load partition statistics concurrently
-		taskCh := make(chan model.PartitionDefinition, len(pi.Definitions))
+		taskCh := make(chan *statstypes.PartitionStatisticLoadTask, len(pi.Definitions)+1)
 		for _, def := range pi.Definitions {
-			taskCh <- def
-		}
-		close(taskCh)
-		var wg sync.WaitGroup
-		e := new(atomic.Pointer[error])
-		for i := 0; i < concurrencyForPartition; i++ {
-			wg.Add(1)
-			s.statsHandler.GPool().Go(func() {
-				defer func() {
-					if r := recover(); r != nil {
-						err := fmt.Errorf("%v", r)
-						e.CompareAndSwap(nil, &err)
-					}
-					wg.Done()
-				}()
-
-				for def := range taskCh {
-					tbl := jsonTbl.Partitions[def.Name.L]
-					if tbl == nil {
-						continue
-					}
-
-					loadFunc := s.loadStatsFromJSON
-					if intest.InTest && ctx.Value(TestLoadStatsErr{}) != nil {
-						loadFunc = ctx.Value(TestLoadStatsErr{}).(func(*model.TableInfo, int64, *util.JSONTable) error)
-					}
-
-					err := loadFunc(tableInfo, def.ID, tbl)
-					if err != nil {
-						e.CompareAndSwap(nil, &err)
-						return
-					}
-					if e.Load() != nil {
-						return
-					}
+			tbl := jsonTbl.Partitions[def.Name.L]
+			if tbl != nil {
+				taskCh <- &statstypes.PartitionStatisticLoadTask{
+					PhysicalID: def.ID,
+					JsonTable:  tbl,
 				}
-			})
-		}
-		wg.Wait()
-		if e.Load() != nil {
-			return *e.Load()
+			}
 		}
 
 		// load global-stats if existed
 		if globalStats, ok := jsonTbl.Partitions[util.TiDBGlobalStats]; ok {
-			if err := s.loadStatsFromJSON(tableInfo, tableInfo.ID, globalStats); err != nil {
-				return errors.Trace(err)
+			taskCh <- &statstypes.PartitionStatisticLoadTask{
+				PhysicalID: tableInfo.ID,
+				JsonTable:  globalStats,
 			}
+		}
+		close(taskCh)
+		if err := s.LoadStatsFromJSONConcurrency(ctx, tableInfo, taskCh, concurrencyForPartition); err != nil {
+			return errors.Trace(err)
 		}
 	}
 	return nil
+}
+
+// LoadStatsFromJSON will load statistic from JSONTable, and save it to the storage.
+// In final, it will also udpate the stats cache.
+func (s *statsReadWriter) LoadStatsFromJSON(ctx context.Context, is infoschema.InfoSchema,
+	jsonTbl *util.JSONTable, concurrencyForPartition int) error {
+	if err := s.LoadStatsFromJSONNoUpdate(ctx, is, jsonTbl, concurrencyForPartition); err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(s.statsHandler.Update(is))
 }
 
 func (s *statsReadWriter) loadStatsFromJSON(tableInfo *model.TableInfo, physicalID int64, jsonTbl *util.JSONTable) error {

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -465,7 +465,7 @@ func (s *statsReadWriter) PersistStatsBySnapshot(
 	dbName string,
 	tableInfo *model.TableInfo,
 	snapshot uint64,
-	persist func(ctx context.Context, jsonTable *util.JSONTable, physicalID int64) error,
+	persist statstypes.PersistFunc,
 ) error {
 	pi := tableInfo.GetPartitionInfo()
 	if pi == nil {
@@ -598,8 +598,8 @@ func (s *statsReadWriter) TableStatsToJSON(dbName string, tableInfo *model.Table
 // TestLoadStatsErr is only for test.
 type TestLoadStatsErr struct{}
 
-// LoadStatsFromJSONConcurrency consumes concurrently the statistic task from `taskCh`.
-func (s *statsReadWriter) LoadStatsFromJSONConcurrency(
+// LoadStatsFromJSONConcurrently consumes concurrently the statistic task from `taskCh`.
+func (s *statsReadWriter) LoadStatsFromJSONConcurrently(
 	ctx context.Context,
 	tableInfo *model.TableInfo,
 	taskCh chan *statstypes.PartitionStatisticLoadTask,
@@ -688,7 +688,7 @@ func (s *statsReadWriter) LoadStatsFromJSONNoUpdate(ctx context.Context, is info
 			}
 		}
 		close(taskCh)
-		if err := s.LoadStatsFromJSONConcurrency(ctx, tableInfo, taskCh, concurrencyForPartition); err != nil {
+		if err := s.LoadStatsFromJSONConcurrently(ctx, tableInfo, taskCh, concurrencyForPartition); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -228,6 +228,12 @@ type StatsLock interface {
 	GetTableLockedAndClearForTest() (map[int64]struct{}, error)
 }
 
+// PartitionStatisticLoadTask currently records a partition-level jsontable.
+type PartitionStatisticLoadTask struct {
+	PhysicalID int64
+	JsonTable  *statsutil.JSONTable
+}
+
 // StatsReadWriter is used to read and write stats to the storage.
 // TODO: merge and remove some methods.
 type StatsReadWriter interface {
@@ -318,6 +324,15 @@ type StatsReadWriter interface {
 
 	// DumpStatsToJSONBySnapshot dumps statistic to json.
 	DumpStatsToJSONBySnapshot(dbName string, tableInfo *model.TableInfo, snapshot uint64, dumpPartitionStats bool) (*statsutil.JSONTable, error)
+
+	// PersistStatsBySnapshot dumps statistic to json and call the function for each partition statistic to persist.
+	// Notice:
+	//  1. It might call the function `persist` with nil jsontable.
+	//  2. It is only used by BR, so partitions' statistic are always dumped.
+	PersistStatsBySnapshot(ctx context.Context, dbName string, tableInfo *model.TableInfo, snapshot uint64, persist func(ctx context.Context, jsonTable *statsutil.JSONTable, physicalID int64) error) error
+
+	// LoadStatsFromJSONConcurrency consumes concurrently the statistic task from `taskCh`.
+	LoadStatsFromJSONConcurrency(ctx context.Context, tableInfo *model.TableInfo, taskCh chan *PartitionStatisticLoadTask, concurrencyForPartition int) error
 
 	// LoadStatsFromJSON will load statistic from JSONTable, and save it to the storage.
 	// In final, it will also udpate the stats cache.

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -234,6 +234,8 @@ type PartitionStatisticLoadTask struct {
 	PhysicalID int64
 }
 
+type PersistFunc func(ctx context.Context, jsonTable *statsutil.JSONTable, physicalID int64) error
+
 // StatsReadWriter is used to read and write stats to the storage.
 // TODO: merge and remove some methods.
 type StatsReadWriter interface {
@@ -329,10 +331,10 @@ type StatsReadWriter interface {
 	// Notice:
 	//  1. It might call the function `persist` with nil jsontable.
 	//  2. It is only used by BR, so partitions' statistic are always dumped.
-	PersistStatsBySnapshot(ctx context.Context, dbName string, tableInfo *model.TableInfo, snapshot uint64, persist func(ctx context.Context, jsonTable *statsutil.JSONTable, physicalID int64) error) error
+	PersistStatsBySnapshot(ctx context.Context, dbName string, tableInfo *model.TableInfo, snapshot uint64, persist PersistFunc) error
 
-	// LoadStatsFromJSONConcurrency consumes concurrently the statistic task from `taskCh`.
-	LoadStatsFromJSONConcurrency(ctx context.Context, tableInfo *model.TableInfo, taskCh chan *PartitionStatisticLoadTask, concurrencyForPartition int) error
+	// LoadStatsFromJSONConcurrently consumes concurrently the statistic task from `taskCh`.
+	LoadStatsFromJSONConcurrently(ctx context.Context, tableInfo *model.TableInfo, taskCh chan *PartitionStatisticLoadTask, concurrencyForPartition int) error
 
 	// LoadStatsFromJSON will load statistic from JSONTable, and save it to the storage.
 	// In final, it will also udpate the stats cache.

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -234,6 +234,7 @@ type PartitionStatisticLoadTask struct {
 	PhysicalID int64
 }
 
+// PersistFunc is used to persist JSONTable in the partition level.
 type PersistFunc func(ctx context.Context, jsonTable *statsutil.JSONTable, physicalID int64) error
 
 // StatsReadWriter is used to read and write stats to the storage.

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -230,8 +230,8 @@ type StatsLock interface {
 
 // PartitionStatisticLoadTask currently records a partition-level jsontable.
 type PartitionStatisticLoadTask struct {
+	JSONTable  *statsutil.JSONTable
 	PhysicalID int64
-	JsonTable  *statsutil.JSONTable
 }
 
 // StatsReadWriter is used to read and write stats to the storage.

--- a/pkg/statistics/handle/util/util.go
+++ b/pkg/statistics/handle/util/util.go
@@ -249,16 +249,16 @@ func GetFullTableName(is infoschema.InfoSchema, tblInfo *model.TableInfo) string
 
 // JSONTable is used for dumping statistics.
 type JSONTable struct {
-	Columns           map[string]*JSONColumn `json:"columns"`
-	Indices           map[string]*JSONColumn `json:"indices"`
-	Partitions        map[string]*JSONTable  `json:"partitions"`
-	DatabaseName      string                 `json:"database_name"`
-	TableName         string                 `json:"table_name"`
-	ExtStats          []*JSONExtendedStats   `json:"ext_stats"`
-	Count             int64                  `json:"count"`
-	ModifyCount       int64                  `json:"modify_count"`
-	Version           uint64                 `json:"version"`
-	IsHistoricalStats bool                   `json:"is_historical_stats"`
+	Columns           map[string]*JSONColumn `json:"columns,omitempty"`
+	Indices           map[string]*JSONColumn `json:"indices,omitempty"`
+	Partitions        map[string]*JSONTable  `json:"partitions,omitempty"`
+	DatabaseName      string                 `json:"database_name,omitempty"`
+	TableName         string                 `json:"table_name,omitempty"`
+	ExtStats          []*JSONExtendedStats   `json:"ext_stats,omitempty"`
+	Count             int64                  `json:"count,omitempty"`
+	ModifyCount       int64                  `json:"modify_count,omitempty"`
+	Version           uint64                 `json:"version,omitempty"`
+	IsHistoricalStats bool                   `json:"is_historical_stats,omitempty"`
 }
 
 // JSONExtendedStats is used for dumping extended statistics.

--- a/pkg/statistics/handle/util/util.go
+++ b/pkg/statistics/handle/util/util.go
@@ -249,16 +249,16 @@ func GetFullTableName(is infoschema.InfoSchema, tblInfo *model.TableInfo) string
 
 // JSONTable is used for dumping statistics.
 type JSONTable struct {
-	Columns           map[string]*JSONColumn `json:"columns,omitempty"`
-	Indices           map[string]*JSONColumn `json:"indices,omitempty"`
-	Partitions        map[string]*JSONTable  `json:"partitions,omitempty"`
-	DatabaseName      string                 `json:"database_name,omitempty"`
-	TableName         string                 `json:"table_name,omitempty"`
-	ExtStats          []*JSONExtendedStats   `json:"ext_stats,omitempty"`
-	Count             int64                  `json:"count,omitempty"`
-	ModifyCount       int64                  `json:"modify_count,omitempty"`
-	Version           uint64                 `json:"version,omitempty"`
-	IsHistoricalStats bool                   `json:"is_historical_stats,omitempty"`
+	Columns           map[string]*JSONColumn `json:"columns"`
+	Indices           map[string]*JSONColumn `json:"indices"`
+	Partitions        map[string]*JSONTable  `json:"partitions"`
+	DatabaseName      string                 `json:"database_name"`
+	TableName         string                 `json:"table_name"`
+	ExtStats          []*JSONExtendedStats   `json:"ext_stats"`
+	Count             int64                  `json:"count"`
+	ModifyCount       int64                  `json:"modify_count"`
+	Version           uint64                 `json:"version"`
+	IsHistoricalStats bool                   `json:"is_historical_stats"`
 }
 
 // JSONExtendedStats is used for dumping extended statistics.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #49627 

Problem Summary:
oom when dump/load the statistic if there are many partitions of a table
### What changed and how does it work?
dump/load statistic data in the partition dimension
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
