### PR TITLE
*: move `StmtCtx.ErrAutoincReadFailedAsWarning` to errctx

### DIFF
--- a/pkg/errctx/context_test.go
+++ b/pkg/errctx/context_test.go
@@ -44,6 +44,15 @@ func TestContext(t *testing.T) {
 	// newCtx will handle the error as a warn
 	require.NoError(t, newCtx.HandleErrorWithAlias(testInternalErr, testErr, testWarn))
 	require.Equal(t, warn, testWarn)
+	levels := newCtx.LevelMap()
+	for i := errctx.ErrGroup(0); i <= errctx.ErrGroup(len(levels)-1); i++ {
+		if i == errctx.ErrGroupTruncate {
+			require.Equal(t, errctx.LevelWarn, levels[i])
+		} else {
+			require.Equal(t, errctx.LevelError, levels[i])
+			require.Equal(t, levels[i], newCtx.LevelForGroup(i))
+		}
+	}
 
 	warn = nil
 	newCtx2 := newCtx.WithStrictErrGroupLevel()
@@ -52,6 +61,7 @@ func TestContext(t *testing.T) {
 	require.Equal(t, warn, testWarn)
 	// newCtx2 will return all errors
 	require.Equal(t, newCtx2.HandleErrorWithAlias(testInternalErr, testErr, testWarn), testErr)
+	require.Equal(t, errctx.LevelMap{}, newCtx2.LevelMap())
 
 	// test `multierr`
 	testErrs := multierr.Append(testInternalErr, testErr)
@@ -61,4 +71,22 @@ func TestContext(t *testing.T) {
 
 	// test nil
 	require.Nil(t, ctx.HandleError(nil))
+
+	// test with a level map
+	levels = errctx.LevelMap{}
+	levels[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelWarn
+	ctx = errctx.NewContextWithLevels(levels, contextutil.NewFuncWarnHandlerForTest(func(err error) {
+		warn = err
+	}))
+	require.Equal(t, levels, ctx.LevelMap())
+	levels2 := errctx.LevelMap{}
+	levels2[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelIgnore
+	ctx = ctx.WithErrGroupLevels(levels2)
+	require.Equal(t, levels2, ctx.LevelMap())
+
+	// original levels should not change
+	ctx = ctx.WithErrGroupLevels(errctx.LevelMap{})
+	require.Equal(t, errctx.LevelMap{}, ctx.LevelMap())
+	require.Equal(t, errctx.LevelWarn, levels[errctx.ErrGroupAutoIncReadFailed])
+	require.Equal(t, errctx.LevelIgnore, levels2[errctx.ErrGroupAutoIncReadFailed])
 }

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -112,6 +112,7 @@ go_library(
         "//pkg/domain",
         "//pkg/domain/infosync",
         "//pkg/domain/resourcegroup",
+        "//pkg/errctx",
         "//pkg/errno",
         "//pkg/executor/aggfuncs",
         "//pkg/executor/aggregate",

--- a/pkg/executor/insert.go
+++ b/pkg/executor/insert.go
@@ -308,11 +308,9 @@ func (e *InsertExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	err := insertRows(ctx, e)
 	if err != nil {
 		terr, ok := errors.Cause(err).(*terror.Error)
-		if ok && len(e.OnDuplicate) == 0 &&
-			e.Ctx().GetSessionVars().StmtCtx.ErrAutoincReadFailedAsWarning &&
-			terr.Code() == errno.ErrAutoincReadFailed {
-			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(err)
-			return nil
+		if ok && len(e.OnDuplicate) == 0 && terr.Code() == errno.ErrAutoincReadFailed {
+			ec := e.Ctx().GetSessionVars().StmtCtx.ErrCtx()
+			return ec.HandleError(err)
 		}
 		return err
 	}

--- a/pkg/sessionctx/stmtctx/BUILD.bazel
+++ b/pkg/sessionctx/stmtctx/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/parser/mysql",
         "//pkg/parser/terror",
         "//pkg/types",
+        "//pkg/util/context",
         "//pkg/util/disk",
         "//pkg/util/execdetails",
         "//pkg/util/intest",
@@ -43,6 +44,7 @@ go_test(
     flaky = True,
     shard_count = 12,
     deps = [
+        "//pkg/errctx",
         "//pkg/kv",
         "//pkg/sessionctx/variable",
         "//pkg/testkit",

--- a/pkg/sessionctx/stmtctx/stmtctx_test.go
+++ b/pkg/sessionctx/stmtctx/stmtctx_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
@@ -317,6 +318,7 @@ func TestNewStmtCtx(t *testing.T) {
 	require.Equal(t, types.DefaultStmtFlags, sc.TypeFlags())
 	require.Same(t, time.UTC, sc.TimeZone())
 	require.Same(t, time.UTC, sc.TimeZone())
+	require.Equal(t, errctx.NewContextWithLevels(errctx.LevelMap{}, sc), sc.ErrCtx())
 	sc.AppendWarning(errors.NewNoStackError("err1"))
 	warnings := sc.GetWarnings()
 	require.Equal(t, 1, len(warnings))
@@ -328,6 +330,7 @@ func TestNewStmtCtx(t *testing.T) {
 	require.Equal(t, types.DefaultStmtFlags, sc.TypeFlags())
 	require.Same(t, tz, sc.TimeZone())
 	require.Same(t, tz, sc.TimeZone())
+	require.Equal(t, errctx.NewContextWithLevels(errctx.LevelMap{}, sc), sc.ErrCtx())
 	sc.AppendWarning(errors.NewNoStackError("err2"))
 	warnings = sc.GetWarnings()
 	require.Equal(t, 1, len(warnings))
@@ -347,13 +350,17 @@ func TestSetStmtCtxTypeFlags(t *testing.T) {
 	sc := stmtctx.NewStmtCtx()
 	require.Equal(t, types.DefaultStmtFlags, sc.TypeFlags())
 
+	levels := errctx.LevelMap{}
 	sc.SetTypeFlags(types.FlagAllowNegativeToUnsigned | types.FlagSkipASCIICheck)
 	require.Equal(t, types.FlagAllowNegativeToUnsigned|types.FlagSkipASCIICheck, sc.TypeFlags())
 	require.Equal(t, sc.TypeFlags(), sc.TypeFlags())
+	require.Equal(t, errctx.NewContextWithLevels(levels, sc), sc.ErrCtx())
 
 	sc.SetTypeFlags(types.FlagSkipASCIICheck | types.FlagSkipUTF8Check | types.FlagTruncateAsWarning)
 	require.Equal(t, types.FlagSkipASCIICheck|types.FlagSkipUTF8Check|types.FlagTruncateAsWarning, sc.TypeFlags())
 	require.Equal(t, sc.TypeFlags(), sc.TypeFlags())
+	levels[errctx.ErrGroupTruncate] = errctx.LevelWarn
+	require.Equal(t, errctx.NewContextWithLevels(levels, sc), sc.ErrCtx())
 }
 
 func TestResetStmtCtx(t *testing.T) {
@@ -362,14 +369,17 @@ func TestResetStmtCtx(t *testing.T) {
 
 	tz := time.FixedZone("UTC+1", 2*60*60)
 	sc.SetTimeZone(tz)
-	sc.SetTypeFlags(types.FlagAllowNegativeToUnsigned | types.FlagSkipASCIICheck)
+	sc.SetTypeFlags(types.FlagIgnoreTruncateErr | types.FlagAllowNegativeToUnsigned | types.FlagSkipASCIICheck)
 	sc.AppendWarning(errors.NewNoStackError("err1"))
 	sc.InRestrictedSQL = true
 	sc.StmtType = "Insert"
 
 	require.Same(t, tz, sc.TimeZone())
-	require.Equal(t, types.FlagAllowNegativeToUnsigned|types.FlagSkipASCIICheck, sc.TypeFlags())
+	require.Equal(t, types.FlagIgnoreTruncateErr|types.FlagAllowNegativeToUnsigned|types.FlagSkipASCIICheck, sc.TypeFlags())
 	require.Equal(t, 1, len(sc.GetWarnings()))
+	levels := errctx.LevelMap{}
+	levels[errctx.ErrGroupTruncate] = errctx.LevelIgnore
+	require.Equal(t, errctx.NewContextWithLevels(levels, sc), sc.ErrCtx())
 
 	sc.Reset()
 	require.Same(t, time.UTC, sc.TimeZone())
@@ -384,6 +394,8 @@ func TestResetStmtCtx(t *testing.T) {
 	require.Equal(t, 1, len(warnings))
 	require.Equal(t, stmtctx.WarnLevelWarning, warnings[0].Level)
 	require.Equal(t, "err2", warnings[0].Err.Error())
+	levels = errctx.LevelMap{}
+	require.Equal(t, errctx.NewContextWithLevels(levels, sc), sc.ErrCtx())
 }
 
 func TestStmtCtxID(t *testing.T) {
@@ -413,10 +425,27 @@ func TestErrCtx(t *testing.T) {
 	// the default errCtx
 	err := types.ErrTruncated
 	require.Error(t, sc.HandleError(err))
+	levels := errctx.LevelMap{}
+	require.Equal(t, errctx.NewContextWithLevels(levels, sc), sc.ErrCtx())
 
-	// reset the types flags will re-initialize the error flag
+	// set error levels
+	levels[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelIgnore
+	sc.SetErrLevels(levels)
+	require.Equal(t, errctx.NewContextWithLevels(levels, sc), sc.ErrCtx())
+
+	// reset the types flags will re-initialize the error flag, but keeps the error levels unchanged except for ErrGroupTruncate
 	sc.SetTypeFlags(types.DefaultStmtFlags | types.FlagTruncateAsWarning)
 	require.NoError(t, sc.HandleError(err))
+	levels = errctx.LevelMap{}
+	levels[errctx.ErrGroupTruncate] = errctx.LevelWarn
+	levels[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelIgnore
+	require.Equal(t, errctx.NewContextWithLevels(levels, sc), sc.ErrCtx())
+
+	// SetErrLevels will not affect ErrGroupTruncate
+	sc.SetErrLevels(errctx.LevelMap{})
+	levels = errctx.LevelMap{}
+	levels[errctx.ErrGroupTruncate] = errctx.LevelWarn
+	require.Equal(t, errctx.NewContextWithLevels(levels, sc), sc.ErrCtx())
 }
 
 func BenchmarkErrCtx(b *testing.B) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49991

### What changed and how does it work?

Use `errctx.Context` to handle `ErrAutoincReadFailed` to make error handling decouple with `stmtctx`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
