### PR TITLE
planner: fix agg push down rule mistake order by item inside agg function

### DIFF
--- a/pkg/planner/core/rule_aggregation_push_down.go
+++ b/pkg/planner/core/rule_aggregation_push_down.go
@@ -608,7 +608,7 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan, opt *logicalOptim
 							break
 						}
 					}
-					for j, item := range newAggOrderItems {
+					for j, item := range newAggOrderItems[i] {
 						if item == nil {
 							continue
 						}

--- a/tests/integrationtest/r/expression/issues.result
+++ b/tests/integrationtest/r/expression/issues.result
@@ -3177,3 +3177,18 @@ a	b
 update test.t set b = 0 where (a, b) in (('a', 1), (null, 0));
 SHOW WARNINGS;
 Level	Code	Message
+drop table if exists test.t;
+create table if not exists test.ast (i varchar(20));
+create table if not exists test.acc (j varchar(20), k varchar(20), l varchar(20), m varchar(20));
+explain format='brief' with t as(select i, (case when b.j = '20001' then b.l else b.k end) an from test.ast a inner join test.acc b on (a.i = b.m) and a.i = 'astp2019121731703151'), t1 as (select i, group_concat(an order by an separator '; ') an from t group by i) select * from t1;
+id	estRows	task	access object	operator info
+Projection	8.00	root		test.ast.i, Column#32
+└─HashAgg	8.00	root		group by:Column#37, funcs:group_concat(Column#34 order by Column#35 separator "; ")->Column#32, funcs:firstrow(Column#36)->test.ast.i
+  └─Projection	100.00	root		case(eq(test.acc.j, 20001), test.acc.l, test.acc.k)->Column#34, case(eq(test.acc.j, 20001), test.acc.l, test.acc.k)->Column#35, test.ast.i->Column#36, test.ast.i->Column#37
+    └─HashJoin	100.00	root		CARTESIAN inner join
+      ├─TableReader(Build)	10.00	root		data:Selection
+      │ └─Selection	10.00	cop[tikv]		eq(test.ast.i, "astp2019121731703151")
+      │   └─TableFullScan	10000.00	cop[tikv]	table:a	keep order:false, stats:pseudo
+      └─TableReader(Probe)	10.00	root		data:Selection
+        └─Selection	10.00	cop[tikv]		eq("astp2019121731703151", test.acc.m)
+          └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/expression/issues.test
+++ b/tests/integrationtest/t/expression/issues.test
@@ -2155,3 +2155,9 @@ insert into test.t values ("abc", 1);
 select * from test.t where (a, b) in (('a', 1), (null, 0));
 update test.t set b = 0 where (a, b) in (('a', 1), (null, 0));
 SHOW WARNINGS;
+
+# TestIssue49986
+drop table if exists test.t;
+create table if not exists test.ast (i varchar(20));
+create table if not exists test.acc (j varchar(20), k varchar(20), l varchar(20), m varchar(20));
+explain format='brief' with t as(select i, (case when b.j = '20001' then b.l else b.k end) an from test.ast a inner join test.acc b on (a.i = b.m) and a.i = 'astp2019121731703151'), t1 as (select i, group_concat(an order by an separator '; ') an from t group by i) select * from t1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/49986

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix agg push down rule mistake order by item inside agg function
```
