### PR TITLE
parser: support hints in 'REPLACE INTO' statement

### DIFF
--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -7293,14 +7293,17 @@ OnDuplicateKeyUpdate:
  *
  **********************************************************************************/
 ReplaceIntoStmt:
-	"REPLACE" PriorityOpt IntoOpt TableName PartitionNameListOpt InsertValues
+	"REPLACE" TableOptimizerHintsOpt PriorityOpt IntoOpt TableName PartitionNameListOpt InsertValues
 	{
-		x := $6.(*ast.InsertStmt)
+		x := $7.(*ast.InsertStmt)
+		if $2 != nil {
+			x.TableHints = $2.([]*ast.TableOptimizerHint)
+		}
 		x.IsReplace = true
-		x.Priority = $2.(mysql.PriorityEnum)
-		ts := &ast.TableSource{Source: $4.(*ast.TableName)}
+		x.Priority = $3.(mysql.PriorityEnum)
+		ts := &ast.TableSource{Source: $5.(*ast.TableName)}
 		x.Table = &ast.TableRefsClause{TableRefs: &ast.Join{Left: ts}}
-		x.PartitionNames = $5.([]model.CIStr)
+		x.PartitionNames = $6.([]model.CIStr)
 		$$ = x
 	}
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1150,6 +1150,9 @@ AAAAAAAAAAAA5gm5Mg==
 		{"query watch add SQL TEXT SIMILAR 'select 1'", false, ""},
 		{"query watch remove 1", true, "QUERY WATCH REMOVE 1"},
 		{"query watch remove", false, ""},
+
+		// for issue 34325, "replace into" with hints
+		{"replace /*+ SET_VAR(sql_mode='ALLOW_INVALID_DATES') */ into t values ('2004-04-31');", true, "REPLACE /*+ SET_VAR(sql_mode = ALLOW_INVALID_DATES)*/ INTO `t` VALUES (_UTF8MB4'2004-04-31')"},
 	}
 	RunTest(t, table, false)
 }

--- a/tests/integrationtest/r/parser/integration.result
+++ b/tests/integrationtest/r/parser/integration.result
@@ -1,0 +1,9 @@
+drop table if exists t;
+create table t(d date);
+replace into t values ('2004-04-31');
+Error 1292 (22007): Incorrect date value: '2004-04-31' for column 'd' at row 1
+replace /*+ SET_VAR(sql_mode='ALLOW_INVALID_DATES') */ into t values ('2004-04-31');
+drop table if exists t;
+create table t(a INT, KEY(a));
+insert /*+ SET_VAR(sql_mode='') */ into t values (2);
+replace /*+ SET_VAR(sql_mode='') */ into t values (2);

--- a/tests/integrationtest/t/parser/integration.test
+++ b/tests/integrationtest/t/parser/integration.test
@@ -1,0 +1,10 @@
+# TestIssue34325
+drop table if exists t;
+create table t(d date);
+-- error 1292
+replace into t values ('2004-04-31');
+replace /*+ SET_VAR(sql_mode='ALLOW_INVALID_DATES') */ into t values ('2004-04-31');
+drop table if exists t;
+create table t(a INT, KEY(a));
+insert /*+ SET_VAR(sql_mode='') */ into t values (2);
+replace /*+ SET_VAR(sql_mode='') */ into t values (2);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #34325 

Problem Summary:

Hints are not supported in `REPLACE INTO ...` statement.

### What changed and how does it work?

I simply modify the parser to support this hints. I also tested that some simple hints (e.g. `SET_VAR`) actually work. 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix the issue that hints are not supported in the `REPLACE INTO` statement.
```
