### PR TITLE
planner: do not remove the first row func if it is a constant | tidb-test=pr/2277

### DIFF
--- a/pkg/executor/test/executor/BUILD.bazel
+++ b/pkg/executor/test/executor/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 48,
+    shard_count = 49,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/executor/test/executor/executor_test.go
+++ b/pkg/executor/test/executor/executor_test.go
@@ -2775,3 +2775,14 @@ func TestIssues40463(t *testing.T) {
 
 	tk.MustQuery("select  /*+ use_index_merge( `4f380f26-9af6-4df8-959d-ad6296eff914` ) */ /*+  stream_agg() */  approx_percentile( `4f380f26-9af6-4df8-959d-ad6296eff914`.`f7a9a4be-3728-449b-a5ea-df9b957eec67` , 77 ) as r0 , `4f380f26-9af6-4df8-959d-ad6296eff914`.`f7a9a4be-3728-449b-a5ea-df9b957eec67` as r1 from `4f380f26-9af6-4df8-959d-ad6296eff914` where not( IsNull( `4f380f26-9af6-4df8-959d-ad6296eff914`.`f7a9a4be-3728-449b-a5ea-df9b957eec67` ) ) and not( `4f380f26-9af6-4df8-959d-ad6296eff914`.`f7a9a4be-3728-449b-a5ea-df9b957eec67` in ( select `8a93bdc5-2214-4f96-b5a7-1ba4c0d396ae` from `07ccc74e-14c3-4685-bb41-c78a069b1a6d` where `4f380f26-9af6-4df8-959d-ad6296eff914`.`f7a9a4be-3728-449b-a5ea-df9b957eec67` in ( select `a60d6b5c-08bd-4a6d-b951-716162d004a5` from `ba35a09f-76f4-40aa-9b48-13154a24bdd2` where not( `4f380f26-9af6-4df8-959d-ad6296eff914`.`f7a9a4be-3728-449b-a5ea-df9b957eec67` between 'bpkfo' and '59' ) and not( `4f380f26-9af6-4df8-959d-ad6296eff914`.`f7a9a4be-3728-449b-a5ea-df9b957eec67` in ( select `fb753d37-6252-4bd3-9bd1-0059640e7861` from `ba35a09f-76f4-40aa-9b48-13154a24bdd2` where IsNull( `4f380f26-9af6-4df8-959d-ad6296eff914`.`f7a9a4be-3728-449b-a5ea-df9b957eec67` ) or not( `4f380f26-9af6-4df8-959d-ad6296eff914`.`43ca0135-1650-429b-8887-9eabcae2a234` in ( select `8a93bdc5-2214-4f96-b5a7-1ba4c0d396ae` from `07ccc74e-14c3-4685-bb41-c78a069b1a6d` where IsNull( `4f380f26-9af6-4df8-959d-ad6296eff914`.`43ca0135-1650-429b-8887-9eabcae2a234` ) and not( `4f380f26-9af6-4df8-959d-ad6296eff914`.`f7a9a4be-3728-449b-a5ea-df9b957eec67` between 'neud' and 'bpkfo' ) ) ) ) ) ) ) ) group by `4f380f26-9af6-4df8-959d-ad6296eff914`.`f7a9a4be-3728-449b-a5ea-df9b957eec67`;")
 }
+
+func TestIssue38756(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("create table t (c1 int)")
+	tk.MustExec("insert into t values (1), (2), (3)")
+	tk.MustQuery("SELECT SQRT(1) FROM t").Check(testkit.Rows("1", "1", "1"))
+	tk.MustQuery("(SELECT DISTINCT SQRT(1) FROM t)").Check(testkit.Rows("1"))
+}

--- a/pkg/executor/test/executor/executor_test.go
+++ b/pkg/executor/test/executor/executor_test.go
@@ -2785,4 +2785,5 @@ func TestIssue38756(t *testing.T) {
 	tk.MustExec("insert into t values (1), (2), (3)")
 	tk.MustQuery("SELECT SQRT(1) FROM t").Check(testkit.Rows("1", "1", "1"))
 	tk.MustQuery("(SELECT DISTINCT SQRT(1) FROM t)").Check(testkit.Rows("1"))
+	tk.MustQuery("SELECT DISTINCT cast(1 as double) FROM t").Check(testkit.Rows("1"))
 }

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1891,7 +1891,7 @@ func RemoveUnnecessaryFirstRow(
 					// the firstrow in root task can not be removed.
 					break
 				}
-				// Skip it if it is constant.
+				// Skip if it's a constant.
 				// For SELECT DISTINCT SQRT(1) FROM t.
 				// We shouldn't remove the firstrow(SQRT(1)).
 				if _, ok := gbyExpr.(*expression.Constant); ok {

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1891,6 +1891,12 @@ func RemoveUnnecessaryFirstRow(
 					// the firstrow in root task can not be removed.
 					break
 				}
+				// Skip it if it is constant.
+				// For SELECT DISTINCT SQRT(1) FROM t.
+				// We shouldn't remove the firstrow(SQRT(1)).
+				if _, ok := gbyExpr.(*expression.Constant); ok {
+					continue
+				}
 				if gbyExpr.Equal(sctx, aggFunc.Args[0]) {
 					canOptimize = true
 					firstRowFuncMap[aggFunc].Args[0] = finalGbyItems[j]


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/38756

Problem Summary:

### What changed and how does it work?

Do not remove the first row func if the group by expr is a constant.

For instance, if you try `SELECT DISTINCT SQRT(1) FROM t`
```sql
mysql> explain SELECT DISTINCT SQRT(1) FROM t;
+---------------------------+----------+-----------+---------------+-------------------------------------------------------+
| id                        | estRows  | task      | access object | operator info                                         |
+---------------------------+----------+-----------+---------------+-------------------------------------------------------+
| HashAgg_8                 | 1.00     | root      |               | group by:Column#5, funcs:firstrow(Column#5)->Column#3 |
| └─TableReader_9           | 1.00     | root      |               | data:HashAgg_4                                        |
|   └─HashAgg_4             | 1.00     | cop[tikv] |               | group by:1,                                           |
|     └─TableFullScan_7     | 10000.00 | cop[tikv] | table:t       | keep order:false, stats:pseudo                        |
+---------------------------+----------+-----------+---------------+-------------------------------------------------------+
4 rows in set (0.00 sec)
```

As you can see, we accidentally removed the first-row func because the group by expr is a constant 1 and the arg is also 1.

But if you try `SELECT DISTINCT SQRT(2) FROM t`, it works well.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the TiDB issue with incorrect results when the function's argument matches the group by key
```
