### PR TITLE
executor: fix select wrong partition for hash partition table

### DIFF
--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -196,7 +196,7 @@ func (s *partitionProcessor) getUsedHashPartitions(ctx sessionctx.Context,
 						rangeScalar = 0
 					} else {
 						rangeScalar = uint64(posHigh - posLow)
-						offset = mathutil.Abs(posLow % int64(numPartitions))
+						offset = posLow % int64(numPartitions)
 					}
 				}
 
@@ -204,7 +204,7 @@ func (s *partitionProcessor) getUsedHashPartitions(ctx sessionctx.Context,
 				if rangeScalar < uint64(numPartitions) && !highIsNull && !lowIsNull {
 					var i int64
 					for i = 0; i <= int64(rangeScalar); i++ {
-						idx := (offset + i) % int64(numPartitions)
+						idx := mathutil.Abs(offset+i) % int64(numPartitions)
 						if len(partitionNames) > 0 && !s.findByName(partitionNames, pi.Definitions[idx].Name.L) {
 							continue
 						}

--- a/tests/integrationtest/r/executor/partition/issues.result
+++ b/tests/integrationtest/r/executor/partition/issues.result
@@ -523,3 +523,37 @@ SELECT * FROM `t` WHERE `t`.`col_51` BETWEEN -9223372036854775808 AND 9223372036
 col_51
 -9223372036854775808
 9223372036854775807
+drop table if exists t;
+CREATE TABLE `t` (
+`col_29` tinyint(4) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY HASH (`col_29`) PARTITIONS 7;
+INSERT INTO `t` VALUES (-1), (11), (-128), (39), (-46), (38), (-102), (-99), (-87), (-127), (-89), (43), (108), (59), (0), (24), (101), (37), (-103), (90), (-95), (-44), (123), (124), (-123), (-52), (-49), (-98), (-104), (-68), (2), (-24), (67), (89), (1), (-65), (36), (-109), (41), (5), (98), (-63), (-14), (127), (-6), (121), (14), (-122);
+analyze table t;
+explain select * from t where col_29 between -2 and -1;
+id	estRows	task	access object	operator info
+TableReader_7	1.00	root	partition:p1,p2	data:Selection_6
+└─Selection_6	1.00	cop[tikv]		ge(executor__partition__issues.t.col_29, -2), le(executor__partition__issues.t.col_29, -1)
+  └─TableFullScan_5	48.00	cop[tikv]	table:t	keep order:false
+select * from t where col_29 between -2 and -1;
+col_29
+-1
+explain select * from t where col_29 between -2 and 0;
+id	estRows	task	access object	operator info
+TableReader_7	2.00	root	partition:p0,p1,p2	data:Selection_6
+└─Selection_6	2.00	cop[tikv]		ge(executor__partition__issues.t.col_29, -2), le(executor__partition__issues.t.col_29, 0)
+  └─TableFullScan_5	48.00	cop[tikv]	table:t	keep order:false
+select * from t where col_29 between -2 and 0;
+col_29
+-1
+0
+explain select * from t where col_29 between -2 and 1;
+id	estRows	task	access object	operator info
+TableReader_7	3.00	root	partition:p0,p1,p2	data:Selection_6
+└─Selection_6	3.00	cop[tikv]		ge(executor__partition__issues.t.col_29, -2), le(executor__partition__issues.t.col_29, 1)
+  └─TableFullScan_5	48.00	cop[tikv]	table:t	keep order:false
+select * from t where col_29 between -2 and 1;
+col_29
+-1
+0
+1

--- a/tests/integrationtest/t/executor/partition/issues.test
+++ b/tests/integrationtest/t/executor/partition/issues.test
@@ -305,3 +305,26 @@ analyze table t;
 desc SELECT * FROM `t` WHERE `t`.`col_51` BETWEEN -9223372036854775808 AND 9223372036854775807;
 --sorted_result
 SELECT * FROM `t` WHERE `t`.`col_51` BETWEEN -9223372036854775808 AND 9223372036854775807;
+
+
+# TestIssue50044
+drop table if exists t;
+CREATE TABLE `t` (
+  `col_29` tinyint(4) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+PARTITION BY HASH (`col_29`) PARTITIONS 7;
+INSERT INTO `t` VALUES (-1), (11), (-128), (39), (-46), (38), (-102), (-99), (-87), (-127), (-89), (43), (108), (59), (0), (24), (101), (37), (-103), (90), (-95), (-44), (123), (124), (-123), (-52), (-49), (-98), (-104), (-68), (2), (-24), (67), (89), (1), (-65), (36), (-109), (41), (5), (98), (-63), (-14), (127), (-6), (121), (14), (-122);
+analyze table t;
+
+explain select * from t where col_29 between -2 and -1;
+--sorted_result
+select * from t where col_29 between -2 and -1;
+
+explain select * from t where col_29 between -2 and 0;
+--sorted_result
+select * from t where col_29 between -2 and 0;
+
+explain select * from t where col_29 between -2 and 1;
+--sorted_result
+select * from t where col_29 between -2 and 1;
+


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50044

Problem Summary: Caused by #49853, I made a mistake about `mathutil.Abs` and select a wrong partiton for hash partition table.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
