### PR TITLE
*: memory is not allocated first if the user does not use some information from the table.

### DIFF
--- a/pkg/ddl/constraint_test.go
+++ b/pkg/ddl/constraint_test.go
@@ -97,7 +97,6 @@ func TestAlterAddConstraintStateChange(t *testing.T) {
 			tableCommon, ok := constraintTable.(*tables.TableCommon)
 			require.True(t, ok)
 			originCons := tableCommon.Constraints
-			tableCommon.WritableConstraints = []*table.Constraint{}
 			tableCommon.Constraints = []*table.Constraint{}
 			// insert data
 			tk1.MustExec("insert into t values(1)")
@@ -146,7 +145,6 @@ func TestAlterAddConstraintStateChange1(t *testing.T) {
 			tableCommon, ok := constraintTable.(*tables.TableCommon)
 			require.True(t, ok)
 			originCons := tableCommon.Constraints
-			tableCommon.WritableConstraints = []*table.Constraint{}
 			tableCommon.Constraints = []*table.Constraint{}
 			// insert data
 			tk1.MustExec("insert into t values(1)")
@@ -190,7 +188,6 @@ func TestAlterAddConstraintStateChange2(t *testing.T) {
 			tableCommon, ok := constraintTable.(*tables.TableCommon)
 			require.True(t, ok)
 			tableCommon.Constraints[0].State = model.StateWriteOnly
-			tableCommon.WritableConstraints = []*table.Constraint{}
 			// insert data
 			tk1.MustGetErrMsg("insert into t values(1)", "[table:3819]Check constraint 'c2' is violated.")
 			// recover
@@ -233,7 +230,6 @@ func TestAlterAddConstraintStateChange3(t *testing.T) {
 			tableCommon, ok := constraintTable.(*tables.TableCommon)
 			require.True(t, ok)
 			tableCommon.Constraints[0].State = model.StateWriteReorganization
-			tableCommon.WritableConstraints = []*table.Constraint{}
 			// insert data
 			tk1.MustGetErrMsg("insert into t values(1)", "[table:3819]Check constraint 'c3' is violated.")
 			// recover
@@ -277,7 +273,6 @@ func TestAlterEnforcedConstraintStateChange(t *testing.T) {
 			tableCommon, ok := constraintTable.(*tables.TableCommon)
 			require.True(t, ok)
 			tableCommon.Constraints[0].State = model.StateWriteOnly
-			tableCommon.WritableConstraints = []*table.Constraint{}
 			// insert data
 			tk1.MustGetErrMsg("insert into t values(1)", "[table:3819]Check constraint 'c1' is violated.")
 			// recover

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -66,18 +66,18 @@ type TableCommon struct {
 	// physicalTableID is a unique int64 to identify a physical table.
 	physicalTableID                 int64
 	Columns                         []*table.Column
-	PublicColumns                   []*table.Column
-	VisibleColumns                  []*table.Column
-	HiddenColumns                   []*table.Column
-	WritableColumns                 []*table.Column
-	FullHiddenColsAndVisibleColumns []*table.Column
+	publicColumns                   []*table.Column
+	visibleColumns                  []*table.Column
+	hiddenColumns                   []*table.Column
+	writableColumns                 []*table.Column
+	fullHiddenColsAndVisibleColumns []*table.Column
 	indices                         []table.Index
 	meta                            *model.TableInfo
 	allocs                          autoid.Allocators
 	sequence                        *sequenceCommon
 	dependencyColumnOffsets         []int
 	Constraints                     []*table.Constraint
-	WritableConstraints             []*table.Constraint
+	writableConstraints             []*table.Constraint
 
 	// recordPrefix and indexPrefix are generated using physicalTableID.
 	recordPrefix kv.Key
@@ -203,13 +203,7 @@ func initTableCommon(t *TableCommon, tblInfo *model.TableInfo, physicalTableID i
 	t.allocs = allocs
 	t.meta = tblInfo
 	t.Columns = cols
-	t.PublicColumns = t.Cols()
-	t.VisibleColumns = t.VisibleCols()
-	t.HiddenColumns = t.HiddenCols()
-	t.WritableColumns = t.WritableCols()
-	t.FullHiddenColsAndVisibleColumns = t.FullHiddenColsAndVisibleCols()
 	t.Constraints = constraints
-	t.WritableConstraints = t.WritableConstraint()
 	t.recordPrefix = tablecodec.GenTableRecordPrefix(physicalTableID)
 	t.indexPrefix = tablecodec.GenTableIndexPrefix(physicalTableID)
 	if tblInfo.IsSequence() {
@@ -306,32 +300,32 @@ func (t *TableCommon) getCols(mode getColsMode) []*table.Column {
 
 // Cols implements table.Table Cols interface.
 func (t *TableCommon) Cols() []*table.Column {
-	if len(t.PublicColumns) > 0 {
-		return t.PublicColumns
+	if len(t.publicColumns) > 0 {
+		return t.publicColumns
 	}
 	return t.getCols(full)
 }
 
 // VisibleCols implements table.Table VisibleCols interface.
 func (t *TableCommon) VisibleCols() []*table.Column {
-	if len(t.VisibleColumns) > 0 {
-		return t.VisibleColumns
+	if len(t.visibleColumns) > 0 {
+		return t.visibleColumns
 	}
 	return t.getCols(visible)
 }
 
 // HiddenCols implements table.Table HiddenCols interface.
 func (t *TableCommon) HiddenCols() []*table.Column {
-	if len(t.HiddenColumns) > 0 {
-		return t.HiddenColumns
+	if len(t.hiddenColumns) > 0 {
+		return t.hiddenColumns
 	}
 	return t.getCols(hidden)
 }
 
 // WritableCols implements table WritableCols interface.
 func (t *TableCommon) WritableCols() []*table.Column {
-	if len(t.WritableColumns) > 0 {
-		return t.WritableColumns
+	if len(t.writableColumns) > 0 {
+		return t.writableColumns
 	}
 	writableColumns := make([]*table.Column, 0, len(t.Columns))
 	for _, col := range t.Columns {
@@ -350,8 +344,8 @@ func (t *TableCommon) DeletableCols() []*table.Column {
 
 // WritableConstraint returns constraints of the table in writable states.
 func (t *TableCommon) WritableConstraint() []*table.Constraint {
-	if len(t.WritableConstraints) > 0 {
-		return t.WritableConstraints
+	if len(t.writableConstraints) > 0 {
+		return t.writableConstraints
 	}
 	if t.Constraints == nil {
 		return nil
@@ -385,8 +379,8 @@ func (t *TableCommon) CheckRowConstraint(sctx sessionctx.Context, rowToCheck []t
 
 // FullHiddenColsAndVisibleCols implements table FullHiddenColsAndVisibleCols interface.
 func (t *TableCommon) FullHiddenColsAndVisibleCols() []*table.Column {
-	if len(t.FullHiddenColsAndVisibleColumns) > 0 {
-		return t.FullHiddenColsAndVisibleColumns
+	if len(t.fullHiddenColsAndVisibleColumns) > 0 {
+		return t.fullHiddenColsAndVisibleColumns
 	}
 
 	cols := make([]*table.Column, 0, len(t.Columns))

--- a/pkg/table/tables/tables_test.go
+++ b/pkg/table/tables/tables_test.go
@@ -426,12 +426,6 @@ func TestHiddenColumn(t *testing.T) {
 	colInfo[1].Hidden = true
 	colInfo[3].Hidden = true
 	colInfo[5].Hidden = true
-	tc := tb.(*tables.TableCommon)
-	// Reset related caches
-	tc.VisibleColumns = nil
-	tc.WritableColumns = nil
-	tc.HiddenColumns = nil
-	tc.FullHiddenColsAndVisibleColumns = nil
 
 	// Basic test
 	cols := tb.VisibleCols()

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -998,7 +998,7 @@ func decodeIntHandleInIndexValue(data []byte) kv.Handle {
 
 // EncodeTableIndexPrefix encodes index prefix with tableID and idxID.
 func EncodeTableIndexPrefix(tableID, idxID int64) kv.Key {
-	key := make([]byte, 0, prefixLen)
+	key := make([]byte, 0, prefixLen+idLen)
 	key = appendTableIndexPrefix(key, tableID)
 	key = codec.EncodeInt(key, idxID)
 	return key


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/50077

Problem Summary:
If a large number of tables (such as the 540k table,  2850k partitions in the scenario shown in issue) are used, the OOM situation may occur.

### What changed and how does it work?
Reduce memory allocation
* Do not create columns(PublicColumns, VisibleColumns, WritableColumns, FullHiddenColsAndVisibleColumns) for tables that are not used by users.
* Do preallocate for `EncodeInt` in `EncodeTableIndexPrefix`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Prior to this PR, OOM appeared every 20-30 minutes. After this PR memory is relatively stable without OOM (test 4h+).
See the memory usage chart, memory reduction of about 2G.

#### Before this PR：
![eDtKc4brDk](https://github.com/pingcap/tidb/assets/4242506/4d8584d4-e539-4962-8e33-c6f473d03583)

<img width="553" alt="截屏2024-01-04 16 22 02" src="https://github.com/pingcap/tidb/assets/4242506/a351ed97-d7e2-423e-8416-5094bcdc53d0">


#### After this PR：
![7xfDRRUZda](https://github.com/pingcap/tidb/assets/4242506/d3c7bc0f-c9c2-461b-a140-d8be833a5990)

<img width="288" alt="截屏2024-01-04 16 20 46" src="https://github.com/pingcap/tidb/assets/4242506/b57f95a0-9656-4cb8-ba0d-fa3cbb2756d1">

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
