### PR TITLE
ddl, owner: clean processing ddl jobs when owner retired

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -794,7 +794,9 @@ func (d *ddl) Start(ctxPool *pools.ResourcePool) error {
 	ingest.InitGlobalLightningEnv()
 	d.ownerManager.SetRetireOwnerHook(func() {
 		// Since this instance is not DDL owner anymore, we clean up the processing job info.
-		ingest.LitBackCtxMgr.MarkJobFinish()
+		if ingest.LitBackCtxMgr != nil {
+			ingest.LitBackCtxMgr.MarkJobFinish()
+		}
 	})
 
 	return nil

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -792,6 +792,10 @@ func (d *ddl) Start(ctxPool *pools.ResourcePool) error {
 	defer d.sessPool.Put(ctx)
 
 	ingest.InitGlobalLightningEnv()
+	d.ownerManager.SetRetireOwnerHook(func() {
+		// Since this instance is not DDL owner anymore, we clean up the processing job info.
+		ingest.LitBackCtxMgr.MarkJobFinish()
+	})
 
 	return nil
 }

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -225,6 +225,7 @@ func (d *ddl) getReorgJob(sess *sess.Session) (*model.Job, error) {
 			return false, nil
 		}
 		if (job.Type == model.ActionAddIndex || job.Type == model.ActionAddPrimaryKey) &&
+			job.State == model.JobStateQueueing &&
 			job.ReorgMeta != nil &&
 			job.ReorgMeta.IsFastReorg &&
 			ingest.LitBackCtxMgr != nil {

--- a/pkg/owner/mock.go
+++ b/pkg/owner/mock.go
@@ -42,6 +42,7 @@ type mockManager struct {
 	wg           sync.WaitGroup
 	cancel       context.CancelFunc
 	beOwnerHook  func()
+	retireHook   func()
 	campaignDone chan struct{}
 	resignDone   chan struct{}
 }
@@ -168,8 +169,14 @@ func (*mockManager) RequireOwner(context.Context) error {
 	return nil
 }
 
+// SetBeOwnerHook implements Manager.SetBeOwnerHook interface.
 func (m *mockManager) SetBeOwnerHook(hook func()) {
 	m.beOwnerHook = hook
+}
+
+// SetRetireOwnerHook implements Manager.SetRetireOwnerHook interface.
+func (m *mockManager) SetRetireOwnerHook(hook func()) {
+	m.retireHook = hook
 }
 
 // CampaignCancel implements Manager.CampaignCancel interface


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50073

Problem Summary:

The sequence is as follows:

```
1. tidb-1 owner starts adding index [MarkProcessingJob()]
2. owner switches to tidb-2
3. tidb-2 owner finishes adding index [MarkJobFinished()]
4. owner switches to tidb-1
5. tidb-1 owner reports error: already in used by another DDL job
```

### What changed and how does it work?

When a DDL owner is retired, we mark the job finished on this instance.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  The test code is available at https://github.com/tangenta/dbtool/blob/24a7dc9c5a5808b654f11b229fd70e3103939b31/cases/issue_50073.go
  
  Before this PR:
  
  ```
  Determine the owner of tidb...
  Get tidb owner: root@tcp(127.0.0.1:4001)/test
  Prepare data...
  Start add index on owner...
  Evict DDL owner...
  Evict back DDL owner...
  Add another add index should not block...
  Query last 10 seconds log...
  2024/01/05 00:56:20.483 tidb 127.0.0.1:4001 INFO [session.go:3884] ["CRUCIAL OPERATION"] [conn=3862953990] [schemaVersion=57] [cur_db=test] [sql="alter table t add index idx_a2(a);"] [user=root@%] 
  2024/01/05 00:56:20.493 tidb 127.0.0.1:4001 INFO [ddl_worker.go:254] ["add DDL jobs"] [category=ddl] ["batch count"=1] [jobs="ID:105, Type:add index, State:queueing, SchemaState:none, SchemaID:2, TableID:102, RowCount:0, ArgLen:6, start time:   2024-01-05 00:56:20.451 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:0, UniqueWarnings:0; "] [table=true] 
  2024/01/05 00:56:20.493 tidb 127.0.0.1:4001 INFO [ddl.go:1063] ["start DDL job"] [category=ddl] [job="ID:105, Type:add index, State:queueing, SchemaState:none, SchemaID:2, TableID:102, RowCount:0, ArgLen:6, start time: 2024-01-05 00:56:20.451   +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:0, UniqueWarnings:0"] [query="alter table t add index idx_a2(a);"] 
  2024/01/05 00:56:20.495 tidb 127.0.0.1:4001 INFO [backend_mgr.go:81] ["ingest backfill worker is already in used by another DDL job"] [category=ddl-ingest] ["processing job ID"=104] 
  Admin cancel ddl job(105)...
  ```
  
  After this PR:
  
  ```
  Determine the owner of tidb...
  Get tidb owner: root@tcp(127.0.0.1:4000)/test
  Prepare data...
  Start add index on owner...
  Evict DDL owner...
  Evict back DDL owner...
  Add another add index should not block...
  The test passed!
  ```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
