### PR TITLE
*: remove `stmtctx.BadNullAsWarning` and use `errctx` to handle bad null error

### DIFF
--- a/br/pkg/lightning/backend/kv/base.go
+++ b/br/pkg/lightning/backend/kv/base.go
@@ -270,7 +270,7 @@ func (e *BaseKVEncoder) getActualDatum(col *table.Column, rowID int64, inputDatu
 		// if MutRowFromDatums sees a nil it won't initialize the underlying storage and cause SetDatum to panic.
 		value = types.GetMinValue(&col.FieldType)
 	case isBadNullValue:
-		err = col.HandleBadNull(&value, e.SessionCtx.Vars.StmtCtx, 0)
+		err = col.HandleBadNull(e.SessionCtx.Vars.StmtCtx.ErrCtx(), &value, 0)
 	default:
 		// copy from the following GetColDefaultValue function, when this is true it will use getColDefaultExprValue
 		if col.DefaultIsExpr {

--- a/br/pkg/lightning/backend/kv/session.go
+++ b/br/pkg/lightning/backend/kv/session.go
@@ -286,7 +286,6 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 	vars.SkipUTF8Check = true
 	vars.StmtCtx.InInsertStmt = true
 	vars.StmtCtx.BatchCheck = true
-	vars.StmtCtx.BadNullAsWarning = !sqlMode.HasStrictMode()
 	vars.SQLMode = sqlMode
 
 	typeFlags := vars.StmtCtx.TypeFlags().
@@ -296,6 +295,7 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 	vars.StmtCtx.SetTypeFlags(typeFlags)
 
 	errLevels := vars.StmtCtx.ErrLevels()
+	errLevels[errctx.ErrGroupBadNull] = errctx.ResolveErrLevel(false, !sqlMode.HasStrictMode())
 	errLevels[errctx.ErrGroupDividedByZero] =
 		errctx.ResolveErrLevel(!sqlMode.HasErrorForDivisionByZeroMode(), !sqlMode.HasStrictMode())
 	vars.StmtCtx.SetErrLevels(errLevels)

--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -165,9 +165,9 @@ func initSessCtx(
 		return errors.Trace(err)
 	}
 	sessCtx.GetSessionVars().StmtCtx.SetTimeZone(sessCtx.GetSessionVars().Location())
-	sessCtx.GetSessionVars().StmtCtx.BadNullAsWarning = !sqlMode.HasStrictMode()
 
 	errLevels := sessCtx.GetSessionVars().StmtCtx.ErrLevels()
+	errLevels[errctx.ErrGroupBadNull] = errctx.ResolveErrLevel(false, !sqlMode.HasStrictMode())
 	errLevels[errctx.ErrGroupDividedByZero] =
 		errctx.ResolveErrLevel(!sqlMode.HasErrorForDivisionByZeroMode(), !sqlMode.HasStrictMode())
 	sessCtx.GetSessionVars().StmtCtx.SetErrLevels(errLevels)
@@ -198,7 +198,6 @@ func restoreSessCtx(sessCtx sessionctx.Context) func(sessCtx sessionctx.Context)
 		tz := *sv.TimeZone
 		timezone = &tz
 	}
-	badNullAsWarn := sv.StmtCtx.BadNullAsWarning
 	typeFlags := sv.StmtCtx.TypeFlags()
 	errLevels := sv.StmtCtx.ErrLevels()
 	resGroupName := sv.StmtCtx.ResourceGroupName
@@ -207,7 +206,6 @@ func restoreSessCtx(sessCtx sessionctx.Context) func(sessCtx sessionctx.Context)
 		uv.RowEncoder.Enable = rowEncoder
 		uv.SQLMode = sqlMode
 		uv.TimeZone = timezone
-		uv.StmtCtx.BadNullAsWarning = badNullAsWarn
 		uv.StmtCtx.SetTypeFlags(typeFlags)
 		uv.StmtCtx.SetErrLevels(errLevels)
 		uv.StmtCtx.ResourceGroupName = resGroupName

--- a/pkg/errctx/context.go
+++ b/pkg/errctx/context.go
@@ -193,29 +193,42 @@ const (
 )
 
 func init() {
-	truncateErrCodes := []errors.ErrCode{
-		errno.ErrTruncatedWrongValue,
-		errno.ErrDataTooLong,
-		errno.ErrTruncatedWrongValueForField,
-		errno.ErrWarnDataOutOfRange,
-		errno.ErrDataOutOfRange,
-		errno.ErrBadNumber,
-		errno.ErrWrongValueForType,
-		errno.ErrDatetimeFunctionOverflow,
-		errno.WarnDataTruncated,
-		errno.ErrIncorrectDatetimeValue,
-	}
-	for _, errCode := range truncateErrCodes {
-		errGroupMap[errCode] = ErrGroupTruncate
+	group2Errors := map[ErrGroup][]errors.ErrCode{
+		ErrGroupTruncate: {
+			errno.ErrTruncatedWrongValue,
+			errno.ErrDataTooLong,
+			errno.ErrTruncatedWrongValueForField,
+			errno.ErrWarnDataOutOfRange,
+			errno.ErrDataOutOfRange,
+			errno.ErrBadNumber,
+			errno.ErrWrongValueForType,
+			errno.ErrDatetimeFunctionOverflow,
+			errno.WarnDataTruncated,
+			errno.ErrIncorrectDatetimeValue,
+		},
+		ErrGroupBadNull: {
+			errno.ErrBadNull,
+			errno.ErrWarnNullToNotnull,
+		},
+		ErrGroupDividedByZero: {
+			errno.ErrDivisionByZero,
+		},
+		ErrGroupAutoIncReadFailed: {
+			errno.ErrAutoincReadFailed,
+		},
 	}
 
-	errGroupMap[errno.ErrDivisionByZero] = ErrGroupDividedByZero
-	errGroupMap[errno.ErrAutoincReadFailed] = ErrGroupAutoIncReadFailed
+	for group, codes := range group2Errors {
+		for _, errCode := range codes {
+			errGroupMap[errCode] = group
+		}
+	}
 }
 
 // ResolveErrLevel resolves the error level according to the `ignore` and `warn` flags
 // if ignore is true, it will return `LevelIgnore` to ignore the error,
 // otherwise, it will return `LevelWarn` or `LevelError` according to the `warn` flag
+// Only one of `ignore` and `warn` can be true.
 func ResolveErrLevel(ignore bool, warn bool) Level {
 	if ignore {
 		return LevelIgnore

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2122,11 +2122,11 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		// should make TruncateAsWarning and DividedByZeroAsWarning,
 		// but should not make DupKeyAsWarning.
 		sc.DupKeyAsWarning = stmt.IgnoreErr
-		sc.BadNullAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 		sc.IgnoreNoPartition = stmt.IgnoreErr
 		if stmt.IgnoreErr {
 			errLevels[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelWarn
 		}
+		errLevels[errctx.ErrGroupBadNull] = errctx.ResolveErrLevel(false, !vars.StrictSQLMode || stmt.IgnoreErr)
 		errLevels[errctx.ErrGroupDividedByZero] = errctx.ResolveErrLevel(
 			!vars.SQLMode.HasErrorForDivisionByZeroMode(),
 			!vars.StrictSQLMode || stmt.IgnoreErr,
@@ -2260,7 +2260,7 @@ func ResetUpdateStmtCtx(sc *stmtctx.StatementContext, stmt *ast.UpdateStmt, vars
 	sc.InUpdateStmt = true
 	errLevels := sc.ErrLevels()
 	sc.DupKeyAsWarning = stmt.IgnoreErr
-	sc.BadNullAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
+	errLevels[errctx.ErrGroupBadNull] = errctx.ResolveErrLevel(false, !vars.StrictSQLMode || stmt.IgnoreErr)
 	errLevels[errctx.ErrGroupDividedByZero] = errctx.ResolveErrLevel(
 		!vars.SQLMode.HasErrorForDivisionByZeroMode(),
 		!vars.StrictSQLMode || stmt.IgnoreErr,
@@ -2280,7 +2280,7 @@ func ResetDeleteStmtCtx(sc *stmtctx.StatementContext, stmt *ast.DeleteStmt, vars
 	sc.InDeleteStmt = true
 	errLevels := sc.ErrLevels()
 	sc.DupKeyAsWarning = stmt.IgnoreErr
-	sc.BadNullAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
+	errLevels[errctx.ErrGroupBadNull] = errctx.ResolveErrLevel(false, !vars.StrictSQLMode || stmt.IgnoreErr)
 	errLevels[errctx.ErrGroupDividedByZero] = errctx.ResolveErrLevel(
 		!vars.SQLMode.HasErrorForDivisionByZeroMode(),
 		!vars.StrictSQLMode || stmt.IgnoreErr,

--- a/pkg/executor/executor_pkg_test.go
+++ b/pkg/executor/executor_pkg_test.go
@@ -283,7 +283,13 @@ func TestErrLevelsForResetStmtContext(t *testing.T) {
 			name:    "strict,write",
 			sqlMode: mysql.ModeStrictAllTables | mysql.ModeErrorForDivisionByZero,
 			stmt:    []ast.StmtNode{&ast.InsertStmt{}, &ast.UpdateStmt{}, &ast.DeleteStmt{}},
-			levels:  errctx.LevelMap{},
+			levels: func() (l errctx.LevelMap) {
+				l[errctx.ErrGroupTruncate] = errctx.LevelError
+				l[errctx.ErrGroupBadNull] = errctx.LevelError
+				l[errctx.ErrGroupDividedByZero] = errctx.LevelError
+				l[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelError
+				return
+			}(),
 		},
 		{
 			name:    "non-strict,write",
@@ -291,7 +297,9 @@ func TestErrLevelsForResetStmtContext(t *testing.T) {
 			stmt:    []ast.StmtNode{&ast.InsertStmt{}, &ast.UpdateStmt{}, &ast.DeleteStmt{}},
 			levels: func() (l errctx.LevelMap) {
 				l[errctx.ErrGroupTruncate] = errctx.LevelWarn
+				l[errctx.ErrGroupBadNull] = errctx.LevelWarn
 				l[errctx.ErrGroupDividedByZero] = errctx.LevelWarn
+				l[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelError
 				return
 			}(),
 		},
@@ -301,6 +309,7 @@ func TestErrLevelsForResetStmtContext(t *testing.T) {
 			stmt:    []ast.StmtNode{&ast.InsertStmt{IgnoreErr: true}},
 			levels: func() (l errctx.LevelMap) {
 				l[errctx.ErrGroupTruncate] = errctx.LevelWarn
+				l[errctx.ErrGroupBadNull] = errctx.LevelWarn
 				l[errctx.ErrGroupDividedByZero] = errctx.LevelWarn
 				l[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelWarn
 				return
@@ -312,7 +321,9 @@ func TestErrLevelsForResetStmtContext(t *testing.T) {
 			stmt:    []ast.StmtNode{&ast.UpdateStmt{IgnoreErr: true}, &ast.DeleteStmt{IgnoreErr: true}},
 			levels: func() (l errctx.LevelMap) {
 				l[errctx.ErrGroupTruncate] = errctx.LevelWarn
+				l[errctx.ErrGroupBadNull] = errctx.LevelWarn
 				l[errctx.ErrGroupDividedByZero] = errctx.LevelWarn
+				l[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelError
 				return
 			}(),
 		},
@@ -321,7 +332,10 @@ func TestErrLevelsForResetStmtContext(t *testing.T) {
 			sqlMode: mysql.ModeStrictAllTables,
 			stmt:    []ast.StmtNode{&ast.InsertStmt{}, &ast.UpdateStmt{}, &ast.DeleteStmt{}},
 			levels: func() (l errctx.LevelMap) {
+				l[errctx.ErrGroupTruncate] = errctx.LevelError
+				l[errctx.ErrGroupBadNull] = errctx.LevelError
 				l[errctx.ErrGroupDividedByZero] = errctx.LevelIgnore
+				l[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelError
 				return
 			}(),
 		},
@@ -331,7 +345,9 @@ func TestErrLevelsForResetStmtContext(t *testing.T) {
 			stmt:    []ast.StmtNode{&ast.SelectStmt{}, &ast.SetOprStmt{}},
 			levels: func() (l errctx.LevelMap) {
 				l[errctx.ErrGroupTruncate] = errctx.LevelWarn
+				l[errctx.ErrGroupBadNull] = errctx.LevelError
 				l[errctx.ErrGroupDividedByZero] = errctx.LevelWarn
+				l[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelError
 				return
 			}(),
 		},
@@ -341,7 +357,9 @@ func TestErrLevelsForResetStmtContext(t *testing.T) {
 			stmt:    []ast.StmtNode{&ast.SelectStmt{}, &ast.SetOprStmt{}},
 			levels: func() (l errctx.LevelMap) {
 				l[errctx.ErrGroupTruncate] = errctx.LevelWarn
+				l[errctx.ErrGroupBadNull] = errctx.LevelError
 				l[errctx.ErrGroupDividedByZero] = errctx.LevelWarn
+				l[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelError
 				return
 			}(),
 		},

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -685,7 +685,7 @@ func (e *InsertValues) fillRow(ctx context.Context, row []types.Datum, hasValue 
 				return nil, err
 			}
 			if !e.lazyFillAutoID || (e.lazyFillAutoID && !mysql.HasAutoIncrementFlag(c.GetFlag())) {
-				if err = c.HandleBadNull(&row[i], e.Ctx().GetSessionVars().StmtCtx, rowCntInLoadData); err != nil {
+				if err = c.HandleBadNull(e.Ctx().GetSessionVars().StmtCtx.ErrCtx(), &row[i], rowCntInLoadData); err != nil {
 					return nil, err
 				}
 			}
@@ -724,7 +724,7 @@ func (e *InsertValues) fillRow(ctx context.Context, row []types.Datum, hasValue 
 			warnCnt += len(newWarnings)
 		}
 		// Handle the bad null error.
-		if err = gCol.HandleBadNull(&row[colIdx], sc, rowCntInLoadData); err != nil {
+		if err = gCol.HandleBadNull(sc.ErrCtx(), &row[colIdx], rowCntInLoadData); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/executor/load_data.go
+++ b/pkg/executor/load_data.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/br/pkg/lightning/mydump"
 	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -149,8 +150,9 @@ func setNonRestrictiveFlags(stmtCtx *stmtctx.StatementContext) {
 	// TODO: DupKeyAsWarning represents too many "ignore error" paths, the
 	// meaning of this flag is not clear. I can only reuse it here.
 	stmtCtx.DupKeyAsWarning = true
-	stmtCtx.BadNullAsWarning = true
-
+	levels := stmtCtx.ErrLevels()
+	levels[errctx.ErrGroupBadNull] = errctx.LevelWarn
+	stmtCtx.SetErrLevels(levels)
 	stmtCtx.SetTypeFlags(stmtCtx.TypeFlags().WithTruncateAsWarning(true))
 }
 

--- a/pkg/executor/test/writetest/BUILD.bazel
+++ b/pkg/executor/test/writetest/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
     deps = [
         "//br/pkg/lightning/mydump",
         "//pkg/config",
+        "//pkg/errctx",
         "//pkg/executor",
         "//pkg/kv",
         "//pkg/meta/autoid",

--- a/pkg/executor/test/writetest/write_test.go
+++ b/pkg/executor/test/writetest/write_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/br/pkg/lightning/mydump"
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -236,8 +237,9 @@ func TestIssue18681(t *testing.T) {
 
 	deleteSQL := "delete from load_data_test"
 	selectSQL := "select bin(a), bin(b), bin(c), bin(d) from load_data_test;"
+	levels := ctx.GetSessionVars().StmtCtx.ErrLevels()
 	ctx.GetSessionVars().StmtCtx.DupKeyAsWarning = true
-	ctx.GetSessionVars().StmtCtx.BadNullAsWarning = true
+	levels[errctx.ErrGroupBadNull] = errctx.LevelWarn
 
 	sc := ctx.GetSessionVars().StmtCtx
 	oldTypeFlags := sc.TypeFlags()

--- a/pkg/executor/write.go
+++ b/pkg/executor/write.go
@@ -74,7 +74,7 @@ func updateRecord(
 	// Handle the bad null error.
 	for i, col := range t.Cols() {
 		var err error
-		if err = col.HandleBadNull(&newData[i], sc, 0); err != nil {
+		if err = col.HandleBadNull(sc.ErrCtx(), &newData[i], 0); err != nil {
 			return false, err
 		}
 	}

--- a/pkg/expression/errors.go
+++ b/pkg/expression/errors.go
@@ -61,6 +61,7 @@ var (
 	errUserLockDeadlock              = dbterror.ClassExpression.NewStd(mysql.ErrUserLockDeadlock)
 	errUserLockWrongName             = dbterror.ClassExpression.NewStd(mysql.ErrUserLockWrongName)
 	errJSONInBooleanContext          = dbterror.ClassExpression.NewStd(mysql.ErrJSONInBooleanContext)
+	errBadNull                       = dbterror.ClassExpression.NewStd(mysql.ErrBadNull)
 
 	// Sequence usage privilege check.
 	errSequenceAccessDenied      = dbterror.ClassExpression.NewStd(mysql.ErrTableaccessDenied)

--- a/pkg/expression/evaluator_test.go
+++ b/pkg/expression/evaluator_test.go
@@ -105,7 +105,9 @@ func TestSleep(t *testing.T) {
 
 	fc := funcs[ast.Sleep]
 	// non-strict model
-	sessVars.StmtCtx.BadNullAsWarning = true
+	var levels errctx.LevelMap
+	levels[errctx.ErrGroupBadNull] = errctx.LevelWarn
+	sessVars.StmtCtx.SetErrLevels(levels)
 	d := make([]types.Datum, 1)
 	f, err := fc.getFunction(ctx, datumsToConstants(d))
 	require.NoError(t, err)
@@ -122,7 +124,8 @@ func TestSleep(t *testing.T) {
 	require.Equal(t, int64(0), ret)
 
 	// for error case under the strict model
-	sessVars.StmtCtx.BadNullAsWarning = false
+	levels[errctx.ErrGroupBadNull] = errctx.LevelError
+	sessVars.StmtCtx.SetErrLevels(levels)
 	d[0].SetNull()
 	_, err = fc.getFunction(ctx, datumsToConstants(d))
 	require.NoError(t, err)

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -186,7 +186,6 @@ type StatementContext struct {
 	InSetSessionStatesStmt bool
 	InPreparedPlanBuilding bool
 	DupKeyAsWarning        bool
-	BadNullAsWarning       bool
 	InShowWarning          bool
 	UseCache               bool
 	ForcePlanCache         bool // force the optimizer to use plan cache even if there is risky optimization, see #49736.

--- a/pkg/table/BUILD.bazel
+++ b/pkg/table/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/table",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/errctx",
         "//pkg/errno",
         "//pkg/expression",
         "//pkg/kv",
@@ -51,6 +52,7 @@ go_test(
     race = "on",
     shard_count = 9,
     deps = [
+        "//pkg/errctx",
         "//pkg/errno",
         "//pkg/expression",
         "//pkg/parser/ast",

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -33,7 +34,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	field_types "github.com/pingcap/tidb/pkg/parser/types"
 	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/hack"
@@ -493,10 +493,9 @@ func (c *Column) CheckNotNull(data *types.Datum, rowCntInLoadData uint64) error 
 // error is ErrWarnNullToNotnull.
 // Otherwise, the error is ErrColumnCantNull.
 // If BadNullAsWarning is true, it will append the error as a warning, else return the error.
-func (c *Column) HandleBadNull(d *types.Datum, sc *stmtctx.StatementContext, rowCntInLoadData uint64) error {
+func (c *Column) HandleBadNull(ec errctx.Context, d *types.Datum, rowCntInLoadData uint64) error {
 	if err := c.CheckNotNull(d, rowCntInLoadData); err != nil {
-		if sc.BadNullAsWarning {
-			sc.AppendWarning(err)
+		if ec.HandleError(err) == nil {
 			*d = GetZeroValue(c.ToInfo())
 			return nil
 		}
@@ -655,8 +654,8 @@ func getColDefaultValueFromNil(ctx sessionctx.Context, col *model.ColumnInfo, ar
 			return types.Datum{}, nil
 		}
 	}
-	if sc.BadNullAsWarning {
-		sc.AppendWarning(ErrColumnCantNull.FastGenByArgs(col.Name))
+	ec := sc.ErrCtx()
+	if ec.HandleError(ErrColumnCantNull.FastGenByArgs(col.Name)) == nil {
 		return GetZeroValue(col), nil
 	}
 	return types.Datum{}, ErrNoDefaultValue.GenWithStackByArgs(col.Name)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50119

### What changed and how does it work?

This is one step to move error handling settings from `stmtctx` to `errctx` and this PR:

- remove `stmtctx.BadNullAsWarning`
- use `errctx` to handle bad null errors (with defined as group `errctx.ErrGroupBadNull`).

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
