### PR TITLE
br/lightning: add basicConstraints to test ca

### DIFF
--- a/br/tests/_utils/generate_certs
+++ b/br/tests/_utils/generate_certs
@@ -21,7 +21,7 @@ mkdir -p $TEST_DIR/certs
 openssl ecparam -out "$TEST_DIR/certs/ca.key" -name prime256v1 -genkey
 # CA's Common Name must not be the same as signed certificate.
 openssl req -new -batch -sha256 -subj '/CN=br_tests' -key "$TEST_DIR/certs/ca.key" -out "$TEST_DIR/certs/ca.csr"
-openssl x509 -req -sha256 -days 2 -in "$TEST_DIR/certs/ca.csr" -signkey "$TEST_DIR/certs/ca.key" -out "$TEST_DIR/certs/ca.pem"
+openssl x509 -req -sha256 -days 2 -in "$TEST_DIR/certs/ca.csr" -extfile "${cur_dir}/../config/rootca.conf" -extensions ext -signkey "$TEST_DIR/certs/ca.key" -out "$TEST_DIR/certs/ca.pem"
 for cluster in tidb pd tikv lightning tiflash curl ticdc br; do
     openssl ecparam -out "$TEST_DIR/certs/$cluster.key" -name prime256v1 -genkey
     openssl req -new -batch -sha256 -subj '/CN=localhost' -key "$TEST_DIR/certs/$cluster.key" -out "$TEST_DIR/certs/$cluster.csr"

--- a/br/tests/config/rootca.conf
+++ b/br/tests/config/rootca.conf
@@ -1,0 +1,2 @@
+[ext]
+basicConstraints=CA:TRUE,pathlen:0


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/50150

Problem Summary:

### What changed and how does it work?
- v3 CA requires basic constraints ext `CA:TRUE` exists for self-signed root ca, else it reports `x509: invalid signature: parent certificate cannot sign this kind of certificate`
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
