### PR TITLE
test: fix unstable `TestIndexChange ` and `TestAlterAddConstraintStateChange3`

### DIFF
--- a/pkg/ddl/constraint_test.go
+++ b/pkg/ddl/constraint_test.go
@@ -130,15 +130,11 @@ func TestAlterAddConstraintStateChange1(t *testing.T) {
 	tk1.MustExec("use test")
 	tk1.MustExec("insert into t values(12)")
 
-	var checkErr error
 	d := dom.DDL()
 	originalCallback := d.GetHook()
 	callback := &callback.TestDDLCallback{}
 	// StatNone -> StateWriteOnly
 	onJobUpdatedExportedFunc1 := func(job *model.Job) {
-		if checkErr != nil {
-			return
-		}
 		originalCallback.OnChanged(nil)
 		if job.SchemaState == model.StateWriteOnly {
 			// set constraint state
@@ -174,15 +170,11 @@ func TestAlterAddConstraintStateChange2(t *testing.T) {
 	tk1.MustExec("use test")
 	tk1.MustExec("insert into t values(12)")
 
-	var checkErr error
 	d := dom.DDL()
 	originalCallback := d.GetHook()
 	callback := &callback.TestDDLCallback{}
 	// StateWriteOnly -> StateWriteReorganization
 	onJobUpdatedExportedFunc2 := func(job *model.Job) {
-		if checkErr != nil {
-			return
-		}
 		originalCallback.OnChanged(nil)
 		if job.SchemaState == model.StateWriteReorganization {
 			// set constraint state
@@ -217,13 +209,13 @@ func TestAlterAddConstraintStateChange3(t *testing.T) {
 	tk1.MustExec("use test")
 	tk1.MustExec("insert into t values(12)")
 
-	var checkErr error
+	addCheckDone := false
 	d := dom.DDL()
 	originalCallback := d.GetHook()
 	callback := &callback.TestDDLCallback{}
 	// StateWriteReorganization -> StatePublic
 	onJobUpdatedExportedFunc3 := func(job *model.Job) {
-		if checkErr != nil {
+		if job.Type != model.ActionAddCheckConstraint || job.TableName != "t" {
 			return
 		}
 		originalCallback.OnChanged(nil)
@@ -239,13 +231,19 @@ func TestAlterAddConstraintStateChange3(t *testing.T) {
 			// recover
 			tableCommon.Constraints[0].State = model.StatePublic
 			tableCommon.WritableConstraint()
+			addCheckDone = true
 		}
 	}
 	callback.OnJobUpdatedExported.Store(&onJobUpdatedExportedFunc3)
 	d.SetHook(callback)
 	tk.MustExec("alter table t add constraint c3 check ( a > 10)")
 	// Issue TiDB#48123.
-	time.Sleep(50 * time.Millisecond)
+	for i := 0; i <= 100; i++ {
+		if addCheckDone {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	tk.MustQuery("select * from t").Check(testkit.Rows("12"))
 	tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n  `a` int(11) DEFAULT NULL,\nCONSTRAINT `c3` CHECK ((`a` > 10))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 }
@@ -261,15 +259,11 @@ func TestAlterEnforcedConstraintStateChange(t *testing.T) {
 	tk1.MustExec("use test")
 	tk1.MustExec("insert into t values(12)")
 
-	var checkErr error
 	d := dom.DDL()
 	originalCallback := d.GetHook()
 	callback := &callback.TestDDLCallback{}
 	// StateWriteReorganization -> StatePublic
 	onJobUpdatedExportedFunc3 := func(job *model.Job) {
-		if checkErr != nil {
-			return
-		}
 		originalCallback.OnChanged(nil)
 		if job.SchemaState == model.StateWriteReorganization {
 			// set constraint state

--- a/pkg/ddl/index_change_test.go
+++ b/pkg/ddl/index_change_test.go
@@ -55,6 +55,9 @@ func TestIndexChange(t *testing.T) {
 		publicTable     table.Table
 	)
 	onJobUpdatedExportedFunc := func(job *model.Job) {
+		if job.Type != model.ActionAddIndex || job.TableName != "t" {
+			return
+		}
 		if job.SchemaState == prevState {
 			return
 		}
@@ -87,11 +90,11 @@ func TestIndexChange(t *testing.T) {
 	// We need to make sure onJobUpdated is called in the first hook.
 	// After testCreateIndex(), onJobUpdated() may not be called when job.state is Sync.
 	// If we skip this check, prevState may wrongly set to StatePublic.
-	for i := 0; i <= 10; i++ {
+	for i := 0; i <= 100; i++ {
 		if addIndexDone {
 			break
 		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
 	v := getSchemaVer(t, tk.Session())
 	checkHistoryJobArgs(t, tk.Session(), jobID.Load(), &historyJobArgs{ver: v, tbl: publicTable.Meta()})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50079, close #49825

Problem Summary:

To make the tests easy to reproduce:

```
--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -434,6 +434,9 @@ func (d *ddl) delivery2worker(wk *worker, pool *workerPool, job *model.Job) {
                                d.mu.hook.OnSchemaStateChanged(schemaVer)
                                d.mu.RUnlock()
                        }
+                       if job.SchemaState == model.StatePublic && job.State == model.JobStateSynced && job.TableName == "t" && job.Type == model.ActionCreateTable {
+                               time.Sleep(3000 * time.Millisecond)
+                       }
 
                        d.mu.RLock()
                        d.mu.hook.OnJobUpdated(job)
``` 

This pr:
1. Solve the unstable test.
2. Clean some useless code and make some enhencement.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
