### PR TITLE
planner: fix leading hint cannot take effect in UNION ALL statements

### DIFF
--- a/pkg/planner/core/casetest/hint/BUILD.bazel
+++ b/pkg/planner/core/casetest/hint/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 6,
+    shard_count = 7,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/hint/hint_test.go
+++ b/pkg/planner/core/casetest/hint/hint_test.go
@@ -340,3 +340,13 @@ func TestOptimizeHintOnPartitionTable(t *testing.T) {
 	tk.MustQuery("SELECT /*+ MAX_EXECUTION_TIME(10), dtc(name=tt) unknow(t1,t2) */ SLEEP(5)").Check(testkit.Rows("0"))
 	require.Len(t, tk.Session().GetSessionVars().StmtCtx.GetWarnings(), 2)
 }
+
+func TestIssue50067(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (a int);")
+	tk.MustExec("create table t2 (a int);")
+	tk.MustExec("create table t3 (a int);")
+	tk.MustExec("explain select * from t1, t2, t3 union all select /*+ leading(t3, t2) */ * from t1, t2, t3 union all select * from t1, t2, t3;")
+}

--- a/pkg/planner/core/casetest/hint/testdata/integration_suite_in.json
+++ b/pkg/planner/core/casetest/hint/testdata/integration_suite_in.json
@@ -180,5 +180,11 @@
       "explain format = 'brief' select /*+ use_index(t, idx)*/ * from t",
       "explain format = 'brief' select /*+ use_index(t)*/ * from t"
     ]
+  },
+  {
+    "name": "TestHints",
+    "cases": [
+      "select * from t1, t2, t3 union all select /*+ leading(t3, t2) */ * from t1, t2, t3 union all select * from t1, t2, t3"
+    ]
   }
 ]

--- a/pkg/planner/core/casetest/hint/testdata/integration_suite_out.json
+++ b/pkg/planner/core/casetest/hint/testdata/integration_suite_out.json
@@ -325,7 +325,7 @@
           "        └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "Warn": [
-          "[planner:1815]We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid"
+          "[planner:1815]leading hint is inapplicable, check if the leading hint table is valid"
         ]
       },
       {
@@ -347,7 +347,7 @@
           "        └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "Warn": [
-          "[planner:1815]We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid"
+          "[planner:1815]leading hint is inapplicable, check if the leading hint table is valid"
         ]
       },
       {
@@ -1860,6 +1860,45 @@
           "  └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
+      }
+    ]
+  },
+  {
+    "Name": "TestHints",
+    "Cases": [
+      {
+        "SQL": "select * from t1, t2, t3 union all select /*+ leading(t3, t2) */ * from t1, t2, t3 union all select * from t1, t2, t3",
+        "Plan": [
+          "Union 3000000000000.00 root  ",
+          "├─HashJoin 1000000000000.00 root  CARTESIAN inner join",
+          "│ ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "│ │ └─TableFullScan 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo",
+          "│ └─HashJoin(Probe) 100000000.00 root  CARTESIAN inner join",
+          "│   ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "│   │ └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "│   └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "│     └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "├─Projection 1000000000000.00 root  test.t1.a->Column#19, test.t2.a->Column#20, test.t3.a->Column#21",
+          "│ └─HashJoin 1000000000000.00 root  CARTESIAN inner join",
+          "│   ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "│   │ └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "│   └─HashJoin(Probe) 100000000.00 root  CARTESIAN inner join",
+          "│     ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "│     │ └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "│     └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "│       └─TableFullScan 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo",
+          "└─HashJoin 1000000000000.00 root  CARTESIAN inner join",
+          "  ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "  │ └─TableFullScan 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo",
+          "  └─HashJoin(Probe) 100000000.00 root  CARTESIAN inner join",
+          "    ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "    │ └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "    └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "      └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Warn": [
+          "Warning 1815 leading hint is inapplicable, check if the leading hint table has join conditions with other tables"
+        ]
       }
     ]
   }

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4114,7 +4114,7 @@ func (b *PlanBuilder) pushTableHints(hints []*ast.TableOptimizerHint, currentLev
 			b.ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInternal.FastGen("We can only use the straight_join hint, when we use the leading hint and straight_join hint at the same time, all leading hints will be invalid"))
 		}
 	}
-	b.tableHintInfo = append(b.tableHintInfo, h.TableHintInfo{
+	b.tableHintInfo = append(b.tableHintInfo, &h.TableHintInfo{
 		SortMergeJoinTables:       sortMergeTables,
 		BroadcastJoinTables:       bcTables,
 		ShuffleJoinTables:         shuffleJoinTables,
@@ -4157,7 +4157,7 @@ func (b *PlanBuilder) TableHints() *h.TableHintInfo {
 	if len(b.tableHintInfo) == 0 {
 		return nil
 	}
-	return &(b.tableHintInfo[len(b.tableHintInfo)-1])
+	return b.tableHintInfo[len(b.tableHintInfo)-1]
 }
 
 func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p LogicalPlan, err error) {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -210,7 +210,7 @@ type PlanBuilder struct {
 	colMapper map[*ast.ColumnNameExpr]int
 	// visitInfo is used for privilege check.
 	visitInfo     []visitInfo
-	tableHintInfo []hint.TableHintInfo
+	tableHintInfo []*hint.TableHintInfo
 	// optFlag indicates the flags of the optimizer rules.
 	optFlag uint64
 	// capFlag indicates the capability flags.

--- a/pkg/util/hint/hint.go
+++ b/pkg/util/hint/hint.go
@@ -567,7 +567,7 @@ var (
 )
 
 // CollectUnmatchedHintWarnings collects warnings for unmatched hints from this TableHintInfo.
-func CollectUnmatchedHintWarnings(hintInfo TableHintInfo) (warnings []error) {
+func CollectUnmatchedHintWarnings(hintInfo *TableHintInfo) (warnings []error) {
 	warnings = append(warnings, collectUnmatchedIndexHintWarning(hintInfo.IndexHintList, false)...)
 	warnings = append(warnings, collectUnmatchedIndexHintWarning(hintInfo.IndexMergeHintList, true)...)
 	warnings = append(warnings, collectUnmatchedJoinHintWarning(HintINLJ, TiDBIndexNestedLoopJoin, hintInfo.IndexNestedLoopJoinTables.INLJTables)...)

--- a/pkg/util/hint/hint_processor.go
+++ b/pkg/util/hint/hint_processor.go
@@ -100,6 +100,8 @@ func ExtractTableHintsFromStmtNode(node ast.Node, sctx sessionctx.Context) []*as
 			}
 		}
 		return result
+	case *ast.ExplainStmt:
+		return ExtractTableHintsFromStmtNode(x.Stmt, sctx)
 	default:
 		return nil
 	}

--- a/pkg/util/hint/hint_processor.go
+++ b/pkg/util/hint/hint_processor.go
@@ -100,8 +100,6 @@ func ExtractTableHintsFromStmtNode(node ast.Node, sctx sessionctx.Context) []*as
 			}
 		}
 		return result
-	case *ast.ExplainStmt:
-		return ExtractTableHintsFromStmtNode(x.Stmt, sctx)
 	default:
 		return nil
 	}

--- a/tests/integrationtest/r/planner/core/casetest/rule/rule_join_reorder.result
+++ b/tests/integrationtest/r/planner/core/casetest/rule/rule_join_reorder.result
@@ -5468,24 +5468,19 @@ IndexMergeJoin	4.69	root		inner join, inner:Projection, outer key:planner__core_
     └─TableRowIDScan(Probe)	4.69	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ leading(t2, t3@sel_2) */ * from t1 join t2 on t1.a=t2.a where t1.a in (select t3.a from t3);
 id	estRows	task	access object	operator info
-IndexMergeJoin	4.69	root		inner join, inner:Projection, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a
-├─IndexMergeJoin(Build)	3.75	root		inner join, inner:Projection, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a
-│ ├─StreamAgg(Build)	3.00	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.a)->planner__core__casetest__rule__rule_join_reorder.t3.a
-│ │ └─IndexReader	3.00	root		index:StreamAgg
-│ │   └─StreamAgg	3.00	cop[tikv]		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, 
-│ │     └─IndexFullScan	3.00	cop[tikv]	table:t3, index:a(a)	keep order:true
-│ └─Projection(Probe)	3.75	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t1.b
-│   └─IndexLookUp	3.75	root		
-│     ├─Selection(Build)	3.75	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a))
-│     │ └─IndexRangeScan	3.75	cop[tikv]	table:t1, index:a(a)	range: decided by [eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t3.a)], keep order:true, stats:pseudo
-│     └─TableRowIDScan(Probe)	3.75	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Projection(Probe)	4.69	root		planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t2.b
-  └─IndexLookUp	4.69	root		
-    ├─Selection(Build)	4.69	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
-    │ └─IndexRangeScan	4.69	cop[tikv]	table:t2, index:a(a)	range: decided by [eq(planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t1.a)], keep order:true, stats:pseudo
-    └─TableRowIDScan(Probe)	4.69	cop[tikv]	table:t2	keep order:false, stats:pseudo
-Level	Code	Message
-Warning	1815	We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid
+Projection	37462.50	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t2.b
+└─HashJoin	37462.50	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t1.a) eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)]
+  ├─TableReader(Build)	9990.00	root		data:Selection
+  │ └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a))
+  │   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+  └─HashJoin(Probe)	29970.00	root		CARTESIAN inner join
+    ├─StreamAgg(Build)	3.00	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.a)->planner__core__casetest__rule__rule_join_reorder.t3.a
+    │ └─IndexReader	3.00	root		index:StreamAgg
+    │   └─StreamAgg	3.00	cop[tikv]		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, 
+    │     └─IndexFullScan	3.00	cop[tikv]	table:t3, index:a(a)	keep order:true
+    └─TableReader(Probe)	9990.00	root		data:Selection
+      └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
+        └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ leading(t1, t3@sel_2) */ * from t1 join t2 on t1.a=t2.a where t1.a in (select t3.a from t3);
 id	estRows	task	access object	operator info
 IndexMergeJoin	4.69	root		inner join, inner:Projection, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a
@@ -5504,28 +5499,21 @@ IndexMergeJoin	4.69	root		inner join, inner:Projection, outer key:planner__core_
     ├─Selection(Build)	4.69	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
     │ └─IndexRangeScan	4.69	cop[tikv]	table:t2, index:a(a)	range: decided by [eq(planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t1.a)], keep order:true, stats:pseudo
     └─TableRowIDScan(Probe)	4.69	cop[tikv]	table:t2	keep order:false, stats:pseudo
-Level	Code	Message
-Warning	1815	We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid
 explain format = 'brief' select /*+ leading(t3@sel_2, t2) */ * from t1 join t2 on t1.a=t2.a where t1.a in (select t3.a from t3);
 id	estRows	task	access object	operator info
-IndexMergeJoin	4.69	root		inner join, inner:Projection, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a
-├─IndexMergeJoin(Build)	3.75	root		inner join, inner:Projection, outer key:planner__core__casetest__rule__rule_join_reorder.t3.a, inner key:planner__core__casetest__rule__rule_join_reorder.t1.a
-│ ├─StreamAgg(Build)	3.00	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.a)->planner__core__casetest__rule__rule_join_reorder.t3.a
-│ │ └─IndexReader	3.00	root		index:StreamAgg
-│ │   └─StreamAgg	3.00	cop[tikv]		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, 
-│ │     └─IndexFullScan	3.00	cop[tikv]	table:t3, index:a(a)	keep order:true
-│ └─Projection(Probe)	3.75	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t1.b
-│   └─IndexLookUp	3.75	root		
-│     ├─Selection(Build)	3.75	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a))
-│     │ └─IndexRangeScan	3.75	cop[tikv]	table:t1, index:a(a)	range: decided by [eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t3.a)], keep order:true, stats:pseudo
-│     └─TableRowIDScan(Probe)	3.75	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Projection(Probe)	4.69	root		planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t2.b
-  └─IndexLookUp	4.69	root		
-    ├─Selection(Build)	4.69	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
-    │ └─IndexRangeScan	4.69	cop[tikv]	table:t2, index:a(a)	range: decided by [eq(planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t1.a)], keep order:true, stats:pseudo
-    └─TableRowIDScan(Probe)	4.69	cop[tikv]	table:t2	keep order:false, stats:pseudo
-Level	Code	Message
-Warning	1815	We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid
+Projection	37462.50	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t2.b
+└─HashJoin	37462.50	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t1.a) eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)]
+  ├─TableReader(Build)	9990.00	root		data:Selection
+  │ └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a))
+  │   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+  └─HashJoin(Probe)	29970.00	root		CARTESIAN inner join
+    ├─StreamAgg(Build)	3.00	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.a)->planner__core__casetest__rule__rule_join_reorder.t3.a
+    │ └─IndexReader	3.00	root		index:StreamAgg
+    │   └─StreamAgg	3.00	cop[tikv]		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, 
+    │     └─IndexFullScan	3.00	cop[tikv]	table:t3, index:a(a)	keep order:true
+    └─TableReader(Probe)	9990.00	root		data:Selection
+      └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
+        └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ leading(t3@sel_2, t1) */ * from t1 join t2 on t1.a=t2.a where t1.a in (select t3.a from t3);
 id	estRows	task	access object	operator info
 IndexMergeJoin	4.69	root		inner join, inner:Projection, outer key:planner__core__casetest__rule__rule_join_reorder.t1.a, inner key:planner__core__casetest__rule__rule_join_reorder.t2.a
@@ -5544,8 +5532,6 @@ IndexMergeJoin	4.69	root		inner join, inner:Projection, outer key:planner__core_
     ├─Selection(Build)	4.69	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
     │ └─IndexRangeScan	4.69	cop[tikv]	table:t2, index:a(a)	range: decided by [eq(planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t1.a)], keep order:true, stats:pseudo
     └─TableRowIDScan(Probe)	4.69	cop[tikv]	table:t2	keep order:false, stats:pseudo
-Level	Code	Message
-Warning	1815	We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid
 explain format = 'brief' select /*+ leading(t4) */ * from t1 join t2 on t1.a=t2.a join t4 on t1.b = t4.b where t1.a not in (select t3.a from t3);
 id	estRows	task	access object	operator info
 HashJoin	12475.01	root		Null-aware anti semi join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t3.a)]
@@ -7157,20 +7143,19 @@ HashJoin	12487.50	root		left outer join, equal:[eq(planner__core__casetest__rule
     └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ leading(t2, t3@sel_2) */ * from t1 join t2 on t1.a=t2.a where t1.a in (select t3.a from t3);
 id	estRows	task	access object	operator info
-HashJoin	12487.50	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t3.a)]
-├─StreamAgg(Build)	7992.00	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.a)->planner__core__casetest__rule__rule_join_reorder.t3.a
-│ └─IndexReader	7992.00	root		index:StreamAgg
-│   └─StreamAgg	7992.00	cop[tikv]		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, 
-│     └─IndexFullScan	9990.00	cop[tikv]	table:t3, index:a(a)	keep order:true, stats:pseudo
-└─HashJoin(Probe)	12487.50	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t2.a)]
+Projection	99800100.00	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t2.b
+└─HashJoin	99800100.00	root		inner join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t1.a) eq(planner__core__casetest__rule__rule_join_reorder.t3.a, planner__core__casetest__rule__rule_join_reorder.t1.a)]
   ├─TableReader(Build)	9990.00	root		data:Selection
-  │ └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
-  │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
-  └─TableReader(Probe)	9990.00	root		data:Selection
-    └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a))
-      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-Level	Code	Message
-Warning	1815	We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid
+  │ └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t1.a))
+  │   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+  └─HashJoin(Probe)	79840080.00	root		CARTESIAN inner join
+    ├─StreamAgg(Build)	7992.00	root		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, funcs:firstrow(planner__core__casetest__rule__rule_join_reorder.t3.a)->planner__core__casetest__rule__rule_join_reorder.t3.a
+    │ └─IndexReader	7992.00	root		index:StreamAgg
+    │   └─StreamAgg	7992.00	cop[tikv]		group by:planner__core__casetest__rule__rule_join_reorder.t3.a, 
+    │     └─IndexFullScan	9990.00	cop[tikv]	table:t3, index:a(a)	keep order:true, stats:pseudo
+    └─TableReader(Probe)	9990.00	root		data:Selection
+      └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__rule__rule_join_reorder.t2.a))
+        └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ leading(t4) */ * from t1 left join t2 on t1.a=t2.a right join t4 on t1.b = t4.b where t1.a not in (select t3.a from t3);
 id	estRows	task	access object	operator info
 HashJoin	12487.50	root		Null-aware anti semi join, equal:[eq(planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t3.a)]


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50067

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
