### PR TITLE
*: remove `stmtctx.IgnoreNoPartition` and use `errctx` to handle partition mismatch error

### DIFF
--- a/pkg/errctx/context.go
+++ b/pkg/errctx/context.go
@@ -188,6 +188,8 @@ const (
 	ErrGroupDividedByZero
 	// ErrGroupAutoIncReadFailed is the group of auto increment read failed errors
 	ErrGroupAutoIncReadFailed
+	// ErrGroupNoMatchedPartition is the group of no partition is matched errors.
+	ErrGroupNoMatchedPartition
 	// errGroupCount is the count of all `ErrGroup`. Please leave it at the end of the list.
 	errGroupCount
 )
@@ -215,6 +217,10 @@ func init() {
 		},
 		ErrGroupAutoIncReadFailed: {
 			errno.ErrAutoincReadFailed,
+		},
+		ErrGroupNoMatchedPartition: {
+			errno.ErrNoPartitionForGivenValue,
+			errno.ErrRowDoesNotMatchGivenPartitionSet,
 		},
 	}
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2122,9 +2122,9 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		// should make TruncateAsWarning and DividedByZeroAsWarning,
 		// but should not make DupKeyAsWarning.
 		sc.DupKeyAsWarning = stmt.IgnoreErr
-		sc.IgnoreNoPartition = stmt.IgnoreErr
 		if stmt.IgnoreErr {
 			errLevels[errctx.ErrGroupAutoIncReadFailed] = errctx.LevelWarn
+			errLevels[errctx.ErrGroupNoMatchedPartition] = errctx.LevelWarn
 		}
 		errLevels[errctx.ErrGroupBadNull] = errctx.ResolveErrLevel(false, !vars.StrictSQLMode || stmt.IgnoreErr)
 		errLevels[errctx.ErrGroupDividedByZero] = errctx.ResolveErrLevel(
@@ -2150,7 +2150,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	case *ast.LoadDataStmt:
 		sc.InLoadDataStmt = true
 		// return warning instead of error when load data meet no partition for value
-		sc.IgnoreNoPartition = true
+		errLevels[errctx.ErrGroupNoMatchedPartition] = errctx.LevelWarn
 	case *ast.SelectStmt:
 		sc.InSelectStmt = true
 
@@ -2265,9 +2265,9 @@ func ResetUpdateStmtCtx(sc *stmtctx.StatementContext, stmt *ast.UpdateStmt, vars
 		!vars.SQLMode.HasErrorForDivisionByZeroMode(),
 		!vars.StrictSQLMode || stmt.IgnoreErr,
 	)
+	errLevels[errctx.ErrGroupNoMatchedPartition] = errctx.ResolveErrLevel(false, stmt.IgnoreErr)
 	sc.SetErrLevels(errLevels)
 	sc.Priority = stmt.Priority
-	sc.IgnoreNoPartition = stmt.IgnoreErr
 	sc.SetTypeFlags(sc.TypeFlags().
 		WithTruncateAsWarning(!vars.StrictSQLMode || stmt.IgnoreErr).
 		WithIgnoreInvalidDateErr(vars.SQLMode.HasAllowInvalidDatesMode()).

--- a/pkg/executor/write.go
+++ b/pkg/executor/write.go
@@ -186,18 +186,18 @@ func updateRecord(
 			memBuffer.Release(sh)
 			return true, nil
 		}(); err != nil {
-			if terr, ok := errors.Cause(err).(*terror.Error); sctx.GetSessionVars().StmtCtx.IgnoreNoPartition && ok && (terr.Code() == errno.ErrNoPartitionForGivenValue || terr.Code() == errno.ErrRowDoesNotMatchGivenPartitionSet) {
-				sctx.GetSessionVars().StmtCtx.AppendWarning(err)
-				return false, nil
+			if terr, ok := errors.Cause(err).(*terror.Error); ok && (terr.Code() == errno.ErrNoPartitionForGivenValue || terr.Code() == errno.ErrRowDoesNotMatchGivenPartitionSet) {
+				ec := sctx.GetSessionVars().StmtCtx.ErrCtx()
+				return false, ec.HandleError(err)
 			}
 			return updated, err
 		}
 	} else {
 		// Update record to new value and update index.
 		if err := t.UpdateRecord(ctx, sctx, h, oldData, newData, modified); err != nil {
-			if terr, ok := errors.Cause(err).(*terror.Error); sctx.GetSessionVars().StmtCtx.IgnoreNoPartition && ok && (terr.Code() == errno.ErrNoPartitionForGivenValue || terr.Code() == errno.ErrRowDoesNotMatchGivenPartitionSet) {
-				sctx.GetSessionVars().StmtCtx.AppendWarning(err)
-				return false, nil
+			if terr, ok := errors.Cause(err).(*terror.Error); ok && (terr.Code() == errno.ErrNoPartitionForGivenValue || terr.Code() == errno.ErrRowDoesNotMatchGivenPartitionSet) {
+				ec := sctx.GetSessionVars().StmtCtx.ErrCtx()
+				return false, ec.HandleError(err)
 			}
 			return false, err
 		}

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -192,7 +192,6 @@ type StatementContext struct {
 	CacheType              PlanCacheType
 	BatchCheck             bool
 	InNullRejectCheck      bool
-	IgnoreNoPartition      bool
 	IgnoreExplainIDSuffix  bool
 	MultiSchemaInfo        *model.MultiSchemaInfo
 	// If the select statement was like 'select * from t as of timestamp ...' or in a stale read transaction


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50172

### What changed and how does it work?

Decouple some error handling with stmtctx

- remove `IgnoreNoPartition` in `StatementContext`
- add err group `ErrGroupNoMatchedPartition` to `errctx` to handle the corresponding errors.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
