### PR TITLE
test: remove multi-schema change from mock upgrade test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tests/integrationtest/integration-test.out
 tests/integrationtest/integrationtest_tidb-server
 tests/integrationtest/portgenerator
 tests/integrationtest/s/
+tests/integrationtest/replayer/
 *.fail.go
 tools/bin/
 vendor
@@ -39,3 +40,4 @@ bazel-tidb
 *.log.json
 genkeyword
 test_coverage
+coverage.dat

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -334,6 +335,19 @@ func TestUpgrade(t *testing.T) {
 	require.Equal(t, 1, req.NumRows())
 	require.Equal(t, "False", req.GetRow(0).GetString(0))
 	require.NoError(t, r.Close())
+
+	r = MustExecToRecodeSet(t, se2, "admin show ddl jobs 1000;")
+	req = r.NewChunk(nil)
+	err = r.Next(ctx, req)
+	require.NoError(t, err)
+	rowCnt := req.NumRows()
+	for i := 0; i < rowCnt; i++ {
+		jobType := req.GetRow(i).GetString(3) // get job type.
+		// Should not use multi-schema change in bootstrap DDL because the job arguments may be changed.
+		require.False(t, strings.Contains(jobType, "multi-schema"))
+	}
+	require.NoError(t, r.Close())
+
 	dom.Close()
 }
 
@@ -516,15 +530,6 @@ func TestStmtSummary(t *testing.T) {
 	row := req.GetRow(0)
 	require.Equal(t, []byte("ON"), row.GetBytes(0))
 	require.NoError(t, r.Close())
-}
-
-type bindTestStruct struct {
-	originText   string
-	bindText     string
-	db           string
-	originWithDB string
-	bindWithDB   string
-	deleteText   string
 }
 
 func TestUpdateDuplicateBindInfo(t *testing.T) {

--- a/pkg/session/mock_bootstrap.go
+++ b/pkg/session/mock_bootstrap.go
@@ -66,7 +66,8 @@ var allDDLs = []string{
 	"alter table mock_sys_t alter index idx_v invisible",
 	"alter table mock_sys_partition add partition (partition p6 values less than (8192))",
 	"alter table mock_sys_partition drop partition p6",
-	"alter table mock_sys_t add index mul_idx1(c1), add index mul_idx2(c1)",
+	// Should not use multi-schema change to add index in bootstrap DDL.
+	// "alter table mock_sys_t add index mul_idx1(c1), add index mul_idx2(c1)",
 	"alter table mock_sys_t drop index mul_idx1, drop index mul_idx2",
 	// TODO: Support check the DB for ActionAlterPlacementPolicy.
 	// "alter database mock_sys_db_placement placement policy = 'alter_x'",

--- a/pkg/session/mock_bootstrap.go
+++ b/pkg/session/mock_bootstrap.go
@@ -68,7 +68,7 @@ var allDDLs = []string{
 	"alter table mock_sys_partition drop partition p6",
 	// Should not use multi-schema change to add index in bootstrap DDL.
 	// "alter table mock_sys_t add index mul_idx1(c1), add index mul_idx2(c1)",
-	"alter table mock_sys_t drop index mul_idx1, drop index mul_idx2",
+	// "alter table mock_sys_t drop index mul_idx1, drop index mul_idx2",
 	// TODO: Support check the DB for ActionAlterPlacementPolicy.
 	// "alter database mock_sys_db_placement placement policy = 'alter_x'",
 	"alter table mock_sys_t add index rename_idx1(c1)",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49870

Problem Summary:

Adding multiple indexes in one SQL statement has been optimized in #47135. The first job argument is also changed from `bool` to `[]bool`, and this change is not downgrade-compatible.

In mock upgrade test, it is possible that a new version TiDB submits a DDL job, and the old version TiDB executes it.

### What changed and how does it work?

- Remove multi-schema change in mock upgrade test.
- We should ensure that upgrading DDL does not use multi-schema changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
