### PR TITLE
expression: refine code in `handleInvalidTimeError` and `handleAllowedPacketOverflowed`

### DIFF
--- a/pkg/expression/builtin_cast_vec_test.go
+++ b/pkg/expression/builtin_cast_vec_test.go
@@ -158,7 +158,7 @@ func TestVectorizedBuiltinCastFunc(t *testing.T) {
 
 func TestVectorizedCastRealAsTime(t *testing.T) {
 	col := &Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}
-	ctx := mock.NewContext()
+	ctx := createContext(t)
 	baseFunc, err := newBaseBuiltinFunc(ctx, "", []Expression{col}, types.NewFieldType(mysql.TypeDatetime))
 	if err != nil {
 		panic(err)

--- a/pkg/expression/errors.go
+++ b/pkg/expression/errors.go
@@ -76,12 +76,8 @@ func handleInvalidTimeError(ctx EvalContext, err error) error {
 		types.ErrDatetimeFunctionOverflow.Equal(err) || types.ErrIncorrectDatetimeValue.Equal(err)) {
 		return err
 	}
-	sc := ctx.GetSessionVars().StmtCtx
-	err = sc.HandleTruncate(err)
-	if ctx.GetSessionVars().StrictSQLMode && (sc.InInsertStmt || sc.InUpdateStmt || sc.InDeleteStmt) {
-		return err
-	}
-	return nil
+	tc := ctx.GetSessionVars().StmtCtx.TypeCtx()
+	return tc.HandleTruncate(err)
 }
 
 // handleDivisionByZeroError reports error or warning depend on the context.
@@ -93,17 +89,10 @@ func handleDivisionByZeroError(ctx EvalContext) error {
 // handleAllowedPacketOverflowed reports error or warning depend on the context.
 func handleAllowedPacketOverflowed(ctx EvalContext, exprName string, maxAllowedPacketSize uint64) error {
 	err := errWarnAllowedPacketOverflowed.FastGenByArgs(exprName, maxAllowedPacketSize)
-	sc := ctx.GetSessionVars().StmtCtx
-
-	// insert|update|delete ignore ...
-	if sc.TypeFlags().TruncateAsWarning() {
-		sc.AppendWarning(err)
+	tc := ctx.GetSessionVars().StmtCtx.TypeCtx()
+	if f := tc.Flags(); f.TruncateAsWarning() || f.IgnoreTruncateErr() {
+		tc.AppendWarning(err)
 		return nil
 	}
-
-	if ctx.GetSessionVars().StrictSQLMode && (sc.InInsertStmt || sc.InUpdateStmt || sc.InDeleteStmt) {
-		return errors.Trace(err)
-	}
-	sc.AppendWarning(err)
-	return nil
+	return errors.Trace(err)
 }

--- a/pkg/expression/errors.go
+++ b/pkg/expression/errors.go
@@ -76,8 +76,8 @@ func handleInvalidTimeError(ctx EvalContext, err error) error {
 		types.ErrDatetimeFunctionOverflow.Equal(err) || types.ErrIncorrectDatetimeValue.Equal(err)) {
 		return err
 	}
-	tc := ctx.GetSessionVars().StmtCtx.TypeCtx()
-	return tc.HandleTruncate(err)
+	ec := ctx.GetSessionVars().StmtCtx.ErrCtx()
+	return ec.HandleError(err)
 }
 
 // handleDivisionByZeroError reports error or warning depend on the context.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50178

Problem Summary:

In implement of function `handleInvalidTimeError` and `handleAllowedPacketOverflowed` are using `InInsertStmt /InUpdateStmt /InDeleteStmt` to determine how to handle corresponding errors, but seems necessary now:

- When `StrictSQLMode && (sc.InInsertStmt || sc.InUpdateStmt || sc.InDeleteStmt)`: whether to return an error is determined by whether `insert/update/delete ignore` is used, `HandleTruncate` has the right logic to process it. 
- When `!StrictSQLMode && (sc.InInsertStmt || sc.InUpdateStmt || sc.InDeleteStmt)`: we should see truncate error as warning and  `HandleTruncate` will also do it.
- When `!sc.InInsertStmt && !sc.InUpdateStmt && !sc.InDeleteStmt`: the previous code will append warning and `HandleTruncate` will also do it because `WithTruncateAsWarning` or `WithIgnoreTruncate` is set as `true` in most statements (except SplitRegionStmt). 
- However `SplitRegionStmt` requires a const input for boundary and we do not need to care about it.

### What changed and how does it work?

Remove necessary code in `handleInvalidTimeError` and `handleAllowedPacketOverflowed`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > regress the exist tests

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
