### PR TITLE
planner: avoid scanning multi-valued index when there is no condition related | tidb-test=pr/2276

### DIFF
--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2930,28 +2930,28 @@ func TestAnalyzeMVIndex(t *testing.T) {
 	tk.MustExec("set session tidb_stats_load_sync_wait = 0")
 	tk.MustQuery("explain format = brief select * from t where 1 member of (j->'$.signed')").Check(testkit.Rows(
 		"IndexMerge 0.03 root  type: union",
-		"├─IndexRangeScan(Build) 0.03 cop[tikv] table:t, index:ij_signed(cast(json_extract(`j`, _utf8mb4'$.signed') as signed array)) range:[1,1], keep order:false, stats:partial[ia:allEvicted, ij_signed:allEvicted, ij_unsigned:allEvicted...(more: 3 allEvicted, 1 unInitialized)]",
-		"└─TableRowIDScan(Probe) 0.03 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, ij_signed:allEvicted, ij_unsigned:allEvicted...(more: 3 allEvicted, 1 unInitialized)]",
+		"├─IndexRangeScan(Build) 0.03 cop[tikv] table:t, index:ij_signed(cast(json_extract(`j`, _utf8mb4'$.signed') as signed array)) range:[1,1], keep order:false, stats:partial[ia:allEvicted, ij_signed:allEvicted, j:unInitialized]",
+		"└─TableRowIDScan(Probe) 0.03 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, ij_signed:allEvicted, j:unInitialized]",
 	))
 	tk.MustQuery("explain format = brief select * from t where 1 member of (j->'$.unsigned')").Check(testkit.Rows(
 		"IndexMerge 0.03 root  type: union",
-		"├─IndexRangeScan(Build) 0.03 cop[tikv] table:t, index:ij_unsigned(cast(json_extract(`j`, _utf8mb4'$.unsigned') as unsigned array)) range:[1,1], keep order:false, stats:partial[ia:allEvicted, ij_signed:allEvicted, ij_unsigned:allEvicted...(more: 3 allEvicted, 1 unInitialized)]",
-		"└─TableRowIDScan(Probe) 0.03 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, ij_signed:allEvicted, ij_unsigned:allEvicted...(more: 3 allEvicted, 1 unInitialized)]",
+		"├─IndexRangeScan(Build) 0.03 cop[tikv] table:t, index:ij_unsigned(cast(json_extract(`j`, _utf8mb4'$.unsigned') as unsigned array)) range:[1,1], keep order:false, stats:partial[ia:allEvicted, ij_unsigned:allEvicted, j:unInitialized]",
+		"└─TableRowIDScan(Probe) 0.03 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, ij_unsigned:allEvicted, j:unInitialized]",
 	))
 	tk.MustQuery("explain format = brief select * from t where 10.01 member of (j->'$.dbl')").Check(testkit.Rows(
 		"TableReader 21.60 root  data:Selection",
 		"└─Selection 21.60 cop[tikv]  json_memberof(cast(10.01, json BINARY), json_extract(test.t.j, \"$.dbl\"))",
-		"  └─TableFullScan 27.00 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, ij_signed:allEvicted, ij_unsigned:allEvicted...(more: 2 allEvicted, 1 unInitialized)]",
+		"  └─TableFullScan 27.00 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, j:unInitialized]",
 	))
 	tk.MustQuery("explain format = brief select * from t where '1' member of (j->'$.bin')").Check(testkit.Rows(
 		"IndexMerge 0.03 root  type: union",
-		"├─IndexRangeScan(Build) 0.03 cop[tikv] table:t, index:ij_binary(cast(json_extract(`j`, _utf8mb4'$.bin') as binary(50) array)) range:[\"1\",\"1\"], keep order:false, stats:partial[ia:allEvicted, ij_signed:allEvicted, ij_unsigned:allEvicted...(more: 3 allEvicted, 1 unInitialized)]",
-		"└─TableRowIDScan(Probe) 0.03 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, ij_signed:allEvicted, ij_unsigned:allEvicted...(more: 3 allEvicted, 1 unInitialized)]",
+		"├─IndexRangeScan(Build) 0.03 cop[tikv] table:t, index:ij_binary(cast(json_extract(`j`, _utf8mb4'$.bin') as binary(50) array)) range:[\"1\",\"1\"], keep order:false, stats:partial[ia:allEvicted, ij_binary:allEvicted, j:unInitialized]",
+		"└─TableRowIDScan(Probe) 0.03 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, ij_binary:allEvicted, j:unInitialized]",
 	))
 	tk.MustQuery("explain format = brief select * from t where '1' member of (j->'$.char')").Check(testkit.Rows(
 		"IndexMerge 0.03 root  type: union",
-		"├─IndexRangeScan(Build) 0.03 cop[tikv] table:t, index:ij_char(cast(json_extract(`j`, _utf8mb4'$.char') as char(50) array)) range:[\"1\",\"1\"], keep order:false, stats:partial[ia:allEvicted, ij_signed:allEvicted, ij_unsigned:allEvicted...(more: 3 allEvicted, 1 unInitialized)]",
-		"└─TableRowIDScan(Probe) 0.03 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, ij_signed:allEvicted, ij_unsigned:allEvicted...(more: 3 allEvicted, 1 unInitialized)]",
+		"├─IndexRangeScan(Build) 0.03 cop[tikv] table:t, index:ij_char(cast(json_extract(`j`, _utf8mb4'$.char') as char(50) array)) range:[\"1\",\"1\"], keep order:false, stats:partial[ia:allEvicted, ij_char:allEvicted, j:unInitialized]",
+		"└─TableRowIDScan(Probe) 0.03 cop[tikv] table:t keep order:false, stats:partial[ia:allEvicted, ij_char:allEvicted, j:unInitialized]",
 	))
 	// 3.2. emulate the background async loading
 	require.NoError(t, h.LoadNeededHistograms())

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -477,6 +477,9 @@ func CalcTotalSelectivityForMVIdxPath(
 		//   Selectivity( a = 1 and 1 member of (d->'$.b') ) = 1 / 2
 		// Case 2: Here we should use the index total row count
 		//   Selectivity( a = 1 ) = 4 / 8
+		//
+		// Now, the `Case 2` above has been avoided because a mv index may not contain all rows. See the related issue
+		// https://github.com/pingcap/tidb/issues/50125 and fix https://github.com/pingcap/tidb/pull/50183
 		var virtualCol *expression.Column
 		for _, col := range coll.MVIdx2Columns[path.Index.ID] {
 			if col.VirtualExpr != nil {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1216,6 +1216,19 @@ func getPossibleAccessPaths(ctx sessionctx.Context, tableHints *hint.TableHintIn
 	if len(available) == 0 {
 		available = append(available, tablePath)
 	}
+
+	// If all available paths are Multi-Valued Index, it's possible that the only multi-valued index is inapplicable,
+	// so that the table paths are still added here to avoid failing to find any physical plan.
+	allMVIIndexPath := true
+	for _, availablePath := range available {
+		if !isMVIndexPath(availablePath) {
+			allMVIIndexPath = false
+		}
+	}
+	if allMVIIndexPath {
+		available = append(available, tablePath)
+	}
+
 	return available, nil
 }
 

--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -340,14 +340,14 @@ IndexMerge	0.00	root		type: union
 └─TableRowIDScan(Probe)	0.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index_merge(t, idx) */ * from t where a=1 and b=2;
 id	estRows	task	access object	operator info
-IndexMerge	0.10	root		type: union
-├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:idx(a, b, cast(`j` as signed array), c)	range:[1 2,1 2], keep order:false, stats:pseudo
-└─TableRowIDScan(Probe)	0.10	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader	0.01	root		data:Selection
+└─Selection	0.01	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 1), eq(planner__core__indexmerge_path.t.b, 2)
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index_merge(t, idx) */ * from t where a=1;
 id	estRows	task	access object	operator info
-IndexMerge	10.00	root		type: union
-├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx(a, b, cast(`j` as signed array), c)	range:[1,1], keep order:false, stats:pseudo
-└─TableRowIDScan(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader	10.00	root		data:Selection
+└─Selection	10.00	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 1)
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index_merge(t, idx2) */ * from t where a=1 and b=2 and ('3' member of (j->'$.str')) and c=4;
 id	estRows	task	access object	operator info
 IndexMerge	0.00	root		type: union
@@ -360,14 +360,14 @@ IndexMerge	0.00	root		type: union
 └─TableRowIDScan(Probe)	0.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index_merge(t, idx2) */ * from t where a=1 and b=2;
 id	estRows	task	access object	operator info
-IndexMerge	0.10	root		type: union
-├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:idx(a, b, cast(`j` as signed array), c)	range:[1 2,1 2], keep order:false, stats:pseudo
-└─TableRowIDScan(Probe)	0.10	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader	0.01	root		data:Selection
+└─Selection	0.01	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 1), eq(planner__core__indexmerge_path.t.b, 2)
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index_merge(t, idx2) */ * from t where a=1;
 id	estRows	task	access object	operator info
-IndexMerge	10.00	root		type: union
-├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx(a, b, cast(`j` as signed array), c)	range:[1,1], keep order:false, stats:pseudo
-└─TableRowIDScan(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader	10.00	root		data:Selection
+└─Selection	10.00	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 1)
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index(t, idx) */ * from t where a=1 and b=2 and (3 member of (j)) and c=4;
 id	estRows	task	access object	operator info
 IndexMerge	0.00	root		type: union
@@ -380,14 +380,14 @@ IndexMerge	0.00	root		type: union
 └─TableRowIDScan(Probe)	0.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index(t, idx) */ * from t where a=1 and b=2;
 id	estRows	task	access object	operator info
-IndexMerge	0.10	root		type: union
-├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:idx(a, b, cast(`j` as signed array), c)	range:[1 2,1 2], keep order:false, stats:pseudo
-└─TableRowIDScan(Probe)	0.10	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader	0.01	root		data:Selection
+└─Selection	0.01	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 1), eq(planner__core__indexmerge_path.t.b, 2)
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select * from t use index(idx) where a=1;
 id	estRows	task	access object	operator info
-IndexMerge	10.00	root		type: union
-├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx(a, b, cast(`j` as signed array), c)	range:[1,1], keep order:false, stats:pseudo
-└─TableRowIDScan(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader	10.00	root		data:Selection
+└─Selection	10.00	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 1)
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select * from t force index(idx) where a=1 and b=2 and (3 member of (j));
 id	estRows	task	access object	operator info
 IndexMerge	0.00	root		type: union
@@ -395,9 +395,9 @@ IndexMerge	0.00	root		type: union
 └─TableRowIDScan(Probe)	0.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select * from t force index(idx) where a=1;
 id	estRows	task	access object	operator info
-IndexMerge	10.00	root		type: union
-├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx(a, b, cast(`j` as signed array), c)	range:[1,1], keep order:false, stats:pseudo
-└─TableRowIDScan(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader	10.00	root		data:Selection
+└─Selection	10.00	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 1)
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int, j json,
 index i_int((cast(j->'$.int' as signed array))));
@@ -499,11 +499,18 @@ TableReader_7	8000.00	root		data:Selection_6
 drop table if exists t;
 create table t(a int, j json, index kj((cast(j as signed array))));
 explain format = 'brief' select /*+ use_index(t, kj) */ * from t;
-Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
+id	estRows	task	access object	operator info
+TableReader	10000.00	root		data:TableFullScan
+└─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index(t, kj) */ a from t;
-Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
+id	estRows	task	access object	operator info
+TableReader	10000.00	root		data:TableFullScan
+└─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index(t, kj) */ * from t where a<10;
-Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
+id	estRows	task	access object	operator info
+TableReader	3323.33	root		data:Selection
+└─Selection	3323.33	cop[tikv]		lt(planner__core__indexmerge_path.t.a, 10)
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index(t, kj) */ * from t where (1 member of (j));
 id	estRows	task	access object	operator info
 IndexMerge	10.00	root		type: union
@@ -516,7 +523,10 @@ IndexMerge	0.01	root		type: union
 └─Selection(Probe)	0.01	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 10)
   └─TableRowIDScan	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index(t, kj) */ * from t where (1 member of (j)) or a=10;
-Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
+id	estRows	task	access object	operator info
+TableReader	19.99	root		data:Selection
+└─Selection	19.99	cop[tikv]		or(json_memberof(cast(1, json BINARY), planner__core__indexmerge_path.t.j), eq(planner__core__indexmerge_path.t.a, 10))
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index_merge(t, kj) */ * from t;
 id	estRows	task	access object	operator info
 TableReader	10000.00	root		data:TableFullScan
@@ -578,7 +588,8 @@ select /*+ use_index_merge(t, kj) */ count(*) from t where json_overlaps((j), '[
 count(*)
 2
 select /*+ use_index(t, kj) */ count(*) from t;
-Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
+count(*)
+4
 drop table if exists t;
 create table t(j json, index kj((cast(j as signed array))));
 insert into t values ('[1]');
@@ -664,11 +675,32 @@ set tidb_analyze_version=2;
 analyze table t;
 explain select * from t use index (iad) where a = 1;
 id	estRows	task	access object	operator info
-IndexMerge_7	1.00	root		type: union
-├─IndexRangeScan_5(Build)	4.00	cop[tikv]	table:t, index:iad(a, cast(json_extract(`d`, _utf8mb4'$.b') as signed array))	range:[1,1], keep order:false
-└─TableRowIDScan_6(Probe)	1.00	cop[tikv]	table:t	keep order:false
+TableReader_7	1.00	root		data:Selection_6
+└─Selection_6	1.00	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 1)
+  └─TableFullScan_5	2.00	cop[tikv]	table:t	keep order:false
 explain select * from t use index (iad) where a = 1 and (2 member of (d->'$.b'));
 id	estRows	task	access object	operator info
 IndexMerge_7	1.00	root		type: union
 ├─IndexRangeScan_5(Build)	1.00	cop[tikv]	table:t, index:iad(a, cast(json_extract(`d`, _utf8mb4'$.b') as signed array))	range:[1 2,1 2], keep order:false, stats:partial[d:unInitialized]
 └─TableRowIDScan_6(Probe)	1.00	cop[tikv]	table:t	keep order:false, stats:partial[d:unInitialized]
+drop table if exists t;
+create table t(a int, d json, index iad(a, (cast(d->'$.b' as signed array))));
+insert into t value(1,'{"b":[]}'), (2,'{"b":[]}');
+select * from t use index (iad) where a = 1;
+a	d
+1	{"b": []}
+select * from t ignore index (iad) where a = 1;
+a	d
+1	{"b": []}
+drop table if exists t;
+create table t (j json, key mvi( (cast(j as char(5) array)) ) );
+insert into t values ('[]');
+insert into t values ('["abc"]');
+select * from t use index (mvi) where json_contains(j, '[]');
+j
+[]
+["abc"]
+select * from t ignore index (mvi) where json_contains(j, '[]');
+j
+[]
+["abc"]

--- a/tests/integrationtest/t/planner/core/casetest/index/index.test
+++ b/tests/integrationtest/t/planner/core/casetest/index/index.test
@@ -273,4 +273,3 @@ explain format='brief' select /*+ use_index_merge(t1 primary, c) */ * from t1 wh
 --sorted_result
 select /*+ use_index_merge(t1 primary, c) */ * from t1 where t1.a = 1 and t1.b = '111' or t1.c = 3.3;
 set tidb_enable_clustered_index=default;
-

--- a/tests/integrationtest/t/planner/core/indexmerge_path.test
+++ b/tests/integrationtest/t/planner/core/indexmerge_path.test
@@ -135,15 +135,11 @@ explain select j from t where j in (1, 2);
 # TestEnforceMVIndex
 drop table if exists t;
 create table t(a int, j json, index kj((cast(j as signed array))));
--- error 1815
 explain format = 'brief' select /*+ use_index(t, kj) */ * from t;
--- error 1815
 explain format = 'brief' select /*+ use_index(t, kj) */ a from t;
--- error 1815
 explain format = 'brief' select /*+ use_index(t, kj) */ * from t where a<10;
 explain format = 'brief' select /*+ use_index(t, kj) */ * from t where (1 member of (j));
 explain format = 'brief' select /*+ use_index(t, kj) */ * from t where (1 member of (j)) and a=10;
--- error 1815
 explain format = 'brief' select /*+ use_index(t, kj) */ * from t where (1 member of (j)) or a=10;
 explain format = 'brief' select /*+ use_index_merge(t, kj) */ * from t;
 explain format = 'brief' select /*+ use_index_merge(t, kj) */ a from t;
@@ -173,7 +169,6 @@ select /*+ use_index_merge(t, kj) */ count(*) from t;
 select /*+ use_index_merge(t, kj) */ count(*) from t where (1 member of (j));
 select /*+ use_index_merge(t, kj) */ count(*) from t where json_contains((j), '[1]');
 select /*+ use_index_merge(t, kj) */ count(*) from t where json_overlaps((j), '[1]');
--- error 1815
 select /*+ use_index(t, kj) */ count(*) from t;
 
 
@@ -237,3 +232,16 @@ set tidb_analyze_version=2;
 analyze table t;
 explain select * from t use index (iad) where a = 1;
 explain select * from t use index (iad) where a = 1 and (2 member of (d->'$.b'));
+
+# TestMultiValuedIndexWithoutRelatedColumnCondition
+drop table if exists t;
+create table t(a int, d json, index iad(a, (cast(d->'$.b' as signed array))));
+insert into t value(1,'{"b":[]}'), (2,'{"b":[]}');
+select * from t use index (iad) where a = 1;
+select * from t ignore index (iad) where a = 1;
+drop table if exists t;
+create table t (j json, key mvi( (cast(j as char(5) array)) ) );
+insert into t values ('[]');
+insert into t values ('["abc"]');
+select * from t use index (mvi) where json_contains(j, '[]');
+select * from t ignore index (mvi) where json_contains(j, '[]');


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #50125

### What changed and how does it work?

We cannot blindly scan on the multi-valued index, because scanning on it assumes that the array is not empty. I added a lot comments on related codes to describe why it's safe now.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
Fix the issue that multi-valued index can give incorrect result when the array is empty.
```
