### PR TITLE
store/mockstore: revert using store image to accelerate unit test

### DIFF
--- a/pkg/store/mockstore/mockstore.go
+++ b/pkg/store/mockstore/mockstore.go
@@ -195,12 +195,13 @@ func NewMockStore(options ...MockTiKVStoreOption) (kv.Storage, error) {
 	case MockTiKV:
 		store, err = newMockTikvStore(&opt)
 	case EmbedUnistore:
-		if opt.path == "" && len(options) == 0 && ImageAvailable() {
-			// Create the store from the image.
-			if path, err := copyImage(); err == nil {
-				opt.path = path
-			}
-		}
+		// Don't do this unless we figure out why the test image does not accelerate out unit tests.
+		// if opt.path == "" && len(options) == 0 && ImageAvailable() {
+		// 	// Create the store from the image.
+		// 	if path, err := copyImage(); err == nil {
+		// 		opt.path = path
+		// 	}
+		// }
 
 		store, err = newUnistore(&opt)
 	default:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #42434

Problem Summary:

### What changed and how does it work?

I find https://github.com/pingcap/tidb/pull/42521 does not make the unit test faster ...

Here is an internal document with some investigation progress, but the root cause is still unknown. https://pingcap.feishu.cn/wiki/TpqNwM3eiiWJY1kvJjocWztcn7e?from=from_copylink

Before we know why that doesn't work, it's better to revert first.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test

Revert

- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
