### PR TITLE
*: fix mpp explain analyze wrong when mpp err recovery happens

### DIFF
--- a/pkg/distsql/distsql.go
+++ b/pkg/distsql/distsql.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/tracing"
 	"github.com/pingcap/tidb/pkg/util/trxevents"
@@ -36,8 +37,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// GenSelectResultFromResponse generates an iterator from response.
-func GenSelectResultFromResponse(sctx sessionctx.Context, fieldTypes []*types.FieldType, planIDs []int, rootID int, resp kv.Response) SelectResult {
+// GenSelectResultFromMPPResponse generates an iterator from response.
+func GenSelectResultFromMPPResponse(sctx sessionctx.Context, fieldTypes []*types.FieldType,
+	planIDs []int, rootID int, resp kv.Response,
+	gatherRuntimeStats *execdetails.RuntimeStatsColl) SelectResult {
 	// TODO: Add metric label and set open tracing.
 	return &selectResult{
 		label:      "mpp",
@@ -48,6 +51,8 @@ func GenSelectResultFromResponse(sctx sessionctx.Context, fieldTypes []*types.Fi
 		copPlanIDs: planIDs,
 		rootPlanID: rootID,
 		storeType:  kv.TiFlash,
+
+		tiflashRuntimeStats: gatherRuntimeStats,
 	}
 }
 

--- a/pkg/distsql/distsql.go
+++ b/pkg/distsql/distsql.go
@@ -39,8 +39,7 @@ import (
 
 // GenSelectResultFromMPPResponse generates an iterator from response.
 func GenSelectResultFromMPPResponse(sctx sessionctx.Context, fieldTypes []*types.FieldType,
-	planIDs []int, rootID int, resp kv.Response,
-	gatherRuntimeStats *execdetails.RuntimeStatsColl) SelectResult {
+	planIDs []int, rootID int, resp kv.Response, gatherRuntimeStats *execdetails.RuntimeStatsColl) SelectResult {
 	// TODO: Add metric label and set open tracing.
 	return &selectResult{
 		label:      "mpp",

--- a/pkg/distsql/select_result.go
+++ b/pkg/distsql/select_result.go
@@ -317,7 +317,9 @@ type selectResult struct {
 	distSQLConcurrency int
 	paging             bool
 
-	// gjt todo comments
+	// TiFlash will handle its runtime stats in MPPGather instead of add to StmtCtx.RuntimeStatsColl directly.
+	// Because MPPGather will retry when got mpp err and do gather level retry.
+	// MPPGather will merge this runtime stats to StmtCtx.RuntimeStatsColl when Close().
 	tiflashRuntimeStats *execdetails.RuntimeStatsColl
 }
 

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -147,7 +147,6 @@ type localMppCoordinator struct {
 	// Record node cnt that involved in the mpp computation.
 	nodeCnt int
 
-	// gjt todo maybe tiflashGatherRuntimeStats?
 	tiflashRuntimeStats *execdetails.RuntimeStatsColl
 }
 

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -113,6 +113,8 @@ type localMppCoordinator struct {
 
 	memTracker *memory.Tracker
 
+	tiflashRuntimeStats *execdetails.RuntimeStatsColl
+
 	reportStatusCh chan struct{} // used to notify inside coordinator that all reports has been received
 
 	vars *kv.Variables
@@ -146,8 +148,6 @@ type localMppCoordinator struct {
 
 	// Record node cnt that involved in the mpp computation.
 	nodeCnt int
-
-	tiflashRuntimeStats *execdetails.RuntimeStatsColl
 }
 
 // NewLocalMPPCoordinator creates a new localMppCoordinator instance

--- a/pkg/executor/mpp_gather.go
+++ b/pkg/executor/mpp_gather.go
@@ -336,7 +336,9 @@ func (e *MPPGather) Close() error {
 		e.mppErrRecovery.ResetHolder()
 	}
 
-	e.mergeAndClearRuntimeStats()
+	if err = e.mergeAndClearRuntimeStats(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -349,9 +351,12 @@ func (e *MPPGather) setDummy() {
 	e.dummy = true
 }
 
-func (e *MPPGather) mergeAndClearRuntimeStats() {
+func (e *MPPGather) mergeAndClearRuntimeStats() error {
 	if e.runtimeStats != nil {
-		e.Ctx().GetSessionVars().StmtCtx.RuntimeStatsColl.MergeBasicCopRuntimeStats(e.runtimeStats, e.storeType)
+		if err := e.Ctx().GetSessionVars().StmtCtx.RuntimeStatsColl.MergeBasicCopRuntimeStats(e.runtimeStats, e.storeType); err != nil {
+			return err
+		}
 		e.runtimeStats = nil
 	}
+	return nil
 }

--- a/pkg/executor/mpp_gather.go
+++ b/pkg/executor/mpp_gather.go
@@ -336,10 +336,7 @@ func (e *MPPGather) Close() error {
 		e.mppErrRecovery.ResetHolder()
 	}
 
-	if err = e.mergeAndClearRuntimeStats(); err != nil {
-		return err
-	}
-	return nil
+	return e.mergeAndClearRuntimeStats()
 }
 
 // Table implements the dataSourceExecutor interface.

--- a/pkg/executor/mpp_gather.go
+++ b/pkg/executor/mpp_gather.go
@@ -336,7 +336,7 @@ func (e *MPPGather) Close() error {
 		e.mppErrRecovery.ResetHolder()
 	}
 
-	e.mergeRuntimeStats()
+	e.mergeAndClearRuntimeStats()
 	return nil
 }
 
@@ -349,7 +349,7 @@ func (e *MPPGather) setDummy() {
 	e.dummy = true
 }
 
-func (e *MPPGather) mergeRuntimeStats() {
+func (e *MPPGather) mergeAndClearRuntimeStats() {
 	if e.runtimeStats != nil {
 		e.Ctx().GetSessionVars().StmtCtx.RuntimeStatsColl.MergeBasicCopRuntimeStats(e.runtimeStats, e.storeType)
 		e.runtimeStats = nil

--- a/pkg/executor/mpp_gather.go
+++ b/pkg/executor/mpp_gather.go
@@ -327,7 +327,6 @@ func (e *MPPGather) Close() error {
 	if e.respIter != nil {
 		err = e.respIter.Close()
 	}
-
 	mppcoordmanager.InstanceMPPCoordinatorManager.Unregister(mppcoordmanager.CoordinatorUniqueID{MPPQueryID: e.mppQueryID, GatherID: e.gatherID})
 	if err != nil {
 		return err

--- a/pkg/executor/mpp_gather.go
+++ b/pkg/executor/mpp_gather.go
@@ -149,15 +149,16 @@ func (e *MPPGather) setupRespIter(ctx context.Context, isRecoverying bool) (err 
 		}
 	})
 
+	if e.runtimeStats = execdetails.NewRuntimeStatsColl(nil); e.runtimeStats == nil {
+		return errors.New("alloc runtime stats for mpp_gather failed")
+	}
+
 	e.respIter = distsql.GenSelectResultFromMPPResponse(e.Ctx(), e.RetFieldTypes(), planIDs, e.ID(), resp, e.runtimeStats)
 
 	if e.nodeCnt = coord.GetNodeCnt(); e.nodeCnt <= 0 {
 		return errors.Errorf("tiflash node count should be greater than zero: %v", e.nodeCnt)
 	}
 
-	if e.runtimeStats = execdetails.NewRuntimeStatsColl(nil); e.runtimeStats == nil {
-		return errors.New("alloc runtime stats for mpp_gather failed")
-	}
 	return nil
 }
 

--- a/pkg/util/execdetails/BUILD.bazel
+++ b/pkg/util/execdetails/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_influxdata_tdigest//:tdigest",
+        "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_tipb//go-tipb",
         "@com_github_tikv_client_go_v2//util",
         "@org_uber_go_zap//:zap",

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1057,7 +1057,7 @@ func (e *RuntimeStatsColl) cloneBasicCopRuntimeStats() map[int]map[string]*basic
 	return clone
 }
 
-// MergeCopRuntimeStats merge copStats of another RuntimeStatsColl.
+// MergeBasicCopRuntimeStats merge copStats of another RuntimeStatsColl.
 func (e *RuntimeStatsColl) MergeBasicCopRuntimeStats(other *RuntimeStatsColl, storeType string) error {
 	otherCopStats := other.cloneBasicCopRuntimeStats()
 	if otherCopStats == nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50221

Problem Summary: 
When an 'mpp err recovery' occurs, 'actRows' records all the rows returned by all retry of the MPPTask. Sso if the table has 2 rows, and retry happens n times, tha actRows will be 2 + 2*n, which is unexpected.

This bug is because the logic of recording the execution summary is placed within the 'distsql' layer and directly recorded into the query-level StmtCtx structure when MPPGather retry.

### What changed and how does it work?
In selectResult, add an addition of runtime stats structure for TiFlash. During MPPTask retries, only the runtime stats for the final successful selectResult are recorded in StmtCtx.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test: endless: https://github.com/PingCAP-QE/endless/pull/2168
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
