### PR TITLE
br: fix the --with-sys-table prompt

### DIFF
--- a/br/cmd/br/restore.go
+++ b/br/cmd/br/restore.go
@@ -85,7 +85,7 @@ func printWorkaroundOnFullRestoreError(command *cobra.Command, err error) {
 		fmt.Println("# you can drop existing databases and tables and start restore again")
 	case errors.ErrorEqual(err, berrors.ErrRestoreIncompatibleSys):
 		fmt.Println("# the target cluster is not compatible with the backup data,")
-		fmt.Println("# you can remove 'with-sys-table' flag to skip restoring system tables")
+		fmt.Println("# you can use '--with-sys-table=false' to skip restoring system tables")
 	}
 	fmt.Println("#######################################################################")
 }

--- a/br/tests/br_stats/run.sh
+++ b/br/tests/br_stats/run.sh
@@ -46,13 +46,13 @@ done
 
 rm -f $LOG
 run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --filter "${DB}1.*" || cat $LOG
-load_cnt=$(cat $LOG | grep "restore stat done" | wc -l)
-load_db1_cnt=$(cat $LOG | grep "restore stat done" | grep "${DB}1" | wc -l)
+load_cnt=$(cat $LOG | grep "restore statistic data done" | wc -l)
+load_db1_cnt=$(cat $LOG | grep "restore statistic data done" | grep "${DB}1" | wc -l)
 load_mark=$((${load_cnt}+10*${load_db1_cnt}))
 echo "load stats count: ${load_cnt}; db1 count: ${load_db1_cnt}; load mark: ${load_mark}"
 
 if [ "${load_mark}" -ne "11" ]; then
     echo "TEST: [$TEST_NAME] fail on load stats"
-    echo $(cat $LOG | grep "restore stat done")
+    echo $(cat $LOG | grep "restore statistic data done")
     exit 1
 fi


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50240

Problem Summary:

1. Fix the prompt message on restore sys tables failure.
2. Fix an integration case

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
