### PR TITLE
store: let `MockRegionManager` check region epoch and split region in same lock

### DIFF
--- a/pkg/store/mockstore/unistore/tikv/mock_region.go
+++ b/pkg/store/mockstore/unistore/tikv/mock_region.go
@@ -369,6 +369,8 @@ func (rm *MockRegionManager) SplitTable(tableID int64, count int) {
 	tableStart := tablecodec.GenTableRecordPrefix(tableID)
 	tableEnd := tableStart.PrefixNext()
 	keys := rm.calculateSplitKeys(tableStart, tableEnd, count)
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
 	if _, err := rm.splitKeys(keys); err != nil {
 		panic(err)
 	}
@@ -379,6 +381,8 @@ func (rm *MockRegionManager) SplitIndex(tableID, indexID int64, count int) {
 	indexStart := tablecodec.EncodeTableIndexPrefix(tableID, indexID)
 	indexEnd := indexStart.PrefixNext()
 	keys := rm.calculateSplitKeys(indexStart, indexEnd, count)
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
 	if _, err := rm.splitKeys(keys); err != nil {
 		panic(err)
 	}
@@ -387,6 +391,8 @@ func (rm *MockRegionManager) SplitIndex(tableID, indexID int64, count int) {
 // SplitKeys evenly splits the start, end key into "count" regions.
 func (rm *MockRegionManager) SplitKeys(start, end kv.Key, count int) {
 	keys := rm.calculateSplitKeys(start, end, count)
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
 	if _, err := rm.splitKeys(keys); err != nil {
 		panic(err)
 	}
@@ -394,16 +400,53 @@ func (rm *MockRegionManager) SplitKeys(start, end kv.Key, count int) {
 
 // SplitRegion implements the RegionManager interface.
 func (rm *MockRegionManager) SplitRegion(req *kvrpcpb.SplitRegionRequest) *kvrpcpb.SplitRegionResponse {
-	if _, err := rm.GetRegionFromCtx(req.Context); err != nil {
-		return &kvrpcpb.SplitRegionResponse{RegionError: err}
-	}
 	splitKeys := make([][]byte, 0, len(req.SplitKeys))
 	for _, rawKey := range req.SplitKeys {
 		splitKeys = append(splitKeys, codec.EncodeBytes(nil, rawKey))
 	}
 	slices.SortFunc(splitKeys, bytes.Compare)
 
+	ctxPeer := req.Context.GetPeer()
+	if ctxPeer != nil {
+		_, err := rm.GetStoreAddrByStoreID(ctxPeer.GetStoreId())
+		if err != nil {
+			return &kvrpcpb.SplitRegionResponse{RegionError: &errorpb.Error{
+				Message:       "store not match",
+				StoreNotMatch: &errorpb.StoreNotMatch{},
+			}}
+		}
+	}
+
+	rm.mu.Lock()
+	ri := rm.regions[req.Context.RegionId]
+	if ri == nil {
+		rm.mu.Unlock()
+		return &kvrpcpb.SplitRegionResponse{RegionError: &errorpb.Error{
+			Message: "region not found",
+			RegionNotFound: &errorpb.RegionNotFound{
+				RegionId: req.Context.GetRegionId(),
+			},
+		}}
+	}
+	// Region epoch does not match.
+	if rm.isEpochStale(ri.getRegionEpoch(), req.Context.GetRegionEpoch()) {
+		rm.mu.Unlock()
+		return &kvrpcpb.SplitRegionResponse{RegionError: &errorpb.Error{
+			Message: "stale epoch",
+			EpochNotMatch: &errorpb.EpochNotMatch{
+				CurrentRegions: []*metapb.Region{{
+					Id:          ri.meta.Id,
+					StartKey:    ri.meta.StartKey,
+					EndKey:      ri.meta.EndKey,
+					RegionEpoch: ri.getRegionEpoch(),
+					Peers:       ri.meta.Peers,
+				}},
+			},
+		}}
+	}
+
 	newRegions, err := rm.splitKeys(splitKeys)
+	rm.mu.Unlock()
 	if err != nil {
 		return &kvrpcpb.SplitRegionResponse{RegionError: &errorpb.Error{Message: err.Error()}}
 	}
@@ -448,8 +491,8 @@ func (rm *MockRegionManager) calculateSplitKeys(start, end []byte, count int) []
 	return splitKeys
 }
 
+// Should call `rm.mu.Lock()` before call this method.
 func (rm *MockRegionManager) splitKeys(keys [][]byte) ([]*regionCtx, error) {
-	rm.mu.Lock()
 	newRegions := make([]*regionCtx, 0, len(keys))
 	rm.sortedRegions.AscendGreaterOrEqual(newBtreeSearchItem(keys[0]), func(item btree.Item) bool {
 		if len(keys) == 0 {
@@ -513,7 +556,6 @@ func (rm *MockRegionManager) splitKeys(keys [][]byte) ([]*regionCtx, error) {
 		rm.regions[region.meta.Id] = region
 		rm.sortedRegions.ReplaceOrInsert(newBtreeItem(region))
 	}
-	rm.mu.Unlock()
 	return newRegions, rm.saveRegions(newRegions)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50177

Problem Summary: 

 1. We check the `regionCtx` and it is correct. Then unlock the `MockRegionManager`.
 2. Another goroutine split the region, update region epoch.
 3. Call `newRegions, err := rm.splitKeys(splitKeys)` got one more `newRegions`.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
As diff show in https://github.com/pingcap/tidb/issues/50177#issuecomment-1882561057, no panic any more.
```diff
diff --git a/pkg/store/mockstore/unistore/tikv/mock_region.go b/pkg/store/mockstore/unistore/tikv/mock_region.go
index be4173dd4e..7dfe674ae5 100644
--- a/pkg/store/mockstore/unistore/tikv/mock_region.go
+++ b/pkg/store/mockstore/unistore/tikv/mock_region.go
@@ -445,6 +445,13 @@ func (rm *MockRegionManager) SplitRegion(req *kvrpcpb.SplitRegionRequest) *kvrpc
                }}
        }

+       if len(splitKeys) < 3 {
+               time.Sleep(time.Second * 1)
+       }
+       if len(splitKeys) > 10 {
+               time.Sleep(time.Second * 2)
+       }
+
        newRegions, err := rm.splitKeys(splitKeys)
        rm.mu.Unlock()
        if err != nil {
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
