### PR TITLE
ddl: check owner status before commit DDL changes

### DIFF
--- a/pkg/ddl/ddl_worker.go
+++ b/pkg/ddl/ddl_worker.go
@@ -849,6 +849,11 @@ func (w *JobContext) setDDLLabelForDiagnosis(jobType model.ActionType) {
 }
 
 func (w *worker) HandleJobDone(d *ddlCtx, job *model.Job, t *meta.Meta) error {
+	if !w.ddlCtx.isOwner() && w.tp != localWorker {
+		// This TiDB instance is not DDL owner anymore, it should not commit any transaction.
+		w.sess.Rollback()
+		return dbterror.ErrNotOwner
+	}
 	err := w.finishDDLJob(t, job)
 	if err != nil {
 		w.sess.Rollback()

--- a/pkg/ddl/ddl_worker.go
+++ b/pkg/ddl/ddl_worker.go
@@ -930,13 +930,13 @@ func (w *worker) HandleDDLJobTable(d *ddlCtx, job *model.Job) (int64, error) {
 	// If running job meets error, we will save this error in job Error
 	// and retry later if the job is not cancelled.
 	schemaVer, runJobErr = w.runDDLJob(d, t, job)
+	defer d.unlockSchemaVersion(job.ID)
 
 	d.mu.RLock()
 	d.mu.hook.OnJobRunAfter(job)
 	d.mu.RUnlock()
 
 	if job.IsCancelled() {
-		defer d.unlockSchemaVersion(job.ID)
 		w.sess.Reset()
 		err = w.HandleJobDone(d, job, t)
 		return 0, err
@@ -958,20 +958,22 @@ func (w *worker) HandleDDLJobTable(d *ddlCtx, job *model.Job) (int64, error) {
 	err = w.registerMDLInfo(job, schemaVer)
 	if err != nil {
 		w.sess.Rollback()
-		d.unlockSchemaVersion(job.ID)
 		return 0, err
 	}
 	err = w.updateDDLJob(job, runJobErr != nil)
 	if err = w.handleUpdateJobError(t, job, err); err != nil {
 		w.sess.Rollback()
-		d.unlockSchemaVersion(job.ID)
 		return 0, err
 	}
 	writeBinlog(d.binlogCli, txn, job)
 	// reset the SQL digest to make topsql work right.
 	w.sess.GetSessionVars().StmtCtx.ResetSQLDigest(job.Query)
+	if !w.ddlCtx.isOwner() {
+		// This TiDB instance is not DDL owner anymore, it should not commit any transaction.
+		w.sess.Rollback()
+		return 0, dbterror.ErrNotOwner
+	}
 	err = w.sess.Commit()
-	d.unlockSchemaVersion(job.ID)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50055, close #47105

Problem Summary:

Timeline:

1. `TestFrameworkWithQuery` creates multiple domains in order to test the distributed environment.
2. These domains create & initialize their own DDL structures one by one.
3. The first domain(tidb-0) checks that it is DDL owner, and trying to load DDL jobs and run them. [go runtime is lagging for a while]
4. The second domain(tidb-1) starts, `InitOwner()` assign the DDL owner to tidb-1.
5. tidb-1 starts to load DDL jobs. At the same time, the goroutine in step 3 continues to run.

As a result, there are two DDL owners running the same job concurrently.

### What changed and how does it work?

Before updating the error to job table, TiDB should check whether it is owner itself.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
