### PR TITLE
planner: only change the incorrect comments for the heuristic rule of unique index

### DIFF
--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -360,7 +360,8 @@ func (ds *DataSource) derivePathStatsAndTryHeuristics() error {
 			uniqueIdxAccessCols = append(uniqueIdxAccessCols, uniqueIdx.GetCol2LenFromAccessConds(ds.SCtx()))
 			// Find the unique index with the minimal number of ranges as `uniqueBest`.
 			/*
-				If the range is same but one of unique index can match all of where predicates, it will better than current unique index.
+				If the number of scan ranges are equal, choose the one with the least table predicates - meaning the unique index with the most index predicates.
+				Because the most index predicates means that it is more likely to fetch 0 index rows.
 				Example in the test "TestPointgetIndexChoosen".
 			*/
 			if uniqueBest == nil || len(uniqueIdx.Ranges) < len(uniqueBest.Ranges) ||


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50184 

Problem Summary:

### What changed and how does it work?

Just change the code comments

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
