### PR TITLE
ddl: refine duplicate entry err msg when merging temp index

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -120,6 +120,7 @@ go_library(
         "//pkg/statistics/handle/util",
         "//pkg/store/copr",
         "//pkg/store/driver/backoff",
+        "//pkg/store/driver/txn",
         "//pkg/store/helper",
         "//pkg/table",
         "//pkg/table/tables",

--- a/pkg/ddl/index_merge_tmp.go
+++ b/pkg/ddl/index_merge_tmp.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/parser/model"
+	driver "github.com/pingcap/tidb/pkg/store/driver/txn"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/tablecodec"
@@ -53,6 +54,9 @@ func (w *mergeIndexWorker) batchCheckTemporaryUniqueKey(
 			// Found a value in the original index key.
 			err := checkTempIndexKey(txn, idxRecords[i], val, w.table)
 			if err != nil {
+				if kv.ErrKeyExists.Equal(err) {
+					return driver.ExtractKeyExistsErrFromIndex(key, val, w.table.Meta(), idxInfo.ID)
+				}
 				return errors.Trace(err)
 			}
 		} else if idxRecords[i].distinct {

--- a/pkg/ddl/ingest/BUILD.bazel
+++ b/pkg/ddl/ingest/BUILD.bazel
@@ -66,7 +66,7 @@ go_test(
     embed = [":ingest"],
     flaky = True,
     race = "on",
-    shard_count = 15,
+    shard_count = 16,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/ddl/ingest/mock.go
+++ b/pkg/ddl/ingest/mock.go
@@ -229,7 +229,14 @@ func (m *MockWriter) WriteRow(_ context.Context, key, idxVal []byte, _ kv.Handle
 	if err != nil {
 		return err
 	}
-	return txn.Set(key, idxVal)
+	err = txn.Set(key, idxVal)
+	if err != nil {
+		return err
+	}
+	if MockExecAfterWriteRow != nil {
+		MockExecAfterWriteRow()
+	}
+	return nil
 }
 
 // LockForWrite implements Writer.LockForWrite interface.
@@ -241,3 +248,6 @@ func (*MockWriter) LockForWrite() func() {
 func (*MockWriter) Close(_ context.Context) error {
 	return nil
 }
+
+// MockExecAfterWriteRow is only used for test.
+var MockExecAfterWriteRow func()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49940

Problem Summary:

```
expected: "[kv:1062]Duplicate entry '1' for key 't.idx'"
actual  : "[kv:1062]Duplicate entry '%-.64s' for key '%-.192s'"
```

### What changed and how does it work?

As the title said.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
