### PR TITLE
expression: remove useless `HandleOverflowOnSelection`

### DIFF
--- a/pkg/store/mockstore/mockcopr/executor.go
+++ b/pkg/store/mockstore/mockcopr/executor.go
@@ -415,7 +415,6 @@ func evalBool(exprs []expression.Expression, row []types.Datum, ctx sessionctx.C
 		}
 
 		isBool, err := data.ToBool(ctx.GetSessionVars().StmtCtx.TypeCtx())
-		isBool, err = expression.HandleOverflowOnSelection(ctx.GetSessionVars().StmtCtx, isBool, err)
 		if err != nil {
 			return false, errors.Trace(err)
 		}

--- a/pkg/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/closure_exec.go
@@ -796,7 +796,6 @@ func (e *closureExecutor) processSelection(needCollectDetail bool) (gotRow bool,
 			gotRow = false
 		} else {
 			isTrue, err := d.ToBool(e.sctx.GetSessionVars().StmtCtx.TypeCtx())
-			isTrue, err = expression.HandleOverflowOnSelection(e.sctx.GetSessionVars().StmtCtx, isTrue, err)
 			if err != nil {
 				return false, errors.Trace(err)
 			}

--- a/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
@@ -1143,10 +1143,6 @@ func (e *selExec) next() (*chunk.Chunk, error) {
 					if err != nil {
 						return nil, errors.Trace(err)
 					}
-					isBool, err = expression.HandleOverflowOnSelection(e.sctx.GetSessionVars().StmtCtx, isBool, err)
-					if err != nil {
-						return nil, errors.Trace(err)
-					}
 					passCheck = isBool != 0
 				}
 				if !passCheck {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50278

Problem Summary:

The function `HandleOverflowOnSelection` seems useless. It was introduced in PR #14081 to solve some bugs.

However, in PR #16014, when converting a string to bool, we use `StrToFloat` instead of `StrToInt`. `StrToFloat` does not raise overflow error and all other errors should be swallowed in `StrToFloat` when the statement is `select ..`.

We can remove `HandleOverflowOnSelection` safely now.

### What changed and how does it work?

Remove `HandleOverflowOnSelection`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > regress the old tests

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
