### PR TITLE
*: Support using  `CONNECTION_ID()` function in `EXPLAIN FOR CONNECTION` statement

### DIFF
--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -172,7 +172,7 @@ func (n *TraceStmt) Accept(v Visitor) (Node, bool) {
 	return v.Leave(n)
 }
 
-// ExplainForStmt is a statement to provite information about how is SQL statement executeing
+// ExplainForStmt is a statement to provide information about how is SQL statement executing
 // in connection #ConnectionID
 // See https://dev.mysql.com/doc/refman/5.7/en/explain.html
 type ExplainForStmt struct {
@@ -180,6 +180,7 @@ type ExplainForStmt struct {
 
 	Format       string
 	ConnectionID uint64
+	Expr         ExprNode
 }
 
 // Restore implements Node interface.
@@ -191,7 +192,13 @@ func (n *ExplainForStmt) Restore(ctx *format.RestoreCtx) error {
 	ctx.WritePlain(" ")
 	ctx.WriteKeyWord("FOR ")
 	ctx.WriteKeyWord("CONNECTION ")
-	ctx.WritePlain(strconv.FormatUint(n.ConnectionID, 10))
+	if n.Expr != nil {
+		if err := n.Expr.Restore(ctx); err != nil {
+			return errors.Trace(err)
+		}
+	} else {
+		ctx.WritePlain(strconv.FormatUint(n.ConnectionID, 10))
+	}
 	return nil
 }
 

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -5346,11 +5346,25 @@ ExplainStmt:
 			ConnectionID: getUint64FromNUM($4),
 		}
 	}
+|	ExplainSym "FOR" "CONNECTION" BuiltinFunction
+	{
+		$$ = &ast.ExplainForStmt{
+			Format:       "row",
+			Expr:         $4,
+		}
+	}
 |	ExplainSym "FORMAT" "=" stringLit "FOR" "CONNECTION" NUM
 	{
 		$$ = &ast.ExplainForStmt{
 			Format:       $4,
 			ConnectionID: getUint64FromNUM($7),
+		}
+	}
+|	ExplainSym "FORMAT" "=" stringLit "FOR" "CONNECTION" BuiltinFunction
+	{
+		$$ = &ast.ExplainForStmt{
+			Format:       $4,
+			Expr:         $7,
 		}
 	}
 |	ExplainSym "FORMAT" "=" stringLit ExplainableStmt
@@ -5365,6 +5379,13 @@ ExplainStmt:
 		$$ = &ast.ExplainForStmt{
 			Format:       $4,
 			ConnectionID: getUint64FromNUM($7),
+		}
+	}
+|	ExplainSym "FORMAT" "=" ExplainFormatType "FOR" "CONNECTION" BuiltinFunction
+	{
+		$$ = &ast.ExplainForStmt{
+			Format:       $4,
+			Expr:         $7,
 		}
 	}
 |	ExplainSym "FORMAT" "=" ExplainFormatType ExplainableStmt

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4952,6 +4952,12 @@ func (b *PlanBuilder) buildExplainPlan(targetPlan Plan, format string, explainRo
 // buildExplainFor gets *last* (maybe running or finished) query plan from connection #connection id.
 // See https://dev.mysql.com/doc/refman/8.0/en/explain-for-connection.html.
 func (b *PlanBuilder) buildExplainFor(explainFor *ast.ExplainForStmt) (Plan, error) {
+	if x, ok := explainFor.Expr.(*ast.FuncCallExpr); ok {
+		if x.FnName.L != ast.ConnectionID {
+			return nil, errors.New("Invalid operation. Please use 'EXPLAIN FOR CONNECTION [connectionID | CONNECTION_ID()]' instead")
+		}
+		explainFor.ConnectionID = b.ctx.GetSessionVars().ConnectionID
+	}
 	processInfo, ok := b.ctx.GetSessionManager().GetProcessInfo(explainFor.ConnectionID)
 	if !ok {
 		return nil, ErrNoSuchThread.GenWithStackByArgs(explainFor.ConnectionID)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

Supporting the following syntax makes it easier to retrieve the execution plan of the last SQL statement in the current session.

```sql
EXPLAIN FOR CONNECTION connection_id();
```

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support using  `CONNECTION_ID()` function in `EXPLAIN FOR CONNECTION` statement
```
