### PR TITLE
session: make TestUpgradeVersionForResumeJob faster

### DIFF
--- a/pkg/session/bootstraptest/BUILD.bazel
+++ b/pkg/session/bootstraptest/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "bootstraptest_test",
-    timeout = "moderate",
+    timeout = "short",
     srcs = [
         "bootstrap_upgrade_test.go",  #keep
         "main_test.go",

--- a/pkg/session/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/bootstraptest/bootstrap_upgrade_test.go
@@ -554,24 +554,6 @@ func TestUpgradeVersionForResumeJob(t *testing.T) {
 	ch := make(chan struct{})
 	hook := &callback.TestDDLCallback{}
 	var jobID int64
-	doOnce := true
-	hook.OnGetJobBeforeExported = func(str string) {
-		if jobID == 0 || !doOnce {
-			return
-		}
-
-		for i := 0; i < 50; i++ {
-			sql := fmt.Sprintf("admin show ddl jobs where job_id=%d or job_id=%d", jobID, jobID+1)
-			se := session.CreateSessionAndSetID(t, store)
-			rows, err := execute(context.Background(), se, sql)
-			require.NoError(t, err)
-			if len(rows) == 2 {
-				doOnce = false
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-	}
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	times := 0


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/50292

Problem Summary:
The two "add index" jobIDs are not necessarily serial in `OnGetJobBeforeExported` after https://github.com/pingcap/tidb/pull/48728.


### What changed and how does it work?
Remove the duplicated check.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
