### PR TITLE
statistics: fix missing nil check for mv index

### DIFF
--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -448,7 +448,7 @@ func (coll *HistColl) GetAnalyzeRowCount() float64 {
 func (coll *HistColl) GetScaledRealtimeAndModifyCnt(idxStats *Index) (realtimeCnt, modifyCnt int64) {
 	// In theory, we can apply this scale logic on all indexes. But currently, we only apply it on the mv index to avoid
 	// any unexpected changes caused by factors like precision difference.
-	if idxStats.Info == nil || !idxStats.Info.MVIndex || !idxStats.IsFullLoad() {
+	if idxStats == nil || idxStats.Info == nil || !idxStats.Info.MVIndex || !idxStats.IsFullLoad() {
 		return coll.RealtimeCount, coll.ModifyCount
 	}
 	analyzeRowCount := coll.GetAnalyzeRowCount()

--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -704,3 +704,13 @@ select * from t ignore index (mvi) where json_contains(j, '[]');
 j
 []
 ["abc"]
+drop table if exists t;
+create table t(a int, b json);
+insert into t value (1, '{"a":[1,2,3], "b": [2,3,4]}');
+analyze table t;
+alter table t add index ibb( (cast(b->'$.b' as signed array)) );
+explain select /*+ use_index_merge(t) */ * from t where 10 member of (b->'$.b');
+id	estRows	task	access object	operator info
+IndexMerge_7	1.00	root		type: union
+├─IndexRangeScan_5(Build)	1.00	cop[tikv]	table:t, index:ibb(cast(json_extract(`b`, _utf8mb4'$.b') as signed array))	range:[10,10], keep order:false, stats:partial[ibb:missing, b:unInitialized]
+└─TableRowIDScan_6(Probe)	1.00	cop[tikv]	table:t	keep order:false, stats:partial[ibb:missing, b:unInitialized]

--- a/tests/integrationtest/t/planner/core/indexmerge_path.test
+++ b/tests/integrationtest/t/planner/core/indexmerge_path.test
@@ -245,3 +245,11 @@ insert into t values ('[]');
 insert into t values ('["abc"]');
 select * from t use index (mvi) where json_contains(j, '[]');
 select * from t ignore index (mvi) where json_contains(j, '[]');
+
+# TestIssue50298
+drop table if exists t;
+create table t(a int, b json);
+insert into t value (1, '{"a":[1,2,3], "b": [2,3,4]}');
+analyze table t;
+alter table t add index ibb( (cast(b->'$.b' as signed array)) );
+explain select /*+ use_index_merge(t) */ * from t where 10 member of (b->'$.b');


### PR DESCRIPTION

### What problem does this PR solve?


Issue Number: close #50298

Problem Summary:

Estimation logic for mv index access path will meet panic if it's a new index without stats.

### What changed and how does it work?

Add a nil check.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
