### PR TITLE
test: use test version for realtikv test

### DIFF
--- a/br/pkg/version/build/info.go
+++ b/br/pkg/version/build/info.go
@@ -16,18 +16,21 @@ import (
 
 // Version information.
 var (
-	ReleaseVersion = getReleaseVersion()
-	BuildTS        = versioninfo.TiDBBuildTS
-	GitHash        = versioninfo.TiDBGitHash
-	GitBranch      = versioninfo.TiDBGitBranch
-	goVersion      = runtime.Version()
+	ReleaseVersion        = getReleaseVersion()
+	BuildTS               = versioninfo.TiDBBuildTS
+	GitHash               = versioninfo.TiDBGitHash
+	GitBranch             = versioninfo.TiDBGitBranch
+	goVersion             = runtime.Version()
+	ReleaseVersionForTest = "nightly-dirty"
 )
 
 func getReleaseVersion() string {
 	if mysql.TiDBReleaseVersion != "None" {
 		return mysql.TiDBReleaseVersion
 	}
-	return "v7.0.0-master"
+	// it's unreachable for normal path, only for realtikv tests
+	// we need to set the ReleaseVersion manually.
+	return ReleaseVersionForTest
 }
 
 // AppName is a name of a built binary.

--- a/br/pkg/version/version.go
+++ b/br/pkg/version/version.go
@@ -132,6 +132,9 @@ func CheckVersionForBackup(backupVersion *semver.Version) VerChecker {
 // CheckVersionForBRPiTR checks whether version of the cluster and BR-pitr itself is compatible.
 // Note: BR'version >= 6.1.0 at least in this function
 func CheckVersionForBRPiTR(s *metapb.Store, tikvVersion *semver.Version) error {
+	if build.ReleaseVersion == build.ReleaseVersionForTest {
+		return nil
+	}
 	BRVersion, err := semver.NewVersion(removeVAndHash(build.ReleaseVersion))
 	if err != nil {
 		return errors.Annotatef(berrors.ErrVersionMismatch, "%s: invalid version, please recompile using `git fetch origin --tags && make build`", err)
@@ -186,6 +189,9 @@ func CheckVersionForKeyspaceBR(_ *metapb.Store, tikvVersion *semver.Version) err
 
 // CheckVersionForBR checks whether version of the cluster and BR itself is compatible.
 func CheckVersionForBR(s *metapb.Store, tikvVersion *semver.Version) error {
+	if build.ReleaseVersion == build.ReleaseVersionForTest {
+		return nil
+	}
 	BRVersion, err := semver.NewVersion(removeVAndHash(build.ReleaseVersion))
 	if err != nil {
 		return errors.Annotatef(berrors.ErrVersionMismatch, "%s: invalid version, please recompile using `git fetch origin --tags && make build`", err)

--- a/br/pkg/version/version_test.go
+++ b/br/pkg/version/version_test.go
@@ -45,6 +45,13 @@ func TestCheckClusterVersion(t *testing.T) {
 	mock := mockPDClient{
 		Client: nil,
 	}
+	{
+		mock.getAllStores = func() []*metapb.Store {
+			return []*metapb.Store{{Version: `v5.4.2`}}
+		}
+		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBRPiTR)
+		require.NoError(t, err)
+	}
 
 	{
 		build.ReleaseVersion = "v6.2.0"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Problem Summary:

some realtikv tests need to run backup. which will run br without TiDBReleaseVersion tags makes check version failed.

### What changed and how does it work?

Usually we have to update the default value up to the major version of tikv.
This PR try to fix it totally.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
