### PR TITLE
planner: fix union index merge can merge a embedded intersection index merge with only one partial path | tidb-test=pr/2279

### DIFF
--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -705,10 +705,14 @@ func (ds *DataSource) generateMVIndexPartialPath4Or(normalPathCnt int, indexMerg
 				logutil.BgLogger().Debug("build index merge partial mv index paths failed", zap.Error(err))
 				return nil, nil, false, err
 			}
-			if isIntersection || !ok { // limitation 2
+			if !ok || len(paths) == 0 {
 				continue
 			}
-			if len(paths) == 0 {
+			// only under 2 cases we can fallthrough it.
+			// 1: the index merge only has one partial path.
+			// 2: index merge is UNION type.
+			canFallThrough := len(paths) == 1 || !isIntersection
+			if !canFallThrough {
 				continue
 			}
 			// UNION case, use the max count after access for simplicity.

--- a/tests/integrationtest/r/planner/core/casetest/index/index.result
+++ b/tests/integrationtest/r/planner/core/casetest/index/index.result
@@ -797,3 +797,18 @@ a	b	c	d
 1	111	1.1000000000	11
 3	333	3.3000000000	13
 set tidb_enable_clustered_index=default;
+drop table if exists t;
+create table t(item_primary_key varbinary(255) NOT NULL, domains json null, image_signatures json null, canonical_links json null, feed_profile_ids json null,  KEY `domains` ((cast(`domains` as char(253) array))), KEY `image_signatures` ((cast(`image_signatures` as char(32) array))),KEY `canonical_links` ((cast(`canonical_links` as char(1000) array))), KEY `feed_profile_ids` ((cast(`feed_profile_ids` as unsigned array))));
+explain SELECT   item_primary_key FROM  t WHERE   "B2c32" member of (domains)   OR "2eoqyp6399" member of (image_signatures)   OR "E33EAdAc2Bee.com/s/link" member of (canonical_links)   OR json_contains(feed_profile_ids, '[69236881]') LIMIT   10;
+id	estRows	task	access object	operator info
+Projection_24	10.00	root		planner__core__casetest__index__index.t.item_primary_key
+└─IndexMerge_23	10.00	root		type: union, limit embedded(offset:0, count:10)
+  ├─Limit_19(Build)	2.50	cop[tikv]		offset:0, count:10
+  │ └─IndexRangeScan_14	2.50	cop[tikv]	table:t, index:domains(cast(`domains` as char(253) array))	range:["B2c32","B2c32"], keep order:false, stats:pseudo
+  ├─Limit_20(Build)	2.50	cop[tikv]		offset:0, count:10
+  │ └─IndexRangeScan_15	2.50	cop[tikv]	table:t, index:image_signatures(cast(`image_signatures` as char(32) array))	range:["2eoqyp6399","2eoqyp6399"], keep order:false, stats:pseudo
+  ├─Limit_21(Build)	2.50	cop[tikv]		offset:0, count:10
+  │ └─IndexRangeScan_16	2.50	cop[tikv]	table:t, index:canonical_links(cast(`canonical_links` as char(1000) array))	range:["E33EAdAc2Bee.com/s/link","E33EAdAc2Bee.com/s/link"], keep order:false, stats:pseudo
+  ├─Limit_22(Build)	2.50	cop[tikv]		offset:0, count:10
+  │ └─IndexRangeScan_17	2.50	cop[tikv]	table:t, index:feed_profile_ids(cast(`feed_profile_ids` as unsigned array))	range:[69236881,69236881], keep order:false, stats:pseudo
+  └─TableRowIDScan_18(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/planner/core/casetest/index/index.test
+++ b/tests/integrationtest/t/planner/core/casetest/index/index.test
@@ -29,7 +29,6 @@ explain select /*+ use_index_merge(t2, idx2, idx) */ * from t2 where (1 member o
 explain select /*+ use_index_merge(t2, idx2, idx) */ * from t2 where (1 member of (a) and 1 member of (b) and c=3) or (3 member of (b) and c=4) or e=1; -- 8: OR index merge from multi complicated mv index (memberof), each DNF item should be strict or lax used as index partial path.;
 explain select /*+ use_index_merge(t2, idx2, idx, idx4) */ * from t2 where (1 member of (a) and 1 member of (b) and c=3) or (3 member of (b) and c=4) or d=1; -- 9: OR index merge from multi complicated mv index (memberof), each DNF item should be strict or lax used as index partial path, specify the index in index merge hint;
 
-
 # TestIndexMergeFromComposedCNFCondition
 drop table if exists t1, t2;
 create table t1(pk int primary key, a json, b json, c int, d int, index idx((cast(a as signed array))), index idx2((cast(b as signed array))));
@@ -273,3 +272,9 @@ explain format='brief' select /*+ use_index_merge(t1 primary, c) */ * from t1 wh
 --sorted_result
 select /*+ use_index_merge(t1 primary, c) */ * from t1 where t1.a = 1 and t1.b = '111' or t1.c = 3.3;
 set tidb_enable_clustered_index=default;
+
+# TestIndexMergeIssue50265
+drop table if exists t;
+create table t(item_primary_key varbinary(255) NOT NULL, domains json null, image_signatures json null, canonical_links json null, feed_profile_ids json null,  KEY `domains` ((cast(`domains` as char(253) array))), KEY `image_signatures` ((cast(`image_signatures` as char(32) array))),KEY `canonical_links` ((cast(`canonical_links` as char(1000) array))), KEY `feed_profile_ids` ((cast(`feed_profile_ids` as unsigned array))));
+explain SELECT   item_primary_key FROM  t WHERE   "B2c32" member of (domains)   OR "2eoqyp6399" member of (image_signatures)   OR "E33EAdAc2Bee.com/s/link" member of (canonical_links)   OR json_contains(feed_profile_ids, '[69236881]') LIMIT   10;
+


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/50265

Problem Summary:

### What changed and how does it work?
where
member of(ja)
OR
member of(jb)
OR
member of(jc)
OR
json_contains(jd, [1,2,3])

since json_contains is an intersection index merge itself
for normal cases, we can generate an index merge like the below:
```
IndexMerge(UNION)
     mv-index-path(ja)
     mv-index-path(jb)
     mv-index-path(jc)
     IndexMerge(jd)
          mv-index-path(jd, 1)
          mv-index-path(jd, 2)
          mv-index-path(jd, 3)
````

currently, embedded index merge is banned, for for IndexMerge(jd), if it only have 1 partial path, we can just simply merge it with outer UNION type index merge.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix union index can merge a embedded intersection index merge with only one partial path
```
