### PR TITLE
executor: fix select wrong partition for hash partition table

### DIFF
--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -199,9 +199,9 @@ func (s *partitionProcessor) getUsedHashPartitions(ctx sessionctx.Context,
 
 				// if range is less than the number of partitions, there will be unused partitions we can prune out.
 				if rangeScalar < uint64(numPartitions) && !highIsNull && !lowIsNull {
-					var i, idx int64
+					var i int64
 					for i = 0; i <= int64(rangeScalar); i++ {
-						idx = mathutil.Abs((posLow+i) % int64(numPartitions))
+						idx := mathutil.Abs((posLow+i) % int64(numPartitions))
 						if len(partitionNames) > 0 && !s.findByName(partitionNames, pi.Definitions[idx].Name.L) {
 							continue
 						}

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -201,11 +201,7 @@ func (s *partitionProcessor) getUsedHashPartitions(ctx sessionctx.Context,
 				if rangeScalar < uint64(numPartitions) && !highIsNull && !lowIsNull {
 					var i, idx int64
 					for i = 0; i <= int64(rangeScalar); i++ {
-						if mysql.HasUnsignedFlag(col.RetType.GetFlag()) {
-							idx = int64(uint64(posLow+i) % uint64(numPartitions))
-						} else {
-							idx = mathutil.Abs(posLow+i) % int64(numPartitions)
-						}
+						idx = mathutil.Abs((posLow+i) % int64(numPartitions))
 						if len(partitionNames) > 0 && !s.findByName(partitionNames, pi.Definitions[idx].Name.L) {
 							continue
 						}

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -201,7 +201,7 @@ func (s *partitionProcessor) getUsedHashPartitions(ctx sessionctx.Context,
 				if rangeScalar < uint64(numPartitions) && !highIsNull && !lowIsNull {
 					var i int64
 					for i = 0; i <= int64(rangeScalar); i++ {
-						idx := mathutil.Abs((posLow+i) % int64(numPartitions))
+						idx := mathutil.Abs((posLow + i) % int64(numPartitions))
 						if len(partitionNames) > 0 && !s.findByName(partitionNames, pi.Definitions[idx].Name.L) {
 							continue
 						}

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -181,14 +181,12 @@ func (s *partitionProcessor) getUsedHashPartitions(ctx sessionctx.Context,
 				}
 
 				var rangeScalar uint64
-				var offset int64
 				if mysql.HasUnsignedFlag(col.RetType.GetFlag()) {
 					// Avoid integer overflow
 					if uint64(posHigh) < uint64(posLow) {
 						rangeScalar = 0
 					} else {
 						rangeScalar = uint64(posHigh) - uint64(posLow)
-						offset = int64(uint64(posLow) % uint64(numPartitions))
 					}
 				} else {
 					// Avoid integer overflow
@@ -196,15 +194,18 @@ func (s *partitionProcessor) getUsedHashPartitions(ctx sessionctx.Context,
 						rangeScalar = 0
 					} else {
 						rangeScalar = uint64(posHigh - posLow)
-						offset = posLow % int64(numPartitions)
 					}
 				}
 
 				// if range is less than the number of partitions, there will be unused partitions we can prune out.
 				if rangeScalar < uint64(numPartitions) && !highIsNull && !lowIsNull {
-					var i int64
+					var i, idx int64
 					for i = 0; i <= int64(rangeScalar); i++ {
-						idx := mathutil.Abs(offset+i) % int64(numPartitions)
+						if mysql.HasUnsignedFlag(col.RetType.GetFlag()) {
+							idx = int64(uint64(posLow+i) % uint64(numPartitions))
+						} else {
+							idx = mathutil.Abs(posLow+i) % int64(numPartitions)
+						}
 						if len(partitionNames) > 0 && !s.findByName(partitionNames, pi.Definitions[idx].Name.L) {
 							continue
 						}

--- a/tests/integrationtest/r/executor/partition/issues.result
+++ b/tests/integrationtest/r/executor/partition/issues.result
@@ -465,7 +465,7 @@ CREATE TABLE `t` (
 PRIMARY KEY (`col_51`) /*T![clustered_index] CLUSTERED */
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 PARTITION BY HASH (`col_51`) PARTITIONS 5;
-insert into t values (9223372036854775807), (9223372036854775808), (9223372036854775809);
+insert into t values (9223372036854775807), (9223372036854775808), (9223372036854775809), (9223372036854775812), (9223372036854775813);
 analyze table t;
 desc SELECT * FROM `t` WHERE `t`.`col_51` BETWEEN 9223372036854775807 AND 9223372036854775808;
 id	estRows	task	access object	operator info
@@ -475,6 +475,14 @@ SELECT * FROM `t` WHERE `t`.`col_51` BETWEEN 9223372036854775807 AND 92233720368
 col_51
 9223372036854775807
 9223372036854775808
+explain select * from t where col_51 between 9223372036854775812 and 9223372036854775813;
+id	estRows	task	access object	operator info
+TableReader_6	2.00	root	partition:p3,p4	data:TableRangeScan_5
+└─TableRangeScan_5	2.00	cop[tikv]	table:t	range:[9223372036854775812,9223372036854775813], keep order:false
+select * from t where col_51 between 9223372036854775812 and 9223372036854775813;
+col_51
+9223372036854775812
+9223372036854775813
 drop table if exists t;
 CREATE TABLE `t` (
 `col_51` bigint(20) NOT NULL,

--- a/tests/integrationtest/r/executor/partition/issues.result
+++ b/tests/integrationtest/r/executor/partition/issues.result
@@ -557,3 +557,11 @@ col_29
 -1
 0
 1
+explain select * from t where col_29 between -7 and -6;
+id	estRows	task	access object	operator info
+TableReader_7	1.00	root	partition:p0,p6	data:Selection_6
+└─Selection_6	1.00	cop[tikv]		ge(executor__partition__issues.t.col_29, -7), le(executor__partition__issues.t.col_29, -6)
+  └─TableFullScan_5	48.00	cop[tikv]	table:t	keep order:false
+select * from t where col_29 between -7 and -6;
+col_29
+-6

--- a/tests/integrationtest/t/executor/partition/issues.test
+++ b/tests/integrationtest/t/executor/partition/issues.test
@@ -263,11 +263,15 @@ CREATE TABLE `t` (
   PRIMARY KEY (`col_51`) /*T![clustered_index] CLUSTERED */
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 PARTITION BY HASH (`col_51`) PARTITIONS 5;
-insert into t values (9223372036854775807), (9223372036854775808), (9223372036854775809);
+insert into t values (9223372036854775807), (9223372036854775808), (9223372036854775809), (9223372036854775812), (9223372036854775813);
 analyze table t;
 desc SELECT * FROM `t` WHERE `t`.`col_51` BETWEEN 9223372036854775807 AND 9223372036854775808;
 --sorted_result
 SELECT * FROM `t` WHERE `t`.`col_51` BETWEEN 9223372036854775807 AND 9223372036854775808;
+
+explain select * from t where col_51 between 9223372036854775812 and 9223372036854775813;
+--sorted_result
+select * from t where col_51 between 9223372036854775812 and 9223372036854775813;
 
 drop table if exists t;
 CREATE TABLE `t` (
@@ -332,3 +336,4 @@ select * from t where col_29 between -2 and 1;
 explain select * from t where col_29 between -7 and -6;
 --sorted_result
 select * from t where col_29 between -7 and -6;
+

--- a/tests/integrationtest/t/executor/partition/issues.test
+++ b/tests/integrationtest/t/executor/partition/issues.test
@@ -328,3 +328,7 @@ explain select * from t where col_29 between -2 and 1;
 --sorted_result
 select * from t where col_29 between -2 and 1;
 
+# TestIssue50427
+explain select * from t where col_29 between -7 and -6;
+--sorted_result
+select * from t where col_29 between -7 and -6;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50427

Problem Summary: Still caused by https://github.com/pingcap/tidb/pull/49853, I made a mistake about mathutil.Abs and select a wrong partiton for hash partition table.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
