### PR TITLE
test: fix flaky dispatch loop

### DIFF
--- a/pkg/disttask/framework/scheduler/scheduler_test.go
+++ b/pkg/disttask/framework/scheduler/scheduler_test.go
@@ -496,7 +496,7 @@ func TestIsCancelledErr(t *testing.T) {
 	require.True(t, scheduler.IsCancelledErr(errors.New("cancelled by user")))
 }
 
-func TestManagerDispatchLoop(t *testing.T) {
+func TestManagerScheduleLoop(t *testing.T) {
 	// Mock 16 cpu node.
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", "return(16)"))
 	t.Cleanup(func() {

--- a/pkg/disttask/framework/scheduler/scheduler_test.go
+++ b/pkg/disttask/framework/scheduler/scheduler_test.go
@@ -527,6 +527,9 @@ func TestManagerScheduleLoop(t *testing.T) {
 	}
 	concurrencies := []int{4, 6, 16, 2, 4, 4}
 	waitChannels := make(map[string](chan struct{}))
+	for i := 0; i < len(concurrencies); i++ {
+		waitChannels[fmt.Sprintf("key/%d", i)] = make(chan struct{})
+	}
 	scheduler.RegisterSchedulerFactory(proto.TaskTypeExample,
 		func(ctx context.Context, task *proto.Task, param scheduler.Param) scheduler.Scheduler {
 			mockScheduler = mock.NewMockScheduler(ctrl)
@@ -550,10 +553,8 @@ func TestManagerScheduleLoop(t *testing.T) {
 						proto.TaskStateSucceed, proto.StepDone, task.ID)
 					return err
 				}))
-
 			})
 			mockScheduler.EXPECT().Close()
-			waitChannels[task.Key] = make(chan struct{})
 			return mockScheduler
 		},
 	)

--- a/pkg/disttask/framework/scheduler/scheduler_test.go
+++ b/pkg/disttask/framework/scheduler/scheduler_test.go
@@ -535,6 +535,9 @@ func TestManagerDispatchLoop(t *testing.T) {
 	scheduler.RegisterSchedulerFactory(proto.TaskTypeExample,
 		func(ctx context.Context, task *proto.Task, param scheduler.Param) scheduler.Scheduler {
 			idx := counter.Load()
+			if int(idx) > len(concurrencies) {
+				return nil
+			}
 			mockScheduler = mock.NewMockScheduler(ctrl)
 			// below 2 are for balancer loop, it's async, cannot determine how
 			// many times it will be called.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50409

Problem Summary:

### What changed and how does it work?
Don't start scheduler if it start time(counter) > len(concurrencies)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
