### PR TITLE
expression: provide `BuildExprWithAst` to build expression without planner context

### DIFF
--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -52,6 +52,47 @@ var EvalAstExpr func(sctx sessionctx.Context, expr ast.ExprNode) (types.Datum, e
 // import expression and planner/core together to use EvalAstExpr
 var RewriteAstExpr func(sctx sessionctx.Context, expr ast.ExprNode, schema *Schema, names types.NameSlice, allowCastArray bool) (Expression, error)
 
+// BuildOptions is used to provide optional settings to build an expression
+type BuildOptions struct {
+	// InputSchema is the input schema for expression to build
+	InputSchema *Schema
+	// InputNames is the input names for expression to build
+	InputNames types.NameSlice
+	// SourceTable is used to provide some extra column info.
+	SourceTable *model.TableInfo
+	// AllowCastArray specifies whether to allow casting to an array type.
+	AllowCastArray bool
+}
+
+// BuildOption is a function to apply optional settings
+type BuildOption func(*BuildOptions)
+
+// WithSourceTable specifies the table info to provide some extra column info when building expressions.
+// When `WithInputSchemaAndNames` is not sepecified, it also use the table info to build input schema and names.
+func WithSourceTable(tblInfo *model.TableInfo) BuildOption {
+	return func(options *BuildOptions) {
+		options.SourceTable = tblInfo
+	}
+}
+
+// WithInputSchemaAndNames specifies the input schema and names for the expression to build.
+func WithInputSchemaAndNames(schema *Schema, names types.NameSlice) BuildOption {
+	return func(options *BuildOptions) {
+		options.InputSchema = schema
+		options.InputNames = names
+	}
+}
+
+// WithAllowCastArray specifies whether to allow casting to an array type.
+func WithAllowCastArray(allow bool) BuildOption {
+	return func(options *BuildOptions) {
+		options.AllowCastArray = allow
+	}
+}
+
+// BuildExprWithAst builds an expression from an ast.
+var BuildExprWithAst func(ctx sessionctx.Context, expr ast.ExprNode, opts ...BuildOption) (Expression, error)
+
 // VecExpr contains all vectorized evaluation methods.
 type VecExpr interface {
 	// Vectorized returns if this expression supports vectorized evaluation.

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -266,6 +266,7 @@ go_test(
         "//pkg/types/parser_driver",
         "//pkg/util",
         "//pkg/util/benchdaily",
+        "//pkg/util/chunk",
         "//pkg/util/collate",
         "//pkg/util/dbterror",
         "//pkg/util/hack",

--- a/pkg/planner/core/expression_test.go
+++ b/pkg/planner/core/expression_test.go
@@ -19,12 +19,16 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
+	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/testkit/testutil"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,6 +38,28 @@ func parseExpr(t *testing.T, expr string) ast.ExprNode {
 	require.NoError(t, err)
 	stmt := st.(*ast.SelectStmt)
 	return stmt.Fields.Fields[0].Expr
+}
+
+func buildExpr(t *testing.T, ctx sessionctx.Context, exprNode interface{}, opts ...expression.BuildOption) (expression.Expression, error) {
+	var node ast.ExprNode
+	switch x := exprNode.(type) {
+	case string:
+		node = parseExpr(t, x)
+	case ast.ExprNode:
+		node = x
+	default:
+		require.FailNow(t, "invalid input type: %T", x)
+	}
+
+	return expression.BuildExprWithAst(ctx, node, opts...)
+}
+
+func buildExprAndEval(t *testing.T, ctx sessionctx.Context, exprNode interface{}) types.Datum {
+	expr, err := buildExpr(t, ctx, exprNode)
+	require.NoError(t, err)
+	val, err := expr.Eval(ctx, chunk.Row{})
+	require.NoError(t, err)
+	return val
 }
 
 type testCase struct {
@@ -51,6 +77,10 @@ func runTests(t *testing.T, tests []testCase) {
 		val, err := evalAstExpr(ctx, expr)
 		require.NoError(t, err)
 		valStr := fmt.Sprintf("%v", val.GetValue())
+		require.Equalf(t, tt.resultStr, valStr, "for %s", tt.exprStr)
+
+		val = buildExprAndEval(t, ctx, expr)
+		valStr = fmt.Sprintf("%v", val.GetValue())
 		require.Equalf(t, tt.resultStr, valStr, "for %s", tt.exprStr)
 	}
 }
@@ -102,9 +132,13 @@ func TestCaseWhen(t *testing.T) {
 	v, err := evalAstExpr(ctx, caseExpr)
 	require.NoError(t, err)
 	require.Equal(t, types.NewDatum(int64(1)), v)
+	require.Equal(t, types.NewDatum(int64(1)), buildExprAndEval(t, ctx, caseExpr))
+
 	valExpr.SetValue(4)
 	v, err = evalAstExpr(ctx, caseExpr)
 	require.NoError(t, err)
+	require.Equal(t, types.KindNull, v.Kind())
+	v = buildExprAndEval(t, ctx, caseExpr)
 	require.Equal(t, types.KindNull, v.Kind())
 }
 
@@ -125,11 +159,13 @@ func TestCast(t *testing.T) {
 	v, err := evalAstExpr(ctx, expr)
 	require.NoError(t, err)
 	require.Equal(t, types.NewDatum(int64(1)), v)
+	require.Equal(t, types.NewDatum(int64(1)), buildExprAndEval(t, ctx, expr))
 
 	f.AddFlag(mysql.UnsignedFlag)
 	v, err = evalAstExpr(ctx, expr)
 	require.NoError(t, err)
 	require.Equal(t, types.NewDatum(uint64(1)), v)
+	require.Equal(t, types.NewDatum(uint64(1)), buildExprAndEval(t, ctx, expr))
 
 	f.SetType(mysql.TypeString)
 	f.SetCharset(charset.CharsetBin)
@@ -138,6 +174,7 @@ func TestCast(t *testing.T) {
 	v, err = evalAstExpr(ctx, expr)
 	require.NoError(t, err)
 	testutil.DatumEqual(t, types.NewDatum([]byte("1")), v)
+	testutil.DatumEqual(t, types.NewDatum([]byte("1")), buildExprAndEval(t, ctx, expr))
 
 	f.SetType(mysql.TypeString)
 	f.SetCharset(charset.CharsetUTF8)
@@ -146,10 +183,13 @@ func TestCast(t *testing.T) {
 	v, err = evalAstExpr(ctx, expr)
 	require.NoError(t, err)
 	testutil.DatumEqual(t, types.NewDatum([]byte("1")), v)
+	testutil.DatumEqual(t, types.NewDatum([]byte("1")), buildExprAndEval(t, ctx, expr))
 
 	expr.Expr = ast.NewValueExpr(nil, "", "")
 	v, err = evalAstExpr(ctx, expr)
 	require.NoError(t, err)
+	require.Equal(t, types.KindNull, v.Kind())
+	v = buildExprAndEval(t, ctx, expr)
 	require.Equal(t, types.KindNull, v.Kind())
 }
 
@@ -331,4 +371,94 @@ func TestIsTruth(t *testing.T) {
 		},
 	}
 	runTests(t, tests)
+}
+
+func TestBuildExpression(t *testing.T) {
+	tbl := &model.TableInfo{
+		Columns: []*model.ColumnInfo{
+			{
+				Name:          model.NewCIStr("id"),
+				Offset:        0,
+				State:         model.StatePublic,
+				FieldType:     *types.NewFieldType(mysql.TypeString),
+				DefaultIsExpr: true,
+				DefaultValue:  "uuid()",
+			},
+			{
+				Name:      model.NewCIStr("a"),
+				Offset:    1,
+				State:     model.StatePublic,
+				FieldType: *types.NewFieldType(mysql.TypeLonglong),
+			},
+			{
+				Name:         model.NewCIStr("b"),
+				Offset:       2,
+				State:        model.StatePublic,
+				FieldType:    *types.NewFieldType(mysql.TypeLonglong),
+				DefaultValue: "123",
+			},
+		},
+	}
+
+	ctx := MockContext()
+	defer func() {
+		domain.GetDomain(ctx).StatsHandle().Close()
+	}()
+
+	cols, names, err := expression.ColumnInfos2ColumnsAndNames(ctx, model.NewCIStr(""), tbl.Name, tbl.Cols(), tbl)
+	require.NoError(t, err)
+	schema := expression.NewSchema(cols...)
+
+	// normal build
+	expr, err := buildExpr(t, ctx, "(1+a)*(3+b)", expression.WithSourceTable(tbl))
+	require.NoError(t, err)
+	val, _, err := expr.EvalInt(ctx, chunk.MutRowFromValues("", 1, 2).ToRow())
+	require.NoError(t, err)
+	require.Equal(t, int64(10), val)
+	val, _, err = expr.EvalInt(ctx, chunk.MutRowFromValues("", 3, 4).ToRow())
+	require.NoError(t, err)
+	require.Equal(t, int64(28), val)
+	expr, err = buildExpr(t, ctx, "(1+a)*(3+b)", expression.WithInputSchemaAndNames(schema, names))
+	require.NoError(t, err)
+	val, _, err = expr.EvalInt(ctx, chunk.MutRowFromValues("", 1, 2).ToRow())
+	require.NoError(t, err)
+	require.Equal(t, int64(10), val)
+
+	// build expression without enough columns
+	_, err = buildExpr(t, ctx, "1+a")
+	require.EqualError(t, err, "[planner:1054]Unknown column 'a' in 'expression'")
+	_, err = buildExpr(t, ctx, "(1+a)*(3+b+c)", expression.WithSourceTable(tbl))
+	require.EqualError(t, err, "[planner:1054]Unknown column 'c' in 'expression'")
+
+	// cast to array not supported by default
+	_, err = buildExpr(t, ctx, "cast(1 as signed array)")
+	require.EqualError(t, err, "[expression:1235]This version of TiDB doesn't yet support 'Use of CAST( .. AS .. ARRAY) outside of functional index in CREATE(non-SELECT)/ALTER TABLE or in general expressions'")
+	// use WithAllowCastArray to allow casting to array
+	expr, err = buildExpr(t, ctx, `cast(json_extract('{"a": [1, 2, 3]}', '$.a') as signed array)`, expression.WithAllowCastArray(true))
+	require.NoError(t, err)
+	j, _, err := expr.EvalJSON(ctx, chunk.Row{})
+	require.NoError(t, err)
+	require.Equal(t, types.JSONTypeCodeArray, j.TypeCode)
+	require.Equal(t, "[1, 2, 3]", j.String())
+
+	// default expr
+	expr, err = buildExpr(t, ctx, "default(id)", expression.WithSourceTable(tbl))
+	require.NoError(t, err)
+	s, _, err := expr.EvalString(ctx, chunk.MutRowFromValues("", 1, 2).ToRow())
+	require.NoError(t, err)
+	require.Equal(t, 36, len(s), s)
+
+	expr, err = buildExpr(t, ctx, "default(b)", expression.WithSourceTable(tbl))
+	require.NoError(t, err)
+	d, err := expr.Eval(ctx, chunk.MutRowFromValues("", 1, 2).ToRow())
+	require.NoError(t, err)
+	require.Equal(t, types.NewDatum(int64(123)), d)
+
+	// should report error for default expr when source table not provided
+	_, err = buildExpr(t, ctx, "default(b)", expression.WithInputSchemaAndNames(schema, names))
+	require.EqualError(t, err, "Unsupported expr *ast.DefaultExpr when source table not provided")
+
+	// subquery not supported
+	_, err = buildExpr(t, ctx, "a + (select b from t)", expression.WithSourceTable(tbl))
+	require.EqualError(t, err, "node '*ast.SubqueryExpr' is not allowed when building an expression without planner")
 }

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -1340,6 +1340,7 @@ var DefaultDisabledLogicalRulesList *atomic.Value
 func init() {
 	expression.EvalAstExpr = evalAstExpr
 	expression.RewriteAstExpr = rewriteAstExpr
+	expression.BuildExprWithAst = buildExprWithAst
 	DefaultDisabledLogicalRulesList = new(atomic.Value)
 	DefaultDisabledLogicalRulesList.Store(set.NewStringSet())
 }

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -186,7 +186,7 @@ func TestDisableFold(t *testing.T) {
 		rewriter := builder.getExpressionRewriter(context.TODO(), nil)
 		require.NotNil(t, rewriter)
 		require.Equal(t, 0, rewriter.disableFoldCounter)
-		rewrittenExpression, _, err := builder.rewriteExprNode(rewriter, expr, true)
+		rewrittenExpression, _, err := rewriteExprNode(rewriter, expr, true)
 		require.NoError(t, err)
 		require.Equal(t, 0, rewriter.disableFoldCounter)
 		builder.rewriterCounter--


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50463

### What changed and how does it work?

We provide a new function `expression.BuildExprWithAst` to build some simple expressions. Different with the exists `rewriteAstExpr`, it does not construct a plan builder when building expression. So it requires less context information than `rewriteAstExpr`.

`expression.BuildExprWithAst` is only used to build some simple expressions. When a expression contains a subquery, `BuildExprWithAst` will return an error.

In the later PRs, we should introduce `expression.BuildContext` to replace `sessionctx.Context` as the input context of `BuildExprWithAst`. So that we can build an expression outside a session without using mock context.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
