### PR TITLE
util: Cgroup monitoring and alerting

### DIFF
--- a/cmd/tidb-server/BUILD.bazel
+++ b/cmd/tidb-server/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/store/mockstore",
         "//pkg/tidb-binlog/pump_client",
         "//pkg/util",
+        "//pkg/util/cgmon",
         "//pkg/util/chunk",
         "//pkg/util/cpuprofile",
         "//pkg/util/deadlockhistory",

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -375,6 +375,7 @@ func setCPUAffinity() {
 		os.Exit(1)
 	}
 	if len(cpu) < runtime.GOMAXPROCS(0) {
+		log.Info("cpu number less than maxprocs", zap.Int("cpu number ", len(cpu)), zap.Int("maxprocs", runtime.GOMAXPROCS(0)))
 		runtime.GOMAXPROCS(len(cpu))
 	}
 }

--- a/pkg/metrics/alertmanager/tidb.rules.yml
+++ b/pkg/metrics/alertmanager/tidb.rules.yml
@@ -170,3 +170,27 @@ groups:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'
       summary: TiDB server has been restarted
+
+  - alert: TiDB_cpu_quota
+    expr:  irate(process_cpu_seconds_total{job="tidb"}[30s]) / tidb_server_maxprocs > 0.8
+    for: 45s
+    labels:
+      env: ENV_LABELS_ENV
+      level: warning
+      expr: irate(process_cpu_seconds_total{job="tidb"}[30s]) / tidb_server_maxprocs > 0.8
+    annotations:
+      description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
+      value: '{{ $value }}'
+      summary: TiDB CPU usage is over 80% of CPU quota
+
+  - alert: TiDB_memory_quota
+    expr:  process_resident_memory_bytes{job="tidb"} / tidb_server_memory_quota_bytes > 0.8
+    for: 15s
+    labels:
+      env: ENV_LABELS_ENV
+      level: warning
+      expr: process_resident_memory_bytes{job="tidb"} / tidb_server_memory_quota_bytes > 0.8
+    annotations:
+      description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
+      value: '{{ $value }}'
+      summary: TiDB memory usage is over 80% of memory quota

--- a/pkg/metrics/grafana/overview.json
+++ b/pkg/metrics/grafana/overview.json
@@ -2413,6 +2413,14 @@
               "legendFormat": "HeapInuse-{{instance}}",
               "refId": "B",
               "step": 10
+            },
+            {
+              "expr": "tidb_server_memory_quota_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=\"tidb\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "quota-{{instance}}",
+              "refId": "C",
+              "step": 10
             }
           ],
           "thresholds": [],

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -2439,7 +2439,7 @@
             },
             {
               "expr": "tidb_server_maxprocs{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"}",
-              "legendFormat": "limit-{{instance}}",
+              "legendFormat": "quota-{{instance}}",
               "refId": "B"
             }
           ],
@@ -2606,6 +2606,13 @@
               "intervalFactor": 1,
               "legendFormat": "{{module}}-{{instance}}",
               "refId": "I"
+            },
+            {
+              "expr": "tidb_server_memory_quota_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "quota-{{instance}}",
+              "refId": "J"
             }
           ],
           "thresholds": [],
@@ -18833,7 +18840,7 @@
             },
             {
               "expr": "tidb_server_maxprocs{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"}",
-              "legendFormat": "limit-{{instance}}",
+              "legendFormat": "quota-{{instance}}",
               "refId": "B"
             }
           ],

--- a/pkg/metrics/grafana/tidb_runtime.json
+++ b/pkg/metrics/grafana/tidb_runtime.json
@@ -196,6 +196,14 @@
               "intervalFactor": 1,
               "legendFormat": "gc",
               "refId": "F"
+            },
+            {
+              "expr": "tidb_server_memory_quota_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "quota",
+              "refId": "G"
             }
           ],
           "thresholds": [],
@@ -316,7 +324,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "limit",
+              "legendFormat": "quota",
               "refId": "B"
             }
           ],

--- a/pkg/metrics/grafana/tidb_summary.json
+++ b/pkg/metrics/grafana/tidb_summary.json
@@ -258,7 +258,14 @@
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}}",
                      "refId": "A"
-                  }
+                  },
+                  {
+                     "expr": "tidb_server_maxprocs{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "quota-{{instance}}",
+                     "refId": "B"
+                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
@@ -351,7 +358,14 @@
                      "intervalFactor": 2,
                      "legendFormat": "HeapInuse-{{instance}}",
                      "refId": "B"
-                  }
+                  },
+                  {
+                     "expr": "tidb_server_memory_quota_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tidb\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "quota-{{instance}}",
+                     "refId": "C"
+                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -249,6 +249,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(RegionCheckpointSubscriptionEvent)
 	prometheus.MustRegister(RCCheckTSWriteConfilictCounter)
 	prometheus.MustRegister(FairLockingUsageCount)
+	prometheus.MustRegister(MemoryLimit)
 
 	prometheus.MustRegister(TTLQueryDuration)
 	prometheus.MustRegister(TTLProcessedExpiredRowsCounter)

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -70,6 +70,7 @@ var (
 	CPUProfileCounter               prometheus.Counter
 	LoadTableCacheDurationHistogram prometheus.Histogram
 	RCCheckTSWriteConfilictCounter  *prometheus.CounterVec
+	MemoryLimit                     prometheus.Gauge
 )
 
 // InitServerMetrics initializes server metrics.
@@ -373,6 +374,14 @@ func InitServerMetrics() {
 			Name:      "rc_check_ts_conflict_total",
 			Help:      "Counter of WriteConflict caused by RCCheckTS.",
 		}, []string{LblType})
+
+	MemoryLimit = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "memory_quota_bytes",
+			Help:      "The value of memory quota bytes.",
+		})
 }
 
 // ExecuteErrorToLabel converts an execute error to label.

--- a/pkg/util/cgmon/BUILD.bazel
+++ b/pkg/util/cgmon/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "cgmon",
+    srcs = ["cgmon.go"],
+    importpath = "github.com/pingcap/tidb/pkg/util/cgmon",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/metrics",
+        "//pkg/util",
+        "//pkg/util/cgroup",
+        "@com_github_pingcap_log//:log",
+        "@com_github_shirou_gopsutil_v3//mem",
+        "@org_uber_go_zap//:zap",
+    ],
+)

--- a/pkg/util/cgmon/cgmon.go
+++ b/pkg/util/cgmon/cgmon.go
@@ -62,10 +62,10 @@ func StopCgroupMonitor() {
 func refreshCgroupLoop() {
 	ticker := time.NewTicker(refreshInterval)
 	defer func() {
-		util.Recover("cgmon", "refreshCgroupLoop", nil, false)
 		wg.Done()
 		ticker.Stop()
 	}()
+	defer util.Recover("cgmon", "refreshCgroupLoop", nil, false)
 
 	refreshCgroupCPU()
 	refreshCgroupMemory()

--- a/pkg/util/cgmon/cgmon.go
+++ b/pkg/util/cgmon/cgmon.go
@@ -1,3 +1,17 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cgmon
 
 import (

--- a/pkg/util/cgmon/cgmon.go
+++ b/pkg/util/cgmon/cgmon.go
@@ -16,7 +16,6 @@ package cgmon
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"runtime"
 	"sync"
@@ -113,11 +112,11 @@ func refreshCgroupCPU() {
 
 	if quota != lastMaxProcs && quota < cfgMaxProcs {
 		runtime.GOMAXPROCS(quota)
-		log.Info(fmt.Sprintf("maxprocs set to %v", quota))
+		log.Info("set the maxprocs", zap.Int("quota", quota))
 		metrics.MaxProcs.Set(float64(quota))
 		lastMaxProcs = quota
 	} else if lastMaxProcs == 0 {
-		log.Info(fmt.Sprintf("maxprocs set to %v", cfgMaxProcs))
+		log.Info("set the maxprocs", zap.Int("cfgMaxProcs", cfgMaxProcs))
 		metrics.MaxProcs.Set(float64(cfgMaxProcs))
 		lastMaxProcs = cfgMaxProcs
 	}
@@ -138,7 +137,7 @@ func refreshCgroupMemory() {
 		memLimit = vmem.Total
 	}
 	if memLimit != lastMemoryLimit {
-		log.Info(fmt.Sprintf("memory limit set to %v", memLimit))
+		log.Info("set the memory limit", zap.Uint64("memLimit", memLimit))
 		metrics.MemoryLimit.Set(float64(memLimit))
 		lastMemoryLimit = memLimit
 	}

--- a/pkg/util/cgmon/cgmon.go
+++ b/pkg/util/cgmon/cgmon.go
@@ -1,0 +1,131 @@
+package cgmon
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/metrics"
+	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/cgroup"
+	"github.com/shirou/gopsutil/v3/mem"
+	"go.uber.org/zap"
+)
+
+const (
+	refreshInterval = 10 * time.Second
+)
+
+var (
+	started         bool
+	ctx             context.Context
+	cancel          context.CancelFunc
+	wg              sync.WaitGroup
+	cfgMaxProcs     int
+	lastMaxProcs    int
+	lastMemoryLimit uint64
+)
+
+// StartCgroupMonitor uses to start the cgroup monitoring.
+// WARN: this function is not thread-safe.
+func StartCgroupMonitor() {
+	if started {
+		return
+	}
+	started = true
+	// Get configured maxprocs.
+	cfgMaxProcs = runtime.GOMAXPROCS(0)
+	ctx, cancel = context.WithCancel(context.Background())
+	wg.Add(1)
+	go refreshCgroupLoop()
+	log.Info("cgroup monitor started")
+}
+
+// StopCgroupMonitor uses to stop the cgroup monitoring.
+// WARN: this function is not thread-safe.
+func StopCgroupMonitor() {
+	if !started {
+		return
+	}
+	started = false
+	if cancel != nil {
+		cancel()
+	}
+	wg.Wait()
+	log.Info("cgroup monitor stopped")
+}
+
+func refreshCgroupLoop() {
+	ticker := time.NewTicker(refreshInterval)
+	defer func() {
+		util.Recover("cgmon", "refreshCgroupLoop", nil, false)
+		wg.Done()
+		ticker.Stop()
+	}()
+
+	refreshCgroupCPU()
+	refreshCgroupMemory()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			refreshCgroupCPU()
+			refreshCgroupMemory()
+		}
+	}
+}
+
+func refreshCgroupCPU() {
+	// Get the number of CPUs.
+	quota := runtime.NumCPU()
+
+	// Get CPU quota from cgroup.
+	cpuPeriod, cpuQuota, err := cgroup.GetCPUPeriodAndQuota()
+	if err != nil {
+		log.Warn("failed to get cgroup cpu quota", zap.Error(err))
+		return
+	}
+	if cpuPeriod > 0 && cpuQuota > 0 {
+		ratio := float64(cpuQuota) / float64(cpuPeriod)
+		if ratio < float64(quota) {
+			quota = int(math.Ceil(ratio))
+		}
+	}
+
+	if quota != lastMaxProcs && quota < cfgMaxProcs {
+		runtime.GOMAXPROCS(quota)
+		log.Info(fmt.Sprintf("maxprocs set to %v", quota))
+		metrics.MaxProcs.Set(float64(quota))
+		lastMaxProcs = quota
+	} else if lastMaxProcs == 0 {
+		log.Info(fmt.Sprintf("maxprocs set to %v", cfgMaxProcs))
+		metrics.MaxProcs.Set(float64(cfgMaxProcs))
+		lastMaxProcs = cfgMaxProcs
+	}
+}
+
+func refreshCgroupMemory() {
+	memLimit, err := cgroup.GetMemoryLimit()
+	if err != nil {
+		log.Warn("failed to get cgroup memory limit", zap.Error(err))
+		return
+	}
+	vmem, err := mem.VirtualMemory()
+	if err != nil {
+		log.Warn("failed to get system memory size", zap.Error(err))
+		return
+	}
+	if memLimit > vmem.Total {
+		memLimit = vmem.Total
+	}
+	if memLimit != lastMemoryLimit {
+		log.Info(fmt.Sprintf("memory limit set to %v", memLimit))
+		metrics.MemoryLimit.Set(float64(memLimit))
+		lastMemoryLimit = memLimit
+	}
+}

--- a/pkg/util/cgroup/cgroup.go
+++ b/pkg/util/cgroup/cgroup.go
@@ -142,7 +142,7 @@ func readFile(filepath string) (res []byte, err error) {
 	return res, err
 }
 
-// The field in /proc/self/cgroup and /proc/self/meminfo may appear as "cpuacct,cpu" or "rw,cpuacct,cpu"
+// The field in /proc/self/cgroup and /proc/self/mountinfo may appear as "cpuacct,cpu" or "rw,cpuacct,cpu"
 // while the input controller is "cpu,cpuacct"
 func controllerMatch(field string, controller string) bool {
 	if field == controller {

--- a/pkg/util/cgroup/cgroup_cpu.go
+++ b/pkg/util/cgroup/cgroup_cpu.go
@@ -88,6 +88,49 @@ func getCgroupCPU(root string) (CPUUsage, error) {
 	return res, nil
 }
 
+// Helper function for getCgroupCPUPeriodAndQuota. Root is always "/", except in tests.
+func getCgroupCPUPeriodAndQuota(root string) (period int64, quota int64, err error) {
+	path, err := detectControlPath(filepath.Join(root, procPathCGroup), "cpu")
+	if err != nil {
+		return
+	}
+
+	// No CPU controller detected
+	if path == "" {
+		err = errors.New("no cpu controller detected")
+		return
+	}
+
+	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "cpu")
+	if err != nil {
+		return
+	}
+
+	if len(mount) == 2 {
+		cgroupRootV1 := filepath.Join(root, mount[0])
+		cgroupRootV2 := filepath.Join(root, mount[1], path)
+		period, quota, err = detectCPUQuotaInV2(cgroupRootV2)
+		if err != nil {
+			period, quota, err = detectCPUQuotaInV1(cgroupRootV1)
+		}
+		if err != nil {
+			return
+		}
+	} else {
+		switch ver[0] {
+		case 1:
+			cgroupRoot := filepath.Join(root, mount[0])
+			period, quota, err = detectCPUQuotaInV1(cgroupRoot)
+		case 2:
+			cgroupRoot := filepath.Join(root, mount[0], path)
+			period, quota, err = detectCPUQuotaInV2(cgroupRoot)
+		default:
+			err = fmt.Errorf("detected unknown cgroup version index: %d", ver[0])
+		}
+	}
+	return
+}
+
 // CPUShares returns the number of CPUs this cgroup can be expected to
 // max out. If there's no limit, NumCPU is returned.
 func (c CPUUsage) CPUShares() float64 {

--- a/pkg/util/cgroup/cgroup_cpu_linux.go
+++ b/pkg/util/cgroup/cgroup_cpu_linux.go
@@ -58,7 +58,7 @@ func CPUQuotaToGOMAXPROCS(minValue int) (int, CPUQuotaStatus, error) {
 }
 
 // GetCPUPeriodAndQuota returns CPU period and quota time of cgroup.
-func GetCPUPeriodAndQuota() (int64, int64, error) {
+func GetCPUPeriodAndQuota() (period int64, quota int64, err error) {
 	return getCgroupCPUPeriodAndQuota("/")
 }
 

--- a/pkg/util/cgroup/cgroup_cpu_linux.go
+++ b/pkg/util/cgroup/cgroup_cpu_linux.go
@@ -57,6 +57,11 @@ func CPUQuotaToGOMAXPROCS(minValue int) (int, CPUQuotaStatus, error) {
 	return maxProcs, CPUQuotaUsed, nil
 }
 
+// GetCPUPeriodAndQuota returns CPU period and quota time of cgroup.
+func GetCPUPeriodAndQuota() (int64, int64, error) {
+	return getCgroupCPUPeriodAndQuota("/")
+}
+
 // InContainer returns true if the process is running in a container.
 func InContainer() bool {
 	// for cgroup V1, check /proc/self/cgroup, for V2, check /proc/self/mountinfo

--- a/pkg/util/cgroup/cgroup_cpu_unsupport.go
+++ b/pkg/util/cgroup/cgroup_cpu_unsupport.go
@@ -36,6 +36,12 @@ func GetCgroupCPU() (CPUUsage, error) {
 	return cpuUsage, nil
 }
 
+// GetCPUPeriodAndQuota returns CPU period and quota time of cgroup.
+// This is Linux-specific and not supported in the current OS.
+func GetCPUPeriodAndQuota() (period int64, quota int64, err error) {
+	return -1, -1, nil
+}
+
 // CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
 // to a valid GOMAXPROCS value. This is Linux-specific and not supported in the
 // current OS.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
There isn't yet a mechanism to monitor the cgroup cpu/memory limit and do corresponding alerting.
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50467

Problem Summary:

### What changed and how does it work?
Cgmon pkg was added to periodically watch the cgroup cpu/memory limit setting changes. GOMAXPROCS will be set to the minor one between cgroup limit and maxprocs. Metrics will be set accordingly and displayed on Grafana. New alerting rules were also added for the cpu/memory usage ratio relative to the limits.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
        Grafana display and alerting trigger
        CPU/Memory Quota will be displayed with the usage graphs as another legend like below (playground on Mac m1, no real data):
![image](https://github.com/pingcap/tidb/assets/109205475/d85536cd-c15c-45fc-8554-a62495195648)

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
