### PR TITLE
planner: fix panic when table path and mv index path are both used in access path

### DIFF
--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -714,3 +714,28 @@ id	estRows	task	access object	operator info
 IndexMerge_7	1.00	root		type: union
 ├─IndexRangeScan_5(Build)	1.00	cop[tikv]	table:t, index:ibb(cast(json_extract(`b`, _utf8mb4'$.b') as signed array))	range:[10,10], keep order:false, stats:partial[ibb:missing, b:unInitialized]
 └─TableRowIDScan_6(Probe)	1.00	cop[tikv]	table:t	keep order:false, stats:partial[ibb:missing, b:unInitialized]
+drop table if exists t, t1;
+create table t (j json, i bigint(20) not null primary key, key mvi((cast(j as unsigned array))));
+insert into t values ('[1,2,3]', 1);
+explain format=brief select * from t force index(mvi) where isnull(i) or json_contains(j, '1');
+id	estRows	task	access object	operator info
+IndexMerge	10.00	root		type: union
+├─TableFullScan(Build)	0.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:mvi(cast(`j` as unsigned array))	range:[1,1], keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select * from t force index(mvi) where isnull(i) or json_contains(j, '1');
+j	i
+[1, 2, 3]	1
+create table t1 (j json, a bigint(20), b int, primary key(a,b), key mvi((cast(j as unsigned array))));
+explain format=brief select /*+ use_index_merge(t1, mvi, primary) */ * from t1 where a = 1 or json_contains(j, '1');
+id	estRows	task	access object	operator info
+IndexMerge	19.99	root		type: union
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t1, index:PRIMARY(a, b)	range:[1,1], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t1, index:mvi(cast(`j` as unsigned array))	range:[1,1], keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	19.99	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain format=brief select /*+ use_index_merge(t1, mvi, primary) */ * from t1 where (a = 1 and b = 2) or json_contains(j, '1');
+id	estRows	task	access object	operator info
+IndexMerge	11.00	root		type: union
+├─IndexRangeScan(Build)	1.00	cop[tikv]	table:t1, index:PRIMARY(a, b)	range:[1 2,1 2], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t1, index:mvi(cast(`j` as unsigned array))	range:[1,1], keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	11.00	cop[tikv]	table:t1	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/planner/core/indexmerge_path.test
+++ b/tests/integrationtest/t/planner/core/indexmerge_path.test
@@ -253,3 +253,13 @@ insert into t value (1, '{"a":[1,2,3], "b": [2,3,4]}');
 analyze table t;
 alter table t add index ibb( (cast(b->'$.b' as signed array)) );
 explain select /*+ use_index_merge(t) */ * from t where 10 member of (b->'$.b');
+
+# TestIssue50420
+drop table if exists t, t1;
+create table t (j json, i bigint(20) not null primary key, key mvi((cast(j as unsigned array))));
+insert into t values ('[1,2,3]', 1);
+explain format=brief select * from t force index(mvi) where isnull(i) or json_contains(j, '1');
+select * from t force index(mvi) where isnull(i) or json_contains(j, '1');
+create table t1 (j json, a bigint(20), b int, primary key(a,b), key mvi((cast(j as unsigned array))));
+explain format=brief select /*+ use_index_merge(t1, mvi, primary) */ * from t1 where a = 1 or json_contains(j, '1');
+explain format=brief select /*+ use_index_merge(t1, mvi, primary) */ * from t1 where (a = 1 and b = 2) or json_contains(j, '1');


### PR DESCRIPTION

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50420

Problem Summary:

Please see the comments in the issue.

### What changed and how does it work?

Make the scaling realtime row count logic only applies to the mv index partial path.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
