### PR TITLE
restore: fix choose the emptry key as split key

### DIFF
--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -203,21 +203,15 @@ func (rs *RegionSplitter) executeSplitByRanges(
 				scanStartKey := ranges[0].StartKey
 				// if ranges is less than store count, we can't split it by range
 				if len(ranges) <= sctx.storeCount {
+					log.Info("no enouth ranges for split region, fallback to split by keys", logutil.Region(region.Region))
 					return rs.executeSplitByKeys(ectx, sctx, scanStartKey, allKeys)
 				}
-				expectSplitSize := rangeSize / uint64(sctx.storeCount)
-				size := uint64(0)
-				keys := make([][]byte, 0, sctx.storeCount)
-				for _, rg := range ranges {
-					if size >= expectSplitSize {
-						// collect enough ranges, choose this one
-						keys = append(keys, rg.EndKey)
-						log.Info("choose the split key", zap.Uint64("split size", size), logutil.Key("key", rg.EndKey))
-						size = 0
-					}
-					size += rg.Size
+				keys, expectSplitSize := ChooseSplitKeysBySize(rangeSize, sctx.storeCount, ranges)
+				if len(keys) == 0 {
+					// no need split by ranges, fallback to split by keys
+					log.Info("no keys are choosen for region, fallback to split by keys", logutil.Region(region.Region))
+					return rs.executeSplitByKeys(ectx, sctx, scanStartKey, allKeys)
 				}
-				keys = keys[:sctx.storeCount-1]
 				log.Info("get split ranges for region",
 					zap.Int("keys", len(keys)),
 					zap.Uint64("expect split size", expectSplitSize),
@@ -658,6 +652,41 @@ func (rs *RegionSplitter) WaitForScatterRegionsTimeout(ctx context.Context, regi
 	}
 
 	return len(leftRegions)
+}
+
+func ChooseSplitKeysBySize(totalSize uint64, storeCount int, ranges []rtree.Range) ([][]byte, uint64) {
+	if storeCount <= 0 {
+		return nil, 0
+	}
+	expectSplitSize := totalSize / uint64(storeCount)
+	if expectSplitSize <= 0 {
+		return nil, 0
+	}
+	size := uint64(0)
+	keys := make([][]byte, 0, storeCount)
+	cnt := 0
+	for _, rg := range ranges {
+		size += rg.Size
+		if size >= expectSplitSize {
+			// collect enough ranges, choose this one
+			cnt += 1
+			keys = append(keys, rg.EndKey)
+			log.Info("choose the split key", zap.Uint64("split size", size), logutil.Key("key", rg.EndKey))
+			size = 0
+		}
+	}
+	if cnt >= storeCount {
+		// we only use the first storeCount-1 ranges to split
+		// because we want have storeCount regions after split
+		keys = keys[:storeCount-1]
+	}
+	if cnt < storeCount {
+		// the range size are not balance
+		// in this case we should try best effort to split
+		// even not reach the storeCount
+		keys = keys[:cnt]
+	}
+	return keys, expectSplitSize
 }
 
 func mapRegionInfoSlice(regionInfos []*split.RegionInfo) map[uint64]*split.RegionInfo {

--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -209,7 +209,7 @@ func (rs *RegionSplitter) executeSplitByRanges(
 				keys, expectSplitSize := ChooseSplitKeysBySize(rangeSize, sctx.storeCount, ranges)
 				if len(keys) == 0 {
 					// no need split by ranges, fallback to split by keys
-					log.Info("no keys are choosen for region, fallback to split by keys", logutil.Region(region.Region))
+					log.Info("no keys are chosen for region, fallback to split by keys", logutil.Region(region.Region))
 					return rs.executeSplitByKeys(ectx, sctx, scanStartKey, allKeys)
 				}
 				log.Info("get split ranges for region",

--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -47,7 +47,7 @@ const (
 
 const (
 	splitRegionKeysConcurrency   = 8
-	splitRegionRangesConcurrency = 16
+	splitRegionRangesConcurrency = 32
 )
 
 type SplitContext struct {

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -727,7 +727,6 @@ func TestChooseSplitKeysBySize(t *testing.T) {
 	keys, size = restore.ChooseSplitKeysBySize(10, 100, rg.GetSortedRanges())
 	require.Len(t, keys, 0)
 	require.EqualValues(t, size, 0)
-
 }
 
 func TestNeedSplit(t *testing.T) {

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -641,6 +641,72 @@ FindRegion:
 	return true
 }
 
+func TestChooseSplitKeysBySize(t *testing.T) {
+	// case #0 store count is zero, return nil
+	keys, _ := restore.ChooseSplitKeysBySize(0, 0, nil)
+	require.Len(t, keys, 0)
+
+	// case #1 choose the first two keys as split keys
+	rg := rtree.NewRangeTree()
+	firstEndKey := []byte("2")
+	SecondEndKey := []byte("3")
+	rg.InsertRange(rtree.Range{
+		StartKey: []byte("1"),
+		EndKey:   firstEndKey,
+		Size:     3,
+	})
+	rg.InsertRange(rtree.Range{
+		StartKey: []byte("2"),
+		EndKey:   SecondEndKey,
+		Size:     3,
+	})
+	rg.InsertRange(rtree.Range{
+		StartKey: []byte("3"),
+		EndKey:   []byte("4"),
+		Size:     4,
+	})
+
+	keys, size := restore.ChooseSplitKeysBySize(10, 3, rg.GetSortedRanges())
+	require.Len(t, keys, 2)
+	require.EqualValues(t, size, 3)
+	require.ElementsMatch(t, keys, [][]byte{[]byte("2"), []byte("3")})
+
+	// case #2 choose the first key as split key, because the first range is large enough
+	rg = rtree.NewRangeTree()
+	rg.InsertRange(rtree.Range{
+		StartKey: []byte("1"),
+		EndKey:   []byte("2"),
+		Size:     8,
+	})
+	rg.InsertRange(rtree.Range{
+		StartKey: []byte("3"),
+		EndKey:   []byte("4"),
+		Size:     1,
+	})
+	rg.InsertRange(rtree.Range{
+		StartKey: []byte("4"),
+		EndKey:   []byte("5"),
+		Size:     1,
+	})
+
+	keys, size = restore.ChooseSplitKeysBySize(10, 3, rg.GetSortedRanges())
+	require.Len(t, keys, 1)
+	require.ElementsMatch(t, keys, [][]byte{[]byte("2")})
+	require.EqualValues(t, size, 3)
+
+	// case #4 too many stores, no need to split
+	rg = rtree.NewRangeTree()
+	rg.InsertRange(rtree.Range{
+		StartKey: []byte("1"),
+		EndKey:   []byte("2"),
+		Size:     8,
+	})
+	keys, size = restore.ChooseSplitKeysBySize(10, 100, rg.GetSortedRanges())
+	require.Len(t, keys, 0)
+	require.EqualValues(t, size, 0)
+
+}
+
 func TestNeedSplit(t *testing.T) {
 	testNeedSplit(t, false)
 	testNeedSplit(t, true)

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -669,19 +669,42 @@ func TestChooseSplitKeysBySize(t *testing.T) {
 	keys, size := restore.ChooseSplitKeysBySize(10, 3, rg.GetSortedRanges())
 	require.Len(t, keys, 2)
 	require.EqualValues(t, size, 3)
-	require.ElementsMatch(t, keys, [][]byte{[]byte("2"), []byte("3")})
+	require.ElementsMatch(t, keys, [][]byte{firstEndKey, SecondEndKey})
 
 	// case #2 choose the first key as split key, because the first range is large enough
 	rg = rtree.NewRangeTree()
 	rg.InsertRange(rtree.Range{
 		StartKey: []byte("1"),
-		EndKey:   []byte("2"),
+		EndKey:   firstEndKey,
 		Size:     8,
+	})
+	rg.InsertRange(rtree.Range{
+		StartKey: []byte("2"),
+		EndKey:   SecondEndKey,
+		Size:     1,
 	})
 	rg.InsertRange(rtree.Range{
 		StartKey: []byte("3"),
 		EndKey:   []byte("4"),
 		Size:     1,
+	})
+
+	keys, size = restore.ChooseSplitKeysBySize(10, 3, rg.GetSortedRanges())
+	require.Len(t, keys, 1)
+	require.ElementsMatch(t, keys, [][]byte{firstEndKey})
+	require.EqualValues(t, size, 3)
+
+	// case #3 choose the second key as split key, because the first+second range is large enough
+	rg = rtree.NewRangeTree()
+	rg.InsertRange(rtree.Range{
+		StartKey: []byte("1"),
+		EndKey:   firstEndKey,
+		Size:     1,
+	})
+	rg.InsertRange(rtree.Range{
+		StartKey: []byte("3"),
+		EndKey:   SecondEndKey,
+		Size:     8,
 	})
 	rg.InsertRange(rtree.Range{
 		StartKey: []byte("4"),
@@ -691,7 +714,7 @@ func TestChooseSplitKeysBySize(t *testing.T) {
 
 	keys, size = restore.ChooseSplitKeysBySize(10, 3, rg.GetSortedRanges())
 	require.Len(t, keys, 1)
-	require.ElementsMatch(t, keys, [][]byte{[]byte("2")})
+	require.ElementsMatch(t, keys, [][]byte{SecondEndKey})
 	require.EqualValues(t, size, 3)
 
 	// case #4 too many stores, no need to split


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/50471 https://github.com/pingcap/tidb/issues/50477

Problem Summary:
1. new split approach will choose empty key in some case. this PR tried to fix it.
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
