### PR TITLE
executor: fix the issue of coordinator.Close() taking too long

### DIFF
--- a/pkg/executor/internal/mpp/executor_with_retry.go
+++ b/pkg/executor/internal/mpp/executor_with_retry.go
@@ -131,6 +131,7 @@ func (r *ExecutorWithRetry) Next(ctx context.Context) (resp kv.ResultSubset, err
 func (r *ExecutorWithRetry) Close() error {
 	r.mppErrRecovery.ResetHolder()
 	r.memTracker.Detach()
+	// Need to close coordinator before unregister to avoid coord.Close() takes too long.
 	err := r.coord.Close()
 	mppcoordmanager.InstanceMPPCoordinatorManager.Unregister(r.getCoordUniqueID())
 	return err

--- a/pkg/executor/internal/mpp/executor_with_retry.go
+++ b/pkg/executor/internal/mpp/executor_with_retry.go
@@ -76,7 +76,6 @@ func NewExecutorWithRetry(ctx context.Context, sctx sessionctx.Context, parentTr
 	// For now, use the number of tipb.DataPacket as capacity.
 	const holdCap = 2
 
-	logutil.BgLogger().Info("gjt 1", zap.Any("now", time.Now()))
 	disaggTiFlashWithAutoScaler := config.GetGlobalConfig().DisaggregatedTiFlash && config.GetGlobalConfig().UseAutoScaler
 	_, allowTiFlashFallback := sctx.GetSessionVars().AllowFallbackToTiKV[kv.TiFlash]
 
@@ -107,44 +106,34 @@ func NewExecutorWithRetry(ctx context.Context, sctx sessionctx.Context, parentTr
 		queryID:        queryID,
 		mppErrRecovery: recoveryHandler,
 	}
-	logutil.BgLogger().Info("gjt 2", zap.Any("now", time.Now()))
 
 	var err error
 	retryer.KVRanges, err = retryer.setupMPPCoordinator(ctx, false)
-	logutil.BgLogger().Info("gjt 3", zap.Any("now", time.Now()))
 	return retryer, err
 }
 
 // Next implements kv.Response interface.
 func (r *ExecutorWithRetry) Next(ctx context.Context) (resp kv.ResultSubset, err error) {
-   logutil.BgLogger().Info("gjt next 1", zap.Any("now", time.Now()))
 	if err = r.nextWithRecovery(ctx); err != nil {
 		return nil, err
 	}
 
 	if r.mppErrRecovery.NumHoldResp() != 0 {
-	   logutil.BgLogger().Info("gjt nextWithRecovery 2", zap.Any("now", time.Now()))
 		if resp, err = r.mppErrRecovery.PopFrontResp(); err != nil {
 			return nil, err
 		}
 	} else if resp, err = r.coord.Next(ctx); err != nil {
 		return nil, err
 	}
-   logutil.BgLogger().Info("gjt next 2", zap.Any("now", time.Now()))
 	return resp, nil
 }
 
 // Close implements kv.Response interface.
 func (r *ExecutorWithRetry) Close() error {
-	logutil.BgLogger().Info("gjt close 1", zap.Any("now", time.Now()))
 	r.mppErrRecovery.ResetHolder()
-	logutil.BgLogger().Info("gjt close 2", zap.Any("now", time.Now()))
 	r.memTracker.Detach()
-	logutil.BgLogger().Info("gjt close 3", zap.Any("now", time.Now()))
 	err := r.coord.Close()
-	logutil.BgLogger().Info("gjt close 4", zap.Any("now", time.Now()))
 	mppcoordmanager.InstanceMPPCoordinatorManager.Unregister(r.getCoordUniqueID())
-	logutil.BgLogger().Info("gjt close 5", zap.Any("now", time.Now()))
 	return err
 }
 
@@ -159,7 +148,6 @@ func (r *ExecutorWithRetry) setupMPPCoordinator(ctx context.Context, recoverying
 		mppcoordmanager.InstanceMPPCoordinatorManager.Unregister(r.getCoordUniqueID())
 	}
 
-   logutil.BgLogger().Info("gjt setup coord 1", zap.Any("now", time.Now()))
 	// Make sure gatherID is updated before build coord.
 	r.gatherID = allocMPPGatherID(r.sctx)
 
@@ -167,18 +155,15 @@ func (r *ExecutorWithRetry) setupMPPCoordinator(ctx context.Context, recoverying
 	if err := mppcoordmanager.InstanceMPPCoordinatorManager.Register(r.getCoordUniqueID(), r.coord); err != nil {
 		return nil, err
 	}
-   logutil.BgLogger().Info("gjt setup coord 2", zap.Any("now", time.Now()))
 
 	_, kvRanges, err := r.coord.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
-   logutil.BgLogger().Info("gjt setup coord 3", zap.Any("now", time.Now()))
 
 	if r.nodeCnt = r.coord.GetNodeCnt(); r.nodeCnt <= 0 {
 		return nil, errors.Errorf("tiflash node count should be greater than zero: %v", r.nodeCnt)
 	}
-   logutil.BgLogger().Info("gjt setup coord 4", zap.Any("now", time.Now()))
 	return kvRanges, err
 }
 
@@ -186,7 +171,6 @@ func (r *ExecutorWithRetry) nextWithRecovery(ctx context.Context) error {
 	if !r.mppErrRecovery.Enabled() {
 		return nil
 	}
-	logutil.BgLogger().Info("gjt nextWithRecovery", zap.Any("now", time.Now()))
 
 	for r.mppErrRecovery.CanHoldResult() {
 		resp, mppErr := r.coord.Next(ctx)

--- a/pkg/executor/internal/mpp/executor_with_retry.go
+++ b/pkg/executor/internal/mpp/executor_with_retry.go
@@ -141,9 +141,9 @@ func (r *ExecutorWithRetry) Close() error {
 	logutil.BgLogger().Info("gjt close 2", zap.Any("now", time.Now()))
 	r.memTracker.Detach()
 	logutil.BgLogger().Info("gjt close 3", zap.Any("now", time.Now()))
-	mppcoordmanager.InstanceMPPCoordinatorManager.Unregister(r.getCoordUniqueID())
-	logutil.BgLogger().Info("gjt close 4", zap.Any("now", time.Now()))
 	err := r.coord.Close()
+	logutil.BgLogger().Info("gjt close 4", zap.Any("now", time.Now()))
+	mppcoordmanager.InstanceMPPCoordinatorManager.Unregister(r.getCoordUniqueID())
 	logutil.BgLogger().Info("gjt close 5", zap.Any("now", time.Now()))
 	return err
 }

--- a/pkg/executor/internal/mpp/executor_with_retry.go
+++ b/pkg/executor/internal/mpp/executor_with_retry.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -546,9 +546,6 @@ func (c *localMppCoordinator) ReportStatus(info kv.ReportStatusRequest) error {
 	}
 	executionInfo := new(tipb.TiFlashExecutionInfo)
 	err := executionInfo.Unmarshal(info.Request.GetData())
-	logutil.BgLogger().Info("gjt report status 1",
-	zap.Any("report cnt", c.reportedReqCount),
-	zap.Any("err", err))
 	if err != nil {
 		// since it is very corner case to reach here, and it won't cause forever hang due to not close reportStatusCh
 		return err

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -546,6 +546,9 @@ func (c *localMppCoordinator) ReportStatus(info kv.ReportStatusRequest) error {
 	}
 	executionInfo := new(tipb.TiFlashExecutionInfo)
 	err := executionInfo.Unmarshal(info.Request.GetData())
+	logutil.BgLogger().Info("gjt report status 1",
+	zap.Any("report cnt", c.reportedReqCount),
+	zap.Any("err", err))
 	if err != nil {
 		// since it is very corner case to reach here, and it won't cause forever hang due to not close reportStatusCh
 		return err
@@ -613,17 +616,24 @@ func (c *localMppCoordinator) IsClosed() bool {
 // Close implements MppCoordinator interface
 // TODO: Test the case that user cancels the query.
 func (c *localMppCoordinator) Close() error {
+	logutil.BgLogger().Info("gjt coord 0", zap.Any("now", time.Now()))
 	c.closeWithoutReport()
+	logutil.BgLogger().Info("gjt coord 5", zap.Any("now", time.Now()))
 	c.handleAllReports()
+	logutil.BgLogger().Info("gjt coord 6", zap.Any("now", time.Now()))
 	return nil
 }
 
 func (c *localMppCoordinator) closeWithoutReport() {
+	logutil.BgLogger().Info("gjt coord 1", zap.Any("now", time.Now()))
 	if atomic.CompareAndSwapUint32(&c.closed, 0, 1) {
 		close(c.finishCh)
 	}
+	logutil.BgLogger().Info("gjt coord 2", zap.Any("now", time.Now()))
 	c.cancelFunc()
+	logutil.BgLogger().Info("gjt coord 3", zap.Any("now", time.Now()))
 	<-c.wgDoneChan
+	logutil.BgLogger().Info("gjt coord 4", zap.Any("now", time.Now()))
 }
 
 func (c *localMppCoordinator) handleMPPStreamResponse(bo *backoff.Backoffer, response *mpp.MPPDataPacket, req *kv.MPPDispatchRequest) (err error) {

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -616,24 +616,17 @@ func (c *localMppCoordinator) IsClosed() bool {
 // Close implements MppCoordinator interface
 // TODO: Test the case that user cancels the query.
 func (c *localMppCoordinator) Close() error {
-	logutil.BgLogger().Info("gjt coord 0", zap.Any("now", time.Now()))
 	c.closeWithoutReport()
-	logutil.BgLogger().Info("gjt coord 5", zap.Any("now", time.Now()))
 	c.handleAllReports()
-	logutil.BgLogger().Info("gjt coord 6", zap.Any("now", time.Now()))
 	return nil
 }
 
 func (c *localMppCoordinator) closeWithoutReport() {
-	logutil.BgLogger().Info("gjt coord 1", zap.Any("now", time.Now()))
 	if atomic.CompareAndSwapUint32(&c.closed, 0, 1) {
 		close(c.finishCh)
 	}
-	logutil.BgLogger().Info("gjt coord 2", zap.Any("now", time.Now()))
 	c.cancelFunc()
-	logutil.BgLogger().Info("gjt coord 3", zap.Any("now", time.Now()))
 	<-c.wgDoneChan
-	logutil.BgLogger().Info("gjt coord 4", zap.Any("now", time.Now()))
 }
 
 func (c *localMppCoordinator) handleMPPStreamResponse(bo *backoff.Backoffer, response *mpp.MPPDataPacket, req *kv.MPPDispatchRequest) (err error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50493

Problem Summary:

### What changed and how does it work?
Should `close coordinator` before `unregister` it, otherwise coordinator manager cannot find it to call `ReportStatus()`, which makes `coordinator.Close()` to wait `3 seconds` to finish, check [here](https://github.com/pingcap/tidb/blob/master/pkg/executor/internal/mpp/local_mpp_coordinator.go#L597)
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Needs real tiflash to cover, and we already have a integration test in tiflash repo.

before: 
![c7c5b5a1-f485-411e-87a4-00ff29a2caaf](https://github.com/pingcap/tidb/assets/7493273/dce44082-437c-432a-80bc-cc97ef620926)

after:
![74c29e31-d6a8-468f-a21d-284cdf3b059a](https://github.com/pingcap/tidb/assets/7493273/c315609a-90ad-490e-b26f-8e0cb5fddc90)


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
