### PR TITLE
privilege: add min TLS version for LDAP

### DIFF
--- a/pkg/privilege/privileges/ldap/BUILD.bazel
+++ b/pkg/privilege/privileges/ldap/BUILD.bazel
@@ -29,5 +29,6 @@ go_test(
         "test/ldap.key",
     ],
     flaky = True,
+    shard_count = 3,
     deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/privilege/privileges/ldap/ldap_common.go
+++ b/pkg/privilege/privileges/ldap/ldap_common.go
@@ -123,6 +123,7 @@ func (impl *ldapAuthImpl) tryConnectLDAPThroughStartTLS(address string) (*ldap.C
 	err = ldapConnection.StartTLS(&tls.Config{
 		RootCAs:    impl.caPool,
 		ServerName: impl.ldapServerHost,
+		MinVersion: tls.VersionTLS12,
 	})
 	if err != nil {
 		ldapConnection.Close()
@@ -136,6 +137,7 @@ func (impl *ldapAuthImpl) tryConnectLDAPThroughTLS(address string) (*ldap.Conn, 
 	ldapConnection, err := ldap.DialTLS("tcp", address, &tls.Config{
 		RootCAs:    impl.caPool,
 		ServerName: impl.ldapServerHost,
+		MinVersion: tls.VersionTLS12,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/privilege/privileges/ldap/ldap_common_test.go
+++ b/pkg/privilege/privileges/ldap/ldap_common_test.go
@@ -108,3 +108,67 @@ func TestConnectThrough636(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 }
+
+func TestConnectWithTLS11(t *testing.T) {
+	var ln net.Listener
+
+	startListen := make(chan struct{})
+
+	// this test only tests whether the LDAP with LTS enabled will fallback from StartTLS
+	randomTLSServicePort := rand.Int()%10000 + 10000
+	serverWg := &sync.WaitGroup{}
+	serverWg.Add(1)
+	go func() {
+		defer close(startListen)
+		defer serverWg.Done()
+
+		cert, err := tls.X509KeyPair(tlsCrtStr, tlsKeyStr)
+		require.NoError(t, err)
+		tlsConfig := &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MaxVersion:   tls.VersionTLS11,
+		}
+		ln, err = tls.Listen("tcp", fmt.Sprintf("localhost:%d", randomTLSServicePort), tlsConfig)
+		require.NoError(t, err)
+		startListen <- struct{}{}
+
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				break
+			}
+
+			// handling one connection at a time is enough for test
+			func() {
+				defer func() {
+					require.NoError(t, conn.Close())
+				}()
+
+				r := bufio.NewReader(conn)
+				for {
+					_, err := r.ReadByte()
+					if err != nil {
+						break
+					}
+				}
+			}()
+		}
+	}()
+
+	<-startListen
+	defer func() {
+		require.NoError(t, ln.Close())
+		serverWg.Wait()
+	}()
+
+	impl := &ldapAuthImpl{}
+	impl.SetEnableTLS(true)
+	impl.SetLDAPServerHost("localhost")
+	impl.SetLDAPServerPort(randomTLSServicePort)
+
+	impl.caPool = x509.NewCertPool()
+	require.True(t, impl.caPool.AppendCertsFromPEM(tlsCAStr))
+
+	_, err := impl.connectionFactory()
+	require.ErrorContains(t, err, "protocol version not supported")
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #36036

Problem Summary:

### What changed and how does it work?

TLS1.0/1.1 has security issues, remove the support of them.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
remove TLS1.0, TLS1.1 support
```
