### PR TITLE
expression: wrap some read action in `EvalContext` to functions

### DIFF
--- a/pkg/expression/builtin_arithmetic_vec.go
+++ b/pkg/expression/builtin_arithmetic_vec.go
@@ -82,7 +82,7 @@ func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(ctx EvalContext, inpu
 	y := buf.Decimals()
 	var to types.MyDecimal
 	var frac int
-	sc := ctx.GetSessionVars().StmtCtx
+	ec := errCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -95,7 +95,7 @@ func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(ctx EvalContext, inpu
 			result.SetNull(i, true)
 			continue
 		} else if err == types.ErrTruncated {
-			if err = sc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", to)); err != nil {
+			if err = ec.HandleError(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", to)); err != nil {
 				return err
 			}
 		} else if err == nil {
@@ -383,7 +383,7 @@ func (b *builtinArithmeticMinusIntSig) vecEvalInt(ctx EvalContext, input *chunk.
 	rhi64s := rh.Int64s()
 	resulti64s := result.Int64s()
 
-	forceToSigned := ctx.GetSessionVars().SQLMode.HasNoUnsignedSubtractionMode()
+	forceToSigned := sqlMode(ctx).HasNoUnsignedSubtractionMode()
 	isLHSUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
 	isRHSUnsigned := mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag())
 
@@ -564,7 +564,7 @@ func (b *builtinArithmeticIntDivideDecimalSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	sc := ctx.GetSessionVars().StmtCtx
+	ec := errCtx(ctx)
 	n := input.NumRows()
 	var err error
 	var buf [2]*chunk.Column
@@ -605,10 +605,10 @@ func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(ctx EvalContext, input
 			continue
 		}
 		if err == types.ErrTruncated {
-			err = sc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
+			err = ec.HandleError(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
 		} else if err == types.ErrOverflow {
 			newErr := errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c)
-			err = sc.HandleError(newErr)
+			err = ec.HandleError(newErr)
 		}
 		if err != nil {
 			return err

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -47,11 +47,9 @@ func (b *builtinCastIntAsDurationSig) vecEvalDuration(ctx EvalContext, input *ch
 		}
 		dur, err := types.NumberToDuration(i64s[i], b.tp.GetDecimal())
 		if err != nil {
-			if types.ErrOverflow.Equal(err) {
-				err = ctx.GetSessionVars().StmtCtx.HandleError(err)
-			}
-			if types.ErrTruncatedWrongVal.Equal(err) {
-				err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+			if types.ErrOverflow.Equal(err) || types.ErrTruncatedWrongVal.Equal(err) {
+				ec := errCtx(ctx)
+				err = ec.HandleError(err)
 			}
 			if err != nil {
 				return err
@@ -217,13 +215,13 @@ func (b *builtinCastRealAsStringSig) vecEvalString(ctx EvalContext, input *chunk
 	var res string
 	f64s := buf.Float64s()
 	result.ReserveString(n)
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i, v := range f64s {
 		if buf.IsNull(i) {
 			result.AppendNull()
 			continue
 		}
-		res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(v, 'f', -1, bits), b.tp, sc.TypeCtx(), false)
+		res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(v, 'f', -1, bits), b.tp, tc, false)
 		if err != nil {
 			return err
 		}
@@ -255,7 +253,7 @@ func (b *builtinCastDecimalAsStringSig) vecEvalString(ctx EvalContext, input *ch
 		return err
 	}
 
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	vas := buf.Decimals()
 	result.ReserveString(n)
 	for i, v := range vas {
@@ -263,7 +261,7 @@ func (b *builtinCastDecimalAsStringSig) vecEvalString(ctx EvalContext, input *ch
 			result.AppendNull()
 			continue
 		}
-		res, e := types.ProduceStrWithSpecifiedTp(string(v.ToString()), b.tp, sc.TypeCtx(), false)
+		res, e := types.ProduceStrWithSpecifiedTp(string(v.ToString()), b.tp, tc, false)
 		if e != nil {
 			return e
 		}
@@ -299,7 +297,7 @@ func (b *builtinCastTimeAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 	result.MergeNulls(buf)
 	times := buf.Times()
 	decs := result.Decimals()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc, ec := typeCtx(ctx), errCtx(ctx)
 	dec := new(types.MyDecimal)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -307,8 +305,8 @@ func (b *builtinCastTimeAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 		}
 		*dec = types.MyDecimal{}
 		times[i].FillNumber(dec)
-		dec, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), dec, b.tp)
-		if err = sc.HandleError(err); err != nil {
+		dec, err = types.ProduceDecWithSpecifiedTp(tc, dec, b.tp)
+		if err = ec.HandleError(err); err != nil {
 			return err
 		}
 		decs[i] = *dec
@@ -338,6 +336,7 @@ func (b *builtinCastDurationAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.C
 	ds := buf.GoDurations()
 	fsp := b.args[0].GetType().GetDecimal()
 	isYear := b.tp.GetType() == mysql.TypeYear
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -347,10 +346,10 @@ func (b *builtinCastDurationAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.C
 		duration.Fsp = fsp
 
 		if isYear {
-			i64s[i], err = duration.ConvertToYear(ctx.GetSessionVars().StmtCtx.TypeCtx())
+			i64s[i], err = duration.ConvertToYear(tc)
 		} else {
 			var dur types.Duration
-			dur, err = duration.RoundFrac(types.DefaultFsp, ctx.GetSessionVars().Location())
+			dur, err = duration.RoundFrac(types.DefaultFsp, location(ctx))
 			if err != nil {
 				return err
 			}
@@ -383,7 +382,7 @@ func (b *builtinCastIntAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chun
 	result.MergeNulls(buf)
 	times := result.Times()
 	i64s := buf.Int64s()
-	stmt := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	fsp := b.tp.GetDecimal()
 
 	var tm types.Time
@@ -395,7 +394,7 @@ func (b *builtinCastIntAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chun
 		if b.args[0].GetType().GetType() == mysql.TypeYear {
 			tm, err = types.ParseTimeFromYear(i64s[i])
 		} else {
-			tm, err = types.ParseTimeFromNum(stmt.TypeCtx(), i64s[i], b.tp.GetType(), fsp)
+			tm, err = types.ParseTimeFromNum(tc, i64s[i], b.tp.GetType(), fsp)
 		}
 
 		if err != nil {
@@ -459,12 +458,12 @@ func (b *builtinCastJSONAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chu
 	result.ResizeFloat64(n, false)
 	result.MergeNulls(buf)
 	f64s := result.Float64s()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		f64s[i], err = types.ConvertJSONToFloat(sc.TypeCtx(), buf.GetJSON(i))
+		f64s[i], err = types.ConvertJSONToFloat(tc, buf.GetJSON(i))
 		if err != nil {
 			return err
 		}
@@ -491,7 +490,7 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 	result.MergeNulls(buf)
 	times := result.Times()
 
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	ts, err := getStmtTimestamp(ctx)
 	if err != nil {
 		ts = gotime.Now()
@@ -519,8 +518,8 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 		case types.JSONTypeCodeDuration:
 			duration := val.GetDuration()
 
-			sc := ctx.GetSessionVars().StmtCtx
-			tm, err := duration.ConvertToTimeWithTimestamp(sc.TypeCtx(), b.tp.GetType(), ts)
+			tc := typeCtx(ctx)
+			tm, err := duration.ConvertToTimeWithTimestamp(tc, b.tp.GetType(), ts)
 			if err != nil {
 				if err = handleInvalidTimeError(ctx, err); err != nil {
 					return err
@@ -528,7 +527,7 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 				result.SetNull(i, true)
 				continue
 			}
-			tm, err = tm.RoundFrac(stmtCtx.TypeCtx(), fsp)
+			tm, err = tm.RoundFrac(tc, fsp)
 			if err != nil {
 				return err
 			}
@@ -538,7 +537,7 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 			if err != nil {
 				return err
 			}
-			tm, err := types.ParseTime(stmtCtx.TypeCtx(), s, b.tp.GetType(), fsp)
+			tm, err := types.ParseTime(tc, s, b.tp.GetType(), fsp)
 			if err != nil {
 				if err = handleInvalidTimeError(ctx, err); err != nil {
 					return err
@@ -581,7 +580,7 @@ func (b *builtinCastRealAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 	result.MergeNulls(buf)
 	times := result.Times()
 	f64s := buf.Float64s()
-	stmt := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	fsp := b.tp.GetDecimal()
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
@@ -592,7 +591,7 @@ func (b *builtinCastRealAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 			times[i] = types.ZeroTime
 			continue
 		}
-		tm, err := types.ParseTimeFromFloatString(stmt.TypeCtx(), fv, b.tp.GetType(), fsp)
+		tm, err := types.ParseTimeFromFloatString(tc, fv, b.tp.GetType(), fsp)
 		if err != nil {
 			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
@@ -620,7 +619,7 @@ func (b *builtinCastDecimalAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *
 
 	n := input.NumRows()
 	decs := result.Decimals()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc, ec := typeCtx(ctx), errCtx(ctx)
 	conditionUnionAndUnsigned := b.inUnion && mysql.HasUnsignedFlag(b.tp.GetFlag())
 	dec := new(types.MyDecimal)
 	for i := 0; i < n; i++ {
@@ -631,8 +630,8 @@ func (b *builtinCastDecimalAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *
 		if !(conditionUnionAndUnsigned && decs[i].IsNegative()) {
 			*dec = decs[i]
 		}
-		dec, err := types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), dec, b.tp)
-		if err = sc.HandleError(err); err != nil {
+		dec, err := types.ProduceDecWithSpecifiedTp(tc, dec, b.tp)
+		if err = ec.HandleError(err); err != nil {
 			return err
 		}
 		decs[i] = *dec
@@ -660,7 +659,7 @@ func (b *builtinCastDurationAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk
 	var duration types.Duration
 	ds := buf.GoDurations()
 	times := result.Times()
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	ts, err := getStmtTimestamp(ctx)
 	if err != nil {
 		ts = gotime.Now()
@@ -673,7 +672,7 @@ func (b *builtinCastDurationAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk
 
 		duration.Duration = ds[i]
 		duration.Fsp = fsp
-		tm, err := duration.ConvertToTimeWithTimestamp(stmtCtx.TypeCtx(), b.tp.GetType(), ts)
+		tm, err := duration.ConvertToTimeWithTimestamp(tc, b.tp.GetType(), ts)
 		if err != nil {
 			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
@@ -681,7 +680,7 @@ func (b *builtinCastDurationAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk
 			result.SetNull(i, true)
 			continue
 		}
-		tm, err = tm.RoundFrac(stmtCtx.TypeCtx(), fsp)
+		tm, err = tm.RoundFrac(tc, fsp)
 		if err != nil {
 			return err
 		}
@@ -724,7 +723,7 @@ func (b *builtinCastIntAsStringSig) vecEvalString(ctx EvalContext, input *chunk.
 		if isYearType && str == "0" {
 			str = "0000"
 		}
-		str, err = types.ProduceStrWithSpecifiedTp(str, b.tp, ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
+		str, err = types.ProduceStrWithSpecifiedTp(str, b.tp, typeCtx(ctx), false)
 		if err != nil {
 			return err
 		}
@@ -773,12 +772,13 @@ func (b *builtinCastRealAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 			i64s[i] = 0
 		} else {
 			var uintVal uint64
-			sc := ctx.GetSessionVars().StmtCtx
-			uintVal, err = types.ConvertFloatToUint(sc.TypeFlags(), f64s[i], types.IntergerUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
+			tc := typeCtx(ctx)
+			uintVal, err = types.ConvertFloatToUint(tc.Flags(), f64s[i], types.IntergerUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
 			i64s[i] = int64(uintVal)
 		}
 		if types.ErrOverflow.Equal(err) {
-			err = ctx.GetSessionVars().StmtCtx.HandleError(err)
+			ec := errCtx(ctx)
+			err = ec.HandleError(err)
 		}
 		if err != nil {
 			return err
@@ -812,7 +812,8 @@ func (b *builtinCastTimeAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chu
 		f64, err := times[i].ToNumber().ToFloat64()
 		if err != nil {
 			if types.ErrOverflow.Equal(err) {
-				err = ctx.GetSessionVars().StmtCtx.HandleError(err)
+				ec := errCtx(ctx)
+				err = ec.HandleError(err)
 			}
 			if err != nil {
 				return err
@@ -907,7 +908,7 @@ func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 	result.MergeNulls(buf)
 	bufreal := buf.Float64s()
 	resdecimal := result.Decimals()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc, ec := typeCtx(ctx), errCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -916,7 +917,7 @@ func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 			if err = resdecimal[i].FromFloat64(bufreal[i]); err != nil {
 				if types.ErrOverflow.Equal(err) {
 					warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0])
-					err = ctx.GetSessionVars().StmtCtx.HandleErrorWithAlias(err, err, warnErr)
+					err = ec.HandleErrorWithAlias(err, err, warnErr)
 				} else if types.ErrTruncated.Equal(err) {
 					// This behavior is consistent with MySQL.
 					err = nil
@@ -926,8 +927,8 @@ func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 				}
 			}
 		}
-		dec, err := types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), &resdecimal[i], b.tp)
-		if err = sc.HandleError(err); err != nil {
+		dec, err := types.ProduceDecWithSpecifiedTp(tc, &resdecimal[i], b.tp)
+		if err = ec.HandleError(err); err != nil {
 			return err
 		}
 		resdecimal[i] = *dec
@@ -960,7 +961,7 @@ func (b *builtinCastStringAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 		return err
 	}
 	result.MergeNulls(buf)
-	typeCtx := ctx.GetSessionVars().StmtCtx.TypeCtx()
+	tc := typeCtx(ctx)
 	i64s := result.Int64s()
 	isUnsigned := mysql.HasUnsignedFlag(b.tp.GetFlag())
 	unionUnsigned := isUnsigned && b.inUnion
@@ -975,18 +976,18 @@ func (b *builtinCastStringAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 		val := strings.TrimSpace(buf.GetString(i))
 		isNegative := len(val) > 1 && val[0] == '-'
 		if !isNegative {
-			ures, err = types.StrToUint(typeCtx, val, true)
+			ures, err = types.StrToUint(tc, val, true)
 			if !isUnsigned && err == nil && ures > uint64(math.MaxInt64) {
-				typeCtx.AppendWarning(types.ErrCastAsSignedOverflow)
+				tc.AppendWarning(types.ErrCastAsSignedOverflow)
 			}
 			res = int64(ures)
 		} else if unionUnsigned {
 			res = 0
 		} else {
-			res, err = types.StrToInt(typeCtx, val, true)
+			res, err = types.StrToInt(tc, val, true)
 			if err == nil && isUnsigned {
 				// If overflow, don't append this warnings
-				typeCtx.AppendWarning(types.ErrCastNegIntAsUnsigned)
+				tc.AppendWarning(types.ErrCastNegIntAsUnsigned)
 			}
 		}
 		res, err = b.handleOverflow(ctx, res, val, err, isNegative)
@@ -1015,14 +1016,15 @@ func (b *builtinCastStringAsDurationSig) vecEvalDuration(ctx EvalContext, input 
 	result.ResizeGoDuration(n, false)
 	result.MergeNulls(buf)
 	ds := result.GoDurations()
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		dur, isNull, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), buf.GetString(i), b.tp.GetDecimal())
+		dur, isNull, err := types.ParseDuration(tc, buf.GetString(i), b.tp.GetDecimal())
 		if err != nil {
 			if types.ErrTruncatedWrongVal.Equal(err) {
-				err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+				err = tc.HandleTruncate(err)
 			}
 			if err != nil {
 				return err
@@ -1056,7 +1058,7 @@ func (b *builtinCastDurationAsDecimalSig) vecEvalDecimal(ctx EvalContext, input 
 	d64s := result.Decimals()
 	var duration types.Duration
 	ds := buf.GoDurations()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc, ec := typeCtx(ctx), errCtx(ctx)
 	fsp := b.args[0].GetType().GetDecimal()
 	if fsp, err = types.CheckFsp(fsp); err != nil {
 		return err
@@ -1067,8 +1069,8 @@ func (b *builtinCastDurationAsDecimalSig) vecEvalDecimal(ctx EvalContext, input 
 		}
 		duration.Duration = ds[i]
 		duration.Fsp = fsp
-		res, err := types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), duration.ToNumber(), b.tp)
-		if err = sc.HandleError(err); err != nil {
+		res, err := types.ProduceDecWithSpecifiedTp(tc, duration.ToNumber(), b.tp)
+		if err = ec.HandleError(err); err != nil {
 			return err
 		}
 		d64s[i] = *res
@@ -1097,7 +1099,7 @@ func (b *builtinCastIntAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chun
 	result.ResizeDecimal(n, false)
 	result.MergeNulls(buf)
 	decs := result.Decimals()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc, ec := typeCtx(ctx), errCtx(ctx)
 	dec := new(types.MyDecimal)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -1113,8 +1115,8 @@ func (b *builtinCastIntAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chun
 			dec.FromUint(uint64(nums[i]))
 		}
 
-		dec, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), dec, b.tp)
-		if err = sc.HandleError(err); err != nil {
+		dec, err = types.ProduceDecWithSpecifiedTp(tc, dec, b.tp)
+		if err = ec.HandleError(err); err != nil {
 			return err
 		}
 		decs[i] = *dec
@@ -1191,12 +1193,13 @@ func (b *builtinCastJSONAsStringSig) vecEvalString(ctx EvalContext, input *chunk
 	}
 
 	result.ReserveString(n)
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			result.AppendNull()
 			continue
 		}
-		s, err := types.ProduceStrWithSpecifiedTp(buf.GetJSON(i).String(), b.tp, ctx.GetSessionVars().StmtCtx.TypeCtx(), false)
+		s, err := types.ProduceStrWithSpecifiedTp(buf.GetJSON(i).String(), b.tp, tc, false)
 		if err != nil {
 			return err
 		}
@@ -1262,14 +1265,13 @@ func (b *builtinCastJSONAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	result.ResizeInt64(n, false)
 	result.MergeNulls(buf)
 	i64s := result.Int64s()
-	sc := ctx.GetSessionVars().StmtCtx
-	tc := sc.TypeCtx()
+	tc, ec := typeCtx(ctx), errCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		i64s[i], err = types.ConvertJSONToInt64(tc, buf.GetJSON(i), mysql.HasUnsignedFlag(b.tp.GetFlag()))
-		if err = sc.HandleError(err); err != nil {
+		if err = ec.HandleError(err); err != nil {
 			return err
 		}
 	}
@@ -1294,14 +1296,15 @@ func (b *builtinCastRealAsDurationSig) vecEvalDuration(ctx EvalContext, input *c
 	result.MergeNulls(buf)
 	f64s := buf.Float64s()
 	ds := result.GoDurations()
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		dur, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), strconv.FormatFloat(f64s[i], 'f', -1, 64), b.tp.GetDecimal())
+		dur, _, err := types.ParseDuration(tc, strconv.FormatFloat(f64s[i], 'f', -1, 64), b.tp.GetDecimal())
 		if err != nil {
 			if types.ErrTruncatedWrongVal.Equal(err) {
-				err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+				err = tc.HandleTruncate(err)
 				if err != nil {
 					return err
 				}
@@ -1342,7 +1345,7 @@ func (b *builtinCastTimeAsDurationSig) vecEvalDuration(ctx EvalContext, input *c
 		if err != nil {
 			return err
 		}
-		d, err = d.RoundFrac(b.tp.GetDecimal(), ctx.GetSessionVars().Location())
+		d, err = d.RoundFrac(b.tp.GetDecimal(), location(ctx))
 		if err != nil {
 			return err
 		}
@@ -1371,7 +1374,7 @@ func (b *builtinCastDurationAsDurationSig) vecEvalDuration(ctx EvalContext, inpu
 			continue
 		}
 		dur.Duration = v
-		rd, err = dur.RoundFrac(b.tp.GetDecimal(), ctx.GetSessionVars().Location())
+		rd, err = dur.RoundFrac(b.tp.GetDecimal(), location(ctx))
 		if err != nil {
 			return err
 		}
@@ -1397,7 +1400,7 @@ func (b *builtinCastDurationAsStringSig) vecEvalString(ctx EvalContext, input *c
 
 	var res string
 	var isNull bool
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	result.ReserveString(n)
 	fsp := b.args[0].GetType().GetDecimal()
 	for i := 0; i < n; i++ {
@@ -1405,7 +1408,7 @@ func (b *builtinCastDurationAsStringSig) vecEvalString(ctx EvalContext, input *c
 			result.AppendNull()
 			continue
 		}
-		res, err = types.ProduceStrWithSpecifiedTp(buf.GetDuration(i, fsp).String(), b.tp, sc.TypeCtx(), false)
+		res, err = types.ProduceStrWithSpecifiedTp(buf.GetDuration(i, fsp).String(), b.tp, tc, false)
 		if err != nil {
 			return err
 		}
@@ -1455,7 +1458,8 @@ func (b *builtinCastDecimalAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.
 		res, err := d[i].ToFloat64()
 		if err != nil {
 			if types.ErrOverflow.Equal(err) {
-				err = ctx.GetSessionVars().StmtCtx.HandleError(err)
+				ec := errCtx(ctx)
+				err = ec.HandleError(err)
 			}
 			if err != nil {
 				return err
@@ -1487,13 +1491,13 @@ func (b *builtinCastDecimalAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.
 	result.MergeNulls(buf)
 	times := result.Times()
 	decimals := buf.Decimals()
-	stmt := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	fsp := b.tp.GetDecimal()
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			continue
 		}
-		tm, err := types.ParseTimeFromFloatString(stmt.TypeCtx(), string(decimals[i].ToString()), b.tp.GetType(), fsp)
+		tm, err := types.ParseTimeFromFloatString(tc, string(decimals[i].ToString()), b.tp.GetType(), fsp)
 		if err != nil {
 			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
@@ -1529,12 +1533,12 @@ func (b *builtinCastTimeAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	result.MergeNulls(buf)
 	times := buf.Times()
 	i64s := result.Int64s()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		t, err := times[i].RoundFrac(sc.TypeCtx(), types.DefaultFsp)
+		t, err := times[i].RoundFrac(tc, types.DefaultFsp)
 		if err != nil {
 			return err
 		}
@@ -1557,13 +1561,13 @@ func (b *builtinCastTimeAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 	}
 
 	times := result.Times()
-	stmt := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	fsp := b.tp.GetDecimal()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		res, err := times[i].Convert(stmt.TypeCtx(), b.tp.GetType())
+		res, err := times[i].Convert(tc, b.tp.GetType())
 		if err != nil {
 			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
@@ -1571,7 +1575,7 @@ func (b *builtinCastTimeAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 			result.SetNull(i, true)
 			continue
 		}
-		tm, err := res.RoundFrac(stmt.TypeCtx(), fsp)
+		tm, err := res.RoundFrac(tc, fsp)
 		if err != nil {
 			return err
 		}
@@ -1602,7 +1606,7 @@ func (b *builtinCastTimeAsStringSig) vecEvalString(ctx EvalContext, input *chunk
 
 	var res string
 	var isNull bool
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	vas := buf.Times()
 	result.ReserveString(n)
 	for i, v := range vas {
@@ -1610,7 +1614,7 @@ func (b *builtinCastTimeAsStringSig) vecEvalString(ctx EvalContext, input *chunk
 			result.AppendNull()
 			continue
 		}
-		res, err = types.ProduceStrWithSpecifiedTp(v.String(), b.tp, sc.TypeCtx(), false)
+		res, err = types.ProduceStrWithSpecifiedTp(v.String(), b.tp, tc, false)
 		if err != nil {
 			return err
 		}
@@ -1641,7 +1645,7 @@ func (b *builtinCastJSONAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 	if err = b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
-	sc := ctx.GetSessionVars().StmtCtx
+	tc, ec := typeCtx(ctx), errCtx(ctx)
 	result.ResizeDecimal(n, false)
 	result.MergeNulls(buf)
 	res := result.Decimals()
@@ -1649,12 +1653,12 @@ func (b *builtinCastJSONAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 		if result.IsNull(i) {
 			continue
 		}
-		tempres, err := types.ConvertJSONToDecimal(sc.TypeCtx(), buf.GetJSON(i))
+		tempres, err := types.ConvertJSONToDecimal(tc, buf.GetJSON(i))
 		if err != nil {
 			return err
 		}
-		tempres, err = types.ProduceDecWithSpecifiedTp(sc.TypeCtx(), tempres, b.tp)
-		if err = sc.HandleError(err); err != nil {
+		tempres, err = types.ProduceDecWithSpecifiedTp(tc, tempres, b.tp)
+		if err = ec.HandleError(err); err != nil {
 			return err
 		}
 		res[i] = *tempres
@@ -1689,13 +1693,13 @@ func (b *builtinCastStringAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.C
 	result.ResizeFloat64(n, false)
 	result.MergeNulls(buf)
 	ret := result.Float64s()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		res, err := types.StrToFloat(sc.TypeCtx(), buf.GetString(i), true)
+		res, err := types.StrToFloat(tc, buf.GetString(i), true)
 		if err != nil {
 			return err
 		}
@@ -1731,7 +1735,7 @@ func (b *builtinCastStringAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *c
 	result.ResizeDecimal(n, false)
 	result.MergeNulls(buf)
 	res := result.Decimals()
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc, ec := typeCtx(ctx), errCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -1740,11 +1744,11 @@ func (b *builtinCastStringAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *c
 		isNegative := len(val) > 0 && val[0] == '-'
 		dec := new(types.MyDecimal)
 		if !(b.inUnion && mysql.HasUnsignedFlag(b.tp.GetFlag()) && isNegative) {
-			if err := stmtCtx.HandleTruncate(dec.FromString([]byte(val))); err != nil {
+			if err := tc.HandleTruncate(dec.FromString([]byte(val))); err != nil {
 				return err
 			}
-			dec, err := types.ProduceDecWithSpecifiedTp(stmtCtx.TypeCtx(), dec, b.tp)
-			if err = stmtCtx.HandleError(err); err != nil {
+			dec, err := types.ProduceDecWithSpecifiedTp(tc, dec, b.tp)
+			if err = ec.HandleError(err); err != nil {
 				return err
 			}
 			res[i] = *dec
@@ -1771,13 +1775,13 @@ func (b *builtinCastStringAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.C
 	result.ResizeTime(n, false)
 	result.MergeNulls(buf)
 	times := result.Times()
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	fsp := b.tp.GetDecimal()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		tm, err := types.ParseTime(stmtCtx.TypeCtx(), buf.GetString(i), b.tp.GetType(), fsp)
+		tm, err := types.ParseTime(tc, buf.GetString(i), b.tp.GetType(), fsp)
 		if err != nil {
 			if errors.Is(err, strconv.ErrSyntax) || errors.Is(err, strconv.ErrRange) {
 				err = types.ErrIncorrectDatetimeValue.GenWithStackByArgs(buf.GetString(i))
@@ -1788,7 +1792,7 @@ func (b *builtinCastStringAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.C
 			result.SetNull(i, true)
 			continue
 		}
-		if tm.IsZero() && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
+		if tm.IsZero() && sqlMode(ctx).HasNoZeroDateMode() {
 			err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, tm.String()))
 			if err != nil {
 				return err
@@ -1847,8 +1851,9 @@ func (b *builtinCastDecimalAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 		}
 
 		if types.ErrOverflow.Equal(err) {
+			ec := errCtx(ctx)
 			warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", d64s[i])
-			err = ctx.GetSessionVars().StmtCtx.HandleErrorWithAlias(err, err, warnErr)
+			err = ec.HandleErrorWithAlias(err, err, warnErr)
 		}
 
 		if err != nil {
@@ -1877,14 +1882,15 @@ func (b *builtinCastDecimalAsDurationSig) vecEvalDuration(ctx EvalContext, input
 	result.MergeNulls(buf)
 	args := buf.Decimals()
 	ds := result.GoDurations()
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		dur, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), string(args[i].ToString()), b.tp.GetDecimal())
+		dur, _, err := types.ParseDuration(tc, string(args[i].ToString()), b.tp.GetDecimal())
 		if err != nil {
 			if types.ErrTruncatedWrongVal.Equal(err) {
-				err = ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
+				err = tc.HandleTruncate(err)
 				if err != nil {
 					return err
 				}
@@ -1916,14 +1922,14 @@ func (b *builtinCastStringAsStringSig) vecEvalString(ctx EvalContext, input *chu
 
 	var res string
 	var isNull bool
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	result.ReserveString(n)
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			result.AppendNull()
 			continue
 		}
-		res, err = types.ProduceStrWithSpecifiedTp(buf.GetString(i), b.tp, sc.TypeCtx(), false)
+		res, err = types.ProduceStrWithSpecifiedTp(buf.GetString(i), b.tp, tc, false)
 		if err != nil {
 			return err
 		}
@@ -1955,7 +1961,7 @@ func (b *builtinCastJSONAsDurationSig) vecEvalDuration(ctx EvalContext, input *c
 		return err
 	}
 
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 
 	result.ResizeGoDuration(n, false)
 	result.MergeNulls(buf)
@@ -1974,7 +1980,7 @@ func (b *builtinCastJSONAsDurationSig) vecEvalDuration(ctx EvalContext, input *c
 			if err != nil {
 				return err
 			}
-			d, err = d.RoundFrac(b.tp.GetDecimal(), ctx.GetSessionVars().Location())
+			d, err = d.RoundFrac(b.tp.GetDecimal(), location(ctx))
 			if err != nil {
 				return err
 			}
@@ -1987,9 +1993,9 @@ func (b *builtinCastJSONAsDurationSig) vecEvalDuration(ctx EvalContext, input *c
 			if err != nil {
 				return err
 			}
-			dur, _, err = types.ParseDuration(stmtCtx.TypeCtx(), s, b.tp.GetDecimal())
+			dur, _, err = types.ParseDuration(tc, s, b.tp.GetDecimal())
 			if types.ErrTruncatedWrongVal.Equal(err) {
-				err = stmtCtx.HandleTruncate(err)
+				err = tc.HandleTruncate(err)
 			}
 			if err != nil {
 				return err
@@ -1997,7 +2003,7 @@ func (b *builtinCastJSONAsDurationSig) vecEvalDuration(ctx EvalContext, input *c
 			ds[i] = dur.Duration
 		default:
 			err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), val.String())
-			err = stmtCtx.HandleTruncate(err)
+			err = tc.HandleTruncate(err)
 			if err != nil {
 				return err
 			}

--- a/pkg/expression/builtin_compare_vec.go
+++ b/pkg/expression/builtin_compare_vec.go
@@ -634,7 +634,6 @@ func (b *builtinGreatestCmpStringAsTimeSig) vectorized() bool {
 }
 
 func (b *builtinGreatestCmpStringAsTimeSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	sc := ctx.GetSessionVars().StmtCtx
 	n := input.NumRows()
 
 	dstStrings := make([]string, n)
@@ -653,7 +652,7 @@ func (b *builtinGreatestCmpStringAsTimeSig) vecEvalString(ctx EvalContext, input
 			// NOTE: can't use Column.GetString because it returns an unsafe string, copy the row instead.
 			argTimeStr := string(result.GetBytes(i))
 			var err error
-			argTimeStr, err = doTimeConversionForGL(b.cmpAsDate, ctx, sc, argTimeStr)
+			argTimeStr, err = doTimeConversionForGL(b.cmpAsDate, ctx, argTimeStr)
 			if err != nil {
 				return err
 			}
@@ -715,7 +714,6 @@ func (b *builtinLeastCmpStringAsTimeSig) vectorized() bool {
 }
 
 func (b *builtinLeastCmpStringAsTimeSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	sc := ctx.GetSessionVars().StmtCtx
 	n := input.NumRows()
 
 	dstStrings := make([]string, n)
@@ -734,7 +732,7 @@ func (b *builtinLeastCmpStringAsTimeSig) vecEvalString(ctx EvalContext, input *c
 			// NOTE: can't use Column.GetString because it returns an unsafe string, copy the row instead.
 			argTimeStr := string(result.GetBytes(i))
 			var err error
-			argTimeStr, err = doTimeConversionForGL(b.cmpAsDate, ctx, sc, argTimeStr)
+			argTimeStr, err = doTimeConversionForGL(b.cmpAsDate, ctx, argTimeStr)
 			if err != nil {
 				return err
 			}
@@ -837,11 +835,11 @@ func (b *builtinGreatestTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 			}
 		}
 	}
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	resTimeTp := getAccurateTimeTypeForGLRet(b.cmpAsDate)
 	for rowIdx := 0; rowIdx < n; rowIdx++ {
 		resTimes := result.Times()
-		resTimes[rowIdx], err = resTimes[rowIdx].Convert(sc.TypeCtx(), resTimeTp)
+		resTimes[rowIdx], err = resTimes[rowIdx].Convert(tc, resTimeTp)
 		if err != nil {
 			return err
 		}
@@ -878,11 +876,11 @@ func (b *builtinLeastTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, r
 			}
 		}
 	}
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	resTimeTp := getAccurateTimeTypeForGLRet(b.cmpAsDate)
 	for rowIdx := 0; rowIdx < n; rowIdx++ {
 		resTimes := result.Times()
-		resTimes[rowIdx], err = resTimes[rowIdx].Convert(sc.TypeCtx(), resTimeTp)
+		resTimes[rowIdx], err = resTimes[rowIdx].Convert(tc, resTimeTp)
 		if err != nil {
 			return err
 		}

--- a/pkg/expression/builtin_compare_vec_generated.go
+++ b/pkg/expression/builtin_compare_vec_generated.go
@@ -1646,14 +1646,13 @@ func (b *builtinCoalesceIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalInt(ctx, input, buf1)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalInt(ctx, input, result)
 		}
@@ -1703,14 +1702,13 @@ func (b *builtinCoalesceRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalReal(ctx, input, buf1)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalReal(ctx, input, result)
 		}
@@ -1760,14 +1758,13 @@ func (b *builtinCoalesceDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalDecimal(ctx, input, buf1)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalDecimal(ctx, input, result)
 		}
@@ -1811,8 +1808,7 @@ func (b *builtinCoalesceStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 	argLen := len(b.args)
 
 	bufs := make([]*chunk.Column, argLen)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	for i := 0; i < argLen; i++ {
 		buf, err := b.bufAllocator.get()
 		if err != nil {
@@ -1820,10 +1816,10 @@ func (b *builtinCoalesceStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 		}
 		defer b.bufAllocator.put(buf)
 		err = b.args[i].VecEvalString(ctx, input, buf)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalString(ctx, input, result)
 		}
@@ -1880,15 +1876,14 @@ func (b *builtinCoalesceTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalTime(ctx, input, buf1)
 		fsp := b.tp.GetDecimal()
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalTime(ctx, input, result)
 		}
@@ -1939,14 +1934,13 @@ func (b *builtinCoalesceDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalDuration(ctx, input, buf1)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalDuration(ctx, input, result)
 		}
@@ -1990,8 +1984,7 @@ func (b *builtinCoalesceJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 	argLen := len(b.args)
 
 	bufs := make([]*chunk.Column, argLen)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	for i := 0; i < argLen; i++ {
 		buf, err := b.bufAllocator.get()
 		if err != nil {
@@ -1999,10 +1992,10 @@ func (b *builtinCoalesceJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 		}
 		defer b.bufAllocator.put(buf)
 		err = b.args[i].VecEvalJSON(ctx, input, buf)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalJSON(ctx, input, result)
 		}

--- a/pkg/expression/builtin_control_vec_generated.go
+++ b/pkg/expression/builtin_control_vec_generated.go
@@ -56,8 +56,7 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	var eLse *chunk.Column
 	thensSlice := make([][]int64, l/2)
 	var eLseSlice []int64
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
 		bufWhen, err := b.bufAllocator.get()
@@ -66,10 +65,10 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 		}
 		defer b.bufAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalInt(ctx, input, result)
 		}
@@ -82,10 +81,10 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 		}
 		defer b.bufAllocator.put(bufThen)
 		err = args[j+1].VecEvalInt(ctx, input, bufThen)
-		afterWarns = sc.WarningCount()
+		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalInt(ctx, input, result)
 		}
@@ -102,10 +101,10 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 		}
 		defer b.bufAllocator.put(bufElse)
 		err = args[l-1].VecEvalInt(ctx, input, bufElse)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalInt(ctx, input, result)
 		}
@@ -167,8 +166,7 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 	var eLse *chunk.Column
 	thensSlice := make([][]float64, l/2)
 	var eLseSlice []float64
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
 		bufWhen, err := b.bufAllocator.get()
@@ -177,10 +175,10 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 		}
 		defer b.bufAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalReal(ctx, input, result)
 		}
@@ -193,10 +191,10 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 		}
 		defer b.bufAllocator.put(bufThen)
 		err = args[j+1].VecEvalReal(ctx, input, bufThen)
-		afterWarns = sc.WarningCount()
+		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalReal(ctx, input, result)
 		}
@@ -213,10 +211,10 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 		}
 		defer b.bufAllocator.put(bufElse)
 		err = args[l-1].VecEvalReal(ctx, input, bufElse)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalReal(ctx, input, result)
 		}
@@ -278,8 +276,7 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 	var eLse *chunk.Column
 	thensSlice := make([][]types.MyDecimal, l/2)
 	var eLseSlice []types.MyDecimal
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
 		bufWhen, err := b.bufAllocator.get()
@@ -288,10 +285,10 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 		}
 		defer b.bufAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalDecimal(ctx, input, result)
 		}
@@ -304,10 +301,10 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 		}
 		defer b.bufAllocator.put(bufThen)
 		err = args[j+1].VecEvalDecimal(ctx, input, bufThen)
-		afterWarns = sc.WarningCount()
+		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalDecimal(ctx, input, result)
 		}
@@ -324,10 +321,10 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 		}
 		defer b.bufAllocator.put(bufElse)
 		err = args[l-1].VecEvalDecimal(ctx, input, bufElse)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalDecimal(ctx, input, result)
 		}
@@ -384,8 +381,7 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 	whensSlice := make([][]int64, l/2)
 	thens := make([]*chunk.Column, l/2)
 	var eLse *chunk.Column
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
 		bufWhen, err := b.bufAllocator.get()
@@ -394,10 +390,10 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 		}
 		defer b.bufAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalString(ctx, input, result)
 		}
@@ -410,10 +406,10 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 		}
 		defer b.bufAllocator.put(bufThen)
 		err = args[j+1].VecEvalString(ctx, input, bufThen)
-		afterWarns = sc.WarningCount()
+		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalString(ctx, input, result)
 		}
@@ -429,10 +425,10 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 		}
 		defer b.bufAllocator.put(bufElse)
 		err = args[l-1].VecEvalString(ctx, input, bufElse)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalString(ctx, input, result)
 		}
@@ -498,8 +494,7 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 	var eLse *chunk.Column
 	thensSlice := make([][]types.Time, l/2)
 	var eLseSlice []types.Time
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
 		bufWhen, err := b.bufAllocator.get()
@@ -508,10 +503,10 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 		}
 		defer b.bufAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalTime(ctx, input, result)
 		}
@@ -524,10 +519,10 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 		}
 		defer b.bufAllocator.put(bufThen)
 		err = args[j+1].VecEvalTime(ctx, input, bufThen)
-		afterWarns = sc.WarningCount()
+		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalTime(ctx, input, result)
 		}
@@ -544,10 +539,10 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 		}
 		defer b.bufAllocator.put(bufElse)
 		err = args[l-1].VecEvalTime(ctx, input, bufElse)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalTime(ctx, input, result)
 		}
@@ -609,8 +604,7 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 	var eLse *chunk.Column
 	thensSlice := make([][]time.Duration, l/2)
 	var eLseSlice []time.Duration
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
 		bufWhen, err := b.bufAllocator.get()
@@ -619,10 +613,10 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 		}
 		defer b.bufAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalDuration(ctx, input, result)
 		}
@@ -635,10 +629,10 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 		}
 		defer b.bufAllocator.put(bufThen)
 		err = args[j+1].VecEvalDuration(ctx, input, bufThen)
-		afterWarns = sc.WarningCount()
+		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalDuration(ctx, input, result)
 		}
@@ -655,10 +649,10 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 		}
 		defer b.bufAllocator.put(bufElse)
 		err = args[l-1].VecEvalDuration(ctx, input, bufElse)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalDuration(ctx, input, result)
 		}
@@ -715,8 +709,7 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 	whensSlice := make([][]int64, l/2)
 	thens := make([]*chunk.Column, l/2)
 	var eLse *chunk.Column
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
 		bufWhen, err := b.bufAllocator.get()
@@ -725,10 +718,10 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 		}
 		defer b.bufAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalJSON(ctx, input, result)
 		}
@@ -741,10 +734,10 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 		}
 		defer b.bufAllocator.put(bufThen)
 		err = args[j+1].VecEvalJSON(ctx, input, bufThen)
-		afterWarns = sc.WarningCount()
+		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalJSON(ctx, input, result)
 		}
@@ -760,10 +753,10 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 		}
 		defer b.bufAllocator.put(bufElse)
 		err = args[l-1].VecEvalJSON(ctx, input, bufElse)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEvalJSON(ctx, input, result)
 		}
@@ -830,13 +823,12 @@ func (b *builtinIfNullIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalInt(ctx, input, buf1)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalInt(ctx, input, result)
 	}
@@ -885,13 +877,12 @@ func (b *builtinIfNullRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, 
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalReal(ctx, input, buf1)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalReal(ctx, input, result)
 	}
@@ -940,13 +931,12 @@ func (b *builtinIfNullDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.C
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalDecimal(ctx, input, buf1)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalDecimal(ctx, input, result)
 	}
@@ -997,13 +987,12 @@ func (b *builtinIfNullStringSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalString(ctx, input, buf1)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalString(ctx, input, result)
 	}
@@ -1055,13 +1044,12 @@ func (b *builtinIfNullTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, 
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalTime(ctx, input, buf1)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalTime(ctx, input, result)
 	}
@@ -1110,13 +1098,12 @@ func (b *builtinIfNullDurationSig) vecEvalDuration(ctx EvalContext, input *chunk
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalDuration(ctx, input, buf1)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalDuration(ctx, input, result)
 	}
@@ -1167,13 +1154,12 @@ func (b *builtinIfNullJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalJSON(ctx, input, buf1)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalJSON(ctx, input, result)
 	}
@@ -1225,13 +1211,12 @@ func (b *builtinIfIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalInt(ctx, input, result)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalInt(ctx, input, result)
 	}
@@ -1242,10 +1227,10 @@ func (b *builtinIfIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	}
 	defer b.bufAllocator.put(buf2)
 	err = b.args[2].VecEvalInt(ctx, input, buf2)
-	afterWarns = sc.WarningCount()
+	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalInt(ctx, input, result)
 	}
@@ -1304,13 +1289,12 @@ func (b *builtinIfRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, resu
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalReal(ctx, input, result)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalReal(ctx, input, result)
 	}
@@ -1321,10 +1305,10 @@ func (b *builtinIfRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, resu
 	}
 	defer b.bufAllocator.put(buf2)
 	err = b.args[2].VecEvalReal(ctx, input, buf2)
-	afterWarns = sc.WarningCount()
+	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalReal(ctx, input, result)
 	}
@@ -1383,13 +1367,12 @@ func (b *builtinIfDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalDecimal(ctx, input, result)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalDecimal(ctx, input, result)
 	}
@@ -1400,10 +1383,10 @@ func (b *builtinIfDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk
 	}
 	defer b.bufAllocator.put(buf2)
 	err = b.args[2].VecEvalDecimal(ctx, input, buf2)
-	afterWarns = sc.WarningCount()
+	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalDecimal(ctx, input, result)
 	}
@@ -1459,18 +1442,17 @@ func (b *builtinIfStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	buf1, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
 	err = b.args[1].VecEvalString(ctx, input, buf1)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalString(ctx, input, result)
 	}
@@ -1481,10 +1463,10 @@ func (b *builtinIfStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	}
 	defer b.bufAllocator.put(buf2)
 	err = b.args[2].VecEvalString(ctx, input, buf2)
-	afterWarns = sc.WarningCount()
+	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalString(ctx, input, result)
 	}
@@ -1546,13 +1528,12 @@ func (b *builtinIfTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, resu
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalTime(ctx, input, result)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalTime(ctx, input, result)
 	}
@@ -1563,10 +1544,10 @@ func (b *builtinIfTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, resu
 	}
 	defer b.bufAllocator.put(buf2)
 	err = b.args[2].VecEvalTime(ctx, input, buf2)
-	afterWarns = sc.WarningCount()
+	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalTime(ctx, input, result)
 	}
@@ -1625,13 +1606,12 @@ func (b *builtinIfDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chu
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalDuration(ctx, input, result)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalDuration(ctx, input, result)
 	}
@@ -1642,10 +1622,10 @@ func (b *builtinIfDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chu
 	}
 	defer b.bufAllocator.put(buf2)
 	err = b.args[2].VecEvalDuration(ctx, input, buf2)
-	afterWarns = sc.WarningCount()
+	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalDuration(ctx, input, result)
 	}
@@ -1701,18 +1681,17 @@ func (b *builtinIfJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, resu
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	buf1, err := b.bufAllocator.get()
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
 	err = b.args[1].VecEvalJSON(ctx, input, buf1)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalJSON(ctx, input, result)
 	}
@@ -1723,10 +1702,10 @@ func (b *builtinIfJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, resu
 	}
 	defer b.bufAllocator.put(buf2)
 	err = b.args[2].VecEvalJSON(ctx, input, buf2)
-	afterWarns = sc.WarningCount()
+	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-			sc.TruncateWarnings(int(beforeWarns))
+			truncateWarnings(ctx, beforeWarns)
 		}
 		return b.fallbackEvalJSON(ctx, input, result)
 	}

--- a/pkg/expression/builtin_encryption_vec.go
+++ b/pkg/expression/builtin_encryption_vec.go
@@ -80,7 +80,7 @@ func (b *builtinAesDecryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	}
 
 	result.ReserveString(n)
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		// According to doc: If either function argument is NULL, the function returns NULL.
 		if strBuf.IsNull(i) || keyBuf.IsNull(i) {
@@ -89,7 +89,7 @@ func (b *builtinAesDecryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 		}
 		if isWarning {
 			// For modes that do not require init_vector, it is ignored and a warning is generated if it is specified.
-			stmtCtx.AppendWarning(errWarnOptionIgnored.FastGenByArgs("IV"))
+			tc.AppendWarning(errWarnOptionIgnored.FastGenByArgs("IV"))
 		}
 		if !isConstKey {
 			key = encrypt.DeriveKeyMySQL(keyBuf.GetBytes(i), b.keySize)
@@ -678,7 +678,7 @@ func (b *builtinAesEncryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 		key = encrypt.DeriveKeyMySQL(keyBuf.GetBytes(0), b.keySize)
 	}
 
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	result.ReserveString(n)
 	for i := 0; i < n; i++ {
 		// According to doc: If either function argument is NULL, the function returns NULL.
@@ -687,7 +687,7 @@ func (b *builtinAesEncryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 			continue
 		}
 		if isWarning {
-			sc.AppendWarning(errWarnOptionIgnored.FastGenByArgs("IV"))
+			tc.AppendWarning(errWarnOptionIgnored.FastGenByArgs("IV"))
 		}
 		if !isConst {
 			key = encrypt.DeriveKeyMySQL(keyBuf.GetBytes(i), b.keySize)
@@ -736,7 +736,8 @@ func (b *builtinPasswordSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 
 		// We should append a warning here because function "PASSWORD" is deprecated since MySQL 5.7.6.
 		// See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.FastGenByArgs("PASSWORD"))
+		tc := typeCtx(ctx)
+		tc.AppendWarning(errDeprecatedSyntaxNoReplacement.FastGenByArgs("PASSWORD"))
 
 		result.AppendString(auth.EncodePasswordBytes(passBytes))
 	}
@@ -793,7 +794,7 @@ func (b *builtinUncompressSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	}
 
 	result.ReserveString(n)
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			result.AppendNull()
@@ -808,19 +809,19 @@ func (b *builtinUncompressSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 		}
 		if len(payload) <= 4 {
 			// corrupted
-			sc.AppendWarning(errZlibZData)
+			tc.AppendWarning(errZlibZData)
 			result.AppendNull()
 			continue
 		}
 		length := binary.LittleEndian.Uint32([]byte(payload[0:4]))
 		bytes, err := inflate([]byte(payload[4:]))
 		if err != nil {
-			sc.AppendWarning(errZlibZData)
+			tc.AppendWarning(errZlibZData)
 			result.AppendNull()
 			continue
 		}
 		if length < uint32(len(bytes)) {
-			sc.AppendWarning(errZlibZBuf)
+			tc.AppendWarning(errZlibZBuf)
 			result.AppendNull()
 			continue
 		}
@@ -836,7 +837,7 @@ func (b *builtinUncompressedLengthSig) vectorized() bool {
 }
 
 func (b *builtinUncompressedLengthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	nr := input.NumRows()
 	payloadBuf, err := b.bufAllocator.get()
 	if err != nil {
@@ -860,7 +861,7 @@ func (b *builtinUncompressedLengthSig) vecEvalInt(ctx EvalContext, input *chunk.
 			continue
 		}
 		if len(str) <= 4 {
-			sc.AppendWarning(errZlibZData)
+			tc.AppendWarning(errZlibZData)
 			i64s[i] = 0
 			continue
 		}

--- a/pkg/expression/builtin_info.go
+++ b/pkg/expression/builtin_info.go
@@ -920,7 +920,8 @@ func (b *builtinTiDBDecodeSQLDigestsSig) evalString(ctx EvalContext, row chunk.R
 		if len(digestsStr) > errMsgMaxLength {
 			digestsStr = digestsStr[:errMsgMaxLength] + "..."
 		}
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errIncorrectArgs.FastGen("The argument can't be unmarshalled as JSON array: '%s'", digestsStr))
+		tc := typeCtx(ctx)
+		tc.AppendWarning(errIncorrectArgs.FastGen("The argument can't be unmarshalled as JSON array: '%s'", digestsStr))
 		return "", true, nil
 	}
 
@@ -949,7 +950,8 @@ func (b *builtinTiDBDecodeSQLDigestsSig) evalString(ctx EvalContext, row chunk.R
 			return "", true, errUnknown.GenWithStack("Retrieving cancelled internally with error: %v", err)
 		}
 
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknown.FastGen("Retrieving statements information failed with error: %v", err))
+		tc := typeCtx(ctx)
+		tc.AppendWarning(errUnknown.FastGen("Retrieving statements information failed with error: %v", err))
 		return "", true, nil
 	}
 
@@ -972,7 +974,8 @@ func (b *builtinTiDBDecodeSQLDigestsSig) evalString(ctx EvalContext, row chunk.R
 
 	resultStr, err := json.Marshal(result)
 	if err != nil {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnknown.FastGen("Marshalling result as JSON failed with error: %v", err))
+		tc := typeCtx(ctx)
+		tc.AppendWarning(errUnknown.FastGen("Marshalling result as JSON failed with error: %v", err))
 		return "", true, nil
 	}
 
@@ -1077,7 +1080,8 @@ func (b *builtinTiDBDecodeBinaryPlanSig) evalString(ctx EvalContext, row chunk.R
 	}
 	planTree, err := plancodec.DecodeBinaryPlan(planString)
 	if err != nil {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(err)
+		tc := typeCtx(ctx)
+		tc.AppendWarning(err)
 		return "", false, nil
 	}
 	return planTree, false, nil

--- a/pkg/expression/builtin_json.go
+++ b/pkg/expression/builtin_json.go
@@ -494,7 +494,8 @@ func (b *builtinJSONMergeSig) evalJSON(ctx EvalContext, row chunk.Row) (res type
 	// function "JSON_MERGE" is deprecated since MySQL 5.7.22. Synonym for function "JSON_MERGE_PRESERVE".
 	// See https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-merge
 	if b.pbCode == tipb.ScalarFuncSig_JsonMergeSig {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.FastGenByArgs("JSON_MERGE"))
+		tc := typeCtx(ctx)
+		tc.AppendWarning(errDeprecatedSyntaxNoReplacement.FastGenByArgs("JSON_MERGE"))
 	}
 	return res, false, nil
 }

--- a/pkg/expression/builtin_json_vec.go
+++ b/pkg/expression/builtin_json_vec.go
@@ -1103,7 +1103,8 @@ func (b *builtinJSONMergeSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, r
 			if result.IsNull(i) {
 				continue
 			}
-			ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.FastGenByArgs("JSON_MERGE"))
+			tc := typeCtx(ctx)
+			tc.AppendWarning(errDeprecatedSyntaxNoReplacement.FastGenByArgs("JSON_MERGE"))
 		}
 	}
 

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -888,7 +888,8 @@ func (b *builtinLog1ArgSig) evalReal(ctx EvalContext, row chunk.Row) (float64, b
 		return 0, isNull, err
 	}
 	if val <= 0 {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+		tc := typeCtx(ctx)
+		tc.AppendWarning(ErrInvalidArgumentForLogarithm)
 		return 0, true, nil
 	}
 	return math.Log(val), false, nil
@@ -918,7 +919,8 @@ func (b *builtinLog2ArgsSig) evalReal(ctx EvalContext, row chunk.Row) (float64, 
 	}
 
 	if val1 <= 0 || val1 == 1 || val2 <= 0 {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+		tc := typeCtx(ctx)
+		tc.AppendWarning(ErrInvalidArgumentForLogarithm)
 		return 0, true, nil
 	}
 
@@ -960,7 +962,8 @@ func (b *builtinLog2Sig) evalReal(ctx EvalContext, row chunk.Row) (float64, bool
 		return 0, isNull, err
 	}
 	if val <= 0 {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+		tc := typeCtx(ctx)
+		tc.AppendWarning(ErrInvalidArgumentForLogarithm)
 		return 0, true, nil
 	}
 	return math.Log2(val), false, nil
@@ -1001,7 +1004,8 @@ func (b *builtinLog10Sig) evalReal(ctx EvalContext, row chunk.Row) (float64, boo
 		return 0, isNull, err
 	}
 	if val <= 0 {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+		tc := typeCtx(ctx)
+		tc.AppendWarning(ErrInvalidArgumentForLogarithm)
 		return 0, true, nil
 	}
 	return math.Log10(val), false, nil

--- a/pkg/expression/builtin_math_vec.go
+++ b/pkg/expression/builtin_math_vec.go
@@ -36,7 +36,8 @@ func (b *builtinLog1ArgSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, res
 			continue
 		}
 		if f64s[i] <= 0 {
-			ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+			tc := typeCtx(ctx)
+			tc.AppendWarning(ErrInvalidArgumentForLogarithm)
 			result.SetNull(i, true)
 		} else {
 			f64s[i] = math.Log(f64s[i])
@@ -59,7 +60,8 @@ func (b *builtinLog2Sig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result
 			continue
 		}
 		if f64s[i] <= 0 {
-			ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+			tc := typeCtx(ctx)
+			tc.AppendWarning(ErrInvalidArgumentForLogarithm)
 			result.SetNull(i, true)
 		} else {
 			f64s[i] = math.Log2(f64s[i])
@@ -82,7 +84,8 @@ func (b *builtinLog10Sig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, resul
 			continue
 		}
 		if f64s[i] <= 0 {
-			ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+			tc := typeCtx(ctx)
+			tc.AppendWarning(ErrInvalidArgumentForLogarithm)
 			result.SetNull(i, true)
 		} else {
 			f64s[i] = math.Log10(f64s[i])
@@ -478,7 +481,8 @@ func (b *builtinLog2ArgsSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, re
 			continue
 		}
 		if d[i] <= 0 || d[i] == 1 || x[i] <= 0 {
-			ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInvalidArgumentForLogarithm)
+			tc := typeCtx(ctx)
+			tc.AppendWarning(ErrInvalidArgumentForLogarithm)
 			result.SetNull(i, true)
 		}
 		d[i] = math.Log(x[i]) / math.Log(d[i])

--- a/pkg/expression/builtin_miscellaneous_vec.go
+++ b/pkg/expression/builtin_miscellaneous_vec.go
@@ -317,12 +317,11 @@ func (b *builtinSleepSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
 
-	ec := ctx.GetSessionVars().StmtCtx.ErrCtx()
+	ec := errCtx(ctx)
 	for i := 0; i < n; i++ {
 		isNull := buf.IsNull(i)
 		val := buf.GetFloat64(i)
 
-		sessVars := ctx.GetSessionVars()
 		if isNull || val < 0 {
 			// for insert ignore stmt, the StrictSQLMode and ignoreErr should both be considered.
 			err := ec.HandleErrorWithAlias(errBadNull,
@@ -339,7 +338,7 @@ func (b *builtinSleepSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 			return errIncorrectArgs.GenWithStackByArgs("sleep")
 		}
 
-		if isKilled := doSleep(val, sessVars); isKilled {
+		if isKilled := doSleep(val, ctx.GetSessionVars()); isKilled {
 			for j := i; j < n; j++ {
 				i64s[j] = 1
 			}

--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -1210,7 +1210,7 @@ func (b *builtinValuesIntSig) evalInt(ctx EvalContext, _ chunk.Row) (int64, bool
 		}
 		if len(val) < 8 {
 			var binary types.BinaryLiteral = val
-			v, err := binary.ToInt(ctx.GetSessionVars().StmtCtx.TypeCtx())
+			v, err := binary.ToInt(typeCtx(ctx))
 			if err != nil {
 				return 0, true, errors.Trace(err)
 			}

--- a/pkg/expression/builtin_string_vec.go
+++ b/pkg/expression/builtin_string_vec.go
@@ -2330,7 +2330,7 @@ func (b *builtinCharSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	}
 	encBuf := &bytes.Buffer{}
 	enc := charset.FindEncoding(b.tp.GetCharset())
-	hasStrictMode := ctx.GetSessionVars().StrictSQLMode
+	hasStrictMode := strictMode(ctx)
 	for i := 0; i < n; i++ {
 		bigints = bigints[0:0]
 		for j := 0; j < l-1; j++ {
@@ -2342,7 +2342,8 @@ func (b *builtinCharSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 		dBytes := b.convertToBytes(bigints)
 		resultBytes, err := enc.Transform(encBuf, dBytes, charset.OpDecode)
 		if err != nil {
-			ctx.GetSessionVars().StmtCtx.AppendWarning(err)
+			tc := typeCtx(ctx)
+			tc.AppendWarning(err)
 			if hasStrictMode {
 				result.AppendNull()
 				continue
@@ -2951,7 +2952,7 @@ func (b *builtinCharLengthUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chun
 	return nil
 }
 
-func formatDecimal(sctx EvalContext, xBuf *chunk.Column, dInt64s []int64, result *chunk.Column, localeBuf *chunk.Column) error {
+func formatDecimal(ctx EvalContext, xBuf *chunk.Column, dInt64s []int64, result *chunk.Column, localeBuf *chunk.Column) error {
 	xDecimals := xBuf.Decimals()
 	for i := range xDecimals {
 		if xBuf.IsNull(i) {
@@ -2972,10 +2973,12 @@ func formatDecimal(sctx EvalContext, xBuf *chunk.Column, dInt64s []int64, result
 			// FORMAT(x, d)
 		} else if localeBuf.IsNull(i) {
 			// FORMAT(x, d, NULL)
-			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.FastGenByArgs("NULL"))
+			tc := typeCtx(ctx)
+			tc.AppendWarning(errUnknownLocale.FastGenByArgs("NULL"))
 		} else if !strings.EqualFold(localeBuf.GetString(i), "en_US") {
 			// TODO: support other locales.
-			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.FastGenByArgs(localeBuf.GetString(i)))
+			tc := typeCtx(ctx)
+			tc.AppendWarning(errUnknownLocale.FastGenByArgs(localeBuf.GetString(i)))
 		}
 
 		xStr := roundFormatArgs(x.String(), int(d))
@@ -2991,7 +2994,7 @@ func formatDecimal(sctx EvalContext, xBuf *chunk.Column, dInt64s []int64, result
 	return nil
 }
 
-func formatReal(sctx EvalContext, xBuf *chunk.Column, dInt64s []int64, result *chunk.Column, localeBuf *chunk.Column) error {
+func formatReal(ctx EvalContext, xBuf *chunk.Column, dInt64s []int64, result *chunk.Column, localeBuf *chunk.Column) error {
 	xFloat64s := xBuf.Float64s()
 	for i := range xFloat64s {
 		if xBuf.IsNull(i) {
@@ -3012,10 +3015,12 @@ func formatReal(sctx EvalContext, xBuf *chunk.Column, dInt64s []int64, result *c
 			// FORMAT(x, d)
 		} else if localeBuf.IsNull(i) {
 			// FORMAT(x, d, NULL)
-			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.FastGenByArgs("NULL"))
+			tc := typeCtx(ctx)
+			tc.AppendWarning(errUnknownLocale.FastGenByArgs("NULL"))
 		} else if !strings.EqualFold(localeBuf.GetString(i), "en_US") {
 			// TODO: support other locales.
-			sctx.GetSessionVars().StmtCtx.AppendWarning(errUnknownLocale.FastGenByArgs(localeBuf.GetString(i)))
+			tc := typeCtx(ctx)
+			tc.AppendWarning(errUnknownLocale.FastGenByArgs(localeBuf.GetString(i)))
 		}
 
 		xStr := roundFormatArgs(strconv.FormatFloat(x, 'f', -1, 64), int(d))

--- a/pkg/expression/builtin_time_test.go
+++ b/pkg/expression/builtin_time_test.go
@@ -1162,7 +1162,7 @@ func TestSysDate(t *testing.T) {
 				geners:        []dataGenerator{newRangeInt64Gener(0, 7)},
 			})
 		resetStmtContext(ctx)
-		loc := ctx.GetSessionVars().Location()
+		loc := location(ctx)
 		startTm := time.Now().In(loc)
 		err = baseFunc.vecEvalTime(ctx, input, output)
 		require.NoError(t, err)

--- a/pkg/expression/builtin_time_vec.go
+++ b/pkg/expression/builtin_time_vec.go
@@ -95,7 +95,7 @@ func (b *builtinDateSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result
 		if result.IsNull(i) {
 			continue
 		}
-		if times[i].IsZero() && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
+		if times[i].IsZero() && sqlMode(ctx).HasNoZeroDateMode() {
 			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, times[i].String())); err != nil {
 				return err
 			}
@@ -167,7 +167,7 @@ func (b *builtinSysDateWithoutFspSig) vectorized() bool {
 
 func (b *builtinSysDateWithoutFspSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	loc := ctx.GetSessionVars().Location()
+	loc := location(ctx)
 	now := time.Now().In(loc)
 
 	result.ResizeTime(n, false)
@@ -396,7 +396,7 @@ func (b *builtinUTCTimeWithArgSig) vecEvalDuration(ctx EvalContext, input *chunk
 		return err
 	}
 	utc := nowTs.UTC().Format(types.TimeFSPFormat)
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	result.ResizeGoDuration(n, false)
 	d64s := result.GoDurations()
 	i64s := buf.Int64s()
@@ -412,7 +412,7 @@ func (b *builtinUTCTimeWithArgSig) vecEvalDuration(ctx EvalContext, input *chunk
 		if fsp < int64(types.MinFsp) {
 			return errors.Errorf("Invalid negative %d specified, must in [0, 6]", fsp)
 		}
-		res, _, err := types.ParseDuration(stmtCtx.TypeCtx(), utc, int(fsp))
+		res, _, err := types.ParseDuration(tc, utc, int(fsp))
 		if err != nil {
 			return err
 		}
@@ -671,7 +671,7 @@ func (b *builtinLastDaySig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, res
 		}
 		tm := times[i]
 		year, month := tm.Year(), tm.Month()
-		if tm.Month() == 0 || (tm.Day() == 0 && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()) {
+		if tm.Month() == 0 || (tm.Day() == 0 && sqlMode(ctx).HasNoZeroDateMode()) {
 			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, times[i].String())); err != nil {
 				return err
 			}
@@ -711,13 +711,13 @@ func (b *builtinStrToDateDateSig) vecEvalTime(ctx EvalContext, input *chunk.Chun
 	result.ResizeTime(n, false)
 	result.MergeNulls(bufStrings, bufFormats)
 	times := result.Times()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		var t types.Time
-		succ := t.StrToDate(sc.TypeCtx(), bufStrings.GetString(i), bufFormats.GetString(i))
+		succ := t.StrToDate(tc, bufStrings.GetString(i), bufFormats.GetString(i))
 		if !succ {
 			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
 				return err
@@ -725,7 +725,7 @@ func (b *builtinStrToDateDateSig) vecEvalTime(ctx EvalContext, input *chunk.Chun
 			result.SetNull(i, true)
 			continue
 		}
-		if ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() && (t.Year() == 0 || t.Month() == 0 || t.Day() == 0) {
+		if sqlMode(ctx).HasNoZeroDateMode() && (t.Year() == 0 || t.Month() == 0 || t.Day() == 0) {
 			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
 				return err
 			}
@@ -754,7 +754,7 @@ func (b *builtinSysDateWithFspSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 		return err
 	}
 
-	loc := ctx.GetSessionVars().Location()
+	loc := location(ctx)
 	now := time.Now().In(loc)
 
 	result.ResizeTime(n, false)
@@ -803,7 +803,7 @@ func (b *builtinTidbParseTsoSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 		}
 		t := oracle.GetTimeFromTS(uint64(args[i]))
 		r := types.NewTime(types.FromGoTime(t), mysql.TypeDatetime, types.MaxFsp)
-		if err := r.ConvertTimeZone(time.Local, ctx.GetSessionVars().Location()); err != nil {
+		if err := r.ConvertTimeZone(time.Local, location(ctx)); err != nil {
 			return err
 		}
 		times[i] = r
@@ -1123,13 +1123,13 @@ func (b *builtinStrToDateDurationSig) vecEvalDuration(ctx EvalContext, input *ch
 	result.ResizeGoDuration(n, false)
 	result.MergeNulls(bufStrings, bufFormats)
 	d64s := result.GoDurations()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		var t types.Time
-		succ := t.StrToDate(sc.TypeCtx(), bufStrings.GetString(i), bufFormats.GetString(i))
+		succ := t.StrToDate(tc, bufStrings.GetString(i), bufFormats.GetString(i))
 		if !succ {
 			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
 				return err
@@ -1482,8 +1482,8 @@ func (b *builtinStrToDateDatetimeSig) vecEvalTime(ctx EvalContext, input *chunk.
 	result.ResizeTime(n, false)
 	result.MergeNulls(dateBuf, formatBuf)
 	times := result.Times()
-	sc := ctx.GetSessionVars().StmtCtx
-	hasNoZeroDateMode := ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()
+	tc := typeCtx(ctx)
+	hasNoZeroDateMode := sqlMode(ctx).HasNoZeroDateMode()
 	fsp := b.tp.GetDecimal()
 
 	for i := 0; i < n; i++ {
@@ -1491,7 +1491,7 @@ func (b *builtinStrToDateDatetimeSig) vecEvalTime(ctx EvalContext, input *chunk.
 			continue
 		}
 		var t types.Time
-		succ := t.StrToDate(sc.TypeCtx(), dateBuf.GetString(i), formatBuf.GetString(i))
+		succ := t.StrToDate(tc, dateBuf.GetString(i), formatBuf.GetString(i))
 		if !succ {
 			if err = handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, t.String())); err != nil {
 				return err
@@ -1714,7 +1714,8 @@ func (b *builtinTimestampAddSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 
 		tm1, err := arg.GoTime(time.Local)
 		if err != nil {
-			ctx.GetSessionVars().StmtCtx.AppendWarning(err)
+			tc := typeCtx(ctx)
+			tc.AppendWarning(err)
 			result.AppendNull()
 			continue
 		}
@@ -1735,7 +1736,7 @@ func (b *builtinTimestampAddSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 			fsp = types.MaxFsp
 		}
 		r := types.NewTime(types.FromGoTime(tb), b.resolveType(arg.Type(), unit), fsp)
-		if err = r.Check(ctx.GetSessionVars().StmtCtx.TypeCtx()); err != nil {
+		if err = r.Check(typeCtx(ctx)); err != nil {
 			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
@@ -1919,7 +1920,8 @@ func (b *builtinSecToTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chun
 			minute = 59
 			second = 59
 			demical = 0
-			err = ctx.GetSessionVars().StmtCtx.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("time", strconv.FormatFloat(secondsFloat, 'f', -1, 64)))
+			tc := typeCtx(ctx)
+			err = tc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("time", strconv.FormatFloat(secondsFloat, 'f', -1, 64)))
 			if err != nil {
 				return err
 			}
@@ -1928,7 +1930,7 @@ func (b *builtinSecToTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chun
 			second = seconds % 60
 		}
 		secondDemical := float64(second) + demical
-		duration, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), fmt.Sprintf("%s%02d:%02d:%s", negative, hour, minute, strconv.FormatFloat(secondDemical, 'f', -1, 64)), b.tp.GetDecimal())
+		duration, _, err := types.ParseDuration(typeCtx(ctx), fmt.Sprintf("%s%02d:%02d:%s", negative, hour, minute, strconv.FormatFloat(secondDemical, 'f', -1, 64)), b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}
@@ -1949,7 +1951,7 @@ func (b *builtinUTCTimeWithoutArgSig) vecEvalDuration(ctx EvalContext, input *ch
 	if err != nil {
 		return err
 	}
-	res, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), nowTs.UTC().Format(types.TimeFormat), types.DefaultFsp)
+	res, _, err := types.ParseDuration(typeCtx(ctx), nowTs.UTC().Format(types.TimeFormat), types.DefaultFsp)
 	if err != nil {
 		return err
 	}
@@ -2020,7 +2022,7 @@ func (b *builtinCurrentDateSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk,
 		return err
 	}
 
-	tz := ctx.GetSessionVars().Location()
+	tz := location(ctx)
 	year, month, day := nowTs.In(tz).Date()
 	timeValue := types.NewTime(types.FromDate(year, int(month), day, 0, 0, 0, 0), mysql.TypeDate, 0)
 
@@ -2093,7 +2095,7 @@ func (b *builtinMakeTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk
 			result.SetNull(i, true)
 			continue
 		}
-		dur, err := b.makeTime(ctx.GetSessionVars().StmtCtx.TypeCtx(), hours[i], minutes[i], seconds[i], hourUnsignedFlag)
+		dur, err := b.makeTime(typeCtx(ctx), hours[i], minutes[i], seconds[i], hourUnsignedFlag)
 		if err != nil {
 			return err
 		}
@@ -2350,9 +2352,9 @@ func (b *builtinCurrentTime0ArgSig) vecEvalDuration(ctx EvalContext, input *chun
 	if err != nil {
 		return err
 	}
-	tz := ctx.GetSessionVars().Location()
+	tz := location(ctx)
 	dur := nowTs.In(tz).Format(types.TimeFormat)
-	res, _, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx.TypeCtx(), dur, types.MinFsp)
+	res, _, err := types.ParseDuration(typeCtx(ctx), dur, types.MinFsp)
 	if err != nil {
 		return err
 	}
@@ -2382,7 +2384,7 @@ func (b *builtinTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, re
 	result.ResizeGoDuration(n, false)
 	result.MergeNulls(buf)
 	ds := result.GoDurations()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -2400,9 +2402,9 @@ func (b *builtinTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, re
 		}
 		fsp = tmpFsp
 
-		res, _, err := types.ParseDuration(sc.TypeCtx(), expr, fsp)
+		res, _, err := types.ParseDuration(tc, expr, fsp)
 		if types.ErrTruncatedWrongVal.Equal(err) {
-			err = sc.HandleTruncate(err)
+			err = tc.HandleTruncate(err)
 		}
 		if err != nil {
 			return err
@@ -2418,7 +2420,7 @@ func (b *builtinDateLiteralSig) vectorized() bool {
 
 func (b *builtinDateLiteralSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	mode := ctx.GetSessionVars().SQLMode
+	mode := sqlMode(ctx)
 	if mode.HasNoZeroDateMode() && b.literal.IsZero() {
 		return types.ErrWrongValue.GenWithStackByArgs(types.DateStr, b.literal.String())
 	}
@@ -2467,7 +2469,7 @@ func (b *builtinMonthNameSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 			continue
 		}
 		mon := ds[i].Month()
-		if (ds[i].IsZero() && ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()) || mon < 0 || mon > len(types.MonthNames) {
+		if (ds[i].IsZero() && sqlMode(ctx).HasNoZeroDateMode()) || mon < 0 || mon > len(types.MonthNames) {
 			if err := handleInvalidTimeError(ctx, types.ErrWrongValue.GenWithStackByArgs(types.DateTimeStr, ds[i].String())); err != nil {
 				return err
 			}
@@ -2539,14 +2541,14 @@ func (b *builtinCurrentTime1ArgSig) vecEvalDuration(ctx EvalContext, input *chun
 	if err != nil {
 		return err
 	}
-	tz := ctx.GetSessionVars().Location()
+	tz := location(ctx)
 	dur := nowTs.In(tz).Format(types.TimeFSPFormat)
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	i64s := buf.Int64s()
 	result.ResizeGoDuration(n, false)
 	durations := result.GoDurations()
 	for i := 0; i < n; i++ {
-		res, _, err := types.ParseDuration(stmtCtx.TypeCtx(), dur, int(i64s[i]))
+		res, _, err := types.ParseDuration(tc, dur, int(i64s[i]))
 		if err != nil {
 			return err
 		}
@@ -2640,7 +2642,7 @@ func (b *builtinTimestamp1ArgSig) vecEvalTime(ctx EvalContext, input *chunk.Chun
 	result.ResizeTime(n, false)
 	result.MergeNulls(buf)
 	times := result.Times()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	var tm types.Time
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -2649,9 +2651,9 @@ func (b *builtinTimestamp1ArgSig) vecEvalTime(ctx EvalContext, input *chunk.Chun
 		s := buf.GetString(i)
 
 		if b.isFloat {
-			tm, err = types.ParseTimeFromFloatString(sc.TypeCtx(), s, mysql.TypeDatetime, types.GetFsp(s))
+			tm, err = types.ParseTimeFromFloatString(tc, s, mysql.TypeDatetime, types.GetFsp(s))
 		} else {
-			tm, err = types.ParseTime(sc.TypeCtx(), s, mysql.TypeDatetime, types.GetFsp(s))
+			tm, err = types.ParseTime(tc, s, mysql.TypeDatetime, types.GetFsp(s))
 		}
 		if err != nil {
 			if err = handleInvalidTimeError(ctx, err); err != nil {
@@ -2692,7 +2694,7 @@ func (b *builtinTimestamp2ArgsSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 	result.ResizeTime(n, false)
 	result.MergeNulls(buf0, buf1)
 	times := result.Times()
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	var tm types.Time
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -2702,9 +2704,9 @@ func (b *builtinTimestamp2ArgsSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 		arg1 := buf1.GetString(i)
 
 		if b.isFloat {
-			tm, err = types.ParseTimeFromFloatString(sc.TypeCtx(), arg0, mysql.TypeDatetime, types.GetFsp(arg0))
+			tm, err = types.ParseTimeFromFloatString(tc, arg0, mysql.TypeDatetime, types.GetFsp(arg0))
 		} else {
-			tm, err = types.ParseTime(sc.TypeCtx(), arg0, mysql.TypeDatetime, types.GetFsp(arg0))
+			tm, err = types.ParseTime(tc, arg0, mysql.TypeDatetime, types.GetFsp(arg0))
 		}
 		if err != nil {
 			if err = handleInvalidTimeError(ctx, err); err != nil {
@@ -2725,7 +2727,7 @@ func (b *builtinTimestamp2ArgsSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 			continue
 		}
 
-		duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
+		duration, _, err := types.ParseDuration(tc, arg1, types.GetFsp(arg1))
 		if err != nil {
 			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
@@ -2733,7 +2735,7 @@ func (b *builtinTimestamp2ArgsSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 			result.SetNull(i, true)
 			continue
 		}
-		tmp, err := tm.Add(sc.TypeCtx(), duration)
+		tmp, err := tm.Add(tc, duration)
 		if err != nil {
 			return err
 		}
@@ -2914,13 +2916,13 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalTime(ctx EvalContext, input *ch
 	result.MergeNulls(durBuf, intervalBuf)
 	resDates := result.Times()
 	iterDuration := types.Duration{Fsp: types.MaxFsp}
-	sc := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		iterDuration.Duration = goDurations[i]
-		t, err := iterDuration.ConvertToTime(sc.TypeCtx(), mysql.TypeDatetime)
+		t, err := iterDuration.ConvertToTime(tc, mysql.TypeDatetime)
 		if err != nil {
 			result.SetNull(i, true)
 		}

--- a/pkg/expression/builtin_time_vec_generated.go
+++ b/pkg/expression/builtin_time_vec_generated.go
@@ -62,7 +62,7 @@ func (b *builtinAddDatetimeAndDurationSig) vecEvalTime(ctx EvalContext, input *c
 
 		// calculate
 
-		output, err := arg0.Add(ctx.GetSessionVars().StmtCtx.TypeCtx(), types.Duration{Duration: arg1, Fsp: -1})
+		output, err := arg0.Add(typeCtx(ctx), types.Duration{Duration: arg1, Fsp: -1})
 
 		if err != nil {
 			return err
@@ -121,18 +121,18 @@ func (b *builtinAddDatetimeAndStringSig) vecEvalTime(ctx EvalContext, input *chu
 			result.SetNull(i, true) // fixed: true
 			continue
 		}
-		sc := ctx.GetSessionVars().StmtCtx
-		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
+		tc := typeCtx(ctx)
+		arg1Duration, _, err := types.ParseDuration(tc, arg1, types.GetFsp(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.SetNull(i, true) // fixed: true
 				continue
 			}
 			return err
 		}
 
-		output, err := arg0.Add(sc.TypeCtx(), arg1Duration)
+		output, err := arg0.Add(typeCtx(ctx), arg1Duration)
 
 		if err != nil {
 			return err
@@ -247,11 +247,11 @@ func (b *builtinAddDurationAndStringSig) vecEvalDuration(ctx EvalContext, input 
 			result.SetNull(i, true) // fixed: true
 			continue
 		}
-		sc := ctx.GetSessionVars().StmtCtx
-		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
+		tc := typeCtx(ctx)
+		arg1Duration, _, err := types.ParseDuration(tc, arg1, types.GetFsp(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.SetNull(i, true) // fixed: true
 				continue
 			}
@@ -315,18 +315,18 @@ func (b *builtinAddStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 
 		// calculate
 
-		sc := ctx.GetSessionVars().StmtCtx
+		tc := typeCtx(ctx)
 		fsp1 := b.args[1].GetType().GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 		var output string
 		var isNull bool
 		if isDuration(arg0) {
 
-			output, err = strDurationAddDuration(sc, arg0, arg1Duration)
+			output, err = strDurationAddDuration(tc, arg0, arg1Duration)
 
 			if err != nil {
 				if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-					sc.AppendWarning(err)
+					tc.AppendWarning(err)
 					result.AppendNull() // fixed: false
 					continue
 				}
@@ -334,13 +334,13 @@ func (b *builtinAddStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 			}
 		} else {
 
-			output, isNull, err = strDatetimeAddDuration(sc, arg0, arg1Duration)
+			output, isNull, err = strDatetimeAddDuration(tc, arg0, arg1Duration)
 
 			if err != nil {
 				return err
 			}
 			if isNull {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.AppendNull() // fixed: false
 				continue
 			}
@@ -405,11 +405,11 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 
 		// calculate
 
-		sc := ctx.GetSessionVars().StmtCtx
-		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, getFsp4TimeAddSub(arg1))
+		tc := typeCtx(ctx)
+		arg1Duration, _, err := types.ParseDuration(tc, arg1, getFsp4TimeAddSub(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.AppendNull() // fixed: false
 				continue
 			}
@@ -420,11 +420,11 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 		var isNull bool
 		if isDuration(arg0) {
 
-			output, err = strDurationAddDuration(sc, arg0, arg1Duration)
+			output, err = strDurationAddDuration(tc, arg0, arg1Duration)
 
 			if err != nil {
 				if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-					sc.AppendWarning(err)
+					tc.AppendWarning(err)
 					result.AppendNull() // fixed: false
 					continue
 				}
@@ -432,13 +432,13 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 			}
 		} else {
 
-			output, isNull, err = strDatetimeAddDuration(sc, arg0, arg1Duration)
+			output, isNull, err = strDatetimeAddDuration(tc, arg0, arg1Duration)
 
 			if err != nil {
 				return err
 			}
 			if isNull {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.AppendNull() // fixed: false
 				continue
 			}
@@ -565,11 +565,11 @@ func (b *builtinAddDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 			result.AppendNull() // fixed: false
 			continue
 		}
-		sc := ctx.GetSessionVars().StmtCtx
-		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, getFsp4TimeAddSub(arg1))
+		tc := typeCtx(ctx)
+		arg1Duration, _, err := types.ParseDuration(tc, arg1, getFsp4TimeAddSub(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.AppendNull() // fixed: false
 				continue
 			}
@@ -675,9 +675,9 @@ func (b *builtinSubDatetimeAndDurationSig) vecEvalTime(ctx EvalContext, input *c
 
 		// calculate
 
-		sc := ctx.GetSessionVars().StmtCtx
+		tc := typeCtx(ctx)
 		arg1Duration := types.Duration{Duration: arg1, Fsp: -1}
-		output, err := arg0.Add(sc.TypeCtx(), arg1Duration.Neg())
+		output, err := arg0.Add(tc, arg1Duration.Neg())
 
 		if err != nil {
 			return err
@@ -736,17 +736,17 @@ func (b *builtinSubDatetimeAndStringSig) vecEvalTime(ctx EvalContext, input *chu
 			result.SetNull(i, true) // fixed: true
 			continue
 		}
-		sc := ctx.GetSessionVars().StmtCtx
-		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
+		tc := typeCtx(ctx)
+		arg1Duration, _, err := types.ParseDuration(tc, arg1, types.GetFsp(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.SetNull(i, true) // fixed: true
 				continue
 			}
 			return err
 		}
-		output, err := arg0.Add(sc.TypeCtx(), arg1Duration.Neg())
+		output, err := arg0.Add(typeCtx(ctx), arg1Duration.Neg())
 
 		if err != nil {
 			return err
@@ -861,11 +861,11 @@ func (b *builtinSubDurationAndStringSig) vecEvalDuration(ctx EvalContext, input 
 			result.SetNull(i, true) // fixed: true
 			continue
 		}
-		sc := ctx.GetSessionVars().StmtCtx
-		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
+		tc := typeCtx(ctx)
+		arg1Duration, _, err := types.ParseDuration(tc, arg1, types.GetFsp(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.SetNull(i, true) // fixed: true
 				continue
 			}
@@ -929,18 +929,18 @@ func (b *builtinSubStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 
 		// calculate
 
-		sc := ctx.GetSessionVars().StmtCtx
+		tc := typeCtx(ctx)
 		fsp1 := b.args[1].GetType().GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 		var output string
 		var isNull bool
 		if isDuration(arg0) {
 
-			output, err = strDurationSubDuration(sc, arg0, arg1Duration)
+			output, err = strDurationSubDuration(tc, arg0, arg1Duration)
 
 			if err != nil {
 				if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-					sc.AppendWarning(err)
+					tc.AppendWarning(err)
 					result.AppendNull() // fixed: false
 					continue
 				}
@@ -948,13 +948,13 @@ func (b *builtinSubStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 			}
 		} else {
 
-			output, isNull, err = strDatetimeSubDuration(sc, arg0, arg1Duration)
+			output, isNull, err = strDatetimeSubDuration(tc, arg0, arg1Duration)
 
 			if err != nil {
 				return err
 			}
 			if isNull {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.AppendNull() // fixed: false
 				continue
 			}
@@ -1019,11 +1019,11 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 
 		// calculate
 
-		sc := ctx.GetSessionVars().StmtCtx
-		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, getFsp4TimeAddSub(arg1))
+		tc := typeCtx(ctx)
+		arg1Duration, _, err := types.ParseDuration(tc, arg1, getFsp4TimeAddSub(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.AppendNull() // fixed: false
 				continue
 			}
@@ -1034,11 +1034,11 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 		var isNull bool
 		if isDuration(arg0) {
 
-			output, err = strDurationSubDuration(sc, arg0, arg1Duration)
+			output, err = strDurationSubDuration(tc, arg0, arg1Duration)
 
 			if err != nil {
 				if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-					sc.AppendWarning(err)
+					tc.AppendWarning(err)
 					result.AppendNull() // fixed: false
 					continue
 				}
@@ -1046,13 +1046,13 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 			}
 		} else {
 
-			output, isNull, err = strDatetimeSubDuration(sc, arg0, arg1Duration)
+			output, isNull, err = strDatetimeSubDuration(tc, arg0, arg1Duration)
 
 			if err != nil {
 				return err
 			}
 			if isNull {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.AppendNull() // fixed: false
 				continue
 			}
@@ -1179,11 +1179,11 @@ func (b *builtinSubDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 			result.AppendNull() // fixed: false
 			continue
 		}
-		sc := ctx.GetSessionVars().StmtCtx
-		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, getFsp4TimeAddSub(arg1))
+		tc := typeCtx(ctx)
+		arg1Duration, _, err := types.ParseDuration(tc, arg1, getFsp4TimeAddSub(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.AppendNull() // fixed: false
 				continue
 			}
@@ -1285,13 +1285,13 @@ func (b *builtinTimeStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 
 	result.MergeNulls(buf0, buf1)
 	arg0 := buf0.Times()
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		lhsTime := arg0[i]
-		_, rhsTime, rhsIsDuration, err := convertStringToDuration(stmtCtx, buf1.GetString(i), b.tp.GetDecimal())
+		_, rhsTime, rhsIsDuration, err := convertStringToDuration(tc, buf1.GetString(i), b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}
@@ -1299,7 +1299,7 @@ func (b *builtinTimeStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 			result.SetNull(i, true)
 			continue
 		}
-		d, isNull, err := calculateTimeDiff(stmtCtx, lhsTime, rhsTime)
+		d, isNull, err := calculateTimeDiff(tc, lhsTime, rhsTime)
 		if err != nil {
 			return err
 		}
@@ -1340,13 +1340,13 @@ func (b *builtinDurationStringTimeDiffSig) vecEvalDuration(ctx EvalContext, inpu
 		lhs types.Duration
 		rhs types.Duration
 	)
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		lhs.Duration = arg0[i]
-		rhsDur, _, rhsIsDuration, err := convertStringToDuration(stmtCtx, buf1.GetString(i), b.tp.GetDecimal())
+		rhsDur, _, rhsIsDuration, err := convertStringToDuration(tc, buf1.GetString(i), b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}
@@ -1445,12 +1445,12 @@ func (b *builtinStringTimeTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 
 	result.MergeNulls(buf0, buf1)
 	arg1 := buf1.Times()
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		_, lhsTime, lhsIsDuration, err := convertStringToDuration(stmtCtx, buf0.GetString(i), b.tp.GetDecimal())
+		_, lhsTime, lhsIsDuration, err := convertStringToDuration(tc, buf0.GetString(i), b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}
@@ -1459,7 +1459,7 @@ func (b *builtinStringTimeTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 			continue
 		}
 		rhsTime := arg1[i]
-		d, isNull, err := calculateTimeDiff(stmtCtx, lhsTime, rhsTime)
+		d, isNull, err := calculateTimeDiff(tc, lhsTime, rhsTime)
 		if err != nil {
 			return err
 		}
@@ -1500,12 +1500,12 @@ func (b *builtinStringDurationTimeDiffSig) vecEvalDuration(ctx EvalContext, inpu
 		lhs types.Duration
 		rhs types.Duration
 	)
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		lhsDur, _, lhsIsDuration, err := convertStringToDuration(stmtCtx, buf0.GetString(i), b.tp.GetDecimal())
+		lhsDur, _, lhsIsDuration, err := convertStringToDuration(tc, buf0.GetString(i), b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}
@@ -1556,16 +1556,16 @@ func (b *builtinStringStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input 
 	}
 
 	result.MergeNulls(buf0, buf1)
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		lhsDur, lhsTime, lhsIsDuration, err := convertStringToDuration(stmtCtx, buf0.GetString(i), b.tp.GetDecimal())
+		lhsDur, lhsTime, lhsIsDuration, err := convertStringToDuration(tc, buf0.GetString(i), b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}
-		rhsDur, rhsTime, rhsIsDuration, err := convertStringToDuration(stmtCtx, buf1.GetString(i), b.tp.GetDecimal())
+		rhsDur, rhsTime, rhsIsDuration, err := convertStringToDuration(tc, buf1.GetString(i), b.tp.GetDecimal())
 		if err != nil {
 			return err
 		}
@@ -1580,7 +1580,7 @@ func (b *builtinStringStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input 
 		if lhsIsDuration {
 			d, isNull, err = calculateDurationTimeDiff(ctx, lhsDur, rhsDur)
 		} else {
-			d, isNull, err = calculateTimeDiff(stmtCtx, lhsTime, rhsTime)
+			d, isNull, err = calculateTimeDiff(tc, lhsTime, rhsTime)
 		}
 		if err != nil {
 			return err
@@ -1624,14 +1624,14 @@ func (b *builtinTimeTimeTimeDiffSig) vecEvalDuration(ctx EvalContext, input *chu
 	result.MergeNulls(buf0, buf1)
 	arg0 := buf0.Times()
 	arg1 := buf1.Times()
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		lhsTime := arg0[i]
 		rhsTime := arg1[i]
-		d, isNull, err := calculateTimeDiff(stmtCtx, lhsTime, rhsTime)
+		d, isNull, err := calculateTimeDiff(tc, lhsTime, rhsTime)
 		if err != nil {
 			return err
 		}

--- a/pkg/expression/builtin_vectorized_test.go
+++ b/pkg/expression/builtin_vectorized_test.go
@@ -283,7 +283,7 @@ func (p *mockBuiltinDouble) vecEvalTime(ctx EvalContext, input *chunk.Chunk, res
 		if err != nil {
 			return err
 		}
-		if ts[i], err = ts[i].Add(ctx.GetSessionVars().StmtCtx.TypeCtx(), d); err != nil {
+		if ts[i], err = ts[i].Add(typeCtx(ctx), d); err != nil {
 			return err
 		}
 	}
@@ -375,7 +375,7 @@ func (p *mockBuiltinDouble) evalTime(ctx EvalContext, row chunk.Row) (types.Time
 	if err != nil {
 		return types.ZeroTime, false, err
 	}
-	v, err = v.Add(ctx.GetSessionVars().StmtCtx.TypeCtx(), d)
+	v, err = v.Add(typeCtx(ctx), d)
 	return v, isNull, err
 }
 

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -98,7 +98,7 @@ func (col *CorrelatedColumn) EvalInt(ctx EvalContext, row chunk.Row) (int64, boo
 		return 0, true, nil
 	}
 	if col.GetType().Hybrid() {
-		res, err := col.Data.ToInt64(ctx.GetSessionVars().StmtCtx.TypeCtx())
+		res, err := col.Data.ToInt64(typeCtx(ctx))
 		return res, err != nil, err
 	}
 	return col.Data.GetInt64(), false, nil
@@ -430,10 +430,10 @@ func (col *Column) EvalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) 
 			return 0, true, nil
 		}
 		if val.Kind() == types.KindMysqlBit {
-			val, err := val.GetBinaryLiteral().ToInt(ctx.GetSessionVars().StmtCtx.TypeCtx())
+			val, err := val.GetBinaryLiteral().ToInt(typeCtx(ctx))
 			return int64(val), err != nil, err
 		}
-		res, err := val.ToInt64(ctx.GetSessionVars().StmtCtx.TypeCtx())
+		res, err := val.ToInt64(typeCtx(ctx))
 		return res, err != nil, err
 	}
 	if row.IsNull(col.Index) {

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -248,7 +248,7 @@ func (c *Constant) Eval(ctx EvalContext, row chunk.Row) (types.Datum, error) {
 		}
 		if c.DeferredExpr != nil {
 			if dt.Kind() != types.KindMysqlDecimal {
-				val, err := dt.ConvertTo(ctx.GetSessionVars().StmtCtx.TypeCtx(), c.RetType)
+				val, err := dt.ConvertTo(typeCtx(ctx), c.RetType)
 				if err != nil {
 					return dt, err
 				}
@@ -275,13 +275,13 @@ func (c *Constant) EvalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) 
 	if c.GetType().GetType() == mysql.TypeNull || dt.IsNull() {
 		return 0, true, nil
 	} else if dt.Kind() == types.KindBinaryLiteral {
-		val, err := dt.GetBinaryLiteral().ToInt(ctx.GetSessionVars().StmtCtx.TypeCtx())
+		val, err := dt.GetBinaryLiteral().ToInt(typeCtx(ctx))
 		return int64(val), err != nil, err
 	} else if c.GetType().Hybrid() || dt.Kind() == types.KindString {
-		res, err := dt.ToInt64(ctx.GetSessionVars().StmtCtx.TypeCtx())
+		res, err := dt.ToInt64(typeCtx(ctx))
 		return res, false, err
 	} else if dt.Kind() == types.KindMysqlBit {
-		uintVal, err := dt.GetBinaryLiteral().ToInt(ctx.GetSessionVars().StmtCtx.TypeCtx())
+		uintVal, err := dt.GetBinaryLiteral().ToInt(typeCtx(ctx))
 		return int64(uintVal), false, err
 	}
 	return dt.GetInt64(), false, nil
@@ -300,7 +300,7 @@ func (c *Constant) EvalReal(ctx EvalContext, row chunk.Row) (float64, bool, erro
 		return 0, true, nil
 	}
 	if c.GetType().Hybrid() || dt.Kind() == types.KindBinaryLiteral || dt.Kind() == types.KindString {
-		res, err := dt.ToFloat64(ctx.GetSessionVars().StmtCtx.TypeCtx())
+		res, err := dt.ToFloat64(typeCtx(ctx))
 		return res, false, err
 	}
 	return dt.GetFloat64(), false, nil
@@ -334,7 +334,7 @@ func (c *Constant) EvalDecimal(ctx EvalContext, row chunk.Row) (*types.MyDecimal
 	if c.GetType().GetType() == mysql.TypeNull || dt.IsNull() {
 		return nil, true, nil
 	}
-	res, err := dt.ToDecimal(ctx.GetSessionVars().StmtCtx.TypeCtx())
+	res, err := dt.ToDecimal(typeCtx(ctx))
 	if err != nil {
 		return nil, false, err
 	}
@@ -409,7 +409,7 @@ func (c *Constant) Equal(ctx EvalContext, b Expression) bool {
 	if err1 != nil || err2 != nil {
 		return false
 	}
-	con, err := c.Value.Compare(ctx.GetSessionVars().StmtCtx.TypeCtx(), &y.Value, collate.GetBinaryCollator())
+	con, err := c.Value.Compare(typeCtx(ctx), &y.Value, collate.GetBinaryCollator())
 	if err != nil || con != 0 {
 		return false
 	}

--- a/pkg/expression/context.go
+++ b/pkg/expression/context.go
@@ -16,10 +16,15 @@ package expression
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/types"
 )
 
 // EvalContext is used to evaluate an expression
@@ -44,4 +49,32 @@ type EvalContext interface {
 	GetInfoSchema() sessionctx.InfoschemaMetaVersion
 	// GetDomainInfoSchema returns the latest information schema in domain
 	GetDomainInfoSchema() sessionctx.InfoschemaMetaVersion
+}
+
+func sqlMode(ctx EvalContext) mysql.SQLMode {
+	return ctx.GetSessionVars().SQLMode
+}
+
+func strictMode(ctx EvalContext) bool {
+	return ctx.GetSessionVars().StrictSQLMode
+}
+
+func typeCtx(ctx EvalContext) types.Context {
+	return ctx.GetSessionVars().StmtCtx.TypeCtx()
+}
+
+func errCtx(ctx EvalContext) errctx.Context {
+	return ctx.GetSessionVars().StmtCtx.ErrCtx()
+}
+
+func location(ctx EvalContext) *time.Location {
+	return ctx.GetSessionVars().Location()
+}
+
+func warningCount(ctx EvalContext) int {
+	return int(ctx.GetSessionVars().StmtCtx.WarningCount())
+}
+
+func truncateWarnings(ctx EvalContext, start int) []stmtctx.SQLWarn {
+	return ctx.GetSessionVars().StmtCtx.TruncateWarnings(start)
 }

--- a/pkg/expression/errors.go
+++ b/pkg/expression/errors.go
@@ -76,20 +76,20 @@ func handleInvalidTimeError(ctx EvalContext, err error) error {
 		types.ErrDatetimeFunctionOverflow.Equal(err) || types.ErrIncorrectDatetimeValue.Equal(err)) {
 		return err
 	}
-	ec := ctx.GetSessionVars().StmtCtx.ErrCtx()
+	ec := errCtx(ctx)
 	return ec.HandleError(err)
 }
 
 // handleDivisionByZeroError reports error or warning depend on the context.
 func handleDivisionByZeroError(ctx EvalContext) error {
-	ec := ctx.GetSessionVars().StmtCtx.ErrCtx()
+	ec := errCtx(ctx)
 	return ec.HandleError(ErrDivisionByZero)
 }
 
 // handleAllowedPacketOverflowed reports error or warning depend on the context.
 func handleAllowedPacketOverflowed(ctx EvalContext, exprName string, maxAllowedPacketSize uint64) error {
 	err := errWarnAllowedPacketOverflowed.FastGenByArgs(exprName, maxAllowedPacketSize)
-	tc := ctx.GetSessionVars().StmtCtx.TypeCtx()
+	tc := typeCtx(ctx)
 	if f := tc.Flags(); f.TruncateAsWarning() || f.IgnoreTruncateErr() {
 		tc.AppendWarning(err)
 		return nil

--- a/pkg/expression/expr_to_pb.go
+++ b/pkg/expression/expr_to_pb.go
@@ -142,9 +142,9 @@ func (pc *PbConverter) encodeDatum(ft *types.FieldType, d types.Datum) (tipb.Exp
 	case types.KindMysqlTime:
 		if pc.client.IsRequestTypeSupported(kv.ReqTypeDAG, int64(tipb.ExprType_MysqlTime)) {
 			tp = tipb.ExprType_MysqlTime
-			sc := pc.ctx.GetSessionVars().StmtCtx
-			val, err := codec.EncodeMySQLTime(sc.TimeZone(), d.GetMysqlTime(), ft.GetType(), nil)
-			err = sc.HandleError(err)
+			tc, ec := typeCtx(pc.ctx), errCtx(pc.ctx)
+			val, err := codec.EncodeMySQLTime(tc.Location(), d.GetMysqlTime(), ft.GetType(), nil)
+			err = ec.HandleError(err)
 			if err != nil {
 				logutil.BgLogger().Error("encode mysql time", zap.Error(err))
 				return tp, nil, false

--- a/pkg/expression/generator/compare_vec.go
+++ b/pkg/expression/generator/compare_vec.go
@@ -221,17 +221,16 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEval{{ .ty
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++{
 		err := b.args[j].VecEval{{ .type.TypeName }}(ctx, input, buf1)
         {{- if eq .type.TypeName "Time" }}
         fsp := b.tp.GetDecimal()
         {{- end }}
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEval{{ .type.TypeName }}(ctx, input, result)
 		}
@@ -254,8 +253,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEval{{ .ty
 	argLen := len(b.args)
 
 	bufs := make([]*chunk.Column, argLen)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	for i := 0; i < argLen; i++ {
 		buf, err := b.bufAllocator.get()
 		if err != nil {
@@ -263,10 +261,10 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEval{{ .ty
 		}
 		defer b.bufAllocator.put(buf)
 		err = b.args[i].VecEval{{ .type.TypeName }}(ctx, input, buf)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEval{{ .type.TypeName }}(ctx, input, result)
 		}

--- a/pkg/expression/generator/control_vec.go
+++ b/pkg/expression/generator/control_vec.go
@@ -111,8 +111,7 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalConte
 	thensSlice := make([][]{{.TypeNameGo}}, l/2)
 	var eLseSlice []{{.TypeNameGo}}
 	{{- end }}
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j+=2 {
 		bufWhen, err := b.bufAllocator.get()
@@ -121,10 +120,10 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalConte
 		}
 		defer b.bufAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEval{{ .TypeName }}(ctx, input, result)
 		}
@@ -137,10 +136,10 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalConte
 		}
 		defer b.bufAllocator.put(bufThen)
 		err = args[j+1].VecEval{{ .TypeName }}(ctx, input, bufThen)
-		afterWarns = sc.WarningCount()
+		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEval{{ .TypeName }}(ctx, input, result)
 		}
@@ -159,10 +158,10 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalConte
 		}
 		defer b.bufAllocator.put(bufElse)
 		err = args[l-1].VecEval{{ .TypeName }}(ctx, input, bufElse)
-		afterWarns := sc.WarningCount()
+		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
 			if afterWarns > beforeWarns {
-				sc.TruncateWarnings(int(beforeWarns))
+				truncateWarnings(ctx, beforeWarns)
 			}
 			return b.fallbackEval{{ .TypeName }}(ctx, input, result)
 		}
@@ -277,13 +276,12 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-      		sc.TruncateWarnings(int(beforeWarns))
+      		truncateWarnings(ctx, beforeWarns)
 		}
       	return b.fallbackEval{{ .TypeName }}(ctx, input, result)
    	}
@@ -309,13 +307,12 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-      		sc.TruncateWarnings(int(beforeWarns))
+      		truncateWarnings(ctx, beforeWarns)
 		}
       	return b.fallbackEval{{ .TypeName }}(ctx, input,result)
    	}
@@ -392,8 +389,7 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext, in
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	sc := ctx.GetSessionVars().StmtCtx
-	beforeWarns := sc.WarningCount()
+	beforeWarns := warningCount(ctx)
 {{- if .Fixed }}
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, result)
 {{- else }}
@@ -404,10 +400,10 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext, in
 	defer b.bufAllocator.put(buf1)
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
 {{- end }}
-	afterWarns := sc.WarningCount()
+	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-      		sc.TruncateWarnings(int(beforeWarns))
+      		truncateWarnings(ctx, beforeWarns)
 		}
       	return b.fallbackEval{{ .TypeName }}(ctx, input, result)
    	}
@@ -418,10 +414,10 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext, in
 	}
 	defer b.bufAllocator.put(buf2)
 	err = b.args[2].VecEval{{ .TypeName }}(ctx, input, buf2)
-	afterWarns = sc.WarningCount()
+	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
 		if afterWarns > beforeWarns {
-      		sc.TruncateWarnings(int(beforeWarns))
+      		truncateWarnings(ctx, beforeWarns)
 		}
       	return b.fallbackEval{{ .TypeName }}(ctx, input, result)
    	}

--- a/pkg/expression/generator/time_vec.go
+++ b/pkg/expression/generator/time_vec.go
@@ -62,11 +62,11 @@ import (
 			{{ template "SetNull" . }}
 			continue
 		}{{ end }}
-		sc := ctx.GetSessionVars().StmtCtx
-		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, {{if eq .Output.TypeName "String"}}getFsp4TimeAddSub{{else}}types.GetFsp{{end}}(arg1))
+		tc := typeCtx(ctx)
+		arg1Duration, _, err := types.ParseDuration(tc, arg1, {{if eq .Output.TypeName "String"}}getFsp4TimeAddSub{{else}}types.GetFsp{{end}}(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				{{ template "SetNull" . }}
 				continue
 			}
@@ -171,11 +171,11 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 		// calculate
 	{{ if or (eq .SigName "builtinAddDatetimeAndDurationSig") (eq .SigName "builtinSubDatetimeAndDurationSig") }}
 		{{ if eq $.FuncName "AddTime" }}
-		output, err := arg0.Add(ctx.GetSessionVars().StmtCtx.TypeCtx(), types.Duration{Duration: arg1, Fsp: -1})
+		output, err := arg0.Add(typeCtx(ctx), types.Duration{Duration: arg1, Fsp: -1})
 		{{ else }}
-		sc := ctx.GetSessionVars().StmtCtx
+		tc := typeCtx(ctx)
 		arg1Duration := types.Duration{Duration: arg1, Fsp: -1}
-		output, err := arg0.Add(sc.TypeCtx(), arg1Duration.Neg())
+		output, err := arg0.Add(tc, arg1Duration.Neg())
 		{{ end }}
 		if err != nil {
 			return err
@@ -184,23 +184,23 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 	{{ else if or (eq .SigName "builtinAddDatetimeAndStringSig") (eq .SigName "builtinSubDatetimeAndStringSig") }}
 		{{ if eq $.FuncName "AddTime" }}
 		{{ template "ConvertStringToDuration" . }}
-		output, err := arg0.Add(sc.TypeCtx(), arg1Duration)
+		output, err := arg0.Add(typeCtx(ctx), arg1Duration)
 		{{ else }}
 		if !isDuration(arg1) {
 			result.SetNull(i, true) // fixed: true
 			continue
 		}
-		sc := ctx.GetSessionVars().StmtCtx
-		arg1Duration, _, err := types.ParseDuration(sc.TypeCtx(), arg1, types.GetFsp(arg1))
+		tc := typeCtx(ctx)
+		arg1Duration, _, err := types.ParseDuration(tc, arg1, types.GetFsp(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				result.SetNull(i, true) // fixed: true
 				continue
 			}
 			return err
 		}
-		output, err := arg0.Add(sc.TypeCtx(), arg1Duration.Neg())
+		output, err := arg0.Add(typeCtx(ctx), arg1Duration.Neg())
 		{{ end }}
 		if err != nil {
 			return err
@@ -231,20 +231,20 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 		}
 		{{ end }}
 	{{ else if or (eq .SigName "builtinAddStringAndDurationSig") (eq .SigName "builtinSubStringAndDurationSig") }}
-		sc := ctx.GetSessionVars().StmtCtx
+		tc := typeCtx(ctx)
 		fsp1 := b.args[1].GetType().GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 		var output string
 		var isNull bool
 		if isDuration(arg0) {
 			{{ if eq $.FuncName "AddTime" }}
-			output, err = strDurationAddDuration(sc, arg0, arg1Duration)
+			output, err = strDurationAddDuration(tc, arg0, arg1Duration)
 			{{ else }}
-			output, err = strDurationSubDuration(sc, arg0, arg1Duration)
+			output, err = strDurationSubDuration(tc, arg0, arg1Duration)
 			{{ end }}
 			if err != nil {
 				if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-					sc.AppendWarning(err)
+					tc.AppendWarning(err)
 					{{ template "SetNull" . }}
 					continue
 				}
@@ -252,15 +252,15 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 			}
 		} else {
 			{{ if eq $.FuncName "AddTime" }}
-			output, isNull, err = strDatetimeAddDuration(sc, arg0, arg1Duration)
+			output, isNull, err = strDatetimeAddDuration(tc, arg0, arg1Duration)
 			{{ else }}
-			output, isNull, err = strDatetimeSubDuration(sc, arg0, arg1Duration)
+			output, isNull, err = strDatetimeSubDuration(tc, arg0, arg1Duration)
 			{{ end }}
 			if err != nil {
 				return err
 			}
 			if isNull {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				{{ template "SetNull" . }}
 				continue
 			}
@@ -271,13 +271,13 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 		var isNull bool
 		if isDuration(arg0) {
 			{{ if eq $.FuncName "AddTime" }}
-			output, err = strDurationAddDuration(sc, arg0, arg1Duration)
+			output, err = strDurationAddDuration(tc, arg0, arg1Duration)
 			{{ else }}
-			output, err = strDurationSubDuration(sc, arg0, arg1Duration)
+			output, err = strDurationSubDuration(tc, arg0, arg1Duration)
 			{{ end }}
 			if err != nil {
 				if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-					sc.AppendWarning(err)
+					tc.AppendWarning(err)
 					{{ template "SetNull" . }}
 					continue
 				}
@@ -285,15 +285,15 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 			}
 		} else {
 			{{ if eq $.FuncName "AddTime" }}
-			output, isNull, err = strDatetimeAddDuration(sc, arg0, arg1Duration)
+			output, isNull, err = strDatetimeAddDuration(tc, arg0, arg1Duration)
 			{{ else }}
-			output, isNull, err = strDatetimeSubDuration(sc, arg0, arg1Duration)
+			output, isNull, err = strDatetimeSubDuration(tc, arg0, arg1Duration)
 			{{ end }}
 			if err != nil {
 				return err
 			}
 			if isNull {
-				sc.AppendWarning(err)
+				tc.AppendWarning(err)
 				{{ template "SetNull" . }}
 				continue
 			}
@@ -415,7 +415,7 @@ func (b *{{.SigName}}) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, resu
 			)
 		{{- end }}
 		{{- if or (or $AIsString $BIsString) (and $AIsTime $BIsTime) }}
-			stmtCtx := ctx.GetSessionVars().StmtCtx
+			tc := typeCtx(ctx)
 		{{- end }}
 	for i:=0; i<n ; i++{
 		if result.IsNull(i) {
@@ -426,7 +426,7 @@ func (b *{{.SigName}}) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, resu
 			{{ if $BIsDuration }} lhsDur, _, lhsIsDuration,
 			{{- else if $BIsTime }} _, lhsTime, lhsIsDuration,
 			{{- else if $BIsString }} lhsDur, lhsTime, lhsIsDuration,
-			{{- end }}  err := convertStringToDuration(stmtCtx, buf0.GetString(i), b.tp.GetDecimal())
+			{{- end }}  err := convertStringToDuration(tc, buf0.GetString(i), b.tp.GetDecimal())
 			if err != nil  {
 				return err
 			}
@@ -452,7 +452,7 @@ func (b *{{.SigName}}) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, resu
 			{{ if $AIsDuration }} rhsDur, _, rhsIsDuration,
 			{{- else if $AIsTime }}_, rhsTime, rhsIsDuration,
 			{{- else if $AIsString }} rhsDur, rhsTime, rhsIsDuration,
-			{{- end}}  err := convertStringToDuration(stmtCtx, buf1.GetString(i), b.tp.GetDecimal())
+			{{- end}}  err := convertStringToDuration(tc, buf1.GetString(i), b.tp.GetDecimal())
 			if err != nil  {
 				return err
 			}
@@ -486,12 +486,12 @@ func (b *{{.SigName}}) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, resu
 			if lhsIsDuration {
 				d, isNull, err = calculateDurationTimeDiff(ctx, lhsDur, rhsDur)
 			} else {
-				d, isNull, err = calculateTimeDiff(stmtCtx, lhsTime, rhsTime)
+				d, isNull, err = calculateTimeDiff(tc, lhsTime, rhsTime)
 			}
 		{{- else if or $AIsDuration $BIsDuration }}
 			d, isNull, err := calculateDurationTimeDiff(ctx, lhs, rhs)
 		{{- else if or $AIsTime $BIsTime }}
-			d, isNull, err := calculateTimeDiff(stmtCtx, lhsTime, rhsTime)
+			d, isNull, err := calculateTimeDiff(tc, lhsTime, rhsTime)
 		{{- end }}
 		if err != nil {
 			return err

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -418,9 +418,8 @@ func (sf *ScalarFunction) Eval(ctx EvalContext, row chunk.Row) (d types.Datum, e
 		str, isNull, err = sf.EvalString(ctx, row)
 		if !isNull && err == nil && tp.GetType() == mysql.TypeEnum {
 			res, err = types.ParseEnum(tp.GetElems(), str, tp.GetCollate())
-			if sc := ctx.GetSessionVars().StmtCtx; sc != nil {
-				err = sc.HandleTruncate(err)
-			}
+			tc := typeCtx(ctx)
+			err = tc.HandleTruncate(err)
 		} else {
 			res = str
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #49090

### What changed and how does it work?

Some common fields are general used in expression like `SQLMode`, `types.Context` or `errctx.Context`. In this PR, we provide some common functions to read them from `EvalContext` to:

1. make code shorter.
2. easy to analyze which fields are accessed from `sessionVars` to help to do the further refactor works.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > just to regress the exists tests

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
