### PR TITLE
executor: fix TestAggPartialResultMapperB in go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gostaticanalysis/forcetypeassert v0.1.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/jedib0t/go-pretty/v6 v6.2.2
 	github.com/jellydator/ttlcache/v3 v3.0.1


### PR DESCRIPTION
This PR is trivial. 

As the [discussion](https://github.com/golang/go/issues/63438) indicates load factor of map in 1.21 would be 6 rather than 6.5 in other version. The whole test of `TestaggPartiualResultMap` depends on the assumption that load factor of map in golang would be 6.5. 

To adopt this breaking behavior, the codebase of tidb should makes changes accordingly. 

This PR fixes https://github.com/pingcap/tidb/issues/50544. 

Tests
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ]  No code