### PR TITLE
executor: adapt to the go1.21 map loadFactor setting value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gostaticanalysis/forcetypeassert v0.1.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/jedib0t/go-pretty/v6 v6.2.2
 	github.com/jellydator/ttlcache/v3 v3.0.1

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -456,6 +456,7 @@ go_test(
         "//pkg/util/tableutil",
         "//pkg/util/topsql/state",
         "@com_github_gorilla_mux//:mux",
+        "@com_github_hashicorp_go_version//:go-version",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_fn//:fn",

--- a/pkg/executor/concurrent_map_test.go
+++ b/pkg/executor/concurrent_map_test.go
@@ -70,7 +70,7 @@ func TestConcurrentMap(t *testing.T) {
 
 func TestConcurrentMapMemoryUsage(t *testing.T) {
 	m := newConcurrentMap()
-	const iterations = 1024 * hack.LoadFactorNum / hack.LoadFactorDen
+	var iterations = 1024 * hack.LoadFactorNum / hack.LoadFactorDen
 	var memUsage int64
 	wg := &sync.WaitGroup{}
 	wg.Add(2)

--- a/pkg/executor/executor_pkg_test.go
+++ b/pkg/executor/executor_pkg_test.go
@@ -170,9 +170,12 @@ func TestAggPartialResultMapperB(t *testing.T) {
 	// skip err, since we guarantee the success of execution
 	go113, _ := version.NewVersion(`1.13`)
 	actualVerStr := strings.SplitAfter(runtime.Version(), `go`)[1]
-	actualVer, _ := version.NewVersion(actualVerStr)
+	actualVer, err := version.NewVersion(actualVerStr)
+	if err != nil {
+		t.Fatalf("Cannot get actual go version with error %v\n", err)
+	}
 	if actualVer.LessThan(go113) {
-		t.Fatalf("Unsupported version and should never use any version less than go1.13")
+		t.Fatalf("Unsupported version and should never use any version less than go1.13\n")
 	}
 	type testCase struct {
 		rowNum          int

--- a/pkg/executor/executor_pkg_test.go
+++ b/pkg/executor/executor_pkg_test.go
@@ -16,7 +16,6 @@ package executor
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"runtime"
 	"strconv"
 	"strings"
@@ -24,6 +23,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/hashicorp/go-version"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/executor/aggfuncs"

--- a/pkg/executor/executor_pkg_test.go
+++ b/pkg/executor/executor_pkg_test.go
@@ -169,8 +169,9 @@ func TestSlowQueryRuntimeStats(t *testing.T) {
 func TestAggPartialResultMapperB(t *testing.T) {
 	// skip err, since we guarantee the success of execution
 	go113, _ := version.NewVersion(`1.13`)
-	actualVerStr := strings.SplitAfter(runtime.Version(), `go`)[1]
-	actualVer, err := version.NewVersion(actualVerStr)
+	// go version format is `gox.y.z foobar`, we only need x.y.z part
+	// The following is pretty hacky, but it only in test which is ok to do so.
+	actualVer, err := version.NewVersion(runtime.Version()[2:6])
 	if err != nil {
 		t.Fatalf("Cannot get actual go version with error %v\n", err)
 	}

--- a/pkg/executor/hash_table_test.go
+++ b/pkg/executor/hash_table_test.go
@@ -167,7 +167,7 @@ func testHashRowContainer(t *testing.T, hashFunc func() hash.Hash64, spill bool)
 
 func TestConcurrentMapHashTableMemoryUsage(t *testing.T) {
 	m := newConcurrentMapHashTable()
-	const iterations = 1024 * hack.LoadFactorNum / hack.LoadFactorDen // 6656
+	var iterations = 1024 * hack.LoadFactorNum / hack.LoadFactorDen // 6656
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	// Note: Now concurrentMapHashTable doesn't support inserting in parallel.

--- a/pkg/util/hack/hack.go
+++ b/pkg/util/hack/hack.go
@@ -15,6 +15,8 @@
 package hack
 
 import (
+	"runtime"
+	"strings"
 	"unsafe"
 )
 
@@ -41,11 +43,20 @@ func Slice(s string) []byte {
 // Represent as LoadFactorNum/LoadFactorDen, to allow integer math.
 // They are from the golang definition. ref: https://github.com/golang/go/blob/go1.13.15/src/runtime/map.go#L68-L71
 const (
-	// LoadFactorNum is the numerator of load factor
-	LoadFactorNum = 13
 	// LoadFactorDen is the denominator of load factor
 	LoadFactorDen = 2
 )
+
+// LoadFactorNum is the numerator of load factor
+var LoadFactorNum = 13
+
+func init() {
+	// In go1.21, the load factor num becomes 12 and go team has decided not to backport the fix to 1.21.
+	// See more details in https://github.com/golang/go/issues/63438
+	if strings.Contains(runtime.Version(), `go1.21`) {
+		LoadFactorNum = 12
+	}
+}
 
 const (
 	// DefBucketMemoryUsageForMapStrToSlice = bucketSize*(1+unsafe.Sizeof(string) + unsafe.Sizeof(slice))+2*ptrSize

--- a/pkg/util/set/mem_aware_map.go
+++ b/pkg/util/set/mem_aware_map.go
@@ -37,7 +37,7 @@ func EstimateMapSize(length int, bucketSize uint64) uint64 {
 	if length == 0 {
 		return 0
 	}
-	bInMap := uint64(math.Ceil(math.Log2(float64(length) * hack.LoadFactorDen / hack.LoadFactorNum)))
+	bInMap := uint64(math.Ceil(math.Log2(float64(length) * hack.LoadFactorDen / float64(hack.LoadFactorNum))))
 	return bucketSize * uint64(1<<bInMap)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50544 and #50552 

Problem Summary:

### What changed and how does it work?
This PR is trivial.
As the [discussion](https://github.com/golang/go/issues/63438) indicates load factor of map in 1.21 would be 6 rather than 6.5 in other version. The whole test of TestaggPartiualResultMap depends on the assumption that load factor of map in golang would be 6.5.
To adopt this breaking behavior, the codebase of tidb should makes changes accordingly.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

