### PR TITLE
conn, util: make `opentracing` work again

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -1260,7 +1260,7 @@ func (cc *clientConn) dispatch(ctx context.Context, data []byte) error {
 	cfg := config.GetGlobalConfig()
 	if cfg.OpenTracing.Enable {
 		var r tracing.Region
-		r, ctx = tracing.StartRegionEx(ctx, "server.dispatch")
+		r, ctx = tracing.StartRegionWithNewRootSpan(ctx, "server.dispatch")
 		defer r.End()
 	}
 

--- a/pkg/util/tracing/util.go
+++ b/pkg/util/tracing/util.go
@@ -73,6 +73,18 @@ func ChildSpanFromContxt(ctx context.Context, opName string) (opentracing.Span, 
 	return noopSpan(), ctx
 }
 
+// StartRegionWithNewRootSpan return Region together with the context.
+// It create and start a new span by globalTracer and store it into `ctx`.
+func StartRegionWithNewRootSpan(ctx context.Context, regionType string) (Region, context.Context) {
+	span := opentracing.GlobalTracer().StartSpan(regionType)
+	r := Region{
+		Region: trace.StartRegion(ctx, regionType),
+		Span:   span,
+	}
+	ctx = opentracing.ContextWithSpan(ctx, span)
+	return r, ctx
+}
+
 // StartRegion provides better API, integrating both opentracing and runtime.trace facilities into one.
 // Recommended usage is
 //


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50508

Problem Summary: Caused by https://github.com/pingcap/tidb/pull/40825, miss root span for opentracing tools.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Start a TiDB cluster as #50508 said, and use JaegerUI to get trace info success.
![image](https://github.com/pingcap/tidb/assets/17435596/e588ff0a-f850-4003-9f0c-73439be30a3b)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
