### PR TITLE
planner: fix single mv index merge case couldn't be hinted by use_index_merge

### DIFF
--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -279,6 +279,7 @@ func (ds *DataSource) generateIndexMergeOrPaths(filters []expression.Expression)
 // (1) there's no IndexMerge hint, (2) there's IndexMerge hint but no specified index names, or (3) the input index
 // name is specified in the IndexMerge hints.
 func (ds *DataSource) isInIndexMergeHints(name string) bool {
+	// if not index merge hints, all mv index is accessible,
 	if len(ds.indexMergeHints) == 0 {
 		return true
 	}
@@ -915,6 +916,11 @@ func (ds *DataSource) generateIndexMergeOnDNF4MVIndex(normalPathCnt int, filters
 			continue // not a MVIndex path
 		}
 
+		// for single MV index usage, if specified use the specified one, if not, all can be access and chosen by cost model.
+		if !ds.isInIndexMergeHints(ds.possibleAccessPaths[idx].Index.Name.L) {
+			continue
+		}
+
 		idxCols, ok := PrepareCols4MVIndex(ds.table.Meta(), ds.possibleAccessPaths[idx].Index, ds.TblCols)
 		if !ok {
 			continue
@@ -1174,6 +1180,11 @@ func (ds *DataSource) generateIndexMerge4MVIndex(normalPathCnt int, filters []ex
 	for idx := 0; idx < normalPathCnt; idx++ {
 		if !isMVIndexPath(ds.possibleAccessPaths[idx]) {
 			continue // not a MVIndex path
+		}
+
+		// for single MV index usage, if specified use the specified one, if not, all can be access and chosen by cost model.
+		if !ds.isInIndexMergeHints(ds.possibleAccessPaths[idx].Index.Name.L) {
+			continue
 		}
 
 		idxCols, ok := PrepareCols4MVIndex(ds.table.Meta(), ds.possibleAccessPaths[idx].Index, ds.TblCols)

--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -279,7 +279,7 @@ func (ds *DataSource) generateIndexMergeOrPaths(filters []expression.Expression)
 // (1) there's no IndexMerge hint, (2) there's IndexMerge hint but no specified index names, or (3) the input index
 // name is specified in the IndexMerge hints.
 func (ds *DataSource) isInIndexMergeHints(name string) bool {
-	// if not index merge hints, all mv index is accessible,
+	// if no index merge hints, all mv index is accessible
 	if len(ds.indexMergeHints) == 0 {
 		return true
 	}

--- a/tests/integrationtest/r/planner/core/casetest/index/index.result
+++ b/tests/integrationtest/r/planner/core/casetest/index/index.result
@@ -835,3 +835,19 @@ IndexMerge	0.01	root		type: intersection, limit embedded(offset:0, count:10)
 ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:fpi(cast(`fpi` as unsigned array))	range:[15975127,15975127], keep order:false, stats:pseudo
 ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:nslc(cast(`nslc` as char(1000) array), point_of_sale_country)	range:["OC8p0106XTkt.org/s/link","OC8p0106XTkt.org/s/link"], keep order:false, stats:pseudo
 └─TableRowIDScan(Probe)	0.01	cop[tikv]	table:t	keep order:false, stats:pseudo
+drop table if exists t;
+CREATE TABLE t (nslc json DEFAULT NULL,fpi json DEFAULT NULL,point_of_sale_country int,KEY nslc ((cast(nslc as char(1000) array)),point_of_sale_country),KEY fpi ((cast(fpi as unsigned array))));
+explain SELECT /*+ use_index(items, nslc) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;
+id	estRows	task	access object	operator info
+Limit_10	0.01	root		offset:0, count:1
+└─IndexMerge_35	0.01	root		type: union
+  ├─IndexRangeScan_32(Build)	10.00	cop[tikv]	table:t, index:fpi(cast(`fpi` as unsigned array))	range:[57260686,57260686], keep order:false, stats:pseudo
+  └─Selection_34(Probe)	0.01	cop[tikv]		json_memberof(cast("OC8p1763XTkt.org/s/link", json BINARY), planner__core__casetest__index__index.t.nslc)
+    └─TableRowIDScan_33	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+explain SELECT /*+ use_index(items, fpi) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;
+id	estRows	task	access object	operator info
+Limit_10	0.01	root		offset:0, count:1
+└─IndexMerge_35	0.01	root		type: union
+  ├─IndexRangeScan_32(Build)	10.00	cop[tikv]	table:t, index:fpi(cast(`fpi` as unsigned array))	range:[57260686,57260686], keep order:false, stats:pseudo
+  └─Selection_34(Probe)	0.01	cop[tikv]		json_memberof(cast("OC8p1763XTkt.org/s/link", json BINARY), planner__core__casetest__index__index.t.nslc)
+    └─TableRowIDScan_33	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/planner/core/casetest/index/index.result
+++ b/tests/integrationtest/r/planner/core/casetest/index/index.result
@@ -837,14 +837,14 @@ IndexMerge	0.01	root		type: intersection, limit embedded(offset:0, count:10)
 └─TableRowIDScan(Probe)	0.01	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t;
 CREATE TABLE t (nslc json DEFAULT NULL,fpi json DEFAULT NULL,point_of_sale_country int,KEY nslc ((cast(nslc as char(1000) array)),point_of_sale_country),KEY fpi ((cast(fpi as unsigned array))));
-explain SELECT /*+ use_index(items, nslc) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;
+explain SELECT /*+ use_index_merge(items, nslc) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;
 id	estRows	task	access object	operator info
 Limit_10	0.01	root		offset:0, count:1
 └─IndexMerge_35	0.01	root		type: union
   ├─IndexRangeScan_32(Build)	10.00	cop[tikv]	table:t, index:fpi(cast(`fpi` as unsigned array))	range:[57260686,57260686], keep order:false, stats:pseudo
   └─Selection_34(Probe)	0.01	cop[tikv]		json_memberof(cast("OC8p1763XTkt.org/s/link", json BINARY), planner__core__casetest__index__index.t.nslc)
     └─TableRowIDScan_33	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-explain SELECT /*+ use_index(items, fpi) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;
+explain SELECT /*+ use_index_merge(items, fpi) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;
 id	estRows	task	access object	operator info
 Limit_10	0.01	root		offset:0, count:1
 └─IndexMerge_35	0.01	root		type: union

--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -90,8 +90,8 @@ IndexMerge	3.32	root		type: union
 explain format = 'brief' select /*+ use_index_merge(t, j1) */ * from t where (1 member of (j0->'$.path1')) and (2 member of (j1)) and a<10;
 id	estRows	task	access object	operator info
 IndexMerge	0.00	root		type: union
-├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:j0_1(cast(json_extract(`j0`, _utf8mb4'$.path1') as signed array))	range:[1,1], keep order:false, stats:pseudo
-└─Selection(Probe)	0.00	cop[tikv]		json_memberof(cast(2, json BINARY), planner__core__indexmerge_path.t.j1), lt(planner__core__indexmerge_path.t.a, 10)
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:j1(cast(`j1` as signed array))	range:[2,2], keep order:false, stats:pseudo
+└─Selection(Probe)	0.00	cop[tikv]		json_memberof(cast(1, json BINARY), json_extract(planner__core__indexmerge_path.t.j0, "$.path1")), lt(planner__core__indexmerge_path.t.a, 10)
   └─TableRowIDScan	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index_merge(t, j0_0) */ * from t where json_contains((j0->'$.path0'), '[1, 2, 3]');
 id	estRows	task	access object	operator info

--- a/tests/integrationtest/t/planner/core/casetest/index/index.test
+++ b/tests/integrationtest/t/planner/core/casetest/index/index.test
@@ -293,5 +293,5 @@ EXPLAIN format='brief' SELECT /*+ use_index_merge(t, fpi, nslc_old, nslc) */ * F
 # TestIndexMergeSingleCaseCouldFeelIndexMergeHint
 drop table if exists t;
 CREATE TABLE t (nslc json DEFAULT NULL,fpi json DEFAULT NULL,point_of_sale_country int,KEY nslc ((cast(nslc as char(1000) array)),point_of_sale_country),KEY fpi ((cast(fpi as unsigned array))));
-explain SELECT /*+ use_index(items, nslc) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;
-explain SELECT /*+ use_index(items, fpi) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;
+explain SELECT /*+ use_index_merge(items, nslc) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;
+explain SELECT /*+ use_index_merge(items, fpi) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;

--- a/tests/integrationtest/t/planner/core/casetest/index/index.test
+++ b/tests/integrationtest/t/planner/core/casetest/index/index.test
@@ -290,3 +290,8 @@ DROP table if exists t;
 CREATE TABLE `t` (`pk` varbinary(255) NOT NULL,`nslc` json DEFAULT NULL,`fpi` json DEFAULT NULL,`point_of_sale_country` varchar(2) DEFAULT NULL,PRIMARY KEY (`pk`) /*T![clustered_index] CLUSTERED */,KEY `fpi` ((cast(`fpi` as unsigned array))),KEY `nslc` ((cast(`nslc` as char(1000) array)),`point_of_sale_country`),KEY `nslc_old` ((cast(`nslc` as char(1000) array))));
 EXPLAIN format='brief' SELECT /*+ use_index_merge(t, fpi, nslc_old, nslc) */ * FROM   t WHERE   15975127 member of (fpi)   AND "OC8p0106XTkt.org/s/link" member of (nslc) LIMIT   10;
 
+# TestIndexMergeSingleCaseCouldFeelIndexMergeHint
+drop table if exists t;
+CREATE TABLE t (nslc json DEFAULT NULL,fpi json DEFAULT NULL,point_of_sale_country int,KEY nslc ((cast(nslc as char(1000) array)),point_of_sale_country),KEY fpi ((cast(fpi as unsigned array))));
+explain SELECT /*+ use_index(items, nslc) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;
+explain SELECT /*+ use_index(items, fpi) */ *  FROM t WHERE  57260686 member of (fpi)  AND "OC8p1763XTkt.org/s/link" member of (nslc)  LIMIT  1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/50553

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
