### PR TITLE
executor: adapt to the go1.21 map loadFactor setting value (#50545)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gostaticanalysis/forcetypeassert v0.1.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/jedib0t/go-pretty/v6 v6.2.2
 	github.com/jellydator/ttlcache/v3 v3.0.1

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -455,6 +455,7 @@ go_test(
         "//pkg/util/tableutil",
         "//pkg/util/topsql/state",
         "@com_github_gorilla_mux//:mux",
+        "@com_github_hashicorp_go_version//:go-version",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_fn//:fn",

--- a/pkg/executor/concurrent_map_test.go
+++ b/pkg/executor/concurrent_map_test.go
@@ -70,7 +70,7 @@ func TestConcurrentMap(t *testing.T) {
 
 func TestConcurrentMapMemoryUsage(t *testing.T) {
 	m := newConcurrentMap()
-	const iterations = 1024 * hack.LoadFactorNum / hack.LoadFactorDen
+	var iterations = 1024 * hack.LoadFactorNum / hack.LoadFactorDen
 	var memUsage int64
 	wg := &sync.WaitGroup{}
 	wg.Add(2)

--- a/pkg/executor/executor_pkg_test.go
+++ b/pkg/executor/executor_pkg_test.go
@@ -18,11 +18,15 @@ import (
 	"context"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 	"unsafe"
 
 	"github.com/pingcap/failpoint"
+	"github.com/hashicorp/go-version"
+	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/executor/aggfuncs"
 	"github.com/pingcap/tidb/pkg/executor/aggregate"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
@@ -164,57 +168,113 @@ func TestSlowQueryRuntimeStats(t *testing.T) {
 }
 
 // Test whether the actual buckets in Golang Map is same with the estimated number.
-// The test relies the implement of Golang Map. ref https://github.com/golang/go/blob/go1.13/src/runtime/map.go#L114
+// The test relies on the implement of Golang Map. ref https://github.com/golang/go/blob/go1.13/src/runtime/map.go#L114
 func TestAggPartialResultMapperB(t *testing.T) {
-	if runtime.Version() < `go1.13` {
-		t.Skip("Unsupported version")
+	// skip err, since we guarantee the success of execution
+	go113, _ := version.NewVersion(`1.13`)
+	// go version format is `gox.y.z foobar`, we only need x.y.z part
+	// The following is pretty hacky, but it only in test which is ok to do so.
+	actualVer, err := version.NewVersion(runtime.Version()[2:6])
+	if err != nil {
+		t.Fatalf("Cannot get actual go version with error %v\n", err)
+	}
+	if actualVer.LessThan(go113) {
+		t.Fatalf("Unsupported version and should never use any version less than go1.13\n")
 	}
 	type testCase struct {
 		rowNum          int
 		expectedB       int
 		expectedGrowing bool
 	}
-	cases := []testCase{
-		{
-			rowNum:          0,
-			expectedB:       0,
-			expectedGrowing: false,
-		},
-		{
-			rowNum:          100,
-			expectedB:       5,
-			expectedGrowing: true,
-		},
-		{
-			rowNum:          10000,
-			expectedB:       11,
-			expectedGrowing: false,
-		},
-		{
-			rowNum:          1000000,
-			expectedB:       18,
-			expectedGrowing: false,
-		},
-		{
-			rowNum:          851968, // 6.5 * (1 << 17)
-			expectedB:       18,
-			expectedGrowing: true,
-		},
-		{
-			rowNum:          851969, // 6.5 * (1 << 17) + 1
-			expectedB:       18,
-			expectedGrowing: true,
-		},
-		{
-			rowNum:          425984, // 6.5 * (1 << 16)
-			expectedB:       17,
-			expectedGrowing: true,
-		},
-		{
-			rowNum:          425985, // 6.5 * (1 << 16) + 1
-			expectedB:       17,
-			expectedGrowing: true,
-		},
+	var cases []testCase
+	// https://github.com/golang/go/issues/63438
+	// in 1.21, the load factor of map is 6 rather than 6.5 and the go team refused to backport to 1.21.
+	if strings.Contains(runtime.Version(), `go1.21`) {
+		cases = []testCase{
+			{
+				rowNum:          0,
+				expectedB:       0,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          95,
+				expectedB:       4,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          10000, // 6 * (1 << 11) is 12288
+				expectedB:       11,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          1000000, // 6 * (1 << 18) is 1572864
+				expectedB:       18,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          786432, // 6 * (1 << 17)
+				expectedB:       17,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          786433, // 6 * (1 << 17) + 1
+				expectedB:       18,
+				expectedGrowing: true,
+			},
+			{
+				rowNum:          393216, // 6 * (1 << 16)
+				expectedB:       16,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          393217, // 6 * (1 << 16) + 1
+				expectedB:       17,
+				expectedGrowing: true,
+			},
+		}
+	} else {
+		cases = []testCase{
+			{
+				rowNum:          0,
+				expectedB:       0,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          100,
+				expectedB:       4,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          10000,
+				expectedB:       11,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          1000000,
+				expectedB:       18,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          851968, // 6.5 * (1 << 17)
+				expectedB:       17,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          851969, // 6.5 * (1 << 17) + 1
+				expectedB:       18,
+				expectedGrowing: true,
+			},
+			{
+				rowNum:          425984, // 6.5 * (1 << 16)
+				expectedB:       16,
+				expectedGrowing: false,
+			},
+			{
+				rowNum:          425985, // 6.5 * (1 << 16) + 1
+				expectedB:       17,
+				expectedGrowing: true,
+			},
+		}
 	}
 
 	for _, tc := range cases {

--- a/pkg/executor/executor_pkg_test.go
+++ b/pkg/executor/executor_pkg_test.go
@@ -23,10 +23,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/pingcap/failpoint"
 	"github.com/hashicorp/go-version"
-	"github.com/pingcap/tidb/pkg/domain"
-	"github.com/pingcap/tidb/pkg/errctx"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/executor/aggfuncs"
 	"github.com/pingcap/tidb/pkg/executor/aggregate"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"

--- a/pkg/executor/hash_table_test.go
+++ b/pkg/executor/hash_table_test.go
@@ -167,7 +167,7 @@ func testHashRowContainer(t *testing.T, hashFunc func() hash.Hash64, spill bool)
 
 func TestConcurrentMapHashTableMemoryUsage(t *testing.T) {
 	m := newConcurrentMapHashTable()
-	const iterations = 1024 * hack.LoadFactorNum / hack.LoadFactorDen // 6656
+	var iterations = 1024 * hack.LoadFactorNum / hack.LoadFactorDen // 6656
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	// Note: Now concurrentMapHashTable doesn't support inserting in parallel.

--- a/pkg/util/hack/hack.go
+++ b/pkg/util/hack/hack.go
@@ -15,6 +15,8 @@
 package hack
 
 import (
+	"runtime"
+	"strings"
 	"unsafe"
 )
 
@@ -41,11 +43,20 @@ func Slice(s string) []byte {
 // Represent as LoadFactorNum/LoadFactorDen, to allow integer math.
 // They are from the golang definition. ref: https://github.com/golang/go/blob/go1.13.15/src/runtime/map.go#L68-L71
 const (
-	// LoadFactorNum is the numerator of load factor
-	LoadFactorNum = 13
 	// LoadFactorDen is the denominator of load factor
 	LoadFactorDen = 2
 )
+
+// LoadFactorNum is the numerator of load factor
+var LoadFactorNum = 13
+
+func init() {
+	// In go1.21, the load factor num becomes 12 and go team has decided not to backport the fix to 1.21.
+	// See more details in https://github.com/golang/go/issues/63438
+	if strings.Contains(runtime.Version(), `go1.21`) {
+		LoadFactorNum = 12
+	}
+}
 
 const (
 	// DefBucketMemoryUsageForMapStrToSlice = bucketSize*(1+unsafe.Sizeof(string) + unsafe.Sizeof(slice))+2*ptrSize

--- a/pkg/util/set/mem_aware_map.go
+++ b/pkg/util/set/mem_aware_map.go
@@ -37,7 +37,7 @@ func EstimateMapSize(length int, bucketSize uint64) uint64 {
 	if length == 0 {
 		return 0
 	}
-	bInMap := uint64(math.Ceil(math.Log2(float64(length) * hack.LoadFactorDen / hack.LoadFactorNum)))
+	bInMap := uint64(math.Ceil(math.Log2(float64(length) * hack.LoadFactorDen / float64(hack.LoadFactorNum))))
 	return bucketSize * uint64(1<<bInMap)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->
This is an cherry-pick of https://github.com/pingcap/tidb/pull/50545 to relase-7.5

Issue Number: close https://github.com/pingcap/tidb/issues/50544 and https://github.com/pingcap/tidb/issues/50552

Problem Summary:
This PR is trivial.
As the https://github.com/golang/go/issues/63438 indicates load factor of map in 1.21 would be 6 rather than 6.5 in other version. The whole test of TestaggPartiualResultMap depends on the assumption that load factor of map in golang would be 6.5.
To adopt this breaking behavior, the codebase of tidb should makes changes accordingly.
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility


