### PR TITLE
expression/infer_pushdown: enable json_replace/json_array_append/json_merge_patch pushdown

### DIFF
--- a/pkg/expression/distsql_builtin.go
+++ b/pkg/expression/distsql_builtin.go
@@ -701,7 +701,8 @@ func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *ti
 		f = &builtinJSONArrayAppendSig{base}
 	case tipb.ScalarFuncSig_JsonArrayInsertSig:
 		f = &builtinJSONArrayInsertSig{base}
-	// case tipb.ScalarFuncSig_JsonMergePatchSig:
+	case tipb.ScalarFuncSig_JsonMergePatchSig:
+		f = &builtinJSONMergePatchSig{base}
 	case tipb.ScalarFuncSig_JsonMergePreserveSig:
 		f = &builtinJSONMergeSig{base}
 	case tipb.ScalarFuncSig_JsonContainsPathSig:

--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -1437,7 +1437,7 @@ func TestExprPushDownToTiKV(t *testing.T) {
 
 	exprs := make([]Expression, 0)
 
-	//jsonColumn := genColumn(mysql.TypeJSON, 1)
+	jsonColumn := genColumn(mysql.TypeJSON, 1)
 	intColumn := genColumn(mysql.TypeLonglong, 2)
 	realColumn := genColumn(mysql.TypeDouble, 3)
 	//decimalColumn := genColumn(mysql.TypeNewDecimal, 4)
@@ -1625,6 +1625,21 @@ func TestExprPushDownToTiKV(t *testing.T) {
 			functionName: ast.Power,
 			retType:      types.NewFieldType(mysql.TypeDouble),
 			args:         []Expression{realColumn, realColumn},
+		},
+		{
+			functionName: ast.JSONReplace,
+			retType:      types.NewFieldType(mysql.TypeJSON),
+			args:         []Expression{jsonColumn, stringColumn, jsonColumn, stringColumn, jsonColumn},
+		},
+		{
+			functionName: ast.JSONArrayAppend,
+			retType:      types.NewFieldType(mysql.TypeJSON),
+			args:         []Expression{jsonColumn, stringColumn, jsonColumn, stringColumn, jsonColumn},
+		},
+		{
+			functionName: ast.JSONMergePatch,
+			retType:      types.NewFieldType(mysql.TypeJSON),
+			args:         []Expression{jsonColumn, jsonColumn, jsonColumn},
 		},
 	}
 

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -205,7 +205,7 @@ func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
 
 		// json functions.
 		ast.JSONType, ast.JSONExtract, ast.JSONObject, ast.JSONArray, ast.JSONMerge, ast.JSONSet,
-		ast.JSONInsert, ast.JSONReplace, ast.JSONRemove, ast.JSONLength,
+		ast.JSONInsert, ast.JSONReplace, ast.JSONRemove, ast.JSONLength, ast.JSONMergePatch,
 		ast.JSONUnquote, ast.JSONContains, ast.JSONValid, ast.JSONMemberOf, ast.JSONArrayAppend,
 
 		// date functions.

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -206,7 +206,7 @@ func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
 		// json functions.
 		ast.JSONType, ast.JSONExtract, ast.JSONObject, ast.JSONArray, ast.JSONMerge, ast.JSONSet,
 		ast.JSONInsert, ast.JSONReplace, ast.JSONRemove, ast.JSONLength,
-		ast.JSONUnquote, ast.JSONContains, ast.JSONValid, ast.JSONMemberOf,
+		ast.JSONUnquote, ast.JSONContains, ast.JSONValid, ast.JSONMemberOf, ast.JSONArrayAppend,
 
 		// date functions.
 		ast.Date, ast.Week /* ast.YearWeek, ast.ToSeconds */, ast.DateDiff,

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -205,7 +205,7 @@ func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
 
 		// json functions.
 		ast.JSONType, ast.JSONExtract, ast.JSONObject, ast.JSONArray, ast.JSONMerge, ast.JSONSet,
-		ast.JSONInsert /*ast.JSONReplace,*/, ast.JSONRemove, ast.JSONLength,
+		ast.JSONInsert, ast.JSONReplace, ast.JSONRemove, ast.JSONLength,
 		ast.JSONUnquote, ast.JSONContains, ast.JSONValid, ast.JSONMemberOf,
 
 		// date functions.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->


Issue Number: close #50601

Problem Summary:

### What changed and how does it work?
```
-- Create the table
CREATE TABLE products (
    id INT AUTO_INCREMENT PRIMARY KEY,
    name VARCHAR(100),
    attributes JSON
);

-- Insert some sample data
INSERT INTO products (name, attributes) VALUES
('Product A', '{"color": "Red", "size": "Medium"}'),
('Product B', '{"color": "Blue", "size": "Small"}');

-- Example usage of JSON_REPLACE()
explain analyze
select *
from products
where 
JSON_REPLACE(attributes, '$.color', 'Green') = JSON_OBJECT('color', 'Green', 'size', 'Medium');
+-------------------------+---------+---------+-----------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| id                      | estRows | actRows | task      | access object  | execution info                                                                                                                                                                                                                                   | operator info                                                                                                                                                            | memory    | disk |
+-------------------------+---------+---------+-----------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| TableReader_7           | 1.60    | 1       | root      |                | time:651.1µs, loops:2, RU:0.500751, cop_task: {num: 1, max: 590.2µs, proc_keys: 2, tot_proc: 68.2µs, tot_wait: 69.6µs, rpc_num: 1, rpc_time: 572.4µs, copr_cache_hit_ratio: 0.00, build_task_duration: 4.75µs, max_distsql_concurrency: 1}       | data:Selection_6                                                                                                                                                         | 376 Bytes | N/A  |
| └─Selection_6           | 1.60    | 1       | cop[tikv] |                | tikv_task:{time:0s, loops:1}, scan_detail: {total_process_keys: 2, total_process_keys_size: 198, total_keys: 3, get_snapshot_time: 52.9µs, rocksdb: {key_skipped_count: 2, block: {}}}                                                           | eq(json_replace(test.products.attributes, "$.color", cast("Green", json BINARY)), json_object("color", cast("Green", json BINARY), "size", cast("Medium", json BINARY))) | N/A       | N/A  |
|   └─TableFullScan_5     | 2.00    | 2       | cop[tikv] | table:products | tikv_task:{time:0s, loops:1}                                                                                                                                                                                                                     | keep order:false, stats:pseudo                                                                                                                                           | N/A       | N/A  |
+-------------------------+---------+---------+-----------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
3 rows in set (0.04 sec)

-- Example usage of JSON_ARRAY_APPEND()
explain analyze
select *
from products
where 
JSON_ARRAY_APPEND(attributes, '$.color', 'Green') = JSON_OBJECT('color', JSON_ARRAY('Red', 'Green'), 'size', 'Medium');
+-------------------------+---------+---------+-----------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| id                      | estRows | actRows | task      | access object  | execution info                                                                                                                                                                                                                                 | operator info                                                                                                                                                                                                       | memory    | disk |
+-------------------------+---------+---------+-----------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| TableReader_7           | 1.60    | 1       | root      |                | time:529.5µs, loops:2, RU:0.497357, cop_task: {num: 1, max: 484.3µs, proc_keys: 2, tot_proc: 58µs, tot_wait: 71.2µs, rpc_num: 1, rpc_time: 469.5µs, copr_cache_hit_ratio: 0.00, build_task_duration: 3.81µs, max_distsql_concurrency: 1}       | data:Selection_6                                                                                                                                                                                                    | 376 Bytes | N/A  |
| └─Selection_6           | 1.60    | 1       | cop[tikv] |                | tikv_task:{time:0s, loops:1}, scan_detail: {total_process_keys: 2, total_process_keys_size: 198, total_keys: 3, get_snapshot_time: 57.5µs, rocksdb: {key_skipped_count: 2, block: {}}}                                                         | eq(json_array_append(test.products.attributes, "$.color", cast("Green", json BINARY)), json_object("color", json_array(cast("Red", json BINARY), cast("Green", json BINARY)), "size", cast("Medium", json BINARY))) | N/A       | N/A  |
|   └─TableFullScan_5     | 2.00    | 2       | cop[tikv] | table:products | tikv_task:{time:0s, loops:1}                                                                                                                                                                                                                   | keep order:false, stats:pseudo                                                                                                                                                                                      | N/A       | N/A  |
+-------------------------+---------+---------+-----------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
3 rows in set (0.04 sec)

-- Example usage of JSON_MERGE_PATCH()
explain analyze
select *
from products
where 
JSON_MERGE_PATCH(attributes, '{"color": "Green"}') = JSON_OBJECT('color', 'Green', 'size', 'Medium');
+-------------------------+---------+---------+-----------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| id                      | estRows | actRows | task      | access object  | execution info                                                                                                                                                                                                                                  | operator info                                                                                                                                                                  | memory    | disk |
+-------------------------+---------+---------+-----------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| TableReader_7           | 1.60    | 1       | root      |                | time:458.3µs, loops:2, RU:0.493892, cop_task: {num: 1, max: 409.2µs, proc_keys: 2, tot_proc: 47.6µs, tot_wait: 55.6µs, rpc_num: 1, rpc_time: 396.3µs, copr_cache_hit_ratio: 0.00, build_task_duration: 3.2µs, max_distsql_concurrency: 1}       | data:Selection_6                                                                                                                                                               | 376 Bytes | N/A  |
| └─Selection_6           | 1.60    | 1       | cop[tikv] |                | tikv_task:{time:0s, loops:1}, scan_detail: {total_process_keys: 2, total_process_keys_size: 198, total_keys: 3, get_snapshot_time: 46µs, rocksdb: {key_skipped_count: 2, block: {}}}                                                            | eq(json_merge_patch(test.products.attributes, cast("{"color": "Green"}", json BINARY)), json_object("color", cast("Green", json BINARY), "size", cast("Medium", json BINARY))) | N/A       | N/A  |
|   └─TableFullScan_5     | 2.00    | 2       | cop[tikv] | table:products | tikv_task:{time:0s, loops:1}                                                                                                                                                                                                                    | keep order:false, stats:pseudo                                                                                                                                                 | N/A       | N/A  |
+-------------------------+---------+---------+-----------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
3 rows in set (0.03 sec)

explain analyze
select *
from products
where 
JSON_MERGE_PATCH(attributes, '{"color": null}') = JSON_OBJECT('size', 'Medium');
+-------------------------+---------+---------+-----------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| id                      | estRows | actRows | task      | access object  | execution info                                                                                                                                                                                                                                 | operator info                                                                                                                          | memory    | disk |
+-------------------------+---------+---------+-----------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| TableReader_7           | 1.60    | 1       | root      |                | time:574.8µs, loops:2, RU:0.496371, cop_task: {num: 1, max: 514.9µs, proc_keys: 2, tot_proc: 55.1µs, tot_wait: 73.4µs, rpc_num: 1, rpc_time: 496µs, copr_cache_hit_ratio: 0.00, build_task_duration: 6.22µs, max_distsql_concurrency: 1}       | data:Selection_6                                                                                                                       | 376 Bytes | N/A  |
| └─Selection_6           | 1.60    | 1       | cop[tikv] |                | tikv_task:{time:0s, loops:1}, scan_detail: {total_process_keys: 2, total_process_keys_size: 198, total_keys: 3, get_snapshot_time: 59.7µs, rocksdb: {key_skipped_count: 2, block: {}}}                                                         | eq(json_merge_patch(test.products.attributes, cast("{"color": null}", json BINARY)), json_object("size", cast("Medium", json BINARY))) | N/A       | N/A  |
|   └─TableFullScan_5     | 2.00    | 2       | cop[tikv] | table:products | tikv_task:{time:0s, loops:1}                                                                                                                                                                                                                   | keep order:false, stats:pseudo                                                                                                         | N/A       | N/A  |
+-------------------------+---------+---------+-----------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+-----------+------+
3 rows in set (0.04 sec)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
Push down JSON_REPLACE(), JSON_APPEND() to TiKV