### PR TITLE
br: check the first run by checkpoint meta

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -279,35 +279,22 @@ func (rc *Client) InitCheckpoint(
 	s storage.ExternalStorage,
 	taskName string,
 	config *pdutil.ClusterConfig,
-	useCheckpoint bool,
-) (map[int64]map[string]struct{}, *pdutil.ClusterConfig, bool, error) {
+	checkpointFirstRun bool,
+) (map[int64]map[string]struct{}, *pdutil.ClusterConfig, error) {
 	var (
 		// checkpoint sets distinguished by range key
 		checkpointSetWithTableID = make(map[int64]map[string]struct{})
 
 		checkpointClusterConfig *pdutil.ClusterConfig
 
-		firstRun bool = true
+		err error
 	)
 
-	// if not use checkpoint, return empty checkpoint ranges and new gc-safepoint id
-	if !useCheckpoint {
-		return checkpointSetWithTableID, nil, firstRun, nil
-	}
-
-	// if the checkpoint metadata exists in the external storage, the restore is not
-	// for the first time.
-	exists, err := checkpoint.ExistsRestoreCheckpoint(ctx, s, taskName)
-	if err != nil {
-		return checkpointSetWithTableID, nil, firstRun, errors.Trace(err)
-	}
-
-	if exists {
-		firstRun = false
+	if !checkpointFirstRun {
 		// load the checkpoint since this is not the first time to restore
 		meta, err := checkpoint.LoadCheckpointMetadataForRestore(ctx, s, taskName)
 		if err != nil {
-			return checkpointSetWithTableID, nil, firstRun, errors.Trace(err)
+			return checkpointSetWithTableID, nil, errors.Trace(err)
 		}
 
 		// The schedulers config is nil, so the restore-schedulers operation is just nil.
@@ -327,12 +314,12 @@ func (rc *Client) InitCheckpoint(
 			checkpointSet[rangeKey.RangeKey] = struct{}{}
 		})
 		if err != nil {
-			return checkpointSetWithTableID, nil, firstRun, errors.Trace(err)
+			return checkpointSetWithTableID, nil, errors.Trace(err)
 		}
 		// t2 is the latest time the checkpoint checksum persisted to the external storage.
 		checkpointChecksum, t2, err := checkpoint.LoadCheckpointChecksumForRestore(ctx, s, taskName)
 		if err != nil {
-			return checkpointSetWithTableID, nil, firstRun, errors.Trace(err)
+			return checkpointSetWithTableID, nil, errors.Trace(err)
 		}
 		rc.checkpointChecksum = checkpointChecksum
 		// use the later time to adjust the summary elapsed time.
@@ -349,12 +336,12 @@ func (rc *Client) InitCheckpoint(
 			meta.SchedulersConfig = &pdutil.ClusterConfig{Schedulers: config.Schedulers, ScheduleCfg: config.ScheduleCfg}
 		}
 		if err = checkpoint.SaveCheckpointMetadataForRestore(ctx, s, meta, taskName); err != nil {
-			return checkpointSetWithTableID, nil, firstRun, errors.Trace(err)
+			return checkpointSetWithTableID, nil, errors.Trace(err)
 		}
 	}
 
 	rc.checkpointRunner, err = checkpoint.StartCheckpointRunnerForRestore(ctx, s, rc.cipher, taskName)
-	return checkpointSetWithTableID, checkpointClusterConfig, firstRun, errors.Trace(err)
+	return checkpointSetWithTableID, checkpointClusterConfig, errors.Trace(err)
 }
 
 func (rc *Client) WaitForFinishCheckpoint(ctx context.Context, flush bool) {

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -280,31 +280,34 @@ func (rc *Client) InitCheckpoint(
 	taskName string,
 	config *pdutil.ClusterConfig,
 	useCheckpoint bool,
-) (map[int64]map[string]struct{}, *pdutil.ClusterConfig, error) {
+) (map[int64]map[string]struct{}, *pdutil.ClusterConfig, bool, error) {
 	var (
 		// checkpoint sets distinguished by range key
 		checkpointSetWithTableID = make(map[int64]map[string]struct{})
 
 		checkpointClusterConfig *pdutil.ClusterConfig
+
+		firstRun bool = true
 	)
 
 	// if not use checkpoint, return empty checkpoint ranges and new gc-safepoint id
 	if !useCheckpoint {
-		return checkpointSetWithTableID, nil, nil
+		return checkpointSetWithTableID, nil, firstRun, nil
 	}
 
 	// if the checkpoint metadata exists in the external storage, the restore is not
 	// for the first time.
 	exists, err := checkpoint.ExistsRestoreCheckpoint(ctx, s, taskName)
 	if err != nil {
-		return checkpointSetWithTableID, nil, errors.Trace(err)
+		return checkpointSetWithTableID, nil, firstRun, errors.Trace(err)
 	}
 
 	if exists {
+		firstRun = false
 		// load the checkpoint since this is not the first time to restore
 		meta, err := checkpoint.LoadCheckpointMetadataForRestore(ctx, s, taskName)
 		if err != nil {
-			return checkpointSetWithTableID, nil, errors.Trace(err)
+			return checkpointSetWithTableID, nil, firstRun, errors.Trace(err)
 		}
 
 		// The schedulers config is nil, so the restore-schedulers operation is just nil.
@@ -324,12 +327,12 @@ func (rc *Client) InitCheckpoint(
 			checkpointSet[rangeKey.RangeKey] = struct{}{}
 		})
 		if err != nil {
-			return checkpointSetWithTableID, nil, errors.Trace(err)
+			return checkpointSetWithTableID, nil, firstRun, errors.Trace(err)
 		}
 		// t2 is the latest time the checkpoint checksum persisted to the external storage.
 		checkpointChecksum, t2, err := checkpoint.LoadCheckpointChecksumForRestore(ctx, s, taskName)
 		if err != nil {
-			return checkpointSetWithTableID, nil, errors.Trace(err)
+			return checkpointSetWithTableID, nil, firstRun, errors.Trace(err)
 		}
 		rc.checkpointChecksum = checkpointChecksum
 		// use the later time to adjust the summary elapsed time.
@@ -346,12 +349,12 @@ func (rc *Client) InitCheckpoint(
 			meta.SchedulersConfig = &pdutil.ClusterConfig{Schedulers: config.Schedulers, ScheduleCfg: config.ScheduleCfg}
 		}
 		if err = checkpoint.SaveCheckpointMetadataForRestore(ctx, s, meta, taskName); err != nil {
-			return checkpointSetWithTableID, nil, errors.Trace(err)
+			return checkpointSetWithTableID, nil, firstRun, errors.Trace(err)
 		}
 	}
 
 	rc.checkpointRunner, err = checkpoint.StartCheckpointRunnerForRestore(ctx, s, rc.cipher, taskName)
-	return checkpointSetWithTableID, checkpointClusterConfig, errors.Trace(err)
+	return checkpointSetWithTableID, checkpointClusterConfig, firstRun, errors.Trace(err)
 }
 
 func (rc *Client) WaitForFinishCheckpoint(ctx context.Context, flush bool) {

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -801,9 +801,10 @@ func runRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	}()
 
 	var checkpointSetWithTableID map[int64]map[string]struct{}
+	var checkpointFirstRun bool
 	if cfg.UseCheckpoint {
 		taskName := cfg.generateSnapshotRestoreTaskName(client.GetClusterID(ctx))
-		sets, restoreSchedulersConfigFromCheckpoint, err := client.InitCheckpoint(ctx, s, taskName, schedulersConfig, cfg.UseCheckpoint)
+		sets, restoreSchedulersConfigFromCheckpoint, firstRun, err := client.InitCheckpoint(ctx, s, taskName, schedulersConfig, cfg.UseCheckpoint)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -811,6 +812,7 @@ func runRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 			restoreSchedulers = mgr.MakeUndoFunctionByConfig(*restoreSchedulersConfigFromCheckpoint)
 		}
 		checkpointSetWithTableID = sets
+		checkpointFirstRun = firstRun
 
 		defer func() {
 			// need to flush the whole checkpoint data so that br can quickly jump to
@@ -822,7 +824,7 @@ func runRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 
 	if isFullRestore(cmdName) {
 		// we need check cluster is fresh every time. except restore from a checkpoint.
-		if client.IsFull() && len(checkpointSetWithTableID) == 0 {
+		if client.IsFull() && checkpointFirstRun {
 			if err = client.CheckTargetClusterFresh(ctx); err != nil {
 				return errors.Trace(err)
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50232

Problem Summary:
Currently BR determines whether the cluster is fresh by checking the sst checkpoint data.
### What changed and how does it work?
Instead, it would determines by checking the checkpoint meta which generated during checkpoint initialization.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
