### PR TITLE
disttask: decouple handleExecutableTask from manager & separate executor context

### DIFF
--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -142,7 +142,9 @@ func (s *backfillDistExecutor) Init(ctx context.Context) error {
 		return err
 	}
 	pdLeaderAddr := d.store.(tikv.Storage).GetRegionCache().PDClient().GetLeaderAddr()
-	bc, err := ingest.LitBackCtxMgr.Register(ctx, unique, job.ID, d.etcdCli, pdLeaderAddr, job.ReorgMeta.ResourceGroupName)
+	// TODO: local backend should be inited when step executor is created.
+	// TODO here we have to use executor ctx to avoid it keeps running when task is canceled.
+	bc, err := ingest.LitBackCtxMgr.Register(s.BaseTaskExecutor.Ctx(), unique, job.ID, d.etcdCli, pdLeaderAddr, job.ReorgMeta.ResourceGroupName)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -60,7 +60,7 @@ type BackfillSubTaskMeta struct {
 }
 
 // NewBackfillSubtaskExecutor creates a new backfill subtask executor.
-func NewBackfillSubtaskExecutor(_ context.Context, taskMeta []byte, d *ddl,
+func NewBackfillSubtaskExecutor(taskMeta []byte, d *ddl,
 	bc ingest.BackendCtx, stage proto.Step, summary *execute.Summary) (execute.StepExecutor, error) {
 	bgm := &BackfillTaskMeta{}
 	err := json.Unmarshal(taskMeta, bgm)
@@ -165,10 +165,10 @@ func decodeIndexUniqueness(job *model.Job) (bool, error) {
 	return unique[0], nil
 }
 
-func (s *backfillDistExecutor) GetStepExecutor(ctx context.Context, task *proto.Task, summary *execute.Summary, _ *proto.StepResource) (execute.StepExecutor, error) {
+func (s *backfillDistExecutor) GetStepExecutor(task *proto.Task, summary *execute.Summary, _ *proto.StepResource) (execute.StepExecutor, error) {
 	switch task.Step {
 	case proto.BackfillStepReadIndex, proto.BackfillStepMergeSort, proto.BackfillStepWriteAndIngest:
-		return NewBackfillSubtaskExecutor(ctx, task.Meta, s.d, s.backendCtx, task.Step, summary)
+		return NewBackfillSubtaskExecutor(task.Meta, s.d, s.backendCtx, task.Step, summary)
 	default:
 		return nil, errors.Errorf("unknown backfill step %d for task %d", task.Step, task.ID)
 	}

--- a/pkg/disttask/framework/BUILD.bazel
+++ b/pkg/disttask/framework/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "//pkg/disttask/framework/proto",
         "//pkg/disttask/framework/scheduler",
         "//pkg/disttask/framework/storage",
+        "//pkg/disttask/framework/taskexecutor",
         "//pkg/disttask/framework/testutil",
         "//pkg/testkit",
         "//pkg/util",

--- a/pkg/disttask/framework/framework_ha_test.go
+++ b/pkg/disttask/framework/framework_ha_test.go
@@ -16,10 +16,12 @@ package framework_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
+	"github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor"
 	"github.com/pingcap/tidb/pkg/disttask/framework/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +34,7 @@ func submitTaskAndCheckSuccessForHA(ctx context.Context, t *testing.T, taskKey s
 }
 
 func TestHABasic(t *testing.T) {
+	taskexecutor.TestContexts = sync.Map{}
 	ctx, ctrl, testContext, distContext := testutil.InitTestContext(t, 4)
 	defer ctrl.Finish()
 
@@ -47,6 +50,7 @@ func TestHABasic(t *testing.T) {
 }
 
 func TestHAManyNodes(t *testing.T) {
+	taskexecutor.TestContexts = sync.Map{}
 	ctx, ctrl, testContext, distContext := testutil.InitTestContext(t, 30)
 	defer ctrl.Finish()
 
@@ -62,6 +66,7 @@ func TestHAManyNodes(t *testing.T) {
 }
 
 func TestHAFailInDifferentStage(t *testing.T) {
+	taskexecutor.TestContexts = sync.Map{}
 	ctx, ctrl, testContext, distContext := testutil.InitTestContext(t, 6)
 	defer ctrl.Finish()
 
@@ -82,6 +87,7 @@ func TestHAFailInDifferentStage(t *testing.T) {
 }
 
 func TestHAFailInDifferentStageManyNodes(t *testing.T) {
+	taskexecutor.TestContexts = sync.Map{}
 	ctx, ctrl, testContext, distContext := testutil.InitTestContext(t, 30)
 	defer ctrl.Finish()
 

--- a/pkg/disttask/framework/mock/task_executor_mock.go
+++ b/pkg/disttask/framework/mock/task_executor_mock.go
@@ -363,6 +363,30 @@ func (m *MockTaskExecutor) EXPECT() *MockTaskExecutorMockRecorder {
 	return m.recorder
 }
 
+// Cancel mocks base method.
+func (m *MockTaskExecutor) Cancel() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Cancel")
+}
+
+// Cancel indicates an expected call of Cancel.
+func (mr *MockTaskExecutorMockRecorder) Cancel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cancel", reflect.TypeOf((*MockTaskExecutor)(nil).Cancel))
+}
+
+// CancelRunningSubtask mocks base method.
+func (m *MockTaskExecutor) CancelRunningSubtask() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CancelRunningSubtask")
+}
+
+// CancelRunningSubtask indicates an expected call of CancelRunningSubtask.
+func (mr *MockTaskExecutorMockRecorder) CancelRunningSubtask() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelRunningSubtask", reflect.TypeOf((*MockTaskExecutor)(nil).CancelRunningSubtask))
+}
+
 // Close mocks base method.
 func (m *MockTaskExecutor) Close() {
 	m.ctrl.T.Helper()
@@ -373,6 +397,20 @@ func (m *MockTaskExecutor) Close() {
 func (mr *MockTaskExecutorMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockTaskExecutor)(nil).Close))
+}
+
+// GetTask mocks base method.
+func (m *MockTaskExecutor) GetTask() *proto.Task {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTask")
+	ret0, _ := ret[0].(*proto.Task)
+	return ret0
+}
+
+// GetTask indicates an expected call of GetTask.
+func (mr *MockTaskExecutorMockRecorder) GetTask() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTask", reflect.TypeOf((*MockTaskExecutor)(nil).GetTask))
 }
 
 // Init mocks base method.
@@ -403,32 +441,16 @@ func (mr *MockTaskExecutorMockRecorder) IsRetryableError(arg0 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRetryableError", reflect.TypeOf((*MockTaskExecutor)(nil).IsRetryableError), arg0)
 }
 
-// Rollback mocks base method.
-func (m *MockTaskExecutor) Rollback(arg0 context.Context, arg1 *proto.Task) error {
+// Run mocks base method.
+func (m *MockTaskExecutor) Run(arg0 *proto.StepResource) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rollback", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "Run", arg0)
 }
 
-// Rollback indicates an expected call of Rollback.
-func (mr *MockTaskExecutorMockRecorder) Rollback(arg0, arg1 any) *gomock.Call {
+// Run indicates an expected call of Run.
+func (mr *MockTaskExecutorMockRecorder) Run(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockTaskExecutor)(nil).Rollback), arg0, arg1)
-}
-
-// RunStep mocks base method.
-func (m *MockTaskExecutor) RunStep(arg0 context.Context, arg1 *proto.Task, arg2 *proto.StepResource) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunStep", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RunStep indicates an expected call of RunStep.
-func (mr *MockTaskExecutorMockRecorder) RunStep(arg0, arg1, arg2 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunStep", reflect.TypeOf((*MockTaskExecutor)(nil).RunStep), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockTaskExecutor)(nil).Run), arg0)
 }
 
 // MockExtension is a mock of Extension interface.
@@ -455,18 +477,18 @@ func (m *MockExtension) EXPECT() *MockExtensionMockRecorder {
 }
 
 // GetStepExecutor mocks base method.
-func (m *MockExtension) GetStepExecutor(arg0 context.Context, arg1 *proto.Task, arg2 *execute.Summary, arg3 *proto.StepResource) (execute.StepExecutor, error) {
+func (m *MockExtension) GetStepExecutor(arg0 *proto.Task, arg1 *execute.Summary, arg2 *proto.StepResource) (execute.StepExecutor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStepExecutor", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetStepExecutor", arg0, arg1, arg2)
 	ret0, _ := ret[0].(execute.StepExecutor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetStepExecutor indicates an expected call of GetStepExecutor.
-func (mr *MockExtensionMockRecorder) GetStepExecutor(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockExtensionMockRecorder) GetStepExecutor(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStepExecutor", reflect.TypeOf((*MockExtension)(nil).GetStepExecutor), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStepExecutor", reflect.TypeOf((*MockExtension)(nil).GetStepExecutor), arg0, arg1, arg2)
 }
 
 // IsIdempotent mocks base method.

--- a/pkg/disttask/framework/taskexecutor/interface.go
+++ b/pkg/disttask/framework/taskexecutor/interface.go
@@ -68,6 +68,11 @@ type Pool interface {
 
 // TaskExecutor is the executor for a task.
 // Each task type should implement this interface.
+// context tree of task execution:
+//
+//	Manager.ctx
+//	└── TaskExecutor.ctx: Cancel cancels this one
+//	   └── RunStep.ctx: CancelRunningSubtask cancels this one
 type TaskExecutor interface {
 	// Init initializes the TaskExecutor, the returned error is fatal, it will fail
 	// the task directly, so be careful what to put into it.
@@ -91,6 +96,7 @@ type TaskExecutor interface {
 	Cancel()
 	// Close closes the TaskExecutor.
 	Close()
+	IsRetryableError(err error) bool
 }
 
 // Extension extends the TaskExecutor.

--- a/pkg/disttask/framework/taskexecutor/interface.go
+++ b/pkg/disttask/framework/taskexecutor/interface.go
@@ -66,14 +66,31 @@ type Pool interface {
 	ReleaseAndWait()
 }
 
-// TaskExecutor is the subtask executor for a task.
+// TaskExecutor is the executor for a task.
 // Each task type should implement this interface.
 type TaskExecutor interface {
+	// Init initializes the TaskExecutor, the returned error is fatal, it will fail
+	// the task directly, so be careful what to put into it.
 	Init(context.Context) error
-	RunStep(context.Context, *proto.Task, *proto.StepResource) error
-	Rollback(context.Context, *proto.Task) error
+	// Run runs the task with given resource, it will try to run each step one by
+	// one, if it cannot find any subtask to run for a while(10s now), it will exit,
+	// so manager can free and reuse the resource.
+	// we assume that all steps will have same resource usage now, will change it
+	// when we support different resource usage for different steps.
+	Run(resource *proto.StepResource)
+	// GetTask returns the task, returned value is for read only, don't change it.
+	GetTask() *proto.Task
+	// CancelRunningSubtask cancels the running subtask and change its state to `cancelled`,
+	// the task executor will keep running, so we can have a context to update the
+	// subtask state or keep handling revert logic.
+	CancelRunningSubtask()
+	// Cancel cancels the task executor, the state of running subtask is not changed.
+	// it's separated with Close as Close mostly mean will wait all resource released
+	// before return, but we only want its context cancelled and check whether it's
+	// closed later.
+	Cancel()
+	// Close closes the TaskExecutor.
 	Close()
-	IsRetryableError(err error) bool
 }
 
 // Extension extends the TaskExecutor.
@@ -88,7 +105,7 @@ type Extension interface {
 	// Note:
 	// 1. summary is the summary manager of all subtask of the same type now.
 	// 2. should not retry the error from it.
-	GetStepExecutor(ctx context.Context, task *proto.Task, summary *execute.Summary, resource *proto.StepResource) (execute.StepExecutor, error)
+	GetStepExecutor(task *proto.Task, summary *execute.Summary, resource *proto.StepResource) (execute.StepExecutor, error)
 	// IsRetryableError returns whether the error is transient.
 	// When error is transient, the framework won't mark subtasks as failed,
 	// then the TaskExecutor can load the subtask again and redo it.

--- a/pkg/disttask/framework/taskexecutor/interface.go
+++ b/pkg/disttask/framework/taskexecutor/interface.go
@@ -76,6 +76,8 @@ type Pool interface {
 type TaskExecutor interface {
 	// Init initializes the TaskExecutor, the returned error is fatal, it will fail
 	// the task directly, so be careful what to put into it.
+	// The context passing in is Manager.ctx, don't use it to init long-running routines,
+	// as it will NOT be cancelled when the task is finished.
 	Init(context.Context) error
 	// Run runs the task with given resource, it will try to run each step one by
 	// one, if it cannot find any subtask to run for a while(10s now), it will exit,

--- a/pkg/disttask/framework/taskexecutor/main_test.go
+++ b/pkg/disttask/framework/taskexecutor/main_test.go
@@ -16,10 +16,21 @@ package taskexecutor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
 	"go.uber.org/goleak"
 )
+
+func ReduceCheckInterval(t *testing.T) {
+	checkIntervalBak := defaultCheckInterval
+	maxIntervalBak := maxCheckInterval
+	t.Cleanup(func() {
+		defaultCheckInterval = checkIntervalBak
+		maxCheckInterval = maxIntervalBak
+	})
+	maxCheckInterval, defaultCheckInterval = time.Millisecond, time.Millisecond
+}
 
 func TestMain(m *testing.M) {
 	testsetup.SetupForCommonTest()

--- a/pkg/disttask/framework/taskexecutor/manager.go
+++ b/pkg/disttask/framework/taskexecutor/manager.go
@@ -22,11 +22,9 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/storage"
-	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/metrics"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/cpu"
@@ -37,7 +35,7 @@ import (
 
 var (
 	// same as scheduler
-	checkInterval           = 300 * time.Millisecond
+	defaultCheckInterval    = 300 * time.Millisecond
 	maxCheckInterval        = 2 * time.Second
 	maxChecksWhenNoSubtask  = 7
 	recoverMetaInterval     = 90 * time.Second
@@ -54,9 +52,8 @@ type Manager struct {
 	taskTable TaskTable
 	mu        struct {
 		sync.RWMutex
-		// taskID -> CancelCauseFunc.
-		// CancelCauseFunc is used to fast cancel the executor.Run.
-		handlingTasks map[int64]context.CancelCauseFunc
+		// taskID -> TaskExecutor.
+		taskExecutors map[int64]TaskExecutor
 	}
 	// id, it's the same as server id now, i.e. host:port.
 	id          string
@@ -98,7 +95,7 @@ func NewManager(ctx context.Context, id string, taskTable TaskTable) (*Manager, 
 		totalMem: int64(totalMem),
 	}
 	m.ctx, m.cancel = context.WithCancel(ctx)
-	m.mu.handlingTasks = make(map[int64]context.CancelCauseFunc)
+	m.mu.taskExecutors = make(map[int64]TaskExecutor)
 
 	return m, nil
 }
@@ -171,7 +168,7 @@ func (m *Manager) Stop() {
 // NOT running by executor before mark the task as paused.
 func (m *Manager) handleTasksLoop() {
 	defer tidbutil.Recover(metrics.LabelDomain, "handleTasksLoop", m.handleTasksLoop, false)
-	ticker := time.NewTicker(checkInterval)
+	ticker := time.NewTicker(defaultCheckInterval)
 	for {
 		select {
 		case <-m.ctx.Done():
@@ -230,14 +227,7 @@ func (m *Manager) handleExecutableTasks(taskInfos []*storage.TaskExecInfo) {
 			m.logger.Debug("no enough slots to run task", zap.Int64("task-id", task.ID))
 			continue
 		}
-		m.addHandlingTask(task.ID)
-		m.slotManager.alloc(task.Task)
-		t := task.Task
-		m.executorWG.RunWithLog(func() {
-			defer m.slotManager.free(t.ID)
-			m.handleExecutableTask(t)
-			m.removeHandlingTask(t.ID)
-		})
+		m.startTaskExecutor(task.Task)
 	}
 }
 
@@ -246,10 +236,9 @@ func (m *Manager) handleExecutableTasks(taskInfos []*storage.TaskExecInfo) {
 func (m *Manager) cancelRunningSubtaskOf(taskID int64) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	if cancel, ok := m.mu.handlingTasks[taskID]; ok && cancel != nil {
+	if executor, ok := m.mu.taskExecutors[taskID]; ok {
 		m.logger.Info("onCanceledTasks", zap.Int64("task-id", taskID))
-		// subtask needs to change its state to `canceled`.
-		cancel(ErrCancelSubtask)
+		executor.CancelRunningSubtask()
 	}
 }
 
@@ -258,9 +247,8 @@ func (m *Manager) handlePausingTask(taskID int64) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	m.logger.Info("handle pausing task", zap.Int64("task-id", taskID))
-	if cancel, ok := m.mu.handlingTasks[taskID]; ok && cancel != nil {
-		// cancel the task executor
-		cancel(nil)
+	if executor, ok := m.mu.taskExecutors[taskID]; ok {
+		executor.Cancel()
 	}
 	// we pause subtasks belongs to this exec node even when there's no executor running.
 	// as balancer might move subtasks to this node when the executor hasn't started.
@@ -296,9 +284,8 @@ func (m *Manager) cancelTaskExecutors(tasks []*proto.Task) {
 	defer m.mu.RUnlock()
 	for _, task := range tasks {
 		m.logger.Info("cancelTasks", zap.Int64("task-id", task.ID))
-		if cancel, ok := m.mu.handlingTasks[task.ID]; ok && cancel != nil {
-			// only cancel the executor, subtask state is not changed.
-			cancel(nil)
+		if executor, ok := m.mu.taskExecutors[task.ID]; ok {
+			executor.Cancel()
 		}
 	}
 }
@@ -311,83 +298,34 @@ type TestContext struct {
 
 var testContexts sync.Map
 
-// handleExecutableTask handles a runnable task.
-func (m *Manager) handleExecutableTask(task *proto.Task) {
-	m.logger.Info("handleExecutableTask", zap.Int64("task-id", task.ID), zap.Stringer("type", task.Type))
+// startTaskExecutor handles a runnable task.
+func (m *Manager) startTaskExecutor(task *proto.Task) {
 	// runCtx only used in executor.Run, cancel in m.fetchAndFastCancelTasks.
 	factory := GetTaskExecutorFactory(task.Type)
 	if factory == nil {
 		err := errors.Errorf("task type %s not found", task.Type)
-		m.logErrAndPersist(err, task.ID, nil)
+		m.logErrAndPersist(err, task.ID)
 		return
 	}
 	executor := factory(m.ctx, m.id, task, m.taskTable)
-	taskCtx, taskCancel := context.WithCancelCause(m.ctx)
-	m.registerCancelFunc(task.ID, taskCancel)
-	defer taskCancel(nil)
-	// executor should init before run()/pause()/rollback().
-	err := executor.Init(taskCtx)
+	err := executor.Init(m.ctx)
 	if err != nil {
-		m.logErrAndPersist(err, task.ID, executor)
+		m.logErrAndPersist(err, task.ID)
 		return
 	}
-	defer executor.Close()
-	for {
-		select {
-		case <-m.ctx.Done():
-			m.logger.Info("handleExecutableTask exit for cancel", zap.Int64("task-id", task.ID), zap.Stringer("type", task.Type))
-			return
-		case <-time.After(checkInterval):
-		}
-		failpoint.Inject("mockStopManager", func() {
-			testContexts.Store(m.id, &TestContext{make(chan struct{}), atomic.Bool{}})
-			go func() {
-				v, ok := testContexts.Load(m.id)
-				if ok {
-					<-v.(*TestContext).TestSyncSubtaskRun
-					infosync.MockGlobalServerInfoManagerEntry.DeleteByExecID(m.id)
-					m.Stop()
-				}
-			}()
-		})
-		task, err = m.taskTable.GetTaskByID(m.ctx, task.ID)
-		if err != nil {
-			m.logErr(err)
-			return
-		}
-		if task.State != proto.TaskStateRunning && task.State != proto.TaskStateReverting {
-			m.logger.Info("handleExecutableTask exit",
-				zap.Int64("task-id", task.ID), zap.String("step", proto.Step2Str(task.Type, task.Step)), zap.Stringer("state", task.State))
-			return
-		}
-		if exist, err := m.taskTable.HasSubtasksInStates(m.ctx, m.id, task.ID, task.Step,
-			unfinishedSubtaskStates...); err != nil {
-			m.logErr(err)
-			return
-		} else if !exist {
-			// TODO we can remove previous HasSubtasksInStates check if we merge it with RunStep loop.
-			return
-		}
-		stepResource := m.getStepResource(task.Concurrency)
-		m.logger.Info("execute task step with resource",
-			zap.Int64("task-id", task.ID), zap.String("step", proto.Step2Str(task.Type, task.Step)),
-			zap.Stringer("resource", stepResource))
-		switch task.State {
-		case proto.TaskStateRunning:
-			if taskCtx.Err() != nil {
-				return
-			}
-			// use taskCtx for canceling.
-			err = executor.RunStep(taskCtx, task, stepResource)
-		case proto.TaskStateReverting:
-			// use m.ctx since this process should not be canceled.
-			// TODO: will remove it later, leave it now.
-			err = executor.Rollback(m.ctx, task)
-		}
-		if err != nil {
-			m.logger.Error("failed to handle task", zap.Error(err))
-		}
-	}
+	m.logger.Info("task executor started", zap.Int64("task-id", task.ID), zap.Stringer("type", task.Type))
+	m.addTaskExecutor(executor)
+	m.slotManager.alloc(task)
+	resource := m.getStepResource(task.Concurrency)
+	m.executorWG.RunWithLog(func() {
+		defer func() {
+			m.logger.Info("task executor exit", zap.Int64("task-id", task.ID), zap.Stringer("type", task.Type))
+			m.slotManager.free(task.ID)
+			m.delTaskExecutor(executor)
+			executor.Close()
+		}()
+		executor.Run(resource)
+	})
 }
 
 func (m *Manager) getStepResource(concurrency int) *proto.StepResource {
@@ -398,31 +336,22 @@ func (m *Manager) getStepResource(concurrency int) *proto.StepResource {
 	}
 }
 
-// addHandlingTask adds a task to the handling task set.
-func (m *Manager) addHandlingTask(id int64) {
+func (m *Manager) addTaskExecutor(executor TaskExecutor) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.mu.handlingTasks[id] = nil
+	m.mu.taskExecutors[executor.GetTask().ID] = executor
 }
 
-// registerCancelFunc registers a cancel function for a task.
-func (m *Manager) registerCancelFunc(id int64, cancel context.CancelCauseFunc) {
+func (m *Manager) delTaskExecutor(executor TaskExecutor) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.mu.handlingTasks[id] = cancel
-}
-
-// removeHandlingTask removes a task from the handling task set.
-func (m *Manager) removeHandlingTask(id int64) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	delete(m.mu.handlingTasks, id)
+	delete(m.mu.taskExecutors, executor.GetTask().ID)
 }
 
 func (m *Manager) isExecutorStarted(taskID int64) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	_, ok := m.mu.handlingTasks[taskID]
+	_, ok := m.mu.taskExecutors[taskID]
 	return ok
 }
 
@@ -430,12 +359,8 @@ func (m *Manager) logErr(err error) {
 	m.logger.Error("task manager met error", zap.Error(err), zap.Stack("stack"))
 }
 
-func (m *Manager) logErrAndPersist(err error, taskID int64, taskExecutor TaskExecutor) {
+func (m *Manager) logErrAndPersist(err error, taskID int64) {
 	m.logErr(err)
-	if taskExecutor != nil && taskExecutor.IsRetryableError(err) {
-		m.logger.Error("met retryable err", zap.Error(err), zap.Stack("stack"))
-		return
-	}
 	err1 := m.taskTable.FailSubtask(m.ctx, m.id, taskID, err)
 	if err1 != nil {
 		m.logger.Error("update to subtask failed", zap.Error(err1), zap.Stack("stack"))

--- a/pkg/disttask/framework/taskexecutor/manager.go
+++ b/pkg/disttask/framework/taskexecutor/manager.go
@@ -296,6 +296,7 @@ type TestContext struct {
 	mockDown           atomic.Bool
 }
 
+// TestContexts only used in tests.
 var TestContexts sync.Map
 
 // startTaskExecutor handles a runnable task.

--- a/pkg/disttask/framework/taskexecutor/manager.go
+++ b/pkg/disttask/framework/taskexecutor/manager.go
@@ -296,7 +296,7 @@ type TestContext struct {
 	mockDown           atomic.Bool
 }
 
-var testContexts sync.Map
+var TestContexts sync.Map
 
 // startTaskExecutor handles a runnable task.
 func (m *Manager) startTaskExecutor(task *proto.Task) {

--- a/pkg/disttask/framework/taskexecutor/manager_test.go
+++ b/pkg/disttask/framework/taskexecutor/manager_test.go
@@ -17,7 +17,6 @@ package taskexecutor
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 	"time"
 
@@ -52,7 +51,7 @@ func TestBuildManager(t *testing.T) {
 	require.ErrorContains(t, err, "invalid cpu or memory")
 }
 
-func TestManageTask(t *testing.T) {
+func TestManageTaskExecutor(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -60,38 +59,42 @@ func TestManageTask(t *testing.T) {
 	m, err := NewManager(context.Background(), "test", mockTaskTable)
 	require.NoError(t, err)
 
-	m.addHandlingTask(1)
-	require.Len(t, m.mu.handlingTasks, 1)
+	// add executor 1
+	executor1 := mock.NewMockTaskExecutor(ctrl)
+	executor1.EXPECT().GetTask().Return(&proto.Task{ID: 1})
+	m.addTaskExecutor(executor1)
+	require.Len(t, m.mu.taskExecutors, 1)
 	require.True(t, m.isExecutorStarted(1))
-	m.addHandlingTask(2)
+	require.True(t, ctrl.Satisfied())
+	// add executor 2
+	executor2 := mock.NewMockTaskExecutor(ctrl)
+	executor2.EXPECT().GetTask().Return(&proto.Task{ID: 2})
+	m.addTaskExecutor(executor2)
 	require.True(t, m.isExecutorStarted(2))
-	m.removeHandlingTask(1)
+	require.True(t, ctrl.Satisfied())
+	// delete executor 1
+	executor1.EXPECT().GetTask().Return(&proto.Task{ID: 1})
+	m.delTaskExecutor(executor1)
 	require.False(t, m.isExecutorStarted(1))
+	require.True(t, ctrl.Satisfied())
 
-	ctx1, cancel1 := context.WithCancelCause(context.Background())
-	m.registerCancelFunc(2, cancel1)
+	// cancel executor 2
+	executor2.EXPECT().Cancel()
 	m.cancelTaskExecutors([]*proto.Task{{ID: 2}})
-	require.Equal(t, context.Canceled, ctx1.Err())
-
-	// test cancel.
-	m.addHandlingTask(1)
-	ctx2, cancel2 := context.WithCancelCause(context.Background())
-	m.registerCancelFunc(1, cancel2)
-	ctx3, cancel3 := context.WithCancelCause(context.Background())
-	m.registerCancelFunc(2, cancel3)
-	m.cancelRunningSubtaskOf(1)
-	require.Equal(t, context.Canceled, ctx2.Err())
-	require.NoError(t, ctx3.Err())
-
-	// test pause.
-	m.addHandlingTask(3)
-	ctx4, cancel4 := context.WithCancelCause(context.Background())
-	m.registerCancelFunc(1, cancel4)
+	require.True(t, ctrl.Satisfied())
+	// cancel running subtask of 2
+	executor2.EXPECT().CancelRunningSubtask()
+	m.cancelRunningSubtaskOf(2)
+	require.True(t, ctrl.Satisfied())
+	// handle pause
+	executor1.EXPECT().GetTask().Return(&proto.Task{ID: 1})
+	executor1.EXPECT().Cancel().Times(2)
+	m.addTaskExecutor(executor1)
 	mockTaskTable.EXPECT().PauseSubtasks(m.ctx, "test", int64(1)).Return(nil)
 	require.NoError(t, m.handlePausingTask(1))
-	require.Equal(t, context.Canceled, ctx4.Err())
 	mockTaskTable.EXPECT().PauseSubtasks(m.ctx, "test", int64(1)).Return(errors.New("pause failed"))
 	require.ErrorContains(t, m.handlePausingTask(1), "pause failed")
+	require.True(t, ctrl.Satisfied())
 }
 
 func TestHandleExecutableTasks(t *testing.T) {
@@ -103,10 +106,12 @@ func TestHandleExecutableTasks(t *testing.T) {
 
 	id := "test"
 	taskID := int64(1)
-	task := &proto.Task{ID: taskID, State: proto.TaskStateRunning, Step: proto.StepOne, Type: "type"}
+	task := &proto.Task{ID: taskID, State: proto.TaskStateRunning, Step: proto.StepOne, Type: "type", Concurrency: 6}
+	mockInternalExecutor.EXPECT().GetTask().Return(task).AnyTimes()
 
 	m, err := NewManager(ctx, id, mockTaskTable)
 	require.NoError(t, err)
+	m.slotManager.available = 16
 
 	// no task
 	m.handleExecutableTasks(nil)
@@ -126,100 +131,72 @@ func TestHandleExecutableTasks(t *testing.T) {
 	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(executorErr)
 	mockInternalExecutor.EXPECT().IsRetryableError(executorErr).Return(false)
 	mockTaskTable.EXPECT().FailSubtask(m.ctx, id, taskID, executorErr)
-	m.startTaskExecutor(task)
-	m.removeHandlingTask(taskID)
+	m.handleExecutableTasks([]*storage.TaskExecInfo{{Task: task}})
 	require.Equal(t, true, ctrl.Satisfied())
 
 	// executor init failed retryable
 	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(executorErr)
 	mockInternalExecutor.EXPECT().IsRetryableError(executorErr).Return(true)
-	m.startTaskExecutor(task)
-	m.removeHandlingTask(taskID)
+	m.handleExecutableTasks([]*storage.TaskExecInfo{{Task: task}})
 	require.Equal(t, true, ctrl.Satisfied())
 
+	ch := make(chan struct{})
 	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockInternalExecutor.EXPECT().Close()
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID).Return(task, nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID, proto.StepOne,
-		unfinishedSubtaskStates).Return(true, nil)
-	mockInternalExecutor.EXPECT().RunStep(gomock.Any(), task, gomock.Any()).Return(nil)
-
-	// StepTwo failed
-	task1 := &proto.Task{ID: taskID, State: proto.TaskStateRunning, Step: proto.StepTwo}
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID).Return(task1, nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID, proto.StepTwo,
-		unfinishedSubtaskStates).Return(true, nil)
-	mockInternalExecutor.EXPECT().RunStep(gomock.Any(), task1, gomock.Any()).Return(errors.New("run err"))
-
-	task2 := &proto.Task{ID: taskID, State: proto.TaskStateReverting, Step: proto.StepTwo}
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID).Return(task2, nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID, proto.StepTwo,
-		unfinishedSubtaskStates).Return(true, nil)
-	mockInternalExecutor.EXPECT().Rollback(gomock.Any(), task2).Return(nil)
-
-	task3 := &proto.Task{ID: taskID, State: proto.TaskStateReverted, Step: proto.StepTwo}
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID).Return(task3, nil)
-
+	mockInternalExecutor.EXPECT().Run(gomock.Any()).DoAndReturn(func(*proto.StepResource) {
+		<-ch
+	})
 	m.handleExecutableTasks([]*storage.TaskExecInfo{{Task: task}})
+	require.Eventually(t, func() bool {
+		return ctrl.Satisfied()
+	}, 5*time.Second, 100*time.Millisecond)
+	require.Equal(t, 10, m.slotManager.available)
+	require.True(t, m.isExecutorStarted(taskID))
+	close(ch)
+	mockInternalExecutor.EXPECT().Close()
 	m.executorWG.Wait()
 	require.True(t, ctrl.Satisfied())
-
-	// no subtask to run
-	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockInternalExecutor.EXPECT().Close()
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID).Return(task, nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID, proto.StepOne,
-		unfinishedSubtaskStates).Return(false, nil)
-	m.handleExecutableTasks([]*storage.TaskExecInfo{{Task: task}})
-	m.executorWG.Wait()
-	require.True(t, ctrl.Satisfied())
+	require.Equal(t, 16, m.slotManager.available)
+	require.False(t, m.isExecutorStarted(taskID))
 }
 
 func TestManager(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockTaskTable := mock.NewMockTaskTable(ctrl)
-	mockInternalExecutor := mock.NewMockTaskExecutor(ctrl)
+	mockInternalExecutors := map[int64]*mock.MockTaskExecutor{
+		1: mock.NewMockTaskExecutor(ctrl),
+		2: mock.NewMockTaskExecutor(ctrl),
+		3: mock.NewMockTaskExecutor(ctrl),
+	}
 	RegisterTaskType("type",
 		func(ctx context.Context, id string, task *proto.Task, taskTable TaskTable) TaskExecutor {
-			return mockInternalExecutor
+			return mockInternalExecutors[task.ID]
 		})
 	id := "test"
 
 	m, err := NewManager(context.Background(), id, mockTaskTable)
 	require.NoError(t, err)
 
-	taskID1 := int64(1)
-	taskID2 := int64(2)
-	taskID3 := int64(3)
-	task1 := &proto.Task{ID: taskID1, State: proto.TaskStateRunning, Step: proto.StepOne, Type: "type"}
-	task2 := &proto.Task{ID: taskID2, State: proto.TaskStateReverting, Step: proto.StepOne, Type: "type"}
-	task3 := &proto.Task{ID: taskID3, State: proto.TaskStatePausing, Step: proto.StepOne, Type: "type"}
+	task1 := &proto.Task{ID: 1, State: proto.TaskStateRunning, Step: proto.StepOne, Type: "type"}
+	task2 := &proto.Task{ID: 2, State: proto.TaskStateReverting, Step: proto.StepOne, Type: "type"}
+	task3 := &proto.Task{ID: 3, State: proto.TaskStatePausing, Step: proto.StepOne, Type: "type"}
 
 	mockTaskTable.EXPECT().InitMeta(m.ctx, "test", "").Return(nil).Times(1)
 	mockTaskTable.EXPECT().GetTaskExecInfoByExecID(m.ctx, m.id).
 		Return([]*storage.TaskExecInfo{{Task: task1}, {Task: task2}, {Task: task3}}, nil)
 	mockTaskTable.EXPECT().GetTaskExecInfoByExecID(m.ctx, m.id).Return(nil, nil).AnyTimes()
 	// task1
-	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID1).Return(task1, nil).AnyTimes()
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
-		unfinishedSubtaskStates).Return(true, nil)
-	mockInternalExecutor.EXPECT().RunStep(gomock.Any(), task1, gomock.Any()).Return(nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
-		unfinishedSubtaskStates).Return(false, nil)
-	mockInternalExecutor.EXPECT().Close()
+	mockInternalExecutors[task1.ID].EXPECT().GetTask().Return(task1).Times(2)
+	mockInternalExecutors[task1.ID].EXPECT().Init(gomock.Any()).Return(nil)
+	mockInternalExecutors[task1.ID].EXPECT().Run(gomock.Any())
+	mockInternalExecutors[task1.ID].EXPECT().Close()
 	// task2
-	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID2).Return(task2, nil).AnyTimes()
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID2, proto.StepOne,
-		unfinishedSubtaskStates).Return(true, nil)
-	mockInternalExecutor.EXPECT().Rollback(gomock.Any(), task2).Return(nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID2, proto.StepOne,
-		unfinishedSubtaskStates).Return(false, nil)
-	mockInternalExecutor.EXPECT().Close()
+	mockInternalExecutors[task2.ID].EXPECT().GetTask().Return(task2).Times(2)
+	mockInternalExecutors[task2.ID].EXPECT().Init(gomock.Any()).Return(nil)
+	mockInternalExecutors[task2.ID].EXPECT().Run(gomock.Any())
+	mockInternalExecutors[task2.ID].EXPECT().Close()
 	// task3
-	mockTaskTable.EXPECT().PauseSubtasks(m.ctx, id, taskID3).Return(nil).AnyTimes()
+	mockTaskTable.EXPECT().PauseSubtasks(m.ctx, id, task3.ID).Return(nil).AnyTimes()
 
 	require.NoError(t, m.InitMeta())
 	require.NoError(t, m.Start())
@@ -247,9 +224,9 @@ func TestManagerHandleTasks(t *testing.T) {
 	// failed to get tasks
 	mockTaskTable.EXPECT().GetTaskExecInfoByExecID(m.ctx, m.id).
 		Return(nil, errors.New("mock err"))
-	require.Len(t, m.mu.handlingTasks, 0)
+	require.Len(t, m.mu.taskExecutors, 0)
 	m.handleTasks()
-	require.Len(t, m.mu.handlingTasks, 0)
+	require.Len(t, m.mu.taskExecutors, 0)
 	require.True(t, ctrl.Satisfied())
 
 	// handle pausing tasks
@@ -263,26 +240,17 @@ func TestManagerHandleTasks(t *testing.T) {
 	defer close(ch)
 	task1 := &proto.Task{ID: 1, State: proto.TaskStateRunning, Step: proto.StepOne, Type: "type", Concurrency: 1}
 
+	mockInternalExecutor.EXPECT().GetTask().Return(task1).AnyTimes()
 	// handle pending tasks
-	var task1Ctx context.Context
-	var mu sync.Mutex
 	mockTaskTable.EXPECT().GetTaskExecInfoByExecID(m.ctx, m.id).
 		Return([]*storage.TaskExecInfo{{Task: task1}}, nil)
 	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, task1.ID).Return(task1, nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, task1.ID, proto.StepOne,
-		unfinishedSubtaskStates).Return(true, nil)
-	mockInternalExecutor.EXPECT().RunStep(gomock.Any(), task1, gomock.Any()).DoAndReturn(func(ctx context.Context, _ *proto.Task, _ *proto.StepResource) error {
-		mu.Lock()
-		task1Ctx = ctx
-		mu.Unlock()
+	mockInternalExecutor.EXPECT().Run(gomock.Any()).DoAndReturn(func(_ *proto.StepResource) error {
 		return <-ch
 	})
 	m.handleTasks()
 	require.Eventually(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return task1Ctx != nil && ctrl.Satisfied()
+		return ctrl.Satisfied()
 	}, 5*time.Second, 100*time.Millisecond)
 	require.True(t, m.isExecutorStarted(task1.ID))
 
@@ -296,15 +264,13 @@ func TestManagerHandleTasks(t *testing.T) {
 	task1.State = proto.TaskStateReverting
 	mockTaskTable.EXPECT().GetTaskExecInfoByExecID(m.ctx, m.id).
 		Return([]*storage.TaskExecInfo{{Task: task1}}, nil)
+	mockInternalExecutor.EXPECT().CancelRunningSubtask()
 	m.handleTasks()
 	require.True(t, ctrl.Satisfied())
 	require.True(t, m.isExecutorStarted(task1.ID))
-	require.Error(t, task1Ctx.Err())
-	require.ErrorIs(t, context.Cause(task1Ctx), ErrCancelSubtask)
 
 	// finish task1, executor will be closed
 	task1.State = proto.TaskStateReverted
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, task1.ID).Return(task1, nil)
 	mockInternalExecutor.EXPECT().Close()
 	ch <- nil
 	require.Eventually(t, func() bool {
@@ -319,10 +285,14 @@ func TestSlotManagerInManager(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockTaskTable := mock.NewMockTaskTable(ctrl)
-	mockInternalExecutor := mock.NewMockTaskExecutor(ctrl)
+	mockInternalExecutors := map[int64]*mock.MockTaskExecutor{
+		1: mock.NewMockTaskExecutor(ctrl),
+		2: mock.NewMockTaskExecutor(ctrl),
+		3: mock.NewMockTaskExecutor(ctrl),
+	}
 	RegisterTaskType("type",
 		func(ctx context.Context, id string, task *proto.Task, taskTable TaskTable) TaskExecutor {
-			return mockInternalExecutor
+			return mockInternalExecutors[task.ID]
 		})
 	id := "test"
 
@@ -331,24 +301,32 @@ func TestSlotManagerInManager(t *testing.T) {
 	m.slotManager.available = 10
 
 	var (
-		taskID1 = int64(1)
-		taskID2 = int64(2)
-
 		task1 = &proto.Task{
-			ID:          taskID1,
+			ID:          1,
 			State:       proto.TaskStateRunning,
 			Concurrency: 10,
 			Step:        proto.StepOne,
 			Type:        "type",
 		}
 		task2 = &proto.Task{
-			ID:          taskID2,
+			ID:          2,
 			State:       proto.TaskStateRunning,
 			Concurrency: 1,
 			Step:        proto.StepOne,
 			Type:        "type",
 		}
+		task3 = &proto.Task{
+			ID:          3,
+			State:       proto.TaskStateRunning,
+			Concurrency: 1,
+			Priority:    -1,
+			Step:        proto.StepOne,
+			Type:        "type",
+		}
 	)
+	mockInternalExecutors[task1.ID].EXPECT().GetTask().Return(task1).AnyTimes()
+	mockInternalExecutors[task2.ID].EXPECT().GetTask().Return(task2).AnyTimes()
+	mockInternalExecutors[task3.ID].EXPECT().GetTask().Return(task3).AnyTimes()
 
 	ch := make(chan error)
 	defer close(ch)
@@ -359,129 +337,86 @@ func TestSlotManagerInManager(t *testing.T) {
 	// 3. task1 run success
 
 	// mock inside startTaskExecutor
-	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID1).Return(task1, nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
-		unfinishedSubtaskStates).
-		Return(true, nil)
+	mockInternalExecutors[task1.ID].EXPECT().Init(gomock.Any()).Return(nil)
 	// task1 start running
-	mockInternalExecutor.EXPECT().RunStep(gomock.Any(), task1, gomock.Any()).DoAndReturn(func(_ context.Context, _ *proto.Task, _ *proto.StepResource) error {
+	mockInternalExecutors[task1.ID].EXPECT().Run(gomock.Any()).DoAndReturn(func(_ *proto.StepResource) error {
 		return <-ch
 	})
 
 	m.handleExecutableTasks([]*storage.TaskExecInfo{{Task: task1}, {Task: task2}})
 	// task1 alloc resource success
 	require.Eventually(t, func() bool {
-		if m.slotManager.available != 0 || len(m.slotManager.executorTasks) != 1 ||
-			m.slotManager.executorTasks[0].ID != task1.ID {
-			return false
-		}
 		return ctrl.Satisfied()
 	}, 2*time.Second, 300*time.Millisecond)
-	ch <- nil
-
+	require.True(t, m.isExecutorStarted(task1.ID))
+	require.Equal(t, 0, m.slotManager.available)
+	require.Len(t, m.slotManager.executorTasks, 1)
 	// task1 succeed
-	task1.State = proto.TaskStateSucceed
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID1).Return(task1, nil)
-	mockInternalExecutor.EXPECT().Close()
+	ch <- nil
+	mockInternalExecutors[task1.ID].EXPECT().Close()
 	m.executorWG.Wait()
 	require.Equal(t, 10, m.slotManager.available)
-	require.Equal(t, 0, len(m.slotManager.executorTasks))
+	require.False(t, m.isExecutorStarted(task1.ID))
+	require.Len(t, m.slotManager.executorTasks, 0)
 	require.True(t, ctrl.Satisfied())
 
 	// ******** Test task occupation ********
-	task1.State = proto.TaskStateRunning
-	var (
-		taskID3 = int64(3)
-		task3   = &proto.Task{
-			ID:          taskID3,
-			State:       proto.TaskStateRunning,
-			Concurrency: 1,
-			Priority:    -1,
-			Step:        proto.StepOne,
-			Type:        "type",
-		}
-	)
-	// 1. task1 alloc success
-
-	// mock inside startTaskExecutor
-	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID1).Return(task1, nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
-		unfinishedSubtaskStates).
-		Return(true, nil)
 	// task1 start running
-	mockInternalExecutor.EXPECT().RunStep(gomock.Any(), task1, gomock.Any()).DoAndReturn(func(_ context.Context, _ *proto.Task, _ *proto.StepResource) error {
+	mockInternalExecutors[task1.ID].EXPECT().Init(gomock.Any()).Return(nil)
+	mockInternalExecutors[task1.ID].EXPECT().Run(gomock.Any()).DoAndReturn(func(_ *proto.StepResource) error {
 		return <-ch
 	})
 
 	m.handleExecutableTasks([]*storage.TaskExecInfo{{Task: task1}, {Task: task2}})
 	// task1 alloc resource success
 	require.Eventually(t, func() bool {
-		if m.slotManager.available != 0 || len(m.slotManager.executorTasks) != 1 ||
-			m.slotManager.executorTasks[0].ID != task1.ID {
-			return false
-		}
 		return ctrl.Satisfied()
 	}, 2*time.Second, 300*time.Millisecond)
+	require.True(t, m.isExecutorStarted(task1.ID))
+	require.Equal(t, 0, m.slotManager.available)
+	require.Len(t, m.slotManager.executorTasks, 1)
 
 	// 2. task1 is preempted by task3, task1 start to pausing
 	// 3. task3 is waiting for task1 to be released, and task2 can't be allocated
 	// the priority of task3 is higher than task2, so task3 is in front of task2
+	mockInternalExecutors[task1.ID].EXPECT().Cancel()
 	m.handleExecutableTasks([]*storage.TaskExecInfo{{Task: task3}, {Task: task2}})
-	require.Equal(t, 0, m.slotManager.available)
-	require.Equal(t, []*proto.Task{task1}, m.slotManager.executorTasks)
 	require.True(t, ctrl.Satisfied())
-
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID1).Return(task1, nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
-		unfinishedSubtaskStates).
-		Return(true, nil)
-	mockInternalExecutor.EXPECT().Close()
+	require.Equal(t, 0, m.slotManager.available)
+	require.Len(t, m.slotManager.executorTasks, 1)
+	require.True(t, m.isExecutorStarted(task1.ID))
 
 	// 4. task1 is released, task3 alloc success, start to run
+	mockInternalExecutors[task1.ID].EXPECT().Close()
 	ch <- context.Canceled
 	m.executorWG.Wait()
 	require.Equal(t, 10, m.slotManager.available)
 	require.Len(t, m.slotManager.executorTasks, 0)
+	require.False(t, m.isExecutorStarted(task1.ID))
 	require.True(t, ctrl.Satisfied())
 
-	// mock inside startTaskExecutor
-	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID3).Return(task3, nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID3, proto.StepOne,
-		unfinishedSubtaskStates).
-		Return(true, nil)
-	mockInternalExecutor.EXPECT().RunStep(gomock.Any(), task3, gomock.Any()).DoAndReturn(func(_ context.Context, _ *proto.Task, _ *proto.StepResource) error {
+	// 5. available is enough, task3/task2 alloc success,
+	mockInternalExecutors[task2.ID].EXPECT().Init(gomock.Any()).Return(nil)
+	mockInternalExecutors[task2.ID].EXPECT().Run(gomock.Any()).DoAndReturn(func(_ *proto.StepResource) error {
 		return <-ch
 	})
-
-	// 5. available is enough, task2 alloc success,
-	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID2).Return(task2, nil)
-	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID2, proto.StepOne,
-		unfinishedSubtaskStates).
-		Return(true, nil)
-	mockInternalExecutor.EXPECT().RunStep(gomock.Any(), task2, gomock.Any()).DoAndReturn(func(_ context.Context, _ *proto.Task, _ *proto.StepResource) error {
+	mockInternalExecutors[task3.ID].EXPECT().Init(gomock.Any()).Return(nil)
+	mockInternalExecutors[task3.ID].EXPECT().Run(gomock.Any()).DoAndReturn(func(_ *proto.StepResource) error {
 		return <-ch
 	})
 
 	m.handleExecutableTasks([]*storage.TaskExecInfo{{Task: task3}, {Task: task1}, {Task: task2}})
-	time.Sleep(2 * time.Second)
 	require.Eventually(t, func() bool {
-		if m.slotManager.available != 8 || len(m.slotManager.executorTasks) != 2 {
-			return false
-		}
 		return ctrl.Satisfied()
 	}, 2*time.Second, 300*time.Millisecond)
+	require.Equal(t, 8, m.slotManager.available)
+	require.Len(t, m.slotManager.executorTasks, 2)
+	require.True(t, m.isExecutorStarted(task2.ID))
+	require.True(t, m.isExecutorStarted(task3.ID))
 
 	// 6. task3/task2 run success
-	task3.State = proto.TaskStateSucceed
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID3).Return(task3, nil)
-	mockInternalExecutor.EXPECT().Close()
-	task2.State = proto.TaskStateSucceed
-	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID2).Return(task2, nil)
-	mockInternalExecutor.EXPECT().Close()
+	mockInternalExecutors[task2.ID].EXPECT().Close()
+	mockInternalExecutors[task3.ID].EXPECT().Close()
 	ch <- nil
 	ch <- nil
 	m.executorWG.Wait()

--- a/pkg/disttask/framework/taskexecutor/manager_test.go
+++ b/pkg/disttask/framework/taskexecutor/manager_test.go
@@ -113,7 +113,7 @@ func TestHandleExecutableTasks(t *testing.T) {
 
 	// type not found
 	mockTaskTable.EXPECT().FailSubtask(m.ctx, id, taskID, gomock.Any())
-	m.handleExecutableTask(task)
+	m.startTaskExecutor(task)
 	require.True(t, ctrl.Satisfied())
 
 	RegisterTaskType("type",
@@ -126,14 +126,14 @@ func TestHandleExecutableTasks(t *testing.T) {
 	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(executorErr)
 	mockInternalExecutor.EXPECT().IsRetryableError(executorErr).Return(false)
 	mockTaskTable.EXPECT().FailSubtask(m.ctx, id, taskID, executorErr)
-	m.handleExecutableTask(task)
+	m.startTaskExecutor(task)
 	m.removeHandlingTask(taskID)
 	require.Equal(t, true, ctrl.Satisfied())
 
 	// executor init failed retryable
 	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(executorErr)
 	mockInternalExecutor.EXPECT().IsRetryableError(executorErr).Return(true)
-	m.handleExecutableTask(task)
+	m.startTaskExecutor(task)
 	m.removeHandlingTask(taskID)
 	require.Equal(t, true, ctrl.Satisfied())
 
@@ -358,7 +358,7 @@ func TestSlotManagerInManager(t *testing.T) {
 	// 2. task2 alloc failed
 	// 3. task1 run success
 
-	// mock inside handleExecutableTask
+	// mock inside startTaskExecutor
 	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
 	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID1).Return(task1, nil)
 	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
@@ -404,7 +404,7 @@ func TestSlotManagerInManager(t *testing.T) {
 	)
 	// 1. task1 alloc success
 
-	// mock inside handleExecutableTask
+	// mock inside startTaskExecutor
 	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
 	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID1).Return(task1, nil)
 	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID1, proto.StepOne,
@@ -446,7 +446,7 @@ func TestSlotManagerInManager(t *testing.T) {
 	require.Len(t, m.slotManager.executorTasks, 0)
 	require.True(t, ctrl.Satisfied())
 
-	// mock inside handleExecutableTask
+	// mock inside startTaskExecutor
 	mockInternalExecutor.EXPECT().Init(gomock.Any()).Return(nil)
 	mockTaskTable.EXPECT().GetTaskByID(m.ctx, taskID3).Return(task3, nil)
 	mockTaskTable.EXPECT().HasSubtasksInStates(m.ctx, id, taskID3, proto.StepOne,

--- a/pkg/disttask/framework/taskexecutor/task_executor.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor.go
@@ -187,6 +187,7 @@ func (e *BaseTaskExecutor) Run(resource *proto.StepResource) {
 		}
 		if exist, err := e.taskTable.HasSubtasksInStates(e.ctx, e.id, task.ID, task.Step,
 			unfinishedSubtaskStates...); err != nil {
+			e.logger.Error("check whether there are subtasks to run failed", zap.Error(err))
 			continue
 		} else if !exist {
 			if noSubtaskCheckCnt >= maxChecksWhenNoSubtask {
@@ -766,6 +767,7 @@ func (e *BaseTaskExecutor) cancelSubtaskWithRetry(ctx context.Context, taskID in
 func (e *BaseTaskExecutor) updateSubtask(err error) error {
 	task := e.task.Load()
 	err = errors.Cause(err)
+	// TODO this branch is unreachable now, remove it when we refactor error handling.
 	if e.ctx.Err() != nil && context.Cause(e.ctx) == ErrCancelSubtask {
 		return e.cancelSubtaskWithRetry(e.ctx, task.ID, ErrCancelSubtask)
 	} else if e.IsRetryableError(err) {

--- a/pkg/disttask/framework/taskexecutor/task_executor.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor.go
@@ -258,7 +258,6 @@ func (e *BaseTaskExecutor) runStep(resource *proto.StepResource) (resErr error) 
 	task := e.task.Load()
 	stepLogger := llog.BeginTask(e.logger.With(
 		zap.String("step", proto.Step2Str(task.Type, task.Step)),
-		zap.Int("concurrency", task.Concurrency),
 		zap.Float64("mem-limit-percent", gctuner.GlobalMemoryLimitTuner.GetPercentage()),
 		zap.String("server-mem-limit", memory.ServerMemoryLimitOriginText.Load()),
 		zap.Stringer("resource", resource),

--- a/pkg/disttask/framework/taskexecutor/task_executor.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor.go
@@ -66,8 +66,8 @@ type BaseTaskExecutor struct {
 	task      atomic.Pointer[proto.Task]
 	taskTable TaskTable
 	logger    *zap.Logger
-	// ctx from manager
-	ctx context.Context
+	ctx       context.Context
+	cancel    context.CancelFunc
 	Extension
 
 	currSubtaskID atomic.Int64
@@ -84,10 +84,12 @@ type BaseTaskExecutor struct {
 
 // NewBaseTaskExecutor creates a new BaseTaskExecutor.
 func NewBaseTaskExecutor(ctx context.Context, id string, task *proto.Task, taskTable TaskTable) *BaseTaskExecutor {
+	subCtx, cancelFunc := context.WithCancel(ctx)
 	taskExecutorImpl := &BaseTaskExecutor{
 		id:        id,
 		taskTable: taskTable,
-		ctx:       ctx,
+		ctx:       subCtx,
+		cancel:    cancelFunc,
 		logger: log.L().With(zap.Int64("task-id", task.ID),
 			zap.String("task-type", string(task.Type))),
 	}
@@ -119,7 +121,8 @@ func (e *BaseTaskExecutor) checkBalanceSubtask(ctx context.Context) {
 		}
 		if len(subtasks) == 0 {
 			e.logger.Info("subtask is scheduled away, cancel running")
-			e.cancelRunStep()
+			// cancels runStep, but leave the subtask state unchanged.
+			e.cancelRunStepWith(nil)
 			return
 		}
 
@@ -147,21 +150,83 @@ func (*BaseTaskExecutor) Init(_ context.Context) error {
 	return nil
 }
 
+// Run implements the TaskExecutor interface.
+func (e *BaseTaskExecutor) Run(resource *proto.StepResource) {
+	var err error
+	// task executor occupies resources, if there's no subtask to run for 10s,
+	// we release the resources so that other tasks can use them.
+	// 300ms + 600ms + 1.2s + 2s * 4 = 10.1s
+	backoffer := backoff.NewExponential(defaultCheckInterval, 2, maxCheckInterval)
+	checkInterval, noSubtaskCheckCnt := defaultCheckInterval, 0
+	for {
+		select {
+		case <-e.ctx.Done():
+			return
+		case <-time.After(checkInterval):
+		}
+		failpoint.Inject("mockStopManager", func() {
+			testContexts.Store(e.id, &TestContext{make(chan struct{}), atomic.Bool{}})
+			go func() {
+				v, ok := testContexts.Load(e.id)
+				if ok {
+					<-v.(*TestContext).TestSyncSubtaskRun
+					infosync.MockGlobalServerInfoManagerEntry.DeleteByExecID(e.id)
+				}
+			}()
+		})
+		if err = e.refreshTask(); err != nil {
+			if errors.Cause(err) == storage.ErrTaskNotFound {
+				return
+			}
+			e.logger.Error("refresh task failed", zap.Error(err))
+			continue
+		}
+		task := e.task.Load()
+		if task.State != proto.TaskStateRunning && task.State != proto.TaskStateReverting {
+			return
+		}
+		if exist, err := e.taskTable.HasSubtasksInStates(e.ctx, e.id, task.ID, task.Step,
+			unfinishedSubtaskStates...); err != nil {
+			continue
+		} else if !exist {
+			if noSubtaskCheckCnt >= maxChecksWhenNoSubtask {
+				break
+			}
+			checkInterval = backoffer.Backoff(noSubtaskCheckCnt)
+			noSubtaskCheckCnt++
+			continue
+		}
+		// reset it when we get a subtask
+		checkInterval, noSubtaskCheckCnt = defaultCheckInterval, 0
+
+		switch task.State {
+		case proto.TaskStateRunning:
+			err = e.RunStep(resource)
+		case proto.TaskStateReverting:
+			// use m.ctx since this process should not be canceled.
+			// TODO: will remove it later, leave it now.
+			err = e.Rollback()
+		}
+		if err != nil {
+			e.logger.Error("failed to handle task", zap.Error(err))
+		}
+	}
+}
+
 // RunStep start to fetch and run all subtasks for the step of task on the node.
-func (e *BaseTaskExecutor) RunStep(ctx context.Context, task *proto.Task, resource *proto.StepResource) (err error) {
+// return if there's no subtask to run.
+func (e *BaseTaskExecutor) RunStep(resource *proto.StepResource) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			e.logger.Error("BaseTaskExecutor panicked", zap.Any("recover", r), zap.Stack("stack"))
 			err4Panic := errors.Errorf("%v", r)
-			err1 := e.updateSubtask(ctx, task.ID, err4Panic)
+			err1 := e.updateSubtask(err4Panic)
 			if err == nil {
 				err = err1
 			}
 		}
 	}()
-	// TODO: we can centralized this when we move handleExecutableTask loop here.
-	e.task.Store(task)
-	err = e.runStep(ctx, task, resource)
+	err = e.runStep(resource)
 	if e.mu.handled {
 		return err
 	}
@@ -172,43 +237,44 @@ func (e *BaseTaskExecutor) RunStep(ctx context.Context, task *proto.Task, resour
 		// TODO: refine onError/getError
 		if e.getError() != nil {
 			err = e.getError()
-		} else if ctx.Err() != nil {
-			err = ctx.Err()
+		} else if e.ctx.Err() != nil {
+			err = e.ctx.Err()
 		} else {
 			return nil
 		}
 	}
 
-	return e.updateSubtask(ctx, task.ID, err)
+	return e.updateSubtask(err)
 }
 
-func (e *BaseTaskExecutor) runStep(ctx context.Context, task *proto.Task, resource *proto.StepResource) (resErr error) {
-	if ctx.Err() != nil {
-		e.onError(ctx.Err())
-		return e.getError()
-	}
-	runCtx, runCancel := context.WithCancelCause(ctx)
-	defer runCancel(ErrFinishSubtask)
-	e.registerCancelFunc(runCancel)
+func (e *BaseTaskExecutor) runStep(resource *proto.StepResource) (resErr error) {
+	runStepCtx, runStepCancel := context.WithCancelCause(e.ctx)
+	e.registerRunStepCancelFunc(runStepCancel)
+	defer func() {
+		runStepCancel(ErrFinishSubtask)
+		e.unregisterRunStepCancelFunc()
+	}()
 	e.resetError()
+	task := e.task.Load()
 	stepLogger := llog.BeginTask(e.logger.With(
 		zap.String("step", proto.Step2Str(task.Type, task.Step)),
 		zap.Int("concurrency", task.Concurrency),
 		zap.Float64("mem-limit-percent", gctuner.GlobalMemoryLimitTuner.GetPercentage()),
 		zap.String("server-mem-limit", memory.ServerMemoryLimitOriginText.Load()),
-	), "execute task")
+		zap.Stringer("resource", resource),
+	), "execute task step")
 	// log as info level, subtask might be cancelled, let caller check it.
 	defer func() {
 		stepLogger.End(zap.InfoLevel, resErr)
 	}()
 
-	summary, cleanup, err := runSummaryCollectLoop(ctx, task, e.taskTable)
+	summary, cleanup, err := runSummaryCollectLoop(runStepCtx, task, e.taskTable)
 	if err != nil {
 		e.onError(err)
 		return e.getError()
 	}
 	defer cleanup()
-	stepExecutor, err := e.GetStepExecutor(ctx, task, summary, resource)
+	stepExecutor, err := e.GetStepExecutor(task, summary, resource)
 	if err != nil {
 		e.onError(err)
 		return e.getError()
@@ -217,13 +283,13 @@ func (e *BaseTaskExecutor) runStep(ctx context.Context, task *proto.Task, resour
 	failpoint.Inject("mockExecSubtaskInitEnvErr", func() {
 		failpoint.Return(errors.New("mockExecSubtaskInitEnvErr"))
 	})
-	if err := stepExecutor.Init(runCtx); err != nil {
+	if err := stepExecutor.Init(runStepCtx); err != nil {
 		e.onError(err)
 		return e.getError()
 	}
 
 	defer func() {
-		err := stepExecutor.Cleanup(runCtx)
+		err := stepExecutor.Cleanup(runStepCtx)
 		if err != nil {
 			e.logger.Error("cleanup subtask exec env failed", zap.Error(err))
 			e.onError(err)
@@ -231,7 +297,7 @@ func (e *BaseTaskExecutor) runStep(ctx context.Context, task *proto.Task, resour
 	}()
 
 	subtasks, err := e.taskTable.GetSubtasksByExecIDAndStepAndStates(
-		runCtx, e.id, task.ID, task.Step,
+		runStepCtx, e.id, task.ID, task.Step,
 		proto.SubtaskStatePending, proto.SubtaskStateRunning)
 	if err != nil {
 		e.onError(err)
@@ -242,71 +308,37 @@ func (e *BaseTaskExecutor) runStep(ctx context.Context, task *proto.Task, resour
 		metrics.StartDistTaskSubTask(subtask)
 	}
 
-	// task executor occupies resources, if there's no subtask to run for 10s,
-	// we release the resources so that other tasks can use them.
-	// 300ms + 600ms + 1.2s + 2s * 4 = 10.1s
-	backoffer := backoff.NewExponential(checkInterval, 2, maxCheckInterval)
-	noSubtaskCheckCnt := 0
-outer:
 	for {
 		// check if any error occurs.
 		if err := e.getError(); err != nil {
 			break
 		}
-		if runCtx.Err() != nil {
-			e.logger.Info("taskExecutor runSubtask loop exit")
+		if runStepCtx.Err() != nil {
 			break
 		}
 
-		subtask, err := e.taskTable.GetFirstSubtaskInStates(runCtx, e.id, task.ID, task.Step,
+		subtask, err := e.taskTable.GetFirstSubtaskInStates(runStepCtx, e.id, task.ID, task.Step,
 			proto.SubtaskStatePending, proto.SubtaskStateRunning)
 		if err != nil {
 			e.logger.Warn("GetFirstSubtaskInStates meets error", zap.Error(err))
 			continue
 		}
 		if subtask == nil {
-			failpoint.Inject("breakInTaskExecutorUT", func() {
-				failpoint.Break()
-			})
-			newTask, err := e.taskTable.GetTaskByID(runCtx, task.ID)
-			// When the task move history table of not found, the task executor should exit.
-			if err == storage.ErrTaskNotFound {
-				break
-			}
-			if err != nil {
-				e.logger.Warn("GetTaskByID meets error", zap.Error(err))
-				continue
-			}
-			// When the task move to next step or task state changes, the task executor should exit.
-			if newTask.Step != task.Step || newTask.State != task.State {
-				break
-			}
-			if noSubtaskCheckCnt >= maxChecksWhenNoSubtask {
-				break
-			}
-			select {
-			case <-runCtx.Done():
-				break outer
-			case <-time.After(backoffer.Backoff(noSubtaskCheckCnt)):
-				noSubtaskCheckCnt++
-				continue
-			}
+			break
 		}
-		// reset it when we get a subtask
-		noSubtaskCheckCnt = 0
 
 		if subtask.State == proto.SubtaskStateRunning {
 			if !e.IsIdempotent(subtask) {
 				e.logger.Info("subtask in running state and is not idempotent, fail it",
 					zap.Int64("subtask-id", subtask.ID))
 				e.onError(ErrNonIdempotentSubtask)
-				e.updateSubtaskStateAndError(runCtx, subtask, proto.SubtaskStateFailed, ErrNonIdempotentSubtask)
+				e.updateSubtaskStateAndError(runStepCtx, subtask, proto.SubtaskStateFailed, ErrNonIdempotentSubtask)
 				e.markErrorHandled()
 				break
 			}
 		} else {
 			// subtask.State == proto.SubtaskStatePending
-			err := e.startSubtaskAndUpdateState(runCtx, subtask)
+			err := e.startSubtaskAndUpdateState(runStepCtx, subtask)
 			if err != nil {
 				e.logger.Warn("startSubtaskAndUpdateState meets error", zap.Error(err))
 				// should ignore ErrSubtaskNotFound
@@ -329,10 +361,10 @@ outer:
 		})
 
 		failpoint.Inject("cancelBeforeRunSubtask", func() {
-			runCancel(nil)
+			runStepCancel(nil)
 		})
 
-		e.runSubtask(runCtx, stepExecutor, subtask)
+		e.runSubtask(runStepCtx, stepExecutor, subtask)
 	}
 	return e.getError()
 }
@@ -459,10 +491,8 @@ func (e *BaseTaskExecutor) onSubtaskFinished(ctx context.Context, executor execu
 
 // Rollback rollbacks the subtask.
 // TODO no need to start executor to do it, refactor it later.
-func (e *BaseTaskExecutor) Rollback(ctx context.Context, task *proto.Task) error {
-	// TODO: we can centralized this when we move handleExecutableTask loop here.
-	e.task.Store(task)
-
+func (e *BaseTaskExecutor) Rollback() error {
+	task := e.task.Load()
 	e.resetError()
 	e.logger.Info("taskExecutor rollback a step", zap.String("step", proto.Step2Str(task.Type, task.Step)))
 
@@ -470,7 +500,7 @@ func (e *BaseTaskExecutor) Rollback(ctx context.Context, task *proto.Task) error
 	for {
 		// TODO we can update them using one sql, but requires change the metric
 		// gathering logic.
-		subtask, err := e.taskTable.GetFirstSubtaskInStates(ctx, e.id, task.ID, task.Step,
+		subtask, err := e.taskTable.GetFirstSubtaskInStates(e.ctx, e.id, task.ID, task.Step,
 			proto.SubtaskStatePending, proto.SubtaskStateRunning)
 		if err != nil {
 			e.onError(err)
@@ -481,7 +511,7 @@ func (e *BaseTaskExecutor) Rollback(ctx context.Context, task *proto.Task) error
 			break
 		}
 
-		e.updateSubtaskStateAndError(ctx, subtask, proto.SubtaskStateCanceled, nil)
+		e.updateSubtaskStateAndError(e.ctx, subtask, proto.SubtaskStateCanceled, nil)
 		if err = e.getError(); err != nil {
 			return err
 		}
@@ -489,8 +519,35 @@ func (e *BaseTaskExecutor) Rollback(ctx context.Context, task *proto.Task) error
 	return e.getError()
 }
 
+// GetTask implements TaskExecutor.GetTask.
+func (e *BaseTaskExecutor) GetTask() *proto.Task {
+	return e.task.Load()
+}
+
+// CancelRunningSubtask implements TaskExecutor.CancelRunningSubtask.
+func (e *BaseTaskExecutor) CancelRunningSubtask() {
+	e.cancelRunStepWith(ErrCancelSubtask)
+}
+
+// Cancel implements TaskExecutor.Cancel.
+func (e *BaseTaskExecutor) Cancel() {
+	e.cancel()
+}
+
 // Close closes the TaskExecutor when all the subtasks are complete.
-func (*BaseTaskExecutor) Close() {
+func (e *BaseTaskExecutor) Close() {
+	e.Cancel()
+}
+
+// refreshTask fetch task state from tidb_global_task table.
+func (e *BaseTaskExecutor) refreshTask() error {
+	task := e.GetTask()
+	newTask, err := e.taskTable.GetTaskByID(e.ctx, task.ID)
+	if err != nil {
+		return err
+	}
+	e.task.Store(newTask)
+	return nil
 }
 
 func runSummaryCollectLoop(
@@ -518,19 +575,23 @@ func runSummaryCollectLoop(
 	return nil, func() {}, nil
 }
 
-func (e *BaseTaskExecutor) registerCancelFunc(cancel context.CancelCauseFunc) {
+func (e *BaseTaskExecutor) registerRunStepCancelFunc(cancel context.CancelCauseFunc) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.mu.runtimeCancel = cancel
 }
 
-// cancelRunStep cancels runStep, i.e. the running process, but leave the subtask
-// state unchanged.
-func (e *BaseTaskExecutor) cancelRunStep() {
+func (e *BaseTaskExecutor) unregisterRunStepCancelFunc() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.mu.runtimeCancel = nil
+}
+
+func (e *BaseTaskExecutor) cancelRunStepWith(cause error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.mu.runtimeCancel != nil {
-		e.mu.runtimeCancel(nil)
+		e.mu.runtimeCancel(cause)
 	}
 }
 
@@ -701,18 +762,19 @@ func (e *BaseTaskExecutor) cancelSubtaskWithRetry(ctx context.Context, taskID in
 // 1. Only cancel subtasks when meet ErrCancelSubtask.
 // 2. Only fail subtasks when meet non retryable error.
 // 3. When meet other errors, don't change subtasks' state.
-// Handled errors should not happened during subtasks execution.
+// Handled errors should not happen during subtasks execution.
 // Only handle errors before subtasks execution and after subtasks execution.
-func (e *BaseTaskExecutor) updateSubtask(ctx context.Context, taskID int64, err error) error {
+func (e *BaseTaskExecutor) updateSubtask(err error) error {
+	task := e.task.Load()
 	err = errors.Cause(err)
-	if ctx.Err() != nil && context.Cause(ctx) == ErrCancelSubtask {
-		return e.cancelSubtaskWithRetry(ctx, taskID, ErrCancelSubtask)
+	if e.ctx.Err() != nil && context.Cause(e.ctx) == ErrCancelSubtask {
+		return e.cancelSubtaskWithRetry(e.ctx, task.ID, ErrCancelSubtask)
 	} else if e.IsRetryableError(err) {
 		e.logger.Warn("meet retryable error", zap.Error(err))
 	} else if common.IsContextCanceledError(err) {
 		e.logger.Info("meet context canceled for gracefully shutdown", zap.Error(err))
 	} else {
-		return e.failSubtaskWithRetry(ctx, taskID, err)
+		return e.failSubtaskWithRetry(e.ctx, task.ID, err)
 	}
 	return nil
 }

--- a/pkg/disttask/framework/taskexecutor/task_executor.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor.go
@@ -165,9 +165,9 @@ func (e *BaseTaskExecutor) Run(resource *proto.StepResource) {
 		case <-time.After(checkInterval):
 		}
 		failpoint.Inject("mockStopManager", func() {
-			testContexts.Store(e.id, &TestContext{make(chan struct{}), atomic.Bool{}})
+			TestContexts.Store(e.id, &TestContext{make(chan struct{}), atomic.Bool{}})
 			go func() {
-				v, ok := testContexts.Load(e.id)
+				v, ok := TestContexts.Load(e.id)
 				if ok {
 					<-v.(*TestContext).TestSyncSubtaskRun
 					infosync.MockGlobalServerInfoManagerEntry.DeleteByExecID(e.id)
@@ -352,7 +352,7 @@ func (e *BaseTaskExecutor) runStep(resource *proto.StepResource) (resErr error) 
 		}
 
 		failpoint.Inject("mockCleanExecutor", func() {
-			v, ok := testContexts.Load(e.id)
+			v, ok := TestContexts.Load(e.id)
 			if ok {
 				if v.(*TestContext).mockDown.Load() {
 					failpoint.Break()
@@ -409,7 +409,7 @@ func (e *BaseTaskExecutor) runSubtask(ctx context.Context, stepExecutor execute.
 	failpoint.Inject("mockTiDBDown", func(val failpoint.Value) {
 		e.logger.Info("trigger mockTiDBDown")
 		if e.id == val.(string) || e.id == ":4001" || e.id == ":4002" {
-			v, ok := testContexts.Load(e.id)
+			v, ok := TestContexts.Load(e.id)
 			if ok {
 				v.(*TestContext).TestSyncSubtaskRun <- struct{}{}
 				v.(*TestContext).mockDown.Store(true)
@@ -421,7 +421,7 @@ func (e *BaseTaskExecutor) runSubtask(ctx context.Context, stepExecutor execute.
 	})
 	failpoint.Inject("mockTiDBDown2", func() {
 		if e.id == ":4003" && subtask.Step == proto.StepTwo {
-			v, ok := testContexts.Load(e.id)
+			v, ok := TestContexts.Load(e.id)
 			if ok {
 				v.(*TestContext).TestSyncSubtaskRun <- struct{}{}
 				v.(*TestContext).mockDown.Store(true)

--- a/pkg/disttask/framework/taskexecutor/task_executor.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor.go
@@ -150,6 +150,12 @@ func (*BaseTaskExecutor) Init(_ context.Context) error {
 	return nil
 }
 
+// Ctx returns the context of the task executor.
+// TODO: remove it when add-index.taskexecutor.Init don't depends on it.
+func (e *BaseTaskExecutor) Ctx() context.Context {
+	return e.ctx
+}
+
 // Run implements the TaskExecutor interface.
 func (e *BaseTaskExecutor) Run(resource *proto.StepResource) {
 	var err error
@@ -191,6 +197,7 @@ func (e *BaseTaskExecutor) Run(resource *proto.StepResource) {
 			continue
 		} else if !exist {
 			if noSubtaskCheckCnt >= maxChecksWhenNoSubtask {
+				e.logger.Info("no subtask to run for a while, exit")
 				break
 			}
 			checkInterval = backoffer.Backoff(noSubtaskCheckCnt)

--- a/pkg/disttask/framework/taskexecutor/task_executor.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor.go
@@ -211,7 +211,6 @@ func (e *BaseTaskExecutor) Run(resource *proto.StepResource) {
 		case proto.TaskStateRunning:
 			err = e.RunStep(resource)
 		case proto.TaskStateReverting:
-			// use m.ctx since this process should not be canceled.
 			// TODO: will remove it later, leave it now.
 			err = e.Rollback()
 		}

--- a/pkg/disttask/framework/taskexecutor/task_executor_test.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor_test.go
@@ -394,13 +394,13 @@ func TestTaskExecutor(t *testing.T) {
 	require.True(t, ctrl.Satisfied())
 
 	// no subtask to run, should exit the loop after some time.
-	checkIntervalBak := checkInterval
+	checkIntervalBak := defaultCheckInterval
 	maxIntervalBak := maxCheckInterval
 	defer func() {
-		checkInterval = checkIntervalBak
+		defaultCheckInterval = checkIntervalBak
 		maxCheckInterval = maxIntervalBak
 	}()
-	maxCheckInterval, checkInterval = time.Millisecond, time.Millisecond
+	maxCheckInterval, defaultCheckInterval = time.Millisecond, time.Millisecond
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
@@ -499,7 +499,7 @@ func TestCheckBalanceSubtask(t *testing.T) {
 	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "tidb1",
 		task.ID, task.Step, proto.SubtaskStateRunning).Return([]*proto.Subtask{}, nil)
 	runCtx, cancelCause := context.WithCancelCause(ctx)
-	taskExecutor.registerCancelFunc(cancelCause)
+	taskExecutor.registerRunStepCancelFunc(cancelCause)
 	require.NoError(t, runCtx.Err())
 	taskExecutor.checkBalanceSubtask(ctx)
 	require.ErrorIs(t, runCtx.Err(), context.Canceled)

--- a/pkg/disttask/framework/taskexecutor/task_executor_test.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor_test.go
@@ -39,94 +39,89 @@ var (
 
 func TestTaskExecutorRun(t *testing.T) {
 	var tp proto.TaskType = "test_task_executor_run"
-	var taskID int64 = 1
 	var concurrency = 10
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	runCtx, runCancel := context.WithCancel(ctx)
-	defer runCancel()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockSubtaskTable := mock.NewMockTaskTable(ctrl)
 	mockStepExecutor := mockexecute.NewMockStepExecutor(ctrl)
 	mockExtension := mock.NewMockExtension(ctrl)
-	mockExtension.EXPECT().IsRetryableError(gomock.Any()).AnyTimes()
+	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(false).AnyTimes()
 
+	task1 := &proto.Task{Step: proto.StepOne, Type: tp, ID: 1, Concurrency: concurrency}
 	// mock for checkBalanceSubtask
 	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id",
-		taskID, proto.StepOne, proto.SubtaskStateRunning).Return([]*proto.Subtask{{ID: 1}}, nil).AnyTimes()
+		task1.ID, proto.StepOne, proto.SubtaskStateRunning).Return([]*proto.Subtask{{ID: 1}}, nil).AnyTimes()
 
-	task1 := &proto.Task{Step: proto.StepOne, Type: tp}
 	// 1. no taskExecutor constructor
 	taskExecutorRegisterErr := errors.Errorf("constructor of taskExecutor for key not found")
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, taskExecutorRegisterErr).Times(2)
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, taskExecutorRegisterErr).Times(2)
 	taskExecutor := NewBaseTaskExecutor(ctx, "id", task1, mockSubtaskTable)
 	taskExecutor.Extension = mockExtension
-	err := taskExecutor.runStep(runCtx, task1, nil)
+	err := taskExecutor.runStep(nil)
 	require.EqualError(t, err, taskExecutorRegisterErr.Error())
-	mockSubtaskTable.EXPECT().FailSubtask(runCtx, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	err = taskExecutor.RunStep(runCtx, task1, nil)
+	mockSubtaskTable.EXPECT().FailSubtask(taskExecutor.ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	err = taskExecutor.RunStep(nil)
 	require.NoError(t, err)
 	require.True(t, ctrl.Satisfied())
 
 	// 2. init subtask exec env failed
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStepExecutor, nil).AnyTimes()
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStepExecutor, nil).AnyTimes()
 
 	initErr := errors.New("init error")
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(initErr)
-	err = taskExecutor.runStep(runCtx, task1, nil)
+	err = taskExecutor.runStep(nil)
 	require.EqualError(t, err, initErr.Error())
 	require.True(t, ctrl.Satisfied())
 
-	task := &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}
 	// 3. run subtask failed
 	runSubtaskErr := errors.New("run subtask error")
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}}, nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
-	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(nil)
+	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), task1.ID, "id").Return(nil)
 	mockStepExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(runSubtaskErr)
-	mockSubtaskTable.EXPECT().UpdateSubtaskStateAndError(gomock.Any(), "id", taskID, proto.SubtaskStateFailed, gomock.Any()).Return(nil)
+	mockSubtaskTable.EXPECT().UpdateSubtaskStateAndError(gomock.Any(), "id", task1.ID, proto.SubtaskStateFailed, gomock.Any()).Return(nil)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
 
-	err = taskExecutor.RunStep(runCtx, task, nil)
+	err = taskExecutor.RunStep(nil)
 	require.EqualError(t, err, runSubtaskErr.Error())
 	require.True(t, ctrl.Satisfied())
 
 	// 4. run subtask success
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}}, nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
-	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(nil)
+	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), task1.ID, "id").Return(nil)
 	mockStepExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(nil)
 	mockStepExecutor.EXPECT().OnFinished(gomock.Any(), gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().FinishSubtask(gomock.Any(), "id", int64(1), gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	mockSubtaskTable.EXPECT().GetTaskByID(gomock.Any(), gomock.Any()).Return(&proto.Task{ID: taskID, Step: proto.StepTwo}, nil)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.RunStep(runCtx, task, nil)
+	err = taskExecutor.RunStep(nil)
 	require.NoError(t, err)
 	require.True(t, ctrl.Satisfied())
 
 	// 5. run subtask one by one
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(
 		[]*proto.Subtask{
 			{ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"},
 			{ID: 2, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"},
 		}, nil)
 	// first round of the run loop
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
 	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), int64(1), "id").Return(nil)
@@ -134,7 +129,7 @@ func TestTaskExecutorRun(t *testing.T) {
 	mockStepExecutor.EXPECT().OnFinished(gomock.Any(), gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().FinishSubtask(gomock.Any(), "id", int64(1), gomock.Any()).Return(nil)
 	// second round of the run loop
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 2, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
 	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), int64(2), "id").Return(nil)
@@ -142,11 +137,10 @@ func TestTaskExecutorRun(t *testing.T) {
 	mockStepExecutor.EXPECT().OnFinished(gomock.Any(), gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().FinishSubtask(gomock.Any(), "id", int64(2), gomock.Any()).Return(nil)
 	// third round of the run loop
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	mockSubtaskTable.EXPECT().GetTaskByID(gomock.Any(), gomock.Any()).Return(&proto.Task{ID: taskID, Step: proto.StepTwo}, nil)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.RunStep(runCtx, task, nil)
+	err = taskExecutor.RunStep(nil)
 	require.NoError(t, err)
 	require.True(t, ctrl.Satisfied())
 
@@ -154,96 +148,95 @@ func TestTaskExecutorRun(t *testing.T) {
 	// idempotent, so fail it.
 	subtaskID := int64(2)
 	theSubtask := &proto.Subtask{ID: subtaskID, Type: tp, Step: proto.StepOne, State: proto.SubtaskStateRunning, ExecID: "id"}
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{theSubtask}, nil)
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(theSubtask, nil)
 	mockExtension.EXPECT().IsIdempotent(gomock.Any()).Return(false)
 	mockSubtaskTable.EXPECT().UpdateSubtaskStateAndError(gomock.Any(), "id", subtaskID, proto.SubtaskStateFailed, gomock.Any()).Return(nil)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.RunStep(runCtx, task, nil)
+	err = taskExecutor.RunStep(nil)
 	require.ErrorContains(t, err, "subtask in running state and is not idempotent")
 	require.True(t, ctrl.Satisfied())
 
 	// run previous left subtask in running state again, but the subtask idempotent,
 	// run it again.
 	theSubtask = &proto.Subtask{ID: subtaskID, Type: tp, Step: proto.StepOne, State: proto.SubtaskStateRunning, ExecID: "id"}
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{theSubtask}, nil)
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
 	// first round of the run loop
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(theSubtask, nil)
 	mockExtension.EXPECT().IsIdempotent(gomock.Any()).Return(true)
 	mockStepExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(nil)
 	mockStepExecutor.EXPECT().OnFinished(gomock.Any(), gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().FinishSubtask(gomock.Any(), "id", subtaskID, gomock.Any()).Return(nil)
 	// second round of the run loop
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	mockSubtaskTable.EXPECT().GetTaskByID(gomock.Any(), gomock.Any()).Return(&proto.Task{ID: taskID, Step: proto.StepTwo}, nil)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.RunStep(runCtx, task, nil)
+	err = taskExecutor.RunStep(nil)
 	require.NoError(t, err)
 	require.True(t, ctrl.Satisfied())
 
 	// 6. cancel
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{{
 		ID: 2, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}}, nil)
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
-	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(nil)
+	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), task1.ID, "id").Return(nil)
 	mockStepExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(ErrCancelSubtask)
-	mockSubtaskTable.EXPECT().UpdateSubtaskStateAndError(gomock.Any(), "id", taskID, proto.SubtaskStateCanceled, gomock.Any()).Return(nil)
+	mockSubtaskTable.EXPECT().UpdateSubtaskStateAndError(gomock.Any(), "id", task1.ID, proto.SubtaskStateCanceled, gomock.Any()).Return(nil)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.RunStep(runCtx, task, nil)
+	err = taskExecutor.RunStep(nil)
 	require.EqualError(t, err, ErrCancelSubtask.Error())
 	require.True(t, ctrl.Satisfied())
 
 	// 7. RunSubtask return context.Canceled
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{{
 		ID: 2, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}}, nil)
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
-	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(nil)
+	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), task1.ID, "id").Return(nil)
 	mockStepExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(context.Canceled)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.RunStep(runCtx, task, nil)
+	err = taskExecutor.RunStep(nil)
 	require.EqualError(t, err, context.Canceled.Error())
 	require.True(t, ctrl.Satisfied())
 
 	// 8. grpc cancel
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{{
 		ID: 2, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}}, nil)
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
-	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(nil)
+	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), task1.ID, "id").Return(nil)
 	grpcErr := status.Error(codes.Canceled, "test cancel")
 	mockStepExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(grpcErr)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.RunStep(runCtx, task, nil)
+	err = taskExecutor.RunStep(nil)
 	require.EqualError(t, err, grpcErr.Error())
 	require.True(t, ctrl.Satisfied())
 
 	// 9. annotate grpc cancel
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{{
 		ID: 2, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}}, nil)
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
-	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(nil)
+	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), task1.ID, "id").Return(nil)
 	grpcErr = status.Error(codes.Canceled, "test cancel")
 	annotatedError := errors.Annotatef(
 		grpcErr,
@@ -252,26 +245,24 @@ func TestTaskExecutorRun(t *testing.T) {
 	)
 	mockStepExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(annotatedError)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.RunStep(runCtx, task, nil)
+	err = taskExecutor.RunStep(nil)
 	require.EqualError(t, err, annotatedError.Error())
 	require.True(t, ctrl.Satisfied())
 
 	// 10. subtask owned by other executor
 	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}}, nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(storage.ErrSubtaskNotFound)
-	mockSubtaskTable.EXPECT().GetTaskByID(gomock.Any(), gomock.Any()).Return(&proto.Task{ID: taskID, Step: proto.StepTwo}, nil)
+	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), task1.ID, "id").Return(storage.ErrSubtaskNotFound)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.RunStep(runCtx, task, nil)
+	err = taskExecutor.RunStep(nil)
 	require.NoError(t, err)
-	runCancel()
 	require.True(t, ctrl.Satisfied())
 }
 
@@ -292,38 +283,37 @@ func TestTaskExecutorRollback(t *testing.T) {
 	taskExecutor := NewBaseTaskExecutor(ctx, "id", task1, mockSubtaskTable)
 	taskExecutor.Extension = mockExtension
 
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStepExecutor, nil).AnyTimes()
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStepExecutor, nil).AnyTimes()
 
 	// 2. get subtask failed
 	getSubtaskErr := errors.New("get subtask error")
-	var taskID int64 = 1
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, getSubtaskErr)
-	err := taskExecutor.Rollback(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID})
+	err := taskExecutor.Rollback()
 	require.EqualError(t, err, getSubtaskErr.Error())
 
 	// 3. no subtask
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	err = taskExecutor.Rollback(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID})
+	err = taskExecutor.Rollback()
 	require.NoError(t, err)
 
 	// 5. rollback success
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{ID: 1, ExecID: "id"}, nil)
 	mockSubtaskTable.EXPECT().UpdateSubtaskStateAndError(runCtx, "id", int64(1), proto.SubtaskStateCanceled, nil).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{ID: 2, ExecID: "id"}, nil)
 	mockSubtaskTable.EXPECT().UpdateSubtaskStateAndError(runCtx, "id", int64(2), proto.SubtaskStateCanceled, nil).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	err = taskExecutor.Rollback(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID})
+	err = taskExecutor.Rollback()
 	require.NoError(t, err)
 
 	// rollback again for previous left subtask in TaskStateReverting state
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", task1.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	err = taskExecutor.Rollback(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID})
+	err = taskExecutor.Rollback()
 	require.NoError(t, err)
 }
 
@@ -333,15 +323,13 @@ func TestTaskExecutor(t *testing.T) {
 	var concurrency = 10
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	runCtx, runCancel := context.WithCancel(ctx)
-	defer runCancel()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockSubtaskTable := mock.NewMockTaskTable(ctrl)
 	mockStepExecutor := mockexecute.NewMockStepExecutor(ctrl)
 	mockExtension := mock.NewMockExtension(ctrl)
 	mockSubtaskTable.EXPECT().UpdateSubtaskStateAndError(gomock.Any(), "id", taskID, proto.SubtaskStateFailed, gomock.Any()).Return(nil)
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStepExecutor, nil).AnyTimes()
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStepExecutor, nil).AnyTimes()
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(false).AnyTimes()
 	// mock for checkBalanceSubtask
 	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id",
@@ -364,14 +352,14 @@ func TestTaskExecutor(t *testing.T) {
 	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(nil)
 	mockStepExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(runSubtaskErr)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err := taskExecutor.runStep(runCtx, task, nil)
+	err := taskExecutor.runStep(nil)
 	require.EqualError(t, err, runSubtaskErr.Error())
 	require.True(t, ctrl.Satisfied())
 
 	// 2. rollback success.
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(runCtx, "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(taskExecutor.ctx, "id", taskID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	err = taskExecutor.Rollback(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID})
+	err = taskExecutor.Rollback()
 	require.NoError(t, err)
 	require.True(t, ctrl.Satisfied())
 
@@ -387,50 +375,8 @@ func TestTaskExecutor(t *testing.T) {
 	mockSubtaskTable.EXPECT().FinishSubtask(gomock.Any(), "id", int64(1), gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	mockSubtaskTable.EXPECT().GetTaskByID(gomock.Any(), gomock.Any()).Return(nil, storage.ErrTaskNotFound)
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.runStep(runCtx, task, nil)
-	require.NoError(t, err)
-	require.True(t, ctrl.Satisfied())
-
-	// no subtask to run, should exit the loop after some time.
-	checkIntervalBak := defaultCheckInterval
-	maxIntervalBak := maxCheckInterval
-	defer func() {
-		defaultCheckInterval = checkIntervalBak
-		maxCheckInterval = maxIntervalBak
-	}()
-	maxCheckInterval, defaultCheckInterval = time.Millisecond, time.Millisecond
-	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
-		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
-		unfinishedNormalSubtaskStates...).Return(nil, nil).Times(8)
-	mockSubtaskTable.EXPECT().GetTaskByID(gomock.Any(), gomock.Any()).Return(task, nil).Times(8)
-	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.runStep(runCtx, task, nil)
-	require.NoError(t, err)
-	require.True(t, ctrl.Satisfied())
-
-	// no-subtask check counter should be reset after a subtask is run.
-	mockStepExecutor.EXPECT().Init(gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "id", taskID, proto.StepOne,
-		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	// no subtask to run for 4 times.
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
-		unfinishedNormalSubtaskStates...).Return(nil, nil).Times(4)
-	mockSubtaskTable.EXPECT().GetTaskByID(gomock.Any(), gomock.Any()).Return(task, nil).Times(4)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
-		unfinishedNormalSubtaskStates...).Return(subtasks[0], nil)
-	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(nil)
-	mockStepExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(nil)
-	mockStepExecutor.EXPECT().OnFinished(gomock.Any(), gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().FinishSubtask(gomock.Any(), "id", int64(1), gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
-		unfinishedNormalSubtaskStates...).Return(nil, nil).Times(8)
-	mockSubtaskTable.EXPECT().GetTaskByID(gomock.Any(), gomock.Any()).Return(task, nil).Times(8)
-	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	err = taskExecutor.runStep(runCtx, task, nil)
+	err = taskExecutor.runStep(nil)
 	require.NoError(t, err)
 	require.True(t, ctrl.Satisfied())
 }
@@ -454,7 +400,7 @@ func TestRunStepCurrentSubtaskScheduledAway(t *testing.T) {
 	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "tidb1",
 		task.ID, proto.StepOne, proto.SubtaskStateRunning).Return([]*proto.Subtask{}, nil)
 	// mock for runStep
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStepExecutor, nil)
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStepExecutor, nil)
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(false)
 	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(gomock.Any(), "tidb1", task.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(subtasks, nil)
@@ -467,7 +413,7 @@ func TestRunStepCurrentSubtaskScheduledAway(t *testing.T) {
 		return ctx.Err()
 	})
 	mockStepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	require.ErrorIs(t, taskExecutor.runStep(ctx, task, nil), context.Canceled)
+	require.ErrorIs(t, taskExecutor.runStep(nil), context.Canceled)
 	require.True(t, ctrl.Satisfied())
 }
 
@@ -532,54 +478,51 @@ func TestCheckBalanceSubtask(t *testing.T) {
 
 func TestExecutorErrHandling(t *testing.T) {
 	var tp proto.TaskType = "test_task_executor"
-	var taskID int64 = 1
 	var concurrency = 10
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	runCtx, runCancel := context.WithCancel(ctx)
-	defer runCancel()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockSubtaskTable := mock.NewMockTaskTable(ctrl)
 	mockSubtaskExecutor := mockexecute.NewMockStepExecutor(ctrl)
 	mockExtension := mock.NewMockExtension(ctrl)
-	task := &proto.Task{Step: proto.StepOne, Type: tp}
+	task := &proto.Task{Step: proto.StepOne, Type: tp, ID: 1, Concurrency: concurrency}
 	taskExecutor := NewBaseTaskExecutor(ctx, "id", task, mockSubtaskTable)
 	taskExecutor.Extension = mockExtension
 
 	// 1. GetStepExecutor meet retryable error.
 	getSubtaskExecutorErr := errors.New("get executor err")
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, getSubtaskExecutorErr)
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, getSubtaskExecutorErr)
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(true)
-	require.NoError(t, taskExecutor.RunStep(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
+	require.NoError(t, taskExecutor.RunStep(nil))
 	require.True(t, ctrl.Satisfied())
 
 	// 2. GetStepExecutor meet non retryable error.
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, getSubtaskExecutorErr)
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, getSubtaskExecutorErr)
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(false)
-	mockSubtaskTable.EXPECT().FailSubtask(runCtx, taskExecutor.id, gomock.Any(), getSubtaskExecutorErr)
-	require.NoError(t, taskExecutor.RunStep(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
+	mockSubtaskTable.EXPECT().FailSubtask(taskExecutor.ctx, taskExecutor.id, gomock.Any(), getSubtaskExecutorErr)
+	require.NoError(t, taskExecutor.RunStep(nil))
 	require.True(t, ctrl.Satisfied())
 
 	// 3. Init meet retryable error.
 	initErr := errors.New("executor init err")
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
 	mockSubtaskExecutor.EXPECT().Init(gomock.Any()).Return(initErr)
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(true)
-	require.NoError(t, taskExecutor.RunStep(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
+	require.NoError(t, taskExecutor.RunStep(nil))
 	require.True(t, ctrl.Satisfied())
 
 	// 4. Init meet non retryable error.
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
 	mockSubtaskExecutor.EXPECT().Init(gomock.Any()).Return(initErr)
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(false)
-	mockSubtaskTable.EXPECT().FailSubtask(runCtx, taskExecutor.id, gomock.Any(), initErr)
-	require.NoError(t, taskExecutor.RunStep(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
+	mockSubtaskTable.EXPECT().FailSubtask(taskExecutor.ctx, taskExecutor.id, gomock.Any(), initErr)
+	require.NoError(t, taskExecutor.RunStep(nil))
 	require.True(t, ctrl.Satisfied())
 
 	// 5. GetSubtasksByStepAndStates meet retryable error.
 	getSubtasksByExecIDAndStepAndStatesErr := errors.New("get subtasks err")
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
 	mockSubtaskExecutor.EXPECT().Init(gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(
 		gomock.Any(),
@@ -589,11 +532,11 @@ func TestExecutorErrHandling(t *testing.T) {
 		unfinishedNormalSubtaskStates...).Return(nil, getSubtasksByExecIDAndStepAndStatesErr)
 	mockSubtaskExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(true)
-	require.NoError(t, taskExecutor.RunStep(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
+	require.NoError(t, taskExecutor.RunStep(nil))
 	require.True(t, ctrl.Satisfied())
 
 	// 6. GetSubtasksByExecIDAndStepAndStates meet non retryable error.
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
 	mockSubtaskExecutor.EXPECT().Init(gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(
 		gomock.Any(),
@@ -603,13 +546,13 @@ func TestExecutorErrHandling(t *testing.T) {
 		unfinishedNormalSubtaskStates...).Return(nil, getSubtasksByExecIDAndStepAndStatesErr)
 	mockSubtaskExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(false)
-	mockSubtaskTable.EXPECT().FailSubtask(runCtx, taskExecutor.id, gomock.Any(), getSubtasksByExecIDAndStepAndStatesErr)
-	require.NoError(t, taskExecutor.RunStep(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
+	mockSubtaskTable.EXPECT().FailSubtask(taskExecutor.ctx, taskExecutor.id, gomock.Any(), getSubtasksByExecIDAndStepAndStatesErr)
+	require.NoError(t, taskExecutor.RunStep(nil))
 	require.True(t, ctrl.Satisfied())
 
 	// 7. Cleanup meet retryable error.
 	cleanupErr := errors.New("cleanup err")
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
 	mockSubtaskExecutor.EXPECT().Init(gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(
 		gomock.Any(),
@@ -618,23 +561,22 @@ func TestExecutorErrHandling(t *testing.T) {
 		proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}}, nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
-	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(nil)
+	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), task.ID, "id").Return(nil)
 	mockSubtaskExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(nil)
 	mockSubtaskExecutor.EXPECT().OnFinished(gomock.Any(), gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().FinishSubtask(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	mockSubtaskTable.EXPECT().GetTaskByID(gomock.Any(), gomock.Any()).Return(&proto.Task{ID: taskID, Step: proto.StepTwo}, nil)
 	mockSubtaskExecutor.EXPECT().Cleanup(gomock.Any()).Return(cleanupErr)
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(true)
-	require.NoError(t, taskExecutor.RunStep(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
+	require.NoError(t, taskExecutor.RunStep(nil))
 	require.True(t, ctrl.Satisfied())
 
 	// 8. Cleanup meet non retryable error.
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
 	mockSubtaskExecutor.EXPECT().Init(gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(
 		gomock.Any(),
@@ -643,51 +585,36 @@ func TestExecutorErrHandling(t *testing.T) {
 		proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}}, nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
-	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(nil)
+	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), task.ID, "id").Return(nil)
 	mockSubtaskExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(nil)
 	mockSubtaskExecutor.EXPECT().OnFinished(gomock.Any(), gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().FinishSubtask(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	mockSubtaskTable.EXPECT().GetTaskByID(gomock.Any(), gomock.Any()).Return(&proto.Task{ID: taskID, Step: proto.StepTwo}, nil)
 	mockSubtaskExecutor.EXPECT().Cleanup(gomock.Any()).Return(cleanupErr)
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(false)
-	mockSubtaskTable.EXPECT().FailSubtask(runCtx, taskExecutor.id, gomock.Any(), cleanupErr)
-	require.NoError(t, taskExecutor.RunStep(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
+	mockSubtaskTable.EXPECT().FailSubtask(taskExecutor.ctx, taskExecutor.id, gomock.Any(), cleanupErr)
+	require.NoError(t, taskExecutor.RunStep(nil))
 	require.True(t, ctrl.Satisfied())
 
 	// 9. runSummaryCollectLoop meet retryable error.
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/mockSummaryCollectErr", "return()"))
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(true)
-	require.NoError(t, taskExecutor.RunStep(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
+	require.NoError(t, taskExecutor.RunStep(nil))
 	require.True(t, ctrl.Satisfied())
 
 	// 10. runSummaryCollectLoop meet non retryable error.
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(false)
-	mockSubtaskTable.EXPECT().FailSubtask(runCtx, taskExecutor.id, gomock.Any(), gomock.Any())
-	require.NoError(t, taskExecutor.RunStep(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
+	mockSubtaskTable.EXPECT().FailSubtask(taskExecutor.ctx, taskExecutor.id, gomock.Any(), gomock.Any())
+	require.NoError(t, taskExecutor.RunStep(nil))
 	require.True(t, ctrl.Satisfied())
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/mockSummaryCollectErr"))
 
-	// 11. meet cancel before register cancel.
-	runCtx1, runCancel1 := context.WithCancel(ctx)
-	runCancel1()
-	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(true)
-	require.NoError(t, taskExecutor.RunStep(runCtx1, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
-	require.True(t, ctrl.Satisfied())
-
-	// 12. meet ErrCancelSubtask before register cancel.
-	runCtx2, runCancel2 := context.WithCancelCause(ctx)
-	runCancel2(ErrCancelSubtask)
-	mockSubtaskTable.EXPECT().CancelSubtask(runCtx2, taskExecutor.id, gomock.Any())
-	require.NoError(t, taskExecutor.RunStep(runCtx2, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
-	require.True(t, ctrl.Satisfied())
-
 	// 13. subtask succeed.
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockSubtaskExecutor, nil)
 	mockSubtaskExecutor.EXPECT().Init(gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().GetSubtasksByExecIDAndStepAndStates(
 		gomock.Any(),
@@ -696,17 +623,16 @@ func TestExecutorErrHandling(t *testing.T) {
 		proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return([]*proto.Subtask{{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}}, nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(&proto.Subtask{
 		ID: 1, Type: tp, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}, nil)
-	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), taskID, "id").Return(nil)
+	mockSubtaskTable.EXPECT().StartSubtask(gomock.Any(), task.ID, "id").Return(nil)
 	mockSubtaskExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).Return(nil)
 	mockSubtaskExecutor.EXPECT().OnFinished(gomock.Any(), gomock.Any()).Return(nil)
 	mockSubtaskTable.EXPECT().FinishSubtask(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", taskID, proto.StepOne,
+	mockSubtaskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", task.ID, proto.StepOne,
 		unfinishedNormalSubtaskStates...).Return(nil, nil)
-	mockSubtaskTable.EXPECT().GetTaskByID(gomock.Any(), gomock.Any()).Return(&proto.Task{ID: taskID, Step: proto.StepTwo}, nil)
 	mockSubtaskExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
-	require.NoError(t, taskExecutor.RunStep(runCtx, &proto.Task{Step: proto.StepOne, Type: tp, ID: taskID, Concurrency: concurrency}, nil))
+	require.NoError(t, taskExecutor.RunStep(nil))
 	require.True(t, ctrl.Satisfied())
 }

--- a/pkg/disttask/framework/taskexecutor/task_executor_testkit_test.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor_testkit_test.go
@@ -68,7 +68,7 @@ func TestTaskExecutorBasic(t *testing.T) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/breakInTaskExecutorUT", "return()"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/domain/MockDisableDistTask"))
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/breakInTaskExecutorUT"))
+		removed require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/breakInTaskExecutorUT"))
 	}()
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/disttask/framework/taskexecutor/task_executor_testkit_test.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor_testkit_test.go
@@ -39,36 +39,44 @@ func runOneTask(ctx context.Context, t *testing.T, mgr *storage.TaskManager, tas
 	require.NoError(t, err)
 	task, err := mgr.GetTaskByID(ctx, taskID)
 	require.NoError(t, err)
+
+	checkSubtasks := func(step proto.Step, state proto.SubtaskState) {
+		subtasks, err := mgr.GetAllSubtasksByStepAndState(ctx, taskID, step, state)
+		require.NoError(t, err)
+		require.Len(t, subtasks, subtaskCnt)
+	}
 	// 1. stepOne
 	err = mgr.SwitchTaskStep(ctx, task, proto.TaskStateRunning, proto.StepOne, nil)
 	require.NoError(t, err)
 	for i := 0; i < subtaskCnt; i++ {
-		testutil.CreateSubTask(t, mgr, taskID, proto.StepOne, ":4000", nil, proto.TaskTypeExample, 11)
+		testutil.CreateSubTask(t, mgr, taskID, proto.StepOne, ":4000", nil, proto.TaskTypeExample, 1)
 	}
+	checkSubtasks(proto.StepOne, proto.SubtaskStatePending)
 	task, err = mgr.GetTaskByID(ctx, taskID)
 	require.NoError(t, err)
 	factory := taskexecutor.GetTaskExecutorFactory(task.Type)
 	require.NotNil(t, factory)
 	executor := factory(ctx, ":4000", task, mgr)
-	require.NoError(t, executor.RunStep(ctx, task, nil))
+	executor.Run(&proto.StepResource{})
+	checkSubtasks(proto.StepOne, proto.SubtaskStateSucceed)
 	// 2. stepTwo
 	err = mgr.SwitchTaskStep(ctx, task, proto.TaskStateRunning, proto.StepTwo, nil)
 	require.NoError(t, err)
 	for i := 0; i < subtaskCnt; i++ {
 		testutil.CreateSubTask(t, mgr, taskID, proto.StepTwo, ":4000", nil, proto.TaskTypeExample, 11)
 	}
+	checkSubtasks(proto.StepTwo, proto.SubtaskStatePending)
 	task, err = mgr.GetTaskByID(ctx, taskID)
 	require.NoError(t, err)
-	require.NoError(t, executor.RunStep(ctx, task, nil))
+	executor.Run(&proto.StepResource{})
+	checkSubtasks(proto.StepTwo, proto.SubtaskStateSucceed)
 }
 
 func TestTaskExecutorBasic(t *testing.T) {
 	// must disable disttask framework to ensure the test pure.
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/domain/MockDisableDistTask", "return(true)"))
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/breakInTaskExecutorUT", "return()"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/domain/MockDisableDistTask"))
-		removed require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/breakInTaskExecutorUT"))
 	}()
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -81,6 +89,8 @@ func TestTaskExecutorBasic(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mgr := storage.NewTaskManager(pool)
+
+	taskexecutor.ReduceCheckInterval(t)
 
 	testutil.InitTaskExecutor(ctrl, func(ctx context.Context, subtask *proto.Subtask) error {
 		switch subtask.Step {

--- a/pkg/disttask/framework/testutil/disttest_util.go
+++ b/pkg/disttask/framework/testutil/disttest_util.go
@@ -50,7 +50,7 @@ func RegisterTaskMeta(t *testing.T, ctrl *gomock.Controller, schedulerHandle sch
 		mockStepExecutor.EXPECT().RunSubtask(gomock.Any(), gomock.Any()).DoAndReturn(runSubtaskFn).AnyTimes()
 	}
 	mockExtension.EXPECT().IsIdempotent(gomock.Any()).Return(true).AnyTimes()
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStepExecutor, nil).AnyTimes()
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockStepExecutor, nil).AnyTimes()
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(false).AnyTimes()
 	registerTaskMetaInner(t, proto.TaskTypeExample, mockExtension, mockCleanupRountine, schedulerHandle)
 }
@@ -97,7 +97,7 @@ func RegisterRollbackTaskMeta(t *testing.T, ctrl *gomock.Controller, mockSchedul
 		}).AnyTimes()
 	mockExecutor.EXPECT().OnFinished(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockExtension.EXPECT().IsIdempotent(gomock.Any()).Return(true).AnyTimes()
-	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockExecutor, nil).AnyTimes()
+	mockExtension.EXPECT().GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockExecutor, nil).AnyTimes()
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(false).AnyTimes()
 
 	registerTaskMetaInner(t, proto.TaskTypeExample, mockExtension, mockCleanupRountine, mockScheduler)

--- a/pkg/disttask/framework/testutil/executor_util.go
+++ b/pkg/disttask/framework/testutil/executor_util.go
@@ -37,7 +37,7 @@ func GetMockStepExecutor(ctrl *gomock.Controller) *mockexecute.MockStepExecutor 
 func GetMockTaskExecutorExtension(ctrl *gomock.Controller, mockStepExecutor *mockexecute.MockStepExecutor) *mock.MockExtension {
 	mockExtension := mock.NewMockExtension(ctrl)
 	mockExtension.EXPECT().
-		GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		GetStepExecutor(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(mockStepExecutor, nil).AnyTimes()
 	mockExtension.EXPECT().IsRetryableError(gomock.Any()).Return(false).AnyTimes()
 	return mockExtension

--- a/pkg/disttask/importinto/task_executor.go
+++ b/pkg/disttask/importinto/task_executor.go
@@ -520,7 +520,7 @@ func (*importExecutor) GetStepExecutor(task *proto.Task, _ *execute.Summary, _ *
 
 func (e *importExecutor) Close() {
 	task := e.GetTask()
-	defer metricsManager.unregister(task.ID)
+	metricsManager.unregister(task.ID)
 	e.BaseTaskExecutor.Close()
 }
 

--- a/pkg/disttask/importinto/task_executor.go
+++ b/pkg/disttask/importinto/task_executor.go
@@ -463,7 +463,6 @@ type importExecutor struct {
 
 func newImportExecutor(ctx context.Context, id string, task *proto.Task, taskTable taskexecutor.TaskTable) taskexecutor.TaskExecutor {
 	metrics := metricsManager.getOrCreateMetrics(task.ID)
-	defer metricsManager.unregister(task.ID)
 	subCtx := metric.WithCommonMetric(ctx, metrics)
 	s := &importExecutor{
 		BaseTaskExecutor: taskexecutor.NewBaseTaskExecutor(subCtx, id, task, taskTable),
@@ -517,6 +516,12 @@ func (*importExecutor) GetStepExecutor(task *proto.Task, _ *execute.Summary, _ *
 	default:
 		return nil, errors.Errorf("unknown step %d for import task %d", task.Step, task.ID)
 	}
+}
+
+func (e *importExecutor) Close() {
+	task := e.GetTask()
+	defer metricsManager.unregister(task.ID)
+	e.BaseTaskExecutor.Close()
 }
 
 func init() {

--- a/pkg/disttask/importinto/task_executor_test.go
+++ b/pkg/disttask/importinto/task_executor_test.go
@@ -43,12 +43,12 @@ func TestImportTaskExecutor(t *testing.T) {
 		proto.ImportStepWriteAndIngest,
 		proto.ImportStepPostProcess,
 	} {
-		exe, err := executor.GetStepExecutor(ctx, &proto.Task{Step: step, Meta: []byte("{}")}, nil, nil)
+		exe, err := executor.GetStepExecutor(&proto.Task{Step: step, Meta: []byte("{}")}, nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, exe)
 	}
-	_, err := executor.GetStepExecutor(ctx, &proto.Task{Step: proto.StepInit, Meta: []byte("{}")}, nil, nil)
+	_, err := executor.GetStepExecutor(&proto.Task{Step: proto.StepInit, Meta: []byte("{}")}, nil, nil)
 	require.Error(t, err)
-	_, err = executor.GetStepExecutor(ctx, &proto.Task{Step: proto.ImportStepImport, Meta: []byte("")}, nil, nil)
+	_, err = executor.GetStepExecutor(&proto.Task{Step: proto.ImportStepImport, Meta: []byte("")}, nil, nil)
 	require.Error(t, err)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #49008

Problem Summary:

### What changed and how does it work?
- decouple some logic(previous handleExecutableTask) which should belongs to task-executor from manager
- separate task-executor context and run-step context, so we can cancel right context as needed(we are relying on manager context previously to do some task state handling)
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
