### PR TITLE
sessionctx: fix data race of SessionVars.Status

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -1973,7 +1973,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	}
 	vars.StmtCtx.SetVarHintRestore = nil
 	var sc *stmtctx.StatementContext
-	if vars.TxnCtx.CouldRetry || mysql.HasCursorExistsFlag(vars.Status) {
+	if vars.TxnCtx.CouldRetry || vars.HasStatusFlag(mysql.ServerStatusCursorExists) {
 		// Must construct new statement context object, the retry history need context for every statement.
 		// TODO: Maybe one day we can get rid of transaction retry, then this logic can be deleted.
 		sc = stmtctx.NewStmtCtx()

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -129,7 +129,7 @@ func TestTransaction(t *testing.T) {
 }
 
 func inTxn(ctx sessionctx.Context) bool {
-	return (ctx.GetSessionVars().Status & mysql.ServerStatusInTrans) > 0
+	return ctx.GetSessionVars().InTxn()
 }
 
 func TestRole(t *testing.T) {

--- a/pkg/planner/core/debugtrace.go
+++ b/pkg/planner/core/debugtrace.go
@@ -91,7 +91,7 @@ func DebugTraceReceivedCommand(s sessionctx.Context, cmd byte, stmtNode ast.Stmt
 			binaryParams, _ = execStmt.BinaryArgs.([]expression.Expression)
 		}
 	}
-	useCursor := mysql.HasCursorExistsFlag(sessionVars.Status)
+	useCursor := sessionVars.HasStatusFlag(mysql.ServerStatusCursorExists)
 	// If none of them needs record, we don't need a executeInfo.
 	if binaryParams == nil && planCacheStmt == nil && !useCursor {
 		return

--- a/pkg/plugin/conn_ip_example/conn_ip_example.go
+++ b/pkg/plugin/conn_ip_example/conn_ip_example.go
@@ -94,7 +94,7 @@ func OnShutdown(ctx context.Context, manifest *plugin.Manifest) error {
 func OnGeneralEvent(ctx context.Context, sctx *variable.SessionVars, event plugin.GeneralEvent, cmd string) {
 	fmt.Println("## conn_ip_example OnGeneralEvent called ##")
 	if sctx != nil {
-		fmt.Printf("---- session status: %d\n", sctx.Status)
+		fmt.Printf("---- session status: %d\n", sctx.Status())
 		digest, _ := sctx.StmtCtx.SQLDigest()
 		fmt.Printf("---- statement sql: %s, digest: %s\n", sctx.StmtCtx.OriginalSQL, digest)
 		if len(sctx.StmtCtx.Tables) > 0 {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -321,7 +321,7 @@ func (s *session) cleanRetryInfo() {
 }
 
 func (s *session) Status() uint16 {
-	return s.sessionVars.Status
+	return s.sessionVars.Status()
 }
 
 func (s *session) LastInsertID() uint64 {
@@ -1041,7 +1041,7 @@ func (s *session) String() string {
 		"id":         sessVars.ConnectionID,
 		"user":       sessVars.User,
 		"currDBName": sessVars.CurrentDB,
-		"status":     sessVars.Status,
+		"status":     sessVars.Status(),
 		"strictMode": sessVars.SQLMode.HasStrictMode(),
 	}
 	if s.txn.Valid() {

--- a/pkg/sessionctx/sessionstates/session_states.go
+++ b/pkg/sessionctx/sessionstates/session_states.go
@@ -70,7 +70,7 @@ type SessionStates struct {
 	SystemVars           map[string]string            `json:"sys-vars,omitempty"`
 	PreparedStmts        map[uint32]*PreparedStmtInfo `json:"prepared-stmts,omitempty"`
 	PreparedStmtID       uint32                       `json:"prepared-stmt-id,omitempty"`
-	Status               uint16                       `json:"status,omitempty"`
+	Status               uint32                       `json:"status,omitempty"`
 	CurrentDB            string                       `json:"current-db,omitempty"`
 	LastTxnInfo          string                       `json:"txn-info,omitempty"`
 	LastQueryInfo        *QueryInfo                   `json:"query-info,omitempty"`

--- a/pkg/sessionctx/sessionstates/session_states_test.go
+++ b/pkg/sessionctx/sessionstates/session_states_test.go
@@ -364,7 +364,7 @@ func TestSessionCtx(t *testing.T) {
 		{
 			// check Status
 			checkFunc: func(tk *testkit.TestKit, param any) {
-				require.Equal(t, mysql.ServerStatusAutocommit, tk.Session().GetSessionVars().Status&mysql.ServerStatusAutocommit)
+				require.True(t, tk.Session().GetSessionVars().IsAutocommit())
 			},
 		},
 		{
@@ -374,7 +374,7 @@ func TestSessionCtx(t *testing.T) {
 				return nil
 			},
 			checkFunc: func(tk *testkit.TestKit, param any) {
-				require.Equal(t, uint16(0), tk.Session().GetSessionVars().Status&mysql.ServerStatusAutocommit)
+				require.False(t, tk.Session().GetSessionVars().IsAutocommit())
 			},
 		},
 		{

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -722,8 +722,8 @@ type SessionVars struct {
 		value string
 	}
 
-	// Status stands for the session status. e.g. in transaction or not, auto commit is on or off, and so on.
-	Status uint16
+	// status stands for the session status. e.g. in transaction or not, auto commit is on or off, and so on.
+	status atomic.Uint32
 
 	// ClientCapability is client's capability.
 	ClientCapability uint32
@@ -1943,7 +1943,6 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		ActiveRoles:                   make([]*auth.RoleIdentity, 0, 10),
 		AutoIncrementIncrement:        DefAutoIncrementIncrement,
 		AutoIncrementOffset:           DefAutoIncrementOffset,
-		Status:                        mysql.ServerStatusAutocommit,
 		StmtCtx:                       stmtctx.NewStmtCtx(),
 		AllowAggPushDown:              false,
 		AllowCartesianBCJ:             DefOptCartesianBCJ,
@@ -2033,6 +2032,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		ResourceGroupName:             resourcegroup.DefaultResourceGroupName,
 		DefaultCollationForUTF8MB4:    mysql.DefaultCollationName,
 	}
+	vars.status.Store(uint32(mysql.ServerStatusAutocommit))
 	vars.StmtCtx.ResourceGroupName = resourcegroup.DefaultResourceGroupName
 	vars.KVVars = tikvstore.NewVariables(&vars.SQLKiller.Signal)
 	vars.Concurrency = Concurrency{
@@ -2268,15 +2268,35 @@ func (s *SessionVars) SetLastInsertID(insertID uint64) {
 // otherwise removes the flag.
 func (s *SessionVars) SetStatusFlag(flag uint16, on bool) {
 	if on {
-		s.Status |= flag
+		for {
+			status := s.status.Load()
+			if status&uint32(flag) > 0 {
+				break
+			}
+			if s.status.CompareAndSwap(status, status|uint32(flag)) {
+				break
+			}
+		}
 		return
 	}
-	s.Status &= ^flag
+	for {
+		status := s.status.Load()
+		if status&uint32(flag) == 0 {
+			break
+		}
+		if s.status.CompareAndSwap(status, status&^uint32(flag)) {
+			break
+		}
+	}
 }
 
-// GetStatusFlag gets the session server status variable, returns true if it is on.
-func (s *SessionVars) GetStatusFlag(flag uint16) bool {
-	return s.Status&flag > 0
+// HasStatusFlag gets the session server status variable, returns true if it is on.
+func (s *SessionVars) HasStatusFlag(flag uint16) bool {
+	return s.status.Load()&uint32(flag) > 0
+}
+
+func (s *SessionVars) Status() uint16 {
+	return uint16(s.status.Load())
 }
 
 // SetInTxn sets whether the session is in transaction.
@@ -2290,12 +2310,12 @@ func (s *SessionVars) SetInTxn(val bool) {
 
 // InTxn returns if the session is in transaction.
 func (s *SessionVars) InTxn() bool {
-	return s.GetStatusFlag(mysql.ServerStatusInTrans)
+	return s.HasStatusFlag(mysql.ServerStatusInTrans)
 }
 
 // IsAutocommit returns if the session is set to autocommit.
 func (s *SessionVars) IsAutocommit() bool {
-	return s.GetStatusFlag(mysql.ServerStatusAutocommit)
+	return s.HasStatusFlag(mysql.ServerStatusAutocommit)
 }
 
 // IsIsolation if true it means the transaction is at that isolation level.
@@ -2648,7 +2668,7 @@ func (s *SessionVars) EncodeSessionStates(_ context.Context, sessionStates *sess
 
 	// Encode other session contexts.
 	sessionStates.PreparedStmtID = s.preparedStmtID
-	sessionStates.Status = s.Status
+	sessionStates.Status = s.status.Load()
 	sessionStates.CurrentDB = s.CurrentDB
 	sessionStates.LastTxnInfo = s.LastTxnInfo
 	if s.LastQueryInfo.StartTS != 0 {
@@ -2684,7 +2704,7 @@ func (s *SessionVars) DecodeSessionStates(_ context.Context, sessionStates *sess
 
 	// Decode other session contexts.
 	s.preparedStmtID = sessionStates.PreparedStmtID
-	s.Status = sessionStates.Status
+	s.status.Store(sessionStates.Status)
 	s.CurrentDB = sessionStates.CurrentDB
 	s.LastTxnInfo = sessionStates.LastTxnInfo
 	if sessionStates.LastQueryInfo != nil {

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2270,7 +2270,7 @@ func (s *SessionVars) SetStatusFlag(flag uint16, on bool) {
 	if on {
 		for {
 			status := s.status.Load()
-			if status&uint32(flag) > 0 {
+			if status&uint32(flag) == uint32(flag) {
 				break
 			}
 			if s.status.CompareAndSwap(status, status|uint32(flag)) {

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2295,6 +2295,7 @@ func (s *SessionVars) HasStatusFlag(flag uint16) bool {
 	return s.status.Load()&uint32(flag) > 0
 }
 
+// Status returns the server status.
 func (s *SessionVars) Status() uint16 {
 	return uint16(s.status.Load())
 }

--- a/pkg/sessionctx/variable/session_test.go
+++ b/pkg/sessionctx/variable/session_test.go
@@ -544,3 +544,16 @@ func TestUserVarConcurrently(t *testing.T) {
 	wg.Wait()
 	cancel()
 }
+
+func TestSetStatus(t *testing.T) {
+	sv := variable.NewSessionVars(nil)
+	require.True(t, sv.IsAutocommit())
+	sv.SetStatusFlag(mysql.ServerStatusInTrans, true)
+	require.True(t, sv.InTxn())
+	sv.SetStatusFlag(mysql.ServerStatusCursorExists, true)
+	require.True(t, sv.InTxn())
+	sv.SetStatusFlag(mysql.ServerStatusInTrans, false)
+	require.True(t, sv.HasStatusFlag(mysql.ServerStatusCursorExists))
+	require.False(t, sv.InTxn())
+	require.Equal(t, mysql.ServerStatusAutocommit|mysql.ServerStatusCursorExists, sv.Status())
+}

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -1288,7 +1288,8 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 		}
 	}
 	SetGlobalResourceControl.Store(&setGlobalResourceControlFunc)
-	require.False(t, EnableResourceControl.Load())
+	// Reset the switch. It may be set by other tests.
+	EnableResourceControl.Store(false)
 
 	vars := NewSessionVars(nil)
 	mock := NewMockGlobalAccessor4Tests()

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -1288,6 +1288,7 @@ func TestTiDBEnableResourceControl(t *testing.T) {
 		}
 	}
 	SetGlobalResourceControl.Store(&setGlobalResourceControlFunc)
+	require.False(t, EnableResourceControl.Load())
 
 	vars := NewSessionVars(nil)
 	mock := NewMockGlobalAccessor4Tests()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50715

Problem Summary:
This problem was introduced by #44953, which calls `InTxn()` in another goroutine but `Status` is not thread-safe.

### What changed and how does it work?
- Change `Status` from `uint16` to `atomic.Uint32`
- Rename `Status` to `status` to avoid it to be visited outside
- Make `TestTiDBEnableResourceControl` stable because it always fails after this PR

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
