### PR TITLE
txn: support pessimistic rollback with scan first in mockstore

### DIFF
--- a/pkg/store/mockstore/unistore/tikv/mvcc.go
+++ b/pkg/store/mockstore/unistore/tikv/mvcc.go
@@ -418,7 +418,7 @@ func (store *MVCCStore) PessimisticRollbackWithScanFirst(reqCtx *requestCtx, req
 	if len(req.Keys) > 0 {
 		return errors.Errorf("pessimistic rollback request invalid: there should be no input lock keys but got %v", len(req.Keys))
 	}
-	locks, err := store.ScanPessimisticLocks(reqCtx, req.StartVersion, req.ForUpdateTs)
+	locks, err := store.scanPessimisticLocks(reqCtx, req.StartVersion, req.ForUpdateTs)
 	if err != nil {
 		return err
 	}
@@ -1445,8 +1445,8 @@ func (store *MVCCStore) appendScannedLock(locks []*kvrpcpb.LockInfo, it *locksto
 	return locks
 }
 
-// ScanPessimisticLocks returns matching pessimistic locks.
-func (store *MVCCStore) ScanPessimisticLocks(reqCtx *requestCtx, startTS uint64, forUpdateTS uint64) ([]*kvrpcpb.LockInfo, error) {
+// scanPessimisticLocks returns matching pessimistic locks.
+func (store *MVCCStore) scanPessimisticLocks(reqCtx *requestCtx, startTS uint64, forUpdateTS uint64) ([]*kvrpcpb.LockInfo, error) {
 	var locks []*kvrpcpb.LockInfo
 	it := store.lockStore.NewIterator()
 	for it.Seek(reqCtx.regCtx.RawStart()); it.Valid(); it.Next() {

--- a/pkg/store/mockstore/unistore/tikv/mvcc.go
+++ b/pkg/store/mockstore/unistore/tikv/mvcc.go
@@ -412,6 +412,8 @@ func (store *MVCCStore) checkExtraTxnStatus(reqCtx *requestCtx, key []byte, star
 	return extraTxnStatus{commitTS: userMeta.CommitTS()}
 }
 
+// PessimisticRollbackWithScanFirst is used to scan the region first to collect related pessimistic locks and
+// then pessimistic rollback them.
 func (store *MVCCStore) PessimisticRollbackWithScanFirst(reqCtx *requestCtx, req *kvrpcpb.PessimisticRollbackRequest) error {
 	if len(req.Keys) > 0 {
 		return errors.Errorf("pessimistic rollback request invalid: there should be no input lock keys but got %v", len(req.Keys))

--- a/pkg/store/mockstore/unistore/tikv/server.go
+++ b/pkg/store/mockstore/unistore/tikv/server.go
@@ -270,7 +270,11 @@ func (svr *Server) KVPessimisticRollback(ctx context.Context, req *kvrpcpb.Pessi
 	if reqCtx.regErr != nil {
 		return &kvrpcpb.PessimisticRollbackResponse{RegionError: reqCtx.regErr}, nil
 	}
-	err = svr.mvccStore.PessimisticRollback(reqCtx, req)
+	if len(req.Keys) == 0 {
+		err = svr.mvccStore.PessimisticRollbackWithScanFirst(reqCtx, req)
+	} else {
+		err = svr.mvccStore.PessimisticRollback(reqCtx, req)
+	}
 	resp := &kvrpcpb.PessimisticRollbackResponse{}
 	resp.Errors, resp.RegionError = convertToPBErrors(err)
 	return resp, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50731 

Problem Summary:
Introduce lock scan phase for pessimistic lock rollback.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->



Side effects


Documentation


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
