### PR TITLE
lightning: fix duplicate extend columns when resume from checkpoint

### DIFF
--- a/br/pkg/lightning/importer/chunk_process.go
+++ b/br/pkg/lightning/importer/chunk_process.go
@@ -301,9 +301,13 @@ func (cr *chunkProcessor) encodeLoop(
 	// but since ColumnPermutation also depends on the hypothesis that the columns in one source file is the same
 	// so this should be ok.
 	var (
-		filteredColumns []string
-		extendVals      []types.Datum
+		filteredColumns   []string
+		extendVals        []types.Datum
+		// some columns should not record in checkpoint, like extra columns
+		// so we copy a new one from chunk.ColumnPermutation
+		columnPermutation = make([]int, 0, len(cr.chunk.ColumnPermutation))
 	)
+	columnPermutation = append(columnPermutation, cr.chunk.ColumnPermutation...)
 	ignoreColumns, err1 := rc.cfg.Mydumper.IgnoreColumns.GetIgnoreColumns(t.dbInfo.Name, t.tableInfo.Core.Name.O, rc.cfg.Mydumper.CaseSensitive)
 	if err1 != nil {
 		err = err1
@@ -362,6 +366,7 @@ func (cr *chunkProcessor) encodeLoop(
 						if err = t.initializeColumns(columnNames, cr.chunk); err != nil {
 							return
 						}
+						columnPermutation = append(columnPermutation, cr.chunk.ColumnPermutation...)
 					}
 					filteredColumns = columnNames
 					ignoreColsMap := ignoreColumns.ColumnsMap()
@@ -376,7 +381,7 @@ func (cr *chunkProcessor) encodeLoop(
 					}
 					for i, col := range t.tableInfo.Core.Columns {
 						if p, ok := extendColsMap[col.Name.O]; ok {
-							cr.chunk.ColumnPermutation[i] = p
+							columnPermutation[i] = p
 						}
 					}
 					initializedColumns = true
@@ -431,10 +436,11 @@ func (cr *chunkProcessor) encodeLoop(
 						lastRow,
 						lastOffset,
 						dupIgnoreRowsIter.UnsafeValue(),
+						columnPermutation,
 						t.tableInfo.Desired,
 						logger,
 					)
-					rowText := tidb.EncodeRowForRecord(ctx, t.encTable, rc.cfg.TiDB.SQLMode, lastRow.Row, cr.chunk.ColumnPermutation)
+					rowText := tidb.EncodeRowForRecord(ctx, t.encTable, rc.cfg.TiDB.SQLMode, lastRow.Row, columnPermutation)
 					err = rc.errorMgr.RecordDuplicate(
 						ctx,
 						logger,
@@ -453,12 +459,12 @@ func (cr *chunkProcessor) encodeLoop(
 			}
 
 			// sql -> kv
-			kvs, encodeErr := kvEncoder.Encode(lastRow.Row, lastRow.RowID, cr.chunk.ColumnPermutation, curOffset)
+			kvs, encodeErr := kvEncoder.Encode(lastRow.Row, lastRow.RowID, columnPermutation, curOffset)
 			encodeDur += time.Since(encodeDurStart)
 
 			hasIgnoredEncodeErr := false
 			if encodeErr != nil {
-				rowText := tidb.EncodeRowForRecord(ctx, t.encTable, rc.cfg.TiDB.SQLMode, lastRow.Row, cr.chunk.ColumnPermutation)
+				rowText := tidb.EncodeRowForRecord(ctx, t.encTable, rc.cfg.TiDB.SQLMode, lastRow.Row, columnPermutation)
 				encodeErr = rc.errorMgr.RecordTypeError(ctx, logger, t.tableName, cr.chunk.Key.Path, newOffset, rowText, encodeErr)
 				if encodeErr != nil {
 					err = common.ErrEncodeKV.Wrap(encodeErr).GenWithStackByArgs(&cr.chunk.Key, newOffset)
@@ -524,6 +530,7 @@ func (cr *chunkProcessor) getDuplicateMessage(
 	lastRow mydump.Row,
 	lastOffset int64,
 	encodedIdxID []byte,
+	columnPermutation []int,
 	tableInfo *model.TableInfo,
 	logger log.Logger,
 ) string {
@@ -531,7 +538,7 @@ func (cr *chunkProcessor) getDuplicateMessage(
 	if err != nil {
 		return err.Error()
 	}
-	kvs, err := kvEncoder.Encode(lastRow.Row, lastRow.RowID, cr.chunk.ColumnPermutation, lastOffset)
+	kvs, err := kvEncoder.Encode(lastRow.Row, lastRow.RowID, columnPermutation, lastOffset)
 	if err != nil {
 		return err.Error()
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50786

Problem Summary:

### What changed and how does it work?
- copy ColumnPermutation for extend columns so it will not be saved in checkpoint
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
1. manually create dm task with extend column
2. pause task in load stage
3. resume task and task succeed
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
