### PR TITLE
statistics: remove a old logic related with statistics

### DIFF
--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -98,7 +98,7 @@ func (s *StatsCacheImpl) Update(is infoschema.InfoSchema) error {
 		if oldTbl, ok := s.Get(physicalID); ok && oldTbl.Version >= version && tableInfo.UpdateTS == oldTbl.TblInfoUpdateTS {
 			continue
 		}
-		tbl, err := s.statsHandle.TableStatsFromStorage(tableInfo, physicalID, false, 0)
+		tbl, err := s.statsHandle.TableStatsFromStorage(tableInfo, physicalID, false)
 		// Error is not nil may mean that there are some ddl changes on this table, we will not update it.
 		if err != nil {
 			statslogutil.StatsLogger().Error("error occurred when read table stats", zap.String("table", tableInfo.Name.O), zap.Error(err))

--- a/pkg/statistics/handle/handletest/analyze/analyze_test.go
+++ b/pkg/statistics/handle/handletest/analyze/analyze_test.go
@@ -40,7 +40,7 @@ func checkForGlobalStatsWithOpts(t *testing.T, dom *domain.Domain, db, tt, pp st
 			}
 		}
 	}
-	tblStats, err := dom.StatsHandle().TableStatsFromStorage(tblInfo, physicalID, true, 0)
+	tblStats, err := dom.StatsHandle().TableStatsFromStorage(tblInfo, physicalID, true)
 	require.NoError(t, err)
 
 	delta := buckets/2 + 10

--- a/pkg/statistics/handle/handletest/handle_test.go
+++ b/pkg/statistics/handle/handletest/handle_test.go
@@ -1121,7 +1121,7 @@ func TestLoadHistogramWithCollate(t *testing.T) {
 	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tblInfo := tbl.Meta()
-	_, err = h.TableStatsFromStorage(tblInfo, tblInfo.ID, true, 0)
+	_, err = h.TableStatsFromStorage(tblInfo, tblInfo.ID, true)
 	require.NoError(t, err)
 }
 

--- a/pkg/statistics/handle/storage/dump_test.go
+++ b/pkg/statistics/handle/storage/dump_test.go
@@ -450,7 +450,7 @@ func TestDumpVer2Stats(t *testing.T) {
 	tableInfo, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 
-	storageTbl, err := h.TableStatsFromStorage(tableInfo.Meta(), tableInfo.Meta().ID, false, 0)
+	storageTbl, err := h.TableStatsFromStorage(tableInfo.Meta(), tableInfo.Meta().ID, false)
 	require.NoError(t, err)
 
 	dumpJSONTable, err := h.DumpStatsToJSON("test", tableInfo.Meta(), nil, true)
@@ -502,7 +502,7 @@ func TestLoadStatsForNewCollation(t *testing.T) {
 	tableInfo, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 
-	storageTbl, err := h.TableStatsFromStorage(tableInfo.Meta(), tableInfo.Meta().ID, false, 0)
+	storageTbl, err := h.TableStatsFromStorage(tableInfo.Meta(), tableInfo.Meta().ID, false)
 	require.NoError(t, err)
 
 	dumpJSONTable, err := h.DumpStatsToJSON("test", tableInfo.Meta(), nil, true)

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -250,7 +250,7 @@ type PersistFunc func(ctx context.Context, jsonTable *statsutil.JSONTable, physi
 // TODO: merge and remove some methods.
 type StatsReadWriter interface {
 	// TableStatsFromStorage loads table stats info from storage.
-	TableStatsFromStorage(tableInfo *model.TableInfo, physicalID int64, loadAll bool, snapshot uint64) (statsTbl *statistics.Table, err error)
+	TableStatsFromStorage(tableInfo *model.TableInfo, physicalID int64, loadAll bool) (statsTbl *statistics.Table, err error)
 
 	// LoadTablePartitionStats loads partition stats info from storage.
 	LoadTablePartitionStats(tableInfo *model.TableInfo, partitionDef *model.PartitionDefinition) (*statistics.Table, error)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

The code is introduced by https://github.com/pingcap/tidb/pull/6565/files#diff-5a16cfaf3a94b6aae3fafc2709020d48b95a2dd1857ccfc3d48e08ff3ed73bcaL209. Related with our old feedback logic.

This code segment will cause the following inconsistency:
- If the table has pseudo stats and there's one column/index that doesn't have stats, we will go to the Pseudo table's Copy and then we have a fake Column object for that column.
- If the table has pseudo stats, like that the bootstrap's initialization, we will create a Table object and then we don't have that fake Column object.

I think we can safely remove it since the feedback has been removed.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
