### PR TITLE
statistics: do not need to introduce another test flag

### DIFF
--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -40,8 +40,6 @@ type LFU struct {
 	closeOnce    sync.Once
 }
 
-var testMode = false
-
 // NewLFU creates a new LFU cache.
 func NewLFU(totalMemCost int64) (*LFU, error) {
 	cost, err := adjustMemCost(totalMemCost)
@@ -64,8 +62,8 @@ func NewLFU(totalMemCost int64) (*LFU, error) {
 			OnEvict:            result.onEvict,
 			OnExit:             result.onExit,
 			OnReject:           result.onReject,
-			IgnoreInternalCost: testMode,
-			Metrics:            testMode,
+			IgnoreInternalCost: intest.InTest,
+			Metrics:            intest.InTest,
 		},
 	)
 	if err != nil {

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
@@ -32,7 +32,6 @@ var (
 )
 
 func TestLFUPutGetDel(t *testing.T) {
-	testMode = true
 	capacity := int64(100)
 	lfu, err := NewLFU(capacity)
 	require.NoError(t, err)
@@ -50,7 +49,6 @@ func TestLFUPutGetDel(t *testing.T) {
 }
 
 func TestLFUFreshMemUsage(t *testing.T) {
-	testMode = true
 	lfu, err := NewLFU(10000)
 	require.NoError(t, err)
 	t1 := testutil.NewMockStatisticsTable(1, 1, true, false, false)
@@ -85,7 +83,6 @@ func TestLFUFreshMemUsage(t *testing.T) {
 }
 
 func TestLFUPutTooBig(t *testing.T) {
-	testMode = true
 	lfu, err := NewLFU(1)
 	require.NoError(t, err)
 	mockTable := testutil.NewMockStatisticsTable(1, 1, true, false, false)
@@ -98,7 +95,6 @@ func TestLFUPutTooBig(t *testing.T) {
 }
 
 func TestCacheLen(t *testing.T) {
-	testMode = true
 	capacity := int64(12)
 	lfu, err := NewLFU(capacity)
 	require.NoError(t, err)
@@ -121,7 +117,6 @@ func TestCacheLen(t *testing.T) {
 }
 
 func TestLFUCachePutGetWithManyConcurrency(t *testing.T) {
-	testMode = true
 	// to test DATA RACE
 	capacity := int64(100000000000)
 	lfu, err := NewLFU(capacity)
@@ -147,7 +142,6 @@ func TestLFUCachePutGetWithManyConcurrency(t *testing.T) {
 }
 
 func TestLFUCachePutGetWithManyConcurrency2(t *testing.T) {
-	testMode = true
 	// to test DATA RACE
 	capacity := int64(100000000000)
 	lfu, err := NewLFU(capacity)
@@ -178,7 +172,6 @@ func TestLFUCachePutGetWithManyConcurrency2(t *testing.T) {
 }
 
 func TestLFUCachePutGetWithManyConcurrencyAndSmallConcurrency(t *testing.T) {
-	testMode = true
 	// to test DATA RACE
 
 	capacity := int64(100)
@@ -244,7 +237,6 @@ func checkTable(t *testing.T, tbl *statistics.Table) {
 }
 
 func TestLFUReject(t *testing.T) {
-	testMode = true
 	capacity := int64(100000000000)
 	lfu, err := NewLFU(capacity)
 	require.NoError(t, err)
@@ -273,7 +265,6 @@ func TestLFUReject(t *testing.T) {
 }
 
 func TestMemoryControl(t *testing.T) {
-	testMode = true
 	capacity := int64(100000000000)
 	lfu, err := NewLFU(capacity)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/40791

Problem Summary:

### What changed and how does it work?

We can reuse intest.InTest here instead of introducing a new one.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
