### PR TITLE
executor: record the index usage on a the whole table

### DIFF
--- a/pkg/executor/batch_point_get.go
+++ b/pkg/executor/batch_point_get.go
@@ -168,10 +168,9 @@ func (e *BatchPointGetExec) Close() error {
 	}
 	if e.indexUsageReporter != nil && e.idxInfo != nil {
 		kvReqTotal := e.stats.GetCmdRPCCount(tikvrpc.CmdBatchGet)
-		// We cannot distinguish how many rows are coming from each partition. Here, we record all index usages on the
-		// table itself (but not for the partition physical table), which is different from how an index usage is
-		// treated for a local index.
-		e.indexUsageReporter.ReportPointGetIndexUsage(e.tblInfo.ID, e.idxInfo.ID, e.ID(), kvReqTotal)
+		// We cannot distinguish how many rows are coming from each partition. Here, we calculate all index usages
+		// percentage according to the row counts for the whole table.
+		e.indexUsageReporter.ReportPointGetIndexUsage(e.tblInfo.ID, e.tblInfo.ID, e.idxInfo.ID, e.ID(), kvReqTotal)
 	}
 	e.inited = 0
 	e.index = 0

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -226,7 +226,7 @@ func (e *IndexReaderExecutor) setDummy() {
 // Close clears all resources hold by current object.
 func (e *IndexReaderExecutor) Close() (err error) {
 	if e.indexUsageReporter != nil {
-		e.indexUsageReporter.ReportCopIndexUsage(e.physicalTableID, e.index.ID, e.plans[0].ID())
+		e.indexUsageReporter.ReportCopIndexUsageForTable(e.table, e.index.ID, e.plans[0].ID())
 	}
 
 	if e.result != nil {
@@ -831,8 +831,8 @@ func (e *IndexLookUpExecutor) Close() error {
 		defer e.Ctx().GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(e.ID(), e.stats)
 	}
 	if e.indexUsageReporter != nil {
-		e.indexUsageReporter.ReportCopIndexUsage(
-			e.table.Meta().ID,
+		e.indexUsageReporter.ReportCopIndexUsageForTable(
+			e.table,
 			e.index.ID,
 			e.idxPlans[0].ID())
 	}

--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -912,14 +912,13 @@ func (e *IndexMergeReaderExecutor) Close() error {
 		defer e.Ctx().GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(e.ID(), e.stats)
 	}
 	if e.indexUsageReporter != nil {
-		tableID := e.table.Meta().ID
 		for _, p := range e.partialPlans {
 			is, ok := p[0].(*plannercore.PhysicalIndexScan)
 			if !ok {
 				continue
 			}
 
-			e.indexUsageReporter.ReportCopIndexUsage(tableID, is.Index.ID, is.ID())
+			e.indexUsageReporter.ReportCopIndexUsageForTable(e.table, is.Index.ID, is.ID())
 		}
 	}
 	if e.finished == nil {

--- a/pkg/executor/internal/exec/BUILD.bazel
+++ b/pkg/executor/internal/exec/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/statistics",
         "//pkg/statistics/handle/usage/indexusage",
+        "//pkg/table",
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/chunk",

--- a/pkg/executor/internal/exec/indexusage.go
+++ b/pkg/executor/internal/exec/indexusage.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/usage/indexusage"
+	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 )
 
@@ -39,9 +40,23 @@ func NewIndexUsageReporter(reporter *indexusage.StmtIndexUsageCollector,
 	}
 }
 
-// ReportCopIndexUsage reports the index usage to the inside collector
-func (e *IndexUsageReporter) ReportCopIndexUsage(tableID int64, indexID int64, planID int) {
-	tableRowCount, ok := e.getTableRowCount(tableID)
+// ReportCopIndexUsageForTable wraps around `ReportCopIndexUsage` to get `tableID` and `physicalTableID` from the
+// `table.Table`. If it's expected to calculate the percentage according to the size of partition, the `tbl` argument
+// should be a `table.PhysicalTable`, or the percentage will be calculated using the size of whole table.
+func (e *IndexUsageReporter) ReportCopIndexUsageForTable(tbl table.Table, indexID int64, planID int) {
+	tableID := tbl.Meta().ID
+	physicalTableID := tableID
+	if physicalTable, ok := tbl.(table.PhysicalTable); ok {
+		physicalTableID = physicalTable.GetPhysicalID()
+	}
+
+	e.ReportCopIndexUsage(tableID, physicalTableID, indexID, planID)
+}
+
+// ReportCopIndexUsage reports the index usage to the inside collector. The index usage will be recorded in the
+// `tableID+indexID`, but the percentage is calculated using the size of the table specified by `physicalTableID`.
+func (e *IndexUsageReporter) ReportCopIndexUsage(tableID int64, physicalTableID int64, indexID int64, planID int) {
+	tableRowCount, ok := e.getTableRowCount(physicalTableID)
 	if !ok {
 		// skip if the table is empty or the stats is not valid
 		return
@@ -61,8 +76,8 @@ func (e *IndexUsageReporter) ReportCopIndexUsage(tableID int64, indexID int64, p
 }
 
 // ReportPointGetIndexUsage reports the index usage of a point get or batch point get
-func (e *IndexUsageReporter) ReportPointGetIndexUsage(tableID int64, indexID int64, planID int, kvRequestTotal int64) {
-	tableRowCount, ok := e.getTableRowCount(tableID)
+func (e *IndexUsageReporter) ReportPointGetIndexUsage(tableID int64, physicalTableID int64, indexID int64, planID int, kvRequestTotal int64) {
+	tableRowCount, ok := e.getTableRowCount(physicalTableID)
 	if !ok {
 		// skip if the table is empty or the stats is not valid
 		return

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -205,11 +205,12 @@ func (e *PointGetExecutor) Close() error {
 	}
 	if e.indexUsageReporter != nil && e.idxInfo != nil {
 		tableID := e.tblInfo.ID
+		physicalTableID := tableID
 		if e.partitionDef != nil {
-			tableID = e.partitionDef.ID
+			physicalTableID = e.partitionDef.ID
 		}
 		kvReqTotal := e.stats.SnapshotRuntimeStats.GetCmdRPCCount(tikvrpc.CmdGet)
-		e.indexUsageReporter.ReportPointGetIndexUsage(tableID, e.idxInfo.ID, e.ID(), kvReqTotal)
+		e.indexUsageReporter.ReportPointGetIndexUsage(tableID, physicalTableID, e.idxInfo.ID, e.ID(), kvReqTotal)
 	}
 	e.done = false
 	return nil

--- a/pkg/statistics/handle/usage/indexusage/collector.go
+++ b/pkg/statistics/handle/usage/indexusage/collector.go
@@ -257,6 +257,8 @@ func (s *StmtIndexUsageCollector) Update(tableID int64, indexID int64, sample Sa
 	s.Lock()
 	defer s.Unlock()
 
+	// If the usage of the table/index has been recorded in the statement, it'll not update the `QueryTotal`. Before the
+	// execution of each statement, the `StmtIndexUsageCollector` and internal map will be re-created.
 	idxID := GlobalIndexID{IndexID: indexID, TableID: tableID}
 	if _, ok := s.recordedIndex[idxID]; !ok {
 		sample.QueryTotal = 1


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #50814

Problem Summary:

Previously, the usage is recorded on each partitions, so that the queries on different partitions will not be deduplicated 🤦  and will be recorded multiple times.

### What changed and how does it work?

This PR adds one more argument on the `ReportPointGetIndexUsage` and `ReportCopIndexUsage` function to get both the `physicalTableID` and `tableID`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
