### PR TITLE
pkg/autoid_service: add lock to make API thread-safe

### DIFF
--- a/pkg/autoid_service/BUILD.bazel
+++ b/pkg/autoid_service/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     srcs = ["autoid_test.go"],
     embed = [":autoid_service"],
     flaky = True,
+    shard_count = 3,
     deps = [
         "//pkg/parser/model",
         "//pkg/testkit",

--- a/pkg/autoid_service/autoid.go
+++ b/pkg/autoid_service/autoid.go
@@ -453,6 +453,8 @@ func (s *Service) allocAutoID(ctx context.Context, req *autoid.AutoIDRequest) (*
 	})
 
 	val := s.getAlloc(req.DbID, req.TblID, req.IsUnsigned)
+	val.Lock()
+	defer val.Unlock()
 
 	if req.N == 0 {
 		if val.base != 0 {
@@ -482,9 +484,6 @@ func (s *Service) allocAutoID(ctx context.Context, req *autoid.AutoIDRequest) (*
 			Max: currentEnd,
 		}, nil
 	}
-
-	val.Lock()
-	defer val.Unlock()
 
 	var min, max int64
 	var err error
@@ -546,6 +545,9 @@ func (s *Service) Rebase(ctx context.Context, req *autoid.RebaseRequest) (*autoi
 	}
 
 	val := s.getAlloc(req.DbID, req.TblID, req.IsUnsigned)
+	val.Lock()
+	defer val.Unlock()
+
 	if req.Force {
 		err := val.forceRebase(ctx, s.store, req.DbID, req.TblID, req.Base, req.IsUnsigned)
 		if err != nil {

--- a/pkg/autoid_service/autoid_test.go
+++ b/pkg/autoid_service/autoid_test.go
@@ -90,10 +90,10 @@ func TestConcurrent(t *testing.T) {
 	// Rebase to some value
 	rebaseRequest(t, cli, to, true, 666).check("")
 	checkCurrValue(t, cli, to, 666, 666)
-	// And +1 concurrently for 20 times
+	// And +1 concurrently for 30 times
 	close(notify)
 	wg.Wait()
-	// Check the result is increased by 20
+	// Check the result is increased by 30
 	checkCurrValue(t, cli, to, 666+concurrency, 666+concurrency)
 }
 

--- a/pkg/autoid_service/autoid_test.go
+++ b/pkg/autoid_service/autoid_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"math"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -58,6 +59,83 @@ func (resp rebaseResp) check(msg string) {
 	require.Equal(resp.T, string(resp.RebaseResponse.GetErrmsg()), msg)
 }
 
+func TestConcurrent(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	cli := MockForTest(store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (id int key auto_increment);")
+	is := dom.InfoSchema()
+	dbInfo, ok := is.SchemaByName(model.NewCIStr("test"))
+	require.True(t, ok)
+
+	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
+	require.NoError(t, err)
+	tbInfo := tbl.Meta()
+
+	to := dest{dbID: dbInfo.ID, tblID: tbInfo.ID}
+
+	const concurrency = 30
+	notify := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+			<-notify
+			autoIDRequest(t, cli, to, false, 1)
+		}()
+	}
+
+	// Rebase to some value
+	rebaseRequest(t, cli, to, true, 666).check("")
+	checkCurrValue(t, cli, to, 666, 666)
+	// And +1 concurrently for 20 times
+	close(notify)
+	wg.Wait()
+	// Check the result is increased by 20
+	checkCurrValue(t, cli, to, 666+concurrency, 666+concurrency)
+}
+
+type dest struct {
+	dbID  int64
+	tblID int64
+}
+
+func checkCurrValue(t *testing.T, cli autoid.AutoIDAllocClient, to dest, min, max int64) {
+	req := &autoid.AutoIDRequest{DbID: to.dbID, TblID: to.tblID, N: 0, KeyspaceID: uint32(tikv.NullspaceID)}
+	ctx := context.Background()
+	resp, err := cli.AllocAutoID(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, resp, &autoid.AutoIDResponse{Min: min, Max: max})
+}
+
+func autoIDRequest(t *testing.T, cli autoid.AutoIDAllocClient, to dest, unsigned bool, n uint64, more ...int64) autoIDResp {
+	increment := int64(1)
+	offset := int64(1)
+	if len(more) >= 1 {
+		increment = more[0]
+	}
+	if len(more) >= 2 {
+		offset = more[1]
+	}
+	req := &autoid.AutoIDRequest{DbID: to.dbID, TblID: to.tblID, IsUnsigned: unsigned, N: n, Increment: increment, Offset: offset, KeyspaceID: uint32(tikv.NullspaceID)}
+	resp, err := cli.AllocAutoID(context.Background(), req)
+	return autoIDResp{resp, err, t}
+}
+
+func rebaseRequest(t *testing.T, cli autoid.AutoIDAllocClient, to dest, unsigned bool, n int64, force ...struct{}) rebaseResp {
+	req := &autoid.RebaseRequest{
+		DbID:       to.dbID,
+		TblID:      to.tblID,
+		Base:       n,
+		IsUnsigned: unsigned,
+		Force:      len(force) > 0,
+	}
+	resp, err := cli.Rebase(context.Background(), req)
+	return rebaseResp{resp, err, t}
+}
+
 func TestAPI(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
@@ -72,80 +150,50 @@ func TestAPI(t *testing.T) {
 	require.NoError(t, err)
 	tbInfo := tbl.Meta()
 
-	ctx := context.Background()
-	checkCurrValue := func(t *testing.T, cli autoid.AutoIDAllocClient, min, max int64) {
-		req := &autoid.AutoIDRequest{DbID: dbInfo.ID, TblID: tbInfo.ID, N: 0, KeyspaceID: uint32(tikv.NullspaceID)}
-		resp, err := cli.AllocAutoID(ctx, req)
-		require.NoError(t, err)
-		require.Equal(t, resp, &autoid.AutoIDResponse{Min: min, Max: max})
-	}
-	autoIDRequest := func(t *testing.T, cli autoid.AutoIDAllocClient, unsigned bool, n uint64, more ...int64) autoIDResp {
-		increment := int64(1)
-		offset := int64(1)
-		if len(more) >= 1 {
-			increment = more[0]
-		}
-		if len(more) >= 2 {
-			offset = more[1]
-		}
-		req := &autoid.AutoIDRequest{DbID: dbInfo.ID, TblID: tbInfo.ID, IsUnsigned: unsigned, N: n, Increment: increment, Offset: offset, KeyspaceID: uint32(tikv.NullspaceID)}
-		resp, err := cli.AllocAutoID(ctx, req)
-		return autoIDResp{resp, err, t}
-	}
-	rebaseRequest := func(t *testing.T, cli autoid.AutoIDAllocClient, unsigned bool, n int64, force ...struct{}) rebaseResp {
-		req := &autoid.RebaseRequest{
-			DbID:       dbInfo.ID,
-			TblID:      tbInfo.ID,
-			Base:       n,
-			IsUnsigned: unsigned,
-			Force:      len(force) > 0,
-		}
-		resp, err := cli.Rebase(ctx, req)
-		return rebaseResp{resp, err, t}
-	}
+	to := dest{dbID: dbInfo.ID, tblID: tbInfo.ID}
 	var force = struct{}{}
 
 	// basic auto id operation
-	autoIDRequest(t, cli, false, 1).check(0, 1)
-	autoIDRequest(t, cli, false, 10).check(1, 11)
-	checkCurrValue(t, cli, 11, 11)
-	autoIDRequest(t, cli, false, 128).check(11, 139)
-	autoIDRequest(t, cli, false, 1, 10, 5).check(139, 145)
+	autoIDRequest(t, cli, to, false, 1).check(0, 1)
+	autoIDRequest(t, cli, to, false, 10).check(1, 11)
+	checkCurrValue(t, cli, to, 11, 11)
+	autoIDRequest(t, cli, to, false, 128).check(11, 139)
+	autoIDRequest(t, cli, to, false, 1, 10, 5).check(139, 145)
 
 	// basic rebase operation
-	rebaseRequest(t, cli, false, 666).check("")
-	autoIDRequest(t, cli, false, 1).check(666, 667)
+	rebaseRequest(t, cli, to, false, 666).check("")
+	autoIDRequest(t, cli, to, false, 1).check(666, 667)
 
-	rebaseRequest(t, cli, false, 6666).check("")
-	autoIDRequest(t, cli, false, 1).check(6666, 6667)
+	rebaseRequest(t, cli, to, false, 6666).check("")
+	autoIDRequest(t, cli, to, false, 1).check(6666, 6667)
 
 	// rebase will not decrease the value without 'force'
-	rebaseRequest(t, cli, false, 44).check("")
-	checkCurrValue(t, cli, 6667, 6667)
-	rebaseRequest(t, cli, false, 44, force).check("")
-	checkCurrValue(t, cli, 44, 44)
+	rebaseRequest(t, cli, to, false, 44).check("")
+	checkCurrValue(t, cli, to, 6667, 6667)
+	rebaseRequest(t, cli, to, false, 44, force).check("")
+	checkCurrValue(t, cli, to, 44, 44)
 
 	// max increase 1
-	rebaseRequest(t, cli, false, math.MaxInt64, force).check("")
-	checkCurrValue(t, cli, math.MaxInt64, math.MaxInt64)
-	autoIDRequest(t, cli, false, 1).checkErrmsg()
+	rebaseRequest(t, cli, to, false, math.MaxInt64, force).check("")
+	checkCurrValue(t, cli, to, math.MaxInt64, math.MaxInt64)
+	autoIDRequest(t, cli, to, false, 1).checkErrmsg()
 
-	rebaseRequest(t, cli, true, 0, force).check("")
-	checkCurrValue(t, cli, 0, 0)
-	autoIDRequest(t, cli, true, 1).check(0, 1)
-	autoIDRequest(t, cli, true, 10).check(1, 11)
-	autoIDRequest(t, cli, true, 128).check(11, 139)
-	autoIDRequest(t, cli, true, 1, 10, 5).check(139, 145)
+	rebaseRequest(t, cli, to, true, 0, force).check("")
+	checkCurrValue(t, cli, to, 0, 0)
+	autoIDRequest(t, cli, to, true, 1).check(0, 1)
+	autoIDRequest(t, cli, to, true, 10).check(1, 11)
+	autoIDRequest(t, cli, to, true, 128).check(11, 139)
+	autoIDRequest(t, cli, to, true, 1, 10, 5).check(139, 145)
 
 	// max increase 1
-	rebaseRequest(t, cli, true, math.MaxInt64).check("")
-	checkCurrValue(t, cli, math.MaxInt64, math.MaxInt64)
-	autoIDRequest(t, cli, true, 1).check(math.MaxInt64, math.MinInt64)
-	autoIDRequest(t, cli, true, 1).check(math.MinInt64, math.MinInt64+1)
+	rebaseRequest(t, cli, to, true, math.MaxInt64).check("")
+	checkCurrValue(t, cli, to, math.MaxInt64, math.MaxInt64)
+	autoIDRequest(t, cli, to, true, 1).check(math.MaxInt64, math.MinInt64)
+	autoIDRequest(t, cli, to, true, 1).check(math.MinInt64, math.MinInt64+1)
 
-	rebaseRequest(t, cli, true, -1).check("")
-	checkCurrValue(t, cli, -1, -1)
-	autoIDRequest(t, cli, true, 1).check(-1, 0)
+	rebaseRequest(t, cli, to, true, -1).check("")
+	checkCurrValue(t, cli, to, -1, -1)
+	autoIDRequest(t, cli, to, true, 1).check(-1, 0)
 }
 
 func TestGRPC(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50819

Problem Summary:

### What changed and how does it work?

The exposed API should be thread-safe, and `forceRebase`   `allocAutoID`   `alloc4Unsigned`   `alloc4Signed` ... all those internal functions should be called under lock. 

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
