### PR TITLE
fix CTE goroutine leak when child.Close() return error

### DIFF
--- a/pkg/executor/cte.go
+++ b/pkg/executor/cte.go
@@ -238,19 +238,18 @@ func (p *cteProducer) closeProducer() (firstErr error) {
 		}
 	}
 
-	if err := exec.Close(p.seedExec); err != nil {
-		setFirstErr(err)
-	}
+	err := exec.Close(p.seedExec)
+	setFirstErr(err)
+
 	if p.recursiveExec != nil {
-		if err := exec.Close(p.recursiveExec); err != nil {
-			setFirstErr(err)
-		}
+		err = exec.Close(p.recursiveExec)
+		setFirstErr(err)
+
 		// `iterInTbl` and `resTbl` are shared by multiple operators,
 		// so will be closed when the SQL finishes.
 		if p.iterOutTbl != nil {
-			if err := p.iterOutTbl.DerefAndClose(); err != nil {
-				setFirstErr(err)
-			}
+			err = p.iterOutTbl.DerefAndClose()
+			setFirstErr(err)
 		}
 	}
 	p.closed = true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50337

Problem Summary:
when child.Close() return error, there may leaking resource

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```
drop table if exists t, t1, t2;
create table t (id int,name varchar(10));
insert into t values(1,'tt');
create table t1(id int,name varchar(10),name1 varchar(10),name2 varchar(10));
insert into t1 values(1,'tt','ttt','tttt'),(2,'dd','ddd','dddd');
create table t2(id int,name varchar(10),name1 varchar(10),name2 varchar(10),`date1` date);
insert into t2 values(1,'tt','ttt','tttt','2099-12-31'),(2,'dd','ddd','dddd','2099-12-31');
set tidb_mem_quota_query = 7000;
run cte sql for 2000 times (check https://github.com/pingcap/tidb/issues/50337 for detailed sql)

curl 'http://127.0.0.1:10080/debug/zip?seconds=5' --output debug4.zip and search copIteratorTaskSender to check if any goroutine leak.
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix CTE goroutine leak when child.Close() return error
```
