### PR TITLE
*: force_init_stats doesn't block http api's startup

### DIFF
--- a/br/pkg/mock/mock_cluster.go
+++ b/br/pkg/mock/mock_cluster.go
@@ -103,7 +103,7 @@ func (mock *Cluster) Start() error {
 	}
 	mock.Server = svr
 	go func() {
-		if err1 := svr.Run(); err1 != nil {
+		if err1 := svr.Run(nil); err1 != nil {
 			panic(err1)
 		}
 	}()

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -317,10 +317,8 @@ func main() {
 		close(exited)
 	})
 	topsql.SetupTopSQL()
-	if config.GetGlobalConfig().Performance.ForceInitStats {
-		<-dom.StatsHandle().InitStatsDone
-	}
-	terror.MustNil(svr.Run())
+
+	terror.MustNil(svr.Run(dom))
 	<-exited
 	syncLog()
 }

--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -659,9 +659,7 @@ func TestGCBindRecord(t *testing.T) {
 
 	tk.MustExec("drop global binding for select * from t where a = 1")
 	tk.MustQuery("show global bindings").Check(testkit.Rows())
-	tk.MustQuery("select status from mysql.bind_info where original_sql = 'select * from `test` . `t` where `a` = ?'").Check(testkit.Rows(
-		"deleted",
-	))
+	tk.MustQuery("select status from mysql.bind_info where original_sql = 'select * from `test` . `t` where `a` = ?'").Check(testkit.Rows())
 	require.NoError(t, h.GCGlobalBinding())
 	tk.MustQuery("show global bindings").Check(testkit.Rows())
 	tk.MustQuery("select status from mysql.bind_info where original_sql = 'select * from `test` . `t` where `a` = ?'").Check(testkit.Rows())

--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -659,7 +659,9 @@ func TestGCBindRecord(t *testing.T) {
 
 	tk.MustExec("drop global binding for select * from t where a = 1")
 	tk.MustQuery("show global bindings").Check(testkit.Rows())
-	tk.MustQuery("select status from mysql.bind_info where original_sql = 'select * from `test` . `t` where `a` = ?'").Check(testkit.Rows())
+	tk.MustQuery("select status from mysql.bind_info where original_sql = 'select * from `test` . `t` where `a` = ?'").Check(testkit.Rows(
+		"deleted",
+	))
 	require.NoError(t, h.GCGlobalBinding())
 	tk.MustQuery("show global bindings").Check(testkit.Rows())
 	tk.MustQuery("select status from mysql.bind_info where original_sql = 'select * from `test` . `t` where `a` = ?'").Check(testkit.Rows())

--- a/pkg/server/handler/extractorhandler/extract_test.go
+++ b/pkg/server/handler/extractorhandler/extract_test.go
@@ -63,7 +63,7 @@ func TestExtractHandler(t *testing.T) {
 	client.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	client.StatusPort = testutil.GetPortFromTCPAddr(server.StatusListenerAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	client.WaitUntilServerOnline()

--- a/pkg/server/handler/optimizor/optimize_trace_test.go
+++ b/pkg/server/handler/optimizor/optimize_trace_test.go
@@ -52,7 +52,7 @@ func TestDumpOptimizeTraceAPI(t *testing.T) {
 	client.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	client.StatusPort = testutil.GetPortFromTCPAddr(server.StatusListenerAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(dom)
 		require.NoError(t, err)
 	}()
 	client.WaitUntilServerOnline()

--- a/pkg/server/handler/optimizor/optimize_trace_test.go
+++ b/pkg/server/handler/optimizor/optimize_trace_test.go
@@ -52,7 +52,7 @@ func TestDumpOptimizeTraceAPI(t *testing.T) {
 	client.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	client.StatusPort = testutil.GetPortFromTCPAddr(server.StatusListenerAddr())
 	go func() {
-		err := server.Run(dom)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	client.WaitUntilServerOnline()

--- a/pkg/server/handler/optimizor/plan_replayer_test.go
+++ b/pkg/server/handler/optimizor/plan_replayer_test.go
@@ -94,7 +94,7 @@ func prepareServerAndClientForTest(t *testing.T, store kv.Storage, dom *domain.D
 	srv.SetDomain(dom)
 	require.NoError(t, err)
 	go func() {
-		err := srv.Run()
+		err := srv.Run(nil)
 		require.NoError(t, err)
 	}()
 

--- a/pkg/server/handler/optimizor/statistics_handler_test.go
+++ b/pkg/server/handler/optimizor/statistics_handler_test.go
@@ -59,7 +59,7 @@ func TestDumpStatsAPI(t *testing.T) {
 	client.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	client.StatusPort = testutil.GetPortFromTCPAddr(server.StatusListenerAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	client.WaitUntilServerOnline()

--- a/pkg/server/handler/tests/http_handler_test.go
+++ b/pkg/server/handler/tests/http_handler_test.go
@@ -469,7 +469,7 @@ func (ts *basicHTTPHandlerTestSuite) startServer(t *testing.T) {
 	ts.server = server
 	ts.server.SetDomain(ts.domain)
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.domain)
 		require.NoError(t, err)
 	}()
 	ts.WaitUntilServerOnline()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -420,13 +420,16 @@ func (s *Server) reportConfig() {
 }
 
 // Run runs the server.
-func (s *Server) Run() error {
+func (s *Server) Run(dom *domain.Domain) error {
 	metrics.ServerEventCounter.WithLabelValues(metrics.ServerStart).Inc()
 	s.reportConfig()
 
 	// Start HTTP API to report tidb info such as TPS.
 	if s.cfg.Status.ReportStatus {
 		s.startStatusHTTP()
+	}
+	if config.GetGlobalConfig().Performance.ForceInitStats && dom != nil {
+		<-dom.StatsHandle().InitStatsDone
 	}
 	// If error should be reported and exit the server it can be sent on this
 	// channel. Otherwise, end with sending a nil error to signal "done"

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -2953,7 +2953,7 @@ func TestProxyProtocolWithIpNoFallbackable(t *testing.T) {
 	require.NoError(t, err)
 	server.SetDomain(ts.Domain)
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 1000)

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -2888,7 +2888,7 @@ func TestProxyProtocolWithIpFallbackable(t *testing.T) {
 	require.NoError(t, err)
 	server.SetDomain(ts.Domain)
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -170,7 +170,7 @@ func TestSocketForwarding(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -202,7 +202,7 @@ func TestSocket(t *testing.T) {
 	require.NoError(t, err)
 	server.SetDomain(ts.Domain)
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -238,7 +238,7 @@ func TestSocketAndIp(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	cli.WaitUntilServerCanConnect()
@@ -402,7 +402,7 @@ func TestOnlySocket(t *testing.T) {
 	require.NoError(t, err)
 	server.SetDomain(ts.Domain)
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -904,7 +904,7 @@ func TestGracefulShutdown(t *testing.T) {
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	cli.StatusPort = testutil.GetPortFromTCPAddr(server.StatusListenerAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -2147,7 +2147,7 @@ func TestLocalhostClientMapping(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	defer server.Close()
@@ -2888,7 +2888,7 @@ func TestProxyProtocolWithIpFallbackable(t *testing.T) {
 	require.NoError(t, err)
 	server.SetDomain(ts.Domain)
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -2953,7 +2953,7 @@ func TestProxyProtocolWithIpNoFallbackable(t *testing.T) {
 	require.NoError(t, err)
 	server.SetDomain(ts.Domain)
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 1000)

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -170,7 +170,7 @@ func TestSocketForwarding(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -202,7 +202,7 @@ func TestSocket(t *testing.T) {
 	require.NoError(t, err)
 	server.SetDomain(ts.Domain)
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -238,7 +238,7 @@ func TestSocketAndIp(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	cli.WaitUntilServerCanConnect()
@@ -402,7 +402,7 @@ func TestOnlySocket(t *testing.T) {
 	require.NoError(t, err)
 	server.SetDomain(ts.Domain)
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -2147,7 +2147,7 @@ func TestLocalhostClientMapping(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	defer server.Close()

--- a/pkg/server/tests/servertestkit/testkit.go
+++ b/pkg/server/tests/servertestkit/testkit.go
@@ -78,7 +78,7 @@ func CreateTidbTestSuiteWithCfg(t *testing.T, cfg *config.Config) *TidbTestSuite
 	ts.Server.SetDomain(ts.Domain)
 	ts.Domain.InfoSyncer().SetSessionManager(ts.Server)
 	go func() {
-		err := ts.Server.Run(ts.Domain)
+		err := ts.Server.Run(nil)
 		require.NoError(t, err)
 	}()
 	ts.WaitUntilServerOnline()

--- a/pkg/server/tests/servertestkit/testkit.go
+++ b/pkg/server/tests/servertestkit/testkit.go
@@ -78,7 +78,7 @@ func CreateTidbTestSuiteWithCfg(t *testing.T, cfg *config.Config) *TidbTestSuite
 	ts.Server.SetDomain(ts.Domain)
 	ts.Domain.InfoSyncer().SetSessionManager(ts.Server)
 	go func() {
-		err := ts.Server.Run()
+		err := ts.Server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	ts.WaitUntilServerOnline()

--- a/pkg/server/tests/tls/tls_test.go
+++ b/pkg/server/tests/tls/tls_test.go
@@ -308,7 +308,7 @@ func TestTLSBasic(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)

--- a/pkg/server/tests/tls/tls_test.go
+++ b/pkg/server/tests/tls/tls_test.go
@@ -443,7 +443,7 @@ func TestReloadTLS(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -594,7 +594,7 @@ func TestStatusAPIWithTLSCNCheck(t *testing.T) {
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	cli.StatusPort = testutil.GetPortFromTCPAddr(server.StatusListenerAddr())
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	defer server.Close()
@@ -652,7 +652,7 @@ func TestTLSAuto(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)

--- a/pkg/server/tests/tls/tls_test.go
+++ b/pkg/server/tests/tls/tls_test.go
@@ -216,7 +216,7 @@ func TestTLSVerify(t *testing.T) {
 	defer server.Close()
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)

--- a/pkg/server/tests/tls/tls_test.go
+++ b/pkg/server/tests/tls/tls_test.go
@@ -216,7 +216,7 @@ func TestTLSVerify(t *testing.T) {
 	defer server.Close()
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -308,7 +308,7 @@ func TestTLSBasic(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -384,7 +384,7 @@ func TestErrorNoRollback(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	defer server.Close()
@@ -443,7 +443,7 @@ func TestReloadTLS(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -536,7 +536,7 @@ func TestStatusAPIWithTLS(t *testing.T) {
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	cli.StatusPort = testutil.GetPortFromTCPAddr(server.StatusListenerAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)
@@ -594,7 +594,7 @@ func TestStatusAPIWithTLSCNCheck(t *testing.T) {
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	cli.StatusPort = testutil.GetPortFromTCPAddr(server.StatusListenerAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	defer server.Close()
@@ -652,7 +652,7 @@ func TestTLSAuto(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run()
+		err := server.Run(ts.Domain)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)

--- a/pkg/server/tests/tls/tls_test.go
+++ b/pkg/server/tests/tls/tls_test.go
@@ -384,7 +384,7 @@ func TestErrorNoRollback(t *testing.T) {
 	server.SetDomain(ts.Domain)
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	defer server.Close()

--- a/pkg/server/tests/tls/tls_test.go
+++ b/pkg/server/tests/tls/tls_test.go
@@ -536,7 +536,7 @@ func TestStatusAPIWithTLS(t *testing.T) {
 	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
 	cli.StatusPort = testutil.GetPortFromTCPAddr(server.StatusListenerAddr())
 	go func() {
-		err := server.Run(ts.Domain)
+		err := server.Run(nil)
 		require.NoError(t, err)
 	}()
 	time.Sleep(time.Millisecond * 100)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50854

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

create many tables, we can read the metrics HTTP API but cannot operator MySQL port.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
