### PR TITLE
ebs br: rename a tag for EBS snapshots

### DIFF
--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -74,7 +74,7 @@ func (e *EC2Session) CreateSnapshots(backupInfo *config.EBSBasedBRMeta) (map[str
 	}
 
 	tags := []*ec2.Tag{
-		ec2Tag("TiDBCluster-BR", "new"),
+		ec2Tag("TiDBCluster-BR-Snapshot", "new"),
 	}
 
 	workerPool := utils.NewWorkerPool(e.concurrency, "create snapshots")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50878 

Problem Summary:

### What changed and how does it work?
This PR is to address a name duplication issue doing backup from a restored cluster. The tag key of snapshots is renamed from `TiDBCluster-BR` to `TiDBCluster-BR-Snapshot`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
