### PR TITLE
planner: make tryWhereIn2BatchPointGet support _tidb_rowid

### DIFF
--- a/pkg/planner/core/plan_cache_test.go
+++ b/pkg/planner/core/plan_cache_test.go
@@ -1287,6 +1287,27 @@ func TestWarningWithDisablePlanCacheStmt(t *testing.T) {
 	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1105 skip prepared plan-cache: query accesses partitioned tables is un-cacheable"))
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 }
+func TestFastPlanCachedBatchGetRowId(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int);")
+	tk.MustExec("insert t values (1, 7), (1, 8), (1, 9), (1, 10);")
+	tk.MustExec(`prepare stmt from 'select * from t where _tidb_rowid in (1, ?, ?)'`)
+	tk.MustExec(`set @a2=2, @a3=3`)
+	tk.MustQuery("execute stmt using @a2, @a3;").Sort().Check(testkit.Rows("1 7", "1 8", "1 9"))
+	tk.MustExec(`set @a2=4, @a3=2`)
+	tk.MustQuery("execute stmt using @a2, @a3;").Sort().Check(testkit.Rows("1 10", "1 7", "1 8"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+
+	// execute again to check plan
+	tk.MustQuery("execute stmt using @a2, @a3;").Sort().Check(testkit.Rows("1 10", "1 7", "1 8"))
+	tkProcess := tk.Session().ShowProcess()
+	ps := []*util.ProcessInfo{tkProcess}
+	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
+	tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).CheckContain("Batch_Point_Get")
+}
 
 func BenchmarkPlanCacheBindingMatch(b *testing.B) {
 	store := testkit.CreateMockStore(b)

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -998,6 +998,8 @@ func tryWhereIn2BatchPointGet(ctx sessionctx.Context, selStmt *ast.SelectStmt) *
 					break
 				}
 			}
+		} else if !tbl.IsCommonHandle && colName.Name.Name.L == model.ExtraHandleName.L {
+			handleCol = model.NewExtraHandleColInfo()
 		}
 		if handleCol == nil {
 			// Downgrade to use unique index

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -998,7 +998,7 @@ func tryWhereIn2BatchPointGet(ctx sessionctx.Context, selStmt *ast.SelectStmt) *
 					break
 				}
 			}
-		} else if !tbl.IsCommonHandle && colName.Name.Name.L == model.ExtraHandleName.L {
+		} else if tbl.GetPartitionInfo() == nil && !tbl.IsCommonHandle && colName.Name.Name.L == model.ExtraHandleName.L {
 			handleCol = model.NewExtraHandleColInfo()
 		}
 		if handleCol == nil {

--- a/tests/integrationtest/r/planner/core/tests/prepare/prepare.result
+++ b/tests/integrationtest/r/planner/core/tests/prepare/prepare.result
@@ -718,9 +718,9 @@ a	b
 set @a2=4, @a3=2;
 execute stmt using @a2, @a3;
 a	b
+1	10
 1	7
 1	8
-1	10
 select @@last_plan_from_cache;
 @@last_plan_from_cache
 1

--- a/tests/integrationtest/r/planner/core/tests/prepare/prepare.result
+++ b/tests/integrationtest/r/planner/core/tests/prepare/prepare.result
@@ -723,7 +723,7 @@ a	b
 1	10
 select @@last_plan_from_cache;
 @@last_plan_from_cache
-0
+1
 drop table if exists t;
 create table t(a int, b int, c int , index idx(a));
 insert into t values(1,2, -1), (1,2, 1), (1,2, -1), (4,4,3);

--- a/tests/integrationtest/t/planner/core/tests/prepare/prepare.test
+++ b/tests/integrationtest/t/planner/core/tests/prepare/prepare.test
@@ -416,8 +416,10 @@ create table t (a int, b int);
 insert t values (1, 7), (1, 8), (1, 9), (1, 10);
 prepare stmt from 'select * from t where _tidb_rowid in (1, ?, ?)';
 set @a2=2, @a3=3;
+--sorted_result
 execute stmt using @a2, @a3;
 set @a2=4, @a3=2;
+--sorted_result
 execute stmt using @a2, @a3;
 select @@last_plan_from_cache;
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50884 

Problem Summary: simple in rowid query is not cacheable.

### What changed and how does it work?
make tryWhereIn2BatchPointGet aware of _tidb_rowid, construct a fake column info if so.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
