### PR TITLE
bootstrap, br: add `sys.schema_unused_indexes` view | tidb-test=pr/2287

### DIFF
--- a/br/pkg/backup/schema_test.go
+++ b/br/pkg/backup/schema_test.go
@@ -122,7 +122,7 @@ func TestBuildBackupRangeAndSchema(t *testing.T) {
 
 	// Empty database.
 	// Filter out system tables manually.
-	noFilter, err := filter.Parse([]string{"*.*", "!mysql.*"})
+	noFilter, err := filter.Parse([]string{"*.*", "!mysql.*", "!sys.*"})
 	require.NoError(t, err)
 	_, backupSchemas, _, err = backup.BuildBackupRangeAndInitSchema(
 		m.Storage, noFilter, math.MaxUint64, false, true)

--- a/br/pkg/restore/BUILD.bazel
+++ b/br/pkg/restore/BUILD.bazel
@@ -154,6 +154,7 @@ go_test(
         "//pkg/parser/model",
         "//pkg/parser/mysql",
         "//pkg/parser/types",
+        "//pkg/session",
         "//pkg/sessionctx/stmtctx",
         "//pkg/store/pdtypes",
         "//pkg/tablecodec",

--- a/br/pkg/restore/db_test.go
+++ b/br/pkg/restore/db_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/types"
+	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -424,8 +425,5 @@ func TestGetExistedUserDBs(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	s := createRestoreSchemaSuite(t)
-	tk := testkit.NewTestKit(t, s.mock.Storage)
-	ret := tk.MustQuery("SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'mysql'")
-	ret.Equal([][]any{{55}})
+	require.Equal(t, int64(185), session.CurrentBootstrapVersion)
 }

--- a/br/pkg/task/restore_test.go
+++ b/br/pkg/task/restore_test.go
@@ -154,6 +154,18 @@ func TestCheckRestoreDBAndTable(t *testing.T) {
 				"__TiDB_BR_Temporary_mysql": {"tablE"},
 			}),
 		},
+		{
+			cfgSchemas: map[string]struct{}{
+				utils.EncloseName("sys"): {},
+			},
+			cfgTables: map[string]struct{}{
+				utils.EncloseDBAndTable("sys", "t"):  {},
+				utils.EncloseDBAndTable("sys", "t2"): {},
+			},
+			backupDBs: mockReadSchemasFromBackupMeta(t, map[string][]string{
+				"__TiDB_BR_Temporary_sys": {"T", "T2"},
+			}),
+		},
 	}
 
 	cfg := &RestoreConfig{}

--- a/br/pkg/utils/schema.go
+++ b/br/pkg/utils/schema.go
@@ -12,7 +12,6 @@ import (
 
 // temporaryDBNamePrefix is the prefix name of system db, e.g. mysql system db will be rename to __TiDB_BR_Temporary_mysql
 const temporaryDBNamePrefix = "__TiDB_BR_Temporary_"
-const temporarySysDB = temporaryDBNamePrefix + "mysql"
 
 // NeedAutoID checks whether the table needs backing up with an autoid.
 func NeedAutoID(tblInfo *model.TableInfo) bool {
@@ -31,15 +30,15 @@ func EncloseDBAndTable(database, table string) string {
 	return fmt.Sprintf("%s.%s", EncloseName(database), EncloseName(table))
 }
 
-// IsTemplateSysDB checks wheterh the dbname is temporary system database(__TiDB_BR_Temporary_mysql).
+// IsTemplateSysDB checks wheterh the dbname is temporary system database(__TiDB_BR_Temporary_mysql or __TiDB_BR_Temporary_sys).
 func IsTemplateSysDB(dbname model.CIStr) bool {
-	return dbname.O == temporarySysDB
+	return dbname.O == temporaryDBNamePrefix+mysql.SystemDB || dbname.O == temporaryDBNamePrefix+mysql.SysDB
 }
 
 // IsSysDB tests whether the database is system DB.
-// Currently, the only system DB is mysql.
+// Currently, both `mysql` and `sys` are system DB.
 func IsSysDB(dbLowerName string) bool {
-	return dbLowerName == mysql.SystemDB
+	return dbLowerName == mysql.SystemDB || dbLowerName == mysql.SysDB
 }
 
 // TemporaryDBName makes a 'private' database name.

--- a/br/tests/_utils/make_tiflash_config
+++ b/br/tests/_utils/make_tiflash_config
@@ -63,7 +63,6 @@ pd_addr = "$PD_ADDR"
 [profiles.default]
 load_balancing = "random"
 max_memory_usage = 10000000000
-use_uncompressed_cache = 0
 
 [users]
 [users.default]

--- a/br/tests/br_backup_version/run.sh
+++ b/br/tests/br_backup_version/run.sh
@@ -21,8 +21,8 @@ DB="$TEST_NAME"
 #    "cluster_id": 6931331682760961243
 expected_cluster_id=`run_curl "https://$PD_ADDR/pd/api/v1/members" | grep "cluster_id"`
 # example
-#"4.0.10"
-expected_cluster_version=`run_curl "https://$PD_ADDR/pd/api/v1/config/cluster-version"`
+#4.0.10
+expected_cluster_version=`run_curl "https://$PD_ADDR/pd/api/v1/config/cluster-version" | tr -d '"'`
 unset BR_LOG_TO_TERM
 
 function check_version() {

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -6741,8 +6741,8 @@ var systemTables = map[string]struct{}{
 	"gc_delete_range_done": {},
 }
 
-func isSystemTable(schema, table string) bool {
-	if schema != "mysql" {
+func isUndroppableTable(schema, table string) bool {
+	if schema != mysql.SystemDB {
 		return false
 	}
 	if _, ok := systemTables[table]; ok {
@@ -6818,7 +6818,7 @@ func (d *ddl) dropTableObject(
 
 		// Protect important system table from been dropped by a mistake.
 		// I can hardly find a case that a user really need to do this.
-		if isSystemTable(tn.Schema.L, tn.Name.L) {
+		if isUndroppableTable(tn.Schema.L, tn.Name.L) {
 			return errors.Errorf("Drop tidb system table '%s.%s' is forbidden", tn.Schema.L, tn.Name.L)
 		}
 		switch tableObjectType {

--- a/pkg/executor/importer/importer_testkit_test.go
+++ b/pkg/executor/importer/importer_testkit_test.go
@@ -360,7 +360,7 @@ func TestProcessChunkWith(t *testing.T) {
 		require.Len(t, progress.GetColSize(), 3)
 		checksumMap := checksum.GetInnerChecksums()
 		require.Len(t, checksumMap, 1)
-		require.Equal(t, verify.MakeKVChecksum(111, 3, 0xde5c27fa54065037), *checksumMap[verify.DataKVGroupID])
+		require.Equal(t, verify.MakeKVChecksum(111, 3, 14231358899564314836), *checksumMap[verify.DataKVGroupID])
 	})
 }
 

--- a/pkg/executor/infoschema_cluster_table_test.go
+++ b/pkg/executor/infoschema_cluster_table_test.go
@@ -387,7 +387,7 @@ func TestTableStorageStats(t *testing.T) {
 		"test 2",
 	))
 	rows := tk.MustQuery("select TABLE_NAME from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql';").Rows()
-	result := 55
+	result := 54
 	require.Len(t, rows, result)
 
 	// More tests about the privileges.

--- a/pkg/infoschema/test/clustertablestest/BUILD.bazel
+++ b/pkg/infoschema/test/clustertablestest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "tables_test.go",
     ],
     flaky = True,
-    shard_count = 49,
+    shard_count = 50,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/parser/mysql/const.go
+++ b/pkg/parser/mysql/const.go
@@ -191,6 +191,9 @@ const (
 const (
 	// SystemDB is the name of system database.
 	SystemDB = "mysql"
+	// SysDB is the name of `sys` schema, which is a set of objects to help users to interpret data collected
+	// in `information_schema`.
+	SysDB = "sys"
 	// GlobalPrivTable is the table in system db contains global scope privilege info.
 	GlobalPrivTable = "global_priv"
 	// UserTable is the table in system db contains user info.

--- a/pkg/server/handler/tests/http_handler_test.go
+++ b/pkg/server/handler/tests/http_handler_test.go
@@ -849,7 +849,7 @@ func TestGetSchema(t *testing.T) {
 	err = decoder.Decode(&dbs)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	expects := []string{"information_schema", "metrics_schema", "mysql", "performance_schema", "test", "tidb"}
+	expects := []string{"information_schema", "metrics_schema", "mysql", "performance_schema", "sys", "test", "tidb"}
 	names := make([]string, len(dbs))
 	for i, v := range dbs {
 		names[i] = v.Name.L

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -686,6 +686,24 @@ const (
 		PRIMARY KEY (id),
 		KEY (created_by),
 		KEY (status));`
+
+	// DropMySQLIndexUsageTable removes the table `mysql.schema_index_usage`
+	DropMySQLIndexUsageTable = "DROP TABLE IF EXISTS mysql.schema_index_usage"
+
+	// CreateSysSchema creates a new schema called `sys`.
+	CreateSysSchema = `CREATE DATABASE IF NOT EXISTS sys;`
+
+	// CreateSchemaUnusedIndexesView creates a view to use `information_schema.tidb_index_usage` to get the unused indexes.
+	CreateSchemaUnusedIndexesView = `CREATE OR REPLACE VIEW sys.schema_unused_indexes AS
+		SELECT
+			table_schema as object_schema,
+			table_name as object_name,
+			index_name
+		FROM information_schema.cluster_tidb_index_usage
+		WHERE
+			last_access_time is null and
+			table_schema not in ('sys', 'mysql', 'INFORMATION_SCHEMA', 'PERFORMANCE_SCHEMA') and
+			index_name != 'PRIMARY';`
 )
 
 // CreateTimers is a table to store all timers for tidb
@@ -1048,11 +1066,17 @@ const (
 	// version 184
 	//   remove `mysql.load_data_jobs` table
 	version184 = 184
+
+	// version 185
+	//   drop `mysql.schema_index_usage` table
+	//   create `sys` schema
+	//   create `sys.schema_unused_indexes` table
+	version185 = 185
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version184
+var currentBootstrapVersion int64 = version185
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1212,6 +1236,7 @@ var (
 		upgradeToVer182,
 		upgradeToVer183,
 		upgradeToVer184,
+		upgradeToVer185,
 	}
 )
 
@@ -2977,6 +3002,16 @@ func upgradeToVer184(s sessiontypes.Session, ver int64) {
 	mustExecute(s, "DROP TABLE IF EXISTS mysql.load_data_jobs")
 }
 
+func upgradeToVer185(s sessiontypes.Session, ver int64) {
+	if ver >= version185 {
+		return
+	}
+
+	doReentrantDDL(s, DropMySQLIndexUsageTable)
+	doReentrantDDL(s, CreateSysSchema)
+	doReentrantDDL(s, CreateSchemaUnusedIndexesView)
+}
+
 func writeOOMAction(s sessiontypes.Session) {
 	comment := "oom-action is `log` by default in v3.0.x, `cancel` by default in v4.0.11+"
 	mustExecute(s, `INSERT HIGH_PRIORITY INTO %n.%n VALUES (%?, %?, %?) ON DUPLICATE KEY UPDATE VARIABLE_VALUE= %?`,
@@ -3052,8 +3087,6 @@ func doDDLWorks(s sessiontypes.Session) {
 	mustExecute(s, CreateOptRuleBlacklist)
 	// Create stats_extended table.
 	mustExecute(s, CreateStatsExtended)
-	// Create schema_index_usage.
-	mustExecute(s, CreateSchemaIndexUsageTable)
 	// Create stats_fm_sketch table.
 	mustExecute(s, CreateStatsFMSketchTable)
 	// Create global_grants
@@ -3106,6 +3139,10 @@ func doDDLWorks(s sessiontypes.Session) {
 	mustExecute(s, CreateDistFrameworkMeta)
 	// create request_unit_by_group
 	mustExecute(s, CreateRequestUnitByGroupTable)
+	// create `sys` schema
+	mustExecute(s, CreateSysSchema)
+	// create `sys.schema_unused_indexes` view
+	mustExecute(s, CreateSchemaUnusedIndexesView)
 }
 
 // doBootstrapSQLFile executes SQL commands in a file as the last stage of bootstrap.

--- a/pkg/statistics/handle/storage/dump_test.go
+++ b/pkg/statistics/handle/storage/dump_test.go
@@ -75,7 +75,6 @@ func cleanStats(tk *testkit.TestKit, do *domain.Domain) {
 	tk.MustExec("delete from mysql.stats_buckets")
 	tk.MustExec("delete from mysql.stats_extended")
 	tk.MustExec("delete from mysql.stats_fm_sketch")
-	tk.MustExec("delete from mysql.schema_index_usage")
 	tk.MustExec("delete from mysql.column_stats_usage")
 	do.StatsHandle().Clear()
 }

--- a/pkg/telemetry/BUILD.bazel
+++ b/pkg/telemetry/BUILD.bazel
@@ -61,7 +61,7 @@ go_test(
     ],
     embed = [":telemetry"],
     flaky = True,
-    shard_count = 35,
+    shard_count = 34,
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",

--- a/pkg/telemetry/data_feature_usage_test.go
+++ b/pkg/telemetry/data_feature_usage_test.go
@@ -411,21 +411,6 @@ func TestAutoCapture(t *testing.T) {
 	require.True(t, usage.AutoCapture)
 }
 
-func TestClusterIndexUsageInfo(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t1(a int key clustered);")
-	tk.MustExec("create table t2(a int);")
-
-	usage, err := telemetry.GetFeatureUsage(tk.Session())
-	require.NoError(t, err)
-	require.NotNil(t, usage.ClusterIndex)
-	require.Equal(t, uint64(1), usage.NewClusterIndex.NumClusteredTables)
-	require.Equal(t, uint64(2), usage.NewClusterIndex.NumTotalTables)
-}
-
 func TestNonTransactionalUsage(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 

--- a/pkg/util/misc.go
+++ b/pkg/util/misc.go
@@ -206,7 +206,7 @@ func IsMemDB(dbLowerName string) bool {
 
 // IsSysDB checks whether dbLowerName is system database.
 func IsSysDB(dbLowerName string) bool {
-	return dbLowerName == mysql.SystemDB
+	return dbLowerName == mysql.SystemDB || dbLowerName == mysql.SysDB
 }
 
 // IsSystemView is similar to IsMemOrSyDB, but does not include the mysql schema

--- a/pkg/util/sem/sem.go
+++ b/pkg/util/sem/sem.go
@@ -99,7 +99,7 @@ func IsInvisibleSchema(dbName string) bool {
 	return strings.EqualFold(dbName, metricsSchema)
 }
 
-// IsInvisibleTable returns true if the  table needs to be hidden
+// IsInvisibleTable returns true if the table needs to be hidden
 // when sem is enabled.
 func IsInvisibleTable(dbLowerName, tblLowerName string) bool {
 	switch dbLowerName {

--- a/tests/integrationtest/r/executor/infoschema_reader.result
+++ b/tests/integrationtest/r/executor/infoschema_reader.result
@@ -49,6 +49,7 @@ select TABLE_COLLATION is null from INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='
 TABLE_COLLATION is null
 1
 1
+1
 SELECT * FROM information_schema.views WHERE table_schema='executor__infoschema_reader' AND table_name='v1';
 TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	VIEW_DEFINITION	CHECK_OPTION	IS_UPDATABLE	DEFINER	SECURITY_TYPE	CHARACTER_SET_CLIENT	COLLATION_CONNECTION
 def	executor__infoschema_reader	v1	SELECT 1 AS `1`	CASCADED	NO	root@localhost	DEFINER	utf8mb4	utf8mb4_general_ci


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #50886

Problem Summary:

### What changed and how does it work?

Add a new database `sys`
Add a new view `sys.schema_unused_indexes` to show show the index which hasn't been used since last restart.

Adding a new system database is risky. I've considered the following related codes and have made some change:
1. For BR, it handles the system table specially. I modified these code logic to also handle the new `sys` database as a special system database. The new view `schema_unused_indexes` will be skipped (like `tidb_mdl_view`).
2. For TiFlash, this PR modifies the `ddl` and also adds some tests to make sure the database is not allowed to add TiFlash replica.

For other tools, I didn't notice any special code logic about the system table 🤔 . I'll do some manually/automatic tests for them.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add a new system database `sys`.
Add a new view `sys.schema_unused_index`.
Remove the table `mysql.schema_index_usage`.
```
