### PR TITLE
ddl: make local sort generate only one subtask for each instance

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -315,7 +315,6 @@ go_test(
         "//pkg/util/sem",
         "//pkg/util/sqlexec",
         "//pkg/util/timeutil",
-        "@com_github_docker_go_units//:go-units",
         "@com_github_ngaut_pools//:pools",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -35,7 +35,6 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/parser/model"
-	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/store/helper"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/util/logutil"

--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -320,7 +320,9 @@ func generateNonPartitionPlan(
 func calculateRegionBatch(totalRegionCnt int, instanceCnt int, useLocalDisk bool) int {
 	var regionBatch int
 	avgTasksPerInstance := (totalRegionCnt + instanceCnt - 1) / instanceCnt // ceiling
-	if !useLocalDisk {
+	if useLocalDisk {
+		regionBatch = avgTasksPerInstance
+	} else {
 		// For cloud storage, each subtask should contain no more than 100 regions.
 		regionBatch = min(100, avgTasksPerInstance)
 	}

--- a/pkg/ddl/backfilling_dist_scheduler_test.go
+++ b/pkg/ddl/backfilling_dist_scheduler_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/go-units"
 	"github.com/ngaut/pools"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/br/pkg/lightning/backend/external"
@@ -32,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/util"
@@ -115,21 +113,19 @@ func TestBackfillingSchedulerLocalMode(t *testing.T) {
 func TestCalculateRegionBatch(t *testing.T) {
 	// Test calculate in cloud storage.
 	batchCnt := ddl.CalculateRegionBatchForTest(100, 8, false)
-	require.Equal(t, 12, batchCnt)
+	require.Equal(t, 13, batchCnt)
 	batchCnt = ddl.CalculateRegionBatchForTest(2, 8, false)
 	require.Equal(t, 1, batchCnt)
 	batchCnt = ddl.CalculateRegionBatchForTest(8, 8, false)
 	require.Equal(t, 1, batchCnt)
 
 	// Test calculate in local storage.
-	variable.DDLDiskQuota.Store(96 * units.MiB * 1000)
 	batchCnt = ddl.CalculateRegionBatchForTest(100, 8, true)
-	require.Equal(t, 12, batchCnt)
+	require.Equal(t, 13, batchCnt)
 	batchCnt = ddl.CalculateRegionBatchForTest(2, 8, true)
 	require.Equal(t, 1, batchCnt)
-	variable.DDLDiskQuota.Store(96 * units.MiB * 2)
 	batchCnt = ddl.CalculateRegionBatchForTest(24, 8, true)
-	require.Equal(t, 2, batchCnt)
+	require.Equal(t, 3, batchCnt)
 }
 
 func TestBackfillingSchedulerGlobalSortMode(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #48795

Problem Summary:

Previously, the subtask count is unreasonable:

https://github.com/pingcap/tidb/blob/35a7c9e2f7c5b6413a1dd30b9d4957552a0d95a9/pkg/ddl/backfilling_dist_scheduler.go#L325-L327

It is inaccurate to use 96M to calculate the size of index data in a region. As a result, the number of subtasks will become very large, which is quite inefficient.

### What changed and how does it work?

Make local sort generate only one subtask for each instance.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  1.194TiB table, 8 worker count:
  Before this PR: 1 hour 1 min 29 sec
  ![image](https://github.com/pingcap/tidb/assets/24713065/aa4fa979-5e80-47ea-97a1-f465d468f52d)
  After this PR: 26 min 10 sec
  ![image](https://github.com/pingcap/tidb/assets/24713065/a6e12a5b-7b7e-4924-a923-83386ed94896)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
