### PR TITLE
planner: skip MDL when analyzing table

### DIFF
--- a/pkg/ddl/tests/metadatalock/BUILD.bazel
+++ b/pkg/ddl/tests/metadatalock/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "mdl_test.go",
     ],
     flaky = True,
-    shard_count = 32,
+    shard_count = 34,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/ddl/tests/metadatalock/mdl_test.go
+++ b/pkg/ddl/tests/metadatalock/mdl_test.go
@@ -473,6 +473,49 @@ func TestMDLAnalyze(t *testing.T) {
 	require.Greater(t, ts1, ts2)
 }
 
+func TestMDLAnalyzePartition(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	sv := server.CreateMockServer(t, store)
+
+	sv.SetDomain(dom)
+	dom.InfoSyncer().SetSessionManager(sv)
+	defer sv.Close()
+
+	conn1 := server.CreateMockConn(t, sv)
+	tk := testkit.NewTestKitWithSession(t, store, conn1.Context().Session)
+	conn2 := server.CreateMockConn(t, sv)
+	tkDDL := testkit.NewTestKitWithSession(t, store, conn2.Context().Session)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_partition_prune_mode='dynamic'")
+	tk.MustExec("set global tidb_enable_metadata_lock=1")
+	tk.MustExec("create table t(a int) partition by range(a) ( PARTITION p0 VALUES LESS THAN (0), PARTITION p1 VALUES LESS THAN (100), PARTITION p2 VALUES LESS THAN MAXVALUE );")
+	tk.MustExec("insert into t values(1), (2), (3), (4);")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var ts2 time.Time
+	var ts1 time.Time
+
+	go func() {
+		tk.MustExec("begin")
+		tk.MustExec("analyze table t;")
+		tk.MustExec("analyze table t partition p1;")
+		tk.MustQuery("select sleep(2);")
+		tk.MustExec("commit")
+		ts1 = time.Now()
+		wg.Done()
+	}()
+
+	go func() {
+		tkDDL.MustExec("alter table test.t drop partition p2;")
+		ts2 = time.Now()
+		wg.Done()
+	}()
+
+	wg.Wait()
+	require.Greater(t, ts1, ts2)
+}
+
 func TestMDLAutoCommitNonReadOnly(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	sv := server.CreateMockServer(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47475

Problem Summary:

### What changed and how does it work?
Skip lock if the statement is analyze stmt

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Analyze doesn't block DDL any more 
```
