### PR TITLE
planner: stop pushing Agg down through Projection if substitution fail

### DIFF
--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -409,6 +409,7 @@ func SetExprColumnInOperand(expr Expression) Expression {
 
 // ColumnSubstitute substitutes the columns in filter to expressions in select fields.
 // e.g. select * from (select b as a from t) k where a < 10 => select * from (select b as a from t where b < 10) k.
+// TODO: remove this function and only use ColumnSubstituteImpl since this function swallows the error, which seems unsafe.
 func ColumnSubstitute(ctx sessionctx.Context, expr Expression, schema *Schema, newExprs []Expression) Expression {
 	_, _, resExpr := ColumnSubstituteImpl(ctx, expr, schema, newExprs, false)
 	return resExpr

--- a/pkg/planner/core/casetest/BUILD.bazel
+++ b/pkg/planner/core/casetest/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 18,
+    shard_count = 19,
     deps = [
         "//pkg/domain",
         "//pkg/parser",

--- a/pkg/planner/core/casetest/integration_test.go
+++ b/pkg/planner/core/casetest/integration_test.go
@@ -353,7 +353,7 @@ func TestIssue50926(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int)")
-	tk.MustExec("create or replace algorithm=undefined view v (a,b) AS select 1 as a, json_object('k', '0') as b from t")
+	tk.MustExec("create or replace definer='root'@'localhost' view v (a,b) AS select 1 as a, json_object('k', '0') as b from t")
 	tk.MustQuery("select sum(json_extract(b, '$.path')) from v group by a").Check(testkit.Rows()) // no error
 }
 

--- a/pkg/planner/core/casetest/integration_test.go
+++ b/pkg/planner/core/casetest/integration_test.go
@@ -348,6 +348,15 @@ func TestTiFlashFineGrainedShuffle(t *testing.T) {
 	}
 }
 
+func TestIssue50926(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("create or replace algorithm=undefined view v (a,b) AS select 1 as a, json_object('k', '0') as b from t")
+	tk.MustQuery("select sum(json_extract(b, '$.path')) from v group by a").Check(testkit.Rows()) // no error
+}
+
 func TestFixControl45132(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/rule_aggregation_push_down.go
+++ b/pkg/planner/core/rule_aggregation_push_down.go
@@ -560,7 +560,7 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan, opt *logicalOptim
 				for _, gbyItem := range agg.GroupByItems {
 					_, failed, groupBy := expression.ColumnSubstituteImpl(ctx, gbyItem, proj.schema, proj.Exprs, true)
 					if failed {
-						return p, nil
+						noSideEffects = false
 					}
 					newGbyItems = append(newGbyItems, groupBy)
 					if ExprsHasSideEffects(newGbyItems) {
@@ -579,7 +579,7 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan, opt *logicalOptim
 						for _, arg := range aggFunc.Args {
 							_, failed, newArg := expression.ColumnSubstituteImpl(ctx, arg, proj.schema, proj.Exprs, true)
 							if failed {
-								return p, nil
+								noSideEffects = false
 							}
 							newArgs = append(newArgs, newArg)
 						}
@@ -595,7 +595,7 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan, opt *logicalOptim
 							for _, oby := range aggFunc.OrderByItems {
 								_, failed, byItem := expression.ColumnSubstituteImpl(ctx, oby.Expr, proj.schema, proj.Exprs, true)
 								if failed {
-									return p, nil
+									noSideEffects = false
 								}
 								newOrderByItems = append(newOrderByItems, byItem)
 							}

--- a/pkg/planner/core/rule_aggregation_push_down.go
+++ b/pkg/planner/core/rule_aggregation_push_down.go
@@ -561,6 +561,7 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan, opt *logicalOptim
 					_, failed, groupBy := expression.ColumnSubstituteImpl(ctx, gbyItem, proj.schema, proj.Exprs, true)
 					if failed {
 						noSideEffects = false
+						break
 					}
 					newGbyItems = append(newGbyItems, groupBy)
 					if ExprsHasSideEffects(newGbyItems) {
@@ -580,6 +581,7 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan, opt *logicalOptim
 							_, failed, newArg := expression.ColumnSubstituteImpl(ctx, arg, proj.schema, proj.Exprs, true)
 							if failed {
 								noSideEffects = false
+								break
 							}
 							newArgs = append(newArgs, newArg)
 						}
@@ -596,6 +598,7 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan, opt *logicalOptim
 								_, failed, byItem := expression.ColumnSubstituteImpl(ctx, oby.Expr, proj.schema, proj.Exprs, true)
 								if failed {
 									noSideEffects = false
+									break
 								}
 								newOrderByItems = append(newOrderByItems, byItem)
 							}
@@ -616,6 +619,9 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan, opt *logicalOptim
 					}
 				}
 				for i, funcsArgs := range oldAggFuncsArgs {
+					if !noSideEffects {
+						break
+					}
 					for j := range funcsArgs {
 						if oldAggFuncsArgs[i][j].GetType().EvalType() != newAggFuncsArgs[i][j].GetType().EvalType() {
 							noSideEffects = false
@@ -631,9 +637,6 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan, opt *logicalOptim
 							noSideEffects = false
 							break
 						}
-					}
-					if !noSideEffects {
-						break
 					}
 				}
 				if noSideEffects {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50926

Problem Summary: planner: stop pushing Agg down through Projection if substitution fail

### What changed and how does it work?

planner: stop pushing Agg down through Projection if substitution fail

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
