### PR TITLE
codec: fix row codec unit test on timestamp cannot pass caused by local time zone not utc

### DIFF
--- a/pkg/util/rowcodec/rowcodec_test.go
+++ b/pkg/util/rowcodec/rowcodec_test.go
@@ -863,6 +863,10 @@ func TestColumnEncode(t *testing.T) {
 	encodeBytes := func(v []byte) []byte {
 		return append(binary.LittleEndian.AppendUint32(nil, uint32(len(v))), v...)
 	}
+	convertTZ := func(ts types.Time) types.Time {
+		require.NoError(t, ts.ConvertTimeZone(time.Local, time.UTC))
+		return ts
+	}
 	var (
 		buf     = make([]byte, 0, 128)
 		intZero = 0
@@ -982,25 +986,25 @@ func TestColumnEncode(t *testing.T) {
 		{
 			"timestamp", types.NewFieldType(mysql.TypeTimestamp),
 			types.NewTimeDatum(types.NewTime(ct, mysql.TypeTimestamp, 3)),
-			encodeBytes([]byte(types.NewTime(ct, mysql.TypeTimestamp, 3).String())),
+			encodeBytes([]byte(convertTZ(types.NewTime(ct, mysql.TypeTimestamp, 3)).String())),
 			true,
 		},
 		{
 			"timestamp/zero", types.NewFieldType(mysql.TypeTimestamp),
 			types.NewTimeDatum(types.ZeroTimestamp),
-			encodeBytes([]byte(types.ZeroTimestamp.String())),
+			encodeBytes([]byte(convertTZ(types.ZeroTimestamp).String())),
 			true,
 		},
 		{
 			"timestamp/min", types.NewFieldType(mysql.TypeTimestamp),
 			types.NewTimeDatum(types.MinTimestamp),
-			encodeBytes([]byte(types.MinTimestamp.String())),
+			encodeBytes([]byte(convertTZ(types.MinTimestamp).String())),
 			true,
 		},
 		{
 			"timestamp/max", types.NewFieldType(mysql.TypeTimestamp),
 			types.NewTimeDatum(types.MaxTimestamp),
-			encodeBytes([]byte(types.MaxTimestamp.String())),
+			encodeBytes([]byte(convertTZ(types.MaxTimestamp).String())),
 			true,
 		},
 		{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50851

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
