### PR TITLE
planner: fix incorrect tableDual plan caused by comparing year with big value

### DIFF
--- a/pkg/planner/core/casetest/BUILD.bazel
+++ b/pkg/planner/core/casetest/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 19,
+    shard_count = 20,
     deps = [
         "//pkg/domain",
         "//pkg/parser",

--- a/pkg/planner/core/casetest/stats_test.go
+++ b/pkg/planner/core/casetest/stats_test.go
@@ -151,3 +151,23 @@ func TestNDVGroupCols(t *testing.T) {
 		tk.MustQuery("explain format = 'brief' " + tt).Check(testkit.Rows(output[i].Plan...))
 	}
 }
+
+func TestTest50235(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE tlff7fd271 (
+  col_45 bit(3) NOT NULL DEFAULT b'101',
+  col_46 year(4) NOT NULL DEFAULT '2016',
+  col_47 double NOT NULL DEFAULT '2508.393214016021',
+  col_48 timestamp NOT NULL DEFAULT '2025-11-27 00:00:00',
+  KEY idx_15 (col_45,col_47),
+  PRIMARY KEY (col_46,col_45,col_48) /*T![clustered_index] NONCLUSTERED */,
+  KEY idx_17 (col_45,col_46,col_47),
+  UNIQUE KEY idx_18 (col_45,col_48,col_46)
+);`)
+	tk.MustQuery("desc SELECT `tlff7fd271`.`col_46` AS `r0` FROM `tlff7fd271` where `col_46` <= 16212511333665770580;").Check(
+		testkit.Rows(
+			"IndexReader_6 3323.33 root  index:IndexRangeScan_5",
+			"└─IndexRangeScan_5 3323.33 cop[tikv] table:tlff7fd271, index:PRIMARY(col_46, col_45, col_48) range:[-inf,2155], keep order:false, stats:pseudo"))
+}

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1236,7 +1236,7 @@ func getPossibleAccessPaths(ctx PlanContext, tableHints *hint.PlanHints, indexHi
 
 func filterPathByIsolationRead(ctx PlanContext, paths []*util.AccessPath, tblName model.CIStr, dbName model.CIStr) ([]*util.AccessPath, error) {
 	// TODO: filter paths with isolation read locations.
-	if dbName.L == mysql.SystemDB {
+	if util2.IsSysDB(dbName.L) {
 		return paths, nil
 	}
 	isolationReadEngines := ctx.GetSessionVars().GetIsolationReadEngines()

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1236,7 +1236,7 @@ func getPossibleAccessPaths(ctx PlanContext, tableHints *hint.PlanHints, indexHi
 
 func filterPathByIsolationRead(ctx PlanContext, paths []*util.AccessPath, tblName model.CIStr, dbName model.CIStr) ([]*util.AccessPath, error) {
 	// TODO: filter paths with isolation read locations.
-	if util2.IsSysDB(dbName.L) {
+	if dbName.L == mysql.SystemDB {
 		return paths, nil
 	}
 	isolationReadEngines := ctx.GetSessionVars().GetIsolationReadEngines()

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -159,6 +159,10 @@ func (d *Datum) GetUint64() uint64 {
 // SetUint64 sets uint64 value.
 func (d *Datum) SetUint64(i uint64) {
 	d.k = KindUint64
+	if i > uint64(math.MaxInt64) {
+		d.i = math.MaxInt64
+		return
+	}
 	d.i = int64(i)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50235

Problem Summary:

When we parser the value from ast. we need to convert this value of uint64 into int64. so 
Overflow may occur during the conversion. Therefore, it is necessary to align with the upper and lower bounds.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
