### PR TITLE
expression: fix some failed tests in local env

### DIFF
--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -108,6 +108,7 @@ select * from t;`
 	loc, err := time.LoadLocation("Asia/Shanghai")
 	require.NoError(t, err)
 	sctx := mock.NewContext()
+	sctx.ResetSessionAndStmtTimeZone(loc)
 	sctx.GetSessionVars().TimeZone = loc
 	_, err = parseSlowLog(sctx, reader)
 	require.Error(t, err)
@@ -150,7 +151,7 @@ select * from t;`
 	loc, err := time.LoadLocation("Asia/Shanghai")
 	require.NoError(t, err)
 	ctx := mock.NewContext()
-	ctx.GetSessionVars().TimeZone = loc
+	ctx.ResetSessionAndStmtTimeZone(loc)
 	rows, err := parseSlowLog(ctx, reader)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
@@ -250,7 +251,7 @@ func TestParseSlowLogFileSerial(t *testing.T) {
 	loc, err := time.LoadLocation("Asia/Shanghai")
 	require.NoError(t, err)
 	ctx := mock.NewContext()
-	ctx.GetSessionVars().TimeZone = loc
+	ctx.ResetSessionAndStmtTimeZone(loc)
 	// test for bufio.Scanner: token too long.
 	slowLog := bytes.NewBufferString(
 		`# Time: 2019-04-28T15:24:04.309074+08:00
@@ -318,7 +319,7 @@ select * from t;`)
 	loc, err := time.LoadLocation("Asia/Shanghai")
 	require.NoError(t, err)
 	ctx := mock.NewContext()
-	ctx.GetSessionVars().TimeZone = loc
+	ctx.ResetSessionAndStmtTimeZone(loc)
 	_, err = parseSlowLog(ctx, scanner)
 	require.NoError(t, err)
 
@@ -459,7 +460,7 @@ select 7;`
 	loc, err := time.LoadLocation("Asia/Shanghai")
 	require.NoError(t, err)
 	sctx := mock.NewContext()
-	sctx.GetSessionVars().TimeZone = loc
+	sctx.ResetSessionAndStmtTimeZone(loc)
 	sctx.GetSessionVars().SlowQueryFile = fileName3
 	for i, cas := range cases {
 		extractor := &plannercore.SlowQueryExtractor{Enable: len(cas.startTime) > 0 && len(cas.endTime) > 0}
@@ -633,7 +634,7 @@ select 9;`
 	loc, err := time.LoadLocation("Asia/Shanghai")
 	require.NoError(t, err)
 	sctx := mock.NewContext()
-	sctx.GetSessionVars().TimeZone = loc
+	sctx.ResetSessionAndStmtTimeZone(loc)
 	sctx.GetSessionVars().SlowQueryFile = fileName3
 	for i, cas := range cases {
 		extractor := &plannercore.SlowQueryExtractor{Enable: len(cas.startTime) > 0 && len(cas.endTime) > 0, Desc: true}

--- a/pkg/executor/stmtsummary_test.go
+++ b/pkg/executor/stmtsummary_test.go
@@ -57,7 +57,8 @@ func TestStmtSummaryRetriverV2_TableStatementsSummary(t *testing.T) {
 
 	ctx := context.Background()
 	sctx := mock.NewContext()
-	sctx.GetSessionVars().TimeZone, _ = time.LoadLocation("Asia/Shanghai")
+	tz, _ := time.LoadLocation("Asia/Shanghai")
+	sctx.ResetSessionAndStmtTimeZone(tz)
 
 	var results [][]types.Datum
 	for {
@@ -99,7 +100,8 @@ func TestStmtSummaryRetriverV2_TableStatementsSummaryEvicted(t *testing.T) {
 
 	ctx := context.Background()
 	sctx := mock.NewContext()
-	sctx.GetSessionVars().TimeZone, _ = time.LoadLocation("Asia/Shanghai")
+	tz, _ := time.LoadLocation("Asia/Shanghai")
+	sctx.ResetSessionAndStmtTimeZone(tz)
 
 	var results [][]types.Datum
 	for {
@@ -167,7 +169,8 @@ func TestStmtSummaryRetriverV2_TableStatementsSummaryHistory(t *testing.T) {
 
 	ctx := context.Background()
 	sctx := mock.NewContext()
-	sctx.GetSessionVars().TimeZone, _ = time.LoadLocation("Asia/Shanghai")
+	tz, _ := time.LoadLocation("Asia/Shanghai")
+	sctx.ResetSessionAndStmtTimeZone(tz)
 
 	var results [][]types.Datum
 	for {

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -290,22 +290,9 @@ var (
 
 func TestCastFuncSig(t *testing.T) {
 	ctx := createContext(t)
-
+	ctx.ResetSessionAndStmtTimeZone(time.UTC)
 	sc := ctx.GetSessionVars().StmtCtx
-	originIgnoreTruncate := sc.TypeFlags().IgnoreTruncateErr()
-	originTZ := sc.TimeZone()
 	sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(true))
-	sc.SetTimeZone(time.UTC)
-	defer func() {
-		sc.SetTypeFlags(sc.TypeFlags().WithIgnoreTruncateErr(originIgnoreTruncate))
-		sc.SetTimeZone(originTZ)
-	}()
-
-	oldTypeFlags := sc.TypeFlags()
-	defer func() {
-		sc.SetTypeFlags(oldTypeFlags)
-	}()
-	sc.SetTypeFlags(oldTypeFlags.WithIgnoreTruncateErr(true))
 	var sig builtinFunc
 
 	durationColumn := &Column{RetType: types.NewFieldType(mysql.TypeDuration), Index: 0}
@@ -1307,12 +1294,7 @@ func TestWrapWithCastAsTypesClasses(t *testing.T) {
 
 func TestWrapWithCastAsTime(t *testing.T) {
 	ctx := createContext(t)
-	sc := ctx.GetSessionVars().StmtCtx
-	save := sc.TimeZone()
-	sc.SetTimeZone(time.UTC)
-	defer func() {
-		sc.SetTimeZone(save)
-	}()
+	ctx.ResetSessionAndStmtTimeZone(time.UTC)
 	cases := []struct {
 		expr Expression
 		tp   *types.FieldType

--- a/pkg/expression/context.go
+++ b/pkg/expression/context.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 // EvalContext is used to evaluate an expression
@@ -64,7 +65,11 @@ func errCtx(ctx EvalContext) errctx.Context {
 }
 
 func location(ctx EvalContext) *time.Location {
-	tc := ctx.GetSessionVars().StmtCtx.TypeCtx()
+	vars := ctx.GetSessionVars()
+	sc := vars.StmtCtx
+	tc := sc.TypeCtx()
+	intest.Assert(vars.Location() == sc.TimeZone())
+	intest.Assert(sc.TimeZone() == tc.Location())
 	return tc.Location()
 }
 

--- a/pkg/expression/helper_test.go
+++ b/pkg/expression/helper_test.go
@@ -87,7 +87,7 @@ func TestGetTimeValue(t *testing.T) {
 		Ret  any
 	}{
 		{"2012-12-12 00:00:00", "2012-12-12 00:00:00"},
-		{ast.CurrentTimestamp, time.Unix(1234, 0).Format(types.TimeFormat)},
+		{ast.CurrentTimestamp, time.Unix(1234, 0).In(ctx.GetSessionVars().TimeZone).Format(types.TimeFormat)},
 		{types.ZeroDatetimeStr, "0000-00-00 00:00:00"},
 		{ast.NewValueExpr("2012-12-12 00:00:00", charset.CharsetUTF8MB4, charset.CollationUTF8MB4), "2012-12-12 00:00:00"},
 		{ast.NewValueExpr(int64(0), "", ""), "0000-00-00 00:00:00"},

--- a/pkg/expression/main_test.go
+++ b/pkg/expression/main_test.go
@@ -63,7 +63,10 @@ func createContext(t *testing.T) *mock.Context {
 	require.NoError(t, err)
 	require.True(t, sqlMode.HasStrictMode())
 	ctx.GetSessionVars().SQLMode = sqlMode
-	ctx.GetSessionVars().StmtCtx.SetTimeZone(time.Local)
+	// sets default time zone to UTC+11 value to make it different with most CI and development environments and forbid
+	// some tests are success in some environments but failed in some others.
+	tz := time.FixedZone("UTC+11", 11*3600)
+	ctx.ResetSessionAndStmtTimeZone(tz)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.SetTypeFlags(sc.TypeFlags().WithTruncateAsWarning(true))
 	require.NoError(t, ctx.GetSessionVars().SetSystemVar("max_allowed_packet", "67108864"))

--- a/pkg/store/mockstore/mockcopr/cop_handler_dag.go
+++ b/pkg/store/mockstore/mockcopr/cop_handler_dag.go
@@ -467,6 +467,7 @@ func flagsAndTzToSessionContext(flags uint64, tz *time.Location) sessionctx.Cont
 	sc := stmtctx.NewStmtCtx()
 	sc.InitFromPBFlagAndTz(flags, tz)
 	sctx.GetSessionVars().StmtCtx = sc
+	sctx.GetSessionVars().TimeZone = tz
 	return sctx
 }
 

--- a/pkg/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/pkg/store/mockstore/unistore/cophandler/cop_handler.go
@@ -433,6 +433,7 @@ func flagsAndTzToSessionContext(flags uint64, tz *time.Location) sessionctx.Cont
 	sc.InitFromPBFlagAndTz(flags, tz)
 	sctx := mock.NewContext()
 	sctx.GetSessionVars().StmtCtx = sc
+	sctx.GetSessionVars().TimeZone = tz
 	return sctx
 }
 

--- a/pkg/table/column_test.go
+++ b/pkg/table/column_test.go
@@ -17,6 +17,7 @@ package table
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -335,8 +336,14 @@ func TestGetDefaultValue(t *testing.T) {
 	var nilDt types.Datum
 	nilDt.SetNull()
 	ctx := mock.NewContext()
+	tz, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+	ctx.ResetSessionAndStmtTimeZone(tz)
 	zeroTimestamp := types.ZeroTimestamp
 	timestampValue := types.NewTime(types.FromDate(2019, 5, 6, 12, 48, 49, 0), mysql.TypeTimestamp, types.DefaultFsp)
+	timestampValueUTC := types.NewTime(timestampValue.CoreTime(), timestampValue.Type(), timestampValue.Fsp())
+	err = timestampValueUTC.ConvertTimeZone(tz, time.UTC)
+	require.NoError(t, err)
 
 	tp0 := types.FieldType{}
 	tp0.SetType(mysql.TypeLonglong)
@@ -412,8 +419,9 @@ func TestGetDefaultValue(t *testing.T) {
 		{
 			&model.ColumnInfo{
 				FieldType:          tp3,
-				OriginDefaultValue: timestampValue.String(),
-				DefaultValue:       timestampValue.String(),
+				OriginDefaultValue: timestampValueUTC.String(),
+				DefaultValue:       timestampValueUTC.String(),
+				Version:            2,
 			},
 			true,
 			types.NewDatum(timestampValue),

--- a/pkg/table/column_test.go
+++ b/pkg/table/column_test.go
@@ -421,7 +421,7 @@ func TestGetDefaultValue(t *testing.T) {
 				FieldType:          tp3,
 				OriginDefaultValue: timestampValueUTC.String(),
 				DefaultValue:       timestampValueUTC.String(),
-				Version:            2,
+				Version:            model.ColumnInfoVersion2,
 			},
 			true,
 			types.NewDatum(timestampValue),

--- a/pkg/util/mock/context.go
+++ b/pkg/util/mock/context.go
@@ -456,6 +456,12 @@ func (c *Context) SetInfoSchema(is sessionctx.InfoschemaMetaVersion) {
 	c.is = is
 }
 
+// ResetSessionAndStmtTimeZone resets the timezone for session and statement.
+func (c *Context) ResetSessionAndStmtTimeZone(tz *time.Location) {
+	c.GetSessionVars().TimeZone = tz
+	c.GetSessionVars().StmtCtx.SetTimeZone(tz)
+}
+
 // ReportUsageStats implements the sessionctx.Context interface.
 func (*Context) ReportUsageStats() {}
 
@@ -479,6 +485,7 @@ func NewContext() *Context {
 	sctx.sessionVars = vars
 	vars.InitChunkSize = 2
 	vars.MaxChunkSize = 32
+	vars.TimeZone = time.UTC
 	vars.StmtCtx.SetTimeZone(time.UTC)
 	vars.MemTracker.SetBytesLimit(-1)
 	vars.DiskTracker.SetBytesLimit(-1)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50953

Problem Summary:

See issue. The failed test is caused by PR: #50530. In this PR, we unified the code to read the timezone info from `stmtctx.TimeZone`. In product environment, `sc.TimeZone` should be the same with `sessionVars.TimeZone`, but in some test cases, not all of them are set to a same value. So the some tests failed.

The reason why verify check success is because the remote machine is using UTC as the system timezone, but in local environment, it is not.

### What changed and how does it work?

1. Both set timezone to session variable and statement context in some tests.
2. For `createContext` in `expression.main_test.go`, we set the location to `UTC+11` to make the default time zone different with most CI and dev envrioments.
3. Add an assert in `location` method in `expression/context.go` to check these timezone info are all the same

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
