### PR TITLE
external: onefile writer should have onClose, and add KV count to WriteSummary

### DIFF
--- a/br/pkg/lightning/backend/external/merge_v2.go
+++ b/br/pkg/lightning/backend/external/merge_v2.go
@@ -77,10 +77,7 @@ func MergeOverlappingFilesV2(
 		SetPropKeysDistance(propKeysDist).
 		SetPropSizeDistance(propSizeDist).
 		SetOnCloseFunc(onClose).
-		BuildOneFile(
-			store,
-			newFilePrefix,
-			writerID)
+		BuildOneFile(store, newFilePrefix, writerID)
 	defer func() {
 		err = splitter.Close()
 		if err != nil {
@@ -102,7 +99,6 @@ func MergeOverlappingFilesV2(
 	loaded := &memKVsAndBuffers{}
 	curStart := kv.Key(startKey).Clone()
 	var curEnd kv.Key
-	var maxKey, minKey kv.Key
 
 	for {
 		endKeyOfGroup, dataFilesOfGroup, statFilesOfGroup, _, err1 := splitter.SplitOneRangesGroup()
@@ -159,10 +155,6 @@ func MergeOverlappingFilesV2(
 			zap.Duration("write time", writeTime),
 			zap.Int("key len", len(loaded.keys)))
 
-		if len(minKey) == 0 {
-			minKey = kv.Key(loaded.keys[0]).Clone()
-		}
-		maxKey = kv.Key(loaded.keys[len(loaded.keys)-1]).Clone()
 		curStart = curEnd.Clone()
 		loaded.keys = nil
 		loaded.values = nil
@@ -171,22 +163,6 @@ func MergeOverlappingFilesV2(
 		if len(endKeyOfGroup) == 0 {
 			break
 		}
-	}
-
-	var stat MultipleFilesStat
-	stat.Filenames = append(stat.Filenames,
-		[2]string{writer.dataFile, writer.statFile})
-
-	stat.build([]kv.Key{minKey}, []kv.Key{curEnd})
-	if onClose != nil {
-		onClose(&WriterSummary{
-			WriterID:           writer.writerID,
-			Seq:                0,
-			Min:                minKey,
-			Max:                maxKey,
-			TotalSize:          writer.totalSize,
-			MultipleFilesStats: []MultipleFilesStat{stat},
-		})
 	}
 	return
 }

--- a/br/pkg/lightning/backend/external/onefile_writer_test.go
+++ b/br/pkg/lightning/backend/external/onefile_writer_test.go
@@ -343,6 +343,7 @@ func TestOnefileWriterManyRows(t *testing.T) {
 	require.Equal(t, expected.Filenames, resSummary.MultipleFilesStats[0].Filenames)
 	require.Equal(t, expected.MaxOverlappingNum, resSummary.MultipleFilesStats[0].MaxOverlappingNum)
 	require.EqualValues(t, expectedTotalSize, resSummary.TotalSize)
+	require.EqualValues(t, kvCnt, resSummary.TotalCnt)
 }
 
 func TestOnefilePropOffset(t *testing.T) {

--- a/br/pkg/lightning/backend/external/util.go
+++ b/br/pkg/lightning/backend/external/util.go
@@ -244,6 +244,7 @@ type SortedKVMeta struct {
 	StartKey           []byte              `json:"start-key"`
 	EndKey             []byte              `json:"end-key"` // exclusive
 	TotalKVSize        uint64              `json:"total-kv-size"`
+	TotalKVCnt         uint64              `json:"total-kv-cnt"`
 	MultipleFilesStats []MultipleFilesStat `json:"multiple-files-stats"`
 }
 
@@ -257,6 +258,7 @@ func NewSortedKVMeta(summary *WriterSummary) *SortedKVMeta {
 		StartKey:           summary.Min.Clone(),
 		EndKey:             summary.Max.Clone().Next(),
 		TotalKVSize:        summary.TotalSize,
+		TotalKVCnt:         summary.TotalCnt,
 		MultipleFilesStats: summary.MultipleFilesStats,
 	}
 }
@@ -274,6 +276,7 @@ func (m *SortedKVMeta) Merge(other *SortedKVMeta) {
 	m.StartKey = BytesMin(m.StartKey, other.StartKey)
 	m.EndKey = BytesMax(m.EndKey, other.EndKey)
 	m.TotalKVSize += other.TotalKVSize
+	m.TotalKVCnt += other.TotalKVCnt
 
 	m.MultipleFilesStats = append(m.MultipleFilesStats, other.MultipleFilesStats...)
 }

--- a/pkg/disttask/importinto/BUILD.bazel
+++ b/pkg/disttask/importinto/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//br/pkg/lightning/metric",
         "//br/pkg/lightning/mydump",
         "//br/pkg/lightning/verification",
+        "//br/pkg/logutil",
         "//br/pkg/storage",
         "//br/pkg/utils",
         "//pkg/disttask/framework/handle",

--- a/pkg/disttask/importinto/task_executor.go
+++ b/pkg/disttask/importinto/task_executor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
 	"github.com/pingcap/tidb/br/pkg/lightning/metric"
 	"github.com/pingcap/tidb/br/pkg/lightning/verification"
+	brlogutil "github.com/pingcap/tidb/br/pkg/logutil"
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor"
 	"github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/execute"
@@ -308,7 +309,7 @@ func (m *mergeSortStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 
 	logger.Info("merge sort partSize", zap.String("size", units.BytesSize(float64(m.partSize))))
 
-	return external.MergeOverlappingFiles(
+	err = external.MergeOverlappingFiles(
 		logutil.WithFields(ctx, zap.String("kv-group", sm.KVGroup), zap.Int64("subtask-id", subtask.ID)),
 		sm.DataFiles,
 		m.controller.GlobalSortStore,
@@ -323,6 +324,15 @@ func (m *mergeSortStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 		onClose,
 		m.taskMeta.Plan.ThreadCnt,
 		false)
+	logger.Info(
+		"merge sort finished",
+		zap.String("kv-group", sm.KVGroup),
+		zap.Uint64("total-kv-size", m.subtaskSortedKVMeta.TotalKVSize),
+		zap.Uint64("total-kv-count", m.subtaskSortedKVMeta.TotalKVCnt),
+		brlogutil.Key("start-key", m.subtaskSortedKVMeta.StartKey),
+		brlogutil.Key("end-key", m.subtaskSortedKVMeta.EndKey),
+	)
+	return err
 }
 
 func (m *mergeSortStepExecutor) OnFinished(_ context.Context, subtask *proto.Subtask) error {

--- a/pkg/disttask/importinto/task_executor.go
+++ b/pkg/disttask/importinto/task_executor.go
@@ -309,7 +309,7 @@ func (m *mergeSortStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 	logger.Info("merge sort partSize", zap.String("size", units.BytesSize(float64(m.partSize))))
 
 	return external.MergeOverlappingFiles(
-		ctx,
+		logutil.WithFields(ctx, zap.String("kv-group", sm.KVGroup), zap.Int64("subtask-id", subtask.ID)),
 		sm.DataFiles,
 		m.controller.GlobalSortStore,
 		m.partSize,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50832

Problem Summary:

### What changed and how does it work?

as title

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
