### PR TITLE
[DNM]: Revert "makefile: simplify code" to Test the execution time of bazel ut.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -130,4 +130,5 @@ ifneq ("$(CI)", "")
 	BAZEL_CMD_CONFIG := --config=ci --repository_cache=/home/jenkins/.tidb/tmp
 	BAZEL_SYNC_CONFIG := --repository_cache=/home/jenkins/.tidb/tmp
 endif
-BAZEL_INSTRUMENTATION_FILTER := --instrument_test_targets --instrumentation_filter=//pkg/...,//br/...,//dumpling/...
+BAZEL_INSTRUMENTATION_FILTER_PACKAGE := go list ./...| sed 's/github.com\/pingcap\/tidb//g'
+BAZEL_INSTRUMENTATION_FILTER := --instrument_test_targets --instrumentation_filter='${BAZEL_INSTRUMENTATION_FILTER_PACKAGE}'

--- a/tests/realtikvtest/brietest/BUILD.bazel
+++ b/tests/realtikvtest/brietest/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "brietest_test",
-    timeout = "long",
+    timeout = "moderate",
     srcs = [
         "backup_restore_test.go",
         "binlog_test.go",


### PR DESCRIPTION
Reverts pingcap/tidb#50054

Test the execution time of bazel ut to confirm whether it has caused an increase in UT execution time.