### PR TITLE
ddl: table meta should store column without db and table name

### DIFF
--- a/pkg/ddl/constraint.go
+++ b/pkg/ddl/constraint.go
@@ -314,7 +314,7 @@ func buildConstraintInfo(tblInfo *model.TableInfo, dependedCols []model.CIStr, c
 	// Restore check constraint expression to string.
 	var sb strings.Builder
 	restoreFlags := format.RestoreStringSingleQuotes | format.RestoreKeyWordLowercase | format.RestoreNameBackQuotes |
-		format.RestoreSpacesAroundBinaryOperation
+		format.RestoreSpacesAroundBinaryOperation | format.RestoreWithoutSchemaName | format.RestoreWithoutTableName
 	restoreCtx := format.NewRestoreCtx(restoreFlags, &sb)
 
 	sb.Reset()

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -2304,7 +2304,7 @@ func checkTableInfoValidWithStmt(ctx sessionctx.Context, tbInfo *model.TableInfo
 			return errors.Trace(err)
 		}
 		if s.Partition != nil {
-			if err := checkPartitionFuncType(ctx, s.Partition.Expr, tbInfo); err != nil {
+			if err := checkPartitionFuncType(ctx, s.Partition.Expr, s.Table.Schema, tbInfo); err != nil {
 				return errors.Trace(err)
 			}
 			if err := checkPartitioningKeysConstraints(ctx, s, tbInfo); err != nil {

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -560,7 +560,9 @@ func buildTablePartitionInfo(ctx sessionctx.Context, s *ast.PartitionOptions, tb
 			return errors.Trace(err)
 		}
 		buf := new(bytes.Buffer)
-		restoreCtx := format.NewRestoreCtx(format.DefaultRestoreFlags|format.RestoreBracketAroundBinaryOperation, buf)
+		restoreFlags := format.DefaultRestoreFlags | format.RestoreBracketAroundBinaryOperation |
+			format.RestoreWithoutSchemaName | format.RestoreWithoutTableName
+		restoreCtx := format.NewRestoreCtx(restoreFlags, buf)
 		if err := s.Expr.Restore(restoreCtx); err != nil {
 			return err
 		}
@@ -1578,12 +1580,21 @@ func checkResultOK(ok bool) error {
 }
 
 // checkPartitionFuncType checks partition function return type.
-func checkPartitionFuncType(ctx sessionctx.Context, expr ast.ExprNode, tblInfo *model.TableInfo) error {
+func checkPartitionFuncType(ctx sessionctx.Context, expr ast.ExprNode, dbName model.CIStr, tblInfo *model.TableInfo) error {
 	if expr == nil {
 		return nil
 	}
 
-	e, err := expression.RewriteSimpleExprWithTableInfo(ctx, tblInfo, expr, false)
+	if dbName.L == "" {
+		dbName = model.NewCIStr(ctx.GetSessionVars().CurrentDB)
+	}
+
+	columns, names, err := expression.ColumnInfos2ColumnsAndNames(ctx, dbName, tblInfo.Name, tblInfo.Cols(), tblInfo)
+	if err != nil {
+		return err
+	}
+
+	e, err := expression.RewriteAstExpr(ctx, expr, expression.NewSchema(columns...), names, false)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/tests/integrationtest/r/ddl/constraint.result
+++ b/tests/integrationtest/r/ddl/constraint.result
@@ -821,4 +821,22 @@ Table	Create Table
 t	CREATE TABLE `t` (
   `a` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+set @@global.tidb_enable_check_constraint = 1;
+drop table if exists t;
+create table t(a int, check((test.t.a > 1)));
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int(11) DEFAULT NULL,
+CONSTRAINT `t_chk_1` CHECK (((`a` > 1)))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+alter table t add constraint chk check((test.t.a < 100));
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int(11) DEFAULT NULL,
+CONSTRAINT `t_chk_1` CHECK (((`a` > 1))),
+CONSTRAINT `chk` CHECK (((`a` < 100)))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+drop table if exists t;
 set @@global.tidb_enable_check_constraint = 0;

--- a/tests/integrationtest/r/ddl/partition.result
+++ b/tests/integrationtest/r/ddl/partition.result
@@ -177,3 +177,55 @@ t	CREATE TABLE `t` (
   KEY `b` (`b`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 PARTITION BY KEY (`a`) PARTITIONS 5
+drop table if exists test.issue50972_1, test.issue50972_2, test.issue50972_3;
+CREATE TABLE test.issue50972_1 (id1 int) PARTITION BY HASH( test.issue50972_1.id1 ) PARTITIONS 4;
+CREATE TABLE test.issue50972_2 (id2 int) PARTITION BY RANGE (test.issue50972_2.id2) ( PARTITION p0 VALUES LESS THAN (6));
+CREATE TABLE test.issue50972_3 (id3 int) PARTITION BY LIST (test.issue50972_3.id3) ( PARTITION p0 VALUES IN (1, 2) );
+show create table test.issue50972_1;
+Table	Create Table
+issue50972_1	CREATE TABLE `issue50972_1` (
+  `id1` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY HASH (`id1`) PARTITIONS 4
+show create table test.issue50972_2;
+Table	Create Table
+issue50972_2	CREATE TABLE `issue50972_2` (
+  `id2` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE (`id2`)
+(PARTITION `p0` VALUES LESS THAN (6))
+show create table test.issue50972_3;
+Table	Create Table
+issue50972_3	CREATE TABLE `issue50972_3` (
+  `id3` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY LIST (`id3`)
+(PARTITION `p0` VALUES IN (1,2))
+drop table if exists test.issue50972_1, test.issue50972_2, test.issue50972_3;
+CREATE TABLE test.issue50972_1 (id1 int);
+CREATE TABLE test.issue50972_2 (id2 int);
+CREATE TABLE test.issue50972_3 (id3 int);
+ALTER TABLE test.issue50972_1 PARTITION BY HASH( test.issue50972_1.id1 ) PARTITIONS 4;
+ALTER TABLE test.issue50972_2 PARTITION BY RANGE (test.issue50972_2.id2) ( PARTITION p0 VALUES LESS THAN (6));
+ALTER TABLE test.issue50972_3 PARTITION BY LIST (test.issue50972_3.id3) ( PARTITION p0 VALUES IN (1, 2) );
+show create table test.issue50972_1;
+Table	Create Table
+issue50972_1	CREATE TABLE `issue50972_1` (
+  `id1` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY HASH (`id1`) PARTITIONS 4
+show create table test.issue50972_2;
+Table	Create Table
+issue50972_2	CREATE TABLE `issue50972_2` (
+  `id2` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE (`id2`)
+(PARTITION `p0` VALUES LESS THAN (6))
+show create table test.issue50972_3;
+Table	Create Table
+issue50972_3	CREATE TABLE `issue50972_3` (
+  `id3` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY LIST (`id3`)
+(PARTITION `p0` VALUES IN (1,2))
+drop table if exists test.issue50972_1, test.issue50972_2, test.issue50972_3;

--- a/tests/integrationtest/t/ddl/constraint.test
+++ b/tests/integrationtest/t/ddl/constraint.test
@@ -676,4 +676,13 @@ show create table t;
 alter table t drop CONSTRAINT chk;
 show create table t;
 
+# Related issue TiDB#50972, constraint expression should ignore schema and table name when restore
+set @@global.tidb_enable_check_constraint = 1;
+drop table if exists t;
+create table t(a int, check((test.t.a > 1)));
+show create table t;
+alter table t add constraint chk check((test.t.a < 100));
+show create table t;
+drop table if exists t;
+
 set @@global.tidb_enable_check_constraint = 0;

--- a/tests/integrationtest/t/ddl/partition.test
+++ b/tests/integrationtest/t/ddl/partition.test
@@ -135,3 +135,23 @@ show create table t;
 alter table t partition by key(a) partitions 5;
 show create table t;
 
+# Related issue TiDB#50972, partition expression should ignore schema and table name when restore
+drop table if exists test.issue50972_1, test.issue50972_2, test.issue50972_3;
+CREATE TABLE test.issue50972_1 (id1 int) PARTITION BY HASH( test.issue50972_1.id1 ) PARTITIONS 4;
+CREATE TABLE test.issue50972_2 (id2 int) PARTITION BY RANGE (test.issue50972_2.id2) ( PARTITION p0 VALUES LESS THAN (6));
+CREATE TABLE test.issue50972_3 (id3 int) PARTITION BY LIST (test.issue50972_3.id3) ( PARTITION p0 VALUES IN (1, 2) );
+show create table test.issue50972_1;
+show create table test.issue50972_2;
+show create table test.issue50972_3;
+drop table if exists test.issue50972_1, test.issue50972_2, test.issue50972_3;
+CREATE TABLE test.issue50972_1 (id1 int);
+CREATE TABLE test.issue50972_2 (id2 int);
+CREATE TABLE test.issue50972_3 (id3 int);
+ALTER TABLE test.issue50972_1 PARTITION BY HASH( test.issue50972_1.id1 ) PARTITIONS 4;
+ALTER TABLE test.issue50972_2 PARTITION BY RANGE (test.issue50972_2.id2) ( PARTITION p0 VALUES LESS THAN (6));
+ALTER TABLE test.issue50972_3 PARTITION BY LIST (test.issue50972_3.id3) ( PARTITION p0 VALUES IN (1, 2) );
+show create table test.issue50972_1;
+show create table test.issue50972_2;
+show create table test.issue50972_3;
+drop table if exists test.issue50972_1, test.issue50972_2, test.issue50972_3;
+


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50972

### What changed and how does it work?

When storing an expression in table meta, the column name should be restored without db and table name to make sure the meta is still valid after renaming a table.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix a issue that some DDL will hang in some some cases.
```
