### PR TITLE
br: make log command visible in cli

### DIFF
--- a/br/cmd/br/stream.go
+++ b/br/cmd/br/stream.go
@@ -57,7 +57,7 @@ func NewStreamCommand() *cobra.Command {
 		command.Root().HelpFunc()(command, strings)
 	})
 
-	command.Hidden = true
+	command.Hidden = false
 	return command
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50927 

Problem Summary:

The command was set `hidden`, now it has been set visible.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->
- [x] Manual test (add detailed scripts or steps below)
![image](https://github.com/pingcap/tidb/assets/79858083/263bf696-2f26-4ef4-a14c-24602c77e045)

  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Now the candidate command "log" in br is visible in help.
```
