### PR TITLE
external: use 2 membuf pools of difference block size

### DIFF
--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -759,14 +759,15 @@ func TestReadAllData(t *testing.T) {
 	// 1000 files read one KV (~100B), 1000 files read ~900KB, 90 files read 10MB,
 	// 1 file read 1G. total read size = 1000*100B + 1000*900KB + 90*10MB + 1*1G = 2.8G
 
+	ctx := context.Background()
 	store := openTestingStorage(t)
+	cleanOldFiles(ctx, store, "/")
+
 	readRangeStart := []byte("key0")
 	readRangeEnd := []byte("key88888888")
 	keyAfterRange := []byte("key9")
 	keyAfterRange2 := []byte("key9")
-
-	ctx := context.Background()
-
+	
 	fileIdx := 0
 	val := make([]byte, 90)
 	eg := errgroup.Group{}

--- a/br/pkg/lightning/backend/external/bench_test.go
+++ b/br/pkg/lightning/backend/external/bench_test.go
@@ -657,14 +657,18 @@ func TestReadAllDataLargeFiles(t *testing.T) {
 	intest.AssertNoError(err)
 	endKey, err := hex.DecodeString("00a00000000000000000")
 	intest.AssertNoError(err)
-	bufPool := membuf.NewPool(
+	smallBlockBufPool := membuf.NewPool(
+		membuf.WithBlockNum(0),
+		membuf.WithBlockSize(smallBlockSize),
+	)
+	largeBlockBufPool := membuf.NewPool(
 		membuf.WithBlockNum(0),
 		membuf.WithBlockSize(ConcurrentReaderBufferSizePerConc),
 	)
 	output := &memKVsAndBuffers{}
 	now := time.Now()
 
-	err = readAllData(ctx, store, dataFiles, statFiles, startKey, endKey, bufPool, output)
+	err = readAllData(ctx, store, dataFiles, statFiles, startKey, endKey, smallBlockBufPool, largeBlockBufPool, output)
 	t.Logf("read all data cost: %s", time.Since(now))
 	intest.AssertNoError(err)
 }
@@ -806,14 +810,18 @@ finishCreateFiles:
 	require.Equal(t, 2091, len(dataFiles))
 
 	p := newProfiler(true, true)
-	bufPool := membuf.NewPool(
+	smallBlockBufPool := membuf.NewPool(
+		membuf.WithBlockNum(0),
+		membuf.WithBlockSize(smallBlockSize),
+	)
+	largeBlockBufPool := membuf.NewPool(
 		membuf.WithBlockNum(0),
 		membuf.WithBlockSize(ConcurrentReaderBufferSizePerConc),
 	)
 	output := &memKVsAndBuffers{}
 	p.beforeTest()
 	now := time.Now()
-	err = readAllData(ctx, store, dataFiles, statFiles, readRangeStart, readRangeEnd, bufPool, output)
+	err = readAllData(ctx, store, dataFiles, statFiles, readRangeStart, readRangeEnd, smallBlockBufPool, largeBlockBufPool, output)
 	require.NoError(t, err)
 	output.build(ctx)
 	elapsed := time.Since(now)

--- a/br/pkg/lightning/backend/external/byte_reader.go
+++ b/br/pkg/lightning/backend/external/byte_reader.go
@@ -31,7 +31,10 @@ import (
 var (
 	// ConcurrentReaderBufferSizePerConc is the buffer size for concurrent reader per
 	// concurrency.
-	ConcurrentReaderBufferSizePerConc = int(2 * size.MB)
+	ConcurrentReaderBufferSizePerConc = int(8 * size.MB)
+	// in readAllData, expected concurrency less than this value will not use
+	// concurrent reader.
+	readAllDataConcThreshold = uint64(4)
 )
 
 // byteReader provides structured reading on a byte stream of external storage.

--- a/br/pkg/lightning/backend/external/byte_reader.go
+++ b/br/pkg/lightning/backend/external/byte_reader.go
@@ -32,7 +32,6 @@ var (
 	// ConcurrentReaderBufferSizePerConc is the buffer size for concurrent reader per
 	// concurrency.
 	ConcurrentReaderBufferSizePerConc = int(2 * size.MB)
-	readAllDataConcThreshold          = uint64(16)
 )
 
 // byteReader provides structured reading on a byte stream of external storage.

--- a/br/pkg/lightning/backend/external/merge_v2.go
+++ b/br/pkg/lightning/backend/external/merge_v2.go
@@ -119,6 +119,7 @@ func MergeOverlappingFilesV2(
 			curStart,
 			curEnd,
 			bufPool,
+			bufPool,
 			loaded,
 		)
 		if err1 != nil {

--- a/br/pkg/lightning/backend/external/reader.go
+++ b/br/pkg/lightning/backend/external/reader.go
@@ -35,7 +35,8 @@ func readAllData(
 	store storage.ExternalStorage,
 	dataFiles, statsFiles []string,
 	startKey, endKey []byte,
-	bufPool *membuf.Pool,
+	smallBlockBufPool *membuf.Pool,
+	largeBlockBufPool *membuf.Pool,
 	output *memKVsAndBuffers,
 ) (err error) {
 	task := log.BeginTask(logutil.Logger(ctx), "read all data")
@@ -80,8 +81,8 @@ func readAllData(
 	for readIdx := 0; readIdx < readConn; readIdx++ {
 		readIdx := readIdx
 		eg.Go(func() error {
-			output.memKVBuffers[readIdx] = bufPool.NewBuffer()
-			output.memKVBuffers[readIdx+readConn] = bufPool.NewBuffer()
+			output.memKVBuffers[readIdx] = smallBlockBufPool.NewBuffer()
+			output.memKVBuffers[readIdx+readConn] = largeBlockBufPool.NewBuffer()
 			smallBlockBuf := output.memKVBuffers[readIdx]
 			largeBlockBuf := output.memKVBuffers[readIdx+readConn]
 

--- a/br/pkg/lightning/backend/external/reader.go
+++ b/br/pkg/lightning/backend/external/reader.go
@@ -76,6 +76,7 @@ func readAllData(
 
 	eg, egCtx := util.NewErrorGroupWithRecoverWithCtx(ctx)
 	readConn := 1000
+	readConn = min(readConn, len(dataFiles))
 	taskCh := make(chan int)
 	output.memKVBuffers = make([]*membuf.Buffer, readConn*2)
 	for readIdx := 0; readIdx < readConn; readIdx++ {

--- a/br/pkg/lightning/backend/external/reader.go
+++ b/br/pkg/lightning/backend/external/reader.go
@@ -69,36 +69,58 @@ func readAllData(
 		startKey,
 		endKey,
 	)
-	// TODO(lance6716): refine adjust concurrency
-	for i, c := range concurrences {
-		if c < readAllDataConcThreshold {
-			concurrences[i] = 1
-		}
-	}
-
 	if err != nil {
 		return err
 	}
+
 	eg, egCtx := util.NewErrorGroupWithRecoverWithCtx(ctx)
-	// limit the concurrency to avoid open too many connections at the same time
-	eg.SetLimit(1000)
-	for i := range dataFiles {
-		i := i
+	readConn := 1000
+	taskCh := make(chan int)
+	output.memKVBuffers = make([]*membuf.Buffer, readConn*2)
+	for readIdx := 0; readIdx < readConn; readIdx++ {
+		readIdx := readIdx
 		eg.Go(func() error {
-			err2 := readOneFile(
-				egCtx,
-				store,
-				dataFiles[i],
-				startKey,
-				endKey,
-				startOffsets[i],
-				concurrences[i],
-				bufPool,
-				output,
-			)
-			return errors.Annotatef(err2, "failed to read file %s", dataFiles[i])
+			output.memKVBuffers[readIdx] = bufPool.NewBuffer()
+			output.memKVBuffers[readIdx+readConn] = bufPool.NewBuffer()
+			smallBlockBuf := output.memKVBuffers[readIdx]
+			largeBlockBuf := output.memKVBuffers[readIdx+readConn]
+
+			for {
+				select {
+				case <-egCtx.Done():
+					return egCtx.Err()
+				case fileIdx, ok := <-taskCh:
+					if !ok {
+						return nil
+					}
+					err2 := readOneFile(
+						egCtx,
+						store,
+						dataFiles[fileIdx],
+						startKey,
+						endKey,
+						startOffsets[fileIdx],
+						concurrences[fileIdx],
+						smallBlockBuf,
+						largeBlockBuf,
+						output,
+					)
+					if err2 != nil {
+						return errors.Annotatef(err2, "failed to read file %s", dataFiles[fileIdx])
+					}
+				}
+			}
 		})
 	}
+
+	for fileIdx := range dataFiles {
+		select {
+		case <-egCtx.Done():
+			return eg.Wait()
+		case taskCh <- fileIdx:
+		}
+	}
+	close(taskCh)
 	return eg.Wait()
 }
 
@@ -109,7 +131,8 @@ func readOneFile(
 	startKey, endKey []byte,
 	startOffset uint64,
 	concurrency uint64,
-	bufPool *membuf.Pool,
+	smallBlockBuf *membuf.Buffer,
+	largeBlockBuf *membuf.Buffer,
 	output *memKVsAndBuffers,
 ) error {
 	readAndSortDurHist := metrics.GlobalSortReadFromCloudStorageDuration.WithLabelValues("read_one_file")
@@ -127,7 +150,7 @@ func readOneFile(
 			dataFile,
 			int(concurrency),
 			ConcurrentReaderBufferSizePerConc,
-			bufPool.NewBuffer(),
+			largeBlockBuf,
 		)
 		err = rd.byteReader.switchConcurrentMode(true)
 		if err != nil {
@@ -135,8 +158,6 @@ func readOneFile(
 		}
 	}
 
-	// this buffer is associated with data slices and will return to caller
-	memBuf := bufPool.NewBuffer()
 	keys := make([][]byte, 0, 1024)
 	values := make([][]byte, 0, 1024)
 	size := 0
@@ -159,15 +180,14 @@ func readOneFile(
 		}
 		// TODO(lance6716): we are copying every KV from rd's buffer to memBuf, can we
 		// directly read into memBuf?
-		keys = append(keys, memBuf.AddBytes(k))
-		values = append(values, memBuf.AddBytes(v))
+		keys = append(keys, smallBlockBuf.AddBytes(k))
+		values = append(values, smallBlockBuf.AddBytes(v))
 		size += len(k) + len(v)
 	}
 	readAndSortDurHist.Observe(time.Since(ts).Seconds())
 	output.mu.Lock()
 	output.keysPerFile = append(output.keysPerFile, keys)
 	output.valuesPerFile = append(output.valuesPerFile, values)
-	output.memKVBuffers = append(output.memKVBuffers, memBuf)
 	output.size += size
 	output.droppedSizePerFile = append(output.droppedSizePerFile, droppedSize)
 	output.mu.Unlock()

--- a/br/pkg/lightning/backend/external/reader_test.go
+++ b/br/pkg/lightning/backend/external/reader_test.go
@@ -139,7 +139,11 @@ func TestReadLargeFile(t *testing.T) {
 	failpoint.Enable("github.com/pingcap/tidb/br/pkg/lightning/backend/external/assertReloadAtMostOnce", "return()")
 	defer failpoint.Disable("github.com/pingcap/tidb/br/pkg/lightning/backend/external/assertReloadAtMostOnce")
 
-	bufPool := membuf.NewPool(
+	smallBlockBufPool := membuf.NewPool(
+		membuf.WithBlockNum(0),
+		membuf.WithBlockSize(smallBlockSize),
+	)
+	largeBlockBufPool := membuf.NewPool(
 		membuf.WithBlockNum(0),
 		membuf.WithBlockSize(ConcurrentReaderBufferSizePerConc),
 	)
@@ -147,7 +151,7 @@ func TestReadLargeFile(t *testing.T) {
 	startKey := []byte("key000000")
 	maxKey := []byte("key004998")
 	endKey := []byte("key004999")
-	err = readAllData(ctx, memStore, datas, stats, startKey, endKey, bufPool, output)
+	err = readAllData(ctx, memStore, datas, stats, startKey, endKey, smallBlockBufPool, largeBlockBufPool, output)
 	require.NoError(t, err)
 	output.build(ctx)
 	require.Equal(t, startKey, output.keys[0])

--- a/br/pkg/lightning/backend/external/testutil.go
+++ b/br/pkg/lightning/backend/external/testutil.go
@@ -79,6 +79,7 @@ func testReadAndCompare(
 			curStart,
 			curEnd,
 			bufPool,
+			bufPool,
 			loaded,
 		)
 		require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50752

Problem Summary:

### What changed and how does it work?

use 2 membuf.Pool that shares one membuf.Limiter.
- smallBlockBufPool: block size 1M, used to store the KV pairs that will be sent to TiKV. KV size larger than 1M can be allocated but will not be tracked by membuf.Limiter.
- largeBlockBufPool: block size 8M, used by concurrent reader

Also, in readAllData spawn constant number of worker, each with a smallBlockBuf and largeBlockBuf. So the memory usage is no longer relevant to number of files to be read.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

run `TestReadAllData`, before this PR

```
    bench_test.go:821: readAllData time cost: 1m41.626412352s, size: 2939207462
```

and peak memory usage is 8.29G

after

```
    bench_test.go:829: readAllData time cost: 39.031899936s, size: 2939207462
```

and peak memory usage is 5.11G

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
