### PR TITLE
executor,planner: make used stats info thread safe

### DIFF
--- a/pkg/executor/internal/exec/indexusage.go
+++ b/pkg/executor/internal/exec/indexusage.go
@@ -26,13 +26,13 @@ import (
 type IndexUsageReporter struct {
 	reporter         *indexusage.StmtIndexUsageCollector
 	runtimeStatsColl *execdetails.RuntimeStatsColl
-	statsMap         map[int64]*stmtctx.UsedStatsInfoForTable
+	statsMap         *stmtctx.UsedStatsInfo
 }
 
 // NewIndexUsageReporter creates an index usage reporter util
 func NewIndexUsageReporter(reporter *indexusage.StmtIndexUsageCollector,
 	runtimeStatsColl *execdetails.RuntimeStatsColl,
-	statsMap map[int64]*stmtctx.UsedStatsInfoForTable) *IndexUsageReporter {
+	statsMap *stmtctx.UsedStatsInfo) *IndexUsageReporter {
 	return &IndexUsageReporter{
 		reporter:         reporter,
 		runtimeStatsColl: runtimeStatsColl,
@@ -95,8 +95,8 @@ func (e *IndexUsageReporter) ReportPointGetIndexUsage(tableID int64, physicalTab
 
 // getTableRowCount returns the `RealtimeCount` of a table
 func (e *IndexUsageReporter) getTableRowCount(tableID int64) (int64, bool) {
-	stats, ok := e.statsMap[tableID]
-	if !ok {
+	stats := e.statsMap.GetUsedInfo(tableID)
+	if stats == nil {
 		return 0, false
 	}
 	if stats.Version == statistics.PseudoVersion {

--- a/pkg/executor/internal/exec/indexusage_test.go
+++ b/pkg/executor/internal/exec/indexusage_test.go
@@ -43,10 +43,10 @@ func TestIndexUsageReporter(t *testing.T) {
 
 	sc := tk.Session().GetSessionVars().StmtCtx
 	statsMap := sc.GetUsedStatsInfo(true)
-	statsMap[tableID] = &stmtctx.UsedStatsInfoForTable{
+	statsMap.RecordUsedInfo(tableID, &stmtctx.UsedStatsInfoForTable{
 		Version:       123,
 		RealtimeCount: 100,
-	}
+	})
 	reporter := exec.NewIndexUsageReporter(sc.IndexUsageCollector, sc.RuntimeStatsColl, statsMap)
 	runtimeStatsColl := sc.RuntimeStatsColl
 
@@ -82,10 +82,10 @@ func TestIndexUsageReporter(t *testing.T) {
 	}, time.Second*5, time.Millisecond)
 
 	// If the version is pseudo, skip it
-	statsMap[tableID] = &stmtctx.UsedStatsInfoForTable{
+	statsMap.RecordUsedInfo(tableID, &stmtctx.UsedStatsInfoForTable{
 		Version:       statistics.PseudoVersion,
 		RealtimeCount: 100,
-	}
+	})
 	planID = 4
 	runtimeStatsColl.GetBasicRuntimeStats(planID).Record(time.Second, 2024)
 	reporter.ReportPointGetIndexUsage(tableID, tableID, indexID, planID, 1)

--- a/pkg/planner/cardinality/trace.go
+++ b/pkg/planner/cardinality/trace.go
@@ -175,14 +175,14 @@ func recordUsedItemStatsStatus(sctx sessionctx.Context, stats any, tableID, id i
 
 	// need to record
 	statsRecord := sctx.GetSessionVars().StmtCtx.GetUsedStatsInfo(true)
-	if statsRecord[tableID] == nil {
+	if statsRecord.GetUsedInfo(tableID) == nil {
 		name, tblInfo := GetTblInfoForUsedStatsByPhysicalID(sctx, tableID)
-		statsRecord[tableID] = &stmtctx.UsedStatsInfoForTable{
+		statsRecord.RecordUsedInfo(tableID, &stmtctx.UsedStatsInfoForTable{
 			Name:    name,
 			TblInfo: tblInfo,
-		}
+		})
 	}
-	recordForTbl := statsRecord[tableID]
+	recordForTbl := statsRecord.GetUsedInfo(tableID)
 
 	var recordForColOrIdx map[int64]string
 	if isIndex {

--- a/pkg/planner/core/casetest/planstats/plan_stats_test.go
+++ b/pkg/planner/core/casetest/planstats/plan_stats_test.go
@@ -315,7 +315,7 @@ func TestPlanStatsStatusRecord(t *testing.T) {
 	// drop stats in order to change status
 	domain.GetDomain(tk.Session()).StatsHandle().SetStatsCacheCapacity(1)
 	tk.MustQuery("select * from t where b >= 1")
-	for _, usedStatsForTbl := range tk.Session().GetSessionVars().StmtCtx.GetUsedStatsInfo(false) {
+	for _, usedStatsForTbl := range tk.Session().GetSessionVars().StmtCtx.GetUsedStatsInfo(false).Values() {
 		if usedStatsForTbl == nil {
 			continue
 		}

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1113,8 +1113,8 @@ func (p *LogicalJoin) constructInnerTableScanTask(
 		// NDV would not be used in cost computation of IndexJoin, set leave it as default nil.
 	})
 	usedStats := p.SCtx().GetSessionVars().StmtCtx.GetUsedStatsInfo(false)
-	if usedStats != nil && usedStats[ts.physicalTableID] != nil {
-		ts.usedStatsInfo = usedStats[ts.physicalTableID]
+	if usedStats != nil && usedStats.GetUsedInfo(ts.physicalTableID) != nil {
+		ts.usedStatsInfo = usedStats.GetUsedInfo(ts.physicalTableID)
 	}
 	copTask := &copTask{
 		tablePlan:         ts,
@@ -1320,8 +1320,8 @@ func (p *LogicalJoin) constructInnerIndexScanTask(
 		// the other hand, it may be hard to identify `StatsVersion` of `ts` in `(*copTask).finishIndexPlan`.
 		ts.SetStats(&property.StatsInfo{StatsVersion: ds.tableStats.StatsVersion})
 		usedStats := p.SCtx().GetSessionVars().StmtCtx.GetUsedStatsInfo(false)
-		if usedStats != nil && usedStats[ts.physicalTableID] != nil {
-			ts.usedStatsInfo = usedStats[ts.physicalTableID]
+		if usedStats != nil && usedStats.GetUsedInfo(ts.physicalTableID) != nil {
+			ts.usedStatsInfo = usedStats.GetUsedInfo(ts.physicalTableID)
 		}
 		// If inner cop task need keep order, the extraHandleCol should be set.
 		if cop.keepOrder && !ds.tableInfo.IsCommonHandle {
@@ -1416,8 +1416,8 @@ func (p *LogicalJoin) constructInnerIndexScanTask(
 	}
 	is.SetStats(ds.tableStats.ScaleByExpectCnt(tmpPath.CountAfterAccess))
 	usedStats := ds.SCtx().GetSessionVars().StmtCtx.GetUsedStatsInfo(false)
-	if usedStats != nil && usedStats[is.physicalTableID] != nil {
-		is.usedStatsInfo = usedStats[is.physicalTableID]
+	if usedStats != nil && usedStats.GetUsedInfo(is.physicalTableID) != nil {
+		is.usedStatsInfo = usedStats.GetUsedInfo(is.physicalTableID)
 	}
 	finalStats := ds.tableStats.ScaleByExpectCnt(rowCount)
 	is.addPushedDownSelection(cop, ds, tmpPath, finalStats)

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1547,8 +1547,8 @@ func (ds *DataSource) buildIndexMergeTableScan(tableFilters []expression.Express
 	}
 	ts.SetStats(ds.tableStats.ScaleByExpectCnt(totalRowCount))
 	usedStats := ds.SCtx().GetSessionVars().StmtCtx.GetUsedStatsInfo(false)
-	if usedStats != nil && usedStats[ts.physicalTableID] != nil {
-		ts.usedStatsInfo = usedStats[ts.physicalTableID]
+	if usedStats != nil && usedStats.GetUsedInfo(ts.physicalTableID) != nil {
+		ts.usedStatsInfo = usedStats.GetUsedInfo(ts.physicalTableID)
 	}
 	if ds.statisticTable.Pseudo {
 		ts.StatsInfo().StatsVersion = statistics.PseudoVersion
@@ -1787,8 +1787,8 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty,
 		// the other hand, it may be hard to identify `StatsVersion` of `ts` in `(*copTask).finishIndexPlan`.
 		ts.SetStats(&property.StatsInfo{StatsVersion: ds.tableStats.StatsVersion})
 		usedStats := ds.SCtx().GetSessionVars().StmtCtx.GetUsedStatsInfo(false)
-		if usedStats != nil && usedStats[ts.physicalTableID] != nil {
-			ts.usedStatsInfo = usedStats[ts.physicalTableID]
+		if usedStats != nil && usedStats.GetUsedInfo(ts.physicalTableID) != nil {
+			ts.usedStatsInfo = usedStats.GetUsedInfo(ts.physicalTableID)
 		}
 		cop.tablePlan = ts
 	}
@@ -2528,8 +2528,8 @@ func (ds *DataSource) getOriginalPhysicalTableScan(prop *property.PhysicalProper
 	// for all columns now, as we do in `deriveStatsByFilter`.
 	ts.SetStats(ds.tableStats.ScaleByExpectCnt(rowCount))
 	usedStats := ds.SCtx().GetSessionVars().StmtCtx.GetUsedStatsInfo(false)
-	if usedStats != nil && usedStats[ts.physicalTableID] != nil {
-		ts.usedStatsInfo = usedStats[ts.physicalTableID]
+	if usedStats != nil && usedStats.GetUsedInfo(ts.physicalTableID) != nil {
+		ts.usedStatsInfo = usedStats.GetUsedInfo(ts.physicalTableID)
 	}
 	if isMatchProp {
 		ts.Desc = prop.SortItems[0].Desc
@@ -2581,8 +2581,8 @@ func (ds *DataSource) getOriginalPhysicalIndexScan(prop *property.PhysicalProper
 		is.SetStats(ds.tableStats.ScaleByExpectCnt(rowCount))
 	}
 	usedStats := ds.SCtx().GetSessionVars().StmtCtx.GetUsedStatsInfo(false)
-	if usedStats != nil && usedStats[is.physicalTableID] != nil {
-		is.usedStatsInfo = usedStats[is.physicalTableID]
+	if usedStats != nil && usedStats.GetUsedInfo(is.physicalTableID) != nil {
+		is.usedStatsInfo = usedStats.GetUsedInfo(is.physicalTableID)
 	}
 	if isMatchProp {
 		is.Desc = prop.SortItems[0].Desc

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -262,13 +262,13 @@ func (ds *DataSource) initStats(colGroups [][]*expression.Column) {
 
 	statsRecord := ds.SCtx().GetSessionVars().StmtCtx.GetUsedStatsInfo(true)
 	name, tblInfo := getTblInfoForUsedStatsByPhysicalID(ds.SCtx(), ds.physicalTableID)
-	statsRecord[ds.physicalTableID] = &stmtctx.UsedStatsInfoForTable{
+	statsRecord.RecordUsedInfo(ds.physicalTableID, &stmtctx.UsedStatsInfoForTable{
 		Name:          name,
 		TblInfo:       tblInfo,
 		Version:       tableStats.StatsVersion,
 		RealtimeCount: tableStats.HistColl.RealtimeCount,
 		ModifyCount:   tableStats.HistColl.ModifyCount,
-	}
+	})
 
 	for _, col := range ds.schema.Columns {
 		tableStats.ColNDVs[col.UniqueID] = cardinality.EstimateColumnNDV(ds.statisticTable, col.ID)
@@ -1071,21 +1071,18 @@ func (p *LogicalSequence) DeriveStats(childStats []*property.StatsInfo, _ *expre
 // loadTableStats loads the stats of the table and store it in the statement `UsedStatsInfo` if it didn't exist
 func loadTableStats(ctx sessionctx.Context, tblInfo *model.TableInfo, pid int64) {
 	statsRecord := ctx.GetSessionVars().StmtCtx.GetUsedStatsInfo(true)
-	if _, ok := statsRecord[pid]; ok {
+	if statsRecord.GetUsedInfo(pid) != nil {
 		return
 	}
 
 	tableStats := getStatsTable(ctx, tblInfo, pid)
 	name, _ := getTblInfoForUsedStatsByPhysicalID(ctx, pid)
-
-	statsRecord[pid] = &stmtctx.UsedStatsInfoForTable{
+	usedStats := &stmtctx.UsedStatsInfoForTable{
 		Name:          name,
 		TblInfo:       tblInfo,
 		RealtimeCount: tableStats.HistColl.RealtimeCount,
 		ModifyCount:   tableStats.HistColl.ModifyCount,
 		Version:       tableStats.Version,
 	}
-	if tableStats.Pseudo {
-		statsRecord[pid].Version = statistics.PseudoVersion
-	}
+	statsRecord.RecordUsedInfo(pid, usedStats)
 }

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -1084,5 +1084,8 @@ func loadTableStats(ctx sessionctx.Context, tblInfo *model.TableInfo, pid int64)
 		ModifyCount:   tableStats.HistColl.ModifyCount,
 		Version:       tableStats.Version,
 	}
+	if tableStats.Pseudo {
+		usedStats.Version = statistics.PseudoVersion
+	}
 	statsRecord.RecordUsedInfo(pid, usedStats)
 }

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -1528,10 +1528,10 @@ func (u *UsedStatsInfo) RecordUsedInfo(tableID int64, info *UsedStatsInfoForTabl
 
 // Keys returns all the table IDs for the used stats info.
 func (u *UsedStatsInfo) Keys() []int64 {
-	if u == nil {
-		return nil
-	}
 	var ret []int64
+	if u == nil {
+		return ret
+	}
 	u.store.Range(func(k, v any) bool {
 		ret = append(ret, k.(int64))
 		return true
@@ -1542,6 +1542,9 @@ func (u *UsedStatsInfo) Keys() []int64 {
 // Values returns all the used stats info for the table.
 func (u *UsedStatsInfo) Values() []*UsedStatsInfoForTable {
 	var ret []*UsedStatsInfoForTable
+	if u == nil {
+		return ret
+	}
 	u.store.Range(func(k, v any) bool {
 		ret = append(ret, v.(*UsedStatsInfoForTable))
 		return true

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -383,7 +383,7 @@ type StatementContext struct {
 	IsReadOnly bool
 	// usedStatsInfo records version of stats of each table used in the query.
 	// It's a map of table physical id -> *UsedStatsInfoForTable
-	usedStatsInfo map[int64]*UsedStatsInfoForTable
+	usedStatsInfo atomic.Pointer[UsedStatsInfo]
 	// IsSyncStatsFailed indicates whether any failure happened during sync stats
 	IsSyncStatsFailed bool
 	// UseDynamicPruneMode indicates whether use UseDynamicPruneMode in query stmt
@@ -1348,17 +1348,17 @@ func (d *CopTasksDetails) ToZapFields() (fields []zap.Field) {
 
 // GetUsedStatsInfo returns the map for recording the used stats during query.
 // If initIfNil is true, it will initialize it when this map is nil.
-func (sc *StatementContext) GetUsedStatsInfo(initIfNil bool) map[int64]*UsedStatsInfoForTable {
-	if sc.usedStatsInfo == nil && initIfNil {
-		sc.usedStatsInfo = make(map[int64]*UsedStatsInfoForTable)
+func (sc *StatementContext) GetUsedStatsInfo(initIfNil bool) *UsedStatsInfo {
+	if sc.usedStatsInfo.Load() == nil && initIfNil {
+		sc.usedStatsInfo.CompareAndSwap(nil, &UsedStatsInfo{})
 	}
-	return sc.usedStatsInfo
+	return sc.usedStatsInfo.Load()
 }
 
 // RecordedStatsLoadStatusCnt returns the total number of recorded column/index stats status, which is not full loaded.
 func (sc *StatementContext) RecordedStatsLoadStatusCnt() (cnt int) {
 	allStatus := sc.GetUsedStatsInfo(false)
-	for _, status := range allStatus {
+	for _, status := range allStatus.Values() {
 		if status == nil {
 			continue
 		}
@@ -1504,6 +1504,54 @@ func (s *UsedStatsInfoForTable) collectFromColOrIdxStatus(
 
 func (s *UsedStatsInfoForTable) recordedColIdxCount() int {
 	return len(s.IndexStatsLoadStatus) + len(s.ColumnStatsLoadStatus)
+}
+
+type UsedStatsInfo struct {
+	store sync.Map
+}
+
+// GetUsedInfo gets the used stats info for the table.
+func (u *UsedStatsInfo) GetUsedInfo(tableID int64) *UsedStatsInfoForTable {
+	v, ok := u.store.Load(tableID)
+	if !ok {
+		return nil
+	}
+	return v.(*UsedStatsInfoForTable)
+}
+
+// RecordUsedInfo records the used stats info for the table.
+func (u *UsedStatsInfo) RecordUsedInfo(tableID int64, info *UsedStatsInfoForTable) {
+	u.store.Store(tableID, info)
+}
+
+// Keys returns all the table IDs for the used stats info.
+func (u *UsedStatsInfo) Keys() []int64 {
+	var ret []int64
+	u.store.Range(func(k, v interface{}) bool {
+		ret = append(ret, k.(int64))
+		return true
+	})
+	return ret
+}
+
+// Values returns all the used stats info for the table.
+func (u *UsedStatsInfo) Values() []*UsedStatsInfoForTable {
+	var ret []*UsedStatsInfoForTable
+	u.store.Range(func(k, v interface{}) bool {
+		ret = append(ret, v.(*UsedStatsInfoForTable))
+		return true
+	})
+	return ret
+}
+
+// Len returns the number of used stats info for the table.
+func (u *UsedStatsInfo) Len() int {
+	var cnt int
+	u.store.Range(func(k, v interface{}) bool {
+		cnt++
+		return true
+	})
+	return cnt
 }
 
 // StatsLoadResult indicates result for StatsLoad

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -1528,6 +1528,9 @@ func (u *UsedStatsInfo) RecordUsedInfo(tableID int64, info *UsedStatsInfoForTabl
 
 // Keys returns all the table IDs for the used stats info.
 func (u *UsedStatsInfo) Keys() []int64 {
+	if u == nil {
+		return nil
+	}
 	var ret []int64
 	u.store.Range(func(k, v any) bool {
 		ret = append(ret, k.(int64))

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -1506,6 +1506,8 @@ func (s *UsedStatsInfoForTable) recordedColIdxCount() int {
 	return len(s.IndexStatsLoadStatus) + len(s.ColumnStatsLoadStatus)
 }
 
+// UsedStatsInfo is a map for recording the used stats during query.
+// The key is the table ID, and the value is the used stats info for the table.
 type UsedStatsInfo struct {
 	store sync.Map
 }

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -1527,7 +1527,7 @@ func (u *UsedStatsInfo) RecordUsedInfo(tableID int64, info *UsedStatsInfoForTabl
 // Keys returns all the table IDs for the used stats info.
 func (u *UsedStatsInfo) Keys() []int64 {
 	var ret []int64
-	u.store.Range(func(k, v interface{}) bool {
+	u.store.Range(func(k, v any) bool {
 		ret = append(ret, k.(int64))
 		return true
 	})
@@ -1537,7 +1537,7 @@ func (u *UsedStatsInfo) Keys() []int64 {
 // Values returns all the used stats info for the table.
 func (u *UsedStatsInfo) Values() []*UsedStatsInfoForTable {
 	var ret []*UsedStatsInfoForTable
-	u.store.Range(func(k, v interface{}) bool {
+	u.store.Range(func(k, v any) bool {
 		ret = append(ret, v.(*UsedStatsInfoForTable))
 		return true
 	})
@@ -1547,7 +1547,7 @@ func (u *UsedStatsInfo) Values() []*UsedStatsInfoForTable {
 // Len returns the number of used stats info for the table.
 func (u *UsedStatsInfo) Len() int {
 	var cnt int
-	u.store.Range(func(k, v interface{}) bool {
+	u.store.Range(func(k, v any) bool {
 		cnt++
 		return true
 	})

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -1546,16 +1546,6 @@ func (u *UsedStatsInfo) Values() []*UsedStatsInfoForTable {
 	return ret
 }
 
-// Len returns the number of used stats info for the table.
-func (u *UsedStatsInfo) Len() int {
-	var cnt int
-	u.store.Range(func(k, v any) bool {
-		cnt++
-		return true
-	})
-	return cnt
-}
-
 // StatsLoadResult indicates result for StatsLoad
 type StatsLoadResult struct {
 	Item  model.TableItemID

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -3198,7 +3198,7 @@ type SlowQueryLogItems struct {
 	ResultRows        int64
 	IsExplicitTxn     bool
 	IsWriteCacheTable bool
-	UsedStats         map[int64]*stmtctx.UsedStatsInfoForTable
+	UsedStats         *stmtctx.UsedStatsInfo
 	IsSyncStatsFailed bool
 	Warnings          []JSONSQLWarnForSlowLog
 	ResourceGroupName string
@@ -3293,13 +3293,13 @@ func (s *SessionVars) SlowLogFormat(logItems *SlowQueryLogItems) string {
 	if len(logItems.Digest) > 0 {
 		writeSlowLogItem(&buf, SlowLogDigestStr, logItems.Digest)
 	}
-	if len(logItems.UsedStats) > 0 {
+	if logItems.UsedStats.Len() > 0 {
 		buf.WriteString(SlowLogRowPrefixStr + SlowLogStatsInfoStr + SlowLogSpaceMarkStr)
 		firstComma := false
-		keys := maps.Keys(logItems.UsedStats)
+		keys := logItems.UsedStats.Keys()
 		slices.Sort(keys)
 		for _, id := range keys {
-			usedStatsForTbl := logItems.UsedStats[id]
+			usedStatsForTbl := logItems.UsedStats.GetUsedInfo(id)
 			if usedStatsForTbl == nil {
 				continue
 			}

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -3293,10 +3293,10 @@ func (s *SessionVars) SlowLogFormat(logItems *SlowQueryLogItems) string {
 	if len(logItems.Digest) > 0 {
 		writeSlowLogItem(&buf, SlowLogDigestStr, logItems.Digest)
 	}
-	if logItems.UsedStats.Len() > 0 {
+	keys := logItems.UsedStats.Keys()
+	if len(keys) > 0 {
 		buf.WriteString(SlowLogRowPrefixStr + SlowLogStatsInfoStr + SlowLogSpaceMarkStr)
 		firstComma := false
-		keys := logItems.UsedStats.Keys()
 		slices.Sort(keys)
 		for _, id := range keys {
 			usedStatsForTbl := logItems.UsedStats.GetUsedInfo(id)

--- a/pkg/sessionctx/variable/session_test.go
+++ b/pkg/sessionctx/variable/session_test.go
@@ -300,12 +300,14 @@ func TestSlowLogFormat(t *testing.T) {
 		ExecRetryTime:     5*time.Second + time.Millisecond*100,
 		IsExplicitTxn:     true,
 		IsWriteCacheTable: true,
-		UsedStats:         map[int64]*stmtctx.UsedStatsInfoForTable{1: usedStats1, 2: usedStats2},
+		UsedStats:         &stmtctx.UsedStatsInfo{},
 		ResourceGroupName: "rg1",
 		RRU:               50.0,
 		WRU:               100.56,
 		WaitRUDuration:    134 * time.Millisecond,
 	}
+	logItems.UsedStats.RecordUsedInfo(1, usedStats1)
+	logItems.UsedStats.RecordUsedInfo(2, usedStats2)
 	logString := seVar.SlowLogFormat(logItems)
 	require.Equal(t, resultFields+"\n"+sql, logString)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/50835

Problem Summary:

### What changed and how does it work?

Introduced by https://github.com/pingcap/tidb/pull/50643/files

Make usedStatsInfo thread-safe and also use CAS to init it.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
