### PR TITLE
ddl/ingest: fix local flush logic for multi-schema change

### DIFF
--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2124,11 +2124,6 @@ func (w *worker) executeDistTask(reorgInfo *reorgInfo) error {
 			return err
 		})
 	} else {
-		elemIDs := make([]int64, 0, len(reorgInfo.elements))
-		for _, elem := range reorgInfo.elements {
-			elemIDs = append(elemIDs, elem.ID)
-		}
-
 		job := reorgInfo.Job
 		workerCntLimit := int(variable.GetDDLReorgWorkerCounter())
 		cpuCount, err := handle.GetCPUCountOfManagedNode(ctx)
@@ -2141,7 +2136,7 @@ func (w *worker) executeDistTask(reorgInfo *reorgInfo) error {
 			zap.String("task-key", taskKey))
 		taskMeta := &BackfillTaskMeta{
 			Job:             *job.Clone(),
-			EleIDs:          elemIDs,
+			EleIDs:          extractElemIDs(reorgInfo),
 			EleTypeKey:      reorgInfo.currElement.TypeKey,
 			CloudStorageURI: w.jobContext(job.ID, job.ReorgMeta).cloudStorageURI,
 		}

--- a/pkg/ddl/ingest/checkpoint.go
+++ b/pkg/ddl/ingest/checkpoint.go
@@ -200,7 +200,7 @@ func (s *CheckpointManager) tryFlushAllIndexes(mode FlushMode) (flushed, importe
 	for _, idxID := range s.indexIDs {
 		flushed, imported, err := s.flushCtrl.Flush(idxID, mode)
 		if err != nil {
-			return allFlushed, false, err
+			return false, false, err
 		}
 		allFlushed = allFlushed && flushed
 		allImported = allImported && imported

--- a/pkg/ddl/ingest/checkpoint.go
+++ b/pkg/ddl/ingest/checkpoint.go
@@ -40,7 +40,7 @@ type CheckpointManager struct {
 	flushCtrl FlushController
 	sessPool  *sess.Pool
 	jobID     int64
-	indexID   int64
+	indexIDs  []int64
 
 	// Derived and unchanged after the initialization.
 	instanceAddr     string
@@ -89,14 +89,14 @@ type FlushController interface {
 
 // NewCheckpointManager creates a new checkpoint manager.
 func NewCheckpointManager(ctx context.Context, flushCtrl FlushController,
-	sessPool *sess.Pool, jobID, indexID int64) (*CheckpointManager, error) {
+	sessPool *sess.Pool, jobID int64, indexIDs []int64) (*CheckpointManager, error) {
 	instanceAddr := InitInstanceAddr()
 	cm := &CheckpointManager{
 		ctx:           ctx,
 		flushCtrl:     flushCtrl,
 		sessPool:      sessPool,
 		jobID:         jobID,
-		indexID:       indexID,
+		indexIDs:      indexIDs,
 		checkpoints:   make(map[int]*TaskCheckpoint, 16),
 		mu:            sync.Mutex{},
 		instanceAddr:  instanceAddr,
@@ -114,7 +114,7 @@ func NewCheckpointManager(ctx context.Context, flushCtrl FlushController,
 		cm.updaterWg.Done()
 	}()
 	logutil.BgLogger().Info("create checkpoint manager", zap.String("category", "ddl-ingest"),
-		zap.Int64("jobID", jobID), zap.Int64("indexID", indexID))
+		zap.Int64("jobID", jobID), zap.Int64s("indexIDs", indexIDs))
 	return cm, nil
 }
 
@@ -174,7 +174,7 @@ func (s *CheckpointManager) UpdateCurrent(taskID int, added int) error {
 	cp.currentKeys += added
 	s.mu.Unlock()
 
-	flushed, imported, err := s.flushCtrl.Flush(s.indexID, FlushModeAuto)
+	flushed, imported, err := s.tryFlushAllIndexes(FlushModeAuto)
 	if !flushed || err != nil {
 		return err
 	}
@@ -192,6 +192,20 @@ func (s *CheckpointManager) UpdateCurrent(taskID int, added int) error {
 		s.endGlobal = s.endLocal
 	}
 	return nil
+}
+
+func (s *CheckpointManager) tryFlushAllIndexes(mode FlushMode) (flushed, imported bool, err error) {
+	allFlushed := true
+	allImported := true
+	for _, idxID := range s.indexIDs {
+		flushed, imported, err := s.flushCtrl.Flush(idxID, mode)
+		if err != nil {
+			return flushed, false, err
+		}
+		allFlushed = allFlushed && flushed
+		allImported = allImported && imported
+	}
+	return allFlushed, allImported, nil
 }
 
 func (s *CheckpointManager) progressLocalSyncMinKey() {
@@ -213,12 +227,12 @@ func (s *CheckpointManager) Close() {
 	s.updaterExitCh <- struct{}{}
 	s.updaterWg.Wait()
 	logutil.BgLogger().Info("close checkpoint manager", zap.String("category", "ddl-ingest"),
-		zap.Int64("jobID", s.jobID), zap.Int64("indexID", s.indexID))
+		zap.Int64("jobID", s.jobID), zap.Int64s("indexIDs", s.indexIDs))
 }
 
 // Sync syncs the checkpoint.
 func (s *CheckpointManager) Sync() {
-	_, _, err := s.flushCtrl.Flush(s.indexID, FlushModeForceLocal)
+	_, _, err := s.tryFlushAllIndexes(FlushModeForceLocal)
 	if err != nil {
 		logutil.BgLogger().Warn("flush local engine failed", zap.String("category", "ddl-ingest"), zap.Error(err))
 	}
@@ -237,7 +251,7 @@ func (s *CheckpointManager) Reset(newPhysicalID int64, start, end kv.Key) {
 	defer s.mu.Unlock()
 	logutil.BgLogger().Info("reset checkpoint manager", zap.String("category", "ddl-ingest"),
 		zap.Int64("newPhysicalID", newPhysicalID), zap.Int64("oldPhysicalID", s.pidLocal),
-		zap.Int64("indexID", s.indexID), zap.Int64("jobID", s.jobID), zap.Int("localCnt", s.localCnt))
+		zap.Int64s("indexIDs", s.indexIDs), zap.Int64("jobID", s.jobID), zap.Int("localCnt", s.localCnt))
 	if s.pidLocal != newPhysicalID {
 		s.minKeySyncLocal = nil
 		s.minKeySyncGlobal = nil
@@ -282,8 +296,8 @@ func (s *CheckpointManager) resumeCheckpoint() error {
 	defer s.sessPool.Put(sessCtx)
 	ddlSess := sess.NewSession(sessCtx)
 	return ddlSess.RunInTxn(func(se *sess.Session) error {
-		template := "select reorg_meta from mysql.tidb_ddl_reorg where job_id = %d and ele_id = %d and ele_type = %s;"
-		sql := fmt.Sprintf(template, s.jobID, s.indexID, util.WrapKey2String(meta.IndexElementKey))
+		template := "select reorg_meta from mysql.tidb_ddl_reorg where job_id = %d and ele_type = %s;"
+		sql := fmt.Sprintf(template, s.jobID, util.WrapKey2String(meta.IndexElementKey))
 		ctx := kv.WithInternalSourceType(s.ctx, kv.InternalTxnBackfillDDLPrefix+"add_index")
 		rows, err := se.Execute(ctx, sql, "get_checkpoint")
 		if err != nil {
@@ -310,7 +324,7 @@ func (s *CheckpointManager) resumeCheckpoint() error {
 				s.localCnt = cp.LocalKeyCount
 			}
 			logutil.BgLogger().Info("resume checkpoint", zap.String("category", "ddl-ingest"),
-				zap.Int64("job ID", s.jobID), zap.Int64("index ID", s.indexID),
+				zap.Int64("job ID", s.jobID), zap.Int64s("index IDs", s.indexIDs),
 				zap.String("local checkpoint", hex.EncodeToString(s.minKeySyncLocal)),
 				zap.String("global checkpoint", hex.EncodeToString(s.minKeySyncGlobal)),
 				zap.Int64("physical table ID", cp.PhysicalID),
@@ -319,7 +333,7 @@ func (s *CheckpointManager) resumeCheckpoint() error {
 			return nil
 		}
 		logutil.BgLogger().Info("checkpoint is empty", zap.String("category", "ddl-ingest"),
-			zap.Int64("job ID", s.jobID), zap.Int64("index ID", s.indexID))
+			zap.Int64("job ID", s.jobID), zap.Int64s("index IDs", s.indexIDs))
 		return nil
 	})
 }
@@ -348,7 +362,7 @@ func (s *CheckpointManager) updateCheckpoint() error {
 	defer s.sessPool.Put(sessCtx)
 	ddlSess := sess.NewSession(sessCtx)
 	err = ddlSess.RunInTxn(func(se *sess.Session) error {
-		template := "update mysql.tidb_ddl_reorg set reorg_meta = %s where job_id = %d and ele_id = %d and ele_type = %s;"
+		template := "update mysql.tidb_ddl_reorg set reorg_meta = %s where job_id = %d and ele_type = %s;"
 		cp := &ReorgCheckpoint{
 			LocalSyncKey:   currentLocalKey,
 			GlobalSyncKey:  currentGlobalKey,
@@ -364,7 +378,7 @@ func (s *CheckpointManager) updateCheckpoint() error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		sql := fmt.Sprintf(template, util.WrapKey2String(rawReorgMeta), s.jobID, s.indexID, util.WrapKey2String(meta.IndexElementKey))
+		sql := fmt.Sprintf(template, util.WrapKey2String(rawReorgMeta), s.jobID, util.WrapKey2String(meta.IndexElementKey))
 		ctx := kv.WithInternalSourceType(s.ctx, kv.InternalTxnBackfillDDLPrefix+"add_index")
 		_, err = se.Execute(ctx, sql, "update_checkpoint")
 		if err != nil {
@@ -376,7 +390,7 @@ func (s *CheckpointManager) updateCheckpoint() error {
 		return nil
 	})
 	logutil.BgLogger().Info("update checkpoint", zap.String("category", "ddl-ingest"),
-		zap.Int64("job ID", s.jobID), zap.Int64("index ID", s.indexID),
+		zap.Int64("job ID", s.jobID), zap.Int64s("index IDs", s.indexIDs),
 		zap.String("local checkpoint", hex.EncodeToString(currentLocalKey)),
 		zap.String("global checkpoint", hex.EncodeToString(currentGlobalKey)),
 		zap.Int64("global physical ID", currentGlobalPID),

--- a/pkg/ddl/ingest/checkpoint.go
+++ b/pkg/ddl/ingest/checkpoint.go
@@ -200,7 +200,7 @@ func (s *CheckpointManager) tryFlushAllIndexes(mode FlushMode) (flushed, importe
 	for _, idxID := range s.indexIDs {
 		flushed, imported, err := s.flushCtrl.Flush(idxID, mode)
 		if err != nil {
-			return flushed, false, err
+			return allFlushed, false, err
 		}
 		allFlushed = allFlushed && flushed
 		allImported = allImported && imported

--- a/pkg/ddl/ingest/checkpoint_test.go
+++ b/pkg/ddl/ingest/checkpoint_test.go
@@ -38,7 +38,7 @@ func TestCheckpointManager(t *testing.T) {
 	ctx := context.Background()
 	sessPool := session.NewSessionPool(rs, store)
 	flushCtrl := &dummyFlushCtrl{imported: false}
-	mgr, err := ingest.NewCheckpointManager(ctx, flushCtrl, sessPool, 1, 1)
+	mgr, err := ingest.NewCheckpointManager(ctx, flushCtrl, sessPool, 1, []int64{1})
 	require.NoError(t, err)
 	defer mgr.Close()
 
@@ -91,7 +91,7 @@ func TestCheckpointManagerUpdateReorg(t *testing.T) {
 	ctx := context.Background()
 	sessPool := session.NewSessionPool(rs, store)
 	flushCtrl := &dummyFlushCtrl{imported: true}
-	mgr, err := ingest.NewCheckpointManager(ctx, flushCtrl, sessPool, 1, 1)
+	mgr, err := ingest.NewCheckpointManager(ctx, flushCtrl, sessPool, 1, []int64{1})
 	require.NoError(t, err)
 	defer mgr.Close()
 
@@ -140,7 +140,7 @@ func TestCheckpointManagerResumeReorg(t *testing.T) {
 	ctx := context.Background()
 	sessPool := session.NewSessionPool(rs, store)
 	flushCtrl := &dummyFlushCtrl{imported: false}
-	mgr, err := ingest.NewCheckpointManager(ctx, flushCtrl, sessPool, 1, 1)
+	mgr, err := ingest.NewCheckpointManager(ctx, flushCtrl, sessPool, 1, []int64{1})
 	require.NoError(t, err)
 	defer mgr.Close()
 	require.True(t, mgr.IsComplete([]byte{'1', '9'}))

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -291,7 +291,11 @@ func overwriteReorgInfoFromGlobalCheckpoint(w *worker, sess *sess.Session, job *
 	if ok {
 		// We create the checkpoint manager here because we need to wait for the reorg meta to be initialized.
 		if bc.GetCheckpointManager() == nil {
-			mgr, err := ingest.NewCheckpointManager(w.ctx, bc, w.sessPool, job.ID, reorgInfo.currElement.ID)
+			elemIDs := make([]int64, 0, len(reorgInfo.elements))
+			for _, elem := range reorgInfo.elements {
+				elemIDs = append(elemIDs, elem.ID)
+			}
+			mgr, err := ingest.NewCheckpointManager(w.ctx, bc, w.sessPool, job.ID, elemIDs)
 			if err != nil {
 				logutil.BgLogger().Warn("create checkpoint manager failed", zap.String("category", "ddl-ingest"), zap.Error(err))
 			}

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -291,11 +291,7 @@ func overwriteReorgInfoFromGlobalCheckpoint(w *worker, sess *sess.Session, job *
 	if ok {
 		// We create the checkpoint manager here because we need to wait for the reorg meta to be initialized.
 		if bc.GetCheckpointManager() == nil {
-			elemIDs := make([]int64, 0, len(reorgInfo.elements))
-			for _, elem := range reorgInfo.elements {
-				elemIDs = append(elemIDs, elem.ID)
-			}
-			mgr, err := ingest.NewCheckpointManager(w.ctx, bc, w.sessPool, job.ID, elemIDs)
+			mgr, err := ingest.NewCheckpointManager(w.ctx, bc, w.sessPool, job.ID, extractElemIDs(reorgInfo))
 			if err != nil {
 				logutil.BgLogger().Warn("create checkpoint manager failed", zap.String("category", "ddl-ingest"), zap.Error(err))
 			}
@@ -312,6 +308,14 @@ func overwriteReorgInfoFromGlobalCheckpoint(w *worker, sess *sess.Session, job *
 		reorgInfo.PhysicalTableID = pid
 	}
 	return nil
+}
+
+func extractElemIDs(r *reorgInfo) []int64 {
+	elemIDs := make([]int64, 0, len(r.elements))
+	for _, elem := range r.elements {
+		elemIDs = append(elemIDs, elem.ID)
+	}
+	return elemIDs
 }
 
 func (w *worker) mergeWarningsIntoJob(job *model.Job) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50990

Problem Summary:

For multi-schema change like `add index i1, add index i2`, only one index is imported when `ddl_disk_quota` is reached:

```
/tmp/tidb/tmp_ddl-4000/108$ du -hs ./*
16K     ./35a62bba-3aab-5322-b59b-c5bc8baf9c9d
4.0K    ./35a62bba-3aab-5322-b59b-c5bc8baf9c9d.sst
16K     ./8d2242cb-c9a7-5915-a93a-45927b24759d
4.0G    ./8d2242cb-c9a7-5915-a93a-45927b24759d.sst

/tmp/tidb/tmp_ddl-4000/108$ du -hs ./*
16K     ./35a62bba-3aab-5322-b59b-c5bc8baf9c9d
4.0K    ./35a62bba-3aab-5322-b59b-c5bc8baf9c9d.sst
16K     ./8d2242cb-c9a7-5915-a93a-45927b24759d
16G     ./8d2242cb-c9a7-5915-a93a-45927b24759d.sst

/tmp/tidb/tmp_ddl-4000/108$ du -hs ./*
16K     ./35a62bba-3aab-5322-b59b-c5bc8baf9c9d
4.0K    ./35a62bba-3aab-5322-b59b-c5bc8baf9c9d.sst
16K     ./8d2242cb-c9a7-5915-a93a-45927b24759d
18G     ./8d2242cb-c9a7-5915-a93a-45927b24759d.sst
```

As a result, almost every region batch triggers import, making it very slow.

### What changed and how does it work?

Import all indexes if `ddl_disk_quota` is reached.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
