### PR TITLE
BR: Make pd backoff wait more than 5 minutes.

### DIFF
--- a/br/pkg/conn/conn.go
+++ b/br/pkg/conn/conn.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/docker/go-units"
 	"github.com/opentracing/opentracing-go"
@@ -349,6 +350,13 @@ func (mgr *Mgr) GetConfigFromTiKV(ctx context.Context, cli *http.Client, fn func
 		}
 		configAddr := fmt.Sprintf("%s/config", addr.String())
 
+		// we don't need wait too much time to get tikv config.
+		// because we will fall back to use default config when cannot connect to tikv.
+		state := utils.InitialRetryState(
+			16,
+			time.Millisecond*10,
+			time.Second,
+		)
 		err = utils.WithRetry(ctx, func() error {
 			resp, e := cli.Get(configAddr)
 			if e != nil {
@@ -360,7 +368,7 @@ func (mgr *Mgr) GetConfigFromTiKV(ctx context.Context, cli *http.Client, fn func
 			}
 			_ = resp.Body.Close()
 			return nil
-		}, utils.NewPDReqBackoffer())
+		}, &state)
 		if err != nil {
 			// if one store failed, break and return error
 			return err

--- a/br/pkg/conn/conn_test.go
+++ b/br/pkg/conn/conn_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
@@ -67,7 +68,7 @@ func TestGetAllTiKVStoresWithUnknown(t *testing.T) {
 	defer func() {
 		_ = failpoint.Disable("github.com/pingcap/tidb/br/pkg/conn/hint-GetAllTiKVStores-error")
 	}()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	stores := []*metapb.Store{

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -31,9 +31,9 @@ const (
 	backupSSTWaitInterval    = 2 * time.Second
 	backupSSTMaxWaitInterval = 3 * time.Second
 
-	resetTSRetryTime       = 16
-	resetTSWaitInterval    = 50 * time.Millisecond
-	resetTSMaxWaitInterval = 500 * time.Millisecond
+	resetTSRetryTime       = 32
+	resetTSWaitInterval    = 1 * time.Second
+	resetTSMaxWaitInterval = 16 * time.Second
 
 	resetTSRetryTimeExt       = 600
 	resetTSWaitIntervalExt    = 500 * time.Millisecond

--- a/br/pkg/utils/backoff_test.go
+++ b/br/pkg/utils/backoff_test.go
@@ -120,30 +120,16 @@ func TestPdBackoffWithRetryableError(t *testing.T) {
 	gRPCError := status.Error(codes.Unavailable, "transport is closing")
 	err := utils.WithRetry(context.Background(), func() error {
 		defer func() { counter++ }()
-		if counter == 2 {
+		if counter == 1 {
 			return io.EOF
+		}
+		if counter == 2 {
+			return nil
 		}
 		return gRPCError
 	}, backoffer)
-	require.Equal(t, 16, counter)
-	require.Equal(t, []error{
-		gRPCError,
-		gRPCError,
-		io.EOF,
-		gRPCError,
-		gRPCError,
-		gRPCError,
-		gRPCError,
-		gRPCError,
-		gRPCError,
-		gRPCError,
-		gRPCError,
-		gRPCError,
-		gRPCError,
-		gRPCError,
-		gRPCError,
-		gRPCError,
-	}, multierr.Errors(err))
+	require.Equal(t, 3, counter)
+	require.NoError(t, err)
 }
 
 func TestNewImportSSTBackofferWithSucess(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/51056

Problem Summary:
1. As issue said.

### What changed and how does it work?
wait 32 times at least 5mins
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
