### PR TITLE
ddl: update TestDefaultColumnWithReplace error code

### DIFF
--- a/pkg/ddl/db_integration_test.go
+++ b/pkg/ddl/db_integration_test.go
@@ -1628,7 +1628,16 @@ func TestDefaultColumnWithReplace(t *testing.T) {
 
 	// insert records
 	tk.MustExec("insert into t(c) values (1),(2),(3)")
+	// Different UUID values will result in different error code.
 	tk.MustGetErrCode("insert into t1(c) values (1)", errno.ErrTruncatedWrongValue)
+	_, err := tk.Exec("insert into t1(c) values (1)")
+	originErr := errors.Cause(err)
+	tErr, ok := originErr.(*terror.Error)
+	require.Truef(t, ok, "expect type 'terror.Error', but obtain '%T': %v", originErr, originErr)
+	sqlErr := terror.ToSQLError(tErr)
+	if int(sqlErr.Code) != errno.ErrTruncatedWrongValue {
+		require.Equal(t, errno.ErrDataOutOfRange, int(sqlErr.Code))
+	}
 
 	rows := tk.MustQuery("SELECT c1 from t").Rows()
 	for _, row := range rows {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/51114

Problem Summary:
Different UUID values will result in different error code.
```
tidb> create table t1 (c int(10), c1 int default (REPLACE(UPPER(UUID()), '-', '')));
Query OK, 0 rows affected (0.04 sec)

tidb> insert into t1(c) values (1),(2),(3);
ERROR 1690 (22003): BIGINT value is out of range in '451E9'
tidb> insert into t1(c) values (1),(2),(3);
ERROR 1292 (22007): Truncated incorrect DOUBLE value: '463ED8D2CE3911EE988E3C7D0A09BA5A'
```

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
