### PR TITLE
log_backup: added more info for slow regions in log backup advancer

### DIFF
--- a/br/pkg/streamhelper/regioniter.go
+++ b/br/pkg/streamhelper/regioniter.go
@@ -82,6 +82,19 @@ func IterateRegion(cli TiKVClusterMeta, startKey, endKey []byte) *RegionIter {
 	}
 }
 
+// locateKeyOfRegion locates the place of the region in the key.
+func locateKeyOfRegion(ctx context.Context, cli TiKVClusterMeta, key []byte) (RegionWithLeader, error) {
+	regions, err := cli.RegionScan(ctx, key, kv.Key(key).Next(), 1)
+	if err != nil {
+		return RegionWithLeader{}, err
+	}
+	if len(regions) == 0 {
+		return RegionWithLeader{}, errors.Annotatef(berrors.ErrPDBatchScanRegion,
+			"scanning the key %s returns empty region", redact.Key(key))
+	}
+	return regions[0], nil
+}
+
 func CheckRegionConsistency(startKey, endKey []byte, regions []RegionWithLeader) error {
 	// current pd can't guarantee the consistency of returned regions
 	if len(regions) == 0 {

--- a/pkg/metrics/log_backup.go
+++ b/pkg/metrics/log_backup.go
@@ -28,6 +28,9 @@ var (
 	RegionCheckpointRequest           *prometheus.CounterVec
 	RegionCheckpointFailure           *prometheus.CounterVec
 	RegionCheckpointSubscriptionEvent *prometheus.HistogramVec
+
+	LogBackupCurrentLastRegionID            prometheus.Gauge
+	LogBackupCurrentLastRegionLeaderStoreID prometheus.Gauge
 )
 
 // InitLogBackupMetrics initializes log backup metrics.
@@ -84,4 +87,17 @@ func InitLogBackupMetrics() {
 		Help:      "The region flush event size.",
 		Buckets:   prometheus.ExponentialBuckets(8, 2.0, 12),
 	}, []string{"store"})
+
+	LogBackupCurrentLastRegionID = NewGauge(prometheus.GaugeOpts{
+		Namespace: "tidb",
+		Subsystem: "log_backup",
+		Name:      "current_last_region_id",
+		Help:      "The id of the region have minimal checkpoint ts in the current running task.",
+	})
+	LogBackupCurrentLastRegionLeaderStoreID = NewGauge(prometheus.GaugeOpts{
+		Namespace: "tidb",
+		Subsystem: "log_backup",
+		Name:      "current_last_region_leader_store_id",
+		Help:      "The leader's store id of the region have minimal checkpoint ts in the current running task.",
+	})
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51046

Problem Summary:
It is painful for debugging slow regions in log backup for now. Exactly when there are many TiKV nodes in the cluster: we only have a range but know nothing about which region this key belongs to.
Also we must pick the TiDB log (which isn't always easily accessible.) for such information.

### What changed and how does it work?
This PR added two new series to the log backup advancer, which presents the current slowest region's leader location and its region id.
Also we will append more detailed hints about the slowest range.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
A simple log:
![CleanShot 2024-02-19 at 14 20 11@2x](https://github.com/pingcap/tidb/assets/36239017/90c18b75-69c3-4ddb-94ca-96bb417fed39)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
