### PR TITLE
statistics: fix the test case by increase the time interval

### DIFF
--- a/pkg/statistics/handle/autoanalyze/priorityqueue/job_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/job_test.go
@@ -259,11 +259,11 @@ func TestIsValidToAnalyze(t *testing.T) {
 	// Just failed.
 	now := tk.MustQuery("select now()").Rows()[0][0].(string)
 	insertFailedJobWithStartTime(tk, job.TableSchema, job.TableName, "", now)
-	valid, failReason = job.IsValidToAnalyze(sctx)
+	// Note: The failure reason is not checked in this test because the time duration can sometimes be inaccurate.(not now)
+	valid, _ = job.IsValidToAnalyze(sctx)
 	require.False(t, valid)
-	require.Equal(t, "last analysis just failed", failReason)
-	// Failed 1 second ago.
-	startTime := tk.MustQuery("select now() - interval 1 second").Rows()[0][0].(string)
+	// Failed 10 seconds ago.
+	startTime := tk.MustQuery("select now() - interval 10 second").Rows()[0][0].(string)
 	insertFailedJobWithStartTime(tk, job.TableSchema, job.TableName, "", startTime)
 	valid, failReason = job.IsValidToAnalyze(sctx)
 	require.False(t, valid)
@@ -330,11 +330,11 @@ func TestIsValidToAnalyzeForPartitionedTba(t *testing.T) {
 	// Just failed.
 	now := tk.MustQuery("select now()").Rows()[0][0].(string)
 	insertFailedJobWithStartTime(tk, job.TableSchema, job.TableName, "p0", now)
-	valid, failReason = job.IsValidToAnalyze(sctx)
+	// Note: The failure reason is not checked in this test because the time duration can sometimes be inaccurate.(not now)
+	valid, _ = job.IsValidToAnalyze(sctx)
 	require.False(t, valid)
-	require.Equal(t, "last analysis just failed", failReason)
-	// Failed 1 second ago.
-	startTime := tk.MustQuery("select now() - interval 1 second").Rows()[0][0].(string)
+	// Failed 10 seconds ago.
+	startTime := tk.MustQuery("select now() - interval 10 second").Rows()[0][0].(string)
 	insertFailedJobWithStartTime(tk, job.TableSchema, job.TableName, "p0", startTime)
 	valid, failReason = job.IsValidToAnalyze(sctx)
 	require.False(t, valid)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/51142

Problem Summary:

### What changed and how does it work?

![img_v3_0287_9543bbb9-934b-4786-921a-c5c61c4a554g](https://github.com/pingcap/tidb/assets/29879298/b1d63bfa-93f1-45e3-92ec-e472019141ff)

We received some unstable test reports regarding certain cases. The instability arose from the fact that the case attempted to verify if the job had failed just by now. However, in some instances, if the test case was running slowly, it wouldn't be considered as just failing now because it is more than one second. To address this, we decided to omit the fail reason check in this PR. Additionally, we changed the timer intervals from 1 second to 10 seconds.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
