### PR TITLE
storage: local storage tolerates broken symlink when Walk

### DIFF
--- a/br/pkg/storage/local.go
+++ b/br/pkg/storage/local.go
@@ -130,7 +130,11 @@ func (l *LocalStorage) WalkDir(_ context.Context, opt *WalkOption, fn func(strin
 		if !f.Mode().IsRegular() {
 			stat, err := os.Stat(filepath.Join(l.base, path))
 			if err != nil {
-				return errors.Trace(err)
+				// error may happen because of file deleted after walk started, or other errors
+				// like #49423. We just return 0 size and let the caller handle it in later
+				// logic.
+				log.Warn("failed to get file size", zap.String("path", path), zap.Error(err))
+				return fn(path, 0)
 			}
 			size = stat.Size()
 		}

--- a/br/pkg/storage/local_test.go
+++ b/br/pkg/storage/local_test.go
@@ -238,7 +238,7 @@ func TestLocalFileReadRange(t *testing.T) {
 	require.Equal(t, "23", string(smallBuf[:n]))
 }
 
-func TestWalkDeadSymLink(t *testing.T) {
+func TestWalkBrokenSymLink(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	err := os.Symlink(filepath.Join(dir, "non-existing-file"), filepath.Join(dir, "file-that-should-be-ignored"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49423

Problem Summary:

### What changed and how does it work?

see issue

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
