### PR TITLE
lightning: don't check TiKV free space after v8.0.0

### DIFF
--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -583,7 +583,7 @@ func NewBackend(
 	if err = local.checkMultiIngestSupport(ctx); err != nil {
 		return nil, common.ErrCheckMultiIngest.Wrap(err).GenWithStackByArgs()
 	}
-	local.checkTiKVSideFreeSpace(ctx)
+	local.tikvSideCheckFreeSpace(ctx)
 
 	return local, nil
 }
@@ -681,7 +681,10 @@ func (local *Backend) checkMultiIngestSupport(ctx context.Context) error {
 
 var errorTiKVTooOld = errors.New("TiKV is too old")
 
-func (local *Backend) checkTiKVSideFreeSpace(ctx context.Context) {
+func (local *Backend) tikvSideCheckFreeSpace(ctx context.Context) {
+	if !local.ShouldCheckTiKV {
+		return
+	}
 	err := tikv.ForTiKVVersions(
 		ctx,
 		local.pdHTTPCli,

--- a/br/pkg/lightning/common/retry.go
+++ b/br/pkg/lightning/common/retry.go
@@ -143,6 +143,10 @@ func isSingleRetryableError(err error) bool {
 			codes.ResourceExhausted, codes.Aborted, codes.OutOfRange, codes.Unavailable, codes.DataLoss:
 			return true
 		case codes.Unknown:
+			errMsg := rpcStatus.Message()
+			if strings.Contains(errMsg, "DiskSpaceNotEnough") {
+				return false
+			}
 			// cases we have met during import:
 			// 1. in scatter region: rpc error: code = Unknown desc = region 31946583 is not fully replicated
 			// 2. in write TiKV: rpc error: code = Unknown desc = EngineTraits(Engine(Status { code: IoError, sub_code:

--- a/br/pkg/lightning/tikv/tikv.go
+++ b/br/pkg/lightning/tikv/tikv.go
@@ -235,6 +235,21 @@ func CheckTiKVVersion(
 	pdHTTPCli pdhttp.Client,
 	requiredMinVersion, requiredMaxVersion semver.Version,
 ) error {
+	return ForTiKVVersions(
+		ctx,
+		pdHTTPCli,
+		func(ver *semver.Version, addrMsg string) error {
+			return version.CheckVersion(addrMsg, *ver, requiredMinVersion, requiredMaxVersion)
+		},
+	)
+}
+
+// ForTiKVVersions runs the given action for all versions of TiKV nodes.
+func ForTiKVVersions(
+	ctx context.Context,
+	pdHTTPCli pdhttp.Client,
+	action func(ver *semver.Version, addrMsg string) error,
+) error {
 	return ForAllStores(
 		ctx,
 		pdHTTPCli,
@@ -245,7 +260,7 @@ func CheckTiKVVersion(
 			if err != nil {
 				return errors.Annotate(err, component)
 			}
-			return version.CheckVersion(component, *ver, requiredMinVersion, requiredMaxVersion)
+			return action(ver, component)
 		},
 	)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50998 close #43636

Problem Summary:

### What changed and how does it work?

be aware of TiKV's new error `DiskSpaceNotEnough`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below) manually build a TiKV with version v8.0.0 and check
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
