### PR TITLE
planner: fix ExtractCorrelatedCols method in PhysicalTableScan 

### DIFF
--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -437,3 +437,57 @@ func TestPhysicalPlanMemoryTrace(t *testing.T) {
 	pp.MPPPartitionCols = append(pp.MPPPartitionCols, &property.MPPPartitionColumn{})
 	require.Greater(t, pp.MemoryUsage(), size)
 }
+
+func TestPhysicalTableScanExtractCorrelatedCols(t *testing.T) {
+	store := testkit.CreateMockStore(t, internal.WithMockTiFlash(2))
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (id int, client_type tinyint, client_no char(18), taxpayer_no varchar(50), status tinyint, update_time datetime)")
+	tk.MustExec("alter table t1 set tiflash replica 1")
+	tb := external.GetTableByName(t, tk, "test", "t1")
+	err := domain.GetDomain(tk.Session()).DDL().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
+	require.NoError(t, err)
+	tk.MustExec("create table t2 (id int, company_no char(18), name varchar(200), tax_registry_no varchar(30))")
+	tk.MustExec("insert into t1(id, taxpayer_no, client_no, client_type, status, update_time) values (1, 'TAX001', 'Z9005', 1, 1, '2024-02-18 10:00:00'), (2, 'TAX002', 'Z9005', 1, 0, '2024-02-18 09:00:00'), (3, 'TAX003', 'Z9005', 2, 1, '2024-02-18 08:00:00'), (4, 'TAX004', 'Z9006', 1, 1, '2024-02-18 12:00:00')")
+	tk.MustExec("insert into t2(id, company_no, name, tax_registry_no) values (1, 'Z9005', 'AA', 'aaa'), (2, 'Z9006', 'BB', 'bbb'), (3, 'Z9007', 'CC', 'ccc')")
+
+	sql := "select company_no, ifnull((select /*+ read_from_storage(tiflash[test.t1]) */ taxpayer_no from test.t1 where client_no = c.company_no and client_type = 1 and status = 1 order by update_time desc limit 1), tax_registry_no) as tax_registry_no from test.t2 c where company_no = 'Z9005' limit 1"
+	tk.MustExec(sql)
+	info := tk.Session().ShowProcess()
+	require.NotNil(t, info)
+	p, ok := info.Plan.(core.Plan)
+	require.True(t, ok)
+
+	var find_table_scan func(p core.Plan) *core.PhysicalTableScan
+	find_table_scan = func(p core.Plan) *core.PhysicalTableScan {
+		if p == nil {
+			return nil
+		}
+		switch v := p.(type) {
+		case *core.PhysicalTableScan:
+			if v.Table.Name.L == "t1" {
+				return v
+			}
+			return nil
+		case *core.PhysicalTableReader:
+			return find_table_scan(v.TablePlans[0])
+		default:
+			physicayPlan := p.(core.PhysicalPlan)
+			for _, child := range physicayPlan.Children() {
+				if ts := find_table_scan(child); ts != nil {
+					return ts
+				}
+			}
+			return nil
+		}
+	}
+	ts := find_table_scan(p)
+	require.NotNil(t, ts)
+
+	pb, err := ts.ToPB(tk.Session(), kv.TiFlash)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(pb.TblScan.PushedDownFilterConditions))
+	correlated := ts.ExtractCorrelatedCols()
+	require.Equal(t, 1, len(correlated))
+	require.Equal(t, "test.t2.company_no", correlated[0].String())
+}

--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -458,8 +458,8 @@ func TestPhysicalTableScanExtractCorrelatedCols(t *testing.T) {
 	p, ok := info.Plan.(core.Plan)
 	require.True(t, ok)
 
-	var find_table_scan func(p core.Plan) *core.PhysicalTableScan
-	find_table_scan = func(p core.Plan) *core.PhysicalTableScan {
+	var findTableScan func(p core.Plan) *core.PhysicalTableScan
+	findTableScan = func(p core.Plan) *core.PhysicalTableScan {
 		if p == nil {
 			return nil
 		}
@@ -470,18 +470,18 @@ func TestPhysicalTableScanExtractCorrelatedCols(t *testing.T) {
 			}
 			return nil
 		case *core.PhysicalTableReader:
-			return find_table_scan(v.TablePlans[0])
+			return findTableScan(v.TablePlans[0])
 		default:
 			physicayPlan := p.(core.PhysicalPlan)
 			for _, child := range physicayPlan.Children() {
-				if ts := find_table_scan(child); ts != nil {
+				if ts := findTableScan(child); ts != nil {
 					return ts
 				}
 			}
 			return nil
 		}
 	}
-	ts := find_table_scan(p)
+	ts := findTableScan(p)
 	require.NotNil(t, ts)
 
 	pb, err := ts.ToPB(tk.Session(), kv.TiFlash)

--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/external"
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
+	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -486,7 +487,10 @@ func TestPhysicalTableScanExtractCorrelatedCols(t *testing.T) {
 
 	pb, err := ts.ToPB(tk.Session(), kv.TiFlash)
 	require.NoError(t, err)
+	// make sure the pushed down filter condition is correct
 	require.Equal(t, 1, len(pb.TblScan.PushedDownFilterConditions))
+	require.Equal(t, tipb.ExprType_ColumnRef, pb.TblScan.PushedDownFilterConditions[0].Children[0].Tp)
+	// make sure the correlated columns are extracted correctly
 	correlated := ts.ExtractCorrelatedCols()
 	require.Equal(t, 1, len(correlated))
 	require.Equal(t, "test.t2.company_no", correlated[0].String())

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -918,6 +918,7 @@ func (ts *PhysicalTableScan) Clone() (PhysicalPlan, error) {
 	clonedScan.physicalSchemaProducer = *prod
 	clonedScan.AccessCondition = util.CloneExprs(ts.AccessCondition)
 	clonedScan.filterCondition = util.CloneExprs(ts.filterCondition)
+	clonedScan.LateMaterializationFilterCondition = util.CloneExprs(ts.LateMaterializationFilterCondition)
 	if ts.Table != nil {
 		clonedScan.Table = ts.Table.Clone()
 	}
@@ -935,11 +936,14 @@ func (ts *PhysicalTableScan) Clone() (PhysicalPlan, error) {
 
 // ExtractCorrelatedCols implements PhysicalPlan interface.
 func (ts *PhysicalTableScan) ExtractCorrelatedCols() []*expression.CorrelatedColumn {
-	corCols := make([]*expression.CorrelatedColumn, 0, len(ts.AccessCondition)+len(ts.filterCondition))
+	corCols := make([]*expression.CorrelatedColumn, 0, len(ts.AccessCondition)+len(ts.filterCondition)+len(ts.LateMaterializationFilterCondition))
 	for _, expr := range ts.AccessCondition {
 		corCols = append(corCols, expression.ExtractCorColumns(expr)...)
 	}
 	for _, expr := range ts.filterCondition {
+		corCols = append(corCols, expression.ExtractCorColumns(expr)...)
+	}
+	for _, expr := range ts.LateMaterializationFilterCondition {
 		corCols = append(corCols, expression.ExtractCorColumns(expr)...)
 	}
 	return corCols
@@ -1047,6 +1051,9 @@ func (ts *PhysicalTableScan) MemoryUsage() (sum int64) {
 		sum += cond.MemoryUsage()
 	}
 	for _, cond := range ts.filterCondition {
+		sum += cond.MemoryUsage()
+	}
+	for _, cond := range ts.LateMaterializationFilterCondition {
 		sum += cond.MemoryUsage()
 	}
 	for _, rang := range ts.Ranges {

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -940,9 +940,6 @@ func (ts *PhysicalTableScan) ExtractCorrelatedCols() []*expression.CorrelatedCol
 	for _, expr := range ts.AccessCondition {
 		corCols = append(corCols, expression.ExtractCorColumns(expr)...)
 	}
-	for _, expr := range ts.filterCondition {
-		corCols = append(corCols, expression.ExtractCorColumns(expr)...)
-	}
 	for _, expr := range ts.LateMaterializationFilterCondition {
 		corCols = append(corCols, expression.ExtractCorColumns(expr)...)
 	}

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -936,7 +936,7 @@ func (ts *PhysicalTableScan) Clone() (PhysicalPlan, error) {
 
 // ExtractCorrelatedCols implements PhysicalPlan interface.
 func (ts *PhysicalTableScan) ExtractCorrelatedCols() []*expression.CorrelatedColumn {
-	corCols := make([]*expression.CorrelatedColumn, 0, len(ts.AccessCondition)+len(ts.filterCondition)+len(ts.LateMaterializationFilterCondition))
+	corCols := make([]*expression.CorrelatedColumn, 0, len(ts.AccessCondition)+len(ts.LateMaterializationFilterCondition))
 	for _, expr := range ts.AccessCondition {
 		corCols = append(corCols, expression.ExtractCorColumns(expr)...)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51204

Problem Summary:

### What changed and how does it work?

Before, we do not try to extract correlated column in LateMaterializationFilterCondition. So when the correlated columns only in LateMaterializationFilterCondition, exprs failed to fill in correlated column with constant value during Plan2Pb, and it leads to wrong query result.

Now, in ExtractCorrelatedCols method, we will also try to extract correlated column in LateMaterializationFilterCondition.

Also fix other methods.

### Check List

Currently, integration test do not support TiFlash, so I will add tests in https://github.com/pingcap/tiflash

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix wrong query result of Apply operator when there are correlated column in push down conditions
```
