### PR TITLE
pitr: support log backup to s3 when object lock is enabled

### DIFF
--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -421,9 +421,8 @@ func NewS3Storage(ctx context.Context, backend *backuppb.S3, opts *ExternalStora
 		svc:     c,
 		options: &qs,
 	}
-	if opts.CheckS3ObjectLockOptions {
-		backend.ObjectLockEnabled = s3Storage.IsObjectLockEnabled()
-	}
+	
+	backend.ObjectLockEnabled = s3Storage.IsObjectLockEnabled()
 	return s3Storage, nil
 }
 

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -177,7 +177,7 @@ type ExternalStorageOptions struct {
 
 	// CheckObjectLockOptions check the s3 bucket has enabled the ObjectLock.
 	// if enabled. it will send the options to tikv.
-	CheckS3ObjectLockOptions bool
+	// CheckS3ObjectLockOptions bool
 }
 
 // Create creates ExternalStorage.

--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -443,7 +443,6 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	opts := storage.ExternalStorageOptions{
 		NoCredentials:            cfg.NoCreds,
 		SendCredentials:          cfg.SendCreds,
-		CheckS3ObjectLockOptions: true,
 	}
 	if err = client.SetStorageAndCheckNotInUse(ctx, u, &opts); err != nil {
 		return errors.Trace(err)

--- a/br/pkg/task/backup_raw.go
+++ b/br/pkg/task/backup_raw.go
@@ -148,7 +148,6 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 	opts := storage.ExternalStorageOptions{
 		NoCredentials:            cfg.NoCreds,
 		SendCredentials:          cfg.SendCreds,
-		CheckS3ObjectLockOptions: true,
 	}
 	if err = client.SetStorageAndCheckNotInUse(ctx, u, &opts); err != nil {
 		return errors.Trace(err)

--- a/br/pkg/task/backup_txn.go
+++ b/br/pkg/task/backup_txn.go
@@ -127,7 +127,6 @@ func RunBackupTxn(c context.Context, g glue.Glue, cmdName string, cfg *TxnKvConf
 	opts := storage.ExternalStorageOptions{
 		NoCredentials:            cfg.NoCreds,
 		SendCredentials:          cfg.SendCreds,
-		CheckS3ObjectLockOptions: true,
 	}
 	if err = client.SetStorageAndCheckNotInUse(ctx, u, &opts); err != nil {
 		return errors.Trace(err)

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -319,7 +319,6 @@ func NewStreamMgr(ctx context.Context, cfg *StreamConfig, g glue.Glue, isStreamS
 		opts := storage.ExternalStorageOptions{
 			NoCredentials:   cfg.NoCreds,
 			SendCredentials: cfg.SendCreds,
-			CheckS3ObjectLockOptions: true,
 		}
 		if err = client.SetStorage(ctx, backend, &opts); err != nil {
 			return nil, errors.Trace(err)

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -319,6 +319,7 @@ func NewStreamMgr(ctx context.Context, cfg *StreamConfig, g glue.Glue, isStreamS
 		opts := storage.ExternalStorageOptions{
 			NoCredentials:   cfg.NoCreds,
 			SendCredentials: cfg.SendCreds,
+			CheckS3ObjectLockOptions: true,
 		}
 		if err = client.SetStorage(ctx, backend, &opts); err != nil {
 			return nil, errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51184

Problem Summary:

### What changed and how does it work?

Removed the `ExternalStorageOptions.CheckS3ObjectLockOptions` to make sure add content-MD5 in header whenever needed.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that when repentant time is enabled in aws s3, log backup will cause error: “HTTP header is required for Put Object requests with Object Lock parameters”
```
