### PR TITLE
planner: allow read from TiKV for `sys` schema when `tidb_isolation_read_engines` is set to tiflash

### DIFF
--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1236,7 +1236,7 @@ func getPossibleAccessPaths(ctx PlanContext, tableHints *hint.PlanHints, indexHi
 
 func filterPathByIsolationRead(ctx PlanContext, paths []*util.AccessPath, tblName model.CIStr, dbName model.CIStr) ([]*util.AccessPath, error) {
 	// TODO: filter paths with isolation read locations.
-	if dbName.L == mysql.SystemDB {
+	if util2.IsSysDB(dbName.L) {
 		return paths, nil
 	}
 	isolationReadEngines := ctx.GetSessionVars().GetIsolationReadEngines()

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -4352,3 +4352,12 @@ StreamAgg	1.00	root		group by:planner__core__integration.sbtest.k, funcs:count(1
   └─TableReader	1.00	root		data:TableRangeScan
     └─TableRangeScan	1.00	cop[tikv]	table:sbtest	range:[0,1), keep order:false, stats:pseudo
 set @@tidb_opt_fix_control = default;
+create table sys.t (id int);
+insert into sys.t values (1),(2);
+set tidb_isolation_read_engines='tiflash';
+select * from sys.t;
+id
+1
+2
+drop table sys.t;
+set tidb_isolation_read_engines=DEFAULT;

--- a/tests/integrationtest/t/planner/core/integration.test
+++ b/tests/integrationtest/t/planner/core/integration.test
@@ -2386,3 +2386,11 @@ set @@tidb_opt_fix_control = '46177:on';
 explain format='brief'  select row_number() over(order by a.k) from (select * from sbtest where id<10) a;
 explain format='brief' select /*+ stream_agg() */ count(1) from sbtest where id<1 group by k;
 set @@tidb_opt_fix_control = default;
+
+# TestSysIsAccessibleWithTiFlashReadIsolation
+create table sys.t (id int);
+insert into sys.t values (1),(2);
+set tidb_isolation_read_engines='tiflash';
+select * from sys.t;
+drop table sys.t;
+set tidb_isolation_read_engines=DEFAULT;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51218

Problem Summary:

### What changed and how does it work?

Tell whether a table is `SysDB` with `IsSysDB`, but not `== mysql.SystemDB`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
None
```
