### PR TITLE
bootstrap: don't create sys schema for upgrade

### DIFF
--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -3008,8 +3008,6 @@ func upgradeToVer185(s sessiontypes.Session, ver int64) {
 	}
 
 	doReentrantDDL(s, DropMySQLIndexUsageTable)
-	doReentrantDDL(s, CreateSysSchema)
-	doReentrantDDL(s, CreateSchemaUnusedIndexesView)
 }
 
 func writeOOMAction(s sessiontypes.Session) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51220

Problem Summary:

`create database sys` and internal tables will make smooth upgrade failed, because the old version of TiDB doesn't think `sys` is a system table. This PR will avoid running these DDL for upgrade, so that the users will have to run these DDL manually if they need the view provided by `sys`.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Run a TiDB cluster with 2 TiDB: `tiup playground v7.5.0 --db 2 --tiflash 0`
Start the smooth upgrade: ` curl -X POST http://127.0.0.1:10081/upgrade/start`
Kill the first TiDB whose port is 4000: `kill .....`. Record the arguments.
Start the TiDB compiled with this patch: `./bin/tidb-server -P 4000 --store=tikv --host=127.0.0.1 --status=10080 --path=127.0.0.1:2379 --log-file=/home/yangkeao/.tiup/data/U4zeIfM/tidb-0/tidb.log --config=/home/yangkeao/.tiup/data/U4zeIfM/tidb-0/tidb.toml`

After a while, you'll find that the new TiDB starts and upgrades successfully.

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
