### PR TITLE
statistics: remove unnecessary copy in the baseCollector

### DIFF
--- a/pkg/statistics/row_sampler.go
+++ b/pkg/statistics/row_sampler.go
@@ -317,9 +317,7 @@ func (s *baseCollector) FromProto(pbCollector *tipb.RowSampleCollector, memTrack
 		rowLen := len(pbSample.Row)
 		data := make([]types.Datum, 0, rowLen)
 		for _, col := range pbSample.Row {
-			b := make([]byte, len(col))
-			copy(b, col)
-			data = append(data, types.NewBytesDatum(b))
+			data = append(data, types.NewBytesDatum(col))
 		}
 		// Directly copy the weight.
 		sampleItem := &ReservoirRowSampleItem{Columns: data, Weight: pbSample.Weight}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/51246

Problem Summary:

### What changed and how does it work?

baseCollector.FromProto will copy the bytes in the ```tipb.RowSampleCollector```. it is unnecessary. After FromProto, it will not be used again.

BTW Someone said the protobuf have a problem to make statistics wrong if we remove this copy. so let us check it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
