### PR TITLE
ddl: let tidb_ddl_reorg_worker_cnt controls fast DDL local backend concurrency

### DIFF
--- a/pkg/ddl/ingest/config.go
+++ b/pkg/ddl/ingest/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/lightning/common"
 	lightning "github.com/pingcap/tidb/br/pkg/lightning/config"
 	tidb "github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/size"
 	"go.uber.org/zap"
@@ -51,6 +52,8 @@ func genConfig(ctx context.Context, memRoot MemRoot, jobID int64, unique bool, r
 	cfg.TikvImporter.SortedKVDir = filepath.Join(LitSortPath, EncodeBackendTag(jobID))
 	if ImporterRangeConcurrencyForTest != nil {
 		cfg.TikvImporter.RangeConcurrency = int(ImporterRangeConcurrencyForTest.Load())
+	} else {
+		cfg.TikvImporter.RangeConcurrency = int(variable.GetDDLReorgWorkerCounter())
 	}
 	err := cfg.AdjustForDDL()
 	if err != nil {
@@ -143,7 +146,7 @@ func adjustImportMemory(ctx context.Context, memRoot MemRoot, cfg *lightning.Con
 
 	cfg.TikvImporter.LocalWriterMemCacheSize /= lightning.ByteSize(scale)
 	cfg.TikvImporter.EngineMemCacheSize /= lightning.ByteSize(scale)
-	// TODO: adjust range concurrency number to control total concurrency in the future.
+
 	logutil.Logger(ctx).Info(LitInfoChgMemSetting,
 		zap.Int64("local writer memory cache size", int64(cfg.TikvImporter.LocalWriterMemCacheSize)),
 		zap.Int64("engine memory cache size", int64(cfg.TikvImporter.EngineMemCacheSize)),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #51272

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

run 3 ADD INDEX tests,

```
CREATE TABLE `sbtest1` (
  `id` int(11) NOT NULL,
  `k` int(11) NOT NULL DEFAULT '0',
  `c` char(120) NOT NULL DEFAULT '',
  `pad` char(60) NOT NULL DEFAULT '',
  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
  KEY `k_1` (`k`),
  KEY `new_16` (`k`,`c`,`pad`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
```

1) before this PR 2) with this PR, with default 4 concurrency from tidb_ddl_reorg_worker_cnt 3) with this PR, with 16 concurrency which is the same value as before . Surprisingly the time costs and CPU does not change a lot.

![image](https://github.com/pingcap/tidb/assets/1689766/d89ecb7e-3581-4a5e-a340-e66c6ad298d3)

ADD INDEX time cost

```
 CREATE_TIME: 2024-02-27 02:29:25
  START_TIME: 2024-02-27 02:29:25
    END_TIME: 2024-02-27 03:20:53
~51min

 CREATE_TIME: 2024-02-27 03:32:44
  START_TIME: 2024-02-27 03:32:44
    END_TIME: 2024-02-27 04:28:30
~56min

 CREATE_TIME: 2024-02-27 05:03:29
  START_TIME: 2024-02-27 05:03:29
    END_TIME: 2024-02-27 05:56:27
~53min
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
tidb_ddl_reorg_worker_cnt now controls the ingest concurrency in fast DDL mode
```
