### PR TITLE
bootstrap: aggregate the unused index across multiple nodes

### DIFF
--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -701,9 +701,11 @@ const (
 			index_name
 		FROM information_schema.cluster_tidb_index_usage
 		WHERE
-			last_access_time is null and
 			table_schema not in ('sys', 'mysql', 'INFORMATION_SCHEMA', 'PERFORMANCE_SCHEMA') and
-			index_name != 'PRIMARY';`
+			index_name != 'PRIMARY'
+		GROUP BY table_schema, table_name, index_name
+		HAVING
+			sum(last_access_time) is null;`
 )
 
 // CreateTimers is a table to store all timers for tidb


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51269

### What changed and how does it work?

Aggregate the unused index across multiple nodes. The original SQL didn't aggregate them 🤦 , so an index will appear multiple times. A silly bug.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Create a cluster with two tidb nodes

```
tiup playground --db 2 --db.binpath ./bin/tidb-server
```

Run the following SQLs

```
create table t (id_1 int, id_2 int, unique key idx_1(id_1), unique key idx_2(id_2));
insert into t with recursive seq as (select 1 as id union all select id + 1 from seq where seq.id < 100) select id as id_1, id as id_2 from seq;
analyze table t;
select * from t use index(idx_1) where id_1 > 60;
select * from sys.schema_unused_indexes;
```

It'll give:

```
mysql> select * from sys.schema_unused_indexes;
+---------------+-------------+------------+
| object_schema | object_name | index_name |
+---------------+-------------+------------+
| test          | t           | idx_2      |
+---------------+-------------+------------+
1 row in set (0.00 sec)
```

The plan is like:

```
+----------------------------------+----------+-----------+--------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id                               | estRows  | task      | access object                  | operator info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+----------------------------------+----------+-----------+--------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Projection_9                     | 1846.12  | root      |                                | information_schema.cluster_tidb_index_usage.table_schema, information_schema.cluster_tidb_index_usage.table_name, information_schema.cluster_tidb_index_usage.index_name                                                                                                                                                                                                                                                                                                                                           |
| └─Selection_10                   | 1846.12  | root      |                                | isnull(Column#17)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
|   └─HashAgg_11                   | 2307.64  | root      |                                | group by:Column#25, Column#26, Column#27, funcs:sum(Column#21)->Column#17, funcs:firstrow(Column#22)->information_schema.cluster_tidb_index_usage.table_schema, funcs:firstrow(Column#23)->information_schema.cluster_tidb_index_usage.table_name, funcs:firstrow(Column#24)->information_schema.cluster_tidb_index_usage.index_name                                                                                                                                                                               |
|     └─Projection_15              | 2884.56  | root      |                                | cast(information_schema.cluster_tidb_index_usage.last_access_time, double BINARY)->Column#21, information_schema.cluster_tidb_index_usage.table_schema->Column#22, information_schema.cluster_tidb_index_usage.table_name->Column#23, information_schema.cluster_tidb_index_usage.index_name->Column#24, information_schema.cluster_tidb_index_usage.table_schema->Column#25, information_schema.cluster_tidb_index_usage.table_name->Column#26, information_schema.cluster_tidb_index_usage.index_name->Column#27 |
|       └─TableReader_14           | 2884.56  | root      |                                | data:Selection_13                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
|         └─Selection_13           | 2884.56  | cop[tidb] |                                | ne(information_schema.cluster_tidb_index_usage.index_name, "PRIMARY"), not(in(information_schema.cluster_tidb_index_usage.table_schema, "sys", "mysql", "INFORMATION_SCHEMA", "PERFORMANCE_SCHEMA"))                                                                                                                                                                                                                                                                                                               |
|           └─TableFullScan_12     | 10000.00 | cop[tidb] | table:CLUSTER_TIDB_INDEX_USAGE | keep order:false, stats:pseudo                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+----------------------------------+----------+-----------+--------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
7 rows in set (0.00 sec)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
