### PR TITLE
statistics: use correct last update version

### DIFF
--- a/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
     srcs = ["refresher_test.go"],
     embed = [":refresher"],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/parser/model",
         "//pkg/statistics",

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -302,14 +302,14 @@ func getTableLastAnalyzeDuration(
 	tblStats *statistics.Table,
 	currentTs uint64,
 ) time.Duration {
-	versionTime := findLastAnalyzeVersion(tblStats, currentTs)
+	lastTime := findLastAnalyzeTime(tblStats, currentTs)
 	currentTime := oracle.GetTimeFromTS(currentTs)
 
 	// Calculate the duration since last analyze.
-	return currentTime.Sub(versionTime)
+	return currentTime.Sub(lastTime)
 }
 
-func findLastAnalyzeVersion(
+func findLastAnalyzeTime(
 	tblStats *statistics.Table,
 	currentTs uint64,
 ) time.Time {

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -170,6 +170,7 @@ func (r *Refresher) rebuildTableAnalysisJobQueue() error {
 							sctx,
 							db,
 							tblInfo,
+							// TODO: use GetPartitionStatsForAutoAnalyze to save memory.
 							r.statsHandle.GetPartitionStats(tblInfo, tblInfo.ID),
 							autoAnalyzeRatio,
 							currentTs,

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -312,7 +312,6 @@ func findLastAnalyzeTime(
 	tblStats *statistics.Table,
 	currentTs uint64,
 ) time.Time {
-	// Big enough to make sure the first version is smaller than this.
 	maxVersion := uint64(0)
 	for _, idx := range tblStats.Indices {
 		if idx.IsAnalyzed() {

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -15,7 +15,6 @@
 package refresher
 
 import (
-	"math"
 	"strings"
 	"time"
 
@@ -314,24 +313,23 @@ func findLastAnalyzeTime(
 	currentTs uint64,
 ) time.Time {
 	// Big enough to make sure the first version is smaller than this.
-	minVersion := uint64(math.MaxUint64)
+	maxVersion := uint64(0)
 	for _, idx := range tblStats.Indices {
 		if idx.IsAnalyzed() {
-			minVersion = min(minVersion, idx.LastUpdateVersion)
+			maxVersion = max(maxVersion, idx.LastUpdateVersion)
 		}
 	}
 	for _, col := range tblStats.Columns {
 		if col.IsAnalyzed() {
-			minVersion = min(minVersion, col.LastUpdateVersion)
+			maxVersion = max(maxVersion, col.LastUpdateVersion)
 		}
 	}
-
 	// Table is not analyzed, compose a fake version.
-	if minVersion == math.MaxUint64 {
+	if maxVersion == 0 {
 		phy := oracle.GetTimeFromTS(currentTs)
 		return phy.Add(unanalyzedTableDefaultLastUpdateDuration)
 	}
-	return oracle.GetTimeFromTS(minVersion)
+	return oracle.GetTimeFromTS(maxVersion)
 }
 
 func checkIndexesNeedAnalyze(

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -35,7 +35,9 @@ import (
 )
 
 const (
-	unanalyzedTableDefaultChangePercentage   = 1
+	// unanalyzedTableDefaultChangePercentage is the default change percentage of unanalyzed table.
+	unanalyzedTableDefaultChangePercentage = 1
+	// unanalyzedTableDefaultLastUpdateDuration is the default last update duration of unanalyzed table.
 	unanalyzedTableDefaultLastUpdateDuration = -30 * time.Minute
 )
 
@@ -308,6 +310,10 @@ func getTableLastAnalyzeDuration(
 	return currentTime.Sub(lastTime)
 }
 
+// findLastAnalyzeTime finds the last analyze time of the table.
+// It uses `LastUpdateVersion` to find the last analyze time.
+// The `LastUpdateVersion` is the version of the transaction that updates the statistics.
+// It always not null(default 0), so we can use it to find the last analyze time.
 func findLastAnalyzeTime(
 	tblStats *statistics.Table,
 	currentTs uint64,

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
@@ -402,8 +402,12 @@ func TestCheckIndexesNeedAnalyze(t *testing.T) {
 }
 
 func TestCalculateIndicatorsForPartitions(t *testing.T) {
-	currentTs := oracle.ComposeTS((time.Hour.Nanoseconds()+time.Second.Nanoseconds())*1000, 0)
-
+	// 2024-01-01 10:00:00
+	currentTime := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	currentTs := oracle.GoTimeToTS(currentTime)
+	// 2023-12-31 10:00:00
+	lastUpdateTime := time.Date(2023, 12, 31, 10, 0, 0, 0, time.UTC)
+	lastUpdateTs := oracle.GoTimeToTS(lastUpdateTime)
 	tests := []struct {
 		name                       string
 		tblInfo                    *model.TableInfo
@@ -441,14 +445,12 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 						Pseudo:        false,
 						RealtimeCount: exec.AutoAnalyzeMinCnt + 1,
 					},
-					Version: currentTs,
 				},
 				2: {
 					HistColl: statistics.HistColl{
 						Pseudo:        false,
 						RealtimeCount: exec.AutoAnalyzeMinCnt + 1,
 					},
-					Version: currentTs,
 				},
 			},
 			defs: []model.PartitionDefinition{
@@ -465,7 +467,7 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 			currentTs:                  currentTs,
 			wantAvgChangePercentage:    1,
 			wantAvgSize:                2002,
-			wantAvgLastAnalyzeDuration: 0,
+			wantAvgLastAnalyzeDuration: 1800 * time.Second,
 			wantPartitions:             []string{"p0", "p1"},
 		},
 		{
@@ -496,9 +498,15 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 						Columns: map[int64]*statistics.Column{
 							1: {
 								StatsVer: 2,
+								Histogram: statistics.Histogram{
+									LastUpdateVersion: lastUpdateTs,
+								},
 							},
 							2: {
 								StatsVer: 2,
+								Histogram: statistics.Histogram{
+									LastUpdateVersion: lastUpdateTs,
+								},
 							},
 						},
 					},
@@ -512,9 +520,15 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 						Columns: map[int64]*statistics.Column{
 							1: {
 								StatsVer: 2,
+								Histogram: statistics.Histogram{
+									LastUpdateVersion: lastUpdateTs,
+								},
 							},
 							2: {
 								StatsVer: 2,
+								Histogram: statistics.Histogram{
+									LastUpdateVersion: lastUpdateTs,
+								},
 							},
 						},
 					},
@@ -535,7 +549,7 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 			currentTs:                  currentTs,
 			wantAvgChangePercentage:    2,
 			wantAvgSize:                2002,
-			wantAvgLastAnalyzeDuration: 0,
+			wantAvgLastAnalyzeDuration: 24 * time.Hour,
 			wantPartitions:             []string{"p0"},
 		},
 		{
@@ -566,9 +580,15 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 						Columns: map[int64]*statistics.Column{
 							1: {
 								StatsVer: 2,
+								Histogram: statistics.Histogram{
+									LastUpdateVersion: lastUpdateTs,
+								},
 							},
 							2: {
 								StatsVer: 2,
+								Histogram: statistics.Histogram{
+									LastUpdateVersion: lastUpdateTs,
+								},
 							},
 						},
 					},
@@ -582,9 +602,15 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 						Columns: map[int64]*statistics.Column{
 							1: {
 								StatsVer: 2,
+								Histogram: statistics.Histogram{
+									LastUpdateVersion: lastUpdateTs,
+								},
 							},
 							2: {
 								StatsVer: 2,
+								Histogram: statistics.Histogram{
+									LastUpdateVersion: lastUpdateTs,
+								},
 							},
 						},
 					},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/50132

Problem Summary:

### What changed and how does it work?

There are two versions here:
1. Version: The last stats update version(count and modify_count).
2. LastUpdateVersion: The last update time of the histogram. We can take it as the last analysis time.

We should use the second one here instead of the first one.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
