### PR TITLE
executor: make `checksum` block gc

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -560,12 +560,6 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		}
 	}
 
-	breakpoint.Inject(a.Ctx, sessiontxn.BreakPointBeforeExecutorFirstRun)
-	if err = a.openExecutor(ctx, e); err != nil {
-		terror.Log(exec.Close(e))
-		return nil, err
-	}
-
 	cmd32 := atomic.LoadUint32(&sctx.GetSessionVars().CommandValue)
 	cmd := byte(cmd32)
 	var pi processinfoSetter
@@ -582,6 +576,12 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 			maxExecutionTime = 0
 		}
 		pi.SetProcessInfo(sql, time.Now(), cmd, maxExecutionTime)
+	}
+
+	breakpoint.Inject(a.Ctx, sessiontxn.BreakPointBeforeExecutorFirstRun)
+	if err = a.openExecutor(ctx, e); err != nil {
+		terror.Log(exec.Close(e))
+		return nil, err
 	}
 
 	isPessimistic := sctx.GetSessionVars().TxnCtx.IsPessimistic


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50920

Problem Summary:

### What changed and how does it work?

As https://github.com/pingcap/tidb/issues/50920#issuecomment-1963492417 described, we now have two choices to fix it:
1. move the time-cost work of `CheckSum` from `Open` to `Next`.
2. make `CheckSum` processInfo updated earlier.

This pr chooses the second one, there seems no bad effects we move `SetProcessInfo` before `openExecutor` is called.
And this can alse fix similar problems like `CheckSum` who's time-cost work is placed in `Open` function.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test as follow steps:
1. update code like this:
```
$ git diff
diff --git a/pkg/executor/checksum.go b/pkg/executor/checksum.go
index bca0af9..b3b31e3 100644
--- a/pkg/executor/checksum.go
+++ b/pkg/executor/checksum.go
@@ -17,6 +17,7 @@ package executor
 import (
        "context"
        "strconv"
+       "time"
 
        "github.com/pingcap/failpoint"
        "github.com/pingcap/tidb/pkg/distsql"
@@ -90,6 +91,7 @@ func (e *ChecksumTableExec) Open(ctx context.Context) error {
        if err != nil {
                return err
        }
+       time.Sleep(30*time.Minute)
 
        return nil
 }
```

2. Deploy tidb cluster with above tidb version.
3. mysql execute "select now();" to check current time.
4. then execute "admin checksum table t";
5. then check that before above query exits, `tikv_gc_safe_point` can nerver newer than the time step 3 shows.

The tests shows:

Before the admin query, the gc safepoint is:
```
| tikv_gc_last_run_time    | 20240226-16:04:06.548 +0800                                                                     |
| tikv_gc_safe_point       | 20240226-15:54:06.548 +0800 
```
Then the query block gc, the gc can only push to:
```
| tikv_gc_last_run_time    | 20240226-16:15:06.548 +0800                                                                     |
| tikv_gc_safe_point       | 20240226-15:54:26.797 +0800 
```
After the query finish, the gc push forward again.
```
| tikv_gc_last_run_time    | 20240226-16:26:06.548 +0800                                                                     |
| tikv_gc_safe_point       | 20240226-16:16:06.548 +0800  
```


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
