### PR TITLE
executor: I have aligned behavior of foreign keys in "SHOW CREATE TABLE" with MySQL.

### DIFF
--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -1172,7 +1172,7 @@ func constructResultOfShowCreateTable(ctx sessionctx.Context, dbName *model.CISt
 			colNames = append(colNames, stringutil.Escape(col.O, sqlMode))
 		}
 		fmt.Fprintf(buf, "(%s)", strings.Join(colNames, ","))
-		if fk.RefSchema.L != "" {
+		if fk.RefSchema.L != "" && dbName != nil && fk.RefSchema.L != dbName.L {
 			fmt.Fprintf(buf, " REFERENCES %s.%s ", stringutil.Escape(fk.RefSchema.O, sqlMode), stringutil.Escape(fk.RefTable.O, sqlMode))
 		} else {
 			fmt.Fprintf(buf, " REFERENCES %s ", stringutil.Escape(fk.RefTable.O, sqlMode))

--- a/tests/integrationtest/r/ddl/column_type_change.result
+++ b/tests/integrationtest/r/ddl/column_type_change.result
@@ -2066,7 +2066,7 @@ orders	CREATE TABLE `orders` (
   `doc` json DEFAULT NULL,
   PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
   KEY `fk_user_id` (`user_id`),
-  CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `ddl__column_type_change`.`users` (`id`)
+  CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 drop table if exists users, orders;
 CREATE TABLE users (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, doc JSON);
@@ -2080,7 +2080,7 @@ orders	CREATE TABLE `orders` (
   `doc` json DEFAULT NULL,
   PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
   KEY `fk_user_id` (`user_id2`),
-  CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id2`) REFERENCES `ddl__column_type_change`.`users` (`id`)
+  CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id2`) REFERENCES `users` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 drop table if exists users, orders;
 CREATE TABLE users (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, doc JSON);
@@ -2094,7 +2094,7 @@ orders	CREATE TABLE `orders` (
   `doc` json DEFAULT NULL,
   PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
   KEY `fk_user_id` (`user_id`),
-  CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `ddl__column_type_change`.`users` (`id`)
+  CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 drop table if exists users, orders;
 CREATE TABLE users (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, doc JSON);

--- a/tests/integrationtest/r/ddl/foreign_key.result
+++ b/tests/integrationtest/r/ddl/foreign_key.result
@@ -132,8 +132,8 @@ t2	CREATE TABLE `t2` (
   `b` int(11) DEFAULT NULL,
   KEY `fk_1` (`a`),
   KEY `fk_2` (`b`),
-  CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `ddl__foreign_key`.`t1` (`id`),
-  CONSTRAINT `fk_2` FOREIGN KEY (`b`) REFERENCES `ddl__foreign_key`.`t1` (`id`)
+  CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `t1` (`id`),
+  CONSTRAINT `fk_2` FOREIGN KEY (`b`) REFERENCES `t1` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 drop table t2;
 create table t2 (a int, b int, index idx0(a,b), index idx1(a), index idx2(b));

--- a/tests/integrationtest/r/executor/foreign_key.result
+++ b/tests/integrationtest/r/executor/foreign_key.result
@@ -115,7 +115,7 @@ t1	CREATE TABLE `t1` (
   PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
   KEY `leader` (`leader`),
   KEY `leader2` (`leader2`),
-  CONSTRAINT `fk` FOREIGN KEY (`leader`) REFERENCES `executor__foreign_key`.`t1` (`id`) ON DELETE CASCADE ON UPDATE SET NULL /* FOREIGN KEY INVALID */
+  CONSTRAINT `fk` FOREIGN KEY (`leader`) REFERENCES `t1` (`id`) ON DELETE CASCADE ON UPDATE SET NULL /* FOREIGN KEY INVALID */
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 set @@global.tidb_enable_foreign_key=1;
 alter table t1 add constraint fk2 foreign key (leader2) references t1 (id);
@@ -128,8 +128,8 @@ t1	CREATE TABLE `t1` (
   PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
   KEY `leader` (`leader`),
   KEY `leader2` (`leader2`),
-  CONSTRAINT `fk` FOREIGN KEY (`leader`) REFERENCES `executor__foreign_key`.`t1` (`id`) ON DELETE CASCADE ON UPDATE SET NULL /* FOREIGN KEY INVALID */,
-  CONSTRAINT `fk2` FOREIGN KEY (`leader2`) REFERENCES `executor__foreign_key`.`t1` (`id`)
+  CONSTRAINT `fk` FOREIGN KEY (`leader`) REFERENCES `t1` (`id`) ON DELETE CASCADE ON UPDATE SET NULL /* FOREIGN KEY INVALID */,
+  CONSTRAINT `fk2` FOREIGN KEY (`leader2`) REFERENCES `t1` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 drop table t1;
 create table t1 (id int key, leader int, leader2 int, index(leader), index(leader2), constraint fk foreign key (leader) references t1(id) /* FOREIGN KEY INVALID */);
@@ -452,5 +452,29 @@ select * from t2 order by id;
 id
 2
 3
+set @@global.tidb_enable_foreign_key=default;
+set @@foreign_key_checks=default;
+set @@global.tidb_enable_foreign_key=1;
+set @@foreign_key_checks=1;
+create database executor__foreign_key_other_schema;
+use executor__foreign_key_other_schema;
+drop table if exists users;
+CREATE TABLE users (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, doc JSON);
+use executor__foreign_key;
+drop table if exists orders;
+CREATE TABLE orders (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, user_id INT NOT NULL, doc JSON, FOREIGN KEY fk_user_id (user_id) REFERENCES executor__foreign_key_other_schema.users(id));
+alter table orders modify user_id int null;
+show create table orders;
+Table	Create Table
+orders	CREATE TABLE `orders` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `doc` json DEFAULT NULL,
+  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
+  KEY `fk_user_id` (`user_id`),
+  CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `executor__foreign_key_other_schema`.`users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+drop table if exists orders;
+drop database executor__foreign_key_other_schema;
 set @@global.tidb_enable_foreign_key=default;
 set @@foreign_key_checks=default;

--- a/tests/integrationtest/r/executor/show.result
+++ b/tests/integrationtest/r/executor/show.result
@@ -370,7 +370,7 @@ child	CREATE TABLE `child` (
   `parent_id` int(11) NOT NULL,
   PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
   KEY `par_ind` (`parent_id`),
-  CONSTRAINT `child_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `executor__show`.`parent` (`id`)
+  CONSTRAINT `child_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 DROP TABLE child;
 CREATE TABLE child (id INT NOT NULL PRIMARY KEY auto_increment, parent_id INT NOT NULL, INDEX par_ind (parent_id), CONSTRAINT child_ibfk_1 FOREIGN KEY (parent_id) REFERENCES parent(id) ON DELETE RESTRICT ON UPDATE CASCADE);
@@ -381,7 +381,7 @@ child	CREATE TABLE `child` (
   `parent_id` int(11) NOT NULL,
   PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
   KEY `par_ind` (`parent_id`),
-  CONSTRAINT `child_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `executor__show`.`parent` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+  CONSTRAINT `child_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 create database test1;
 create database test2;

--- a/tests/integrationtest/t/executor/foreign_key.test
+++ b/tests/integrationtest/t/executor/foreign_key.test
@@ -377,3 +377,19 @@ disconnect conn1;
 set @@global.tidb_enable_foreign_key=default;
 set @@foreign_key_checks=default;
 
+# TestForeignKeyOtherSchema
+set @@global.tidb_enable_foreign_key=1;
+set @@foreign_key_checks=1;
+create database executor__foreign_key_other_schema;
+use executor__foreign_key_other_schema;
+drop table if exists users;
+CREATE TABLE users (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, doc JSON);
+use executor__foreign_key;
+drop table if exists orders;
+CREATE TABLE orders (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, user_id INT NOT NULL, doc JSON, FOREIGN KEY fk_user_id (user_id) REFERENCES executor__foreign_key_other_schema.users(id));
+alter table orders modify user_id int null;
+show create table orders;
+drop table if exists orders;
+drop database executor__foreign_key_other_schema;
+set @@global.tidb_enable_foreign_key=default;
+set @@foreign_key_checks=default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Problem Summary:

I'm using parallel_tests with Ruby.
I copy the schema for use, but since foreign keys have schemas, I need to fix the discrepancy in results.

ex)

* CREATE TABLE
```
CREATE TABLE `foos` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `name` varchar(255) DEFAULT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;

CREATE TABLE `bars` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `foo_id` int(11) NOT NULL,
  PRIMARY KEY (`id`),
  CONSTRAINT `fk_xxx` FOREIGN KEY (`foo_id`) REFERENCES `foo` (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
```

* SHOW CREATE TABLE(MySQL)
```
mysql> SHOW CREATE TABLE bars \G
******************** 1. row ********************
       Table: bars
Create Table: CREATE TABLE `bars` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `foo_id` int(11) NOT NULL,
  PRIMARY KEY (`id`),
  CONSTRAINT `fk_xxx` FOREIGN KEY (`foo_id`) REFERENCES `foo` (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
```
  * SHOW CREATE TABLE(TiDB)
```
mysql> SHOW CREATE TABLE bars \G
******************** 1. row ********************
       Table: bars
Create Table: CREATE TABLE `bars` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `foo_id` int(11) NOT NULL,
  PRIMARY KEY (`id`),
  CONSTRAINT `fk_xxx` FOREIGN KEY (`foo_id`) REFERENCES `schema_name`.`foo` (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
```
It's a quick hack, so it's not a good fix.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
