### PR TITLE
license: ignore checking license on `pkg/extension/enterprise/`

### DIFF
--- a/.github/licenserc.yml
+++ b/.github/licenserc.yml
@@ -53,4 +53,5 @@ header:
     - "OWNERS_ALIASES"
     - "pkg/disttask/**/mock/**/*_mock.go"
     - "pkg/util/sqlexec/mock/*_mock.go"
+    - "pkg/extension/enterprise/"
   comment: on-failure


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51348

Problem Summary:

Since the files on `pkg/extension/enterprise` are not open source, we don't need to check the license of these files.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
