### PR TITLE
util/ranger: do not convert to binary collate for string values when `convertToSortKey` is `false`

### DIFF
--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -778,7 +778,10 @@ func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(condition *expression
 				hasResidual = true
 			}
 			points := rb.build(item, newTpSlice[0], d.lengths[0], d.convertToSortKey)
-			tmpNewTp := convertStringFTToBinaryCollate(newTpSlice[0])
+			tmpNewTp := newTpSlice[0]
+			if d.convertToSortKey {
+				tmpNewTp = convertStringFTToBinaryCollate(tmpNewTp)
+			}
 			// TODO: restrict the mem usage of ranges
 			ranges, rangeFallback, err := points2Ranges(d.sctx, points, tmpNewTp, d.rangeMaxSize)
 			if err != nil {

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -490,7 +490,10 @@ func (d *rangeDetacher) buildRangeOnColsByCNFCond(newTp []*types.FieldType, eqAn
 		if rb.err != nil {
 			return nil, nil, nil, errors.Trace(rb.err)
 		}
-		tmpNewTp := convertStringFTToBinaryCollate(newTp[i])
+		tmpNewTp := newTp[i]
+		if d.convertToSortKey {
+			tmpNewTp = convertStringFTToBinaryCollate(tmpNewTp)
+		}
 		if i == 0 {
 			ranges, rangeFallback, err = points2Ranges(d.sctx, point, tmpNewTp, d.rangeMaxSize)
 		} else {

--- a/tests/integrationtest/r/planner/core/casetest/partition/integration_partition.result
+++ b/tests/integrationtest/r/planner/core/casetest/partition/integration_partition.result
@@ -738,3 +738,15 @@ Projection	10.00	root		list_partition_pruning.thash.a
         └─Limit	10.00	cop[tikv]		offset:0, count:10
           └─Selection	10.00	cop[tikv]		gt(list_partition_pruning.thash.a, 10)
             └─TableFullScan	30.00	cop[tikv]	table:thash, partition:p3	keep order:true, stats:pseudo
+drop table if exists t;
+create table t(col varchar(32) COLLATE utf8mb4_general_ci DEFAULT NULL) PARTITION BY KEY (`col`) PARTITIONS 7;
+explain format = brief select * from t where col = 'linpin';
+id	estRows	task	access object	operator info
+TableReader	10.00	root		data:Selection
+└─Selection	10.00	cop[tikv]		eq(list_partition_pruning.t.col, "linpin")
+  └─TableFullScan	10000.00	cop[tikv]	table:t, partition:p4	keep order:false, stats:pseudo
+explain format = brief select * from t where col = 'LINPIN';
+id	estRows	task	access object	operator info
+TableReader	10.00	root		data:Selection
+└─Selection	10.00	cop[tikv]		eq(list_partition_pruning.t.col, "LINPIN")
+  └─TableFullScan	10000.00	cop[tikv]	table:t, partition:p4	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/planner/core/casetest/partition/integration_partition.test
+++ b/tests/integrationtest/t/planner/core/casetest/partition/integration_partition.test
@@ -180,3 +180,8 @@ explain format='brief' select a from trange use index () where a > 10 order by b
 explain format='brief' select a from tlist use index () where a > 10 order by b limit 10;
 explain format='brief' select a from thash use index () where a > 10 order by b limit 10;
 
+# TestIssue51316
+drop table if exists t;
+create table t(col varchar(32) COLLATE utf8mb4_general_ci DEFAULT NULL) PARTITION BY KEY (`col`) PARTITIONS 7;
+explain format = brief select * from t where col = 'linpin';
+explain format = brief select * from t where col = 'LINPIN';


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51316

Problem Summary:

As said in 3. of #48522, `convertStringFTToBinaryCollate` should be used only for the new `convertToSortKey` case.

But in the code, among the 4 places `convertStringFTToBinaryCollate` is called, 2 of them missed this check, and resulted in values with wrong types in the result `Range`.

Currently `convertToSortKey = false` is only used for partition pruning.

### What changed and how does it work?

As the title says, add check for `convertToSortKey` when using `convertStringFTToBinaryCollate`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
