### PR TITLE
operator: print callstack when exiting before preparing done

### DIFF
--- a/br/cmd/br/main.go
+++ b/br/cmd/br/main.go
@@ -2,39 +2,17 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
 
 func main() {
 	gCtx := context.Background()
-	ctx, cancel := context.WithCancel(gCtx)
-	defer cancel()
-
-	sc := make(chan os.Signal, 1)
-	signal.Notify(sc,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT)
-
-	go func() {
-		sig := <-sc
-		fmt.Printf("\nGot signal [%v] to exit.\n", sig)
-		log.Warn("received signal to exit", zap.Stringer("signal", sig))
-		cancel()
-		fmt.Fprintln(os.Stderr, "gracefully shuting down, press ^C again to force exit")
-		<-sc
-		// Even user use SIGTERM to exit, there isn't any checkpoint for resuming,
-		// hence returning fail exit code.
-		os.Exit(1)
-	}()
+	ctx, cancel := utils.StartExitSingleListener(gCtx)
 
 	rootCmd := &cobra.Command{
 		Use:              "br",

--- a/br/pkg/backup/prepare_snap/prepare.go
+++ b/br/pkg/backup/prepare_snap/prepare.go
@@ -372,6 +372,7 @@ func (p *Preparer) workOnPendingRanges(ctx context.Context) error {
 func (p *Preparer) sendWaitApply(ctx context.Context, reqs pendingRequests) error {
 	logutil.CL(ctx).Info("about to send wait apply to stores", zap.Int("to-stores", len(reqs)))
 	for store, req := range reqs {
+		logutil.CL(ctx).Info("sending wait apply requests to store", zap.Uint64("store", store), zap.Int("regions", len(req.Regions)))
 		stream, err := p.streamOf(ctx, store)
 		if err != nil {
 			return errors.Annotatef(err, "failed to dial the store %d", store)
@@ -380,7 +381,6 @@ func (p *Preparer) sendWaitApply(ctx context.Context, reqs pendingRequests) erro
 		if err != nil {
 			return errors.Annotatef(err, "failed to send message to the store %d", store)
 		}
-		logutil.CL(ctx).Info("sent wait apply requests to store", zap.Uint64("store", store), zap.Int("regions", len(req.Regions)))
 	}
 	return nil
 }

--- a/br/pkg/backup/prepare_snap/prepare.go
+++ b/br/pkg/backup/prepare_snap/prepare.go
@@ -370,6 +370,7 @@ func (p *Preparer) workOnPendingRanges(ctx context.Context) error {
 }
 
 func (p *Preparer) sendWaitApply(ctx context.Context, reqs pendingRequests) error {
+	logutil.CL(ctx).Info("about to send wait apply to stores", zap.Int("to-stores", len(reqs)))
 	for store, req := range reqs {
 		stream, err := p.streamOf(ctx, store)
 		if err != nil {

--- a/br/pkg/task/operator/cmd.go
+++ b/br/pkg/task/operator/cmd.go
@@ -106,6 +106,7 @@ func hintAllReady() {
 // AdaptEnvForSnapshotBackup blocks the current goroutine and pause the GC safepoint and remove the scheduler by the config.
 // This function will block until the context being canceled.
 func AdaptEnvForSnapshotBackup(ctx context.Context, cfg *PauseGcConfig) error {
+	utils.DumpGoroutineWhenExit.Store(true)
 	mgr, err := dialPD(ctx, &cfg.Config)
 	if err != nil {
 		return errors.Annotate(err, "failed to dial PD")
@@ -141,6 +142,7 @@ func AdaptEnvForSnapshotBackup(ctx context.Context, cfg *PauseGcConfig) error {
 		if cfg.OnAllReady != nil {
 			cfg.OnAllReady()
 		}
+		utils.DumpGoroutineWhenExit.Store(false)
 		hintAllReady()
 	}()
 	defer func() {

--- a/br/pkg/utils/misc.go
+++ b/br/pkg/utils/misc.go
@@ -16,8 +16,16 @@ package utils
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"syscall"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
@@ -156,4 +164,53 @@ func WithCleanUp(errOut *error, timeout time.Duration, fn func(context.Context) 
 	} else if err != nil {
 		log.Warn("Encountered but ignored error while cleaning up.", zap.Error(err))
 	}
+}
+
+func AllStackInfo() []byte {
+	res := make([]byte, 256*units.KiB)
+	for {
+		n := runtime.Stack(res, true)
+		if n < len(res) {
+			return res[:n]
+		}
+		res = make([]byte, len(res)*2)
+	}
+}
+
+var (
+	DumpGoroutineWhenExit atomic.Bool
+)
+
+func StartExitSingleListener(ctx context.Context) (context.Context, context.CancelFunc) {
+	cx, cancel := context.WithCancel(ctx)
+	sc := make(chan os.Signal, 1)
+	signal.Notify(sc,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT)
+	go func() {
+		sig := <-sc
+		dumpGoroutine := DumpGoroutineWhenExit.Load()
+		padding := strings.Repeat("=", 8)
+		printDelimate := func(s string) {
+			fmt.Printf("%s[ %s ]%s\n", padding, s, padding)
+		}
+		fmt.Println()
+		printDelimate(fmt.Sprintf("Got signal %v to exit.", sig))
+		printDelimate(fmt.Sprintf("Required Goroutine Dump = %v", dumpGoroutine))
+		if DumpGoroutineWhenExit.Load() {
+			printDelimate("Start Dumping Goroutine")
+			os.Stdout.Write(AllStackInfo())
+			printDelimate("End of Dumping Goroutine")
+		}
+		log.Warn("received signal to exit", zap.Stringer("signal", sig))
+		cancel()
+		fmt.Fprintln(os.Stderr, "gracefully shutting down, press ^C again to force exit")
+		<-sc
+		// Even user use SIGTERM to exit, there isn't any checkpoint for resuming,
+		// hence returning fail exit code.
+		os.Exit(1)
+	}()
+	return cx, cancel
 }

--- a/br/pkg/utils/misc.go
+++ b/br/pkg/utils/misc.go
@@ -199,7 +199,7 @@ func StartExitSingleListener(ctx context.Context) (context.Context, context.Canc
 		fmt.Println()
 		printDelimate(fmt.Sprintf("Got signal %v to exit.", sig))
 		printDelimate(fmt.Sprintf("Required Goroutine Dump = %v", dumpGoroutine))
-		if DumpGoroutineWhenExit.Load() {
+		if dumpGoroutine {
 			printDelimate("Start Dumping Goroutine")
 			os.Stdout.Write(AllStackInfo())
 			printDelimate("End of Dumping Goroutine")

--- a/br/pkg/utils/misc.go
+++ b/br/pkg/utils/misc.go
@@ -201,7 +201,7 @@ func StartExitSingleListener(ctx context.Context) (context.Context, context.Canc
 		printDelimate(fmt.Sprintf("Required Goroutine Dump = %v", dumpGoroutine))
 		if dumpGoroutine {
 			printDelimate("Start Dumping Goroutine")
-			os.Stdout.Write(AllStackInfo())
+			_, _ = os.Stdout.Write(AllStackInfo())
 			printDelimate("End of Dumping Goroutine")
 		}
 		log.Warn("received signal to exit", zap.Stringer("signal", sig))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51370 

Problem Summary:
It is hard to debug what happens when the init pod get timed out.

### What changed and how does it work?
This PR will print all gorouintes to `stdout` once the `prepare-for-snapshot-backup` command exits before finishing the full prepare stage.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

When we are not yet finished:
![CleanShot 2024-02-27 at 19 28 14@2x](https://github.com/pingcap/tidb/assets/36239017/b9b0e4fc-7fba-4ee5-af3e-4b8befcc4749)
When we have finished prepare stage:
![CleanShot 2024-02-27 at 19 28 51@2x](https://github.com/pingcap/tidb/assets/36239017/cce2d235-ee98-4175-85b5-70b73d29f3dc)

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
