### PR TITLE
tools/check: adpot staged build to make ut a little bit faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,11 +129,7 @@ integrationtest: server_check
 ddltest:
 	@cd cmd/ddltest && $(GO) test --tags=deadllock,intest -o ../../bin/ddltest -c
 
-generate-test-build-cache:
-	@echo "generate test build cache"
-	@cd cmd/tidb-server && go test -tags intest -exec true -vet off
-
-ut: tools/bin/ut tools/bin/xprog failpoint-enable generate-test-build-cache
+ut: tools/bin/ut tools/bin/xprog failpoint-enable
 	tools/bin/ut $(X) || { $(FAILPOINT_DISABLE); exit 1; }
 	@$(FAILPOINT_DISABLE)
 	@$(CLEAN_UT_BINARY)

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,11 @@ integrationtest: server_check
 ddltest:
 	@cd cmd/ddltest && $(GO) test --tags=deadllock,intest -o ../../bin/ddltest -c
 
-ut: tools/bin/ut tools/bin/xprog failpoint-enable
+generate-test-build-cache:
+	@echo "generate test build cache"
+	@cd cmd/tidb-server && go test -tags intest -exec true -vet off
+
+ut: tools/bin/ut tools/bin/xprog failpoint-enable generate-test-build-cache
 	tools/bin/ut $(X) || { $(FAILPOINT_DISABLE); exit 1; }
 	@$(FAILPOINT_DISABLE)
 	@$(CLEAN_UT_BINARY)

--- a/tools/check/go-compile-without-link.sh
+++ b/tools/check/go-compile-without-link.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2024 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See https://gist.github.com/howardjohn/c0f5d0bc293ef7d7fada533a2c9ffaf4
+# Usage: go test -exec=true -toolexec=go-compile-without-link -vet=off ./...
+# Preferably as an alias like `alias go-test-compile='go test -exec=true -toolexec=go-compile-without-link -vet=off'`
+# This will compile all tests, but not link them (which is the least cacheable part)
+
+if [[ "${2}" == "-V=full" ]]; then
+  "$@"
+  exit 0
+fi
+case "$(basename ${1})" in
+  link)
+    # Output a dummy file
+    touch "${3}"
+    ;;
+  # We could skip vet as well, but it can be done with -vet=off if desired
+  *)
+    "$@"
+esac

--- a/tools/check/ut.go
+++ b/tools/check/ut.go
@@ -871,7 +871,9 @@ func buildTestBinary(pkg string) error {
 
 func generateBuildCache() error {
 	// cd cmd/tidb-server && go test -tags intest -exec true -vet off
-	cmd := exec.Command("go", "test", "-tags=intest", "-exec", "true", "-vet", "off")
+	cmd := exec.Command("go", "test", "-tags=intest", "-exec=true", "-vet=off")
+	goCompileWithoutLink := fmt.Sprintf("-toolexec=%s/tools/check/go-compile-without-link.sh", workDir)
+	cmd.Args = append(cmd.Args, goCompileWithoutLink)
 	cmd.Dir = path.Join(workDir, "cmd/tidb-server")
 	if err := cmd.Run(); err != nil {
 		return withTrace(err)

--- a/tools/check/ut.go
+++ b/tools/check/ut.go
@@ -870,7 +870,7 @@ func buildTestBinary(pkg string) error {
 }
 
 func generateBuildCache() error {
-	// cd cmd/tidb-server && go test -tags intest -exec true -vet off
+	// cd cmd/tidb-server && go test -tags intest -exec true -vet off -toolexec=go-compile-without-link
 	cmd := exec.Command("go", "test", "-tags=intest", "-exec=true", "-vet=off")
 	goCompileWithoutLink := fmt.Sprintf("-toolexec=%s/tools/check/go-compile-without-link.sh", workDir)
 	cmd.Args = append(cmd.Args, goCompileWithoutLink)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #31880 #30822

Problem Summary:

Maybe we can 'make ut X=build' a little bit faster!

```
go clean -cache
time make ut X='build'
```

After vs Before:

```
real    11m18.792s
user    106m32.408s
sys     8m57.255s

real    10m14.162s
user    98m40.710s
sys     8m16.094s

=====

real    16m2.547s
user    93m58.212s
sys     7m51.199s

real    15m37.476s
user    91m56.299s
sys     8m11.068s
```

### What changed and how does it work?

Behind the scene, it's a technique called 'staged build'.

If we build all the test binaries **parallelly**, the go compiler will detect that much of the pacakge cache are not available, so it would build package cache several times. For example, building `pkg/executor` and `pkg/session` parallelly, they all depends on a lot of other small packages, since those packages do not exist at the time. **The package is built repeatedly because of the parallel**.

If we build all the packages first to make the cache available, and then built the test binaries, we can avoid repeated package building. This make the whole process a little bit faster.


See also
- https://incident.io/blog/go-build-faster
- https://blog.howardjohn.info/posts/go-build-times/#staggered-builds

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

```
go clean -cache
time make ut X='build'
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
