### PR TITLE
ddl: cleaning up `show status` unused fields

### DIFF
--- a/pkg/ddl/restart_test.go
+++ b/pkg/ddl/restart_test.go
@@ -116,11 +116,7 @@ func TestSchemaResume(t *testing.T) {
 	testRunInterruptedJob(t, store, dom, job)
 	testCheckSchemaState(t, store, dbInfo, model.StatePublic)
 
-	job = &model.Job{
-		SchemaID:   dbInfo.ID,
-		Type:       model.ActionDropSchema,
-		BinlogInfo: &model.HistoryInfo{},
-	}
+	job = buildDropSchemaJob(dbInfo)
 	testRunInterruptedJob(t, store, dom, job)
 	testCheckSchemaState(t, store, dbInfo, model.StateNone)
 }
@@ -132,18 +128,7 @@ func TestStat(t *testing.T) {
 	require.NoError(t, err)
 	testCreateSchema(t, testkit.NewTestKit(t, store).Session(), dom.DDL(), dbInfo)
 
-	// TODO: Get this information from etcd.
-	//	m, err := d.Stats(nil)
-	//	c.Assert(err, IsNil)
-	//	c.Assert(m[ddlOwnerID], Equals, d.uuid)
-
-	job := &model.Job{
-		SchemaID:   dbInfo.ID,
-		Type:       model.ActionDropSchema,
-		BinlogInfo: &model.HistoryInfo{},
-		Args:       []any{true},
-	}
-
+	job := buildDropSchemaJob(dbInfo)
 	done := make(chan error, 1)
 	go runInterruptedJob(t, store, dom.DDL(), job, done)
 
@@ -158,8 +143,6 @@ LOOP:
 			restartWorkers(t, store, dom)
 			time.Sleep(time.Millisecond * 20)
 		case err := <-done:
-			// TODO: Get this information from etcd.
-			// m, err := d.Stats(nil)
 			require.Nil(t, err)
 			break LOOP
 		}

--- a/pkg/ddl/schema_test.go
+++ b/pkg/ddl/schema_test.go
@@ -154,6 +154,7 @@ func buildDropSchemaJob(dbInfo *model.DBInfo) *model.Job {
 		SchemaID:   dbInfo.ID,
 		Type:       model.ActionDropSchema,
 		BinlogInfo: &model.HistoryInfo{},
+		Args:       []any{true},
 	}
 }
 

--- a/pkg/ddl/stat.go
+++ b/pkg/ddl/stat.go
@@ -15,27 +15,13 @@
 package ddl
 
 import (
-	"encoding/hex"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 )
 
 var (
-	serverID          = "server_id"
-	ddlSchemaVersion  = "ddl_schema_version"
-	ddlJobID          = "ddl_job_id"
-	ddlJobAction      = "ddl_job_action"
-	ddlJobStartTS     = "ddl_job_start_ts"
-	ddlJobState       = "ddl_job_state"
-	ddlJobError       = "ddl_job_error"
-	ddlJobRows        = "ddl_job_row_count"
-	ddlJobSchemaState = "ddl_job_schema_state"
-	ddlJobSchemaID    = "ddl_job_schema_id"
-	ddlJobTableID     = "ddl_job_table_id"
-	ddlJobSnapshotVer = "ddl_job_snapshot_ver"
-	ddlJobReorgHandle = "ddl_job_reorg_handle"
-	ddlJobArgs        = "ddl_job_args"
+	serverID         = "server_id"
+	ddlSchemaVersion = "ddl_schema_version"
 )
 
 // GetScope gets the status variables scope.
@@ -46,42 +32,18 @@ func (*ddl) GetScope(_ string) variable.ScopeFlag {
 
 // Stats returns the DDL statistics.
 func (d *ddl) Stats(_ *variable.SessionVars) (map[string]any, error) {
-	m := make(map[string]any)
-	m[serverID] = d.uuid
-	var ddlInfo *Info
-
 	s, err := d.sessPool.Get()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	defer d.sessPool.Put(s)
-	ddlInfo, err = GetDDLInfoWithNewTxn(s)
+
+	ddlInfo, err := GetDDLInfoWithNewTxn(s)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
+	m := make(map[string]any)
+	m[serverID] = d.uuid
 	m[ddlSchemaVersion] = ddlInfo.SchemaVer
-	// TODO: Get the owner information.
-	if len(ddlInfo.Jobs) == 0 {
-		return m, nil
-	}
-	// TODO: Add all job information if needed.
-	job := ddlInfo.Jobs[0]
-	m[ddlJobID] = job.ID
-	m[ddlJobAction] = job.Type.String()
-	m[ddlJobStartTS] = job.StartTS
-	m[ddlJobState] = job.State.String()
-	m[ddlJobRows] = job.RowCount
-	if job.Error == nil {
-		m[ddlJobError] = ""
-	} else {
-		m[ddlJobError] = job.Error.Error()
-	}
-	m[ddlJobSchemaState] = job.SchemaState.String()
-	m[ddlJobSchemaID] = job.SchemaID
-	m[ddlJobTableID] = job.TableID
-	m[ddlJobSnapshotVer] = job.SnapshotVer
-	m[ddlJobReorgHandle] = hex.EncodeToString(ddlInfo.ReorgHandle)
-	m[ddlJobArgs] = job.Args
 	return m, nil
 }

--- a/pkg/ddl/stat_test.go
+++ b/pkg/ddl/stat_test.go
@@ -16,13 +16,11 @@ package ddl_test
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/ddl/util/callback"
@@ -32,71 +30,11 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	sessiontypes "github.com/pingcap/tidb/pkg/session/types"
-	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/sessiontxn"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/external"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/stretchr/testify/require"
 )
-
-func TestDDLStatsInfo(t *testing.T) {
-	store, domain := testkit.CreateMockStoreAndDomainWithSchemaLease(t, testLease)
-	d := domain.DDL()
-
-	tk := testkit.NewTestKit(t, store)
-	ctx := tk.Session()
-	dbInfo, err := testSchemaInfo(store, "test_stat")
-	require.NoError(t, err)
-	testCreateSchema(t, ctx, d, dbInfo)
-	tblInfo, err := testTableInfo(store, "t", 2)
-	require.NoError(t, err)
-	testCreateTable(t, ctx, d, dbInfo, tblInfo)
-	err = sessiontxn.NewTxn(context.Background(), ctx)
-	require.NoError(t, err)
-
-	m := testGetTable(t, domain, tblInfo.ID)
-	// insert t values (1, 1), (2, 2), (3, 3)
-	_, err = m.AddRecord(ctx.GetTableCtx(), types.MakeDatums(1, 1))
-	require.NoError(t, err)
-	_, err = m.AddRecord(ctx.GetTableCtx(), types.MakeDatums(2, 2))
-	require.NoError(t, err)
-	_, err = m.AddRecord(ctx.GetTableCtx(), types.MakeDatums(3, 3))
-	require.NoError(t, err)
-	ctx.StmtCommit(context.Background())
-	require.NoError(t, ctx.CommitTxn(context.Background()))
-
-	job := buildCreateIdxJob(dbInfo, tblInfo, true, "idx", "c1")
-
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/checkBackfillWorkerNum", `return(true)`))
-	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/checkBackfillWorkerNum"))
-	}()
-
-	ctx = testkit.NewTestKit(t, store).Session()
-	done := make(chan error, 1)
-	go func() {
-		ctx.SetValue(sessionctx.QueryString, "skip")
-		done <- d.DoDDLJob(ctx, job)
-	}()
-
-	exit := false
-	// a copy of ddl.ddlJobReorgHandle
-	ddlJobReorgHandle := "ddl_job_reorg_handle"
-	for !exit {
-		select {
-		case err := <-done:
-			require.NoError(t, err)
-			exit = true
-		case wg := <-ddl.TestCheckWorkerNumCh:
-			varMap, err := d.Stats(nil)
-			wg.Done()
-			require.NoError(t, err)
-			_, err = hex.DecodeString(varMap[ddlJobReorgHandle].(string))
-			require.NoError(t, err)
-		}
-	}
-}
 
 func TestGetDDLInfo(t *testing.T) {
 	store := testkit.CreateMockStore(t)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/51376

Problem Summary:
In https://docs.pingcap.com/tidb/stable/sql-statement-show-status#examples the `show status` results only the following fields:
```
mysql> SHOW SESSION STATUS;
+-------------------------------+--------------------------------------+
| Variable_name                 | Value                                |
+-------------------------------+--------------------------------------+
| Ssl_cipher                    |                                      |
| Ssl_cipher_list               |                                      |
| Ssl_server_not_after          |                                      |
| Ssl_server_not_before         |                                      |
| Ssl_verify_mode               | 0                                    |
| Ssl_version                   |                                      |
| Uptime                        | 1409                                 |
| ddl_schema_version            | 116                                  |
| last_plan_binding_update_time | 0000-00-00 00:00:00                  |
| server_id                     | 61160e73-ab80-40ff-8f33-27d55d475fd1 |
+-------------------------------+--------------------------------------+
```

However, when there is a running DDL job, the job information is displayed.
```
tidb> show status;
+-------------------------------+--------------------------------------+
| Variable_name                 | Value                                |
+-------------------------------+--------------------------------------+
| Ssl_cipher                    |                                      |
| Ssl_cipher_list               |                                      |
| Ssl_server_not_after          |                                      |
| Ssl_server_not_before         |                                      |
| Ssl_verify_mode               | 0                                    |
| Ssl_version                   |                                      |
| Uptime                        | 34                                   |
| ddl_job_action                | create table                         |
| ddl_job_args                  | []                                   |
| ddl_job_error                 |                                      |
| ddl_job_id                    | 109                                  |
| ddl_job_reorg_handle          |                                      |
| ddl_job_row_count             | 0                                    |
| ddl_job_schema_id             | 2                                    |
| ddl_job_schema_state          | none                                 |
| ddl_job_snapshot_ver          | 0                                    |
| ddl_job_start_ts              | 448028215742300161                   |
| ddl_job_state                 | queueing                             |
| ddl_job_table_id              | 108                                  |
| ddl_schema_version            | 52                                   |
| last_plan_binding_update_time | 0000-00-00 00:00:00                  |
| server_id                     | 9cda270d-107f-4ced-a837-edd86583c899 |
+-------------------------------+--------------------------------------+
22 rows in set (0.00 sec)
```

We will remove DDL job information that is not described in the documentation. Besides, if we want get the DDL job information, we can replace it with `admin show ddl;`, `admin show ddl jobs;` or `select * from mysql.tidb_ddl_job limit 1;`.

### What changed and how does it work?
Remove the unused fields and the related tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
After this PR：
```
tidb> show status;
+-------------------------------+--------------------------------------+
| Variable_name                 | Value                                |
+-------------------------------+--------------------------------------+
| Compression                   | OFF                                  |
| Compression_algorithm         |                                      |
| Compression_level             | 0                                    |
| Ssl_cipher                    |                                      |
| Ssl_cipher_list               |                                      |
| Ssl_server_not_after          |                                      |
| Ssl_server_not_before         |                                      |
| Ssl_verify_mode               | 0                                    |
| Ssl_version                   |                                      |
| Uptime                        | 39                                   |
| ddl_schema_version            | 129                                  |
| last_plan_binding_update_time | 0000-00-00 00:00:00                  |
| server_id                     | 2012262c-3d25-419c-aefe-8bfbcfd35c0a |
+-------------------------------+--------------------------------------+
13 rows in set (0.00 sec)
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fields that do not show "show status" in the document will be deleted
```
