### PR TITLE
sessionctx: Switch to tls.VersionName()

### DIFF
--- a/pkg/sessionctx/variable/statusvar.go
+++ b/pkg/sessionctx/variable/statusvar.go
@@ -121,13 +121,6 @@ var tlsCiphers = []uint16{
 
 var tlsSupportedCiphers string
 
-// Taken from https://github.com/openssl/openssl/blob/c784a838e0947fcca761ee62def7d077dc06d37f/include/openssl/ssl.h#L141 .
-// Update: remove tlsv1.0 and v1.1 support
-var tlsVersionString = map[uint16]string{
-	tls.VersionTLS12: "TLSv1.2",
-	tls.VersionTLS13: "TLSv1.3",
-}
-
 var defaultStatus = map[string]*StatusVal{
 	"Ssl_cipher":      {ScopeGlobal | ScopeSession, ""},
 	"Ssl_cipher_list": {ScopeGlobal | ScopeSession, ""},
@@ -155,11 +148,7 @@ func (s defaultStatusStat) Stats(vars *SessionVars) (map[string]any, error) {
 		statusVars["Ssl_cipher_list"] = tlsSupportedCiphers
 		// tls.VerifyClientCertIfGiven == SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE
 		statusVars["Ssl_verify_mode"] = 0x01 | 0x04
-		if tlsVersion, tlsVersionKnown := tlsVersionString[vars.TLSConnectionState.Version]; tlsVersionKnown {
-			statusVars["Ssl_version"] = tlsVersion
-		} else {
-			statusVars["Ssl_version"] = "unknown_tls_version"
-		}
+		statusVars["Ssl_version"] = tls.VersionName(vars.TLSConnectionState.Version)
 	}
 
 	return statusVars, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51392

Problem Summary:

Use [`tls.VersionName()`](https://pkg.go.dev/crypto/tls#VersionName) that was introduced in [Go 1.21](https://go.dev/doc/go1.21)

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
