### PR TITLE
expression: use the correct type when eval decimal system var

### DIFF
--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -1052,7 +1052,11 @@ func (b *builtinGetRealVarSig) evalReal(ctx EvalContext, row chunk.Row) (float64
 	}
 	varName = strings.ToLower(varName)
 	if v, ok := sessionVars.GetUserVarVal(varName); ok {
-		return v.GetFloat64(), false, nil
+		d, err := v.ToFloat64(typeCtx(ctx))
+		if err != nil {
+			return 0, false, err
+		}
+		return d, false, nil
 	}
 	return 0, true, nil
 }

--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -1092,7 +1092,11 @@ func (b *builtinGetDecimalVarSig) evalDecimal(ctx EvalContext, row chunk.Row) (*
 	}
 	varName = strings.ToLower(varName)
 	if v, ok := sessionVars.GetUserVarVal(varName); ok {
-		return v.GetMysqlDecimal(), false, nil
+		d, err := v.ToDecimal(typeCtx(ctx))
+		if err != nil {
+			return nil, false, err
+		}
+		return d, false, nil
 	}
 	return nil, true, nil
 }

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -2976,3 +2976,14 @@ func TestTiDBRowChecksumBuiltin(t *testing.T) {
 	tk.MustGetDBError("select tidb_row_checksum() from t", expression.ErrNotSupportedYet)
 	tk.MustGetDBError("select tidb_row_checksum() from t where id > 0", expression.ErrNotSupportedYet)
 }
+
+func TestIssue43527(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table test (a datetime, b bigint, c decimal(10, 2))")
+	tk.MustExec("insert into test values('2010-10-10 10:10:10', 100, 100)")
+	tk.MustQuery(
+		"SELECT @total := @total + c FROM (SELECT c FROM test) AS temp, (SELECT @total := 200) AS T1",
+	).Check(testkit.Rows("300.00"))
+}

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -2981,9 +2981,14 @@ func TestIssue43527(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	tk.MustExec("create table test (a datetime, b bigint, c decimal(10, 2))")
-	tk.MustExec("insert into test values('2010-10-10 10:10:10', 100, 100)")
+	tk.MustExec("create table test (a datetime, b bigint, c decimal(10, 2), d float)")
+	tk.MustExec("insert into test values('2010-10-10 10:10:10', 100, 100.01, 100)")
+	// Decimal.
 	tk.MustQuery(
 		"SELECT @total := @total + c FROM (SELECT c FROM test) AS temp, (SELECT @total := 200) AS T1",
-	).Check(testkit.Rows("300.00"))
+	).Check(testkit.Rows("300.01"))
+	// Float.
+	tk.MustQuery(
+		"SELECT @total := @total + d FROM (SELECT d FROM test) AS temp, (SELECT @total := 200) AS T1",
+	).Check(testkit.Rows("300"))
 }


### PR DESCRIPTION
Signed-off-by: hi-rustin <rustin.liu@gmail.com><!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/43527

Problem Summary:

### What changed and how does it work?

```sql
create table test (a datetime, b bigint, c decimal(10, 2), d float);
insert into test values('2010-10-10 10:10:10', 100, 100.01, 100);
SELECT @total := @total + c FROM (SELECT c FROM test) AS temp, (SELECT @total := 200) AS T1;
```

In the SQL, `@total` type is int64, but when we do eval decimal we will directly convert it as decimal then we will get a panic because there is no `c` for int value.
GetMysqlDecimal: 
```go
func (d *Datum) GetMysqlDecimal() *MyDecimal {
	return d.x.(*MyDecimal)
}
```
ToDecimal: 
```go
func (d *Datum) ToDecimal(ctx Context) (*MyDecimal, error) {
	switch d.Kind() {
	case KindMysqlTime:
		return d.GetMysqlTime().ToNumber(), nil
	case KindMysqlDuration:
		return d.GetMysqlDuration().ToNumber(), nil
	default:
		return ConvertDatumToDecimal(ctx, *d)
	}
}
```


So we have to try to convert it explicitly.

Same for the float value eval process. We also need to convert it.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed an issue that TiDB could not correctly convert the type of a session variable
```
