### PR TITLE
parser, server: unify writeData and writeError functions

### DIFF
--- a/pkg/parser/mysql/charset.go
+++ b/pkg/parser/mysql/charset.go
@@ -531,7 +531,6 @@ var CollationNames = map[string]uint16{
 const (
 	UTF8Charset    = "utf8"
 	UTF8MB4Charset = "utf8mb4"
-	Latin1Charset  = "latin1"
 	DefaultCharset = UTF8MB4Charset
 	// DefaultCollationID is utf8mb4_bin(46)
 	DefaultCollationID        = 46
@@ -540,7 +539,6 @@ const (
 	UTF8DefaultCollationID    = 83
 	UTF8MB4DefaultCollationID = 46
 	BinaryDefaultCollationID  = 63
-	UTF8DefaultCollation      = "utf8_bin"
 	UTF8MB4DefaultCollation   = "utf8mb4_bin"
 	DefaultCollationName      = UTF8MB4DefaultCollation
 

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -67,25 +67,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func writeError(w http.ResponseWriter, err error) {
-	w.WriteHeader(http.StatusBadRequest)
-	_, err = w.Write([]byte(err.Error()))
-	terror.Log(errors.Trace(err))
-}
-
-func writeData(w http.ResponseWriter, data any) {
-	js, err := json.MarshalIndent(data, "", " ")
-	if err != nil {
-		writeError(w, err)
-		return
-	}
-	// write response
-	w.Header().Set(handler.HeaderContentType, handler.ContentTypeJSON)
-	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(js)
-	terror.Log(errors.Trace(err))
-}
-
 // SettingsHandler is the handler for list tidb server settings.
 type SettingsHandler struct {
 	*handler.TikvHandlerTool
@@ -273,47 +254,47 @@ func (ValueHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	colID, err := strconv.ParseInt(params[handler.ColumnID], 0, 64)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	colTp, err := strconv.ParseInt(params[handler.ColumnTp], 0, 64)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	colFlag, err := strconv.ParseUint(params[handler.ColumnFlag], 0, 64)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	colLen, err := strconv.ParseInt(params[handler.ColumnLen], 0, 64)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 
 	// Get the unchanged binary.
 	if req.URL == nil {
 		err = errors.BadRequestf("Invalid URL")
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	values := make(url.Values)
 
 	err = parseQuery(req.URL.RawQuery, values, false)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	if len(values[handler.RowBin]) != 1 {
 		err = errors.BadRequestf("Invalid Query:%v", values[handler.RowBin])
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	bin := values[handler.RowBin][0]
 	valData, err := base64.StdEncoding.DecodeString(bin)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	// Construct field type.
@@ -325,17 +306,17 @@ func (ValueHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	loc := time.UTC
 	vals, err := tablecodec.DecodeRowToDatumMap(valData, m, loc)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 
 	v := vals[colID]
 	val, err := v.ToString()
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
-	writeData(w, val)
+	handler.WriteData(w, val)
 }
 
 // TableRegions is the response data for list table's regions.
@@ -440,13 +421,13 @@ func (h SettingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "POST" {
 		err := req.ParseForm()
 		if err != nil {
-			writeError(w, err)
+			handler.WriteError(w, err)
 			return
 		}
 		if levelStr := req.Form.Get("log_level"); levelStr != "" {
 			err1 := logutil.SetLevel(levelStr)
 			if err1 != nil {
-				writeError(w, err1)
+				handler.WriteError(w, err1)
 				return
 			}
 
@@ -459,14 +440,14 @@ func (h SettingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			case "1":
 				variable.ProcessGeneralLog.Store(true)
 			default:
-				writeError(w, errors.New("illegal argument"))
+				handler.WriteError(w, errors.New("illegal argument"))
 				return
 			}
 		}
 		if asyncCommit := req.Form.Get("tidb_enable_async_commit"); asyncCommit != "" {
 			s, err := session.CreateSession(h.Store)
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
 			defer s.Close()
@@ -477,18 +458,18 @@ func (h SettingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			case "1":
 				err = s.GetSessionVars().GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBEnableAsyncCommit, variable.On)
 			default:
-				writeError(w, errors.New("illegal argument"))
+				handler.WriteError(w, errors.New("illegal argument"))
 				return
 			}
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
 		}
 		if onePC := req.Form.Get("tidb_enable_1pc"); onePC != "" {
 			s, err := session.CreateSession(h.Store)
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
 			defer s.Close()
@@ -499,18 +480,18 @@ func (h SettingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			case "1":
 				err = s.GetSessionVars().GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBEnable1PC, variable.On)
 			default:
-				writeError(w, errors.New("illegal argument"))
+				handler.WriteError(w, errors.New("illegal argument"))
 				return
 			}
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
 		}
 		if ddlSlowThreshold := req.Form.Get("ddl_slow_threshold"); ddlSlowThreshold != "" {
 			threshold, err1 := strconv.Atoi(ddlSlowThreshold)
 			if err1 != nil {
-				writeError(w, err1)
+				handler.WriteError(w, err1)
 				return
 			}
 			if threshold > 0 {
@@ -524,17 +505,17 @@ func (h SettingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			case "1":
 				config.GetGlobalConfig().Instance.CheckMb4ValueInUTF8.Store(true)
 			default:
-				writeError(w, errors.New("illegal argument"))
+				handler.WriteError(w, errors.New("illegal argument"))
 				return
 			}
 		}
 		if deadlockHistoryCapacity := req.Form.Get("deadlock_history_capacity"); deadlockHistoryCapacity != "" {
 			capacity, err := strconv.Atoi(deadlockHistoryCapacity)
 			if err != nil {
-				writeError(w, errors.New("illegal argument"))
+				handler.WriteError(w, errors.New("illegal argument"))
 				return
 			} else if capacity < 0 || capacity > 10000 {
-				writeError(w, errors.New("deadlock_history_capacity out of range, should be in 0 to 10000"))
+				handler.WriteError(w, errors.New("deadlock_history_capacity out of range, should be in 0 to 10000"))
 				return
 			}
 			cfg := config.GetGlobalConfig()
@@ -545,7 +526,7 @@ func (h SettingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if deadlockCollectRetryable := req.Form.Get("deadlock_history_collect_retryable"); deadlockCollectRetryable != "" {
 			collectRetryable, err := strconv.ParseBool(deadlockCollectRetryable)
 			if err != nil {
-				writeError(w, errors.New("illegal argument"))
+				handler.WriteError(w, errors.New("illegal argument"))
 				return
 			}
 			cfg := config.GetGlobalConfig()
@@ -555,7 +536,7 @@ func (h SettingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if mutationChecker := req.Form.Get("tidb_enable_mutation_checker"); mutationChecker != "" {
 			s, err := session.CreateSession(h.Store)
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
 			defer s.Close()
@@ -566,21 +547,21 @@ func (h SettingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			case "1":
 				err = s.GetSessionVars().GlobalVarsAccessor.SetGlobalSysVar(context.Background(), variable.TiDBEnableMutationChecker, variable.On)
 			default:
-				writeError(w, errors.New("illegal argument"))
+				handler.WriteError(w, errors.New("illegal argument"))
 				return
 			}
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
 		}
 		if transactionSummaryCapacity := req.Form.Get("transaction_summary_capacity"); transactionSummaryCapacity != "" {
 			capacity, err := strconv.Atoi(transactionSummaryCapacity)
 			if err != nil {
-				writeError(w, errors.New("illegal argument"))
+				handler.WriteError(w, errors.New("illegal argument"))
 				return
 			} else if capacity < 0 || capacity > 5000 {
-				writeError(w, errors.New("transaction_summary_capacity out of range, should be in 0 to 5000"))
+				handler.WriteError(w, errors.New("transaction_summary_capacity out of range, should be in 0 to 5000"))
 				return
 			}
 			cfg := config.GetGlobalConfig()
@@ -591,10 +572,10 @@ func (h SettingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if transactionIDDigestMinDuration := req.Form.Get("transaction_id_digest_min_duration"); transactionIDDigestMinDuration != "" {
 			duration, err := strconv.Atoi(transactionIDDigestMinDuration)
 			if err != nil {
-				writeError(w, errors.New("illegal argument"))
+				handler.WriteError(w, errors.New("illegal argument"))
 				return
 			} else if duration < 0 || duration > 2147483647 {
-				writeError(w, errors.New("transaction_id_digest_min_duration out of range, should be in 0 to 2147483647"))
+				handler.WriteError(w, errors.New("transaction_id_digest_min_duration out of range, should be in 0 to 2147483647"))
 				return
 			}
 			cfg := config.GetGlobalConfig()
@@ -603,7 +584,7 @@ func (h SettingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			txninfo.Recorder.SetMinDuration(time.Duration(duration) * time.Millisecond)
 		}
 	} else {
-		writeData(w, config.GetGlobalConfig())
+		handler.WriteData(w, config.GetGlobalConfig())
 	}
 }
 
@@ -616,7 +597,7 @@ func (BinlogRecover) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	case "nowait":
 		err := binloginfo.DisableSkipBinlogFlag()
 		if err != nil {
-			writeError(w, err)
+			handler.WriteError(w, err)
 			return
 		}
 	case "status":
@@ -627,17 +608,17 @@ func (BinlogRecover) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		err = binloginfo.DisableSkipBinlogFlag()
 		if err != nil {
-			writeError(w, err)
+			handler.WriteError(w, err)
 			return
 		}
 		timeout := time.Duration(sec) * time.Second
 		err = binloginfo.WaitBinlogRecover(timeout)
 		if err != nil {
-			writeError(w, err)
+			handler.WriteError(w, err)
 			return
 		}
 	}
-	writeData(w, binloginfo.GetBinlogStatus())
+	handler.WriteData(w, binloginfo.GetBinlogStatus())
 }
 
 // TableFlashReplicaInfo is the replica information of a table.
@@ -658,7 +639,7 @@ func (h FlashReplicaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 	}
 	schema, err := h.Schema()
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	replicaInfos := make([]*TableFlashReplicaInfo, 0)
@@ -671,11 +652,11 @@ func (h FlashReplicaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 	}
 	dropedOrTruncateReplicaInfos, err := h.getDropOrTruncateTableTiflash(schema)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	replicaInfos = append(replicaInfos, dropedOrTruncateReplicaInfos...)
-	writeData(w, replicaInfos)
+	handler.WriteData(w, replicaInfos)
 }
 
 func (FlashReplicaHandler) getTiFlashReplicaInfo(tblInfo *model.TableInfo, replicaInfos []*TableFlashReplicaInfo) []*TableFlashReplicaInfo {
@@ -775,17 +756,17 @@ func (h FlashReplicaHandler) handleStatusReport(w http.ResponseWriter, req *http
 	var status tableFlashReplicaStatus
 	err := json.NewDecoder(req.Body).Decode(&status)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	do, err := session.GetDomain(h.Store)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	s, err := session.CreateSession(h.Store)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	defer s.Close()
@@ -793,7 +774,7 @@ func (h FlashReplicaHandler) handleStatusReport(w http.ResponseWriter, req *http
 	available := status.checkTableFlashReplicaAvailable()
 	err = do.DDL().UpdateTableReplicaInfo(s, status.ID, available)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 	}
 	if available {
 		var tableInfo model.TableInfo
@@ -804,7 +785,7 @@ func (h FlashReplicaHandler) handleStatusReport(w http.ResponseWriter, req *http
 		err = infosync.UpdateTiFlashProgressCache(status.ID, progress)
 	}
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 	}
 
 	logutil.BgLogger().Info("handle flash replica report", zap.Int64("table ID", status.ID), zap.Uint64("region count",
@@ -888,7 +869,7 @@ func getSchemaTablesStorageInfo(h *SchemaStorageHandler, schema *model.CIStr, ta
 func (h SchemaStorageHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	schema, err := h.Schema()
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 
@@ -906,7 +887,7 @@ func (h SchemaStorageHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		// all table schemas in a specified database
 		schemaInfo, exists := schema.SchemaByName(cDBName)
 		if !exists {
-			writeError(w, infoschema.ErrDatabaseNotExists.GenWithStackByArgs(reqDbName))
+			handler.WriteError(w, infoschema.ErrDatabaseNotExists.GenWithStackByArgs(reqDbName))
 			return
 		}
 		dbName = &schemaInfo.Name
@@ -916,7 +897,7 @@ func (h SchemaStorageHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 			cTableName := model.NewCIStr(reqTableName)
 			data, e := schema.TableByName(cDBName, cTableName)
 			if e != nil {
-				writeError(w, e)
+				handler.WriteError(w, e)
 				return
 			}
 			tableName = &data.Meta().Name
@@ -925,12 +906,12 @@ func (h SchemaStorageHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 	}
 
 	if results, e := getSchemaTablesStorageInfo(&h, dbName, tableName); e != nil {
-		writeError(w, e)
+		handler.WriteError(w, e)
 	} else {
 		if isSingle {
-			writeData(w, results[0])
+			handler.WriteData(w, results[0])
 		} else {
-			writeData(w, results)
+			handler.WriteData(w, results)
 		}
 	}
 }
@@ -943,7 +924,7 @@ func (h SchemaStorageHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 // Note: It would return StatusOK even if errors occur. But if errors occur, there must be some bugs.
 func WriteDBTablesData(w http.ResponseWriter, tbs []table.Table) {
 	if len(tbs) == 0 {
-		writeData(w, []*model.TableInfo{})
+		handler.WriteData(w, []*model.TableInfo{})
 		return
 	}
 	w.Header().Set(handler.HeaderContentType, handler.ContentTypeJSON)
@@ -984,7 +965,7 @@ func WriteDBTablesData(w http.ResponseWriter, tbs []table.Table) {
 func (h SchemaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	schema, err := h.Schema()
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 
@@ -998,10 +979,10 @@ func (h SchemaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			cTableName := model.NewCIStr(tableName)
 			data, err := schema.TableByName(cDBName, cTableName)
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
-			writeData(w, data.Meta())
+			handler.WriteData(w, data.Meta())
 			return
 		}
 		// all table schemas in a specified database
@@ -1010,7 +991,7 @@ func (h SchemaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			WriteDBTablesData(w, tbs)
 			return
 		}
-		writeError(w, infoschema.ErrDatabaseNotExists.GenWithStackByArgs(dbName))
+		handler.WriteError(w, infoschema.ErrDatabaseNotExists.GenWithStackByArgs(dbName))
 		return
 	}
 
@@ -1018,29 +999,29 @@ func (h SchemaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// table schema of a specified tableID
 		tid, err := strconv.Atoi(tableID)
 		if err != nil {
-			writeError(w, err)
+			handler.WriteError(w, err)
 			return
 		}
 		if tid < 0 {
-			writeError(w, infoschema.ErrTableNotExists.GenWithStack("Table which ID = %s does not exist.", tableID))
+			handler.WriteError(w, infoschema.ErrTableNotExists.GenWithStack("Table which ID = %s does not exist.", tableID))
 			return
 		}
 		if data, ok := schema.TableByID(int64(tid)); ok {
-			writeData(w, data.Meta())
+			handler.WriteData(w, data.Meta())
 			return
 		}
 		// The tid maybe a partition ID of the partition-table.
 		tbl, _, _ := schema.FindTableByPartitionID(int64(tid))
 		if tbl == nil {
-			writeError(w, infoschema.ErrTableNotExists.GenWithStack("Table which ID = %s does not exist.", tableID))
+			handler.WriteError(w, infoschema.ErrTableNotExists.GenWithStack("Table which ID = %s does not exist.", tableID))
 			return
 		}
-		writeData(w, tbl.Meta())
+		handler.WriteData(w, tbl.Meta())
 		return
 	}
 
 	// all databases' schemas
-	writeData(w, schema.AllSchemas())
+	handler.WriteData(w, schema.AllSchemas())
 }
 
 // ServeHTTP handles table related requests, such as table's region information, disk usage.
@@ -1051,14 +1032,14 @@ func (h *TableHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	tableName := params[handler.TableName]
 	schema, err := h.Schema()
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 
 	tableName, partitionName := handler.ExtractTableAndPartitionName(tableName)
 	tableVal, err := schema.TableByName(model.NewCIStr(dbName), model.NewCIStr(tableName))
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	switch h.op {
@@ -1072,19 +1053,19 @@ func (h *TableHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// supports partition table, only get one physical table, prevent too many scatter schedulers.
 		ptbl, err := h.GetPartition(tableVal, partitionName)
 		if err != nil {
-			writeError(w, err)
+			handler.WriteError(w, err)
 			return
 		}
 		h.handleScatterTableRequest(ptbl, w)
 	case OpStopTableScatter:
 		ptbl, err := h.GetPartition(tableVal, partitionName)
 		if err != nil {
-			writeError(w, err)
+			handler.WriteError(w, err)
 			return
 		}
 		h.handleStopScatterTableRequest(ptbl, w)
 	default:
-		writeError(w, errors.New("method not found"))
+		handler.WriteError(w, errors.New("method not found"))
 	}
 }
 
@@ -1095,32 +1076,32 @@ func (h DDLHistoryJobHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 	if jobValue := req.FormValue(handler.JobID); len(jobValue) > 0 {
 		jobID, err = strconv.Atoi(jobValue)
 		if err != nil {
-			writeError(w, err)
+			handler.WriteError(w, err)
 			return
 		}
 		if jobID < 1 {
-			writeError(w, errors.New("ddl history start_job_id must be greater than 0"))
+			handler.WriteError(w, errors.New("ddl history start_job_id must be greater than 0"))
 			return
 		}
 	}
 	if limitValue := req.FormValue(handler.Limit); len(limitValue) > 0 {
 		limitID, err = strconv.Atoi(limitValue)
 		if err != nil {
-			writeError(w, err)
+			handler.WriteError(w, err)
 			return
 		}
 		if limitID < 1 {
-			writeError(w, errors.New("ddl history limit must be greater than 0"))
+			handler.WriteError(w, errors.New("ddl history limit must be greater than 0"))
 			return
 		}
 	}
 
 	jobs, err := h.getHistoryDDL(jobID, limitID)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
-	writeData(w, jobs)
+	handler.WriteData(w, jobs)
 }
 
 func (h DDLHistoryJobHandler) getHistoryDDL(jobID, limit int) (jobs []*model.Job, err error) {
@@ -1158,18 +1139,18 @@ func (h DDLResignOwnerHandler) resignDDLOwner() error {
 // ServeHTTP handles request of resigning ddl owner.
 func (h DDLResignOwnerHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
-		writeError(w, errors.Errorf("This api only support POST method"))
+		handler.WriteError(w, errors.Errorf("This api only support POST method"))
 		return
 	}
 
 	err := h.resignDDLOwner()
 	if err != nil {
 		log.Error("failed to resign DDL owner", zap.Error(err))
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 
-	writeData(w, "success!")
+	handler.WriteData(w, "success!")
 }
 
 func (h *TableHandler) getPDAddr() ([]string, error) {
@@ -1242,7 +1223,7 @@ func (h *TableHandler) handleScatterTableRequest(tbl table.PhysicalTable, w http
 	tableName := fmt.Sprintf("%s-%d", tbl.Meta().Name.String(), tableID)
 	err := h.addScatterSchedule(startKey, endKey, tableName)
 	if err != nil {
-		writeError(w, errors.Annotate(err, "scatter record error"))
+		handler.WriteError(w, errors.Annotate(err, "scatter record error"))
 		return
 	}
 	// for indices
@@ -1255,11 +1236,11 @@ func (h *TableHandler) handleScatterTableRequest(tbl table.PhysicalTable, w http
 		name := tableName + "-" + indexName
 		err := h.addScatterSchedule(startKey, endKey, name)
 		if err != nil {
-			writeError(w, errors.Annotatef(err, "scatter index(%s) error", name))
+			handler.WriteError(w, errors.Annotatef(err, "scatter index(%s) error", name))
 			return
 		}
 	}
-	writeData(w, "success!")
+	handler.WriteData(w, "success!")
 }
 
 func (h *TableHandler) handleStopScatterTableRequest(tbl table.PhysicalTable, w http.ResponseWriter) {
@@ -1267,7 +1248,7 @@ func (h *TableHandler) handleStopScatterTableRequest(tbl table.PhysicalTable, w 
 	tableName := fmt.Sprintf("%s-%d", tbl.Meta().Name.String(), tbl.GetPhysicalID())
 	err := h.deleteScatterSchedule(tableName)
 	if err != nil {
-		writeError(w, errors.Annotate(err, "stop scatter record error"))
+		handler.WriteError(w, errors.Annotate(err, "stop scatter record error"))
 		return
 	}
 	// for indices
@@ -1276,11 +1257,11 @@ func (h *TableHandler) handleStopScatterTableRequest(tbl table.PhysicalTable, w 
 		name := tableName + "-" + indexName
 		err := h.deleteScatterSchedule(name)
 		if err != nil {
-			writeError(w, errors.Annotatef(err, "delete scatter index(%s) error", name))
+			handler.WriteError(w, errors.Annotatef(err, "delete scatter index(%s) error", name))
 			return
 		}
 	}
-	writeData(w, "success!")
+	handler.WriteData(w, "success!")
 }
 
 func (h *TableHandler) handleRegionRequest(tbl table.Table, w http.ResponseWriter) {
@@ -1291,24 +1272,24 @@ func (h *TableHandler) handleRegionRequest(tbl table.Table, w http.ResponseWrite
 		for _, def := range pi.Definitions {
 			tableRegions, err := h.getRegionsByID(tbl, def.ID, def.Name.O)
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
 
 			data = append(data, tableRegions)
 		}
-		writeData(w, data)
+		handler.WriteData(w, data)
 		return
 	}
 
 	meta := tbl.Meta()
 	tableRegions, err := h.getRegionsByID(tbl, meta.ID, meta.Name.O)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 
-	writeData(w, tableRegions)
+	handler.WriteData(w, tableRegions)
 }
 
 func createTableRanges(tblID int64, tblName string, indices []*model.IndexInfo) *TableRanges {
@@ -1343,11 +1324,11 @@ func (*TableHandler) handleRangeRequest(tbl table.Table, w http.ResponseWriter) 
 		for _, def := range pi.Definitions {
 			data = append(data, createTableRanges(def.ID, def.Name.String(), meta.Indices))
 		}
-		writeData(w, data)
+		handler.WriteData(w, data)
 		return
 	}
 
-	writeData(w, createTableRanges(meta.ID, meta.Name.String(), meta.Indices))
+	handler.WriteData(w, createTableRanges(meta.ID, meta.Name.String(), meta.Indices))
 }
 
 func (h *TableHandler) getRegionsByID(tbl table.Table, id int64, name string) (*TableRegions, error) {
@@ -1406,10 +1387,10 @@ func (h *TableHandler) getRegionsByID(tbl table.Table, id int64, name string) (*
 func (h *TableHandler) handleDiskUsageRequest(tbl table.Table, w http.ResponseWriter) {
 	stats, err := h.GetPDRegionStats(context.Background(), tbl.Meta().ID, false)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
-	writeData(w, stats.StorageSize)
+	handler.WriteData(w, stats.StorageSize)
 }
 
 // ServeHTTP handles request of get region by ID.
@@ -1424,36 +1405,36 @@ func (h RegionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 			recordRegionIDs, err := h.RegionCache.ListRegionIDsInKeyRange(tikv.NewBackofferWithVars(context.Background(), 500, nil), startKey, endKey)
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
 
 			recordRegions, err := h.GetRegionsMeta(recordRegionIDs)
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
-			writeData(w, recordRegions)
+			handler.WriteData(w, recordRegions)
 			return
 		}
 		if router == "RegionHot" {
 			schema, err := h.Schema()
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
 			ctx := context.Background()
 			hotRead, err := h.ScrapeHotInfo(ctx, helper.HotRead, schema.AllSchemas())
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
 			hotWrite, err := h.ScrapeHotInfo(ctx, helper.HotWrite, schema.AllSchemas())
 			if err != nil {
-				writeError(w, err)
+				handler.WriteError(w, err)
 				return
 			}
-			writeData(w, map[string]any{
+			handler.WriteData(w, map[string]any{
 				"write": hotWrite,
 				"read":  hotRead,
 			})
@@ -1464,7 +1445,7 @@ func (h RegionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	regionIDInt, err := strconv.ParseInt(params[handler.RegionID], 0, 64)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	regionID := uint64(regionIDInt)
@@ -1472,13 +1453,13 @@ func (h RegionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// locate region
 	region, err := h.RegionCache.LocateRegionByID(tikv.NewBackofferWithVars(context.Background(), 500, nil), regionID)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 
 	frameRange, err := helper.NewRegionFrameRange(region)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 
@@ -1489,7 +1470,7 @@ func (h RegionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	schema, err := h.Schema()
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	// Since we need a database's name for each frame, and a table's database name can not
@@ -1504,7 +1485,7 @@ func (h RegionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			regionDetail.addTableInRange(db.Name.String(), tableVal, frameRange)
 		}
 	}
-	writeData(w, regionDetail)
+	handler.WriteData(w, regionDetail)
 }
 
 // parseQuery is used to parse query string in URL with shouldUnescape, due to golang http package can not distinguish
@@ -1582,9 +1563,9 @@ func (h MvccTxnHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		err = errors.NotSupportedf("Operation not supported.")
 	}
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 	} else {
-		writeData(w, data)
+		handler.WriteData(w, data)
 	}
 }
 
@@ -1722,21 +1703,21 @@ type ServerInfo struct {
 func (h ServerInfoHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	do, err := session.GetDomain(h.Store)
 	if err != nil {
-		writeError(w, errors.New("create session error"))
+		handler.WriteError(w, errors.New("create session error"))
 		log.Error("failed to get session domain", zap.Error(err))
 		return
 	}
 	info := ServerInfo{}
 	info.ServerInfo, err = infosync.GetServerInfo()
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		log.Error("failed to get server info", zap.Error(err))
 		return
 	}
 	info.IsOwner = do.DDL().OwnerManager().IsOwner()
 	info.MaxProcs = runtime.GOMAXPROCS(0)
 	info.GOGC = util.GetGOGC()
-	writeData(w, info)
+	handler.WriteData(w, info)
 }
 
 // ClusterServerInfo is used to report cluster servers info when do http request.
@@ -1752,14 +1733,14 @@ type ClusterServerInfo struct {
 func (h AllServerInfoHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	do, err := session.GetDomain(h.Store)
 	if err != nil {
-		writeError(w, errors.New("create session error"))
+		handler.WriteError(w, errors.New("create session error"))
 		log.Error("failed to get session domain", zap.Error(err))
 		return
 	}
 	ctx := context.Background()
 	allServersInfo, err := infosync.GetAllServerInfo(ctx)
 	if err != nil {
-		writeError(w, errors.New("ddl server information not found"))
+		handler.WriteError(w, errors.New("ddl server information not found"))
 		log.Error("failed to get all server info", zap.Error(err))
 		return
 	}
@@ -1767,7 +1748,7 @@ func (h AllServerInfoHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) 
 	ownerID, err := do.DDL().OwnerManager().GetOwnerID(ctx)
 	cancel()
 	if err != nil {
-		writeError(w, errors.New("ddl server information not found"))
+		handler.WriteError(w, errors.New("ddl server information not found"))
 		log.Error("failed to get owner id", zap.Error(err))
 		return
 	}
@@ -1791,7 +1772,7 @@ func (h AllServerInfoHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) 
 	if !clusterInfo.IsAllServerVersionConsistent {
 		clusterInfo.AllServersDiffVersions = allVersions
 	}
-	writeData(w, clusterInfo)
+	handler.WriteData(w, clusterInfo)
 }
 
 // DBTableInfo is used to report the database, table information and the current schema version.
@@ -1807,13 +1788,13 @@ func (h DBTableHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	tableID := params[handler.TableID]
 	physicalID, err := strconv.Atoi(tableID)
 	if err != nil {
-		writeError(w, errors.Errorf("Wrong tableID: %v", tableID))
+		handler.WriteError(w, errors.Errorf("Wrong tableID: %v", tableID))
 		return
 	}
 
 	schema, err := h.Schema()
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 
@@ -1826,29 +1807,29 @@ func (h DBTableHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		dbInfo, ok := infoschema.SchemaByTable(schema, dbTblInfo.TableInfo)
 		if !ok {
 			logutil.BgLogger().Error("can not find the database of the table", zap.Int64("table id", dbTblInfo.TableInfo.ID), zap.String("table name", dbTblInfo.TableInfo.Name.L))
-			writeError(w, infoschema.ErrTableNotExists.GenWithStack("Table which ID = %s does not exist.", tableID))
+			handler.WriteError(w, infoschema.ErrTableNotExists.GenWithStack("Table which ID = %s does not exist.", tableID))
 			return
 		}
 		dbTblInfo.DBInfo = dbInfo
-		writeData(w, dbTblInfo)
+		handler.WriteData(w, dbTblInfo)
 		return
 	}
 	// The physicalID maybe a partition ID of the partition-table.
 	tbl, dbInfo, _ := schema.FindTableByPartitionID(int64(physicalID))
 	if tbl == nil {
-		writeError(w, infoschema.ErrTableNotExists.GenWithStack("Table which ID = %s does not exist.", tableID))
+		handler.WriteError(w, infoschema.ErrTableNotExists.GenWithStack("Table which ID = %s does not exist.", tableID))
 		return
 	}
 	dbTblInfo.TableInfo = tbl.Meta()
 	dbTblInfo.DBInfo = dbInfo
-	writeData(w, dbTblInfo)
+	handler.WriteData(w, dbTblInfo)
 }
 
 // ServeHTTP handles request of TiDB metric profile.
 func (h ProfileHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	sctx, err := session.CreateSession(h.Store)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	defer sctx.Close()
@@ -1857,7 +1838,7 @@ func (h ProfileHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.FormValue("end") != "" {
 		end, err = time.ParseInLocation(time.RFC3339, req.FormValue("end"), sctx.GetSessionVars().Location())
 		if err != nil {
-			writeError(w, err)
+			handler.WriteError(w, err)
 			return
 		}
 	} else {
@@ -1866,7 +1847,7 @@ func (h ProfileHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.FormValue("start") != "" {
 		start, err = time.ParseInLocation(time.RFC3339, req.FormValue("start"), sctx.GetSessionVars().Location())
 		if err != nil {
-			writeError(w, err)
+			handler.WriteError(w, err)
 			return
 		}
 	} else {
@@ -1875,12 +1856,12 @@ func (h ProfileHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	valueTp := req.FormValue("type")
 	pb, err := executor.NewProfileBuilder(sctx, start, end, valueTp)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	err = pb.Collect()
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 	_, err = w.Write(pb.Build())
@@ -1911,7 +1892,7 @@ func (h *TestHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	case "gc":
 		h.handleGC(op, w, req)
 	default:
-		writeError(w, errors.NotSupportedf("module(%s)", mod))
+		handler.WriteError(w, errors.NotSupportedf("module(%s)", mod))
 	}
 }
 
@@ -1921,7 +1902,7 @@ func (h *TestHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 //   - physical: whether it uses physical(green GC) mode to scan locks. Default is true.
 func (h *TestHandler) handleGC(op string, w http.ResponseWriter, req *http.Request) {
 	if !atomic.CompareAndSwapUint32(&h.gcIsRunning, 0, 1) {
-		writeError(w, errors.New("GC is running"))
+		handler.WriteError(w, errors.New("GC is running"))
 		return
 	}
 	defer atomic.StoreUint32(&h.gcIsRunning, 0)
@@ -1930,7 +1911,7 @@ func (h *TestHandler) handleGC(op string, w http.ResponseWriter, req *http.Reque
 	case "resolvelock":
 		h.handleGCResolveLocks(w, req)
 	default:
-		writeError(w, errors.NotSupportedf("operation(%s)", op))
+		handler.WriteError(w, errors.NotSupportedf("operation(%s)", op))
 	}
 }
 
@@ -1938,39 +1919,39 @@ func (h *TestHandler) handleGCResolveLocks(w http.ResponseWriter, req *http.Requ
 	s := req.FormValue("safepoint")
 	safePoint, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
-		writeError(w, errors.Errorf("parse safePoint(%s) failed", s))
+		handler.WriteError(w, errors.Errorf("parse safePoint(%s) failed", s))
 		return
 	}
 	ctx := req.Context()
 	logutil.Logger(ctx).Info("start resolving locks", zap.Uint64("safePoint", safePoint))
 	err = gcworker.RunResolveLocks(ctx, h.Store, h.RegionCache.PDClient(), safePoint, "testGCWorker", 3)
 	if err != nil {
-		writeError(w, errors.Annotate(err, "resolveLocks failed"))
+		handler.WriteError(w, errors.Annotate(err, "resolveLocks failed"))
 	}
 }
 
 // ServeHTTP handles request of resigning ddl owner.
 func (h DDLHookHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
-		writeError(w, errors.Errorf("This api only support POST method"))
+		handler.WriteError(w, errors.Errorf("This api only support POST method"))
 		return
 	}
 
 	dom, err := session.GetDomain(h.store)
 	if err != nil {
 		log.Error("failed to get session domain", zap.Error(err))
-		writeError(w, err)
+		handler.WriteError(w, err)
 	}
 
 	newCallbackFunc, err := ddl.GetCustomizedHook(req.FormValue("ddl_hook"))
 	if err != nil {
 		log.Error("failed to get customized hook", zap.Error(err))
-		writeError(w, err)
+		handler.WriteError(w, err)
 	}
 	callback := newCallbackFunc(dom)
 
 	dom.DDL().SetHook(callback)
-	writeData(w, "success!")
+	handler.WriteData(w, "success!")
 
 	ctx := req.Context()
 	logutil.Logger(ctx).Info("change ddl hook success", zap.String("to_ddl_hook", req.FormValue("ddl_hook")))
@@ -1979,14 +1960,14 @@ func (h DDLHookHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // ServeHTTP handles request of set server labels.
 func (LabelHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
-		writeError(w, errors.Errorf("This api only support POST method"))
+		handler.WriteError(w, errors.Errorf("This api only support POST method"))
 		return
 	}
 
 	labels := make(map[string]string)
 	err := json.NewDecoder(req.Body).Decode(&labels)
 	if err != nil {
-		writeError(w, err)
+		handler.WriteError(w, err)
 		return
 	}
 
@@ -2005,5 +1986,5 @@ func (LabelHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		logutil.BgLogger().Info("update server labels", zap.Any("labels", cfg.Labels))
 	}
 
-	writeData(w, config.GetGlobalConfig().Labels)
+	handler.WriteData(w, config.GetGlobalConfig().Labels)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/51408

Problem Summary:

### What changed and how does it work?
* Using `WriteError` and `WriteData` instead of `writeError` and `writeData`.
* Remove two useless constants.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
