### PR TITLE
disttask: refresh whole task info when state/step changed

### DIFF
--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -153,7 +153,7 @@ func updateMeta(task *proto.Task, taskMeta *BackfillTaskMeta) error {
 }
 
 // GetNextStep implements scheduler.Extension interface.
-func (sch *BackfillingSchedulerExt) GetNextStep(task *proto.Task) proto.Step {
+func (sch *BackfillingSchedulerExt) GetNextStep(task *proto.TaskBase) proto.Step {
 	switch task.Step {
 	case proto.StepInit:
 		return proto.BackfillStepReadIndex

--- a/pkg/disttask/framework/integrationtests/bench_test.go
+++ b/pkg/disttask/framework/integrationtests/bench_test.go
@@ -181,7 +181,7 @@ func registerTaskTypeForBench(c *testutil.TestDXFContext) {
 	schedulerExt.EXPECT().GetEligibleInstances(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	schedulerExt.EXPECT().IsRetryableErr(gomock.Any()).Return(false).AnyTimes()
 	schedulerExt.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
-		func(task *proto.Task) proto.Step {
+		func(task *proto.TaskBase) proto.Step {
 			return stepTransition[task.Step]
 		},
 	).AnyTimes()

--- a/pkg/disttask/framework/integrationtests/framework_pause_and_resume_test.go
+++ b/pkg/disttask/framework/integrationtests/framework_pause_and_resume_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/disttask/framework/handle"
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
-	"github.com/pingcap/tidb/pkg/disttask/framework/scheduler"
 	"github.com/pingcap/tidb/pkg/disttask/framework/storage"
 	"github.com/pingcap/tidb/pkg/disttask/framework/testutil"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -47,37 +46,33 @@ func TestFrameworkPauseAndResume(t *testing.T) {
 	testutil.RegisterTaskMeta(t, c.MockCtrl, testutil.GetMockBasicSchedulerExt(c.MockCtrl), c.TestContext, nil)
 	// 1. schedule and pause one running task.
 	testkit.EnableFailPoint(t, "github.com/pingcap/tidb/pkg/disttask/framework/scheduler/pauseTaskAfterRefreshTask", "2*return(true)")
-	testkit.EnableFailPoint(t, "github.com/pingcap/tidb/pkg/disttask/framework/scheduler/syncAfterResume", "return()")
 	task1 := testutil.SubmitAndWaitTask(c.Ctx, t, "key1", 1)
 	require.Equal(t, proto.TaskStatePaused, task1.State)
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/scheduler/pauseTaskAfterRefreshTask"))
 	// 4 subtask scheduled.
 	require.NoError(t, handle.ResumeTask(c.Ctx, "key1"))
-	<-scheduler.TestSyncChan
-	testutil.WaitTaskDoneOrPaused(c.Ctx, t, task1.Key)
-	CheckSubtasksState(c.Ctx, t, 1, proto.SubtaskStateSucceed, 4)
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/scheduler/syncAfterResume"))
+	task1Base := testutil.WaitTaskDone(c.Ctx, t, task1.Key)
+	require.Equal(t, proto.TaskStateSucceed, task1Base.State)
+	CheckSubtasksState(c.Ctx, t, task1.ID, proto.SubtaskStateSucceed, 4)
 
 	mgr, err := storage.GetTaskManager()
 	require.NoError(t, err)
-	errs, err := mgr.GetSubtaskErrors(c.Ctx, 1)
+	errs, err := mgr.GetSubtaskErrors(c.Ctx, task1.ID)
 	require.NoError(t, err)
 	require.Empty(t, errs)
 
 	// 2. pause pending task.
 	testkit.EnableFailPoint(t, "github.com/pingcap/tidb/pkg/disttask/framework/scheduler/pausePendingTask", "2*return(true)")
-	testkit.EnableFailPoint(t, "github.com/pingcap/tidb/pkg/disttask/framework/scheduler/syncAfterResume", "1*return()")
 	task2 := testutil.SubmitAndWaitTask(c.Ctx, t, "key2", 1)
 	require.Equal(t, proto.TaskStatePaused, task2.State)
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/scheduler/pausePendingTask"))
 	// 4 subtask scheduled.
 	require.NoError(t, handle.ResumeTask(c.Ctx, "key2"))
-	<-scheduler.TestSyncChan
-	testutil.WaitTaskDoneOrPaused(c.Ctx, t, task2.Key)
-	CheckSubtasksState(c.Ctx, t, 1, proto.SubtaskStateSucceed, 4)
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/scheduler/syncAfterResume"))
+	task2Base := testutil.WaitTaskDone(c.Ctx, t, task2.Key)
+	require.Equal(t, proto.TaskStateSucceed, task2Base.State)
+	CheckSubtasksState(c.Ctx, t, task2.ID, proto.SubtaskStateSucceed, 4)
 
-	errs, err = mgr.GetSubtaskErrors(c.Ctx, 1)
+	errs, err = mgr.GetSubtaskErrors(c.Ctx, task2.ID)
 	require.NoError(t, err)
 	require.Empty(t, errs)
 }

--- a/pkg/disttask/framework/integrationtests/resource_control_test.go
+++ b/pkg/disttask/framework/integrationtests/resource_control_test.go
@@ -64,7 +64,7 @@ func (c *resourceCtrlCaseContext) init(subtaskCntMap map[int64]map[proto.Step]in
 	schedulerExt.EXPECT().GetEligibleInstances(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	schedulerExt.EXPECT().IsRetryableErr(gomock.Any()).Return(false).AnyTimes()
 	schedulerExt.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
-		func(task *proto.Task) proto.Step {
+		func(task *proto.TaskBase) proto.Step {
 			return stepTransition[task.Step]
 		},
 	).AnyTimes()

--- a/pkg/disttask/framework/mock/scheduler_mock.go
+++ b/pkg/disttask/framework/mock/scheduler_mock.go
@@ -69,7 +69,7 @@ func (mr *MockSchedulerMockRecorder) GetEligibleInstances(arg0, arg1 any) *gomoc
 }
 
 // GetNextStep mocks base method.
-func (m *MockScheduler) GetNextStep(arg0 *proto.Task) proto.Step {
+func (m *MockScheduler) GetNextStep(arg0 *proto.TaskBase) proto.Step {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNextStep", arg0)
 	ret0, _ := ret[0].(proto.Step)

--- a/pkg/disttask/framework/scheduler/BUILD.bazel
+++ b/pkg/disttask/framework/scheduler/BUILD.bazel
@@ -53,7 +53,7 @@ go_test(
     embed = [":scheduler"],
     flaky = True,
     race = "off",
-    shard_count = 29,
+    shard_count = 31,
     deps = [
         "//pkg/config",
         "//pkg/disttask/framework/mock",

--- a/pkg/disttask/framework/scheduler/interface.go
+++ b/pkg/disttask/framework/scheduler/interface.go
@@ -129,7 +129,9 @@ type Extension interface {
 	// GetNextStep is used to get the next step for the task.
 	// if task runs successfully, it should go from StepInit to business steps,
 	// then to StepDone, then scheduler will mark it as finished.
-	GetNextStep(task *proto.Task) proto.Step
+	// NOTE: don't depend on task meta to decide the next step, if it's really needed,
+	// initialize required fields on scheduler.Init
+	GetNextStep(task *proto.TaskBase) proto.Step
 }
 
 // Param is used to pass parameters when creating scheduler.

--- a/pkg/disttask/framework/scheduler/mock/scheduler_mock.go
+++ b/pkg/disttask/framework/scheduler/mock/scheduler_mock.go
@@ -56,7 +56,7 @@ func (mr *MockExtensionMockRecorder) GetEligibleInstances(arg0, arg1 any) *gomoc
 }
 
 // GetNextStep mocks base method.
-func (m *MockExtension) GetNextStep(arg0 *proto.Task) proto.Step {
+func (m *MockExtension) GetNextStep(arg0 *proto.TaskBase) proto.Step {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNextStep", arg0)
 	ret0, _ := ret[0].(proto.Step)

--- a/pkg/disttask/framework/scheduler/scheduler.go
+++ b/pkg/disttask/framework/scheduler/scheduler.go
@@ -136,13 +136,28 @@ func (s *BaseScheduler) refreshTask() error {
 	task := s.GetTask()
 	// we only refresh the base fields of task to reduce memory usage, other fields
 	// must be maintained in memory by the scheduler itself.
-	// TODO it's possible we have a stale task meta on network partition, get task meta when needed??
+	// in case of network partition, we check whether task info is stale by checking
+	// state/step of the task, if changed we refresh the whole task object.
 	newTaskBase, err := s.taskMgr.GetTaskBaseByID(s.ctx, task.ID)
 	if err != nil {
 		return err
 	}
-	newTask := *task
-	newTask.TaskBase = *newTaskBase
+	var newTask proto.Task
+	if newTaskBase.State != task.State || newTaskBase.Step != task.Step {
+		s.logger.Info("task state/step changed by user or other scheduler",
+			zap.Stringer("old-state", task.State),
+			zap.Stringer("new-state", newTaskBase.State),
+			zap.String("old-step", proto.Step2Str(task.Type, task.Step)),
+			zap.String("new-step", proto.Step2Str(task.Type, newTaskBase.Step)))
+		gotNewTask, err := s.taskMgr.GetTaskByID(s.ctx, task.ID)
+		if err != nil {
+			return err
+		}
+		newTask = *gotNewTask
+	} else {
+		newTask = *task
+		newTask.TaskBase = *newTaskBase
+	}
 	s.task.Store(&newTask)
 	return nil
 }
@@ -154,7 +169,7 @@ func (s *BaseScheduler) scheduleTask() {
 	for {
 		select {
 		case <-s.ctx.Done():
-			s.logger.Info("schedule task exits", zap.Error(s.ctx.Err()))
+			s.logger.Info("schedule task exits")
 			return
 		case <-ticker.C:
 			err := s.refreshTask()
@@ -227,7 +242,6 @@ func (s *BaseScheduler) scheduleTask() {
 			}
 
 			failpoint.Inject("mockOwnerChange", func() {
-				s.logger.Info("mockOwnerChange called")
 				MockOwnerChange()
 				time.Sleep(time.Second)
 			})
@@ -239,13 +253,13 @@ func (s *BaseScheduler) scheduleTask() {
 func (s *BaseScheduler) onCancelling() error {
 	task := s.GetTask()
 	s.logger.Info("on cancelling state", zap.Stringer("state", task.State), zap.String("step", proto.Step2Str(task.Type, task.Step)))
-	errs := []error{errors.New(taskCancelMsg)}
-	return s.onErrHandlingStage(errs)
+
+	return s.revertTask(errors.New(taskCancelMsg))
 }
 
 // handle task in pausing state, cancel all running subtasks.
 func (s *BaseScheduler) onPausing() error {
-	task := s.GetTask()
+	task := *s.GetTask()
 	s.logger.Info("on pausing state", zap.Stringer("state", task.State), zap.String("step", proto.Step2Str(task.Type, task.Step)))
 	cntByStates, err := s.taskMgr.GetSubtaskCntGroupByStates(s.ctx, task.ID, task.Step)
 	if err != nil {
@@ -253,11 +267,17 @@ func (s *BaseScheduler) onPausing() error {
 		return err
 	}
 	runningPendingCnt := cntByStates[proto.SubtaskStateRunning] + cntByStates[proto.SubtaskStatePending]
-	if runningPendingCnt == 0 {
-		s.logger.Info("all running subtasks paused, update the task to paused state")
-		return s.taskMgr.PausedTask(s.ctx, task.ID)
+	if runningPendingCnt > 0 {
+		s.logger.Debug("on pausing state, this task keeps current state", zap.Stringer("state", task.State))
+		return nil
 	}
-	s.logger.Debug("on pausing state, this task keeps current state", zap.Stringer("state", task.State))
+
+	s.logger.Info("all running subtasks paused, update the task to paused state")
+	if err = s.taskMgr.PausedTask(s.ctx, task.ID); err != nil {
+		return err
+	}
+	task.State = proto.TaskStatePaused
+	s.task.Store(&task)
 	return nil
 }
 
@@ -276,12 +296,9 @@ func (s *BaseScheduler) onPaused() error {
 	return nil
 }
 
-// TestSyncChan is used to sync the test.
-var TestSyncChan = make(chan struct{})
-
 // handle task in resuming state.
 func (s *BaseScheduler) onResuming() error {
-	task := s.GetTask()
+	task := *s.GetTask()
 	s.logger.Info("on resuming state", zap.Stringer("state", task.State), zap.String("step", proto.Step2Str(task.Type, task.Step)))
 	cntByStates, err := s.taskMgr.GetSubtaskCntGroupByStates(s.ctx, task.ID, task.Step)
 	if err != nil {
@@ -291,11 +308,12 @@ func (s *BaseScheduler) onResuming() error {
 	if cntByStates[proto.SubtaskStatePaused] == 0 {
 		// Finish the resuming process.
 		s.logger.Info("all paused tasks converted to pending state, update the task to running state")
-		err := s.taskMgr.ResumedTask(s.ctx, task.ID)
-		failpoint.Inject("syncAfterResume", func() {
-			TestSyncChan <- struct{}{}
-		})
-		return err
+		if err = s.taskMgr.ResumedTask(s.ctx, task.ID); err != nil {
+			return err
+		}
+		task.State = proto.TaskStateRunning
+		s.task.Store(&task)
+		return nil
 	}
 
 	return s.taskMgr.ResumeSubtasks(s.ctx, task.ID)
@@ -303,22 +321,27 @@ func (s *BaseScheduler) onResuming() error {
 
 // handle task in reverting state, check all revert subtasks finishes.
 func (s *BaseScheduler) onReverting() error {
-	task := s.GetTask()
+	task := *s.GetTask()
 	s.logger.Debug("on reverting state", zap.Stringer("state", task.State), zap.String("step", proto.Step2Str(task.Type, task.Step)))
 	cntByStates, err := s.taskMgr.GetSubtaskCntGroupByStates(s.ctx, task.ID, task.Step)
 	if err != nil {
 		s.logger.Warn("check task failed", zap.Error(err))
 		return err
 	}
-	activeRevertCnt := cntByStates[proto.SubtaskStatePending] + cntByStates[proto.SubtaskStateRunning]
-	if activeRevertCnt == 0 {
-		if err = s.OnDone(s.ctx, s, task); err != nil {
+	runnableSubtaskCnt := cntByStates[proto.SubtaskStatePending] + cntByStates[proto.SubtaskStateRunning]
+	if runnableSubtaskCnt == 0 {
+		if err = s.OnDone(s.ctx, s, &task); err != nil {
 			return errors.Trace(err)
 		}
-		return s.taskMgr.RevertedTask(s.ctx, task.ID)
+		if err = s.taskMgr.RevertedTask(s.ctx, task.ID); err != nil {
+			return errors.Trace(err)
+		}
+		task.State = proto.TaskStateReverted
+		s.task.Store(&task)
+		return nil
 	}
 	// Wait all subtasks in this step finishes.
-	s.OnTick(s.ctx, task)
+	s.OnTick(s.ctx, &task)
 	s.logger.Debug("on reverting state, this task keeps current state", zap.Stringer("state", task.State))
 	return nil
 }
@@ -350,8 +373,9 @@ func (s *BaseScheduler) onRunning() error {
 			return err
 		}
 		if len(subTaskErrs) > 0 {
-			s.logger.Warn("subtasks encounter errors")
-			return s.onErrHandlingStage(subTaskErrs)
+			s.logger.Warn("subtasks encounter errors", zap.Errors("subtask-errs", subTaskErrs))
+			// we only store the first error as task error.
+			return s.revertTask(subTaskErrs[0])
 		}
 	} else if s.isStepSucceed(cntByStates) {
 		return s.switch2NextStep()
@@ -369,30 +393,24 @@ func (s *BaseScheduler) onFinished() {
 	s.logger.Debug("schedule task, task is finished", zap.Stringer("state", task.State))
 }
 
-func (s *BaseScheduler) onErrHandlingStage(receiveErrs []error) error {
+func (s *BaseScheduler) switch2NextStep() error {
 	task := *s.GetTask()
-	// we only store the first error.
-	task.Error = receiveErrs[0]
-	s.task.Store(&task)
-
-	return s.taskMgr.RevertTask(s.ctx, task.ID, task.State, task.Error)
-}
-
-func (s *BaseScheduler) switch2NextStep() (err error) {
-	task := *s.GetTask()
-	nextStep := s.GetNextStep(&task)
+	nextStep := s.GetNextStep(&task.TaskBase)
 	s.logger.Info("switch to next step",
 		zap.String("current-step", proto.Step2Str(task.Type, task.Step)),
 		zap.String("next-step", proto.Step2Str(task.Type, nextStep)))
 
 	if nextStep == proto.StepDone {
-		task.Step = nextStep
-		task.StateUpdateTime = time.Now().UTC()
-		s.task.Store(&task)
-		if err = s.OnDone(s.ctx, s, &task); err != nil {
+		if err := s.OnDone(s.ctx, s, &task); err != nil {
 			return errors.Trace(err)
 		}
-		return s.taskMgr.SucceedTask(s.ctx, task.ID)
+		if err := s.taskMgr.SucceedTask(s.ctx, task.ID); err != nil {
+			return errors.Trace(err)
+		}
+		task.Step = nextStep
+		task.State = proto.TaskStateSucceed
+		s.task.Store(&task)
+		return nil
 	}
 
 	eligibleNodes, err := getEligibleNodes(s.ctx, s, s.nodeMgr.getManagedNodes())
@@ -409,10 +427,15 @@ func (s *BaseScheduler) switch2NextStep() (err error) {
 		s.logger.Warn("generate part of subtasks failed", zap.Error(err))
 		return s.handlePlanErr(err)
 	}
-	// OnNextSubtasksBatch might change meta of task.
-	s.task.Store(&task)
 
-	return s.scheduleSubTask(nextStep, metas, eligibleNodes)
+	if err = s.scheduleSubTask(nextStep, metas, eligibleNodes); err != nil {
+		return err
+	}
+	task.Step = nextStep
+	task.State = proto.TaskStateRunning
+	// and OnNextSubtasksBatch might change meta of task.
+	s.task.Store(&task)
+	return nil
 }
 
 func (s *BaseScheduler) scheduleSubTask(
@@ -422,7 +445,7 @@ func (s *BaseScheduler) scheduleSubTask(
 	task := s.GetTask()
 	s.logger.Info("schedule subtasks",
 		zap.Stringer("state", task.State),
-		zap.String("step", proto.Step2Str(task.Type, task.Step)),
+		zap.String("step", proto.Step2Str(task.Type, subtaskStep)),
 		zap.Int("concurrency", task.Concurrency),
 		zap.Int("subtasks", len(metas)))
 
@@ -482,9 +505,18 @@ func (s *BaseScheduler) handlePlanErr(err error) error {
 	if s.IsRetryableErr(err) {
 		return err
 	}
-	task.Error = err
+	return s.revertTask(err)
+}
+
+func (s *BaseScheduler) revertTask(taskErr error) error {
+	task := *s.GetTask()
+	if err := s.taskMgr.RevertTask(s.ctx, task.ID, task.State, taskErr); err != nil {
+		return err
+	}
+	task.State = proto.TaskStateReverting
+	task.Error = taskErr
 	s.task.Store(&task)
-	return s.taskMgr.RevertTask(s.ctx, task.ID, task.State, task.Error)
+	return nil
 }
 
 // MockServerInfo exported for scheduler_test.go

--- a/pkg/disttask/framework/scheduler/scheduler_nokit_test.go
+++ b/pkg/disttask/framework/scheduler/scheduler_nokit_test.go
@@ -62,8 +62,7 @@ func TestDispatcherOnNextStage(t *testing.T) {
 	schExt.EXPECT().OnDone(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("done err"))
 	require.ErrorContains(t, sch.Switch2NextStep(), "done err")
 	require.True(t, ctrl.Satisfied())
-	// we update task step before OnDone
-	require.Equal(t, proto.StepDone, sch.GetTask().Step)
+	require.Equal(t, proto.StepInit, sch.GetTask().Step)
 	taskClone2 := task
 	sch.task.Store(&taskClone2)
 	schExt.EXPECT().GetNextStep(gomock.Any()).Return(proto.StepDone)

--- a/pkg/disttask/framework/scheduler/scheduler_nokit_test.go
+++ b/pkg/disttask/framework/scheduler/scheduler_nokit_test.go
@@ -16,6 +16,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -24,7 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/disttask/framework/mock"
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
-	mockDispatch "github.com/pingcap/tidb/pkg/disttask/framework/scheduler/mock"
+	schmock "github.com/pingcap/tidb/pkg/disttask/framework/scheduler/mock"
 	"github.com/pingcap/tidb/pkg/disttask/framework/storage"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/stretchr/testify/require"
@@ -36,7 +37,7 @@ func TestDispatcherOnNextStage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	taskMgr := mock.NewMockTaskManager(ctrl)
-	schExt := mockDispatch.NewMockExtension(ctrl)
+	schExt := schmock.NewMockExtension(ctrl)
 
 	ctx := context.Background()
 	ctx = util.WithInternalSourceType(ctx, "dispatcher")
@@ -266,4 +267,232 @@ func TestSchedulerCleanupTask(t *testing.T) {
 	require.True(t, ctrl.Satisfied())
 
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/disttask/framework/scheduler/WaitCleanUpFinished"))
+}
+
+func TestSchedulerRefreshTask(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskMgr := mock.NewMockTaskManager(ctrl)
+
+	ctx := context.Background()
+	task := proto.Task{
+		TaskBase: proto.TaskBase{
+			ID:    1,
+			State: proto.TaskStateRunning,
+			Step:  proto.StepOne,
+		},
+		Meta: []byte("aaa"),
+	}
+	schTask := task
+	scheduler := NewBaseScheduler(ctx, &schTask, Param{taskMgr: taskMgr})
+
+	// get task base error
+	taskMgr.EXPECT().GetTaskBaseByID(gomock.Any(), task.ID).Return(nil, errors.New("get task err"))
+	require.ErrorContains(t, scheduler.refreshTaskIfNeeded(), "get task err")
+	require.True(t, ctrl.Satisfied())
+	// state/step not changed, no need to refresh
+	taskMgr.EXPECT().GetTaskBaseByID(gomock.Any(), task.ID).Return(&task.TaskBase, nil)
+	require.NoError(t, scheduler.refreshTaskIfNeeded())
+	require.Equal(t, *scheduler.GetTask(), task)
+	require.True(t, ctrl.Satisfied())
+	// get task by id failed
+	tmpTask := task
+	tmpTask.State = proto.TaskStateCancelling
+	taskMgr.EXPECT().GetTaskBaseByID(gomock.Any(), task.ID).Return(&tmpTask.TaskBase, nil)
+	taskMgr.EXPECT().GetTaskByID(gomock.Any(), task.ID).Return(nil, errors.New("get task by id err"))
+	require.ErrorContains(t, scheduler.refreshTaskIfNeeded(), "get task by id err")
+	require.Equal(t, *scheduler.GetTask(), task)
+	require.True(t, ctrl.Satisfied())
+	// state changed
+	tmpTask = task
+	tmpTask.State = proto.TaskStateCancelling
+	taskMgr.EXPECT().GetTaskBaseByID(gomock.Any(), task.ID).Return(&tmpTask.TaskBase, nil)
+	taskMgr.EXPECT().GetTaskByID(gomock.Any(), task.ID).Return(&tmpTask, nil)
+	require.NoError(t, scheduler.refreshTaskIfNeeded())
+	require.Equal(t, *scheduler.GetTask(), tmpTask)
+	require.True(t, ctrl.Satisfied())
+	// step changed
+	scheduler.task.Store(&schTask) // revert
+	tmpTask = task
+	tmpTask.Step = proto.StepTwo
+	taskMgr.EXPECT().GetTaskBaseByID(gomock.Any(), task.ID).Return(&tmpTask.TaskBase, nil)
+	taskMgr.EXPECT().GetTaskByID(gomock.Any(), task.ID).Return(&tmpTask, nil)
+	require.NoError(t, scheduler.refreshTaskIfNeeded())
+	require.Equal(t, *scheduler.GetTask(), tmpTask)
+	require.True(t, ctrl.Satisfied())
+}
+
+func TestSchedulerMaintainTaskFields(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskMgr := mock.NewMockTaskManager(ctrl)
+	schExt := schmock.NewMockExtension(ctrl)
+	schExt.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(func(base *proto.TaskBase) proto.Step {
+		switch base.Step {
+		case proto.StepInit:
+			return proto.StepOne
+		default:
+			return proto.StepDone
+		}
+	}).AnyTimes()
+	schExt.EXPECT().GetEligibleInstances(gomock.Any(), gomock.Any()).Return([]string{":4000"}, nil).AnyTimes()
+
+	ctx := context.Background()
+	task := proto.Task{
+		TaskBase: proto.TaskBase{
+			ID:    1,
+			State: proto.TaskStatePending,
+			Step:  proto.StepInit,
+		},
+		Meta: []byte("aaa"),
+	}
+	schTask := task
+	scheduler := NewBaseScheduler(ctx, &schTask, Param{
+		taskMgr: taskMgr,
+		nodeMgr: newNodeManager(":4000"),
+		slotMgr: newSlotManager(),
+	})
+	scheduler.Extension = schExt
+
+	t.Run("test onPausing", func(t *testing.T) {
+		scheduler.task.Store(&schTask)
+
+		taskMgr.EXPECT().GetSubtaskCntGroupByStates(gomock.Any(), task.ID, gomock.Any()).Return(nil, nil)
+		taskMgr.EXPECT().PausedTask(gomock.Any(), task.ID).Return(fmt.Errorf("pause err"))
+		require.ErrorContains(t, scheduler.onPausing(), "pause err")
+		require.Equal(t, *scheduler.GetTask(), task)
+		require.True(t, ctrl.Satisfied())
+
+		// pause task successfully
+		taskMgr.EXPECT().GetSubtaskCntGroupByStates(gomock.Any(), task.ID, gomock.Any()).Return(nil, nil)
+		taskMgr.EXPECT().PausedTask(gomock.Any(), task.ID).Return(nil)
+		require.NoError(t, scheduler.onPausing())
+		tmpTask := task
+		tmpTask.State = proto.TaskStatePaused
+		require.Equal(t, *scheduler.GetTask(), tmpTask)
+		require.True(t, ctrl.Satisfied())
+	})
+
+	t.Run("test onResuming", func(t *testing.T) {
+		scheduler.task.Store(&schTask)
+
+		taskMgr.EXPECT().GetSubtaskCntGroupByStates(gomock.Any(), task.ID, gomock.Any()).Return(nil, nil)
+		taskMgr.EXPECT().ResumedTask(gomock.Any(), task.ID).Return(fmt.Errorf("resume err"))
+		require.ErrorContains(t, scheduler.onResuming(), "resume err")
+		require.Equal(t, *scheduler.GetTask(), task)
+		require.True(t, ctrl.Satisfied())
+
+		// resume task successfully
+		taskMgr.EXPECT().GetSubtaskCntGroupByStates(gomock.Any(), task.ID, gomock.Any()).Return(nil, nil)
+		taskMgr.EXPECT().ResumedTask(gomock.Any(), task.ID).Return(nil)
+		require.NoError(t, scheduler.onResuming())
+		tmpTask := task
+		tmpTask.State = proto.TaskStateRunning
+		require.Equal(t, *scheduler.GetTask(), tmpTask)
+		require.True(t, ctrl.Satisfied())
+	})
+
+	t.Run("test onReverting", func(t *testing.T) {
+		scheduler.task.Store(&schTask)
+
+		taskMgr.EXPECT().GetSubtaskCntGroupByStates(gomock.Any(), task.ID, gomock.Any()).Return(nil, nil)
+		schExt.EXPECT().OnDone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		taskMgr.EXPECT().RevertedTask(gomock.Any(), task.ID).Return(fmt.Errorf("reverted err"))
+		require.ErrorContains(t, scheduler.onReverting(), "reverted err")
+		require.Equal(t, *scheduler.GetTask(), task)
+		require.True(t, ctrl.Satisfied())
+
+		// revert task successfully
+		taskMgr.EXPECT().GetSubtaskCntGroupByStates(gomock.Any(), task.ID, gomock.Any()).Return(nil, nil)
+		schExt.EXPECT().OnDone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		taskMgr.EXPECT().RevertedTask(gomock.Any(), task.ID).Return(nil)
+		require.NoError(t, scheduler.onReverting())
+		tmpTask := task
+		tmpTask.State = proto.TaskStateReverted
+		require.Equal(t, *scheduler.GetTask(), tmpTask)
+		require.True(t, ctrl.Satisfied())
+	})
+
+	t.Run("test switch2NextStep", func(t *testing.T) {
+		scheduler.task.Store(&schTask)
+
+		// retryable plan error, nothing changes
+		schExt.EXPECT().OnNextSubtasksBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("plan err"))
+		schExt.EXPECT().IsRetryableErr(gomock.Any()).Return(true)
+		require.ErrorContains(t, scheduler.switch2NextStep(), "plan err")
+		require.Equal(t, *scheduler.GetTask(), task)
+		require.True(t, ctrl.Satisfied())
+		// non-retryable plan error, but failed to revert, task state unchanged
+		schExt.EXPECT().OnNextSubtasksBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("plan err"))
+		schExt.EXPECT().IsRetryableErr(gomock.Any()).Return(false)
+		taskMgr.EXPECT().RevertTask(gomock.Any(), task.ID, gomock.Any(), gomock.Any()).Return(fmt.Errorf("revert err"))
+		require.ErrorContains(t, scheduler.switch2NextStep(), "revert err")
+		require.Equal(t, *scheduler.GetTask(), task)
+		require.True(t, ctrl.Satisfied())
+		// non-retryable plan error, task state changed to reverting
+		schExt.EXPECT().OnNextSubtasksBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("revert err"))
+		schExt.EXPECT().IsRetryableErr(gomock.Any()).Return(false)
+		taskMgr.EXPECT().RevertTask(gomock.Any(), task.ID, gomock.Any(), gomock.Any()).Return(nil)
+		require.NoError(t, scheduler.switch2NextStep())
+		tmpTask := task
+		tmpTask.State = proto.TaskStateReverting
+		tmpTask.Error = fmt.Errorf("revert err")
+		require.Equal(t, *scheduler.GetTask(), tmpTask)
+		require.True(t, ctrl.Satisfied())
+
+		// revert task back
+		scheduler.task.Store(&schTask)
+
+		// switch to next step, but update failed
+		schExt.EXPECT().OnNextSubtasksBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, nil)
+		taskMgr.EXPECT().GetUsedSlotsOnNodes(gomock.Any()).Return(nil, fmt.Errorf("update err"))
+		require.ErrorContains(t, scheduler.switch2NextStep(), "update err")
+		require.Equal(t, *scheduler.GetTask(), task)
+		require.True(t, ctrl.Satisfied())
+		// switch to next step successfully
+		schExt.EXPECT().OnNextSubtasksBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, nil)
+		taskMgr.EXPECT().GetUsedSlotsOnNodes(gomock.Any()).Return(nil, nil)
+		taskMgr.EXPECT().SwitchTaskStep(gomock.Any(), gomock.Any(), proto.TaskStateRunning, proto.StepOne, gomock.Any()).Return(nil)
+		require.NoError(t, scheduler.switch2NextStep())
+		tmpTask = task
+		tmpTask.State = proto.TaskStateRunning
+		tmpTask.Step = proto.StepOne
+		require.Equal(t, *scheduler.GetTask(), tmpTask)
+		require.True(t, ctrl.Satisfied())
+
+		// task done, but update failed, task state unchanged
+		schExt.EXPECT().OnDone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		taskMgr.EXPECT().SucceedTask(gomock.Any(), task.ID).Return(fmt.Errorf("update err"))
+		require.ErrorContains(t, scheduler.switch2NextStep(), "update err")
+		require.Equal(t, *scheduler.GetTask(), tmpTask)
+		// task done successfully, task state changed
+		schExt.EXPECT().OnDone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		taskMgr.EXPECT().SucceedTask(gomock.Any(), task.ID).Return(nil)
+		require.NoError(t, scheduler.switch2NextStep())
+		tmpTask.State = proto.TaskStateSucceed
+		tmpTask.Step = proto.StepDone
+		require.Equal(t, *scheduler.GetTask(), tmpTask)
+	})
+
+	t.Run("test revertTask", func(t *testing.T) {
+		scheduler.task.Store(&schTask)
+
+		taskMgr.EXPECT().RevertTask(gomock.Any(), task.ID, gomock.Any(), gomock.Any()).Return(fmt.Errorf("revert err"))
+		require.ErrorContains(t, scheduler.revertTask(fmt.Errorf("task err")), "revert err")
+		require.Equal(t, *scheduler.GetTask(), task)
+		require.True(t, ctrl.Satisfied())
+
+		taskMgr.EXPECT().RevertTask(gomock.Any(), task.ID, gomock.Any(), gomock.Any()).Return(nil)
+		require.NoError(t, scheduler.revertTask(fmt.Errorf("task err")))
+		tmpTask := task
+		tmpTask.State = proto.TaskStateReverting
+		tmpTask.Error = fmt.Errorf("task err")
+		require.Equal(t, *scheduler.GetTask(), tmpTask)
+		require.True(t, ctrl.Satisfied())
+	})
 }

--- a/pkg/disttask/framework/scheduler/scheduler_test.go
+++ b/pkg/disttask/framework/scheduler/scheduler_test.go
@@ -56,7 +56,7 @@ func getTestSchedulerExt(ctrl *gomock.Controller) scheduler.Extension {
 	).AnyTimes()
 	mockScheduler.EXPECT().IsRetryableErr(gomock.Any()).Return(true).AnyTimes()
 	mockScheduler.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
-		func(task *proto.Task) proto.Step {
+		func(task *proto.TaskBase) proto.Step {
 			return proto.StepDone
 		},
 	).AnyTimes()
@@ -80,7 +80,7 @@ func getNumberExampleSchedulerExt(ctrl *gomock.Controller) scheduler.Extension {
 	).AnyTimes()
 	mockScheduler.EXPECT().IsRetryableErr(gomock.Any()).Return(true).AnyTimes()
 	mockScheduler.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
-		func(task *proto.Task) proto.Step {
+		func(task *proto.TaskBase) proto.Step {
 			switch task.Step {
 			case proto.StepInit:
 				return proto.StepOne

--- a/pkg/disttask/framework/testutil/scheduler_util.go
+++ b/pkg/disttask/framework/testutil/scheduler_util.go
@@ -78,7 +78,7 @@ func GetMockSchedulerExt(ctrl *gomock.Controller, schedulerInfo SchedulerInfo) s
 	mockScheduler.EXPECT().GetEligibleInstances(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	mockScheduler.EXPECT().IsRetryableErr(gomock.Any()).Return(schedulerInfo.AllErrorRetryable).AnyTimes()
 	mockScheduler.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
-		func(task *proto.Task) proto.Step {
+		func(task *proto.TaskBase) proto.Step {
 			return stepTransition[task.Step]
 		},
 	).AnyTimes()
@@ -147,7 +147,7 @@ func GetPlanErrSchedulerExt(ctrl *gomock.Controller, testContext *TestContext) s
 	).AnyTimes()
 	mockScheduler.EXPECT().IsRetryableErr(gomock.Any()).Return(true).AnyTimes()
 	mockScheduler.EXPECT().GetNextStep(gomock.Any()).DoAndReturn(
-		func(task *proto.Task) proto.Step {
+		func(task *proto.TaskBase) proto.Step {
 			switch task.Step {
 			case proto.StepInit:
 				return proto.StepOne

--- a/pkg/disttask/importinto/proto.go
+++ b/pkg/disttask/importinto/proto.go
@@ -30,7 +30,7 @@ import (
 // TaskMeta is the task of IMPORT INTO.
 // All the field should be serializable.
 type TaskMeta struct {
-	// IMPORT INTO job id.
+	// IMPORT INTO job id, see mysql.tidb_import_jobs.
 	JobID  int64
 	Plan   importer.Plan
 	Stmt   string

--- a/pkg/disttask/importinto/scheduler.go
+++ b/pkg/disttask/importinto/scheduler.go
@@ -351,7 +351,7 @@ func (*ImportSchedulerExt) IsRetryableErr(error) bool {
 }
 
 // GetNextStep implements scheduler.Extension interface.
-func (sch *ImportSchedulerExt) GetNextStep(task *proto.Task) proto.Step {
+func (sch *ImportSchedulerExt) GetNextStep(task *proto.TaskBase) proto.Step {
 	switch task.Step {
 	case proto.StepInit:
 		if sch.GlobalSort {

--- a/pkg/disttask/importinto/scheduler_test.go
+++ b/pkg/disttask/importinto/scheduler_test.go
@@ -114,9 +114,7 @@ func (s *importIntoSuite) TestSchedulerInit() {
 }
 
 func (s *importIntoSuite) TestGetNextStep() {
-	task := &proto.Task{
-		TaskBase: proto.TaskBase{Step: proto.StepInit},
-	}
+	task := &proto.TaskBase{Step: proto.StepInit}
 	ext := &ImportSchedulerExt{}
 	for _, nextStep := range []proto.Step{proto.ImportStepImport, proto.ImportStepPostProcess, proto.StepDone} {
 		s.Equal(nextStep, ext.GetNextStep(task))

--- a/pkg/disttask/importinto/scheduler_testkit_test.go
+++ b/pkg/disttask/importinto/scheduler_testkit_test.go
@@ -92,10 +92,10 @@ func TestSchedulerExtLocalSort(t *testing.T) {
 	// to import stage, job should be running
 	d := sch.MockScheduler(task)
 	ext := importinto.ImportSchedulerExt{}
-	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(task))
+	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
-	nextStep := ext.GetNextStep(task)
+	nextStep := ext.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.ImportStepImport, nextStep)
 	gotJobInfo, err = importer.GetJob(ctx, conn, jobID, "root", true)
 	require.NoError(t, err)
@@ -114,20 +114,20 @@ func TestSchedulerExtLocalSort(t *testing.T) {
 		require.NoError(t, manager.FinishSubtask(ctx, s.ExecID, s.ID, []byte("{}")))
 	}
 	// to post-process stage, job should be running and in validating step
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
-	task.Step = ext.GetNextStep(task)
+	task.Step = ext.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.ImportStepPostProcess, task.Step)
 	gotJobInfo, err = importer.GetJob(ctx, conn, jobID, "root", true)
 	require.NoError(t, err)
 	require.Equal(t, "running", gotJobInfo.Status)
 	require.Equal(t, "validating", gotJobInfo.Step)
 	// on next stage, job should be finished
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 0)
-	task.Step = ext.GetNextStep(task)
+	task.Step = ext.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.StepDone, task.Step)
 	require.NoError(t, ext.OnDone(ctx, d, task))
 	gotJobInfo, err = importer.GetJob(ctx, conn, jobID, "root", true)
@@ -237,10 +237,10 @@ func TestSchedulerExtGlobalSort(t *testing.T) {
 	ext := importinto.ImportSchedulerExt{
 		GlobalSort: true,
 	}
-	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(task))
+	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 2)
-	nextStep := ext.GetNextStep(task)
+	nextStep := ext.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.ImportStepEncodeAndSort, nextStep)
 	gotJobInfo, err = importer.GetJob(ctx, conn, jobID, "root", true)
 	require.NoError(t, err)
@@ -292,10 +292,10 @@ func TestSchedulerExtGlobalSort(t *testing.T) {
 
 	// to merge-sort stage
 	testkit.EnableFailPoint(t, "github.com/pingcap/tidb/pkg/disttask/importinto/forceMergeSort", `return("data")`)
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
-	nextStep = ext.GetNextStep(task)
+	nextStep = ext.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.ImportStepMergeSort, nextStep)
 	gotJobInfo, err = importer.GetJob(ctx, conn, jobID, "root", true)
 	require.NoError(t, err)
@@ -328,29 +328,29 @@ func TestSchedulerExtGlobalSort(t *testing.T) {
 
 	// to write-and-ingest stage
 	testkit.EnableFailPoint(t, "github.com/pingcap/tidb/pkg/disttask/importinto/mockWriteIngestSpecs", "return(true)")
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 2)
-	task.Step = ext.GetNextStep(task)
+	task.Step = ext.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.ImportStepWriteAndIngest, task.Step)
 	gotJobInfo, err = importer.GetJob(ctx, conn, jobID, "root", true)
 	require.NoError(t, err)
 	require.Equal(t, "running", gotJobInfo.Status)
 	require.Equal(t, "importing", gotJobInfo.Step)
 	// on next stage, to post-process stage
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
-	task.Step = ext.GetNextStep(task)
+	task.Step = ext.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.ImportStepPostProcess, task.Step)
 	gotJobInfo, err = importer.GetJob(ctx, conn, jobID, "root", true)
 	require.NoError(t, err)
 	require.Equal(t, "running", gotJobInfo.Status)
 	require.Equal(t, "validating", gotJobInfo.Step)
 	// next stage, done
-	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(task))
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 0)
-	task.Step = ext.GetNextStep(task)
+	task.Step = ext.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.StepDone, task.Step)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #49008

Problem Summary:

### What changed and how does it work?
- after #51241, we only refresh task base on scheduler loop, but task-meta might be changed by other scheduler in network-partition cases. to avoid this case, we maintain state/step change in memory, refresh whole task info when we detected state/step is changed by others, either by other scheduler or by explicit state change operation such as cancel or pause.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
