### PR TITLE
prepare_snap: establish connection to all stores before pausing admin

### DIFF
--- a/br/pkg/backup/prepare_snap/BUILD.bazel
+++ b/br/pkg/backup/prepare_snap/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     timeout = "short",
     srcs = ["prepare_test.go"],
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         ":prepare_snap",
         "//br/pkg/utils",

--- a/br/pkg/backup/prepare_snap/prepare.go
+++ b/br/pkg/backup/prepare_snap/prepare.go
@@ -385,7 +385,7 @@ func (p *Preparer) sendWaitApply(ctx context.Context, reqs pendingRequests) erro
 }
 
 func (p *Preparer) streamOf(ctx context.Context, storeID uint64) (*prepareStream, error) {
-	s, ok := p.clients[storeID]
+	_, ok := p.clients[storeID]
 	if !ok {
 		log.Warn("stream of store found a store not established connection", zap.Uint64("store", storeID))
 		cli, err := p.env.ConnectToStore(ctx, storeID)
@@ -396,7 +396,7 @@ func (p *Preparer) streamOf(ctx context.Context, storeID uint64) (*prepareStream
 			return nil, errors.Annotatef(err, "failed to create and cache stream for store %d", storeID)
 		}
 	}
-	return s, nil
+	return p.clients[storeID], nil
 }
 
 func (p *Preparer) createAndCacheStream(ctx context.Context, cli PrepareClient, storeID uint64) error {

--- a/br/pkg/backup/prepare_snap/prepare.go
+++ b/br/pkg/backup/prepare_snap/prepare.go
@@ -155,7 +155,7 @@ func (p *Preparer) DriveLoopAndWaitPrepare(ctx context.Context) error {
 		zap.Int("retry_limit", p.RetryLimit),
 		zap.Duration("lease_duration", p.LeaseDuration))
 	p.retryTime = 0
-	if err := p.prepareConnections(ctx); err != nil {
+	if err := p.PrepareConnections(ctx); err != nil {
 		log.Error("failed to prepare connections", logutil.ShortError(err))
 		return errors.Annotate(err, "failed to prepare connections")
 	}
@@ -387,21 +387,29 @@ func (p *Preparer) sendWaitApply(ctx context.Context, reqs pendingRequests) erro
 func (p *Preparer) streamOf(ctx context.Context, storeID uint64) (*prepareStream, error) {
 	s, ok := p.clients[storeID]
 	if !ok {
+		log.Warn("stream of store found a store not established connection", zap.Uint64("store", storeID))
 		cli, err := p.env.ConnectToStore(ctx, storeID)
 		if err != nil {
 			return nil, errors.Annotatef(err, "failed to dial store %d", storeID)
 		}
-		s = new(prepareStream)
-		s.storeID = storeID
-		s.output = p.eventChan
-		s.leaseDuration = p.LeaseDuration
-		err = s.InitConn(ctx, cli)
-		if err != nil {
-			return nil, err
+		if err := p.createAndCacheStream(ctx, cli, storeID); err != nil {
+			return nil, errors.Annotatef(err, "failed to create and cache stream for store %d", storeID)
 		}
-		p.clients[storeID] = s
 	}
 	return s, nil
+}
+
+func (p *Preparer) createAndCacheStream(ctx context.Context, cli PrepareClient, storeID uint64) error {
+	s := new(prepareStream)
+	s.storeID = storeID
+	s.output = p.eventChan
+	s.leaseDuration = p.LeaseDuration
+	err := s.InitConn(ctx, cli)
+	if err != nil {
+		return err
+	}
+	p.clients[storeID] = s
+	return nil
 }
 
 func (p *Preparer) pushWaitApply(reqs pendingRequests, region Region) {
@@ -414,17 +422,31 @@ func (p *Preparer) pushWaitApply(reqs pendingRequests, region Region) {
 	p.inflightReqs[region.GetMeta().Id] = *region.GetMeta()
 }
 
-func (p *Preparer) prepareConnections(ctx context.Context) error {
+// PrepareConnections prepares the connections for each store.
+// This will pause the admin commands for each store.
+func (p *Preparer) PrepareConnections(ctx context.Context) error {
 	log.Info("Preparing connections to stores.")
 	stores, err := p.env.GetAllLiveStores(ctx)
 	if err != nil {
 		return errors.Annotate(err, "failed to get all live stores")
 	}
+
+	log.Info("Start to initialize the connections.", zap.Int("stores", len(stores)))
+	clients := map[uint64]PrepareClient{}
 	for _, store := range stores {
-		_, err := p.streamOf(ctx, store.Id)
+		cli, err := p.env.ConnectToStore(ctx, store.Id)
 		if err != nil {
-			return errors.Annotatef(err, "failed to prepare connection to store %d", store.Id)
+			return errors.Annotatef(err, "failed to dial the store %d", store.Id)
+		}
+		clients[store.Id] = cli
+	}
+
+	for id, cli := range clients {
+		log.Info("Start to pause the admin commands.", zap.Uint64("store", id))
+		if err := p.createAndCacheStream(ctx, cli, id); err != nil {
+			return errors.Annotatef(err, "failed to create and cache stream for store %d", id)
 		}
 	}
+
 	return nil
 }

--- a/br/pkg/backup/prepare_snap/stream.go
+++ b/br/pkg/backup/prepare_snap/stream.go
@@ -70,6 +70,7 @@ func (p *prepareStream) InitConn(ctx context.Context, cli PrepareClient) error {
 	p.cli = cli
 	p.clientLoopHandle, ctx = errgroup.WithContext(ctx)
 	ctx, p.stopBgTasks = context.WithCancel(ctx)
+	log.Info("initializing", zap.Uint64("store", p.storeID))
 	return p.GoLeaseLoop(ctx, p.leaseDuration)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51448 

Problem Summary:
Now if we cannot connect to a TiKV, it will block at creating connection.
But, in this scenario, some of TiKVs' admin commands are paused. That will impact the TP workload more.

### What changed and how does it work?
After this PR, we won't pause the admin commands before connections to all TiKV nodes established.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
