### PR TITLE
parser,ddl: support altering the comment of a sequence

### DIFF
--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -8537,7 +8537,7 @@ func (d *ddl) AlterSequence(ctx sessionctx.Context, stmt *ast.AlterSequenceStmt)
 	// Validate the new sequence option value in old sequenceInfo.
 	oldSequenceInfo := tbl.Meta().Sequence
 	copySequenceInfo := *oldSequenceInfo
-	_, _, err = alterSequenceOptions(stmt.SeqOptions, ident, &copySequenceInfo)
+	_, _, err = alterSequenceOptions(stmt.SeqOptions, stmt.TblOptions, ident, &copySequenceInfo)
 	if err != nil {
 		return err
 	}
@@ -8549,7 +8549,7 @@ func (d *ddl) AlterSequence(ctx sessionctx.Context, stmt *ast.AlterSequenceStmt)
 		TableName:      tbl.Meta().Name.L,
 		Type:           model.ActionAlterSequence,
 		BinlogInfo:     &model.HistoryInfo{},
-		Args:           []any{ident, stmt.SeqOptions},
+		Args:           []any{ident, stmt.SeqOptions, stmt.TblOptions},
 		CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
 		SQLMode:        ctx.GetSessionVars().SQLMode,
 	}

--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -4725,6 +4725,7 @@ type AlterSequenceStmt struct {
 
 	IfExists   bool
 	SeqOptions []*SequenceOption
+	TblOptions []*TableOption
 }
 
 func (n *AlterSequenceStmt) Restore(ctx *format.RestoreCtx) error {
@@ -4739,6 +4740,12 @@ func (n *AlterSequenceStmt) Restore(ctx *format.RestoreCtx) error {
 		ctx.WritePlain(" ")
 		if err := option.Restore(ctx); err != nil {
 			return errors.Annotatef(err, "An error occurred while splicing AlterSequenceStmt SequenceOption: [%v]", i)
+		}
+	}
+	for i, option := range n.TblOptions {
+		ctx.WritePlain(" ")
+		if err := option.Restore(ctx); err != nil {
+			return errors.Annotatef(err, "An error occurred while splicing AlterSequenceStmt TableOption: [%v]", i)
 		}
 	}
 	return nil

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -15109,14 +15109,24 @@ DropSequenceStmt:
  *	[ RESTART [WITH | = ] restart ]
  ********************************************************************************************/
 AlterSequenceStmt:
-	"ALTER" "SEQUENCE" IfExists TableName AlterSequenceOptionList
+	"ALTER" "SEQUENCE" IfExists TableName AlterSequenceOptionList PartDefOptionList
 	{
 		$$ = &ast.AlterSequenceStmt{
 			IfExists:   $3.(bool),
 			Name:       $4.(*ast.TableName),
 			SeqOptions: $5.([]*ast.SequenceOption),
+			TblOptions: $6.([]*ast.TableOption),
 		}
 	}
+|	"ALTER" "SEQUENCE" IfExists TableName PartDefOptionList
+	{
+		$$ = &ast.AlterSequenceStmt{
+			IfExists:   $3.(bool),
+			Name:       $4.(*ast.TableName),
+			TblOptions: $5.([]*ast.TableOption),
+		}
+	}
+
 
 AlterSequenceOptionList:
 	AlterSequenceOption

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -3727,7 +3727,7 @@ func TestDDL(t *testing.T) {
 
 		// for alter sequence
 		{"alter sequence seq", false, ""},
-		{"alter sequence seq comment=\"haha\"", false, ""},
+		{"alter sequence seq comment=\"haha\"", true, "ALTER SEQUENCE `seq` COMMENT = 'haha'"},
 		{"alter sequence seq start = 1", true, "ALTER SEQUENCE `seq` START WITH 1"},
 		{"alter sequence seq start with 1 increment by 1", true, "ALTER SEQUENCE `seq` START WITH 1 INCREMENT BY 1"},
 		{"alter sequence seq start with 1 increment by 2 minvalue 0 maxvalue 100", true, "ALTER SEQUENCE `seq` START WITH 1 INCREMENT BY 2 MINVALUE 0 MAXVALUE 100"},

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -3726,7 +3726,7 @@ func TestDDL(t *testing.T) {
 		{"alter table t auto_increment 30, force auto_random_base 40", true, "ALTER TABLE `t` AUTO_INCREMENT = 30, FORCE AUTO_RANDOM_BASE = 40"},
 
 		// for alter sequence
-		{"alter sequence seq", false, ""},
+		{"alter sequence seq", true, "ALTER SEQUENCE `seq`"},
 		{"alter sequence seq comment=\"haha\"", true, "ALTER SEQUENCE `seq` COMMENT = 'haha'"},
 		{"alter sequence seq start = 1", true, "ALTER SEQUENCE `seq` START WITH 1"},
 		{"alter sequence seq start with 1 increment by 1", true, "ALTER SEQUENCE `seq` START WITH 1 INCREMENT BY 1"},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51433

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
It is now possible to change the comment of a sequence with a `ALTER SEQUENCE` statement.
```
