### PR TITLE
session: load variables before parsing SQL

### DIFF
--- a/pkg/server/tests/commontest/BUILD.bazel
+++ b/pkg/server/tests/commontest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "tidb_test.go",
     ],
     flaky = True,
-    shard_count = 47,
+    shard_count = 48,
     deps = [
         "//pkg/config",
         "//pkg/ddl/util",

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3061,3 +3061,8 @@ func TestPrepareCount(t *testing.T) {
 	require.Equal(t, prepareCnt, atomic.LoadInt64(&variable.PreparedStmtCount))
 	require.NoError(t, qctx.Close())
 }
+
+func TestSQLModeIsLoadedBeforeQuery(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+	ts.RunTestSQLModeIsLoadedBeforeQuery(t)
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1652,6 +1652,13 @@ func (s *session) Execute(ctx context.Context, sql string) (recordSets []sqlexec
 func (s *session) Parse(ctx context.Context, sql string) ([]ast.StmtNode, error) {
 	logutil.Logger(ctx).Debug("parse", zap.String("sql", sql))
 	parseStartTime := time.Now()
+
+	// Load the session variables to the context.
+	// This is necessary for the parser to get the current sql_mode.
+	if err := s.loadCommonGlobalVariablesIfNeeded(); err != nil {
+		return nil, err
+	}
+
 	stmts, warns, err := s.ParseSQL(ctx, sql, s.sessionVars.GetParseParams()...)
 	if err != nil {
 		s.rollbackOnError(ctx)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51387

Problem Summary:

The session variables are not loaded before parsing the SQL statements, which makes SQLMode incorrect.

### What changed and how does it work?

Load session variables before parsing the statements.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
Fix the issue that SQLMode doesn't have effect on the first statement in a session.
```
