### PR TITLE
executor: add microservice into table cluster_config

### DIFF
--- a/pkg/executor/memtable_reader.go
+++ b/pkg/executor/memtable_reader.go
@@ -206,6 +206,10 @@ func fetchClusterConfig(sctx sessionctx.Context, nodeTypes, nodeAddrs set.String
 					url = fmt.Sprintf("%s://%s/api/admin/config?format=json", util.InternalHTTPSchema(), statusAddr)
 				case "ticdc":
 					url = fmt.Sprintf("%s://%s/config", util.InternalHTTPSchema(), statusAddr)
+				case "tso":
+					url = fmt.Sprintf("%s://%s/tso/api/v1/config", util.InternalHTTPSchema(), statusAddr)
+				case "scheduling":
+					url = fmt.Sprintf("%s://%s/scheduling/api/v1/config", util.InternalHTTPSchema(), statusAddr)
 				default:
 					ch <- result{err: errors.Errorf("currently we do not support get config from node type: %s(%s)", typ, address)}
 					return

--- a/pkg/executor/memtable_reader_test.go
+++ b/pkg/executor/memtable_reader_test.go
@@ -154,10 +154,14 @@ func TestTiDBClusterConfig(t *testing.T) {
 	router.Handle("/config", fn.Wrap(mockConfig))
 	// Tiproxy config
 	router.Handle("/api/admin/config", fn.Wrap(mockConfig))
+	// TSO config
+	router.Handle("/tso/api/v1/config", fn.Wrap(mockConfig))
+	// Scheduling config
+	router.Handle("/scheduling/api/v1/config", fn.Wrap(mockConfig))
 
 	// mock servers
 	var servers []string
-	for _, typ := range []string{"tidb", "tikv", "tiflash", "tiproxy", "pd"} {
+	for _, typ := range []string{"tidb", "tikv", "tiflash", "tiproxy", "pd", "tso", "scheduling"} {
 		for _, server := range testServers {
 			servers = append(servers, strings.Join([]string{typ, server.address, server.address}, ","))
 		}
@@ -215,10 +219,28 @@ func TestTiDBClusterConfig(t *testing.T) {
 		"pd key1 value1",
 		"pd key2.nest1 n-value1",
 		"pd key2.nest2 n-value2",
+		"tso key1 value1",
+		"tso key2.nest1 n-value1",
+		"tso key2.nest2 n-value2",
+		"tso key1 value1",
+		"tso key2.nest1 n-value1",
+		"tso key2.nest2 n-value2",
+		"tso key1 value1",
+		"tso key2.nest1 n-value1",
+		"tso key2.nest2 n-value2",
+		"scheduling key1 value1",
+		"scheduling key2.nest1 n-value1",
+		"scheduling key2.nest2 n-value2",
+		"scheduling key1 value1",
+		"scheduling key2.nest1 n-value1",
+		"scheduling key2.nest2 n-value2",
+		"scheduling key1 value1",
+		"scheduling key2.nest1 n-value1",
+		"scheduling key2.nest2 n-value2",
 	))
 	warnings := tk.Session().GetSessionVars().StmtCtx.GetWarnings()
 	require.Len(t, warnings, 0, fmt.Sprintf("unexpected warnings: %+v", warnings))
-	require.Equal(t, int32(15), requestCounter)
+	require.Equal(t, int32(21), requestCounter)
 
 	// TODO: we need remove it when index usage is GA.
 	rs := tk.MustQuery("show config").Rows()
@@ -235,7 +257,7 @@ func TestTiDBClusterConfig(t *testing.T) {
 
 	// type => server index => row
 	rows := map[string][][]string{}
-	for _, typ := range []string{"tidb", "tikv", "tiflash", "tiproxy", "pd"} {
+	for _, typ := range []string{"tidb", "tikv", "tiflash", "tiproxy", "pd", "tso", "scheduling"} {
 		for _, server := range testServers {
 			rows[typ] = append(rows[typ], []string{
 				fmt.Sprintf("%s %s key1 value1", typ, server.address),
@@ -258,7 +280,7 @@ func TestTiDBClusterConfig(t *testing.T) {
 	}{
 		{
 			sql:      "select * from information_schema.cluster_config",
-			reqCount: 15,
+			reqCount: 21,
 			rows: flatten(
 				rows["tidb"][0],
 				rows["tidb"][1],
@@ -275,6 +297,12 @@ func TestTiDBClusterConfig(t *testing.T) {
 				rows["pd"][0],
 				rows["pd"][1],
 				rows["pd"][2],
+				rows["tso"][0],
+				rows["tso"][1],
+				rows["tso"][2],
+				rows["scheduling"][0],
+				rows["scheduling"][1],
+				rows["scheduling"][2],
 			),
 		},
 		{
@@ -291,7 +319,7 @@ func TestTiDBClusterConfig(t *testing.T) {
 		},
 		{
 			sql:      "select * from information_schema.cluster_config where type='pd' or instance='" + testServers[0].address + "'",
-			reqCount: 15,
+			reqCount: 21,
 			rows: flatten(
 				rows["tidb"][0],
 				rows["tikv"][0],
@@ -300,6 +328,8 @@ func TestTiDBClusterConfig(t *testing.T) {
 				rows["pd"][0],
 				rows["pd"][1],
 				rows["pd"][2],
+				rows["tso"][0],
+				rows["scheduling"][0],
 			),
 		},
 		{
@@ -372,13 +402,15 @@ func TestTiDBClusterConfig(t *testing.T) {
 		{
 			sql: fmt.Sprintf(`select * from information_schema.cluster_config where instance='%s'`,
 				testServers[0].address),
-			reqCount: 5,
+			reqCount: 7,
 			rows: flatten(
 				rows["tidb"][0],
 				rows["tikv"][0],
 				rows["tiflash"][0],
 				rows["tiproxy"][0],
 				rows["pd"][0],
+				rows["tso"][0],
+				rows["scheduling"][0],
 			),
 		},
 		{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51495

Problem Summary:

### What changed and how does it work?

```
mysql> select * from information_schema.cluster_config;
+------------+------------------+-------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| TYPE       | INSTANCE         | KEY                                                                                 | VALUE                                                                                                                                                                                                                                                                                           |
+------------+------------------+-------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
...
| tso        | 10.2.8.101:35317 | LogProps.Core.LevelEnabler                                                          | info                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | LogProps.Level                                                                      | info                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | LogProps.Syncer.Writer.compress                                                     | false                                                                                                                                                                                                                                                                                           |
| tso        | 10.2.8.101:35317 | LogProps.Syncer.Writer.filename                                                     | /data/nvme0n1/ryan/.tiup/data/U67Wpt1/pd-tso-0/tso.log                                                                                                                                                                                                                                          |
| tso        | 10.2.8.101:35317 | LogProps.Syncer.Writer.localtime                                                    | true                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | LogProps.Syncer.Writer.maxage                                                       | 0                                                                                                                                                                                                                                                                                               |
| tso        | 10.2.8.101:35317 | LogProps.Syncer.Writer.maxbackups                                                   | 0                                                                                                                                                                                                                                                                                               |
| tso        | 10.2.8.101:35317 | LogProps.Syncer.Writer.maxsize                                                      | 300                                                                                                                                                                                                                                                                                             |
| tso        | 10.2.8.101:35317 | WarningMsgs                                                                         | null                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | advertise-listen-addr                                                               | http://10.2.8.101:35317                                                                                                                                                                                                                                                                         |
| tso        | 10.2.8.101:35317 | backend-endpoints                                                                   | http://10.2.8.101:44969                                                                                                                                                                                                                                                                         |
| tso        | 10.2.8.101:35317 | data-dir                                                                            | /data/nvme0n1/ryan/.tiup/data/U67Wpt1/pd-tso-0/default-datadir.TSO-cloud-ecosystem-00                                                                                                                                                                                                           |
| tso        | 10.2.8.101:35317 | enable-grpc-gateway                                                                 | true                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | enable-local-tso                                                                    | false                                                                                                                                                                                                                                                                                           |
| tso        | 10.2.8.101:35317 | lease                                                                               | 3                                                                                                                                                                                                                                                                                               |
| tso        | 10.2.8.101:35317 | listen-addr                                                                         | http://10.2.8.101:35317                                                                                                                                                                                                                                                                         |
| tso        | 10.2.8.101:35317 | log.development                                                                     | false                                                                                                                                                                                                                                                                                           |
| tso        | 10.2.8.101:35317 | log.disable-caller                                                                  | false                                                                                                                                                                                                                                                                                           |
| tso        | 10.2.8.101:35317 | log.disable-error-verbose                                                           | true                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | log.disable-stacktrace                                                              | false                                                                                                                                                                                                                                                                                           |
| tso        | 10.2.8.101:35317 | log.disable-timestamp                                                               | false                                                                                                                                                                                                                                                                                           |
| tso        | 10.2.8.101:35317 | log.error-output-path                                                               |                                                                                                                                                                                                                                                                                                 |
| tso        | 10.2.8.101:35317 | log.file.filename                                                                   | /data/nvme0n1/ryan/.tiup/data/U67Wpt1/pd-tso-0/tso.log                                                                                                                                                                                                                                          |
| tso        | 10.2.8.101:35317 | log.file.max-backups                                                                | 0                                                                                                                                                                                                                                                                                               |
| tso        | 10.2.8.101:35317 | log.file.max-days                                                                   | 0                                                                                                                                                                                                                                                                                               |
| tso        | 10.2.8.101:35317 | log.file.max-size                                                                   | 0                                                                                                                                                                                                                                                                                               |
| tso        | 10.2.8.101:35317 | log.format                                                                          | text                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | log.level                                                                           | info                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | log.sampling                                                                        | null                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | max-gap-reset-ts                                                                    | 24h0m0s                                                                                                                                                                                                                                                                                         |
| tso        | 10.2.8.101:35317 | metric.address                                                                      |                                                                                                                                                                                                                                                                                                 |
| tso        | 10.2.8.101:35317 | metric.interval                                                                     | 0s                                                                                                                                                                                                                                                                                              |
| tso        | 10.2.8.101:35317 | metric.job                                                                          |                                                                                                                                                                                                                                                                                                 |
| tso        | 10.2.8.101:35317 | name                                                                                | TSO-cloud-ecosystem-00                                                                                                                                                                                                                                                                          |
| tso        | 10.2.8.101:35317 | security.SSLCABytes                                                                 | null                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | security.SSLCertBytes                                                               | null                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | security.SSLKEYBytes                                                                | null                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | security.cacert-path                                                                |                                                                                                                                                                                                                                                                                                 |
| tso        | 10.2.8.101:35317 | security.cert-allowed-cn                                                            | null                                                                                                                                                                                                                                                                                            |
| tso        | 10.2.8.101:35317 | security.cert-path                                                                  |                                                                                                                                                                                                                                                                                                 |
| tso        | 10.2.8.101:35317 | security.encryption.data-encryption-method                                          | plaintext                                                                                                                                                                                                                                                                                       |
| tso        | 10.2.8.101:35317 | security.encryption.data-key-rotation-period                                        | 168h0m0s                                                                                                                                                                                                                                                                                        |
| tso        | 10.2.8.101:35317 | security.encryption.master-key.endpoint                                             |                                                                                                                                                                                                                                                                                                 |
| tso        | 10.2.8.101:35317 | security.encryption.master-key.key-id                                               |                                                                                                                                                                                                                                                                                                 |
| tso        | 10.2.8.101:35317 | security.encryption.master-key.path                                                 |                                                                                                                                                                                                                                                                                                 |
| tso        | 10.2.8.101:35317 | security.encryption.master-key.region                                               |                                                                                                                                                                                                                                                                                                 |
| tso        | 10.2.8.101:35317 | security.encryption.master-key.type                                                 | plaintext                                                                                                                                                                                                                                                                                       |
| tso        | 10.2.8.101:35317 | security.key-path                                                                   |                                                                                                                                                                                                                                                                                                 |
| tso        | 10.2.8.101:35317 | security.redact-info-log                                                            | false                                                                                                                                                                                                                                                                                           |
| tso        | 10.2.8.101:35317 | tso-save-interval                                                                   | 3s                                                                                                                                                                                                                                                                                              |
| tso        | 10.2.8.101:35317 | tso-update-physical-interval                                                        | 50ms                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | WarningMsgs                                                                         | null                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | advertise-listen-addr                                                               | http://10.2.8.101:39397                                                                                                                                                                                                                                                                         |
| scheduling | 10.2.8.101:39397 | backend-endpoints                                                                   | http://10.2.8.101:44969                                                                                                                                                                                                                                                                         |
| scheduling | 10.2.8.101:39397 | cluster-version                                                                     | 8.0.0-alpha                                                                                                                                                                                                                                                                                     |
| scheduling | 10.2.8.101:39397 | data-dir                                                                            | /data/nvme0n1/ryan/.tiup/data/U67Wpt1/pd-scheduling-0/default.Scheduling-cloud-ecosystem-00                                                                                                                                                                                                     |
| scheduling | 10.2.8.101:39397 | enable-grpc-gateway                                                                 | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | lease                                                                               | 3                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | listen-addr                                                                         | http://10.2.8.101:39397                                                                                                                                                                                                                                                                         |
| scheduling | 10.2.8.101:39397 | log.development                                                                     | false                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | log.disable-caller                                                                  | false                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | log.disable-error-verbose                                                           | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | log.disable-stacktrace                                                              | false                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | log.disable-timestamp                                                               | false                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | log.error-output-path                                                               |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | log.file.filename                                                                   | /data/nvme0n1/ryan/.tiup/data/U67Wpt1/pd-scheduling-0/scheduling.log                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | log.file.max-backups                                                                | 0                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | log.file.max-days                                                                   | 0                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | log.file.max-size                                                                   | 0                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | log.format                                                                          | text                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | log.level                                                                           | info                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | log.sampling                                                                        | null                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | metric.address                                                                      |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | metric.interval                                                                     | 0s                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | metric.job                                                                          |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | name                                                                                | Scheduling-cloud-ecosystem-00                                                                                                                                                                                                                                                                   |
| scheduling | 10.2.8.101:39397 | replication.enable-placement-rules                                                  | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | replication.enable-placement-rules-cache                                            | false                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | replication.isolation-level                                                         |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | replication.location-labels                                                         |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | replication.max-replicas                                                            | 3                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | replication.strictly-match-label                                                    | false                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | schedule.enable-cross-table-merge                                                   | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.enable-debug-metrics                                                       | false                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | schedule.enable-diagnostic                                                          | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.enable-joint-consensus                                                     | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.enable-location-replacement                                                | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.enable-make-up-replica                                                     | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.enable-one-way-merge                                                       | false                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | schedule.enable-remove-down-replica                                                 | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.enable-remove-extra-replica                                                | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.enable-replace-offline-replica                                             | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.enable-tikv-split-region                                                   | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.enable-witness                                                             | false                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | schedule.high-space-ratio                                                           | 0.7                                                                                                                                                                                                                                                                                             |
| scheduling | 10.2.8.101:39397 | schedule.hot-region-cache-hits-threshold                                            | 3                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | schedule.hot-region-schedule-limit                                                  | 4                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | schedule.hot-regions-reserved-days                                                  | 7                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | schedule.hot-regions-write-interval                                                 | 10m0s                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | schedule.leader-schedule-limit                                                      | 4                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | schedule.leader-schedule-policy                                                     | count                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | schedule.low-space-ratio                                                            | 0.8                                                                                                                                                                                                                                                                                             |
| scheduling | 10.2.8.101:39397 | schedule.max-merge-region-keys                                                      | 200000                                                                                                                                                                                                                                                                                          |
| scheduling | 10.2.8.101:39397 | schedule.max-merge-region-size                                                      | 20                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.max-movable-hot-peer-size                                                  | 512                                                                                                                                                                                                                                                                                             |
| scheduling | 10.2.8.101:39397 | schedule.max-pending-peer-count                                                     | 64                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.max-snapshot-count                                                         | 64                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.max-store-down-time                                                        | 30m0s                                                                                                                                                                                                                                                                                           |
| scheduling | 10.2.8.101:39397 | schedule.max-store-preparing-time                                                   | 48h0m0s                                                                                                                                                                                                                                                                                         |
| scheduling | 10.2.8.101:39397 | schedule.merge-schedule-limit                                                       | 8                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | schedule.patrol-region-interval                                                     | 10ms                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.region-schedule-limit                                                      | 2048                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.region-score-formula-version                                               | v2                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.replica-schedule-limit                                                     | 64                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.scheduler-max-waiting-operator                                             | 5                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.byte-rate-rank-step-ratio  | 0.05                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.count-rank-step-ratio      | 0.01                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.dst-tolerance-ratio        | 1.05                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.enable-for-tiflash         | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.forbid-rw-type             | none                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.great-dec-ratio            | 0.95                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.key-rate-rank-step-ratio   | 0.05                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.max-peer-number            | 1000                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.max-zombie-rounds          | 3                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.min-hot-byte-rate          | 100                                                                                                                                                                                                                                                                                             |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.min-hot-key-rate           | 10                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.min-hot-query-rate         | 10                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.minor-dec-ratio            | 0.99                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.query-rate-rank-step-ratio | 0.05                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.rank-formula-version       | v2                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.read-priorities            | ["query","byte"]                                                                                                                                                                                                                                                                                |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.split-thresholds           | 0.2                                                                                                                                                                                                                                                                                             |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.src-tolerance-ratio        | 1.05                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.strict-picking-store       | true                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.write-leader-priorities    | ["query","byte"]                                                                                                                                                                                                                                                                                |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-hot-region-scheduler.write-peer-priorities      | ["byte","key"]                                                                                                                                                                                                                                                                                  |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-leader-scheduler.batch                          | 4                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-leader-scheduler.ranges                         | [{"end-key":"","start-key":""}]                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-region-scheduler.name                           | balance-region-scheduler                                                                                                                                                                                                                                                                        |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.balance-region-scheduler.ranges                         | [{"end-key":"","start-key":""}]                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.evict-slow-store-scheduler.evict-stores                 | []                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-payload.evict-slow-store-scheduler.recovery-duration            | 600                                                                                                                                                                                                                                                                                             |
| scheduling | 10.2.8.101:39397 | schedule.schedulers-v2                                                              | [{"args":null,"args-payload":"","disable":false,"type":"balance-region"},{"args":null,"args-payload":"","disable":false,"type":"balance-leader"},{"args":null,"args-payload":"","disable":false,"type":"hot-region"},{"args":null,"args-payload":"","disable":false,"type":"evict-slow-store"}] |
| scheduling | 10.2.8.101:39397 | schedule.slow-store-evicting-affected-store-ratio-threshold                         | 0.3                                                                                                                                                                                                                                                                                             |
| scheduling | 10.2.8.101:39397 | schedule.split-merge-interval                                                       | 1h0m0s                                                                                                                                                                                                                                                                                          |
| scheduling | 10.2.8.101:39397 | schedule.store-limit-version                                                        | v1                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.store-limit.1.add-peer                                                     | 15                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.store-limit.1.remove-peer                                                  | 15                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.store-limit.2.add-peer                                                     | 15                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.store-limit.2.remove-peer                                                  | 15                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.store-limit.3.add-peer                                                     | 15                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.store-limit.3.remove-peer                                                  | 15                                                                                                                                                                                                                                                                                              |
| scheduling | 10.2.8.101:39397 | schedule.switch-witness-interval                                                    | 1h0m0s                                                                                                                                                                                                                                                                                          |
| scheduling | 10.2.8.101:39397 | schedule.tolerant-size-ratio                                                        | 0                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | schedule.witness-schedule-limit                                                     | 4                                                                                                                                                                                                                                                                                               |
| scheduling | 10.2.8.101:39397 | security.SSLCABytes                                                                 | null                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | security.SSLCertBytes                                                               | null                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | security.SSLKEYBytes                                                                | null                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | security.cacert-path                                                                |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | security.cert-allowed-cn                                                            | null                                                                                                                                                                                                                                                                                            |
| scheduling | 10.2.8.101:39397 | security.cert-path                                                                  |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | security.encryption.data-encryption-method                                          | plaintext                                                                                                                                                                                                                                                                                       |
| scheduling | 10.2.8.101:39397 | security.encryption.data-key-rotation-period                                        | 168h0m0s                                                                                                                                                                                                                                                                                        |
| scheduling | 10.2.8.101:39397 | security.encryption.master-key.endpoint                                             |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | security.encryption.master-key.key-id                                               |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | security.encryption.master-key.path                                                 |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | security.encryption.master-key.region                                               |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | security.encryption.master-key.type                                                 | plaintext                                                                                                                                                                                                                                                                                       |
| scheduling | 10.2.8.101:39397 | security.key-path                                                                   |                                                                                                                                                                                                                                                                                                 |
| scheduling | 10.2.8.101:39397 | security.redact-info-log                                                            | false                                                                                                                                                                                                                                                                                           |
+------------+------------------+-------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
2643 rows in set (0.01 sec)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
