### PR TITLE
statistics: Do not create pseudo statistics for the auto-analysis check process

### DIFF
--- a/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
@@ -32,7 +32,7 @@ go_test(
         "queue_test.go",
     ],
     flaky = True,
-    shard_count = 17,
+    shard_count = 22,
     deps = [
         ":priorityqueue",
         "//pkg/parser/model",

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/job.go
@@ -31,10 +31,12 @@ import (
 type analyzeType string
 
 const (
-	analyzeTable          analyzeType = "analyzeTable"
-	analyzeIndex          analyzeType = "analyzeIndex"
-	analyzePartition      analyzeType = "analyzePartition"
-	analyzePartitionIndex analyzeType = "analyzePartitionIndex"
+	analyzeTable                analyzeType = "analyzeTable"
+	analyzeIndex                analyzeType = "analyzeIndex"
+	analyzeStaticPartition      analyzeType = "analyzeStaticPartition"
+	analyzeStaticPartitionIndex analyzeType = "analyzeStaticPartitionIndex"
+	analyzePartition            analyzeType = "analyzePartition"
+	analyzePartitionIndex       analyzeType = "analyzePartitionIndex"
 )
 
 // defaultFailedAnalysisWaitTime is the default wait time for the next analysis after a failed analysis.
@@ -50,20 +52,101 @@ type TableAnalysisJob struct {
 	// and we don't want to analyze the same partition multiple times.
 	// For example, the user may analyze some partitions manually, and we don't want to analyze them again.
 	PartitionIndexes map[string][]string
-	TableSchema      string
-	TableName        string
-	// Only set when table's indexes need to be analyzed.
+
+	TableSchema string
+	// For physical or global tables.
+	TableName string
+	// For static pruned tables.
+	StaticPartitionName string
+	// Only set when table or static partition's indexes need to be analyzed.
 	// This is only for newly added indexes.
 	Indexes []string
+
 	// Only set when table's partitions need to be analyzed.
 	// This will analyze all indexes and columns of the specified partitions.
-	Partitions           []string
-	TableID              int64
+	Partitions []string
+	// The global table ID.
+	TableID int64
+	// The static partition ID.
+	StaticPartitionID int64
+
 	TableStatsVer        int
 	ChangePercentage     float64
 	TableSize            float64
 	LastAnalysisDuration time.Duration
 	Weight               float64
+}
+
+// NewStaticPartitionTableAnalysisJob creates a new TableAnalysisJob for analyzing the static partition.
+func NewStaticPartitionTableAnalysisJob(
+	schema, globalTableName string,
+	globalTableID int64,
+	partitionName string,
+	partitionID int64,
+	indexes []string,
+	tableStatsVer int,
+	changePercentage float64,
+	tableSize float64,
+	lastAnalysisDuration time.Duration,
+) *TableAnalysisJob {
+	return &TableAnalysisJob{
+		TableSchema:          schema,
+		TableName:            globalTableName,
+		TableID:              globalTableID,
+		StaticPartitionName:  partitionName,
+		StaticPartitionID:    partitionID,
+		Indexes:              indexes,
+		TableStatsVer:        tableStatsVer,
+		ChangePercentage:     changePercentage,
+		TableSize:            tableSize,
+		LastAnalysisDuration: lastAnalysisDuration,
+	}
+}
+
+// NewNonPartitionedTableAnalysisJob creates a new TableAnalysisJob for analyzing the table or partition.
+func NewNonPartitionedTableAnalysisJob(
+	schema, tableName string,
+	tableID int64,
+	indexes []string,
+	tableStatsVer int,
+	changePercentage float64,
+	tableSize float64,
+	lastAnalysisDuration time.Duration,
+) *TableAnalysisJob {
+	return &TableAnalysisJob{
+		TableSchema:          schema,
+		TableName:            tableName,
+		TableID:              tableID,
+		Indexes:              indexes,
+		TableStatsVer:        tableStatsVer,
+		ChangePercentage:     changePercentage,
+		TableSize:            tableSize,
+		LastAnalysisDuration: lastAnalysisDuration,
+	}
+}
+
+// NewDynamicPartitionTableAnalysisJob creates a new TableAnalysisJob for analyzing dynamic partitioned table.
+func NewDynamicPartitionTableAnalysisJob(
+	schema, tableName string,
+	tableID int64,
+	partitions []string,
+	partitionIndexes map[string][]string,
+	tableStatsVer int,
+	changePercentage float64,
+	tableSize float64,
+	lastAnalysisDuration time.Duration,
+) *TableAnalysisJob {
+	return &TableAnalysisJob{
+		TableSchema:          schema,
+		TableName:            tableName,
+		TableID:              tableID,
+		Partitions:           partitions,
+		PartitionIndexes:     partitionIndexes,
+		TableStatsVer:        tableStatsVer,
+		ChangePercentage:     changePercentage,
+		TableSize:            tableSize,
+		LastAnalysisDuration: lastAnalysisDuration,
+	}
 }
 
 // HasNewlyAddedIndex checks whether the table has newly added index.
@@ -79,9 +162,10 @@ func (j *TableAnalysisJob) IsValidToAnalyze(
 	sctx sessionctx.Context,
 ) (bool, string) {
 	// No need to analyze this table.
-	// TODO: Usually, we should not put this kind of table into the queue.
-	if j.Weight == 0 {
-		return false, "weight is 0"
+	// Usually, we should not put this kind of table into the queue.
+	// This is just a double check.
+	if j.Weight <= 0 {
+		return false, fmt.Sprintf("weight is less than or equal to 0: %.4f", j.Weight)
 	}
 
 	// Check whether the table or partition is valid to analyze.
@@ -94,6 +178,17 @@ func (j *TableAnalysisJob) IsValidToAnalyze(
 			j.TableSchema,
 			j.TableName,
 			partitions...,
+		); !valid {
+			return false, failReason
+		}
+	} else if j.StaticPartitionName != "" {
+		// For static partition table we only need to check the specified static partition.
+		partitionNames := []string{j.StaticPartitionName}
+		if valid, failReason := isValidToAnalyze(
+			sctx,
+			j.TableSchema,
+			j.TableName,
+			partitionNames...,
 		); !valid {
 			return false, failReason
 		}
@@ -219,7 +314,11 @@ func (j *TableAnalysisJob) Analyze(
 	case analyzePartition:
 		j.analyzePartitions(sctx, statsHandle, sysProcTracker)
 	case analyzePartitionIndex:
-		j.AnalyzePartitionIndexes(sctx, statsHandle, sysProcTracker)
+		j.analyzePartitionIndexes(sctx, statsHandle, sysProcTracker)
+	case analyzeStaticPartition:
+		j.analyzeStaticPartition(sctx, statsHandle, sysProcTracker)
+	case analyzeStaticPartitionIndex:
+		j.analyzeStaticPartitionIndexes(sctx, statsHandle, sysProcTracker)
 	}
 }
 
@@ -230,7 +329,12 @@ func (j *TableAnalysisJob) getAnalyzeType() analyzeType {
 	case len(j.Partitions) > 0:
 		return analyzePartition
 	case len(j.Indexes) > 0:
+		if j.StaticPartitionName != "" {
+			return analyzeStaticPartitionIndex
+		}
 		return analyzeIndex
+	case j.StaticPartitionName != "":
+		return analyzeStaticPartition
 	default:
 		return analyzeTable
 	}
@@ -245,6 +349,15 @@ func (j *TableAnalysisJob) analyzeTable(
 	exec.AutoAnalyze(sctx, statsHandle, sysProcTracker, j.TableStatsVer, sql, params...)
 }
 
+func (j *TableAnalysisJob) analyzeStaticPartition(
+	sctx sessionctx.Context,
+	statsHandle statstypes.StatsHandle,
+	sysProcTracker sessionctx.SysProcTracker,
+) {
+	sql, params := j.GenSQLForAnalyzeStaticPartition()
+	exec.AutoAnalyze(sctx, statsHandle, sysProcTracker, j.TableStatsVer, sql, params...)
+}
+
 func (j *TableAnalysisJob) analyzeIndexes(
 	sctx sessionctx.Context,
 	statsHandle statstypes.StatsHandle,
@@ -252,6 +365,17 @@ func (j *TableAnalysisJob) analyzeIndexes(
 ) {
 	for _, index := range j.Indexes {
 		sql, params := j.GenSQLForAnalyzeIndex(index)
+		exec.AutoAnalyze(sctx, statsHandle, sysProcTracker, j.TableStatsVer, sql, params...)
+	}
+}
+
+func (j *TableAnalysisJob) analyzeStaticPartitionIndexes(
+	sctx sessionctx.Context,
+	statsHandle statstypes.StatsHandle,
+	sysProcTracker sessionctx.SysProcTracker,
+) {
+	for _, index := range j.Indexes {
+		sql, params := j.GenSQLForAnalyzeStaticPartitionIndex(index)
 		exec.AutoAnalyze(sctx, statsHandle, sysProcTracker, j.TableStatsVer, sql, params...)
 	}
 }
@@ -283,8 +407,8 @@ func (j *TableAnalysisJob) analyzePartitions(
 	}
 }
 
-// AnalyzePartitionIndexes performs analysis on the specified partition indexes.
-func (j *TableAnalysisJob) AnalyzePartitionIndexes(
+// analyzePartitionIndexes performs analysis on the specified partition indexes.
+func (j *TableAnalysisJob) analyzePartitionIndexes(
 	sctx sessionctx.Context,
 	statsHandle statstypes.StatsHandle,
 	sysProcTracker sessionctx.SysProcTracker,
@@ -332,10 +456,26 @@ func (j *TableAnalysisJob) GenSQLForAnalyzeTable() (string, []any) {
 	return sql, params
 }
 
+// GenSQLForAnalyzeStaticPartition generates the SQL for analyzing the specified static partition.
+func (j *TableAnalysisJob) GenSQLForAnalyzeStaticPartition() (string, []any) {
+	sql := "analyze table %n.%n partition %n"
+	params := []any{j.TableSchema, j.TableName, j.StaticPartitionName}
+
+	return sql, params
+}
+
 // GenSQLForAnalyzeIndex generates the SQL for analyzing the specified index.
 func (j *TableAnalysisJob) GenSQLForAnalyzeIndex(index string) (string, []any) {
 	sql := "analyze table %n.%n index %n"
 	params := []any{j.TableSchema, j.TableName, index}
+
+	return sql, params
+}
+
+// GenSQLForAnalyzeStaticPartitionIndex generates the SQL for analyzing the specified static partition index.
+func (j *TableAnalysisJob) GenSQLForAnalyzeStaticPartitionIndex(index string) (string, []any) {
+	sql := "analyze table %n.%n partition %n index %n"
+	params := []any{j.TableSchema, j.TableName, j.StaticPartitionName, index}
 
 	return sql, params
 }
@@ -355,6 +495,12 @@ func (j *TableAnalysisJob) String() string {
 	case analyzePartitionIndex:
 		return fmt.Sprintf(`TableAnalysisJob: {AnalyzeType: partitionIndex, PartitionIndexes: %v, Schema: %s, Table: %s, TableID: %d, TableStatsVer: %d, ChangePercentage: %.2f, Weight: %.4f}`,
 			j.PartitionIndexes, j.TableSchema, j.TableName, j.TableID, j.TableStatsVer, j.ChangePercentage, j.Weight)
+	case analyzeStaticPartition:
+		return fmt.Sprintf(`TableAnalysisJob: {AnalyzeType: staticPartition, Schema: %s, Table: %s, TableID: %d, StaticPartition: %s, StaticPartitionID: %d, TableStatsVer: %d, ChangePercentage: %.2f, Weight: %.4f}`,
+			j.TableSchema, j.TableName, j.TableID, j.StaticPartitionName, j.StaticPartitionID, j.TableStatsVer, j.ChangePercentage, j.Weight)
+	case analyzeStaticPartitionIndex:
+		return fmt.Sprintf(`TableAnalysisJob: {AnalyzeType: staticPartitionIndex, Indexes: %s, Schema: %s, Table: %s, TableID: %d, StaticPartition: %s, StaticPartitionID: %d, TableStatsVer: %d, ChangePercentage: %.2f, Weight: %.4f}`,
+			strings.Join(j.Indexes, ", "), j.TableSchema, j.TableName, j.TableID, j.StaticPartitionName, j.StaticPartitionID, j.TableStatsVer, j.ChangePercentage, j.Weight)
 	default:
 		return "TableAnalysisJob: {AnalyzeType: unknown}"
 	}

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/job_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/job_test.go
@@ -40,6 +40,22 @@ func TestGenSQLForAnalyzeTable(t *testing.T) {
 	require.Equal(t, expectedParams, params)
 }
 
+func TestGenSQLForAnalyzeStaticPartition(t *testing.T) {
+	job := &priorityqueue.TableAnalysisJob{
+		TableSchema:         "test_schema",
+		TableName:           "test_table",
+		StaticPartitionName: "p0",
+	}
+
+	expectedSQL := "analyze table %n.%n partition %n"
+	expectedParams := []any{"test_schema", "test_table", "p0"}
+
+	sql, params := job.GenSQLForAnalyzeStaticPartition()
+
+	require.Equal(t, expectedSQL, sql)
+	require.Equal(t, expectedParams, params)
+}
+
 func TestGenSQLForAnalyzeIndex(t *testing.T) {
 	job := &priorityqueue.TableAnalysisJob{
 		TableSchema: "test_schema",
@@ -52,6 +68,24 @@ func TestGenSQLForAnalyzeIndex(t *testing.T) {
 	expectedParams := []any{"test_schema", "test_table", index}
 
 	sql, params := job.GenSQLForAnalyzeIndex(index)
+
+	require.Equal(t, expectedSQL, sql)
+	require.Equal(t, expectedParams, params)
+}
+
+func TestGenSQLForAnalyzePartitionIndex(t *testing.T) {
+	job := &priorityqueue.TableAnalysisJob{
+		TableSchema:         "test_schema",
+		TableName:           "test_table",
+		StaticPartitionName: "p0",
+	}
+
+	index := "test_index"
+
+	expectedSQL := "analyze table %n.%n partition %n index %n"
+	expectedParams := []any{"test_schema", "test_table", "p0", index}
+
+	sql, params := job.GenSQLForAnalyzeStaticPartitionIndex(index)
 
 	require.Equal(t, expectedSQL, sql)
 	require.Equal(t, expectedParams, params)
@@ -74,7 +108,6 @@ func TestAnalyzeTable(t *testing.T) {
 	se := tk.Session()
 	sctx := se.(sessionctx.Context)
 	handle := dom.StatsHandle()
-	// Check the result of analyze.
 	is := dom.InfoSchema()
 	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
@@ -88,6 +121,43 @@ func TestAnalyzeTable(t *testing.T) {
 	require.NoError(t, err)
 	tblStats = handle.GetTableStats(tbl.Meta())
 	require.Equal(t, int64(3), tblStats.RealtimeCount)
+}
+
+func TestAnalyzeStaticPartition(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t (a int, b int, index idx(a)) partition by range (a) (partition p0 values less than (2), partition p1 values less than (4))")
+	tk.MustExec("insert into t values (1, 1), (2, 2), (3, 3)")
+
+	job := &priorityqueue.TableAnalysisJob{
+		TableSchema:         "test",
+		TableName:           "t",
+		StaticPartitionName: "p0",
+		TableStatsVer:       2,
+	}
+
+	// Before analyze the partition.
+	se := tk.Session()
+	sctx := se.(sessionctx.Context)
+	handle := dom.StatsHandle()
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	pid := tbl.Meta().GetPartitionInfo().Definitions[0].ID
+	tblStats := handle.GetPartitionStats(tbl.Meta(), pid)
+	require.True(t, tblStats.Pseudo)
+
+	job.Analyze(sctx, handle, dom.SysProcTracker())
+	// Check the result of analyze.
+	is = dom.InfoSchema()
+	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	pid = tbl.Meta().GetPartitionInfo().Definitions[0].ID
+	tblStats = handle.GetPartitionStats(tbl.Meta(), pid)
+	require.False(t, tblStats.Pseudo)
+	require.Equal(t, int64(1), tblStats.RealtimeCount)
 }
 
 func TestAnalyzeIndexes(t *testing.T) {
@@ -143,6 +213,69 @@ func TestAnalyzeIndexes(t *testing.T) {
 	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tblStats = handle.GetTableStats(tbl.Meta())
+	require.NotNil(t, tblStats.Indices[2])
+	require.True(t, tblStats.Indices[2].IsAnalyzed())
+}
+
+func TestAnalyzeStaticPartitionIndexes(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t (a int, b int, index idx(a)) partition by range (a) (partition p0 values less than (2), partition p1 values less than (4))")
+	tk.MustExec("insert into t values (1, 1), (2, 2), (3, 3)")
+	job := &priorityqueue.TableAnalysisJob{
+		TableSchema:         "test",
+		TableName:           "t",
+		StaticPartitionName: "p0",
+		Indexes:             []string{"idx"},
+		TableStatsVer:       2,
+	}
+	se := tk.Session()
+	sctx := se.(sessionctx.Context)
+	handle := dom.StatsHandle()
+	// Before analyze indexes.
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	pid := tbl.Meta().GetPartitionInfo().Definitions[0].ID
+	tblStats := handle.GetPartitionStats(tbl.Meta(), pid)
+	require.False(t, tblStats.Indices[1].IsAnalyzed())
+
+	job.Analyze(sctx, handle, dom.SysProcTracker())
+	// Check the result of analyze.
+	is = dom.InfoSchema()
+	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	pid = tbl.Meta().GetPartitionInfo().Definitions[0].ID
+	tblStats = handle.GetPartitionStats(tbl.Meta(), pid)
+	require.NotNil(t, tblStats.Indices[1])
+	require.True(t, tblStats.Indices[1].IsAnalyzed())
+	// Add a new index.
+	tk.MustExec("alter table t add index idx2(b)")
+	job = &priorityqueue.TableAnalysisJob{
+		TableSchema:         "test",
+		TableName:           "t",
+		StaticPartitionName: "p0",
+		Indexes:             []string{"idx", "idx2"},
+		TableStatsVer:       2,
+	}
+	require.NoError(t, handle.Update(dom.InfoSchema()))
+	// Before analyze indexes.
+	is = dom.InfoSchema()
+	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	pid = tbl.Meta().GetPartitionInfo().Definitions[0].ID
+	tblStats = handle.GetPartitionStats(tbl.Meta(), pid)
+	require.Len(t, tblStats.Indices, 1)
+
+	job.Analyze(sctx, handle, dom.SysProcTracker())
+	// Check the result of analyze.
+	is = dom.InfoSchema()
+	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	pid = tbl.Meta().GetPartitionInfo().Definitions[0].ID
+	tblStats = handle.GetPartitionStats(tbl.Meta(), pid)
 	require.NotNil(t, tblStats.Indices[2])
 	require.True(t, tblStats.Indices[2].IsAnalyzed())
 }
@@ -215,7 +348,7 @@ func TestAnalyzePartitionIndexes(t *testing.T) {
 	require.NotNil(t, tblStats.Indices[1])
 	require.False(t, tblStats.Indices[1].IsAnalyzed())
 
-	job.AnalyzePartitionIndexes(sctx, handle, dom.SysProcTracker())
+	job.Analyze(sctx, handle, dom.SysProcTracker())
 	// Check the result of analyze.
 	is = dom.InfoSchema()
 	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
@@ -307,7 +440,7 @@ func TestIsValidToAnalyzeWhenOnlyHasFailedAnalysisRecords(t *testing.T) {
 	require.Equal(t, "last failed analysis duration is less than 30m0s", failReason)
 }
 
-func TestIsValidToAnalyzeForPartitionedTba(t *testing.T) {
+func TestIsValidToAnalyzeForPartitionedTable(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -352,6 +485,58 @@ func TestIsValidToAnalyzeForPartitionedTba(t *testing.T) {
 	valid, failReason = job.IsValidToAnalyze(sctx)
 	require.False(t, valid)
 	require.Equal(t, "last failed analysis duration is less than 2 times the average analysis duration", failReason)
+}
+
+func TestIsValidToAnalyzeForStaticPartition(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(session.CreateAnalyzeJobs)
+	job := &priorityqueue.TableAnalysisJob{
+		TableSchema:         "example_schema",
+		TableName:           "example_table",
+		Weight:              2,
+		StaticPartitionName: "p0",
+	}
+	initJobs(tk)
+	insertMultipleFinishedJobs(tk, job.TableName, "p0")
+	insertMultipleFinishedJobs(tk, job.TableName, "p1")
+
+	se := tk.Session()
+	sctx := se.(sessionctx.Context)
+	valid, failReason := job.IsValidToAnalyze(sctx)
+	require.True(t, valid)
+	require.Equal(t, "", failReason)
+
+	// Insert some failed jobs.
+	// Just failed.
+	now := tk.MustQuery("select now()").Rows()[0][0].(string)
+	insertFailedJobWithStartTime(tk, job.TableSchema, job.TableName, "p0", now)
+	// Note: The failure reason is not checked in this test because the time duration can sometimes be inaccurate.(not now)
+	valid, _ = job.IsValidToAnalyze(sctx)
+	require.False(t, valid)
+	// Failed 10 seconds ago.
+	startTime := tk.MustQuery("select now() - interval 10 second").Rows()[0][0].(string)
+	insertFailedJobWithStartTime(tk, job.TableSchema, job.TableName, "p0", startTime)
+	valid, failReason = job.IsValidToAnalyze(sctx)
+	require.False(t, valid)
+	require.Equal(t, "last failed analysis duration is less than 2 times the average analysis duration", failReason)
+	// Failed long long ago.
+	startTime = tk.MustQuery("select now() - interval 300 day").Rows()[0][0].(string)
+	insertFailedJobWithStartTime(tk, job.TableSchema, job.TableName, "p0", startTime)
+	valid, failReason = job.IsValidToAnalyze(sctx)
+	require.True(t, valid)
+	require.Equal(t, "", failReason)
+	// Do not affect other partitions.
+	job = &priorityqueue.TableAnalysisJob{
+		TableSchema:         "example_schema",
+		TableName:           "example_table",
+		Weight:              2,
+		StaticPartitionName: "p1",
+	}
+	valid, failReason = job.IsValidToAnalyze(sctx)
+	require.True(t, valid)
+	require.Equal(t, "", failReason)
 }
 
 func TestStringer(t *testing.T) {
@@ -412,6 +597,35 @@ func TestStringer(t *testing.T) {
 				Weight:           1.999999,
 			},
 			want: "TableAnalysisJob: {AnalyzeType: partitionIndex, PartitionIndexes: map[idx:[p0 p1]], Schema: test_schema, Table: test_table, TableID: 4, TableStatsVer: 1, ChangePercentage: 0.50, Weight: 2.0000}",
+		},
+		{
+			name: "analyze static partition",
+			job: &priorityqueue.TableAnalysisJob{
+				TableID:             5,
+				TableSchema:         "test_schema",
+				TableName:           "test_table",
+				StaticPartitionName: "p0",
+				StaticPartitionID:   6,
+				TableStatsVer:       1,
+				ChangePercentage:    0.5,
+				Weight:              1.999999,
+			},
+			want: "TableAnalysisJob: {AnalyzeType: staticPartition, Schema: test_schema, Table: test_table, TableID: 5, StaticPartition: p0, StaticPartitionID: 6, TableStatsVer: 1, ChangePercentage: 0.50, Weight: 2.0000}",
+		},
+		{
+			name: "analyze static partition index",
+			job: &priorityqueue.TableAnalysisJob{
+				TableID:             7,
+				TableSchema:         "test_schema",
+				TableName:           "test_table",
+				StaticPartitionName: "p0",
+				StaticPartitionID:   8,
+				Indexes:             []string{"idx"},
+				TableStatsVer:       1,
+				ChangePercentage:    0.5,
+				Weight:              1.999999,
+			},
+			want: "TableAnalysisJob: {AnalyzeType: staticPartitionIndex, Indexes: idx, Schema: test_schema, Table: test_table, TableID: 7, StaticPartition: p0, StaticPartitionID: 8, TableStatsVer: 1, ChangePercentage: 0.50, Weight: 2.0000}",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
@@ -28,7 +28,7 @@ go_test(
     timeout = "short",
     srcs = ["refresher_test.go"],
     flaky = True,
-    shard_count = 10,
+    shard_count = 13,
     deps = [
         ":refresher",
         "//pkg/parser/model",

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
@@ -80,6 +80,90 @@ func TestSkipAnalyzeTableWhenAutoAnalyzeRatioIsZero(t *testing.T) {
 	require.True(t, r.PickOneTableAndAnalyzeByPriority())
 }
 
+func TestIgnoreNilOrPseudoStatsOfPartitionedTable(t *testing.T) {
+	exec.AutoAnalyzeMinCnt = 0
+	defer func() {
+		exec.AutoAnalyzeMinCnt = 1000
+	}()
+
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (a int, b int, index idx(a)) partition by range (a) (partition p0 values less than (2), partition p1 values less than (14))")
+	tk.MustExec("create table t2 (a int, b int, index idx(a)) partition by range (a) (partition p0 values less than (2), partition p1 values less than (14))")
+	tk.MustExec("insert into t1 values (1, 1), (2, 2), (3, 3)")
+	tk.MustExec("insert into t2 values (1, 1), (2, 2), (3, 3)")
+	handle := dom.StatsHandle()
+	sysProcTracker := dom.SysProcTracker()
+	r := refresher.NewRefresher(handle, sysProcTracker)
+	r.RebuildTableAnalysisJobQueue()
+	require.Equal(t, 0, r.Jobs.Len(), "No jobs are added because table stats are nil")
+}
+
+func TestIgnoreNilOrPseudoStatsOfNonPartitionedTable(t *testing.T) {
+	exec.AutoAnalyzeMinCnt = 0
+	defer func() {
+		exec.AutoAnalyzeMinCnt = 1000
+	}()
+
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (a int, b int, index idx(a))")
+	tk.MustExec("create table t2 (a int, b int, index idx(a))")
+	tk.MustExec("insert into t1 values (1, 1), (2, 2), (3, 3)")
+	tk.MustExec("insert into t2 values (1, 1), (2, 2), (3, 3)")
+	handle := dom.StatsHandle()
+	sysProcTracker := dom.SysProcTracker()
+	r := refresher.NewRefresher(handle, sysProcTracker)
+	r.RebuildTableAnalysisJobQueue()
+	require.Equal(t, 0, r.Jobs.Len(), "No jobs are added because table stats are nil")
+}
+
+func TestIgnoreTinyTable(t *testing.T) {
+	exec.AutoAnalyzeMinCnt = 10
+	defer func() {
+		exec.AutoAnalyzeMinCnt = 1000
+	}()
+
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (a int, b int, index idx(a)) partition by range (a) (partition p0 values less than (2), partition p1 values less than (14))")
+	tk.MustExec("create table t2 (a int, b int, index idx(a)) partition by range (a) (partition p0 values less than (2), partition p1 values less than (14))")
+	tk.MustExec("insert into t1 values (1, 1), (2, 2), (3, 3)")
+	tk.MustExec("insert into t2 values (1, 1), (2, 2), (3, 3)")
+	handle := dom.StatsHandle()
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(dom.InfoSchema()))
+	// Analyze those tables first.
+	tk.MustExec("analyze table t1")
+	tk.MustExec("analyze table t2")
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(dom.InfoSchema()))
+	// Make sure table stats are not pseudo.
+	tbl1, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
+	require.NoError(t, err)
+	pid1 := tbl1.Meta().GetPartitionInfo().Definitions[1].ID
+	tblStats1 := handle.GetPartitionStats(tbl1.Meta(), pid1)
+	require.False(t, tblStats1.Pseudo)
+	tbl2, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t2"))
+	require.NoError(t, err)
+	pid2 := tbl2.Meta().GetPartitionInfo().Definitions[1].ID
+	tblStats2 := handle.GetPartitionStats(tbl2.Meta(), pid2)
+	require.False(t, tblStats2.Pseudo)
+
+	// Insert more data into t1 and t2, but more data is inserted into t1.
+	tk.MustExec("insert into t1 values (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13)")
+	tk.MustExec("insert into t2 values (4, 4)")
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(dom.InfoSchema()))
+	sysProcTracker := dom.SysProcTracker()
+	r := refresher.NewRefresher(handle, sysProcTracker)
+	r.RebuildTableAnalysisJobQueue()
+	require.Equal(t, 1, r.Jobs.Len(), "Only t1 is added to the job queue, because t2 is a tiny table(not enough data)")
+}
+
 func TestPickOneTableAndAnalyzeByPriority(t *testing.T) {
 	exec.AutoAnalyzeMinCnt = 0
 	defer func() {
@@ -298,26 +382,6 @@ func TestCalculateChangePercentage(t *testing.T) {
 		want             float64
 	}{
 		{
-			name: "Test Pseudo",
-			tblStats: &statistics.Table{
-				HistColl: statistics.HistColl{
-					Pseudo: true,
-				},
-			},
-			autoAnalyzeRatio: 0.5,
-			want:             0,
-		},
-		{
-			name: "Test RealtimeCount less than AutoAnalyzeMinCnt",
-			tblStats: &statistics.Table{
-				HistColl: statistics.HistColl{
-					RealtimeCount: exec.AutoAnalyzeMinCnt - 1,
-				},
-			},
-			autoAnalyzeRatio: 0.5,
-			want:             0,
-		},
-		{
 			name: "Test Table not analyzed",
 			tblStats: &statistics.Table{
 				HistColl: statistics.HistColl{
@@ -458,7 +522,7 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 	tests := []struct {
 		name                       string
 		tblInfo                    *model.TableInfo
-		partitionStats             map[int64]*statistics.Table
+		partitionStats             map[refresher.PartitionIDAndName]*statistics.Table
 		defs                       []model.PartitionDefinition
 		autoAnalyzeRatio           float64
 		currentTs                  uint64
@@ -486,14 +550,20 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 					},
 				},
 			},
-			partitionStats: map[int64]*statistics.Table{
-				1: {
+			partitionStats: map[refresher.PartitionIDAndName]*statistics.Table{
+				{
+					ID:   1,
+					Name: "p0",
+				}: {
 					HistColl: statistics.HistColl{
 						Pseudo:        false,
 						RealtimeCount: exec.AutoAnalyzeMinCnt + 1,
 					},
 				},
-				2: {
+				{
+					ID:   2,
+					Name: "p1",
+				}: {
 					HistColl: statistics.HistColl{
 						Pseudo:        false,
 						RealtimeCount: exec.AutoAnalyzeMinCnt + 1,
@@ -536,8 +606,11 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 					},
 				},
 			},
-			partitionStats: map[int64]*statistics.Table{
-				1: {
+			partitionStats: map[refresher.PartitionIDAndName]*statistics.Table{
+				{
+					ID:   1,
+					Name: "p0",
+				}: {
 					HistColl: statistics.HistColl{
 						Pseudo:        false,
 						RealtimeCount: exec.AutoAnalyzeMinCnt + 1,
@@ -559,7 +632,10 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 					},
 					Version: currentTs,
 				},
-				2: {
+				{
+					ID:   2,
+					Name: "p1",
+				}: {
 					HistColl: statistics.HistColl{
 						Pseudo:        false,
 						RealtimeCount: exec.AutoAnalyzeMinCnt + 1,
@@ -618,8 +694,11 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 					},
 				},
 			},
-			partitionStats: map[int64]*statistics.Table{
-				1: {
+			partitionStats: map[refresher.PartitionIDAndName]*statistics.Table{
+				{
+					ID:   1,
+					Name: "p0",
+				}: {
 					HistColl: statistics.HistColl{
 						Pseudo:        false,
 						RealtimeCount: exec.AutoAnalyzeMinCnt + 1,
@@ -641,7 +720,10 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 					},
 					Version: currentTs,
 				},
-				2: {
+				{
+					ID:   2,
+					Name: "p1",
+				}: {
 					HistColl: statistics.HistColl{
 						Pseudo:        false,
 						RealtimeCount: exec.AutoAnalyzeMinCnt + 1,
@@ -692,7 +774,6 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 				refresher.CalculateIndicatorsForPartitions(
 					tt.tblInfo,
 					tt.partitionStats,
-					tt.defs,
 					tt.autoAnalyzeRatio,
 					tt.currentTs,
 				)
@@ -727,8 +808,11 @@ func TestCheckNewlyAddedIndexesNeedAnalyzeForPartitionedTable(t *testing.T) {
 			},
 		},
 	}
-	partitionStats := map[int64]*statistics.Table{
-		1: {
+	partitionStats := map[refresher.PartitionIDAndName]*statistics.Table{
+		{
+			ID:   1,
+			Name: "p0",
+		}: {
 			HistColl: statistics.HistColl{
 				Pseudo:        false,
 				RealtimeCount: exec.AutoAnalyzeMinCnt + 1,
@@ -736,7 +820,10 @@ func TestCheckNewlyAddedIndexesNeedAnalyzeForPartitionedTable(t *testing.T) {
 				Indices:       map[int64]*statistics.Index{},
 			},
 		},
-		2: {
+		{
+			ID:   2,
+			Name: "p1",
+		}: {
 			HistColl: statistics.HistColl{
 				Pseudo:        false,
 				RealtimeCount: exec.AutoAnalyzeMinCnt + 1,
@@ -749,18 +836,7 @@ func TestCheckNewlyAddedIndexesNeedAnalyzeForPartitionedTable(t *testing.T) {
 			},
 		},
 	}
-	defs := []model.PartitionDefinition{
-		{
-			ID:   1,
-			Name: model.NewCIStr("p0"),
-		},
-		{
-			ID:   2,
-			Name: model.NewCIStr("p1"),
-		},
-	}
-
-	partitionIndexes := refresher.CheckNewlyAddedIndexesNeedAnalyzeForPartitionedTable(&tblInfo, defs, partitionStats)
+	partitionIndexes := refresher.CheckNewlyAddedIndexesNeedAnalyzeForPartitionedTable(&tblInfo, partitionStats)
 	expected := map[string][]string{"index1": {"p0", "p1"}, "index2": {"p0"}}
 	require.Equal(t, len(expected), len(partitionIndexes))
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/50132

Problem Summary:

### What changed and how does it work?

In this PR, we solved two problems:

1. We shouldn't create pseudo stats during auto-analyze check processing. We only need the real row count of tables, so no need for pseudo stats. This would help us to reduce memory consumption and alleviate GC pressure.
2. We should analyze static partitions one by one instead of analyzing the entry global table again and again.

So I made the following changes:
1. I changed the refresher to use `GetPartitionStatsForAutoAnalyze` and `GetTableStatsForAutoAnalyze ` to avoid creating the pseudo stats.
2. I added a new type of job for the static partition. It will execute the analysis jobs in these ways:
a. `analyze table %n.%n partition %n`
b. `analyze table %n.%n partition %n index %n`

In the old implementation, we wrongly analyze the entire table. 

I also did some refactorings to help us construct the job.
- NewStaticPartitionTableAnalysisJob
- NewNonPartitionedTableAnalysisJob
- NewDynamicPartitionTableAnalysisJob

I think I can use generic to reduce the confusion of the job structure, but this PR is already big enough. So I will do it in my following PR.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test See: https://github.com/pingcap/tidb/pull/51479#issuecomment-1978124017
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
