### PR TITLE
expression: introduce optional properties for `EvalContext`

### DIFF
--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -75,6 +75,7 @@ go_library(
         "//pkg/errctx",
         "//pkg/errno",
         "//pkg/expression/context",
+        "//pkg/expression/contextopt",
         "//pkg/extension",
         "//pkg/kv",
         "//pkg/parser",

--- a/pkg/expression/builtin.go
+++ b/pkg/expression/builtin.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/expression/contextopt"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -61,6 +62,10 @@ type baseBuiltinFunc struct {
 
 func (b *baseBuiltinFunc) PbCode() tipb.ScalarFuncSig {
 	return b.pbCode
+}
+
+func (*baseBuiltinFunc) RequiredOptionalEvalProps() (set OptionalEvalPropKeySet) {
+	return
 }
 
 // metadata returns the metadata of a function.
@@ -475,6 +480,7 @@ type vecBuiltinFunc interface {
 
 // builtinFunc stands for a particular function signature.
 type builtinFunc interface {
+	contextopt.RequireOptionalEvalProps
 	vecBuiltinFunc
 
 	// evalInt evaluates int result of builtinFunc by given row.

--- a/pkg/expression/builtin_info.go
+++ b/pkg/expression/builtin_info.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/expression/contextopt"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -173,12 +174,13 @@ func (c *currentUserFunctionClass) getFunction(ctx BuildContext, args []Expressi
 		return nil, err
 	}
 	bf.tp.SetFlen(64)
-	sig := &builtinCurrentUserSig{bf}
+	sig := &builtinCurrentUserSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinCurrentUserSig struct {
 	baseBuiltinFunc
+	contextopt.CurrentUserPropReader
 }
 
 func (b *builtinCurrentUserSig) Clone() builtinFunc {
@@ -187,14 +189,22 @@ func (b *builtinCurrentUserSig) Clone() builtinFunc {
 	return newSig
 }
 
+// RequiredOptionalEvalProps implements the RequireOptionalEvalProps interface.
+func (b *builtinCurrentUserSig) RequiredOptionalEvalProps() (set OptionalEvalPropKeySet) {
+	return b.CurrentUserPropReader.RequiredOptionalEvalProps()
+}
+
 // evalString evals a builtinCurrentUserSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_current-user
-func (b *builtinCurrentUserSig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
-	data := ctx.GetSessionVars()
-	if data == nil || data.User == nil {
+func (b *builtinCurrentUserSig) evalString(ctx EvalContext, _ chunk.Row) (string, bool, error) {
+	user, err := b.CurrentUser(ctx)
+	if err != nil {
+		return "", true, err
+	}
+	if user == nil {
 		return "", true, errors.Errorf("Missing session variable when eval builtin")
 	}
-	return data.User.String(), false, nil
+	return user.String(), false, nil
 }
 
 type currentRoleFunctionClass struct {
@@ -210,12 +220,13 @@ func (c *currentRoleFunctionClass) getFunction(ctx BuildContext, args []Expressi
 		return nil, err
 	}
 	bf.tp.SetFlen(64)
-	sig := &builtinCurrentRoleSig{bf}
+	sig := &builtinCurrentRoleSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinCurrentRoleSig struct {
 	baseBuiltinFunc
+	contextopt.CurrentUserPropReader
 }
 
 func (b *builtinCurrentRoleSig) Clone() builtinFunc {
@@ -224,24 +235,32 @@ func (b *builtinCurrentRoleSig) Clone() builtinFunc {
 	return newSig
 }
 
+// RequiredOptionalEvalProps implements the RequireOptionalEvalProps interface.
+func (b *builtinCurrentRoleSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
+	return b.CurrentUserPropReader.RequiredOptionalEvalProps()
+}
+
 // evalString evals a builtinCurrentUserSig.
 // See https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_current-role
 func (b *builtinCurrentRoleSig) evalString(ctx EvalContext, row chunk.Row) (res string, isNull bool, err error) {
-	data := ctx.GetSessionVars()
-	if data == nil || data.ActiveRoles == nil {
+	roles, err := b.ActiveRoles(ctx)
+	if err != nil {
+		return "", true, err
+	}
+	if roles == nil {
 		return "", true, errors.Errorf("Missing session variable when eval builtin")
 	}
-	if len(data.ActiveRoles) == 0 {
+	if len(roles) == 0 {
 		return "NONE", false, nil
 	}
 	sortedRes := make([]string, 0, 10)
-	for _, r := range data.ActiveRoles {
+	for _, r := range roles {
 		sortedRes = append(sortedRes, r.String())
 	}
 	slices.Sort(sortedRes)
 	for i, r := range sortedRes {
 		res += r
-		if i != len(data.ActiveRoles)-1 {
+		if i != len(roles)-1 {
 			res += ","
 		}
 	}
@@ -309,12 +328,13 @@ func (c *userFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 		return nil, err
 	}
 	bf.tp.SetFlen(64)
-	sig := &builtinUserSig{bf}
+	sig := &builtinUserSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinUserSig struct {
 	baseBuiltinFunc
+	contextopt.CurrentUserPropReader
 }
 
 func (b *builtinUserSig) Clone() builtinFunc {
@@ -323,14 +343,22 @@ func (b *builtinUserSig) Clone() builtinFunc {
 	return newSig
 }
 
+// RequiredOptionalEvalProps implements the RequireOptionalEvalProps interface.
+func (b *builtinUserSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
+	return b.CurrentUserPropReader.RequiredOptionalEvalProps()
+}
+
 // evalString evals a builtinUserSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_user
-func (b *builtinUserSig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
-	data := ctx.GetSessionVars()
-	if data == nil || data.User == nil {
+func (b *builtinUserSig) evalString(ctx EvalContext, _ chunk.Row) (string, bool, error) {
+	user, err := b.CurrentUser(ctx)
+	if err != nil {
+		return "", true, err
+	}
+	if user == nil {
 		return "", true, errors.Errorf("Missing session variable when eval builtin")
 	}
-	return data.User.LoginString(), false, nil
+	return user.LoginString(), false, nil
 }
 
 type connectionIDFunctionClass struct {

--- a/pkg/expression/context.go
+++ b/pkg/expression/context.go
@@ -31,6 +31,18 @@ type EvalContext = context.EvalContext
 // BuildContext is used to build an expression
 type BuildContext = context.BuildContext
 
+// OptionalEvalPropKey is an alias of context.OptionalEvalPropKey
+type OptionalEvalPropKey = context.OptionalEvalPropKey
+
+// OptionalEvalPropProvider is an alias of context.OptionalEvalPropProvider
+type OptionalEvalPropProvider = context.OptionalEvalPropProvider
+
+// OptionalEvalPropKeySet is an alias of context.OptionalEvalPropKeySet
+type OptionalEvalPropKeySet = context.OptionalEvalPropKeySet
+
+// OptionalEvalPropDesc is an alias of context.OptionalEvalPropDesc
+type OptionalEvalPropDesc = context.OptionalEvalPropDesc
+
 func sqlMode(ctx EvalContext) mysql.SQLMode {
 	return ctx.SQLMode()
 }

--- a/pkg/expression/context/BUILD.bazel
+++ b/pkg/expression/context/BUILD.bazel
@@ -1,8 +1,11 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "context",
-    srcs = ["context.go"],
+    srcs = [
+        "context.go",
+        "optional.go",
+    ],
     importpath = "github.com/pingcap/tidb/pkg/expression/context",
     visibility = ["//visibility:public"],
     deps = [
@@ -14,4 +17,14 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/types",
     ],
+)
+
+go_test(
+    name = "context_test",
+    timeout = "short",
+    srcs = ["optional_test.go"],
+    embed = [":context"],
+    flaky = True,
+    shard_count = 4,
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -71,6 +71,8 @@ type EvalContext interface {
 	GetInfoSchema() infoschema.InfoSchemaMetaVersion
 	// GetDomainInfoSchema returns the latest information schema in domain
 	GetDomainInfoSchema() infoschema.InfoSchemaMetaVersion
+	// GetOptionalPropProvider gets the optional property provider by key
+	GetOptionalPropProvider(OptionalEvalPropKey) (OptionalEvalPropProvider, bool)
 }
 
 // BuildContext is used to build an expression

--- a/pkg/expression/context/optional.go
+++ b/pkg/expression/context/optional.go
@@ -1,0 +1,134 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"fmt"
+	"log"
+	"unsafe"
+)
+
+func init() {
+	// Ensure the count of optional properties is less than the bits of OptionalEvalProps.
+	if maxCnt := int64(unsafe.Sizeof(*new(OptionalEvalPropKeySet))) * 8; int64(OptPropsCnt) > maxCnt {
+		log.Fatalf(
+			"The count optional properties should less than the bits of OptionalEvalProps, but %d > %d",
+			OptPropsCnt, maxCnt,
+		)
+	}
+
+	// check optionalPropertyDescList are valid
+	if len(optionalPropertyDescList) != OptPropsCnt {
+		log.Fatalf(
+			"The lenghth of OptionalPropertieDescs should be %d, but got %d",
+			OptPropsCnt, len(optionalPropertyDescList),
+		)
+	}
+
+	for i := 0; i < OptPropsCnt; i++ {
+		if key := optionalPropertyDescList[i].Key(); key != OptionalEvalPropKey(i) {
+			log.Fatalf(
+				"Invalid optionalPropertyDescList[%d].Key, unexpected index: %d",
+				i, key,
+			)
+		}
+	}
+}
+
+// OptionalEvalPropKey is the key for optional evaluation properties in EvalContext.
+type OptionalEvalPropKey int
+
+// AsPropKeySet returns the set only contains the property key.
+func (k OptionalEvalPropKey) AsPropKeySet() OptionalEvalPropKeySet {
+	return 1 << k
+}
+
+// Desc returns the description for the property key.
+func (k OptionalEvalPropKey) Desc() *OptionalEvalPropDesc {
+	return &optionalPropertyDescList[k]
+}
+
+// String implements fmt.Stringer interface.
+func (k OptionalEvalPropKey) String() string {
+	if k < optPropsCnt {
+		return k.Desc().str
+	}
+	return fmt.Sprintf("UnknownOptionalEvalPropKey(%d)", k)
+}
+
+const (
+	// OptPropCurrentUser indicates the current user property
+	OptPropCurrentUser OptionalEvalPropKey = iota
+	optPropsCnt
+)
+
+const allOptPropsMask = (1 << optPropsCnt) - 1
+
+// OptPropsCnt is the count of optional properties.
+const OptPropsCnt = int(optPropsCnt)
+
+// OptionalEvalPropDesc is the description for optional evaluation properties in EvalContext.
+type OptionalEvalPropDesc struct {
+	key OptionalEvalPropKey
+	str string
+	// TODO: add more fields if needed
+}
+
+// Key returns the property key.
+func (desc *OptionalEvalPropDesc) Key() OptionalEvalPropKey {
+	return desc.key
+}
+
+// OptionalEvalPropProvider is the interface to provide optional properties in EvalContext.
+type OptionalEvalPropProvider interface {
+	Desc() *OptionalEvalPropDesc
+}
+
+// optionalPropertyDescList contains all optional property descriptions in EvalContext.
+var optionalPropertyDescList = []OptionalEvalPropDesc{
+	{
+		key: OptPropCurrentUser,
+		str: "OptPropCurrentUser",
+	},
+}
+
+// OptionalEvalPropKeySet is a bit map for optional evaluation properties in EvalContext
+// to indicate whether some properties are set.
+type OptionalEvalPropKeySet uint64
+
+// Add adds the property key to the set
+func (b OptionalEvalPropKeySet) Add(key OptionalEvalPropKey) OptionalEvalPropKeySet {
+	return b | key.AsPropKeySet()
+}
+
+// Remove removes the property key from the set
+func (b OptionalEvalPropKeySet) Remove(key OptionalEvalPropKey) OptionalEvalPropKeySet {
+	return b &^ key.AsPropKeySet()
+}
+
+// Contains checks whether the set contains the property
+func (b OptionalEvalPropKeySet) Contains(key OptionalEvalPropKey) bool {
+	return b&key.AsPropKeySet() != 0
+}
+
+// IsEmpty checks whether the bit map is empty.
+func (b OptionalEvalPropKeySet) IsEmpty() bool {
+	return b&allOptPropsMask == 0
+}
+
+// IsFull checks whether all optional properties are contained in the bit map.
+func (b OptionalEvalPropKeySet) IsFull() bool {
+	return b&allOptPropsMask == allOptPropsMask
+}

--- a/pkg/expression/context/optional_test.go
+++ b/pkg/expression/context/optional_test.go
@@ -1,0 +1,76 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionalPropKeySet(t *testing.T) {
+	var keySet OptionalEvalPropKeySet
+	require.True(t, keySet.IsEmpty())
+	require.False(t, keySet.IsFull())
+	require.False(t, keySet.Contains(OptPropCurrentUser))
+
+	// Add one key
+	keySet2 := keySet.Add(OptPropCurrentUser)
+	require.True(t, keySet2.Contains(OptPropCurrentUser))
+	require.False(t, keySet2.IsEmpty())
+	require.True(t, keySet2.IsFull())
+
+	// old key is not affected
+	require.True(t, keySet.IsEmpty())
+
+	// remove one key
+	keySet3 := keySet2.Remove(OptPropCurrentUser)
+	require.True(t, keySet3.IsEmpty())
+	require.False(t, keySet2.IsEmpty())
+}
+
+func TestOptionalPropKeySetWithUnusedBits(t *testing.T) {
+	require.Less(t, OptPropsCnt, 64)
+	full := OptionalEvalPropKeySet(math.MaxUint64)
+
+	bits := full << OptionalEvalPropKeySet(OptPropsCnt)
+	require.True(t, bits.IsEmpty())
+	require.False(t, bits.Contains(OptPropCurrentUser))
+	bits = bits.Add(OptPropCurrentUser)
+	require.True(t, bits.Contains(OptPropCurrentUser))
+
+	bits = full >> (64 - OptPropsCnt)
+	require.True(t, bits.IsFull())
+	require.True(t, bits.Contains(OptPropCurrentUser))
+	bits = bits.Remove(OptPropCurrentUser)
+	require.False(t, bits.Contains(OptPropCurrentUser))
+}
+
+func TestOptionalPropKey(t *testing.T) {
+	keySet := OptPropCurrentUser.AsPropKeySet()
+	require.True(t, keySet.Contains(OptPropCurrentUser))
+	keySet = keySet.Remove(OptPropCurrentUser)
+	require.True(t, keySet.IsEmpty())
+}
+
+func TestOptionalPropDescList(t *testing.T) {
+	require.Equal(t, OptPropsCnt, len(optionalPropertyDescList))
+	for i := 0; i < OptPropsCnt; i++ {
+		key := OptionalEvalPropKey(i)
+		require.Equal(t, key, optionalPropertyDescList[i].Key())
+		require.Same(t, &optionalPropertyDescList[i], key.Desc())
+	}
+}

--- a/pkg/expression/contextimpl/BUILD.bazel
+++ b/pkg/expression/contextimpl/BUILD.bazel
@@ -8,11 +8,14 @@ go_library(
     deps = [
         "//pkg/errctx",
         "//pkg/expression/context",
+        "//pkg/expression/contextopt",
+        "//pkg/parser/auth",
         "//pkg/parser/mysql",
         "//pkg/sessionctx",
         "//pkg/sessionctx/stmtctx",
         "//pkg/sessionctx/variable",
         "//pkg/types",
+        "//pkg/util/intest",
     ],
 )
 
@@ -24,6 +27,9 @@ go_test(
     deps = [
         ":contextimpl",
         "//pkg/errctx",
+        "//pkg/expression/context",
+        "//pkg/expression/contextopt",
+        "//pkg/parser/auth",
         "//pkg/parser/mysql",
         "//pkg/sessionctx/stmtctx",
         "//pkg/types",

--- a/pkg/expression/contextimpl/sessionctx.go
+++ b/pkg/expression/contextimpl/sessionctx.go
@@ -19,11 +19,14 @@ import (
 
 	"github.com/pingcap/tidb/pkg/errctx"
 	exprctx "github.com/pingcap/tidb/pkg/expression/context"
+	"github.com/pingcap/tidb/pkg/expression/contextopt"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 // sessionctx.Context + *ExprCtxExtendedImpl should implement `expression.BuildContext`
@@ -35,12 +38,25 @@ var _ exprctx.BuildContext = struct {
 
 // ExprCtxExtendedImpl extends the sessionctx.Context to implement `expression.BuildContext`
 type ExprCtxExtendedImpl struct {
-	sctx sessionctx.Context
+	sctx  sessionctx.Context
+	props contextopt.OptionalEvalPropProviders
 }
 
 // NewExprExtendedImpl creates a new ExprCtxExtendedImpl.
 func NewExprExtendedImpl(sctx sessionctx.Context) *ExprCtxExtendedImpl {
-	return &ExprCtxExtendedImpl{sctx: sctx}
+	impl := &ExprCtxExtendedImpl{sctx: sctx}
+	// set all optional properties
+	impl.setOptionalProp(currentUserProp(sctx))
+	// When EvalContext is created from a session, it should contain all the optional properties.
+	intest.Assert(impl.props.PropKeySet().IsFull())
+	return impl
+}
+
+func (ctx *ExprCtxExtendedImpl) setOptionalProp(prop exprctx.OptionalEvalPropProvider) {
+	intest.AssertFunc(func() bool {
+		return !ctx.props.Contains(prop.Desc().Key())
+	})
+	ctx.props.Add(prop)
 }
 
 // CtxID returns the context id.
@@ -101,4 +117,16 @@ func (ctx *ExprCtxExtendedImpl) GetDefaultWeekFormatMode() string {
 		return "0"
 	}
 	return mode
+}
+
+// GetOptionalPropProvider gets the optional property provider by key
+func (ctx *ExprCtxExtendedImpl) GetOptionalPropProvider(key exprctx.OptionalEvalPropKey) (exprctx.OptionalEvalPropProvider, bool) {
+	return ctx.props.Get(key)
+}
+
+func currentUserProp(sctx sessionctx.Context) exprctx.OptionalEvalPropProvider {
+	return contextopt.CurrentUserPropProvider(func() (*auth.UserIdentity, []*auth.RoleIdentity) {
+		vars := sctx.GetSessionVars()
+		return vars.User, vars.ActiveRoles
+	})
 }

--- a/pkg/expression/contextopt/BUILD.bazel
+++ b/pkg/expression/contextopt/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "contextopt",
+    srcs = [
+        "current_user.go",
+        "optional.go",
+    ],
+    importpath = "github.com/pingcap/tidb/pkg/expression/contextopt",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/expression/context",
+        "//pkg/parser/auth",
+        "//pkg/util/intest",
+        "@com_github_pingcap_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "contextopt_test",
+    timeout = "short",
+    srcs = ["optional_test.go"],
+    embed = [":contextopt"],
+    flaky = True,
+    deps = [
+        "//pkg/expression/context",
+        "//pkg/parser/auth",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/expression/contextopt/current_user.go
+++ b/pkg/expression/contextopt/current_user.go
@@ -39,7 +39,7 @@ func (r CurrentUserPropReader) RequiredOptionalEvalProps() context.OptionalEvalP
 
 // CurrentUser returns the current user
 func (r CurrentUserPropReader) CurrentUser(ctx context.EvalContext) (*auth.UserIdentity, error) {
-	p, err := getPropProvider[CurrentUserPropProvider](ctx, context.OptPropCurrentUser)
+	p, err := r.getProvider(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -49,10 +49,14 @@ func (r CurrentUserPropReader) CurrentUser(ctx context.EvalContext) (*auth.UserI
 
 // ActiveRoles returns the active roles
 func (r CurrentUserPropReader) ActiveRoles(ctx context.EvalContext) ([]*auth.RoleIdentity, error) {
-	p, err := getPropProvider[CurrentUserPropProvider](ctx, context.OptPropCurrentUser)
+	p, err := r.getProvider(ctx)
 	if err != nil {
 		return nil, err
 	}
 	_, roles := p()
 	return roles, nil
+}
+
+func (r CurrentUserPropReader) getProvider(ctx context.EvalContext) (CurrentUserPropProvider, error) {
+	return getPropProvider[CurrentUserPropProvider](ctx, context.OptPropCurrentUser)
 }

--- a/pkg/expression/contextopt/current_user.go
+++ b/pkg/expression/contextopt/current_user.go
@@ -1,0 +1,58 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contextopt
+
+import (
+	"github.com/pingcap/tidb/pkg/expression/context"
+	"github.com/pingcap/tidb/pkg/parser/auth"
+)
+
+var _ RequireOptionalEvalProps = CurrentUserPropReader{}
+
+// CurrentUserPropProvider is a provider to get the current user
+type CurrentUserPropProvider func() (*auth.UserIdentity, []*auth.RoleIdentity)
+
+// Desc returns the description for the property key.
+func (p CurrentUserPropProvider) Desc() *context.OptionalEvalPropDesc {
+	return context.OptPropCurrentUser.Desc()
+}
+
+// CurrentUserPropReader is used by expression to read property context.OptPropCurrentUser
+type CurrentUserPropReader struct{}
+
+// RequiredOptionalEvalProps implements the RequireOptionalEvalProps interface.
+func (r CurrentUserPropReader) RequiredOptionalEvalProps() context.OptionalEvalPropKeySet {
+	return context.OptPropCurrentUser.AsPropKeySet()
+}
+
+// CurrentUser returns the current user
+func (r CurrentUserPropReader) CurrentUser(ctx context.EvalContext) (*auth.UserIdentity, error) {
+	p, err := getPropProvider[CurrentUserPropProvider](ctx, context.OptPropCurrentUser)
+	if err != nil {
+		return nil, err
+	}
+	user, _ := p()
+	return user, nil
+}
+
+// ActiveRoles returns the active roles
+func (r CurrentUserPropReader) ActiveRoles(ctx context.EvalContext) ([]*auth.RoleIdentity, error) {
+	p, err := getPropProvider[CurrentUserPropProvider](ctx, context.OptPropCurrentUser)
+	if err != nil {
+		return nil, err
+	}
+	_, roles := p()
+	return roles, nil
+}

--- a/pkg/expression/contextopt/optional.go
+++ b/pkg/expression/contextopt/optional.go
@@ -1,0 +1,87 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contextopt
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/expression/context"
+	"github.com/pingcap/tidb/pkg/util/intest"
+)
+
+// RequireOptionalEvalProps is the interface for the function that requires optional evaluation properties or not.
+type RequireOptionalEvalProps interface {
+	// RequiredOptionalEvalProps returns the optional properties that this function requires.
+	// If the returned `OptionalEvalPropKeySet` is empty,
+	// it means this function does not require any optional properties.
+	RequiredOptionalEvalProps() context.OptionalEvalPropKeySet
+}
+
+// OptionalEvalPropProviders contains some evaluation property providers in EvalContext.
+type OptionalEvalPropProviders [context.OptPropsCnt]context.OptionalEvalPropProvider
+
+// Contains checks whether the provider by key exists.
+func (o *OptionalEvalPropProviders) Contains(key context.OptionalEvalPropKey) bool {
+	return o[key] != nil
+}
+
+// Get gets the provider by key.
+func (o *OptionalEvalPropProviders) Get(key context.OptionalEvalPropKey) (context.OptionalEvalPropProvider, bool) {
+	if val := o[key]; val != nil {
+		intest.Assert(key == val.Desc().Key())
+		return val, true
+	}
+	return nil, false
+}
+
+// Add adds an optional property
+func (o *OptionalEvalPropProviders) Add(val context.OptionalEvalPropProvider) {
+	intest.AssertFunc(func() bool {
+		intest.AssertNotNil(val)
+		switch val.Desc().Key() {
+		case context.OptPropCurrentUser:
+			_, ok := val.(CurrentUserPropProvider)
+			intest.Assert(ok)
+		default:
+			intest.Assert(false)
+		}
+		return true
+	})
+	o[val.Desc().Key()] = val
+}
+
+// PropKeySet returns the set for optional evaluation properties in EvalContext.
+func (o *OptionalEvalPropProviders) PropKeySet() (set context.OptionalEvalPropKeySet) {
+	for _, p := range o {
+		if p != nil {
+			set = set.Add(p.Desc().Key())
+		}
+	}
+	return
+}
+
+func getPropProvider[T context.OptionalEvalPropProvider](ctx context.EvalContext, key context.OptionalEvalPropKey) (p T, _ error) {
+	val, ok := ctx.GetOptionalPropProvider(key)
+	if !ok {
+		return p, errors.Errorf("optional property: '%s' not exists in EvalContext", key)
+	}
+
+	p, ok = val.(T)
+	if !ok {
+		intest.Assert(false)
+		return p, errors.Errorf("cannot cast OptionalEvalPropProvider to %T for key '%s'", p, key)
+	}
+
+	return p, nil
+}

--- a/pkg/expression/contextopt/optional_test.go
+++ b/pkg/expression/contextopt/optional_test.go
@@ -1,0 +1,46 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contextopt
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/expression/context"
+	"github.com/pingcap/tidb/pkg/parser/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionalEvalPropProviders(t *testing.T) {
+	var providers OptionalEvalPropProviders
+	require.True(t, providers.PropKeySet().IsEmpty())
+	require.False(t, providers.Contains(context.OptPropCurrentUser))
+	val, ok := providers.Get(context.OptPropCurrentUser)
+	require.False(t, ok)
+	require.Nil(t, val)
+
+	var p context.OptionalEvalPropProvider
+
+	user := &auth.UserIdentity{Username: "u1", Hostname: "h1"}
+	roles := []*auth.RoleIdentity{{Username: "u2", Hostname: "h2"}, {Username: "u3", Hostname: "h3"}}
+	p = CurrentUserPropProvider(func() (*auth.UserIdentity, []*auth.RoleIdentity) { return user, roles })
+	providers.Add(p)
+	require.True(t, providers.PropKeySet().Contains(context.OptPropCurrentUser))
+	require.True(t, providers.Contains(context.OptPropCurrentUser))
+	val, ok = providers.Get(context.OptPropCurrentUser)
+	require.True(t, ok)
+	user2, roles2 := val.(CurrentUserPropProvider)()
+	require.Equal(t, user, user2)
+	require.Equal(t, roles, roles2)
+}

--- a/pkg/expression/distsql_builtin.go
+++ b/pkg/expression/distsql_builtin.go
@@ -597,9 +597,9 @@ func getSignatureByPB(ctx BuildContext, sigCode tipb.ScalarFuncSig, tp *tipb.Fie
 	case tipb.ScalarFuncSig_FoundRows:
 		f = &builtinFoundRowsSig{base}
 	case tipb.ScalarFuncSig_CurrentUser:
-		f = &builtinCurrentUserSig{base}
+		f = &builtinCurrentUserSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_User:
-		f = &builtinUserSig{base}
+		f = &builtinUserSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ConnectionID:
 		f = &builtinConnectionIDSig{base}
 	case tipb.ScalarFuncSig_LastInsertID:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51477

Problem Summary:

copied from issue:

The `EvalContext` has many fields to provide but not all of them are required in every scene. So it's better to classify these fields into two categories:

1. **Basic properties** such as `type.Context`, `errctx.Context`, `SQLMode`, etc... These properties are used by functions widely. For example, `errctx.Context` used by most functions to handle some errors. The basic properties are also simple, they should be easy to clone and mock. The `EvalContext` MUST provide basic properties. 
2. **Optional properties**, as its name, is "optional". In some scenes such as [TiDB Lightning](https://github.com/pingcap/br/tree/master/pkg/lightning), it only requires some of the properties, so these properties are provided on demand. Optional properties are not widely used, for example, `tidb_is_ddl_owner` requires `EvalContext` to provide the information on whether the current tidb is DDL owner, but this function is forbidden in most other scenes except SQL query, like partition expressions or generated column expressions. Some optional properties are complex, so not all of them can be cloned or migrated. 

### What changed and how does it work?

This PR adds a new method `GetOptionalPropProvider` to `EvalContext` to provide some "optional" properties, and the other methods in `EvalContext` provide the "basic" properties.

The difference between "basic" and "optional" properties is that "basic" properties should be simple, widely used, and easy to clone and migrate.  On the contrary, the "optional" properties are not so widely used, and not all of them is able to clone or migrate.

To make it easy to manage optional properties, we defined an enum for these properties:

```go
const (
	// OptPropCurrentUser indicates the current user property
	OptPropCurrentUser OptionalEvalPropKey = iota
	optPropsCnt
)
```

This key can be used as the argument of method `GetOptionalPropProvider`:

```go
type EvalContext interface {
	...
	// GetOptionalPropProvider gets the optional property provider by key
	GetOptionalPropProvider(OptionalEvalPropKey) (OptionalEvalPropProvider, bool)
	...
}
```

Each optional property should be self-explanation, so `OptionalEvalPropDesc` is defined to provide some extra information about the corresponding property:

```go
// OptionalEvalPropDesc is the description for optional evaluation properties in EvalContext.
type OptionalEvalPropDesc struct {
	key OptionalEvalPropKey
	// TODO: add more fields if needed
}

// Key returns the property key.
func (desc *OptionalEvalPropDesc) Key() OptionalEvalPropKey {
	return desc.key
}

// OptionalPropertyDescList contains all optional property descriptions in EvalContext.
var OptionalPropertyDescList = []*OptionalEvalPropDesc{
	{
		key: OptPropCurrentUser,
	},
}
```

To indicate whether a function require some optional properties, we added a new interface:

```go
// RequireOptionalEvalProps is the interface for the function that requires optional evaluation properties or not.
type RequireOptionalEvalProps interface {
	// RequiredOptionalEvalProps returns the optional properties that this function requires.
	// If the returned `OptionalEvalPropKeySet` is empty,
	// it means this function does not require any optional properties.
	RequiredOptionalEvalProps() context.OptionalEvalPropKeySet
}
```

and the `builtinFunc` should implement it:

```go
type builtinFunc interface {
	contextopt.RequireOptionalEvalProps
	vecBuiltinFunc

	// evalInt evaluates int result of builtinFunc by given row.
	evalInt(ctx EvalContext, row chunk.Row) (val int64, isNull bool, err error)

	...
```

By default, `RequiredOptionalEvalProps` returns an empty set, but if it needs any optional properties, tie `RequiredOptionalEvalProps` should return the property set with corresponding keys.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
