### PR TITLE
session: migrate to the new redact function

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -91,6 +91,7 @@ go_library(
         "//pkg/util/logutil",
         "//pkg/util/memory",
         "//pkg/util/printer",
+        "//pkg/util/redact",
         "//pkg/util/resourcegrouptag",
         "//pkg/util/sqlexec",
         "//pkg/util/sqlkiller",

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -102,6 +102,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/pingcap/tidb/pkg/util/redact"
 	"github.com/pingcap/tidb/pkg/util/resourcegrouptag"
 	tlsutil "github.com/pingcap/tidb/pkg/util/tls"
 	"github.com/pingcap/tidb/pkg/util/topsql"
@@ -1159,7 +1160,7 @@ func (cc *clientConn) Run(ctx context.Context) {
 					zap.Stringer("sql", getLastStmtInConn{cc}),
 					zap.String("txn_mode", txnMode),
 					zap.Uint64("timestamp", startTS),
-					zap.String("err", errStrForLog(err, cc.ctx.GetSessionVars().EnableRedactLog)),
+					zap.String("err", errStrForLog(err, cc.ctx.GetSessionVars().EnableRedactNew)),
 				)
 			}
 			err1 := cc.writeError(ctx, err)
@@ -1171,19 +1172,22 @@ func (cc *clientConn) Run(ctx context.Context) {
 	}
 }
 
-func errStrForLog(err error, enableRedactLog bool) string {
-	if enableRedactLog {
+func errStrForLog(err error, redactMode string) string {
+	if redactMode == "ON" {
 		// currently, only ErrParse is considered when enableRedactLog because it may contain sensitive information like
 		// password or accesskey
 		if parser.ErrParse.Equal(err) {
 			return "fail to parse SQL and can't redact when enable log redaction"
 		}
 	}
+	var ret string
 	if kv.ErrKeyExists.Equal(err) || parser.ErrParse.Equal(err) || infoschema.ErrTableNotExists.Equal(err) {
 		// Do not log stack for duplicated entry error.
-		return err.Error()
+		ret = err.Error()
+	} else {
+		ret = errors.ErrorStack(err)
 	}
-	return errors.ErrorStack(err)
+	return redact.Redact(redactMode, ret)
 }
 
 func (cc *clientConn) addMetrics(cmd byte, startTime time.Time, err error) {

--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -104,6 +104,7 @@ go_library(
         "//pkg/util/logutil/consistency",
         "//pkg/util/memory",
         "//pkg/util/parser",
+        "//pkg/util/redact",
         "//pkg/util/sem",
         "//pkg/util/sli",
         "//pkg/util/sqlescape",

--- a/pkg/session/nontransactional.go
+++ b/pkg/session/nontransactional.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/memory"
+	"github.com/pingcap/tidb/pkg/util/redact"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"go.uber.org/zap"
 )
@@ -67,11 +68,8 @@ type statementBuildInfo struct {
 	originalCondition ast.ExprNode
 }
 
-func (j job) String(redacted bool) string {
-	if redacted {
-		return fmt.Sprintf("job id: %d, estimated size: %d", j.jobID, j.jobSize)
-	}
-	return fmt.Sprintf("job id: %d, estimated size: %d, sql: %s", j.jobID, j.jobSize, j.sql)
+func (j job) String(redacted string) string {
+	return fmt.Sprintf("job id: %d, estimated size: %d, sql: %s", j.jobID, j.jobSize, redact.Redact(redacted, j.sql))
 }
 
 // HandleNonTransactionalDML is the entry point for a non-transactional DML statement
@@ -122,7 +120,7 @@ func HandleNonTransactionalDML(ctx context.Context, stmt *ast.NonTransactionalDM
 	if stmt.DryRun == ast.DryRunSplitDml {
 		return buildDryRunResults(stmt.DryRun, splitStmts, se.GetSessionVars().BatchSize.MaxChunkSize)
 	}
-	return buildExecuteResults(ctx, jobs, se.GetSessionVars().BatchSize.MaxChunkSize, se.GetSessionVars().EnableRedactLog)
+	return buildExecuteResults(ctx, jobs, se.GetSessionVars().BatchSize.MaxChunkSize, se.GetSessionVars().EnableRedactNew)
 }
 
 // we require:
@@ -282,7 +280,7 @@ func runJobs(ctx context.Context, jobs []job, stmt *ast.NonTransactionalDMLStmt,
 			failedJobs := make([]string, 0)
 			for _, job := range jobs {
 				if job.err != nil {
-					failedJobs = append(failedJobs, fmt.Sprintf("job:%s, error: %s", job.String(se.GetSessionVars().EnableRedactLog), job.err.Error()))
+					failedJobs = append(failedJobs, fmt.Sprintf("job:%s, error: %s", job.String(se.GetSessionVars().EnableRedactNew), job.err.Error()))
 				}
 			}
 			if len(failedJobs) == 0 {
@@ -326,7 +324,7 @@ func runJobs(ctx context.Context, jobs []job, stmt *ast.NonTransactionalDMLStmt,
 			return nil, errors.Annotate(jobs[i].err, "Early return: error occurred in the first job. All jobs are canceled")
 		}
 		if jobs[i].err != nil && !se.GetSessionVars().NonTransactionalIgnoreError {
-			return nil, ErrNonTransactionalJobFailure.GenWithStackByArgs(jobs[i].jobID, len(jobs), jobs[i].start.String(), jobs[i].end.String(), jobs[i].String(se.GetSessionVars().EnableRedactLog), jobs[i].err.Error())
+			return nil, ErrNonTransactionalJobFailure.GenWithStackByArgs(jobs[i].jobID, len(jobs), jobs[i].start.String(), jobs[i].end.String(), jobs[i].String(se.GetSessionVars().EnableRedactNew), jobs[i].err.Error())
 		}
 	}
 	return splitStmts, nil
@@ -412,7 +410,7 @@ func doOneJob(ctx context.Context, job *job, totalJobCount int, options statemen
 
 	job.sql = dmlSQL
 	logutil.Logger(ctx).Info("start a Non-transactional DML",
-		zap.String("job", job.String(se.GetSessionVars().EnableRedactLog)), zap.Int("totalJobCount", totalJobCount))
+		zap.String("job", job.String(se.GetSessionVars().EnableRedactNew)), zap.Int("totalJobCount", totalJobCount))
 	var dmlSQLInLog string
 	if se.GetSessionVars().EnableRedactLog {
 		dmlSQLInLog = parser.Normalize(dmlSQL)
@@ -804,7 +802,7 @@ func buildDryRunResults(dryRunOption int, results []string, maxChunkSize int) (s
 	}, nil
 }
 
-func buildExecuteResults(ctx context.Context, jobs []job, maxChunkSize int, redactLog bool) (sqlexec.RecordSet, error) {
+func buildExecuteResults(ctx context.Context, jobs []job, maxChunkSize int, redactLog string) (sqlexec.RecordSet, error) {
 	failedJobs := make([]job, 0)
 	for _, job := range jobs {
 		if job.err != nil {

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1204,6 +1204,8 @@ type SessionVars struct {
 
 	// EnableRedactLog indicates that whether redact log.
 	EnableRedactLog bool
+	// EnableRedactNew indicates that whether redact log.
+	EnableRedactNew string
 
 	// ShardAllocateStep indicates the max size of continuous rowid shard in one transaction.
 	ShardAllocateStep int64

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2153,6 +2153,7 @@ var defaultSysVars = []*SysVar{
 	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBRedactLog, Value: DefTiDBRedactLog, Type: TypeEnum, PossibleValues: []string{Off, On, Marker}, SetSession: func(s *SessionVars, val string) error {
 		s.EnableRedactLog = val != Off
+		s.EnableRedactNew = val
 		errors.RedactLogEnabled.Store(s.EnableRedactLog)
 		return nil
 	}},

--- a/pkg/util/redact/BUILD.bazel
+++ b/pkg/util/redact/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "redact",
+    srcs = ["redact.go"],
+    importpath = "github.com/pingcap/tidb/pkg/util/redact",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "redact_test",
+    timeout = "short",
+    srcs = ["redact_test.go"],
+    embed = [":redact"],
+    flaky = True,
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/util/redact/redact.go
+++ b/pkg/util/redact/redact.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 )
 
+// Redact will redact the input string according to 'mode'. Check 'tidb_redact_log': https://github.com/pingcap/tidb/blob/acf9e3128693a5a13f31027f05f4de41edf8d7b2/pkg/sessionctx/variable/sysvar.go#L2154.
 func Redact(mode string, input string) string {
 	switch mode {
 	case "MARKER":

--- a/pkg/util/redact/redact.go
+++ b/pkg/util/redact/redact.go
@@ -1,0 +1,42 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redact
+
+import (
+	"strings"
+)
+
+func Redact(mode string, input string) string {
+	switch mode {
+	case "MARKER":
+		b := &strings.Builder{}
+		b.Grow(len(input))
+		_, _ = b.WriteRune('‹')
+		for _, c := range input {
+			if c == '‹' || c == '›' {
+				_, _ = b.WriteRune(c)
+				_, _ = b.WriteRune(c)
+			} else {
+				_, _ = b.WriteRune(c)
+			}
+		}
+		_, _ = b.WriteRune('›')
+		return b.String()
+	case "OFF":
+		return input
+	default:
+		return ""
+	}
+}

--- a/pkg/util/redact/redact_test.go
+++ b/pkg/util/redact/redact_test.go
@@ -1,0 +1,37 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redact
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedact(t *testing.T) {
+	for _, c := range []struct {
+		mode   string
+		input  string
+		output string
+	}{
+		{"OFF", "fxcv", "fxcv"},
+		{"OFF", "f‹xcv", "f‹xcv"},
+		{"ON", "f‹xcv", ""},
+		{"MARKER", "f‹xcv", "‹f‹‹xcv›"},
+		{"MARKER", "f›xcv", "‹f››xcv›"},
+	} {
+		require.Equal(t, c.output, Redact(c.mode, c.input))
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51557

Problem Summary: add `redact.Mode` and `sessVars.EnableRedactNew`. Use them to desensitive logs.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
