### PR TITLE
json: don't resize slice to get extra zero when the length is unspecified

### DIFF
--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -878,7 +878,7 @@ func (b *builtinCastStringAsJSONSig) evalJSON(ctx EvalContext, row chunk.Row) (r
 	typ := b.args[0].GetType()
 	if types.IsBinaryStr(typ) {
 		buf := []byte(val)
-		if typ.GetType() == mysql.TypeString {
+		if typ.GetType() == mysql.TypeString && typ.GetFlen() > 0 {
 			// the tailing zero should also be in the opaque json
 			buf = make([]byte, typ.GetFlen())
 			copy(buf, val)

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -853,7 +853,7 @@ func (b *builtinCastStringAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.C
 
 			val := buf.GetBytes(i)
 			resultBuf := val
-			if typ.GetType() == mysql.TypeString {
+			if typ.GetType() == mysql.TypeString && typ.GetFlen() > 0 {
 				// only for BINARY: the tailing zero should also be in the opaque json
 				resultBuf = make([]byte, typ.GetFlen())
 				copy(resultBuf, val)

--- a/tests/integrationtest/r/expression/json.result
+++ b/tests/integrationtest/r/expression/json.result
@@ -628,3 +628,24 @@ a	cast(a as signed)
 "-1"	-1
 "18446744073709551615"	-1
 "18446744073709552000"	-1
+select cast(binary 'aa' as json);
+cast(binary 'aa' as json)
+"base64:type254:YWE="
+drop table if exists t;
+create table t (vb VARBINARY(10), b BINARY(10), vc VARCHAR(10), c CHAR(10));
+insert into t values ('1', '1', '1', '1');
+select cast(vb as json), cast(b as json), cast(vc as json), cast(c as json) from t;
+cast(vb as json)	cast(b as json)	cast(vc as json)	cast(c as json)
+"base64:type15:MQ=="	"base64:type254:MQAAAAAAAAAAAA=="	1	1
+select 1 from t where cast(vb as json) = '1';
+1
+select 1 from t where cast(b as json) = '1';
+1
+select 1 from t where cast(vc as json) = '1';
+1
+select 1 from t where cast(c as json) = '1';
+1
+select 1 from t where cast(BINARY vc as json) = '1';
+1
+select 1 from t where cast(BINARY c as json) = '1';
+1

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -380,3 +380,16 @@ insert into t values ('"18446744073709552000"');
 select a, cast(a as unsigned) from t;
 -- sorted_result
 select a, cast(a as signed) from t;
+
+# TestCastBinaryStringToJSON
+select cast(binary 'aa' as json);
+drop table if exists t;
+create table t (vb VARBINARY(10), b BINARY(10), vc VARCHAR(10), c CHAR(10));
+insert into t values ('1', '1', '1', '1');
+select cast(vb as json), cast(b as json), cast(vc as json), cast(c as json) from t;
+select 1 from t where cast(vb as json) = '1';
+select 1 from t where cast(b as json) = '1';
+select 1 from t where cast(vc as json) = '1';
+select 1 from t where cast(c as json) = '1';
+select 1 from t where cast(BINARY vc as json) = '1';
+select 1 from t where cast(BINARY c as json) = '1';


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51547

Problem Summary:

### What changed and how does it work?

If the `flen` of a binary string is unspecified, don't resize the target json opaque.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
