### PR TITLE
import into: enable `[]` glob matching

### DIFF
--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -1050,7 +1050,7 @@ func (e *LoadDataController) InitDataFiles(ctx context.Context) error {
 		fileNameKey = strings.Trim(u.Path, "/")
 	}
 	// try to find pattern error in advance
-	_, err2 = filepath.Match(stringutil.EscapeGlobExceptAsterisk(fileNameKey), "")
+	_, err2 = filepath.Match(stringutil.EscapeGlobQuestionMark(fileNameKey), "")
 	if err2 != nil {
 		return exeerrors.ErrLoadDataInvalidURI.GenWithStackByArgs(plannercore.ImportIntoDataSource,
 			"Glob pattern error: "+err2.Error())
@@ -1063,7 +1063,8 @@ func (e *LoadDataController) InitDataFiles(ctx context.Context) error {
 	s := e.dataStore
 	var totalSize int64
 	dataFiles := []*mydump.SourceFileMeta{}
-	idx := strings.IndexByte(fileNameKey, '*')
+	// check glob pattern is present in filename.
+	idx := strings.IndexAny(fileNameKey, "*[")
 	// simple path when the path represent one file
 	sourceType := e.getSourceType()
 	if idx == -1 {
@@ -1098,7 +1099,7 @@ func (e *LoadDataController) InitDataFiles(ctx context.Context) error {
 		// when import from server disk, all entries in parent directory should have READ
 		// access, else walkDir will fail
 		// we only support '*', in order to reuse glob library manually escape the path
-		escapedPath := stringutil.EscapeGlobExceptAsterisk(fileNameKey)
+		escapedPath := stringutil.EscapeGlobQuestionMark(fileNameKey)
 		err := s.WalkDir(ctx, &storage.WalkOption{ObjPrefix: commonPrefix, SkipSubDir: true},
 			func(remotePath string, size int64) error {
 				// we have checked in LoadDataExec.Next

--- a/pkg/executor/importer/import_test.go
+++ b/pkg/executor/importer/import_test.go
@@ -414,6 +414,28 @@ func TestSupportedSuffixForServerDisk(t *testing.T) {
 	require.NoError(t, os.Chmod(path.Join(tempDir, "no-perm"), 0o400))
 	c.Path = path.Join(tempDir, "server-*.csv")
 	require.NoError(t, c.InitDataFiles(ctx))
+	// test glob matching pattern [12]
+	err = os.WriteFile(path.Join(tempDir, "glob-1.csv"), []byte("1,1"), 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(path.Join(tempDir, "glob-2.csv"), []byte("2,2"), 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(path.Join(tempDir, "glob-3.csv"), []byte("3,3"), 0o644)
+	require.NoError(t, err)
+	c.Path = path.Join(tempDir, "glob-[12].csv")
+	require.NoError(t, c.InitDataFiles(ctx))
+	gotPath := make([]string, 0, len(c.dataFiles))
+	for _, f := range c.dataFiles {
+		gotPath = append(gotPath, f.Path)
+	}
+	require.ElementsMatch(t, []string{"glob-1.csv", "glob-2.csv"}, gotPath)
+	// test glob matching pattern [2-3]
+	c.Path = path.Join(tempDir, "glob-[2-3].csv")
+	require.NoError(t, c.InitDataFiles(ctx))
+	gotPath = make([]string, 0, len(c.dataFiles))
+	for _, f := range c.dataFiles {
+		gotPath = append(gotPath, f.Path)
+	}
+	require.ElementsMatch(t, []string{"glob-2.csv", "glob-3.csv"}, gotPath)
 }
 
 func TestGetDataSourceType(t *testing.T) {

--- a/pkg/util/stringutil/string_util.go
+++ b/pkg/util/stringutil/string_util.go
@@ -546,13 +546,13 @@ func LowerOneStringExcludeEscapeChar(str []byte, escapeChar byte) byte {
 	return actualEscapeChar
 }
 
-// EscapeGlobExceptAsterisk escapes '?', '[', ']' for a glob path pattern.
-func EscapeGlobExceptAsterisk(s string) string {
+// EscapeGlobQuestionMark escapes '?' for a glob path pattern.
+func EscapeGlobQuestionMark(s string) string {
 	var buf strings.Builder
 	buf.Grow(len(s))
 	for _, c := range s {
 		switch c {
-		case '?', '[', ']':
+		case '?':
 			buf.WriteByte('\\')
 		}
 		buf.WriteRune(c)

--- a/pkg/util/stringutil/string_util.go
+++ b/pkg/util/stringutil/string_util.go
@@ -553,7 +553,6 @@ func EscapeGlobQuestionMark(s string) string {
 	for _, c := range s {
 		if c == '?' {
 			buf.WriteByte('\\')
-			continue
 		}
 		buf.WriteRune(c)
 	}

--- a/pkg/util/stringutil/string_util.go
+++ b/pkg/util/stringutil/string_util.go
@@ -551,9 +551,9 @@ func EscapeGlobQuestionMark(s string) string {
 	var buf strings.Builder
 	buf.Grow(len(s))
 	for _, c := range s {
-		switch c {
-		case '?':
+		if c == '?' {
 			buf.WriteByte('\\')
+			continue
 		}
 		buf.WriteRune(c)
 	}

--- a/pkg/util/stringutil/string_util_test.go
+++ b/pkg/util/stringutil/string_util_test.go
@@ -202,7 +202,7 @@ func TestEscapeGlobExceptAsterisk(t *testing.T) {
 		{`[1-2]`, `\[1-2\]`},
 	}
 	for _, pair := range cases {
-		require.Equal(t, pair[1], EscapeGlobExceptAsterisk(pair[0]))
+		require.Equal(t, pair[1], EscapeGlobQuestionMark(pair[0]))
 	}
 }
 

--- a/pkg/util/stringutil/string_util_test.go
+++ b/pkg/util/stringutil/string_util_test.go
@@ -194,12 +194,12 @@ func TestBuildStringFromLabels(t *testing.T) {
 	}
 }
 
-func TestEscapeGlobExceptAsterisk(t *testing.T) {
+func TestEscapeGlobQuestionMark(t *testing.T) {
 	cases := [][2]string{
 		{"123", "123"},
 		{"12*3", "12*3"},
 		{"12?", `12\?`},
-		{`[1-2]`, `\[1-2\]`},
+		{`[1-2]`, `[1-2]`},
 	}
 	for _, pair := range cases {
 		require.Equal(t, pair[1], EscapeGlobQuestionMark(pair[0]))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50752

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
IMPORT INTO now can use `[]` of glob pattern matching to match multiple files
```
