### PR TITLE
restore: shift rewrite ranges before split ranges

### DIFF
--- a/br/pkg/restore/batcher.go
+++ b/br/pkg/restore/batcher.go
@@ -36,7 +36,6 @@ const (
 type Batcher struct {
 	cachedTables   []TableWithRange
 	cachedTablesMu *sync.Mutex
-	rewriteRules   *RewriteRules
 
 	// autoCommitJoiner is for joining the background batch sender.
 	autoCommitJoiner chan<- struct{}
@@ -114,7 +113,6 @@ func NewBatcher(
 	outCh := DefaultOutputTableChan()
 	sendChan := make(chan SendType, 2)
 	b := &Batcher{
-		rewriteRules:       EmptyRewriteRule(),
 		sendErr:            errCh,
 		outCh:              outCh,
 		sender:             sender,
@@ -427,7 +425,6 @@ func (b *Batcher) Add(tbs TableWithRange) {
 		zap.Int("batch size", b.Len()),
 	)
 	b.cachedTables = append(b.cachedTables, tbs)
-	b.rewriteRules.Append(*tbs.RewriteRule)
 	atomic.AddInt32(&b.size, int32(len(tbs.Range)))
 	b.cachedTablesMu.Unlock()
 

--- a/br/pkg/restore/batcher.go
+++ b/br/pkg/restore/batcher.go
@@ -238,7 +238,8 @@ func (result DrainResult) Files() []TableIDWithFiles {
 	for i, endOffset := range result.TableEndOffsetInRanges {
 		tableID := result.TablesToSend[i].Table.ID
 		ranges := result.Ranges[startOffset:endOffset]
-		files := make([]*backuppb.File, 0, len(result.Ranges)*2)
+		// each range has at least a default file + a write file
+		files := make([]*backuppb.File, 0, len(ranges)*2)
 		for _, rg := range ranges {
 			files = append(files, rg.Files...)
 		}

--- a/br/pkg/restore/batcher_test.go
+++ b/br/pkg/restore/batcher_test.go
@@ -39,7 +39,9 @@ func (sender *drySender) RestoreBatch(ranges restore.DrainResult) {
 	defer sender.mu.Unlock()
 	log.Info("fake restore range", rtree.ZapRanges(ranges.Ranges))
 	sender.nBatch++
-	sender.rewriteRules.Append(*ranges.RewriteRules)
+	for _, r := range ranges.RewriteRules {
+		sender.rewriteRules.Append(*r)
+	}
 	sender.ranges = append(sender.ranges, ranges.Ranges...)
 	sender.sink.EmitTables(ranges.BlankTablesAfterSend...)
 }

--- a/br/pkg/restore/batcher_test.go
+++ b/br/pkg/restore/batcher_test.go
@@ -39,7 +39,7 @@ func (sender *drySender) RestoreBatch(ranges restore.DrainResult) {
 	defer sender.mu.Unlock()
 	log.Info("fake restore range", rtree.ZapRanges(ranges.Ranges))
 	sender.nBatch++
-	for _, r := range ranges.RewriteRules {
+	for _, r := range ranges.RewriteRulesMap {
 		sender.rewriteRules.Append(*r)
 	}
 	sender.ranges = append(sender.ranges, ranges.Ranges...)

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1469,7 +1469,6 @@ func (rc *Client) WrapLogFilesIterWithCheckpoint(
 func (rc *Client) RestoreSSTFiles(
 	ctx context.Context,
 	tableIDWithFiles []TableIDWithFiles,
-	rewriteRules *RewriteRules,
 	updateCh glue.Progress,
 ) (err error) {
 	start := time.Now()
@@ -1504,6 +1503,7 @@ LOOPFORTABLE:
 	for _, tableIDWithFile := range tableIDWithFiles {
 		tableID := tableIDWithFile.TableID
 		files := tableIDWithFile.Files
+		rules := tableIDWithFile.RewriteRules
 		fileCount += len(files)
 		for rangeFiles, leftFiles = drainFilesByRange(files); len(rangeFiles) != 0; rangeFiles, leftFiles = drainFilesByRange(leftFiles) {
 			filesReplica := rangeFiles
@@ -1526,7 +1526,7 @@ LOOPFORTABLE:
 								zap.Duration("take", time.Since(fileStart)))
 							updateCh.Inc()
 						}()
-						return rc.fileImporter.ImportSSTFiles(ectx, fs, rewriteRules, rc.cipher, rc.dom.Store().GetCodec().GetAPIVersion())
+						return rc.fileImporter.ImportSSTFiles(ectx, fs, rules, rc.cipher, rc.dom.Store().GetCodec().GetAPIVersion())
 					}(filesGroup); importErr != nil {
 						return errors.Trace(importErr)
 					}

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1407,10 +1407,9 @@ func getGroupFiles(files []*backuppb.File, supportMulti bool) [][]*backuppb.File
 // SplitRanges implements TiKVRestorer.
 func (rc *Client) SplitRanges(ctx context.Context,
 	ranges []rtree.Range,
-	rewriteRules *RewriteRules,
 	updateCh glue.Progress,
 	isRawKv bool) error {
-	return SplitRanges(ctx, rc, ranges, rewriteRules, updateCh, isRawKv)
+	return SplitRanges(ctx, rc, ranges, updateCh, isRawKv)
 }
 
 func (rc *Client) WrapLogFilesIterWithSplitHelper(logIter LogIter, rules map[int64]*RewriteRules, g glue.Glue, store kv.Storage) (LogIter, error) {

--- a/br/pkg/restore/merge.go
+++ b/br/pkg/restore/merge.go
@@ -7,8 +7,13 @@ import (
 
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/kvproto/pkg/import_sstpb"
+	"github.com/pingcap/log"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
+	"github.com/pingcap/tidb/br/pkg/logutil"
 	"github.com/pingcap/tidb/br/pkg/rtree"
+	"github.com/pingcap/tidb/pkg/tablecodec"
+	"go.uber.org/zap"
 )
 
 const (
@@ -35,7 +40,10 @@ type MergeRangesStat struct {
 // By merging small ranges, it speeds up restoring a backup that contains many
 // small ranges (regions) as it reduces split region and scatter region.
 func MergeFileRanges(
-	files []*backuppb.File, splitSizeBytes, splitKeyCount uint64,
+	files []*backuppb.File,
+	rewriteRules *RewriteRules,
+	splitSizeBytes,
+	splitKeyCount uint64,
 ) ([]rtree.Range, *MergeRangesStat, error) {
 	if len(files) == 0 {
 		return []rtree.Range{}, &MergeRangesStat{}, nil
@@ -78,12 +86,19 @@ func MergeFileRanges(
 		for _, f := range filesMap[key] {
 			rangeSize += f.Size_
 		}
-		if out := rangeTree.InsertRange(rtree.Range{
+		rg := &rtree.Range{
 			StartKey: files[0].GetStartKey(),
 			EndKey:   files[0].GetEndKey(),
 			Files:    files,
 			Size:     rangeSize,
-		}); out != nil {
+		}
+		// rewrite Range for split.
+		// so that splitRanges no need to handle rewrite rules any more.
+		if err := RewriteRange(rg, rewriteRules); err != nil {
+			return nil, nil, errors.Annotatef(berrors.ErrRestoreInvalidRange,
+				"unable to rewrite range files %+v", files)
+		}
+		if out := rangeTree.InsertRange(*rg); out != nil {
 			return nil, nil, errors.Annotatef(berrors.ErrRestoreInvalidRange,
 				"duplicate range %s files %+v", out, files)
 		}
@@ -106,4 +121,41 @@ func MergeFileRanges(
 		MergedRegionKeysAvg:  int(mergedRegionKeysAvg),
 		MergedRegionBytesAvg: int(mergedRegionBytesAvg),
 	}, nil
+}
+
+func RewriteRange(rg *rtree.Range, rewriteRules *RewriteRules) error {
+	if rewriteRules == nil {
+		return nil
+	}
+	startID := tablecodec.DecodeTableID(rg.StartKey)
+	endID := tablecodec.DecodeTableID(rg.EndKey)
+	var rule *import_sstpb.RewriteRule
+	if startID != endID {
+		log.Warn("table id does not match",
+			logutil.Key("startKey", rg.StartKey),
+			logutil.Key("endKey", rg.EndKey),
+			zap.Int64("startID", startID),
+			zap.Int64("endID", endID))
+		return errors.Annotate(berrors.ErrRestoreTableIDMismatch, "table id mismatch")
+	}
+	rg.StartKey, rule = replacePrefix(rg.StartKey, rewriteRules)
+	if rule == nil {
+		log.Warn("cannot find rewrite rule", logutil.Key("key", rg.StartKey))
+	} else {
+		log.Debug(
+			"rewrite start key",
+			logutil.Key("key", rg.StartKey), logutil.RewriteRule(rule))
+	}
+	oldKey := rg.EndKey
+	rg.EndKey, rule = replacePrefix(rg.EndKey, rewriteRules)
+	if rule == nil {
+		log.Warn("cannot find rewrite rule", logutil.Key("key", rg.EndKey))
+	} else {
+		log.Debug(
+			"rewrite end key",
+			logutil.Key("origin-key", oldKey),
+			logutil.Key("key", rg.EndKey),
+			logutil.RewriteRule(rule))
+	}
+	return nil
 }

--- a/br/pkg/restore/merge.go
+++ b/br/pkg/restore/merge.go
@@ -34,12 +34,12 @@ type MergeRangesStat struct {
 	MergedRegionBytesAvg int
 }
 
-// MergeFileRanges returns ranges of the files are merged based on
+// MergeAndRewriteFileRanges returns ranges of the files are merged based on
 // splitSizeBytes and splitKeyCount.
 //
 // By merging small ranges, it speeds up restoring a backup that contains many
 // small ranges (regions) as it reduces split region and scatter region.
-func MergeFileRanges(
+func MergeAndRewriteFileRanges(
 	files []*backuppb.File,
 	rewriteRules *RewriteRules,
 	splitSizeBytes,

--- a/br/pkg/restore/merge_test.go
+++ b/br/pkg/restore/merge_test.go
@@ -208,7 +208,7 @@ func TestMergeRanges(t *testing.T) {
 		for _, f := range cs.files {
 			files = append(files, fb.build(f[0], f[1], f[2], f[3], f[4])...)
 		}
-		rngs, stat, err := restore.MergeFileRanges(files, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
+		rngs, stat, err := restore.MergeFileRanges(files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
 		require.NoErrorf(t, err, "%+v", cs)
 		require.Equalf(t, cs.stat.TotalRegions, stat.TotalRegions, "%+v", cs)
 		require.Equalf(t, cs.stat.MergedRegions, stat.MergedRegions, "%+v", cs)
@@ -231,7 +231,7 @@ func TestMergeRawKVRanges(t *testing.T) {
 	// RawKV does not have write cf
 	files = files[1:]
 	_, stat, err := restore.MergeFileRanges(
-		files, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
+		files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
 	require.NoError(t, err)
 	require.Equal(t, 1, stat.TotalRegions)
 	require.Equal(t, 1, stat.MergedRegions)
@@ -244,7 +244,7 @@ func TestInvalidRanges(t *testing.T) {
 	files[0].Name = "invalid.sst"
 	files[0].Cf = "invalid"
 	_, _, err := restore.MergeFileRanges(
-		files, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
+		files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
 	require.Error(t, err)
 	require.Equal(t, berrors.ErrRestoreInvalidBackup, errors.Cause(err))
 }
@@ -265,7 +265,7 @@ func benchmarkMergeRanges(b *testing.B, filesCount int) {
 	}
 	var err error
 	for i := 0; i < b.N; i++ {
-		_, _, err = restore.MergeFileRanges(files, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
+		_, _, err = restore.MergeFileRanges(files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
 		if err != nil {
 			b.Error(err)
 		}

--- a/br/pkg/restore/merge_test.go
+++ b/br/pkg/restore/merge_test.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/tidb/br/pkg/conn"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/restore"
+	"github.com/pingcap/tidb/br/pkg/rtree"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
@@ -208,7 +210,7 @@ func TestMergeRanges(t *testing.T) {
 		for _, f := range cs.files {
 			files = append(files, fb.build(f[0], f[1], f[2], f[3], f[4])...)
 		}
-		rngs, stat, err := restore.MergeFileRanges(files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
+		rngs, stat, err := restore.MergeAndRewriteFileRanges(files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
 		require.NoErrorf(t, err, "%+v", cs)
 		require.Equalf(t, cs.stat.TotalRegions, stat.TotalRegions, "%+v", cs)
 		require.Equalf(t, cs.stat.MergedRegions, stat.MergedRegions, "%+v", cs)
@@ -230,7 +232,7 @@ func TestMergeRawKVRanges(t *testing.T) {
 	files = append(files, fb.build(1, 0, 2, 1, 1)...)
 	// RawKV does not have write cf
 	files = files[1:]
-	_, stat, err := restore.MergeFileRanges(
+	_, stat, err := restore.MergeAndRewriteFileRanges(
 		files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
 	require.NoError(t, err)
 	require.Equal(t, 1, stat.TotalRegions)
@@ -243,7 +245,7 @@ func TestInvalidRanges(t *testing.T) {
 	files = append(files, fb.build(1, 0, 1, 1, 1)...)
 	files[0].Name = "invalid.sst"
 	files[0].Cf = "invalid"
-	_, _, err := restore.MergeFileRanges(
+	_, _, err := restore.MergeAndRewriteFileRanges(
 		files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
 	require.Error(t, err)
 	require.Equal(t, berrors.ErrRestoreInvalidBackup, errors.Cause(err))
@@ -265,7 +267,7 @@ func benchmarkMergeRanges(b *testing.B, filesCount int) {
 	}
 	var err error
 	for i := 0; i < b.N; i++ {
-		_, _, err = restore.MergeFileRanges(files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
+		_, _, err = restore.MergeAndRewriteFileRanges(files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
 		if err != nil {
 			b.Error(err)
 		}
@@ -290,4 +292,92 @@ func BenchmarkMergeRanges50k(b *testing.B) {
 
 func BenchmarkMergeRanges100k(b *testing.B) {
 	benchmarkMergeRanges(b, 100000)
+}
+func TestRewriteRange(t *testing.T) {
+	// Define test cases
+	cases := []struct {
+		rg            *rtree.Range
+		rewriteRules  *restore.RewriteRules
+		expectedRange *rtree.Range
+		expectedError error
+	}{
+		// Test case 1: No rewrite rules
+		{
+			rg: &rtree.Range{
+				StartKey: []byte("startKey"),
+				EndKey:   []byte("endKey"),
+			},
+			rewriteRules:  nil,
+			expectedRange: &rtree.Range{StartKey: []byte("startKey"), EndKey: []byte("endKey")},
+			expectedError: nil,
+		},
+		// Test case 2: Rewrite rule found for both start key and end key
+		{
+			rg: &rtree.Range{
+				StartKey: append(tablecodec.GenTableIndexPrefix(1), []byte("startKey")...),
+				EndKey:   append(tablecodec.GenTableIndexPrefix(1), []byte("endKey")...),
+			},
+			rewriteRules: &restore.RewriteRules{
+				Data: []*import_sstpb.RewriteRule{
+					{
+						OldKeyPrefix: tablecodec.GenTableIndexPrefix(1),
+						NewKeyPrefix: tablecodec.GenTableIndexPrefix(2),
+					},
+				},
+			},
+			expectedRange: &rtree.Range{
+				StartKey: append(tablecodec.GenTableIndexPrefix(2), []byte("startKey")...),
+				EndKey:   append(tablecodec.GenTableIndexPrefix(2), []byte("endKey")...),
+			},
+			expectedError: nil,
+		},
+		// Test case 3: Rewrite rule found for end key
+		{
+			rg: &rtree.Range{
+				StartKey: append(tablecodec.GenTableIndexPrefix(1), []byte("startKey")...),
+				EndKey:   append(tablecodec.GenTableIndexPrefix(1), []byte("endKey")...),
+			},
+			rewriteRules: &restore.RewriteRules{
+				Data: []*import_sstpb.RewriteRule{
+					{
+						OldKeyPrefix: append(tablecodec.GenTableIndexPrefix(1), []byte("endKey")...),
+						NewKeyPrefix: append(tablecodec.GenTableIndexPrefix(2), []byte("newEndKey")...),
+					},
+				},
+			},
+			expectedRange: &rtree.Range{
+				StartKey: append(tablecodec.GenTableIndexPrefix(1), []byte("startKey")...),
+				EndKey:   append(tablecodec.GenTableIndexPrefix(2), []byte("newEndKey")...),
+			},
+			expectedError: nil,
+		},
+		// Test case 4: Table ID mismatch
+		{
+			rg: &rtree.Range{
+				StartKey: []byte("t1_startKey"),
+				EndKey:   []byte("t2_endKey"),
+			},
+			rewriteRules: &restore.RewriteRules{
+				Data: []*import_sstpb.RewriteRule{
+					{
+						OldKeyPrefix: []byte("t1_startKey"),
+						NewKeyPrefix: []byte("t2_newStartKey"),
+					},
+				},
+			},
+			expectedRange: nil,
+			expectedError: errors.Annotate(berrors.ErrRestoreTableIDMismatch, "table id mismatch"),
+		},
+	}
+
+	// Run test cases
+	for _, tc := range cases {
+		actualRange, actualError := restore.RewriteRange(tc.rg, tc.rewriteRules)
+		if tc.expectedError != nil {
+			require.EqualError(t, tc.expectedError, actualError.Error())
+		} else {
+			require.NoError(t, actualError)
+		}
+		require.Equal(t, tc.expectedRange, actualRange)
+	}
 }

--- a/br/pkg/restore/pipeline_items.go
+++ b/br/pkg/restore/pipeline_items.go
@@ -161,6 +161,7 @@ func DefaultOutputTableChan() chan *CreatedTable {
 type TableWithRange struct {
 	CreatedTable
 
+	// Range has been rewrited by rewrite rules.
 	Range []rtree.Range
 }
 
@@ -168,7 +169,7 @@ type TableIDWithFiles struct {
 	TableID int64
 
 	Files []*backuppb.File
-	// Rules is the rewrite rules for the specify table.
+	// RewriteRules is the rewrite rules for the specify table.
 	// because these rules belongs to the *one table*.
 	// we can hold them here.
 	RewriteRules *RewriteRules

--- a/br/pkg/restore/pipeline_items.go
+++ b/br/pkg/restore/pipeline_items.go
@@ -203,7 +203,6 @@ type TiKVRestorer interface {
 	// After spliting, it also scatters the fresh regions.
 	SplitRanges(ctx context.Context,
 		ranges []rtree.Range,
-		rewriteRules *RewriteRules,
 		updateCh glue.Progress,
 		isRawKv bool) error
 	// RestoreSSTFiles import the files to the TiKV.
@@ -351,7 +350,7 @@ func (b *tikvSender) splitWorker(ctx context.Context,
 			// hence the checksum would fail.
 			done := b.registerTableIsRestoring(result.TablesToSend)
 			pool.ApplyOnErrorGroup(eg, func() error {
-				err := b.client.SplitRanges(ectx, result.Ranges, result.RewriteRules, b.updateCh, false)
+				err := b.client.SplitRanges(ectx, result.Ranges, b.updateCh, false)
 				if err != nil {
 					log.Error("failed on split range", rtree.ZapRanges(result.Ranges), zap.Error(err))
 					return err

--- a/br/pkg/restore/range.go
+++ b/br/pkg/restore/range.go
@@ -9,8 +9,6 @@ import (
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/logutil"
 	"github.com/pingcap/tidb/br/pkg/rtree"
-	"github.com/pingcap/tidb/pkg/tablecodec"
-	"go.uber.org/zap"
 )
 
 // Range record start and end key for localStoreDir.DB
@@ -24,38 +22,6 @@ type Range struct {
 func SortRanges(ranges []rtree.Range) ([]rtree.Range, error) {
 	rangeTree := rtree.NewRangeTree()
 	for _, rg := range ranges {
-		if rg.RewriteRules != nil {
-			startID := tablecodec.DecodeTableID(rg.StartKey)
-			endID := tablecodec.DecodeTableID(rg.EndKey)
-			var rule *import_sstpb.RewriteRule
-			if startID != endID {
-				log.Warn("table id does not match",
-					logutil.Key("startKey", rg.StartKey),
-					logutil.Key("endKey", rg.EndKey),
-					zap.Int64("startID", startID),
-					zap.Int64("endID", endID))
-				return nil, errors.Annotate(berrors.ErrRestoreTableIDMismatch, "table id mismatch")
-			}
-			rg.StartKey, rule = replacePrefix(rg.StartKey, rg.RewriteRules)
-			if rule == nil {
-				log.Warn("cannot find rewrite rule", logutil.Key("key", rg.StartKey))
-			} else {
-				log.Debug(
-					"rewrite start key",
-					logutil.Key("key", rg.StartKey), logutil.RewriteRule(rule))
-			}
-			oldKey := rg.EndKey
-			rg.EndKey, rule = replacePrefix(rg.EndKey, rg.RewriteRules)
-			if rule == nil {
-				log.Warn("cannot find rewrite rule", logutil.Key("key", rg.EndKey))
-			} else {
-				log.Debug(
-					"rewrite end key",
-					logutil.Key("origin-key", oldKey),
-					logutil.Key("key", rg.EndKey),
-					logutil.RewriteRule(rule))
-			}
-		}
 		if out := rangeTree.InsertRange(rg); out != nil {
 			log.Error("insert ranges overlapped",
 				logutil.Key("startKeyOut", out.StartKey),

--- a/br/pkg/restore/range.go
+++ b/br/pkg/restore/range.go
@@ -21,10 +21,10 @@ type Range struct {
 }
 
 // SortRanges checks if the range overlapped and sort them.
-func SortRanges(ranges []rtree.Range, rewriteRules *RewriteRules) ([]rtree.Range, error) {
+func SortRanges(ranges []rtree.Range) ([]rtree.Range, error) {
 	rangeTree := rtree.NewRangeTree()
 	for _, rg := range ranges {
-		if rewriteRules != nil {
+		if rg.RewriteRules != nil {
 			startID := tablecodec.DecodeTableID(rg.StartKey)
 			endID := tablecodec.DecodeTableID(rg.EndKey)
 			var rule *import_sstpb.RewriteRule
@@ -36,7 +36,7 @@ func SortRanges(ranges []rtree.Range, rewriteRules *RewriteRules) ([]rtree.Range
 					zap.Int64("endID", endID))
 				return nil, errors.Annotate(berrors.ErrRestoreTableIDMismatch, "table id mismatch")
 			}
-			rg.StartKey, rule = replacePrefix(rg.StartKey, rewriteRules)
+			rg.StartKey, rule = replacePrefix(rg.StartKey, rg.RewriteRules)
 			if rule == nil {
 				log.Warn("cannot find rewrite rule", logutil.Key("key", rg.StartKey))
 			} else {
@@ -45,7 +45,7 @@ func SortRanges(ranges []rtree.Range, rewriteRules *RewriteRules) ([]rtree.Range
 					logutil.Key("key", rg.StartKey), logutil.RewriteRule(rule))
 			}
 			oldKey := rg.EndKey
-			rg.EndKey, rule = replacePrefix(rg.EndKey, rewriteRules)
+			rg.EndKey, rule = replacePrefix(rg.EndKey, rg.RewriteRules)
 			if rule == nil {
 				log.Warn("cannot find rewrite rule", logutil.Key("key", rg.EndKey))
 			} else {

--- a/br/pkg/restore/range.go
+++ b/br/pkg/restore/range.go
@@ -81,6 +81,11 @@ func (r *RewriteRules) Append(other RewriteRules) {
 	r.Data = append(r.Data, other.Data...)
 }
 
+// EmptyRewriteRule make a map of new, empty rewrite rules.
+func EmptyRewriteRulesMap() map[int64]*RewriteRules {
+	return make(map[int64]*RewriteRules)
+}
+
 // EmptyRewriteRule make a new, empty rewrite rule.
 func EmptyRewriteRule() *RewriteRules {
 	return &RewriteRules{

--- a/br/pkg/restore/range_test.go
+++ b/br/pkg/restore/range_test.go
@@ -33,8 +33,9 @@ func TestSortRange(t *testing.T) {
 			EndKey:   append(tablecodec.GenTableRecordPrefix(1), []byte("bbb")...), Files: nil,
 		},
 	}
-	for _, rg := range ranges1 {
-		RewriteRange(&rg, rewriteRules)
+	for i, rg := range ranges1 {
+		tmp, _ := RewriteRange(&rg, rewriteRules)
+		ranges1[i] = *tmp
 	}
 	rs1, err := SortRanges(ranges1)
 	require.NoErrorf(t, err, "sort range1 failed: %v", err)
@@ -52,16 +53,16 @@ func TestSortRange(t *testing.T) {
 		},
 	}
 	for _, rg := range ranges2 {
-		RewriteRange(&rg, rewriteRules)
+		_, err := RewriteRange(&rg, rewriteRules)
+		require.Error(t, err)
+		require.Regexp(t, "table id mismatch.*", err.Error())
 	}
-	_, err = SortRanges(ranges2)
-	require.Error(t, err)
-	require.Regexp(t, "table id mismatch.*", err.Error())
 
 	ranges3 := initRanges()
 	rewriteRules1 := initRewriteRules()
-	for _, rg := range ranges3 {
-		RewriteRange(&rg, rewriteRules1)
+	for i, rg := range ranges3 {
+		tmp, _ := RewriteRange(&rg, rewriteRules1)
+		ranges3[i] = *tmp
 	}
 	rs3, err := SortRanges(ranges3)
 	require.NoErrorf(t, err, "sort range1 failed: %v", err)

--- a/br/pkg/restore/range_test.go
+++ b/br/pkg/restore/range_test.go
@@ -33,7 +33,10 @@ func TestSortRange(t *testing.T) {
 			EndKey:   append(tablecodec.GenTableRecordPrefix(1), []byte("bbb")...), Files: nil,
 		},
 	}
-	rs1, err := SortRanges(ranges1, rewriteRules)
+	for _, rg := range ranges1 {
+		RewriteRange(&rg, rewriteRules)
+	}
+	rs1, err := SortRanges(ranges1)
 	require.NoErrorf(t, err, "sort range1 failed: %v", err)
 	rangeEquals(t, rs1, []rtree.Range{
 		{
@@ -48,13 +51,19 @@ func TestSortRange(t *testing.T) {
 			EndKey:   append(tablecodec.GenTableRecordPrefix(2), []byte("bbb")...), Files: nil,
 		},
 	}
-	_, err = SortRanges(ranges2, rewriteRules)
+	for _, rg := range ranges2 {
+		RewriteRange(&rg, rewriteRules)
+	}
+	_, err = SortRanges(ranges2)
 	require.Error(t, err)
 	require.Regexp(t, "table id mismatch.*", err.Error())
 
 	ranges3 := initRanges()
 	rewriteRules1 := initRewriteRules()
-	rs3, err := SortRanges(ranges3, rewriteRules1)
+	for _, rg := range ranges3 {
+		RewriteRange(&rg, rewriteRules1)
+	}
+	rs3, err := SortRanges(ranges3)
 	require.NoErrorf(t, err, "sort range1 failed: %v", err)
 	rangeEquals(t, rs3, []rtree.Range{
 		{StartKey: []byte("bbd"), EndKey: []byte("bbf"), Files: nil},

--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -64,7 +64,6 @@ type OnSplitFunc func(key [][]byte)
 func (rs *RegionSplitter) ExecuteSplit(
 	ctx context.Context,
 	ranges []rtree.Range,
-	rewriteRules *RewriteRules,
 	storeCount int,
 	isRawKv bool,
 	onSplit OnSplitFunc,
@@ -82,7 +81,7 @@ func (rs *RegionSplitter) ExecuteSplit(
 
 	// Sort the range for getting the min and max key of the ranges
 	// TODO: this sort may not needed if we sort tables after creatation outside.
-	sortedRanges, errSplit := SortRanges(ranges, rewriteRules)
+	sortedRanges, errSplit := SortRanges(ranges)
 	if errSplit != nil {
 		return errors.Trace(errSplit)
 	}
@@ -625,7 +624,7 @@ func (helper *LogSplitHelper) splitRegionByPoints(
 				startKey = point
 			}
 
-			return regionSplitter.ExecuteSplit(ctx, ranges, nil, 3, false, func([][]byte) {})
+			return regionSplitter.ExecuteSplit(ctx, ranges, 3, false, func([][]byte) {})
 		}
 		select {
 		case <-ctx.Done():

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -627,7 +627,7 @@ type fakeRestorer struct {
 	tableIDIsInsequence bool
 }
 
-func (f *fakeRestorer) SplitRanges(ctx context.Context, ranges []rtree.Range, rewriteRules *RewriteRules, updateCh glue.Progress, isRawKv bool) error {
+func (f *fakeRestorer) SplitRanges(ctx context.Context, ranges []rtree.Range, updateCh glue.Progress, isRawKv bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -375,8 +375,14 @@ func runWaitScatter(t *testing.T, client *TestClient) {
 func runTestSplitAndScatterWith(t *testing.T, client *TestClient) {
 	ranges := initRanges()
 	regionSplitter := NewRegionSplitter(client)
-
 	ctx := context.Background()
+
+	rules := initRewriteRules()
+	for i, rg := range ranges {
+		tmp, err := RewriteRange(&rg, rules)
+		require.NoError(t, err)
+		ranges[i] = *tmp
+	}
 	err := regionSplitter.ExecuteSplit(ctx, ranges, 1, false, func(key [][]byte) {})
 	require.NoError(t, err)
 	regions := client.GetAllRegions()

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -249,11 +249,10 @@ func TestScanEmptyRegion(t *testing.T) {
 	ranges := initRanges()
 	// make ranges has only one
 	ranges = ranges[0:1]
-	rewriteRules := initRewriteRules()
 	regionSplitter := NewRegionSplitter(client)
 
 	ctx := context.Background()
-	err := regionSplitter.ExecuteSplit(ctx, ranges, rewriteRules, 1, false, func(key [][]byte) {})
+	err := regionSplitter.ExecuteSplit(ctx, ranges, 1, false, func(key [][]byte) {})
 	// should not return error with only one range entry
 	require.NoError(t, err)
 }
@@ -375,11 +374,10 @@ func runWaitScatter(t *testing.T, client *TestClient) {
 
 func runTestSplitAndScatterWith(t *testing.T, client *TestClient) {
 	ranges := initRanges()
-	rewriteRules := initRewriteRules()
 	regionSplitter := NewRegionSplitter(client)
 
 	ctx := context.Background()
-	err := regionSplitter.ExecuteSplit(ctx, ranges, rewriteRules, 1, false, func(key [][]byte) {})
+	err := regionSplitter.ExecuteSplit(ctx, ranges, 1, false, func(key [][]byte) {})
 	require.NoError(t, err)
 	regions := client.GetAllRegions()
 	if !validateRegions(regions) {
@@ -426,7 +424,7 @@ func TestRawSplit(t *testing.T) {
 	ctx := context.Background()
 
 	regionSplitter := NewRegionSplitter(client)
-	err := regionSplitter.ExecuteSplit(ctx, ranges, nil, 1, true, func(key [][]byte) {})
+	err := regionSplitter.ExecuteSplit(ctx, ranges, 1, true, func(key [][]byte) {})
 	require.NoError(t, err)
 	regions := client.GetAllRegions()
 	expectedKeys := []string{"", "aay", "bba", "bbh", "cca", ""}
@@ -644,7 +642,7 @@ func (f *fakeRestorer) SplitRanges(ctx context.Context, ranges []rtree.Range, up
 	return nil
 }
 
-func (f *fakeRestorer) RestoreSSTFiles(ctx context.Context, tableIDWithFiles []TableIDWithFiles, rewriteRules *RewriteRules, updateCh glue.Progress) error {
+func (f *fakeRestorer) RestoreSSTFiles(ctx context.Context, tableIDWithFiles []TableIDWithFiles, updateCh glue.Progress) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/br/pkg/restore/util.go
+++ b/br/pkg/restore/util.go
@@ -366,7 +366,7 @@ func GoValidateFileRanges(
 					}
 				}
 				// Merge small ranges to reduce split and scatter regions.
-				ranges, stat, err := MergeFileRanges(
+				ranges, stat, err := MergeAndRewriteFileRanges(
 					files, t.RewriteRule, splitSizeBytes, splitKeyCount)
 				if err != nil {
 					errCh <- err

--- a/br/pkg/restore/util.go
+++ b/br/pkg/restore/util.go
@@ -367,7 +367,7 @@ func GoValidateFileRanges(
 				}
 				// Merge small ranges to reduce split and scatter regions.
 				ranges, stat, err := MergeFileRanges(
-					files, splitSizeBytes, splitKeyCount)
+					files, t.RewriteRule, splitSizeBytes, splitKeyCount)
 				if err != nil {
 					errCh <- err
 					return

--- a/br/pkg/restore/util.go
+++ b/br/pkg/restore/util.go
@@ -507,7 +507,6 @@ func SplitRanges(
 	ctx context.Context,
 	client *Client,
 	ranges []rtree.Range,
-	rewriteRules *RewriteRules,
 	updateCh glue.Progress,
 	isRawKv bool,
 ) error {
@@ -518,7 +517,7 @@ func SplitRanges(
 		isRawKv,
 	))
 
-	return splitter.ExecuteSplit(ctx, ranges, rewriteRules, client.GetStoreCount(), isRawKv, func(keys [][]byte) {
+	return splitter.ExecuteSplit(ctx, ranges, client.GetStoreCount(), isRawKv, func(keys [][]byte) {
 		for range keys {
 			updateCh.Inc()
 		}

--- a/br/pkg/rtree/rtree.go
+++ b/br/pkg/rtree/rtree.go
@@ -9,6 +9,7 @@ import (
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/logutil"
+	"github.com/pingcap/tidb/br/pkg/restore"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 )
@@ -18,7 +19,10 @@ type Range struct {
 	StartKey []byte
 	EndKey   []byte
 	Files    []*backuppb.File
-	Size     uint64
+	// Rules is the rewrite rules for the range.
+	// the range belongs to the *one table*.
+	RewriteRules *restore.RewriteRules
+	Size         uint64
 }
 
 // BytesAndKeys returns total bytes and keys in a range.

--- a/br/pkg/rtree/rtree.go
+++ b/br/pkg/rtree/rtree.go
@@ -9,7 +9,6 @@ import (
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/logutil"
-	"github.com/pingcap/tidb/br/pkg/restore"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 )
@@ -19,10 +18,7 @@ type Range struct {
 	StartKey []byte
 	EndKey   []byte
 	Files    []*backuppb.File
-	// Rules is the rewrite rules for the range.
-	// the range belongs to the *one table*.
-	RewriteRules *restore.RewriteRules
-	Size         uint64
+	Size     uint64
 }
 
 // BytesAndKeys returns total bytes and keys in a range.

--- a/br/pkg/task/restore_raw.go
+++ b/br/pkg/task/restore_raw.go
@@ -137,7 +137,7 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 	}
 	summary.CollectInt("restore files", len(files))
 
-	ranges, _, err := restore.MergeFileRanges(
+	ranges, _, err := restore.MergeAndRewriteFileRanges(
 		files, nil, kvConfigs.MergeRegionSize.Value, kvConfigs.MergeRegionKeyCount.Value)
 	if err != nil {
 		return errors.Trace(err)

--- a/br/pkg/task/restore_raw.go
+++ b/br/pkg/task/restore_raw.go
@@ -138,7 +138,7 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 	summary.CollectInt("restore files", len(files))
 
 	ranges, _, err := restore.MergeFileRanges(
-		files, kvConfigs.MergeRegionSize.Value, kvConfigs.MergeRegionKeyCount.Value)
+		files, nil, kvConfigs.MergeRegionSize.Value, kvConfigs.MergeRegionKeyCount.Value)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -153,7 +153,7 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 		!cfg.LogProgress)
 
 	// RawKV restore does not need to rewrite keys.
-	err = restore.SplitRanges(ctx, client, ranges, nil, updateCh, true)
+	err = restore.SplitRanges(ctx, client, ranges, updateCh, true)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/restore_txn.go
+++ b/br/pkg/task/restore_txn.go
@@ -93,7 +93,7 @@ func RunRestoreTxn(c context.Context, g glue.Glue, cmdName string, cfg *Config) 
 		!cfg.LogProgress)
 
 	// RawKV restore does not need to rewrite keys.
-	err = restore.SplitRanges(ctx, client, ranges, nil, updateCh, false)
+	err = restore.SplitRanges(ctx, client, ranges, updateCh, false)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/restore_txn.go
+++ b/br/pkg/task/restore_txn.go
@@ -79,7 +79,7 @@ func RunRestoreTxn(c context.Context, g glue.Glue, cmdName string, cfg *Config) 
 	summary.CollectInt("restore files", len(files))
 
 	ranges, _, err := restore.MergeFileRanges(
-		files, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
+		files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/restore_txn.go
+++ b/br/pkg/task/restore_txn.go
@@ -78,7 +78,7 @@ func RunRestoreTxn(c context.Context, g glue.Glue, cmdName string, cfg *Config) 
 	}
 	summary.CollectInt("restore files", len(files))
 
-	ranges, _, err := restore.MergeFileRanges(
+	ranges, _, err := restore.MergeAndRewriteFileRanges(
 		files, nil, conn.DefaultMergeRegionSizeBytes, conn.DefaultMergeRegionKeyCount)
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/51685

Problem Summary:
1. when handing files of drainRange result. restore will check the match rewrite rules for each file. this time could be saved when flatten the rewrite rules with map. 

### What changed and how does it work?
1. speed up handling millions of rewrite rules with new split approach by move rewrite ranges forward.
2. reduce the memory allocation of files object copy.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
