### PR TITLE
planner: allow the optimizer to cache query plans accessing generated columns by default

### DIFF
--- a/pkg/executor/explainfor_test.go
+++ b/pkg/executor/explainfor_test.go
@@ -707,8 +707,7 @@ func TestIndexMerge4PlanCache(t *testing.T) {
 	tk.MustExec("prepare stmt from 'SELECT /*+ USE_INDEX_MERGE(t0, i0, PRIMARY)*/ t0.c0 FROM t0 WHERE t0.c1 OR t0.c0;';")
 	tk.MustQuery("execute stmt;").Check(testkit.Rows("1"))
 	tk.MustQuery("execute stmt;").Check(testkit.Rows("1"))
-	// The plan contains the generated column, so it can not be cached.
-	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("0"))
+	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("1"))
 
 	tk.MustExec("drop table if exists t1, t2")
 	tk.MustExec("create table t1(id int primary key, a int, b int, c int, d int)")

--- a/pkg/planner/core/plan_cache_test.go
+++ b/pkg/planner/core/plan_cache_test.go
@@ -1005,6 +1005,8 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"select distinct a from t1 where a > 1 and b < 2",          // distinct
 		"select count(*) from t1 where a > 1 and b < 2 group by a", // group by
 		"select * from t1 order by a",                              // order by
+		"select * from t3 where full_name = 'a b'",                 // generated column
+		"select * from t3 where a > 1 and full_name = 'a b'",
 	}
 
 	unsupported := []string{
@@ -1022,8 +1024,6 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"select * from t where bt > 0", // bit
 		"select * from t where a > 1 and bt > 0",
 		"select data_type from INFORMATION_SCHEMA.columns where table_name = 'v'", // memTable
-		"select * from t3 where full_name = 'a b'",                                // generated column
-		"select * from t3 where a > 1 and full_name = 'a b'",
 		"select * from v",                // view
 		"select * from t where a = null", // null
 		"select * from t where false",    // table dual
@@ -1044,8 +1044,6 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"skip non-prepared plan-cache: query has some filters with JSON, Enum, Set or Bit columns",
 		"skip non-prepared plan-cache: query has some filters with JSON, Enum, Set or Bit columns",
 		"skip non-prepared plan-cache: access tables in system schema",
-		"skip non-prepared plan-cache: query accesses generated columns is un-cacheable",
-		"skip non-prepared plan-cache: query accesses generated columns is un-cacheable",
 		"skip non-prepared plan-cache: queries that access views are not supported",
 		"skip non-prepared plan-cache: query has null constants",
 		"skip non-prepared plan-cache: some parameters may be overwritten when constant propagation",

--- a/pkg/planner/core/plan_cacheable_checker.go
+++ b/pkg/planner/core/plan_cacheable_checker.go
@@ -622,10 +622,11 @@ func getMaxParamLimit(sctx PlanContext) int {
 func enablePlanCacheForGeneratedCols(sctx PlanContext) bool {
 	// disable this by default since it's not well tested.
 	// TODO: complete its test and enable it by default.
+	defaultVal := true
 	if sctx == nil || sctx.GetSessionVars() == nil || sctx.GetSessionVars().GetOptimizerFixControlMap() == nil {
-		return false
+		return defaultVal
 	}
-	return fixcontrol.GetBoolWithDefault(sctx.GetSessionVars().GetOptimizerFixControlMap(), fixcontrol.Fix45798, false)
+	return fixcontrol.GetBoolWithDefault(sctx.GetSessionVars().GetOptimizerFixControlMap(), fixcontrol.Fix45798, defaultVal)
 }
 
 // checkTableCacheable checks whether a query accessing this table is cacheable.

--- a/pkg/planner/core/plan_cacheable_checker.go
+++ b/pkg/planner/core/plan_cacheable_checker.go
@@ -621,7 +621,6 @@ func getMaxParamLimit(sctx PlanContext) int {
 
 func enablePlanCacheForGeneratedCols(sctx PlanContext) bool {
 	// disable this by default since it's not well tested.
-	// TODO: complete its test and enable it by default.
 	defaultVal := true
 	if sctx == nil || sctx.GetSessionVars() == nil || sctx.GetSessionVars().GetOptimizerFixControlMap() == nil {
 		return defaultVal

--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -470,15 +470,13 @@ Selection	23.98	root		json_overlaps(json_extract(planner__core__indexmerge_path.
 drop table if exists t;
 create table t(j json, index kj((cast(j as signed array))));
 prepare st from 'select /*+ use_index_merge(t, kj) */ * from t where (1 member of (j))';
-Level	Code	Message
-Warning	1105	skip prepared plan-cache: query accesses generated columns is un-cacheable
 execute st;
 j
 execute st;
 j
 select @@last_plan_from_cache;
 @@last_plan_from_cache
-0
+1
 drop table if exists t;
 create table t(j json, unique kj((cast(j as signed array))));
 explain select j from t where j=1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45798

Problem Summary: planner: allow the optimizer to cache query plans accessing generated columns by default

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
