### PR TITLE
expression: force scalar expression to implement `RequireOptionalEvalProps` explicitly

### DIFF
--- a/pkg/expression/builtin.go
+++ b/pkg/expression/builtin.go
@@ -46,6 +46,16 @@ import (
 	"github.com/pingcap/tipb/go-tipb"
 )
 
+var _ contextopt.RequireOptionalEvalProps = notRequireOptionalEvalProps{}
+
+// notRequireOptionalEvalProps indicates the function does not require any optional properties.
+type notRequireOptionalEvalProps struct{}
+
+// RequiredOptionalEvalProps implements the RequireOptionalEvalProps interface.
+func (notRequireOptionalEvalProps) RequiredOptionalEvalProps() (set OptionalEvalPropKeySet) {
+	return
+}
+
 // baseBuiltinFunc will be contained in every struct that implement builtinFunc interface.
 type baseBuiltinFunc struct {
 	bufAllocator columnBufferAllocator
@@ -62,10 +72,6 @@ type baseBuiltinFunc struct {
 
 func (b *baseBuiltinFunc) PbCode() tipb.ScalarFuncSig {
 	return b.pbCode
-}
-
-func (*baseBuiltinFunc) RequiredOptionalEvalProps() (set OptionalEvalPropKeySet) {
-	return
 }
 
 // metadata returns the metadata of a function.
@@ -423,6 +429,7 @@ func (*baseBuiltinFunc) Clone() builtinFunc {
 // baseBuiltinCastFunc will be contained in every struct that implement cast builtinFunc.
 type baseBuiltinCastFunc struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	// inUnion indicates whether cast is in union context.
 	inUnion bool

--- a/pkg/expression/builtin_arithmetic.go
+++ b/pkg/expression/builtin_arithmetic.go
@@ -177,7 +177,7 @@ func (c *arithmeticPlusFunctionClass) getFunction(ctx BuildContext, args []Expre
 			return nil, err
 		}
 		setFlenDecimal4RealOrDecimal(bf.tp, args[0], args[1], true, false)
-		sig := &builtinArithmeticPlusRealSig{bf}
+		sig := &builtinArithmeticPlusRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_PlusReal)
 		return sig, nil
 	} else if lhsEvalTp == types.ETDecimal || rhsEvalTp == types.ETDecimal {
@@ -186,7 +186,7 @@ func (c *arithmeticPlusFunctionClass) getFunction(ctx BuildContext, args []Expre
 			return nil, err
 		}
 		setFlenDecimal4RealOrDecimal(bf.tp, args[0], args[1], false, false)
-		sig := &builtinArithmeticPlusDecimalSig{bf}
+		sig := &builtinArithmeticPlusDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_PlusDecimal)
 		return sig, nil
 	}
@@ -197,13 +197,14 @@ func (c *arithmeticPlusFunctionClass) getFunction(ctx BuildContext, args []Expre
 	if mysql.HasUnsignedFlag(args[0].GetType().GetFlag()) || mysql.HasUnsignedFlag(args[1].GetType().GetFlag()) {
 		bf.tp.AddFlag(mysql.UnsignedFlag)
 	}
-	sig := &builtinArithmeticPlusIntSig{bf}
+	sig := &builtinArithmeticPlusIntSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_PlusInt)
 	return sig, nil
 }
 
 type builtinArithmeticPlusIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticPlusIntSig) Clone() builtinFunc {
@@ -256,6 +257,7 @@ func (s *builtinArithmeticPlusIntSig) evalInt(ctx EvalContext, row chunk.Row) (v
 
 type builtinArithmeticPlusDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticPlusDecimalSig) Clone() builtinFunc {
@@ -286,6 +288,7 @@ func (s *builtinArithmeticPlusDecimalSig) evalDecimal(ctx EvalContext, row chunk
 
 type builtinArithmeticPlusRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticPlusRealSig) Clone() builtinFunc {
@@ -327,7 +330,7 @@ func (c *arithmeticMinusFunctionClass) getFunction(ctx BuildContext, args []Expr
 			return nil, err
 		}
 		setFlenDecimal4RealOrDecimal(bf.tp, args[0], args[1], true, false)
-		sig := &builtinArithmeticMinusRealSig{bf}
+		sig := &builtinArithmeticMinusRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_MinusReal)
 		return sig, nil
 	} else if lhsEvalTp == types.ETDecimal || rhsEvalTp == types.ETDecimal {
@@ -336,7 +339,7 @@ func (c *arithmeticMinusFunctionClass) getFunction(ctx BuildContext, args []Expr
 			return nil, err
 		}
 		setFlenDecimal4RealOrDecimal(bf.tp, args[0], args[1], false, false)
-		sig := &builtinArithmeticMinusDecimalSig{bf}
+		sig := &builtinArithmeticMinusDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_MinusDecimal)
 		return sig, nil
 	}
@@ -354,6 +357,7 @@ func (c *arithmeticMinusFunctionClass) getFunction(ctx BuildContext, args []Expr
 
 type builtinArithmeticMinusRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticMinusRealSig) Clone() builtinFunc {
@@ -379,6 +383,7 @@ func (s *builtinArithmeticMinusRealSig) evalReal(ctx EvalContext, row chunk.Row)
 
 type builtinArithmeticMinusDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticMinusDecimalSig) Clone() builtinFunc {
@@ -409,6 +414,7 @@ func (s *builtinArithmeticMinusDecimalSig) evalDecimal(ctx EvalContext, row chun
 
 type builtinArithmeticMinusIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticMinusIntSig) Clone() builtinFunc {
@@ -511,7 +517,7 @@ func (c *arithmeticMultiplyFunctionClass) getFunction(ctx BuildContext, args []E
 			return nil, err
 		}
 		setFlenDecimal4RealOrDecimal(bf.tp, args[0], args[1], true, true)
-		sig := &builtinArithmeticMultiplyRealSig{bf}
+		sig := &builtinArithmeticMultiplyRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_MultiplyReal)
 		return sig, nil
 	} else if lhsEvalTp == types.ETDecimal || rhsEvalTp == types.ETDecimal {
@@ -520,7 +526,7 @@ func (c *arithmeticMultiplyFunctionClass) getFunction(ctx BuildContext, args []E
 			return nil, err
 		}
 		setFlenDecimal4RealOrDecimal(bf.tp, args[0], args[1], false, true)
-		sig := &builtinArithmeticMultiplyDecimalSig{bf}
+		sig := &builtinArithmeticMultiplyDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_MultiplyDecimal)
 		return sig, nil
 	}
@@ -530,16 +536,19 @@ func (c *arithmeticMultiplyFunctionClass) getFunction(ctx BuildContext, args []E
 	}
 	if mysql.HasUnsignedFlag(lhsTp.GetFlag()) || mysql.HasUnsignedFlag(rhsTp.GetFlag()) {
 		bf.tp.AddFlag(mysql.UnsignedFlag)
-		sig := &builtinArithmeticMultiplyIntUnsignedSig{bf}
+		sig := &builtinArithmeticMultiplyIntUnsignedSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_MultiplyIntUnsigned)
 		return sig, nil
 	}
-	sig := &builtinArithmeticMultiplyIntSig{bf}
+	sig := &builtinArithmeticMultiplyIntSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_MultiplyInt)
 	return sig, nil
 }
 
-type builtinArithmeticMultiplyRealSig struct{ baseBuiltinFunc }
+type builtinArithmeticMultiplyRealSig struct {
+	baseBuiltinFunc
+	notRequireOptionalEvalProps
+}
 
 func (s *builtinArithmeticMultiplyRealSig) Clone() builtinFunc {
 	newSig := &builtinArithmeticMultiplyRealSig{}
@@ -547,7 +556,10 @@ func (s *builtinArithmeticMultiplyRealSig) Clone() builtinFunc {
 	return newSig
 }
 
-type builtinArithmeticMultiplyDecimalSig struct{ baseBuiltinFunc }
+type builtinArithmeticMultiplyDecimalSig struct {
+	baseBuiltinFunc
+	notRequireOptionalEvalProps
+}
 
 func (s *builtinArithmeticMultiplyDecimalSig) Clone() builtinFunc {
 	newSig := &builtinArithmeticMultiplyDecimalSig{}
@@ -555,7 +567,10 @@ func (s *builtinArithmeticMultiplyDecimalSig) Clone() builtinFunc {
 	return newSig
 }
 
-type builtinArithmeticMultiplyIntUnsignedSig struct{ baseBuiltinFunc }
+type builtinArithmeticMultiplyIntUnsignedSig struct {
+	baseBuiltinFunc
+	notRequireOptionalEvalProps
+}
 
 func (s *builtinArithmeticMultiplyIntUnsignedSig) Clone() builtinFunc {
 	newSig := &builtinArithmeticMultiplyIntUnsignedSig{}
@@ -563,7 +578,10 @@ func (s *builtinArithmeticMultiplyIntUnsignedSig) Clone() builtinFunc {
 	return newSig
 }
 
-type builtinArithmeticMultiplyIntSig struct{ baseBuiltinFunc }
+type builtinArithmeticMultiplyIntSig struct {
+	baseBuiltinFunc
+	notRequireOptionalEvalProps
+}
 
 func (s *builtinArithmeticMultiplyIntSig) Clone() builtinFunc {
 	newSig := &builtinArithmeticMultiplyIntSig{}
@@ -657,7 +675,7 @@ func (c *arithmeticDivideFunctionClass) getFunction(ctx BuildContext, args []Exp
 			return nil, err
 		}
 		c.setType4DivReal(bf.tp)
-		sig := &builtinArithmeticDivideRealSig{bf}
+		sig := &builtinArithmeticDivideRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_DivideReal)
 		return sig, nil
 	}
@@ -666,12 +684,15 @@ func (c *arithmeticDivideFunctionClass) getFunction(ctx BuildContext, args []Exp
 		return nil, err
 	}
 	c.setType4DivDecimal(bf.tp, lhsTp, rhsTp)
-	sig := &builtinArithmeticDivideDecimalSig{bf}
+	sig := &builtinArithmeticDivideDecimalSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DivideDecimal)
 	return sig, nil
 }
 
-type builtinArithmeticDivideRealSig struct{ baseBuiltinFunc }
+type builtinArithmeticDivideRealSig struct {
+	baseBuiltinFunc
+	notRequireOptionalEvalProps
+}
 
 func (s *builtinArithmeticDivideRealSig) Clone() builtinFunc {
 	newSig := &builtinArithmeticDivideRealSig{}
@@ -679,7 +700,10 @@ func (s *builtinArithmeticDivideRealSig) Clone() builtinFunc {
 	return newSig
 }
 
-type builtinArithmeticDivideDecimalSig struct{ baseBuiltinFunc }
+type builtinArithmeticDivideDecimalSig struct {
+	baseBuiltinFunc
+	notRequireOptionalEvalProps
+}
 
 func (s *builtinArithmeticDivideDecimalSig) Clone() builtinFunc {
 	newSig := &builtinArithmeticDivideDecimalSig{}
@@ -753,7 +777,7 @@ func (c *arithmeticIntDivideFunctionClass) getFunction(ctx BuildContext, args []
 		if mysql.HasUnsignedFlag(lhsTp.GetFlag()) || mysql.HasUnsignedFlag(rhsTp.GetFlag()) {
 			bf.tp.AddFlag(mysql.UnsignedFlag)
 		}
-		sig := &builtinArithmeticIntDivideIntSig{bf}
+		sig := &builtinArithmeticIntDivideIntSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IntDivideInt)
 		return sig, nil
 	}
@@ -764,12 +788,15 @@ func (c *arithmeticIntDivideFunctionClass) getFunction(ctx BuildContext, args []
 	if mysql.HasUnsignedFlag(lhsTp.GetFlag()) || mysql.HasUnsignedFlag(rhsTp.GetFlag()) {
 		bf.tp.AddFlag(mysql.UnsignedFlag)
 	}
-	sig := &builtinArithmeticIntDivideDecimalSig{bf}
+	sig := &builtinArithmeticIntDivideDecimalSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_IntDivideDecimal)
 	return sig, nil
 }
 
-type builtinArithmeticIntDivideIntSig struct{ baseBuiltinFunc }
+type builtinArithmeticIntDivideIntSig struct {
+	baseBuiltinFunc
+	notRequireOptionalEvalProps
+}
 
 func (s *builtinArithmeticIntDivideIntSig) Clone() builtinFunc {
 	newSig := &builtinArithmeticIntDivideIntSig{}
@@ -777,7 +804,10 @@ func (s *builtinArithmeticIntDivideIntSig) Clone() builtinFunc {
 	return newSig
 }
 
-type builtinArithmeticIntDivideDecimalSig struct{ baseBuiltinFunc }
+type builtinArithmeticIntDivideDecimalSig struct {
+	baseBuiltinFunc
+	notRequireOptionalEvalProps
+}
 
 func (s *builtinArithmeticIntDivideDecimalSig) Clone() builtinFunc {
 	newSig := &builtinArithmeticIntDivideDecimalSig{}
@@ -913,7 +943,7 @@ func (c *arithmeticModFunctionClass) getFunction(ctx BuildContext, args []Expres
 		if mysql.HasUnsignedFlag(lhsTp.GetFlag()) {
 			bf.tp.AddFlag(mysql.UnsignedFlag)
 		}
-		sig := &builtinArithmeticModRealSig{bf}
+		sig := &builtinArithmeticModRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ModReal)
 		return sig, nil
 	} else if lhsEvalTp == types.ETDecimal || rhsEvalTp == types.ETDecimal {
@@ -925,7 +955,7 @@ func (c *arithmeticModFunctionClass) getFunction(ctx BuildContext, args []Expres
 		if mysql.HasUnsignedFlag(lhsTp.GetFlag()) {
 			bf.tp.AddFlag(mysql.UnsignedFlag)
 		}
-		sig := &builtinArithmeticModDecimalSig{bf}
+		sig := &builtinArithmeticModDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ModDecimal)
 		return sig, nil
 	}
@@ -940,19 +970,19 @@ func (c *arithmeticModFunctionClass) getFunction(ctx BuildContext, args []Expres
 	isRHSUnsigned := mysql.HasUnsignedFlag(args[1].GetType().GetFlag())
 	switch {
 	case isLHSUnsigned && isRHSUnsigned:
-		sig := &builtinArithmeticModIntUnsignedUnsignedSig{bf}
+		sig := &builtinArithmeticModIntUnsignedUnsignedSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ModIntUnsignedUnsigned)
 		return sig, nil
 	case isLHSUnsigned && !isRHSUnsigned:
-		sig := &builtinArithmeticModIntUnsignedSignedSig{bf}
+		sig := &builtinArithmeticModIntUnsignedSignedSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ModIntUnsignedSigned)
 		return sig, nil
 	case !isLHSUnsigned && isRHSUnsigned:
-		sig := &builtinArithmeticModIntSignedUnsignedSig{bf}
+		sig := &builtinArithmeticModIntSignedUnsignedSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ModIntSignedUnsigned)
 		return sig, nil
 	default:
-		sig := &builtinArithmeticModIntSignedSignedSig{bf}
+		sig := &builtinArithmeticModIntSignedSignedSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ModIntSignedSigned)
 		return sig, nil
 	}
@@ -960,6 +990,7 @@ func (c *arithmeticModFunctionClass) getFunction(ctx BuildContext, args []Expres
 
 type builtinArithmeticModRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticModRealSig) Clone() builtinFunc {
@@ -992,6 +1023,7 @@ func (s *builtinArithmeticModRealSig) evalReal(ctx EvalContext, row chunk.Row) (
 
 type builtinArithmeticModDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticModDecimalSig) Clone() builtinFunc {
@@ -1019,6 +1051,7 @@ func (s *builtinArithmeticModDecimalSig) evalDecimal(ctx EvalContext, row chunk.
 
 type builtinArithmeticModIntUnsignedUnsignedSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticModIntUnsignedUnsignedSig) Clone() builtinFunc {
@@ -1053,6 +1086,7 @@ func (s *builtinArithmeticModIntUnsignedUnsignedSig) evalInt(ctx EvalContext, ro
 
 type builtinArithmeticModIntUnsignedSignedSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticModIntUnsignedSignedSig) Clone() builtinFunc {
@@ -1092,6 +1126,7 @@ func (s *builtinArithmeticModIntUnsignedSignedSig) evalInt(ctx EvalContext, row 
 
 type builtinArithmeticModIntSignedUnsignedSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticModIntSignedUnsignedSig) Clone() builtinFunc {
@@ -1131,6 +1166,7 @@ func (s *builtinArithmeticModIntSignedUnsignedSig) evalInt(ctx EvalContext, row 
 
 type builtinArithmeticModIntSignedSignedSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (s *builtinArithmeticModIntSignedSignedSig) Clone() builtinFunc {

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -281,7 +281,7 @@ func (c *castAsStringFunctionClass) getFunction(ctx BuildContext, args []Express
 		return nil, err
 	}
 	if args[0].GetType().Hybrid() {
-		sig = &builtinCastStringAsStringSig{bf}
+		sig = &builtinCastStringAsStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastStringAsString)
 		return sig, nil
 	}
@@ -305,28 +305,28 @@ func (c *castAsStringFunctionClass) getFunction(ctx BuildContext, args []Express
 				bf.tp.SetFlen(args[0].GetType().GetFlen())
 			}
 		}
-		sig = &builtinCastIntAsStringSig{bf}
+		sig = &builtinCastIntAsStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastIntAsString)
 	case types.ETReal:
-		sig = &builtinCastRealAsStringSig{bf}
+		sig = &builtinCastRealAsStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastRealAsString)
 	case types.ETDecimal:
-		sig = &builtinCastDecimalAsStringSig{bf}
+		sig = &builtinCastDecimalAsStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastDecimalAsString)
 	case types.ETDatetime, types.ETTimestamp:
-		sig = &builtinCastTimeAsStringSig{bf}
+		sig = &builtinCastTimeAsStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastTimeAsString)
 	case types.ETDuration:
-		sig = &builtinCastDurationAsStringSig{bf}
+		sig = &builtinCastDurationAsStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastDurationAsString)
 	case types.ETJson:
-		sig = &builtinCastJSONAsStringSig{bf}
+		sig = &builtinCastJSONAsStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastJsonAsString)
 	case types.ETString:
 		// When cast from binary to some other charsets, we should check if the binary is valid or not.
 		// so we build a from_binary function to do this check.
 		bf.args[0] = HandleBinaryLiteral(ctx, args[0], &ExprCollation{Charset: c.tp.GetCharset(), Collation: c.tp.GetCollate()}, c.funcName)
-		sig = &builtinCastStringAsStringSig{bf}
+		sig = &builtinCastStringAsStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastStringAsString)
 	default:
 		panic("unsupported types.EvalType in castAsStringFunctionClass")
@@ -351,25 +351,25 @@ func (c *castAsTimeFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	argTp := args[0].GetType().EvalType()
 	switch argTp {
 	case types.ETInt:
-		sig = &builtinCastIntAsTimeSig{bf}
+		sig = &builtinCastIntAsTimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastIntAsTime)
 	case types.ETReal:
-		sig = &builtinCastRealAsTimeSig{bf}
+		sig = &builtinCastRealAsTimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastRealAsTime)
 	case types.ETDecimal:
-		sig = &builtinCastDecimalAsTimeSig{bf}
+		sig = &builtinCastDecimalAsTimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastDecimalAsTime)
 	case types.ETDatetime, types.ETTimestamp:
-		sig = &builtinCastTimeAsTimeSig{bf}
+		sig = &builtinCastTimeAsTimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastTimeAsTime)
 	case types.ETDuration:
-		sig = &builtinCastDurationAsTimeSig{bf}
+		sig = &builtinCastDurationAsTimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastDurationAsTime)
 	case types.ETJson:
-		sig = &builtinCastJSONAsTimeSig{bf}
+		sig = &builtinCastJSONAsTimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastJsonAsTime)
 	case types.ETString:
-		sig = &builtinCastStringAsTimeSig{bf}
+		sig = &builtinCastStringAsTimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastStringAsTime)
 	default:
 		panic("unsupported types.EvalType in castAsTimeFunctionClass")
@@ -394,25 +394,25 @@ func (c *castAsDurationFunctionClass) getFunction(ctx BuildContext, args []Expre
 	argTp := args[0].GetType().EvalType()
 	switch argTp {
 	case types.ETInt:
-		sig = &builtinCastIntAsDurationSig{bf}
+		sig = &builtinCastIntAsDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastIntAsDuration)
 	case types.ETReal:
-		sig = &builtinCastRealAsDurationSig{bf}
+		sig = &builtinCastRealAsDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastRealAsDuration)
 	case types.ETDecimal:
-		sig = &builtinCastDecimalAsDurationSig{bf}
+		sig = &builtinCastDecimalAsDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastDecimalAsDuration)
 	case types.ETDatetime, types.ETTimestamp:
-		sig = &builtinCastTimeAsDurationSig{bf}
+		sig = &builtinCastTimeAsDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastTimeAsDuration)
 	case types.ETDuration:
-		sig = &builtinCastDurationAsDurationSig{bf}
+		sig = &builtinCastDurationAsDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastDurationAsDuration)
 	case types.ETJson:
-		sig = &builtinCastJSONAsDurationSig{bf}
+		sig = &builtinCastJSONAsDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastJsonAsDuration)
 	case types.ETString:
-		sig = &builtinCastStringAsDurationSig{bf}
+		sig = &builtinCastStringAsDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastStringAsDuration)
 	default:
 		panic("unsupported types.EvalType in castAsDurationFunctionClass")
@@ -458,12 +458,13 @@ func (c *castAsArrayFunctionClass) getFunction(ctx BuildContext, args []Expressi
 	if err != nil {
 		return nil, err
 	}
-	sig = &castJSONAsArrayFunctionSig{bf}
+	sig = &castJSONAsArrayFunctionSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type castJSONAsArrayFunctionSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *castJSONAsArrayFunctionSig) Clone() builtinFunc {
@@ -594,25 +595,25 @@ func (c *castAsJSONFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	argTp := args[0].GetType().EvalType()
 	switch argTp {
 	case types.ETInt:
-		sig = &builtinCastIntAsJSONSig{bf}
+		sig = &builtinCastIntAsJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastIntAsJson)
 	case types.ETReal:
-		sig = &builtinCastRealAsJSONSig{bf}
+		sig = &builtinCastRealAsJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastRealAsJson)
 	case types.ETDecimal:
-		sig = &builtinCastDecimalAsJSONSig{bf}
+		sig = &builtinCastDecimalAsJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastDecimalAsJson)
 	case types.ETDatetime, types.ETTimestamp:
-		sig = &builtinCastTimeAsJSONSig{bf}
+		sig = &builtinCastTimeAsJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastTimeAsJson)
 	case types.ETDuration:
-		sig = &builtinCastDurationAsJSONSig{bf}
+		sig = &builtinCastDurationAsJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastDurationAsJson)
 	case types.ETJson:
-		sig = &builtinCastJSONAsJSONSig{bf}
+		sig = &builtinCastJSONAsJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastJsonAsJson)
 	case types.ETString:
-		sig = &builtinCastStringAsJSONSig{bf}
+		sig = &builtinCastStringAsJSONSig{baseBuiltinFunc: bf}
 		sig.getRetTp().AddFlag(mysql.ParseToJSONFlag)
 		sig.setPbCode(tipb.ScalarFuncSig_CastStringAsJson)
 	default:
@@ -708,6 +709,7 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row)
 
 type builtinCastIntAsStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastIntAsStringSig) Clone() builtinFunc {
@@ -739,6 +741,7 @@ func (b *builtinCastIntAsStringSig) evalString(ctx EvalContext, row chunk.Row) (
 
 type builtinCastIntAsTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastIntAsTimeSig) Clone() builtinFunc {
@@ -771,6 +774,7 @@ func (b *builtinCastIntAsTimeSig) evalTime(ctx EvalContext, row chunk.Row) (res 
 
 type builtinCastIntAsDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastIntAsDurationSig) Clone() builtinFunc {
@@ -797,6 +801,7 @@ func (b *builtinCastIntAsDurationSig) evalDuration(ctx EvalContext, row chunk.Ro
 
 type builtinCastIntAsJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastIntAsJSONSig) Clone() builtinFunc {
@@ -822,6 +827,7 @@ func (b *builtinCastIntAsJSONSig) evalJSON(ctx EvalContext, row chunk.Row) (res 
 
 type builtinCastRealAsJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastRealAsJSONSig) Clone() builtinFunc {
@@ -838,6 +844,7 @@ func (b *builtinCastRealAsJSONSig) evalJSON(ctx EvalContext, row chunk.Row) (res
 
 type builtinCastDecimalAsJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastDecimalAsJSONSig) Clone() builtinFunc {
@@ -861,6 +868,7 @@ func (b *builtinCastDecimalAsJSONSig) evalJSON(ctx EvalContext, row chunk.Row) (
 
 type builtinCastStringAsJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastStringAsJSONSig) Clone() builtinFunc {
@@ -900,6 +908,7 @@ func (b *builtinCastStringAsJSONSig) evalJSON(ctx EvalContext, row chunk.Row) (r
 
 type builtinCastDurationAsJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastDurationAsJSONSig) Clone() builtinFunc {
@@ -919,6 +928,7 @@ func (b *builtinCastDurationAsJSONSig) evalJSON(ctx EvalContext, row chunk.Row) 
 
 type builtinCastTimeAsJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastTimeAsJSONSig) Clone() builtinFunc {
@@ -1025,6 +1035,7 @@ func (b *builtinCastRealAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row
 
 type builtinCastRealAsStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastRealAsStringSig) Clone() builtinFunc {
@@ -1055,6 +1066,7 @@ func (b *builtinCastRealAsStringSig) evalString(ctx EvalContext, row chunk.Row) 
 
 type builtinCastRealAsTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastRealAsTimeSig) Clone() builtinFunc {
@@ -1086,6 +1098,7 @@ func (b *builtinCastRealAsTimeSig) evalTime(ctx EvalContext, row chunk.Row) (typ
 
 type builtinCastRealAsDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastRealAsDurationSig) Clone() builtinFunc {
@@ -1180,6 +1193,7 @@ func (b *builtinCastDecimalAsIntSig) evalInt(ctx EvalContext, row chunk.Row) (re
 
 type builtinCastDecimalAsStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastDecimalAsStringSig) Clone() builtinFunc {
@@ -1239,6 +1253,7 @@ func (b *builtinCastDecimalAsRealSig) evalReal(ctx EvalContext, row chunk.Row) (
 
 type builtinCastDecimalAsTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastDecimalAsTimeSig) Clone() builtinFunc {
@@ -1265,6 +1280,7 @@ func (b *builtinCastDecimalAsTimeSig) evalTime(ctx EvalContext, row chunk.Row) (
 
 type builtinCastDecimalAsDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastDecimalAsDurationSig) Clone() builtinFunc {
@@ -1290,6 +1306,7 @@ func (b *builtinCastDecimalAsDurationSig) evalDuration(ctx EvalContext, row chun
 
 type builtinCastStringAsStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastStringAsStringSig) Clone() builtinFunc {
@@ -1462,6 +1479,7 @@ func (b *builtinCastStringAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.R
 
 type builtinCastStringAsTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastStringAsTimeSig) Clone() builtinFunc {
@@ -1491,6 +1509,7 @@ func (b *builtinCastStringAsTimeSig) evalTime(ctx EvalContext, row chunk.Row) (r
 
 type builtinCastStringAsDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastStringAsDurationSig) Clone() builtinFunc {
@@ -1514,6 +1533,7 @@ func (b *builtinCastStringAsDurationSig) evalDuration(ctx EvalContext, row chunk
 
 type builtinCastTimeAsTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastTimeAsTimeSig) Clone() builtinFunc {
@@ -1607,6 +1627,7 @@ func (b *builtinCastTimeAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row
 
 type builtinCastTimeAsStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastTimeAsStringSig) Clone() builtinFunc {
@@ -1629,6 +1650,7 @@ func (b *builtinCastTimeAsStringSig) evalString(ctx EvalContext, row chunk.Row) 
 
 type builtinCastTimeAsDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastTimeAsDurationSig) Clone() builtinFunc {
@@ -1652,6 +1674,7 @@ func (b *builtinCastTimeAsDurationSig) evalDuration(ctx EvalContext, row chunk.R
 
 type builtinCastDurationAsDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastDurationAsDurationSig) Clone() builtinFunc {
@@ -1746,6 +1769,7 @@ func (b *builtinCastDurationAsDecimalSig) evalDecimal(ctx EvalContext, row chunk
 
 type builtinCastDurationAsStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastDurationAsStringSig) Clone() builtinFunc {
@@ -1781,6 +1805,7 @@ func padZeroForBinaryType(s string, tp *types.FieldType, ctx EvalContext) (strin
 
 type builtinCastDurationAsTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastDurationAsTimeSig) Clone() builtinFunc {
@@ -1809,6 +1834,7 @@ func (b *builtinCastDurationAsTimeSig) evalTime(ctx EvalContext, row chunk.Row) 
 
 type builtinCastJSONAsJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastJSONAsJSONSig) Clone() builtinFunc {
@@ -1888,6 +1914,7 @@ func (b *builtinCastJSONAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row
 
 type builtinCastJSONAsStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastJSONAsStringSig) Clone() builtinFunc {
@@ -1910,6 +1937,7 @@ func (b *builtinCastJSONAsStringSig) evalString(ctx EvalContext, row chunk.Row) 
 
 type builtinCastJSONAsTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastJSONAsTimeSig) Clone() builtinFunc {
@@ -1970,6 +1998,7 @@ func (b *builtinCastJSONAsTimeSig) evalTime(ctx EvalContext, row chunk.Row) (res
 
 type builtinCastJSONAsDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCastJSONAsDurationSig) Clone() builtinFunc {

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -653,19 +653,19 @@ func TestCastFuncSig(t *testing.T) {
 		require.NoError(t, err)
 		switch i {
 		case 0:
-			sig = &builtinCastRealAsStringSig{stringFunc}
+			sig = &builtinCastRealAsStringSig{baseBuiltinFunc: stringFunc}
 		case 1:
-			sig = &builtinCastDecimalAsStringSig{stringFunc}
+			sig = &builtinCastDecimalAsStringSig{baseBuiltinFunc: stringFunc}
 		case 2:
-			sig = &builtinCastIntAsStringSig{stringFunc}
+			sig = &builtinCastIntAsStringSig{baseBuiltinFunc: stringFunc}
 		case 3:
-			sig = &builtinCastTimeAsStringSig{stringFunc}
+			sig = &builtinCastTimeAsStringSig{baseBuiltinFunc: stringFunc}
 		case 4:
-			sig = &builtinCastDurationAsStringSig{stringFunc}
+			sig = &builtinCastDurationAsStringSig{baseBuiltinFunc: stringFunc}
 		case 5:
-			sig = &builtinCastJSONAsStringSig{stringFunc}
+			sig = &builtinCastJSONAsStringSig{baseBuiltinFunc: stringFunc}
 		case 6:
-			sig = &builtinCastStringAsStringSig{stringFunc}
+			sig = &builtinCastStringAsStringSig{baseBuiltinFunc: stringFunc}
 		}
 		res, isNull, err := sig.evalString(ctx, c.row.ToRow())
 		require.False(t, isNull)
@@ -739,20 +739,20 @@ func TestCastFuncSig(t *testing.T) {
 		require.NoError(t, err)
 		switch i {
 		case 0:
-			sig = &builtinCastRealAsStringSig{stringFunc}
+			sig = &builtinCastRealAsStringSig{baseBuiltinFunc: stringFunc}
 		case 1:
-			sig = &builtinCastDecimalAsStringSig{stringFunc}
+			sig = &builtinCastDecimalAsStringSig{baseBuiltinFunc: stringFunc}
 		case 2:
-			sig = &builtinCastIntAsStringSig{stringFunc}
+			sig = &builtinCastIntAsStringSig{baseBuiltinFunc: stringFunc}
 		case 3:
-			sig = &builtinCastTimeAsStringSig{stringFunc}
+			sig = &builtinCastTimeAsStringSig{baseBuiltinFunc: stringFunc}
 		case 4:
-			sig = &builtinCastDurationAsStringSig{stringFunc}
+			sig = &builtinCastDurationAsStringSig{baseBuiltinFunc: stringFunc}
 		case 5:
 			stringFunc.tp.SetCharset(charset.CharsetUTF8)
-			sig = &builtinCastStringAsStringSig{stringFunc}
+			sig = &builtinCastStringAsStringSig{baseBuiltinFunc: stringFunc}
 		case 6:
-			sig = &builtinCastJSONAsStringSig{stringFunc}
+			sig = &builtinCastJSONAsStringSig{baseBuiltinFunc: stringFunc}
 		}
 		res, isNull, err := sig.evalString(ctx, c.row.ToRow())
 		require.False(t, isNull)
@@ -816,19 +816,19 @@ func TestCastFuncSig(t *testing.T) {
 		require.NoError(t, err)
 		switch i {
 		case 0:
-			sig = &builtinCastRealAsTimeSig{timeFunc}
+			sig = &builtinCastRealAsTimeSig{baseBuiltinFunc: timeFunc}
 		case 1:
-			sig = &builtinCastDecimalAsTimeSig{timeFunc}
+			sig = &builtinCastDecimalAsTimeSig{baseBuiltinFunc: timeFunc}
 		case 2:
-			sig = &builtinCastIntAsTimeSig{timeFunc}
+			sig = &builtinCastIntAsTimeSig{baseBuiltinFunc: timeFunc}
 		case 3:
-			sig = &builtinCastStringAsTimeSig{timeFunc}
+			sig = &builtinCastStringAsTimeSig{baseBuiltinFunc: timeFunc}
 		case 4:
-			sig = &builtinCastDurationAsTimeSig{timeFunc}
+			sig = &builtinCastDurationAsTimeSig{baseBuiltinFunc: timeFunc}
 		case 5:
-			sig = &builtinCastJSONAsTimeSig{timeFunc}
+			sig = &builtinCastJSONAsTimeSig{baseBuiltinFunc: timeFunc}
 		case 6:
-			sig = &builtinCastTimeAsTimeSig{timeFunc}
+			sig = &builtinCastTimeAsTimeSig{baseBuiltinFunc: timeFunc}
 		}
 		res, isNull, err := sig.evalTime(ctx, c.row.ToRow())
 		require.NoError(t, err)
@@ -900,17 +900,17 @@ func TestCastFuncSig(t *testing.T) {
 		require.NoError(t, err)
 		switch i {
 		case 0:
-			sig = &builtinCastRealAsTimeSig{timeFunc}
+			sig = &builtinCastRealAsTimeSig{baseBuiltinFunc: timeFunc}
 		case 1:
-			sig = &builtinCastDecimalAsTimeSig{timeFunc}
+			sig = &builtinCastDecimalAsTimeSig{baseBuiltinFunc: timeFunc}
 		case 2:
-			sig = &builtinCastIntAsTimeSig{timeFunc}
+			sig = &builtinCastIntAsTimeSig{baseBuiltinFunc: timeFunc}
 		case 3:
-			sig = &builtinCastStringAsTimeSig{timeFunc}
+			sig = &builtinCastStringAsTimeSig{baseBuiltinFunc: timeFunc}
 		case 4:
-			sig = &builtinCastDurationAsTimeSig{timeFunc}
+			sig = &builtinCastDurationAsTimeSig{baseBuiltinFunc: timeFunc}
 		case 5:
-			sig = &builtinCastTimeAsTimeSig{timeFunc}
+			sig = &builtinCastTimeAsTimeSig{baseBuiltinFunc: timeFunc}
 		}
 		res, isNull, err := sig.evalTime(ctx, c.row.ToRow())
 		require.Equal(t, false, isNull)
@@ -981,19 +981,19 @@ func TestCastFuncSig(t *testing.T) {
 		require.NoError(t, err)
 		switch i {
 		case 0:
-			sig = &builtinCastRealAsDurationSig{durationFunc}
+			sig = &builtinCastRealAsDurationSig{baseBuiltinFunc: durationFunc}
 		case 1:
-			sig = &builtinCastDecimalAsDurationSig{durationFunc}
+			sig = &builtinCastDecimalAsDurationSig{baseBuiltinFunc: durationFunc}
 		case 2:
-			sig = &builtinCastIntAsDurationSig{durationFunc}
+			sig = &builtinCastIntAsDurationSig{baseBuiltinFunc: durationFunc}
 		case 3:
-			sig = &builtinCastStringAsDurationSig{durationFunc}
+			sig = &builtinCastStringAsDurationSig{baseBuiltinFunc: durationFunc}
 		case 4:
-			sig = &builtinCastTimeAsDurationSig{durationFunc}
+			sig = &builtinCastTimeAsDurationSig{baseBuiltinFunc: durationFunc}
 		case 5:
-			sig = &builtinCastJSONAsDurationSig{durationFunc}
+			sig = &builtinCastJSONAsDurationSig{baseBuiltinFunc: durationFunc}
 		case 6:
-			sig = &builtinCastDurationAsDurationSig{durationFunc}
+			sig = &builtinCastDurationAsDurationSig{baseBuiltinFunc: durationFunc}
 		}
 		res, isNull, err := sig.evalDuration(ctx, c.row.ToRow())
 		require.False(t, isNull)
@@ -1058,17 +1058,17 @@ func TestCastFuncSig(t *testing.T) {
 		require.NoError(t, err)
 		switch i {
 		case 0:
-			sig = &builtinCastRealAsDurationSig{durationFunc}
+			sig = &builtinCastRealAsDurationSig{baseBuiltinFunc: durationFunc}
 		case 1:
-			sig = &builtinCastDecimalAsDurationSig{durationFunc}
+			sig = &builtinCastDecimalAsDurationSig{baseBuiltinFunc: durationFunc}
 		case 2:
-			sig = &builtinCastIntAsDurationSig{durationFunc}
+			sig = &builtinCastIntAsDurationSig{baseBuiltinFunc: durationFunc}
 		case 3:
-			sig = &builtinCastStringAsDurationSig{durationFunc}
+			sig = &builtinCastStringAsDurationSig{baseBuiltinFunc: durationFunc}
 		case 4:
-			sig = &builtinCastTimeAsDurationSig{durationFunc}
+			sig = &builtinCastTimeAsDurationSig{baseBuiltinFunc: durationFunc}
 		case 5:
-			sig = &builtinCastDurationAsDurationSig{durationFunc}
+			sig = &builtinCastDurationAsDurationSig{baseBuiltinFunc: durationFunc}
 		}
 		res, isNull, err := sig.evalDuration(ctx, c.row.ToRow())
 		require.False(t, isNull)
@@ -1088,7 +1088,7 @@ func TestCastFuncSig(t *testing.T) {
 	row := chunk.MutRowFromDatums([]types.Datum{types.NewDatum(nil)})
 	bf, err := newBaseBuiltinFunc(ctx, "", args, types.NewFieldType(mysql.TypeVarString))
 	require.NoError(t, err)
-	sig = &builtinCastRealAsStringSig{bf}
+	sig = &builtinCastRealAsStringSig{baseBuiltinFunc: bf}
 	sRes, isNull, err := sig.evalString(ctx, row.ToRow())
 	require.Equal(t, "", sRes)
 	require.Equal(t, true, isNull)
@@ -1632,7 +1632,7 @@ func TestCastBinaryStringAsJSONSig(t *testing.T) {
 		tp.SetDecimal(types.DefaultFsp)
 		jsonFunc, err := newBaseBuiltinFunc(ctx, "", args, tp)
 		require.NoError(t, err)
-		sig := &builtinCastStringAsJSONSig{jsonFunc}
+		sig := &builtinCastStringAsJSONSig{baseBuiltinFunc: jsonFunc}
 
 		row := chunk.MutRowFromDatums(
 			[]types.Datum{types.NewCollationStringDatum(tt.str, charset.CollationBin)},

--- a/pkg/expression/builtin_cast_vec_test.go
+++ b/pkg/expression/builtin_cast_vec_test.go
@@ -163,7 +163,7 @@ func TestVectorizedCastRealAsTime(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	cast := &builtinCastRealAsTimeSig{baseFunc}
+	cast := &builtinCastRealAsTimeSig{baseBuiltinFunc: baseFunc}
 
 	inputChunk, expect := genCastRealAsTime()
 	inputs := []*chunk.Chunk{

--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -144,27 +144,27 @@ func (c *coalesceFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 	switch retEvalTp {
 	case types.ETInt:
-		sig = &builtinCoalesceIntSig{bf}
+		sig = &builtinCoalesceIntSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CoalesceInt)
 	case types.ETReal:
-		sig = &builtinCoalesceRealSig{bf}
+		sig = &builtinCoalesceRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CoalesceReal)
 	case types.ETDecimal:
-		sig = &builtinCoalesceDecimalSig{bf}
+		sig = &builtinCoalesceDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CoalesceDecimal)
 	case types.ETString:
-		sig = &builtinCoalesceStringSig{bf}
+		sig = &builtinCoalesceStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CoalesceString)
 	case types.ETDatetime, types.ETTimestamp:
 		bf.tp.SetDecimal(resultFieldType.GetDecimal())
-		sig = &builtinCoalesceTimeSig{bf}
+		sig = &builtinCoalesceTimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CoalesceTime)
 	case types.ETDuration:
 		bf.tp.SetDecimal(resultFieldType.GetDecimal())
-		sig = &builtinCoalesceDurationSig{bf}
+		sig = &builtinCoalesceDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CoalesceDuration)
 	case types.ETJson:
-		sig = &builtinCoalesceJSONSig{bf}
+		sig = &builtinCoalesceJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CoalesceJson)
 	}
 
@@ -175,6 +175,7 @@ func (c *coalesceFunctionClass) getFunction(ctx BuildContext, args []Expression)
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_coalesce
 type builtinCoalesceIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCoalesceIntSig) Clone() builtinFunc {
@@ -197,6 +198,7 @@ func (b *builtinCoalesceIntSig) evalInt(ctx EvalContext, row chunk.Row) (res int
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_coalesce
 type builtinCoalesceRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCoalesceRealSig) Clone() builtinFunc {
@@ -219,6 +221,7 @@ func (b *builtinCoalesceRealSig) evalReal(ctx EvalContext, row chunk.Row) (res f
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_coalesce
 type builtinCoalesceDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCoalesceDecimalSig) Clone() builtinFunc {
@@ -241,6 +244,7 @@ func (b *builtinCoalesceDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row) 
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_coalesce
 type builtinCoalesceStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCoalesceStringSig) Clone() builtinFunc {
@@ -263,6 +267,7 @@ func (b *builtinCoalesceStringSig) evalString(ctx EvalContext, row chunk.Row) (r
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_coalesce
 type builtinCoalesceTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCoalesceTimeSig) Clone() builtinFunc {
@@ -287,6 +292,7 @@ func (b *builtinCoalesceTimeSig) evalTime(ctx EvalContext, row chunk.Row) (res t
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_coalesce
 type builtinCoalesceDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCoalesceDurationSig) Clone() builtinFunc {
@@ -310,6 +316,7 @@ func (b *builtinCoalesceDurationSig) evalDuration(ctx EvalContext, row chunk.Row
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_coalesce
 type builtinCoalesceJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCoalesceJSONSig) Clone() builtinFunc {
@@ -466,34 +473,34 @@ func (c *greatestFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	switch argTp {
 	case types.ETInt:
 		bf.tp.AddFlag(resFieldType.GetFlag())
-		sig = &builtinGreatestIntSig{bf}
+		sig = &builtinGreatestIntSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_GreatestInt)
 	case types.ETReal:
-		sig = &builtinGreatestRealSig{bf}
+		sig = &builtinGreatestRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_GreatestReal)
 	case types.ETDecimal:
-		sig = &builtinGreatestDecimalSig{bf}
+		sig = &builtinGreatestDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_GreatestDecimal)
 	case types.ETString:
 		if cmpStringMode == GLCmpStringAsDate {
-			sig = &builtinGreatestCmpStringAsTimeSig{bf, true}
+			sig = &builtinGreatestCmpStringAsTimeSig{baseBuiltinFunc: bf, cmpAsDate: true}
 			sig.setPbCode(tipb.ScalarFuncSig_GreatestCmpStringAsDate)
 		} else if cmpStringMode == GLCmpStringAsDatetime {
-			sig = &builtinGreatestCmpStringAsTimeSig{bf, false}
+			sig = &builtinGreatestCmpStringAsTimeSig{baseBuiltinFunc: bf, cmpAsDate: false}
 			sig.setPbCode(tipb.ScalarFuncSig_GreatestCmpStringAsTime)
 		} else {
-			sig = &builtinGreatestStringSig{bf}
+			sig = &builtinGreatestStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GreatestString)
 		}
 	case types.ETDuration:
-		sig = &builtinGreatestDurationSig{bf}
+		sig = &builtinGreatestDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_GreatestDuration)
 	case types.ETDatetime, types.ETTimestamp:
 		if fieldTimeType == GLRetDate {
-			sig = &builtinGreatestTimeSig{bf, true}
+			sig = &builtinGreatestTimeSig{baseBuiltinFunc: bf, cmpAsDate: true}
 			sig.setPbCode(tipb.ScalarFuncSig_GreatestDate)
 		} else {
-			sig = &builtinGreatestTimeSig{bf, false}
+			sig = &builtinGreatestTimeSig{baseBuiltinFunc: bf, cmpAsDate: false}
 			sig.setPbCode(tipb.ScalarFuncSig_GreatestTime)
 		}
 	}
@@ -520,6 +527,7 @@ func fixFlenAndDecimalForGreatestAndLeast(args []Expression) (flen, decimal int)
 
 type builtinGreatestIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGreatestIntSig) Clone() builtinFunc {
@@ -550,6 +558,7 @@ func (b *builtinGreatestIntSig) evalInt(ctx EvalContext, row chunk.Row) (max int
 
 type builtinGreatestRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGreatestRealSig) Clone() builtinFunc {
@@ -580,6 +589,7 @@ func (b *builtinGreatestRealSig) evalReal(ctx EvalContext, row chunk.Row) (max f
 
 type builtinGreatestDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGreatestDecimalSig) Clone() builtinFunc {
@@ -610,6 +620,7 @@ func (b *builtinGreatestDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row) 
 
 type builtinGreatestStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGreatestStringSig) Clone() builtinFunc {
@@ -640,6 +651,7 @@ func (b *builtinGreatestStringSig) evalString(ctx EvalContext, row chunk.Row) (m
 
 type builtinGreatestCmpStringAsTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	cmpAsDate bool
 }
 
@@ -697,6 +709,7 @@ func doTimeConversionForGL(cmpAsDate bool, ctx EvalContext, strVal string) (stri
 
 type builtinGreatestTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	cmpAsDate bool
 }
 
@@ -728,6 +741,7 @@ func (b *builtinGreatestTimeSig) evalTime(ctx EvalContext, row chunk.Row) (res t
 
 type builtinGreatestDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGreatestDurationSig) Clone() builtinFunc {
@@ -779,34 +793,34 @@ func (c *leastFunctionClass) getFunction(ctx BuildContext, args []Expression) (s
 	switch argTp {
 	case types.ETInt:
 		bf.tp.AddFlag(resFieldType.GetFlag())
-		sig = &builtinLeastIntSig{bf}
+		sig = &builtinLeastIntSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_LeastInt)
 	case types.ETReal:
-		sig = &builtinLeastRealSig{bf}
+		sig = &builtinLeastRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_LeastReal)
 	case types.ETDecimal:
-		sig = &builtinLeastDecimalSig{bf}
+		sig = &builtinLeastDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_LeastDecimal)
 	case types.ETString:
 		if cmpStringMode == GLCmpStringAsDate {
-			sig = &builtinLeastCmpStringAsTimeSig{bf, true}
+			sig = &builtinLeastCmpStringAsTimeSig{baseBuiltinFunc: bf, cmpAsDate: true}
 			sig.setPbCode(tipb.ScalarFuncSig_LeastCmpStringAsDate)
 		} else if cmpStringMode == GLCmpStringAsDatetime {
-			sig = &builtinLeastCmpStringAsTimeSig{bf, false}
+			sig = &builtinLeastCmpStringAsTimeSig{baseBuiltinFunc: bf, cmpAsDate: false}
 			sig.setPbCode(tipb.ScalarFuncSig_LeastCmpStringAsTime)
 		} else {
-			sig = &builtinLeastStringSig{bf}
+			sig = &builtinLeastStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LeastString)
 		}
 	case types.ETDuration:
-		sig = &builtinLeastDurationSig{bf}
+		sig = &builtinLeastDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_LeastDuration)
 	case types.ETDatetime, types.ETTimestamp:
 		if fieldTimeType == GLRetDate {
-			sig = &builtinLeastTimeSig{bf, true}
+			sig = &builtinLeastTimeSig{baseBuiltinFunc: bf, cmpAsDate: true}
 			sig.setPbCode(tipb.ScalarFuncSig_LeastDate)
 		} else {
-			sig = &builtinLeastTimeSig{bf, false}
+			sig = &builtinLeastTimeSig{baseBuiltinFunc: bf, cmpAsDate: false}
 			sig.setPbCode(tipb.ScalarFuncSig_LeastTime)
 		}
 	}
@@ -818,6 +832,7 @@ func (c *leastFunctionClass) getFunction(ctx BuildContext, args []Expression) (s
 
 type builtinLeastIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLeastIntSig) Clone() builtinFunc {
@@ -848,6 +863,7 @@ func (b *builtinLeastIntSig) evalInt(ctx EvalContext, row chunk.Row) (min int64,
 
 type builtinLeastRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLeastRealSig) Clone() builtinFunc {
@@ -878,6 +894,7 @@ func (b *builtinLeastRealSig) evalReal(ctx EvalContext, row chunk.Row) (min floa
 
 type builtinLeastDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLeastDecimalSig) Clone() builtinFunc {
@@ -908,6 +925,7 @@ func (b *builtinLeastDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row) (mi
 
 type builtinLeastStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLeastStringSig) Clone() builtinFunc {
@@ -938,6 +956,7 @@ func (b *builtinLeastStringSig) evalString(ctx EvalContext, row chunk.Row) (min 
 
 type builtinLeastCmpStringAsTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	cmpAsDate bool
 }
 
@@ -970,6 +989,7 @@ func (b *builtinLeastCmpStringAsTimeSig) evalString(ctx EvalContext, row chunk.R
 
 type builtinLeastTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	cmpAsDate bool
 }
 
@@ -1011,6 +1031,7 @@ func getAccurateTimeTypeForGLRet(cmpAsDate bool) byte {
 
 type builtinLeastDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLeastDurationSig) Clone() builtinFunc {
@@ -1070,10 +1091,10 @@ func (c *intervalFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	}
 	var sig builtinFunc
 	if allInt {
-		sig = &builtinIntervalIntSig{bf, hasNullable}
+		sig = &builtinIntervalIntSig{baseBuiltinFunc: bf, hasNullable: hasNullable}
 		sig.setPbCode(tipb.ScalarFuncSig_IntervalInt)
 	} else {
-		sig = &builtinIntervalRealSig{bf, hasNullable}
+		sig = &builtinIntervalRealSig{baseBuiltinFunc: bf, hasNullable: hasNullable}
 		sig.setPbCode(tipb.ScalarFuncSig_IntervalReal)
 	}
 	return sig, nil
@@ -1081,6 +1102,7 @@ func (c *intervalFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 type builtinIntervalIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	hasNullable bool
 }
 
@@ -1177,6 +1199,7 @@ func (b *builtinIntervalIntSig) binSearch(ctx EvalContext, target int64, isUint1
 
 type builtinIntervalRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	hasNullable bool
 }
 
@@ -1792,169 +1815,169 @@ func (c *compareFunctionClass) generateCmpSigs(ctx BuildContext, args []Expressi
 	case types.ETInt:
 		switch c.op {
 		case opcode.LT:
-			sig = &builtinLTIntSig{bf}
+			sig = &builtinLTIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LTInt)
 		case opcode.LE:
-			sig = &builtinLEIntSig{bf}
+			sig = &builtinLEIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LEInt)
 		case opcode.GT:
-			sig = &builtinGTIntSig{bf}
+			sig = &builtinGTIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GTInt)
 		case opcode.EQ:
-			sig = &builtinEQIntSig{bf}
+			sig = &builtinEQIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_EQInt)
 		case opcode.GE:
-			sig = &builtinGEIntSig{bf}
+			sig = &builtinGEIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GEInt)
 		case opcode.NE:
-			sig = &builtinNEIntSig{bf}
+			sig = &builtinNEIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NEInt)
 		case opcode.NullEQ:
-			sig = &builtinNullEQIntSig{bf}
+			sig = &builtinNullEQIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NullEQInt)
 		}
 	case types.ETReal:
 		switch c.op {
 		case opcode.LT:
-			sig = &builtinLTRealSig{bf}
+			sig = &builtinLTRealSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LTReal)
 		case opcode.LE:
-			sig = &builtinLERealSig{bf}
+			sig = &builtinLERealSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LEReal)
 		case opcode.GT:
-			sig = &builtinGTRealSig{bf}
+			sig = &builtinGTRealSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GTReal)
 		case opcode.GE:
-			sig = &builtinGERealSig{bf}
+			sig = &builtinGERealSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GEReal)
 		case opcode.EQ:
-			sig = &builtinEQRealSig{bf}
+			sig = &builtinEQRealSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_EQReal)
 		case opcode.NE:
-			sig = &builtinNERealSig{bf}
+			sig = &builtinNERealSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NEReal)
 		case opcode.NullEQ:
-			sig = &builtinNullEQRealSig{bf}
+			sig = &builtinNullEQRealSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NullEQReal)
 		}
 	case types.ETDecimal:
 		switch c.op {
 		case opcode.LT:
-			sig = &builtinLTDecimalSig{bf}
+			sig = &builtinLTDecimalSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LTDecimal)
 		case opcode.LE:
-			sig = &builtinLEDecimalSig{bf}
+			sig = &builtinLEDecimalSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LEDecimal)
 		case opcode.GT:
-			sig = &builtinGTDecimalSig{bf}
+			sig = &builtinGTDecimalSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GTDecimal)
 		case opcode.GE:
-			sig = &builtinGEDecimalSig{bf}
+			sig = &builtinGEDecimalSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GEDecimal)
 		case opcode.EQ:
-			sig = &builtinEQDecimalSig{bf}
+			sig = &builtinEQDecimalSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_EQDecimal)
 		case opcode.NE:
-			sig = &builtinNEDecimalSig{bf}
+			sig = &builtinNEDecimalSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NEDecimal)
 		case opcode.NullEQ:
-			sig = &builtinNullEQDecimalSig{bf}
+			sig = &builtinNullEQDecimalSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NullEQDecimal)
 		}
 	case types.ETString:
 		switch c.op {
 		case opcode.LT:
-			sig = &builtinLTStringSig{bf}
+			sig = &builtinLTStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LTString)
 		case opcode.LE:
-			sig = &builtinLEStringSig{bf}
+			sig = &builtinLEStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LEString)
 		case opcode.GT:
-			sig = &builtinGTStringSig{bf}
+			sig = &builtinGTStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GTString)
 		case opcode.GE:
-			sig = &builtinGEStringSig{bf}
+			sig = &builtinGEStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GEString)
 		case opcode.EQ:
-			sig = &builtinEQStringSig{bf}
+			sig = &builtinEQStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_EQString)
 		case opcode.NE:
-			sig = &builtinNEStringSig{bf}
+			sig = &builtinNEStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NEString)
 		case opcode.NullEQ:
-			sig = &builtinNullEQStringSig{bf}
+			sig = &builtinNullEQStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NullEQString)
 		}
 	case types.ETDuration:
 		switch c.op {
 		case opcode.LT:
-			sig = &builtinLTDurationSig{bf}
+			sig = &builtinLTDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LTDuration)
 		case opcode.LE:
-			sig = &builtinLEDurationSig{bf}
+			sig = &builtinLEDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LEDuration)
 		case opcode.GT:
-			sig = &builtinGTDurationSig{bf}
+			sig = &builtinGTDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GTDuration)
 		case opcode.GE:
-			sig = &builtinGEDurationSig{bf}
+			sig = &builtinGEDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GEDuration)
 		case opcode.EQ:
-			sig = &builtinEQDurationSig{bf}
+			sig = &builtinEQDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_EQDuration)
 		case opcode.NE:
-			sig = &builtinNEDurationSig{bf}
+			sig = &builtinNEDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NEDuration)
 		case opcode.NullEQ:
-			sig = &builtinNullEQDurationSig{bf}
+			sig = &builtinNullEQDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NullEQDuration)
 		}
 	case types.ETDatetime, types.ETTimestamp:
 		switch c.op {
 		case opcode.LT:
-			sig = &builtinLTTimeSig{bf}
+			sig = &builtinLTTimeSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LTTime)
 		case opcode.LE:
-			sig = &builtinLETimeSig{bf}
+			sig = &builtinLETimeSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LETime)
 		case opcode.GT:
-			sig = &builtinGTTimeSig{bf}
+			sig = &builtinGTTimeSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GTTime)
 		case opcode.GE:
-			sig = &builtinGETimeSig{bf}
+			sig = &builtinGETimeSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GETime)
 		case opcode.EQ:
-			sig = &builtinEQTimeSig{bf}
+			sig = &builtinEQTimeSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_EQTime)
 		case opcode.NE:
-			sig = &builtinNETimeSig{bf}
+			sig = &builtinNETimeSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NETime)
 		case opcode.NullEQ:
-			sig = &builtinNullEQTimeSig{bf}
+			sig = &builtinNullEQTimeSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NullEQTime)
 		}
 	case types.ETJson:
 		switch c.op {
 		case opcode.LT:
-			sig = &builtinLTJSONSig{bf}
+			sig = &builtinLTJSONSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LTJson)
 		case opcode.LE:
-			sig = &builtinLEJSONSig{bf}
+			sig = &builtinLEJSONSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_LEJson)
 		case opcode.GT:
-			sig = &builtinGTJSONSig{bf}
+			sig = &builtinGTJSONSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GTJson)
 		case opcode.GE:
-			sig = &builtinGEJSONSig{bf}
+			sig = &builtinGEJSONSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_GEJson)
 		case opcode.EQ:
-			sig = &builtinEQJSONSig{bf}
+			sig = &builtinEQJSONSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_EQJson)
 		case opcode.NE:
-			sig = &builtinNEJSONSig{bf}
+			sig = &builtinNEJSONSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NEJson)
 		case opcode.NullEQ:
-			sig = &builtinNullEQJSONSig{bf}
+			sig = &builtinNullEQJSONSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NullEQJson)
 		}
 	}
@@ -1963,6 +1986,7 @@ func (c *compareFunctionClass) generateCmpSigs(ctx BuildContext, args []Expressi
 
 type builtinLTIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLTIntSig) Clone() builtinFunc {
@@ -1977,6 +2001,7 @@ func (b *builtinLTIntSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, is
 
 type builtinLTRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLTRealSig) Clone() builtinFunc {
@@ -1991,6 +2016,7 @@ func (b *builtinLTRealSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinLTDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLTDecimalSig) Clone() builtinFunc {
@@ -2005,6 +2031,7 @@ func (b *builtinLTDecimalSig) evalInt(ctx EvalContext, row chunk.Row) (val int64
 
 type builtinLTStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLTStringSig) Clone() builtinFunc {
@@ -2019,6 +2046,7 @@ func (b *builtinLTStringSig) evalInt(ctx EvalContext, row chunk.Row) (val int64,
 
 type builtinLTDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLTDurationSig) Clone() builtinFunc {
@@ -2033,6 +2061,7 @@ func (b *builtinLTDurationSig) evalInt(ctx EvalContext, row chunk.Row) (val int6
 
 type builtinLTTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLTTimeSig) Clone() builtinFunc {
@@ -2047,6 +2076,7 @@ func (b *builtinLTTimeSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinLTJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLTJSONSig) Clone() builtinFunc {
@@ -2061,6 +2091,7 @@ func (b *builtinLTJSONSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinLEIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLEIntSig) Clone() builtinFunc {
@@ -2075,6 +2106,7 @@ func (b *builtinLEIntSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, is
 
 type builtinLERealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLERealSig) Clone() builtinFunc {
@@ -2089,6 +2121,7 @@ func (b *builtinLERealSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinLEDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLEDecimalSig) Clone() builtinFunc {
@@ -2103,6 +2136,7 @@ func (b *builtinLEDecimalSig) evalInt(ctx EvalContext, row chunk.Row) (val int64
 
 type builtinLEStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLEStringSig) Clone() builtinFunc {
@@ -2117,6 +2151,7 @@ func (b *builtinLEStringSig) evalInt(ctx EvalContext, row chunk.Row) (val int64,
 
 type builtinLEDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLEDurationSig) Clone() builtinFunc {
@@ -2131,6 +2166,7 @@ func (b *builtinLEDurationSig) evalInt(ctx EvalContext, row chunk.Row) (val int6
 
 type builtinLETimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLETimeSig) Clone() builtinFunc {
@@ -2145,6 +2181,7 @@ func (b *builtinLETimeSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinLEJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLEJSONSig) Clone() builtinFunc {
@@ -2159,6 +2196,7 @@ func (b *builtinLEJSONSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinGTIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGTIntSig) Clone() builtinFunc {
@@ -2173,6 +2211,7 @@ func (b *builtinGTIntSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, is
 
 type builtinGTRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGTRealSig) Clone() builtinFunc {
@@ -2187,6 +2226,7 @@ func (b *builtinGTRealSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinGTDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGTDecimalSig) Clone() builtinFunc {
@@ -2201,6 +2241,7 @@ func (b *builtinGTDecimalSig) evalInt(ctx EvalContext, row chunk.Row) (val int64
 
 type builtinGTStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGTStringSig) Clone() builtinFunc {
@@ -2215,6 +2256,7 @@ func (b *builtinGTStringSig) evalInt(ctx EvalContext, row chunk.Row) (val int64,
 
 type builtinGTDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGTDurationSig) Clone() builtinFunc {
@@ -2229,6 +2271,7 @@ func (b *builtinGTDurationSig) evalInt(ctx EvalContext, row chunk.Row) (val int6
 
 type builtinGTTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGTTimeSig) Clone() builtinFunc {
@@ -2243,6 +2286,7 @@ func (b *builtinGTTimeSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinGTJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGTJSONSig) Clone() builtinFunc {
@@ -2257,6 +2301,7 @@ func (b *builtinGTJSONSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinGEIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGEIntSig) Clone() builtinFunc {
@@ -2271,6 +2316,7 @@ func (b *builtinGEIntSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, is
 
 type builtinGERealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGERealSig) Clone() builtinFunc {
@@ -2285,6 +2331,7 @@ func (b *builtinGERealSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinGEDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGEDecimalSig) Clone() builtinFunc {
@@ -2299,6 +2346,7 @@ func (b *builtinGEDecimalSig) evalInt(ctx EvalContext, row chunk.Row) (val int64
 
 type builtinGEStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGEStringSig) Clone() builtinFunc {
@@ -2313,6 +2361,7 @@ func (b *builtinGEStringSig) evalInt(ctx EvalContext, row chunk.Row) (val int64,
 
 type builtinGEDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGEDurationSig) Clone() builtinFunc {
@@ -2327,6 +2376,7 @@ func (b *builtinGEDurationSig) evalInt(ctx EvalContext, row chunk.Row) (val int6
 
 type builtinGETimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGETimeSig) Clone() builtinFunc {
@@ -2341,6 +2391,7 @@ func (b *builtinGETimeSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinGEJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGEJSONSig) Clone() builtinFunc {
@@ -2355,6 +2406,7 @@ func (b *builtinGEJSONSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinEQIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinEQIntSig) Clone() builtinFunc {
@@ -2369,6 +2421,7 @@ func (b *builtinEQIntSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, is
 
 type builtinEQRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinEQRealSig) Clone() builtinFunc {
@@ -2383,6 +2436,7 @@ func (b *builtinEQRealSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinEQDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinEQDecimalSig) Clone() builtinFunc {
@@ -2397,6 +2451,7 @@ func (b *builtinEQDecimalSig) evalInt(ctx EvalContext, row chunk.Row) (val int64
 
 type builtinEQStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinEQStringSig) Clone() builtinFunc {
@@ -2411,6 +2466,7 @@ func (b *builtinEQStringSig) evalInt(ctx EvalContext, row chunk.Row) (val int64,
 
 type builtinEQDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinEQDurationSig) Clone() builtinFunc {
@@ -2425,6 +2481,7 @@ func (b *builtinEQDurationSig) evalInt(ctx EvalContext, row chunk.Row) (val int6
 
 type builtinEQTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinEQTimeSig) Clone() builtinFunc {
@@ -2439,6 +2496,7 @@ func (b *builtinEQTimeSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinEQJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinEQJSONSig) Clone() builtinFunc {
@@ -2453,6 +2511,7 @@ func (b *builtinEQJSONSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinNEIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNEIntSig) Clone() builtinFunc {
@@ -2467,6 +2526,7 @@ func (b *builtinNEIntSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, is
 
 type builtinNERealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNERealSig) Clone() builtinFunc {
@@ -2481,6 +2541,7 @@ func (b *builtinNERealSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinNEDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNEDecimalSig) Clone() builtinFunc {
@@ -2495,6 +2556,7 @@ func (b *builtinNEDecimalSig) evalInt(ctx EvalContext, row chunk.Row) (val int64
 
 type builtinNEStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNEStringSig) Clone() builtinFunc {
@@ -2509,6 +2571,7 @@ func (b *builtinNEStringSig) evalInt(ctx EvalContext, row chunk.Row) (val int64,
 
 type builtinNEDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNEDurationSig) Clone() builtinFunc {
@@ -2523,6 +2586,7 @@ func (b *builtinNEDurationSig) evalInt(ctx EvalContext, row chunk.Row) (val int6
 
 type builtinNETimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNETimeSig) Clone() builtinFunc {
@@ -2537,6 +2601,7 @@ func (b *builtinNETimeSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinNEJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNEJSONSig) Clone() builtinFunc {
@@ -2551,6 +2616,7 @@ func (b *builtinNEJSONSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, i
 
 type builtinNullEQIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNullEQIntSig) Clone() builtinFunc {
@@ -2585,6 +2651,7 @@ func (b *builtinNullEQIntSig) evalInt(ctx EvalContext, row chunk.Row) (val int64
 
 type builtinNullEQRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNullEQRealSig) Clone() builtinFunc {
@@ -2616,6 +2683,7 @@ func (b *builtinNullEQRealSig) evalInt(ctx EvalContext, row chunk.Row) (val int6
 
 type builtinNullEQDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNullEQDecimalSig) Clone() builtinFunc {
@@ -2647,6 +2715,7 @@ func (b *builtinNullEQDecimalSig) evalInt(ctx EvalContext, row chunk.Row) (val i
 
 type builtinNullEQStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNullEQStringSig) Clone() builtinFunc {
@@ -2678,6 +2747,7 @@ func (b *builtinNullEQStringSig) evalInt(ctx EvalContext, row chunk.Row) (val in
 
 type builtinNullEQDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNullEQDurationSig) Clone() builtinFunc {
@@ -2709,6 +2779,7 @@ func (b *builtinNullEQDurationSig) evalInt(ctx EvalContext, row chunk.Row) (val 
 
 type builtinNullEQTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNullEQTimeSig) Clone() builtinFunc {
@@ -2740,6 +2811,7 @@ func (b *builtinNullEQTimeSig) evalInt(ctx EvalContext, row chunk.Row) (val int6
 
 type builtinNullEQJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNullEQJSONSig) Clone() builtinFunc {

--- a/pkg/expression/builtin_control.go
+++ b/pkg/expression/builtin_control.go
@@ -351,26 +351,26 @@ func (c *caseWhenFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	switch tp {
 	case types.ETInt:
 		bf.tp.SetDecimal(0)
-		sig = &builtinCaseWhenIntSig{bf}
+		sig = &builtinCaseWhenIntSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CaseWhenInt)
 	case types.ETReal:
-		sig = &builtinCaseWhenRealSig{bf}
+		sig = &builtinCaseWhenRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CaseWhenReal)
 	case types.ETDecimal:
-		sig = &builtinCaseWhenDecimalSig{bf}
+		sig = &builtinCaseWhenDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CaseWhenDecimal)
 	case types.ETString:
 		bf.tp.SetDecimal(types.UnspecifiedLength)
-		sig = &builtinCaseWhenStringSig{bf}
+		sig = &builtinCaseWhenStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CaseWhenString)
 	case types.ETDatetime, types.ETTimestamp:
-		sig = &builtinCaseWhenTimeSig{bf}
+		sig = &builtinCaseWhenTimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CaseWhenTime)
 	case types.ETDuration:
-		sig = &builtinCaseWhenDurationSig{bf}
+		sig = &builtinCaseWhenDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CaseWhenDuration)
 	case types.ETJson:
-		sig = &builtinCaseWhenJSONSig{bf}
+		sig = &builtinCaseWhenJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CaseWhenJson)
 	}
 	return sig, nil
@@ -378,6 +378,7 @@ func (c *caseWhenFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 type builtinCaseWhenIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCaseWhenIntSig) Clone() builtinFunc {
@@ -414,6 +415,7 @@ func (b *builtinCaseWhenIntSig) evalInt(ctx EvalContext, row chunk.Row) (ret int
 
 type builtinCaseWhenRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCaseWhenRealSig) Clone() builtinFunc {
@@ -450,6 +452,7 @@ func (b *builtinCaseWhenRealSig) evalReal(ctx EvalContext, row chunk.Row) (ret f
 
 type builtinCaseWhenDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCaseWhenDecimalSig) Clone() builtinFunc {
@@ -486,6 +489,7 @@ func (b *builtinCaseWhenDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row) 
 
 type builtinCaseWhenStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCaseWhenStringSig) Clone() builtinFunc {
@@ -522,6 +526,7 @@ func (b *builtinCaseWhenStringSig) evalString(ctx EvalContext, row chunk.Row) (r
 
 type builtinCaseWhenTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCaseWhenTimeSig) Clone() builtinFunc {
@@ -558,6 +563,7 @@ func (b *builtinCaseWhenTimeSig) evalTime(ctx EvalContext, row chunk.Row) (ret t
 
 type builtinCaseWhenDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCaseWhenDurationSig) Clone() builtinFunc {
@@ -594,6 +600,7 @@ func (b *builtinCaseWhenDurationSig) evalDuration(ctx EvalContext, row chunk.Row
 
 type builtinCaseWhenJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCaseWhenJSONSig) Clone() builtinFunc {
@@ -653,25 +660,25 @@ func (c *ifFunctionClass) getFunction(ctx BuildContext, args []Expression) (sig 
 	bf.tp = retTp
 	switch evalTps {
 	case types.ETInt:
-		sig = &builtinIfIntSig{bf}
+		sig = &builtinIfIntSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfInt)
 	case types.ETReal:
-		sig = &builtinIfRealSig{bf}
+		sig = &builtinIfRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfReal)
 	case types.ETDecimal:
-		sig = &builtinIfDecimalSig{bf}
+		sig = &builtinIfDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfDecimal)
 	case types.ETString:
-		sig = &builtinIfStringSig{bf}
+		sig = &builtinIfStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfString)
 	case types.ETDatetime, types.ETTimestamp:
-		sig = &builtinIfTimeSig{bf}
+		sig = &builtinIfTimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfTime)
 	case types.ETDuration:
-		sig = &builtinIfDurationSig{bf}
+		sig = &builtinIfDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfDuration)
 	case types.ETJson:
-		sig = &builtinIfJSONSig{bf}
+		sig = &builtinIfJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfJson)
 	}
 	return sig, nil
@@ -679,6 +686,7 @@ func (c *ifFunctionClass) getFunction(ctx BuildContext, args []Expression) (sig 
 
 type builtinIfIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfIntSig) Clone() builtinFunc {
@@ -700,6 +708,7 @@ func (b *builtinIfIntSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, is
 
 type builtinIfRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfRealSig) Clone() builtinFunc {
@@ -721,6 +730,7 @@ func (b *builtinIfRealSig) evalReal(ctx EvalContext, row chunk.Row) (val float64
 
 type builtinIfDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfDecimalSig) Clone() builtinFunc {
@@ -742,6 +752,7 @@ func (b *builtinIfDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row) (val *
 
 type builtinIfStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfStringSig) Clone() builtinFunc {
@@ -763,6 +774,7 @@ func (b *builtinIfStringSig) evalString(ctx EvalContext, row chunk.Row) (val str
 
 type builtinIfTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfTimeSig) Clone() builtinFunc {
@@ -784,6 +796,7 @@ func (b *builtinIfTimeSig) evalTime(ctx EvalContext, row chunk.Row) (ret types.T
 
 type builtinIfDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfDurationSig) Clone() builtinFunc {
@@ -805,6 +818,7 @@ func (b *builtinIfDurationSig) evalDuration(ctx EvalContext, row chunk.Row) (ret
 
 type builtinIfJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfJSONSig) Clone() builtinFunc {
@@ -853,25 +867,25 @@ func (c *ifNullFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	bf.tp = retTp
 	switch evalTps {
 	case types.ETInt:
-		sig = &builtinIfNullIntSig{bf}
+		sig = &builtinIfNullIntSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfNullInt)
 	case types.ETReal:
-		sig = &builtinIfNullRealSig{bf}
+		sig = &builtinIfNullRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfNullReal)
 	case types.ETDecimal:
-		sig = &builtinIfNullDecimalSig{bf}
+		sig = &builtinIfNullDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfNullDecimal)
 	case types.ETString:
-		sig = &builtinIfNullStringSig{bf}
+		sig = &builtinIfNullStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfNullString)
 	case types.ETDatetime, types.ETTimestamp:
-		sig = &builtinIfNullTimeSig{bf}
+		sig = &builtinIfNullTimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfNullTime)
 	case types.ETDuration:
-		sig = &builtinIfNullDurationSig{bf}
+		sig = &builtinIfNullDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfNullDuration)
 	case types.ETJson:
-		sig = &builtinIfNullJSONSig{bf}
+		sig = &builtinIfNullJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IfNullJson)
 	}
 	return sig, nil
@@ -879,6 +893,7 @@ func (c *ifNullFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 
 type builtinIfNullIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfNullIntSig) Clone() builtinFunc {
@@ -898,6 +913,7 @@ func (b *builtinIfNullIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bo
 
 type builtinIfNullRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfNullRealSig) Clone() builtinFunc {
@@ -917,6 +933,7 @@ func (b *builtinIfNullRealSig) evalReal(ctx EvalContext, row chunk.Row) (float64
 
 type builtinIfNullDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfNullDecimalSig) Clone() builtinFunc {
@@ -936,6 +953,7 @@ func (b *builtinIfNullDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row) (*
 
 type builtinIfNullStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfNullStringSig) Clone() builtinFunc {
@@ -955,6 +973,7 @@ func (b *builtinIfNullStringSig) evalString(ctx EvalContext, row chunk.Row) (str
 
 type builtinIfNullTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfNullTimeSig) Clone() builtinFunc {
@@ -974,6 +993,7 @@ func (b *builtinIfNullTimeSig) evalTime(ctx EvalContext, row chunk.Row) (types.T
 
 type builtinIfNullDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfNullDurationSig) Clone() builtinFunc {
@@ -993,6 +1013,7 @@ func (b *builtinIfNullDurationSig) evalDuration(ctx EvalContext, row chunk.Row) 
 
 type builtinIfNullJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIfNullJSONSig) Clone() builtinFunc {

--- a/pkg/expression/builtin_convert_charset.go
+++ b/pkg/expression/builtin_convert_charset.go
@@ -71,7 +71,7 @@ func (c *tidbToBinaryFunctionClass) getFunction(ctx BuildContext, args []Express
 		bf.tp.SetType(mysql.TypeVarString)
 		bf.tp.SetCharset(charset.CharsetBin)
 		bf.tp.SetCollate(charset.CollationBin)
-		sig = &builtinInternalToBinarySig{bf}
+		sig = &builtinInternalToBinarySig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ToBinary)
 	default:
 		return nil, fmt.Errorf("unexpected argTp: %d", argTp)
@@ -81,6 +81,7 @@ func (c *tidbToBinaryFunctionClass) getFunction(ctx BuildContext, args []Express
 
 type builtinInternalToBinarySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinInternalToBinarySig) Clone() builtinFunc {
@@ -150,7 +151,7 @@ func (c *tidbFromBinaryFunctionClass) getFunction(ctx BuildContext, args []Expre
 			return nil, err
 		}
 		bf.tp = c.tp
-		sig = &builtinInternalFromBinarySig{bf}
+		sig = &builtinInternalFromBinarySig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_FromBinary)
 	default:
 		return nil, fmt.Errorf("unexpected argTp: %d", argTp)
@@ -160,6 +161,7 @@ func (c *tidbFromBinaryFunctionClass) getFunction(ctx BuildContext, args []Expre
 
 type builtinInternalFromBinarySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinInternalFromBinarySig) Clone() builtinFunc {

--- a/pkg/expression/builtin_encryption.go
+++ b/pkg/expression/builtin_encryption.go
@@ -130,17 +130,18 @@ func (c *aesDecryptFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		if len(args) != 3 {
 			return nil, ErrIncorrectParameterCount.GenWithStackByArgs("aes_decrypt")
 		}
-		sig := &builtinAesDecryptIVSig{bf, mode}
+		sig := &builtinAesDecryptIVSig{baseBuiltinFunc: bf, aesModeAttr: mode}
 		sig.setPbCode(tipb.ScalarFuncSig_AesDecryptIV)
 		return sig, nil
 	}
-	sig := &builtinAesDecryptSig{bf, mode}
+	sig := &builtinAesDecryptSig{baseBuiltinFunc: bf, aesModeAttr: mode}
 	sig.setPbCode(tipb.ScalarFuncSig_AesDecrypt)
 	return sig, nil
 }
 
 type builtinAesDecryptSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	*aesModeAttr
 }
 
@@ -185,6 +186,7 @@ func (b *builtinAesDecryptSig) evalString(ctx EvalContext, row chunk.Row) (strin
 
 type builtinAesDecryptIVSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	*aesModeAttr
 }
 
@@ -265,17 +267,18 @@ func (c *aesEncryptFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		if len(args) != 3 {
 			return nil, ErrIncorrectParameterCount.GenWithStackByArgs("aes_encrypt")
 		}
-		sig := &builtinAesEncryptIVSig{bf, mode}
+		sig := &builtinAesEncryptIVSig{baseBuiltinFunc: bf, aesModeAttr: mode}
 		sig.setPbCode(tipb.ScalarFuncSig_AesEncryptIV)
 		return sig, nil
 	}
-	sig := &builtinAesEncryptSig{bf, mode}
+	sig := &builtinAesEncryptSig{baseBuiltinFunc: bf, aesModeAttr: mode}
 	sig.setPbCode(tipb.ScalarFuncSig_AesEncrypt)
 	return sig, nil
 }
 
 type builtinAesEncryptSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	*aesModeAttr
 }
 
@@ -320,6 +323,7 @@ func (b *builtinAesEncryptSig) evalString(ctx EvalContext, row chunk.Row) (strin
 
 type builtinAesEncryptIVSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	*aesModeAttr
 }
 
@@ -387,13 +391,14 @@ func (c *decodeFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	}
 
 	bf.tp.SetFlen(args[0].GetType().GetFlen())
-	sig := &builtinDecodeSig{bf}
+	sig := &builtinDecodeSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Decode)
 	return sig, nil
 }
 
 type builtinDecodeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDecodeSig) Clone() builtinFunc {
@@ -450,13 +455,14 @@ func (c *encodeFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	}
 
 	bf.tp.SetFlen(args[0].GetType().GetFlen())
-	sig := &builtinEncodeSig{bf}
+	sig := &builtinEncodeSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Encode)
 	return sig, nil
 }
 
 type builtinEncodeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinEncodeSig) Clone() builtinFunc {
@@ -511,13 +517,14 @@ func (c *passwordFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		return nil, err
 	}
 	bf.tp.SetFlen(mysql.PWDHashLen + 1)
-	sig := &builtinPasswordSig{bf}
+	sig := &builtinPasswordSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Password)
 	return sig, nil
 }
 
 type builtinPasswordSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinPasswordSig) Clone() builtinFunc {
@@ -560,12 +567,13 @@ func (c *randomBytesFunctionClass) getFunction(ctx BuildContext, args []Expressi
 	}
 	bf.tp.SetFlen(1024) // Max allowed random bytes
 	types.SetBinChsClnFlag(bf.tp)
-	sig := &builtinRandomBytesSig{bf}
+	sig := &builtinRandomBytesSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinRandomBytesSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRandomBytesSig) Clone() builtinFunc {
@@ -610,13 +618,14 @@ func (c *md5FunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(32)
-	sig := &builtinMD5Sig{bf}
+	sig := &builtinMD5Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_MD5)
 	return sig, nil
 }
 
 type builtinMD5Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinMD5Sig) Clone() builtinFunc {
@@ -653,13 +662,14 @@ func (c *sha1FunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(40)
-	sig := &builtinSHA1Sig{bf}
+	sig := &builtinSHA1Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_SHA1)
 	return sig, nil
 }
 
 type builtinSHA1Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSHA1Sig) Clone() builtinFunc {
@@ -700,13 +710,14 @@ func (c *sha2FunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(128) // sha512
-	sig := &builtinSHA2Sig{bf}
+	sig := &builtinSHA2Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_SHA2)
 	return sig, nil
 }
 
 type builtinSHA2Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSHA2Sig) Clone() builtinFunc {
@@ -731,12 +742,13 @@ func (c *sm3FunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(40)
-	sig := &builtinSM3Sig{bf}
+	sig := &builtinSM3Sig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinSM3Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSM3Sig) Clone() builtinFunc {
@@ -851,13 +863,14 @@ func (c *compressFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	}
 	bf.tp.SetFlen(compressBound)
 	types.SetBinChsClnFlag(bf.tp)
-	sig := &builtinCompressSig{bf}
+	sig := &builtinCompressSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Compress)
 	return sig, nil
 }
 
 type builtinCompressSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCompressSig) Clone() builtinFunc {
@@ -917,13 +930,14 @@ func (c *uncompressFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	}
 	bf.tp.SetFlen(mysql.MaxBlobWidth)
 	types.SetBinChsClnFlag(bf.tp)
-	sig := &builtinUncompressSig{bf}
+	sig := &builtinUncompressSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Uncompress)
 	return sig, nil
 }
 
 type builtinUncompressSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUncompressSig) Clone() builtinFunc {
@@ -974,13 +988,14 @@ func (c *uncompressedLengthFunctionClass) getFunction(ctx BuildContext, args []E
 		return nil, err
 	}
 	bf.tp.SetFlen(10)
-	sig := &builtinUncompressedLengthSig{bf}
+	sig := &builtinUncompressedLengthSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_UncompressedLength)
 	return sig, nil
 }
 
 type builtinUncompressedLengthSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUncompressedLengthSig) Clone() builtinFunc {
@@ -1021,12 +1036,13 @@ func (c *validatePasswordStrengthFunctionClass) getFunction(ctx BuildContext, ar
 		return nil, err
 	}
 	bf.tp.SetFlen(21)
-	sig := &builtinValidatePasswordStrengthSig{bf}
+	sig := &builtinValidatePasswordStrengthSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinValidatePasswordStrengthSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinValidatePasswordStrengthSig) Clone() builtinFunc {

--- a/pkg/expression/builtin_grouping.go
+++ b/pkg/expression/builtin_grouping.go
@@ -50,7 +50,7 @@ func (c *groupingImplFunctionClass) getFunction(ctx BuildContext, args []Express
 	// grouping(x,y,z) is a singed UInt64 (while MySQL is Int64 which is unreasonable)
 	bf.tp.SetFlag(bf.tp.GetFlag() | mysql.UnsignedFlag)
 	// default filled meta is invalid for grouping evaluation, so the initialized flag is false.
-	sig := &BuiltinGroupingImplSig{bf, 0, []map[uint64]struct{}{}, false}
+	sig := &BuiltinGroupingImplSig{baseBuiltinFunc: bf, mode: 0, groupingMarks: []map[uint64]struct{}{}, isMetaInited: false}
 	sig.setPbCode(tipb.ScalarFuncSig_GroupingSig)
 	return sig, nil
 }
@@ -62,6 +62,7 @@ func (c *groupingImplFunctionClass) getFunction(ctx BuildContext, args []Express
 // BuiltinGroupingImplSig receives.
 type BuiltinGroupingImplSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	// TODO these are two temporary fields for tests
 	mode          tipb.GroupingMode

--- a/pkg/expression/builtin_grouping_test.go
+++ b/pkg/expression/builtin_grouping_test.go
@@ -48,7 +48,7 @@ func createGroupingFunc(args []Expression) (*BuiltinGroupingImplSig, error) {
 		return nil, err
 	}
 	bf.tp.SetFlen(1)
-	sig := &BuiltinGroupingImplSig{bf, 0, []map[uint64]struct{}{}, false}
+	sig := &BuiltinGroupingImplSig{baseBuiltinFunc: bf, mode: 0, groupingMarks: []map[uint64]struct{}{}, isMetaInited: false}
 	sig.setPbCode(tipb.ScalarFuncSig_GroupingSig)
 	return sig, nil
 }

--- a/pkg/expression/builtin_ilike.go
+++ b/pkg/expression/builtin_ilike.go
@@ -52,6 +52,7 @@ func (c *ilikeFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 
 type builtinIlikeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	// pattern is not serialized with builtinIlikeSig, treat them as a cache to accelerate
 	// the evaluation of builtinIlikeSig.
 	patternCache builtinFuncCache[collate.WildcardPattern]

--- a/pkg/expression/builtin_info.go
+++ b/pkg/expression/builtin_info.go
@@ -102,12 +102,13 @@ func (c *databaseFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		return nil, err
 	}
 	bf.tp.SetFlen(64)
-	sig := &builtinDatabaseSig{bf}
+	sig := &builtinDatabaseSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinDatabaseSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDatabaseSig) Clone() builtinFunc {
@@ -136,12 +137,13 @@ func (c *foundRowsFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 	bf.tp.AddFlag(mysql.UnsignedFlag)
-	sig := &builtinFoundRowsSig{bf}
+	sig := &builtinFoundRowsSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinFoundRowsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFoundRowsSig) Clone() builtinFunc {
@@ -189,11 +191,6 @@ func (b *builtinCurrentUserSig) Clone() builtinFunc {
 	return newSig
 }
 
-// RequiredOptionalEvalProps implements the RequireOptionalEvalProps interface.
-func (b *builtinCurrentUserSig) RequiredOptionalEvalProps() (set OptionalEvalPropKeySet) {
-	return b.CurrentUserPropReader.RequiredOptionalEvalProps()
-}
-
 // evalString evals a builtinCurrentUserSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_current-user
 func (b *builtinCurrentUserSig) evalString(ctx EvalContext, _ chunk.Row) (string, bool, error) {
@@ -233,11 +230,6 @@ func (b *builtinCurrentRoleSig) Clone() builtinFunc {
 	newSig := &builtinCurrentRoleSig{}
 	newSig.cloneFrom(&b.baseBuiltinFunc)
 	return newSig
-}
-
-// RequiredOptionalEvalProps implements the RequireOptionalEvalProps interface.
-func (b *builtinCurrentRoleSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
-	return b.CurrentUserPropReader.RequiredOptionalEvalProps()
 }
 
 // evalString evals a builtinCurrentUserSig.
@@ -280,12 +272,13 @@ func (c *currentResourceGroupFunctionClass) getFunction(ctx BuildContext, args [
 		return nil, err
 	}
 	bf.tp.SetFlen(64)
-	sig := &builtinCurrentResourceGroupSig{bf}
+	sig := &builtinCurrentResourceGroupSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinCurrentResourceGroupSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCurrentResourceGroupSig) Clone() builtinFunc {
@@ -343,11 +336,6 @@ func (b *builtinUserSig) Clone() builtinFunc {
 	return newSig
 }
 
-// RequiredOptionalEvalProps implements the RequireOptionalEvalProps interface.
-func (b *builtinUserSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
-	return b.CurrentUserPropReader.RequiredOptionalEvalProps()
-}
-
 // evalString evals a builtinUserSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_user
 func (b *builtinUserSig) evalString(ctx EvalContext, _ chunk.Row) (string, bool, error) {
@@ -374,12 +362,13 @@ func (c *connectionIDFunctionClass) getFunction(ctx BuildContext, args []Express
 		return nil, err
 	}
 	bf.tp.AddFlag(mysql.UnsignedFlag)
-	sig := &builtinConnectionIDSig{bf}
+	sig := &builtinConnectionIDSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinConnectionIDSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinConnectionIDSig) Clone() builtinFunc {
@@ -416,10 +405,10 @@ func (c *lastInsertIDFunctionClass) getFunction(ctx BuildContext, args []Express
 	bf.tp.AddFlag(mysql.UnsignedFlag)
 
 	if len(args) == 1 {
-		sig = &builtinLastInsertIDWithIDSig{bf}
+		sig = &builtinLastInsertIDWithIDSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_LastInsertIDWithID)
 	} else {
-		sig = &builtinLastInsertIDSig{bf}
+		sig = &builtinLastInsertIDSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_LastInsertID)
 	}
 	return sig, err
@@ -427,6 +416,7 @@ func (c *lastInsertIDFunctionClass) getFunction(ctx BuildContext, args []Express
 
 type builtinLastInsertIDSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLastInsertIDSig) Clone() builtinFunc {
@@ -444,6 +434,7 @@ func (b *builtinLastInsertIDSig) evalInt(ctx EvalContext, row chunk.Row) (res in
 
 type builtinLastInsertIDWithIDSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLastInsertIDWithIDSig) Clone() builtinFunc {
@@ -477,12 +468,13 @@ func (c *versionFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 		return nil, err
 	}
 	bf.tp.SetFlen(64)
-	sig := &builtinVersionSig{bf}
+	sig := &builtinVersionSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinVersionSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinVersionSig) Clone() builtinFunc {
@@ -510,12 +502,13 @@ func (c *tidbVersionFunctionClass) getFunction(ctx BuildContext, args []Expressi
 		return nil, err
 	}
 	bf.tp.SetFlen(len(printer.GetTiDBInfo()))
-	sig := &builtinTiDBVersionSig{bf}
+	sig := &builtinTiDBVersionSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinTiDBVersionSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTiDBVersionSig) Clone() builtinFunc {
@@ -542,12 +535,13 @@ func (c *tidbIsDDLOwnerFunctionClass) getFunction(ctx BuildContext, args []Expre
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinTiDBIsDDLOwnerSig{bf}
+	sig := &builtinTiDBIsDDLOwnerSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinTiDBIsDDLOwnerSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTiDBIsDDLOwnerSig) Clone() builtinFunc {
@@ -590,12 +584,13 @@ func (c *benchmarkFunctionClass) getFunction(ctx BuildContext, args []Expression
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinBenchmarkSig{bf, constLoopCount}
+	sig := &builtinBenchmarkSig{baseBuiltinFunc: bf, constLoopCount: constLoopCount}
 	return sig, nil
 }
 
 type builtinBenchmarkSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	constLoopCount int64
 }
 
@@ -710,12 +705,13 @@ func (c *charsetFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(64)
-	sig := &builtinCharsetSig{bf}
+	sig := &builtinCharsetSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinCharsetSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCharsetSig) Clone() builtinFunc {
@@ -740,13 +736,14 @@ func (c *coercibilityFunctionClass) getFunction(ctx BuildContext, args []Express
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinCoercibilitySig{bf}
+	sig := &builtinCoercibilitySig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Unspecified)
 	return sig, nil
 }
 
 type builtinCoercibilitySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (c *builtinCoercibilitySig) evalInt(ctx EvalContext, row chunk.Row) (val int64, isNull bool, err error) {
@@ -779,12 +776,13 @@ func (c *collationFunctionClass) getFunction(ctx BuildContext, args []Expression
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(64)
-	sig := &builtinCollationSig{bf}
+	sig := &builtinCollationSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinCollationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCollationSig) Clone() builtinFunc {
@@ -809,13 +807,14 @@ func (c *rowCountFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	if err != nil {
 		return nil, err
 	}
-	sig = &builtinRowCountSig{bf}
+	sig = &builtinRowCountSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_RowCount)
 	return sig, nil
 }
 
 type builtinRowCountSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRowCountSig) Clone() builtinFunc {
@@ -843,12 +842,13 @@ func (c *tidbDecodeKeyFunctionClass) getFunction(ctx BuildContext, args []Expres
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinTiDBDecodeKeySig{bf}
+	sig := &builtinTiDBDecodeKeySig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinTiDBDecodeKeySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTiDBDecodeKeySig) Clone() builtinFunc {
@@ -905,12 +905,13 @@ func (c *tidbDecodeSQLDigestsFunctionClass) getFunction(ctx BuildContext, args [
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinTiDBDecodeSQLDigestsSig{bf}
+	sig := &builtinTiDBDecodeSQLDigestsSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinTiDBDecodeSQLDigestsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTiDBDecodeSQLDigestsSig) Clone() builtinFunc {
@@ -1023,12 +1024,13 @@ func (c *tidbEncodeSQLDigestFunctionClass) getFunction(ctx BuildContext, args []
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinTiDBEncodeSQLDigestSig{bf}
+	sig := &builtinTiDBEncodeSQLDigestSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinTiDBEncodeSQLDigestSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTiDBEncodeSQLDigestSig) Clone() builtinFunc {
@@ -1061,15 +1063,16 @@ func (c *tidbDecodePlanFunctionClass) getFunction(ctx BuildContext, args []Expre
 		return nil, err
 	}
 	if c.funcName == ast.TiDBDecodePlan {
-		return &builtinTiDBDecodePlanSig{bf}, nil
+		return &builtinTiDBDecodePlanSig{baseBuiltinFunc: bf}, nil
 	} else if c.funcName == ast.TiDBDecodeBinaryPlan {
-		return &builtinTiDBDecodeBinaryPlanSig{bf}, nil
+		return &builtinTiDBDecodeBinaryPlanSig{baseBuiltinFunc: bf}, nil
 	}
 	return nil, errors.New("unknown decode plan function")
 }
 
 type builtinTiDBDecodePlanSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTiDBDecodePlanSig) Clone() builtinFunc {
@@ -1092,6 +1095,7 @@ func (b *builtinTiDBDecodePlanSig) evalString(ctx EvalContext, row chunk.Row) (s
 
 type builtinTiDBDecodeBinaryPlanSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTiDBDecodeBinaryPlanSig) Clone() builtinFunc {
@@ -1126,13 +1130,14 @@ func (c *nextValFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinNextValSig{bf}
+	sig := &builtinNextValSig{baseBuiltinFunc: bf}
 	bf.tp.SetFlen(10)
 	return sig, nil
 }
 
 type builtinNextValSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNextValSig) Clone() builtinFunc {
@@ -1182,13 +1187,14 @@ func (c *lastValFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinLastValSig{bf}
+	sig := &builtinLastValSig{baseBuiltinFunc: bf}
 	bf.tp.SetFlen(10)
 	return sig, nil
 }
 
 type builtinLastValSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLastValSig) Clone() builtinFunc {
@@ -1232,13 +1238,14 @@ func (c *setValFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinSetValSig{bf}
+	sig := &builtinSetValSig{baseBuiltinFunc: bf}
 	bf.tp.SetFlen(args[1].GetType().GetFlen())
 	return sig, nil
 }
 
 type builtinSetValSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSetValSig) Clone() builtinFunc {
@@ -1297,12 +1304,13 @@ func (c *formatBytesFunctionClass) getFunction(ctx BuildContext, args []Expressi
 	charset, collate := ctx.GetSessionVars().GetCharsetInfo()
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
-	sig := &builtinFormatBytesSig{bf}
+	sig := &builtinFormatBytesSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinFormatBytesSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFormatBytesSig) Clone() builtinFunc {
@@ -1336,12 +1344,13 @@ func (c *formatNanoTimeFunctionClass) getFunction(ctx BuildContext, args []Expre
 	charset, collate := ctx.GetSessionVars().GetCharsetInfo()
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
-	sig := &builtinFormatNanoTimeSig{bf}
+	sig := &builtinFormatNanoTimeSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinFormatNanoTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFormatNanoTimeSig) Clone() builtinFunc {

--- a/pkg/expression/builtin_json.go
+++ b/pkg/expression/builtin_json.go
@@ -92,6 +92,7 @@ type jsonTypeFunctionClass struct {
 
 type builtinJSONTypeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONTypeSig) Clone() builtinFunc {
@@ -113,7 +114,7 @@ func (c *jsonTypeFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(51) // flen of JSON_TYPE is length of UNSIGNED INTEGER.
 	bf.tp.AddFlag(mysql.BinaryFlag)
-	sig := &builtinJSONTypeSig{bf}
+	sig := &builtinJSONTypeSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonTypeSig)
 	return sig, nil
 }
@@ -133,6 +134,7 @@ type jsonExtractFunctionClass struct {
 
 type builtinJSONExtractSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONExtractSig) Clone() builtinFunc {
@@ -164,7 +166,7 @@ func (c *jsonExtractFunctionClass) getFunction(ctx BuildContext, args []Expressi
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONExtractSig{bf}
+	sig := &builtinJSONExtractSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonExtractSig)
 	return sig, nil
 }
@@ -200,6 +202,7 @@ type jsonUnquoteFunctionClass struct {
 
 type builtinJSONUnquoteSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONUnquoteSig) Clone() builtinFunc {
@@ -229,7 +232,7 @@ func (c *jsonUnquoteFunctionClass) getFunction(ctx BuildContext, args []Expressi
 	bf.tp.SetFlen(args[0].GetType().GetFlen())
 	bf.tp.AddFlag(mysql.BinaryFlag)
 	DisableParseJSONFlag4Expr(args[0])
-	sig := &builtinJSONUnquoteSig{bf}
+	sig := &builtinJSONUnquoteSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonUnquoteSig)
 	return sig, nil
 }
@@ -255,6 +258,7 @@ type jsonSetFunctionClass struct {
 
 type builtinJSONSetSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONSetSig) Clone() builtinFunc {
@@ -282,7 +286,7 @@ func (c *jsonSetFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	for i := 2; i < len(args); i += 2 {
 		DisableParseJSONFlag4Expr(args[i])
 	}
-	sig := &builtinJSONSetSig{bf}
+	sig := &builtinJSONSetSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonSetSig)
 	return sig, nil
 }
@@ -298,6 +302,7 @@ type jsonInsertFunctionClass struct {
 
 type builtinJSONInsertSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONInsertSig) Clone() builtinFunc {
@@ -325,7 +330,7 @@ func (c *jsonInsertFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	for i := 2; i < len(args); i += 2 {
 		DisableParseJSONFlag4Expr(args[i])
 	}
-	sig := &builtinJSONInsertSig{bf}
+	sig := &builtinJSONInsertSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonInsertSig)
 	return sig, nil
 }
@@ -341,6 +346,7 @@ type jsonReplaceFunctionClass struct {
 
 type builtinJSONReplaceSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONReplaceSig) Clone() builtinFunc {
@@ -368,7 +374,7 @@ func (c *jsonReplaceFunctionClass) getFunction(ctx BuildContext, args []Expressi
 	for i := 2; i < len(args); i += 2 {
 		DisableParseJSONFlag4Expr(args[i])
 	}
-	sig := &builtinJSONReplaceSig{bf}
+	sig := &builtinJSONReplaceSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonReplaceSig)
 	return sig, nil
 }
@@ -384,6 +390,7 @@ type jsonRemoveFunctionClass struct {
 
 type builtinJSONRemoveSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONRemoveSig) Clone() builtinFunc {
@@ -405,7 +412,7 @@ func (c *jsonRemoveFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONRemoveSig{bf}
+	sig := &builtinJSONRemoveSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonRemoveSig)
 	return sig, nil
 }
@@ -454,6 +461,7 @@ func (c *jsonMergeFunctionClass) verifyArgs(args []Expression) error {
 
 type builtinJSONMergeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONMergeSig) Clone() builtinFunc {
@@ -474,7 +482,7 @@ func (c *jsonMergeFunctionClass) getFunction(ctx BuildContext, args []Expression
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONMergeSig{bf}
+	sig := &builtinJSONMergeSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonMergeSig)
 	return sig, nil
 }
@@ -505,6 +513,7 @@ type jsonObjectFunctionClass struct {
 
 type builtinJSONObjectSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONObjectSig) Clone() builtinFunc {
@@ -534,7 +543,7 @@ func (c *jsonObjectFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	for i := 1; i < len(args); i += 2 {
 		DisableParseJSONFlag4Expr(args[i])
 	}
-	sig := &builtinJSONObjectSig{bf}
+	sig := &builtinJSONObjectSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonObjectSig)
 	return sig, nil
 }
@@ -581,6 +590,7 @@ type jsonArrayFunctionClass struct {
 
 type builtinJSONArraySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONArraySig) Clone() builtinFunc {
@@ -604,7 +614,7 @@ func (c *jsonArrayFunctionClass) getFunction(ctx BuildContext, args []Expression
 	for i := range args {
 		DisableParseJSONFlag4Expr(args[i])
 	}
-	sig := &builtinJSONArraySig{bf}
+	sig := &builtinJSONArraySig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonArraySig)
 	return sig, nil
 }
@@ -634,6 +644,7 @@ type jsonContainsPathFunctionClass struct {
 
 type builtinJSONContainsPathSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONContainsPathSig) Clone() builtinFunc {
@@ -664,7 +675,7 @@ func (c *jsonContainsPathFunctionClass) getFunction(ctx BuildContext, args []Exp
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONContainsPathSig{bf}
+	sig := &builtinJSONContainsPathSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonContainsPathSig)
 	return sig, nil
 }
@@ -750,6 +761,7 @@ type jsonMemberOfFunctionClass struct {
 
 type builtinJSONMemberOfSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONMemberOfSig) Clone() builtinFunc {
@@ -778,7 +790,7 @@ func (c *jsonMemberOfFunctionClass) getFunction(ctx BuildContext, args []Express
 		return nil, err
 	}
 	DisableParseJSONFlag4Expr(args[0])
-	sig := &builtinJSONMemberOfSig{bf}
+	sig := &builtinJSONMemberOfSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonMemberOfSig)
 	return sig, nil
 }
@@ -813,6 +825,7 @@ type jsonContainsFunctionClass struct {
 
 type builtinJSONContainsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONContainsSig) Clone() builtinFunc {
@@ -847,7 +860,7 @@ func (c *jsonContainsFunctionClass) getFunction(ctx BuildContext, args []Express
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONContainsSig{bf}
+	sig := &builtinJSONContainsSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonContainsSig)
 	return sig, nil
 }
@@ -893,6 +906,7 @@ type jsonOverlapsFunctionClass struct {
 
 type builtinJSONOverlapsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONOverlapsSig) Clone() builtinFunc {
@@ -924,7 +938,7 @@ func (c *jsonOverlapsFunctionClass) getFunction(ctx BuildContext, args []Express
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONOverlapsSig{bf}
+	sig := &builtinJSONOverlapsSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
@@ -960,21 +974,21 @@ func (c *jsonValidFunctionClass) getFunction(ctx BuildContext, args []Expression
 		if err != nil {
 			return nil, err
 		}
-		sig = &builtinJSONValidJSONSig{bf}
+		sig = &builtinJSONValidJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_JsonValidJsonSig)
 	case types.ETString:
 		bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, types.ETString)
 		if err != nil {
 			return nil, err
 		}
-		sig = &builtinJSONValidStringSig{bf}
+		sig = &builtinJSONValidStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_JsonValidStringSig)
 	default:
 		bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, argType)
 		if err != nil {
 			return nil, err
 		}
-		sig = &builtinJSONValidOthersSig{bf}
+		sig = &builtinJSONValidOthersSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_JsonValidOthersSig)
 	}
 	return sig, nil
@@ -982,6 +996,7 @@ func (c *jsonValidFunctionClass) getFunction(ctx BuildContext, args []Expression
 
 type builtinJSONValidJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONValidJSONSig) Clone() builtinFunc {
@@ -999,6 +1014,7 @@ func (b *builtinJSONValidJSONSig) evalInt(ctx EvalContext, row chunk.Row) (val i
 
 type builtinJSONValidStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONValidStringSig) Clone() builtinFunc {
@@ -1024,6 +1040,7 @@ func (b *builtinJSONValidStringSig) evalInt(ctx EvalContext, row chunk.Row) (res
 
 type builtinJSONValidOthersSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONValidOthersSig) Clone() builtinFunc {
@@ -1044,6 +1061,7 @@ type jsonArrayAppendFunctionClass struct {
 
 type builtinJSONArrayAppendSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (c *jsonArrayAppendFunctionClass) verifyArgs(args []Expression) error {
@@ -1069,7 +1087,7 @@ func (c *jsonArrayAppendFunctionClass) getFunction(ctx BuildContext, args []Expr
 	for i := 2; i < len(args); i += 2 {
 		DisableParseJSONFlag4Expr(args[i])
 	}
-	sig := &builtinJSONArrayAppendSig{bf}
+	sig := &builtinJSONArrayAppendSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonArrayAppendSig)
 	return sig, nil
 }
@@ -1144,6 +1162,7 @@ type jsonArrayInsertFunctionClass struct {
 
 type builtinJSONArrayInsertSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (c *jsonArrayInsertFunctionClass) getFunction(ctx BuildContext, args []Expression) (builtinFunc, error) {
@@ -1166,7 +1185,7 @@ func (c *jsonArrayInsertFunctionClass) getFunction(ctx BuildContext, args []Expr
 	for i := 2; i < len(args); i += 2 {
 		DisableParseJSONFlag4Expr(args[i])
 	}
-	sig := &builtinJSONArrayInsertSig{bf}
+	sig := &builtinJSONArrayInsertSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonArrayInsertSig)
 	return sig, nil
 }
@@ -1243,13 +1262,14 @@ func (c *jsonMergePatchFunctionClass) getFunction(ctx BuildContext, args []Expre
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONMergePatchSig{bf}
+	sig := &builtinJSONMergePatchSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonMergePatchSig)
 	return sig, nil
 }
 
 type builtinJSONMergePatchSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONMergePatchSig) Clone() builtinFunc {
@@ -1312,7 +1332,7 @@ func (c *jsonMergePreserveFunctionClass) getFunction(ctx BuildContext, args []Ex
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONMergeSig{bf}
+	sig := &builtinJSONMergeSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonMergePreserveSig)
 	return sig, nil
 }
@@ -1323,6 +1343,7 @@ type jsonPrettyFunctionClass struct {
 
 type builtinJSONSPrettySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONSPrettySig) Clone() builtinFunc {
@@ -1342,7 +1363,7 @@ func (c *jsonPrettyFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	}
 	bf.tp.AddFlag(mysql.BinaryFlag)
 	bf.tp.SetFlen(mysql.MaxBlobWidth * 4)
-	sig := &builtinJSONSPrettySig{bf}
+	sig := &builtinJSONSPrettySig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonPrettySig)
 	return sig, nil
 }
@@ -1370,6 +1391,7 @@ type jsonQuoteFunctionClass struct {
 
 type builtinJSONQuoteSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONQuoteSig) Clone() builtinFunc {
@@ -1399,7 +1421,7 @@ func (c *jsonQuoteFunctionClass) getFunction(ctx BuildContext, args []Expression
 	DisableParseJSONFlag4Expr(args[0])
 	bf.tp.AddFlag(mysql.BinaryFlag)
 	bf.tp.SetFlen(args[0].GetType().GetFlen()*6 + 2)
-	sig := &builtinJSONQuoteSig{bf}
+	sig := &builtinJSONQuoteSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonQuoteSig)
 	return sig, nil
 }
@@ -1418,6 +1440,7 @@ type jsonSearchFunctionClass struct {
 
 type builtinJSONSearchSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONSearchSig) Clone() builtinFunc {
@@ -1450,7 +1473,7 @@ func (c *jsonSearchFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONSearchSig{bf}
+	sig := &builtinJSONSearchSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonSearchSig)
 	return sig, nil
 }
@@ -1521,6 +1544,7 @@ type jsonStorageFreeFunctionClass struct {
 
 type builtinJSONStorageFreeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONStorageFreeSig) Clone() builtinFunc {
@@ -1538,7 +1562,7 @@ func (c *jsonStorageFreeFunctionClass) getFunction(ctx BuildContext, args []Expr
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONStorageFreeSig{bf}
+	sig := &builtinJSONStorageFreeSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonStorageFreeSig)
 	return sig, nil
 }
@@ -1558,6 +1582,7 @@ type jsonStorageSizeFunctionClass struct {
 
 type builtinJSONStorageSizeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONStorageSizeSig) Clone() builtinFunc {
@@ -1575,7 +1600,7 @@ func (c *jsonStorageSizeFunctionClass) getFunction(ctx BuildContext, args []Expr
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONStorageSizeSig{bf}
+	sig := &builtinJSONStorageSizeSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonStorageSizeSig)
 	return sig, nil
 }
@@ -1596,6 +1621,7 @@ type jsonDepthFunctionClass struct {
 
 type builtinJSONDepthSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONDepthSig) Clone() builtinFunc {
@@ -1613,7 +1639,7 @@ func (c *jsonDepthFunctionClass) getFunction(ctx BuildContext, args []Expression
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONDepthSig{bf}
+	sig := &builtinJSONDepthSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonDepthSig)
 	return sig, nil
 }
@@ -1660,10 +1686,10 @@ func (c *jsonKeysFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	var sig builtinFunc
 	switch len(args) {
 	case 1:
-		sig = &builtinJSONKeysSig{bf}
+		sig = &builtinJSONKeysSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_JsonKeysSig)
 	case 2:
-		sig = &builtinJSONKeys2ArgsSig{bf}
+		sig = &builtinJSONKeys2ArgsSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_JsonKeys2ArgsSig)
 	}
 	return sig, nil
@@ -1671,6 +1697,7 @@ func (c *jsonKeysFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 type builtinJSONKeysSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONKeysSig) Clone() builtinFunc {
@@ -1692,6 +1719,7 @@ func (b *builtinJSONKeysSig) evalJSON(ctx EvalContext, row chunk.Row) (res types
 
 type builtinJSONKeys2ArgsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONKeys2ArgsSig) Clone() builtinFunc {
@@ -1736,6 +1764,7 @@ type jsonLengthFunctionClass struct {
 
 type builtinJSONLengthSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONLengthSig) Clone() builtinFunc {
@@ -1759,7 +1788,7 @@ func (c *jsonLengthFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinJSONLengthSig{bf}
+	sig := &builtinJSONLengthSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonLengthSig)
 	return sig, nil
 }

--- a/pkg/expression/builtin_like.go
+++ b/pkg/expression/builtin_like.go
@@ -51,6 +51,7 @@ func (c *likeFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 
 type builtinLikeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	// pattern is not serialized with builtinLikeSig, treat them as a cache to accelerate
 	// the evaluation of builtinLikeSig.
 	patternCache builtinFuncCache[collate.WildcardPattern]

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -144,17 +144,17 @@ func (c *absFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 	switch argTp {
 	case types.ETInt:
 		if mysql.HasUnsignedFlag(argFieldTp.GetFlag()) {
-			sig = &builtinAbsUIntSig{bf}
+			sig = &builtinAbsUIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AbsUInt)
 		} else {
-			sig = &builtinAbsIntSig{bf}
+			sig = &builtinAbsIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AbsInt)
 		}
 	case types.ETDecimal:
-		sig = &builtinAbsDecSig{bf}
+		sig = &builtinAbsDecSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_AbsDecimal)
 	case types.ETReal:
-		sig = &builtinAbsRealSig{bf}
+		sig = &builtinAbsRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_AbsReal)
 	default:
 		panic("unexpected argTp")
@@ -164,6 +164,7 @@ func (c *absFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 
 type builtinAbsRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAbsRealSig) Clone() builtinFunc {
@@ -184,6 +185,7 @@ func (b *builtinAbsRealSig) evalReal(ctx EvalContext, row chunk.Row) (float64, b
 
 type builtinAbsIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAbsIntSig) Clone() builtinFunc {
@@ -210,6 +212,7 @@ func (b *builtinAbsIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool,
 
 type builtinAbsUIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAbsUIntSig) Clone() builtinFunc {
@@ -226,6 +229,7 @@ func (b *builtinAbsUIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool
 
 type builtinAbsDecSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAbsDecSig) Clone() builtinFunc {
@@ -291,13 +295,13 @@ func (c *roundFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	if len(args) > 1 {
 		switch argTp {
 		case types.ETInt:
-			sig = &builtinRoundWithFracIntSig{bf}
+			sig = &builtinRoundWithFracIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_RoundWithFracInt)
 		case types.ETDecimal:
-			sig = &builtinRoundWithFracDecSig{bf}
+			sig = &builtinRoundWithFracDecSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_RoundWithFracDec)
 		case types.ETReal:
-			sig = &builtinRoundWithFracRealSig{bf}
+			sig = &builtinRoundWithFracRealSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_RoundWithFracReal)
 		default:
 			panic("unexpected argTp")
@@ -305,13 +309,13 @@ func (c *roundFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	} else {
 		switch argTp {
 		case types.ETInt:
-			sig = &builtinRoundIntSig{bf}
+			sig = &builtinRoundIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_RoundInt)
 		case types.ETDecimal:
-			sig = &builtinRoundDecSig{bf}
+			sig = &builtinRoundDecSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_RoundDec)
 		case types.ETReal:
-			sig = &builtinRoundRealSig{bf}
+			sig = &builtinRoundRealSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_RoundReal)
 		default:
 			panic("unexpected argTp")
@@ -341,6 +345,7 @@ func calculateDecimal4RoundAndTruncate(ctx BuildContext, args []Expression, retT
 
 type builtinRoundRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRoundRealSig) Clone() builtinFunc {
@@ -361,6 +366,7 @@ func (b *builtinRoundRealSig) evalReal(ctx EvalContext, row chunk.Row) (float64,
 
 type builtinRoundIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRoundIntSig) Clone() builtinFunc {
@@ -377,6 +383,7 @@ func (b *builtinRoundIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, boo
 
 type builtinRoundDecSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRoundDecSig) Clone() builtinFunc {
@@ -401,6 +408,7 @@ func (b *builtinRoundDecSig) evalDecimal(ctx EvalContext, row chunk.Row) (*types
 
 type builtinRoundWithFracRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRoundWithFracRealSig) Clone() builtinFunc {
@@ -425,6 +433,7 @@ func (b *builtinRoundWithFracRealSig) evalReal(ctx EvalContext, row chunk.Row) (
 
 type builtinRoundWithFracIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRoundWithFracIntSig) Clone() builtinFunc {
@@ -449,6 +458,7 @@ func (b *builtinRoundWithFracIntSig) evalInt(ctx EvalContext, row chunk.Row) (in
 
 type builtinRoundWithFracDecSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRoundWithFracDecSig) Clone() builtinFunc {
@@ -499,22 +509,22 @@ func (c *ceilFunctionClass) getFunction(ctx BuildContext, args []Expression) (si
 	switch argTp {
 	case types.ETInt:
 		if retTp == types.ETInt {
-			sig = &builtinCeilIntToIntSig{bf}
+			sig = &builtinCeilIntToIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_CeilIntToInt)
 		} else {
-			sig = &builtinCeilIntToDecSig{bf}
+			sig = &builtinCeilIntToDecSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_CeilIntToDec)
 		}
 	case types.ETDecimal:
 		if retTp == types.ETInt {
-			sig = &builtinCeilDecToIntSig{bf}
+			sig = &builtinCeilDecToIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_CeilDecToInt)
 		} else {
-			sig = &builtinCeilDecToDecSig{bf}
+			sig = &builtinCeilDecToDecSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_CeilDecToDec)
 		}
 	default:
-		sig = &builtinCeilRealSig{bf}
+		sig = &builtinCeilRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CeilReal)
 	}
 	return sig, nil
@@ -522,6 +532,7 @@ func (c *ceilFunctionClass) getFunction(ctx BuildContext, args []Expression) (si
 
 type builtinCeilRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCeilRealSig) Clone() builtinFunc {
@@ -542,6 +553,7 @@ func (b *builtinCeilRealSig) evalReal(ctx EvalContext, row chunk.Row) (float64, 
 
 type builtinCeilIntToIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCeilIntToIntSig) Clone() builtinFunc {
@@ -558,6 +570,7 @@ func (b *builtinCeilIntToIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 
 type builtinCeilIntToDecSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCeilIntToDecSig) Clone() builtinFunc {
@@ -582,6 +595,7 @@ func (b *builtinCeilIntToDecSig) evalDecimal(ctx EvalContext, row chunk.Row) (*t
 
 type builtinCeilDecToIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCeilDecToIntSig) Clone() builtinFunc {
@@ -610,6 +624,7 @@ func (b *builtinCeilDecToIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 
 type builtinCeilDecToDecSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCeilDecToDecSig) Clone() builtinFunc {
@@ -690,22 +705,22 @@ func (c *floorFunctionClass) getFunction(ctx BuildContext, args []Expression) (s
 	switch argTp {
 	case types.ETInt:
 		if retTp == types.ETInt {
-			sig = &builtinFloorIntToIntSig{bf}
+			sig = &builtinFloorIntToIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_FloorIntToInt)
 		} else {
-			sig = &builtinFloorIntToDecSig{bf}
+			sig = &builtinFloorIntToDecSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_FloorIntToDec)
 		}
 	case types.ETDecimal:
 		if retTp == types.ETInt {
-			sig = &builtinFloorDecToIntSig{bf}
+			sig = &builtinFloorDecToIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_FloorDecToInt)
 		} else {
-			sig = &builtinFloorDecToDecSig{bf}
+			sig = &builtinFloorDecToDecSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_FloorDecToDec)
 		}
 	default:
-		sig = &builtinFloorRealSig{bf}
+		sig = &builtinFloorRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_FloorReal)
 	}
 	return sig, nil
@@ -713,6 +728,7 @@ func (c *floorFunctionClass) getFunction(ctx BuildContext, args []Expression) (s
 
 type builtinFloorRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFloorRealSig) Clone() builtinFunc {
@@ -733,6 +749,7 @@ func (b *builtinFloorRealSig) evalReal(ctx EvalContext, row chunk.Row) (float64,
 
 type builtinFloorIntToIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFloorIntToIntSig) Clone() builtinFunc {
@@ -749,6 +766,7 @@ func (b *builtinFloorIntToIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64
 
 type builtinFloorIntToDecSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFloorIntToDecSig) Clone() builtinFunc {
@@ -773,6 +791,7 @@ func (b *builtinFloorIntToDecSig) evalDecimal(ctx EvalContext, row chunk.Row) (*
 
 type builtinFloorDecToIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFloorDecToIntSig) Clone() builtinFunc {
@@ -801,6 +820,7 @@ func (b *builtinFloorDecToIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64
 
 type builtinFloorDecToDecSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFloorDecToDecSig) Clone() builtinFunc {
@@ -859,10 +879,10 @@ func (c *logFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 	}
 
 	if argsLen == 1 {
-		sig = &builtinLog1ArgSig{bf}
+		sig = &builtinLog1ArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Log1Arg)
 	} else {
-		sig = &builtinLog2ArgsSig{bf}
+		sig = &builtinLog2ArgsSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Log2Args)
 	}
 
@@ -871,6 +891,7 @@ func (c *logFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 
 type builtinLog1ArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLog1ArgSig) Clone() builtinFunc {
@@ -896,6 +917,7 @@ func (b *builtinLog1ArgSig) evalReal(ctx EvalContext, row chunk.Row) (float64, b
 
 type builtinLog2ArgsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLog2ArgsSig) Clone() builtinFunc {
@@ -938,13 +960,14 @@ func (c *log2FunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinLog2Sig{bf}
+	sig := &builtinLog2Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Log2)
 	return sig, nil
 }
 
 type builtinLog2Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLog2Sig) Clone() builtinFunc {
@@ -980,13 +1003,14 @@ func (c *log10FunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinLog10Sig{bf}
+	sig := &builtinLog10Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Log10)
 	return sig, nil
 }
 
 type builtinLog10Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLog10Sig) Clone() builtinFunc {
@@ -1029,7 +1053,7 @@ func (c *randFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	}
 	bt := bf
 	if len(args) == 0 {
-		sig = &builtinRandSig{bt, ctx.GetSessionVars().Rng}
+		sig = &builtinRandSig{baseBuiltinFunc: bt, mysqlRng: ctx.GetSessionVars().Rng}
 		sig.setPbCode(tipb.ScalarFuncSig_Rand)
 	} else if _, isConstant := args[0].(*Constant); isConstant {
 		// According to MySQL manual:
@@ -1045,10 +1069,10 @@ func (c *randFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 			// The behavior same as MySQL.
 			seed = 0
 		}
-		sig = &builtinRandSig{bt, mathutil.NewWithSeed(seed)}
+		sig = &builtinRandSig{baseBuiltinFunc: bt, mysqlRng: mathutil.NewWithSeed(seed)}
 		sig.setPbCode(tipb.ScalarFuncSig_Rand)
 	} else {
-		sig = &builtinRandWithSeedFirstGenSig{bt}
+		sig = &builtinRandWithSeedFirstGenSig{baseBuiltinFunc: bt}
 		sig.setPbCode(tipb.ScalarFuncSig_RandWithSeedFirstGen)
 	}
 	return sig, nil
@@ -1056,6 +1080,7 @@ func (c *randFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 
 type builtinRandSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	mysqlRng *mathutil.MysqlRng
 }
 
@@ -1074,6 +1099,7 @@ func (b *builtinRandSig) evalReal(ctx EvalContext, row chunk.Row) (float64, bool
 
 type builtinRandWithSeedFirstGenSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRandWithSeedFirstGenSig) Clone() builtinFunc {
@@ -1113,13 +1139,14 @@ func (c *powFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinPowSig{bf}
+	sig := &builtinPowSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Pow)
 	return sig, nil
 }
 
 type builtinPowSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinPowSig) Clone() builtinFunc {
@@ -1167,13 +1194,14 @@ func (c *convFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(64)
-	sig := &builtinConvSig{bf}
+	sig := &builtinConvSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Conv)
 	return sig, nil
 }
 
 type builtinConvSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinConvSig) Clone() builtinFunc {
@@ -1303,13 +1331,14 @@ func (c *crc32FunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	}
 	bf.tp.SetFlen(10)
 	bf.tp.AddFlag(mysql.UnsignedFlag)
-	sig := &builtinCRC32Sig{bf}
+	sig := &builtinCRC32Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_CRC32)
 	return sig, nil
 }
 
 type builtinCRC32Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCRC32Sig) Clone() builtinFunc {
@@ -1341,13 +1370,14 @@ func (c *signFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinSignSig{bf}
+	sig := &builtinSignSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Sign)
 	return sig, nil
 }
 
 type builtinSignSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSignSig) Clone() builtinFunc {
@@ -1383,13 +1413,14 @@ func (c *sqrtFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinSqrtSig{bf}
+	sig := &builtinSqrtSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Sqrt)
 	return sig, nil
 }
 
 type builtinSqrtSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSqrtSig) Clone() builtinFunc {
@@ -1423,13 +1454,14 @@ func (c *acosFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinAcosSig{bf}
+	sig := &builtinAcosSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Acos)
 	return sig, nil
 }
 
 type builtinAcosSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAcosSig) Clone() builtinFunc {
@@ -1464,13 +1496,14 @@ func (c *asinFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinAsinSig{bf}
+	sig := &builtinAsinSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Asin)
 	return sig, nil
 }
 
 type builtinAsinSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAsinSig) Clone() builtinFunc {
@@ -1522,10 +1555,10 @@ func (c *atanFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	}
 
 	if argsLen == 1 {
-		sig = &builtinAtan1ArgSig{bf}
+		sig = &builtinAtan1ArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Atan1Arg)
 	} else {
-		sig = &builtinAtan2ArgsSig{bf}
+		sig = &builtinAtan2ArgsSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Atan2Args)
 	}
 
@@ -1534,6 +1567,7 @@ func (c *atanFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 
 type builtinAtan1ArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAtan1ArgSig) Clone() builtinFunc {
@@ -1555,6 +1589,7 @@ func (b *builtinAtan1ArgSig) evalReal(ctx EvalContext, row chunk.Row) (float64, 
 
 type builtinAtan2ArgsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAtan2ArgsSig) Clone() builtinFunc {
@@ -1591,13 +1626,14 @@ func (c *cosFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinCosSig{bf}
+	sig := &builtinCosSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Cos)
 	return sig, nil
 }
 
 type builtinCosSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCosSig) Clone() builtinFunc {
@@ -1628,13 +1664,14 @@ func (c *cotFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinCotSig{bf}
+	sig := &builtinCotSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Cot)
 	return sig, nil
 }
 
 type builtinCotSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCotSig) Clone() builtinFunc {
@@ -1673,13 +1710,14 @@ func (c *degreesFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinDegreesSig{bf}
+	sig := &builtinDegreesSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Degrees)
 	return sig, nil
 }
 
 type builtinDegreesSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDegreesSig) Clone() builtinFunc {
@@ -1711,13 +1749,14 @@ func (c *expFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinExpSig{bf}
+	sig := &builtinExpSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Exp)
 	return sig, nil
 }
 
 type builtinExpSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinExpSig) Clone() builtinFunc {
@@ -1761,13 +1800,14 @@ func (c *piFunctionClass) getFunction(ctx BuildContext, args []Expression) (buil
 	}
 	bf.tp.SetDecimal(6)
 	bf.tp.SetFlen(8)
-	sig = &builtinPISig{bf}
+	sig = &builtinPISig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_PI)
 	return sig, nil
 }
 
 type builtinPISig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinPISig) Clone() builtinFunc {
@@ -1794,13 +1834,14 @@ func (c *radiansFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinRadiansSig{bf}
+	sig := &builtinRadiansSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Radians)
 	return sig, nil
 }
 
 type builtinRadiansSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRadiansSig) Clone() builtinFunc {
@@ -1831,13 +1872,14 @@ func (c *sinFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinSinSig{bf}
+	sig := &builtinSinSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Sin)
 	return sig, nil
 }
 
 type builtinSinSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSinSig) Clone() builtinFunc {
@@ -1868,13 +1910,14 @@ func (c *tanFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinTanSig{bf}
+	sig := &builtinTanSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Tan)
 	return sig, nil
 }
 
 type builtinTanSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTanSig) Clone() builtinFunc {
@@ -1922,17 +1965,17 @@ func (c *truncateFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	switch argTp {
 	case types.ETInt:
 		if mysql.HasUnsignedFlag(args[0].GetType().GetFlag()) {
-			sig = &builtinTruncateUintSig{bf}
+			sig = &builtinTruncateUintSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_TruncateUint)
 		} else {
-			sig = &builtinTruncateIntSig{bf}
+			sig = &builtinTruncateIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_TruncateInt)
 		}
 	case types.ETReal:
-		sig = &builtinTruncateRealSig{bf}
+		sig = &builtinTruncateRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_TruncateReal)
 	case types.ETDecimal:
-		sig = &builtinTruncateDecimalSig{bf}
+		sig = &builtinTruncateDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_TruncateDecimal)
 	default:
 		return nil, errIncorrectArgs.GenWithStackByArgs("truncate")
@@ -1943,6 +1986,7 @@ func (c *truncateFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 type builtinTruncateDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTruncateDecimalSig) Clone() builtinFunc {
@@ -1973,6 +2017,7 @@ func (b *builtinTruncateDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row) 
 
 type builtinTruncateRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTruncateRealSig) Clone() builtinFunc {
@@ -1999,6 +2044,7 @@ func (b *builtinTruncateRealSig) evalReal(ctx EvalContext, row chunk.Row) (float
 
 type builtinTruncateIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTruncateIntSig) Clone() builtinFunc {
@@ -2042,6 +2088,7 @@ func (b *builtinTruncateUintSig) Clone() builtinFunc {
 
 type builtinTruncateUintSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 // evalInt evals a TRUNCATE(X,D).

--- a/pkg/expression/builtin_miscellaneous.go
+++ b/pkg/expression/builtin_miscellaneous.go
@@ -117,12 +117,13 @@ func (c *sleepFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 		return nil, err
 	}
 	bf.tp.SetFlen(21)
-	sig := &builtinSleepSig{bf}
+	sig := &builtinSleepSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinSleepSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSleepSig) Clone() builtinFunc {
@@ -172,13 +173,14 @@ func (c *lockFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinLockSig{bf}
+	sig := &builtinLockSig{baseBuiltinFunc: bf}
 	bf.tp.SetFlen(1)
 	return sig, nil
 }
 
 type builtinLockSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLockSig) Clone() builtinFunc {
@@ -256,13 +258,14 @@ func (c *releaseLockFunctionClass) getFunction(ctx BuildContext, args []Expressi
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinReleaseLockSig{bf}
+	sig := &builtinReleaseLockSig{baseBuiltinFunc: bf}
 	bf.tp.SetFlen(1)
 	return sig, nil
 }
 
 type builtinReleaseLockSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinReleaseLockSig) Clone() builtinFunc {
@@ -317,30 +320,30 @@ func (c *anyValueFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	var sig builtinFunc
 	switch argTp {
 	case types.ETDecimal:
-		sig = &builtinDecimalAnyValueSig{bf}
+		sig = &builtinDecimalAnyValueSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_DecimalAnyValue)
 	case types.ETDuration:
-		sig = &builtinDurationAnyValueSig{bf}
+		sig = &builtinDurationAnyValueSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_DurationAnyValue)
 	case types.ETInt:
 		bf.tp.SetDecimal(0)
-		sig = &builtinIntAnyValueSig{bf}
+		sig = &builtinIntAnyValueSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IntAnyValue)
 	case types.ETJson:
-		sig = &builtinJSONAnyValueSig{bf}
+		sig = &builtinJSONAnyValueSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_JSONAnyValue)
 	case types.ETReal:
-		sig = &builtinRealAnyValueSig{bf}
+		sig = &builtinRealAnyValueSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_RealAnyValue)
 	case types.ETString:
 		bf.tp.SetDecimal(types.UnspecifiedLength)
-		sig = &builtinStringAnyValueSig{bf}
+		sig = &builtinStringAnyValueSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_StringAnyValue)
 	case types.ETDatetime, types.ETTimestamp:
 		bf.tp.SetCharset(mysql.DefaultCharset)
 		bf.tp.SetCollate(mysql.DefaultCollationName)
 		bf.tp.SetFlag(0)
-		sig = &builtinTimeAnyValueSig{bf}
+		sig = &builtinTimeAnyValueSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_TimeAnyValue)
 	default:
 		return nil, errIncorrectArgs.GenWithStackByArgs("ANY_VALUE")
@@ -350,6 +353,7 @@ func (c *anyValueFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 type builtinDecimalAnyValueSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDecimalAnyValueSig) Clone() builtinFunc {
@@ -366,6 +370,7 @@ func (b *builtinDecimalAnyValueSig) evalDecimal(ctx EvalContext, row chunk.Row) 
 
 type builtinDurationAnyValueSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDurationAnyValueSig) Clone() builtinFunc {
@@ -382,6 +387,7 @@ func (b *builtinDurationAnyValueSig) evalDuration(ctx EvalContext, row chunk.Row
 
 type builtinIntAnyValueSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIntAnyValueSig) Clone() builtinFunc {
@@ -398,6 +404,7 @@ func (b *builtinIntAnyValueSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 
 type builtinJSONAnyValueSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinJSONAnyValueSig) Clone() builtinFunc {
@@ -414,6 +421,7 @@ func (b *builtinJSONAnyValueSig) evalJSON(ctx EvalContext, row chunk.Row) (types
 
 type builtinRealAnyValueSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRealAnyValueSig) Clone() builtinFunc {
@@ -430,6 +438,7 @@ func (b *builtinRealAnyValueSig) evalReal(ctx EvalContext, row chunk.Row) (float
 
 type builtinStringAnyValueSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinStringAnyValueSig) Clone() builtinFunc {
@@ -446,6 +455,7 @@ func (b *builtinStringAnyValueSig) evalString(ctx EvalContext, row chunk.Row) (s
 
 type builtinTimeAnyValueSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTimeAnyValueSig) Clone() builtinFunc {
@@ -482,13 +492,14 @@ func (c *inetAtonFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	}
 	bf.tp.SetFlen(21)
 	bf.tp.AddFlag(mysql.UnsignedFlag)
-	sig := &builtinInetAtonSig{bf}
+	sig := &builtinInetAtonSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_InetAton)
 	return sig, nil
 }
 
 type builtinInetAtonSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinInetAtonSig) Clone() builtinFunc {
@@ -562,13 +573,14 @@ func (c *inetNtoaFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(93)
 	bf.tp.SetDecimal(0)
-	sig := &builtinInetNtoaSig{bf}
+	sig := &builtinInetNtoaSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_InetNtoa)
 	return sig, nil
 }
 
 type builtinInetNtoaSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinInetNtoaSig) Clone() builtinFunc {
@@ -615,13 +627,14 @@ func (c *inet6AtonFunctionClass) getFunction(ctx BuildContext, args []Expression
 	bf.tp.SetFlen(16)
 	types.SetBinChsClnFlag(bf.tp)
 	bf.tp.SetDecimal(0)
-	sig := &builtinInet6AtonSig{bf}
+	sig := &builtinInet6AtonSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Inet6Aton)
 	return sig, nil
 }
 
 type builtinInet6AtonSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinInet6AtonSig) Clone() builtinFunc {
@@ -690,13 +703,14 @@ func (c *inet6NtoaFunctionClass) getFunction(ctx BuildContext, args []Expression
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(117)
 	bf.tp.SetDecimal(0)
-	sig := &builtinInet6NtoaSig{bf}
+	sig := &builtinInet6NtoaSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Inet6Ntoa)
 	return sig, nil
 }
 
 type builtinInet6NtoaSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinInet6NtoaSig) Clone() builtinFunc {
@@ -736,13 +750,14 @@ func (c *isFreeLockFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinFreeLockSig{bf}
+	sig := &builtinFreeLockSig{baseBuiltinFunc: bf}
 	bf.tp.SetFlen(1)
 	return sig, nil
 }
 
 type builtinFreeLockSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFreeLockSig) Clone() builtinFunc {
@@ -791,13 +806,14 @@ func (c *isIPv4FunctionClass) getFunction(ctx BuildContext, args []Expression) (
 		return nil, err
 	}
 	bf.tp.SetFlen(1)
-	sig := &builtinIsIPv4Sig{bf}
+	sig := &builtinIsIPv4Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_IsIPv4)
 	return sig, nil
 }
 
 type builtinIsIPv4Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIsIPv4Sig) Clone() builtinFunc {
@@ -859,13 +875,14 @@ func (c *isIPv4CompatFunctionClass) getFunction(ctx BuildContext, args []Express
 		return nil, err
 	}
 	bf.tp.SetFlen(1)
-	sig := &builtinIsIPv4CompatSig{bf}
+	sig := &builtinIsIPv4CompatSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_IsIPv4Compat)
 	return sig, nil
 }
 
 type builtinIsIPv4CompatSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIsIPv4CompatSig) Clone() builtinFunc {
@@ -908,13 +925,14 @@ func (c *isIPv4MappedFunctionClass) getFunction(ctx BuildContext, args []Express
 		return nil, err
 	}
 	bf.tp.SetFlen(1)
-	sig := &builtinIsIPv4MappedSig{bf}
+	sig := &builtinIsIPv4MappedSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_IsIPv4Mapped)
 	return sig, nil
 }
 
 type builtinIsIPv4MappedSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIsIPv4MappedSig) Clone() builtinFunc {
@@ -957,13 +975,14 @@ func (c *isIPv6FunctionClass) getFunction(ctx BuildContext, args []Expression) (
 		return nil, err
 	}
 	bf.tp.SetFlen(1)
-	sig := &builtinIsIPv6Sig{bf}
+	sig := &builtinIsIPv6Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_IsIPv6)
 	return sig, nil
 }
 
 type builtinIsIPv6Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIsIPv6Sig) Clone() builtinFunc {
@@ -998,13 +1017,14 @@ func (c *isUsedLockFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinUsedLockSig{bf}
+	sig := &builtinUsedLockSig{baseBuiltinFunc: bf}
 	bf.tp.SetFlen(1)
 	return sig, nil
 }
 
 type builtinUsedLockSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUsedLockSig) Clone() builtinFunc {
@@ -1050,13 +1070,14 @@ func (c *isUUIDFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 		return nil, err
 	}
 	bf.tp.SetFlen(1)
-	sig := &builtinIsUUIDSig{bf}
+	sig := &builtinIsUUIDSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_IsUUID)
 	return sig, nil
 }
 
 type builtinIsUUIDSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIsUUIDSig) Clone() builtinFunc {
@@ -1103,24 +1124,24 @@ func (c *nameConstFunctionClass) getFunction(ctx BuildContext, args []Expression
 	var sig builtinFunc
 	switch argTp {
 	case types.ETDecimal:
-		sig = &builtinNameConstDecimalSig{bf}
+		sig = &builtinNameConstDecimalSig{baseBuiltinFunc: bf}
 	case types.ETDuration:
-		sig = &builtinNameConstDurationSig{bf}
+		sig = &builtinNameConstDurationSig{baseBuiltinFunc: bf}
 	case types.ETInt:
 		bf.tp.SetDecimal(0)
-		sig = &builtinNameConstIntSig{bf}
+		sig = &builtinNameConstIntSig{baseBuiltinFunc: bf}
 	case types.ETJson:
-		sig = &builtinNameConstJSONSig{bf}
+		sig = &builtinNameConstJSONSig{baseBuiltinFunc: bf}
 	case types.ETReal:
-		sig = &builtinNameConstRealSig{bf}
+		sig = &builtinNameConstRealSig{baseBuiltinFunc: bf}
 	case types.ETString:
 		bf.tp.SetDecimal(types.UnspecifiedLength)
-		sig = &builtinNameConstStringSig{bf}
+		sig = &builtinNameConstStringSig{baseBuiltinFunc: bf}
 	case types.ETDatetime, types.ETTimestamp:
 		bf.tp.SetCharset(mysql.DefaultCharset)
 		bf.tp.SetCollate(mysql.DefaultCollationName)
 		bf.tp.SetFlag(0)
-		sig = &builtinNameConstTimeSig{bf}
+		sig = &builtinNameConstTimeSig{baseBuiltinFunc: bf}
 	default:
 		return nil, errIncorrectArgs.GenWithStackByArgs("NAME_CONST")
 	}
@@ -1129,6 +1150,7 @@ func (c *nameConstFunctionClass) getFunction(ctx BuildContext, args []Expression
 
 type builtinNameConstDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNameConstDecimalSig) Clone() builtinFunc {
@@ -1143,6 +1165,7 @@ func (b *builtinNameConstDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row)
 
 type builtinNameConstIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNameConstIntSig) Clone() builtinFunc {
@@ -1157,6 +1180,7 @@ func (b *builtinNameConstIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 
 type builtinNameConstRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNameConstRealSig) Clone() builtinFunc {
@@ -1171,6 +1195,7 @@ func (b *builtinNameConstRealSig) evalReal(ctx EvalContext, row chunk.Row) (floa
 
 type builtinNameConstStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNameConstStringSig) Clone() builtinFunc {
@@ -1185,6 +1210,7 @@ func (b *builtinNameConstStringSig) evalString(ctx EvalContext, row chunk.Row) (
 
 type builtinNameConstJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNameConstJSONSig) Clone() builtinFunc {
@@ -1199,6 +1225,7 @@ func (b *builtinNameConstJSONSig) evalJSON(ctx EvalContext, row chunk.Row) (type
 
 type builtinNameConstDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNameConstDurationSig) Clone() builtinFunc {
@@ -1213,6 +1240,7 @@ func (b *builtinNameConstDurationSig) evalDuration(ctx EvalContext, row chunk.Ro
 
 type builtinNameConstTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNameConstTimeSig) Clone() builtinFunc {
@@ -1237,13 +1265,14 @@ func (c *releaseAllLocksFunctionClass) getFunction(ctx BuildContext, args []Expr
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinReleaseAllLocksSig{bf}
+	sig := &builtinReleaseAllLocksSig{baseBuiltinFunc: bf}
 	bf.tp.SetFlen(1)
 	return sig, nil
 }
 
 type builtinReleaseAllLocksSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinReleaseAllLocksSig) Clone() builtinFunc {
@@ -1275,13 +1304,14 @@ func (c *uuidFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(36)
-	sig := &builtinUUIDSig{bf}
+	sig := &builtinUUIDSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_UUID)
 	return sig, nil
 }
 
 type builtinUUIDSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUUIDSig) Clone() builtinFunc {
@@ -1327,13 +1357,14 @@ func (c *vitessHashFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	bf.tp.AddFlag(mysql.UnsignedFlag)
 	types.SetBinChsClnFlag(bf.tp)
 
-	sig := &builtinVitessHashSig{bf}
+	sig := &builtinVitessHashSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_VitessHash)
 	return sig, nil
 }
 
 type builtinVitessHashSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinVitessHashSig) Clone() builtinFunc {
@@ -1375,12 +1406,13 @@ func (c *uuidToBinFunctionClass) getFunction(ctx BuildContext, args []Expression
 	bf.tp.SetFlen(16)
 	types.SetBinChsClnFlag(bf.tp)
 	bf.tp.SetDecimal(0)
-	sig := &builtinUUIDToBinSig{bf}
+	sig := &builtinUUIDToBinSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinUUIDToBinSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUUIDToBinSig) Clone() builtinFunc {
@@ -1444,12 +1476,13 @@ func (c *binToUUIDFunctionClass) getFunction(ctx BuildContext, args []Expression
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(32)
 	bf.tp.SetDecimal(0)
-	sig := &builtinBinToUUIDSig{bf}
+	sig := &builtinBinToUUIDSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinBinToUUIDSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinBinToUUIDSig) Clone() builtinFunc {
@@ -1527,13 +1560,14 @@ func (c *tidbShardFunctionClass) getFunction(ctx BuildContext, args []Expression
 	bf.tp.AddFlag(mysql.UnsignedFlag)
 	types.SetBinChsClnFlag(bf.tp)
 
-	sig := &builtinTidbShardSig{bf}
+	sig := &builtinTidbShardSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_TiDBShard)
 	return sig, nil
 }
 
 type builtinTidbShardSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTidbShardSig) Clone() builtinFunc {

--- a/pkg/expression/builtin_op.go
+++ b/pkg/expression/builtin_op.go
@@ -81,7 +81,7 @@ func (c *logicAndFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinLogicAndSig{bf}
+	sig := &builtinLogicAndSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_LogicalAnd)
 	sig.tp.SetFlen(1)
 	return sig, nil
@@ -89,6 +89,7 @@ func (c *logicAndFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 type builtinLogicAndSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLogicAndSig) Clone() builtinFunc {
@@ -135,13 +136,14 @@ func (c *logicOrFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 		return nil, err
 	}
 	bf.tp.SetFlen(1)
-	sig := &builtinLogicOrSig{bf}
+	sig := &builtinLogicOrSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_LogicalOr)
 	return sig, nil
 }
 
 type builtinLogicOrSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLogicOrSig) Clone() builtinFunc {
@@ -193,7 +195,7 @@ func (c *logicXorFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinLogicXorSig{bf}
+	sig := &builtinLogicXorSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_LogicalXor)
 	sig.tp.SetFlen(1)
 	return sig, nil
@@ -201,6 +203,7 @@ func (c *logicXorFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 type builtinLogicXorSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLogicXorSig) Clone() builtinFunc {
@@ -237,7 +240,7 @@ func (c *bitAndFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinBitAndSig{bf}
+	sig := &builtinBitAndSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_BitAndSig)
 	sig.tp.AddFlag(mysql.UnsignedFlag)
 	return sig, nil
@@ -245,6 +248,7 @@ func (c *bitAndFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 
 type builtinBitAndSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinBitAndSig) Clone() builtinFunc {
@@ -278,7 +282,7 @@ func (c *bitOrFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinBitOrSig{bf}
+	sig := &builtinBitOrSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_BitOrSig)
 	sig.tp.AddFlag(mysql.UnsignedFlag)
 	return sig, nil
@@ -286,6 +290,7 @@ func (c *bitOrFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 
 type builtinBitOrSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinBitOrSig) Clone() builtinFunc {
@@ -319,7 +324,7 @@ func (c *bitXorFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinBitXorSig{bf}
+	sig := &builtinBitXorSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_BitXorSig)
 	sig.tp.AddFlag(mysql.UnsignedFlag)
 	return sig, nil
@@ -327,6 +332,7 @@ func (c *bitXorFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 
 type builtinBitXorSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinBitXorSig) Clone() builtinFunc {
@@ -360,7 +366,7 @@ func (c *leftShiftFunctionClass) getFunction(ctx BuildContext, args []Expression
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinLeftShiftSig{bf}
+	sig := &builtinLeftShiftSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_LeftShift)
 	sig.tp.AddFlag(mysql.UnsignedFlag)
 	return sig, nil
@@ -368,6 +374,7 @@ func (c *leftShiftFunctionClass) getFunction(ctx BuildContext, args []Expression
 
 type builtinLeftShiftSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLeftShiftSig) Clone() builtinFunc {
@@ -401,7 +408,7 @@ func (c *rightShiftFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinRightShiftSig{bf}
+	sig := &builtinRightShiftSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_RightShift)
 	sig.tp.AddFlag(mysql.UnsignedFlag)
 	return sig, nil
@@ -409,6 +416,7 @@ func (c *rightShiftFunctionClass) getFunction(ctx BuildContext, args []Expressio
 
 type builtinRightShiftSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRightShiftSig) Clone() builtinFunc {
@@ -466,21 +474,21 @@ func (c *isTrueOrFalseFunctionClass) getFunction(ctx BuildContext, args []Expres
 	case opcode.IsTruth:
 		switch argTp {
 		case types.ETReal:
-			sig = &builtinRealIsTrueSig{bf, c.keepNull}
+			sig = &builtinRealIsTrueSig{baseBuiltinFunc: bf, keepNull: c.keepNull}
 			if c.keepNull {
 				sig.setPbCode(tipb.ScalarFuncSig_RealIsTrueWithNull)
 			} else {
 				sig.setPbCode(tipb.ScalarFuncSig_RealIsTrue)
 			}
 		case types.ETDecimal:
-			sig = &builtinDecimalIsTrueSig{bf, c.keepNull}
+			sig = &builtinDecimalIsTrueSig{baseBuiltinFunc: bf, keepNull: c.keepNull}
 			if c.keepNull {
 				sig.setPbCode(tipb.ScalarFuncSig_DecimalIsTrueWithNull)
 			} else {
 				sig.setPbCode(tipb.ScalarFuncSig_DecimalIsTrue)
 			}
 		case types.ETInt:
-			sig = &builtinIntIsTrueSig{bf, c.keepNull}
+			sig = &builtinIntIsTrueSig{baseBuiltinFunc: bf, keepNull: c.keepNull}
 			if c.keepNull {
 				sig.setPbCode(tipb.ScalarFuncSig_IntIsTrueWithNull)
 			} else {
@@ -492,21 +500,21 @@ func (c *isTrueOrFalseFunctionClass) getFunction(ctx BuildContext, args []Expres
 	case opcode.IsFalsity:
 		switch argTp {
 		case types.ETReal:
-			sig = &builtinRealIsFalseSig{bf, c.keepNull}
+			sig = &builtinRealIsFalseSig{baseBuiltinFunc: bf, keepNull: c.keepNull}
 			if c.keepNull {
 				sig.setPbCode(tipb.ScalarFuncSig_RealIsFalseWithNull)
 			} else {
 				sig.setPbCode(tipb.ScalarFuncSig_RealIsFalse)
 			}
 		case types.ETDecimal:
-			sig = &builtinDecimalIsFalseSig{bf, c.keepNull}
+			sig = &builtinDecimalIsFalseSig{baseBuiltinFunc: bf, keepNull: c.keepNull}
 			if c.keepNull {
 				sig.setPbCode(tipb.ScalarFuncSig_DecimalIsFalseWithNull)
 			} else {
 				sig.setPbCode(tipb.ScalarFuncSig_DecimalIsFalse)
 			}
 		case types.ETInt:
-			sig = &builtinIntIsFalseSig{bf, c.keepNull}
+			sig = &builtinIntIsFalseSig{baseBuiltinFunc: bf, keepNull: c.keepNull}
 			if c.keepNull {
 				sig.setPbCode(tipb.ScalarFuncSig_IntIsFalseWithNull)
 			} else {
@@ -521,6 +529,7 @@ func (c *isTrueOrFalseFunctionClass) getFunction(ctx BuildContext, args []Expres
 
 type builtinRealIsTrueSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	keepNull bool
 }
 
@@ -546,6 +555,7 @@ func (b *builtinRealIsTrueSig) evalInt(ctx EvalContext, row chunk.Row) (int64, b
 
 type builtinDecimalIsTrueSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	keepNull bool
 }
 
@@ -571,6 +581,7 @@ func (b *builtinDecimalIsTrueSig) evalInt(ctx EvalContext, row chunk.Row) (int64
 
 type builtinIntIsTrueSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	keepNull bool
 }
 
@@ -596,6 +607,7 @@ func (b *builtinIntIsTrueSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bo
 
 type builtinRealIsFalseSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	keepNull bool
 }
 
@@ -621,6 +633,7 @@ func (b *builtinRealIsFalseSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 
 type builtinDecimalIsFalseSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	keepNull bool
 }
 
@@ -646,6 +659,7 @@ func (b *builtinDecimalIsFalseSig) evalInt(ctx EvalContext, row chunk.Row) (int6
 
 type builtinIntIsFalseSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	keepNull bool
 }
 
@@ -682,13 +696,14 @@ func (c *bitNegFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 		return nil, err
 	}
 	bf.tp.AddFlag(mysql.UnsignedFlag)
-	sig := &builtinBitNegSig{bf}
+	sig := &builtinBitNegSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_BitNegSig)
 	return sig, nil
 }
 
 type builtinBitNegSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinBitNegSig) Clone() builtinFunc {
@@ -730,17 +745,17 @@ func (c *unaryNotFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	var sig builtinFunc
 	switch argTp {
 	case types.ETReal:
-		sig = &builtinUnaryNotRealSig{bf}
+		sig = &builtinUnaryNotRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UnaryNotReal)
 	case types.ETDecimal:
-		sig = &builtinUnaryNotDecimalSig{bf}
+		sig = &builtinUnaryNotDecimalSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UnaryNotDecimal)
 	case types.ETInt:
-		sig = &builtinUnaryNotIntSig{bf}
+		sig = &builtinUnaryNotIntSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UnaryNotInt)
 	case types.ETJson:
 		ctx.GetSessionVars().StmtCtx.AppendWarning(errJSONInBooleanContext)
-		sig = &builtinUnaryNotJSONSig{bf}
+		sig = &builtinUnaryNotJSONSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UnaryNotJSON)
 	default:
 		return nil, errors.Errorf("unexpected types.EvalType %v", argTp)
@@ -750,6 +765,7 @@ func (c *unaryNotFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 type builtinUnaryNotRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUnaryNotRealSig) Clone() builtinFunc {
@@ -771,6 +787,7 @@ func (b *builtinUnaryNotRealSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 
 type builtinUnaryNotDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUnaryNotDecimalSig) Clone() builtinFunc {
@@ -792,6 +809,7 @@ func (b *builtinUnaryNotDecimalSig) evalInt(ctx EvalContext, row chunk.Row) (int
 
 type builtinUnaryNotIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUnaryNotIntSig) Clone() builtinFunc {
@@ -813,6 +831,7 @@ func (b *builtinUnaryNotIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 
 type builtinUnaryNotJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUnaryNotJSONSig) Clone() builtinFunc {
@@ -891,14 +910,14 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 			if err != nil {
 				return nil, err
 			}
-			sig = &builtinUnaryMinusDecimalSig{bf, true}
+			sig = &builtinUnaryMinusDecimalSig{baseBuiltinFunc: bf, constantArgOverflow: true}
 			sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusDecimal)
 		} else {
 			bf, err = newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, types.ETInt)
 			if err != nil {
 				return nil, err
 			}
-			sig = &builtinUnaryMinusIntSig{bf}
+			sig = &builtinUnaryMinusIntSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusInt)
 		}
 		bf.tp.SetDecimal(0)
@@ -908,14 +927,14 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 			return nil, err
 		}
 		bf.tp.SetDecimalUnderLimit(argExprTp.GetDecimal())
-		sig = &builtinUnaryMinusDecimalSig{bf, false}
+		sig = &builtinUnaryMinusDecimalSig{baseBuiltinFunc: bf, constantArgOverflow: false}
 		sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusDecimal)
 	case types.ETReal:
 		bf, err = newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETReal, types.ETReal)
 		if err != nil {
 			return nil, err
 		}
-		sig = &builtinUnaryMinusRealSig{bf}
+		sig = &builtinUnaryMinusRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusReal)
 	default:
 		tp := argExpr.GetType().GetType()
@@ -924,14 +943,14 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 			if err != nil {
 				return nil, err
 			}
-			sig = &builtinUnaryMinusDecimalSig{bf, false}
+			sig = &builtinUnaryMinusDecimalSig{baseBuiltinFunc: bf, constantArgOverflow: false}
 			sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusDecimal)
 		} else {
 			bf, err = newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETReal, types.ETReal)
 			if err != nil {
 				return nil, err
 			}
-			sig = &builtinUnaryMinusRealSig{bf}
+			sig = &builtinUnaryMinusRealSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_UnaryMinusReal)
 		}
 	}
@@ -941,6 +960,7 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 
 type builtinUnaryMinusIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUnaryMinusIntSig) Clone() builtinFunc {
@@ -971,6 +991,7 @@ func (b *builtinUnaryMinusIntSig) evalInt(ctx EvalContext, row chunk.Row) (res i
 
 type builtinUnaryMinusDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	constantArgOverflow bool
 }
@@ -991,6 +1012,7 @@ func (b *builtinUnaryMinusDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row
 
 type builtinUnaryMinusRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUnaryMinusRealSig) Clone() builtinFunc {
@@ -1026,22 +1048,22 @@ func (c *isNullFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	var sig builtinFunc
 	switch argTp {
 	case types.ETInt:
-		sig = &builtinIntIsNullSig{bf}
+		sig = &builtinIntIsNullSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_IntIsNull)
 	case types.ETDecimal:
-		sig = &builtinDecimalIsNullSig{bf}
+		sig = &builtinDecimalIsNullSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_DecimalIsNull)
 	case types.ETReal:
-		sig = &builtinRealIsNullSig{bf}
+		sig = &builtinRealIsNullSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_RealIsNull)
 	case types.ETDatetime:
-		sig = &builtinTimeIsNullSig{bf}
+		sig = &builtinTimeIsNullSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_TimeIsNull)
 	case types.ETDuration:
-		sig = &builtinDurationIsNullSig{bf}
+		sig = &builtinDurationIsNullSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_DurationIsNull)
 	case types.ETString:
-		sig = &builtinStringIsNullSig{bf}
+		sig = &builtinStringIsNullSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_StringIsNull)
 	default:
 		panic("unexpected types.EvalType")
@@ -1051,6 +1073,7 @@ func (c *isNullFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 
 type builtinDecimalIsNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDecimalIsNullSig) Clone() builtinFunc {
@@ -1076,6 +1099,7 @@ func (b *builtinDecimalIsNullSig) evalInt(ctx EvalContext, row chunk.Row) (int64
 
 type builtinDurationIsNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDurationIsNullSig) Clone() builtinFunc {
@@ -1091,6 +1115,7 @@ func (b *builtinDurationIsNullSig) evalInt(ctx EvalContext, row chunk.Row) (int6
 
 type builtinIntIsNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinIntIsNullSig) Clone() builtinFunc {
@@ -1106,6 +1131,7 @@ func (b *builtinIntIsNullSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bo
 
 type builtinRealIsNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRealIsNullSig) Clone() builtinFunc {
@@ -1121,6 +1147,7 @@ func (b *builtinRealIsNullSig) evalInt(ctx EvalContext, row chunk.Row) (int64, b
 
 type builtinStringIsNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinStringIsNullSig) Clone() builtinFunc {
@@ -1136,6 +1163,7 @@ func (b *builtinStringIsNullSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 
 type builtinTimeIsNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTimeIsNullSig) Clone() builtinFunc {

--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -179,6 +179,7 @@ func (c *inFunctionClass) verifyArgs(ctx BuildContext, args []Expression) ([]Exp
 // nolint:structcheck
 type baseInSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	// nonConstArgsIdx stores the indices of non-constant args in the baseBuiltinFunc.args (the first arg is not included).
 	// It works with builtinInXXXSig.hashset to accelerate 'eval'.
 	nonConstArgsIdx []int
@@ -648,6 +649,7 @@ func (b *builtinInDurationSig) evalInt(ctx EvalContext, row chunk.Row) (int64, b
 // builtinInJSONSig see https://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_in
 type builtinInJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinInJSONSig) Clone() builtinFunc {
@@ -695,12 +697,13 @@ func (c *rowFunctionClass) getFunction(ctx BuildContext, args []Expression) (sig
 	if err != nil {
 		return nil, err
 	}
-	sig = &builtinRowSig{bf}
+	sig = &builtinRowSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinRowSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRowSig) Clone() builtinFunc {
@@ -733,15 +736,15 @@ func (c *setVarFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	bf.tp.SetFlenUnderLimit(args[1].GetType().GetFlen())
 	switch argTp {
 	case types.ETString:
-		sig = &builtinSetStringVarSig{bf}
+		sig = &builtinSetStringVarSig{baseBuiltinFunc: bf}
 	case types.ETReal:
-		sig = &builtinSetRealVarSig{bf}
+		sig = &builtinSetRealVarSig{baseBuiltinFunc: bf}
 	case types.ETDecimal:
-		sig = &builtinSetDecimalVarSig{bf}
+		sig = &builtinSetDecimalVarSig{baseBuiltinFunc: bf}
 	case types.ETInt:
-		sig = &builtinSetIntVarSig{bf}
+		sig = &builtinSetIntVarSig{baseBuiltinFunc: bf}
 	case types.ETDatetime:
-		sig = &builtinSetTimeVarSig{bf}
+		sig = &builtinSetTimeVarSig{baseBuiltinFunc: bf}
 	default:
 		return nil, errors.Errorf("unexpected types.EvalType %v", argTp)
 	}
@@ -750,6 +753,7 @@ func (c *setVarFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 
 type builtinSetStringVarSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSetStringVarSig) Clone() builtinFunc {
@@ -780,6 +784,7 @@ func (b *builtinSetStringVarSig) evalString(ctx EvalContext, row chunk.Row) (res
 
 type builtinSetRealVarSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSetRealVarSig) Clone() builtinFunc {
@@ -808,6 +813,7 @@ func (b *builtinSetRealVarSig) evalReal(ctx EvalContext, row chunk.Row) (res flo
 
 type builtinSetDecimalVarSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSetDecimalVarSig) Clone() builtinFunc {
@@ -835,6 +841,7 @@ func (b *builtinSetDecimalVarSig) evalDecimal(ctx EvalContext, row chunk.Row) (*
 
 type builtinSetIntVarSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSetIntVarSig) Clone() builtinFunc {
@@ -862,6 +869,7 @@ func (b *builtinSetIntVarSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bo
 
 type builtinSetTimeVarSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSetTimeVarSig) Clone() builtinFunc {
@@ -938,12 +946,13 @@ func (c *getStringVarFunctionClass) getFunction(ctx BuildContext, args []Express
 		bf.tp.SetCharset(c.tp.GetCharset())
 		bf.tp.SetCollate(c.tp.GetCollate())
 	}
-	sig = &builtinGetStringVarSig{bf}
+	sig = &builtinGetStringVarSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinGetStringVarSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGetStringVarSig) Clone() builtinFunc {
@@ -990,12 +999,13 @@ func (c *getIntVarFunctionClass) getFunction(ctx BuildContext, args []Expression
 	}
 	bf.tp.SetFlen(c.tp.GetFlen())
 	bf.tp.SetFlag(c.tp.GetFlag())
-	sig = &builtinGetIntVarSig{bf}
+	sig = &builtinGetIntVarSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinGetIntVarSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGetIntVarSig) Clone() builtinFunc {
@@ -1030,12 +1040,13 @@ func (c *getRealVarFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		return nil, err
 	}
 	bf.tp.SetFlen(c.tp.GetFlen())
-	sig = &builtinGetRealVarSig{bf}
+	sig = &builtinGetRealVarSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinGetRealVarSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGetRealVarSig) Clone() builtinFunc {
@@ -1074,12 +1085,13 @@ func (c *getDecimalVarFunctionClass) getFunction(ctx BuildContext, args []Expres
 		return nil, err
 	}
 	bf.tp.SetFlenUnderLimit(c.tp.GetFlen())
-	sig = &builtinGetDecimalVarSig{bf}
+	sig = &builtinGetDecimalVarSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinGetDecimalVarSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGetDecimalVarSig) Clone() builtinFunc {
@@ -1126,12 +1138,13 @@ func (c *getTimeVarFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	} else {
 		bf.setDecimalAndFlenForDate()
 	}
-	sig = &builtinGetTimeVarSig{bf}
+	sig = &builtinGetTimeVarSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinGetTimeVarSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGetTimeVarSig) Clone() builtinFunc {
@@ -1170,25 +1183,26 @@ func (c *valuesFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	}
 	switch c.tp.EvalType() {
 	case types.ETInt:
-		sig = &builtinValuesIntSig{bf, c.offset}
+		sig = &builtinValuesIntSig{baseBuiltinFunc: bf, offset: c.offset}
 	case types.ETReal:
-		sig = &builtinValuesRealSig{bf, c.offset}
+		sig = &builtinValuesRealSig{baseBuiltinFunc: bf, offset: c.offset}
 	case types.ETDecimal:
-		sig = &builtinValuesDecimalSig{bf, c.offset}
+		sig = &builtinValuesDecimalSig{baseBuiltinFunc: bf, offset: c.offset}
 	case types.ETString:
-		sig = &builtinValuesStringSig{bf, c.offset}
+		sig = &builtinValuesStringSig{baseBuiltinFunc: bf, offset: c.offset}
 	case types.ETDatetime, types.ETTimestamp:
-		sig = &builtinValuesTimeSig{bf, c.offset}
+		sig = &builtinValuesTimeSig{baseBuiltinFunc: bf, offset: c.offset}
 	case types.ETDuration:
-		sig = &builtinValuesDurationSig{bf, c.offset}
+		sig = &builtinValuesDurationSig{baseBuiltinFunc: bf, offset: c.offset}
 	case types.ETJson:
-		sig = &builtinValuesJSONSig{bf, c.offset}
+		sig = &builtinValuesJSONSig{baseBuiltinFunc: bf, offset: c.offset}
 	}
 	return sig, nil
 }
 
 type builtinValuesIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	offset int
 }
@@ -1230,6 +1244,7 @@ func (b *builtinValuesIntSig) evalInt(ctx EvalContext, _ chunk.Row) (int64, bool
 
 type builtinValuesRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	offset int
 }
@@ -1261,6 +1276,7 @@ func (b *builtinValuesRealSig) evalReal(ctx EvalContext, _ chunk.Row) (float64, 
 
 type builtinValuesDecimalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	offset int
 }
@@ -1289,6 +1305,7 @@ func (b *builtinValuesDecimalSig) evalDecimal(ctx EvalContext, _ chunk.Row) (*ty
 
 type builtinValuesStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	offset int
 }
@@ -1326,6 +1343,7 @@ func (b *builtinValuesStringSig) evalString(ctx EvalContext, _ chunk.Row) (strin
 
 type builtinValuesTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	offset int
 }
@@ -1354,6 +1372,7 @@ func (b *builtinValuesTimeSig) evalTime(ctx EvalContext, _ chunk.Row) (types.Tim
 
 type builtinValuesDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	offset int
 }
@@ -1383,6 +1402,7 @@ func (b *builtinValuesDurationSig) evalDuration(ctx EvalContext, _ chunk.Row) (t
 
 type builtinValuesJSONSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	offset int
 }
@@ -1422,12 +1442,13 @@ func (c *bitCountFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		return nil, err
 	}
 	bf.tp.SetFlen(2)
-	sig := &builtinBitCountSig{bf}
+	sig := &builtinBitCountSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinBitCountSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinBitCountSig) Clone() builtinFunc {
@@ -1465,12 +1486,13 @@ func (c *getParamFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		return nil, err
 	}
 	bf.tp.SetFlen(mysql.MaxFieldVarCharLength)
-	sig := &builtinGetParamStringSig{bf}
+	sig := &builtinGetParamStringSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinGetParamStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGetParamStringSig) Clone() builtinFunc {

--- a/pkg/expression/builtin_regexp.go
+++ b/pkg/expression/builtin_regexp.go
@@ -67,6 +67,8 @@ var validMatchType = set.NewStringSet(
 
 type regexpBaseFuncSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
+
 	memorizedRegexp builtinFuncCache[regexpMemorizedSig]
 }
 

--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -199,13 +199,14 @@ func (c *lengthFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 		return nil, err
 	}
 	bf.tp.SetFlen(10)
-	sig := &builtinLengthSig{bf}
+	sig := &builtinLengthSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Length)
 	return sig, nil
 }
 
 type builtinLengthSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLengthSig) Clone() builtinFunc {
@@ -237,13 +238,14 @@ func (c *asciiFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 		return nil, err
 	}
 	bf.tp.SetFlen(3)
-	sig := &builtinASCIISig{bf}
+	sig := &builtinASCIISig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_ASCII)
 	return sig, nil
 }
 
 type builtinASCIISig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinASCIISig) Clone() builtinFunc {
@@ -297,13 +299,14 @@ func (c *concatFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	}
 
 	maxAllowedPacket := ctx.GetMaxAllowedPacket()
-	sig := &builtinConcatSig{bf, maxAllowedPacket}
+	sig := &builtinConcatSig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 	sig.setPbCode(tipb.ScalarFuncSig_Concat)
 	return sig, nil
 }
 
 type builtinConcatSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -374,13 +377,14 @@ func (c *concatWSFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	}
 
 	maxAllowedPacket := ctx.GetMaxAllowedPacket()
-	sig := &builtinConcatWSSig{bf, maxAllowedPacket}
+	sig := &builtinConcatWSSig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 	sig.setPbCode(tipb.ScalarFuncSig_ConcatWS)
 	return sig, nil
 }
 
 type builtinConcatWSSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -453,17 +457,18 @@ func (c *leftFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
 	if types.IsBinaryStr(argType) {
-		sig := &builtinLeftSig{bf}
+		sig := &builtinLeftSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Left)
 		return sig, nil
 	}
-	sig := &builtinLeftUTF8Sig{bf}
+	sig := &builtinLeftUTF8Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_LeftUTF8)
 	return sig, nil
 }
 
 type builtinLeftSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLeftSig) Clone() builtinFunc {
@@ -494,6 +499,7 @@ func (b *builtinLeftSig) evalString(ctx EvalContext, row chunk.Row) (string, boo
 
 type builtinLeftUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLeftUTF8Sig) Clone() builtinFunc {
@@ -538,17 +544,18 @@ func (c *rightFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
 	if types.IsBinaryStr(argType) {
-		sig := &builtinRightSig{bf}
+		sig := &builtinRightSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Right)
 		return sig, nil
 	}
-	sig := &builtinRightUTF8Sig{bf}
+	sig := &builtinRightUTF8Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_RightUTF8)
 	return sig, nil
 }
 
 type builtinRightSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRightSig) Clone() builtinFunc {
@@ -579,6 +586,7 @@ func (b *builtinRightSig) evalString(ctx EvalContext, row chunk.Row) (string, bo
 
 type builtinRightUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRightUTF8Sig) Clone() builtinFunc {
@@ -623,13 +631,14 @@ func (c *repeatFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	bf.tp.SetFlen(mysql.MaxBlobWidth)
 	SetBinFlagOrBinStr(args[0].GetType(), bf.tp)
 	maxAllowedPacket := ctx.GetMaxAllowedPacket()
-	sig := &builtinRepeatSig{bf, maxAllowedPacket}
+	sig := &builtinRepeatSig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 	sig.setPbCode(tipb.ScalarFuncSig_Repeat)
 	return sig, nil
 }
 
 type builtinRepeatSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -684,10 +693,10 @@ func (c *lowerFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	SetBinFlagOrBinStr(argTp, bf.tp)
 	var sig builtinFunc
 	if types.IsBinaryStr(argTp) {
-		sig = &builtinLowerSig{bf}
+		sig = &builtinLowerSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Lower)
 	} else {
-		sig = &builtinLowerUTF8Sig{bf}
+		sig = &builtinLowerUTF8Sig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_LowerUTF8)
 	}
 	return sig, nil
@@ -695,6 +704,7 @@ func (c *lowerFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 
 type builtinLowerUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLowerUTF8Sig) Clone() builtinFunc {
@@ -716,6 +726,7 @@ func (b *builtinLowerUTF8Sig) evalString(ctx EvalContext, row chunk.Row) (d stri
 
 type builtinLowerSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLowerSig) Clone() builtinFunc {
@@ -753,10 +764,10 @@ func (c *reverseFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	addBinFlag(bf.tp)
 	var sig builtinFunc
 	if types.IsBinaryStr(argTp) || types.IsTypeBit(argTp) {
-		sig = &builtinReverseSig{bf}
+		sig = &builtinReverseSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Reverse)
 	} else {
-		sig = &builtinReverseUTF8Sig{bf}
+		sig = &builtinReverseUTF8Sig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ReverseUTF8)
 	}
 	return sig, nil
@@ -764,6 +775,7 @@ func (c *reverseFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 
 type builtinReverseSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinReverseSig) Clone() builtinFunc {
@@ -785,6 +797,7 @@ func (b *builtinReverseSig) evalString(ctx EvalContext, row chunk.Row) (string, 
 
 type builtinReverseUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinReverseUTF8Sig) Clone() builtinFunc {
@@ -821,13 +834,14 @@ func (c *spaceFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(mysql.MaxBlobWidth)
 	maxAllowedPacket := ctx.GetMaxAllowedPacket()
-	sig := &builtinSpaceSig{bf, maxAllowedPacket}
+	sig := &builtinSpaceSig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 	sig.setPbCode(tipb.ScalarFuncSig_Space)
 	return sig, nil
 }
 
 type builtinSpaceSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -876,10 +890,10 @@ func (c *upperFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	SetBinFlagOrBinStr(argTp, bf.tp)
 	var sig builtinFunc
 	if types.IsBinaryStr(argTp) {
-		sig = &builtinUpperSig{bf}
+		sig = &builtinUpperSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Upper)
 	} else {
-		sig = &builtinUpperUTF8Sig{bf}
+		sig = &builtinUpperUTF8Sig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UpperUTF8)
 	}
 	return sig, nil
@@ -887,6 +901,7 @@ func (c *upperFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 
 type builtinUpperUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUpperUTF8Sig) Clone() builtinFunc {
@@ -908,6 +923,7 @@ func (b *builtinUpperUTF8Sig) evalString(ctx EvalContext, row chunk.Row) (d stri
 
 type builtinUpperSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUpperSig) Clone() builtinFunc {
@@ -941,13 +957,14 @@ func (c *strcmpFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	}
 	bf.tp.SetFlen(2)
 	types.SetBinChsClnFlag(bf.tp)
-	sig := &builtinStrcmpSig{bf}
+	sig := &builtinStrcmpSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Strcmp)
 	return sig, nil
 }
 
 type builtinStrcmpSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinStrcmpSig) Clone() builtinFunc {
@@ -993,7 +1010,7 @@ func (c *replaceFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	for _, a := range args {
 		SetBinFlagOrBinStr(a.GetType(), bf.tp)
 	}
-	sig := &builtinReplaceSig{bf}
+	sig := &builtinReplaceSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Replace)
 	return sig, nil
 }
@@ -1011,6 +1028,7 @@ func (c *replaceFunctionClass) fixLength(args []Expression) int {
 
 type builtinReplaceSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinReplaceSig) Clone() builtinFunc {
@@ -1089,13 +1107,14 @@ func (c *convertFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	}
 
 	bf.tp.SetFlen(mysql.MaxBlobWidth)
-	sig := &builtinConvertSig{bf}
+	sig := &builtinConvertSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Convert)
 	return sig, nil
 }
 
 type builtinConvertSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinConvertSig) Clone() builtinFunc {
@@ -1159,16 +1178,16 @@ func (c *substringFunctionClass) getFunction(ctx BuildContext, args []Expression
 	var sig builtinFunc
 	switch {
 	case len(args) == 3 && types.IsBinaryStr(argType):
-		sig = &builtinSubstring3ArgsSig{bf}
+		sig = &builtinSubstring3ArgsSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Substring3Args)
 	case len(args) == 3:
-		sig = &builtinSubstring3ArgsUTF8Sig{bf}
+		sig = &builtinSubstring3ArgsUTF8Sig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Substring3ArgsUTF8)
 	case len(args) == 2 && types.IsBinaryStr(argType):
-		sig = &builtinSubstring2ArgsSig{bf}
+		sig = &builtinSubstring2ArgsSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Substring2Args)
 	case len(args) == 2:
-		sig = &builtinSubstring2ArgsUTF8Sig{bf}
+		sig = &builtinSubstring2ArgsUTF8Sig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Substring2ArgsUTF8)
 	default:
 		// Should never happens.
@@ -1179,6 +1198,7 @@ func (c *substringFunctionClass) getFunction(ctx BuildContext, args []Expression
 
 type builtinSubstring2ArgsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubstring2ArgsSig) Clone() builtinFunc {
@@ -1212,6 +1232,7 @@ func (b *builtinSubstring2ArgsSig) evalString(ctx EvalContext, row chunk.Row) (s
 
 type builtinSubstring2ArgsUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubstring2ArgsUTF8Sig) Clone() builtinFunc {
@@ -1246,6 +1267,7 @@ func (b *builtinSubstring2ArgsUTF8Sig) evalString(ctx EvalContext, row chunk.Row
 
 type builtinSubstring3ArgsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubstring3ArgsSig) Clone() builtinFunc {
@@ -1289,6 +1311,7 @@ func (b *builtinSubstring3ArgsSig) evalString(ctx EvalContext, row chunk.Row) (s
 
 type builtinSubstring3ArgsUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubstring3ArgsUTF8Sig) Clone() builtinFunc {
@@ -1346,13 +1369,14 @@ func (c *substringIndexFunctionClass) getFunction(ctx BuildContext, args []Expre
 	argType := args[0].GetType()
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
-	sig := &builtinSubstringIndexSig{bf}
+	sig := &builtinSubstringIndexSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_SubstringIndex)
 	return sig, nil
 }
 
 type builtinSubstringIndexSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubstringIndexSig) Clone() builtinFunc {
@@ -1432,16 +1456,16 @@ func (c *locateFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	useBinary := bf.collation == charset.CollationBin
 	switch {
 	case hasStartPos && useBinary:
-		sig = &builtinLocate3ArgsSig{bf}
+		sig = &builtinLocate3ArgsSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Locate3Args)
 	case hasStartPos:
-		sig = &builtinLocate3ArgsUTF8Sig{bf}
+		sig = &builtinLocate3ArgsUTF8Sig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Locate3ArgsUTF8)
 	case useBinary:
-		sig = &builtinLocate2ArgsSig{bf}
+		sig = &builtinLocate2ArgsSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Locate2Args)
 	default:
-		sig = &builtinLocate2ArgsUTF8Sig{bf}
+		sig = &builtinLocate2ArgsUTF8Sig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Locate2ArgsUTF8)
 	}
 	return sig, nil
@@ -1449,6 +1473,7 @@ func (c *locateFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 
 type builtinLocate2ArgsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLocate2ArgsSig) Clone() builtinFunc {
@@ -1481,6 +1506,7 @@ func (b *builtinLocate2ArgsSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 
 type builtinLocate2ArgsUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLocate2ArgsUTF8Sig) Clone() builtinFunc {
@@ -1509,6 +1535,7 @@ func (b *builtinLocate2ArgsUTF8Sig) evalInt(ctx EvalContext, row chunk.Row) (int
 
 type builtinLocate3ArgsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLocate3ArgsSig) Clone() builtinFunc {
@@ -1550,6 +1577,7 @@ func (b *builtinLocate3ArgsSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 
 type builtinLocate3ArgsUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLocate3ArgsUTF8Sig) Clone() builtinFunc {
@@ -1613,7 +1641,7 @@ func (c *hexFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 		argFieldTp := args[0].GetType()
 		// Use UTF8MB4 as default.
 		bf.tp.SetFlen(argFieldTp.GetFlen() * 4 * 2)
-		sig := &builtinHexStrArgSig{bf}
+		sig := &builtinHexStrArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_HexStrArg)
 		return sig, nil
 	case types.ETInt, types.ETReal, types.ETDecimal:
@@ -1625,7 +1653,7 @@ func (c *hexFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 		charset, collate := ctx.GetSessionVars().GetCharsetInfo()
 		bf.tp.SetCharset(charset)
 		bf.tp.SetCollate(collate)
-		sig := &builtinHexIntArgSig{bf}
+		sig := &builtinHexIntArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_HexIntArg)
 		return sig, nil
 	default:
@@ -1635,6 +1663,7 @@ func (c *hexFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 
 type builtinHexStrArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinHexStrArgSig) Clone() builtinFunc {
@@ -1655,6 +1684,7 @@ func (b *builtinHexStrArgSig) evalString(ctx EvalContext, row chunk.Row) (string
 
 type builtinHexIntArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinHexIntArgSig) Clone() builtinFunc {
@@ -1708,13 +1738,14 @@ func (c *unhexFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	}
 	bf.tp.SetFlen(retFlen)
 	types.SetBinChsClnFlag(bf.tp)
-	sig := &builtinUnHexSig{bf}
+	sig := &builtinUnHexSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_UnHex)
 	return sig, nil
 }
 
 type builtinUnHexSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUnHexSig) Clone() builtinFunc {
@@ -1766,7 +1797,7 @@ func (c *trimFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 		argType := args[0].GetType()
 		bf.tp.SetFlen(argType.GetFlen())
 		SetBinFlagOrBinStr(argType, bf.tp)
-		sig := &builtinTrim1ArgSig{bf}
+		sig := &builtinTrim1ArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Trim1Arg)
 		return sig, nil
 
@@ -1777,7 +1808,7 @@ func (c *trimFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 		}
 		argType := args[0].GetType()
 		SetBinFlagOrBinStr(argType, bf.tp)
-		sig := &builtinTrim2ArgsSig{bf}
+		sig := &builtinTrim2ArgsSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Trim2Args)
 		return sig, nil
 
@@ -1789,7 +1820,7 @@ func (c *trimFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 		argType := args[0].GetType()
 		bf.tp.SetFlen(argType.GetFlen())
 		SetBinFlagOrBinStr(argType, bf.tp)
-		sig := &builtinTrim3ArgsSig{bf}
+		sig := &builtinTrim3ArgsSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Trim3Args)
 		return sig, nil
 
@@ -1800,6 +1831,7 @@ func (c *trimFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 
 type builtinTrim1ArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTrim1ArgSig) Clone() builtinFunc {
@@ -1820,6 +1852,7 @@ func (b *builtinTrim1ArgSig) evalString(ctx EvalContext, row chunk.Row) (d strin
 
 type builtinTrim2ArgsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTrim2ArgsSig) Clone() builtinFunc {
@@ -1848,6 +1881,7 @@ func (b *builtinTrim2ArgsSig) evalString(ctx EvalContext, row chunk.Row) (d stri
 
 type builtinTrim3ArgsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTrim3ArgsSig) Clone() builtinFunc {
@@ -1905,13 +1939,14 @@ func (c *lTrimFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	argType := args[0].GetType()
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
-	sig := &builtinLTrimSig{bf}
+	sig := &builtinLTrimSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_LTrim)
 	return sig, nil
 }
 
 type builtinLTrimSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLTrimSig) Clone() builtinFunc {
@@ -1945,13 +1980,14 @@ func (c *rTrimFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	argType := args[0].GetType()
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
-	sig := &builtinRTrimSig{bf}
+	sig := &builtinRTrimSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_RTrim)
 	return sig, nil
 }
 
 type builtinRTrimSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinRTrimSig) Clone() builtinFunc {
@@ -2021,20 +2057,21 @@ func (c *lpadFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 
 	maxAllowedPacket := ctx.GetMaxAllowedPacket()
 	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[2].GetType()) {
-		sig := &builtinLpadSig{bf, maxAllowedPacket}
+		sig := &builtinLpadSig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 		sig.setPbCode(tipb.ScalarFuncSig_Lpad)
 		return sig, nil
 	}
 	if bf.tp.SetFlen(bf.tp.GetFlen() * 4); bf.tp.GetFlen() > mysql.MaxBlobWidth {
 		bf.tp.SetFlen(mysql.MaxBlobWidth)
 	}
-	sig := &builtinLpadUTF8Sig{bf, maxAllowedPacket}
+	sig := &builtinLpadUTF8Sig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 	sig.setPbCode(tipb.ScalarFuncSig_LpadUTF8)
 	return sig, nil
 }
 
 type builtinLpadSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -2083,6 +2120,7 @@ func (b *builtinLpadSig) evalString(ctx EvalContext, row chunk.Row) (string, boo
 
 type builtinLpadUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -2146,20 +2184,21 @@ func (c *rpadFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 
 	maxAllowedPacket := ctx.GetMaxAllowedPacket()
 	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[2].GetType()) {
-		sig := &builtinRpadSig{bf, maxAllowedPacket}
+		sig := &builtinRpadSig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 		sig.setPbCode(tipb.ScalarFuncSig_Rpad)
 		return sig, nil
 	}
 	if bf.tp.SetFlen(bf.tp.GetFlen() * 4); bf.tp.GetFlen() > mysql.MaxBlobWidth {
 		bf.tp.SetFlen(mysql.MaxBlobWidth)
 	}
-	sig := &builtinRpadUTF8Sig{bf, maxAllowedPacket}
+	sig := &builtinRpadUTF8Sig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 	sig.setPbCode(tipb.ScalarFuncSig_RpadUTF8)
 	return sig, nil
 }
 
 type builtinRpadSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -2207,6 +2246,7 @@ func (b *builtinRpadSig) evalString(ctx EvalContext, row chunk.Row) (string, boo
 
 type builtinRpadUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -2266,13 +2306,14 @@ func (c *bitLengthFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 	bf.tp.SetFlen(10)
-	sig := &builtinBitLengthSig{bf}
+	sig := &builtinBitLengthSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_BitLength)
 	return sig, nil
 }
 
 type builtinBitLengthSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinBitLengthSig) Clone() builtinFunc {
@@ -2333,13 +2374,14 @@ func (c *charFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	}
 	bf.tp.SetFlen(4 * (len(args) - 1))
 
-	sig := &builtinCharSig{bf}
+	sig := &builtinCharSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Char)
 	return sig, nil
 }
 
 type builtinCharSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCharSig) Clone() builtinFunc {
@@ -2403,17 +2445,18 @@ func (c *charLengthFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		return nil, err
 	}
 	if types.IsBinaryStr(args[0].GetType()) {
-		sig := &builtinCharLengthBinarySig{bf}
+		sig := &builtinCharLengthBinarySig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CharLength)
 		return sig, nil
 	}
-	sig := &builtinCharLengthUTF8Sig{bf}
+	sig := &builtinCharLengthUTF8Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_CharLengthUTF8)
 	return sig, nil
 }
 
 type builtinCharLengthBinarySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCharLengthBinarySig) Clone() builtinFunc {
@@ -2434,6 +2477,7 @@ func (b *builtinCharLengthBinarySig) evalInt(ctx EvalContext, row chunk.Row) (in
 
 type builtinCharLengthUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCharLengthUTF8Sig) Clone() builtinFunc {
@@ -2465,13 +2509,14 @@ func (c *findInSetFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 	bf.tp.SetFlen(3)
-	sig := &builtinFindInSetSig{bf}
+	sig := &builtinFindInSetSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_FindInSet)
 	return sig, nil
 }
 
 type builtinFindInSetSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFindInSetSig) Clone() builtinFunc {
@@ -2540,13 +2585,13 @@ func (c *fieldFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	var sig builtinFunc
 	switch argTp {
 	case types.ETReal:
-		sig = &builtinFieldRealSig{bf}
+		sig = &builtinFieldRealSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_FieldReal)
 	case types.ETInt:
-		sig = &builtinFieldIntSig{bf}
+		sig = &builtinFieldIntSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_FieldInt)
 	case types.ETString:
-		sig = &builtinFieldStringSig{bf}
+		sig = &builtinFieldStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_FieldString)
 	}
 	return sig, nil
@@ -2554,6 +2599,7 @@ func (c *fieldFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 
 type builtinFieldIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFieldIntSig) Clone() builtinFunc {
@@ -2583,6 +2629,7 @@ func (b *builtinFieldIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, boo
 
 type builtinFieldRealSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFieldRealSig) Clone() builtinFunc {
@@ -2612,6 +2659,7 @@ func (b *builtinFieldRealSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bo
 
 type builtinFieldStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFieldStringSig) Clone() builtinFunc {
@@ -2684,13 +2732,14 @@ func (c *makeSetFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	if bf.tp.GetFlen() > mysql.MaxBlobWidth {
 		bf.tp.SetFlen(mysql.MaxBlobWidth)
 	}
-	sig := &builtinMakeSetSig{bf}
+	sig := &builtinMakeSetSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_MakeSet)
 	return sig, nil
 }
 
 type builtinMakeSetSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinMakeSetSig) Clone() builtinFunc {
@@ -2744,7 +2793,7 @@ func (c *octFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 
 		bf.tp.SetFlen(64)
 		bf.tp.SetDecimal(types.UnspecifiedLength)
-		sig = &builtinOctIntSig{bf}
+		sig = &builtinOctIntSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_OctInt)
 	} else {
 		bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETString, types.ETString)
@@ -2756,7 +2805,7 @@ func (c *octFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 		bf.tp.SetCollate(collate)
 		bf.tp.SetFlen(64)
 		bf.tp.SetDecimal(types.UnspecifiedLength)
-		sig = &builtinOctStringSig{bf}
+		sig = &builtinOctStringSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_OctString)
 	}
 
@@ -2765,6 +2814,7 @@ func (c *octFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 
 type builtinOctIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinOctIntSig) Clone() builtinFunc {
@@ -2786,6 +2836,7 @@ func (b *builtinOctIntSig) evalString(ctx EvalContext, row chunk.Row) (string, b
 
 type builtinOctStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinOctStringSig) Clone() builtinFunc {
@@ -2838,13 +2889,14 @@ func (c *ordFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 		return nil, err
 	}
 	bf.tp.SetFlen(10)
-	sig := &builtinOrdSig{bf}
+	sig := &builtinOrdSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Ord)
 	return sig, nil
 }
 
 type builtinOrdSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinOrdSig) Clone() builtinFunc {
@@ -2900,13 +2952,14 @@ func (c *quoteFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	if bf.tp.GetFlen() > mysql.MaxBlobWidth {
 		bf.tp.SetFlen(mysql.MaxBlobWidth)
 	}
-	sig := &builtinQuoteSig{bf}
+	sig := &builtinQuoteSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Quote)
 	return sig, nil
 }
 
 type builtinQuoteSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinQuoteSig) Clone() builtinFunc {
@@ -2970,13 +3023,14 @@ func (c *binFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(64)
-	sig := &builtinBinSig{bf}
+	sig := &builtinBinSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Bin)
 	return sig, nil
 }
 
 type builtinBinSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinBinSig) Clone() builtinFunc {
@@ -3021,13 +3075,14 @@ func (c *eltFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 			bf.tp.SetFlen(argType.GetFlen())
 		}
 	}
-	sig := &builtinEltSig{bf}
+	sig := &builtinEltSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Elt)
 	return sig, nil
 }
 
 type builtinEltSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinEltSig) Clone() builtinFunc {
@@ -3085,13 +3140,13 @@ func (c *exportSetFunctionClass) getFunction(ctx BuildContext, args []Expression
 	bf.tp.SetFlen((l*64 + sepL*63) * 4)
 	switch len(args) {
 	case 3:
-		sig = &builtinExportSet3ArgSig{bf}
+		sig = &builtinExportSet3ArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ExportSet3Arg)
 	case 4:
-		sig = &builtinExportSet4ArgSig{bf}
+		sig = &builtinExportSet4ArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ExportSet4Arg)
 	case 5:
-		sig = &builtinExportSet5ArgSig{bf}
+		sig = &builtinExportSet5ArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ExportSet5Arg)
 	}
 	return sig, nil
@@ -3116,6 +3171,7 @@ func exportSet(bits int64, on, off, separator string, numberOfBits int64) string
 
 type builtinExportSet3ArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinExportSet3ArgSig) Clone() builtinFunc {
@@ -3147,6 +3203,7 @@ func (b *builtinExportSet3ArgSig) evalString(ctx EvalContext, row chunk.Row) (st
 
 type builtinExportSet4ArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinExportSet4ArgSig) Clone() builtinFunc {
@@ -3183,6 +3240,7 @@ func (b *builtinExportSet4ArgSig) evalString(ctx EvalContext, row chunk.Row) (st
 
 type builtinExportSet5ArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinExportSet5ArgSig) Clone() builtinFunc {
@@ -3254,10 +3312,10 @@ func (c *formatFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	bf.tp.SetFlen(mysql.MaxBlobWidth)
 	var sig builtinFunc
 	if len(args) == 3 {
-		sig = &builtinFormatWithLocaleSig{bf}
+		sig = &builtinFormatWithLocaleSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_FormatWithLocale)
 	} else {
-		sig = &builtinFormatSig{bf}
+		sig = &builtinFormatSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Format)
 	}
 	return sig, nil
@@ -3355,6 +3413,7 @@ func roundFormatArgs(xStr string, maxNumDecimals int) string {
 
 type builtinFormatWithLocaleSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFormatWithLocaleSig) Clone() builtinFunc {
@@ -3387,6 +3446,7 @@ func (b *builtinFormatWithLocaleSig) evalString(ctx EvalContext, row chunk.Row) 
 
 type builtinFormatSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFormatSig) Clone() builtinFunc {
@@ -3430,7 +3490,7 @@ func (c *fromBase64FunctionClass) getFunction(ctx BuildContext, args []Expressio
 
 	maxAllowedPacket := ctx.GetMaxAllowedPacket()
 	types.SetBinChsClnFlag(bf.tp)
-	sig := &builtinFromBase64Sig{bf, maxAllowedPacket}
+	sig := &builtinFromBase64Sig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 	sig.setPbCode(tipb.ScalarFuncSig_FromBase64)
 	return sig, nil
 }
@@ -3449,6 +3509,7 @@ func base64NeededDecodedLength(n int) int {
 
 type builtinFromBase64Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -3508,13 +3569,14 @@ func (c *toBase64FunctionClass) getFunction(ctx BuildContext, args []Expression)
 	}
 
 	maxAllowedPacket := ctx.GetMaxAllowedPacket()
-	sig := &builtinToBase64Sig{bf, maxAllowedPacket}
+	sig := &builtinToBase64Sig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 	sig.setPbCode(tipb.ScalarFuncSig_ToBase64)
 	return sig, nil
 }
 
 type builtinToBase64Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -3607,10 +3669,10 @@ func (c *insertFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 
 	maxAllowedPacket := ctx.GetMaxAllowedPacket()
 	if types.IsBinaryStr(bf.tp) {
-		sig = &builtinInsertSig{bf, maxAllowedPacket}
+		sig = &builtinInsertSig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 		sig.setPbCode(tipb.ScalarFuncSig_Insert)
 	} else {
-		sig = &builtinInsertUTF8Sig{bf, maxAllowedPacket}
+		sig = &builtinInsertUTF8Sig{baseBuiltinFunc: bf, maxAllowedPacket: maxAllowedPacket}
 		sig.setPbCode(tipb.ScalarFuncSig_InsertUTF8)
 	}
 	return sig, nil
@@ -3618,6 +3680,7 @@ func (c *insertFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 
 type builtinInsertSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -3668,6 +3731,7 @@ func (b *builtinInsertSig) evalString(ctx EvalContext, row chunk.Row) (string, b
 
 type builtinInsertUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	maxAllowedPacket uint64
 }
 
@@ -3732,16 +3796,19 @@ func (c *instrFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	}
 	bf.tp.SetFlen(11)
 	if bf.collation == charset.CollationBin {
-		sig := &builtinInstrSig{bf}
+		sig := &builtinInstrSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Instr)
 		return sig, nil
 	}
-	sig := &builtinInstrUTF8Sig{bf}
+	sig := &builtinInstrUTF8Sig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_InstrUTF8)
 	return sig, nil
 }
 
-type builtinInstrUTF8Sig struct{ baseBuiltinFunc }
+type builtinInstrUTF8Sig struct {
+	baseBuiltinFunc
+	notRequireOptionalEvalProps
+}
 
 func (b *builtinInstrUTF8Sig) Clone() builtinFunc {
 	newSig := &builtinInstrUTF8Sig{}
@@ -3749,7 +3816,10 @@ func (b *builtinInstrUTF8Sig) Clone() builtinFunc {
 	return newSig
 }
 
-type builtinInstrSig struct{ baseBuiltinFunc }
+type builtinInstrSig struct {
+	baseBuiltinFunc
+	notRequireOptionalEvalProps
+}
 
 func (b *builtinInstrSig) Clone() builtinFunc {
 	newSig := &builtinInstrSig{}
@@ -3816,12 +3886,13 @@ func (c *loadFileFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(64)
-	sig := &builtinLoadFileSig{bf}
+	sig := &builtinLoadFileSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinLoadFileSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLoadFileSig) evalString(ctx EvalContext, row chunk.Row) (d string, isNull bool, err error) {
@@ -3918,16 +3989,17 @@ func (c *weightStringFunctionClass) getFunction(ctx BuildContext, args []Express
 	types.SetBinChsClnFlag(bf.tp)
 	var sig builtinFunc
 	if padding == weightStringPaddingNull {
-		sig = &builtinWeightStringNullSig{bf}
+		sig = &builtinWeightStringNullSig{baseBuiltinFunc: bf}
 	} else {
 		maxAllowedPacket := ctx.GetMaxAllowedPacket()
-		sig = &builtinWeightStringSig{bf, padding, length, maxAllowedPacket}
+		sig = &builtinWeightStringSig{baseBuiltinFunc: bf, padding: padding, length: length, maxAllowedPacket: maxAllowedPacket}
 	}
 	return sig, nil
 }
 
 type builtinWeightStringNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinWeightStringNullSig) Clone() builtinFunc {
@@ -3944,6 +4016,7 @@ func (b *builtinWeightStringNullSig) evalString(ctx EvalContext, row chunk.Row) 
 
 type builtinWeightStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	padding          weightStringPadding
 	length           int
@@ -4030,15 +4103,16 @@ func (c *translateFunctionClass) getFunction(ctx BuildContext, args []Expression
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
 	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[1].GetType()) || types.IsBinaryStr(args[2].GetType()) {
-		sig := &builtinTranslateBinarySig{bf}
+		sig := &builtinTranslateBinarySig{baseBuiltinFunc: bf}
 		return sig, nil
 	}
-	sig := &builtinTranslateUTF8Sig{bf}
+	sig := &builtinTranslateUTF8Sig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinTranslateBinarySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTranslateBinarySig) Clone() builtinFunc {
@@ -4082,6 +4156,7 @@ func (b *builtinTranslateBinarySig) evalString(ctx EvalContext, row chunk.Row) (
 
 type builtinTranslateUTF8Sig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTranslateUTF8Sig) Clone() builtinFunc {

--- a/pkg/expression/builtin_string_test.go
+++ b/pkg/expression/builtin_string_test.go
@@ -235,7 +235,7 @@ func TestConcatSig(t *testing.T) {
 		&Column{Index: 1, RetType: colTypes[1]},
 	}
 	base := baseBuiltinFunc{args: args, tp: resultType}
-	concat := &builtinConcatSig{base, 5}
+	concat := &builtinConcatSig{baseBuiltinFunc: base, maxAllowedPacket: 5}
 
 	cases := []struct {
 		args     []any
@@ -356,7 +356,7 @@ func TestConcatWSSig(t *testing.T) {
 		&Column{Index: 2, RetType: colTypes[2]},
 	}
 	base := baseBuiltinFunc{args: args, tp: resultType}
-	concat := &builtinConcatWSSig{base, 6}
+	concat := &builtinConcatWSSig{baseBuiltinFunc: base, maxAllowedPacket: 6}
 
 	cases := []struct {
 		args     []any
@@ -533,7 +533,7 @@ func TestRepeatSig(t *testing.T) {
 		&Column{Index: 1, RetType: colTypes[1]},
 	}
 	base := baseBuiltinFunc{args: args, tp: resultType}
-	repeat := &builtinRepeatSig{base, 1000}
+	repeat := &builtinRepeatSig{baseBuiltinFunc: base, maxAllowedPacket: 1000}
 
 	cases := []struct {
 		args    []any
@@ -1011,7 +1011,7 @@ func TestSpaceSig(t *testing.T) {
 		&Column{Index: 0, RetType: colTypes[0]},
 	}
 	base := baseBuiltinFunc{args: args, tp: resultType}
-	space := &builtinSpaceSig{base, 1000}
+	space := &builtinSpaceSig{baseBuiltinFunc: base, maxAllowedPacket: 1000}
 	input := chunk.NewChunkWithCapacity(colTypes, 10)
 	input.AppendInt64(0, 6)
 	input.AppendInt64(0, 1001)
@@ -1642,7 +1642,7 @@ func TestRpadSig(t *testing.T) {
 	}
 
 	base := baseBuiltinFunc{args: args, tp: resultType}
-	rpad := &builtinRpadUTF8Sig{base, 1000}
+	rpad := &builtinRpadUTF8Sig{baseBuiltinFunc: base, maxAllowedPacket: 1000}
 
 	input := chunk.NewChunkWithCapacity(colTypes, 10)
 	input.AppendString(0, "abc")
@@ -1688,7 +1688,7 @@ func TestInsertBinarySig(t *testing.T) {
 	}
 
 	base := baseBuiltinFunc{args: args, tp: resultType}
-	insert := &builtinInsertSig{base, 3}
+	insert := &builtinInsertSig{baseBuiltinFunc: base, maxAllowedPacket: 3}
 
 	input := chunk.NewChunkWithCapacity(colTypes, 2)
 	input.AppendString(0, "abc")
@@ -2124,7 +2124,7 @@ func TestFromBase64Sig(t *testing.T) {
 		resultType.SetType(mysql.TypeVarchar)
 		resultType.SetFlen(mysql.MaxBlobWidth)
 		base := baseBuiltinFunc{args: args, tp: resultType}
-		fromBase64 := &builtinFromBase64Sig{base, test.maxAllowPacket}
+		fromBase64 := &builtinFromBase64Sig{baseBuiltinFunc: base, maxAllowedPacket: test.maxAllowPacket}
 
 		input := chunk.NewChunkWithCapacity(colTypes, 1)
 		input.AppendString(0, test.args)
@@ -2491,7 +2491,7 @@ func TestToBase64Sig(t *testing.T) {
 		resultType.SetType(mysql.TypeVarchar)
 		resultType.SetFlen(base64NeededEncodedLength(len(test.args)))
 		base := baseBuiltinFunc{args: args, tp: resultType}
-		toBase64 := &builtinToBase64Sig{base, test.maxAllowPacket}
+		toBase64 := &builtinToBase64Sig{baseBuiltinFunc: base, maxAllowedPacket: test.maxAllowPacket}
 
 		input := chunk.NewChunkWithCapacity(colTypes, 1)
 		input.AppendString(0, test.args)

--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -252,13 +252,14 @@ func (c *dateFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 		return nil, err
 	}
 	bf.setDecimalAndFlenForDate()
-	sig := &builtinDateSig{bf}
+	sig := &builtinDateSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Date)
 	return sig, nil
 }
 
 type builtinDateSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDateSig) Clone() builtinFunc {
@@ -313,12 +314,13 @@ func (c *dateLiteralFunctionClass) getFunction(ctx BuildContext, args []Expressi
 		return nil, err
 	}
 	bf.setDecimalAndFlenForDate()
-	sig := &builtinDateLiteralSig{bf, tm}
+	sig := &builtinDateLiteralSig{baseBuiltinFunc: bf, literal: tm}
 	return sig, nil
 }
 
 type builtinDateLiteralSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	literal types.Time
 }
 
@@ -353,13 +355,14 @@ func (c *dateDiffFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinDateDiffSig{bf}
+	sig := &builtinDateDiffSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DateDiff)
 	return sig, nil
 }
 
 type builtinDateDiffSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDateDiffSig) Clone() builtinFunc {
@@ -432,37 +435,37 @@ func (c *timeDiffFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	case types.ETDuration:
 		switch arg1Tp {
 		case types.ETDuration:
-			sig = &builtinDurationDurationTimeDiffSig{bf}
+			sig = &builtinDurationDurationTimeDiffSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_DurationDurationTimeDiff)
 		case types.ETDatetime, types.ETTimestamp:
-			sig = &builtinNullTimeDiffSig{bf}
+			sig = &builtinNullTimeDiffSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NullTimeDiff)
 		default:
-			sig = &builtinDurationStringTimeDiffSig{bf}
+			sig = &builtinDurationStringTimeDiffSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_DurationStringTimeDiff)
 		}
 	case types.ETDatetime, types.ETTimestamp:
 		switch arg1Tp {
 		case types.ETDuration:
-			sig = &builtinNullTimeDiffSig{bf}
+			sig = &builtinNullTimeDiffSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_NullTimeDiff)
 		case types.ETDatetime, types.ETTimestamp:
-			sig = &builtinTimeTimeTimeDiffSig{bf}
+			sig = &builtinTimeTimeTimeDiffSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_TimeTimeTimeDiff)
 		default:
-			sig = &builtinTimeStringTimeDiffSig{bf}
+			sig = &builtinTimeStringTimeDiffSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_TimeStringTimeDiff)
 		}
 	default:
 		switch arg1Tp {
 		case types.ETDuration:
-			sig = &builtinStringDurationTimeDiffSig{bf}
+			sig = &builtinStringDurationTimeDiffSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_StringDurationTimeDiff)
 		case types.ETDatetime, types.ETTimestamp:
-			sig = &builtinStringTimeTimeDiffSig{bf}
+			sig = &builtinStringTimeTimeDiffSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_StringTimeTimeDiff)
 		default:
-			sig = &builtinStringStringTimeDiffSig{bf}
+			sig = &builtinStringStringTimeDiffSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_StringStringTimeDiff)
 		}
 	}
@@ -471,6 +474,7 @@ func (c *timeDiffFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 type builtinDurationDurationTimeDiffSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDurationDurationTimeDiffSig) Clone() builtinFunc {
@@ -498,6 +502,7 @@ func (b *builtinDurationDurationTimeDiffSig) evalDuration(ctx EvalContext, row c
 
 type builtinTimeTimeTimeDiffSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTimeTimeTimeDiffSig) Clone() builtinFunc {
@@ -526,6 +531,7 @@ func (b *builtinTimeTimeTimeDiffSig) evalDuration(ctx EvalContext, row chunk.Row
 
 type builtinDurationStringTimeDiffSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDurationStringTimeDiffSig) Clone() builtinFunc {
@@ -559,6 +565,7 @@ func (b *builtinDurationStringTimeDiffSig) evalDuration(ctx EvalContext, row chu
 
 type builtinStringDurationTimeDiffSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinStringDurationTimeDiffSig) Clone() builtinFunc {
@@ -617,6 +624,7 @@ func calculateDurationTimeDiff(ctx EvalContext, lhs, rhs types.Duration) (d type
 
 type builtinTimeStringTimeDiffSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTimeStringTimeDiffSig) Clone() builtinFunc {
@@ -650,6 +658,7 @@ func (b *builtinTimeStringTimeDiffSig) evalDuration(ctx EvalContext, row chunk.R
 
 type builtinStringTimeTimeDiffSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinStringTimeTimeDiffSig) Clone() builtinFunc {
@@ -683,6 +692,7 @@ func (b *builtinStringTimeTimeDiffSig) evalDuration(ctx EvalContext, row chunk.R
 
 type builtinStringStringTimeDiffSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinStringStringTimeDiffSig) Clone() builtinFunc {
@@ -731,6 +741,7 @@ func (b *builtinStringStringTimeDiffSig) evalDuration(ctx EvalContext, row chunk
 
 type builtinNullTimeDiffSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNullTimeDiffSig) Clone() builtinFunc {
@@ -772,13 +783,14 @@ func (c *dateFormatFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	}
 	// worst case: formatMask=%r%r%r...%r, each %r takes 11 characters
 	bf.tp.SetFlen((args[1].GetType().GetFlen() + 1) / 2 * 11)
-	sig := &builtinDateFormatSig{bf}
+	sig := &builtinDateFormatSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DateFormatSig)
 	return sig, nil
 }
 
 type builtinDateFormatSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDateFormatSig) Clone() builtinFunc {
@@ -834,13 +846,14 @@ func (c *fromDaysFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		return nil, err
 	}
 	bf.setDecimalAndFlenForDate()
-	sig := &builtinFromDaysSig{bf}
+	sig := &builtinFromDaysSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_FromDays)
 	return sig, nil
 }
 
 type builtinFromDaysSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFromDaysSig) Clone() builtinFunc {
@@ -878,13 +891,14 @@ func (c *hourFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	}
 	bf.tp.SetFlen(3)
 	bf.tp.SetDecimal(0)
-	sig := &builtinHourSig{bf}
+	sig := &builtinHourSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Hour)
 	return sig, nil
 }
 
 type builtinHourSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinHourSig) Clone() builtinFunc {
@@ -918,13 +932,14 @@ func (c *minuteFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	}
 	bf.tp.SetFlen(2)
 	bf.tp.SetDecimal(0)
-	sig := &builtinMinuteSig{bf}
+	sig := &builtinMinuteSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Minute)
 	return sig, nil
 }
 
 type builtinMinuteSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinMinuteSig) Clone() builtinFunc {
@@ -958,13 +973,14 @@ func (c *secondFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	}
 	bf.tp.SetFlen(2)
 	bf.tp.SetDecimal(0)
-	sig := &builtinSecondSig{bf}
+	sig := &builtinSecondSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Second)
 	return sig, nil
 }
 
 type builtinSecondSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSecondSig) Clone() builtinFunc {
@@ -998,13 +1014,14 @@ func (c *microSecondFunctionClass) getFunction(ctx BuildContext, args []Expressi
 	}
 	bf.tp.SetFlen(6)
 	bf.tp.SetDecimal(0)
-	sig := &builtinMicroSecondSig{bf}
+	sig := &builtinMicroSecondSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_MicroSecond)
 	return sig, nil
 }
 
 type builtinMicroSecondSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinMicroSecondSig) Clone() builtinFunc {
@@ -1038,13 +1055,14 @@ func (c *monthFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	}
 	bf.tp.SetFlen(2)
 	bf.tp.SetDecimal(0)
-	sig := &builtinMonthSig{bf}
+	sig := &builtinMonthSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Month)
 	return sig, nil
 }
 
 type builtinMonthSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinMonthSig) Clone() builtinFunc {
@@ -1082,13 +1100,14 @@ func (c *monthNameFunctionClass) getFunction(ctx BuildContext, args []Expression
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(10)
-	sig := &builtinMonthNameSig{bf}
+	sig := &builtinMonthNameSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_MonthName)
 	return sig, nil
 }
 
 type builtinMonthNameSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinMonthNameSig) Clone() builtinFunc {
@@ -1127,13 +1146,14 @@ func (c *dayNameFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 	bf.tp.SetFlen(10)
-	sig := &builtinDayNameSig{bf}
+	sig := &builtinDayNameSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DayName)
 	return sig, nil
 }
 
 type builtinDayNameSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDayNameSig) Clone() builtinFunc {
@@ -1196,13 +1216,14 @@ func (c *dayOfMonthFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		return nil, err
 	}
 	bf.tp.SetFlen(2)
-	sig := &builtinDayOfMonthSig{bf}
+	sig := &builtinDayOfMonthSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DayOfMonth)
 	return sig, nil
 }
 
 type builtinDayOfMonthSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDayOfMonthSig) Clone() builtinFunc {
@@ -1234,13 +1255,14 @@ func (c *dayOfWeekFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 	bf.tp.SetFlen(1)
-	sig := &builtinDayOfWeekSig{bf}
+	sig := &builtinDayOfWeekSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DayOfWeek)
 	return sig, nil
 }
 
 type builtinDayOfWeekSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDayOfWeekSig) Clone() builtinFunc {
@@ -1276,13 +1298,14 @@ func (c *dayOfYearFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 	bf.tp.SetFlen(3)
-	sig := &builtinDayOfYearSig{bf}
+	sig := &builtinDayOfYearSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DayOfYear)
 	return sig, nil
 }
 
 type builtinDayOfYearSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinDayOfYearSig) Clone() builtinFunc {
@@ -1328,10 +1351,10 @@ func (c *weekFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 
 	var sig builtinFunc
 	if len(args) == 2 {
-		sig = &builtinWeekWithModeSig{bf}
+		sig = &builtinWeekWithModeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_WeekWithMode)
 	} else {
-		sig = &builtinWeekWithoutModeSig{bf}
+		sig = &builtinWeekWithoutModeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_WeekWithoutMode)
 	}
 	return sig, nil
@@ -1339,6 +1362,7 @@ func (c *weekFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 
 type builtinWeekWithModeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinWeekWithModeSig) Clone() builtinFunc {
@@ -1371,6 +1395,7 @@ func (b *builtinWeekWithModeSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 
 type builtinWeekWithoutModeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinWeekWithoutModeSig) Clone() builtinFunc {
@@ -1419,13 +1444,14 @@ func (c *weekDayFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	}
 	bf.tp.SetFlen(1)
 
-	sig := &builtinWeekDaySig{bf}
+	sig := &builtinWeekDaySig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_WeekDay)
 	return sig, nil
 }
 
 type builtinWeekDaySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinWeekDaySig) Clone() builtinFunc {
@@ -1462,13 +1488,14 @@ func (c *weekOfYearFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	}
 	bf.tp.SetFlen(2)
 	bf.tp.SetDecimal(0)
-	sig := &builtinWeekOfYearSig{bf}
+	sig := &builtinWeekOfYearSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_WeekOfYear)
 	return sig, nil
 }
 
 type builtinWeekOfYearSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinWeekOfYearSig) Clone() builtinFunc {
@@ -1508,13 +1535,14 @@ func (c *yearFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	}
 	bf.tp.SetFlen(4)
 	bf.tp.SetDecimal(0)
-	sig := &builtinYearSig{bf}
+	sig := &builtinYearSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Year)
 	return sig, nil
 }
 
 type builtinYearSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinYearSig) Clone() builtinFunc {
@@ -1557,10 +1585,10 @@ func (c *yearWeekFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 	var sig builtinFunc
 	if len(args) == 2 {
-		sig = &builtinYearWeekWithModeSig{bf}
+		sig = &builtinYearWeekWithModeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_YearWeekWithMode)
 	} else {
-		sig = &builtinYearWeekWithoutModeSig{bf}
+		sig = &builtinYearWeekWithoutModeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_YearWeekWithoutMode)
 	}
 	return sig, nil
@@ -1568,6 +1596,7 @@ func (c *yearWeekFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 type builtinYearWeekWithModeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinYearWeekWithModeSig) Clone() builtinFunc {
@@ -1605,6 +1634,7 @@ func (b *builtinYearWeekWithModeSig) evalInt(ctx EvalContext, row chunk.Row) (in
 
 type builtinYearWeekWithoutModeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinYearWeekWithoutModeSig) Clone() builtinFunc {
@@ -1672,7 +1702,7 @@ func (c *fromUnixTimeFunctionClass) getFunction(ctx BuildContext, args []Express
 	}
 
 	if len(args) > 1 {
-		sig = &builtinFromUnixTime2ArgSig{bf}
+		sig = &builtinFromUnixTime2ArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_FromUnixTime2Arg)
 		return sig, nil
 	}
@@ -1686,7 +1716,7 @@ func (c *fromUnixTimeFunctionClass) getFunction(ctx BuildContext, args []Express
 	}
 	bf.setDecimalAndFlenForDatetime(fsp)
 
-	sig = &builtinFromUnixTime1ArgSig{bf}
+	sig = &builtinFromUnixTime1ArgSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_FromUnixTime1Arg)
 	return sig, nil
 }
@@ -1751,6 +1781,7 @@ func fieldString(fieldType byte) bool {
 
 type builtinFromUnixTime1ArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFromUnixTime1ArgSig) Clone() builtinFunc {
@@ -1771,6 +1802,7 @@ func (b *builtinFromUnixTime1ArgSig) evalTime(ctx EvalContext, row chunk.Row) (r
 
 type builtinFromUnixTime2ArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinFromUnixTime2ArgSig) Clone() builtinFunc {
@@ -1811,13 +1843,14 @@ func (c *getFormatFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 	bf.tp.SetFlen(17)
-	sig := &builtinGetFormatSig{bf}
+	sig := &builtinGetFormatSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_GetFormat)
 	return sig, nil
 }
 
 type builtinGetFormatSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinGetFormatSig) Clone() builtinFunc {
@@ -1882,7 +1915,7 @@ func (c *strToDateFunctionClass) getFunction(ctx BuildContext, args []Expression
 			return nil, err
 		}
 		bf.setDecimalAndFlenForDate()
-		sig = &builtinStrToDateDateSig{bf}
+		sig = &builtinStrToDateDateSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_StrToDateDate)
 	case mysql.TypeDatetime:
 		bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETDatetime, types.ETString, types.ETString)
@@ -1890,7 +1923,7 @@ func (c *strToDateFunctionClass) getFunction(ctx BuildContext, args []Expression
 			return nil, err
 		}
 		bf.setDecimalAndFlenForDatetime(fsp)
-		sig = &builtinStrToDateDatetimeSig{bf}
+		sig = &builtinStrToDateDatetimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_StrToDateDatetime)
 	case mysql.TypeDuration:
 		bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETDuration, types.ETString, types.ETString)
@@ -1898,7 +1931,7 @@ func (c *strToDateFunctionClass) getFunction(ctx BuildContext, args []Expression
 			return nil, err
 		}
 		bf.setDecimalAndFlenForTime(fsp)
-		sig = &builtinStrToDateDurationSig{bf}
+		sig = &builtinStrToDateDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_StrToDateDuration)
 	}
 	return sig, nil
@@ -1906,6 +1939,7 @@ func (c *strToDateFunctionClass) getFunction(ctx BuildContext, args []Expression
 
 type builtinStrToDateDateSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinStrToDateDateSig) Clone() builtinFunc {
@@ -1939,6 +1973,7 @@ func (b *builtinStrToDateDateSig) evalTime(ctx EvalContext, row chunk.Row) (type
 
 type builtinStrToDateDatetimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinStrToDateDatetimeSig) Clone() builtinFunc {
@@ -1972,6 +2007,7 @@ func (b *builtinStrToDateDatetimeSig) evalTime(ctx EvalContext, row chunk.Row) (
 
 type builtinStrToDateDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinStrToDateDurationSig) Clone() builtinFunc {
@@ -2029,10 +2065,10 @@ func (c *sysDateFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 
 	var sig builtinFunc
 	if len(args) == 1 {
-		sig = &builtinSysDateWithFspSig{bf}
+		sig = &builtinSysDateWithFspSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_SysDateWithFsp)
 	} else {
-		sig = &builtinSysDateWithoutFspSig{bf}
+		sig = &builtinSysDateWithoutFspSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_SysDateWithoutFsp)
 	}
 	return sig, nil
@@ -2040,6 +2076,7 @@ func (c *sysDateFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 
 type builtinSysDateWithFspSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSysDateWithFspSig) Clone() builtinFunc {
@@ -2067,6 +2104,7 @@ func (b *builtinSysDateWithFspSig) evalTime(ctx EvalContext, row chunk.Row) (val
 
 type builtinSysDateWithoutFspSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSysDateWithoutFspSig) Clone() builtinFunc {
@@ -2100,12 +2138,13 @@ func (c *currentDateFunctionClass) getFunction(ctx BuildContext, args []Expressi
 		return nil, err
 	}
 	bf.setDecimalAndFlenForDate()
-	sig := &builtinCurrentDateSig{bf}
+	sig := &builtinCurrentDateSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinCurrentDateSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCurrentDateSig) Clone() builtinFunc {
@@ -2153,17 +2192,18 @@ func (c *currentTimeFunctionClass) getFunction(ctx BuildContext, args []Expressi
 	// 2. hour is in the 2-digit range.
 	bf.tp.SetFlen(bf.tp.GetFlen() - 2)
 	if len(args) == 0 {
-		sig = &builtinCurrentTime0ArgSig{bf}
+		sig = &builtinCurrentTime0ArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CurrentTime0Arg)
 		return sig, nil
 	}
-	sig = &builtinCurrentTime1ArgSig{bf}
+	sig = &builtinCurrentTime1ArgSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_CurrentTime1Arg)
 	return sig, nil
 }
 
 type builtinCurrentTime0ArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCurrentTime0ArgSig) Clone() builtinFunc {
@@ -2188,6 +2228,7 @@ func (b *builtinCurrentTime0ArgSig) evalDuration(ctx EvalContext, row chunk.Row)
 
 type builtinCurrentTime1ArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinCurrentTime1ArgSig) Clone() builtinFunc {
@@ -2233,13 +2274,14 @@ func (c *timeFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 		return nil, err
 	}
 	bf.setDecimalAndFlenForTime(fsp)
-	sig := &builtinTimeSig{bf}
+	sig := &builtinTimeSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Time)
 	return sig, nil
 }
 
 type builtinTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTimeSig) Clone() builtinFunc {
@@ -2304,12 +2346,13 @@ func (c *timeLiteralFunctionClass) getFunction(ctx BuildContext, args []Expressi
 		return nil, err
 	}
 	bf.setDecimalAndFlenForTime(duration.Fsp)
-	sig := &builtinTimeLiteralSig{bf, duration}
+	sig := &builtinTimeLiteralSig{baseBuiltinFunc: bf, duration: duration}
 	return sig, nil
 }
 
 type builtinTimeLiteralSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	duration types.Duration
 }
 
@@ -2338,12 +2381,13 @@ func (c *utcDateFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 		return nil, err
 	}
 	bf.setDecimalAndFlenForDate()
-	sig := &builtinUTCDateSig{bf}
+	sig := &builtinUTCDateSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinUTCDateSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUTCDateSig) Clone() builtinFunc {
@@ -2388,10 +2432,10 @@ func (c *utcTimestampFunctionClass) getFunction(ctx BuildContext, args []Express
 	bf.setDecimalAndFlenForDatetime(fsp)
 	var sig builtinFunc
 	if len(args) == 1 {
-		sig = &builtinUTCTimestampWithArgSig{bf}
+		sig = &builtinUTCTimestampWithArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UTCTimestampWithArg)
 	} else {
-		sig = &builtinUTCTimestampWithoutArgSig{bf}
+		sig = &builtinUTCTimestampWithoutArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UTCTimestampWithoutArg)
 	}
 	return sig, nil
@@ -2411,6 +2455,7 @@ func evalUTCTimestampWithFsp(ctx EvalContext, fsp int) (types.Time, bool, error)
 
 type builtinUTCTimestampWithArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUTCTimestampWithArgSig) Clone() builtinFunc {
@@ -2440,6 +2485,7 @@ func (b *builtinUTCTimestampWithArgSig) evalTime(ctx EvalContext, row chunk.Row)
 
 type builtinUTCTimestampWithoutArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUTCTimestampWithoutArgSig) Clone() builtinFunc {
@@ -2480,10 +2526,10 @@ func (c *nowFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 
 	var sig builtinFunc
 	if len(args) == 1 {
-		sig = &builtinNowWithArgSig{bf}
+		sig = &builtinNowWithArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_NowWithArg)
 	} else {
-		sig = &builtinNowWithoutArgSig{bf}
+		sig = &builtinNowWithoutArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_NowWithoutArg)
 	}
 	return sig, nil
@@ -2532,6 +2578,7 @@ func evalNowWithFsp(ctx EvalContext, fsp int) (types.Time, bool, error) {
 
 type builtinNowWithArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNowWithArgSig) Clone() builtinFunc {
@@ -2563,6 +2610,7 @@ func (b *builtinNowWithArgSig) evalTime(ctx EvalContext, row chunk.Row) (types.T
 
 type builtinNowWithoutArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinNowWithoutArgSig) Clone() builtinFunc {
@@ -2612,14 +2660,14 @@ func (c *extractFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 			if err != nil {
 				return nil, err
 			}
-			sig = &builtinExtractDatetimeSig{bf}
+			sig = &builtinExtractDatetimeSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_ExtractDatetime)
 		} else if args[1].GetType().EvalType() == types.ETDuration {
 			bf, err = newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, types.ETString, types.ETDuration)
 			if err != nil {
 				return nil, err
 			}
-			sig = &builtinExtractDurationSig{bf}
+			sig = &builtinExtractDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_ExtractDuration)
 		} else {
 			bf, err = newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, types.ETString, types.ETString)
@@ -2627,7 +2675,7 @@ func (c *extractFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 				return nil, err
 			}
 			bf.args[1].GetType().SetDecimal(int(types.MaxFsp))
-			sig = &builtinExtractDatetimeFromStringSig{bf}
+			sig = &builtinExtractDatetimeFromStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_ExtractDatetimeFromString)
 		}
 	} else if isClockUnit {
@@ -2636,7 +2684,7 @@ func (c *extractFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 		if err != nil {
 			return nil, err
 		}
-		sig = &builtinExtractDurationSig{bf}
+		sig = &builtinExtractDurationSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ExtractDuration)
 	} else {
 		// Date units interpret the second argument as datetime.
@@ -2644,7 +2692,7 @@ func (c *extractFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 		if err != nil {
 			return nil, err
 		}
-		sig = &builtinExtractDatetimeSig{bf}
+		sig = &builtinExtractDatetimeSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ExtractDatetime)
 	}
 	return sig, nil
@@ -2652,6 +2700,7 @@ func (c *extractFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 
 type builtinExtractDatetimeFromStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinExtractDatetimeFromStringSig) Clone() builtinFunc {
@@ -2696,6 +2745,7 @@ func (b *builtinExtractDatetimeFromStringSig) evalInt(ctx EvalContext, row chunk
 
 type builtinExtractDatetimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinExtractDatetimeSig) Clone() builtinFunc {
@@ -2721,6 +2771,7 @@ func (b *builtinExtractDatetimeSig) evalInt(ctx EvalContext, row chunk.Row) (int
 
 type builtinExtractDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinExtractDurationSig) Clone() builtinFunc {
@@ -3919,6 +3970,7 @@ func (c *addSubDateFunctionClass) getFunction(ctx BuildContext, args []Expressio
 
 type builtinAddSubDateAsStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	baseDateArithmetical
 	getDate        funcGetDateForDateAddSub
 	vecGetDate     funcVecGetDateForDateAddSub
@@ -3971,6 +4023,7 @@ func (b *builtinAddSubDateAsStringSig) evalString(ctx EvalContext, row chunk.Row
 
 type builtinAddSubDateDatetimeAnySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	baseDateArithmetical
 	getInterval    funcGetIntervalForDateAddSub
 	vecGetInterval funcVecGetIntervalForDateAddSub
@@ -4010,6 +4063,7 @@ func (b *builtinAddSubDateDatetimeAnySig) evalTime(ctx EvalContext, row chunk.Ro
 
 type builtinAddSubDateDurationAnySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	baseDateArithmetical
 	getInterval    funcGetIntervalForDateAddSub
 	vecGetInterval funcVecGetIntervalForDateAddSub
@@ -4086,13 +4140,14 @@ func (c *timestampDiffFunctionClass) getFunction(ctx BuildContext, args []Expres
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinTimestampDiffSig{bf}
+	sig := &builtinTimestampDiffSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_TimestampDiff)
 	return sig, nil
 }
 
 type builtinTimestampDiffSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTimestampDiffSig) Clone() builtinFunc {
@@ -4190,13 +4245,13 @@ func (c *unixTimestampFunctionClass) getFunction(ctx BuildContext, args []Expres
 
 	var sig builtinFunc
 	if len(args) == 0 {
-		sig = &builtinUnixTimestampCurrentSig{bf}
+		sig = &builtinUnixTimestampCurrentSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UnixTimestampCurrent)
 	} else if retTp == types.ETInt {
-		sig = &builtinUnixTimestampIntSig{bf}
+		sig = &builtinUnixTimestampIntSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UnixTimestampInt)
 	} else if retTp == types.ETDecimal {
-		sig = &builtinUnixTimestampDecSig{bf}
+		sig = &builtinUnixTimestampDecSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UnixTimestampDec)
 	}
 	return sig, nil
@@ -4237,6 +4292,7 @@ func goTimeToMysqlUnixTimestamp(t time.Time, decimal int) (*types.MyDecimal, err
 
 type builtinUnixTimestampCurrentSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUnixTimestampCurrentSig) Clone() builtinFunc {
@@ -4265,6 +4321,7 @@ func (b *builtinUnixTimestampCurrentSig) evalInt(ctx EvalContext, row chunk.Row)
 
 type builtinUnixTimestampIntSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUnixTimestampIntSig) Clone() builtinFunc {
@@ -4303,6 +4360,7 @@ func (b *builtinUnixTimestampIntSig) evalInt(ctx EvalContext, row chunk.Row) (in
 
 type builtinUnixTimestampDecSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUnixTimestampDecSig) Clone() builtinFunc {
@@ -4364,10 +4422,10 @@ func (c *timestampFunctionClass) getFunction(ctx BuildContext, args []Expression
 	bf.setDecimalAndFlenForDatetime(fsp)
 	var sig builtinFunc
 	if argLen == 2 {
-		sig = &builtinTimestamp2ArgsSig{bf, isFloat}
+		sig = &builtinTimestamp2ArgsSig{baseBuiltinFunc: bf, isFloat: isFloat}
 		sig.setPbCode(tipb.ScalarFuncSig_Timestamp2Args)
 	} else {
-		sig = &builtinTimestamp1ArgSig{bf, isFloat}
+		sig = &builtinTimestamp1ArgSig{baseBuiltinFunc: bf, isFloat: isFloat}
 		sig.setPbCode(tipb.ScalarFuncSig_Timestamp1Arg)
 	}
 	return sig, nil
@@ -4375,6 +4433,7 @@ func (c *timestampFunctionClass) getFunction(ctx BuildContext, args []Expression
 
 type builtinTimestamp1ArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	isFloat bool
 }
@@ -4407,6 +4466,7 @@ func (b *builtinTimestamp1ArgSig) evalTime(ctx EvalContext, row chunk.Row) (type
 
 type builtinTimestamp2ArgsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	isFloat bool
 }
@@ -4489,12 +4549,14 @@ func (c *timestampLiteralFunctionClass) getFunction(ctx BuildContext, args []Exp
 		return nil, err
 	}
 	bf.setDecimalAndFlenForDatetime(tm.Fsp())
-	sig := &builtinTimestampLiteralSig{bf, tm}
+	sig := &builtinTimestampLiteralSig{baseBuiltinFunc: bf, tm: tm}
 	return sig, nil
 }
 
 type builtinTimestampLiteralSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
+
 	tm types.Time
 }
 
@@ -4676,13 +4738,13 @@ func (c *addTimeFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	case mysql.TypeDatetime, mysql.TypeTimestamp:
 		switch tp2.GetType() {
 		case mysql.TypeDuration:
-			sig = &builtinAddDatetimeAndDurationSig{bf}
+			sig = &builtinAddDatetimeAndDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddDatetimeAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
-			sig = &builtinAddTimeDateTimeNullSig{bf}
+			sig = &builtinAddTimeDateTimeNullSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddTimeDateTimeNull)
 		default:
-			sig = &builtinAddDatetimeAndStringSig{bf}
+			sig = &builtinAddDatetimeAndStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddDatetimeAndString)
 		}
 	case mysql.TypeDate:
@@ -4691,37 +4753,37 @@ func (c *addTimeFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 		bf.tp.SetCollate(collate)
 		switch tp2.GetType() {
 		case mysql.TypeDuration:
-			sig = &builtinAddDateAndDurationSig{bf}
+			sig = &builtinAddDateAndDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddDateAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
-			sig = &builtinAddTimeStringNullSig{bf}
+			sig = &builtinAddTimeStringNullSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddTimeStringNull)
 		default:
-			sig = &builtinAddDateAndStringSig{bf}
+			sig = &builtinAddDateAndStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddDateAndString)
 		}
 	case mysql.TypeDuration:
 		switch tp2.GetType() {
 		case mysql.TypeDuration:
-			sig = &builtinAddDurationAndDurationSig{bf}
+			sig = &builtinAddDurationAndDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddDurationAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
-			sig = &builtinAddTimeDurationNullSig{bf}
+			sig = &builtinAddTimeDurationNullSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddTimeDurationNull)
 		default:
-			sig = &builtinAddDurationAndStringSig{bf}
+			sig = &builtinAddDurationAndStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddDurationAndString)
 		}
 	default:
 		switch tp2.GetType() {
 		case mysql.TypeDuration:
-			sig = &builtinAddStringAndDurationSig{bf}
+			sig = &builtinAddStringAndDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddStringAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
-			sig = &builtinAddTimeStringNullSig{bf}
+			sig = &builtinAddTimeStringNullSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddTimeStringNull)
 		default:
-			sig = &builtinAddStringAndStringSig{bf}
+			sig = &builtinAddStringAndStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_AddStringAndString)
 		}
 	}
@@ -4730,6 +4792,7 @@ func (c *addTimeFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 
 type builtinAddTimeDateTimeNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAddTimeDateTimeNullSig) Clone() builtinFunc {
@@ -4746,6 +4809,7 @@ func (b *builtinAddTimeDateTimeNullSig) evalTime(ctx EvalContext, row chunk.Row)
 
 type builtinAddDatetimeAndDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAddDatetimeAndDurationSig) Clone() builtinFunc {
@@ -4771,6 +4835,7 @@ func (b *builtinAddDatetimeAndDurationSig) evalTime(ctx EvalContext, row chunk.R
 
 type builtinAddDatetimeAndStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAddDatetimeAndStringSig) Clone() builtinFunc {
@@ -4808,6 +4873,7 @@ func (b *builtinAddDatetimeAndStringSig) evalTime(ctx EvalContext, row chunk.Row
 
 type builtinAddTimeDurationNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAddTimeDurationNullSig) Clone() builtinFunc {
@@ -4824,6 +4890,7 @@ func (b *builtinAddTimeDurationNullSig) evalDuration(ctx EvalContext, row chunk.
 
 type builtinAddDurationAndDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAddDurationAndDurationSig) Clone() builtinFunc {
@@ -4852,6 +4919,7 @@ func (b *builtinAddDurationAndDurationSig) evalDuration(ctx EvalContext, row chu
 
 type builtinAddDurationAndStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAddDurationAndStringSig) Clone() builtinFunc {
@@ -4892,6 +4960,7 @@ func (b *builtinAddDurationAndStringSig) evalDuration(ctx EvalContext, row chunk
 
 type builtinAddTimeStringNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAddTimeStringNullSig) Clone() builtinFunc {
@@ -4908,6 +4977,7 @@ func (b *builtinAddTimeStringNullSig) evalString(ctx EvalContext, row chunk.Row)
 
 type builtinAddStringAndDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAddStringAndDurationSig) Clone() builtinFunc {
@@ -4949,6 +5019,7 @@ func (b *builtinAddStringAndDurationSig) evalString(ctx EvalContext, row chunk.R
 
 type builtinAddStringAndStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAddStringAndStringSig) Clone() builtinFunc {
@@ -5012,6 +5083,7 @@ func (b *builtinAddStringAndStringSig) evalString(ctx EvalContext, row chunk.Row
 
 type builtinAddDateAndDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAddDateAndDurationSig) Clone() builtinFunc {
@@ -5037,6 +5109,7 @@ func (b *builtinAddDateAndDurationSig) evalString(ctx EvalContext, row chunk.Row
 
 type builtinAddDateAndStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinAddDateAndStringSig) Clone() builtinFunc {
@@ -5126,6 +5199,7 @@ func (c *convertTzFunctionClass) getFunction(ctx BuildContext, args []Expression
 
 type builtinConvertTzSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	timezoneRegex *regexp.Regexp
 }
 
@@ -5215,13 +5289,14 @@ func (c *makeDateFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		return nil, err
 	}
 	bf.setDecimalAndFlenForDate()
-	sig := &builtinMakeDateSig{bf}
+	sig := &builtinMakeDateSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_MakeDate)
 	return sig, nil
 }
 
 type builtinMakeDateSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinMakeDateSig) Clone() builtinFunc {
@@ -5288,13 +5363,14 @@ func (c *makeTimeFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		return nil, err
 	}
 	bf.setDecimalAndFlenForTime(decimal)
-	sig := &builtinMakeTimeSig{bf}
+	sig := &builtinMakeTimeSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_MakeTime)
 	return sig, nil
 }
 
 type builtinMakeTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinMakeTimeSig) Clone() builtinFunc {
@@ -5374,7 +5450,7 @@ func (c *periodAddFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 	bf.tp.SetFlen(6)
-	sig := &builtinPeriodAddSig{bf}
+	sig := &builtinPeriodAddSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
@@ -5418,6 +5494,7 @@ func month2Period(month uint64) uint64 {
 
 type builtinPeriodAddSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinPeriodAddSig) Clone() builtinFunc {
@@ -5461,12 +5538,13 @@ func (c *periodDiffFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		return nil, err
 	}
 	bf.tp.SetFlen(6)
-	sig := &builtinPeriodDiffSig{bf}
+	sig := &builtinPeriodDiffSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinPeriodDiffSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinPeriodDiffSig) Clone() builtinFunc {
@@ -5514,13 +5592,14 @@ func (c *quarterFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	}
 	bf.tp.SetFlen(1)
 
-	sig := &builtinQuarterSig{bf}
+	sig := &builtinQuarterSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Quarter)
 	return sig, nil
 }
 
 type builtinQuarterSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinQuarterSig) Clone() builtinFunc {
@@ -5566,13 +5645,14 @@ func (c *secToTimeFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 	bf.setDecimalAndFlenForTime(retFsp)
-	sig := &builtinSecToTimeSig{bf}
+	sig := &builtinSecToTimeSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_SecToTime)
 	return sig, nil
 }
 
 type builtinSecToTimeSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSecToTimeSig) Clone() builtinFunc {
@@ -5645,13 +5725,13 @@ func (c *subTimeFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	case mysql.TypeDatetime, mysql.TypeTimestamp:
 		switch tp2.GetType() {
 		case mysql.TypeDuration:
-			sig = &builtinSubDatetimeAndDurationSig{bf}
+			sig = &builtinSubDatetimeAndDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubDatetimeAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
-			sig = &builtinSubTimeDateTimeNullSig{bf}
+			sig = &builtinSubTimeDateTimeNullSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubTimeDateTimeNull)
 		default:
-			sig = &builtinSubDatetimeAndStringSig{bf}
+			sig = &builtinSubDatetimeAndStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubDatetimeAndString)
 		}
 	case mysql.TypeDate:
@@ -5660,37 +5740,37 @@ func (c *subTimeFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 		bf.tp.SetCollate(collate)
 		switch tp2.GetType() {
 		case mysql.TypeDuration:
-			sig = &builtinSubDateAndDurationSig{bf}
+			sig = &builtinSubDateAndDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubDateAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
-			sig = &builtinSubTimeStringNullSig{bf}
+			sig = &builtinSubTimeStringNullSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubTimeStringNull)
 		default:
-			sig = &builtinSubDateAndStringSig{bf}
+			sig = &builtinSubDateAndStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubDateAndString)
 		}
 	case mysql.TypeDuration:
 		switch tp2.GetType() {
 		case mysql.TypeDuration:
-			sig = &builtinSubDurationAndDurationSig{bf}
+			sig = &builtinSubDurationAndDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubDurationAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
-			sig = &builtinSubTimeDurationNullSig{bf}
+			sig = &builtinSubTimeDurationNullSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubTimeDurationNull)
 		default:
-			sig = &builtinSubDurationAndStringSig{bf}
+			sig = &builtinSubDurationAndStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubDurationAndString)
 		}
 	default:
 		switch tp2.GetType() {
 		case mysql.TypeDuration:
-			sig = &builtinSubStringAndDurationSig{bf}
+			sig = &builtinSubStringAndDurationSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubStringAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
-			sig = &builtinSubTimeStringNullSig{bf}
+			sig = &builtinSubTimeStringNullSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubTimeStringNull)
 		default:
-			sig = &builtinSubStringAndStringSig{bf}
+			sig = &builtinSubStringAndStringSig{baseBuiltinFunc: bf}
 			sig.setPbCode(tipb.ScalarFuncSig_SubStringAndString)
 		}
 	}
@@ -5699,6 +5779,7 @@ func (c *subTimeFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 
 type builtinSubDatetimeAndDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubDatetimeAndDurationSig) Clone() builtinFunc {
@@ -5725,6 +5806,7 @@ func (b *builtinSubDatetimeAndDurationSig) evalTime(ctx EvalContext, row chunk.R
 
 type builtinSubDatetimeAndStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubDatetimeAndStringSig) Clone() builtinFunc {
@@ -5762,6 +5844,7 @@ func (b *builtinSubDatetimeAndStringSig) evalTime(ctx EvalContext, row chunk.Row
 
 type builtinSubTimeDateTimeNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubTimeDateTimeNullSig) Clone() builtinFunc {
@@ -5778,6 +5861,7 @@ func (b *builtinSubTimeDateTimeNullSig) evalTime(ctx EvalContext, row chunk.Row)
 
 type builtinSubStringAndDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubStringAndDurationSig) Clone() builtinFunc {
@@ -5819,6 +5903,7 @@ func (b *builtinSubStringAndDurationSig) evalString(ctx EvalContext, row chunk.R
 
 type builtinSubStringAndStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubStringAndStringSig) Clone() builtinFunc {
@@ -5872,6 +5957,7 @@ func (b *builtinSubStringAndStringSig) evalString(ctx EvalContext, row chunk.Row
 
 type builtinSubTimeStringNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubTimeStringNullSig) Clone() builtinFunc {
@@ -5888,6 +5974,7 @@ func (b *builtinSubTimeStringNullSig) evalString(ctx EvalContext, row chunk.Row)
 
 type builtinSubDurationAndDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubDurationAndDurationSig) Clone() builtinFunc {
@@ -5916,6 +6003,7 @@ func (b *builtinSubDurationAndDurationSig) evalDuration(ctx EvalContext, row chu
 
 type builtinSubDurationAndStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubDurationAndStringSig) Clone() builtinFunc {
@@ -5953,6 +6041,7 @@ func (b *builtinSubDurationAndStringSig) evalDuration(ctx EvalContext, row chunk
 
 type builtinSubTimeDurationNullSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubTimeDurationNullSig) Clone() builtinFunc {
@@ -5969,6 +6058,7 @@ func (b *builtinSubTimeDurationNullSig) evalDuration(ctx EvalContext, row chunk.
 
 type builtinSubDateAndDurationSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubDateAndDurationSig) Clone() builtinFunc {
@@ -5994,6 +6084,7 @@ func (b *builtinSubDateAndDurationSig) evalString(ctx EvalContext, row chunk.Row
 
 type builtinSubDateAndStringSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinSubDateAndStringSig) Clone() builtinFunc {
@@ -6046,13 +6137,14 @@ func (c *timeFormatFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	}
 	// worst case: formatMask=%r%r%r...%r, each %r takes 11 characters
 	bf.tp.SetFlen((args[1].GetType().GetFlen() + 1) / 2 * 11)
-	sig := &builtinTimeFormatSig{bf}
+	sig := &builtinTimeFormatSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_TimeFormat)
 	return sig, nil
 }
 
 type builtinTimeFormatSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTimeFormatSig) Clone() builtinFunc {
@@ -6098,13 +6190,14 @@ func (c *timeToSecFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 	bf.tp.SetFlen(10)
-	sig := &builtinTimeToSecSig{bf}
+	sig := &builtinTimeToSecSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_TimeToSec)
 	return sig, nil
 }
 
 type builtinTimeToSecSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTimeToSecSig) Clone() builtinFunc {
@@ -6155,13 +6248,14 @@ func (c *timestampAddFunctionClass) getFunction(ctx BuildContext, args []Express
 	}
 
 	bf.tp.SetFlen(flen)
-	sig := &builtinTimestampAddSig{bf}
+	sig := &builtinTimestampAddSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_TimestampAdd)
 	return sig, nil
 }
 
 type builtinTimestampAddSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTimestampAddSig) Clone() builtinFunc {
@@ -6315,13 +6409,14 @@ func (c *toDaysFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinToDaysSig{bf}
+	sig := &builtinToDaysSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_ToDays)
 	return sig, nil
 }
 
 type builtinToDaysSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinToDaysSig) Clone() builtinFunc {
@@ -6360,13 +6455,14 @@ func (c *toSecondsFunctionClass) getFunction(ctx BuildContext, args []Expression
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinToSecondsSig{bf}
+	sig := &builtinToSecondsSig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_ToSeconds)
 	return sig, nil
 }
 
 type builtinToSecondsSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinToSecondsSig) Clone() builtinFunc {
@@ -6419,10 +6515,10 @@ func (c *utcTimeFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 
 	var sig builtinFunc
 	if len(args) == 1 {
-		sig = &builtinUTCTimeWithArgSig{bf}
+		sig = &builtinUTCTimeWithArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UTCTimeWithArg)
 	} else {
-		sig = &builtinUTCTimeWithoutArgSig{bf}
+		sig = &builtinUTCTimeWithoutArgSig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_UTCTimeWithoutArg)
 	}
 	return sig, nil
@@ -6430,6 +6526,7 @@ func (c *utcTimeFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 
 type builtinUTCTimeWithoutArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUTCTimeWithoutArgSig) Clone() builtinFunc {
@@ -6451,6 +6548,7 @@ func (b *builtinUTCTimeWithoutArgSig) evalDuration(ctx EvalContext, row chunk.Ro
 
 type builtinUTCTimeWithArgSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinUTCTimeWithArgSig) Clone() builtinFunc {
@@ -6493,13 +6591,14 @@ func (c *lastDayFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 		return nil, err
 	}
 	bf.setDecimalAndFlenForDate()
-	sig := &builtinLastDaySig{bf}
+	sig := &builtinLastDaySig{baseBuiltinFunc: bf}
 	sig.setPbCode(tipb.ScalarFuncSig_LastDay)
 	return sig, nil
 }
 
 type builtinLastDaySig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinLastDaySig) Clone() builtinFunc {
@@ -6558,12 +6657,13 @@ func (c *tidbParseTsoFunctionClass) getFunction(ctx BuildContext, args []Express
 	bf.tp.SetType(mysql.TypeDatetime)
 	bf.tp.SetFlen(mysql.MaxDateWidth)
 	bf.tp.SetDecimal(types.DefaultFsp)
-	sig := &builtinTidbParseTsoSig{bf}
+	sig := &builtinTidbParseTsoSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinTidbParseTsoSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTidbParseTsoSig) Clone() builtinFunc {
@@ -6602,12 +6702,13 @@ func (c *tidbParseTsoLogicalFunctionClass) getFunction(ctx BuildContext, args []
 		return nil, err
 	}
 
-	sig := &builtinTidbParseTsoLogicalSig{bf}
+	sig := &builtinTidbParseTsoLogicalSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinTidbParseTsoLogicalSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTidbParseTsoLogicalSig) Clone() builtinFunc {
@@ -6642,12 +6743,13 @@ func (c *tidbBoundedStalenessFunctionClass) getFunction(ctx BuildContext, args [
 		return nil, err
 	}
 	bf.setDecimalAndFlenForDatetime(3)
-	sig := &builtinTiDBBoundedStalenessSig{bf}
+	sig := &builtinTiDBBoundedStalenessSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinTiDBBoundedStalenessSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTiDBBoundedStalenessSig) Clone() builtinFunc {
@@ -6781,12 +6883,13 @@ func (c *tidbCurrentTsoFunctionClass) getFunction(ctx BuildContext, args []Expre
 	if err != nil {
 		return nil, err
 	}
-	sig := &builtinTiDBCurrentTsoSig{bf}
+	sig := &builtinTiDBCurrentTsoSig{baseBuiltinFunc: bf}
 	return sig, nil
 }
 
 type builtinTiDBCurrentTsoSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 }
 
 func (b *builtinTiDBCurrentTsoSig) Clone() builtinFunc {

--- a/pkg/expression/builtin_vectorized_test.go
+++ b/pkg/expression/builtin_vectorized_test.go
@@ -208,6 +208,7 @@ func BenchmarkPlusIntBufAllocator(b *testing.B) {
 
 type mockBuiltinDouble struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 
 	evalType  types.EvalType
 	enableVec bool
@@ -439,7 +440,7 @@ func genMockRowDouble(ctx BuildContext, eType types.EvalType, enableVec bool) (b
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	rowDouble := &mockBuiltinDouble{bf, eType, enableVec}
+	rowDouble := &mockBuiltinDouble{baseBuiltinFunc: bf, evalType: eType, enableVec: enableVec}
 	input := chunk.New([]*types.FieldType{tp}, 1024, 1024)
 	buf := chunk.NewColumn(types.NewFieldType(convertETType(eType)), 1024)
 	for i := 0; i < 1024; i++ {

--- a/pkg/expression/distsql_builtin.go
+++ b/pkg/expression/distsql_builtin.go
@@ -48,474 +48,474 @@ func getSignatureByPB(ctx BuildContext, sigCode tipb.ScalarFuncSig, tp *tipb.Fie
 	case tipb.ScalarFuncSig_CastIntAsReal:
 		f = &builtinCastIntAsRealSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastIntAsString:
-		f = &builtinCastIntAsStringSig{base}
+		f = &builtinCastIntAsStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastIntAsDecimal:
 		f = &builtinCastIntAsDecimalSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastIntAsTime:
-		f = &builtinCastIntAsTimeSig{base}
+		f = &builtinCastIntAsTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastIntAsDuration:
-		f = &builtinCastIntAsDurationSig{base}
+		f = &builtinCastIntAsDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastIntAsJson:
-		f = &builtinCastIntAsJSONSig{base}
+		f = &builtinCastIntAsJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastRealAsInt:
 		f = &builtinCastRealAsIntSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastRealAsReal:
 		f = &builtinCastRealAsRealSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastRealAsString:
-		f = &builtinCastRealAsStringSig{base}
+		f = &builtinCastRealAsStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastRealAsDecimal:
 		f = &builtinCastRealAsDecimalSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastRealAsTime:
-		f = &builtinCastRealAsTimeSig{base}
+		f = &builtinCastRealAsTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastRealAsDuration:
-		f = &builtinCastRealAsDurationSig{base}
+		f = &builtinCastRealAsDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastRealAsJson:
-		f = &builtinCastRealAsJSONSig{base}
+		f = &builtinCastRealAsJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastDecimalAsInt:
 		f = &builtinCastDecimalAsIntSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastDecimalAsReal:
 		f = &builtinCastDecimalAsRealSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastDecimalAsString:
-		f = &builtinCastDecimalAsStringSig{base}
+		f = &builtinCastDecimalAsStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastDecimalAsDecimal:
 		f = &builtinCastDecimalAsDecimalSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastDecimalAsTime:
-		f = &builtinCastDecimalAsTimeSig{base}
+		f = &builtinCastDecimalAsTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastDecimalAsDuration:
-		f = &builtinCastDecimalAsDurationSig{base}
+		f = &builtinCastDecimalAsDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastDecimalAsJson:
-		f = &builtinCastDecimalAsJSONSig{base}
+		f = &builtinCastDecimalAsJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastStringAsInt:
 		f = &builtinCastStringAsIntSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastStringAsReal:
 		f = &builtinCastStringAsRealSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastStringAsString:
-		f = &builtinCastStringAsStringSig{base}
+		f = &builtinCastStringAsStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastStringAsDecimal:
 		f = &builtinCastStringAsDecimalSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastStringAsTime:
-		f = &builtinCastStringAsTimeSig{base}
+		f = &builtinCastStringAsTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastStringAsDuration:
-		f = &builtinCastStringAsDurationSig{base}
+		f = &builtinCastStringAsDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastStringAsJson:
-		f = &builtinCastStringAsJSONSig{base}
+		f = &builtinCastStringAsJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastTimeAsInt:
 		f = &builtinCastTimeAsIntSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastTimeAsReal:
 		f = &builtinCastTimeAsRealSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastTimeAsString:
-		f = &builtinCastTimeAsStringSig{base}
+		f = &builtinCastTimeAsStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastTimeAsDecimal:
 		f = &builtinCastTimeAsDecimalSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastTimeAsTime:
-		f = &builtinCastTimeAsTimeSig{base}
+		f = &builtinCastTimeAsTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastTimeAsDuration:
-		f = &builtinCastTimeAsDurationSig{base}
+		f = &builtinCastTimeAsDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastTimeAsJson:
-		f = &builtinCastTimeAsJSONSig{base}
+		f = &builtinCastTimeAsJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastDurationAsInt:
 		f = &builtinCastDurationAsIntSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastDurationAsReal:
 		f = &builtinCastDurationAsRealSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastDurationAsString:
-		f = &builtinCastDurationAsStringSig{base}
+		f = &builtinCastDurationAsStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastDurationAsDecimal:
 		f = &builtinCastDurationAsDecimalSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastDurationAsTime:
-		f = &builtinCastDurationAsTimeSig{base}
+		f = &builtinCastDurationAsTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastDurationAsDuration:
-		f = &builtinCastDurationAsDurationSig{base}
+		f = &builtinCastDurationAsDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastDurationAsJson:
-		f = &builtinCastDurationAsJSONSig{base}
+		f = &builtinCastDurationAsJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastJsonAsInt:
 		f = &builtinCastJSONAsIntSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastJsonAsReal:
 		f = &builtinCastJSONAsRealSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastJsonAsString:
-		f = &builtinCastJSONAsStringSig{base}
+		f = &builtinCastJSONAsStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastJsonAsDecimal:
 		f = &builtinCastJSONAsDecimalSig{newBaseBuiltinCastFunc(base, false)}
 	case tipb.ScalarFuncSig_CastJsonAsTime:
-		f = &builtinCastJSONAsTimeSig{base}
+		f = &builtinCastJSONAsTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastJsonAsDuration:
-		f = &builtinCastJSONAsDurationSig{base}
+		f = &builtinCastJSONAsDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CastJsonAsJson:
-		f = &builtinCastJSONAsJSONSig{base}
+		f = &builtinCastJSONAsJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CoalesceInt:
-		f = &builtinCoalesceIntSig{base}
+		f = &builtinCoalesceIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CoalesceReal:
-		f = &builtinCoalesceRealSig{base}
+		f = &builtinCoalesceRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CoalesceDecimal:
-		f = &builtinCoalesceDecimalSig{base}
+		f = &builtinCoalesceDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CoalesceString:
-		f = &builtinCoalesceStringSig{base}
+		f = &builtinCoalesceStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CoalesceTime:
-		f = &builtinCoalesceTimeSig{base}
+		f = &builtinCoalesceTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CoalesceDuration:
-		f = &builtinCoalesceDurationSig{base}
+		f = &builtinCoalesceDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CoalesceJson:
-		f = &builtinCoalesceJSONSig{base}
+		f = &builtinCoalesceJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LTInt:
-		f = &builtinLTIntSig{base}
+		f = &builtinLTIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LTReal:
-		f = &builtinLTRealSig{base}
+		f = &builtinLTRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LTDecimal:
-		f = &builtinLTDecimalSig{base}
+		f = &builtinLTDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LTString:
-		f = &builtinLTStringSig{base}
+		f = &builtinLTStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LTTime:
-		f = &builtinLTTimeSig{base}
+		f = &builtinLTTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LTDuration:
-		f = &builtinLTDurationSig{base}
+		f = &builtinLTDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LTJson:
-		f = &builtinLTJSONSig{base}
+		f = &builtinLTJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LEInt:
-		f = &builtinLEIntSig{base}
+		f = &builtinLEIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LEReal:
-		f = &builtinLERealSig{base}
+		f = &builtinLERealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LEDecimal:
-		f = &builtinLEDecimalSig{base}
+		f = &builtinLEDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LEString:
-		f = &builtinLEStringSig{base}
+		f = &builtinLEStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LETime:
-		f = &builtinLETimeSig{base}
+		f = &builtinLETimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LEDuration:
-		f = &builtinLEDurationSig{base}
+		f = &builtinLEDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LEJson:
-		f = &builtinLEJSONSig{base}
+		f = &builtinLEJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GTInt:
-		f = &builtinGTIntSig{base}
+		f = &builtinGTIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GTReal:
-		f = &builtinGTRealSig{base}
+		f = &builtinGTRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GTDecimal:
-		f = &builtinGTDecimalSig{base}
+		f = &builtinGTDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GTString:
-		f = &builtinGTStringSig{base}
+		f = &builtinGTStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GTTime:
-		f = &builtinGTTimeSig{base}
+		f = &builtinGTTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GTDuration:
-		f = &builtinGTDurationSig{base}
+		f = &builtinGTDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GTJson:
-		f = &builtinGTJSONSig{base}
+		f = &builtinGTJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GreatestInt:
-		f = &builtinGreatestIntSig{base}
+		f = &builtinGreatestIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GreatestReal:
-		f = &builtinGreatestRealSig{base}
+		f = &builtinGreatestRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GreatestDecimal:
-		f = &builtinGreatestDecimalSig{base}
+		f = &builtinGreatestDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GreatestString:
-		f = &builtinGreatestStringSig{base}
+		f = &builtinGreatestStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GreatestTime:
-		f = &builtinGreatestTimeSig{base, false}
+		f = &builtinGreatestTimeSig{baseBuiltinFunc: base, cmpAsDate: false}
 	case tipb.ScalarFuncSig_GreatestDate:
-		f = &builtinGreatestTimeSig{base, true}
+		f = &builtinGreatestTimeSig{baseBuiltinFunc: base, cmpAsDate: true}
 	case tipb.ScalarFuncSig_GreatestCmpStringAsTime:
-		f = &builtinGreatestCmpStringAsTimeSig{base, false}
+		f = &builtinGreatestCmpStringAsTimeSig{baseBuiltinFunc: base, cmpAsDate: false}
 	case tipb.ScalarFuncSig_GreatestCmpStringAsDate:
-		f = &builtinGreatestCmpStringAsTimeSig{base, true}
+		f = &builtinGreatestCmpStringAsTimeSig{baseBuiltinFunc: base, cmpAsDate: true}
 	case tipb.ScalarFuncSig_GreatestDuration:
-		f = &builtinGreatestDurationSig{base}
+		f = &builtinGreatestDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LeastInt:
-		f = &builtinLeastIntSig{base}
+		f = &builtinLeastIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LeastReal:
-		f = &builtinLeastRealSig{base}
+		f = &builtinLeastRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LeastDecimal:
-		f = &builtinLeastDecimalSig{base}
+		f = &builtinLeastDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LeastString:
-		f = &builtinLeastStringSig{base}
+		f = &builtinLeastStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LeastTime:
-		f = &builtinLeastTimeSig{base, false}
+		f = &builtinLeastTimeSig{baseBuiltinFunc: base, cmpAsDate: false}
 	case tipb.ScalarFuncSig_LeastDate:
-		f = &builtinLeastTimeSig{base, true}
+		f = &builtinLeastTimeSig{baseBuiltinFunc: base, cmpAsDate: true}
 	case tipb.ScalarFuncSig_LeastCmpStringAsTime:
-		f = &builtinLeastCmpStringAsTimeSig{base, false}
+		f = &builtinLeastCmpStringAsTimeSig{baseBuiltinFunc: base, cmpAsDate: false}
 	case tipb.ScalarFuncSig_LeastCmpStringAsDate:
-		f = &builtinLeastCmpStringAsTimeSig{base, true}
+		f = &builtinLeastCmpStringAsTimeSig{baseBuiltinFunc: base, cmpAsDate: true}
 	case tipb.ScalarFuncSig_LeastDuration:
-		f = &builtinLeastDurationSig{base}
+		f = &builtinLeastDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IntervalInt:
-		f = &builtinIntervalIntSig{base, false} // Since interval function won't be pushed down to TiKV, therefore it doesn't matter what value we give to hasNullable
+		f = &builtinIntervalIntSig{baseBuiltinFunc: base, hasNullable: false} // Since interval function won't be pushed down to TiKV, therefore it doesn't matter what value we give to hasNullable
 	case tipb.ScalarFuncSig_IntervalReal:
-		f = &builtinIntervalRealSig{base, false}
+		f = &builtinIntervalRealSig{baseBuiltinFunc: base, hasNullable: false}
 	case tipb.ScalarFuncSig_GEInt:
-		f = &builtinGEIntSig{base}
+		f = &builtinGEIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GEReal:
-		f = &builtinGERealSig{base}
+		f = &builtinGERealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GEDecimal:
-		f = &builtinGEDecimalSig{base}
+		f = &builtinGEDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GEString:
-		f = &builtinGEStringSig{base}
+		f = &builtinGEStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GETime:
-		f = &builtinGETimeSig{base}
+		f = &builtinGETimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GEDuration:
-		f = &builtinGEDurationSig{base}
+		f = &builtinGEDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GEJson:
-		f = &builtinGEJSONSig{base}
+		f = &builtinGEJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_EQInt:
-		f = &builtinEQIntSig{base}
+		f = &builtinEQIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_EQReal:
-		f = &builtinEQRealSig{base}
+		f = &builtinEQRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_EQDecimal:
-		f = &builtinEQDecimalSig{base}
+		f = &builtinEQDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_EQString:
-		f = &builtinEQStringSig{base}
+		f = &builtinEQStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_EQTime:
-		f = &builtinEQTimeSig{base}
+		f = &builtinEQTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_EQDuration:
-		f = &builtinEQDurationSig{base}
+		f = &builtinEQDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_EQJson:
-		f = &builtinEQJSONSig{base}
+		f = &builtinEQJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NEInt:
-		f = &builtinNEIntSig{base}
+		f = &builtinNEIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NEReal:
-		f = &builtinNERealSig{base}
+		f = &builtinNERealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NEDecimal:
-		f = &builtinNEDecimalSig{base}
+		f = &builtinNEDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NEString:
-		f = &builtinNEStringSig{base}
+		f = &builtinNEStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NETime:
-		f = &builtinNETimeSig{base}
+		f = &builtinNETimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NEDuration:
-		f = &builtinNEDurationSig{base}
+		f = &builtinNEDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NEJson:
-		f = &builtinNEJSONSig{base}
+		f = &builtinNEJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NullEQInt:
-		f = &builtinNullEQIntSig{base}
+		f = &builtinNullEQIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NullEQReal:
-		f = &builtinNullEQRealSig{base}
+		f = &builtinNullEQRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NullEQDecimal:
-		f = &builtinNullEQDecimalSig{base}
+		f = &builtinNullEQDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NullEQString:
-		f = &builtinNullEQStringSig{base}
+		f = &builtinNullEQStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NullEQTime:
-		f = &builtinNullEQTimeSig{base}
+		f = &builtinNullEQTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NullEQDuration:
-		f = &builtinNullEQDurationSig{base}
+		f = &builtinNullEQDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NullEQJson:
-		f = &builtinNullEQJSONSig{base}
+		f = &builtinNullEQJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_PlusReal:
-		f = &builtinArithmeticPlusRealSig{base}
+		f = &builtinArithmeticPlusRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_PlusDecimal:
-		f = &builtinArithmeticPlusDecimalSig{base}
+		f = &builtinArithmeticPlusDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_PlusInt:
-		f = &builtinArithmeticPlusIntSig{base}
+		f = &builtinArithmeticPlusIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MinusReal:
-		f = &builtinArithmeticMinusRealSig{base}
+		f = &builtinArithmeticMinusRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MinusDecimal:
-		f = &builtinArithmeticMinusDecimalSig{base}
+		f = &builtinArithmeticMinusDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MinusInt:
-		f = &builtinArithmeticMinusIntSig{base}
+		f = &builtinArithmeticMinusIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MultiplyReal:
-		f = &builtinArithmeticMultiplyRealSig{base}
+		f = &builtinArithmeticMultiplyRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MultiplyDecimal:
-		f = &builtinArithmeticMultiplyDecimalSig{base}
+		f = &builtinArithmeticMultiplyDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MultiplyInt:
-		f = &builtinArithmeticMultiplyIntSig{base}
+		f = &builtinArithmeticMultiplyIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DivideReal:
-		f = &builtinArithmeticDivideRealSig{base}
+		f = &builtinArithmeticDivideRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DivideDecimal:
-		f = &builtinArithmeticDivideDecimalSig{base}
+		f = &builtinArithmeticDivideDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IntDivideInt:
-		f = &builtinArithmeticIntDivideIntSig{base}
+		f = &builtinArithmeticIntDivideIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IntDivideDecimal:
-		f = &builtinArithmeticIntDivideDecimalSig{base}
+		f = &builtinArithmeticIntDivideDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ModReal:
-		f = &builtinArithmeticModRealSig{base}
+		f = &builtinArithmeticModRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ModDecimal:
-		f = &builtinArithmeticModDecimalSig{base}
+		f = &builtinArithmeticModDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ModIntUnsignedUnsigned:
-		f = &builtinArithmeticModIntUnsignedUnsignedSig{base}
+		f = &builtinArithmeticModIntUnsignedUnsignedSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ModIntUnsignedSigned:
-		f = &builtinArithmeticModIntUnsignedSignedSig{base}
+		f = &builtinArithmeticModIntUnsignedSignedSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ModIntSignedUnsigned:
-		f = &builtinArithmeticModIntSignedUnsignedSig{base}
+		f = &builtinArithmeticModIntSignedUnsignedSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ModIntSignedSigned:
-		f = &builtinArithmeticModIntSignedSignedSig{base}
+		f = &builtinArithmeticModIntSignedSignedSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MultiplyIntUnsigned:
-		f = &builtinArithmeticMultiplyIntUnsignedSig{base}
+		f = &builtinArithmeticMultiplyIntUnsignedSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AbsInt:
-		f = &builtinAbsIntSig{base}
+		f = &builtinAbsIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AbsUInt:
-		f = &builtinAbsUIntSig{base}
+		f = &builtinAbsUIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AbsReal:
-		f = &builtinAbsRealSig{base}
+		f = &builtinAbsRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AbsDecimal:
-		f = &builtinAbsDecSig{base}
+		f = &builtinAbsDecSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CeilIntToDec:
-		f = &builtinCeilIntToDecSig{base}
+		f = &builtinCeilIntToDecSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CeilIntToInt:
-		f = &builtinCeilIntToIntSig{base}
+		f = &builtinCeilIntToIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CeilDecToInt:
-		f = &builtinCeilDecToIntSig{base}
+		f = &builtinCeilDecToIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CeilDecToDec:
-		f = &builtinCeilDecToDecSig{base}
+		f = &builtinCeilDecToDecSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CeilReal:
-		f = &builtinCeilRealSig{base}
+		f = &builtinCeilRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FloorIntToDec:
-		f = &builtinFloorIntToDecSig{base}
+		f = &builtinFloorIntToDecSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FloorIntToInt:
-		f = &builtinFloorIntToIntSig{base}
+		f = &builtinFloorIntToIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FloorDecToInt:
-		f = &builtinFloorDecToIntSig{base}
+		f = &builtinFloorDecToIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FloorDecToDec:
-		f = &builtinFloorDecToDecSig{base}
+		f = &builtinFloorDecToDecSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FloorReal:
-		f = &builtinFloorRealSig{base}
+		f = &builtinFloorRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RoundReal:
-		f = &builtinRoundRealSig{base}
+		f = &builtinRoundRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RoundInt:
-		f = &builtinRoundIntSig{base}
+		f = &builtinRoundIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RoundDec:
-		f = &builtinRoundDecSig{base}
+		f = &builtinRoundDecSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RoundWithFracReal:
-		f = &builtinRoundWithFracRealSig{base}
+		f = &builtinRoundWithFracRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RoundWithFracInt:
-		f = &builtinRoundWithFracIntSig{base}
+		f = &builtinRoundWithFracIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RoundWithFracDec:
-		f = &builtinRoundWithFracDecSig{base}
+		f = &builtinRoundWithFracDecSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Log1Arg:
-		f = &builtinLog1ArgSig{base}
+		f = &builtinLog1ArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Log2Args:
-		f = &builtinLog2ArgsSig{base}
+		f = &builtinLog2ArgsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Log2:
-		f = &builtinLog2Sig{base}
+		f = &builtinLog2Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Log10:
-		f = &builtinLog10Sig{base}
+		f = &builtinLog10Sig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_Rand:
 	case tipb.ScalarFuncSig_RandWithSeedFirstGen:
-		f = &builtinRandWithSeedFirstGenSig{base}
+		f = &builtinRandWithSeedFirstGenSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Pow:
-		f = &builtinPowSig{base}
+		f = &builtinPowSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Conv:
-		f = &builtinConvSig{base}
+		f = &builtinConvSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CRC32:
-		f = &builtinCRC32Sig{base}
+		f = &builtinCRC32Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Sign:
-		f = &builtinSignSig{base}
+		f = &builtinSignSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Sqrt:
-		f = &builtinSqrtSig{base}
+		f = &builtinSqrtSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Acos:
-		f = &builtinAcosSig{base}
+		f = &builtinAcosSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Asin:
-		f = &builtinAsinSig{base}
+		f = &builtinAsinSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Atan1Arg:
-		f = &builtinAtan1ArgSig{base}
+		f = &builtinAtan1ArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Atan2Args:
-		f = &builtinAtan2ArgsSig{base}
+		f = &builtinAtan2ArgsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Cos:
-		f = &builtinCosSig{base}
+		f = &builtinCosSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Cot:
-		f = &builtinCotSig{base}
+		f = &builtinCotSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Degrees:
-		f = &builtinDegreesSig{base}
+		f = &builtinDegreesSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Exp:
-		f = &builtinExpSig{base}
+		f = &builtinExpSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_PI:
-		f = &builtinPISig{base}
+		f = &builtinPISig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Radians:
-		f = &builtinRadiansSig{base}
+		f = &builtinRadiansSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Sin:
-		f = &builtinSinSig{base}
+		f = &builtinSinSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Tan:
-		f = &builtinTanSig{base}
+		f = &builtinTanSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TruncateInt:
-		f = &builtinTruncateIntSig{base}
+		f = &builtinTruncateIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TruncateReal:
-		f = &builtinTruncateRealSig{base}
+		f = &builtinTruncateRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TruncateDecimal:
-		f = &builtinTruncateDecimalSig{base}
+		f = &builtinTruncateDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TruncateUint:
-		f = &builtinTruncateUintSig{base}
+		f = &builtinTruncateUintSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LogicalAnd:
-		f = &builtinLogicAndSig{base}
+		f = &builtinLogicAndSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LogicalOr:
-		f = &builtinLogicOrSig{base}
+		f = &builtinLogicOrSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LogicalXor:
-		f = &builtinLogicXorSig{base}
+		f = &builtinLogicXorSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UnaryNotInt:
-		f = &builtinUnaryNotIntSig{base}
+		f = &builtinUnaryNotIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UnaryNotDecimal:
-		f = &builtinUnaryNotDecimalSig{base}
+		f = &builtinUnaryNotDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UnaryNotReal:
-		f = &builtinUnaryNotRealSig{base}
+		f = &builtinUnaryNotRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UnaryMinusInt:
-		f = &builtinUnaryMinusIntSig{base}
+		f = &builtinUnaryMinusIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UnaryMinusReal:
-		f = &builtinUnaryMinusRealSig{base}
+		f = &builtinUnaryMinusRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UnaryMinusDecimal:
-		f = &builtinUnaryMinusDecimalSig{base, false}
+		f = &builtinUnaryMinusDecimalSig{baseBuiltinFunc: base, constantArgOverflow: false}
 	case tipb.ScalarFuncSig_DecimalIsNull:
-		f = &builtinDecimalIsNullSig{base}
+		f = &builtinDecimalIsNullSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DurationIsNull:
-		f = &builtinDurationIsNullSig{base}
+		f = &builtinDurationIsNullSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RealIsNull:
-		f = &builtinRealIsNullSig{base}
+		f = &builtinRealIsNullSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_StringIsNull:
-		f = &builtinStringIsNullSig{base}
+		f = &builtinStringIsNullSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TimeIsNull:
-		f = &builtinTimeIsNullSig{base}
+		f = &builtinTimeIsNullSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IntIsNull:
-		f = &builtinIntIsNullSig{base}
+		f = &builtinIntIsNullSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_JsonIsNull:
 	case tipb.ScalarFuncSig_BitAndSig:
-		f = &builtinBitAndSig{base}
+		f = &builtinBitAndSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_BitOrSig:
-		f = &builtinBitOrSig{base}
+		f = &builtinBitOrSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_BitXorSig:
-		f = &builtinBitXorSig{base}
+		f = &builtinBitXorSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_BitNegSig:
-		f = &builtinBitNegSig{base}
+		f = &builtinBitNegSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IntIsTrue:
-		f = &builtinIntIsTrueSig{base, false}
+		f = &builtinIntIsTrueSig{baseBuiltinFunc: base, keepNull: false}
 	case tipb.ScalarFuncSig_RealIsTrue:
-		f = &builtinRealIsTrueSig{base, false}
+		f = &builtinRealIsTrueSig{baseBuiltinFunc: base, keepNull: false}
 	case tipb.ScalarFuncSig_DecimalIsTrue:
-		f = &builtinDecimalIsTrueSig{base, false}
+		f = &builtinDecimalIsTrueSig{baseBuiltinFunc: base, keepNull: false}
 	case tipb.ScalarFuncSig_IntIsFalse:
-		f = &builtinIntIsFalseSig{base, false}
+		f = &builtinIntIsFalseSig{baseBuiltinFunc: base, keepNull: false}
 	case tipb.ScalarFuncSig_RealIsFalse:
-		f = &builtinRealIsFalseSig{base, false}
+		f = &builtinRealIsFalseSig{baseBuiltinFunc: base, keepNull: false}
 	case tipb.ScalarFuncSig_DecimalIsFalse:
-		f = &builtinDecimalIsFalseSig{base, false}
+		f = &builtinDecimalIsFalseSig{baseBuiltinFunc: base, keepNull: false}
 	case tipb.ScalarFuncSig_IntIsTrueWithNull:
-		f = &builtinIntIsTrueSig{base, true}
+		f = &builtinIntIsTrueSig{baseBuiltinFunc: base, keepNull: true}
 	case tipb.ScalarFuncSig_RealIsTrueWithNull:
-		f = &builtinRealIsTrueSig{base, true}
+		f = &builtinRealIsTrueSig{baseBuiltinFunc: base, keepNull: true}
 	case tipb.ScalarFuncSig_DecimalIsTrueWithNull:
-		f = &builtinDecimalIsTrueSig{base, true}
+		f = &builtinDecimalIsTrueSig{baseBuiltinFunc: base, keepNull: true}
 	case tipb.ScalarFuncSig_IntIsFalseWithNull:
-		f = &builtinIntIsFalseSig{base, true}
+		f = &builtinIntIsFalseSig{baseBuiltinFunc: base, keepNull: true}
 	case tipb.ScalarFuncSig_RealIsFalseWithNull:
-		f = &builtinRealIsFalseSig{base, true}
+		f = &builtinRealIsFalseSig{baseBuiltinFunc: base, keepNull: true}
 	case tipb.ScalarFuncSig_DecimalIsFalseWithNull:
-		f = &builtinDecimalIsFalseSig{base, true}
+		f = &builtinDecimalIsFalseSig{baseBuiltinFunc: base, keepNull: true}
 	case tipb.ScalarFuncSig_LeftShift:
-		f = &builtinLeftShiftSig{base}
+		f = &builtinLeftShiftSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RightShift:
-		f = &builtinRightShiftSig{base}
+		f = &builtinRightShiftSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_BitCount:
-		f = &builtinBitCountSig{base}
+		f = &builtinBitCountSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GetParamString:
-		f = &builtinGetParamStringSig{base}
+		f = &builtinGetParamStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GetVar:
-		f = &builtinGetStringVarSig{base}
+		f = &builtinGetStringVarSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_RowSig:
 	case tipb.ScalarFuncSig_SetVar:
-		f = &builtinSetStringVarSig{base}
+		f = &builtinSetStringVarSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_ValuesDecimal:
-	// 	f = &builtinValuesDecimalSig{base}
+	// 	f = &builtinValuesDecimalSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_ValuesDuration:
-	// 	f = &builtinValuesDurationSig{base}
+	// 	f = &builtinValuesDurationSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_ValuesInt:
-	// 	f = &builtinValuesIntSig{base}
+	// 	f = &builtinValuesIntSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_ValuesJSON:
-	// 	f = &builtinValuesJSONSig{base}
+	// 	f = &builtinValuesJSONSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_ValuesReal:
-	// 	f = &builtinValuesRealSig{base}
+	// 	f = &builtinValuesRealSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_ValuesString:
-	// 	f = &builtinValuesStringSig{base}
+	// 	f = &builtinValuesStringSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_ValuesTime:
-	// 	f = &builtinValuesTimeSig{base}
+	// 	f = &builtinValuesTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_InInt:
 		f = &builtinInIntSig{baseInSig: baseInSig{baseBuiltinFunc: base}}
 	case tipb.ScalarFuncSig_InReal:
@@ -531,125 +531,125 @@ func getSignatureByPB(ctx BuildContext, sigCode tipb.ScalarFuncSig, tp *tipb.Fie
 	case tipb.ScalarFuncSig_InJson:
 		f = &builtinInJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfNullInt:
-		f = &builtinIfNullIntSig{base}
+		f = &builtinIfNullIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfNullReal:
-		f = &builtinIfNullRealSig{base}
+		f = &builtinIfNullRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfNullDecimal:
-		f = &builtinIfNullDecimalSig{base}
+		f = &builtinIfNullDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfNullString:
-		f = &builtinIfNullStringSig{base}
+		f = &builtinIfNullStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfNullTime:
-		f = &builtinIfNullTimeSig{base}
+		f = &builtinIfNullTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfNullDuration:
-		f = &builtinIfNullDurationSig{base}
+		f = &builtinIfNullDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfInt:
-		f = &builtinIfIntSig{base}
+		f = &builtinIfIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfReal:
-		f = &builtinIfRealSig{base}
+		f = &builtinIfRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfDecimal:
-		f = &builtinIfDecimalSig{base}
+		f = &builtinIfDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfString:
-		f = &builtinIfStringSig{base}
+		f = &builtinIfStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfTime:
-		f = &builtinIfTimeSig{base}
+		f = &builtinIfTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfDuration:
-		f = &builtinIfDurationSig{base}
+		f = &builtinIfDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfNullJson:
-		f = &builtinIfNullJSONSig{base}
+		f = &builtinIfNullJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IfJson:
-		f = &builtinIfJSONSig{base}
+		f = &builtinIfJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CaseWhenInt:
-		f = &builtinCaseWhenIntSig{base}
+		f = &builtinCaseWhenIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CaseWhenReal:
-		f = &builtinCaseWhenRealSig{base}
+		f = &builtinCaseWhenRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CaseWhenDecimal:
-		f = &builtinCaseWhenDecimalSig{base}
+		f = &builtinCaseWhenDecimalSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CaseWhenString:
-		f = &builtinCaseWhenStringSig{base}
+		f = &builtinCaseWhenStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CaseWhenTime:
-		f = &builtinCaseWhenTimeSig{base}
+		f = &builtinCaseWhenTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CaseWhenDuration:
-		f = &builtinCaseWhenDurationSig{base}
+		f = &builtinCaseWhenDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CaseWhenJson:
-		f = &builtinCaseWhenJSONSig{base}
+		f = &builtinCaseWhenJSONSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_AesDecrypt:
-	// 	f = &builtinAesDecryptSig{base}
+	// 	f = &builtinAesDecryptSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_AesEncrypt:
-	// 	f = &builtinAesEncryptSig{base}
+	// 	f = &builtinAesEncryptSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Compress:
-		f = &builtinCompressSig{base}
+		f = &builtinCompressSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MD5:
-		f = &builtinMD5Sig{base}
+		f = &builtinMD5Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Password:
-		f = &builtinPasswordSig{base}
+		f = &builtinPasswordSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RandomBytes:
-		f = &builtinRandomBytesSig{base}
+		f = &builtinRandomBytesSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SHA1:
-		f = &builtinSHA1Sig{base}
+		f = &builtinSHA1Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SHA2:
-		f = &builtinSHA2Sig{base}
+		f = &builtinSHA2Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Uncompress:
-		f = &builtinUncompressSig{base}
+		f = &builtinUncompressSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UncompressedLength:
-		f = &builtinUncompressedLengthSig{base}
+		f = &builtinUncompressedLengthSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Database:
-		f = &builtinDatabaseSig{base}
+		f = &builtinDatabaseSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FoundRows:
-		f = &builtinFoundRowsSig{base}
+		f = &builtinFoundRowsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CurrentUser:
 		f = &builtinCurrentUserSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_User:
 		f = &builtinUserSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ConnectionID:
-		f = &builtinConnectionIDSig{base}
+		f = &builtinConnectionIDSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LastInsertID:
-		f = &builtinLastInsertIDSig{base}
+		f = &builtinLastInsertIDSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LastInsertIDWithID:
-		f = &builtinLastInsertIDWithIDSig{base}
+		f = &builtinLastInsertIDWithIDSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Version:
-		f = &builtinVersionSig{base}
+		f = &builtinVersionSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TiDBVersion:
-		f = &builtinTiDBVersionSig{base}
+		f = &builtinTiDBVersionSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RowCount:
-		f = &builtinRowCountSig{base}
+		f = &builtinRowCountSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Sleep:
-		f = &builtinSleepSig{base}
+		f = &builtinSleepSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Lock:
-		f = &builtinLockSig{base}
+		f = &builtinLockSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ReleaseLock:
-		f = &builtinReleaseLockSig{base}
+		f = &builtinReleaseLockSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DecimalAnyValue:
-		f = &builtinDecimalAnyValueSig{base}
+		f = &builtinDecimalAnyValueSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DurationAnyValue:
-		f = &builtinDurationAnyValueSig{base}
+		f = &builtinDurationAnyValueSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IntAnyValue:
-		f = &builtinIntAnyValueSig{base}
+		f = &builtinIntAnyValueSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JSONAnyValue:
-		f = &builtinJSONAnyValueSig{base}
+		f = &builtinJSONAnyValueSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RealAnyValue:
-		f = &builtinRealAnyValueSig{base}
+		f = &builtinRealAnyValueSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_StringAnyValue:
-		f = &builtinStringAnyValueSig{base}
+		f = &builtinStringAnyValueSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TimeAnyValue:
-		f = &builtinTimeAnyValueSig{base}
+		f = &builtinTimeAnyValueSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_InetAton:
-		f = &builtinInetAtonSig{base}
+		f = &builtinInetAtonSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_InetNtoa:
-		f = &builtinInetNtoaSig{base}
+		f = &builtinInetNtoaSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Inet6Aton:
-		f = &builtinInet6AtonSig{base}
+		f = &builtinInet6AtonSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Inet6Ntoa:
-		f = &builtinInet6NtoaSig{base}
+		f = &builtinInet6NtoaSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IsIPv4:
-		f = &builtinIsIPv4Sig{base}
+		f = &builtinIsIPv4Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IsIPv4Compat:
-		f = &builtinIsIPv4CompatSig{base}
+		f = &builtinIsIPv4CompatSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IsIPv4Mapped:
-		f = &builtinIsIPv4MappedSig{base}
+		f = &builtinIsIPv4MappedSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IsIPv6:
-		f = &builtinIsIPv6Sig{base}
+		f = &builtinIsIPv6Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UUID:
-		f = &builtinUUIDSig{base}
+		f = &builtinUUIDSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LikeSig:
 		f = &builtinLikeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_IlikeSig:
@@ -667,413 +667,413 @@ func getSignatureByPB(ctx BuildContext, sigCode tipb.ScalarFuncSig, tp *tipb.Fie
 	case tipb.ScalarFuncSig_RegexpReplaceSig:
 		f = &builtinRegexpReplaceFuncSig{regexpBaseFuncSig: regexpBaseFuncSig{baseBuiltinFunc: base}}
 	case tipb.ScalarFuncSig_JsonExtractSig:
-		f = &builtinJSONExtractSig{base}
+		f = &builtinJSONExtractSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonUnquoteSig:
-		f = &builtinJSONUnquoteSig{base}
+		f = &builtinJSONUnquoteSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonTypeSig:
-		f = &builtinJSONTypeSig{base}
+		f = &builtinJSONTypeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonSetSig:
-		f = &builtinJSONSetSig{base}
+		f = &builtinJSONSetSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonInsertSig:
-		f = &builtinJSONInsertSig{base}
+		f = &builtinJSONInsertSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonReplaceSig:
-		f = &builtinJSONReplaceSig{base}
+		f = &builtinJSONReplaceSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonRemoveSig:
-		f = &builtinJSONRemoveSig{base}
+		f = &builtinJSONRemoveSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonMergeSig:
-		f = &builtinJSONMergeSig{base}
+		f = &builtinJSONMergeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonObjectSig:
-		f = &builtinJSONObjectSig{base}
+		f = &builtinJSONObjectSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonArraySig:
-		f = &builtinJSONArraySig{base}
+		f = &builtinJSONArraySig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonValidJsonSig:
-		f = &builtinJSONValidJSONSig{base}
+		f = &builtinJSONValidJSONSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonContainsSig:
-		f = &builtinJSONContainsSig{base}
+		f = &builtinJSONContainsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonArrayAppendSig:
-		f = &builtinJSONArrayAppendSig{base}
+		f = &builtinJSONArrayAppendSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonArrayInsertSig:
-		f = &builtinJSONArrayInsertSig{base}
+		f = &builtinJSONArrayInsertSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_JsonMergePatchSig:
 	case tipb.ScalarFuncSig_JsonMergePreserveSig:
-		f = &builtinJSONMergeSig{base}
+		f = &builtinJSONMergeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonContainsPathSig:
-		f = &builtinJSONContainsPathSig{base}
+		f = &builtinJSONContainsPathSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_JsonPrettySig:
 	case tipb.ScalarFuncSig_JsonQuoteSig:
-		f = &builtinJSONQuoteSig{base}
+		f = &builtinJSONQuoteSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonSearchSig:
-		f = &builtinJSONSearchSig{base}
+		f = &builtinJSONSearchSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonStorageSizeSig:
-		f = &builtinJSONStorageSizeSig{base}
+		f = &builtinJSONStorageSizeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonDepthSig:
-		f = &builtinJSONDepthSig{base}
+		f = &builtinJSONDepthSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonKeysSig:
-		f = &builtinJSONKeysSig{base}
+		f = &builtinJSONKeysSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonLengthSig:
-		f = &builtinJSONLengthSig{base}
+		f = &builtinJSONLengthSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonKeys2ArgsSig:
-		f = &builtinJSONKeys2ArgsSig{base}
+		f = &builtinJSONKeys2ArgsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonValidStringSig:
-		f = &builtinJSONValidStringSig{base}
+		f = &builtinJSONValidStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonValidOthersSig:
-		f = &builtinJSONValidOthersSig{base}
+		f = &builtinJSONValidOthersSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_JsonMemberOfSig:
-		f = &builtinJSONMemberOfSig{base}
+		f = &builtinJSONMemberOfSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DateFormatSig:
-		f = &builtinDateFormatSig{base}
+		f = &builtinDateFormatSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_DateLiteral:
-	// 	f = &builtinDateLiteralSig{base}
+	// 	f = &builtinDateLiteralSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DateDiff:
-		f = &builtinDateDiffSig{base}
+		f = &builtinDateDiffSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NullTimeDiff:
-		f = &builtinNullTimeDiffSig{base}
+		f = &builtinNullTimeDiffSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TimeStringTimeDiff:
-		f = &builtinTimeStringTimeDiffSig{base}
+		f = &builtinTimeStringTimeDiffSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DurationStringTimeDiff:
-		f = &builtinDurationStringTimeDiffSig{base}
+		f = &builtinDurationStringTimeDiffSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DurationDurationTimeDiff:
-		f = &builtinDurationDurationTimeDiffSig{base}
+		f = &builtinDurationDurationTimeDiffSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_StringTimeTimeDiff:
-		f = &builtinStringTimeTimeDiffSig{base}
+		f = &builtinStringTimeTimeDiffSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_StringDurationTimeDiff:
-		f = &builtinStringDurationTimeDiffSig{base}
+		f = &builtinStringDurationTimeDiffSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_StringStringTimeDiff:
-		f = &builtinStringStringTimeDiffSig{base}
+		f = &builtinStringStringTimeDiffSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TimeTimeTimeDiff:
-		f = &builtinTimeTimeTimeDiffSig{base}
+		f = &builtinTimeTimeTimeDiffSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Date:
-		f = &builtinDateSig{base}
+		f = &builtinDateSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Hour:
-		f = &builtinHourSig{base}
+		f = &builtinHourSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Minute:
-		f = &builtinMinuteSig{base}
+		f = &builtinMinuteSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Second:
-		f = &builtinSecondSig{base}
+		f = &builtinSecondSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MicroSecond:
-		f = &builtinMicroSecondSig{base}
+		f = &builtinMicroSecondSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Month:
-		f = &builtinMonthSig{base}
+		f = &builtinMonthSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MonthName:
-		f = &builtinMonthNameSig{base}
+		f = &builtinMonthNameSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NowWithArg:
-		f = &builtinNowWithArgSig{base}
+		f = &builtinNowWithArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_NowWithoutArg:
-		f = &builtinNowWithoutArgSig{base}
+		f = &builtinNowWithoutArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DayName:
-		f = &builtinDayNameSig{base}
+		f = &builtinDayNameSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DayOfMonth:
-		f = &builtinDayOfMonthSig{base}
+		f = &builtinDayOfMonthSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DayOfWeek:
-		f = &builtinDayOfWeekSig{base}
+		f = &builtinDayOfWeekSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_DayOfYear:
-		f = &builtinDayOfYearSig{base}
+		f = &builtinDayOfYearSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_WeekWithMode:
-		f = &builtinWeekWithModeSig{base}
+		f = &builtinWeekWithModeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_WeekWithoutMode:
-		f = &builtinWeekWithoutModeSig{base}
+		f = &builtinWeekWithoutModeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_WeekDay:
-		f = &builtinWeekDaySig{base}
+		f = &builtinWeekDaySig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_WeekOfYear:
-		f = &builtinWeekOfYearSig{base}
+		f = &builtinWeekOfYearSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Year:
-		f = &builtinYearSig{base}
+		f = &builtinYearSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_YearWeekWithMode:
-		f = &builtinYearWeekWithModeSig{base}
+		f = &builtinYearWeekWithModeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_YearWeekWithoutMode:
-		f = &builtinYearWeekWithoutModeSig{base}
+		f = &builtinYearWeekWithoutModeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_GetFormat:
-		f = &builtinGetFormatSig{base}
+		f = &builtinGetFormatSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SysDateWithFsp:
-		f = &builtinSysDateWithFspSig{base}
+		f = &builtinSysDateWithFspSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SysDateWithoutFsp:
-		f = &builtinSysDateWithoutFspSig{base}
+		f = &builtinSysDateWithoutFspSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CurrentDate:
-		f = &builtinCurrentDateSig{base}
+		f = &builtinCurrentDateSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CurrentTime0Arg:
-		f = &builtinCurrentTime0ArgSig{base}
+		f = &builtinCurrentTime0ArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CurrentTime1Arg:
-		f = &builtinCurrentTime1ArgSig{base}
+		f = &builtinCurrentTime1ArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Time:
-		f = &builtinTimeSig{base}
+		f = &builtinTimeSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_TimeLiteral:
-	// 	f = &builtinTimeLiteralSig{base}
+	// 	f = &builtinTimeLiteralSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UTCDate:
-		f = &builtinUTCDateSig{base}
+		f = &builtinUTCDateSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UTCTimestampWithArg:
-		f = &builtinUTCTimestampWithArgSig{base}
+		f = &builtinUTCTimestampWithArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UTCTimestampWithoutArg:
-		f = &builtinUTCTimestampWithoutArgSig{base}
+		f = &builtinUTCTimestampWithoutArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AddDatetimeAndDuration:
-		f = &builtinAddDatetimeAndDurationSig{base}
+		f = &builtinAddDatetimeAndDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AddDatetimeAndString:
-		f = &builtinAddDatetimeAndStringSig{base}
+		f = &builtinAddDatetimeAndStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AddTimeDateTimeNull:
-		f = &builtinAddTimeDateTimeNullSig{base}
+		f = &builtinAddTimeDateTimeNullSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AddStringAndDuration:
-		f = &builtinAddStringAndDurationSig{base}
+		f = &builtinAddStringAndDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AddStringAndString:
-		f = &builtinAddStringAndStringSig{base}
+		f = &builtinAddStringAndStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AddTimeStringNull:
-		f = &builtinAddTimeStringNullSig{base}
+		f = &builtinAddTimeStringNullSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AddDurationAndDuration:
-		f = &builtinAddDurationAndDurationSig{base}
+		f = &builtinAddDurationAndDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AddDurationAndString:
-		f = &builtinAddDurationAndStringSig{base}
+		f = &builtinAddDurationAndStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AddTimeDurationNull:
-		f = &builtinAddTimeDurationNullSig{base}
+		f = &builtinAddTimeDurationNullSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AddDateAndDuration:
-		f = &builtinAddDateAndDurationSig{base}
+		f = &builtinAddDateAndDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_AddDateAndString:
-		f = &builtinAddDateAndStringSig{base}
+		f = &builtinAddDateAndStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubDatetimeAndDuration:
-		f = &builtinSubDatetimeAndDurationSig{base}
+		f = &builtinSubDatetimeAndDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubDatetimeAndString:
-		f = &builtinSubDatetimeAndStringSig{base}
+		f = &builtinSubDatetimeAndStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubTimeDateTimeNull:
-		f = &builtinSubTimeDateTimeNullSig{base}
+		f = &builtinSubTimeDateTimeNullSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubStringAndDuration:
-		f = &builtinSubStringAndDurationSig{base}
+		f = &builtinSubStringAndDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubStringAndString:
-		f = &builtinSubStringAndStringSig{base}
+		f = &builtinSubStringAndStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubTimeStringNull:
-		f = &builtinSubTimeStringNullSig{base}
+		f = &builtinSubTimeStringNullSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubDurationAndDuration:
-		f = &builtinSubDurationAndDurationSig{base}
+		f = &builtinSubDurationAndDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubDurationAndString:
-		f = &builtinSubDurationAndStringSig{base}
+		f = &builtinSubDurationAndStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubTimeDurationNull:
-		f = &builtinSubTimeDurationNullSig{base}
+		f = &builtinSubTimeDurationNullSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubDateAndDuration:
-		f = &builtinSubDateAndDurationSig{base}
+		f = &builtinSubDateAndDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubDateAndString:
-		f = &builtinSubDateAndStringSig{base}
+		f = &builtinSubDateAndStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UnixTimestampCurrent:
-		f = &builtinUnixTimestampCurrentSig{base}
+		f = &builtinUnixTimestampCurrentSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UnixTimestampInt:
-		f = &builtinUnixTimestampIntSig{base}
+		f = &builtinUnixTimestampIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UnixTimestampDec:
-		f = &builtinUnixTimestampDecSig{base}
+		f = &builtinUnixTimestampDecSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_ConvertTz:
-	// 	f = &builtinConvertTzSig{base}
+	// 	f = &builtinConvertTzSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MakeDate:
-		f = &builtinMakeDateSig{base}
+		f = &builtinMakeDateSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_MakeTime:
-		f = &builtinMakeTimeSig{base}
+		f = &builtinMakeTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_PeriodAdd:
-		f = &builtinPeriodAddSig{base}
+		f = &builtinPeriodAddSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_PeriodDiff:
-		f = &builtinPeriodDiffSig{base}
+		f = &builtinPeriodDiffSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Quarter:
-		f = &builtinQuarterSig{base}
+		f = &builtinQuarterSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SecToTime:
-		f = &builtinSecToTimeSig{base}
+		f = &builtinSecToTimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TimeToSec:
-		f = &builtinTimeToSecSig{base}
+		f = &builtinTimeToSecSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TimestampAdd:
-		f = &builtinTimestampAddSig{base}
+		f = &builtinTimestampAddSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ToDays:
-		f = &builtinToDaysSig{base}
+		f = &builtinToDaysSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ToSeconds:
-		f = &builtinToSecondsSig{base}
+		f = &builtinToSecondsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UTCTimeWithArg:
-		f = &builtinUTCTimeWithArgSig{base}
+		f = &builtinUTCTimeWithArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UTCTimeWithoutArg:
-		f = &builtinUTCTimeWithoutArgSig{base}
+		f = &builtinUTCTimeWithoutArgSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_Timestamp1Arg:
-	// 	f = &builtinTimestamp1ArgSig{base}
+	// 	f = &builtinTimestamp1ArgSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_Timestamp2Args:
-	// 	f = &builtinTimestamp2ArgsSig{base}
+	// 	f = &builtinTimestamp2ArgsSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_TimestampLiteral:
-	// 	f = &builtinTimestampLiteralSig{base}
+	// 	f = &builtinTimestampLiteralSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LastDay:
-		f = &builtinLastDaySig{base}
+		f = &builtinLastDaySig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_StrToDateDate:
-		f = &builtinStrToDateDateSig{base}
+		f = &builtinStrToDateDateSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_StrToDateDatetime:
-		f = &builtinStrToDateDatetimeSig{base}
+		f = &builtinStrToDateDatetimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_StrToDateDuration:
-		f = &builtinStrToDateDurationSig{base}
+		f = &builtinStrToDateDurationSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FromUnixTime1Arg:
-		f = &builtinFromUnixTime1ArgSig{base}
+		f = &builtinFromUnixTime1ArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FromUnixTime2Arg:
-		f = &builtinFromUnixTime2ArgSig{base}
+		f = &builtinFromUnixTime2ArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ExtractDatetimeFromString:
-		f = &builtinExtractDatetimeFromStringSig{base}
+		f = &builtinExtractDatetimeFromStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ExtractDatetime:
-		f = &builtinExtractDatetimeSig{base}
+		f = &builtinExtractDatetimeSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ExtractDuration:
-		f = &builtinExtractDurationSig{base}
+		f = &builtinExtractDurationSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_AddDateStringString:
-	// 	f = &builtinAddDateStringStringSig{base}
+	// 	f = &builtinAddDateStringStringSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_AddDateStringInt:
-	// 	f = &builtinAddDateStringIntSig{base}
+	// 	f = &builtinAddDateStringIntSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_AddDateStringDecimal:
-	// 	f = &builtinAddDateStringDecimalSig{base}
+	// 	f = &builtinAddDateStringDecimalSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_AddDateIntString:
-	// 	f = &builtinAddDateIntStringSig{base}
+	// 	f = &builtinAddDateIntStringSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_AddDateIntInt:
-	// 	f = &builtinAddDateIntIntSig{base}
+	// 	f = &builtinAddDateIntIntSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_AddDateDatetimeString:
-	// 	f = &builtinAddDateDatetimeStringSig{base}
+	// 	f = &builtinAddDateDatetimeStringSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_AddDateDatetimeInt:
-	// 	f = &builtinAddDateDatetimeIntSig{base}
+	// 	f = &builtinAddDateDatetimeIntSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_SubDateStringString:
-	// 	f = &builtinSubDateStringStringSig{base}
+	// 	f = &builtinSubDateStringStringSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_SubDateStringInt:
-	// 	f = &builtinSubDateStringIntSig{base}
+	// 	f = &builtinSubDateStringIntSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_SubDateStringDecimal:
-	// 	f = &builtinSubDateStringDecimalSig{base}
+	// 	f = &builtinSubDateStringDecimalSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_SubDateIntString:
-	// 	f = &builtinSubDateIntStringSig{base}
+	// 	f = &builtinSubDateIntStringSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_SubDateIntInt:
-	// 	f = &builtinSubDateIntIntSig{base}
+	// 	f = &builtinSubDateIntIntSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_SubDateDatetimeString:
-	// 	f = &builtinSubDateDatetimeStringSig{base}
+	// 	f = &builtinSubDateDatetimeStringSig{baseBuiltinFunc: base}
 	// case tipb.ScalarFuncSig_SubDateDatetimeInt:
-	// 	f = &builtinSubDateDatetimeIntSig{base}
+	// 	f = &builtinSubDateDatetimeIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FromDays:
-		f = &builtinFromDaysSig{base}
+		f = &builtinFromDaysSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TimeFormat:
-		f = &builtinTimeFormatSig{base}
+		f = &builtinTimeFormatSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_TimestampDiff:
-		f = &builtinTimestampDiffSig{base}
+		f = &builtinTimestampDiffSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_BitLength:
-		f = &builtinBitLengthSig{base}
+		f = &builtinBitLengthSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Bin:
-		f = &builtinBinSig{base}
+		f = &builtinBinSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ASCII:
-		f = &builtinASCIISig{base}
+		f = &builtinASCIISig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Char:
-		f = &builtinCharSig{base}
+		f = &builtinCharSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CharLengthUTF8:
-		f = &builtinCharLengthUTF8Sig{base}
+		f = &builtinCharLengthUTF8Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_CharLength:
-		f = &builtinCharLengthBinarySig{base}
+		f = &builtinCharLengthBinarySig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Concat:
-		f = &builtinConcatSig{base, maxAllowedPacket}
+		f = &builtinConcatSig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_ConcatWS:
-		f = &builtinConcatWSSig{base, maxAllowedPacket}
+		f = &builtinConcatWSSig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_Convert:
-		f = &builtinConvertSig{base}
+		f = &builtinConvertSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Elt:
-		f = &builtinEltSig{base}
+		f = &builtinEltSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ExportSet3Arg:
-		f = &builtinExportSet3ArgSig{base}
+		f = &builtinExportSet3ArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ExportSet4Arg:
-		f = &builtinExportSet4ArgSig{base}
+		f = &builtinExportSet4ArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ExportSet5Arg:
-		f = &builtinExportSet5ArgSig{base}
+		f = &builtinExportSet5ArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FieldInt:
-		f = &builtinFieldIntSig{base}
+		f = &builtinFieldIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FieldReal:
-		f = &builtinFieldRealSig{base}
+		f = &builtinFieldRealSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FieldString:
-		f = &builtinFieldStringSig{base}
+		f = &builtinFieldStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FindInSet:
-		f = &builtinFindInSetSig{base}
+		f = &builtinFindInSetSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Format:
-		f = &builtinFormatSig{base}
+		f = &builtinFormatSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FormatWithLocale:
-		f = &builtinFormatWithLocaleSig{base}
+		f = &builtinFormatWithLocaleSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FromBase64:
-		f = &builtinFromBase64Sig{base, maxAllowedPacket}
+		f = &builtinFromBase64Sig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_HexIntArg:
-		f = &builtinHexIntArgSig{base}
+		f = &builtinHexIntArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_HexStrArg:
-		f = &builtinHexStrArgSig{base}
+		f = &builtinHexStrArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_InsertUTF8:
-		f = &builtinInsertUTF8Sig{base, maxAllowedPacket}
+		f = &builtinInsertUTF8Sig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_Insert:
-		f = &builtinInsertSig{base, maxAllowedPacket}
+		f = &builtinInsertSig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_InstrUTF8:
-		f = &builtinInstrUTF8Sig{base}
+		f = &builtinInstrUTF8Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Instr:
-		f = &builtinInstrSig{base}
+		f = &builtinInstrSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LTrim:
-		f = &builtinLTrimSig{base}
+		f = &builtinLTrimSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LeftUTF8:
-		f = &builtinLeftUTF8Sig{base}
+		f = &builtinLeftUTF8Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Left:
-		f = &builtinLeftSig{base}
+		f = &builtinLeftSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Length:
-		f = &builtinLengthSig{base}
+		f = &builtinLengthSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Locate2ArgsUTF8:
-		f = &builtinLocate2ArgsUTF8Sig{base}
+		f = &builtinLocate2ArgsUTF8Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Locate3ArgsUTF8:
-		f = &builtinLocate3ArgsUTF8Sig{base}
+		f = &builtinLocate3ArgsUTF8Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Locate2Args:
-		f = &builtinLocate2ArgsSig{base}
+		f = &builtinLocate2ArgsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Locate3Args:
-		f = &builtinLocate3ArgsSig{base}
+		f = &builtinLocate3ArgsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Lower:
-		f = &builtinLowerSig{base}
+		f = &builtinLowerSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LowerUTF8:
-		f = &builtinLowerUTF8Sig{base}
+		f = &builtinLowerUTF8Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_LpadUTF8:
-		f = &builtinLpadUTF8Sig{base, maxAllowedPacket}
+		f = &builtinLpadUTF8Sig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_Lpad:
-		f = &builtinLpadSig{base, maxAllowedPacket}
+		f = &builtinLpadSig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_MakeSet:
-		f = &builtinMakeSetSig{base}
+		f = &builtinMakeSetSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_OctInt:
-		f = &builtinOctIntSig{base}
+		f = &builtinOctIntSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_OctString:
-		f = &builtinOctStringSig{base}
+		f = &builtinOctStringSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Ord:
-		f = &builtinOrdSig{base}
+		f = &builtinOrdSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Quote:
-		f = &builtinQuoteSig{base}
+		f = &builtinQuoteSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RTrim:
-		f = &builtinRTrimSig{base}
+		f = &builtinRTrimSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Repeat:
-		f = &builtinRepeatSig{base, maxAllowedPacket}
+		f = &builtinRepeatSig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_Replace:
-		f = &builtinReplaceSig{base}
+		f = &builtinReplaceSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ReverseUTF8:
-		f = &builtinReverseUTF8Sig{base}
+		f = &builtinReverseUTF8Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Reverse:
-		f = &builtinReverseSig{base}
+		f = &builtinReverseSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RightUTF8:
-		f = &builtinRightUTF8Sig{base}
+		f = &builtinRightUTF8Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Right:
-		f = &builtinRightSig{base}
+		f = &builtinRightSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_RpadUTF8:
-		f = &builtinRpadUTF8Sig{base, maxAllowedPacket}
+		f = &builtinRpadUTF8Sig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_Rpad:
-		f = &builtinRpadSig{base, maxAllowedPacket}
+		f = &builtinRpadSig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_Space:
-		f = &builtinSpaceSig{base, maxAllowedPacket}
+		f = &builtinSpaceSig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_Strcmp:
-		f = &builtinStrcmpSig{base}
+		f = &builtinStrcmpSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Substring2ArgsUTF8:
-		f = &builtinSubstring2ArgsUTF8Sig{base}
+		f = &builtinSubstring2ArgsUTF8Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Substring3ArgsUTF8:
-		f = &builtinSubstring3ArgsUTF8Sig{base}
+		f = &builtinSubstring3ArgsUTF8Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Substring2Args:
-		f = &builtinSubstring2ArgsSig{base}
+		f = &builtinSubstring2ArgsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Substring3Args:
-		f = &builtinSubstring3ArgsSig{base}
+		f = &builtinSubstring3ArgsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_SubstringIndex:
-		f = &builtinSubstringIndexSig{base}
+		f = &builtinSubstringIndexSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ToBase64:
-		f = &builtinToBase64Sig{base, maxAllowedPacket}
+		f = &builtinToBase64Sig{baseBuiltinFunc: base, maxAllowedPacket: maxAllowedPacket}
 	case tipb.ScalarFuncSig_Trim1Arg:
-		f = &builtinTrim1ArgSig{base}
+		f = &builtinTrim1ArgSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Trim2Args:
-		f = &builtinTrim2ArgsSig{base}
+		f = &builtinTrim2ArgsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Trim3Args:
-		f = &builtinTrim3ArgsSig{base}
+		f = &builtinTrim3ArgsSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UnHex:
-		f = &builtinUnHexSig{base}
+		f = &builtinUnHexSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_Upper:
-		f = &builtinUpperSig{base}
+		f = &builtinUpperSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_UpperUTF8:
-		f = &builtinUpperUTF8Sig{base}
+		f = &builtinUpperUTF8Sig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ToBinary:
-		f = &builtinInternalToBinarySig{base}
+		f = &builtinInternalToBinarySig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_FromBinary:
-		f = &builtinInternalFromBinarySig{base}
+		f = &builtinInternalFromBinarySig{baseBuiltinFunc: base}
 
 	default:
 		e = ErrFunctionNotExists.GenWithStackByArgs("FUNCTION", sigCode)

--- a/pkg/expression/extension.go
+++ b/pkg/expression/extension.go
@@ -108,7 +108,7 @@ func (c *extensionFuncClass) getFunction(ctx BuildContext, args []Expression) (b
 		return nil, err
 	}
 	bf.tp.SetFlen(c.flen)
-	sig := &extensionFuncSig{bf, c.funcDef}
+	sig := &extensionFuncSig{baseBuiltinFunc: bf, FunctionDef: c.funcDef}
 	return sig, nil
 }
 
@@ -144,6 +144,7 @@ var _ extension.FunctionContext = extensionFnContext{}
 
 type extensionFuncSig struct {
 	baseBuiltinFunc
+	notRequireOptionalEvalProps
 	extension.FunctionDef
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51656

### What changed and how does it work?

This PR removes default implement for `RequireOptionalEvalProps` in `baseBuiltinFunc` that forcing all scalar functions to have their own `RequireOptionalEvalProps` defined to tell the framework which optional properties they need. This is better than the previous one because it reduces the chances that the coder forget to declar optional property requirements when adding a new function.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
