### PR TITLE
pkg: fix update calls to `runtime.fastrand` to use `cheaprand` for compatibility with Go 1.22

### DIFF
--- a/pkg/util/fastrand/BUILD.bazel
+++ b/pkg/util/fastrand/BUILD.bazel
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "fastrand",
-    srcs = ["random.go"],
+    srcs = [
+        "random.go",
+        "runtime.go",
+        "runtime_1.22.go",
+    ],
     importpath = "github.com/pingcap/tidb/pkg/util/fastrand",
     visibility = ["//visibility:public"],
 )

--- a/pkg/util/fastrand/random.go
+++ b/pkg/util/fastrand/random.go
@@ -16,7 +16,6 @@ package fastrand
 
 import (
 	"math/bits"
-	_ "unsafe" // required by go:linkname
 )
 
 // wyrand is a fast PRNG. See https://github.com/wangyi-fudan/wyhash
@@ -47,11 +46,6 @@ func Buf(size int) []byte {
 	}
 	return buf
 }
-
-// Uint32 returns a lock free uint32 value.
-//
-//go:linkname Uint32 runtime.fastrand
-func Uint32() uint32
 
 // Uint32N returns, as an uint32, a pseudo-random number in [0,n).
 func Uint32N(n uint32) uint32 {

--- a/pkg/util/fastrand/runtime.go
+++ b/pkg/util/fastrand/runtime.go
@@ -1,0 +1,12 @@
+//go:build !go1.22
+
+package fastrand
+
+import (
+	_ "unsafe" // required by go:linkname
+)
+
+// Uint32 returns a lock free uint32 value.
+//
+//go:linkname Uint32 runtime.fastrand
+func Uint32() uint32

--- a/pkg/util/fastrand/runtime.go
+++ b/pkg/util/fastrand/runtime.go
@@ -1,3 +1,17 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build !go1.22
 
 package fastrand

--- a/pkg/util/fastrand/runtime_1.22.go
+++ b/pkg/util/fastrand/runtime_1.22.go
@@ -1,3 +1,17 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build go1.22
 
 package fastrand

--- a/pkg/util/fastrand/runtime_1.22.go
+++ b/pkg/util/fastrand/runtime_1.22.go
@@ -1,0 +1,12 @@
+//go:build go1.22
+
+package fastrand
+
+import (
+	_ "unsafe" // required by go:linkname
+)
+
+// Uint32 returns a lock free uint32 value.
+//
+//go:linkname Uint32 runtime.cheaprand
+func Uint32() uint32


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50765

Problem Summary:

Fix: update calls to `runtime.fastrand` to use `cheaprand` for compatibility with Go 1.22

In Golang 1.22, the `runtime.fastrand` method was renamed to `cheaprand`. This commit updates all occurrences of `runtime.fastrand` in the project to use the new `cheaprand` method to maintain compatibility with the latest Golang version and address performance concerns.

Refer: https://gist.github.com/Aoang/3dc06f127f3f54507b7e06b7b6550c28


### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
