### PR TITLE
ttl: fix expire time drift for daylighting-save time case

### DIFF
--- a/pkg/ttl/cache/table.go
+++ b/pkg/ttl/cache/table.go
@@ -208,7 +208,11 @@ func (t *PhysicalTable) EvalExpireTime(ctx context.Context, se session.Session,
 		return time.Time{}, err
 	}
 
-	expire = now.In(globalTz).
+	expire = now.
+		In(globalTz).
+		// Truncate to second to make sure the precision is always the same with the one stored in a table to avoid some
+		// comparing problems in testing.
+		Truncate(time.Second).
 		AddDate(-int(y), -int(m), -int(d)).
 		Add(-time.Duration(nanosecond)).
 		In(now.Location())

--- a/pkg/ttl/cache/table.go
+++ b/pkg/ttl/cache/table.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
-	"fmt"
 	"math"
 	"time"
 
@@ -32,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/ttl/session"
 	"github.com/pingcap/tidb/pkg/types"
-	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/intest"
@@ -185,68 +183,36 @@ func (t *PhysicalTable) ValidateKeyPrefix(key []types.Datum) error {
 	return nil
 }
 
-// EvalExpireTime returns the expired time
+// EvalExpireTime returns the expired time.
+// It uses the global timezone to compute the expired time.
+// Then we'll reset the returned expired time to the same timezone as the input `now`.
 func (t *PhysicalTable) EvalExpireTime(ctx context.Context, se session.Session,
 	now time.Time) (expire time.Time, err error) {
-	tz := se.GetSessionVars().Location()
-	now = now.In(tz)
-
 	expireExpr := t.TTLInfo.IntervalExprStr
 	unit := ast.TimeUnitType(t.TTLInfo.IntervalTimeUnit)
 
-	if now.Unix() < 0 {
-		return time.Time{}, errors.Errorf(
-			"current time must be after the UTC time January 1, 1970, 00:00:00. Received time: %s",
-			now,
-		)
-	}
-
-	var rows []chunk.Row
-	rows, err = se.ExecuteSQL(
-		ctx,
-		fmt.Sprintf("SELECT FROM_UNIXTIME(%d) - INTERVAL %s %s", now.Unix(), expireExpr, unit.String()),
-	)
-
-	if err != nil {
-		return
-	}
-
-	tm := rows[0].GetTime(0)
-	formatted, err := tm.DateFormat("%Y-%m-%d %H:%i:%s.%f")
+	y, m, d, nanosecond, _, err := types.ParseDurationValue(unit.String(), expireExpr)
 	if err != nil {
 		return time.Time{}, err
 	}
 
-	expire, err = time.ParseInLocation("2006-01-02 15:04:05.000000", formatted, tz)
+	// Use the global time zone to compute expire time.
+	// Different timezones may have different results event with the same "now" time and TTL expression.
+	// Consider a TTL setting with the expiration `INTERVAL 1 MONTH`.
+	// If the current timezone is `Asia/Shanghai` and now is `2021-03-01 00:00:00 +0800`
+	// the expired time should be `2022-02-01 00:00:00 +0800`, corresponding to UTC time `2022-01-31 16:00:00 UTC`.
+	// But if we use the `UTC` time zone, the current time is `2021-02-28 16:00:00 UTC`,
+	// and the expired time should be `2021-01-28 16:00:00 UTC` that is not the same the previous one.
+	globalTz, err := se.GlobalTimeZone(ctx)
 	if err != nil {
 		return time.Time{}, err
 	}
 
-	if expire.Hour() != tm.Hour() {
-		// For the daylight-saving time, the hour may be different, and it means the tm we get is not a "valid" date.
-		// For example, if we computed an expired `types.Time` with value "2024-03-10 02:30:00",
-		// this time does not "exist" in timezone `America/Los_Angeles` because after "2024-03-10 02:00:00",
-		// the time will leap to "2024-03-10 03:00:00" directly.
-		// If then we parse "2024-03-10 02:30:00" with `time.ParseInLocation` we will get a Go time "2024-03-10 01:30:00".
-		// So, return the parsed time directly.
-		return expire, nil
-	}
-
-	_, offsetNow := now.Zone()
-	_, offsetExpire := expire.Zone()
-	if interval := offsetExpire - offsetNow; interval < 0 {
-		// Consider daylight saving time, if the offsetNow > offsetExpire, that means we may delete the data that
-		// is still fresh.
-		// For example, in time zone `America/Los_Angeles` after `2024-03-10 02:00`, the time will
-		// leap to `2024-03-10 03:00`.
-		// If we start a job at that time, it will delete the data before `2024-03-10 01:30`
-		// while the expired duration is 90 minutes.
-		// But the data to be deleted was inserted 30 minutes ago, not 90 minutes.
-		// To make sure we do not delete the fresh data, we need to add the offset difference to the expired time.
-		expire = expire.Add(time.Second * time.Duration(interval))
-	}
-
-	return expire, nil
+	expire = now.In(globalTz).
+		AddDate(-int(y), -int(m), -int(d)).
+		Add(-time.Duration(nanosecond)).
+		In(now.Location())
+	return
 }
 
 // SplitScanRanges split ranges for TTL scan

--- a/pkg/ttl/cache/table.go
+++ b/pkg/ttl/cache/table.go
@@ -200,7 +200,7 @@ func (t *PhysicalTable) EvalExpireTime(ctx context.Context, se session.Session,
 	// Different timezones may have different results event with the same "now" time and TTL expression.
 	// Consider a TTL setting with the expiration `INTERVAL 1 MONTH`.
 	// If the current timezone is `Asia/Shanghai` and now is `2021-03-01 00:00:00 +0800`
-	// the expired time should be `2022-02-01 00:00:00 +0800`, corresponding to UTC time `2022-01-31 16:00:00 UTC`.
+	// the expired time should be `2021-02-01 00:00:00 +0800`, corresponding to UTC time `2021-01-31 16:00:00 UTC`.
 	// But if we use the `UTC` time zone, the current time is `2021-02-28 16:00:00 UTC`,
 	// and the expired time should be `2021-01-28 16:00:00 UTC` that is not the same the previous one.
 	globalTz, err := se.GlobalTimeZone(ctx)

--- a/pkg/ttl/cache/table.go
+++ b/pkg/ttl/cache/table.go
@@ -195,7 +195,7 @@ func (t *PhysicalTable) EvalExpireTime(ctx context.Context, se session.Session,
 	unit := ast.TimeUnitType(t.TTLInfo.IntervalTimeUnit)
 
 	if now.Unix() < 0 {
-		return time.Time{}, errors.Errorf("current time must after UTC time 1970-01-01 00:00:00, but %s", now)
+		return time.Time{}, errors.Errorf("Current time must be after the UTC time January 1, 1970, 00:00:00. Received time: %s.", now)
 	}
 
 	var rows []chunk.Row

--- a/pkg/ttl/cache/table.go
+++ b/pkg/ttl/cache/table.go
@@ -195,7 +195,10 @@ func (t *PhysicalTable) EvalExpireTime(ctx context.Context, se session.Session,
 	unit := ast.TimeUnitType(t.TTLInfo.IntervalTimeUnit)
 
 	if now.Unix() < 0 {
-		return time.Time{}, errors.Errorf("Current time must be after the UTC time January 1, 1970, 00:00:00. Received time: %s.", now)
+		return time.Time{}, errors.Errorf(
+			"current time must be after the UTC time January 1, 1970, 00:00:00. Received time: %s",
+			now,
+		)
 	}
 
 	var rows []chunk.Row

--- a/pkg/ttl/cache/table_test.go
+++ b/pkg/ttl/cache/table_test.go
@@ -248,4 +248,16 @@ func TestEvalTTLExpireTime(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "2024-03-10 01:31:00", tm.Format(time.DateTime))
 	require.Equal(t, tz3.String(), tm.Location().String())
+
+	now, err = time.ParseInLocation(time.DateTime, "2024-11-03 03:00:00", tz3)
+	require.NoError(t, err)
+	tm, err = ttlTbl3.EvalExpireTime(context.TODO(), se, now)
+	require.NoError(t, err)
+	require.Equal(t, "2024-11-03 01:30:00", tm.Format(time.DateTime))
+	require.Equal(t, tz3.String(), tm.Location().String())
+	// 2024-11-03 01:30:00 in America/Los_Angeles has two related time points:
+	// 2024-11-03 01:30:00 -0700 PDT
+	// 2024-11-03 01:30:00 -0800 PST
+	// We must use the earlier one to avoid deleting some unexpected rows.
+	require.Equal(t, int64(9000), now.Unix()-tm.Unix())
 }

--- a/pkg/ttl/cache/table_test.go
+++ b/pkg/ttl/cache/table_test.go
@@ -275,4 +275,12 @@ func TestEvalTTLExpireTime(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "1998-12-01 00:00:00", tm.In(tz1).Format(time.DateTime))
 	require.Same(t, time.UTC, tm.Location())
+
+	// time should be truncated to second to make the result simple
+	now, err = time.ParseInLocation("2006-01-02 15:04:05.000000", "2023-01-02 15:00:01.986542", time.UTC)
+	require.NoError(t, err)
+	tm, err = ttlTbl.EvalExpireTime(context.TODO(), se, now)
+	require.NoError(t, err)
+	require.Equal(t, "2023-01-01 15:00:01.000000", tm.Format("2006-01-02 15:04:05.000000"))
+	require.Same(t, time.UTC, tm.Location())
 }

--- a/pkg/ttl/cache/table_test.go
+++ b/pkg/ttl/cache/table_test.go
@@ -188,31 +188,35 @@ func TestEvalTTLExpireTime(t *testing.T) {
 	tz2, err := time.LoadLocation("Europe/Berlin")
 	require.NoError(t, err)
 
-	se.GetSessionVars().TimeZone = tz1
+	_, err = se.ExecuteSQL(context.TODO(), "SET @@global.time_zone = 'Asia/Shanghai'")
+	require.NoError(t, err)
 	tm, err := ttlTbl.EvalExpireTime(context.TODO(), se, now)
 	require.NoError(t, err)
 	require.Equal(t, now.Add(-time.Hour*24).Unix(), tm.Unix())
-	require.Equal(t, "1969-12-31 08:00:00", tm.Format(time.DateTime))
-	require.Equal(t, tz1.String(), tm.Location().String())
+	require.Equal(t, "1969-12-31 08:00:00", tm.In(tz1).Format(time.DateTime))
+	require.Same(t, now.Location(), tm.Location())
 
-	se.GetSessionVars().TimeZone = tz2
+	_, err = se.ExecuteSQL(context.TODO(), "SET @@global.time_zone = 'Europe/Berlin'")
+	require.NoError(t, err)
 	tm, err = ttlTbl.EvalExpireTime(context.TODO(), se, now)
 	require.NoError(t, err)
 	require.Equal(t, now.Add(-time.Hour*24).Unix(), tm.Unix())
-	require.Equal(t, "1969-12-31 01:00:00", tm.Format(time.DateTime))
-	require.Equal(t, tz2.String(), tm.Location().String())
+	require.Equal(t, "1969-12-31 01:00:00", tm.In(tz2).Format(time.DateTime))
+	require.Same(t, now.Location(), tm.Location())
 
-	se.GetSessionVars().TimeZone = tz1
+	_, err = se.ExecuteSQL(context.TODO(), "SET @@global.time_zone = 'Asia/Shanghai'")
+	require.NoError(t, err)
 	tm, err = ttlTbl2.EvalExpireTime(context.TODO(), se, now)
 	require.NoError(t, err)
-	require.Equal(t, "1969-10-01 08:00:00", tm.Format(time.DateTime))
-	require.Equal(t, tz1.String(), tm.Location().String())
+	require.Equal(t, "1969-10-01 08:00:00", tm.In(tz1).Format(time.DateTime))
+	require.Same(t, now.Location(), tm.Location())
 
-	se.GetSessionVars().TimeZone = tz2
+	_, err = se.ExecuteSQL(context.TODO(), "SET @@global.time_zone = 'Europe/Berlin'")
+	require.NoError(t, err)
 	tm, err = ttlTbl2.EvalExpireTime(context.TODO(), se, now)
 	require.NoError(t, err)
-	require.Equal(t, "1969-10-01 01:00:00", tm.Format(time.DateTime))
-	require.Equal(t, tz2.String(), tm.Location().String())
+	require.Equal(t, "1969-10-01 01:00:00", tm.In(tz2).Format(time.DateTime))
+	require.Same(t, now.Location(), tm.Location())
 
 	// test cases for daylight saving time.
 	// When local standard time was about to reach Sunday, 10 March 2024, 02:00:00 clocks were turned forward 1 hour to
@@ -221,7 +225,8 @@ func TestEvalTTLExpireTime(t *testing.T) {
 	require.NoError(t, err)
 	now, err = time.ParseInLocation(time.DateTime, "2024-03-11 19:49:59", tz3)
 	require.NoError(t, err)
-	se.GetSessionVars().TimeZone = tz3
+	_, err = se.ExecuteSQL(context.TODO(), "SET @@global.time_zone = 'America/Los_Angeles'")
+	require.NoError(t, err)
 	tk.MustExec("create table test.t3(a int, t datetime) ttl = `t` + interval 90 minute")
 	tb3, err := do.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t3"))
 	require.NoError(t, err)
@@ -231,33 +236,43 @@ func TestEvalTTLExpireTime(t *testing.T) {
 	require.NoError(t, err)
 	tm, err = ttlTbl3.EvalExpireTime(context.TODO(), se, now)
 	require.NoError(t, err)
-	require.Equal(t, "2024-03-11 18:19:59", tm.Format(time.DateTime))
-	require.Equal(t, tz3.String(), tm.Location().String())
+	require.Equal(t, "2024-03-11 18:19:59", tm.In(tz3).Format(time.DateTime))
+	require.Same(t, now.Location(), tm.Location())
 
 	// across day light-saving time
 	now, err = time.ParseInLocation(time.DateTime, "2024-03-10 03:01:00", tz3)
 	require.NoError(t, err)
 	tm, err = ttlTbl3.EvalExpireTime(context.TODO(), se, now)
 	require.NoError(t, err)
-	require.Equal(t, "2024-03-10 00:31:00", tm.Format(time.DateTime))
-	require.Equal(t, tz3.String(), tm.Location().String())
+	require.Equal(t, "2024-03-10 00:31:00", tm.In(tz3).Format(time.DateTime))
+	require.Same(t, now.Location(), tm.Location())
 
 	now, err = time.ParseInLocation(time.DateTime, "2024-03-10 04:01:00", tz3)
 	require.NoError(t, err)
 	tm, err = ttlTbl3.EvalExpireTime(context.TODO(), se, now)
 	require.NoError(t, err)
-	require.Equal(t, "2024-03-10 01:31:00", tm.Format(time.DateTime))
-	require.Equal(t, tz3.String(), tm.Location().String())
+	require.Equal(t, "2024-03-10 01:31:00", tm.In(tz3).Format(time.DateTime))
+	require.Same(t, now.Location(), tm.Location())
 
 	now, err = time.ParseInLocation(time.DateTime, "2024-11-03 03:00:00", tz3)
 	require.NoError(t, err)
 	tm, err = ttlTbl3.EvalExpireTime(context.TODO(), se, now)
 	require.NoError(t, err)
-	require.Equal(t, "2024-11-03 01:30:00", tm.Format(time.DateTime))
-	require.Equal(t, tz3.String(), tm.Location().String())
+	require.Equal(t, "2024-11-03 01:30:00", tm.In(tz3).Format(time.DateTime))
+	require.Same(t, now.Location(), tm.Location())
 	// 2024-11-03 01:30:00 in America/Los_Angeles has two related time points:
 	// 2024-11-03 01:30:00 -0700 PDT
 	// 2024-11-03 01:30:00 -0800 PST
 	// We must use the earlier one to avoid deleting some unexpected rows.
-	require.Equal(t, int64(9000), now.Unix()-tm.Unix())
+	require.Equal(t, int64(5400), now.Unix()-tm.Unix())
+
+	// we should use global time zone to calculate the expired time
+	_, err = se.ExecuteSQL(context.TODO(), "SET @@global.time_zone = 'Asia/Shanghai'")
+	require.NoError(t, err)
+	now, err = time.ParseInLocation(time.DateTime, "1999-02-28 16:00:00", time.UTC)
+	require.NoError(t, err)
+	tm, err = ttlTbl2.EvalExpireTime(context.TODO(), se, now)
+	require.NoError(t, err)
+	require.Equal(t, "1998-12-01 00:00:00", tm.In(tz1).Format(time.DateTime))
+	require.Same(t, time.UTC, tm.Location())
 }

--- a/pkg/ttl/session/BUILD.bazel
+++ b/pkg/ttl/session/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/ttl/metrics",
         "//pkg/util/chunk",
         "//pkg/util/sqlexec",
+        "//pkg/util/timeutil",
         "@com_github_pingcap_errors//:errors",
     ],
 )

--- a/pkg/ttl/session/session.go
+++ b/pkg/ttl/session/session.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ttl/metrics"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
+	"github.com/pingcap/tidb/pkg/util/timeutil"
 )
 
 // TxnMode represents using optimistic or pessimistic mode in the transaction
@@ -51,6 +52,8 @@ type Session interface {
 	RunInTxn(ctx context.Context, fn func() error, mode TxnMode) (err error)
 	// ResetWithGlobalTimeZone resets the session time zone to global time zone
 	ResetWithGlobalTimeZone(ctx context.Context) error
+	// GlobalTimeZone returns the global timezone. It is used to compute expire time for TTL
+	GlobalTimeZone(ctx context.Context) (*time.Location, error)
 	// Close closes the session
 	Close()
 	// Now returns the current time in location specified by session var
@@ -166,6 +169,15 @@ func (s *session) ResetWithGlobalTimeZone(ctx context.Context) error {
 
 	_, err := s.ExecuteSQL(ctx, "SET @@time_zone=@@global.time_zone")
 	return err
+}
+
+// GlobalTimeZone returns the global timezone
+func (s *session) GlobalTimeZone(ctx context.Context) (*time.Location, error) {
+	str, err := s.GetSessionVars().GetGlobalSystemVar(ctx, "time_zone")
+	if err != nil {
+		return nil, err
+	}
+	return timeutil.ParseTimeZone(str)
 }
 
 // Close closes the session

--- a/pkg/ttl/ttlworker/BUILD.bazel
+++ b/pkg/ttl/ttlworker/BUILD.bazel
@@ -70,7 +70,7 @@ go_test(
     embed = [":ttlworker"],
     flaky = True,
     race = "on",
-    shard_count = 48,
+    shard_count = 50,
     deps = [
         "//pkg/domain",
         "//pkg/infoschema",

--- a/pkg/ttl/ttlworker/BUILD.bazel
+++ b/pkg/ttl/ttlworker/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/chunk",
+        "//pkg/util/intest",
         "//pkg/util/logutil",
         "//pkg/util/sqlexec",
         "//pkg/util/timeutil",

--- a/pkg/ttl/ttlworker/job.go
+++ b/pkg/ttl/ttlworker/job.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ttl/cache"
 	"github.com/pingcap/tidb/pkg/ttl/session"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
 )
@@ -127,6 +128,7 @@ type ttlJob struct {
 
 // finish turns current job into last job, and update the error message and statistics summary
 func (job *ttlJob) finish(se session.Session, now time.Time, summary *TTLSummary) {
+	intest.Assert(se.GetSessionVars().Location().String() == now.Location().String())
 	// at this time, the job.ctx may have been canceled (to cancel this job)
 	// even when it's canceled, we'll need to update the states, so use another context
 	err := se.RunInTxn(context.TODO(), func() error {

--- a/pkg/ttl/ttlworker/job_manager.go
+++ b/pkg/ttl/ttlworker/job_manager.go
@@ -201,7 +201,7 @@ func (m *JobManager) jobLoop() error {
 		case <-m.ctx.Done():
 			return nil
 		case <-timerTicker:
-			m.onTimerTick(se, timerRT, timerSyncer, time.Now())
+			m.onTimerTick(se, timerRT, timerSyncer, now)
 		case jobReq := <-jobRequestCh:
 			m.handleSubmitJobRequest(se, jobReq)
 		case <-infoSchemaCacheUpdateTicker:
@@ -327,7 +327,7 @@ func (m *JobManager) handleSubmitJobRequest(se session.Session, jobReq *SubmitTT
 		return
 	}
 
-	_, err := m.lockNewJob(m.ctx, se, tbl, time.Now(), jobReq.RequestID, false)
+	_, err := m.lockNewJob(m.ctx, se, tbl, se.Now(), jobReq.RequestID, false)
 	jobReq.RespCh <- err
 }
 

--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/ngaut/pools"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -63,6 +64,45 @@ func sessionFactory(t *testing.T, store kv.Storage) func() session.Session {
 	}
 }
 
+func TestGetSession(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set @@time_zone = 'Asia/Shanghai'")
+	tk.MustExec("set @@global.time_zone= 'Europe/Berlin'")
+	tk.MustExec("set @@tidb_retry_limit=1")
+	tk.MustExec("set @@tidb_enable_1pc=0")
+	tk.MustExec("set @@tidb_enable_async_commit=0")
+	var getCnt atomic.Int32
+
+	pool := pools.NewResourcePool(func() (pools.Resource, error) {
+		if getCnt.CompareAndSwap(0, 1) {
+			return tk.Session(), nil
+		}
+		require.FailNow(t, "get session more than once")
+		return nil, nil
+	}, 1, 1, 0)
+	defer pool.Close()
+
+	se, err := ttlworker.GetSessionForTest(pool)
+	require.NoError(t, err)
+	defer se.Close()
+
+	// global time zone should not change
+	tk.MustQuery("select @@global.time_zone").Check(testkit.Rows("Europe/Berlin"))
+	tz, err := se.GlobalTimeZone(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, "Europe/Berlin", tz.String())
+	// session variables should be set
+	tk.MustQuery("select @@time_zone, @@tidb_retry_limit, @@tidb_enable_1pc, @@tidb_enable_async_commit").
+		Check(testkit.Rows("UTC 0 1 1"))
+
+	se.Close()
+
+	// all session variables should be restored after close
+	tk.MustQuery("select @@time_zone, @@tidb_retry_limit, @@tidb_enable_1pc, @@tidb_enable_async_commit").
+		Check(testkit.Rows("Asia/Shanghai 1 0 0"))
+}
+
 func TestParallelLockNewJob(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	waitAndStopTTLManager(t, dom)
@@ -75,14 +115,14 @@ func TestParallelLockNewJob(t *testing.T) {
 	m.InfoSchemaCache().Tables[testTable.ID] = testTable
 
 	se := sessionFactory()
-	job, err := m.LockJob(context.Background(), se, testTable, time.Now(), uuid.NewString(), false)
+	job, err := m.LockJob(context.Background(), se, testTable, se.Now(), uuid.NewString(), false)
 	require.NoError(t, err)
-	job.Finish(se, time.Now(), &ttlworker.TTLSummary{})
+	job.Finish(se, se.Now(), &ttlworker.TTLSummary{})
 
 	// lock one table in parallel, only one of them should lock successfully
 	testTimes := 100
 	concurrency := 5
-	now := time.Now()
+	now := se.Now()
 	for i := 0; i < testTimes; i++ {
 		successCounter := atomic.NewUint64(0)
 		successJob := &ttlworker.TTLJob{}
@@ -111,7 +151,7 @@ func TestParallelLockNewJob(t *testing.T) {
 		wg.Wait()
 
 		require.Equal(t, uint64(1), successCounter.Load())
-		successJob.Finish(se, time.Now(), &ttlworker.TTLSummary{})
+		successJob.Finish(se, se.Now(), &ttlworker.TTLSummary{})
 	}
 }
 
@@ -131,7 +171,7 @@ func TestFinishJob(t *testing.T) {
 	m := ttlworker.NewJobManager("test-id", nil, store, nil, nil)
 	m.InfoSchemaCache().Tables[testTable.ID] = testTable
 	se := sessionFactory()
-	startTime := time.Now()
+	startTime := se.Now()
 	job, err := m.LockJob(context.Background(), se, testTable, startTime, uuid.NewString(), false)
 	require.NoError(t, err)
 
@@ -156,7 +196,7 @@ func TestFinishJob(t *testing.T) {
 	summary.SummaryText = string(summaryBytes)
 
 	require.NoError(t, err)
-	endTime := time.Now()
+	endTime := se.Now()
 	job.Finish(se, endTime, summary)
 	tk.MustQuery("select table_id, last_job_summary from mysql.tidb_ttl_table_status").Check(testkit.Rows("2 " + summary.SummaryText))
 	tk.MustQuery("select * from mysql.tidb_ttl_task").Check(testkit.Rows())
@@ -609,7 +649,6 @@ func TestJobTimeout(t *testing.T) {
 
 	waitAndStopTTLManager(t, dom)
 
-	now := time.Now()
 	tk.MustExec("create table test.t (id int, created_at datetime) ttl = `created_at` + interval 1 minute ttl_job_interval = '1m'")
 	table, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	tableID := table.Meta().ID
@@ -617,6 +656,7 @@ func TestJobTimeout(t *testing.T) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnTTL)
 
 	se := sessionFactory()
+	now := se.Now()
 	m := ttlworker.NewJobManager("manager-1", nil, store, nil, func() bool {
 		return true
 	})
@@ -1245,4 +1285,21 @@ func TestManagerJobAdapterGetJob(t *testing.T) {
 		require.Equal(t, summary, *job.Summary, status)
 		tk.MustExec("delete from mysql.tidb_ttl_job_history")
 	}
+}
+
+func TestManagerJobAdapterNow(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	adapter := ttlworker.NewManagerJobAdapter(store, dom.SysSessionPool(), nil)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@global.time_zone ='Europe/Berlin'")
+	tk.MustExec("set @@time_zone='Asia/Shanghai'")
+
+	now, err := adapter.Now()
+	require.NoError(t, err)
+	localNow := time.Now()
+
+	require.Equal(t, "Europe/Berlin", now.Location().String())
+	require.InDelta(t, now.Unix(), localNow.Unix(), 10)
 }

--- a/pkg/ttl/ttlworker/job_manager_test.go
+++ b/pkg/ttl/ttlworker/job_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	timerapi "github.com/pingcap/tidb/pkg/timer/api"
@@ -366,7 +367,7 @@ func TestLockTable(t *testing.T) {
 	oldJobExpireTime := now.Add(-time.Hour)
 	oldJobStartTime := now.Add(-30 * time.Minute)
 
-	testPhysicalTable := &cache.PhysicalTable{ID: 1, Schema: model.NewCIStr("test"), TableInfo: &model.TableInfo{ID: 1, Name: model.NewCIStr("t1"), TTLInfo: &model.TTLInfo{ColumnName: model.NewCIStr("test"), IntervalExprStr: "5 Year", JobInterval: "1h"}}}
+	testPhysicalTable := &cache.PhysicalTable{ID: 1, Schema: model.NewCIStr("test"), TableInfo: &model.TableInfo{ID: 1, Name: model.NewCIStr("t1"), TTLInfo: &model.TTLInfo{ColumnName: model.NewCIStr("test"), IntervalExprStr: "1", IntervalTimeUnit: int(ast.TimeUnitMinute), JobInterval: "1h"}}}
 
 	type executeInfo struct {
 		sql  string
@@ -600,7 +601,9 @@ func TestLockTable(t *testing.T) {
 				sqlCounter += 1
 				return
 			}
-			se.evalExpire = newJobExpireTime
+			se.now = func() time.Time {
+				return now
+			}
 
 			var job *ttlJob
 			if c.isCreate {

--- a/pkg/ttl/ttlworker/scan.go
+++ b/pkg/ttl/ttlworker/scan.go
@@ -111,7 +111,7 @@ func (t *ttlScanTask) doScan(ctx context.Context, delCh chan<- *ttlDeleteTask, s
 	}
 	defer rawSess.Close()
 
-	safeExpire, err := t.tbl.EvalExpireTime(taskCtx, rawSess, time.Now())
+	safeExpire, err := t.tbl.EvalExpireTime(taskCtx, rawSess, rawSess.Now())
 	if err != nil {
 		return t.result(err)
 	}

--- a/pkg/ttl/ttlworker/scan.go
+++ b/pkg/ttl/ttlworker/scan.go
@@ -127,7 +127,7 @@ func (t *ttlScanTask) doScan(ctx context.Context, delCh chan<- *ttlDeleteTask, s
 	// because `ExecuteSQLWithCheck` only do checks when the table meta used by task is different with the latest one.
 	// In this case, some rows will be deleted unexpectedly.
 	if t.ExpireTime.After(safeExpire) {
-		return t.result(errors.Errorf("current expire time is after safe expire time. (%d > %d)", t.ExpireTime.UnixMilli(), safeExpire.UnixMilli()))
+		return t.result(errors.Errorf("current expire time is after safe expire time. (%d > %d)", t.ExpireTime.Unix(), safeExpire.Unix()))
 	}
 
 	origConcurrency := rawSess.GetSessionVars().DistSQLScanConcurrency()

--- a/pkg/ttl/ttlworker/scan_test.go
+++ b/pkg/ttl/ttlworker/scan_test.go
@@ -412,7 +412,10 @@ func TestScanTaskDoScan(t *testing.T) {
 func TestScanTaskCheck(t *testing.T) {
 	tbl := newMockTTLTbl(t, "t1")
 	pool := newMockSessionPool(t, tbl)
-	pool.se.evalExpire = time.UnixMilli(100)
+	pool.se.now = func() time.Time {
+		// make expire time time.UnixMilli(100)
+		return time.UnixMilli(100).Add(time.Second)
+	}
 	pool.se.rows = newMockRows(t, types.NewFieldType(mysql.TypeInt24)).Append(12).Rows()
 
 	task := &ttlScanTask{

--- a/pkg/ttl/ttlworker/scan_test.go
+++ b/pkg/ttl/ttlworker/scan_test.go
@@ -414,14 +414,14 @@ func TestScanTaskCheck(t *testing.T) {
 	pool := newMockSessionPool(t, tbl)
 	pool.se.now = func() time.Time {
 		// make expire time time.UnixMilli(100)
-		return time.UnixMilli(100).Add(time.Second)
+		return time.Unix(100, 0).Add(time.Second)
 	}
 	pool.se.rows = newMockRows(t, types.NewFieldType(mysql.TypeInt24)).Append(12).Rows()
 
 	task := &ttlScanTask{
 		ctx: context.Background(),
 		TTLTask: &cache.TTLTask{
-			ExpireTime: time.UnixMilli(101).Add(time.Minute),
+			ExpireTime: time.Unix(101, 0).Add(time.Minute),
 		},
 		tbl:        tbl,
 		statistics: &ttlStatistics{},
@@ -430,14 +430,14 @@ func TestScanTaskCheck(t *testing.T) {
 	ch := make(chan *ttlDeleteTask, 1)
 	result := task.doScan(context.Background(), ch, pool)
 	require.Equal(t, task, result.task)
-	require.EqualError(t, result.err, "current expire time is after safe expire time. (60101 > 60100)")
+	require.EqualError(t, result.err, "current expire time is after safe expire time. (161 > 160)")
 	require.Equal(t, 0, len(ch))
 	require.Equal(t, "Total Rows: 0, Success Rows: 0, Error Rows: 0", task.statistics.String())
 
 	task = &ttlScanTask{
 		ctx: context.Background(),
 		TTLTask: &cache.TTLTask{
-			ExpireTime: time.UnixMilli(100).Add(time.Minute),
+			ExpireTime: time.Unix(100, 0).Add(time.Minute),
 		},
 		tbl:        tbl,
 		statistics: &ttlStatistics{},

--- a/pkg/ttl/ttlworker/task_manager.go
+++ b/pkg/ttl/ttlworker/task_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ttl/cache"
 	"github.com/pingcap/tidb/pkg/ttl/metrics"
 	"github.com/pingcap/tidb/pkg/ttl/session"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
@@ -321,6 +322,7 @@ loop:
 }
 
 func (m *taskManager) peekWaitingScanTasks(se session.Session, now time.Time) ([]*cache.TTLTask, error) {
+	intest.Assert(se.GetSessionVars().Location().String() == now.Location().String())
 	sql, args := cache.PeekWaitingTTLTask(now.Add(-getTaskManagerHeartBeatExpireInterval()))
 	rows, err := se.ExecuteSQL(m.ctx, sql, args...)
 	if err != nil {
@@ -372,6 +374,7 @@ func (m *taskManager) lockScanTask(se session.Session, task *cache.TTLTask, now 
 			return errors.WithStack(errTooManyRunningTasks)
 		}
 
+		intest.Assert(se.GetSessionVars().Location().String() == now.Location().String())
 		sql, args := setTTLTaskOwnerSQL(task.JobID, task.ScanID, m.id, now)
 		_, err = se.ExecuteSQL(ctx, sql, args...)
 		if err != nil {
@@ -440,6 +443,7 @@ func (m *taskManager) updateHeartBeat(ctx context.Context, se session.Session, n
 			state.ScanTaskErr = task.result.err.Error()
 		}
 
+		intest.Assert(se.GetSessionVars().Location().String() == now.Location().String())
 		sql, args, err := updateTTLTaskHeartBeatSQL(task.JobID, task.ScanID, now, state)
 		if err != nil {
 			return err
@@ -482,6 +486,7 @@ func (m *taskManager) reportTaskFinished(se session.Session, now time.Time, task
 		state.ScanTaskErr = task.result.err.Error()
 	}
 
+	intest.Assert(se.GetSessionVars().Location().String() == now.Location().String())
 	sql, args, err := setTTLTaskFinishedSQL(task.JobID, task.ScanID, state, now)
 	if err != nil {
 		return err

--- a/pkg/ttl/ttlworker/timer.go
+++ b/pkg/ttl/ttlworker/timer.go
@@ -50,6 +50,8 @@ type TTLJobTrace struct {
 
 // TTLJobAdapter is used to submit TTL job and trace job status
 type TTLJobAdapter interface {
+	// Now returns the current time with system timezone.
+	Now() (time.Time, error)
 	// CanSubmitJob returns whether a new job can be created for the specified table
 	CanSubmitJob(tableID, physicalID int64) bool
 	// SubmitJob submits a new job
@@ -64,7 +66,6 @@ type ttlTimerHook struct {
 	ctx                 context.Context
 	cancel              func()
 	wg                  sync.WaitGroup
-	nowFunc             func() time.Time
 	checkTTLJobInterval time.Duration
 	// waitJobLoopCounter is only used for test
 	waitJobLoopCounter int64
@@ -77,7 +78,6 @@ func newTTLTimerHook(adapter TTLJobAdapter, cli timerapi.TimerClient) *ttlTimerH
 		cli:                 cli,
 		ctx:                 ctx,
 		cancel:              cancel,
-		nowFunc:             time.Now,
 		checkTTLJobInterval: defaultCheckTTLJobInterval,
 	}
 }
@@ -95,8 +95,13 @@ func (t *ttlTimerHook) OnPreSchedEvent(_ context.Context, event timerapi.TimerSh
 		return
 	}
 
+	now, err := t.adapter.Now()
+	if err != nil {
+		return r, err
+	}
+
 	windowStart, windowEnd := variable.TTLJobScheduleWindowStartTime.Load(), variable.TTLJobScheduleWindowEndTime.Load()
-	if !timeutil.WithinDayTimePeriod(windowStart, windowEnd, t.nowFunc()) {
+	if !timeutil.WithinDayTimePeriod(windowStart, windowEnd, now) {
 		r.Delay = time.Minute
 		return
 	}
@@ -154,7 +159,12 @@ func (t *ttlTimerHook) OnSchedEvent(ctx context.Context, event timerapi.TimerShe
 			logger.Warn("cancel current TTL timer event because table's ttl is not enabled")
 		}
 
-		if t.nowFunc().Sub(timer.EventStart) > 10*time.Minute {
+		now, err := t.adapter.Now()
+		if err != nil {
+			return err
+		}
+
+		if now.Sub(timer.EventStart) > 10*time.Minute {
 			cancel = true
 			logger.Warn("cancel current TTL timer event because job not submitted for a long time")
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51675

### What changed and how does it work?

To make sure we have a right behavior with different timezones, this PR has some modifications:

- `EvalExpireTime` uses go time lib to compute the expired time instead of executing SQL to avoid some problems like: https://bugs.mysql.com/bug.php?id=95219
- `EvalExpireTime` must compute the expired time according to the TiDB global time zone.
- Considering some SQLs are using string format to update timestamp columns. We must ensure that the time argument with type `time.Time` has a location that is the same as the session's location. So I added some asserts.
- We force the session's time zone to 'UTC' for TTL meta operations to make sure we can insert a right time even in daylight saving time.
- We should also considerate the timezone for TTL job window. In this PR, we also use the global time zone in TiDB instead of the local time zone.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix expire time drift for daylighting-save time case
```
