### PR TITLE
ddl, tests: make the error message of the default value expression more appropriate.

### DIFF
--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -1341,7 +1341,8 @@ func getFuncCallDefaultValue(col *table.Column, option *ast.ColumnOption, expr *
 			col.DefaultIsExpr = true
 			return str, false, nil
 		}
-		return nil, false, dbterror.ErrDefValGeneratedNamedFunctionIsNotAllowed.GenWithStackByArgs(col.Name.String(), nowFunc.FnName.String())
+		return nil, false, dbterror.ErrDefValGeneratedNamedFunctionIsNotAllowed.GenWithStackByArgs(col.Name.String(),
+			fmt.Sprintf("%s with disallowed args", expr.FnName.String()))
 	case ast.Replace:
 		if err := expression.VerifyArgsWrapper(expr.FnName.L, len(expr.Args)); err != nil {
 			return nil, false, errors.Trace(err)
@@ -1371,7 +1372,8 @@ func getFuncCallDefaultValue(col *table.Column, option *ast.ColumnOption, expr *
 				return str, false, nil
 			}
 		}
-		return nil, false, dbterror.ErrDefValGeneratedNamedFunctionIsNotAllowed.GenWithStackByArgs(col.Name.String(), expr.FnName.String())
+		return nil, false, dbterror.ErrDefValGeneratedNamedFunctionIsNotAllowed.GenWithStackByArgs(col.Name.String(),
+			fmt.Sprintf("%s with disallowed args", expr.FnName.String()))
 	case ast.Upper:
 		if err := expression.VerifyArgsWrapper(expr.FnName.L, len(expr.Args)); err != nil {
 			return nil, false, errors.Trace(err)
@@ -1397,7 +1399,8 @@ func getFuncCallDefaultValue(col *table.Column, option *ast.ColumnOption, expr *
 				return str, false, nil
 			}
 		}
-		return nil, false, dbterror.ErrDefValGeneratedNamedFunctionIsNotAllowed.GenWithStackByArgs(col.Name.String(), expr.FnName.String())
+		return nil, false, dbterror.ErrDefValGeneratedNamedFunctionIsNotAllowed.GenWithStackByArgs(col.Name.String(),
+			fmt.Sprintf("%s with disallowed args", expr.FnName.String()))
 	case ast.StrToDate: // STR_TO_DATE()
 		if err := expression.VerifyArgsWrapper(expr.FnName.L, len(expr.Args)); err != nil {
 			return nil, false, errors.Trace(err)
@@ -1413,7 +1416,8 @@ func getFuncCallDefaultValue(col *table.Column, option *ast.ColumnOption, expr *
 				return str, false, nil
 			}
 		}
-		return nil, false, dbterror.ErrDefValGeneratedNamedFunctionIsNotAllowed.GenWithStackByArgs(col.Name.String(), fmt.Sprintf("%s with these args", expr.FnName.String()))
+		return nil, false, dbterror.ErrDefValGeneratedNamedFunctionIsNotAllowed.GenWithStackByArgs(col.Name.String(),
+			fmt.Sprintf("%s with disallowed args", expr.FnName.String()))
 	default:
 		return nil, false, dbterror.ErrDefValGeneratedNamedFunctionIsNotAllowed.GenWithStackByArgs(col.Name.String(), expr.FnName.String())
 	}

--- a/tests/integrationtest/r/ddl/default_as_expression.result
+++ b/tests/integrationtest/r/ddl/default_as_expression.result
@@ -132,11 +132,11 @@ create table t (c int(10), c1 varchar(256) default (REPLACE(UPPER(UUID()), '-', 
 create table t1 (c int(10), c1 int default (REPLACE(UPPER(UUID()), '-', '')), index idx(c1));
 create table t2 (c int(10), c1 varchar(256) default (REPLACE(CONVERT(UPPER(UUID()) USING UTF8MB4), '-', '')), index idx(c1));
 create table t1 (c int(10), c1 varchar(256) default (REPLACE('xdfj-jfj', '-', '')));
-Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `REPLACE`.
+Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `REPLACE with disallowed args`.
 create table t1 (c int(10), c1 varchar(256) default (UPPER(UUID())));
-Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `UPPER`.
+Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `UPPER with disallowed args`.
 create table t1 (c int(10), c1 varchar(256) default (REPLACE(UPPER('dfdkj-kjkl-d'), '-', '')));
-Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `REPLACE`.
+Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `REPLACE with disallowed args`.
 alter table t add column c2 varchar(32) default (REPLACE(UPPER(UUID()), '-', ''));
 Error 1674 (HY000): Statement is unsafe because it uses a system function that may return a different value on the slave
 alter table t add column c3 int default (UPPER(UUID()));
@@ -219,9 +219,9 @@ create table t2 (c int(10), c1 blob default (str_to_date('1980-01-01','%Y-%m-%d'
 create table t5 (c int(10), c1 json default (str_to_date('9999-01-01','%Y-%m-%d')), c2 timestamp default (str_to_date('1980-01-01','%Y-%m-%d')));
 set session sql_mode=@sqlMode;
 create table t6 (c int(10), c1 varchar(32) default (str_to_date(upper('1980-01-01'),'%Y-%m-%d')));
-Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `str_to_date with these args`.
+Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `str_to_date with disallowed args`.
 create table t6 (c int(10), c1 varchar(32) default (str_to_date('1980-01-01',upper('%Y-%m-%d'))));
-Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `str_to_date with these args`.
+Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `str_to_date with disallowed args`.
 alter table t0 add column c3 varchar(32) default (str_to_date('1980-01-01','%Y-%m-%d'));
 Error 1674 (HY000): Statement is unsafe because it uses a system function that may return a different value on the slave
 alter table t0 add column c4 int default (str_to_date('1980-01-01','%Y-%m-%d'));
@@ -365,7 +365,7 @@ create table t1 (c int(10), c1 int default (upper(substring_index(user(),_utf8mb
 create table t2 (c int(10), c1 varchar(256) default (substring_index(user(),'@',1)));
 Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `substring_index`.
 create table t2 (c int(10), c1 varchar(256) default (upper(substring_index('fjks@jkkl','@',1))));
-Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `upper`.
+Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `upper with disallowed args`.
 create table t2 (c int(10), c1 varchar(256) default (upper(substring_index(user(),'x',1))));
 Error 3770 (HY000): Default value expression of column 'c1' contains a disallowed function: `KindString x`.
 alter table t add column c2 varchar(32) default (upper(substring_index(user(),'@',1)));


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/51703

Problem Summary:

### What changed and how does it work?
Now we support `REPLACE` as the default value expression, but don't support `REPLACE('xdfj-jfj', '-', ''))`.
So tiny update the error message.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
