### PR TITLE
executor: skip TemporaryTableNoNetwork unit test under infoschema v2

### DIFF
--- a/pkg/executor/temporary_table_test.go
+++ b/pkg/executor/temporary_table_test.go
@@ -75,6 +75,12 @@ func assertTemporaryTableNoNetwork(t *testing.T, createTable func(*testkit.TestK
 
 	tk.MustExec("use test")
 	tk1.MustExec("use test")
+
+	if tk.MustQuery("select @@tidb_schema_cache_size > 0").Equal(testkit.Rows("1")) {
+		// infoschema v2 requires network, so it cannot be tested this way.
+		t.Skip()
+	}
+
 	tk.MustExec("drop table if exists normal, tmp_t")
 	tk.MustExec("create table normal (id int, a int, index(a))")
 	createTable(tk)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50959 

Problem Summary:

### What changed and how does it work?

In TemporaryTableNoNetwork unit test, there is a failpoint assuming that temporary table related operations would not cause network visiting. That's true for infoschema v1.

When using infoschema v2, the API like `SchemaTables` need to visit network to list tables, and also API like `TableByID` may miss table cache and requires reloading ... 
So TemporaryTableNoNetwork can not work under infoschema v2, skip those tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

```
diff --git a/pkg/sessionctx/variable/tidb_vars.go b/pkg/sessionctx/variable/tidb_vars.go
index d655384bfb..7e0bef66e7 100644
--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1482,7 +1482,7 @@ const (
        DefTiDBIdleTransactionTimeout                     = 0
        DefEnableParallelSort                             = false
        DefTiDBTxnEntrySizeLimit                          = 0
-       DefTiDBSchemaCacheSize                            = 0
+       DefTiDBSchemaCacheSize                            = 1024
        DefTiDBLowResolutionTSOUpdateInterval             = 2000
        DefTiDBDMLType                                    = "STANDARD"
 )
```

```
make ut X='run executor' 1>a.log 2>b.log
grep FAIL a.log |wc -l
```

This can fix 5 test cases, FAILED cases reduce from 20 to 15.

And also test the temporary table integration test with infoschema v2 manually:

```
diff --git a/tests/integrationtest/t/session/temporary_table.test b/tests/integrationtest/t/session/temporary_table.test
index c191afe167..41c5a0e0e5 100644
--- a/tests/integrationtest/t/session/temporary_table.test
+++ b/tests/integrationtest/t/session/temporary_table.test
@@ -1,3 +1,5 @@
+set @@global.tidb_schema_cache_size = 1024;
```

Check this work as expected:
 
```
cd tests/integrationtest 
./run-tests.sh -r session/temporary_table
```



- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
