### PR TITLE
pkg/util/chunk, pkg/util/codec: remove redundant stmtctx dependency from tests

### DIFF
--- a/pkg/util/chunk/BUILD.bazel
+++ b/pkg/util/chunk/BUILD.bazel
@@ -65,7 +65,6 @@ go_test(
     deps = [
         "//pkg/config",
         "//pkg/parser/mysql",
-        "//pkg/sessionctx/stmtctx",
         "//pkg/testkit/testsetup",
         "//pkg/types",
         "//pkg/util/collate",

--- a/pkg/util/chunk/chunk_test.go
+++ b/pkg/util/chunk/chunk_test.go
@@ -24,7 +24,6 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/stretchr/testify/require"
 )
@@ -544,8 +543,8 @@ func TestGetDecimalDatum(t *testing.T) {
 	decType := types.NewFieldType(mysql.TypeNewDecimal)
 	decType.SetFlen(4)
 	decType.SetDecimal(2)
-	sc := stmtctx.NewStmtCtx()
-	decDatum, err := datum.ConvertTo(sc.TypeCtx(), decType)
+	typeCtx := types.DefaultStmtNoWarningContext
+	decDatum, err := datum.ConvertTo(typeCtx, decType)
 	require.NoError(t, err)
 
 	chk := NewChunkWithCapacity([]*types.FieldType{decType}, 32)

--- a/pkg/util/chunk/mutrow_test.go
+++ b/pkg/util/chunk/mutrow_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/stretchr/testify/require"
@@ -29,12 +28,12 @@ func TestMutRow(t *testing.T) {
 	allTypes := newAllTypes()
 	mutRow := MutRowFromTypes(allTypes)
 	row := mutRow.ToRow()
-	sc := stmtctx.NewStmtCtx()
+	typeCtx := types.DefaultStmtNoWarningContext
 	for i := 0; i < row.Len(); i++ {
 		val := zeroValForType(allTypes[i])
 		d := row.GetDatum(i, allTypes[i])
 		d2 := types.NewDatum(val)
-		cmp, err := d.Compare(sc.TypeCtx(), &d2, collate.GetCollator(allTypes[i].GetCollate()))
+		cmp, err := d.Compare(typeCtx, &d2, collate.GetCollator(allTypes[i].GetCollate()))
 		require.NoError(t, err)
 		require.Equal(t, 0, cmp)
 	}
@@ -79,7 +78,7 @@ func TestMutRow(t *testing.T) {
 
 	retTypes := []*types.FieldType{types.NewFieldType(mysql.TypeDuration)}
 	chk := New(retTypes, 1, 1)
-	dur, _, err := types.ParseDuration(sc.TypeCtx(), "01:23:45", 0)
+	dur, _, err := types.ParseDuration(typeCtx, "01:23:45", 0)
 	require.NoError(t, err)
 	chk.AppendDuration(0, dur)
 	mutRow = MutRowFromTypes(retTypes)

--- a/pkg/util/codec/BUILD.bazel
+++ b/pkg/util/codec/BUILD.bazel
@@ -39,9 +39,9 @@ go_test(
     embed = [":codec"],
     flaky = True,
     deps = [
+        "//pkg/errctx",
         "//pkg/parser/mysql",
         "//pkg/parser/terror",
-        "//pkg/sessionctx/stmtctx",
         "//pkg/testkit/testsetup",
         "//pkg/types",
         "//pkg/util/benchdaily",

--- a/pkg/util/codec/codec_test.go
+++ b/pkg/util/codec/codec_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/collate"
@@ -72,20 +72,20 @@ func TestCodecKey(t *testing.T) {
 			types.MakeDatums(uint64(1), uint64(1)),
 		},
 	}
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
+	typeCtx := types.DefaultStmtNoWarningContext.WithLocation(time.Local)
 	for i, datums := range table {
 		comment := fmt.Sprintf("%d %v", i, datums)
-		b, err := EncodeKey(sc.TimeZone(), nil, datums.Input...)
+		b, err := EncodeKey(typeCtx.Location(), nil, datums.Input...)
 		require.NoError(t, err, comment)
 
 		args, err := Decode(b, 1)
 		require.NoError(t, err, comment)
 		require.Equal(t, datums.Expect, args, comment)
 
-		b, err = EncodeValue(sc.TimeZone(), nil, datums.Input...)
+		b, err = EncodeValue(typeCtx.Location(), nil, datums.Input...)
 		require.NoError(t, err, comment)
 
-		size, err := estimateValuesSize(sc, datums.Input)
+		size, err := estimateValuesSize(typeCtx, datums.Input)
 		require.NoError(t, err, comment)
 		require.Len(t, b, size, comment)
 
@@ -96,14 +96,14 @@ func TestCodecKey(t *testing.T) {
 
 	var raw types.Datum
 	raw.SetRaw([]byte("raw"))
-	_, err := EncodeKey(sc.TimeZone(), nil, raw)
+	_, err := EncodeKey(typeCtx.Location(), nil, raw)
 	require.Error(t, err)
 }
 
-func estimateValuesSize(sc *stmtctx.StatementContext, vals []types.Datum) (int, error) {
+func estimateValuesSize(typeCtx types.Context, vals []types.Datum) (int, error) {
 	size := 0
 	for _, val := range vals {
-		length, err := EstimateValueSize(sc.TypeCtx(), val)
+		length, err := EstimateValueSize(typeCtx, val)
 		if err != nil {
 			return 0, err
 		}
@@ -214,12 +214,11 @@ func TestCodecKeyCompare(t *testing.T) {
 			-1,
 		},
 	}
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	for _, datums := range table {
-		b1, err := EncodeKey(sc.TimeZone(), nil, datums.Left...)
+		b1, err := EncodeKey(time.Local, nil, datums.Left...)
 		require.NoError(t, err)
 
-		b2, err := EncodeKey(sc.TimeZone(), nil, datums.Right...)
+		b2, err := EncodeKey(time.Local, nil, datums.Right...)
 		require.NoError(t, err)
 
 		comparedRes := bytes.Compare(b1, b2)
@@ -519,8 +518,7 @@ func TestBytes(t *testing.T) {
 }
 
 func parseTime(t *testing.T, s string) types.Time {
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.UTC)
-	m, err := types.ParseTime(sc.TypeCtx(), s, mysql.TypeDatetime, types.DefaultFsp)
+	m, err := types.ParseTime(types.DefaultStmtNoWarningContext, s, mysql.TypeDatetime, types.DefaultFsp)
 	require.NoError(t, err)
 	return m
 }
@@ -537,11 +535,10 @@ func TestTime(t *testing.T) {
 		"2011-01-01 00:00:00",
 		"0001-01-01 00:00:00",
 	}
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	for _, timeDatum := range tbl {
 		m := types.NewDatum(parseTime(t, timeDatum))
 
-		b, err := EncodeKey(sc.TimeZone(), nil, m)
+		b, err := EncodeKey(time.Local, nil, m)
 		require.NoError(t, err)
 		v, err := Decode(b, 1)
 		require.NoError(t, err)
@@ -568,9 +565,9 @@ func TestTime(t *testing.T) {
 		m1 := types.NewDatum(parseTime(t, timeData.Arg1))
 		m2 := types.NewDatum(parseTime(t, timeData.Arg2))
 
-		b1, err := EncodeKey(sc.TimeZone(), nil, m1)
+		b1, err := EncodeKey(time.Local, nil, m1)
 		require.NoError(t, err)
-		b2, err := EncodeKey(sc.TimeZone(), nil, m2)
+		b2, err := EncodeKey(time.Local, nil, m2)
 		require.NoError(t, err)
 
 		ret := bytes.Compare(b1, b2)
@@ -584,11 +581,10 @@ func TestDuration(t *testing.T) {
 		"00:00:00",
 		"1 11:11:11",
 	}
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	for _, duration := range tbl {
 		m := parseDuration(t, duration)
 
-		b, err := EncodeKey(sc.TimeZone(), nil, types.NewDatum(m))
+		b, err := EncodeKey(time.Local, nil, types.NewDatum(m))
 		require.NoError(t, err)
 		v, err := Decode(b, 1)
 		require.NoError(t, err)
@@ -610,9 +606,9 @@ func TestDuration(t *testing.T) {
 		m1 := parseDuration(t, durations.Arg1)
 		m2 := parseDuration(t, durations.Arg2)
 
-		b1, err := EncodeKey(sc.TimeZone(), nil, types.NewDatum(m1))
+		b1, err := EncodeKey(time.Local, nil, types.NewDatum(m1))
 		require.NoError(t, err)
-		b2, err := EncodeKey(sc.TimeZone(), nil, types.NewDatum(m2))
+		b2, err := EncodeKey(time.Local, nil, types.NewDatum(m2))
 		require.NoError(t, err)
 
 		ret := bytes.Compare(b1, b2)
@@ -637,13 +633,13 @@ func TestDecimal(t *testing.T) {
 		"-12.340",
 		"-0.1234",
 	}
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
+	typeCtx := types.DefaultStmtNoWarningContext.WithLocation(time.Local)
 	for _, decimalNum := range tbl {
 		dec := new(types.MyDecimal)
 		err := dec.FromString([]byte(decimalNum))
 		require.NoError(t, err)
 
-		b, err := EncodeKey(sc.TimeZone(), nil, types.NewDatum(dec))
+		b, err := EncodeKey(typeCtx.Location(), nil, types.NewDatum(dec))
 		require.NoError(t, err)
 		v, err := Decode(b, 1)
 		require.NoError(t, err)
@@ -720,12 +716,12 @@ func TestDecimal(t *testing.T) {
 	}
 	for _, decimalNums := range tblCmp {
 		d1 := types.NewDatum(decimalNums.Arg1)
-		dec1, err := d1.ToDecimal(sc.TypeCtxOrDefault())
+		dec1, err := d1.ToDecimal(typeCtx)
 		require.NoError(t, err)
 		d1.SetMysqlDecimal(dec1)
 
 		d2 := types.NewDatum(decimalNums.Arg2)
-		dec2, err := d2.ToDecimal(sc.TypeCtxOrDefault())
+		dec2, err := d2.ToDecimal(typeCtx)
 		require.NoError(t, err)
 		d2.SetMysqlDecimal(dec2)
 
@@ -734,17 +730,17 @@ func TestDecimal(t *testing.T) {
 		d2.SetLength(30)
 		d2.SetFrac(6)
 
-		b1, err := EncodeKey(sc.TimeZone(), nil, d1)
+		b1, err := EncodeKey(typeCtx.Location(), nil, d1)
 		require.NoError(t, err)
-		b2, err := EncodeKey(sc.TimeZone(), nil, d2)
+		b2, err := EncodeKey(typeCtx.Location(), nil, d2)
 		require.NoError(t, err)
 
 		ret := bytes.Compare(b1, b2)
 		require.Equalf(t, decimalNums.Ret, ret, "%v %x %x", decimalNums, b1, b2)
 
-		b1, err = EncodeValue(sc.TimeZone(), b1[:0], d1)
+		b1, err = EncodeValue(typeCtx.Location(), b1[:0], d1)
 		require.NoError(t, err)
-		size, err := EstimateValueSize(sc.TypeCtx(), d1)
+		size, err := EstimateValueSize(typeCtx, d1)
 		require.NoError(t, err)
 		require.Len(t, b1, size)
 	}
@@ -761,7 +757,7 @@ func TestDecimal(t *testing.T) {
 		b, err := EncodeDecimal(nil, d.GetMysqlDecimal(), d.Length(), d.Frac())
 		require.NoError(t, err)
 		decs = append(decs, b)
-		size, err := EstimateValueSize(sc.TypeCtx(), d)
+		size, err := EstimateValueSize(typeCtx, d)
 		require.NoError(t, err)
 		// size - 1 because the flag occupy 1 bit.
 		require.Len(t, b, size-1)
@@ -778,19 +774,19 @@ func TestDecimal(t *testing.T) {
 	_, err = EncodeDecimal(nil, d, 12, 10)
 	require.Truef(t, terror.ErrorEqual(err, types.ErrOverflow), "err %v", err)
 
-	sc.SetTypeFlags(types.DefaultStmtFlags.WithIgnoreTruncateErr(true))
+	errCtx := errctx.StrictNoWarningContext.WithErrGroupLevel(errctx.ErrGroupTruncate, errctx.LevelIgnore)
 	decimalDatum := types.NewDatum(d)
 	decimalDatum.SetLength(20)
 	decimalDatum.SetFrac(5)
-	_, err = EncodeValue(sc.TimeZone(), nil, decimalDatum)
-	err = sc.HandleError(err)
+	_, err = EncodeValue(typeCtx.Location(), nil, decimalDatum)
+	err = errCtx.HandleError(err)
 	require.NoError(t, err)
 
-	sc.SetTypeFlags(types.DefaultStmtFlags.WithTruncateAsWarning(true))
+	errCtx = errctx.StrictNoWarningContext.WithErrGroupLevel(errctx.ErrGroupTruncate, errctx.LevelWarn)
 	decimalDatum.SetLength(12)
 	decimalDatum.SetFrac(10)
-	_, err = EncodeValue(sc.TimeZone(), nil, decimalDatum)
-	err = sc.HandleError(err)
+	_, err = EncodeValue(typeCtx.Location(), nil, decimalDatum)
+	err = errCtx.HandleError(err)
 	require.NoError(t, err)
 }
 
@@ -878,9 +874,8 @@ func TestCut(t *testing.T) {
 			types.MakeDatums(types.CreateBinaryJSON(types.Opaque{TypeCode: mysql.TypeString, Buf: []byte("abc")})),
 		},
 	}
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	for i, datums := range table {
-		b, err := EncodeKey(sc.TimeZone(), nil, datums.Input...)
+		b, err := EncodeKey(time.Local, nil, datums.Input...)
 		require.NoErrorf(t, err, "%d %v", i, datums)
 
 		var d []byte
@@ -889,7 +884,7 @@ func TestCut(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, d)
 
-			ed, err1 := EncodeKey(sc.TimeZone(), nil, e)
+			ed, err1 := EncodeKey(time.Local, nil, e)
 			require.NoError(t, err1)
 			require.Equalf(t, ed, d, "%d:%d %#v", i, j, e)
 		}
@@ -897,7 +892,7 @@ func TestCut(t *testing.T) {
 	}
 
 	for i, datums := range table {
-		b, err := EncodeValue(sc.TimeZone(), nil, datums.Input...)
+		b, err := EncodeValue(time.Local, nil, datums.Input...)
 		require.NoErrorf(t, err, "%d %v", i, datums)
 
 		var d []byte
@@ -906,7 +901,7 @@ func TestCut(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, d)
 
-			ed, err1 := EncodeValue(sc.TimeZone(), nil, e)
+			ed, err1 := EncodeValue(time.Local, nil, e)
 			require.NoError(t, err1)
 			require.Equalf(t, ed, d, "%d:%d %#v", i, j, e)
 		}
@@ -914,7 +909,7 @@ func TestCut(t *testing.T) {
 	}
 
 	input := 42
-	b, err := EncodeValue(sc.TimeZone(), nil, types.NewDatum(input))
+	b, err := EncodeValue(time.Local, nil, types.NewDatum(input))
 	require.NoError(t, err)
 	rem, n, err := CutColumnID(b)
 	require.NoError(t, err)
@@ -935,9 +930,8 @@ func TestCutOneError(t *testing.T) {
 }
 
 func TestSetRawValues(t *testing.T) {
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	datums := types.MakeDatums(1, "abc", 1.1, []byte("def"))
-	rowData, err := EncodeValue(sc.TimeZone(), nil, datums...)
+	rowData, err := EncodeValue(time.Local, nil, datums...)
 	require.NoError(t, err)
 
 	values := make([]types.Datum, 4)
@@ -946,17 +940,17 @@ func TestSetRawValues(t *testing.T) {
 
 	for i, rawVal := range values {
 		require.IsType(t, types.KindRaw, rawVal.Kind())
-		encoded, encodedErr := EncodeValue(sc.TimeZone(), nil, datums[i])
+		encoded, encodedErr := EncodeValue(time.Local, nil, datums[i])
 		require.NoError(t, encodedErr)
 		require.Equal(t, rawVal.GetBytes(), encoded)
 	}
 }
 
 func TestDecodeOneToChunk(t *testing.T) {
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
-	datums, tps := datumsForTest(sc)
+	typeCtx := types.DefaultStmtNoWarningContext.WithLocation(time.Local)
+	datums, tps := datumsForTest()
 	rowCount := 3
-	chk := chunkForTest(t, sc, datums, tps, rowCount)
+	chk := chunkForTest(t, typeCtx.Location(), datums, tps, rowCount)
 	for colIdx, tp := range tps {
 		for rowIdx := 0; rowIdx < rowCount; rowIdx++ {
 			got := chk.GetRow(rowIdx).GetDatum(colIdx, tp)
@@ -965,7 +959,7 @@ func TestDecodeOneToChunk(t *testing.T) {
 				require.True(t, expect.IsNull())
 			} else {
 				if got.Kind() != types.KindMysqlDecimal {
-					cmp, err := got.Compare(sc.TypeCtx(), &expect, collate.GetCollator(tp.GetCollate()))
+					cmp, err := got.Compare(typeCtx, &expect, collate.GetCollator(tp.GetCollate()))
 					require.NoError(t, err)
 					require.Equalf(t, 0, cmp, "expect: %v, got %v", expect, got)
 				} else {
@@ -977,7 +971,6 @@ func TestDecodeOneToChunk(t *testing.T) {
 }
 
 func TestHashGroup(t *testing.T) {
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	tp := types.NewFieldType(mysql.TypeNewDecimal)
 	tps := []*types.FieldType{tp}
 	chk1 := chunk.New(tps, 3, 3)
@@ -990,17 +983,17 @@ func TestHashGroup(t *testing.T) {
 	tp1 := tp
 	tp1.SetFlen(20)
 	tp1.SetDecimal(5)
-	_, err := HashGroupKey(sc.TimeZone(), 3, chk1.Column(0), buf1, tp1)
+	_, err := HashGroupKey(time.Local, 3, chk1.Column(0), buf1, tp1)
 	require.Error(t, err)
 
 	tp2 := tp
 	tp2.SetFlen(12)
 	tp2.SetDecimal(10)
-	_, err = HashGroupKey(sc.TimeZone(), 3, chk1.Column(0), buf1, tp2)
+	_, err = HashGroupKey(time.Local, 3, chk1.Column(0), buf1, tp2)
 	require.Error(t, err)
 }
 
-func datumsForTest(_ *stmtctx.StatementContext) ([]types.Datum, []*types.FieldType) {
+func datumsForTest() ([]types.Datum, []*types.FieldType) {
 	decType := types.NewFieldType(mysql.TypeNewDecimal)
 	decType.SetDecimal(2)
 	_tp1 := types.NewFieldType(mysql.TypeEnum)
@@ -1067,10 +1060,10 @@ func datumsForTest(_ *stmtctx.StatementContext) ([]types.Datum, []*types.FieldTy
 	return datums, tps
 }
 
-func chunkForTest(t *testing.T, sc *stmtctx.StatementContext, datums []types.Datum, tps []*types.FieldType, rowCount int) *chunk.Chunk {
-	decoder := NewDecoder(chunk.New(tps, 32, 32), sc.TimeZone())
+func chunkForTest(t *testing.T, tz *time.Location, datums []types.Datum, tps []*types.FieldType, rowCount int) *chunk.Chunk {
+	decoder := NewDecoder(chunk.New(tps, 32, 32), tz)
 	for rowIdx := 0; rowIdx < rowCount; rowIdx++ {
-		encoded, err := EncodeValue(sc.TimeZone(), nil, datums...)
+		encoded, err := EncodeValue(tz, nil, datums...)
 		require.NoError(t, err)
 		decoder.buf = make([]byte, 0, len(encoded))
 		for colIdx, tp := range tps {
@@ -1105,7 +1098,7 @@ func TestDecodeRange(t *testing.T) {
 }
 
 func testHashChunkRowEqual(t *testing.T, a, b any, equal bool) {
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
+	typeCtx := types.DefaultStmtNoWarningContext.WithLocation(time.Local)
 	buf1 := make([]byte, 1)
 	buf2 := make([]byte, 1)
 
@@ -1124,10 +1117,10 @@ func testHashChunkRowEqual(t *testing.T, a, b any, equal bool) {
 	chk2.AppendDatum(0, &d)
 
 	h := crc32.NewIEEE()
-	err1 := HashChunkRow(sc.TypeCtx(), h, chk1.GetRow(0), []*types.FieldType{tp1}, []int{0}, buf1)
+	err1 := HashChunkRow(typeCtx, h, chk1.GetRow(0), []*types.FieldType{tp1}, []int{0}, buf1)
 	sum1 := h.Sum32()
 	h.Reset()
-	err2 := HashChunkRow(sc.TypeCtx(), h, chk2.GetRow(0), []*types.FieldType{tp2}, []int{0}, buf2)
+	err2 := HashChunkRow(typeCtx, h, chk2.GetRow(0), []*types.FieldType{tp2}, []int{0}, buf2)
 	sum2 := h.Sum32()
 	require.NoError(t, err1)
 	require.NoError(t, err2)
@@ -1136,7 +1129,7 @@ func testHashChunkRowEqual(t *testing.T, a, b any, equal bool) {
 	} else {
 		require.NotEqual(t, sum2, sum1)
 	}
-	e, err := EqualChunkRow(sc.TypeCtx(),
+	e, err := EqualChunkRow(typeCtx,
 		chk1.GetRow(0), []*types.FieldType{tp1}, []int{0},
 		chk2.GetRow(0), []*types.FieldType{tp2}, []int{0})
 	require.NoError(t, err)
@@ -1148,26 +1141,26 @@ func testHashChunkRowEqual(t *testing.T, a, b any, equal bool) {
 }
 
 func TestHashChunkRow(t *testing.T) {
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
+	typeCtx := types.DefaultStmtNoWarningContext.WithLocation(time.Local)
 	buf := make([]byte, 1)
-	datums, tps := datumsForTest(sc)
-	chk := chunkForTest(t, sc, datums, tps, 1)
+	datums, tps := datumsForTest()
+	chk := chunkForTest(t, typeCtx.Location(), datums, tps, 1)
 
 	colIdx := make([]int, len(tps))
 	for i := 0; i < len(tps); i++ {
 		colIdx[i] = i
 	}
 	h := crc32.NewIEEE()
-	err1 := HashChunkRow(sc.TypeCtx(), h, chk.GetRow(0), tps, colIdx, buf)
+	err1 := HashChunkRow(typeCtx, h, chk.GetRow(0), tps, colIdx, buf)
 	sum1 := h.Sum32()
 	h.Reset()
-	err2 := HashChunkRow(sc.TypeCtx(), h, chk.GetRow(0), tps, colIdx, buf)
+	err2 := HashChunkRow(typeCtx, h, chk.GetRow(0), tps, colIdx, buf)
 	sum2 := h.Sum32()
 
 	require.NoError(t, err1)
 	require.NoError(t, err2)
 	require.Equal(t, sum2, sum1)
-	e, err := EqualChunkRow(sc.TypeCtx(),
+	e, err := EqualChunkRow(typeCtx,
 		chk.GetRow(0), tps, colIdx,
 		chk.GetRow(0), tps, colIdx)
 	require.NoError(t, err)
@@ -1236,10 +1229,10 @@ func TestValueSizeOfUnsignedInt(t *testing.T) {
 }
 
 func TestHashChunkColumns(t *testing.T) {
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
+	typeCtx := types.DefaultStmtNoWarningContext.WithLocation(time.Local)
 	buf := make([]byte, 1)
-	datums, tps := datumsForTest(sc)
-	chk := chunkForTest(t, sc, datums, tps, 4)
+	datums, tps := datumsForTest()
+	chk := chunkForTest(t, typeCtx.Location(), datums, tps, 4)
 
 	colIdx := make([]int, len(tps))
 	for i := 0; i < len(tps); i++ {
@@ -1257,10 +1250,10 @@ func TestHashChunkColumns(t *testing.T) {
 	// Test hash value of the first 12 `Null` columns
 	for i := 0; i < 12; i++ {
 		require.True(t, chk.GetRow(0).IsNull(i))
-		err1 := HashChunkSelected(sc.TypeCtx(), vecHash, chk, tps[i], i, buf, hasNull, sel, false)
-		err2 := HashChunkRow(sc.TypeCtx(), rowHash[0], chk.GetRow(0), tps[i:i+1], colIdx[i:i+1], buf)
-		err3 := HashChunkRow(sc.TypeCtx(), rowHash[1], chk.GetRow(1), tps[i:i+1], colIdx[i:i+1], buf)
-		err4 := HashChunkRow(sc.TypeCtx(), rowHash[2], chk.GetRow(2), tps[i:i+1], colIdx[i:i+1], buf)
+		err1 := HashChunkSelected(typeCtx, vecHash, chk, tps[i], i, buf, hasNull, sel, false)
+		err2 := HashChunkRow(typeCtx, rowHash[0], chk.GetRow(0), tps[i:i+1], colIdx[i:i+1], buf)
+		err3 := HashChunkRow(typeCtx, rowHash[1], chk.GetRow(1), tps[i:i+1], colIdx[i:i+1], buf)
+		err4 := HashChunkRow(typeCtx, rowHash[2], chk.GetRow(2), tps[i:i+1], colIdx[i:i+1], buf)
 		require.NoError(t, err1)
 		require.NoError(t, err2)
 		require.NoError(t, err3)
@@ -1282,10 +1275,10 @@ func TestHashChunkColumns(t *testing.T) {
 
 		require.False(t, chk.GetRow(0).IsNull(i))
 
-		err1 := HashChunkSelected(sc.TypeCtx(), vecHash, chk, tps[i], i, buf, hasNull, sel, false)
-		err2 := HashChunkRow(sc.TypeCtx(), rowHash[0], chk.GetRow(0), tps[i:i+1], colIdx[i:i+1], buf)
-		err3 := HashChunkRow(sc.TypeCtx(), rowHash[1], chk.GetRow(1), tps[i:i+1], colIdx[i:i+1], buf)
-		err4 := HashChunkRow(sc.TypeCtx(), rowHash[2], chk.GetRow(2), tps[i:i+1], colIdx[i:i+1], buf)
+		err1 := HashChunkSelected(typeCtx, vecHash, chk, tps[i], i, buf, hasNull, sel, false)
+		err2 := HashChunkRow(typeCtx, rowHash[0], chk.GetRow(0), tps[i:i+1], colIdx[i:i+1], buf)
+		err3 := HashChunkRow(typeCtx, rowHash[1], chk.GetRow(1), tps[i:i+1], colIdx[i:i+1], buf)
+		err4 := HashChunkRow(typeCtx, rowHash[2], chk.GetRow(2), tps[i:i+1], colIdx[i:i+1], buf)
 
 		require.NoError(t, err1)
 		require.NoError(t, err2)

--- a/pkg/util/codec/collation_test.go
+++ b/pkg/util/codec/collation_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/stretchr/testify/require"
@@ -45,17 +44,16 @@ func prepareCollationData() (int, *chunk.Chunk, *chunk.Chunk) {
 }
 
 func TestHashGroupKeyCollation(t *testing.T) {
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
 	tp := types.NewFieldType(mysql.TypeString)
 	n, chk1, chk2 := prepareCollationData()
 
 	tp.SetCollate("utf8_general_ci")
 	buf1 := make([][]byte, n)
 	buf2 := make([][]byte, n)
-	buf1, err := HashGroupKey(sc.TimeZone(), n, chk1.Column(0), buf1, tp)
+	buf1, err := HashGroupKey(time.Local, n, chk1.Column(0), buf1, tp)
 	require.NoError(t, err)
 
-	buf2, err = HashGroupKey(sc.TimeZone(), n, chk2.Column(0), buf2, tp)
+	buf2, err = HashGroupKey(time.Local, n, chk2.Column(0), buf2, tp)
 	require.NoError(t, err)
 
 	for i := 0; i < n; i++ {
@@ -68,9 +66,9 @@ func TestHashGroupKeyCollation(t *testing.T) {
 	tp.SetCollate("utf8_unicode_ci")
 	buf1 = make([][]byte, n)
 	buf2 = make([][]byte, n)
-	buf1, err = HashGroupKey(sc.TimeZone(), n, chk1.Column(0), buf1, tp)
+	buf1, err = HashGroupKey(time.Local, n, chk1.Column(0), buf1, tp)
 	require.NoError(t, err)
-	buf2, err = HashGroupKey(sc.TimeZone(), n, chk2.Column(0), buf2, tp)
+	buf2, err = HashGroupKey(time.Local, n, chk2.Column(0), buf2, tp)
 	require.NoError(t, err)
 
 	for i := 0; i < n; i++ {
@@ -82,7 +80,7 @@ func TestHashGroupKeyCollation(t *testing.T) {
 }
 
 func TestHashChunkRowCollation(t *testing.T) {
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
+	typeCtx := types.DefaultStmtNoWarningContext.WithLocation(time.Local)
 	tp := types.NewFieldType(mysql.TypeString)
 	tps := []*types.FieldType{tp}
 	n, chk1, chk2 := prepareCollationData()
@@ -93,8 +91,8 @@ func TestHashChunkRowCollation(t *testing.T) {
 	for i := 0; i < n; i++ {
 		h1 := crc32.NewIEEE()
 		h2 := crc32.NewIEEE()
-		require.NoError(t, HashChunkRow(sc.TypeCtx(), h1, chk1.GetRow(i), tps, cols, buf))
-		require.NoError(t, HashChunkRow(sc.TypeCtx(), h2, chk2.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(typeCtx, h1, chk1.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(typeCtx, h2, chk2.GetRow(i), tps, cols, buf))
 		require.NotEqual(t, h2.Sum32(), h1.Sum32())
 		h1.Reset()
 		h2.Reset()
@@ -104,8 +102,8 @@ func TestHashChunkRowCollation(t *testing.T) {
 	for i := 0; i < n; i++ {
 		h1 := crc32.NewIEEE()
 		h2 := crc32.NewIEEE()
-		require.NoError(t, HashChunkRow(sc.TypeCtx(), h1, chk1.GetRow(i), tps, cols, buf))
-		require.NoError(t, HashChunkRow(sc.TypeCtx(), h2, chk2.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(typeCtx, h1, chk1.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(typeCtx, h2, chk2.GetRow(i), tps, cols, buf))
 		require.Equal(t, h2.Sum32(), h1.Sum32())
 		h1.Reset()
 		h2.Reset()
@@ -115,8 +113,8 @@ func TestHashChunkRowCollation(t *testing.T) {
 	for i := 0; i < n; i++ {
 		h1 := crc32.NewIEEE()
 		h2 := crc32.NewIEEE()
-		require.NoError(t, HashChunkRow(sc.TypeCtx(), h1, chk1.GetRow(i), tps, cols, buf))
-		require.NoError(t, HashChunkRow(sc.TypeCtx(), h2, chk2.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(typeCtx, h1, chk1.GetRow(i), tps, cols, buf))
+		require.NoError(t, HashChunkRow(typeCtx, h2, chk2.GetRow(i), tps, cols, buf))
 		require.Equal(t, h2.Sum32(), h1.Sum32())
 		h1.Reset()
 		h2.Reset()
@@ -124,7 +122,7 @@ func TestHashChunkRowCollation(t *testing.T) {
 }
 
 func TestHashChunkColumnsCollation(t *testing.T) {
-	sc := stmtctx.NewStmtCtxWithTimeZone(time.Local)
+	typeCtx := types.DefaultStmtNoWarningContext.WithLocation(time.Local)
 	tp := types.NewFieldType(mysql.TypeString)
 	n, chk1, chk2 := prepareCollationData()
 	buf := make([]byte, 1)
@@ -133,8 +131,8 @@ func TestHashChunkColumnsCollation(t *testing.T) {
 	h2s := []hash.Hash64{fnv.New64(), fnv.New64(), fnv.New64()}
 
 	tp.SetCollate("binary")
-	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h1s, chk1, tp, 0, buf, hasNull))
-	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h2s, chk2, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(typeCtx, h1s, chk1, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(typeCtx, h2s, chk2, tp, 0, buf, hasNull))
 
 	for i := 0; i < n; i++ {
 		require.NotEqual(t, h2s[i].Sum64(), h1s[i].Sum64())
@@ -143,15 +141,15 @@ func TestHashChunkColumnsCollation(t *testing.T) {
 	}
 
 	tp.SetCollate("utf8_general_ci")
-	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h1s, chk1, tp, 0, buf, hasNull))
-	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h2s, chk2, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(typeCtx, h1s, chk1, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(typeCtx, h2s, chk2, tp, 0, buf, hasNull))
 	for i := 0; i < n; i++ {
 		require.Equal(t, h2s[i].Sum64(), h1s[i].Sum64())
 	}
 
 	tp.SetCollate("utf8_unicode_ci")
-	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h1s, chk1, tp, 0, buf, hasNull))
-	require.NoError(t, HashChunkColumns(sc.TypeCtx(), h2s, chk2, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(typeCtx, h1s, chk1, tp, 0, buf, hasNull))
+	require.NoError(t, HashChunkColumns(typeCtx, h2s, chk2, tp, 0, buf, hasNull))
 	for i := 0; i < n; i++ {
 		require.Equal(t, h2s[i].Sum64(), h1s[i].Sum64())
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51743

Problem Summary:

### What changed and how does it work?

Replace the `stmtctx` with `*time.Location` or `types.Context`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > Only tests are modified

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
