### PR TITLE
infoschema: support rename table for infoschema v2

### DIFF
--- a/pkg/infoschema/builder.go
+++ b/pkg/infoschema/builder.go
@@ -766,7 +766,6 @@ func (b *Builder) deleteReferredForeignKeys(dbInfo *model.DBInfo, tableID int64)
 func (b *Builder) Build(schemaTS uint64) InfoSchema {
 	if b.enableV2 {
 		b.infoschemaV2.ts = schemaTS
-		b.infoschemaV2.schemaVersion = b.infoSchema.SchemaMetaVersion()
 		updateInfoSchemaBundles(b)
 		return &b.infoschemaV2
 	}
@@ -782,12 +781,10 @@ func (b *Builder) InitWithOldInfoSchema(oldSchema InfoSchema) (*Builder, error) 
 		return nil, errors.New("builder's infoschema mismatch, return error to trigger full reload")
 	}
 
-	var oldIS *infoSchema
 	if schemaV2, ok := oldSchema.(*infoschemaV2); ok {
-		oldIS = schemaV2.infoSchema
-	} else {
-		oldIS = oldSchema.(*infoSchema)
+		b.infoschemaV2.ts = schemaV2.ts
 	}
+	oldIS := oldSchema.base()
 	b.initBundleInfoBuilder()
 	b.infoSchema.schemaMetaVersion = oldIS.schemaMetaVersion
 	b.copySchemasMap(oldIS)

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -59,12 +59,12 @@ type infoSchema struct {
 
 	// sortedTablesBuckets is a slice of sortedTables, a table's bucket index is (tableID % bucketCount).
 	sortedTablesBuckets []sortedTables
-
-	// schemaMetaVersion is the version of schema, and we should check version when change schema.
-	schemaMetaVersion int64
 }
 
 type infoSchemaMisc struct {
+	// schemaMetaVersion is the version of schema, and we should check version when change schema.
+	schemaMetaVersion int64
+
 	// ruleBundleMap stores all placement rules
 	ruleBundleMap map[int64]*placement.Bundle
 
@@ -161,10 +161,6 @@ func (is *infoSchema) SchemaByName(schema model.CIStr) (val *model.DBInfo, ok bo
 		return
 	}
 	return tableNames.dbInfo, true
-}
-
-func (is *infoSchema) SchemaMetaVersion() int64 {
-	return is.schemaMetaVersion
 }
 
 func (is *infoSchema) SchemaExists(schema model.CIStr) bool {
@@ -310,6 +306,10 @@ func (is *infoSchema) FindTableByPartitionID(partitionID int64) (table.Table, *m
 // HasTemporaryTable returns whether information schema has temporary table
 func (is *infoSchemaMisc) HasTemporaryTable() bool {
 	return len(is.temporaryTableIDs) != 0
+}
+
+func (is *infoSchemaMisc) SchemaMetaVersion() int64 {
+	return is.schemaMetaVersion
 }
 
 // GetSequenceByName gets the sequence by name.

--- a/pkg/infoschema/infoschema_test.go
+++ b/pkg/infoschema/infoschema_test.go
@@ -101,7 +101,7 @@ func TestBasic(t *testing.T) {
 	dbInfos := []*model.DBInfo{dbInfo}
 	internal.AddDB(t, re.Store(), dbInfo)
 
-	builder, err := infoschema.NewBuilder(re, nil, nil).InitWithDBInfos(dbInfos, nil, nil, 1)
+	builder, err := infoschema.NewBuilder(re, nil, infoschema.NewData()).InitWithDBInfos(dbInfos, nil, nil, 1)
 	require.NoError(t, err)
 
 	txn, err := re.Store().Begin()

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -41,6 +41,7 @@ type tableItem struct {
 	tableName     string
 	tableID       int64
 	schemaVersion int64
+	tomb          bool
 }
 
 type schemaItem struct {
@@ -163,6 +164,8 @@ func (isd *Data) addDB(schemaVersion int64, dbInfo *model.DBInfo) {
 }
 
 func (isd *Data) remove(item tableItem) {
+	item.tomb = true
+	isd.byName.Set(item)
 	isd.tableCache.Remove(tableCacheKey{item.tableID, item.schemaVersion})
 }
 
@@ -235,10 +238,9 @@ func compareSchemaItem(a, b schemaItem) bool {
 var _ InfoSchema = &infoschemaV2{}
 
 type infoschemaV2 struct {
-	*infoSchema   // in fact, we only need the infoSchemaMisc inside it, but the builder rely on it.
-	r             autoid.Requirement
-	ts            uint64
-	schemaVersion int64
+	*infoSchema // in fact, we only need the infoSchemaMisc inside it, but the builder rely on it.
+	r           autoid.Requirement
+	ts          uint64
 	*Data
 }
 
@@ -284,6 +286,10 @@ func search(bt *btree.BTreeG[tableItem], schemaVersion int64, end tableItem, mat
 		}
 		return true
 	})
+	if ok && target.tomb {
+		// If the item is a tomb record, the table is dropped.
+		ok = false
+	}
 	return target, ok
 }
 
@@ -293,14 +299,14 @@ func (is *infoschemaV2) base() *infoSchema {
 
 func (is *infoschemaV2) TableByID(id int64) (val table.Table, ok bool) {
 	// Get from the cache.
-	key := tableCacheKey{id, is.schemaVersion}
+	key := tableCacheKey{id, is.infoSchema.schemaMetaVersion}
 	tbl, found := is.tableCache.Get(key)
 	if found && tbl != nil {
 		return tbl, true
 	}
 
 	eq := func(a, b *tableItem) bool { return a.tableID == b.tableID }
-	itm, ok := search(is.byID, is.schemaVersion, tableItem{tableID: id, dbID: math.MaxInt64}, eq)
+	itm, ok := search(is.byID, is.infoSchema.schemaMetaVersion, tableItem{tableID: id, dbID: math.MaxInt64}, eq)
 	if !ok {
 		// TODO: in the future, this may happen and we need to check tikv to see whether table exists.
 		return nil, false
@@ -315,7 +321,7 @@ func (is *infoschemaV2) TableByID(id int64) (val table.Table, ok bool) {
 	}
 
 	// Maybe the table is evicted? need to reload.
-	ret, err := loadTableInfo(is.r, is.Data, id, itm.dbID, is.ts, is.schemaVersion)
+	ret, err := loadTableInfo(is.r, is.Data, id, itm.dbID, is.ts, is.infoSchema.schemaMetaVersion)
 	if err != nil || ret == nil {
 		return nil, false
 	}
@@ -341,21 +347,21 @@ func (is *infoschemaV2) TableByName(schema, tbl model.CIStr) (t table.Table, err
 	}
 
 	eq := func(a, b *tableItem) bool { return a.dbName == b.dbName && a.tableName == b.tableName }
-	itm, ok := search(is.byName, is.schemaVersion, tableItem{dbName: schema.L, tableName: tbl.L, tableID: math.MaxInt64}, eq)
+	itm, ok := search(is.byName, is.infoSchema.schemaMetaVersion, tableItem{dbName: schema.L, tableName: tbl.L, tableID: math.MaxInt64}, eq)
 	if !ok {
 		// TODO: in the future, this may happen and we need to check tikv to see whether table exists.
 		return nil, ErrTableNotExists.GenWithStackByArgs(schema, tbl)
 	}
 
 	// Get from the cache.
-	key := tableCacheKey{itm.tableID, is.schemaVersion}
+	key := tableCacheKey{itm.tableID, is.infoSchema.schemaMetaVersion}
 	res, found := is.tableCache.Get(key)
 	if found && res != nil {
 		return res, nil
 	}
 
 	// Maybe the table is evicted? need to reload.
-	ret, err := loadTableInfo(is.r, is.Data, itm.tableID, itm.dbID, is.ts, is.schemaVersion)
+	ret, err := loadTableInfo(is.r, is.Data, itm.tableID, itm.dbID, is.ts, is.infoSchema.schemaMetaVersion)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -375,7 +381,7 @@ func (is *infoschemaV2) SchemaByName(schema model.CIStr) (val *model.DBInfo, ok 
 			ok = false
 			return false
 		}
-		if item.schemaVersion <= is.schemaVersion {
+		if item.schemaVersion <= is.infoSchema.schemaMetaVersion {
 			ok = true
 			val = item.dbInfo
 			return false
@@ -407,10 +413,6 @@ func (is *infoschemaV2) AllSchemaNames() []model.CIStr {
 		rs = append(rs, sc.dbInfo.Name)
 	}
 	return rs
-}
-
-func (is *infoschemaV2) SchemaMetaVersion() int64 {
-	return is.schemaVersion
 }
 
 func (is *infoschemaV2) SchemaExists(schema model.CIStr) bool {
@@ -698,7 +700,6 @@ func (b *Builder) applyDropTableV2(diff *model.SchemaDiff, dbInfo *model.DBInfo,
 	}
 
 	table, ok := b.infoschemaV2.TableByID(tableID)
-
 	if !ok {
 		return nil
 	}

--- a/pkg/infoschema/infoschema_v2_test.go
+++ b/pkg/infoschema/infoschema_v2_test.go
@@ -39,13 +39,13 @@ func TestV2Basic(t *testing.T) {
 	is.Data.addDB(1, dbInfo)
 	internal.AddDB(t, r.Store(), dbInfo)
 	tblInfo := internal.MockTableInfo(t, r.Store(), tableName.O)
-	is.Data.add(tableItem{schemaName.L, dbInfo.ID, tableName.L, tblInfo.ID, 2}, internal.MockTable(t, r.Store(), tblInfo))
+	is.Data.add(tableItem{schemaName.L, dbInfo.ID, tableName.L, tblInfo.ID, 2, false}, internal.MockTable(t, r.Store(), tblInfo))
 	internal.AddTable(t, r.Store(), dbInfo, tblInfo)
 	require.Equal(t, 1, len(is.AllSchemas()))
 	require.Equal(t, 0, len(is.SchemaTables(is.AllSchemas()[0].Name)))
 	ver, err := r.Store().CurrentVersion(kv.GlobalTxnScope)
 	require.NoError(t, err)
-	is.schemaVersion = 2
+	is.base().schemaMetaVersion = 2
 	is.ts = ver.Ver
 	require.Equal(t, 1, len(is.AllSchemas()))
 	require.Equal(t, 1, len(is.SchemaTables(is.AllSchemas()[0].Name)))

--- a/tests/integrationtest/r/infoschema/v2.result
+++ b/tests/integrationtest/r/infoschema/v2.result
@@ -1,0 +1,15 @@
+set @@global.tidb_schema_cache_size = 1024;
+use infoschema__v2;
+drop table if exists t1;
+create table t1 (id int);
+rename table t1 to t2;
+show tables;
+Tables_in_infoschema__v2
+t2
+select * from t2;
+id
+select * from t1;
+Error 1146 (42S02): Table 'infoschema__v2.t1' doesn't exist
+show create table t1;
+Error 1146 (42S02): Table 'infoschema__v2.t1' doesn't exist
+set @@global.tidb_schema_cache_size = default;

--- a/tests/integrationtest/t/infoschema/v2.test
+++ b/tests/integrationtest/t/infoschema/v2.test
@@ -1,0 +1,16 @@
+set @@global.tidb_schema_cache_size = 1024;
+
+# TestRenameTable
+use infoschema__v2;
+drop table if exists t1;
+create table t1 (id int);
+rename table t1 to t2;
+show tables;
+select * from t2;
+-- error 1146
+select * from t1;
+-- error 1146
+show create table t1;
+
+
+set @@global.tidb_schema_cache_size = default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50959 

Problem Summary:

### What changed and how does it work?

Before this fix, this would fail:

```
create table t1 (id int);
rename table t1 to t2;
show create table t1;   // expect error, but not get error
```

Changes:
- now drop table will add tomb record to infoschemaV2's byName field
-  `schemaVersion` field is moved to `infoschemaMisc` because both v1 and v2 use it 


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test
- [X] Manual test (add detailed scripts or steps below)

```
diff --git a/pkg/sessionctx/variable/tidb_vars.go b/pkg/sessionctx/variable/tidb_vars.go
index d655384bfb..7e0bef66e7 100644
--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1482,7 +1482,7 @@ const (
        DefTiDBIdleTransactionTimeout                     = 0
        DefEnableParallelSort                             = false
        DefTiDBTxnEntrySizeLimit                          = 0
-       DefTiDBSchemaCacheSize                            = 0
+       DefTiDBSchemaCacheSize                            = 1024
        DefTiDBLowResolutionTSOUpdateInterval             = 2000
        DefTiDBDMLType                                    = "STANDARD"
 )
```

```
make ut X='run pkg/executor' 1>a.log 2>b.log
grep FAIL a.log |wc -l
```

After this PR, we have only 5 failed... (the number is 12 before)

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
