### PR TITLE
ddl: fix add index's merge with multi-schema optimization

### DIFF
--- a/pkg/ddl/index_merge_tmp.go
+++ b/pkg/ddl/index_merge_tmp.go
@@ -163,9 +163,13 @@ func (w *mergeIndexWorker) validateTaskRange(taskRange *reorgBackfillTask) (skip
 	containsTargetID := false
 	for _, idx := range w.indexes {
 		idxInfo := idx.Meta()
-		if idxInfo.ID == startIndexID || idxInfo.ID == endIndexID {
+		if idxInfo.ID == startIndexID {
 			containsTargetID = true
+			w.currentIndex = idxInfo
 			break
+		}
+		if idxInfo.ID == endIndexID {
+			containsTargetID = true
 		}
 	}
 	return !containsTargetID, nil

--- a/pkg/ddl/ingest/BUILD.bazel
+++ b/pkg/ddl/ingest/BUILD.bazel
@@ -68,7 +68,7 @@ go_test(
     embed = [":ingest"],
     flaky = True,
     race = "on",
-    shard_count = 16,
+    shard_count = 17,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -706,7 +706,10 @@ func getReorgInfo(ctx *JobContext, d *ddlCtx, rh *reorgHandler, job *model.Job, 
 			tb = tbl.(table.PhysicalTable)
 		}
 		if mergingTmpIdx {
-			start, end = tablecodec.GetTableIndexKeyRange(pid, tablecodec.TempIndexPrefix|elements[0].ID)
+			firstElemTempID := tablecodec.TempIndexPrefix | elements[0].ID
+			lastElemTempID := tablecodec.TempIndexPrefix | elements[len(elements)-1].ID
+			start = tablecodec.EncodeIndexSeekKey(pid, firstElemTempID, nil)
+			end = tablecodec.EncodeIndexSeekKey(pid, lastElemTempID, []byte{255})
 		} else {
 			start, end, err = getTableRange(ctx, d, tb, ver.Ver, job.Priority)
 			if err != nil {

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -58,6 +58,7 @@ const (
 	prefixLen = 1 + idLen /*tableID*/ + 2
 	// RecordRowKeyLen is public for calculating average row size.
 	RecordRowKeyLen       = prefixLen + idLen /*handle*/
+	IndexKeyLen           = prefixLen + idLen
 	tablePrefixLength     = 1
 	recordPrefixSepLength = 2
 	metaPrefixLength      = 1
@@ -104,11 +105,6 @@ func EncodeRowKeyWithHandle(tableID int64, handle kv.Handle) kv.Key {
 // CutRowKeyPrefix cuts the row key prefix.
 func CutRowKeyPrefix(key kv.Key) []byte {
 	return key[prefixLen:]
-}
-
-// CutIndexKeyPrefix cuts the index key prefix.
-func CutIndexKeyPrefix(key kv.Key) []byte {
-	return key[len(tablePrefix)+8+len(indexPrefixSep):]
 }
 
 // EncodeRecordKey encodes the recordPrefix, row handle into a kv.Key.

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -58,7 +58,6 @@ const (
 	prefixLen = 1 + idLen /*tableID*/ + 2
 	// RecordRowKeyLen is public for calculating average row size.
 	RecordRowKeyLen       = prefixLen + idLen /*handle*/
-	IndexKeyLen           = prefixLen + idLen
 	tablePrefixLength     = 1
 	recordPrefixSepLength = 2
 	metaPrefixLength      = 1

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -106,6 +106,11 @@ func CutRowKeyPrefix(key kv.Key) []byte {
 	return key[prefixLen:]
 }
 
+// CutIndexKeyPrefix cuts the index key prefix.
+func CutIndexKeyPrefix(key kv.Key) []byte {
+	return key[len(tablePrefix)+8+len(indexPrefixSep):]
+}
+
 // EncodeRecordKey encodes the recordPrefix, row handle into a kv.Key.
 func EncodeRecordKey(recordPrefix kv.Key, h kv.Handle) kv.Key {
 	buf := make([]byte, 0, len(recordPrefix)+h.Len())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51746

Problem Summary:

The bug is introduced by #47135: when merging temp index records from multiple indexes, I didn't set `reorgInfo`'s `StartKey` and `EndKey`  correctly. As a result, only one temp index get merged.

### What changed and how does it work?

This PR initializes `reorgInfo.Start` and `reorgInfo.End` with keys encoded by the first index ID and the last index ID.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
