### PR TITLE
planner: fix the issue about simplify outer join to inner join | tidb-test=pr/2313

### DIFF
--- a/pkg/planner/core/rule_predicate_push_down.go
+++ b/pkg/planner/core/rule_predicate_push_down.go
@@ -395,14 +395,6 @@ func simplifyOuterJoin(p *LogicalJoin, predicates []expression.Expression) {
 		innerTable, outerTable = outerTable, innerTable
 	}
 
-	// first simplify embedded outer join.
-	if innerPlan, ok := innerTable.(*LogicalJoin); ok {
-		simplifyOuterJoin(innerPlan, predicates)
-	}
-	if outerPlan, ok := outerTable.(*LogicalJoin); ok {
-		simplifyOuterJoin(outerPlan, predicates)
-	}
-
 	if p.JoinType == InnerJoin {
 		return
 	}

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -335,3 +335,28 @@ id	value
 3	0
 4	4
 5	5
+create table A(a int primary key, b int);
+create table B(b int primary key);
+create table C(c int primary key, b int);
+insert into A values (2, 1), (3, 2);
+insert into B values (1), (2);
+select b.b
+from A a
+left join (
+B b
+left join C c on b.b = c.b)
+on b.b = a.b
+where a.a in (2, 3);
+b
+1
+2
+select b.b
+from A a
+left join (
+B b
+left join C c on b.b = c.b)
+on b.b = a.b
+where a.a in (2, 3, null);
+b
+1
+2

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -186,3 +186,29 @@ where test2.id in
   select * from v1
 );
 select * from test2;
+
+# https://github.com/pingcap/tidb/issues/51560
+create table A(a int primary key, b int);
+create table B(b int primary key);
+create table C(c int primary key, b int);
+
+insert into A values (2, 1), (3, 2);
+insert into B values (1), (2);
+
+# Returns data as expected
+select b.b
+from A a
+left join (
+  B b
+  left join C c on b.b = c.b)
+on b.b = a.b
+where a.a in (2, 3);
+
+# Returns the same.
+select b.b
+from A a
+left join (
+  B b
+  left join C c on b.b = c.b)
+on b.b = a.b
+where a.a in (2, 3, null);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51560 

Problem Summary:

The original codes will push the predicates that are not related to that child.

### What changed and how does it work?

Don't do the recursively. Let the predicate-push-down to do the recursively.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
