### PR TITLE
planner: output a SQL warning if binding loading is triggered

### DIFF
--- a/pkg/bindinfo/tests/timeout/BUILD.bazel
+++ b/pkg/bindinfo/tests/timeout/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//pkg/bindinfo",
         "//pkg/testkit",
         "//pkg/testkit/testsetup",
+        "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -1,5 +1,4 @@
 set tidb_cost_model_version=2;
-delete from mysql.bind_info;
 drop table if exists t;
 create table t(a varchar(10), b int, c int);
 show columns from t where true;
@@ -306,54 +305,6 @@ c2	c0
 0	0
 1	1
 0	1
-drop table if exists t;
-create table t(a int, b int, unique index i_a (a) invisible, unique index i_b(b));
-insert into t values (1,2);
-admin check table t;
-select a from t order by a;
-a
-1
-explain select a from t order by a;
-id	estRows	task	access object	operator info
-Sort_4	10000.00	root		planner__core__integration.t.a
-└─TableReader_8	10000.00	root		data:TableFullScan_7
-  └─TableFullScan_7	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-select a from t where a > 0;
-a
-1
-explain select a from t where a > 1;
-id	estRows	task	access object	operator info
-TableReader_7	3333.33	root		data:Selection_6
-└─Selection_6	3333.33	cop[tikv]		gt(planner__core__integration.t.a, 1)
-  └─TableFullScan_5	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-select * from t use index(i_a);
-Error 1176 (42000): Key 'i_a' doesn't exist in table 't'
-select * from t force index(i_a);
-Error 1176 (42000): Key 'i_a' doesn't exist in table 't'
-select * from t ignore index(i_a);
-Error 1176 (42000): Key 'i_a' doesn't exist in table 't'
-select /*+ USE_INDEX(t, i_a) */ * from t;
-a	b
-1	2
-Level	Code	Message
-Warning	1176	Key 'i_a' doesn't exist in table 't'
-select /*+ IGNORE_INDEX(t, i_a), USE_INDEX(t, i_b) */ a from t order by a;
-a
-1
-Level	Code	Message
-Warning	1176	Key 'i_a' doesn't exist in table 't'
-select /*+ FORCE_INDEX(t, i_a), USE_INDEX(t, i_b) */ a from t order by a;
-a
-1
-Level	Code	Message
-Warning	1176	Key 'i_a' doesn't exist in table 't'
-select /*+ FORCE_INDEX(aaa) */ * from t;
-a	b
-1	2
-Level	Code	Message
-Warning	1815	force_index(planner__core__integration.aaa) is inapplicable, check whether the table(planner__core__integration.aaa) exists
-admin check table t;
-admin check index t i_a;
 select max(t.col) from (select 'a' as col union all select '' as col) as t;
 max(t.col)
 a

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -1,4 +1,5 @@
 set tidb_cost_model_version=2;
+delete from mysql.bind_info;
 drop table if exists t;
 create table t(a varchar(10), b int, c int);
 show columns from t where true;

--- a/tests/integrationtest/t/planner/core/integration.test
+++ b/tests/integrationtest/t/planner/core/integration.test
@@ -1,6 +1,5 @@
 # TestShowSubquery
 set tidb_cost_model_version=2;
-delete from mysql.bind_info;
 drop table if exists t;
 create table t(a varchar(10), b int, c int);
 show columns from t where true;
@@ -233,31 +232,6 @@ INSERT INTO t1 VALUES (true, true);
 CREATE definer='root'@'localhost'  VIEW v0(c0, c1, c2) AS SELECT t1.c0, LOG10(t0.c0), t1.c0 FROM t0, t1;
 INSERT INTO t0(c0) VALUES (3);
 SELECT /*+ MERGE_JOIN(t1, t0, v0)*/v0.c2, t1.c0 FROM v0,  t0 CROSS JOIN t1 ORDER BY -v0.c1;
-
-
-# TestInvisibleIndex
-drop table if exists t;
-create table t(a int, b int, unique index i_a (a) invisible, unique index i_b(b));
-insert into t values (1,2);
-admin check table t;
-select a from t order by a;
-explain select a from t order by a;
-select a from t where a > 0;
-explain select a from t where a > 1;
---error 1176
-select * from t use index(i_a);
---error 1176
-select * from t force index(i_a);
---error 1176
-select * from t ignore index(i_a);
---enable_warnings
-select /*+ USE_INDEX(t, i_a) */ * from t;
-select /*+ IGNORE_INDEX(t, i_a), USE_INDEX(t, i_b) */ a from t order by a;
-select /*+ FORCE_INDEX(t, i_a), USE_INDEX(t, i_b) */ a from t order by a;
-select /*+ FORCE_INDEX(aaa) */ * from t;
---disable_warnings
-admin check table t;
-admin check index t i_a;
 
 
 # TestTopNByConstFunc

--- a/tests/integrationtest/t/planner/core/integration.test
+++ b/tests/integrationtest/t/planner/core/integration.test
@@ -1,5 +1,6 @@
 # TestShowSubquery
 set tidb_cost_model_version=2;
+delete from mysql.bind_info;
 drop table if exists t;
 create table t(a varchar(10), b int, c int);
 show columns from t where true;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #51347

Problem Summary: planner: output a SQL warning if binding loading is triggered

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
