### PR TITLE
restore: backpressure the importer producer goroutine

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1546,7 +1546,13 @@ LOOPFORTABLE:
 				return nil
 			}
 			if rc.granularity == string(CoarseGrained) {
+				rc.fileImporter.cond.L.Lock()
+				for rc.fileImporter.IsFull() {
+					// wait for download worker notified
+					rc.fileImporter.cond.Wait()
+				}
 				eg.Go(restoreFn)
+				rc.fileImporter.cond.L.Unlock()
 			} else {
 				// if we are not use coarse granularity which means
 				// we still pipeline split & scatter regions and import sst files

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -539,7 +539,6 @@ func (rc *Client) SetStorage(ctx context.Context, backend *backuppb.StorageBacke
 }
 
 func (rc *Client) InitClients(ctx context.Context, backend *backuppb.StorageBackend, isRawKvMode bool, isTxnKvMode bool) {
-	storeWorkerPoolMap := make(map[uint64]chan struct{})
 	stores, err := conn.GetAllTiKVStoresWithRetry(ctx, rc.pdClient, util.SkipTiFlash)
 	if err != nil {
 		log.Fatal("failed to get stores", zap.Error(err))
@@ -552,15 +551,11 @@ func (rc *Client) InitClients(ctx context.Context, backend *backuppb.StorageBack
 		// ToDo remove it when token bucket is stable enough.
 		log.Info("use token bucket to control download and ingest flow")
 		useTokenBucket = true
-		for _, store := range stores {
-			ch := utils.BuildWorkerTokenChannel(concurrencyPerStore)
-			storeWorkerPoolMap[store.Id] = ch
-		}
 	}
 
 	metaClient := split.NewSplitClient(rc.pdClient, rc.pdHTTPClient, rc.tlsConf, isRawKvMode)
 	importCli := NewImportClient(metaClient, rc.tlsConf, rc.keepaliveConf)
-	rc.fileImporter = NewFileImporter(metaClient, importCli, backend, isRawKvMode, isTxnKvMode, storeWorkerPoolMap, rc.rewriteMode, concurrencyPerStore, useTokenBucket)
+	rc.fileImporter = NewFileImporter(metaClient, importCli, backend, isRawKvMode, isTxnKvMode, stores, rc.rewriteMode, concurrencyPerStore, useTokenBucket)
 }
 
 func (rc *Client) SetRawKVClient(c *RawKVBatchClient) {
@@ -1547,7 +1542,7 @@ LOOPFORTABLE:
 			}
 			if rc.granularity == string(CoarseGrained) {
 				rc.fileImporter.cond.L.Lock()
-				for rc.fileImporter.IsFull() {
+				for rc.fileImporter.ShouldBlock() {
 					// wait for download worker notified
 					rc.fileImporter.cond.Wait()
 				}

--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -371,7 +371,7 @@ func (importer *FileImporter) IsFull() bool {
 		defer importer.storeWorkerPoolRWLock.RUnlock()
 		for _, pool := range importer.storeWorkerPoolMap {
 			if len(pool) > 0 {
-				// At leader one store worker pool has available worker
+				// At least one store worker pool has available worker
 				return false
 			}
 		}

--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -380,10 +380,6 @@ func (importer *FileImporter) IsFull() bool {
 	return false
 }
 
-func (importer *FileImporter) Cond() *sync.Cond {
-	return importer.cond
-}
-
 func (importer *FileImporter) Close() error {
 	if importer != nil && importer.importClient != nil {
 		return importer.importClient.CloseGrpcClient()

--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -1075,7 +1075,9 @@ func (importer *FileImporter) downloadSSTV2(
 			defer func() {
 				workerCh <- struct{}{}
 				// finish the download, notify the main goroutine to continue
+				importer.cond.L.Lock()
 				importer.cond.Signal()
+				importer.cond.L.Unlock()
 			}()
 			for _, file := range files {
 				req, ok := downloadReqsMap[file.Name]

--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -275,7 +275,7 @@ func (rs *RegionSplitter) splitRegions(
 // waitRegionsSplitted check multiple regions have finished the split.
 func (rs *RegionSplitter) waitRegionsSplitted(ctx context.Context, splitRegions []*split.RegionInfo) {
 	// Wait for a while until the regions successfully split.
-	for i, region := range splitRegions {
+	for _, region := range splitRegions {
 		rs.waitRegionSplitted(ctx, region.Region.Id)
 	}
 }

--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -276,13 +276,12 @@ func (rs *RegionSplitter) splitRegions(
 func (rs *RegionSplitter) waitRegionsSplitted(ctx context.Context, splitRegions []*split.RegionInfo) {
 	// Wait for a while until the regions successfully split.
 	for i, region := range splitRegions {
-		// only last region need to report the warning log
-		rs.waitRegionSplitted(ctx, region.Region.Id, i == len(splitRegions)-1)
+		rs.waitRegionSplitted(ctx, region.Region.Id)
 	}
 }
 
 // waitRegionSplitted check single region has finished the split.
-func (rs *RegionSplitter) waitRegionSplitted(ctx context.Context, regionID uint64, isLastRegion bool) {
+func (rs *RegionSplitter) waitRegionSplitted(ctx context.Context, regionID uint64) {
 	state := utils.InitialRetryState(
 		split.SplitCheckMaxRetryTimes,
 		split.SplitCheckInterval,
@@ -301,7 +300,7 @@ func (rs *RegionSplitter) waitRegionSplitted(ctx context.Context, regionID uint6
 	}, &state)
 	// we only care about whether the last region splitted successfully.
 	// because we are waiting region report status *sequentially*.
-	if err != nil && isLastRegion {
+	if err != nil {
 		log.Warn("failed to split regions", zap.Uint64("regionID", regionID))
 	}
 }

--- a/br/pkg/restore/split/split.go
+++ b/br/pkg/restore/split/split.go
@@ -30,7 +30,7 @@ const (
 	SplitMaxRetryInterval = 4 * time.Second
 
 	SplitCheckMaxRetryTimes = 64
-	SplitCheckInterval      = 100 * time.Millisecond
+	SplitCheckInterval      = 8 * time.Millisecond
 	SplitMaxCheckInterval   = time.Second
 
 	ScatterWaitMaxRetryTimes = 64

--- a/br/pkg/restore/split/split.go
+++ b/br/pkg/restore/split/split.go
@@ -30,7 +30,7 @@ const (
 	SplitMaxRetryInterval = 4 * time.Second
 
 	SplitCheckMaxRetryTimes = 64
-	SplitCheckInterval      = 8 * time.Millisecond
+	SplitCheckInterval      = 100 * time.Millisecond
 	SplitMaxCheckInterval   = time.Second
 
 	ScatterWaitMaxRetryTimes = 64

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -131,7 +131,7 @@ func (cfg *RestoreCommonConfig) adjust() {
 	if len(cfg.Granularity) == 0 {
 		cfg.Granularity = string(restore.FineGrained)
 	}
-	if cfg.ConcurrencyPerStore.Modified {
+	if !cfg.ConcurrencyPerStore.Modified {
 		cfg.ConcurrencyPerStore.Value = conn.DefaultImportNumGoroutines
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50701 
Problem Summary:
Unlimit goroutines may cause OOM if download and ingest not finished in time. even we had a download quota of importer.
### What changed and how does it work?
introduce backpressure for download worker to notify main goroutine producer. and same to ingest workers.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

with this pr:
Memory usage is stable at 20G.
<img width="854" alt="image" src="https://github.com/pingcap/tidb/assets/5906259/85ff3881-f36d-4d77-a53a-3c1f42b7fb13">

without this pr:
Memory usage reached 80G and eventually OOM.
![img_v3_028v_3a803af2-c085-4a5c-a907-8e46813afb5g](https://github.com/pingcap/tidb/assets/5906259/327a2bcc-14eb-4a47-95f1-a21c6447028f)


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
