### PR TITLE
planner: output a warning instead of returning an error when creating fast binding on a incomplete hint

### DIFF
--- a/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
@@ -1315,7 +1315,8 @@ func TestBindingFromHistoryWithTiFlashBindable(t *testing.T) {
 	sql := "select * from t"
 	tk.MustExec(sql)
 	planDigest := tk.MustQuery(fmt.Sprintf("select plan_digest from information_schema.cluster_statements_summary where query_sample_text = '%s'", sql)).Rows()
-	tk.MustGetErrMsg(fmt.Sprintf("create binding from history using plan digest '%s'", planDigest[0][0]), "can't create binding for query with tiflash engine")
+	tk.MustExec(fmt.Sprintf("create binding from history using plan digest '%s'", planDigest[0][0]))
+	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1105 auto-generated hint for queries accessing TiFlash might not be complete, the plan might change even after creating this binding"))
 }
 
 func TestSetBindingStatusBySQLDigest(t *testing.T) {

--- a/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
@@ -1264,12 +1264,14 @@ func TestErrorCasesCreateBindingFromHistory(t *testing.T) {
 	sql := "select * from t1 where t1.id in (select id from t2)"
 	tk.MustExec(sql)
 	planDigest := tk.MustQuery(fmt.Sprintf("select plan_digest from information_schema.statements_summary where query_sample_text = '%s'", sql)).Rows()
-	tk.MustGetErrMsg(fmt.Sprintf("create binding from history using plan digest '%s'", planDigest[0][0]), "can't create binding for query with sub query")
+	tk.MustExec(fmt.Sprintf("create binding from history using plan digest '%s'", planDigest[0][0]))
+	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1105 auto-generated hint for queries with sub queries might not be complete, the plan might change even after creating this binding"))
 
 	sql = "select * from t1, t2, t3 where t1.id = t2.id and t2.id = t3.id"
 	tk.MustExec(sql)
 	planDigest = tk.MustQuery(fmt.Sprintf("select plan_digest from information_schema.statements_summary where query_sample_text = '%s'", sql)).Rows()
-	tk.MustGetErrMsg(fmt.Sprintf("create binding from history using plan digest '%s'", planDigest[0][0]), "can't create binding for query with more than two table join")
+	tk.MustExec(fmt.Sprintf("create binding from history using plan digest '%s'", planDigest[0][0]))
+	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1105 auto-generated hint for queries with more than 3 table join might not be complete, the plan might change even after creating this binding"))
 }
 
 // withMockTiFlash sets the mockStore to have N TiFlash stores (naming as tiflash0, tiflash1, ...).

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -848,7 +848,7 @@ func (b *PlanBuilder) buildCreateBindPlanFromPlanDigest(v *ast.CreateBindingStmt
 		return nil, errors.Errorf("binding failed: %v", err)
 	}
 	if complete, reason := hint.CheckBindingFromHistoryComplete(originNode, bindableStmt.PlanHint); !complete {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError(reason))...
+		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError(reason))
 	}
 	bindSQL := bindinfo.GenerateBindingSQL(originNode, bindableStmt.PlanHint, true, bindableStmt.Schema)
 	var hintNode ast.StmtNode

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -848,7 +848,7 @@ func (b *PlanBuilder) buildCreateBindPlanFromPlanDigest(v *ast.CreateBindingStmt
 		return nil, errors.Errorf("binding failed: %v", err)
 	}
 	if complete, reason := hint.CheckBindingFromHistoryComplete(originNode, bindableStmt.PlanHint); !complete {
-		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.New(reason))
+		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError(reason))...
 	}
 	bindSQL := bindinfo.GenerateBindingSQL(originNode, bindableStmt.PlanHint, true, bindableStmt.Schema)
 	var hintNode ast.StmtNode

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -847,8 +847,8 @@ func (b *PlanBuilder) buildCreateBindPlanFromPlanDigest(v *ast.CreateBindingStmt
 	if err != nil {
 		return nil, errors.Errorf("binding failed: %v", err)
 	}
-	if err = hint.CheckBindingFromHistoryBindable(originNode, bindableStmt.PlanHint); err != nil {
-		return nil, err
+	if complete, reason := hint.CheckBindingFromHistoryComplete(originNode, bindableStmt.PlanHint); !complete {
+		b.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.New(reason))
 	}
 	bindSQL := bindinfo.GenerateBindingSQL(originNode, bindableStmt.PlanHint, true, bindableStmt.Schema)
 	var hintNode ast.StmtNode

--- a/pkg/util/hint/hint_processor.go
+++ b/pkg/util/hint/hint_processor.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
@@ -355,30 +354,30 @@ func nodeType4Stmt(node ast.StmtNode) NodeType {
 	return TypeInvalid
 }
 
-// CheckBindingFromHistoryBindable checks whether the ast and hint string from history is bindable.
-// Not support:
+// CheckBindingFromHistoryComplete checks whether the ast and hint string from history is complete.
+// For these complex queries, the auto-generated binding might be not complete:
 // 1. query use tiFlash engine
 // 2. query with sub query
 // 3. query with more than 2 table join
-func CheckBindingFromHistoryBindable(node ast.Node, hintStr string) error {
+func CheckBindingFromHistoryComplete(node ast.Node, hintStr string) (complete bool, reason string) {
 	// check tiflash
 	contain := strings.Contains(hintStr, "tiflash")
 	if contain {
-		return errors.New("can't create binding for query with tiflash engine")
+		return false, "auto-generated hint for queries accessing TiFlash might not be complete, the plan might change even after creating this binding"
 	}
 
 	checker := bindableChecker{
-		bindable: true,
+		complete: true,
 		tables:   make(map[model.CIStr]struct{}, 2),
 	}
 	node.Accept(&checker)
-	return checker.reason
+	return checker.complete, checker.reason
 }
 
 // bindableChecker checks whether a binding from history can be created.
 type bindableChecker struct {
-	bindable bool
-	reason   error
+	complete bool
+	reason   string
 	tables   map[model.CIStr]struct{}
 }
 
@@ -386,16 +385,16 @@ type bindableChecker struct {
 func (checker *bindableChecker) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 	switch node := in.(type) {
 	case *ast.ExistsSubqueryExpr, *ast.SubqueryExpr:
-		checker.bindable = false
-		checker.reason = errors.New("can't create binding for query with sub query")
+		checker.complete = false
+		checker.reason = "auto-generated hint for queries with sub queries might not be complete, the plan might change even after creating this binding"
 		return in, true
 	case *ast.TableName:
 		if _, ok := checker.tables[node.Schema]; !ok {
 			checker.tables[node.Name] = struct{}{}
 		}
 		if len(checker.tables) >= 3 {
-			checker.bindable = false
-			checker.reason = errors.New("can't create binding for query with more than two table join")
+			checker.complete = false
+			checker.reason = "auto-generated hint for queries with more than 3 table join might not be complete, the plan might change even after creating this binding"
 			return in, true
 		}
 	}
@@ -404,5 +403,5 @@ func (checker *bindableChecker) Enter(in ast.Node) (out ast.Node, skipChildren b
 
 // Leave implements Visitor interface.
 func (checker *bindableChecker) Leave(in ast.Node) (out ast.Node, ok bool) {
-	return in, checker.bindable
+	return in, checker.complete
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #51347

Problem Summary: planner: output a warning instead of returning an error when creating fast binding on a incomplete hint

### What changed and how does it work?

planner: output a warning instead of returning an error when creating fast binding on a incomplete hint

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
