### PR TITLE
timer: fix some timezone behavior in timer framework

### DIFF
--- a/pkg/timer/BUILD.bazel
+++ b/pkg/timer/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/sessionctx",
         "//pkg/testkit",

--- a/pkg/timer/api/client_test.go
+++ b/pkg/timer/api/client_test.go
@@ -246,7 +246,7 @@ func TestDefaultClient(t *testing.T) {
 	require.Empty(t, timer.EventData)
 	require.True(t, timer.EventStart.IsZero())
 	require.Equal(t, []byte("s1"), timer.SummaryData)
-	require.Equal(t, eventStart, timer.Watermark)
+	require.Equal(t, eventStart.Unix(), timer.Watermark.Unix())
 	require.Equal(t, EventExtra{}, timer.EventExtra)
 
 	// close event with option
@@ -267,7 +267,7 @@ func TestDefaultClient(t *testing.T) {
 	require.Empty(t, timer.EventData)
 	require.True(t, timer.EventStart.IsZero())
 	require.Equal(t, []byte("s2"), timer.SummaryData)
-	require.Equal(t, watermark, timer.Watermark)
+	require.Equal(t, watermark.Unix(), timer.Watermark.Unix())
 
 	// manual trigger
 	err = store.Update(ctx, timer.ID, &TimerUpdate{

--- a/pkg/timer/runtime/worker_test.go
+++ b/pkg/timer/runtime/worker_test.go
@@ -106,7 +106,7 @@ func prepareTimer(t *testing.T, cli api.TimerClient) *api.TimerRecord {
 	require.Equal(t, "1m", timer.SchedPolicyExpr)
 	require.Equal(t, "h1", timer.HookClass)
 	require.True(t, timer.Enable)
-	require.Equal(t, watermark, timer.Watermark)
+	require.Equal(t, watermark.Unix(), timer.Watermark.Unix())
 	require.Equal(t, []byte("summary1"), timer.SummaryData)
 	require.True(t, !timer.CreateTime.Before(now))
 	require.True(t, !timer.CreateTime.After(time.Now()))

--- a/pkg/timer/tablestore/BUILD.bazel
+++ b/pkg/timer/tablestore/BUILD.bazel
@@ -39,9 +39,13 @@ go_test(
     shard_count = 8,
     deps = [
         "//pkg/kv",
+        "//pkg/parser/ast",
+        "//pkg/parser/model",
+        "//pkg/parser/mysql",
         "//pkg/sessionctx",
         "//pkg/sessionctx/variable",
         "//pkg/timer/api",
+        "//pkg/types",
         "//pkg/util/sqlexec",
         "@com_github_ngaut_pools//:pools",
         "@com_github_pingcap_errors//:errors",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51768

### What changed and how does it work?

- fix the timer store's watermark drift for DST
- refine the behavior for the timer store with time zone. For time fields in `TimerRecord`, their location should be same with the `TimerRecord.Location` field

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
