### PR TITLE
statistics: only analyze one index at a time

### DIFF
--- a/pkg/statistics/handle/autoanalyze/priorityqueue/dynamic_partitioned_table_analysis_job_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/dynamic_partitioned_table_analysis_job_test.go
@@ -99,17 +99,20 @@ func TestAnalyzeDynamicPartitionedTableIndexes(t *testing.T) {
 	require.False(t, tblStats.Pseudo)
 	require.NotNil(t, tblStats.Indices[1])
 	require.True(t, tblStats.Indices[1].IsAnalyzed())
+	require.NotNil(t, tblStats.Indices[2])
+	require.True(t, tblStats.Indices[2].IsAnalyzed())
 	// partition p1
 	pid = tbl.Meta().GetPartitionInfo().Definitions[1].ID
 	tblStats = handle.GetPartitionStats(tbl.Meta(), pid)
 	require.False(t, tblStats.Pseudo)
 	require.NotNil(t, tblStats.Indices[1])
 	require.True(t, tblStats.Indices[1].IsAnalyzed())
+	require.NotNil(t, tblStats.Indices[2])
+	require.True(t, tblStats.Indices[2].IsAnalyzed())
 	// Check analyze jobs are created.
 	rows := tk.MustQuery("select * from mysql.analyze_jobs").Rows()
-	// Because analyze one index will analyze all indexes and all columns together, so there are 10 jobs.
-	// FIXME: We should only trigger it once.
-	require.Len(t, rows, 10)
+	// Because analyze one index will analyze all indexes and all columns together, so there are 5 jobs.
+	require.Len(t, rows, 5)
 }
 
 func TestIsValidToAnalyzeForDynamicPartitionedTable(t *testing.T) {

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job.go
@@ -176,7 +176,7 @@ func (j *NonPartitionedTableAnalysisJob) analyzeIndexes(
 	if len(j.Indexes) == 0 {
 		return
 	}
-	// Halt execution after analyzing one index.
+	// Only analyze the first index.
 	// This is because analyzing a single index also analyzes all other indexes and columns.
 	// Therefore, to avoid redundancy, we prevent multiple analyses of the same table.
 	firstIndex := j.Indexes[0]

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job.go
@@ -173,10 +173,15 @@ func (j *NonPartitionedTableAnalysisJob) analyzeIndexes(
 	statsHandle statstypes.StatsHandle,
 	sysProcTracker sessionctx.SysProcTracker,
 ) {
-	for _, index := range j.Indexes {
-		sql, params := j.GenSQLForAnalyzeIndex(index)
-		exec.AutoAnalyze(sctx, statsHandle, sysProcTracker, j.TableStatsVer, sql, params...)
+	if len(j.Indexes) == 0 {
+		return
 	}
+	// Halt execution after analyzing one index.
+	// This is because analyzing a single index also analyzes all other indexes and columns.
+	// Therefore, to avoid redundancy, we prevent multiple analyses of the same table.
+	firstIndex := j.Indexes[0]
+	sql, params := j.GenSQLForAnalyzeIndex(firstIndex)
+	exec.AutoAnalyze(sctx, statsHandle, sysProcTracker, j.TableStatsVer, sql, params...)
 }
 
 // GenSQLForAnalyzeIndex generates the SQL for analyzing the specified index.

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job_test.go
@@ -92,12 +92,12 @@ func TestAnalyzeNonPartitionedIndexes(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	tk.MustExec("create table t (a int, b int, index idx(a))")
+	tk.MustExec("create table t (a int, b int, index idx(a), index idx1(b))")
 	tk.MustExec("insert into t values (1, 1), (2, 2), (3, 3)")
 	job := &priorityqueue.NonPartitionedTableAnalysisJob{
 		TableSchema:   "test",
 		TableName:     "t",
-		Indexes:       []string{"idx"},
+		Indexes:       []string{"idx", "idx1"},
 		TableStatsVer: 2,
 	}
 	handle := dom.StatsHandle()
@@ -116,30 +116,13 @@ func TestAnalyzeNonPartitionedIndexes(t *testing.T) {
 	tblStats = handle.GetTableStats(tbl.Meta())
 	require.NotNil(t, tblStats.Indices[1])
 	require.True(t, tblStats.Indices[1].IsAnalyzed())
-	// Add a new index.
-	tk.MustExec("alter table t add index idx2(b)")
-	job = &priorityqueue.NonPartitionedTableAnalysisJob{
-		TableSchema:   "test",
-		TableName:     "t",
-		Indexes:       []string{"idx", "idx2"},
-		TableStatsVer: 2,
-	}
-	require.NoError(t, handle.Update(dom.InfoSchema()))
-	// Before analyze indexes.
-	is = dom.InfoSchema()
-	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
-	require.NoError(t, err)
-	tblStats = handle.GetTableStats(tbl.Meta())
-	require.Len(t, tblStats.Indices, 1)
-
-	job.Analyze(handle, dom.SysProcTracker())
-	// Check the result of analyze.
-	is = dom.InfoSchema()
-	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
-	require.NoError(t, err)
-	tblStats = handle.GetTableStats(tbl.Meta())
 	require.NotNil(t, tblStats.Indices[2])
 	require.True(t, tblStats.Indices[2].IsAnalyzed())
+	// Check analyze jobs are created.
+	rows := tk.MustQuery("select * from mysql.analyze_jobs").Rows()
+	// Because analyze one index will analyze all indexes and all columns together, so there are 2 jobs.
+	// FIXME: We should only trigger it once.
+	require.Len(t, rows, 2)
 }
 
 func TestNonPartitionedTableIsValidToAnalyze(t *testing.T) {

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job_test.go
@@ -120,9 +120,8 @@ func TestAnalyzeNonPartitionedIndexes(t *testing.T) {
 	require.True(t, tblStats.Indices[2].IsAnalyzed())
 	// Check analyze jobs are created.
 	rows := tk.MustQuery("select * from mysql.analyze_jobs").Rows()
-	// Because analyze one index will analyze all indexes and all columns together, so there are 2 jobs.
-	// FIXME: We should only trigger it once.
-	require.Len(t, rows, 2)
+	// Because analyze one index will analyze all indexes and all columns together, so there is only 1 job.
+	require.Len(t, rows, 1)
 }
 
 func TestNonPartitionedTableIsValidToAnalyze(t *testing.T) {

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
@@ -188,7 +188,7 @@ func (j *StaticPartitionedTableAnalysisJob) analyzeStaticPartitionIndexes(
 	if len(j.Indexes) == 0 {
 		return
 	}
-	// Halt execution after analyzing one index.
+	// Only analyze the first index.
 	// This is because analyzing a single index also analyzes all other indexes and columns.
 	// Therefore, to avoid redundancy, we prevent multiple analyses of the same partition.
 	firstIndex := j.Indexes[0]

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
@@ -185,10 +185,15 @@ func (j *StaticPartitionedTableAnalysisJob) analyzeStaticPartitionIndexes(
 	statsHandle statstypes.StatsHandle,
 	sysProcTracker sessionctx.SysProcTracker,
 ) {
-	for _, index := range j.Indexes {
-		sql, params := j.GenSQLForAnalyzeStaticPartitionIndex(index)
-		exec.AutoAnalyze(sctx, statsHandle, sysProcTracker, j.TableStatsVer, sql, params...)
+	if len(j.Indexes) == 0 {
+		return
 	}
+	// Halt execution after analyzing one index.
+	// This is because analyzing a single index also analyzes all other indexes and columns.
+	// Therefore, to avoid redundancy, we prevent multiple analyses of the same partition.
+	firstIndex := j.Indexes[0]
+	sql, params := j.GenSQLForAnalyzeStaticPartitionIndex(firstIndex)
+	exec.AutoAnalyze(sctx, statsHandle, sysProcTracker, j.TableStatsVer, sql, params...)
 }
 
 // GenSQLForAnalyzeStaticPartition generates the SQL for analyzing the specified static partition.

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job_test.go
@@ -99,13 +99,13 @@ func TestAnalyzeStaticPartitionedTableIndexes(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	tk.MustExec("create table t (a int, b int, index idx(a)) partition by range (a) (partition p0 values less than (2), partition p1 values less than (4))")
+	tk.MustExec("create table t (a int, b int, index idx(a), index idx1(b)) partition by range (a) (partition p0 values less than (2), partition p1 values less than (4))")
 	tk.MustExec("insert into t values (1, 1), (2, 2), (3, 3)")
 	job := &priorityqueue.StaticPartitionedTableAnalysisJob{
 		TableSchema:         "test",
 		GlobalTableName:     "t",
 		StaticPartitionName: "p0",
-		Indexes:             []string{"idx"},
+		Indexes:             []string{"idx", "idx1"},
 		TableStatsVer:       2,
 	}
 	handle := dom.StatsHandle()
@@ -126,33 +126,13 @@ func TestAnalyzeStaticPartitionedTableIndexes(t *testing.T) {
 	tblStats = handle.GetPartitionStats(tbl.Meta(), pid)
 	require.NotNil(t, tblStats.Indices[1])
 	require.True(t, tblStats.Indices[1].IsAnalyzed())
-	// Add a new index.
-	tk.MustExec("alter table t add index idx2(b)")
-	job = &priorityqueue.StaticPartitionedTableAnalysisJob{
-		TableSchema:         "test",
-		GlobalTableName:     "t",
-		StaticPartitionName: "p0",
-		Indexes:             []string{"idx", "idx2"},
-		TableStatsVer:       2,
-	}
-	require.NoError(t, handle.Update(dom.InfoSchema()))
-	// Before analyze indexes.
-	is = dom.InfoSchema()
-	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
-	require.NoError(t, err)
-	pid = tbl.Meta().GetPartitionInfo().Definitions[0].ID
-	tblStats = handle.GetPartitionStats(tbl.Meta(), pid)
-	require.Len(t, tblStats.Indices, 1)
-
-	job.Analyze(handle, dom.SysProcTracker())
-	// Check the result of analyze.
-	is = dom.InfoSchema()
-	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
-	require.NoError(t, err)
-	pid = tbl.Meta().GetPartitionInfo().Definitions[0].ID
-	tblStats = handle.GetPartitionStats(tbl.Meta(), pid)
 	require.NotNil(t, tblStats.Indices[2])
 	require.True(t, tblStats.Indices[2].IsAnalyzed())
+	// Check analyze jobs are created.
+	rows := tk.MustQuery("select * from mysql.analyze_jobs").Rows()
+	// Because analyze one index will analyze all indexes and all columns together, so there are 8 jobs.
+	// FIXME: We should only trigger it once.
+	require.Len(t, rows, 10)
 }
 
 func TestStaticPartitionedTableIsValidToAnalyze(t *testing.T) {

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job_test.go
@@ -130,9 +130,8 @@ func TestAnalyzeStaticPartitionedTableIndexes(t *testing.T) {
 	require.True(t, tblStats.Indices[2].IsAnalyzed())
 	// Check analyze jobs are created.
 	rows := tk.MustQuery("select * from mysql.analyze_jobs").Rows()
-	// Because analyze one index will analyze all indexes and all columns together, so there are 8 jobs.
-	// FIXME: We should only trigger it once.
-	require.Len(t, rows, 10)
+	// Because analyze one index will analyze all indexes and all columns together, so there are 4 jobs.
+	require.Len(t, rows, 4)
 }
 
 func TestStaticPartitionedTableIsValidToAnalyze(t *testing.T) {


### PR DESCRIPTION


### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/51775

Problem Summary:

We are analyzing the same table multiple times because when an index is analyzed in TiDB, it also analyzes other indexes and columns.

### What changed and how does it work?

Only one index should be analyzed. Multiple indexes are stored to track the total analyzed indexes, even if only one is triggered.

You can check the tests to see what is the correct behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
