### PR TITLE
disttask: make sure task meta consistent between scheduler and table

### DIFF
--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -44,9 +44,6 @@ type BackfillTaskMeta struct {
 	EleTypeKey []byte `json:"ele_type_key"`
 
 	CloudStorageURI string `json:"cloud_storage_uri"`
-	// UseMergeSort indicate whether the backfilling task use merge sort step for global sort.
-	// Merge Sort step aims to support more data.
-	UseMergeSort bool `json:"use_merge_sort"`
 }
 
 // BackfillSubTaskMeta is the sub-task meta for backfilling index.

--- a/pkg/disttask/framework/scheduler/scheduler.go
+++ b/pkg/disttask/framework/scheduler/scheduler.go
@@ -451,7 +451,7 @@ func (s *BaseScheduler) switch2NextStep() error {
 		return s.handlePlanErr(err)
 	}
 
-	if err = s.scheduleSubTask(nextStep, metas, eligibleNodes); err != nil {
+	if err = s.scheduleSubTask(&task, nextStep, metas, eligibleNodes); err != nil {
 		return err
 	}
 	task.Step = nextStep
@@ -462,10 +462,10 @@ func (s *BaseScheduler) switch2NextStep() error {
 }
 
 func (s *BaseScheduler) scheduleSubTask(
+	task *proto.Task,
 	subtaskStep proto.Step,
 	metas [][]byte,
 	eligibleNodes []string) error {
-	task := s.GetTask()
 	s.logger.Info("schedule subtasks",
 		zap.Stringer("state", task.State),
 		zap.String("step", proto.Step2Str(task.Type, subtaskStep)),
@@ -589,6 +589,9 @@ func (s *BaseScheduler) GetPreviousSubtaskMetas(taskID int64, step proto.Step) (
 	if err != nil {
 		s.logger.Warn("get previous succeed subtask failed", zap.String("step", proto.Step2Str(s.GetTask().Type, step)))
 		return nil, err
+	}
+	if previousSubtasks == nil {
+		return [][]byte{}, nil
 	}
 	previousSubtaskMetas := make([][]byte, 0, len(previousSubtasks))
 	for _, subtask := range previousSubtasks {

--- a/pkg/disttask/framework/scheduler/scheduler.go
+++ b/pkg/disttask/framework/scheduler/scheduler.go
@@ -590,9 +590,6 @@ func (s *BaseScheduler) GetPreviousSubtaskMetas(taskID int64, step proto.Step) (
 		s.logger.Warn("get previous succeed subtask failed", zap.String("step", proto.Step2Str(s.GetTask().Type, step)))
 		return nil, err
 	}
-	if previousSubtasks == nil {
-		return [][]byte{}, nil
-	}
 	previousSubtaskMetas := make([][]byte, 0, len(previousSubtasks))
 	for _, subtask := range previousSubtasks {
 		previousSubtaskMetas = append(previousSubtaskMetas, subtask.Meta)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51786

Problem Summary:

https://github.com/pingcap/tidb/blob/f46ccb3ec15689b426e230f28dfda5f3e25644d5/pkg/disttask/framework/scheduler/scheduler.go#L419-L462

There are three kinds of `task` in total. Assuming task1 is `scheduler.task`, task2 is the copied one in `switch2NextStep`, and task3 is in table.
1. `OnNextSubtaskBatch` modified the meta of task2 (useMergeSort = true).
2. `scheduleSubTask` load task1 and update it to the table (useMergeSort = false).
3. `s.task.Store (& task)` resets task1 to task2.

The result is that the useMergeSort of task3 and task1 are inconsistent.

### What changed and how does it work?

1. Pass the copied task to `scheduleSubTask` to make it consistent.
2. Remove `UseMergeSort` and make `OnNextSubtaskBatch` do not modify task.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
