### PR TITLE
ddl: fix the wrong logic to assert whether table has foreign key

### DIFF
--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -5225,7 +5225,7 @@ func checkExchangePartition(pt *model.TableInfo, nt *model.TableInfo) error {
 		return errors.Trace(dbterror.ErrPartitionExchangePartTable.GenWithStackByArgs(nt.Name))
 	}
 
-	if nt.ForeignKeys != nil {
+	if len(nt.ForeignKeys) > 0 {
 		return errors.Trace(dbterror.ErrPartitionExchangeForeignKey.GenWithStackByArgs(nt.Name))
 	}
 

--- a/tests/integrationtest/r/ddl/partition.result
+++ b/tests/integrationtest/r/ddl/partition.result
@@ -457,3 +457,12 @@ drop table t;
 set character_set_connection=DEFAULT;
 create table a (col1 int, col2 int, unique key (col1, col2)) partition by range  columns (col1, col2) (partition p0 values less than (NULL, 1 ));
 Error 1566 (HY000): Not allowed to use NULL value in VALUES LESS THAN
+drop table if exists parent, child, child_with_partition;
+create table parent (id int unique);
+create table child (id int, parent_id int, foreign key (parent_id) references parent(id));
+create table child_with_partition(id int, parent_id int) partition by range(id) (partition p1 values less than (100));
+alter table child_with_partition exchange partition p1 with table child;
+Error 1740 (HY000): Table to exchange with partition has foreign key references: 'child'
+alter table child drop foreign key fk_1;
+alter table child drop key fk_1;
+alter table child_with_partition exchange partition p1 with table child;

--- a/tests/integrationtest/t/ddl/partition.test
+++ b/tests/integrationtest/t/ddl/partition.test
@@ -259,3 +259,13 @@ set character_set_connection=DEFAULT;
 -- error 1566
 create table a (col1 int, col2 int, unique key (col1, col2)) partition by range  columns (col1, col2) (partition p0 values less than (NULL, 1 ));
 
+# TestExchangePartitionAfterDropForeignKey
+drop table if exists parent, child, child_with_partition;
+create table parent (id int unique);
+create table child (id int, parent_id int, foreign key (parent_id) references parent(id));
+create table child_with_partition(id int, parent_id int) partition by range(id) (partition p1 values less than (100));
+-- error 1740
+alter table child_with_partition exchange partition p1 with table child;
+alter table child drop foreign key fk_1;
+alter table child drop key fk_1;
+alter table child_with_partition exchange partition p1 with table child;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51807

Problem Summary:

If the foreign key is an empty slice, the condition `nt.ForeignKeys != nil` will meet. It would be better to assert it with `len(nt.ForeignKeys) > 0`

### What changed and how does it work?

Change `nt.ForeignKeys != nil` to `len(nt.ForeignKeys) > 0`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
