### PR TITLE
executor: Fix compact for VARCHAR PK

### DIFF
--- a/pkg/executor/compact_table.go
+++ b/pkg/executor/compact_table.go
@@ -15,7 +15,6 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
 	"time"
@@ -317,7 +316,7 @@ func (task *storeCompactTask) compactOnePhysicalTable(physicalTableID int64) (bo
 
 		// Let's send more compact requests, as there are remaining data to compact.
 		lastEndKey := resp.GetCompactedEndKey()
-		if len(lastEndKey) == 0 || bytes.Compare(lastEndKey, startKey) <= 0 {
+		if len(lastEndKey) == 0 {
 			// The TiFlash server returned an invalid compacted end key.
 			// This is unexpected...
 			warn := errors.NewNoStackErrorf("compact on store %s failed: internal error (check logs for details)", task.targetStore.Address)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: Fix https://github.com/pingcap/tidb/issues/51810

Problem Summary:

### What changed and how does it work?

When returning the Start key and End key to TiDB, TiFlash does not encode them in a memory comparable way, so that we cannot simply compare these keys.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix `ALTER TABLE ... COMPACT` may not work for tables with a VARCHAR primary key
```
