### PR TITLE
operator: pause scheduler after all connections established

### DIFF
--- a/br/pkg/backup/prepare_snap/BUILD.bazel
+++ b/br/pkg/backup/prepare_snap/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     timeout = "short",
     srcs = ["prepare_test.go"],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         ":prepare_snap",
         "//br/pkg/utils",

--- a/br/pkg/backup/prepare_snap/prepare.go
+++ b/br/pkg/backup/prepare_snap/prepare.go
@@ -91,6 +91,9 @@ type Preparer struct {
 	RetryBackoff  time.Duration
 	RetryLimit    int
 	LeaseDuration time.Duration
+
+	/* Observers. Initialize them before starting.*/
+	AfterConnectionsEstablished func()
 }
 
 func New(env Env) *Preparer {
@@ -158,6 +161,9 @@ func (p *Preparer) DriveLoopAndWaitPrepare(ctx context.Context) error {
 	if err := p.PrepareConnections(ctx); err != nil {
 		log.Error("failed to prepare connections", logutil.ShortError(err))
 		return errors.Annotate(err, "failed to prepare connections")
+	}
+	if p.AfterConnectionsEstablished != nil {
+		p.AfterConnectionsEstablished()
 	}
 	if err := p.AdvanceState(ctx); err != nil {
 		log.Error("failed to check the progress of our work", logutil.ShortError(err))

--- a/br/pkg/backup/prepare_snap/prepare_test.go
+++ b/br/pkg/backup/prepare_snap/prepare_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -474,7 +475,6 @@ func TestSplitEnv(t *testing.T) {
 }
 
 func TestConnectionDelay(t *testing.T) {
-	log.SetLevel(zapcore.DebugLevel)
 	req := require.New(t)
 	pdc := fakeCluster(t, 3, dummyRegions(100)...)
 	ms := newTestEnv(pdc)
@@ -509,4 +509,32 @@ func TestConnectionDelay(t *testing.T) {
 	ms.mu.Unlock()
 	delayConn <- struct{}{}
 	req.NoError(<-connectionPrepareResult)
+}
+
+func TestHooks(t *testing.T) {
+	req := require.New(t)
+	pdc := fakeCluster(t, 3, dummyRegions(100)...)
+	pauseWaitApply := make(chan struct{})
+	ms := newTestEnv(pdc)
+	ms.onCreateStore = func(ms *mockStore) {
+		ms.onWaitApply = func(r *metapb.Region) error {
+			<-pauseWaitApply
+			return nil
+		}
+	}
+	adv := New(ms)
+	connectionsEstablished := new(atomic.Bool)
+	adv.AfterConnectionsEstablished = func() {
+		connectionsEstablished.Store(true)
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- adv.DriveLoopAndWaitPrepare(context.Background())
+	}()
+	req.Eventually(connectionsEstablished.Load, 1*time.Second, 100*time.Millisecond)
+	close(pauseWaitApply)
+	req.NoError(<-errCh)
+	ms.AssertSafeForBackup(t)
+	req.NoError(adv.Finalize(context.Background()))
+	ms.AssertIsNormalMode(t)
 }

--- a/br/pkg/task/operator/cmd.go
+++ b/br/pkg/task/operator/cmd.go
@@ -134,9 +134,15 @@ func AdaptEnvForSnapshotBackup(ctx context.Context, cfg *PauseGcConfig) error {
 	}
 	defer cx.Close()
 
+	initChan := make(chan struct{})
 	cx.run(func() error { return pauseGCKeeper(cx) })
-	cx.run(func() error { return pauseSchedulerKeeper(cx) })
-	cx.run(func() error { return pauseAdminAndWaitApply(cx) })
+	cx.run(func() error {
+		log.Info("Pause scheduler waiting all connections established.")
+		<-initChan
+		log.Info("Pause scheduler noticed connections established.")
+		return pauseSchedulerKeeper(cx)
+	})
+	cx.run(func() error { return pauseAdminAndWaitApply(cx, initChan) })
 	go func() {
 		cx.rdGrp.Wait()
 		if cfg.OnAllReady != nil {
@@ -154,7 +160,7 @@ func AdaptEnvForSnapshotBackup(ctx context.Context, cfg *PauseGcConfig) error {
 	return eg.Wait()
 }
 
-func pauseAdminAndWaitApply(cx *AdaptEnvForSnapshotBackupContext) error {
+func pauseAdminAndWaitApply(cx *AdaptEnvForSnapshotBackupContext, afterConnectionsEstablished chan<- struct{}) error {
 	env := preparesnap.CliEnv{
 		Cache: tikv.NewRegionCache(cx.pdMgr.GetPDClient()),
 		Mgr:   cx.kvMgr,
@@ -164,6 +170,10 @@ func pauseAdminAndWaitApply(cx *AdaptEnvForSnapshotBackupContext) error {
 	begin := time.Now()
 	prep := preparesnap.New(retryEnv)
 	prep.LeaseDuration = cx.cfg.TTL
+	prep.AfterConnectionsEstablished = func() {
+		log.Info("All connections are stablished.")
+		close(afterConnectionsEstablished)
+	}
 
 	defer cx.cleanUpWith(func(ctx context.Context) {
 		if err := prep.Finalize(ctx); err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #51448

Problem Summary:

In #51449, we delayed pausing admin commands after all connections are established. But that isn't enough, due to PD schedulers are paused and ID allocation is disabled. 

### What changed and how does it work?
This PR pauses PD's scheduler after all connections are established.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
