### PR TITLE
txn: check unsupported table types for Pipelined DML

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4375,6 +4375,10 @@ func (s *session) usePipelinedDmlOrWarn() bool {
 			)
 			return false
 		}
+		referredFKs := is.GetTableReferredForeignKeys(t.DB, t.Table)
+		if len(referredFKs) > 0 {
+			return false
+		}
 		if tbl.Meta().TempTableType != model.TempTableNone {
 			stmtCtx.AppendWarning(
 				errors.New(

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4347,6 +4347,53 @@ func (s *session) usePipelinedDmlOrWarn() bool {
 		// we enforce that pipelined DML must lazily check key.
 		return false
 	}
+	is, ok := s.GetDomainInfoSchema().(infoschema.InfoSchema)
+	if !ok {
+		stmtCtx.AppendWarning(errors.New("Pipelined DML failed to get latest InfoSchema. Fallback to standard mode"))
+		return false
+	}
+	for _, t := range stmtCtx.Tables {
+		// get table schema from current infoschema
+		tbl, err := is.TableByName(model.NewCIStr(t.DB), model.NewCIStr(t.Table))
+		if err != nil {
+			stmtCtx.AppendWarning(errors.New("Pipelined DML failed to get table schema. Fallback to standard mode"))
+			return false
+		}
+		if tbl.Meta().IsView() {
+			stmtCtx.AppendWarning(errors.New("Pipelined DML can not be used on view. Fallback to standard mode"))
+			return false
+		}
+		if tbl.Meta().IsSequence() {
+			stmtCtx.AppendWarning(errors.New("Pipelined DML can not be used on sequence. Fallback to standard mode"))
+			return false
+		}
+		if len(tbl.Meta().ForeignKeys) > 0 && vars.ForeignKeyChecks {
+			stmtCtx.AppendWarning(
+				errors.New(
+					"Pipelined DML can not be used on table with foreign keys when foreign_key_checks = ON. Fallback to standard mode",
+				),
+			)
+			return false
+		}
+		if tbl.Meta().TempTableType != model.TempTableNone {
+			stmtCtx.AppendWarning(
+				errors.New(
+					"Pipelined DML can not be used on temporary tables. " +
+						"Fallback to standard mode",
+				),
+			)
+			return false
+		}
+		if tbl.Meta().TableCacheStatusType != model.TableCacheStatusDisable {
+			stmtCtx.AppendWarning(
+				errors.New(
+					"Pipelined DML can not be used on cached tables. " +
+						"Fallback to standard mode",
+				),
+			)
+			return false
+		}
+	}
 
 	// tidb_dml_type=bulk will invalidate the config pessimistic-auto-commit.
 	// The behavior is as if the config is set to false. But we generate a warning for it.

--- a/pkg/session/txnmanager.go
+++ b/pkg/session/txnmanager.go
@@ -305,6 +305,14 @@ func (m *txnManager) OnLocalTemporaryTableCreated() {
 }
 
 func (m *txnManager) AdviseWarmup() error {
+	if m.sctx.GetSessionVars().BulkDMLEnabled {
+		// We don't want to validate the feasibility of pipelined DML here.
+		// We'd like to check it later after optimization so that optimizer info can be used.
+		// And it does not make much sense to save such a little time for pipelined-dml as it's
+		// for bulk processing.
+		return nil
+	}
+
 	if m.ctxProvider != nil {
 		return m.ctxProvider.AdviseWarmup()
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50215 

Problem Summary:

Tables with foreign keys and reference by foreign keys when `foreign_key_checks=ON`, temp tables and cached tables are unsupported. Should fallback and generate warnings for them.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
