### PR TITLE
ddl: allow `StatePublic` in `createTableWithForeignKeys` for BR

### DIFF
--- a/br/tests/br_foreign_key/run.sh
+++ b/br/tests/br_foreign_key/run.sh
@@ -17,37 +17,40 @@
 set -eu
 DB="$TEST_NAME"
 
-run_sql "set @@global.foreign_key_checks=1;"
-run_sql "set @@foreign_key_checks=1;"
-run_sql "create schema $DB;"
-run_sql "create table $DB.t1 (id int key);"
-run_sql "create table $DB.t2 (id int key, a int, b int, foreign key fk_1 (a) references t1(id) ON UPDATE SET NULL ON DELETE SET NULL, foreign key fk_2 (b) references t1(id) ON DELETE CASCADE ON UPDATE CASCADE);"
-run_sql "insert into $DB.t1 values (1), (2), (3);"
-run_sql "insert into $DB.t2 values (1, 1, 1), (2, 2, 2), (3, 3, 3);"
-run_sql "update $DB.t1 set id=id+10 where id in (1, 3);"
-run_sql "delete from $DB.t1 where id = 2;"
+for DDL_BATCH_SIZE in 1 2;
+do
+  run_sql "set @@global.foreign_key_checks=1;"
+  run_sql "set @@foreign_key_checks=1;"
+  run_sql "create schema $DB;"
+  run_sql "create table $DB.t1 (id int key);"
+  run_sql "create table $DB.t2 (id int key, a int, b int, foreign key fk_1 (a) references t1(id) ON UPDATE SET NULL ON DELETE SET NULL, foreign key fk_2 (b) references t1(id) ON DELETE CASCADE ON UPDATE CASCADE);"
+  run_sql "insert into $DB.t1 values (1), (2), (3);"
+  run_sql "insert into $DB.t2 values (1, 1, 1), (2, 2, 2), (3, 3, 3);"
+  run_sql "update $DB.t1 set id=id+10 where id in (1, 3);"
+  run_sql "delete from $DB.t1 where id = 2;"
 
-echo "backup start..."
-run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
+  echo "backup start..."
+  run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB-$DDL_BATCH_SIZE" --pd $PD_ADDR
 
-run_sql "drop schema $DB;"
+  run_sql "drop schema $DB;"
 
-echo "restore start..."
-run_br restore db --db $DB -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
+  echo "restore start..."
+  run_br restore db --db $DB -s "local://$TEST_DIR/$DB-$DDL_BATCH_SIZE" --pd $PD_ADDR --ddl-batch-size=$DDL_BATCH_SIZE
 
-set -x
+  set -x
 
-run_sql "select count(*) from $DB.t1;"
-check_contains 'count(*): 2'
+  run_sql "select count(*) from $DB.t1;"
+  check_contains 'count(*): 2'
 
-run_sql "select count(*) from $DB.t2;"
-check_contains 'count(*): 2'
+  run_sql "select count(*) from $DB.t2;"
+  check_contains 'count(*): 2'
 
-run_sql "select id, a, b from $DB.t2;"
-check_contains 'id: 1'
-check_contains 'id: 3'
-check_contains 'a: NULL'
-check_contains 'b: 11'
-check_contains 'b: 13'
+  run_sql "select id, a, b from $DB.t2;"
+  check_contains 'id: 1'
+  check_contains 'id: 3'
+  check_contains 'a: NULL'
+  check_contains 'b: 11'
+  check_contains 'b: 13'
 
-run_sql "drop schema $DB"
+  run_sql "drop schema $DB"
+done

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -194,8 +194,11 @@ func onCreateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 
 func createTableWithForeignKeys(d *ddlCtx, t *meta.Meta, job *model.Job, tbInfo *model.TableInfo, fkCheck bool) (ver int64, err error) {
 	switch tbInfo.State {
-	case model.StateNone:
-		// create table in non-public state
+	case model.StateNone, model.StatePublic:
+		// create table in non-public or public state. The function `createTable` will always reset
+		// the `tbInfo.State` with `model.StateNone`, so it's fine to just call the `createTable` with
+		// public state.
+		// when `br` restores table, the state of `tbInfo` will be public.
 		tbInfo, err = createTable(d, t, job, fkCheck)
 		if err != nil {
 			return ver, errors.Trace(err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51838

Problem Summary:

When restoring some tables, the state can be `StatePublic`, so `createTableWithForeignKeys` should also handle the `StatePublic`.

### What changed and how does it work?

Also handle the `StatePublic` in `createTableWithForeignKeys`. In `createTable`, the `State` will always be reset to `StateNone` (though sounds weird :facepalm:, but this code has been existing for 8 years).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
