### PR TITLE
log_backup: remove checking store number

### DIFF
--- a/br/pkg/task/restore_data.go
+++ b/br/pkg/task/restore_data.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pingcap/tidb/br/pkg/config"
 	"github.com/pingcap/tidb/br/pkg/conn"
 	"github.com/pingcap/tidb/br/pkg/conn/util"
-	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/glue"
 	"github.com/pingcap/tidb/br/pkg/restore"
 	"github.com/pingcap/tidb/br/pkg/storage"
@@ -58,7 +57,7 @@ func RunResolveKvData(c context.Context, g glue.Glue, cmdName string, cfg *Resto
 		return errors.Trace(err)
 	}
 
-	resolveTS, numBackupStore, err := ReadBackupMetaData(ctx, externStorage)
+	resolveTS, numStores, err := ReadBackupMetaData(ctx, externStorage)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -128,26 +127,23 @@ func RunResolveKvData(c context.Context, g glue.Glue, cmdName string, cfg *Resto
 			if err != nil {
 				return errors.Trace(err)
 			}
-			numOnlineStore := len(allStores)
-			// in this version, it suppose to have the same number of tikvs between backup cluster and restore cluster
-			if numOnlineStore != numBackupStore {
-				log.Warn("the restore meta contains the number of tikvs inconsist with the resore cluster, retry ...", zap.Int("current stores", len(allStores)), zap.Int("backup stores", numBackupStore))
-				return errors.Annotatef(berrors.ErrRestoreTotalKVMismatch,
-					"number of tikvs mismatch")
-			}
 			return nil
 		},
 		utils.NewPDReqBackofferExt(),
 	)
+	restoreNumStores := len(allStores)
+	if restoreNumStores != numStores {
+		log.Warn("the number of stores in the cluster has changed", zap.Int("origin", numStores), zap.Int("current", restoreNumStores))
+	}
 
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	log.Debug("total tikv", zap.Int("total", numBackupStore), zap.String("progress file", cfg.ProgressFile))
+	log.Debug("total tikv", zap.Int("total", restoreNumStores), zap.String("progress file", cfg.ProgressFile))
 	// progress = read meta + send recovery + iterate tikv + (1 * prepareflashback + 1 * flashback)
-	progress := g.StartProgress(ctx, cmdName, int64(numBackupStore*3+2), !cfg.LogProgress)
-	go progressFileWriterRoutine(ctx, progress, int64(numBackupStore*3+2), cfg.ProgressFile)
+	progress := g.StartProgress(ctx, cmdName, int64(restoreNumStores*3+2), !cfg.LogProgress)
+	go progressFileWriterRoutine(ctx, progress, int64(restoreNumStores*3+2), cfg.ProgressFile)
 
 	// restore tikv data from a snapshot volume
 	var totalRegions int


### PR DESCRIPTION
warn if store num not match

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51957

Problem Summary:
It is unnecessary to check the store number in data restore phase -- since tidb-operator will help us to check it. 
Now this check breaks a workaround for one store cannot unexpectedly bootstrap after restoring.

### What changed and how does it work?
This PR removes the check to number of stores.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->
  The change is tiny and I manually tested it in a local k8s cluster.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
