### PR TITLE
expression: add `PushDownContext` for push down operations

### DIFF
--- a/pkg/expression/aggregation/agg_to_pb_test.go
+++ b/pkg/expression/aggregation/agg_to_pb_test.go
@@ -66,7 +66,8 @@ func TestAggFunc2Pb(t *testing.T) {
 			aggFunc, err := NewAggFuncDesc(ctx, funcName, args, hasDistinct)
 			require.NoError(t, err)
 			aggFunc.RetTp = funcTypes[i]
-			pbExpr, err := AggFuncToPBExpr(ctx, client, aggFunc, kv.UnSpecified)
+			pushCtx := expression.NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+			pbExpr, err := AggFuncToPBExpr(pushCtx, aggFunc, kv.UnSpecified)
 			require.NoError(t, err)
 			js, err := json.Marshal(pbExpr)
 			require.NoError(t, err)

--- a/pkg/expression/aggregation/window_func.go
+++ b/pkg/expression/aggregation/window_func.go
@@ -142,9 +142,9 @@ func WindowFuncToPBExpr(sctx expression.EvalContext, client kv.Client, desc *Win
 }
 
 // CanPushDownToTiFlash control whether a window function desc can be push down to tiflash.
-func (s *WindowFuncDesc) CanPushDownToTiFlash(ctx expression.EvalContext, client kv.Client) bool {
+func (s *WindowFuncDesc) CanPushDownToTiFlash(ctx expression.PushDownContext) bool {
 	// args
-	if !expression.CanExprsPushDown(ctx, s.Args, client, kv.TiFlash) {
+	if !expression.CanExprsPushDown(ctx, s.Args, kv.TiFlash) {
 		return false
 	}
 	// window functions

--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -45,6 +45,7 @@ func TestConstant2Pb(t *testing.T) {
 	var constExprs []Expression
 	ctx := mock.NewContext()
 	client := new(mock.Client)
+	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	// can be transformed
 	constValue := new(Constant)
@@ -98,7 +99,7 @@ func TestConstant2Pb(t *testing.T) {
 	require.Equal(t, types.KindMysqlEnum, constValue.Value.Kind())
 	constExprs = append(constExprs, constValue)
 
-	pushed, remained := PushDownExprs(ctx, constExprs, client, kv.UnSpecified)
+	pushed, remained := PushDownExprs(pushDownCtx, constExprs, kv.UnSpecified)
 	require.Len(t, pushed, len(constExprs)-3)
 	require.Len(t, remained, 3)
 
@@ -128,12 +129,13 @@ func TestColumn2Pb(t *testing.T) {
 	var colExprs []Expression
 	ctx := mock.NewContext()
 	client := new(mock.Client)
+	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	colExprs = append(colExprs, genColumn(mysql.TypeSet, 1))
 	colExprs = append(colExprs, genColumn(mysql.TypeGeometry, 2))
 	colExprs = append(colExprs, genColumn(mysql.TypeUnspecified, 3))
 
-	pushed, remained := PushDownExprs(ctx, colExprs, client, kv.UnSpecified)
+	pushed, remained := PushDownExprs(pushDownCtx, colExprs, kv.UnSpecified)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(colExprs))
 
@@ -167,7 +169,7 @@ func TestColumn2Pb(t *testing.T) {
 	colExprs = append(colExprs, genColumn(mysql.TypeString, 23))
 	colExprs = append(colExprs, genColumn(mysql.TypeEnum, 24))
 	colExprs = append(colExprs, genColumn(mysql.TypeBit, 25))
-	pushed, remained = PushDownExprs(ctx, colExprs, client, kv.UnSpecified)
+	pushed, remained = PushDownExprs(pushDownCtx, colExprs, kv.UnSpecified)
 	require.Len(t, pushed, len(colExprs))
 	require.Len(t, remained, 0)
 
@@ -211,7 +213,7 @@ func TestColumn2Pb(t *testing.T) {
 		expr.(*Column).Index = 0
 	}
 
-	pushed, remained = PushDownExprs(ctx, colExprs, client, kv.UnSpecified)
+	pushed, remained = PushDownExprs(pushDownCtx, colExprs, kv.UnSpecified)
 	require.Len(t, pushed, len(colExprs))
 	require.Len(t, remained, 0)
 }
@@ -220,6 +222,7 @@ func TestCompareFunc2Pb(t *testing.T) {
 	var compareExprs = make([]Expression, 0)
 	ctx := mock.NewContext()
 	client := new(mock.Client)
+	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	funcNames := []string{ast.LT, ast.LE, ast.GT, ast.GE, ast.EQ, ast.NE, ast.NullEQ}
 	for _, funcName := range funcNames {
@@ -228,7 +231,7 @@ func TestCompareFunc2Pb(t *testing.T) {
 		compareExprs = append(compareExprs, fc)
 	}
 
-	pushed, remained := PushDownExprs(ctx, compareExprs, client, kv.UnSpecified)
+	pushed, remained := PushDownExprs(pushDownCtx, compareExprs, kv.UnSpecified)
 	require.Len(t, pushed, len(compareExprs))
 	require.Len(t, remained, 0)
 
@@ -505,6 +508,7 @@ func TestOtherFunc2Pb(t *testing.T) {
 func TestExprPushDownToFlash(t *testing.T) {
 	ctx := mock.NewContext()
 	client := new(mock.Client)
+	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	exprs := make([]Expression, 0)
 
@@ -1026,7 +1030,7 @@ func TestExprPushDownToFlash(t *testing.T) {
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 
-	canPush := CanExprsPushDown(mock.NewContext(), exprs, client, kv.TiFlash)
+	canPush := CanExprsPushDown(pushDownCtx, exprs, kv.TiFlash)
 	require.Equal(t, true, canPush)
 
 	exprs = exprs[:0]
@@ -1076,11 +1080,11 @@ func TestExprPushDownToFlash(t *testing.T) {
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 
-	pushed, remained := PushDownExprs(ctx, exprs, client, kv.TiFlash)
+	pushed, remained := PushDownExprs(pushDownCtx, exprs, kv.TiFlash)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
 
-	pushed, remained = PushDownExprsWithExtraInfo(ctx, exprs, client, kv.TiFlash, true)
+	pushed, remained = PushDownExprsWithExtraInfo(pushDownCtx, exprs, kv.TiFlash, true)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
 
@@ -1371,11 +1375,11 @@ func TestExprPushDownToFlash(t *testing.T) {
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 
-	pushed, remained = PushDownExprs(ctx, exprs, client, kv.TiFlash)
+	pushed, remained = PushDownExprs(pushDownCtx, exprs, kv.TiFlash)
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
 
-	pushed, remained = PushDownExprsWithExtraInfo(ctx, exprs, client, kv.TiFlash, true)
+	pushed, remained = PushDownExprsWithExtraInfo(pushDownCtx, exprs, kv.TiFlash, true)
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
 }
@@ -1419,20 +1423,22 @@ func TestExprOnlyPushDownToFlash(t *testing.T) {
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 
-	pushed, remained := PushDownExprs(mock.NewContext(), exprs, client, kv.UnSpecified)
+	ctx := mock.NewContext()
+	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+	pushed, remained := PushDownExprs(pushDownCtx, exprs, kv.UnSpecified)
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
 
-	canPush := CanExprsPushDown(mock.NewContext(), exprs, client, kv.TiFlash)
+	canPush := CanExprsPushDown(pushDownCtx, exprs, kv.TiFlash)
 	require.Equal(t, true, canPush)
-	canPush = CanExprsPushDown(mock.NewContext(), exprs, client, kv.TiKV)
+	canPush = CanExprsPushDown(pushDownCtx, exprs, kv.TiKV)
 	require.Equal(t, false, canPush)
 
-	pushed, remained = PushDownExprs(mock.NewContext(), exprs, client, kv.TiFlash)
+	pushed, remained = PushDownExprs(pushDownCtx, exprs, kv.TiFlash)
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
 
-	pushed, remained = PushDownExprs(mock.NewContext(), exprs, client, kv.TiKV)
+	pushed, remained = PushDownExprs(pushDownCtx, exprs, kv.TiKV)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
 }
@@ -1485,7 +1491,9 @@ func TestExprPushDownToTiKV(t *testing.T) {
 	require.NoError(t, err)
 	exprs = append(exprs, function)
 
-	pushed, remained := PushDownExprs(mock.NewContext(), exprs, client, kv.TiKV)
+	ctx := mock.NewContext()
+	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+	pushed, remained := PushDownExprs(pushDownCtx, exprs, kv.TiKV)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
 
@@ -1496,7 +1504,7 @@ func TestExprPushDownToTiKV(t *testing.T) {
 
 	substringRelated := []string{ast.Substr, ast.Substring, ast.Mid}
 	for _, exprName := range substringRelated {
-		function, err = NewFunction(mock.NewContext(), exprName, types.NewFieldType(mysql.TypeString), stringColumn, intColumn, intColumn)
+		function, err = NewFunction(ctx, exprName, types.NewFieldType(mysql.TypeString), stringColumn, intColumn, intColumn)
 		require.NoError(t, err)
 		exprs = append(exprs, function)
 	}
@@ -1633,14 +1641,15 @@ func TestExprPushDownToTiKV(t *testing.T) {
 		},
 	}
 
-	ctx := mock.NewContext()
+	ctx = mock.NewContext()
+	pushDownCtx = NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 	for _, tc := range testcases {
 		function, err = NewFunction(ctx, tc.functionName, tc.retType, tc.args...)
 		require.NoError(t, err)
 		exprs = append(exprs, function)
 	}
 
-	pushed, remained = PushDownExprs(ctx, exprs, client, kv.TiKV)
+	pushed, remained = PushDownExprs(pushDownCtx, exprs, kv.TiKV)
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
 }
@@ -1648,25 +1657,26 @@ func TestExprPushDownToTiKV(t *testing.T) {
 func TestExprOnlyPushDownToTiKV(t *testing.T) {
 	ctx := mock.NewContext()
 	client := new(mock.Client)
+	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	function, err := NewFunction(ctx, "uuid", types.NewFieldType(mysql.TypeLonglong))
 	require.NoError(t, err)
 	var exprs = make([]Expression, 0)
 	exprs = append(exprs, function)
 
-	pushed, remained := PushDownExprs(ctx, exprs, client, kv.UnSpecified)
+	pushed, remained := PushDownExprs(pushDownCtx, exprs, kv.UnSpecified)
 	require.Len(t, pushed, 1)
 	require.Len(t, remained, 0)
 
-	canPush := CanExprsPushDown(ctx, exprs, client, kv.TiFlash)
+	canPush := CanExprsPushDown(pushDownCtx, exprs, kv.TiFlash)
 	require.Equal(t, false, canPush)
-	canPush = CanExprsPushDown(ctx, exprs, client, kv.TiKV)
+	canPush = CanExprsPushDown(pushDownCtx, exprs, kv.TiKV)
 	require.Equal(t, true, canPush)
 
-	pushed, remained = PushDownExprs(ctx, exprs, client, kv.TiFlash)
+	pushed, remained = PushDownExprs(pushDownCtx, exprs, kv.TiFlash)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, 1)
-	pushed, remained = PushDownExprs(ctx, exprs, client, kv.TiKV)
+	pushed, remained = PushDownExprs(pushDownCtx, exprs, kv.TiKV)
 	require.Len(t, pushed, 1)
 	require.Len(t, remained, 0)
 }
@@ -1739,6 +1749,7 @@ func TestNewCollationsEnabled(t *testing.T) {
 	var colExprs []Expression
 	ctx := mock.NewContext()
 	client := new(mock.Client)
+	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	colExprs = colExprs[:0]
 	colExprs = append(colExprs, genColumn(mysql.TypeVarchar, 1))
@@ -1748,7 +1759,7 @@ func TestNewCollationsEnabled(t *testing.T) {
 	colExprs = append(colExprs, columnCollation(genColumn(mysql.TypeVarchar, 5), "utf8", "utf8_bin"))
 	colExprs = append(colExprs, columnCollation(genColumn(mysql.TypeVarchar, 6), "utf8", "utf8_unicode_ci"))
 	colExprs = append(colExprs, columnCollation(genColumn(mysql.TypeVarchar, 7), "utf8mb4", "utf8mb4_zh_pinyin_tidb_as_cs"))
-	pushed, _ := PushDownExprs(ctx, colExprs, client, kv.UnSpecified)
+	pushed, _ := PushDownExprs(pushDownCtx, colExprs, kv.UnSpecified)
 	require.Equal(t, len(colExprs), len(pushed))
 	pbExprs, err := ExpressionsToPBList(ctx, colExprs, client)
 	require.NoError(t, err)

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tipb/go-tipb"
@@ -80,7 +81,7 @@ func canFuncBePushed(sf *ScalarFunction, storeType kv.StoreType) bool {
 	return ret
 }
 
-func canScalarFuncPushDown(scalarFunc *ScalarFunction, pc PbConverter, storeType kv.StoreType) bool {
+func canScalarFuncPushDown(ctx PushDownContext, scalarFunc *ScalarFunction, storeType kv.StoreType) bool {
 	pbCode := scalarFunc.Function.PbCode()
 	// Check whether this function can be pushed.
 	if unspecified := pbCode <= tipb.ScalarFuncSig_Unspecified; unspecified || !canFuncBePushed(scalarFunc, storeType) {
@@ -94,7 +95,7 @@ func canScalarFuncPushDown(scalarFunc *ScalarFunction, pc PbConverter, storeType
 			storageName = "storage layer"
 		}
 		warnErr := errors.NewNoStackError("Scalar function '" + scalarFunc.FuncName.L + "'(signature: " + scalarFunc.Function.PbCode().String() + ", return type: " + scalarFunc.RetType.CompactStr() + ") is not supported to push down to " + storageName + " now.")
-		sc := pc.ctx.GetSessionVars().StmtCtx
+		sc := ctx.GetSessionVars().StmtCtx
 		if sc.InExplainStmt {
 			sc.AppendWarning(warnErr)
 		} else {
@@ -105,7 +106,7 @@ func canScalarFuncPushDown(scalarFunc *ScalarFunction, pc PbConverter, storeType
 	canEnumPush := canEnumPushdownPreliminarily(scalarFunc)
 	// Check whether all of its parameters can be pushed.
 	for _, arg := range scalarFunc.GetArgs() {
-		if !canExprPushDown(arg, pc, storeType, canEnumPush) {
+		if !canExprPushDown(ctx, arg, storeType, canEnumPush) {
 			return false
 		}
 	}
@@ -121,9 +122,10 @@ func canScalarFuncPushDown(scalarFunc *ScalarFunction, pc PbConverter, storeType
 	return true
 }
 
-func canExprPushDown(expr Expression, pc PbConverter, storeType kv.StoreType, canEnumPush bool) bool {
+func canExprPushDown(ctx PushDownContext, expr Expression, storeType kv.StoreType, canEnumPush bool) bool {
+	pc := ctx.PbConverter()
 	if storeType == kv.TiFlash {
-		sc := pc.ctx.GetSessionVars().StmtCtx
+		sc := ctx.sessVars.StmtCtx
 		switch expr.GetType().GetType() {
 		case mysql.TypeEnum, mysql.TypeBit, mysql.TypeSet, mysql.TypeGeometry, mysql.TypeUnspecified:
 			if expr.GetType().GetType() == mysql.TypeEnum && canEnumPush {
@@ -156,7 +158,7 @@ func canExprPushDown(expr Expression, pc PbConverter, storeType kv.StoreType, ca
 	case *Column:
 		return pc.columnToPBExpr(x) != nil
 	case *ScalarFunction:
-		return canScalarFuncPushDown(x, pc, storeType)
+		return canScalarFuncPushDown(ctx, x, storeType)
 	}
 	return false
 }
@@ -427,11 +429,46 @@ func IsPushDownEnabled(name string, storeType kv.StoreType) bool {
 	return true
 }
 
+// PushDownContext is the context used for push down expressions
+type PushDownContext struct {
+	evalCtx  EvalContext
+	client   kv.Client
+	sessVars *variable.SessionVars
+}
+
+// NewPushDownContext returns a new PushDownContext
+func NewPushDownContext(evalCtx EvalContext, sessVars *variable.SessionVars, client kv.Client) PushDownContext {
+	return PushDownContext{
+		evalCtx:  evalCtx,
+		client:   client,
+		sessVars: sessVars,
+	}
+}
+
+// EvalCtx returns the eval context
+func (ctx PushDownContext) EvalCtx() EvalContext {
+	return ctx.evalCtx
+}
+
+// PbConverter returns a new PbConverter
+func (ctx PushDownContext) PbConverter() PbConverter {
+	return NewPBConverter(ctx.client, ctx.evalCtx)
+}
+
+// Client returns the kv client
+func (ctx PushDownContext) Client() kv.Client {
+	return ctx.client
+}
+
+// GetSessionVars returns the session variables
+func (ctx PushDownContext) GetSessionVars() *variable.SessionVars {
+	return ctx.sessVars
+}
+
 // PushDownExprsWithExtraInfo split the input exprs into pushed and remained, pushed include all the exprs that can be pushed down
-func PushDownExprsWithExtraInfo(ctx EvalContext, exprs []Expression, client kv.Client, storeType kv.StoreType, canEnumPush bool) (pushed []Expression, remained []Expression) {
-	pc := PbConverter{ctx: ctx, client: client}
+func PushDownExprsWithExtraInfo(ctx PushDownContext, exprs []Expression, storeType kv.StoreType, canEnumPush bool) (pushed []Expression, remained []Expression) {
 	for _, expr := range exprs {
-		if canExprPushDown(expr, pc, storeType, canEnumPush) {
+		if canExprPushDown(ctx, expr, storeType, canEnumPush) {
 			pushed = append(pushed, expr)
 		} else {
 			remained = append(remained, expr)
@@ -441,19 +478,19 @@ func PushDownExprsWithExtraInfo(ctx EvalContext, exprs []Expression, client kv.C
 }
 
 // PushDownExprs split the input exprs into pushed and remained, pushed include all the exprs that can be pushed down
-func PushDownExprs(ctx EvalContext, exprs []Expression, client kv.Client, storeType kv.StoreType) (pushed []Expression, remained []Expression) {
-	return PushDownExprsWithExtraInfo(ctx, exprs, client, storeType, false)
+func PushDownExprs(ctx PushDownContext, exprs []Expression, storeType kv.StoreType) (pushed []Expression, remained []Expression) {
+	return PushDownExprsWithExtraInfo(ctx, exprs, storeType, false)
 }
 
 // CanExprsPushDownWithExtraInfo return true if all the expr in exprs can be pushed down
-func CanExprsPushDownWithExtraInfo(ctx EvalContext, exprs []Expression, client kv.Client, storeType kv.StoreType, canEnumPush bool) bool {
-	_, remained := PushDownExprsWithExtraInfo(ctx, exprs, client, storeType, canEnumPush)
+func CanExprsPushDownWithExtraInfo(ctx PushDownContext, exprs []Expression, storeType kv.StoreType, canEnumPush bool) bool {
+	_, remained := PushDownExprsWithExtraInfo(ctx, exprs, storeType, canEnumPush)
 	return len(remained) == 0
 }
 
 // CanExprsPushDown return true if all the expr in exprs can be pushed down
-func CanExprsPushDown(ctx EvalContext, exprs []Expression, client kv.Client, storeType kv.StoreType) bool {
-	return CanExprsPushDownWithExtraInfo(ctx, exprs, client, storeType, false)
+func CanExprsPushDown(ctx PushDownContext, exprs []Expression, storeType kv.StoreType) bool {
+	return CanExprsPushDownWithExtraInfo(ctx, exprs, storeType, false)
 }
 
 func storeTypeMask(storeType kv.StoreType) uint32 {

--- a/pkg/planner/cascades/transformation_rules.go
+++ b/pkg/planner/cascades/transformation_rules.go
@@ -331,7 +331,7 @@ func (*PushSelDownTiKVSingleGather) OnTransform(old *memo.ExprIter) (newExprs []
 	childGroup := old.Children[0].Children[0].Group
 	var pushed, remained []expression.Expression
 	sctx := sg.SCtx()
-	pushed, remained = expression.PushDownExprs(sctx.GetExprCtx(), sel.Conditions, sctx.GetClient(), kv.TiKV)
+	pushed, remained = expression.PushDownExprs(plannercore.GetPushDownCtx(sctx), sel.Conditions, kv.TiKV)
 	if len(pushed) == 0 {
 		return nil, false, false, nil
 	}

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -2350,17 +2350,17 @@ func canExprsInJoinPushdown(p *LogicalJoin, storeType kv.StoreType) bool {
 		}
 		equalExprs = append(equalExprs, eqCondition)
 	}
-	ctx := p.SCtx().GetExprCtx()
-	if !expression.CanExprsPushDown(ctx, equalExprs, p.SCtx().GetClient(), storeType) {
+	pushDownCtx := GetPushDownCtx(p.SCtx())
+	if !expression.CanExprsPushDown(pushDownCtx, equalExprs, storeType) {
 		return false
 	}
-	if !expression.CanExprsPushDown(ctx, p.LeftConditions, p.SCtx().GetClient(), storeType) {
+	if !expression.CanExprsPushDown(pushDownCtx, p.LeftConditions, storeType) {
 		return false
 	}
-	if !expression.CanExprsPushDown(ctx, p.RightConditions, p.SCtx().GetClient(), storeType) {
+	if !expression.CanExprsPushDown(pushDownCtx, p.RightConditions, storeType) {
 		return false
 	}
-	if !expression.CanExprsPushDown(ctx, p.OtherConditions, p.SCtx().GetClient(), storeType) {
+	if !expression.CanExprsPushDown(pushDownCtx, p.OtherConditions, storeType) {
 		return false
 	}
 	return true
@@ -2626,15 +2626,15 @@ func (p *LogicalProjection) exhaustPhysicalPlans(prop *property.PhysicalProperty
 	newProps := []*property.PhysicalProperty{newProp}
 	// generate a mpp task candidate if mpp mode is allowed
 	ctx := p.SCtx()
-	exprCtx := ctx.GetExprCtx()
+	pushDownCtx := GetPushDownCtx(ctx)
 	if newProp.TaskTp != property.MppTaskType && ctx.GetSessionVars().IsMPPAllowed() && p.canPushToCop(kv.TiFlash) &&
-		expression.CanExprsPushDown(exprCtx, p.Exprs, ctx.GetClient(), kv.TiFlash) {
+		expression.CanExprsPushDown(pushDownCtx, p.Exprs, kv.TiFlash) {
 		mppProp := newProp.CloneEssentialFields()
 		mppProp.TaskTp = property.MppTaskType
 		newProps = append(newProps, mppProp)
 	}
 	if newProp.TaskTp != property.CopSingleReadTaskType && ctx.GetSessionVars().AllowProjectionPushDown && p.canPushToCop(kv.TiKV) &&
-		expression.CanExprsPushDown(exprCtx, p.Exprs, ctx.GetClient(), kv.TiKV) && !expression.ContainVirtualColumn(p.Exprs) {
+		expression.CanExprsPushDown(pushDownCtx, p.Exprs, kv.TiKV) && !expression.ContainVirtualColumn(p.Exprs) {
 		copProp := newProp.CloneEssentialFields()
 		copProp.TaskTp = property.CopSingleReadTaskType
 		newProps = append(newProps, copProp)
@@ -2646,7 +2646,7 @@ func (p *LogicalProjection) exhaustPhysicalPlans(prop *property.PhysicalProperty
 			Exprs:                p.Exprs,
 			CalculateNoDelay:     p.CalculateNoDelay,
 			AvoidColumnEvaluator: p.AvoidColumnEvaluator,
-		}.Init(p.SCtx(), p.StatsInfo().ScaleByExpectCnt(prop.ExpectedCnt), p.QueryBlockOffset(), newProp)
+		}.Init(ctx, p.StatsInfo().ScaleByExpectCnt(prop.ExpectedCnt), p.QueryBlockOffset(), newProp)
 		proj.SetSchema(p.schema)
 		ret = append(ret, proj)
 	}
@@ -2846,9 +2846,9 @@ func (lw *LogicalWindow) tryToGetMppWindows(prop *property.PhysicalProperty) []P
 
 	{
 		allSupported := true
-		exprCtx := lw.SCtx().GetExprCtx()
+		sctx := lw.SCtx()
 		for _, windowFunc := range lw.WindowFuncDescs {
-			if !windowFunc.CanPushDownToTiFlash(exprCtx, lw.SCtx().GetClient()) {
+			if !windowFunc.CanPushDownToTiFlash(GetPushDownCtx(sctx)) {
 				lw.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced(
 					"MPP mode may be blocked because window function `" + windowFunc.Name + "` or its arguments are not supported now.")
 				allSupported = false
@@ -3476,11 +3476,7 @@ func (p *LogicalSelection) exhaustPhysicalPlans(prop *property.PhysicalProperty)
 func (p *LogicalSelection) canPushDown(storeTp kv.StoreType) bool {
 	return !expression.ContainVirtualColumn(p.Conditions) &&
 		p.canPushToCop(storeTp) &&
-		expression.CanExprsPushDown(
-			p.SCtx().GetExprCtx(),
-			p.Conditions,
-			p.SCtx().GetClient(),
-			storeTp)
+		expression.CanExprsPushDown(GetPushDownCtx(p.SCtx()), p.Conditions, storeTp)
 }
 
 func (p *LogicalLimit) exhaustPhysicalPlans(prop *property.PhysicalProperty) ([]PhysicalPlan, bool, error) {

--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -141,15 +141,12 @@ func (ds *DataSource) generateNormalIndexPartialPaths4DNF(
 ) (paths []*util.AccessPath, needSelection bool, usedMap []bool) {
 	paths = make([]*util.AccessPath, 0, len(dnfItems))
 	usedMap = make([]bool, len(dnfItems))
+	pushDownCtx := GetPushDownCtx(ds.SCtx())
 	for offset, item := range dnfItems {
 		cnfItems := expression.SplitCNFItems(item)
 		pushedDownCNFItems := make([]expression.Expression, 0, len(cnfItems))
 		for _, cnfItem := range cnfItems {
-			if expression.CanExprsPushDown(ds.SCtx().GetExprCtx(),
-				[]expression.Expression{cnfItem},
-				ds.SCtx().GetClient(),
-				kv.TiKV,
-			) {
+			if expression.CanExprsPushDown(pushDownCtx, []expression.Expression{cnfItem}, kv.TiKV) {
 				pushedDownCNFItems = append(pushedDownCNFItems, cnfItem)
 			} else {
 				needSelection = true
@@ -184,7 +181,7 @@ func (ds *DataSource) generateNormalIndexPartialPaths4DNF(
 			partialPath.TableFilters = nil
 		}
 		// If any partial path's index filter cannot be pushed to TiKV, we should keep the whole DNF filter.
-		if len(partialPath.IndexFilters) != 0 && !expression.CanExprsPushDown(ds.SCtx().GetExprCtx(), partialPath.IndexFilters, ds.SCtx().GetClient(), kv.TiKV) {
+		if len(partialPath.IndexFilters) != 0 && !expression.CanExprsPushDown(pushDownCtx, partialPath.IndexFilters, kv.TiKV) {
 			needSelection = true
 			// Clear IndexFilter, the whole filter will be put in indexMergePath.TableFilters.
 			partialPath.IndexFilters = nil
@@ -220,6 +217,7 @@ func (ds *DataSource) generateNormalIndexPartialPaths4DNF(
 //	}
 func (ds *DataSource) generateIndexMergeOrPaths(filters []expression.Expression) error {
 	usedIndexCount := len(ds.possibleAccessPaths)
+	pushDownCtx := GetPushDownCtx(ds.SCtx())
 	for k, cond := range filters {
 		sf, ok := cond.(*expression.ScalarFunction)
 		if !ok || sf.FuncName.L != ast.LogicOr {
@@ -235,11 +233,7 @@ func (ds *DataSource) generateIndexMergeOrPaths(filters []expression.Expression)
 
 			pushedDownCNFItems := make([]expression.Expression, 0, len(cnfItems))
 			for _, cnfItem := range cnfItems {
-				if expression.CanExprsPushDown(ds.SCtx().GetExprCtx(),
-					[]expression.Expression{cnfItem},
-					ds.SCtx().GetClient(),
-					kv.TiKV,
-				) {
+				if expression.CanExprsPushDown(pushDownCtx, []expression.Expression{cnfItem}, kv.TiKV) {
 					pushedDownCNFItems = append(pushedDownCNFItems, cnfItem)
 				} else {
 					shouldKeepCurrentFilter = true
@@ -559,6 +553,7 @@ func (ds *DataSource) generateIndexMergeAndPaths(normalPathCnt int, usedAccessMa
 	finalFilters := make([]expression.Expression, 0)
 	partialFilters := make([]expression.Expression, 0, len(partialPaths))
 	hashCodeSet := make(map[string]struct{})
+	pushDownCtx := GetPushDownCtx(ds.SCtx())
 	for _, path := range partialPaths {
 		// Classify filters into coveredConds and notCoveredConds.
 		coveredConds := make([]expression.Expression, 0, len(path.AccessConds)+len(path.IndexFilters))
@@ -567,7 +562,7 @@ func (ds *DataSource) generateIndexMergeAndPaths(normalPathCnt int, usedAccessMa
 		coveredConds = append(coveredConds, path.AccessConds...)
 		for i, cond := range path.IndexFilters {
 			// IndexFilters can be covered by partial path if it can be pushed down to TiKV.
-			if !expression.CanExprsPushDown(ds.SCtx().GetExprCtx(), []expression.Expression{cond}, ds.SCtx().GetClient(), kv.TiKV) {
+			if !expression.CanExprsPushDown(pushDownCtx, []expression.Expression{cond}, kv.TiKV) {
 				path.IndexFilters = append(path.IndexFilters[:i], path.IndexFilters[i+1:]...)
 				notCoveredConds = append(notCoveredConds, cond)
 			} else {
@@ -757,7 +752,7 @@ func (ds *DataSource) generateIndexMerge4NormalIndex(regularPathCount int, index
 			// PushDownExprs() will append extra warnings, which is annoying. So we reset warnings here.
 			warnings := stmtCtx.GetWarnings()
 			extraWarnings := stmtCtx.GetExtraWarnings()
-			_, remaining := expression.PushDownExprs(ds.SCtx().GetExprCtx(), indexMergeConds, ds.SCtx().GetClient(), kv.UnSpecified)
+			_, remaining := expression.PushDownExprs(GetPushDownCtx(ds.SCtx()), indexMergeConds, kv.UnSpecified)
 			stmtCtx.SetWarnings(warnings)
 			stmtCtx.SetExtraWarnings(extraWarnings)
 			if len(remaining) > 0 {

--- a/pkg/planner/core/plan_to_pb.go
+++ b/pkg/planner/core/plan_to_pb.go
@@ -93,8 +93,9 @@ func (p *PhysicalHashAgg) ToPB(ctx PlanContext, storeType kv.StoreType) (*tipb.E
 	aggExec := &tipb.Aggregation{
 		GroupBy: groupByExprs,
 	}
+	pushDownCtx := GetPushDownCtx(p.SCtx())
 	for _, aggFunc := range p.AggFuncs {
-		agg, err := aggregation.AggFuncToPBExpr(ctx.GetExprCtx(), client, aggFunc, storeType)
+		agg, err := aggregation.AggFuncToPBExpr(pushDownCtx, aggFunc, storeType)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -122,6 +123,7 @@ func (p *PhysicalHashAgg) ToPB(ctx PlanContext, storeType kv.StoreType) (*tipb.E
 func (p *PhysicalStreamAgg) ToPB(ctx PlanContext, storeType kv.StoreType) (*tipb.Executor, error) {
 	client := ctx.GetClient()
 	exprCtx := ctx.GetExprCtx()
+	pushDownCtx := GetPushDownCtx(ctx)
 	groupByExprs, err := expression.ExpressionsToPBList(exprCtx, p.GroupByItems, client)
 	if err != nil {
 		return nil, err
@@ -130,7 +132,7 @@ func (p *PhysicalStreamAgg) ToPB(ctx PlanContext, storeType kv.StoreType) (*tipb
 		GroupBy: groupByExprs,
 	}
 	for _, aggFunc := range p.AggFuncs {
-		agg, err := aggregation.AggFuncToPBExpr(exprCtx, client, aggFunc, storeType)
+		agg, err := aggregation.AggFuncToPBExpr(pushDownCtx, aggFunc, storeType)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/pkg/planner/core/rule_predicate_push_down.go
+++ b/pkg/planner/core/rule_predicate_push_down.go
@@ -139,7 +139,7 @@ func (ds *DataSource) PredicatePushDown(predicates []expression.Expression, opt 
 	// TODO: remove it to the place building logical plan
 	predicates = ds.AddPrefix4ShardIndexes(ds.SCtx(), predicates)
 	ds.allConds = predicates
-	ds.pushedDownConds, predicates = expression.PushDownExprs(ds.SCtx().GetExprCtx(), predicates, ds.SCtx().GetClient(), kv.UnSpecified)
+	ds.pushedDownConds, predicates = expression.PushDownExprs(GetPushDownCtx(ds.SCtx()), predicates, kv.UnSpecified)
 	appendDataSourcePredicatePushDownTraceStep(ds, opt)
 	return predicates, ds
 }

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1112,7 +1112,7 @@ func (p *PhysicalTopN) canExpressionConvertedToPB(storeTp kv.StoreType) bool {
 	for _, item := range p.ByItems {
 		exprs = append(exprs, item.Expr)
 	}
-	return expression.CanExprsPushDown(p.SCtx().GetExprCtx(), exprs, p.SCtx().GetClient(), storeTp)
+	return expression.CanExprsPushDown(GetPushDownCtx(p.SCtx()), exprs, storeTp)
 }
 
 // containVirtualColumn checks whether TopN.ByItems contains virtual generated columns.
@@ -1213,12 +1213,12 @@ func (p *PhysicalExpand) attach2Task(tasks ...task) task {
 func (p *PhysicalProjection) attach2Task(tasks ...task) task {
 	t := tasks[0].copy()
 	if cop, ok := t.(*copTask); ok {
-		if (len(cop.rootTaskConds) == 0 && len(cop.idxMergePartPlans) == 0) && expression.CanExprsPushDown(p.SCtx().GetExprCtx(), p.Exprs, p.SCtx().GetClient(), cop.getStoreType()) {
+		if (len(cop.rootTaskConds) == 0 && len(cop.idxMergePartPlans) == 0) && expression.CanExprsPushDown(GetPushDownCtx(p.SCtx()), p.Exprs, cop.getStoreType()) {
 			copTask := attachPlan2Task(p, cop)
 			return copTask
 		}
 	} else if mpp, ok := t.(*mppTask); ok {
-		if expression.CanExprsPushDown(p.SCtx().GetExprCtx(), p.Exprs, p.SCtx().GetClient(), kv.TiFlash) {
+		if expression.CanExprsPushDown(GetPushDownCtx(p.SCtx()), p.Exprs, kv.TiFlash) {
 			p.SetChildren(mpp.p)
 			mpp.p = p
 			return mpp
@@ -1275,7 +1275,7 @@ func (p *PhysicalUnionAll) attach2Task(tasks ...task) task {
 
 func (sel *PhysicalSelection) attach2Task(tasks ...task) task {
 	if mppTask, _ := tasks[0].(*mppTask); mppTask != nil { // always push to mpp task.
-		if expression.CanExprsPushDown(sel.SCtx().GetExprCtx(), sel.Conditions, sel.SCtx().GetClient(), kv.TiFlash) {
+		if expression.CanExprsPushDown(GetPushDownCtx(sel.SCtx()), sel.Conditions, kv.TiFlash) {
 			return attachPlan2Task(sel, mppTask.copy())
 		}
 	}
@@ -1287,9 +1287,9 @@ func (sel *PhysicalSelection) attach2Task(tasks ...task) task {
 // be pushed down to coprocessor.
 func CheckAggCanPushCop(sctx PlanContext, aggFuncs []*aggregation.AggFuncDesc, groupByItems []expression.Expression, storeType kv.StoreType) bool {
 	sc := sctx.GetSessionVars().StmtCtx
-	client := sctx.GetClient()
 	ret := true
 	reason := ""
+	pushDownCtx := GetPushDownCtx(sctx)
 	for _, aggFunc := range aggFuncs {
 		// if the aggFunc contain VirtualColumn or CorrelatedColumn, it can not be pushed down.
 		if expression.ContainVirtualColumn(aggFunc.Args) || expression.ContainCorrelatedColumn(aggFunc.Args) {
@@ -1302,7 +1302,7 @@ func CheckAggCanPushCop(sctx PlanContext, aggFuncs []*aggregation.AggFuncDesc, g
 			ret = false
 			break
 		}
-		if !expression.CanExprsPushDownWithExtraInfo(sctx.GetExprCtx(), aggFunc.Args, client, storeType, aggFunc.Name == ast.AggFuncSum) {
+		if !expression.CanExprsPushDownWithExtraInfo(GetPushDownCtx(sctx), aggFunc.Args, storeType, aggFunc.Name == ast.AggFuncSum) {
 			reason = "arguments of AggFunc `" + aggFunc.Name + "` contains unsupported exprs"
 			ret = false
 			break
@@ -1313,13 +1313,13 @@ func CheckAggCanPushCop(sctx PlanContext, aggFuncs []*aggregation.AggFuncDesc, g
 			for _, item := range aggFunc.OrderByItems {
 				exprs = append(exprs, item.Expr)
 			}
-			if !expression.CanExprsPushDownWithExtraInfo(sctx.GetExprCtx(), exprs, client, storeType, false) {
+			if !expression.CanExprsPushDownWithExtraInfo(GetPushDownCtx(sctx), exprs, storeType, false) {
 				reason = "arguments of AggFunc `" + aggFunc.Name + "` contains unsupported exprs in order-by clause"
 				ret = false
 				break
 			}
 		}
-		pb, _ := aggregation.AggFuncToPBExpr(sctx.GetExprCtx(), client, aggFunc, storeType)
+		pb, _ := aggregation.AggFuncToPBExpr(pushDownCtx, aggFunc, storeType)
 		if pb == nil {
 			reason = "AggFunc `" + aggFunc.Name + "` can not be converted to pb expr"
 			ret = false
@@ -1330,7 +1330,7 @@ func CheckAggCanPushCop(sctx PlanContext, aggFuncs []*aggregation.AggFuncDesc, g
 		reason = "groupByItems contain virtual columns, which is not supported now"
 		ret = false
 	}
-	if ret && !expression.CanExprsPushDown(sctx.GetExprCtx(), groupByItems, client, storeType) {
+	if ret && !expression.CanExprsPushDown(GetPushDownCtx(sctx), groupByItems, storeType) {
 		reason = "groupByItems contain unsupported exprs"
 		ret = false
 	}

--- a/pkg/planner/core/util.go
+++ b/pkg/planner/core/util.go
@@ -469,3 +469,8 @@ func EncodeUniqueIndexValuesForKey(ctx sessionctx.Context, tblInfo *model.TableI
 	}
 	return encodedIdxVals, nil
 }
+
+// GetPushDownCtx creates a PushDownContext from PlanContext
+func GetPushDownCtx(sctx PlanContext) expression.PushDownContext {
+	return expression.NewPushDownContext(sctx.GetExprCtx(), sctx.GetSessionVars(), sctx.GetClient())
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51890

### What changed and how does it work?

It's better to keep `EvalContext` exposed fewer fields to make sure it is simple and semantically clear. In this PR, we introduce `expression.PushDownContext` context to provide some push down information.

`PushDownContext` contains `EvalContext` and also provides some other fields like `kv.Client` that is not required by `EvalContext`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
