### PR TITLE
br: Change default check point lag limit

### DIFF
--- a/br/pkg/streamhelper/config/advancer_conf.go
+++ b/br/pkg/streamhelper/config/advancer_conf.go
@@ -18,7 +18,7 @@ const (
 
 	DefaultConsistencyCheckTick = 5
 	DefaultTryAdvanceThreshold  = 4 * time.Minute
-	DefaultCheckPointLagLimit   = 12 * time.Hour
+	DefaultCheckPointLagLimit   = 48 * time.Hour
 	DefaultBackOffTime          = 5 * time.Second
 	DefaultTickInterval         = 12 * time.Second
 	DefaultFullScanTick         = 4

--- a/br/pkg/streamhelper/config/advancer_conf.go
+++ b/br/pkg/streamhelper/config/advancer_conf.go
@@ -14,10 +14,11 @@ const (
 	flagFullScanDiffTick    = "full-scan-tick"
 	flagAdvancingByCache    = "advancing-by-cache"
 	flagTryAdvanceThreshold = "try-advance-threshold"
+	flagCheckPointLagLimit  = "check-point-lag-limit"
 
 	DefaultConsistencyCheckTick = 5
 	DefaultTryAdvanceThreshold  = 4 * time.Minute
-	DefaultCheckPointLagLimit   = 0
+	DefaultCheckPointLagLimit   = 12 * time.Hour
 	DefaultBackOffTime          = 5 * time.Second
 	DefaultTickInterval         = 12 * time.Second
 	DefaultFullScanTick         = 4
@@ -46,6 +47,8 @@ func DefineFlagsForCheckpointAdvancerConfig(f *pflag.FlagSet) {
 		"From how long we trigger the tick (advancing the checkpoint).")
 	f.Duration(flagTryAdvanceThreshold, DefaultTryAdvanceThreshold,
 		"If the checkpoint lag is greater than how long, we would try to poll TiKV for checkpoints.")
+	f.Duration(flagCheckPointLagLimit, DefaultCheckPointLagLimit,
+		"The maximum lag could be tolerated for the checkpoint lag.")
 }
 
 func Default() Config {
@@ -68,6 +71,10 @@ func (conf *Config) GetFromFlags(f *pflag.FlagSet) error {
 		return err
 	}
 	conf.TryAdvanceThreshold, err = f.GetDuration(flagTryAdvanceThreshold)
+	if err != nil {
+		return err
+	}
+	conf.CheckPointLagLimit, err = f.GetDuration(flagCheckPointLagLimit)
 	if err != nil {
 		return err
 	}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -82,7 +82,7 @@ var (
 	StreamStatus   = "log status"
 	StreamTruncate = "log truncate"
 	StreamMetadata = "log metadata"
-	StreamCtl      = "log ctl"
+	StreamCtl      = "log advancer"
 
 	skipSummaryCommandList = map[string]struct{}{
 		StreamStatus:   {},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50803

Problem Summary:

### What changed and how does it work?

This PR set the default value of 'check-point-lag-limit' to 24 hours, and also expose the paramter.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] 
<img width="1350" alt="image" src="https://github.com/pingcap/tidb/assets/97348524/09e34dc5-a526-4563-91ab-5147084b0220">

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
