### PR TITLE
ldap: add timeout mechanism and optimize lock for LDAP dial and requests

### DIFF
--- a/pkg/privilege/privileges/ldap/ldap_common.go
+++ b/pkg/privilege/privileges/ldap/ldap_common.go
@@ -32,6 +32,9 @@ import (
 	"go.uber.org/zap"
 )
 
+const getConnectionMaxRetry = 10
+const getConnectionRetryInterval = 500 * time.Millisecond
+
 // ldapTimeout is set to 10s. It works on both the TCP/TLS dialing timeout, and the LDAP request timeout. For connection with TLS, the
 // user may find that it fails after 2*ldapTimeout, because TiDB will try to connect through both `StartTLS` (from a normal TCP connection)
 // and `TLS`, therefore the total time is 2*ldapTimeout.
@@ -41,10 +44,8 @@ var ldapTimeout = 10 * time.Second
 // use `StartTLS`
 var skipTLSForTest = false
 
-// ldapAuthImpl gives the internal utilities of authentication with LDAP.
-// The getter and setter methods will lock the mutex inside, while all other methods don't, so all other method call
-// should be protected by `impl.Lock()`.
-type ldapAuthImpl struct {
+// ldapAuthImplBuilder builds a new `*ldapAuthImpl` from the current configuration.
+type ldapAuthImplBuilder struct {
 	sync.RWMutex
 	// the following attributes are used to search the users
 	bindBaseDN  string
@@ -65,11 +66,321 @@ type ldapAuthImpl struct {
 	ldapConnectionPool *pools.ResourcePool
 }
 
+func (impl *ldapAuthImplBuilder) build() *ldapAuthImpl {
+	impl.RLock()
+	defer impl.RUnlock()
+
+	return &ldapAuthImpl{
+		bindBaseDN:         impl.bindBaseDN,
+		bindRootDN:         impl.bindRootDN,
+		bindRootPWD:        impl.bindRootPWD,
+		searchAttr:         impl.searchAttr,
+		ldapConnectionPool: impl.ldapConnectionPool,
+	}
+}
+
+func (impl *ldapAuthImplBuilder) initializeCAPool() error {
+	if impl.caPath == "" {
+		impl.caPool = nil
+		return nil
+	}
+
+	impl.caPool = x509.NewCertPool()
+	caCert, err := os.ReadFile(impl.caPath)
+	if err != nil {
+		return errors.Wrapf(err, "read ca certificate at %s", caCert)
+	}
+
+	ok := impl.caPool.AppendCertsFromPEM(caCert)
+	if !ok {
+		return errors.New("fail to parse ca certificate")
+	}
+
+	return nil
+}
+
+func tryConnectLDAPThroughStartTLS(address string, tlsConfig *tls.Config) (*ldap.Conn, error) {
+	ldapConnection, err := ldap.DialURL("ldap://"+address, ldap.DialWithDialer(&net.Dialer{
+		Timeout: ldapTimeout,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	ldapConnection.SetTimeout(ldapTimeout)
+
+	err = ldapConnection.StartTLS(tlsConfig)
+	if err != nil {
+		ldapConnection.Close()
+
+		return nil, err
+	}
+	return ldapConnection, nil
+}
+
+func tryConnectLDAPThroughTLS(address string, tlsConfig *tls.Config) (*ldap.Conn, error) {
+	ldapConnection, err := ldap.DialURL("ldaps://"+address, ldap.DialWithTLSDialer(tlsConfig, &net.Dialer{
+		Timeout: ldapTimeout,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	ldapConnection.SetTimeout(ldapTimeout)
+
+	return ldapConnection, nil
+}
+
+func ldapConnectionFactory(address string, tlsConfig *tls.Config) func() (pools.Resource, error) {
+	if tlsConfig != nil {
+		return func() (pools.Resource, error) {
+			ldapConnection, err := tryConnectLDAPThroughStartTLS(address, tlsConfig)
+			if err != nil {
+				if intest.InTest && skipTLSForTest {
+					return nil, errors.Wrap(err, "create ldap connection")
+				}
+
+				ldapConnection, err = tryConnectLDAPThroughTLS(address, tlsConfig)
+				if err != nil {
+					return nil, errors.Wrap(err, "create ldap connection")
+				}
+			}
+
+			return ldapConnection, nil
+		}
+	}
+
+	return func() (pools.Resource, error) {
+		ldapConnection, err := ldap.DialURL("ldap://"+address, ldap.DialWithDialer(
+			&net.Dialer{
+				Timeout: ldapTimeout,
+			},
+		))
+		if err != nil {
+			return nil, errors.Wrap(err, "create ldap connection")
+		}
+
+		return ldapConnection, nil
+	}
+}
+
+func (impl *ldapAuthImplBuilder) initializePool() {
+	if impl.ldapConnectionPool != nil {
+		impl.ldapConnectionPool.Close()
+	}
+
+	// skip initialization when the variables are not correct
+	if impl.initCapacity > 0 && impl.maxCapacity >= impl.initCapacity {
+		address := net.JoinHostPort(impl.ldapServerHost, strconv.FormatUint(uint64(impl.ldapServerPort), 10))
+		var tlsConfig *tls.Config
+		if impl.enableTLS {
+			tlsConfig = &tls.Config{
+				RootCAs:    impl.caPool,
+				ServerName: impl.ldapServerHost,
+				MinVersion: tls.VersionTLS12,
+			}
+		}
+
+		impl.ldapConnectionPool = pools.NewResourcePool(ldapConnectionFactory(address, tlsConfig), impl.initCapacity, impl.maxCapacity, 0)
+	}
+}
+
+// SetBindBaseDN updates the BaseDN used to search the user
+func (impl *ldapAuthImplBuilder) SetBindBaseDN(bindBaseDN string) {
+	impl.Lock()
+	defer impl.Unlock()
+
+	impl.bindBaseDN = bindBaseDN
+}
+
+// SetBindRootDN updates the RootDN. Before searching the users, the connection will bind
+// this root user.
+func (impl *ldapAuthImplBuilder) SetBindRootDN(bindRootDN string) {
+	impl.Lock()
+	defer impl.Unlock()
+
+	impl.bindRootDN = bindRootDN
+}
+
+// SetBindRootPW updates the password of the user specified by `rootDN`.
+func (impl *ldapAuthImplBuilder) SetBindRootPW(bindRootPW string) {
+	impl.Lock()
+	defer impl.Unlock()
+
+	impl.bindRootPWD = bindRootPW
+}
+
+// SetSearchAttr updates the search attributes.
+func (impl *ldapAuthImplBuilder) SetSearchAttr(searchAttr string) {
+	impl.Lock()
+	defer impl.Unlock()
+
+	impl.searchAttr = searchAttr
+}
+
+// SetLDAPServerHost updates the host of LDAP server
+func (impl *ldapAuthImplBuilder) SetLDAPServerHost(ldapServerHost string) {
+	impl.Lock()
+	defer impl.Unlock()
+
+	if ldapServerHost != impl.ldapServerHost {
+		impl.ldapServerHost = ldapServerHost
+		impl.initializePool()
+	}
+}
+
+// SetLDAPServerPort updates the port of LDAP server
+func (impl *ldapAuthImplBuilder) SetLDAPServerPort(ldapServerPort int) {
+	impl.Lock()
+	defer impl.Unlock()
+
+	if ldapServerPort != impl.ldapServerPort {
+		impl.ldapServerPort = ldapServerPort
+		impl.initializePool()
+	}
+}
+
+// SetEnableTLS sets whether to enable StartTLS for LDAP connection
+func (impl *ldapAuthImplBuilder) SetEnableTLS(enableTLS bool) {
+	impl.Lock()
+	defer impl.Unlock()
+
+	if enableTLS != impl.enableTLS {
+		impl.enableTLS = enableTLS
+		impl.initializePool()
+	}
+}
+
+// SetCAPath sets the path of CA certificate used to connect to LDAP server
+func (impl *ldapAuthImplBuilder) SetCAPath(path string) error {
+	impl.Lock()
+	defer impl.Unlock()
+
+	if path != impl.caPath {
+		impl.caPath = path
+		err := impl.initializeCAPool()
+		if err != nil {
+			return err
+		}
+		impl.initializePool()
+	}
+
+	return nil
+}
+
+func (impl *ldapAuthImplBuilder) SetInitCapacity(initCapacity int) {
+	impl.Lock()
+	defer impl.Unlock()
+
+	if initCapacity != impl.initCapacity {
+		impl.initCapacity = initCapacity
+		impl.initializePool()
+	}
+}
+
+func (impl *ldapAuthImplBuilder) SetMaxCapacity(maxCapacity int) {
+	impl.Lock()
+	defer impl.Unlock()
+
+	if maxCapacity != impl.maxCapacity {
+		impl.maxCapacity = maxCapacity
+		impl.initializePool()
+	}
+}
+
+// GetBindBaseDN returns the BaseDN used to search the user
+func (impl *ldapAuthImplBuilder) GetBindBaseDN() string {
+	impl.RLock()
+	defer impl.RUnlock()
+
+	return impl.bindBaseDN
+}
+
+// GetBindRootDN returns the RootDN. Before searching the users, the connection will bind
+// this root user.
+func (impl *ldapAuthImplBuilder) GetBindRootDN() string {
+	impl.RLock()
+	defer impl.RUnlock()
+
+	return impl.bindRootDN
+}
+
+// GetBindRootPW returns the password of the user specified by `rootDN`.
+func (impl *ldapAuthImplBuilder) GetBindRootPW() string {
+	impl.RLock()
+	defer impl.RUnlock()
+
+	return impl.bindRootPWD
+}
+
+// GetSearchAttr returns the search attributes.
+func (impl *ldapAuthImplBuilder) GetSearchAttr() string {
+	impl.RLock()
+	defer impl.RUnlock()
+
+	return impl.searchAttr
+}
+
+// GetLDAPServerHost returns the host of LDAP server
+func (impl *ldapAuthImplBuilder) GetLDAPServerHost() string {
+	impl.RLock()
+	defer impl.RUnlock()
+
+	return impl.ldapServerHost
+}
+
+// GetLDAPServerPort returns the port of LDAP server
+func (impl *ldapAuthImplBuilder) GetLDAPServerPort() int {
+	impl.RLock()
+	defer impl.RUnlock()
+
+	return impl.ldapServerPort
+}
+
+// GetEnableTLS sets whether to enable StartTLS for LDAP connection
+func (impl *ldapAuthImplBuilder) GetEnableTLS() bool {
+	impl.RLock()
+	defer impl.RUnlock()
+
+	return impl.enableTLS
+}
+
+// GetCAPath returns the path of CA certificate used to connect to LDAP server
+func (impl *ldapAuthImplBuilder) GetCAPath() string {
+	impl.RLock()
+	defer impl.RUnlock()
+
+	return impl.caPath
+}
+
+func (impl *ldapAuthImplBuilder) GetInitCapacity() int {
+	impl.RLock()
+	defer impl.RUnlock()
+
+	return impl.initCapacity
+}
+
+func (impl *ldapAuthImplBuilder) GetMaxCapacity() int {
+	impl.RLock()
+	defer impl.RUnlock()
+
+	return impl.maxCapacity
+}
+
+// ldapAuthImpl gives the internal utilities of authentication with LDAP.
+type ldapAuthImpl struct {
+	bindBaseDN  string
+	bindRootDN  string
+	bindRootPWD string
+	searchAttr  string
+
+	ldapConnectionPool *pools.ResourcePool
+}
+
 func (impl *ldapAuthImpl) searchUser(userName string) (dn string, err error) {
 	var l *ldap.Conn
 
 	l, err = impl.getConnection()
 	if err != nil {
+		logutil.BgLogger().Error("fail to create ldap connection", zap.Error(err))
 		return "", err
 	}
 	defer impl.putConnection(l)
@@ -107,100 +418,6 @@ func (impl *ldapAuthImpl) canonicalizeDN(userName string, dn string) string {
 	return dn
 }
 
-func (impl *ldapAuthImpl) initializeCAPool() error {
-	if impl.caPath == "" {
-		impl.caPool = nil
-		return nil
-	}
-
-	impl.caPool = x509.NewCertPool()
-	caCert, err := os.ReadFile(impl.caPath)
-	if err != nil {
-		return errors.Wrapf(err, "read ca certificate at %s", caCert)
-	}
-
-	ok := impl.caPool.AppendCertsFromPEM(caCert)
-	if !ok {
-		return errors.New("fail to parse ca certificate")
-	}
-
-	return nil
-}
-
-func (impl *ldapAuthImpl) tryConnectLDAPThroughStartTLS(address string) (*ldap.Conn, error) {
-	ldapConnection, err := ldap.DialURL("ldap://"+address, ldap.DialWithDialer(&net.Dialer{
-		Timeout: ldapTimeout,
-	}))
-	if err != nil {
-		return nil, err
-	}
-	ldapConnection.SetTimeout(ldapTimeout)
-
-	err = ldapConnection.StartTLS(&tls.Config{
-		RootCAs:    impl.caPool,
-		ServerName: impl.ldapServerHost,
-		MinVersion: tls.VersionTLS12,
-	})
-	if err != nil {
-		ldapConnection.Close()
-
-		return nil, err
-	}
-
-	return ldapConnection, nil
-}
-
-func (impl *ldapAuthImpl) tryConnectLDAPThroughTLS(address string) (*ldap.Conn, error) {
-	tlsConfig := &tls.Config{
-		RootCAs:    impl.caPool,
-		ServerName: impl.ldapServerHost,
-		MinVersion: tls.VersionTLS12,
-	}
-	ldapConnection, err := ldap.DialURL("ldaps://"+address, ldap.DialWithTLSDialer(tlsConfig, &net.Dialer{
-		Timeout: ldapTimeout,
-	}))
-	if err != nil {
-		return nil, err
-	}
-	ldapConnection.SetTimeout(ldapTimeout)
-
-	return ldapConnection, nil
-}
-
-func (impl *ldapAuthImpl) connectionFactory() (pools.Resource, error) {
-	address := net.JoinHostPort(impl.ldapServerHost, strconv.FormatUint(uint64(impl.ldapServerPort), 10))
-
-	// It's fine to load these two TLS configurations one-by-one (but not guarded by a single lock), because there isn't
-	// a way to set two variables atomically.
-	if impl.enableTLS {
-		ldapConnection, err := impl.tryConnectLDAPThroughStartTLS(address)
-		if err != nil {
-			if intest.InTest && skipTLSForTest {
-				return nil, err
-			}
-
-			ldapConnection, err = impl.tryConnectLDAPThroughTLS(address)
-			if err != nil {
-				return nil, errors.Wrap(err, "create ldap connection")
-			}
-		}
-
-		return ldapConnection, nil
-	}
-	ldapConnection, err := ldap.DialURL("ldap://"+address, ldap.DialWithDialer(&net.Dialer{
-		Timeout: ldapTimeout,
-	}))
-	if err != nil {
-		return nil, errors.Wrap(err, "create ldap connection")
-	}
-	ldapConnection.SetTimeout(ldapTimeout)
-
-	return ldapConnection, nil
-}
-
-const getConnectionMaxRetry = 10
-const getConnectionRetryInterval = 500 * time.Millisecond
-
 func (impl *ldapAuthImpl) getConnection() (*ldap.Conn, error) {
 	retryCount := 0
 	for {
@@ -222,6 +439,7 @@ func (impl *ldapAuthImpl) getConnection() (*ldap.Conn, error) {
 		if err != nil {
 			logutil.BgLogger().Warn("fail to use LDAP connection bind to anonymous user. Retrying", zap.Error(err),
 				zap.Duration("backoff", getConnectionRetryInterval))
+			ldapConnection.Close()
 
 			// fail to bind to anonymous user, just release this connection and try to get a new one
 			impl.ldapConnectionPool.Put(nil)
@@ -242,196 +460,4 @@ func (impl *ldapAuthImpl) getConnection() (*ldap.Conn, error) {
 
 func (impl *ldapAuthImpl) putConnection(conn *ldap.Conn) {
 	impl.ldapConnectionPool.Put(conn)
-}
-
-func (impl *ldapAuthImpl) initializePool() {
-	// skip re-initialization when the variables are not correct
-	if impl.initCapacity > 0 && impl.maxCapacity >= impl.initCapacity {
-		if impl.ldapConnectionPool != nil {
-			impl.ldapConnectionPool.Close()
-		}
-
-		impl.ldapConnectionPool = pools.NewResourcePool(impl.connectionFactory, impl.initCapacity, impl.maxCapacity, 0)
-	}
-}
-
-// SetBindBaseDN updates the BaseDN used to search the user
-func (impl *ldapAuthImpl) SetBindBaseDN(bindBaseDN string) {
-	impl.Lock()
-	defer impl.Unlock()
-
-	impl.bindBaseDN = bindBaseDN
-}
-
-// SetBindRootDN updates the RootDN. Before searching the users, the connection will bind
-// this root user.
-func (impl *ldapAuthImpl) SetBindRootDN(bindRootDN string) {
-	impl.Lock()
-	defer impl.Unlock()
-
-	impl.bindRootDN = bindRootDN
-}
-
-// SetBindRootPW updates the password of the user specified by `rootDN`.
-func (impl *ldapAuthImpl) SetBindRootPW(bindRootPW string) {
-	impl.Lock()
-	defer impl.Unlock()
-
-	impl.bindRootPWD = bindRootPW
-}
-
-// SetSearchAttr updates the search attributes.
-func (impl *ldapAuthImpl) SetSearchAttr(searchAttr string) {
-	impl.Lock()
-	defer impl.Unlock()
-
-	impl.searchAttr = searchAttr
-}
-
-// SetLDAPServerHost updates the host of LDAP server
-func (impl *ldapAuthImpl) SetLDAPServerHost(ldapServerHost string) {
-	impl.Lock()
-	defer impl.Unlock()
-
-	if ldapServerHost != impl.ldapServerHost {
-		impl.ldapServerHost = ldapServerHost
-		impl.initializePool()
-	}
-}
-
-// SetLDAPServerPort updates the port of LDAP server
-func (impl *ldapAuthImpl) SetLDAPServerPort(ldapServerPort int) {
-	impl.Lock()
-	defer impl.Unlock()
-
-	if ldapServerPort != impl.ldapServerPort {
-		impl.ldapServerPort = ldapServerPort
-		impl.initializePool()
-	}
-}
-
-// SetEnableTLS sets whether to enable StartTLS for LDAP connection
-func (impl *ldapAuthImpl) SetEnableTLS(enableTLS bool) {
-	impl.Lock()
-	defer impl.Unlock()
-
-	if enableTLS != impl.enableTLS {
-		impl.enableTLS = enableTLS
-		impl.initializePool()
-	}
-}
-
-// SetCAPath sets the path of CA certificate used to connect to LDAP server
-func (impl *ldapAuthImpl) SetCAPath(path string) error {
-	impl.Lock()
-	defer impl.Unlock()
-
-	if path != impl.caPath {
-		impl.caPath = path
-		err := impl.initializeCAPool()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (impl *ldapAuthImpl) SetInitCapacity(initCapacity int) {
-	impl.Lock()
-	defer impl.Unlock()
-
-	if initCapacity != impl.initCapacity {
-		impl.initCapacity = initCapacity
-		impl.initializePool()
-	}
-}
-
-func (impl *ldapAuthImpl) SetMaxCapacity(maxCapacity int) {
-	impl.Lock()
-	defer impl.Unlock()
-
-	if maxCapacity != impl.maxCapacity {
-		impl.maxCapacity = maxCapacity
-		impl.initializePool()
-	}
-}
-
-// GetBindBaseDN returns the BaseDN used to search the user
-func (impl *ldapAuthImpl) GetBindBaseDN() string {
-	impl.RLock()
-	defer impl.RUnlock()
-
-	return impl.bindBaseDN
-}
-
-// GetBindRootDN returns the RootDN. Before searching the users, the connection will bind
-// this root user.
-func (impl *ldapAuthImpl) GetBindRootDN() string {
-	impl.RLock()
-	defer impl.RUnlock()
-
-	return impl.bindRootDN
-}
-
-// GetBindRootPW returns the password of the user specified by `rootDN`.
-func (impl *ldapAuthImpl) GetBindRootPW() string {
-	impl.RLock()
-	defer impl.RUnlock()
-
-	return impl.bindRootPWD
-}
-
-// GetSearchAttr returns the search attributes.
-func (impl *ldapAuthImpl) GetSearchAttr() string {
-	impl.RLock()
-	defer impl.RUnlock()
-
-	return impl.searchAttr
-}
-
-// GetLDAPServerHost returns the host of LDAP server
-func (impl *ldapAuthImpl) GetLDAPServerHost() string {
-	impl.RLock()
-	defer impl.RUnlock()
-
-	return impl.ldapServerHost
-}
-
-// GetLDAPServerPort returns the port of LDAP server
-func (impl *ldapAuthImpl) GetLDAPServerPort() int {
-	impl.RLock()
-	defer impl.RUnlock()
-
-	return impl.ldapServerPort
-}
-
-// GetEnableTLS sets whether to enable StartTLS for LDAP connection
-func (impl *ldapAuthImpl) GetEnableTLS() bool {
-	impl.RLock()
-	defer impl.RUnlock()
-
-	return impl.enableTLS
-}
-
-// GetCAPath returns the path of CA certificate used to connect to LDAP server
-func (impl *ldapAuthImpl) GetCAPath() string {
-	impl.RLock()
-	defer impl.RUnlock()
-
-	return impl.caPath
-}
-
-func (impl *ldapAuthImpl) GetInitCapacity() int {
-	impl.RLock()
-	defer impl.RUnlock()
-
-	return impl.initCapacity
-}
-
-func (impl *ldapAuthImpl) GetMaxCapacity() int {
-	impl.RLock()
-	defer impl.RUnlock()
-
-	return impl.maxCapacity
 }

--- a/pkg/privilege/privileges/ldap/ldap_common_test.go
+++ b/pkg/privilege/privileges/ldap/ldap_common_test.go
@@ -39,9 +39,10 @@ var tlsCrtStr []byte
 var tlsKeyStr []byte
 
 func TestCanonicalizeDN(t *testing.T) {
-	impl := &ldapAuthImpl{
+	implBuilder := &ldapAuthImplBuilder{
 		searchAttr: "cn",
 	}
+	impl := implBuilder.build()
 	require.Equal(t, impl.canonicalizeDN("yka", "cn=y,dc=ping,dc=cap"), "cn=y,dc=ping,dc=cap")
 	require.Equal(t, impl.canonicalizeDN("yka", "+dc=ping,dc=cap"), "cn=yka,dc=ping,dc=cap")
 }
@@ -97,15 +98,17 @@ func TestConnectThrough636(t *testing.T) {
 		serverWg.Wait()
 	}()
 
-	impl := &ldapAuthImpl{}
+	impl := &ldapAuthImplBuilder{}
 	impl.SetEnableTLS(true)
 	impl.SetLDAPServerHost("localhost")
 	impl.SetLDAPServerPort(randomTLSServicePort)
 
 	impl.caPool = x509.NewCertPool()
 	require.True(t, impl.caPool.AppendCertsFromPEM(tlsCAStr))
+	impl.SetInitCapacity(1)
+	impl.SetMaxCapacity(1)
 
-	conn, err := impl.connectionFactory()
+	conn, err := impl.ldapConnectionPool.Get()
 	require.NoError(t, err)
 	defer conn.Close()
 }
@@ -162,15 +165,17 @@ func TestConnectWithTLS11(t *testing.T) {
 		serverWg.Wait()
 	}()
 
-	impl := &ldapAuthImpl{}
+	impl := &ldapAuthImplBuilder{}
 	impl.SetEnableTLS(true)
 	impl.SetLDAPServerHost("localhost")
 	impl.SetLDAPServerPort(randomTLSServicePort)
 
 	impl.caPool = x509.NewCertPool()
 	require.True(t, impl.caPool.AppendCertsFromPEM(tlsCAStr))
+	impl.SetInitCapacity(1)
+	impl.SetMaxCapacity(1)
 
-	_, err := impl.connectionFactory()
+	_, err := impl.ldapConnectionPool.Get()
 	require.ErrorContains(t, err, "protocol version not supported")
 }
 
@@ -216,7 +221,7 @@ func TestLDAPStartTLSTimeout(t *testing.T) {
 		serverWg.Wait()
 	}()
 
-	impl := &ldapAuthImpl{}
+	impl := &ldapAuthImplBuilder{}
 	impl.SetEnableTLS(true)
 	impl.SetLDAPServerHost("localhost")
 	impl.SetLDAPServerPort(randomTLSServicePort)
@@ -227,10 +232,8 @@ func TestLDAPStartTLSTimeout(t *testing.T) {
 	impl.SetMaxCapacity(1)
 
 	now := time.Now()
-	_, err := impl.connectionFactory()
+	_, err := impl.build().getConnection()
 	afterTimeout <- struct{}{}
-	dur := time.Since(now)
-	require.Greater(t, dur, 2*time.Second)
-	require.Less(t, dur, 3*time.Second)
+	require.Greater(t, time.Since(now), 2*time.Second)
 	require.ErrorContains(t, err, "connection timed out")
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51883

Problem Summary:

There are two problems:

1. A pending LDAP authentication process will block `rebuildSysVarCache`.
2. If the LDAP connection lost after the first handshake, the LDAP goroutine and function call will hang forever.

### What changed and how does it work?

I have done two modification to fix this problem:

1. Refactor the original `ldapAuthImpl` to `ldapAuthImplBuilder`, which will copy the configurations (and take a reference to the connection pool, which include a closure with a copy of connection configurations). Therefore, during the scope of any lock, there didn't exist any IO operation, so that the `rebuildSysVarCache` will not be blocked by a network connection.
2. Add timeout to the LDAP requests.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

I used the `yangkeao/ldap-sasl-example` container to run the manual test, steps:

TODO

### Release note

```release-note
None
```
