### PR TITLE
planner: add mutable and immutable ft implementation

### DIFF
--- a/pkg/parser/types/BUILD.bazel
+++ b/pkg/parser/types/BUILD.bazel
@@ -6,6 +6,8 @@ go_library(
         "etc.go",
         "eval_type.go",
         "field_type.go",
+        "immtable_field_types.go",
+        "mutable_field_types.go",
     ],
     importpath = "github.com/pingcap/tidb/pkg/parser/types",
     visibility = ["//visibility:public"],
@@ -24,10 +26,11 @@ go_test(
     srcs = [
         "etc_test.go",
         "field_type_test.go",
+        "immutable_field_types_test.go",
     ],
     embed = [":types"],
     flaky = True,
-    shard_count = 6,
+    shard_count = 8,
     deps = [
         "//pkg/parser",
         "//pkg/parser/ast",

--- a/pkg/parser/types/field_type.go
+++ b/pkg/parser/types/field_type.go
@@ -39,7 +39,8 @@ var (
 	TiDBStrictIntegerDisplayWidth bool
 )
 
-// FieldType records field type information.
+// FieldType is the internal structure records field type information, with all elements unexported.
+// todo: move all the GET and SET from core structure of *FieldType to outer *MutableFieldType and *ImmutableFieldType
 type FieldType struct {
 	// tp is type of the field
 	tp byte
@@ -60,7 +61,8 @@ type FieldType struct {
 	// Please keep in mind that jsonFieldType should be updated if you add a new field here.
 }
 
-// NewFieldType returns a FieldType,
+// NewFieldType returns a FieldType.
+// todo: change NewFieldType as unexported as newFieldType, and it can only be used inside this pkg.
 // with a type and other information about field type.
 func NewFieldType(tp byte) *FieldType {
 	return &FieldType{
@@ -68,6 +70,27 @@ func NewFieldType(tp byte) *FieldType {
 		flen:    UnspecifiedLength,
 		decimal: UnspecifiedLength,
 	}
+}
+
+// ImmutableRef implements the mutable interface by returning an immutable reference to current obj.
+func (ft *FieldType) ImmutableRef() ImmutableFieldType {
+	// no-loss upcast
+	return ft
+}
+
+// MutableRef implements the immutable interface by returning the mutable reference to current obj.
+func (ft *FieldType) MutableRef() MutableFieldType {
+	// no-loss downcast
+	// MutableRef return the mutable reference to the current MutableFieldType.
+	return ft
+}
+
+// MutableCopy implements the immutable interface by returning a new copy the basic ft with COW.
+func (ft *FieldType) MutableCopy() MutableFieldType {
+	// when change an immutable fieldType to a mutable one, its kind of COW logic here.
+	// clone the basic element of original ImmutableFieldType it has, downcast it out.
+	newCP := *ft
+	return &newCP
 }
 
 // IsDecimalValid checks whether the decimal is valid.

--- a/pkg/parser/types/immtable_field_types.go
+++ b/pkg/parser/types/immtable_field_types.go
@@ -66,6 +66,7 @@ type ImmutableFieldType interface {
 	MemoryUsage() (sum int64)
 }
 
+// NewImmutableFieldType create an immutable field type.
 func NewImmutableFieldType(tp byte) ImmutableFieldType {
 	return NewFieldType(tp)
 }

--- a/pkg/parser/types/immtable_field_types.go
+++ b/pkg/parser/types/immtable_field_types.go
@@ -1,0 +1,71 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"io"
+
+	"github.com/pingcap/tidb/pkg/parser/format"
+)
+
+var _ ImmutableFieldType = &FieldType{}
+
+// ImmutableFieldType refs to an immutable field type, with all GET type interface integrated.
+// SET interface.
+// can't be resolved anywhere, lack of definition.
+//
+// GET interface.
+// when calling the ImmutableFieldType.GET(xxx), it resolve the func name successfully itself. The read
+// happens to the deepest internal implemented core structure --- *FieldType.
+//
+// ImmutableFieldType.GET(xxx) (resolve func success itself) ------------> *FieldType (where the read happens)
+type ImmutableFieldType interface {
+	// MutableCopy copy and return a new basic ft with COW.
+	// MutableCopy is different from MutableRef, the inside immutable ref is not point
+	// to original one. In otherwise, it's a brand-new one copied elements from the old.
+	MutableCopy() MutableFieldType
+	// MutableRef downcast the current interface pointer as son.
+	MutableRef() MutableFieldType
+
+	IsDecimalValid() bool
+	IsVarLengthType() bool
+	GetType() byte
+	GetFlag() uint
+	GetFlen() int
+	GetDecimal() int
+	GetCharset() string
+	GetCollate() string
+	GetElems() []string
+	IsArray() bool
+	GetElem(idx int) string
+	GetElemIsBinaryLit(idx int) bool
+	Equal(other *FieldType) bool
+	PartialEqual(other *FieldType, unsafe bool) bool
+	EvalType() EvalType
+	Hybrid() bool
+	CompactStr() string
+	InfoSchemaStr() string
+	String() string
+	Restore(ctx *format.RestoreCtx) error
+	RestoreAsCastType(ctx *format.RestoreCtx, explicitCharset bool)
+	FormatAsCastType(w io.Writer, explicitCharset bool)
+	StorageLength() int
+	MarshalJSON() ([]byte, error)
+	MemoryUsage() (sum int64)
+}
+
+func NewImmutableFieldType(tp byte) ImmutableFieldType {
+	return NewFieldType(tp)
+}

--- a/pkg/parser/types/immutable_field_types_test.go
+++ b/pkg/parser/types/immutable_field_types_test.go
@@ -1,0 +1,126 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type mutable interface {
+	immutable
+	mutable()
+	makeImmutable() immutable
+}
+
+type immutable interface {
+	immutable()
+	makeMutable() mutable
+}
+
+type ONE struct {
+}
+
+func (o *ONE) immutable() {
+	fmt.Printf("immutable,addr %p\n", o)
+}
+
+func (o *ONE) makeMutable() mutable {
+	// no-loss downcast.
+	// since we all know that ONE is implemented both immutable and mutable, we can direct return o here.
+	return o
+}
+
+func (o *ONE) mutable() {
+	fmt.Printf("mutable,addr %p\n", o)
+}
+
+func (o *ONE) makeImmutable() immutable {
+	// no-loss upcast.
+	// since we all know that ONE is implemented both immutable and mutable, we can direct return o here.
+	return o
+}
+
+func TestInterfaceWrapper(t *testing.T) {
+	var one mutable
+	one = &ONE{}
+	one.mutable()
+	one.immutable()
+	var sec immutable
+	sec = one // upcast (no loss)
+	sec.immutable()
+	var third mutable
+	third = sec.(mutable) // downcast (no loss)
+	third.mutable()
+	third.immutable()
+
+	// use normalized-defined interface access point.
+	var forth immutable
+	forth = third.makeImmutable() // upcast
+	forth.immutable()
+	var sixth mutable
+	sixth = forth.makeMutable() // downcast
+	sixth.mutable()
+	sixth.immutable()
+	ft, ok := sixth.(*ONE)
+	require.Equal(t, ok, true)
+	require.NotNil(t, t, ft)
+}
+
+// currently the Mutable and Immutable and basic ft is organized as multi level interface wrapping.
+// why use interface embedding is for no-loss downcast and upcast between mutable pointer and the
+// immutable one.
+//
+//				type ImmutableFieldType interface { // grandparent -----+            <------+
+//					// GET methods & makeImmutable                      |                   |
+//				}                                                       | (downcast)        | (upcast)
+//			                                                            |                   |
+//				type MutableFieldType struct {      // parent      <----+            -------+
+//					ImmutableFieldType                                  |                   |
+//	             // SET methods & makeMutable                        |                   |
+//				}                                                       |                   |
+//	                                                                 | (downcast)        | (upcast)
+//		        type FieldType struct {             // son              |                   |
+//		        ...                                                     |                   |
+//		        }                                                  <----+            -------+
+func TestMutableAndImmutableFT(t *testing.T) {
+	var immutableFT ImmutableFieldType
+	immutableFT = NewFieldType(1)
+	// immutable methods
+	require.Equal(t, immutableFT.GetType(), uint8(1))
+	var mutableFT MutableFieldType
+	mutableFT = immutableFT.MutableRef()
+	mutableFT.SetType(2)
+	// you can call immutable methods directly on mutableFT.
+	require.Equal(t, mutableFT.GetType(), uint8(2))
+	// or you can just up-cast mutableFT as immutableFT
+	immutableFT = mutableFT.ImmutableRef()
+	require.Equal(t, immutableFT.GetType(), uint8(2))
+
+	// make a mutable copy out from immutable pointer.
+	newCP := immutableFT.MutableCopy()
+	newCP.SetType(3)
+	require.Equal(t, newCP.GetType(), uint8(3))
+	// while the original immutableFT stay the same.
+	require.Equal(t, immutableFT.GetType(), uint8(2))
+
+	// make a mutable copy out from mutable pointer.
+	newCP2 := mutableFT.MutableCopy()
+	newCP2.SetType(4)
+	require.Equal(t, newCP2.GetType(), uint8(4))
+	require.Equal(t, immutableFT.GetType(), uint8(2))
+	require.Equal(t, mutableFT.GetType(), uint8(2))
+}

--- a/pkg/parser/types/immutable_field_types_test.go
+++ b/pkg/parser/types/immutable_field_types_test.go
@@ -32,6 +32,7 @@ type immutable interface {
 	makeMutable() mutable
 }
 
+// ONE is a test structure for interface embedding test.
 type ONE struct {
 }
 

--- a/pkg/parser/types/immutable_field_types_test.go
+++ b/pkg/parser/types/immutable_field_types_test.go
@@ -56,24 +56,19 @@ func (o *ONE) makeImmutable() immutable {
 }
 
 func TestInterfaceWrapper(t *testing.T) {
-	var one mutable
-	one = &ONE{}
+	var one mutable = &ONE{}
 	one.mutable()
 	one.immutable()
-	var sec immutable
-	sec = one // upcast (no loss)
+	var sec immutable = one // upcast (no loss)
 	sec.immutable()
-	var third mutable
-	third = sec.(mutable) // downcast (no loss)
+	var third = sec.(mutable) // downcast (no loss)
 	third.mutable()
 	third.immutable()
 
 	// use normalized-defined interface access point.
-	var forth immutable
-	forth = third.makeImmutable() // upcast
+	var forth = third.makeImmutable() // upcast
 	forth.immutable()
-	var sixth mutable
-	sixth = forth.makeMutable() // downcast
+	var sixth = forth.makeMutable() // downcast
 	sixth.mutable()
 	sixth.immutable()
 	ft, ok := sixth.(*ONE)
@@ -98,12 +93,10 @@ func TestInterfaceWrapper(t *testing.T) {
 //		        ...                                                     |                   |
 //		        }                                                  <----+            -------+
 func TestMutableAndImmutableFT(t *testing.T) {
-	var immutableFT ImmutableFieldType
-	immutableFT = NewFieldType(1)
+	var immutableFT ImmutableFieldType = NewFieldType(1)
 	// immutable methods
 	require.Equal(t, immutableFT.GetType(), uint8(1))
-	var mutableFT MutableFieldType
-	mutableFT = immutableFT.MutableRef()
+	var mutableFT = immutableFT.MutableRef()
 	mutableFT.SetType(2)
 	// you can call immutable methods directly on mutableFT.
 	require.Equal(t, mutableFT.GetType(), uint8(2))

--- a/pkg/parser/types/immutable_field_types_test.go
+++ b/pkg/parser/types/immutable_field_types_test.go
@@ -16,8 +16,9 @@ package types
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type mutable interface {

--- a/pkg/parser/types/mutable_field_types.go
+++ b/pkg/parser/types/mutable_field_types.go
@@ -60,6 +60,7 @@ type MutableFieldType interface {
 	UnmarshalJSON(data []byte) error
 }
 
+// NewMutableFieldType create a mutable field type.
 func NewMutableFieldType(tp byte) MutableFieldType {
 	return NewFieldType(tp)
 }

--- a/pkg/parser/types/mutable_field_types.go
+++ b/pkg/parser/types/mutable_field_types.go
@@ -1,0 +1,65 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+var _ MutableFieldType = &FieldType{}
+
+// MutableFieldType refs to a mutable field type, with all SET interface integrated.
+// SET interface.
+// when calling MutableFieldType.SET(xxx), it resolve the func name successfully and change happens
+// on deepest implemented core *FieldType structure
+//
+// MutableFieldType.SET(xxx) -------------------------> *FieldType (where the change happens)
+//
+// GET interface.
+// when calling MutableFieldType.GET(xxx), itself can't resolve the function call of GET cause
+// lack of definition, so it will resort to inner wrapped interface ImmutableFieldType to explain
+// this and it works. Finally, the read happens to the deepest implemented core structure --- *FieldType.
+//
+// MutableFieldType.GET(xxx) (resolve func fail)
+//
+//	+-------------> ImmutableFieldType.GET(xxx) (resolve func success)
+//	                         +---------------------------> *FieldType (where the read happens)
+type MutableFieldType interface {
+	ImmutableFieldType
+	ImmutableRef() ImmutableFieldType
+
+	SetType(tp byte)
+	SetFlag(flag uint)
+	AddFlag(flag uint)
+	AndFlag(flag uint)
+	ToggleFlag(flag uint)
+	DelFlag(flag uint)
+	SetFlen(flen int)
+	SetFlenUnderLimit(flen int)
+	SetDecimal(decimal int)
+	SetDecimalUnderLimit(decimal int)
+	UpdateFlenAndDecimalUnderLimit(old *FieldType, deltaDecimal int, deltaFlen int)
+	SetCharset(charset string)
+	SetCollate(collate string)
+	SetElems(elems []string)
+	SetElem(idx int, element string)
+	SetArray(array bool)
+	ArrayType() *FieldType
+	SetElemWithIsBinaryLit(idx int, element string, isBinaryLit bool)
+	CleanElemIsBinaryLit()
+	Clone() *FieldType
+	Init(tp byte)
+	UnmarshalJSON(data []byte) error
+}
+
+func NewMutableFieldType(tp byte) MutableFieldType {
+	return NewFieldType(tp)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/51664


Problem Summary:

### What changed and how does it work?
Introduce mutable interface{immutable interface{basic structure}} embedded level
From an inheritance perspective: it goes down like the below:
```
// currently the Mutable and Immutable and basic ft is organized as multi level interface wrapping.
// why use interface embedding is for no-loss downcast and upcast between mutable pointer and the
// immutable one.
//
//		    type ImmutableFieldType interface { // grandparent -----+            <------+
//			// GET methods & makeImmutable                      |                   |
//		     }                                                      | (downcast)        | (upcast)
//			                                                    |                   |
//		    type MutableFieldType interface {   // parent      <----+            <------+
//		        ImmutableFieldType                                  |                   |
//	                // SET methods & makeMutable                        |                   |
//		    }                                                       |                   |
//	                                                                    | (downcast)        | (upcast)
//		    type FieldType struct {             // son              |                   |
//		        ...                                                 |                   |
//		    }                                                  <----+            -------+
```
Holding a mutable pointer, you can get access to all SET methods, and implicit upcast as immutable allows it to get access to all GET methods (just like write lock is a superset of read lock, while with all functionality the latter has)**[upcast is no loss, implicit]**

Holding an immutable pointer, you can only get access to all GET methods. The only way you can change a thing is to make a **mutableRef** from the current immutable pointer, we do this with golang.(type) declaration inside, because the basic structure has implemented both of them. **[downcast is no loss, explicit]**. mutableCopy is another way to make a brand-new copy of itself with mutability.

what's the difference between the **interface embedding** and **structure embedding**, the former can use golang.(type) to do no-loss downcast and upcast, while the latter can hardly do that, even with **structure pointer embedding**, when you hold an internal structure pointer(say immutable here), if you want to convert it into a mutable one(son type), the only way you can do that is to create a new mutable structure again and wrap current parent pointer, actually it costs unsafe.size(8) comparatively to create a mutable structure with pointer-type element inside. It even costs more if additional elements are defined in your mutable structure.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
