### PR TITLE
planner: correct plan when scan tidb related cluster table with KeepOrder

### DIFF
--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -2597,6 +2597,10 @@ func convertToTableScan(ds *logicalop.DataSource, prop *property.PhysicalPropert
 	var task base.Task = copTask
 	if candidate.isMatchProp {
 		copTask.keepOrder = true
+		if ds.Table.Type().IsClusterTable() {
+			// TableScan with cluster table can't keep order.
+			return base.InvalidTask, nil
+		}
 		if ds.TableInfo.GetPartitionInfo() != nil {
 			// TableScan on partition table on TiFlash can't keep order.
 			if ts.StoreType == kv.TiFlash {

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -761,6 +761,9 @@ func compareCandidates(sctx base.PlanContext, prop *property.PhysicalProperty, l
 }
 
 func isMatchProp(ds *logicalop.DataSource, path *util.AccessPath, prop *property.PhysicalProperty) bool {
+	if ds.Table.Type().IsClusterTable() {
+		return false
+	}
 	if prop.VectorProp.VSInfo != nil && path.Index != nil && path.Index.VectorInfo != nil {
 		if path.Index == nil || path.Index.VectorInfo == nil {
 			return false
@@ -2597,10 +2600,6 @@ func convertToTableScan(ds *logicalop.DataSource, prop *property.PhysicalPropert
 	var task base.Task = copTask
 	if candidate.isMatchProp {
 		copTask.keepOrder = true
-		if ds.Table.Type().IsClusterTable() {
-			// TableScan with cluster table can't keep order.
-			return base.InvalidTask, nil
-		}
 		if ds.TableInfo.GetPartitionInfo() != nil {
 			// TableScan on partition table on TiFlash can't keep order.
 			if ts.StoreType == kv.TiFlash {

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -761,7 +761,7 @@ func compareCandidates(sctx base.PlanContext, prop *property.PhysicalProperty, l
 }
 
 func isMatchProp(ds *logicalop.DataSource, path *util.AccessPath, prop *property.PhysicalProperty) bool {
-	if ds.Table.Type().IsClusterTable() {
+	if ds.Table.Type().IsClusterTable() && !prop.IsSortItemEmpty() {
 		// TableScan with cluster table can't keep order.
 		return false
 	}

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -762,6 +762,7 @@ func compareCandidates(sctx base.PlanContext, prop *property.PhysicalProperty, l
 
 func isMatchProp(ds *logicalop.DataSource, path *util.AccessPath, prop *property.PhysicalProperty) bool {
 	if ds.Table.Type().IsClusterTable() {
+		// TableScan with cluster table can't keep order.
 		return false
 	}
 	if prop.VectorProp.VSInfo != nil && path.Index != nil && path.Index.VectorInfo != nil {

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1100,10 +1100,6 @@ func (p *PhysicalTopN) pushPartialTopNDownToTiDBCop(copTsk *CopTask) (base.Task,
 		return nil, false
 	}
 
-	if copTsk.tablePlan.(*PhysicalTableScan).Table.Name.O != infoschema.ClusterTableSlowLog {
-		return nil, false
-	}
-
 	var (
 		selOnTblScan   *PhysicalSelection
 		selSelectivity float64
@@ -1121,6 +1117,11 @@ func (p *PhysicalTopN) pushPartialTopNDownToTiDBCop(copTsk *CopTask) (base.Task,
 		finalTblScanPlan = finalTblScanPlan.Children()[0]
 	}
 	tblScan = finalTblScanPlan.(*PhysicalTableScan)
+
+	// Check the table is `CLUSTER_SLOW_QUERY` or not.
+	if tblScan.Table.Name.O != infoschema.ClusterTableSlowLog {
+		return nil, false
+	}
 
 	colsProp, ok := GetPropByOrderByItems(p.ByItems)
 	if !ok {

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1126,7 +1126,7 @@ func (p *PhysicalTopN) pushPartialTopNDownToTiDBCop(copTsk *CopTask) (base.Task,
 	if !ok {
 		return nil, false
 	}
-	if len(colsProp.SortItems) != 1 || !colsProp.SortItems[0].Col.Equal(p.SCtx().GetExprCtx(), tblScan.HandleCols.GetCol(0)) {
+	if len(colsProp.SortItems) != 1 || !colsProp.SortItems[0].Col.Equal(p.SCtx().GetExprCtx().GetEvalCtx(), tblScan.HandleCols.GetCol(0)) {
 		return nil, false
 	}
 	if selOnTblScan != nil && tblScan.StatsInfo().RowCount > 0 {

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1126,7 +1126,7 @@ func (p *PhysicalTopN) pushPartialTopNDownToTiDBCop(copTsk *CopTask) (base.Task,
 	if !ok {
 		return nil, false
 	}
-	if len(colsProp.SortItems) != 1 || !colsProp.SortItems[0].Col.Equal(MockContext(), tblScan.HandleCols.GetCol(0)) {
+	if len(colsProp.SortItems) != 1 || !colsProp.SortItems[0].Col.Equal(p.SCtx().GetExprCtx(), tblScan.HandleCols.GetCol(0)) {
 		return nil, false
 	}
 	if selOnTblScan != nil && tblScan.StatsInfo().RowCount > 0 {

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1153,6 +1153,7 @@ func (p *PhysicalTopN) pushPartialTopNDownToTiDBCop(copTsk *CopTask) (base.Task,
 	return attachPlan2Task(p, rootTask), true
 }
 
+// Attach2Task implements the PhysicalPlan interface.
 func (p *PhysicalTopN) Attach2Task(tasks ...base.Task) base.Task {
 	t := tasks[0].Copy()
 	cols := make([]*expression.Column, 0, len(p.ByItems))

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1091,7 +1091,8 @@ func (p *PhysicalTopN) canPushDownToTiFlash(mppTask *MppTask) bool {
 }
 
 // For https://github.com/pingcap/tidb/issues/51723,
-// This function only supports `CLUSTER_SLOW_QUERY`, it will change
+// This function only supports `CLUSTER_SLOW_QUERY`,
+// it will change plan from
 // TopN -> TableReader -> TopN[cop] -> TableFullScan[cop] to
 // TopN -> TableReader -> Limit[cop] -> TableFullScan[cop] + keepOrder
 func (p *PhysicalTopN) pushPartialTopNDownToTiDBCop(copTsk *CopTask) (base.Task, bool) {

--- a/tests/integrationtest/r/infoschema/cluster_tables.result
+++ b/tests/integrationtest/r/infoschema/cluster_tables.result
@@ -10,3 +10,51 @@ select /*+ ignore_index(t, a) */ * from t where a = 1;
 id	a
 create session binding from history using plan digest '20cf414ff6bd6fff3de17a266966020e81099b9fd1a29c4fd4b8aaf212f5c2c0';
 drop binding for sql digest '83de0854921816c038565229b8008f5d679d373d16bf6b2a5cacd5937e11ea21';
+explain select * from information_schema.cluster_slow_query order by time limit 1;
+id	estRows	task	access object	operator info
+TopN_7	1.00	root		information_schema.cluster_slow_query.time, offset:0, count:1
+└─TableReader_16	1.00	root		data:Limit_15
+  └─Limit_15	1.00	cop[tidb]		offset:0, count:1
+    └─TableFullScan_14	1.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	keep order:true, stats:pseudo
+explain select * from information_schema.cluster_slow_query order by time;
+id	estRows	task	access object	operator info
+Sort_4	10000.00	root		information_schema.cluster_slow_query.time
+└─TableReader_8	10000.00	root		data:TableFullScan_7
+  └─TableFullScan_7	10000.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	keep order:false, stats:pseudo
+explain select * from information_schema.cluster_slow_query order by time desc limit 1;
+id	estRows	task	access object	operator info
+TopN_7	1.00	root		information_schema.cluster_slow_query.time:desc, offset:0, count:1
+└─TableReader_16	1.00	root		data:Limit_15
+  └─Limit_15	1.00	cop[tidb]		offset:0, count:1
+    └─TableFullScan_14	1.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	keep order:true, desc, stats:pseudo
+explain select * from information_schema.cluster_slow_query order by time desc;
+id	estRows	task	access object	operator info
+Sort_4	10000.00	root		information_schema.cluster_slow_query.time:desc
+└─TableReader_8	10000.00	root		data:TableFullScan_7
+  └─TableFullScan_7	10000.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	keep order:false, stats:pseudo
+explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time limit 1;
+id	estRows	task	access object	operator info
+TopN_8	1.00	root		information_schema.cluster_slow_query.time, offset:0, count:1
+└─TableReader_18	1.00	root		data:Limit_17
+  └─Limit_17	1.00	cop[tidb]		offset:0, count:1
+    └─Selection_16	1.00	cop[tidb]		ne(information_schema.cluster_slow_query.query, "x")
+      └─TableRangeScan_15	1.50	cop[tidb]	table:CLUSTER_SLOW_QUERY	range:[2020-09-24 15:23:41.421396,2020-09-25 17:57:35.047111], keep order:true, stats:pseudo
+explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time;
+id	estRows	task	access object	operator info
+Sort_5	166.42	root		information_schema.cluster_slow_query.time
+└─TableReader_10	166.42	root		data:Selection_9
+  └─Selection_9	166.42	cop[tidb]		ne(information_schema.cluster_slow_query.query, "x")
+    └─TableRangeScan_8	250.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	range:[2020-09-24 15:23:41.421396,2020-09-25 17:57:35.047111], keep order:false, stats:pseudo
+explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time desc limit 1;
+id	estRows	task	access object	operator info
+TopN_8	1.00	root		information_schema.cluster_slow_query.time:desc, offset:0, count:1
+└─TableReader_18	1.00	root		data:Limit_17
+  └─Limit_17	1.00	cop[tidb]		offset:0, count:1
+    └─Selection_16	1.00	cop[tidb]		ne(information_schema.cluster_slow_query.query, "x")
+      └─TableRangeScan_15	1.50	cop[tidb]	table:CLUSTER_SLOW_QUERY	range:[2020-09-24 15:23:41.421396,2020-09-25 17:57:35.047111], keep order:true, desc, stats:pseudo
+explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time desc;
+id	estRows	task	access object	operator info
+Sort_5	166.42	root		information_schema.cluster_slow_query.time:desc
+└─TableReader_10	166.42	root		data:Selection_9
+  └─Selection_9	166.42	cop[tidb]		ne(information_schema.cluster_slow_query.query, "x")
+    └─TableRangeScan_8	250.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	range:[2020-09-24 15:23:41.421396,2020-09-25 17:57:35.047111], keep order:false, stats:pseudo

--- a/tests/integrationtest/r/infoschema/cluster_tables.result
+++ b/tests/integrationtest/r/infoschema/cluster_tables.result
@@ -15,46 +15,46 @@ id	estRows	task	access object	operator info
 TopN_7	1.00	root		information_schema.cluster_slow_query.time, offset:0, count:1
 └─TableReader_16	1.00	root		data:Limit_15
   └─Limit_15	1.00	cop[tidb]		offset:0, count:1
-    └─TableFullScan_14	1.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	keep order:true, stats:pseudo
+    └─MemTableScan_14	1.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	
 explain select * from information_schema.cluster_slow_query order by time;
 id	estRows	task	access object	operator info
 Sort_4	10000.00	root		information_schema.cluster_slow_query.time
-└─TableReader_8	10000.00	root		data:TableFullScan_7
-  └─TableFullScan_7	10000.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	keep order:false, stats:pseudo
+└─TableReader_8	10000.00	root		data:MemTableScan_7
+  └─MemTableScan_7	10000.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	
 explain select * from information_schema.cluster_slow_query order by time desc limit 1;
 id	estRows	task	access object	operator info
 TopN_7	1.00	root		information_schema.cluster_slow_query.time:desc, offset:0, count:1
 └─TableReader_16	1.00	root		data:Limit_15
   └─Limit_15	1.00	cop[tidb]		offset:0, count:1
-    └─TableFullScan_14	1.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	keep order:true, desc, stats:pseudo
+    └─MemTableScan_14	1.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	
 explain select * from information_schema.cluster_slow_query order by time desc;
 id	estRows	task	access object	operator info
 Sort_4	10000.00	root		information_schema.cluster_slow_query.time:desc
-└─TableReader_8	10000.00	root		data:TableFullScan_7
-  └─TableFullScan_7	10000.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	keep order:false, stats:pseudo
+└─TableReader_8	10000.00	root		data:MemTableScan_7
+  └─MemTableScan_7	10000.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	
 explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time limit 1;
 id	estRows	task	access object	operator info
 TopN_8	1.00	root		information_schema.cluster_slow_query.time, offset:0, count:1
 └─TableReader_18	1.00	root		data:Limit_17
   └─Limit_17	1.00	cop[tidb]		offset:0, count:1
     └─Selection_16	1.00	cop[tidb]		ne(information_schema.cluster_slow_query.query, "x")
-      └─TableRangeScan_15	1.50	cop[tidb]	table:CLUSTER_SLOW_QUERY	range:[2020-09-24 15:23:41.421396,2020-09-25 17:57:35.047111], keep order:true, stats:pseudo
+      └─MemTableScan_15	1.50	cop[tidb]	table:CLUSTER_SLOW_QUERY	
 explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time;
 id	estRows	task	access object	operator info
 Sort_5	166.42	root		information_schema.cluster_slow_query.time
 └─TableReader_10	166.42	root		data:Selection_9
   └─Selection_9	166.42	cop[tidb]		ne(information_schema.cluster_slow_query.query, "x")
-    └─TableRangeScan_8	250.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	range:[2020-09-24 15:23:41.421396,2020-09-25 17:57:35.047111], keep order:false, stats:pseudo
+    └─MemTableScan_8	250.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	
 explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time desc limit 1;
 id	estRows	task	access object	operator info
 TopN_8	1.00	root		information_schema.cluster_slow_query.time:desc, offset:0, count:1
 └─TableReader_18	1.00	root		data:Limit_17
   └─Limit_17	1.00	cop[tidb]		offset:0, count:1
     └─Selection_16	1.00	cop[tidb]		ne(information_schema.cluster_slow_query.query, "x")
-      └─TableRangeScan_15	1.50	cop[tidb]	table:CLUSTER_SLOW_QUERY	range:[2020-09-24 15:23:41.421396,2020-09-25 17:57:35.047111], keep order:true, desc, stats:pseudo
+      └─MemTableScan_15	1.50	cop[tidb]	table:CLUSTER_SLOW_QUERY	
 explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time desc;
 id	estRows	task	access object	operator info
 Sort_5	166.42	root		information_schema.cluster_slow_query.time:desc
 └─TableReader_10	166.42	root		data:Selection_9
   └─Selection_9	166.42	cop[tidb]		ne(information_schema.cluster_slow_query.query, "x")
-    └─TableRangeScan_8	250.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	range:[2020-09-24 15:23:41.421396,2020-09-25 17:57:35.047111], keep order:false, stats:pseudo
+    └─MemTableScan_8	250.00	cop[tidb]	table:CLUSTER_SLOW_QUERY	

--- a/tests/integrationtest/t/infoschema/cluster_tables.test
+++ b/tests/integrationtest/t/infoschema/cluster_tables.test
@@ -10,3 +10,13 @@ select /*+ ignore_index(t, a) */ * from t where a = 1;
 create session binding from history using plan digest '20cf414ff6bd6fff3de17a266966020e81099b9fd1a29c4fd4b8aaf212f5c2c0';
 drop binding for sql digest '83de0854921816c038565229b8008f5d679d373d16bf6b2a5cacd5937e11ea21';
 
+# TestIssue51723
+explain select * from information_schema.cluster_slow_query order by time limit 1;
+explain select * from information_schema.cluster_slow_query order by time;
+explain select * from information_schema.cluster_slow_query order by time desc limit 1;
+explain select * from information_schema.cluster_slow_query order by time desc;
+explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time limit 1;
+explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time;
+explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time desc limit 1;
+explain select * from information_schema.cluster_slow_query WHERE (time between '2020-09-24 15:23:41.421396' and '2020-09-25 17:57:35.047111') and query != 'x' order by time desc;
+


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51723

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
