### PR TITLE
txn: produce warning for Pipelined DML when falling back because of tidb_constraint_check_in_place

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4345,6 +4345,12 @@ func (s *session) usePipelinedDmlOrWarn() bool {
 	}
 	if s.GetSessionVars().ConstraintCheckInPlace {
 		// we enforce that pipelined DML must lazily check key.
+		stmtCtx.AppendWarning(
+			errors.New(
+				"Pipelined DML can not be used when tidb_constraint_check_in_place=ON. " +
+					"Fallback to standard mode",
+			),
+		)
 		return false
 	}
 	is, ok := s.GetDomainInfoSchema().(infoschema.InfoSchema)

--- a/tests/realtikvtest/pipelineddmltest/pipelineddml_test.go
+++ b/tests/realtikvtest/pipelineddmltest/pipelineddml_test.go
@@ -209,6 +209,12 @@ func TestPipelinedDMLNegative(t *testing.T) {
 	tk.MustExec("insert into t values(10, 10)")
 	tk.MustQuery("show warnings").CheckContain("Pipelined DML can not be used without Metadata Lock. Fallback to standard mode")
 	tk.MustExec("set global tidb_enable_metadata_lock = on")
+
+	// tidb_constraint_check_in_place = ON
+	tk.MustExec("set @@tidb_constraint_check_in_place = 1")
+	tk.MustExec("insert into t values(11, 11)")
+	tk.MustQuery("show warnings").CheckContain("Pipelined DML can not be used when tidb_constraint_check_in_place=ON. Fallback to standard mode")
+	tk.MustExec("set @@tidb_constraint_check_in_place = 0")
 }
 
 func compareTables(t *testing.T, tk *testkit.TestKit, t1, t2 string) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50215 

Problem Summary:


### What changed and how does it work?

Produce warning for Pipelined DML when falling back because of tidb_constraint_check_in_place

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
