### PR TITLE
infoschema: fix foreign key tests for infoschema v2

### DIFF
--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -723,8 +723,18 @@ func (b *Builder) applyDropTableV2(diff *model.SchemaDiff, dbInfo *model.DBInfo,
 	})
 
 	// The old DBInfo still holds a reference to old table info, we need to remove it.
-	b.deleteReferredForeignKeys(dbInfo, tableID)
+	b.deleteReferredForeignKeysV2(dbInfo, tableID)
 	return affected
+}
+
+func (b *Builder) deleteReferredForeignKeysV2(dbInfo *model.DBInfo, tableID int64) {
+	for _, tbl := range b.infoschemaV2.SchemaTables(dbInfo.Name) {
+		tblInfo := tbl.Meta()
+		if tblInfo.ID == tableID {
+			b.infoSchema.deleteReferredForeignKeys(dbInfo.Name, tblInfo)
+			break
+		}
+	}
 }
 
 func (b *Builder) applyModifySchemaCharsetAndCollateV2(m *meta.Meta, diff *model.SchemaDiff) error {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50959 

Problem Summary:

### What changed and how does it work?

```
	tk.MustExec("create table t1 (id int key, name varchar(10), leader int,  index(leader), foreign key (leader) references t1(id) ON DELETE SET NULL);")
	tk.MustExec("drop table t1")
	tk.MustExec("create table t1 (id varchar(10) key, name varchar(10), leader varchar(10),  index(leader), foreign key (leader) references t1(id) ON DELETE SET NULL);")
```

Expect no error, but get 

```
                Messages:       sql:create table t1 (id int key), [], error stack [schema:1146]Table 'test.t1' doesn't exist
                                github.com/pingcap/errors.AddStack
                                        /home/genius/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20240318064555-6bd07397691f/errors.go:178
                                github.com/pingcap/errors.(*Error).GenWithStackByArgs
                                        /home/genius/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20240318064555-6bd07397691f/normalize.go:175
                                github.com/pingcap/tidb/pkg/infoschema.(*infoschemaV2).TableByName
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/infoschema/infoschema_v2.go:353
                                github.com/pingcap/tidb/pkg/ddl.checkTableForeignKeysValid
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/ddl/foreign_key.go:164
                                github.com/pingcap/tidb/pkg/ddl.(*ddl).CreateTable
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/ddl/ddl_api.go:2698
                                github.com/pingcap/tidb/pkg/executor.(*DDLExec).executeCreateTable
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/executor/ddl.go:268
                                github.com/pingcap/tidb/pkg/executor.(*DDLExec).Next
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/executor/ddl.go:160
                                github.com/pingcap/tidb/pkg/executor/internal/exec.Next
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/executor/internal/exec/executor.go:404
                                github.com/pingcap/tidb/pkg/executor.(*ExecStmt).next
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/executor/adapter.go:1206
                                github.com/pingcap/tidb/pkg/executor.(*ExecStmt).handleNoDelayExecutor
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/executor/adapter.go:958
                                github.com/pingcap/tidb/pkg/executor.(*ExecStmt).handleNoDelay
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/executor/adapter.go:792
                                github.com/pingcap/tidb/pkg/executor.(*ExecStmt).Exec
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/executor/adapter.go:557
                                github.com/pingcap/tidb/pkg/session.runStmt
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/session/session.go:2376
                                github.com/pingcap/tidb/pkg/session.(*session).ExecuteStmt
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/session/session.go:2245
                                github.com/pingcap/tidb/pkg/testkit.(*TestKit).ExecWithContext
                                        /home/genius/project/src/github.com/pingcap/tidb/pkg/testkit/testkit.go:365
                                github.com/pingcap/tidb/pkg/testkit.(*TestKit).MustExecWithContext
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

```
diff --git a/pkg/sessionctx/variable/tidb_vars.go b/pkg/sessionctx/variable/tidb_vars.go
index d5e9b34324..73e6f48387 100644
--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1483,7 +1483,7 @@ const (
        DefTiDBSchemaVersionCacheLimit                    = 16
        DefTiDBIdleTransactionTimeout                     = 0
        DefTiDBTxnEntrySizeLimit                          = 0
-       DefTiDBSchemaCacheSize                            = 0
+       DefTiDBSchemaCacheSize                            = 1024
        DefTiDBLowResolutionTSOUpdateInterval             = 2000
        DefDivPrecisionIncrement                          = 4
        DefTiDBDMLType                                    = "STANDARD"


make ut X='run pkg/executor/test/fktest' 1>a.log 2>b.log
```

Fix the foreign key related tests.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
