### PR TITLE
txn: fix race in p-dml caused by `Transaction.SetOption` running with background flushing(#51913)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -628,6 +628,13 @@ bazel_importintotest4: failpoint-enable bazel_ci_simple_prepare
 		-- //tests/realtikvtest/importintotest4/...
 	./build/jenkins_collect_coverage.sh
 
+# on timeout, bazel won't print log sometimes, so we use --test_output=all to print log always
+bazel_pipelineddmltest: failpoint-enable bazel_ci_simple_prepare
+	bazel $(BAZEL_GLOBAL_CONFIG) coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --test_output=all --test_arg=-with-real-tikv --define gotags=deadlock,intest \
+	--@io_bazel_rules_go//go/config:cover_format=go_cover \
+		-- //tests/realtikvtest/pipelineddmltest/...
+	./build/jenkins_collect_coverage.sh
+
 bazel_lint: bazel_prepare
 	bazel build //... --//build:with_nogo_flag=true
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2312,6 +2312,9 @@ func setOptionForTopSQL(sc *stmtctx.StatementContext, snapshot kv.Snapshot) {
 	if snapshot == nil {
 		return
 	}
+	if txn, ok := snapshot.(kv.Transaction); ok && txn.IsPipelined() {
+		return
+	}
 	snapshot.SetOption(kv.ResourceGroupTagger, sc.GetResourceGroupTagger())
 	if sc.KvExecCounter != nil {
 		snapshot.SetOption(kv.RPCInterceptor, sc.KvExecCounter.RPCInterceptor())

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2312,6 +2312,7 @@ func setOptionForTopSQL(sc *stmtctx.StatementContext, snapshot kv.Snapshot) {
 	if snapshot == nil {
 		return
 	}
+	// pipelined dml may already flush in background, don't touch it to avoid race.
 	if txn, ok := snapshot.(kv.Transaction); ok && txn.IsPipelined() {
 		return
 	}

--- a/pkg/executor/update.go
+++ b/pkg/executor/update.go
@@ -285,6 +285,7 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 			}
 		}
 		txn, err := e.Ctx().Txn(true)
+		// pipelined dml may already flush in background, don't touch it to avoid race.
 		if err == nil && !txn.IsPipelined() {
 			sc := e.Ctx().GetSessionVars().StmtCtx
 			txn.SetOption(kv.ResourceGroupTagger, sc.GetResourceGroupTagger())

--- a/pkg/executor/update.go
+++ b/pkg/executor/update.go
@@ -285,7 +285,7 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 			}
 		}
 		txn, err := e.Ctx().Txn(true)
-		if err == nil {
+		if err == nil && !txn.IsPipelined() {
 			sc := e.Ctx().GetSessionVars().StmtCtx
 			txn.SetOption(kv.ResourceGroupTagger, sc.GetResourceGroupTagger())
 			if sc.KvExecCounter != nil {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -495,11 +495,6 @@ func (s *session) doCommit(ctx context.Context) error {
 		return nil
 	}
 
-	// to avoid session set overlap the txn set.
-	if s.GetDiskFullOpt() != kvrpcpb.DiskFullOpt_NotAllowedOnFull {
-		s.txn.SetDiskFullOpt(s.GetDiskFullOpt())
-	}
-
 	defer func() {
 		s.txn.changeToInvalid()
 		s.sessionVars.SetInTxn(false)
@@ -573,29 +568,37 @@ func (s *session) doCommit(ctx context.Context) error {
 	if s.txn.IsPipelined() && !s.GetSessionVars().TxnCtx.EnableMDL {
 		return errors.New("cannot commit pipelined transaction without Metadata Lock: MDL is OFF")
 	}
-	s.txn.SetOption(kv.SchemaChecker, domain.NewSchemaChecker(domain.GetDomain(s), s.GetInfoSchema().SchemaMetaVersion(), physicalTableIDs, needCheckSchema))
-	s.txn.SetOption(kv.InfoSchema, s.sessionVars.TxnCtx.InfoSchema)
+
 	s.txn.SetOption(kv.CommitHook, func(info string, _ error) { s.sessionVars.LastTxnInfo = info })
 	s.txn.SetOption(kv.EnableAsyncCommit, sessVars.EnableAsyncCommit)
 	s.txn.SetOption(kv.Enable1PC, sessVars.Enable1PC)
-	s.txn.SetOption(kv.ResourceGroupTagger, sessVars.StmtCtx.GetResourceGroupTagger())
-	s.txn.SetOption(kv.ExplicitRequestSourceType, sessVars.ExplicitRequestSourceType)
-	if sessVars.StmtCtx.KvExecCounter != nil {
-		// Bind an interceptor for client-go to count the number of SQL executions of each TiKV.
-		s.txn.SetOption(kv.RPCInterceptor, sessVars.StmtCtx.KvExecCounter.RPCInterceptor())
-	}
-	// priority of the sysvar is lower than `start transaction with causal consistency only`
-	if val := s.txn.GetOption(kv.GuaranteeLinearizability); val == nil || val.(bool) {
-		// We needn't ask the TiKV client to guarantee linearizability for auto-commit transactions
-		// because the property is naturally holds:
-		// We guarantee the commitTS of any transaction must not exceed the next timestamp from the TSO.
-		// An auto-commit transaction fetches its startTS from the TSO so its commitTS > its startTS > the commitTS
-		// of any previously committed transactions.
-		s.txn.SetOption(kv.GuaranteeLinearizability,
-			sessVars.TxnCtx.IsExplicit && sessVars.GuaranteeLinearizability)
-	}
-	if tables := sessVars.TxnCtx.TemporaryTables; len(tables) > 0 {
-		s.txn.SetOption(kv.KVFilter, temporaryTableKVFilter(tables))
+	// The pipelined txn will may be flushed in background, not touch the options to avoid races.
+	if !s.txn.IsPipelined() {
+		// to avoid session set overlap the txn set.
+		if s.GetDiskFullOpt() != kvrpcpb.DiskFullOpt_NotAllowedOnFull {
+			s.txn.SetDiskFullOpt(s.GetDiskFullOpt())
+		}
+		s.txn.SetOption(kv.SchemaChecker, domain.NewSchemaChecker(domain.GetDomain(s), s.GetInfoSchema().SchemaMetaVersion(), physicalTableIDs, needCheckSchema))
+		s.txn.SetOption(kv.InfoSchema, s.sessionVars.TxnCtx.InfoSchema)
+		s.txn.SetOption(kv.ResourceGroupTagger, sessVars.StmtCtx.GetResourceGroupTagger())
+		s.txn.SetOption(kv.ExplicitRequestSourceType, sessVars.ExplicitRequestSourceType)
+		if sessVars.StmtCtx.KvExecCounter != nil {
+			// Bind an interceptor for client-go to count the number of SQL executions of each TiKV.
+			s.txn.SetOption(kv.RPCInterceptor, sessVars.StmtCtx.KvExecCounter.RPCInterceptor())
+		}
+		// priority of the sysvar is lower than `start transaction with causal consistency only`
+		if val := s.txn.GetOption(kv.GuaranteeLinearizability); val == nil || val.(bool) {
+			// We needn't ask the TiKV client to guarantee linearizability for auto-commit transactions
+			// because the property is naturally holds:
+			// We guarantee the commitTS of any transaction must not exceed the next timestamp from the TSO.
+			// An auto-commit transaction fetches its startTS from the TSO so its commitTS > its startTS > the commitTS
+			// of any previously committed transactions.
+			s.txn.SetOption(kv.GuaranteeLinearizability,
+				sessVars.TxnCtx.IsExplicit && sessVars.GuaranteeLinearizability)
+		}
+		if tables := sessVars.TxnCtx.TemporaryTables; len(tables) > 0 {
+			s.txn.SetOption(kv.KVFilter, temporaryTableKVFilter(tables))
+		}
 	}
 
 	var txnSource uint64

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4371,16 +4371,12 @@ func (s *session) usePipelinedDmlOrWarn() bool {
 			stmtCtx.AppendWarning(errors.New("Pipelined DML can not be used on sequence. Fallback to standard mode"))
 			return false
 		}
-		if len(tbl.Meta().ForeignKeys) > 0 && vars.ForeignKeyChecks {
+		if vars.ForeignKeyChecks && (len(tbl.Meta().ForeignKeys) > 0 || len(is.GetTableReferredForeignKeys(t.DB, t.Table)) > 0) {
 			stmtCtx.AppendWarning(
 				errors.New(
 					"Pipelined DML can not be used on table with foreign keys when foreign_key_checks = ON. Fallback to standard mode",
 				),
 			)
-			return false
-		}
-		referredFKs := is.GetTableReferredForeignKeys(t.DB, t.Table)
-		if len(referredFKs) > 0 {
 			return false
 		}
 		if tbl.Meta().TempTableType != model.TempTableNone {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -572,6 +572,7 @@ func (s *session) doCommit(ctx context.Context) error {
 	s.txn.SetOption(kv.CommitHook, func(info string, _ error) { s.sessionVars.LastTxnInfo = info })
 	s.txn.SetOption(kv.EnableAsyncCommit, sessVars.EnableAsyncCommit)
 	s.txn.SetOption(kv.Enable1PC, sessVars.Enable1PC)
+	// TODO: refactor SetOption usage to avoid race risk, should detect it in test.
 	// The pipelined txn will may be flushed in background, not touch the options to avoid races.
 	if !s.txn.IsPipelined() {
 		// to avoid session set overlap the txn set.

--- a/tests/realtikvtest/pipelineddmltest/pipelineddml_test.go
+++ b/tests/realtikvtest/pipelineddmltest/pipelineddml_test.go
@@ -198,7 +198,8 @@ func TestPipelinedDMLNegative(t *testing.T) {
 	// for explain and explain analyze
 	tk.Session().GetSessionVars().BinlogClient = binloginfo.MockPumpsClient(&testkit.MockPumpClient{})
 	tk.MustExec("explain insert into t values(8, 8)")
-	tk.MustQuery("show warnings").CheckContain("Pipelined DML can not be used with Binlog: BinlogClient != nil. Fallback to standard mode")
+	// explain is read-only, so it doesn't warn.
+	tk.MustQuery("show warnings").Check(testkit.Rows())
 	tk.MustExec("explain analyze insert into t values(9, 9)")
 	tk.MustQuery("show warnings").CheckContain("Pipelined DML can not be used with Binlog: BinlogClient != nil. Fallback to standard mode")
 	tk.Session().GetSessionVars().BinlogClient = nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50215 close #52028

This PR picks #51867 and #51913

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```bash
 » go test ./tests/realtikvtest/pipelineddmltest --tags=intest -race
# github.com/pingcap/tidb/tests/realtikvtest/pipelineddmltest.test
ok      github.com/pingcap/tidb/tests/realtikvtest/pipelineddmltest     61.492s
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
