### PR TITLE
ddl: limit max concurrency to 16 for add index writers

### DIFF
--- a/pkg/ddl/ingest/engine_mgr.go
+++ b/pkg/ddl/ingest/engine_mgr.go
@@ -24,6 +24,9 @@ import (
 	"go.uber.org/zap"
 )
 
+// maxWriterCount is the max number of writers that can be created for a single engine.
+const maxWriterCount = 16
+
 // Register create a new engineInfo and register it to the backend context.
 func (bc *litBackendCtx) Register(jobID, indexID int64, schemaName, tableName string) (Engine, error) {
 	// Calculate lightning concurrency degree and set memory usage
@@ -65,7 +68,7 @@ func (bc *litBackendCtx) Register(jobID, indexID int64, schemaName, tableName st
 		bc.MemRoot.ConsumeWithTag(encodeEngineTag(jobID, indexID), engineCacheSize)
 		info = LitInfoOpenEngine
 	} else {
-		if en.writerCount+1 > bc.cfg.TikvImporter.RangeConcurrency {
+		if en.writerCount+1 > maxWriterCount {
 			logutil.Logger(bc.ctx).Warn(LitErrExceedConcurrency, zap.Int64("job ID", jobID),
 				zap.Int64("index ID", indexID),
 				zap.Int("concurrency", bc.cfg.TikvImporter.RangeConcurrency))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Problem Summary:

After #51261, `TikvImporter.RangeConcurrency` will be dynamically set by `tidb_ddl_reorg_worker_cnt`. The upper limit should be a constant.

### What changed and how does it work?

Limit max concurrency to 16 for add index writers.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
