### PR TITLE
ddl: enhance row size estimation before adding index

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -117,7 +117,6 @@ go_library(
         "//pkg/sessiontxn",
         "//pkg/statistics",
         "//pkg/statistics/handle",
-        "//pkg/statistics/handle/cache",
         "//pkg/statistics/handle/util",
         "//pkg/store/copr",
         "//pkg/store/driver/backoff",

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -115,7 +115,7 @@ func (s *backfillDistExecutor) newBackfillSubtaskExecutor(
 		ddlObj.setDDLSourceForDiagnosis(jobMeta.ID, jobMeta.Type)
 		return newReadIndexExecutor(ddlObj, jobMeta, indexInfos, tbl, jc, s.getBackendCtx, cloudStorageURI)
 	case proto.BackfillStepMergeSort:
-		return newMergeSortExecutor(jobMeta.ID, len(indexInfos), tbl, cloudStorageURI)
+		return newMergeSortExecutor(jobMeta.ID, ddlObj.store, len(indexInfos), tbl, cloudStorageURI)
 	case proto.BackfillStepWriteAndIngest:
 		if len(cloudStorageURI) == 0 {
 			return nil, errors.Errorf("local import does not have write & ingest step")

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -44,8 +44,7 @@ type BackfillTaskMeta struct {
 	EleTypeKey []byte `json:"ele_type_key"`
 
 	CloudStorageURI string `json:"cloud_storage_uri"`
-
-	EstimateRowSize int `json:"estimate_row_size"`
+	EstimateRowSize int    `json:"estimate_row_size"`
 }
 
 // BackfillSubTaskMeta is the sub-task meta for backfilling index.
@@ -118,7 +117,7 @@ func (s *backfillDistExecutor) newBackfillSubtaskExecutor(
 		ddlObj.setDDLSourceForDiagnosis(jobMeta.ID, jobMeta.Type)
 		return newReadIndexExecutor(ddlObj, jobMeta, indexInfos, tbl, jc, s.getBackendCtx, cloudStorageURI, estRowSize)
 	case proto.BackfillStepMergeSort:
-		return newMergeSortExecutor(jobMeta.ID, ddlObj.store, len(indexInfos), tbl, cloudStorageURI, estRowSize)
+		return newMergeSortExecutor(jobMeta.ID, len(indexInfos), tbl, cloudStorageURI, estRowSize)
 	case proto.BackfillStepWriteAndIngest:
 		if len(cloudStorageURI) == 0 {
 			return nil, errors.Errorf("local import does not have write & ingest step")

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -44,6 +44,8 @@ type BackfillTaskMeta struct {
 	EleTypeKey []byte `json:"ele_type_key"`
 
 	CloudStorageURI string `json:"cloud_storage_uri"`
+
+	EstimateRowSize int `json:"estimate_row_size"`
 }
 
 // BackfillSubTaskMeta is the sub-task meta for backfilling index.
@@ -107,15 +109,16 @@ func (s *backfillDistExecutor) newBackfillSubtaskExecutor(
 		indexInfos = append(indexInfos, indexInfo)
 	}
 	cloudStorageURI := s.taskMeta.CloudStorageURI
+	estRowSize := s.taskMeta.EstimateRowSize
 
 	switch stage {
 	case proto.BackfillStepReadIndex:
 		jc := ddlObj.jobContext(jobMeta.ID, jobMeta.ReorgMeta)
 		ddlObj.setDDLLabelForTopSQL(jobMeta.ID, jobMeta.Query)
 		ddlObj.setDDLSourceForDiagnosis(jobMeta.ID, jobMeta.Type)
-		return newReadIndexExecutor(ddlObj, jobMeta, indexInfos, tbl, jc, s.getBackendCtx, cloudStorageURI)
+		return newReadIndexExecutor(ddlObj, jobMeta, indexInfos, tbl, jc, s.getBackendCtx, cloudStorageURI, estRowSize)
 	case proto.BackfillStepMergeSort:
-		return newMergeSortExecutor(jobMeta.ID, ddlObj.store, len(indexInfos), tbl, cloudStorageURI)
+		return newMergeSortExecutor(jobMeta.ID, ddlObj.store, len(indexInfos), tbl, cloudStorageURI, estRowSize)
 	case proto.BackfillStepWriteAndIngest:
 		if len(cloudStorageURI) == 0 {
 			return nil, errors.Errorf("local import does not have write & ingest step")

--- a/pkg/ddl/backfilling_merge_sort.go
+++ b/pkg/ddl/backfilling_merge_sort.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor"
-	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -37,7 +36,6 @@ type mergeSortExecutor struct {
 	jobID         int64
 	idxNum        int
 	ptbl          table.PhysicalTable
-	store         kv.Storage
 	avgRowSize    int
 	cloudStoreURI string
 
@@ -47,7 +45,6 @@ type mergeSortExecutor struct {
 
 func newMergeSortExecutor(
 	jobID int64,
-	store kv.Storage,
 	idxNum int,
 	ptbl table.PhysicalTable,
 	cloudStoreURI string,
@@ -56,7 +53,6 @@ func newMergeSortExecutor(
 	return &mergeSortExecutor{
 		jobID:         jobID,
 		idxNum:        idxNum,
-		store:         store,
 		ptbl:          ptbl,
 		cloudStoreURI: cloudStoreURI,
 		avgRowSize:    avgRowSize,

--- a/pkg/ddl/backfilling_merge_sort.go
+++ b/pkg/ddl/backfilling_merge_sort.go
@@ -51,6 +51,7 @@ func newMergeSortExecutor(
 	idxNum int,
 	ptbl table.PhysicalTable,
 	cloudStoreURI string,
+	avgRowSize int,
 ) (*mergeSortExecutor, error) {
 	return &mergeSortExecutor{
 		jobID:         jobID,
@@ -58,12 +59,12 @@ func newMergeSortExecutor(
 		store:         store,
 		ptbl:          ptbl,
 		cloudStoreURI: cloudStoreURI,
+		avgRowSize:    avgRowSize,
 	}, nil
 }
 
-func (m *mergeSortExecutor) Init(ctx context.Context) error {
+func (*mergeSortExecutor) Init(ctx context.Context) error {
 	logutil.Logger(ctx).Info("merge sort executor init subtask exec env")
-	m.avgRowSize = estimateRowSize(ctx, m.store, m.ptbl)
 	return nil
 }
 

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -112,11 +112,11 @@ func (ctx *OperatorCtx) OperatorErr() error {
 	return *err
 }
 
-func getWriterMemSize(tblInfo *model.TableInfo, idxNum int) (uint64, error) {
+func getWriterMemSize(avgRowSize int, idxNum int) (uint64, error) {
 	failpoint.Inject("mockWriterMemSize", func() {
 		failpoint.Return(1*size.GB, nil)
 	})
-	_, writerCnt := expectedIngestWorkerCnt(tblInfo)
+	_, writerCnt := expectedIngestWorkerCnt(avgRowSize)
 	memTotal, err := memory.MemTotal()
 	if err != nil {
 		return 0, err
@@ -131,8 +131,8 @@ func getWriterMemSize(tblInfo *model.TableInfo, idxNum int) (uint64, error) {
 	return memSize, nil
 }
 
-func getMergeSortPartSize(tblInfo *model.TableInfo, concurrency int, idxNum int) (uint64, error) {
-	writerMemSize, err := getWriterMemSize(tblInfo, idxNum)
+func getMergeSortPartSize(avgRowSize int, concurrency int, idxNum int) (uint64, error) {
+	writerMemSize, err := getWriterMemSize(avgRowSize, idxNum)
 	if err != nil {
 		return 0, nil
 	}
@@ -155,6 +155,7 @@ func NewAddIndexIngestPipeline(
 	totalRowCount *atomic.Int64,
 	metricCounter prometheus.Counter,
 	reorgMeta *model.DDLReorgMeta,
+	avgRowSize int,
 ) (*operator.AsyncPipeline, error) {
 	indexes := make([]table.Index, 0, len(idxInfos))
 	for _, idxInfo := range idxInfos {
@@ -171,7 +172,7 @@ func NewAddIndexIngestPipeline(
 	for i := 0; i < poolSize; i++ {
 		srcChkPool <- chunk.NewChunkWithCapacity(copCtx.GetBase().FieldTypes, copReadBatchSize())
 	}
-	readerCnt, writerCnt := expectedIngestWorkerCnt(tbl.Meta())
+	readerCnt, writerCnt := expectedIngestWorkerCnt(avgRowSize)
 
 	srcOp := NewTableScanTaskSource(ctx, store, tbl, startKey, endKey)
 	scanOp := NewTableScanOperator(ctx, sessPool, copCtx, srcChkPool, readerCnt)
@@ -207,6 +208,7 @@ func NewWriteIndexToExternalStoragePipeline(
 	metricCounter prometheus.Counter,
 	onClose external.OnCloseFunc,
 	reorgMeta *model.DDLReorgMeta,
+	avgRowSize int,
 ) (*operator.AsyncPipeline, error) {
 	indexes := make([]table.Index, 0, len(idxInfos))
 	for _, idxInfo := range idxInfos {
@@ -223,7 +225,7 @@ func NewWriteIndexToExternalStoragePipeline(
 	for i := 0; i < poolSize; i++ {
 		srcChkPool <- chunk.NewChunkWithCapacity(copCtx.GetBase().FieldTypes, copReadBatchSize())
 	}
-	readerCnt, writerCnt := expectedIngestWorkerCnt(tbl.Meta())
+	readerCnt, writerCnt := expectedIngestWorkerCnt(avgRowSize)
 
 	backend, err := storage.ParseBackend(extStoreURI, nil)
 	if err != nil {
@@ -234,7 +236,7 @@ func NewWriteIndexToExternalStoragePipeline(
 		return nil, err
 	}
 
-	memSize, err := getWriterMemSize(tbl.Meta(), len(indexes))
+	memSize, err := getWriterMemSize(avgRowSize, len(indexes))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -66,6 +66,7 @@ func newReadIndexExecutor(
 	jc *JobContext,
 	bcGetter func() (ingest.BackendCtx, error),
 	cloudStorageURI string,
+	avgRowSize int,
 ) (*readIndexExecutor, error) {
 	bc, err := bcGetter()
 	if err != nil {
@@ -79,14 +80,14 @@ func newReadIndexExecutor(
 		jc:              jc,
 		bc:              bc,
 		cloudStorageURI: cloudStorageURI,
+		avgRowSize:      avgRowSize,
 		curRowCount:     &atomic.Int64{},
 	}, nil
 }
 
-func (r *readIndexExecutor) Init(ctx context.Context) error {
+func (*readIndexExecutor) Init(ctx context.Context) error {
 	logutil.BgLogger().Info("read index executor init subtask exec env",
 		zap.String("category", "ddl"))
-	r.avgRowSize = estimateRowSize(ctx, r.d.store, r.ptbl)
 	return nil
 }
 

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -85,7 +85,7 @@ func newReadIndexExecutor(
 	}, nil
 }
 
-func (*readIndexExecutor) Init(ctx context.Context) error {
+func (*readIndexExecutor) Init(_ context.Context) error {
 	logutil.BgLogger().Info("read index executor init subtask exec env",
 		zap.String("category", "ddl"))
 	return nil

--- a/tests/realtikvtest/addindextest3/operator_test.go
+++ b/tests/realtikvtest/addindextest3/operator_test.go
@@ -196,6 +196,7 @@ func TestBackfillOperatorPipeline(t *testing.T) {
 		totalRowCount,
 		nil,
 		ddl.NewDDLReorgMeta(tk.Session()),
+		0,
 	)
 	require.NoError(t, err)
 	err = pipeline.Execute()
@@ -271,6 +272,7 @@ func TestBackfillOperatorPipelineException(t *testing.T) {
 			&atomic.Int64{},
 			nil,
 			ddl.NewDDLReorgMeta(tk.Session()),
+			0,
 		)
 		require.NoError(t, err)
 		err = pipeline.Execute()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52085

Problem Summary: See #52085.

### What changed and how does it work?

- Move avarage row size estimation to the beginning of adding index.
- Use `approximate-key-size` * `MB` / `approximate-keys` from region info fetched by PD client to enhance row size estimation.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
