### PR TITLE
statistics: ignore more logs

### DIFF
--- a/pkg/statistics/handle/logutil/logutil.go
+++ b/pkg/statistics/handle/logutil/logutil.go
@@ -43,9 +43,9 @@ func SingletonStatsSamplerLogger() *zap.Logger {
 	init := func() {
 		if samplerLogger == nil {
 			// Create a new zapcore sampler with options
-			// This will log the first 2 log entries with the same level and message in a minute and ignore the rest of the logs.
+			// This will log the first log entries with the same level and message in 5 minutes and ignore the rest of the logs.
 			sampler := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-				return zapcore.NewSamplerWithOptions(core, time.Minute, 2, 0)
+				return zapcore.NewSamplerWithOptions(core, 5*time.Minute, 1, 0)
 			})
 			samplerLogger = StatsLogger().WithOptions(sampler)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/52100

Problem Summary:

It is unnecessary to have two of them since they are mostly identical.

### What changed and how does it work?
Only print the first log within 5 minutes.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
