### PR TITLE
expression: set a collation according to the arguments for `ifnull` in constant folding

### DIFF
--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -100,7 +100,15 @@ func ifNullFoldHandler(ctx BuildContext, expr *ScalarFunction) (Expression, bool
 		// evaluated to constArg.Value after foldConstant(args[0]), it's not
 		// needed to be checked.
 		if constArg.Value.IsNull() {
-			return foldConstant(ctx, args[1])
+			foldedExpr, isConstant := foldConstant(ctx, args[1])
+
+			// See https://github.com/pingcap/tidb/issues/51765. If the first argument can
+			// be folded into NULL, the collation of IFNULL should be the same as the second
+			// arguments.
+			expr.GetType().SetCharset(args[1].GetType().GetCharset())
+			expr.GetType().SetCollate(args[1].GetType().GetCollate())
+
+			return foldedExpr, isConstant
 		}
 		return constArg, isDeferred
 	}

--- a/tests/integrationtest/r/expression/constant_fold.result
+++ b/tests/integrationtest/r/expression/constant_fold.result
@@ -1,0 +1,26 @@
+drop table if exists t, t1;
+create table t (id varbinary(16));
+create table t1(id char(16) charset utf8mb4 collate utf8mb4_general_ci);
+insert into t values ();
+insert into t1 values ("Hello World");
+select collation(ifnull(concat(NULL),'~'));
+collation(ifnull(concat(NULL),'~'))
+utf8mb4_general_ci
+select collation(ifnull(concat(NULL),ifnull(concat(NULL),'~')));
+collation(ifnull(concat(NULL),ifnull(concat(NULL),'~')))
+utf8mb4_general_ci
+select collation(ifnull(concat(id),'~')) from t;
+collation(ifnull(concat(id),'~'))
+binary
+select collation(ifnull(concat(NULL),ifnull(concat(id),'~'))) from t;
+collation(ifnull(concat(NULL),ifnull(concat(id),'~')))
+binary
+select collation(ifnull(concat(id),ifnull(concat(id),'~'))) from t;
+collation(ifnull(concat(id),ifnull(concat(id),'~')))
+binary
+select collation(ifnull(concat(NULL),id)) from t1;
+collation(ifnull(concat(NULL),id))
+utf8mb4_general_ci
+select collation(ifnull(concat(NULL),ifnull(concat(NULL),id))) from t1;
+collation(ifnull(concat(NULL),ifnull(concat(NULL),id)))
+utf8mb4_general_ci

--- a/tests/integrationtest/t/expression/constant_fold.test
+++ b/tests/integrationtest/t/expression/constant_fold.test
@@ -1,0 +1,13 @@
+# TestFoldIfNull
+drop table if exists t, t1;
+create table t (id varbinary(16));
+create table t1(id char(16) charset utf8mb4 collate utf8mb4_general_ci);
+insert into t values ();
+insert into t1 values ("Hello World");
+select collation(ifnull(concat(NULL),'~'));
+select collation(ifnull(concat(NULL),ifnull(concat(NULL),'~')));
+select collation(ifnull(concat(id),'~')) from t;
+select collation(ifnull(concat(NULL),ifnull(concat(id),'~'))) from t;
+select collation(ifnull(concat(id),ifnull(concat(id),'~'))) from t;
+select collation(ifnull(concat(NULL),id)) from t1;
+select collation(ifnull(concat(NULL),ifnull(concat(NULL),id))) from t1;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51765

Problem Summary:

The `ifnull` has different behavior in inferring collation for constant folding and normal execution path.

### What changed and how does it work?

Set the collation according to the first argument in the path of constant folding.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
Fix the issue that the collation of `ifnull` expression is different with MySQL when constant folding applies.
```
