### PR TITLE
statistics: fix the potential error when merging buckets

### DIFF
--- a/pkg/statistics/histogram_test.go
+++ b/pkg/statistics/histogram_test.go
@@ -523,6 +523,16 @@ func TestMergeBucketNDV(t *testing.T) {
 			right:  genBucket4Merging4Test(2, 6, 4, 0),
 			result: genBucket4Merging4Test(2, 6, 5, 0),
 		},
+		{
+			left:   genBucket4Merging4Test(3, 5, 0, 0),
+			right:  genBucket4Merging4Test(2, 6, 0, 0),
+			result: genBucket4Merging4Test(2, 6, 0, 0),
+		},
+		{
+			left:   genBucket4Merging4Test(1, 3, 0, 0),
+			right:  genBucket4Merging4Test(4, 6, 0, 0),
+			result: genBucket4Merging4Test(1, 6, 0, 0),
+		},
 	}
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	for _, tt := range tests {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

If we are passing two buckets whose NDV are all 0, you can see that we directly use the right bucket as the merging result.
It's not reasonable.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
