### PR TITLE
expression: minimize the `PushDownContext`

### DIFF
--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -96,6 +96,7 @@ go_library(
         "//pkg/util/chunk",
         "//pkg/util/codec",
         "//pkg/util/collate",
+        "//pkg/util/context",
         "//pkg/util/dbterror",
         "//pkg/util/dbterror/plannererrors",
         "//pkg/util/disjointset",

--- a/pkg/expression/aggregation/agg_to_pb.go
+++ b/pkg/expression/aggregation/agg_to_pb.go
@@ -15,14 +15,12 @@
 package aggregation
 
 import (
-	"context"
 	"strconv"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
-	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tipb/go-tipb"
@@ -130,10 +128,7 @@ func AggFuncToPBExpr(ctx expression.PushDownContext, aggFunc *AggFuncDesc, store
 			orderBy = append(orderBy, pbArg)
 		}
 		// encode GroupConcatMaxLen
-		gcMaxLen, err := ctx.GetSessionVars().GetSessionOrGlobalSystemVar(context.Background(), variable.GroupConcatMaxLen)
-		if err != nil {
-			return nil, errors.Errorf("Error happened when buildGroupConcat: no system variable named '%s'", variable.GroupConcatMaxLen)
-		}
+		gcMaxLen := ctx.GetGroupConcatMaxLen()
 		maxLen, err := strconv.ParseUint(gcMaxLen, 10, 64)
 		// Should never happen
 		if err != nil {

--- a/pkg/expression/aggregation/agg_to_pb.go
+++ b/pkg/expression/aggregation/agg_to_pb.go
@@ -15,8 +15,6 @@
 package aggregation
 
 import (
-	"strconv"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -128,12 +126,7 @@ func AggFuncToPBExpr(ctx expression.PushDownContext, aggFunc *AggFuncDesc, store
 			orderBy = append(orderBy, pbArg)
 		}
 		// encode GroupConcatMaxLen
-		gcMaxLen := ctx.GetGroupConcatMaxLen()
-		maxLen, err := strconv.ParseUint(gcMaxLen, 10, 64)
-		// Should never happen
-		if err != nil {
-			return nil, errors.Errorf("Error happened when buildGroupConcat: %s", err.Error())
-		}
+		maxLen := ctx.GetGroupConcatMaxLen()
 		return &tipb.Expr{Tp: tp, Val: codec.EncodeUint(nil, maxLen), Children: children, FieldType: retType, HasDistinct: aggFunc.HasDistinct, OrderBy: orderBy, AggFuncMode: AggFunctionModeToPB(aggFunc.Mode)}, nil
 	}
 	return &tipb.Expr{Tp: tp, Children: children, FieldType: retType, HasDistinct: aggFunc.HasDistinct, AggFuncMode: AggFunctionModeToPB(aggFunc.Mode)}, nil

--- a/pkg/expression/aggregation/agg_to_pb_test.go
+++ b/pkg/expression/aggregation/agg_to_pb_test.go
@@ -66,7 +66,11 @@ func TestAggFunc2Pb(t *testing.T) {
 			aggFunc, err := NewAggFuncDesc(ctx, funcName, args, hasDistinct)
 			require.NoError(t, err)
 			aggFunc.RetTp = funcTypes[i]
-			pushCtx := expression.NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+			pushCtx := expression.NewPushDownContextFromSessionVars(
+				ctx.GetExprCtx(),
+				ctx.GetSessionVars(),
+				client,
+			)
 			pbExpr, err := AggFuncToPBExpr(pushCtx, aggFunc, kv.UnSpecified)
 			require.NoError(t, err)
 			js, err := json.Marshal(pbExpr)

--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -45,7 +45,7 @@ func TestConstant2Pb(t *testing.T) {
 	var constExprs []Expression
 	ctx := mock.NewContext()
 	client := new(mock.Client)
-	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+	pushDownCtx := NewPushDownContextFromSessionVars(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	// can be transformed
 	constValue := new(Constant)
@@ -129,7 +129,7 @@ func TestColumn2Pb(t *testing.T) {
 	var colExprs []Expression
 	ctx := mock.NewContext()
 	client := new(mock.Client)
-	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+	pushDownCtx := NewPushDownContextFromSessionVars(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	colExprs = append(colExprs, genColumn(mysql.TypeSet, 1))
 	colExprs = append(colExprs, genColumn(mysql.TypeGeometry, 2))
@@ -222,7 +222,7 @@ func TestCompareFunc2Pb(t *testing.T) {
 	var compareExprs = make([]Expression, 0)
 	ctx := mock.NewContext()
 	client := new(mock.Client)
-	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+	pushDownCtx := NewPushDownContextFromSessionVars(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	funcNames := []string{ast.LT, ast.LE, ast.GT, ast.GE, ast.EQ, ast.NE, ast.NullEQ}
 	for _, funcName := range funcNames {
@@ -508,7 +508,7 @@ func TestOtherFunc2Pb(t *testing.T) {
 func TestExprPushDownToFlash(t *testing.T) {
 	ctx := mock.NewContext()
 	client := new(mock.Client)
-	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+	pushDownCtx := NewPushDownContextFromSessionVars(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	exprs := make([]Expression, 0)
 
@@ -1424,7 +1424,7 @@ func TestExprOnlyPushDownToFlash(t *testing.T) {
 	exprs = append(exprs, function)
 
 	ctx := mock.NewContext()
-	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+	pushDownCtx := NewPushDownContextFromSessionVars(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 	pushed, remained := PushDownExprs(pushDownCtx, exprs, kv.UnSpecified)
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
@@ -1492,7 +1492,7 @@ func TestExprPushDownToTiKV(t *testing.T) {
 	exprs = append(exprs, function)
 
 	ctx := mock.NewContext()
-	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+	pushDownCtx := NewPushDownContextFromSessionVars(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 	pushed, remained := PushDownExprs(pushDownCtx, exprs, kv.TiKV)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
@@ -1642,7 +1642,7 @@ func TestExprPushDownToTiKV(t *testing.T) {
 	}
 
 	ctx = mock.NewContext()
-	pushDownCtx = NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+	pushDownCtx = NewPushDownContextFromSessionVars(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 	for _, tc := range testcases {
 		function, err = NewFunction(ctx, tc.functionName, tc.retType, tc.args...)
 		require.NoError(t, err)
@@ -1657,7 +1657,7 @@ func TestExprPushDownToTiKV(t *testing.T) {
 func TestExprOnlyPushDownToTiKV(t *testing.T) {
 	ctx := mock.NewContext()
 	client := new(mock.Client)
-	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+	pushDownCtx := NewPushDownContextFromSessionVars(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	function, err := NewFunction(ctx, "uuid", types.NewFieldType(mysql.TypeLonglong))
 	require.NoError(t, err)
@@ -1749,7 +1749,7 @@ func TestNewCollationsEnabled(t *testing.T) {
 	var colExprs []Expression
 	ctx := mock.NewContext()
 	client := new(mock.Client)
-	pushDownCtx := NewPushDownContext(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
+	pushDownCtx := NewPushDownContextFromSessionVars(ctx.GetExprCtx(), ctx.GetSessionVars(), client)
 
 	colExprs = colExprs[:0]
 	colExprs = append(colExprs, genColumn(mysql.TypeVarchar, 1))

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -422,7 +422,7 @@ type PushDownContext struct {
 	evalCtx           EvalContext
 	client            kv.Client
 	warnHandler       contextutil.WarnHandler
-	groupConcatMaxLen string
+	groupConcatMaxLen uint64
 }
 
 type pushDownWarnHandler struct {
@@ -440,7 +440,7 @@ func (h *pushDownWarnHandler) AppendWarning(err error) {
 }
 
 // NewPushDownContext returns a new PushDownContext
-func NewPushDownContext(evalCtx EvalContext, client kv.Client, inExplainStmt bool, appendWarning func(err error), appendExtraWarning func(err error), groupConcatMaxLen string) PushDownContext {
+func NewPushDownContext(evalCtx EvalContext, client kv.Client, inExplainStmt bool, appendWarning func(err error), appendExtraWarning func(err error), groupConcatMaxLen uint64) PushDownContext {
 	var warnHandler contextutil.WarnHandler
 	if appendWarning != nil && appendExtraWarning != nil {
 		warnHandler = &pushDownWarnHandler{
@@ -485,7 +485,7 @@ func (ctx PushDownContext) Client() kv.Client {
 }
 
 // GetGroupConcatMaxLen returns the max length of group_concat
-func (ctx PushDownContext) GetGroupConcatMaxLen() string {
+func (ctx PushDownContext) GetGroupConcatMaxLen() uint64 {
 	return ctx.groupConcatMaxLen
 }
 

--- a/pkg/planner/core/util.go
+++ b/pkg/planner/core/util.go
@@ -472,5 +472,5 @@ func EncodeUniqueIndexValuesForKey(ctx sessionctx.Context, tblInfo *model.TableI
 
 // GetPushDownCtx creates a PushDownContext from PlanContext
 func GetPushDownCtx(sctx PlanContext) expression.PushDownContext {
-	return expression.NewPushDownContext(sctx.GetExprCtx(), sctx.GetSessionVars(), sctx.GetClient())
+	return expression.NewPushDownContextFromSessionVars(sctx.GetExprCtx(), sctx.GetSessionVars(), sctx.GetClient())
 }

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1583,7 +1583,7 @@ type SessionVars struct {
 	DivPrecisionIncrement int
 
 	// GroupConcatMaxLen represents the maximum length of the result of GROUP_CONCAT.
-	GroupConcatMaxLen string
+	GroupConcatMaxLen uint64
 }
 
 // GetOptimizerFixControlMap returns the specified value of the optimizer fix control.

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1581,6 +1581,9 @@ type SessionVars struct {
 	// DivPrecisionIncrement indicates the number of digits by which to increase the scale of the result
 	// of division operations performed with the / operator.
 	DivPrecisionIncrement int
+
+	// GroupConcatMaxLen represents the maximum length of the result of GROUP_CONCAT.
+	GroupConcatMaxLen string
 }
 
 // GetOptimizerFixControlMap returns the specified value of the optimizer fix control.
@@ -2038,6 +2041,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		TiFlashComputeDispatchPolicy:  tiflashcompute.DispatchPolicyConsistentHash,
 		ResourceGroupName:             resourcegroup.DefaultResourceGroupName,
 		DefaultCollationForUTF8MB4:    mysql.DefaultCollationName,
+		GroupConcatMaxLen:             DefGroupConcatMaxLen,
 	}
 	vars.status.Store(uint32(mysql.ServerStatusAutocommit))
 	vars.StmtCtx.ResourceGroupName = resourcegroup.DefaultResourceGroupName

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1660,7 +1660,7 @@ var defaultSysVars = []*SysVar{
 	{
 		Scope:                   ScopeGlobal | ScopeSession,
 		Name:                    GroupConcatMaxLen,
-		Value:                   "1024",
+		Value:                   DefGroupConcatMaxLen,
 		IsHintUpdatableVerified: true,
 		Type:                    TypeUnsigned,
 		MinValue:                4,
@@ -1681,7 +1681,15 @@ var defaultSysVars = []*SysVar{
 				}
 			}
 			return normalizedValue, nil
-		}},
+		},
+		SetSession: func(sv *SessionVars, s string) error {
+			sv.GroupConcatMaxLen = s
+			return nil
+		},
+		GetSession: func(sv *SessionVars) (string, error) {
+			return sv.GroupConcatMaxLen, nil
+		},
+	},
 	{Scope: ScopeGlobal | ScopeSession, Name: CharacterSetConnection, Value: mysql.DefaultCharset, skipInit: true, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
 		return checkCharacterSet(normalizedValue, CharacterSetConnection)
 	}, SetSession: func(s *SessionVars, val string) error {

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1660,7 +1660,7 @@ var defaultSysVars = []*SysVar{
 	{
 		Scope:                   ScopeGlobal | ScopeSession,
 		Name:                    GroupConcatMaxLen,
-		Value:                   DefGroupConcatMaxLen,
+		Value:                   strconv.FormatUint(DefGroupConcatMaxLen, 10),
 		IsHintUpdatableVerified: true,
 		Type:                    TypeUnsigned,
 		MinValue:                4,
@@ -1683,11 +1683,14 @@ var defaultSysVars = []*SysVar{
 			return normalizedValue, nil
 		},
 		SetSession: func(sv *SessionVars, s string) error {
-			sv.GroupConcatMaxLen = s
+			var err error
+			if sv.GroupConcatMaxLen, err = strconv.ParseUint(s, 10, 64); err != nil {
+				return err
+			}
 			return nil
 		},
 		GetSession: func(sv *SessionVars) (string, error) {
-			return sv.GroupConcatMaxLen, nil
+			return strconv.FormatUint(sv.GroupConcatMaxLen, 10), nil
 		},
 	},
 	{Scope: ScopeGlobal | ScopeSession, Name: CharacterSetConnection, Value: mysql.DefaultCharset, skipInit: true, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1487,6 +1487,7 @@ const (
 	DefTiDBLowResolutionTSOUpdateInterval             = 2000
 	DefDivPrecisionIncrement                          = 4
 	DefTiDBDMLType                                    = "STANDARD"
+	DefGroupConcatMaxLen                              = "1024"
 )
 
 // Process global variables.

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1487,7 +1487,7 @@ const (
 	DefTiDBLowResolutionTSOUpdateInterval             = 2000
 	DefDivPrecisionIncrement                          = 4
 	DefTiDBDMLType                                    = "STANDARD"
-	DefGroupConcatMaxLen                              = "1024"
+	DefGroupConcatMaxLen                              = uint64(1024)
 )
 
 // Process global variables.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #52134

Problem Summary:

The `SessionVars` in `PushDownContext` is too big. If we are going to decide whether we can clone the whole `tableReaderExecutorContext` can be cloned, one big part of it is the `SessionVars` in `PlanContext`, which turns to be stored in `PushDownContext` (and there are other usages, which will be refactored in the future).

### What changed and how does it work?

1. Add a special warning handler, to append warn according to whether the statement is `explain` (or not).
2. Get the variable `GroupConcatMaxLen` before constructing the context.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > No logic change.


### Release note

```release-note
None
```
