### PR TITLE
cop: display kv read time details in the execution information

### DIFF
--- a/pkg/distsql/select_result.go
+++ b/pkg/distsql/select_result.go
@@ -527,6 +527,9 @@ func (r *selectResult) updateCopRuntimeStats(ctx context.Context, copStats *copr
 	if copStats.ScanDetail != nil && len(r.copPlanIDs) > 0 {
 		r.ctx.RuntimeStatsColl.RecordScanDetail(r.copPlanIDs[len(r.copPlanIDs)-1], r.storeType.Name(), copStats.ScanDetail)
 	}
+	if len(r.copPlanIDs) > 0 {
+		r.ctx.RuntimeStatsColl.RecordTimeDetail(r.copPlanIDs[len(r.copPlanIDs)-1], r.storeType.Name(), &copStats.TimeDetail)
+	}
 
 	// If hasExecutor is true, it means the summary is returned from TiFlash.
 	hasExecutor := false

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -733,6 +733,7 @@ type CopRuntimeStats struct {
 	// executed on each instance.
 	stats      map[string]*basicCopRuntimeStats
 	scanDetail *util.ScanDetail
+	timeDetail *util.TimeDetail
 	// do not use kv.StoreType because it will meet cycle import error
 	storeType string
 	sync.Mutex
@@ -859,11 +860,20 @@ func (crs *CopRuntimeStats) String() string {
 			buf.WriteString("}")
 		}
 	}
-	if !isTiFlashCop && crs.scanDetail != nil {
-		detail := crs.scanDetail.String()
-		if detail != "" {
-			buf.WriteString(", ")
-			buf.WriteString(detail)
+	if !isTiFlashCop {
+		if crs.scanDetail != nil {
+			detail := crs.scanDetail.String()
+			if detail != "" {
+				buf.WriteString(", ")
+				buf.WriteString(detail)
+			}
+		}
+		if crs.timeDetail != nil {
+			timeDetailStr := crs.timeDetail.String()
+			if timeDetailStr != "" {
+				buf.WriteString(", ")
+				buf.WriteString(timeDetailStr)
+			}
 		}
 	}
 	return buf.String()
@@ -1358,6 +1368,7 @@ func (e *RuntimeStatsColl) GetOrCreateCopStats(planID int, storeType string) *Co
 		copStats = &CopRuntimeStats{
 			stats:      make(map[string]*basicCopRuntimeStats),
 			scanDetail: &util.ScanDetail{},
+			timeDetail: &util.TimeDetail{},
 			storeType:  storeType,
 		}
 		e.copStats[planID] = copStats
@@ -1391,6 +1402,14 @@ func (e *RuntimeStatsColl) RecordOneCopTask(planID int, storeType string, addres
 func (e *RuntimeStatsColl) RecordScanDetail(planID int, storeType string, detail *util.ScanDetail) {
 	copStats := e.GetOrCreateCopStats(planID, storeType)
 	copStats.scanDetail.Merge(detail)
+}
+
+// RecordTimeDetail records a specific cop tasks's time detail.
+func (e *RuntimeStatsColl) RecordTimeDetail(planID int, storeType string, detail *util.TimeDetail) {
+	copStats := e.GetOrCreateCopStats(planID, storeType)
+	if detail != nil {
+		copStats.timeDetail.Merge(detail)
+	}
 }
 
 // ExistsRootStats checks if the planID exists in the rootStats collection.

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -478,15 +478,27 @@ func TestCopRuntimeStats2(t *testing.T) {
 		RocksdbBlockReadCount:     20,
 		RocksdbBlockReadByte:      100,
 	}
+	timeDetail := &util.TimeDetail{
+		ProcessTime:      10 * time.Millisecond,
+		SuspendTime:      20 * time.Millisecond,
+		WaitTime:         30 * time.Millisecond,
+		KvReadWallTime:   5 * time.Millisecond,
+		TotalRPCWallTime: 50 * time.Millisecond,
+	}
 	stats.RecordScanDetail(tableScanID, "tikv", scanDetail)
 	for i := 0; i < 1005; i++ {
 		stats.RecordOneCopTask(tableScanID, "tikv", "8.8.8.9", mockExecutorExecutionSummary(2, 2, 2))
 		stats.RecordScanDetail(tableScanID, "tikv", scanDetail)
+		stats.RecordTimeDetail(tableScanID, "tikv", timeDetail)
 	}
 
 	cop := stats.GetOrCreateCopStats(tableScanID, "tikv")
 	expected := "tikv_task:{proc max:0s, min:0s, avg: 2ns, p80:2ns, p95:2ns, iters:2010, tasks:1005}, " +
-		"scan_detail: {total_process_keys: 10060, total_process_keys_size: 10060, total_keys: 15090, rocksdb: {delete_skipped_count: 5030, key_skipped_count: 1006, block: {cache_hit_count: 10060, read_count: 20120, read_byte: 98.2 KB}}}"
+		"scan_detail: {total_process_keys: 10060, total_process_keys_size: 10060, total_keys: 15090, " +
+		"rocksdb: {delete_skipped_count: 5030, key_skipped_count: 1006, " +
+		"block: {cache_hit_count: 10060, read_count: 20120, read_byte: 98.2 KB}}}, " +
+		"time_detail: {total_process_time: 10.1s, total_suspend_time: 20.1s, total_wait_time: 30.2s, " +
+		"total_kv_read_wall_time: 5.03s, tikv_wall_time: 50.3s}"
 	require.Equal(t, expected, cop.String())
 	require.Equal(t, expected, cop.String())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #28937 

Problem Summary:
```
explain analyze select * from t1;
+-----------------------+---------+---------+-----------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+-----------+------+
| id                    | estRows | actRows | task      | access object | execution info                                                                                                                                                                                                                                                                                                                                               | operator info                               | memory    | disk |
+-----------------------+---------+---------+-----------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+-----------+------+
| TableReader_5         | 6.00    | 6       | root      |               | time:104.4ms, loops:2, RU:0.714463, cop_task: {num: 1, max: 104.2ms, proc_keys: 6, tot_proc: 704.9µs, tot_wait: 513.1µs, rpc_num: 1, rpc_time: 104.1ms, copr_cache_hit_ratio: 0.00, build_task_duration: 553.6µs, max_distsql_concurrency: 1}                                                                                                                | data:TableFullScan_4                        | 542 Bytes | N/A  |
| └─TableFullScan_4     | 6.00    | 6       | cop[tikv] | table:t1      | tikv_task:{time:104ms, loops:1}, scan_detail: {total_process_keys: 6, total_process_keys_size: 295, total_keys: 7, get_snapshot_time: 206.9µs, rocksdb: {key_skipped_count: 6, block: {cache_hit_count: 2}}}, total_process_time: 704.9µs, total_suspend_time: 100.9ms, total_wait_time: 513.1µs, total_kv_read_wall_time: 104ms, tikv_wall_time: 103.1ms    | keep order:false, stats:partial[k1:missing] | N/A       | N/A  |
+-----------------------+---------+---------+-----------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+-----------+------+

The `total_kv_read_wall_time` could be displayed in the execution information.

```


### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


Side effects


Documentation



### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
