### PR TITLE
operator: make an infinity retry for connecting to store

### DIFF
--- a/br/pkg/backup/prepare_snap/env.go
+++ b/br/pkg/backup/prepare_snap/env.go
@@ -180,9 +180,8 @@ type RetryAndSplitRequestEnv struct {
 }
 
 func (r RetryAndSplitRequestEnv) ConnectToStore(ctx context.Context, storeID uint64) (PrepareClient, error) {
-	// Retry for about 2 minutes.
-	rs := utils.InitialRetryState(12, 10*time.Second, 10*time.Second)
-	bo := utils.Backoffer(&rs)
+	rs := utils.ConstantBackoff(10 * time.Second)
+	bo := utils.Backoffer(rs)
 	if r.GetBackoffer != nil {
 		bo = r.GetBackoffer()
 	}

--- a/br/pkg/utils/BUILD.bazel
+++ b/br/pkg/utils/BUILD.bazel
@@ -77,7 +77,7 @@ go_test(
     ],
     embed = [":utils"],
     flaky = True,
-    shard_count = 32,
+    shard_count = 36,
     deps = [
         "//br/pkg/errors",
         "//pkg/kv",

--- a/br/pkg/utils/BUILD.bazel
+++ b/br/pkg/utils/BUILD.bazel
@@ -77,7 +77,7 @@ go_test(
     ],
     embed = [":utils"],
     flaky = True,
-    shard_count = 36,
+    shard_count = 33,
     deps = [
         "//br/pkg/errors",
         "//pkg/kv",

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"io"
+	"math"
 	"strings"
 	"time"
 
@@ -60,6 +61,20 @@ func isGRPCCancel(err error) bool {
 		}
 	}
 	return false
+}
+
+// ConstantBackoff is a backoffer that retry forever until success.
+type ConstantBackoff time.Duration
+
+// NextBackoff returns a duration to wait before retrying again
+func (c ConstantBackoff) NextBackoff(err error) time.Duration {
+	return time.Duration(c)
+}
+
+// Attempt returns the remain attempt times
+func (c ConstantBackoff) Attempt() int {
+	// A large enough value. Also still safe for arithmetic operations (won't easily overflow).
+	return math.MaxInt16
 }
 
 // RetryState is the mutable state needed for retrying.

--- a/br/pkg/utils/backoff_test.go
+++ b/br/pkg/utils/backoff_test.go
@@ -4,7 +4,9 @@ package utils_test
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"math"
 	"testing"
 	"time"
 
@@ -212,4 +214,44 @@ func TestNewBackupSSTBackofferWithCancel(t *testing.T) {
 		berrors.ErrKVIngestFailed,
 		context.Canceled,
 	}, multierr.Errors(err))
+}
+
+func TestConstantBackoff(t *testing.T) {
+	backedOff := func(t *testing.T) {
+		backoffer := utils.ConstantBackoff(10 * time.Millisecond)
+		ctx, cancel := context.WithCancel(context.Background())
+		i := 0
+		ch := make(chan error)
+
+		go func() {
+			_, err := utils.WithRetryV2(ctx, backoffer, func(ctx context.Context) (struct{}, error) {
+				i += 1
+				return struct{}{}, fmt.Errorf("%d times, no meaning", i)
+			})
+			ch <- err
+		}()
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+		require.Error(t, <-ch)
+		// Make sure we have backed off.
+		require.Less(t, i, 20)
+	}
+
+	infRetry := func(t *testing.T) {
+		backoffer := utils.ConstantBackoff(0)
+		ctx := context.Background()
+		i := math.MaxInt16
+
+		_, err := utils.WithRetryV2(ctx, backoffer, func(ctx context.Context) (struct{}, error) {
+			i -= 1
+			if i == 0 {
+				return struct{}{}, nil
+			}
+			return struct{}{}, fmt.Errorf("try %d more times", i)
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("backedOff", backedOff)
+	t.Run("infRetry", infRetry)
 }

--- a/br/pkg/utils/retry.go
+++ b/br/pkg/utils/retry.go
@@ -238,6 +238,7 @@ func WithRetryV2[T any](
 		allErrors = multierr.Append(allErrors, err)
 		select {
 		case <-ctx.Done():
+			// allErrors must not be `nil` here, so ignore the context error.
 			return *new(T), allErrors
 		case <-time.After(backoffer.NextBackoff(err)):
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52175

Problem Summary:
See the issue.

### What changed and how does it work?
This make an infinity retry for the connecting to store phase.
The retry of waiting apply phase has been kept because it seems waiting apply isn't always lasting for minutes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
