### PR TITLE
infoschema: don't display tables in MemDB when query `TIDB_HOT_REGIONS`

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -1949,12 +1949,11 @@ func (e *memtableRetriever) setDataForTiDBHotRegions(ctx context.Context, sctx s
 	if !ok {
 		return errors.New("Information about hot region can be gotten only when the storage is TiKV")
 	}
-	allSchemas := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema().AllSchemas()
 	tikvHelper := &helper.Helper{
 		Store:       tikvStore,
 		RegionCache: tikvStore.GetRegionCache(),
 	}
-	schemas := tikvHelper.FilterMemDBs(allSchemas)
+	schemas := tikvHelper.FilterMemDBs(sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema().AllSchemas())
 	metrics, err := tikvHelper.ScrapeHotInfo(ctx, helper.HotRead, schemas)
 	if err != nil {
 		return err

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -1949,7 +1949,7 @@ func (e *memtableRetriever) setDataForTiDBHotRegions(ctx context.Context, sctx s
 	if !ok {
 		return errors.New("Information about hot region can be gotten only when the storage is TiKV")
 	}
-	allSchemas := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema().(infoschema.InfoSchema).AllSchemas()
+	allSchemas := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema().AllSchemas()
 	schemas := make([]*model.DBInfo, 0, len(allSchemas))
 	for _, schema := range allSchemas {
 		if util.IsMemDB(schema.Name.L) {

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -1949,12 +1949,19 @@ func (e *memtableRetriever) setDataForTiDBHotRegions(ctx context.Context, sctx s
 	if !ok {
 		return errors.New("Information about hot region can be gotten only when the storage is TiKV")
 	}
-	allSchemas := sctx.GetInfoSchema().(infoschema.InfoSchema).AllSchemas()
+	allSchemas := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema().(infoschema.InfoSchema).AllSchemas()
+	schemas := make([]*model.DBInfo, 0, len(allSchemas))
+	for _, schema := range allSchemas {
+		if util.IsMemDB(schema.Name.L) {
+			continue
+		}
+		schemas = append(schemas, schema)
+	}
 	tikvHelper := &helper.Helper{
 		Store:       tikvStore,
 		RegionCache: tikvStore.GetRegionCache(),
 	}
-	metrics, err := tikvHelper.ScrapeHotInfo(ctx, helper.HotRead, allSchemas)
+	metrics, err := tikvHelper.ScrapeHotInfo(ctx, helper.HotRead, schemas)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50810

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Create a cluster by `tiup playground nightly --db 1 --tiflash 0 --without-monitor` and wait a minutes.

Before this patch sometimes the query result will like 
```
mysql> select * from `TIDB_HOT_REGIONS`;
+---------------------+----------+--------------------+------------------+------------+-----------+------+----------------+--------------+------------+
| TABLE_ID            | INDEX_ID | DB_NAME            | TABLE_NAME       | INDEX_NAME | REGION_ID | TYPE | MAX_HOT_DEGREE | REGION_COUNT | FLOW_BYTES |
+---------------------+----------+--------------------+------------------+------------+-----------+------+----------------+--------------+------------+
| 4611686018427387961 |     NULL | INFORMATION_SCHEMA | INSPECTION_RULES | NULL       |        56 | read |             37 |            0 |      30600 |
+---------------------+----------+--------------------+------------------+------------+-----------+------+----------------+--------------+------------+
1 row in set (0.00 sec)
```

After patch, only get `tidb_ddl_job` table 
```
mysql> select * from `TIDB_HOT_REGIONS`;
+-----------------+----------+---------+--------------+------------+-----------+------+----------------+--------------+------------+
| TABLE_ID        | INDEX_ID | DB_NAME | TABLE_NAME   | INDEX_NAME | REGION_ID | TYPE | MAX_HOT_DEGREE | REGION_COUNT | FLOW_BYTES |
+-----------------+----------+---------+--------------+------------+-----------+------+----------------+--------------+------------+
| 281474976710654 |     NULL | mysql   | tidb_ddl_job | NULL       |        56 | read |             38 |            0 |      30600 |
+-----------------+----------+---------+--------------+------------+-----------+------+----------------+--------------+------------+
1 row in set (0.00 sec)
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
