### PR TITLE
resource_control: Separate the mark for watch and rule and enhance testing

### DIFF
--- a/pkg/domain/resourcegroup/runaway.go
+++ b/pkg/domain/resourcegroup/runaway.go
@@ -442,7 +442,9 @@ type RunawayChecker struct {
 	deadline time.Time
 	setting  *rmpb.RunawaySettings
 
-	marked atomic.Bool
+	markedByRule  atomic.Bool
+	markedByWatch bool
+	action        rmpb.RunawayAction
 }
 
 func newRunawayChecker(manager *RunawayManager, resourceGroupName string, setting *rmpb.RunawaySettings, originalSQL, sqlDigest, planDigest string) *RunawayChecker {
@@ -453,7 +455,8 @@ func newRunawayChecker(manager *RunawayManager, resourceGroupName string, settin
 		sqlDigest:         sqlDigest,
 		planDigest:        planDigest,
 		setting:           setting,
-		marked:            atomic.Bool{},
+		markedByRule:      atomic.Bool{},
+		markedByWatch:     false,
 	}
 	if setting != nil {
 		c.deadline = time.Now().Add(time.Duration(setting.Rule.ExecElapsedTimeMs) * time.Millisecond)
@@ -472,15 +475,16 @@ func (r *RunawayChecker) BeforeExecutor() error {
 			if action == rmpb.RunawayAction_NoneAction && r.setting != nil {
 				action = r.setting.Action
 			}
-			if r.marked.CompareAndSwap(false, true) {
-				now := time.Now()
-				r.markRunaway(RunawayMatchTypeWatch, action, &now)
-			}
+			r.markedByWatch = true
+			now := time.Now()
+			r.action = action
+			r.markRunaway(RunawayMatchTypeWatch, action, &now)
 			// If no match action, it will do nothing.
 			switch action {
 			case rmpb.RunawayAction_Kill:
 				return exeerrors.ErrResourceGroupQueryRunawayQuarantine
 			case rmpb.RunawayAction_CoolDown:
+				// This action should be done in BeforeCopRequest.
 				return nil
 			case rmpb.RunawayAction_DryRun:
 				return nil
@@ -496,9 +500,16 @@ func (r *RunawayChecker) BeforeCopRequest(req *tikvrpc.Request) error {
 	if r.setting == nil {
 		return nil
 	}
-	marked := r.marked.Load()
+	marked := r.markedByRule.Load()
 	if !marked {
 		// note: now we don't check whether query is in watch list again.
+		if r.markedByWatch {
+			switch r.setting.Action {
+			case rmpb.RunawayAction_CoolDown:
+				req.ResourceControlContext.OverridePriority = 1 // set priority to lowest
+			}
+		}
+
 		now := time.Now()
 		until := r.deadline.Sub(now)
 		if until > 0 {
@@ -511,7 +522,7 @@ func (r *RunawayChecker) BeforeCopRequest(req *tikvrpc.Request) error {
 			return nil
 		}
 		// execution time exceeds the threshold, mark the query as runaway
-		if r.marked.CompareAndSwap(false, true) {
+		if r.markedByRule.CompareAndSwap(false, true) {
 			r.markRunaway(RunawayMatchTypeIdentify, r.setting.Action, &now)
 			r.markQuarantine(&now)
 		}
@@ -535,16 +546,16 @@ func (r *RunawayChecker) CheckCopRespError(err error) error {
 		return err
 	}
 	if strings.HasPrefix(err.Error(), "Coprocessor task terminated due to exceeding the deadline") {
-		if !r.marked.Load() {
+		if !r.markedByRule.Load() {
 			now := time.Now()
-			if r.deadline.Before(now) && r.marked.CompareAndSwap(false, true) {
+			if r.deadline.Before(now) && r.markedByRule.CompareAndSwap(false, true) {
 				r.markRunaway(RunawayMatchTypeIdentify, r.setting.Action, &now)
 				r.markQuarantine(&now)
 				return exeerrors.ErrResourceGroupQueryRunawayInterrupted
 			}
 		}
 		// Due to concurrency, check again.
-		if r.marked.Load() {
+		if r.markedByRule.Load() {
 			return exeerrors.ErrResourceGroupQueryRunawayInterrupted
 		}
 	}

--- a/pkg/executor/internal/querywatch/query_watch_test.go
+++ b/pkg/executor/internal/querywatch/query_watch_test.go
@@ -16,9 +16,11 @@ package querywatch_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/pingcap/failpoint"
 	mysql "github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -49,11 +51,12 @@ func TestQueryWatch(t *testing.T) {
 		testkit.Rows("default select * from test.t1 1 1", "default select * from test.t2 2 1"), maxWaitDuration, tryInterval)
 
 	tk.MustExec("create resource group rg1 RU_PER_SEC=1000 QUERY_LIMIT=(EXEC_ELAPSED='50ms' ACTION=KILL)")
+	tk.MustExec("create resource group rg2 RU_PER_SEC=1000 QUERY_LIMIT=(EXEC_ELAPSED='50ms' ACTION=KILL)")
 
 	tk.MustQuery("query watch add resource group rg1 sql text exact to 'select * from test.t1'").Check(testkit.Rows("3"))
 	tk.MustQuery("query watch add resource group rg1 sql text similar to 'select * from test.t2'").Check(testkit.Rows("4"))
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnPrivilege)
-	tk.MustQueryWithContext(ctx, "query watch add resource group rg1 sql text plan to 'select * from test.t3'").Check(testkit.Rows("5"))
+	tk.MustQueryWithContext(ctx, "query watch add resource group rg1 action DRYRUN sql text plan to 'select * from test.t3'").Check(testkit.Rows("5"))
 
 	tk.MustQuery("query watch add action KILL SQL DIGEST '4ea0618129ffc6a7effbc0eff4bbcb41a7f5d4c53a6fa0b2e9be81c7010915b0'").Check(testkit.Rows("6"))
 	tk.MustQuery("query watch add action KILL PLAN DIGEST 'd08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57'").Check(testkit.Rows("7"))
@@ -63,20 +66,22 @@ func TestQueryWatch(t *testing.T) {
 			"default select * from test.t2 2 1",
 			"rg1 select * from test.t1 3 1",
 			"rg1 02576c15e1f35a8aa3eb7e3b1f977c9f9f9921a22421b3e9f42bad5ab632b4f6 3 2",
-			"rg1 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 3 3",
+			"rg1 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 1 3",
 			"default 4ea0618129ffc6a7effbc0eff4bbcb41a7f5d4c53a6fa0b2e9be81c7010915b0 3 2",
 			"default d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 3 3",
 		), maxWaitDuration, tryInterval)
 	tk.MustQuery("query watch add action COOLDOWN sql text similar to 'select * from test.t1'").Check(testkit.Rows("8"))
+	tk.MustQueryWithContext(ctx, "query watch add resource group rg2 action KILL sql text plan to 'select * from test.t3'").Check(testkit.Rows("9"))
 
 	tk.EventuallyMustQueryAndCheck("select SQL_NO_CACHE resource_group_name, watch_text, action, watch from mysql.tidb_runaway_watch order by id", nil,
 		testkit.Rows("default select * from test.t1 1 1",
 			"default select * from test.t2 2 1",
 			"rg1 select * from test.t1 3 1",
 			"rg1 02576c15e1f35a8aa3eb7e3b1f977c9f9f9921a22421b3e9f42bad5ab632b4f6 3 2",
-			"rg1 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 3 3",
+			"rg1 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 1 3",
 			"default d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 3 3",
 			"default 4ea0618129ffc6a7effbc0eff4bbcb41a7f5d4c53a6fa0b2e9be81c7010915b0 2 2",
+			"rg2 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 3 3",
 		), maxWaitDuration, tryInterval)
 
 	tk.EventuallyMustQueryAndCheck("select SQL_NO_CACHE resource_group_name, watch_text, action, watch from information_schema.runaway_watches order by id", nil,
@@ -84,17 +89,33 @@ func TestQueryWatch(t *testing.T) {
 			"default select * from test.t2 CoolDown Exact",
 			"rg1 select * from test.t1 Kill Exact",
 			"rg1 02576c15e1f35a8aa3eb7e3b1f977c9f9f9921a22421b3e9f42bad5ab632b4f6 Kill Similar",
-			"rg1 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 Kill Plan",
+			"rg1 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 DryRun Plan",
 			"default d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 Kill Plan",
 			"default 4ea0618129ffc6a7effbc0eff4bbcb41a7f5d4c53a6fa0b2e9be81c7010915b0 CoolDown Similar",
+			"rg2 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 Kill Plan",
 		), maxWaitDuration, tryInterval)
+
+	// avoid the default resource group to be recorded.
+	tk.MustExec("alter resource group default QUERY_LIMIT=(EXEC_ELAPSED='1000ms' ACTION=DRYRUN)")
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/copr/sleepCoprRequest", fmt.Sprintf("return(%d)", 60)))
+	err = tk.QueryToErr("select /*+ resource_group(rg1) */ * from t3")
+	require.ErrorContains(t, err, "[executor:8253]Query execution was interrupted, identified as runaway query")
+	tk.EventuallyMustQueryAndCheck("select SQL_NO_CACHE resource_group_name, original_sql, match_type from mysql.tidb_runaway_queries", nil,
+		testkit.Rows(
+			"rg1 select /*+ resource_group(rg1) */ * from t3 watch",
+			"rg1 select /*+ resource_group(rg1) */ * from t3 identify",
+		), maxWaitDuration, tryInterval)
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/copr/sleepCoprRequest"))
+
+	tk.MustExec("alter resource group default QUERY_LIMIT=(EXEC_ELAPSED='50ms' ACTION=DRYRUN)")
 	tk.MustGetErrCode("select * from t3", mysql.ErrResourceGroupQueryRunawayQuarantine)
 	tk.MustQuery("select * from t2").Check(testkit.Rows("1"))
 	tk.MustQuery("select /*+ resource_group(rg1) */ * from t1").Check(testkit.Rows("1"))
 	tk.MustExec("SET RESOURCE GROUP rg1")
 	// hit and schema will affect sql digest
 	tk.MustGetErrCode("select * from test.t2", mysql.ErrResourceGroupQueryRunawayQuarantine)
-	tk.MustGetErrCode("select /*+ resource_group(rg1) */ * from t3", mysql.ErrResourceGroupQueryRunawayQuarantine)
+	tk.MustGetErrCode("select /*+ resource_group(rg2) */ * from t3", mysql.ErrResourceGroupQueryRunawayQuarantine)
 
 	tk.MustExec("alter resource group rg1 RU_PER_SEC=1000 QUERY_LIMIT=()")
 	tk.EventuallyMustQueryAndCheck("select SQL_NO_CACHE resource_group_name, watch_text, action, watch from information_schema.runaway_watches order by id", nil,
@@ -102,9 +123,10 @@ func TestQueryWatch(t *testing.T) {
 			"default select * from test.t2 CoolDown Exact",
 			"rg1 select * from test.t1 Kill Exact",
 			"rg1 02576c15e1f35a8aa3eb7e3b1f977c9f9f9921a22421b3e9f42bad5ab632b4f6 Kill Similar",
-			"rg1 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 Kill Plan",
+			"rg1 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 DryRun Plan",
 			"default d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 Kill Plan",
 			"default 4ea0618129ffc6a7effbc0eff4bbcb41a7f5d4c53a6fa0b2e9be81c7010915b0 CoolDown Similar",
+			"rg2 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 Kill Plan",
 		), maxWaitDuration, tryInterval)
 
 	tk.MustExec("alter resource group rg1 RU_PER_SEC=1000 QUERY_LIMIT=(EXEC_ELAPSED='50ms' ACTION=KILL)")
@@ -113,9 +135,10 @@ func TestQueryWatch(t *testing.T) {
 			"default select * from test.t2 CoolDown Exact",
 			"rg1 select * from test.t1 Kill Exact",
 			"rg1 02576c15e1f35a8aa3eb7e3b1f977c9f9f9921a22421b3e9f42bad5ab632b4f6 Kill Similar",
-			"rg1 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 Kill Plan",
+			"rg1 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 DryRun Plan",
 			"default d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 Kill Plan",
 			"default 4ea0618129ffc6a7effbc0eff4bbcb41a7f5d4c53a6fa0b2e9be81c7010915b0 CoolDown Similar",
+			"rg2 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 Kill Plan",
 		), maxWaitDuration, tryInterval)
 
 	// test remove


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #43691

Problem Summary:

### What changed and how does it work?
Separate the mark for watch and rule, and record them twice.
improve test for some cases.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
