### PR TITLE
statistics: reduce the memory of pseudo table

### DIFF
--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -200,15 +200,18 @@ func (m *ColAndIdxExistenceMap) IsEmpty() bool {
 
 // Clone deeply copies the map.
 func (m *ColAndIdxExistenceMap) Clone() (mm *ColAndIdxExistenceMap) {
-	if m.idxInfoMap == nil {
-		mm = NewPseudoTableColAndIndexExistenceMap(len(m.colAnalyzed), len(m.idxAnalyzed))
-	} else {
-		mm = NewColAndIndexExistenceMap(len(m.colAnalyzed), len(m.idxAnalyzed))
+	mm.colAnalyzed = make(map[int64]bool, len(m.colAnalyzed))
+	mm.colAnalyzed = maps.Clone(m.colAnalyzed)
+	mm.idxAnalyzed = make(map[int64]bool, len(m.idxAnalyzed))
+	mm.idxAnalyzed = maps.Clone(m.idxAnalyzed)
+	if m.colInfoMap != nil {
+		mm.colInfoMap = make(map[int64]*model.ColumnInfo, len(m.colInfoMap))
 		mm.colInfoMap = maps.Clone(m.colInfoMap)
+	}
+	if m.idxInfoMap != nil {
+		mm.idxInfoMap = make(map[int64]*model.IndexInfo, len(m.idxInfoMap))
 		mm.idxInfoMap = maps.Clone(m.idxInfoMap)
 	}
-	mm.colAnalyzed = maps.Clone(m.colAnalyzed)
-	mm.idxAnalyzed = maps.Clone(m.idxAnalyzed)
 	return mm
 }
 

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -193,19 +193,16 @@ func (m *ColAndIdxExistenceMap) IsEmpty() bool {
 }
 
 // Clone deeply copies the map.
-func (m *ColAndIdxExistenceMap) Clone() *ColAndIdxExistenceMap {
-	var mm *ColAndIdxExistenceMap
+func (m *ColAndIdxExistenceMap) Clone() (mm *ColAndIdxExistenceMap) {
 	if m.idxInfoMap == nil {
 		mm = NewPseudoTableColAndIndexExistenceMap(len(m.colInfoMap), len(m.idxInfoMap))
-		mm.colAnalyzed = maps.Clone(m.colAnalyzed)
-		mm.idxAnalyzed = maps.Clone(m.idxAnalyzed)
 	} else {
 		mm = NewColAndIndexExistenceMap(len(m.colInfoMap), len(m.idxInfoMap))
 		mm.colInfoMap = maps.Clone(m.colInfoMap)
-		mm.colAnalyzed = maps.Clone(m.colAnalyzed)
 		mm.idxInfoMap = maps.Clone(m.idxInfoMap)
-		mm.idxAnalyzed = maps.Clone(m.idxAnalyzed)
 	}
+	mm.colAnalyzed = maps.Clone(m.colAnalyzed)
+	mm.idxAnalyzed = maps.Clone(m.idxAnalyzed)
 	return mm
 }
 

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -201,9 +201,9 @@ func (m *ColAndIdxExistenceMap) IsEmpty() bool {
 // Clone deeply copies the map.
 func (m *ColAndIdxExistenceMap) Clone() (mm *ColAndIdxExistenceMap) {
 	if m.idxInfoMap == nil {
-		mm = NewPseudoTableColAndIndexExistenceMap(len(m.colInfoMap), len(m.idxInfoMap))
+		mm = NewPseudoTableColAndIndexExistenceMap(len(m.colAnalyzed), len(m.idxAnalyzed))
 	} else {
-		mm = NewColAndIndexExistenceMap(len(m.colInfoMap), len(m.idxInfoMap))
+		mm = NewColAndIndexExistenceMap(len(m.colAnalyzed), len(m.idxAnalyzed))
 		mm.colInfoMap = maps.Clone(m.colInfoMap)
 		mm.idxInfoMap = maps.Clone(m.idxInfoMap)
 	}

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -209,6 +209,7 @@ func NewColAndIndexExistenceMap(colCap, idxCap int) *ColAndIdxExistenceMap {
 	}
 }
 
+// NewPseudoTableColAndIndexExistenceMap return a new object with the given capcity.
 func NewPseudoTableColAndIndexExistenceMap(colCap, idxCap int) *ColAndIdxExistenceMap {
 	return &ColAndIdxExistenceMap{
 		colInfoMap:  nil,
@@ -921,7 +922,7 @@ func PseudoTable(tblInfo *model.TableInfo, allowTriggerLoading bool, allowFillHi
 	}
 	t := &Table{
 		HistColl:              pseudoHistColl,
-		ColAndIdxExistenceMap: NewColAndIndexExistenceMap(len(tblInfo.Columns), len(tblInfo.Indices)),
+		ColAndIdxExistenceMap: NewPseudoTableColAndIndexExistenceMap(len(tblInfo.Columns), len(tblInfo.Indices)),
 	}
 	for _, col := range tblInfo.Columns {
 		// The column is public to use. Also we should check the column is not hidden since hidden means that it's used by expression index.

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -196,7 +196,6 @@ func (m *ColAndIdxExistenceMap) makeIdxInfoMap() {
 	if m.idxInfoMap == nil {
 		m.idxInfoMap = make(map[int64]*model.IndexInfo, len(m.idxAnalyzed))
 	}
-
 }
 
 // NewColAndIndexExistenceMap return a new object with the given capcity.

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -79,9 +79,9 @@ type Table struct {
 // ColAndIdxExistenceMap is the meta map for statistics.Table.
 // It can tell whether a column/index really has its statistics. So we won't send useless kv request when we do online stats loading.
 type ColAndIdxExistenceMap struct {
-	colInfoMap  map[int64]*model.ColumnInfo
+	colInfoMap  map[int64]*model.ColumnInfo // it will be nil when stats is pseudo
 	colAnalyzed map[int64]bool
-	idxInfoMap  map[int64]*model.IndexInfo
+	idxInfoMap  map[int64]*model.IndexInfo // it will be nil when stats is pseudo
 	idxAnalyzed map[int64]bool
 }
 

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -161,7 +161,9 @@ func (m *ColAndIdxExistenceMap) HasAnalyzed(id int64, isIndex bool) bool {
 
 // InsertCol inserts a column with its meta into the map.
 func (m *ColAndIdxExistenceMap) InsertCol(id int64, info *model.ColumnInfo, analyzed bool) {
-	m.makeColInfoMapMap()
+	if m.colInfoMap == nil {
+		m.colInfoMap = make(map[int64]*model.ColumnInfo, len(m.colAnalyzed))
+	}
 	m.colInfoMap[id] = info
 	m.colAnalyzed[id] = analyzed
 }
@@ -176,14 +178,18 @@ func (m *ColAndIdxExistenceMap) GetCol(id int64) *model.ColumnInfo {
 
 // InsertIndex inserts an index with its meta into the map.
 func (m *ColAndIdxExistenceMap) InsertIndex(id int64, info *model.IndexInfo, analyzed bool) {
-	m.makeIdxInfoMap()
+	if m.idxInfoMap == nil {
+		m.idxInfoMap = make(map[int64]*model.IndexInfo, len(m.idxAnalyzed))
+	}
 	m.idxInfoMap[id] = info
 	m.idxAnalyzed[id] = analyzed
 }
 
 // GetIndex gets the meta data of the given index.
 func (m *ColAndIdxExistenceMap) GetIndex(id int64) *model.IndexInfo {
-	m.makeIdxInfoMap()
+	if m.idxInfoMap == nil {
+		return nil
+	}
 	return m.idxInfoMap[id]
 }
 
@@ -204,18 +210,6 @@ func (m *ColAndIdxExistenceMap) Clone() (mm *ColAndIdxExistenceMap) {
 	mm.colAnalyzed = maps.Clone(m.colAnalyzed)
 	mm.idxAnalyzed = maps.Clone(m.idxAnalyzed)
 	return mm
-}
-
-func (m *ColAndIdxExistenceMap) makeColInfoMapMap() {
-	if m.colInfoMap == nil {
-		m.colInfoMap = make(map[int64]*model.ColumnInfo, len(m.colAnalyzed))
-	}
-}
-
-func (m *ColAndIdxExistenceMap) makeIdxInfoMap() {
-	if m.idxInfoMap == nil {
-		m.idxInfoMap = make(map[int64]*model.IndexInfo, len(m.idxAnalyzed))
-	}
 }
 
 // ColAndIdxExistenceMapIsEqual is used in testing, checking whether the two are equal.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46867

Problem Summary:

### What changed and how does it work?

when we create ColAndIdxExistenceMap when stats are pseudo, it will allocate all memory for 4 maps in it. it is unnecessary and costs a lot of memory.

![SXVUMF7Jn9](https://github.com/pingcap/tidb/assets/3427324/fca19013-fea3-419d-9cd8-3f0434ddeac8)

If TiDB has more than 10k+ tables, it will cost too much memory.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
