### PR TITLE
topsql, pprof: use hex string but not binary sql/plan digest in goroutine label

### DIFF
--- a/pkg/util/cpuprofile/testutil/util.go
+++ b/pkg/util/cpuprofile/testutil/util.go
@@ -16,6 +16,7 @@ package testutil
 
 import (
 	"context"
+	"encoding/hex"
 	"runtime/pprof"
 )
 
@@ -24,7 +25,8 @@ func MockCPULoad(ctx context.Context, labels ...string) {
 	lvs := []string{}
 	for _, label := range labels {
 		lvs = append(lvs, label)
-		lvs = append(lvs, label+" value")
+		val := hex.EncodeToString([]byte(label + " value"))
+		lvs = append(lvs, val)
 		// start goroutine with only 1 label.
 		go mockCPULoadByGoroutineWithLabel(ctx, label, label+" value")
 	}

--- a/pkg/util/topsql/collector/BUILD.bazel
+++ b/pkg/util/topsql/collector/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/util",
         "//pkg/util/cpuprofile",
-        "//pkg/util/hack",
         "//pkg/util/logutil",
         "//pkg/util/topsql/state",
         "@com_github_google_pprof//profile",

--- a/pkg/util/topsql/topsql.go
+++ b/pkg/util/topsql/topsql.go
@@ -97,11 +97,11 @@ func RegisterPlan(normalizedPlan string, planDigest *parser.Digest) {
 
 // AttachAndRegisterSQLInfo attach the sql information into Top SQL and register the SQL meta information.
 func AttachAndRegisterSQLInfo(ctx context.Context, normalizedSQL string, sqlDigest *parser.Digest, isInternal bool) context.Context {
-	if sqlDigest == nil || len(sqlDigest.Bytes()) == 0 {
+	if sqlDigest == nil || len(sqlDigest.String()) == 0 {
 		return ctx
 	}
 	sqlDigestBytes := sqlDigest.Bytes()
-	ctx = collector.CtxWithSQLDigest(ctx, sqlDigestBytes)
+	ctx = collector.CtxWithSQLDigest(ctx, sqlDigest.String())
 	pprof.SetGoroutineLabels(ctx)
 
 	linkSQLTextWithDigest(sqlDigestBytes, normalizedSQL, isInternal)
@@ -124,15 +124,15 @@ func AttachAndRegisterSQLInfo(ctx context.Context, normalizedSQL string, sqlDige
 
 // AttachSQLAndPlanInfo attach the sql and plan information into Top SQL
 func AttachSQLAndPlanInfo(ctx context.Context, sqlDigest *parser.Digest, planDigest *parser.Digest) context.Context {
-	if sqlDigest == nil || len(sqlDigest.Bytes()) == 0 {
+	if sqlDigest == nil || len(sqlDigest.String()) == 0 {
 		return ctx
 	}
-	var planDigestBytes []byte
-	sqlDigestBytes := sqlDigest.Bytes()
+	var planDigestStr string
+	sqlDigestStr := sqlDigest.String()
 	if planDigest != nil {
-		planDigestBytes = planDigest.Bytes()
+		planDigestStr = planDigest.String()
 	}
-	ctx = collector.CtxWithSQLAndPlanDigest(ctx, sqlDigestBytes, planDigestBytes)
+	ctx = collector.CtxWithSQLAndPlanDigest(ctx, sqlDigestStr, planDigestStr)
 	pprof.SetGoroutineLabels(ctx)
 
 	failpoint.Inject("mockHighLoadForEachPlan", func(val failpoint.Value) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #52215

Problem Summary:

Use the hex string in goroutine labels. It'll allow us to use the `go tool pprof` and graphviz to handle the protobuf.

Before this PR returned, you can workaround by generating a `dot` file, and use `iconv` to handle the non-utf8 characters manually.

### What changed and how does it work?

Use the pre-ecoded hex string, rather than bytes.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Run any tests (which runs at least some SQLs) and profile it with `-cpuprofile`, and you'll find the protobuf is useable now.

### Release note

```release-note
None
```
