### PR TITLE
executor: fix distorted join probe time

### DIFF
--- a/pkg/executor/join.go
+++ b/pkg/executor/join.go
@@ -518,6 +518,9 @@ func (w *probeWorker) runJoinWorker() {
 			break
 		}
 		start := time.Now()
+		// waitTime is the time cost on w.sendingResult(), it should not be added to probe time, because if
+		// parent executor does not call `e.Next()`, `sendingResult()` will hang, and this hang has nothing to do
+		// with the probe
 		waitTime := int64(0)
 		if w.hashJoinCtx.useOuterToBuild {
 			ok, waitTime, joinResult = w.join2ChunkForOuterHashJoin(probeSideResult, hCtx, joinResult)

--- a/pkg/executor/join.go
+++ b/pkg/executor/join.go
@@ -518,12 +518,13 @@ func (w *probeWorker) runJoinWorker() {
 			break
 		}
 		start := time.Now()
+		waitTime := int64(0)
 		if w.hashJoinCtx.useOuterToBuild {
-			ok, joinResult = w.join2ChunkForOuterHashJoin(probeSideResult, hCtx, joinResult)
+			ok, waitTime, joinResult = w.join2ChunkForOuterHashJoin(probeSideResult, hCtx, joinResult)
 		} else {
-			ok, joinResult = w.join2Chunk(probeSideResult, hCtx, joinResult, selected)
+			ok, waitTime, joinResult = w.join2Chunk(probeSideResult, hCtx, joinResult, selected)
 		}
-		probeTime += int64(time.Since(start))
+		probeTime += int64(time.Since(start)) - waitTime
 		if !ok {
 			break
 		}
@@ -541,16 +542,18 @@ func (w *probeWorker) runJoinWorker() {
 	}
 }
 
-func (w *probeWorker) joinMatchedProbeSideRow2ChunkForOuterHashJoin(probeKey uint64, probeSideRow chunk.Row, hCtx *hashContext, joinResult *hashjoinWorkerResult) (bool, *hashjoinWorkerResult) {
+func (w *probeWorker) joinMatchedProbeSideRow2ChunkForOuterHashJoin(probeKey uint64, probeSideRow chunk.Row, hCtx *hashContext, joinResult *hashjoinWorkerResult) (bool, int64, *hashjoinWorkerResult) {
 	var err error
+	waitTime := int64(0)
+	oneWaitTime := int64(0)
 	w.buildSideRows, w.buildSideRowPtrs, err = w.rowContainerForProbe.GetMatchedRowsAndPtrs(probeKey, probeSideRow, hCtx, w.buildSideRows, w.buildSideRowPtrs, true)
 	buildSideRows, rowsPtrs := w.buildSideRows, w.buildSideRowPtrs
 	if err != nil {
 		joinResult.err = err
-		return false, joinResult
+		return false, waitTime, joinResult
 	}
 	if len(buildSideRows) == 0 {
-		return true, joinResult
+		return true, waitTime, joinResult
 	}
 
 	iter := w.rowIters
@@ -561,7 +564,7 @@ func (w *probeWorker) joinMatchedProbeSideRow2ChunkForOuterHashJoin(probeKey uin
 		outerMatchStatus, err = w.joiner.tryToMatchOuters(iter, probeSideRow, joinResult.chk, outerMatchStatus)
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		for i := range outerMatchStatus {
 			if outerMatchStatus[i] == outerRowMatched {
@@ -570,22 +573,24 @@ func (w *probeWorker) joinMatchedProbeSideRow2ChunkForOuterHashJoin(probeKey uin
 		}
 		rowIdx += len(outerMatchStatus)
 		if joinResult.chk.IsFull() {
-			w.hashJoinCtx.joinResultCh <- joinResult
-			ok, joinResult = w.getNewJoinResult()
+			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			waitTime += oneWaitTime
 			if !ok {
-				return false, joinResult
+				return false, waitTime, joinResult
 			}
 		}
 	}
-	return true, joinResult
+	return true, waitTime, joinResult
 }
 
 // joinNAALOSJMatchProbeSideRow2Chunk implement the matching logic for NA-AntiLeftOuterSemiJoin
-func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeKeyNullBits *bitmap.ConcurrentBitmap, probeSideRow chunk.Row, hCtx *hashContext, joinResult *hashjoinWorkerResult) (bool, *hashjoinWorkerResult) {
+func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeKeyNullBits *bitmap.ConcurrentBitmap, probeSideRow chunk.Row, hCtx *hashContext, joinResult *hashjoinWorkerResult) (bool, int64, *hashjoinWorkerResult) {
 	var (
 		err error
 		ok  bool
 	)
+	waitTime := int64(0)
+	oneWaitTime := int64(0)
 	if probeKeyNullBits == nil {
 		// step1: match the same key bucket first.
 		// because AntiLeftOuterSemiJoin cares about the scalar value. If we both have a match from null
@@ -595,7 +600,7 @@ func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 		buildSideRows := w.buildSideRows
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		if len(buildSideRows) != 0 {
 			iter1 := w.rowIters
@@ -604,18 +609,18 @@ func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 				matched, _, err := w.joiner.tryToMatchInners(probeSideRow, iter1, joinResult.chk, LeftNotNullRightNotNull)
 				if err != nil {
 					joinResult.err = err
-					return false, joinResult
+					return false, waitTime, joinResult
 				}
 				// here matched means: there is a valid same-key bucket row from right side.
 				// as said in the comment, once we meet a same key (NOT IN semantic) in CNF, we can determine the result as <rhs, 0>.
 				if matched {
-					return true, joinResult
+					return true, waitTime, joinResult
 				}
 				if joinResult.chk.IsFull() {
-					w.hashJoinCtx.joinResultCh <- joinResult
-					ok, joinResult = w.getNewJoinResult()
+					ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+					waitTime += oneWaitTime
 					if !ok {
-						return false, joinResult
+						return false, waitTime, joinResult
 					}
 				}
 			}
@@ -625,13 +630,13 @@ func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 		buildSideRows = w.buildSideRows
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		if len(buildSideRows) == 0 {
 			// when reach here, it means we couldn't find a valid same key match from same-key bucket yet
 			// and the null bucket is empty. so the result should be <rhs, 1>.
 			w.joiner.onMissMatch(false, probeSideRow, joinResult.chk)
-			return true, joinResult
+			return true, waitTime, joinResult
 		}
 		iter2 := w.rowIters
 		iter2.Reset(buildSideRows)
@@ -639,18 +644,18 @@ func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 			matched, _, err := w.joiner.tryToMatchInners(probeSideRow, iter2, joinResult.chk, LeftNotNullRightHasNull)
 			if err != nil {
 				joinResult.err = err
-				return false, joinResult
+				return false, waitTime, joinResult
 			}
 			// here matched means: there is a valid null bucket row from right side.
 			// as said in the comment, once we meet a null in CNF, we can determine the result as <rhs, null>.
 			if matched {
-				return true, joinResult
+				return true, waitTime, joinResult
 			}
 			if joinResult.chk.IsFull() {
-				w.hashJoinCtx.joinResultCh <- joinResult
-				ok, joinResult = w.getNewJoinResult()
+				ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+				waitTime += oneWaitTime
 				if !ok {
-					return false, joinResult
+					return false, waitTime, joinResult
 				}
 			}
 		}
@@ -659,7 +664,7 @@ func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 		// case2: x NOT IN (l,m,n...): if other key bucket do have the valid rows.
 		// both cases mean the result should be <rhs, 1>
 		w.joiner.onMissMatch(false, probeSideRow, joinResult.chk)
-		return true, joinResult
+		return true, waitTime, joinResult
 	}
 	// when left side has null values, all we want is to find a valid build side rows (past other condition)
 	// so we can return it as soon as possible. here means two cases:
@@ -670,7 +675,7 @@ func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 	buildSideRows := w.buildSideRows
 	if err != nil {
 		joinResult.err = err
-		return false, joinResult
+		return false, waitTime, joinResult
 	}
 	if len(buildSideRows) != 0 {
 		iter1 := w.rowIters
@@ -679,18 +684,18 @@ func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 			matched, _, err := w.joiner.tryToMatchInners(probeSideRow, iter1, joinResult.chk, LeftHasNullRightHasNull)
 			if err != nil {
 				joinResult.err = err
-				return false, joinResult
+				return false, waitTime, joinResult
 			}
 			// here matched means: there is a valid null bucket row from right side. (not empty)
 			// as said in the comment, once we found at least a valid row, we can determine the result as <rhs, null>.
 			if matched {
-				return true, joinResult
+				return true, waitTime, joinResult
 			}
 			if joinResult.chk.IsFull() {
-				w.hashJoinCtx.joinResultCh <- joinResult
-				ok, joinResult = w.getNewJoinResult()
+				ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+				waitTime += oneWaitTime
 				if !ok {
-					return false, joinResult
+					return false, waitTime, joinResult
 				}
 			}
 		}
@@ -700,13 +705,13 @@ func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 	buildSideRows = w.buildSideRows
 	if err != nil {
 		joinResult.err = err
-		return false, joinResult
+		return false, waitTime, joinResult
 	}
 	if len(buildSideRows) == 0 {
 		// when reach here, it means we couldn't return it quickly in null bucket, and same-bucket is empty,
 		// which means x NOT IN (empty set) or x NOT IN (l,m,n), the result should be <rhs, 1>
 		w.joiner.onMissMatch(false, probeSideRow, joinResult.chk)
-		return true, joinResult
+		return true, waitTime, joinResult
 	}
 	iter2 := w.rowIters
 	iter2.Reset(buildSideRows)
@@ -714,18 +719,18 @@ func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 		matched, _, err := w.joiner.tryToMatchInners(probeSideRow, iter2, joinResult.chk, LeftHasNullRightNotNull)
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		// here matched means: there is a valid same key bucket row from right side. (not empty)
 		// as said in the comment, once we found at least a valid row, we can determine the result as <rhs, null>.
 		if matched {
-			return true, joinResult
+			return true, waitTime, joinResult
 		}
 		if joinResult.chk.IsFull() {
-			w.hashJoinCtx.joinResultCh <- joinResult
-			ok, joinResult = w.getNewJoinResult()
+			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			waitTime += oneWaitTime
 			if !ok {
-				return false, joinResult
+				return false, waitTime, joinResult
 			}
 		}
 	}
@@ -733,15 +738,17 @@ func (w *probeWorker) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 	// case1: <?, null> NOT IN (empty set):
 	// empty set comes from no rows from all bucket can pass other condition. the result should be <rhs, 1>
 	w.joiner.onMissMatch(false, probeSideRow, joinResult.chk)
-	return true, joinResult
+	return true, waitTime, joinResult
 }
 
 // joinNAASJMatchProbeSideRow2Chunk implement the matching logic for NA-AntiSemiJoin
-func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKeyNullBits *bitmap.ConcurrentBitmap, probeSideRow chunk.Row, hCtx *hashContext, joinResult *hashjoinWorkerResult) (bool, *hashjoinWorkerResult) {
+func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKeyNullBits *bitmap.ConcurrentBitmap, probeSideRow chunk.Row, hCtx *hashContext, joinResult *hashjoinWorkerResult) (bool, int64, *hashjoinWorkerResult) {
 	var (
 		err error
 		ok  bool
 	)
+	waitTime := int64(0)
+	oneWaitTime := int64(0)
 	if probeKeyNullBits == nil {
 		// step1: match null bucket first.
 		// need fetch the "valid" rows every time. (nullBits map check is necessary)
@@ -749,7 +756,7 @@ func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKey
 		buildSideRows := w.buildSideRows
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		if len(buildSideRows) != 0 {
 			iter1 := w.rowIters
@@ -758,18 +765,18 @@ func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKey
 				matched, _, err := w.joiner.tryToMatchInners(probeSideRow, iter1, joinResult.chk)
 				if err != nil {
 					joinResult.err = err
-					return false, joinResult
+					return false, waitTime, joinResult
 				}
 				// here matched means: there is a valid null bucket row from right side.
 				// as said in the comment, once we meet a rhs null in CNF, we can determine the reject of lhs row.
 				if matched {
-					return true, joinResult
+					return true, waitTime, joinResult
 				}
 				if joinResult.chk.IsFull() {
-					w.hashJoinCtx.joinResultCh <- joinResult
-					ok, joinResult = w.getNewJoinResult()
+					ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+					waitTime += oneWaitTime
 					if !ok {
-						return false, joinResult
+						return false, waitTime, joinResult
 					}
 				}
 			}
@@ -779,13 +786,13 @@ func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKey
 		buildSideRows = w.buildSideRows
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		if len(buildSideRows) == 0 {
 			// when reach here, it means we couldn't return it quickly in null bucket, and same-bucket is empty,
 			// which means x NOT IN (empty set), accept the rhs row.
 			w.joiner.onMissMatch(false, probeSideRow, joinResult.chk)
-			return true, joinResult
+			return true, waitTime, joinResult
 		}
 		iter2 := w.rowIters
 		iter2.Reset(buildSideRows)
@@ -793,18 +800,18 @@ func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKey
 			matched, _, err := w.joiner.tryToMatchInners(probeSideRow, iter2, joinResult.chk)
 			if err != nil {
 				joinResult.err = err
-				return false, joinResult
+				return false, waitTime, joinResult
 			}
 			// here matched means: there is a valid same key bucket row from right side.
 			// as said in the comment, once we meet a false in CNF, we can determine the reject of lhs row.
 			if matched {
-				return true, joinResult
+				return true, waitTime, joinResult
 			}
 			if joinResult.chk.IsFull() {
-				w.hashJoinCtx.joinResultCh <- joinResult
-				ok, joinResult = w.getNewJoinResult()
+				ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+				waitTime += oneWaitTime
 				if !ok {
-					return false, joinResult
+					return false, waitTime, joinResult
 				}
 			}
 		}
@@ -813,7 +820,7 @@ func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKey
 		// case2: x NOT IN (l,m,n...): if other key bucket do have the valid rows.
 		// both cases should accept the rhs row.
 		w.joiner.onMissMatch(false, probeSideRow, joinResult.chk)
-		return true, joinResult
+		return true, waitTime, joinResult
 	}
 	// when left side has null values, all we want is to find a valid build side rows (passed from other condition)
 	// so we can return it as soon as possible. here means two cases:
@@ -824,7 +831,7 @@ func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKey
 	buildSideRows := w.buildSideRows
 	if err != nil {
 		joinResult.err = err
-		return false, joinResult
+		return false, waitTime, joinResult
 	}
 	if len(buildSideRows) != 0 {
 		iter1 := w.rowIters
@@ -833,18 +840,18 @@ func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKey
 			matched, _, err := w.joiner.tryToMatchInners(probeSideRow, iter1, joinResult.chk)
 			if err != nil {
 				joinResult.err = err
-				return false, joinResult
+				return false, waitTime, joinResult
 			}
 			// here matched means: there is a valid null bucket row from right side. (not empty)
 			// as said in the comment, once we found at least a valid row, we can determine the reject of lhs row.
 			if matched {
-				return true, joinResult
+				return true, waitTime, joinResult
 			}
 			if joinResult.chk.IsFull() {
-				w.hashJoinCtx.joinResultCh <- joinResult
-				ok, joinResult = w.getNewJoinResult()
+				ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+				waitTime += oneWaitTime
 				if !ok {
-					return false, joinResult
+					return false, waitTime, joinResult
 				}
 			}
 		}
@@ -854,13 +861,13 @@ func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKey
 	buildSideRows = w.buildSideRows
 	if err != nil {
 		joinResult.err = err
-		return false, joinResult
+		return false, waitTime, joinResult
 	}
 	if len(buildSideRows) == 0 {
 		// when reach here, it means we couldn't return it quickly in null bucket, and same-bucket is empty,
 		// which means <?,null> NOT IN (empty set) or <?,null> NOT IN (no valid rows) accept the rhs row.
 		w.joiner.onMissMatch(false, probeSideRow, joinResult.chk)
-		return true, joinResult
+		return true, waitTime, joinResult
 	}
 	iter2 := w.rowIters
 	iter2.Reset(buildSideRows)
@@ -868,18 +875,18 @@ func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKey
 		matched, _, err := w.joiner.tryToMatchInners(probeSideRow, iter2, joinResult.chk)
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		// here matched means: there is a valid key row from right side. (not empty)
 		// as said in the comment, once we found at least a valid row, we can determine the reject of lhs row.
 		if matched {
-			return true, joinResult
+			return true, waitTime, joinResult
 		}
 		if joinResult.chk.IsFull() {
-			w.hashJoinCtx.joinResultCh <- joinResult
-			ok, joinResult = w.getNewJoinResult()
+			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			waitTime += oneWaitTime
 			if !ok {
-				return false, joinResult
+				return false, waitTime, joinResult
 			}
 		}
 	}
@@ -887,7 +894,7 @@ func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKey
 	// case1: <?, null> NOT IN (empty set):
 	// empty set comes from no rows from all bucket can pass other condition. we should accept the rhs row.
 	w.joiner.onMissMatch(false, probeSideRow, joinResult.chk)
-	return true, joinResult
+	return true, waitTime, joinResult
 }
 
 // joinNAAJMatchProbeSideRow2Chunk implement the matching priority logic for NA-AntiSemiJoin and NA-AntiLeftOuterSemiJoin
@@ -909,7 +916,7 @@ func (w *probeWorker) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeKey
 //
 //	       For NA-AntiLeftOuterSemiJoin, we couldn't match null-bucket first, because once y set has a same key x and null
 //	       key, we should return the result as left side row appended with a scalar value 0 which is from same key matching failure.
-func (w *probeWorker) joinNAAJMatchProbeSideRow2Chunk(probeKey uint64, probeKeyNullBits *bitmap.ConcurrentBitmap, probeSideRow chunk.Row, hCtx *hashContext, joinResult *hashjoinWorkerResult) (bool, *hashjoinWorkerResult) {
+func (w *probeWorker) joinNAAJMatchProbeSideRow2Chunk(probeKey uint64, probeKeyNullBits *bitmap.ConcurrentBitmap, probeSideRow chunk.Row, hCtx *hashContext, joinResult *hashjoinWorkerResult) (bool, int64, *hashjoinWorkerResult) {
 	naAntiSemiJoin := w.hashJoinCtx.joinType == plannercore.AntiSemiJoin && w.hashJoinCtx.isNullAware
 	naAntiLeftOuterSemiJoin := w.hashJoinCtx.joinType == plannercore.AntiLeftOuterSemiJoin && w.hashJoinCtx.isNullAware
 	if naAntiSemiJoin {
@@ -919,12 +926,14 @@ func (w *probeWorker) joinNAAJMatchProbeSideRow2Chunk(probeKey uint64, probeKeyN
 		return w.joinNAALOSJMatchProbeSideRow2Chunk(probeKey, probeKeyNullBits, probeSideRow, hCtx, joinResult)
 	}
 	// shouldn't be here, not a valid NAAJ.
-	return false, joinResult
+	return false, 0, joinResult
 }
 
 func (w *probeWorker) joinMatchedProbeSideRow2Chunk(probeKey uint64, probeSideRow chunk.Row, hCtx *hashContext,
-	joinResult *hashjoinWorkerResult) (bool, *hashjoinWorkerResult) {
+	joinResult *hashjoinWorkerResult) (bool, int64, *hashjoinWorkerResult) {
 	var err error
+	waitTime := int64(0)
+	oneWaitTime := int64(0)
 	var buildSideRows []chunk.Row
 	if w.joiner.isSemiJoinWithoutCondition() {
 		var rowPtr *chunk.Row
@@ -939,11 +948,11 @@ func (w *probeWorker) joinMatchedProbeSideRow2Chunk(probeKey uint64, probeSideRo
 
 	if err != nil {
 		joinResult.err = err
-		return false, joinResult
+		return false, waitTime, joinResult
 	}
 	if len(buildSideRows) == 0 {
 		w.joiner.onMissMatch(false, probeSideRow, joinResult.chk)
-		return true, joinResult
+		return true, waitTime, joinResult
 	}
 	iter := w.rowIters
 	iter.Reset(buildSideRows)
@@ -952,23 +961,23 @@ func (w *probeWorker) joinMatchedProbeSideRow2Chunk(probeKey uint64, probeSideRo
 		matched, isNull, err := w.joiner.tryToMatchInners(probeSideRow, iter, joinResult.chk)
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		hasMatch = hasMatch || matched
 		hasNull = hasNull || isNull
 
 		if joinResult.chk.IsFull() {
-			w.hashJoinCtx.joinResultCh <- joinResult
-			ok, joinResult = w.getNewJoinResult()
+			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			waitTime += oneWaitTime
 			if !ok {
-				return false, joinResult
+				return false, waitTime, joinResult
 			}
 		}
 	}
 	if !hasMatch {
 		w.joiner.onMissMatch(hasNull, probeSideRow, joinResult.chk)
 	}
-	return true, joinResult
+	return true, waitTime, joinResult
 }
 
 func (w *probeWorker) getNewJoinResult() (bool, *hashjoinWorkerResult) {
@@ -985,12 +994,14 @@ func (w *probeWorker) getNewJoinResult() (bool, *hashjoinWorkerResult) {
 }
 
 func (w *probeWorker) join2Chunk(probeSideChk *chunk.Chunk, hCtx *hashContext, joinResult *hashjoinWorkerResult,
-	selected []bool) (ok bool, _ *hashjoinWorkerResult) {
+	selected []bool) (ok bool, waitTime int64, _ *hashjoinWorkerResult) {
 	var err error
+	waitTime = 0
+	oneWaitTime := int64(0)
 	selected, err = expression.VectorizedFilter(w.hashJoinCtx.sessCtx.GetExprCtx().GetEvalCtx(), w.hashJoinCtx.sessCtx.GetSessionVars().EnableVectorizedExpression, w.hashJoinCtx.outerFilter, chunk.NewIterator4Chunk(probeSideChk), selected)
 	if err != nil {
 		joinResult.err = err
-		return false, joinResult
+		return false, waitTime, joinResult
 	}
 
 	numRows := probeSideChk.NumRows()
@@ -1002,7 +1013,7 @@ func (w *probeWorker) join2Chunk(probeSideChk *chunk.Chunk, hCtx *hashContext, j
 		err = codec.HashChunkSelected(w.rowContainerForProbe.sc.TypeCtx(), hCtx.hashVals, probeSideChk, hCtx.allTypes[keyIdx], i, hCtx.buf, hCtx.hasNull, selected, ignoreNull)
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 	}
 	// 2: write the row data of NA join key to hashVals. (NA EQ key should collect all row including null value, store null value in a special position)
@@ -1012,7 +1023,7 @@ func (w *probeWorker) join2Chunk(probeSideChk *chunk.Chunk, hCtx *hashContext, j
 		err = codec.HashChunkSelected(w.rowContainerForProbe.sc.TypeCtx(), hCtx.hashVals, probeSideChk, hCtx.allTypes[keyIdx], i, hCtx.buf, hCtx.hasNull, selected, false)
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		// after fetch one NA column, collect the null value to null bitmap for every row. (use hasNull flag to accelerate)
 		// eg: if a NA Join cols is (a, b, c), for every build row here we maintained a 3-bit map to mark which column is null for them.
@@ -1035,7 +1046,7 @@ func (w *probeWorker) join2Chunk(probeSideChk *chunk.Chunk, hCtx *hashContext, j
 		})
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		if isNAAJ {
 			if !selected[i] {
@@ -1046,17 +1057,19 @@ func (w *probeWorker) join2Chunk(probeSideChk *chunk.Chunk, hCtx *hashContext, j
 				// here means the probe join connecting column has null value in it and this is special for matching all the hash buckets
 				// for it. (probeKey is not necessary here)
 				probeRow := probeSideChk.GetRow(i)
-				ok, joinResult = w.joinNAAJMatchProbeSideRow2Chunk(0, hCtx.naColNullBitMap[i].Clone(), probeRow, hCtx, joinResult)
+				ok, oneWaitTime, joinResult = w.joinNAAJMatchProbeSideRow2Chunk(0, hCtx.naColNullBitMap[i].Clone(), probeRow, hCtx, joinResult)
+				waitTime += oneWaitTime
 				if !ok {
-					return false, joinResult
+					return false, waitTime, joinResult
 				}
 			} else {
 				// here means the probe join connecting column without null values, where we should match same key bucket and null bucket for it at its order.
 				// step1: process same key matched probe side rows
 				probeKey, probeRow := hCtx.hashVals[i].Sum64(), probeSideChk.GetRow(i)
-				ok, joinResult = w.joinNAAJMatchProbeSideRow2Chunk(probeKey, nil, probeRow, hCtx, joinResult)
+				ok, oneWaitTime, joinResult = w.joinNAAJMatchProbeSideRow2Chunk(probeKey, nil, probeRow, hCtx, joinResult)
+				waitTime += oneWaitTime
 				if !ok {
-					return false, joinResult
+					return false, waitTime, joinResult
 				}
 			}
 		} else {
@@ -1065,31 +1078,42 @@ func (w *probeWorker) join2Chunk(probeSideChk *chunk.Chunk, hCtx *hashContext, j
 				w.joiner.onMissMatch(false, probeSideChk.GetRow(i), joinResult.chk)
 			} else { // process matched probe side rows
 				probeKey, probeRow := hCtx.hashVals[i].Sum64(), probeSideChk.GetRow(i)
-				ok, joinResult = w.joinMatchedProbeSideRow2Chunk(probeKey, probeRow, hCtx, joinResult)
+				ok, oneWaitTime, joinResult = w.joinMatchedProbeSideRow2Chunk(probeKey, probeRow, hCtx, joinResult)
+				waitTime += oneWaitTime
 				if !ok {
-					return false, joinResult
+					return false, waitTime, joinResult
 				}
 			}
 		}
 		if joinResult.chk.IsFull() {
-			w.hashJoinCtx.joinResultCh <- joinResult
-			ok, joinResult = w.getNewJoinResult()
+			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			waitTime += oneWaitTime
 			if !ok {
-				return false, joinResult
+				return false, waitTime, joinResult
 			}
 		}
 	}
-	return true, joinResult
+	return true, waitTime, joinResult
+}
+
+func (w *probeWorker) sendingResult(joinResult *hashjoinWorkerResult) (ok bool, cost int64, newJoinResult *hashjoinWorkerResult) {
+	start := time.Now()
+	w.hashJoinCtx.joinResultCh <- joinResult
+	ok, newJoinResult = w.getNewJoinResult()
+	cost = int64(time.Since(start))
+	return ok, cost, newJoinResult
 }
 
 // join2ChunkForOuterHashJoin joins chunks when using the outer to build a hash table (refer to outer hash join)
-func (w *probeWorker) join2ChunkForOuterHashJoin(probeSideChk *chunk.Chunk, hCtx *hashContext, joinResult *hashjoinWorkerResult) (ok bool, _ *hashjoinWorkerResult) {
+func (w *probeWorker) join2ChunkForOuterHashJoin(probeSideChk *chunk.Chunk, hCtx *hashContext, joinResult *hashjoinWorkerResult) (ok bool, waitTime int64, _ *hashjoinWorkerResult) {
+	waitTime = 0
+	oneWaitTime := int64(0)
 	hCtx.initHash(probeSideChk.NumRows())
 	for keyIdx, i := range hCtx.keyColIdx {
 		err := codec.HashChunkColumns(w.rowContainerForProbe.sc.TypeCtx(), hCtx.hashVals, probeSideChk, hCtx.allTypes[keyIdx], i, hCtx.buf, hCtx.hasNull)
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 	}
 	for i := 0; i < probeSideChk.NumRows(); i++ {
@@ -1101,22 +1125,23 @@ func (w *probeWorker) join2ChunkForOuterHashJoin(probeSideChk *chunk.Chunk, hCtx
 		})
 		if err != nil {
 			joinResult.err = err
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		probeKey, probeRow := hCtx.hashVals[i].Sum64(), probeSideChk.GetRow(i)
-		ok, joinResult = w.joinMatchedProbeSideRow2ChunkForOuterHashJoin(probeKey, probeRow, hCtx, joinResult)
+		ok, oneWaitTime, joinResult = w.joinMatchedProbeSideRow2ChunkForOuterHashJoin(probeKey, probeRow, hCtx, joinResult)
+		waitTime += oneWaitTime
 		if !ok {
-			return false, joinResult
+			return false, waitTime, joinResult
 		}
 		if joinResult.chk.IsFull() {
-			w.hashJoinCtx.joinResultCh <- joinResult
-			ok, joinResult = w.getNewJoinResult()
+			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			waitTime += oneWaitTime
 			if !ok {
-				return false, joinResult
+				return false, waitTime, joinResult
 			}
 		}
 	}
-	return true, joinResult
+	return true, waitTime, joinResult
 }
 
 // Next implements the Executor Next interface.
@@ -1633,7 +1658,7 @@ func (e *hashJoinRuntimeStats) String() string {
 		buf.WriteString(execdetails.FormatDuration(time.Duration(atomic.LoadInt64(&e.maxFetchAndProbe))))
 		buf.WriteString(", probe:")
 		buf.WriteString(execdetails.FormatDuration(time.Duration(e.probe)))
-		buf.WriteString(", fetch:")
+		buf.WriteString(", fetch and wait:")
 		buf.WriteString(execdetails.FormatDuration(time.Duration(e.fetchAndProbe - e.probe)))
 		if e.hashStat.probeCollision > 0 {
 			buf.WriteString(", probe_collision:")

--- a/pkg/executor/join.go
+++ b/pkg/executor/join.go
@@ -1661,6 +1661,8 @@ func (e *hashJoinRuntimeStats) String() string {
 		buf.WriteString(execdetails.FormatDuration(time.Duration(atomic.LoadInt64(&e.maxFetchAndProbe))))
 		buf.WriteString(", probe:")
 		buf.WriteString(execdetails.FormatDuration(time.Duration(e.probe)))
+		// fetch time is the time wait fetch result from its child executor,
+		// wait time is the time wait its parent executor to fetch the joined result
 		buf.WriteString(", fetch and wait:")
 		buf.WriteString(execdetails.FormatDuration(time.Duration(e.fetchAndProbe - e.probe)))
 		if e.hashStat.probeCollision > 0 {

--- a/pkg/executor/join_pkg_test.go
+++ b/pkg/executor/join_pkg_test.go
@@ -124,10 +124,10 @@ func TestHashJoinRuntimeStats(t *testing.T) {
 		concurrent:       4,
 		maxFetchAndProbe: int64(2 * time.Second),
 	}
-	require.Equal(t, "build_hash_table:{total:2s, fetch:1.9s, build:100ms}, probe:{concurrency:4, total:5s, max:2s, probe:4s, fetch:1s, probe_collision:1}", stats.String())
+	require.Equal(t, "build_hash_table:{total:2s, fetch:1.9s, build:100ms}, probe:{concurrency:4, total:5s, max:2s, probe:4s, fetch and wait:1s, probe_collision:1}", stats.String())
 	require.Equal(t, stats.Clone().String(), stats.String())
 	stats.Merge(stats.Clone())
-	require.Equal(t, "build_hash_table:{total:4s, fetch:3.8s, build:200ms}, probe:{concurrency:4, total:10s, max:2s, probe:8s, fetch:2s, probe_collision:2}", stats.String())
+	require.Equal(t, "build_hash_table:{total:4s, fetch:3.8s, build:200ms}, probe:{concurrency:4, total:10s, max:2s, probe:8s, fetch and wait:2s, probe_collision:2}", stats.String())
 }
 
 func TestIndexJoinRuntimeStats(t *testing.T) {

--- a/pkg/executor/test/jointest/hashjoin/hash_join_test.go
+++ b/pkg/executor/test/jointest/hashjoin/hash_join_test.go
@@ -351,7 +351,7 @@ func TestExplainAnalyzeJoin(t *testing.T) {
 	rows = tk.MustQuery("explain analyze select /*+ HASH_JOIN(t1, t2) */ * from t1,t2 where t1.a=t2.a;").Rows()
 	require.Equal(t, 7, len(rows))
 	require.Regexp(t, "HashJoin.*", rows[0][0])
-	require.Regexp(t, "time:.*, loops:.*, build_hash_table:{total:.*, fetch:.*, build:.*}, probe:{concurrency:5, total:.*, max:.*, probe:.*, fetch:.*}", rows[0][5])
+	require.Regexp(t, "time:.*, loops:.*, build_hash_table:{total:.*, fetch:.*, build:.*}, probe:{concurrency:5, total:.*, max:.*, probe:.*, fetch and wait:.*}", rows[0][5])
 	// Test for index merge join.
 	rows = tk.MustQuery("explain analyze select /*+ INL_MERGE_JOIN(t1, t2) */ * from t1,t2 where t1.a=t2.a;").Rows()
 	require.Len(t, rows, 9)

--- a/tests/integrationtest/r/planner/core/cbo.result
+++ b/tests/integrationtest/r/planner/core/cbo.result
@@ -72,7 +72,7 @@ id	estRows	actRows	task	access object	execution info	operator info	memory	disk
 Projection_9	1.00	1	root	NULL	time:<num>, loops:<num>, RU:<num>, Concurrency:OFF	planner__core__cbo.t1.a, planner__core__cbo.t1.b, Column#8	<num>	N/A
 └─StreamAgg_11	1.00	1	root	NULL	time:<num>, loops:<num>	funcs:sum(Column#16)->Column#8, funcs:firstrow(Column#17)->planner__core__cbo.t1.a, funcs:firstrow(Column#18)->planner__core__cbo.t1.b	<num>	N/A
   └─Projection_53	4.00	3	root	NULL	time:<num>, loops:<num>, Concurrency:OFF	cast(planner__core__cbo.t1.c, decimal(10,0) BINARY)->Column#16, planner__core__cbo.t1.a->Column#17, planner__core__cbo.t1.b->Column#18	<num>	N/A
-    └─HashJoin_51	4.00	3	root	NULL	time:<num>, loops:<num>, build_hash_table:{total:<num>, fetch:<num>, build:<num>}, probe:{concurrency:<num>, total:<num>, max:<num>, probe:<num>, fetch:<num>}	inner join, equal:[eq(planner__core__cbo.t1.a, planner__core__cbo.t2.b)]	<num>	<num>
+    └─HashJoin_51	4.00	3	root	NULL	time:<num>, loops:<num>, build_hash_table:{total:<num>, fetch:<num>, build:<num>}, probe:{concurrency:<num>, total:<num>, max:<num>, probe:<num>, fetch and wait:<num>}	inner join, equal:[eq(planner__core__cbo.t1.a, planner__core__cbo.t2.b)]	<num>	<num>
       ├─TableReader_30(Build)	6.00	6	root	NULL	time.*loops.*cop_task.*	data:Selection_29	<num>	N/A
       │ └─Selection_29	6.00	6	cop[tikv]	NULL	tikv_task:{time:<num>, loops:<num>}	gt(planner__core__cbo.t2.b, 1), not(isnull(planner__core__cbo.t2.b))	N/A	N/A
       │   └─TableFullScan_28	6.00	6	cop[tikv]	table:t2	tikv_task:{time:<num>, loops:<num>}	keep order:false	N/A	N/A


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52222

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
run TPCH query 10 base on TPCH-50 dataset
Before this pr
```
|           ├─HashJoin_88(Build)                | 2882295.78  | 2865763  | root      |                                                         | time:4.93s, loops:2802, build_hash_table:{total:160.6µs, fetch:135.6µs, build:25µs}, probe:{concurrency:5, total:50.9s, max:10.2s, probe:27.9s, fetch:23s}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | inner join, equal:[eq(test.customer.c_nationkey, test.nation.n_nationkey)]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 28.5 KB   | 0 Bytes |
|           │ └─HashJoin_99(Probe)              | 2882295.78  | 2865763  | root      |                                                         | time:5.18s, loops:2801, build_hash_table:{total:3.72s, fetch:2.59s, build:1.12s}, probe:{concurrency:5, total:50.9s, max:10.2s, probe:32.2s, fetch:18.7s}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | inner join, equal:[eq(test.customer.c_custkey, test.orders.o_custkey)]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 273.0 MB  | 0 Bytes |
```
The displayed probe time 27.9s for `HashJoin_88` is 27.9s and 32.2s for `HashJoin_99`
After this pr
```
|           ├─HashJoin_88(Build)                | 2882295.78  | 2865763  | root      |                                                         | time:4.78s, loops:2802, build_hash_table:{total:292.5µs, fetch:277.3µs, build:15.2µs}, probe:{concurrency:5, total:48.6s, max:9.71s, probe:3.16s, fetch and wait:45.4s}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | inner join, equal:[eq(test.customer.c_nationkey, test.nation.n_nationkey)]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 35.2 KB   | 0 Bytes |                                                                                                                                                                                                                                                                                                                                                                                                                                              
|           │ └─HashJoin_99(Probe)              | 2882295.78  | 2865763  | root      |                                                         | time:5.01s, loops:2801, build_hash_table:{total:3.62s, fetch:2.52s, build:1.11s}, probe:{concurrency:5, total:48.6s, max:9.71s, probe:7.72s, fetch and wait:40.8s}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | inner join, equal:[eq(test.customer.c_custkey, test.orders.o_custkey)]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 273.2 MB  | 0 Bytes |
```
The displayed probe time is 3.16s for `HashJoin_88` and 7.72s for `HashJoin_99` 
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
