### PR TITLE
server: move all routes to mux router and make sure pprof paths are good

### DIFF
--- a/pkg/server/handler/tests/BUILD.bazel
+++ b/pkg/server/handler/tests/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 37,
+    shard_count = 38,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -440,6 +440,37 @@ func TestTiFlashReplica(t *testing.T) {
 	checkFunc()
 }
 
+func TestDebugRoutes(t *testing.T) {
+	ts := createBasicHTTPHandlerTestSuite()
+	ts.startServer(t)
+	defer ts.stopServer(t)
+
+	debugRoutes := []string{
+		"/debug/pprof/",
+		"/debug/pprof/heap?debug=1",
+		"/debug/pprof/goroutine?debug=1",
+		"/debug/pprof/goroutine?debug=2",
+		"/debug/pprof/allocs?debug=1",
+		"/debug/pprof/block?debug=1",
+		"/debug/pprof/threadcreate?debug=1",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/profile",
+		"/debug/pprof/mutex?debug=1",
+		"/debug/pprof/symbol",
+		"/debug/pprof/trace",
+		"/debug/pprof/profile", // this takes a while to run, so we skip it
+		"/debug/gogc",
+		// "/debug/zip", // this creates unexpected goroutines which will make goleak complain, so we skip it for now
+		"/debug/ballast-object-sz",
+	}
+	for _, route := range debugRoutes {
+		resp, err := ts.FetchStatus(route)
+		require.NoError(t, err, fmt.Sprintf("GET route %s failed", route))
+		require.Equal(t, http.StatusOK, resp.StatusCode, fmt.Sprintf("GET route %s failed", route))
+		require.NoError(t, resp.Body.Close())
+	}
+}
+
 func TestFailpointHandler(t *testing.T) {
 	ts := createBasicHTTPHandlerTestSuite()
 

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -458,7 +458,7 @@ func TestDebugRoutes(t *testing.T) {
 		"/debug/pprof/mutex?debug=1",
 		"/debug/pprof/symbol",
 		"/debug/pprof/trace",
-		"/debug/pprof/profile", // this takes a while to run, so we skip it
+		"/debug/pprof/profile",
 		"/debug/gogc",
 		// "/debug/zip", // this creates unexpected goroutines which will make goleak complain, so we skip it for now
 		"/debug/ballast-object-sz",

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -299,7 +299,7 @@ func (s *Server) startHTTPServer() {
 	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	// Other /debug/pprof paths not covered above are redirected to pprof.Index.
-	router.PathPrefix("/debug/pprof/").Handler(http.HandlerFunc(pprof.Index))
+	router.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
 
 	ballast := newBallast(s.cfg.MaxBallastObjectSize)
 	{
@@ -421,7 +421,7 @@ func (s *Server) startHTTPServer() {
 
 	// failpoint is enabled only for tests so we can add some http APIs here for tests.
 	failpoint.Inject("enableTestAPI", func() {
-		router.HandleFunc("/fail/", func(w http.ResponseWriter, r *http.Request) {
+		router.PathPrefix("/fail/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			r.URL.Path = strings.TrimPrefix(r.URL.Path, "/fail")
 			new(failpoint.HttpHandler).ServeHTTP(w, r)
 		})

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -294,14 +294,12 @@ func (s *Server) startHTTPServer() {
 		router.PathPrefix("/static/").Handler(http.StripPrefix("/static", http.FileServer(static.Data)))
 	}
 
-	serverMux := http.NewServeMux()
-	serverMux.Handle("/", router)
-
-	serverMux.HandleFunc("/debug/pprof/", pprof.Index)
-	serverMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	serverMux.HandleFunc("/debug/pprof/profile", cpuprofile.ProfileHTTPHandler)
-	serverMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	serverMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/profile", cpuprofile.ProfileHTTPHandler)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	// Other /debug/pprof paths not covered above are redirected to pprof.Index.
+	router.PathPrefix("/debug/pprof/").Handler(http.HandlerFunc(pprof.Index))
 
 	ballast := newBallast(s.cfg.MaxBallastObjectSize)
 	{
@@ -310,9 +308,9 @@ func (s *Server) startHTTPServer() {
 			logutil.BgLogger().Error("set initial ballast object size failed", zap.Error(err))
 		}
 	}
-	serverMux.HandleFunc("/debug/ballast-object-sz", ballast.GenHTTPHandler())
+	router.HandleFunc("/debug/ballast-object-sz", ballast.GenHTTPHandler())
 
-	serverMux.HandleFunc("/debug/gogc", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/debug/gogc", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
 			_, err := w.Write([]byte(strconv.Itoa(util.GetGOGC())))
@@ -337,7 +335,7 @@ func (s *Server) startHTTPServer() {
 		}
 	})
 
-	serverMux.HandleFunc("/debug/zip", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/debug/zip", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="tidb_debug"`+time.Now().Format("20060102150405")+".zip"))
 
 		// dump goroutine/heap/mutex
@@ -423,7 +421,7 @@ func (s *Server) startHTTPServer() {
 
 	// failpoint is enabled only for tests so we can add some http APIs here for tests.
 	failpoint.Inject("enableTestAPI", func() {
-		serverMux.HandleFunc("/fail/", func(w http.ResponseWriter, r *http.Request) {
+		router.HandleFunc("/fail/", func(w http.ResponseWriter, r *http.Request) {
 			r.URL.Path = strings.TrimPrefix(r.URL.Path, "/fail")
 			new(failpoint.HttpHandler).ServeHTTP(w, r)
 		})
@@ -467,6 +465,9 @@ func (s *Server) startHTTPServer() {
 			logutil.BgLogger().Error("write HTTP index page failed", zap.Error(err))
 		}
 	})
+
+	serverMux := http.NewServeMux()
+	serverMux.Handle("/", router)
 	s.startStatusServerAndRPCServer(serverMux)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51914 

Problem Summary:

Resubmits https://github.com/pingcap/tidb/pull/51915 and fixes issues with missing `/debug/pprof/` routes.

`pprof.Index` handles multiple sub routes by stripping `/debug/pprof/` from the path and looking the remaining path from a map and load the corresponding HTTP handlers. These handlers are not registered directly to the `http.ServeMux` or `mux.Router`. We have to register `pprof.Index` handler to the `mux.Router` as a backup handler for any `/debug/pprof/*` routes that are not explicitly registered, so that all routes can be found.

Move all status routes to be registered behind `mux.Router` instead of splitting between the router and `http.ServeMux`.

### What changed and how does it work?

All status routes are registered with `mux.Router` and `mux.Router` itself is registered as an HTTP handler for all routes for `http.ServeMux`. There should be NO behavior changes and existing test cases for affected routes should continue to pass.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

New unit test `pkg/server/handler/tests TestDebugRoutes` added which assert on the pprof routes being accessible. However, I had to skip over `/debug/zip` which leaves unexpected goroutine open (see below), which probably goes beyond the scope of this PR since the same test will fail without the changes in this PR.
```
➜  tidb git:(yzhan/muxfix) ✗ make ut X='run pkg/server/handler/tests TestDebugRoutes'     
tools/bin/ut run pkg/server/handler/tests TestDebugRoutes || { find $PWD/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable; exit 1; }
2024/03/29 01:38:30 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
building task finish, parallelism=24, count=1, takes=24.980719459s
...
PASS
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 76654 in state select, with github.com/pingcap/tidb/pkg/util/cpuprofile.(*Collector).StopCPUProfile on top of the stack:
github.com/pingcap/tidb/pkg/util/cpuprofile.(*Collector).StopCPUProfile(0x1400d524000)
        /Users/yzhan/workspace2/tidb/pkg/util/cpuprofile/pprof_api.go:112 +0x84
github.com/pingcap/tidb/pkg/server.(*Server).startHTTPServer.func3({0x1070615c0, 0x1400d5b1180}, 0x1400d470b00)
        /Users/yzhan/workspace2/tidb/pkg/server/http_status.go:388 +0x5f4
net/http.HandlerFunc.ServeHTTP(0x1400d470a00?, {0x1070615c0?, 0x1400d5b1180?}, 0x10268de34?)
        /usr/local/go/src/net/http/server.go:2136 +0x38
github.com/gorilla/mux.(*Router).ServeHTTP(0x1400590c0c0, {0x1070615c0, 0x1400d5b1180}, 0x1400d470900)
        /Users/yzhan/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x194
net/http.(*ServeMux).ServeHTTP(0x14007bdaad8?, {0x1070615c0, 0x1400d5b1180}, 0x1400d470900)
        /usr/local/go/src/net/http/server.go:2514 +0x144
github.com/pingcap/tidb/pkg/server/internal/util.CorsHandler.ServeHTTP({{0x107043040?, 0x14007ed0540?}, 0x1400772f200?}, {0x1070615c0?, 0x1400d5b1180?}, 0x14009eae6e0?)
        /Users/yzhan/workspace2/tidb/pkg/server/internal/util/util.go:219 +0x1ec
net/http.serverHandler.ServeHTTP({0x1400d52eb70?}, {0x1070615c0?, 0x1400d5b1180?}, 0x6?)
        /usr/local/go/src/net/http/server.go:2938 +0xbc
net/http.(*conn).serve(0x1400d4fb830, {0x107078b68, 0x140080c1470})
        /usr/local/go/src/net/http/server.go:2009 +0x518
created by net/http.(*Server).Serve in goroutine 11705
        /usr/local/go/src/net/http/server.go:3086 +0x4cc
 Goroutine 76656 in state select, with github.com/pingcap/tidb/pkg/util/cpuprofile.(*Collector).readProfileData on top of the stack:
github.com/pingcap/tidb/pkg/util/cpuprofile.(*Collector).readProfileData(0x1400d524000)
        /Users/yzhan/workspace2/tidb/pkg/util/cpuprofile/pprof_api.go:139 +0x104
github.com/pingcap/tidb/pkg/util.WithRecovery(0x0?, 0x140010ddfa8?)
        /Users/yzhan/workspace2/tidb/pkg/util/misc.go:97 +0x50
created by github.com/pingcap/tidb/pkg/util/cpuprofile.(*Collector).StartCPUProfile in goroutine 76654
        /Users/yzhan/workspace2/tidb/pkg/util/cpuprofile/pprof_api.go:100 +0xe8
]
run all tasks takes 33.622711542s
make: *** [ut] Error 1
```
After skipping `/debug/zip` in test:
```
➜  tidb git:(yzhan/muxfix) ✗ make ut X='run pkg/server/handler/tests TestDebugRoutes'
tools/bin/ut run pkg/server/handler/tests TestDebugRoutes || { find $PWD/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable; exit 1; }
2024/03/29 01:49:32 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
building task finish, parallelism=24, count=1, takes=24.623807917s
run all tasks takes 1m4.94040975s
```

Changes to the `/fail/` routes should be covered by existing `TestFailpointHandler` test cases.

Tested all paths are reachable via web UI and cURL:
```                                                                                                                                                                                                 ➜  ~ curl localhost:8888/debug/pprof/ -I
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:00:53 GMT

➜  ~ curl localhost:8888/debug/pprof/cmdline -I
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:00:59 GMT
Content-Length: 192

➜  ~ curl localhost:8888/debug/pprof/symbol -I
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:01:11 GMT
Content-Length: 15

➜  ~ curl localhost:8888/debug/pprof/trace -I
HTTP/1.1 200 OK
Content-Disposition: attachment; filename="trace"
Content-Type: application/octet-stream
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:01:16 GMT

➜  ~ curl localhost:8888/debug/ballast-object-sz -I
HTTP/1.1 200 OK
Date: Fri, 29 Mar 2024 08:01:23 GMT

➜  ~ curl localhost:8888/debug/gogc -I
HTTP/1.1 200 OK
Date: Fri, 29 Mar 2024 08:01:27 GMT

➜  ~ curl localhost:8888/debug/zip -I
HTTP/1.1 200 OK
Content-Disposition: attachment; filename="tidb_debug"20240329010132.zip
Date: Fri, 29 Mar 2024 08:01:32 GMT
Content-Type: application/zip

➜  ~ curl "http://localhost:8888/debug/pprof/allocs?debug=1" -I
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:01:43 GMT

➜  ~ curl "http://localhost:8888/debug/pprof/block?debug=1" -I
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:01:49 GMT
Content-Length: 41

➜  ~ curl "http://localhost:8888/debug/pprof/goroutine?debug=1" -I
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:01:54 GMT

➜  ~ curl "http://localhost:8888/debug/pprof/heap?debug=1" -I
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:02:00 GMT

➜  ~ curl "http://localhost:8888/debug/pprof/mutex?debug=1" -I
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:02:08 GMT

➜  ~ curl "http://localhost:8888/debug/pprof/threadcreate?debug=1" -I
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:02:13 GMT
Content-Length: 415

➜  ~ curl "http://localhost:8888/debug/pprof/goroutine?debug=2" -I
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:02:18 GMT

➜  ~ curl -X PUT -d "pause" "http://127.0.0.1:8888/fail/github.com/pingcap/tidb/pkg/ddl/mockDelayInModifyColumnTypeWithData" -i
HTTP/1.1 204 No Content
Date: Fri, 29 Mar 2024 08:02:39 GMT

➜  ~ curl localhost:8888/fail/ -I
HTTP/1.1 405 Method Not Allowed
Allow: PUT
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 29 Mar 2024 08:02:50 GMT
Content-Length: 19

➜  ~ curl localhost:8888/fail/ -i
HTTP/1.1 200 OK
Date: Fri, 29 Mar 2024 08:02:54 GMT
Content-Length: 74
Content-Type: text/plain; charset=utf-8

github.com/pingcap/tidb/pkg/ddl/mockDelayInModifyColumnTypeWithData=pause
➜  ~ curl -X DELETE "http://127.0.0.1:8888/fail/github.com/pingcap/tidb/pkg/ddl/mockDelayInModifyColumnTypeWithData" -i
HTTP/1.1 204 No Content
Date: Fri, 29 Mar 2024 08:03:03 GMT

➜  ~ curl localhost:8888/fail/ -i
HTTP/1.1 200 OK
Date: Fri, 29 Mar 2024 08:03:06 GMT
Content-Length: 69
Content-Type: text/plain; charset=utf-8

github.com/pingcap/tidb/pkg/ddl/mockDelayInModifyColumnTypeWithData=
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
