### PR TITLE
executor: report warning when new handle is found in old row

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -195,6 +195,9 @@ func updateRecord(ctx context.Context, sctx sessionctx.Context, h kv.Handle, old
 		}
 	} else {
 		// Update record to new value and update index.
+		if onDup {
+			ctx = context.WithValue(ctx, "from_on_dup", struct{}{})
+		}
 		if err := t.UpdateRecord(ctx, sctx, h, oldData, newData, modified); err != nil {
 			if terr, ok := errors.Cause(err).(*terror.Error); sctx.GetSessionVars().StmtCtx.IgnoreNoPartition && ok && terr.Code() == errno.ErrNoPartitionForGivenValue {
 				return false, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

1. **With** auto ID conflict:

```sql
drop table if exists t;
create table t (id bigint primary key auto_increment, uid int, amount int, pad varchar(255), unique index (uid));
insert into t(uid, amount, pad) values (1, 10, 'aaa');
insert into t(uid, amount, pad) values (2, 50, 'bbb');
table t;

alter table t force auto_increment = 1;
insert into t(uid, amount, pad) values (2, 60, 'bbb') on duplicate key update amount = amount + 10;
table t;
```

```
+----+------+--------+------+
| id | uid  | amount | pad  |
+----+------+--------+------+
|  1 |    1 |     10 | aaa  |
|  2 |    2 |     50 | bbb  |
+----+------+--------+------+
2 rows in set (0.00 sec)

+----+------+--------+------+
| id | uid  | amount | pad  |
+----+------+--------+------+
|  1 |    1 |     20 | aaa  |
|  2 |    2 |     50 | bbb  |
+----+------+--------+------+
2 rows in set (0.01 sec)
```

```
[2024/03/30 16:47:39.630 +08:00] [WARN] [insert.go:263] ["insert on duplicate update found auto ID conflict"] [handle=8000000000000001]
```

2. **Without** auto ID conflict:

```sql
drop table if exists t;
create table t (id bigint primary key auto_increment, uid int, amount int, pad varchar(255), unique index (uid));
insert into t(uid, amount, pad) values (1, 10, 'aaa');
insert into t(uid, amount, pad) values (2, 50, 'bbb');
table t;

-- alter table t force auto_increment = 1;
insert into t(uid, amount, pad) values (2, 60, 'bbb') on duplicate key update amount = amount + 10;
table t;
```

```
+----+------+--------+------+
| id | uid  | amount | pad  |
+----+------+--------+------+
|  1 |    1 |     10 | aaa  |
|  2 |    2 |     50 | bbb  |
+----+------+--------+------+
2 rows in set (0.00 sec)

+----+------+--------+------+
| id | uid  | amount | pad  |
+----+------+--------+------+
|  1 |    1 |     10 | aaa  |
|  2 |    2 |     60 | bbb  |
+----+------+--------+------+
2 rows in set (0.00 sec)
```

There is no warning log.

3. With unrelated columns update:

```sql
drop table if exists t;
create table t (id bigint primary key auto_increment, uid int, amount int, pad varchar(255), unrelated int, unique index (uid), index(unrelated));
insert into t(uid, amount, pad, unrelated) values (1, 10, 'aaa', 1);
insert into t(uid, amount, pad, unrelated) values (2, 50, 'bbb', 2);
table t;
insert into t(uid, amount, pad, unrelated) values (2, 60, 'bbb', 3) on duplicate key update amount = amount + 10, unrelated = unrelated + 1;
table t;
```

```sql
[2024/03/30 16:45:50.853 +08:00] [WARN] [index.go:121] ["insert on duplicate key update should not modify non-unique indexes"] [index=unrelated] [startTS=448735045443387397]
```


### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
