### PR TITLE
br/operator: fix stuck when terminating

### DIFF
--- a/br/pkg/backup/prepare_snap/BUILD.bazel
+++ b/br/pkg/backup/prepare_snap/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     timeout = "short",
     srcs = ["prepare_test.go"],
     flaky = True,
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         ":prepare_snap",
         "//br/pkg/utils",

--- a/br/pkg/backup/prepare_snap/prepare_test.go
+++ b/br/pkg/backup/prepare_snap/prepare_test.go
@@ -47,7 +47,12 @@ type mockStore struct {
 
 	successRegions []metapb.Region
 	onWaitApply    func(*metapb.Region) error
-	now            func() time.Time
+
+	waitApplyDelay     func()
+	delaiedWaitApplies sync.WaitGroup
+
+	injectConnErr <-chan error
+	now           func() time.Time
 }
 
 func (s *mockStore) Send(req *brpb.PrepareSnapshotBackupRequest) error {
@@ -67,7 +72,16 @@ func (s *mockStore) Send(req *brpb.PrepareSnapshotBackupRequest) error {
 					}
 				}
 			}
-			s.sendResp(resp)
+			if s.waitApplyDelay != nil {
+				s.delaiedWaitApplies.Add(1)
+				go func() {
+					defer s.delaiedWaitApplies.Done()
+					s.waitApplyDelay()
+					s.sendResp(resp)
+				}()
+			} else {
+				s.sendResp(resp)
+			}
 			if resp.Error == nil {
 				s.successRegions = append(s.successRegions, *region)
 			}
@@ -100,11 +114,21 @@ func (s *mockStore) sendResp(resp brpb.PrepareSnapshotBackupResponse) {
 }
 
 func (s *mockStore) Recv() (*brpb.PrepareSnapshotBackupResponse, error) {
-	out, ok := <-s.output
-	if !ok {
-		return nil, io.EOF
+	for {
+		select {
+		case out, ok := <-s.output:
+			if !ok {
+				return nil, io.EOF
+			}
+			return &out, nil
+		case err, ok := <-s.injectConnErr:
+			if ok {
+				return nil, err
+			} else {
+				s.injectConnErr = nil
+			}
+		}
 	}
-	return &out, nil
 }
 
 type mockStores struct {
@@ -167,7 +191,7 @@ func (m *mockStores) ConnectToStore(ctx context.Context, storeID uint64) (Prepar
 	s, ok := m.stores[storeID]
 	if !ok || s == nil {
 		m.stores[storeID] = &mockStore{
-			output:         make(chan brpb.PrepareSnapshotBackupResponse, 16),
+			output:         make(chan brpb.PrepareSnapshotBackupResponse, 20480),
 			successRegions: []metapb.Region{},
 			onWaitApply: func(r *metapb.Region) error {
 				return nil
@@ -537,4 +561,38 @@ func TestHooks(t *testing.T) {
 	ms.AssertSafeForBackup(t)
 	req.NoError(adv.Finalize(context.Background()))
 	ms.AssertIsNormalMode(t)
+}
+
+func TestManyMessagesWhenFinalizing(t *testing.T) {
+	req := require.New(t)
+	pdc := fakeCluster(t, 3, dummyRegions(10240)...)
+	ms := newTestEnv(pdc)
+	blockCh := make(chan struct{})
+	injectErr := make(chan error)
+	ms.onCreateStore = func(ms *mockStore) {
+		ms.waitApplyDelay = func() {
+			<-blockCh
+		}
+		ms.injectConnErr = injectErr
+	}
+	prep := New(ms)
+	ctx := context.Background()
+	req.NoError(prep.PrepareConnections(ctx))
+	errC := async(func() error { return prep.DriveLoopAndWaitPrepare(ctx) })
+	injectErr <- errors.NewNoStackError("whoa!")
+	req.Error(<-errC)
+	close(blockCh)
+	for _, s := range ms.stores {
+		s.delaiedWaitApplies.Wait()
+	}
+	// Closing the stream should be error.
+	req.Error(prep.Finalize(ctx))
+}
+
+func async[T any](f func() T) <-chan T {
+	ch := make(chan T)
+	go func() {
+		ch <- f()
+	}()
+	return ch
 }

--- a/br/pkg/backup/prepare_snap/stream.go
+++ b/br/pkg/backup/prepare_snap/stream.go
@@ -74,6 +74,9 @@ func (p *prepareStream) InitConn(ctx context.Context, cli PrepareClient) error {
 	return p.GoLeaseLoop(ctx, p.leaseDuration)
 }
 
+// Finalize cuts down this connection and remove the lease.
+// This will block until all messages has been flushed to `output` channel.
+// After this return, no more messages should be appended to the `output` channel.
 func (p *prepareStream) Finalize(ctx context.Context) error {
 	log.Info("shutting down", zap.Uint64("store", p.storeID))
 	return p.stopClientLoop(ctx)
@@ -151,7 +154,8 @@ func (p *prepareStream) clientLoop(ctx context.Context, dur time.Duration) error
 			return nil
 		case res := <-p.serverStream:
 			if err := p.onResponse(ctx, res); err != nil {
-				p.sendErr(errors.Annotate(err, "failed to recv from the stream"))
+				err = errors.Annotate(err, "failed to recv from the stream")
+				p.sendErr(err)
 				return err
 			}
 		case <-ticker.C:
@@ -186,6 +190,10 @@ func (p *prepareStream) sendErr(err error) {
 }
 
 func (p *prepareStream) convertToEvent(resp *brpb.PrepareSnapshotBackupResponse) (event, bool) {
+	if resp == nil {
+		log.Warn("Received nil message, that shouldn't happen in a normal cluster.", zap.Uint64("store", p.storeID))
+		return event{}, false
+	}
 	switch resp.Ty {
 	case brpb.PrepareSnapshotBackupEventType_WaitApplyDone:
 		return event{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52243

Problem Summary:
When exiting due to error, we are waiting from the client to finish before receiving from the output channel. In this case, the output channel may be full and blocks the exit procedure.

### What changed and how does it work?
We will poll from both the request exit result and the exit channel.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed an issue where init pod may get stuck when encountering connective errors.
```
