### PR TITLE
tests: fix the error msg in default_as_expession

### DIFF
--- a/tests/integrationtest/r/ddl/default_as_expression.result
+++ b/tests/integrationtest/r/ddl/default_as_expression.result
@@ -100,6 +100,7 @@ t1	CREATE TABLE `t1` (
   KEY `idx` (`c1`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 alter table t0 modify column c1 datetime DEFAULT (date_format(now(), '%Y-%m-%d'));
+Error 1292 (22007): Incorrect datetime value:<time>
 alter table t0 alter column c1 SET DEFAULT (date_format(now(), '%Y-%m-%d'));
 insert into t0 values (5, default);
 alter table t1 modify column c1 datetime DEFAULT (date_format(now(), '%Y-%m-%d'));

--- a/tests/integrationtest/r/ddl/default_as_expression.result
+++ b/tests/integrationtest/r/ddl/default_as_expression.result
@@ -100,7 +100,6 @@ t1	CREATE TABLE `t1` (
   KEY `idx` (`c1`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 alter table t0 modify column c1 datetime DEFAULT (date_format(now(), '%Y-%m-%d'));
-Error 1292 (22007): Incorrect datetime value: '2024-03'
 alter table t0 alter column c1 SET DEFAULT (date_format(now(), '%Y-%m-%d'));
 insert into t0 values (5, default);
 alter table t1 modify column c1 datetime DEFAULT (date_format(now(), '%Y-%m-%d'));

--- a/tests/integrationtest/t/ddl/default_as_expression.test
+++ b/tests/integrationtest/t/ddl/default_as_expression.test
@@ -54,7 +54,7 @@ insert into t0 values (4, default);
 insert into t1 values (4, default);
 show create table t0;
 show create table t1;
--- error 1292
+-- error 0, 1292
 alter table t0 modify column c1 datetime DEFAULT (date_format(now(), '%Y-%m-%d'));
 alter table t0 alter column c1 SET DEFAULT (date_format(now(), '%Y-%m-%d'));
 insert into t0 values (5, default);

--- a/tests/integrationtest/t/ddl/default_as_expression.test
+++ b/tests/integrationtest/t/ddl/default_as_expression.test
@@ -54,7 +54,8 @@ insert into t0 values (4, default);
 insert into t1 values (4, default);
 show create table t0;
 show create table t1;
--- error 0, 1292
+-- replace_regex /Incorrect datetime value:.*/Incorrect datetime value:<time>/
+-- error 1292
 alter table t0 modify column c1 datetime DEFAULT (date_format(now(), '%Y-%m-%d'));
 alter table t0 alter column c1 SET DEFAULT (date_format(now(), '%Y-%m-%d'));
 insert into t0 values (5, default);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/52267

Problem Summary:

### What changed and how does it work?
```
run test [ddl/default_as_expression] err: sql:alter table t0 modify column c1 datetime DEFAULT (date_format(now(), '%Y-%m-%d'));: failed to run query
\"alter table t0 modify column c1 datetime DEFAULT (date_format(now(), '%Y-%m-%d'));\"
 around line 58,
we need(139):
alter table t0 modify column c1 datetime DEFAULT (date_format(now(), '%Y-%m-%d'));
Error 1292 (22007): Incorrect datetime value: '2024-03'

but got(139):
alter table t0 modify column c1 datetime DEFAULT (date_format(now(), '%Y-%m-%d'));
Error 1292 (22007): Incorrect datetime value: '2024-04'
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
