### PR TITLE
importinto: change min thread to 8 for global sort

### DIFF
--- a/pkg/executor/importer/precheck.go
+++ b/pkg/executor/importer/precheck.go
@@ -63,10 +63,10 @@ func (e *LoadDataController) CheckRequirements(ctx context.Context, conn sqlexec
 		if err := e.checkTotalFileSize(); err != nil {
 			return err
 		}
-		// run global sort with < 16 thread might OOM on merge step
+		// run global sort with < 8 thread might OOM on merge step
 		// TODO: remove this limit after control memory usage.
-		if e.IsGlobalSort() && e.ThreadCnt < 16 {
-			return exeerrors.ErrLoadDataPreCheckFailed.FastGenByArgs("global sort requires at least 16 threads")
+		if e.IsGlobalSort() && e.ThreadCnt < 8 {
+			return exeerrors.ErrLoadDataPreCheckFailed.FastGenByArgs("global sort requires at least 8 threads")
 		}
 	}
 	if err := e.checkTableEmpty(ctx, conn); err != nil {

--- a/pkg/executor/importer/precheck.go
+++ b/pkg/executor/importer/precheck.go
@@ -63,7 +63,7 @@ func (e *LoadDataController) CheckRequirements(ctx context.Context, conn sqlexec
 		if err := e.checkTotalFileSize(); err != nil {
 			return err
 		}
-		// run global sort with < 8 thread might OOM on merge step
+		// run global sort with < 8 thread might OOM on ingest step
 		// TODO: remove this limit after control memory usage.
 		if e.IsGlobalSort() && e.ThreadCnt < 8 {
 			return exeerrors.ErrLoadDataPreCheckFailed.FastGenByArgs("global sort requires at least 8 threads")

--- a/pkg/executor/importer/precheck_test.go
+++ b/pkg/executor/importer/precheck_test.go
@@ -104,12 +104,12 @@ func TestCheckRequirements(t *testing.T) {
 
 	// make checkTotalFileSize pass
 	c.TotalFileSize = 1
-	// global sort with thread count < 16
-	c.ThreadCnt = 15
+	// global sort with thread count < 8
+	c.ThreadCnt = 7
 	c.CloudStorageURI = "s3://test"
 	err = c.CheckRequirements(ctx, conn)
 	require.ErrorIs(t, err, exeerrors.ErrLoadDataPreCheckFailed)
-	require.ErrorContains(t, err, "global sort requires at least 16 threads")
+	require.ErrorContains(t, err, "global sort requires at least 8 threads")
 
 	// reset fields, make global sort thread check pass
 	c.ThreadCnt = 1
@@ -179,7 +179,7 @@ func TestCheckRequirements(t *testing.T) {
 	require.NoError(t, c.CheckRequirements(ctx, conn))
 
 	// with global sort
-	c.Plan.ThreadCnt = 16
+	c.Plan.ThreadCnt = 8
 	c.Plan.CloudStorageURI = ":"
 	require.ErrorIs(t, c.CheckRequirements(ctx, conn), exeerrors.ErrLoadDataInvalidURI)
 	c.Plan.CloudStorageURI = "sdsdsdsd://sdsdsdsd"

--- a/tests/realtikvtest/importintotest4/main_test.go
+++ b/tests/realtikvtest/importintotest4/main_test.go
@@ -49,7 +49,7 @@ func TestImportInto(t *testing.T) {
 }
 
 func (s *mockGCSSuite) SetupSuite() {
-	testkit.EnableFailPoint(s.T(), "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", `return(32)`)
+	testkit.EnableFailPoint(s.T(), "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", `return(16)`)
 	s.Require().True(*realtikvtest.WithRealTiKV)
 	testutil.ReduceCheckInterval(s.T())
 	var err error


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #49008 

Problem Summary:

### What changed and how does it work?
- after https://github.com/pingcap/tidb/pull/51924, we can run import with global sort on 8c machine now, so reduce this limit
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
