### PR TITLE
domain: avoit to print too many log if the ddl job of runaway table is not finished

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1290,8 +1290,7 @@ func (do *Domain) Init(
 	do.wg.Run(do.topNSlowQueryLoop, "topNSlowQueryLoop")
 	do.wg.Run(do.infoSyncerKeeper, "infoSyncerKeeper")
 	do.wg.Run(do.globalConfigSyncerKeeper, "globalConfigSyncerKeeper")
-	do.wg.Run(do.runawayRecordFlushLoop, "runawayRecordFlushLoop")
-	do.wg.Run(do.runawayWatchSyncLoop, "runawayWatchSyncLoop")
+	do.wg.Run(do.runawayStartLoop, "runawayStartLoop")
 	do.wg.Run(do.requestUnitsWriterLoop, "requestUnitsWriterLoop")
 	if !skipRegisterToDashboard {
 		do.wg.Run(do.topologySyncerKeeper, "topologySyncerKeeper")

--- a/pkg/domain/resourcegroup/runaway.go
+++ b/pkg/domain/resourcegroup/runaway.go
@@ -184,6 +184,8 @@ func (r *QuarantineRecord) GenDeletionStmt() (string, []any) {
 
 // RunawayManager is used to detect and record runaway queries.
 type RunawayManager struct {
+	syncerInitialized atomic.Bool
+
 	// queryLock is used to avoid repeated additions. Since we will add new items to the system table,
 	// in order to avoid repeated additions, we need a lock to ensure that
 	// action "judging whether there is this record in the current watch list and adding records" have atomicity.
@@ -219,6 +221,7 @@ func NewRunawayManager(resourceGroupCtl *rmclient.ResourceGroupsController, serv
 	go watchList.Start()
 	staleQuarantineChan := make(chan *QuarantineRecord, maxWatchRecordChannelSize)
 	m := &RunawayManager{
+		syncerInitialized:     atomic.Bool{},
 		resourceGroupCtl:      resourceGroupCtl,
 		watchList:             watchList,
 		serverID:              serverAddr,
@@ -243,6 +246,10 @@ func NewRunawayManager(resourceGroupCtl *rmclient.ResourceGroupsController, serv
 		staleQuarantineChan <- i.Value()
 	})
 	return m
+}
+
+func (rm *RunawayManager) MarkSyncerInitialized() {
+	rm.syncerInitialized.Store(true)
 }
 
 // DeriveChecker derives a RunawayChecker from the given resource group
@@ -282,6 +289,13 @@ func (rm *RunawayManager) markQuarantine(resourceGroupName, convict string, watc
 	}
 	// Add record without ID into watch list in this TiDB right now.
 	rm.addWatchList(record, ttl, false)
+	if !rm.syncerInitialized.Load() {
+		logutil.BgLogger().Warn("runaway syncer is not initialized, so can't record runaway watch",
+			zap.String("resource group", resourceGroupName),
+			zap.String("watch-text", convict),
+			zap.String("watch type", watchType.String()))
+		return
+	}
 	select {
 	case rm.quarantineChan <- record:
 	default:
@@ -380,6 +394,12 @@ func (rm *RunawayManager) getWatchFromWatchList(key string) *QuarantineRecord {
 
 func (rm *RunawayManager) markRunaway(resourceGroupName, originalSQL, planDigest string, action string, matchType RunawayMatchType, now *time.Time) {
 	source := rm.serverID
+	if !rm.syncerInitialized.Load() {
+		logutil.BgLogger().Warn("runaway syncer is not initialized, so can't record runaway queries",
+			zap.String("resource group", resourceGroupName),
+			zap.String("sql", originalSQL))
+		return
+	}
 	select {
 	case rm.runawayQueriesChan <- &RunawayRecord{
 		ResourceGroupName: resourceGroupName,

--- a/pkg/domain/resourcegroup/runaway.go
+++ b/pkg/domain/resourcegroup/runaway.go
@@ -248,6 +248,7 @@ func NewRunawayManager(resourceGroupCtl *rmclient.ResourceGroupsController, serv
 	return m
 }
 
+// MarkSyncerInitialized is used to mark the syncer is initialized.
 func (rm *RunawayManager) MarkSyncerInitialized() {
 	rm.syncerInitialized.Store(true)
 }

--- a/pkg/domain/runaway.go
+++ b/pkg/domain/runaway.go
@@ -162,12 +162,12 @@ func (do *Domain) runawayStartLoop() {
 				return
 			}
 		}
-		count++
 		if count %= runawayLoopLogErrorIntervalCount; count == 0 {
 			logutil.BgLogger().Warn(
 				"failed to start runaway manager loop, please check whether the bootstrap or update is finished",
 				zap.Error(err))
 		}
+		count++
 	}
 }
 
@@ -202,10 +202,10 @@ func (do *Domain) runawayWatchSyncLoop() {
 		case <-runawayWatchSyncTicker.C:
 			err := do.updateNewAndDoneWatch()
 			if err != nil {
-				count++
 				if count %= runawayLoopLogErrorIntervalCount; count == 0 {
 					logutil.BgLogger().Warn("get runaway watch record failed", zap.Error(err))
 				}
+				count++
 			}
 		}
 	}


### PR DESCRIPTION
…nished

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52048

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
> 
before
> tiup playground nightly --tag upgrade3 --db 3
> ctrl + C
> tiup playground nightly --tag upgrade3 --db 3
![image](https://github.com/pingcap/tidb/assets/23399268/c6f1413e-399e-4269-a46d-a10466428a29)

after
> tiup playground v7.1.1 --tag upgrade --db 3
> ctrl + C
> tiup playground nightly --tag upgrade --db 3 --db.binpath=~/github/tidb/bin/tidb-server
![image](https://github.com/pingcap/tidb/assets/23399268/8f0267b7-fd97-4afc-8a23-de91c5fce7a7)


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
