### PR TITLE
executor: report error when newly allocated auto ID exists

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -959,7 +959,6 @@ func (b *executorBuilder) buildInsert(v *plannercore.Insert) exec.Executor {
 		hasRefCols:                v.NeedFillDefaultValue,
 		SelectExec:                selectExec,
 		rowLen:                    v.RowLen,
-		colUsedGenID:              make(map[int64]struct{}, 0),
 	}
 	err := ivs.initInsertColumns()
 	if err != nil {

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -959,6 +959,7 @@ func (b *executorBuilder) buildInsert(v *plannercore.Insert) exec.Executor {
 		hasRefCols:                v.NeedFillDefaultValue,
 		SelectExec:                selectExec,
 		rowLen:                    v.RowLen,
+		colUsedGenID:              make(map[int64]struct{}, 0),
 	}
 	err := ivs.initInsertColumns()
 	if err != nil {

--- a/pkg/executor/insert.go
+++ b/pkg/executor/insert.go
@@ -249,7 +249,7 @@ func (e *InsertExec) batchUpdateDupRows(ctx context.Context, newRows [][]types.D
 				// Newly allocated handle is found in old row,
 				// this should not happen for auto_increment/auto_random cases.
 				if pkHasAutoID {
-					return errors.New("new allocated auto ID is conflict with existing one, this may cause unexpected behavior")
+					return autoid.ErrAutoincReadFailed.FastGen("newly allocated auto ID conflicts with the existing one")
 				}
 				continue
 			}

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -899,7 +899,7 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 				}
 				retryInfo.AddAutoIncrementID(id)
 			}
-			e.colUsedGenID[col.ID] = struct{}{}
+			e.recordAutoIDCol(col.ID)
 			continue
 		}
 
@@ -957,7 +957,7 @@ func (e *InsertValues) adjustAutoIncrementDatum(
 		if e.handleErr(c, &d, 0, err) != nil {
 			return types.Datum{}, err
 		}
-		e.colUsedGenID[c.ID] = struct{}{}
+		e.recordAutoIDCol(c.ID)
 		// It's compatible with mysql setting the first allocated autoID to lastInsertID.
 		// Cause autoID may be specified by user, judge only the first row is not suitable.
 		if e.lastInsertID == 0 {
@@ -1043,7 +1043,7 @@ func (e *InsertValues) adjustAutoRandomDatum(
 		if err != nil {
 			return types.Datum{}, err
 		}
-		e.colUsedGenID[c.ID] = struct{}{}
+		e.recordAutoIDCol(c.ID)
 		// It's compatible with mysql setting the first allocated autoID to lastInsertID.
 		// Cause autoID may be specified by user, judge only the first row is not suitable.
 		if e.lastInsertID == 0 {
@@ -1444,6 +1444,13 @@ func (e *InsertValues) addRecordWithAutoIDHint(
 		}
 	}
 	return nil
+}
+
+func (e *InsertValues) recordAutoIDCol(colID int64) {
+	if e.colUsedGenID == nil {
+		e.colUsedGenID = make(map[int64]struct{})
+	}
+	e.colUsedGenID[colID] = struct{}{}
 }
 
 func (e *InsertValues) pkHasAutoID() bool {

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -899,6 +899,7 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 				}
 				retryInfo.AddAutoIncrementID(id)
 			}
+			e.colUsedGenID[col.ID] = struct{}{}
 			continue
 		}
 

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -1454,6 +1454,9 @@ func (e *InsertValues) recordAutoIDCol(colID int64) {
 }
 
 func (e *InsertValues) pkHasAutoID() bool {
+	if len(e.colUsedGenID) == 0 {
+		return false
+	}
 	tblInfo := e.Table.Meta()
 	switch {
 	case tblInfo.PKIsHandle:

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -1713,18 +1713,16 @@ func GetShardingInfo(dbInfo model.CIStr, tableInfo *model.TableInfo) any {
 		return nil
 	}
 	shardingInfo := "NOT_SHARDED"
-	if tableInfo.PKIsHandle {
-		if tableInfo.ContainsAutoRandomBits() {
-			shardingInfo = "PK_AUTO_RANDOM_BITS=" + strconv.Itoa(int(tableInfo.AutoRandomBits))
-			rangeBits := tableInfo.AutoRandomRangeBits
-			if rangeBits != 0 && rangeBits != autoid.AutoRandomRangeBitsDefault {
-				shardingInfo = fmt.Sprintf("%s, RANGE BITS=%d", shardingInfo, rangeBits)
-			}
-		} else {
-			shardingInfo = "NOT_SHARDED(PK_IS_HANDLE)"
+	if tableInfo.ContainsAutoRandomBits() {
+		shardingInfo = "PK_AUTO_RANDOM_BITS=" + strconv.Itoa(int(tableInfo.AutoRandomBits))
+		rangeBits := tableInfo.AutoRandomRangeBits
+		if rangeBits != 0 && rangeBits != autoid.AutoRandomRangeBitsDefault {
+			shardingInfo = fmt.Sprintf("%s, RANGE BITS=%d", shardingInfo, rangeBits)
 		}
 	} else if tableInfo.ShardRowIDBits > 0 {
 		shardingInfo = "SHARD_BITS=" + strconv.Itoa(int(tableInfo.ShardRowIDBits))
+	} else if tableInfo.PKIsHandle {
+		shardingInfo = "NOT_SHARDED(PK_IS_HANDLE)"
 	}
 	return shardingInfo
 }

--- a/tests/integrationtest/r/ddl/db_integration.result
+++ b/tests/integrationtest/r/ddl/db_integration.result
@@ -1298,3 +1298,8 @@ create table t(a int);
 alter table t add column  b int as ((grouping(a))) stored;
 Error 1111 (HY000): Invalid use of group function
 drop table t;
+drop table if exists t;
+create table t (a bigint primary key auto_random, b int, c char(255));
+select TIDB_ROW_ID_SHARDING_INFO from information_schema.tables where TABLE_NAME = 't';
+TIDB_ROW_ID_SHARDING_INFO
+PK_AUTO_RANDOM_BITS=5

--- a/tests/integrationtest/r/executor/insert.result
+++ b/tests/integrationtest/r/executor/insert.result
@@ -1219,11 +1219,10 @@ select * from t;
 id	c1
 32767	1
 insert ignore into t(id) values ('*') on duplicate key update c1 = 2;
-affected rows: 2
-info: 
+Error 1467 (HY000): newly allocated auto ID conflicts with the existing one
 select * from t;
 id	c1
-32767	2
+32767	1
 drop table if exists t;
 create table t (i int not null primary key, j int unique key);
 insert into t values (1, 1), (2, 2);
@@ -2128,3 +2127,21 @@ Level	Code	Message
 Warning	1264	Out of range value for column 'd' at row 1
 Warning	1292	Truncated incorrect INTEGER value: '18446744073709551616'
 set sql_mode=DEFAULT;
+drop table if exists t;
+create table t (id bigint primary key auto_increment, uid int, amount int, pad varchar(255), unique index (uid));
+insert into t(uid, amount, pad) values (1, 10, 'aaa');
+insert into t(uid, amount, pad) values (2, 50, 'bbb');
+alter table t force auto_increment = 1;
+insert into t(uid, amount, pad) values (2, 10, 'bbb') on duplicate key update amount = amount + 10;
+Error 1467 (HY000): newly allocated auto ID conflicts with the existing one
+select * from t;
+id	uid	amount	pad
+1	1	10	aaa
+2	2	50	bbb
+drop table if exists t;
+create table t (id bigint primary key auto_increment, b char(255));
+insert into t(b) values ('bbb');
+insert into t values (1, 'ccc') on duplicate key update b = 'ccc';
+select * from t;
+id	b
+1	ccc

--- a/tests/integrationtest/t/ddl/db_integration.test
+++ b/tests/integrationtest/t/ddl/db_integration.test
@@ -1117,3 +1117,8 @@ create table t(a int);
 --error 1111
 alter table t add column  b int as ((grouping(a))) stored;
 drop table t;
+
+# Test composite primary key should have correct TIDB_ROW_ID_SHARDING_INFO.
+drop table if exists t;
+create table t (a bigint primary key auto_random, b int, c char(255));
+select TIDB_ROW_ID_SHARDING_INFO from information_schema.tables where TABLE_NAME = 't';

--- a/tests/integrationtest/t/executor/insert.test
+++ b/tests/integrationtest/t/executor/insert.test
@@ -951,6 +951,7 @@ insert ignore into t(id) values (194626268);
 --disable_info
 select * from t;
 --enable_info
+-- error 1467
 insert ignore into t(id) values ('*') on duplicate key update c1 = 2;
 --disable_info
 select * from t;
@@ -1600,3 +1601,18 @@ set sql_mode='';
 insert into t values (cast('18446744073709551616' as unsigned));
 --disable_warnings
 set sql_mode=DEFAULT;
+
+drop table if exists t;
+create table t (id bigint primary key auto_increment, uid int, amount int, pad varchar(255), unique index (uid));
+insert into t(uid, amount, pad) values (1, 10, 'aaa');
+insert into t(uid, amount, pad) values (2, 50, 'bbb');
+alter table t force auto_increment = 1;
+-- error 1467
+insert into t(uid, amount, pad) values (2, 10, 'bbb') on duplicate key update amount = amount + 10;
+select * from t;
+
+drop table if exists t;
+create table t (id bigint primary key auto_increment, b char(255));
+insert into t(b) values ('bbb');
+insert into t values (1, 'ccc') on duplicate key update b = 'ccc';
+select * from t;

--- a/tests/integrationtest/t/executor/insert.test
+++ b/tests/integrationtest/t/executor/insert.test
@@ -952,7 +952,6 @@ insert ignore into t(id) values (194626268);
 select * from t;
 -- error 1467
 insert ignore into t(id) values ('*') on duplicate key update c1 = 2;
---disable_info
 select * from t;
 
 # TestInsertIgnoreOnDup

--- a/tests/integrationtest/t/executor/insert.test
+++ b/tests/integrationtest/t/executor/insert.test
@@ -950,7 +950,6 @@ alter table t add column c1 int default 1;
 insert ignore into t(id) values (194626268);
 --disable_info
 select * from t;
---enable_info
 -- error 1467
 insert ignore into t(id) values ('*') on duplicate key update c1 = 2;
 --disable_info


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52299

Problem Summary:

In most cases, it should be a bug when newly allocated auto IDs conflict with existing data. We should report an error to let user fix auto ID cache as early as possible. Otherwise, other unrelated rows maybe updated unexpectedly.

### What changed and how does it work?

- Record whether a column use newly allocated auto ID.
- When the primary key is duplicated, report an error instead of updating the row.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
