### PR TITLE
statistics: add schema ID to check if it is a system or mem table

### DIFF
--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -185,6 +185,7 @@ func onAddColumn(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, err error)
 		// Finish this job.
 		job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
 		addColumnEvent := statsutil.NewAddColumnEvent(
+			job.SchemaID,
 			tblInfo,
 			[]*model.ColumnInfo{columnInfo},
 		)

--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -795,6 +795,7 @@ func (w *worker) doModifyColumnTypeWithData(
 		// Refactor the job args to add the old index ids into delete range table.
 		job.Args = []any{rmIdxIDs, getPartitionIDs(tblInfo)}
 		modifyColumnEvent := statsutil.NewModifyColumnEvent(
+			job.SchemaID,
 			tblInfo,
 			[]*model.ColumnInfo{changingCol},
 		)

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -227,6 +227,7 @@ func (w *worker) onAddTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (v
 		// Finish this job.
 		job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
 		addPartitionEvent := statsutil.NewAddPartitionEvent(
+			job.SchemaID,
 			tblInfo,
 			partInfo,
 		)

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -2755,6 +2755,7 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 
 	job.FinishTableJob(model.JobStateDone, model.StateNone, ver, pt)
 	exchangePartitionEvent := statsutil.NewExchangePartitionEvent(
+		job.SchemaID,
 		pt,
 		&model.PartitionInfo{Definitions: []model.PartitionDefinition{originalPartitionDef}},
 		originalNt,

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -3117,6 +3117,7 @@ func (w *worker) onReorganizePartition(d *ddlCtx, t *meta.Meta, job *model.Job) 
 		// Include the old table ID, if changed, which may contain global statistics,
 		// so it can be reused for the new (non)partitioned table.
 		event, err := newStatsDDLEventForJob(
+			job.SchemaID,
 			job.Type, oldTblID, tblInfo, statisticsPartInfo, droppedPartInfo,
 		)
 		if err != nil {
@@ -3136,6 +3137,7 @@ func (w *worker) onReorganizePartition(d *ddlCtx, t *meta.Meta, job *model.Job) 
 // newStatsDDLEventForJob creates a statsutil.DDLEvent for a job.
 // It is used for reorganize partition, add partitioning and remove partitioning.
 func newStatsDDLEventForJob(
+	schemaID int64,
 	jobType model.ActionType,
 	oldTblID int64,
 	tblInfo *model.TableInfo,
@@ -3146,18 +3148,21 @@ func newStatsDDLEventForJob(
 	switch jobType {
 	case model.ActionReorganizePartition:
 		event = statsutil.NewReorganizePartitionEvent(
+			schemaID,
 			tblInfo,
 			addedPartInfo,
 			droppedPartInfo,
 		)
 	case model.ActionAlterTablePartitioning:
 		event = statsutil.NewAddPartitioningEvent(
+			schemaID,
 			oldTblID,
 			tblInfo,
 			addedPartInfo,
 		)
 	case model.ActionRemovePartitioning:
 		event = statsutil.NewRemovePartitioningEvent(
+			schemaID,
 			oldTblID,
 			tblInfo,
 			droppedPartInfo,

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -2245,6 +2245,7 @@ func (w *worker) onTruncateTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 		// Finish this job.
 		job.FinishTableJob(model.JobStateDone, model.StateNone, ver, tblInfo)
 		truncatePartitionEvent := statsutil.NewTruncatePartitionEvent(
+			job.SchemaID,
 			tblInfo,
 			&model.PartitionInfo{Definitions: newPartitions},
 			&model.PartitionInfo{Definitions: oldPartitions},
@@ -2383,6 +2384,7 @@ func (w *worker) onTruncateTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 		// Finish this job.
 		job.FinishTableJob(model.JobStateDone, model.StateNone, ver, tblInfo)
 		truncatePartitionEvent := statsutil.NewTruncatePartitionEvent(
+			job.SchemaID,
 			tblInfo,
 			&model.PartitionInfo{Definitions: newPartitions},
 			&model.PartitionInfo{Definitions: oldPartitions},

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -2153,6 +2153,7 @@ func (w *worker) onDropTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (
 		job.SchemaState = model.StateNone
 		job.FinishTableJob(model.JobStateDone, model.StateNone, ver, tblInfo)
 		dropPartitionEvent := statsutil.NewDropPartitionEvent(
+			job.SchemaID,
 			tblInfo,
 			&model.PartitionInfo{Definitions: droppedDefs},
 		)

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -858,6 +858,7 @@ func (w *worker) onTruncateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver i
 	}
 	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
 	truncateTableEvent := statsutil.NewTruncateTableEvent(
+		job.SchemaID,
 		tblInfo,
 		oldTblInfo,
 	)

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -414,6 +414,7 @@ func onDropTableOrView(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ er
 		job.Args = append(job.Args, startKey, oldIDs, ruleIDs)
 		if !tblInfo.IsSequence() && !tblInfo.IsView() {
 			dropTableEvent := statsutil.NewDropTableEvent(
+				job.SchemaID,
 				tblInfo,
 			)
 			asyncNotifyEvent(d, dropTableEvent)

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -186,6 +186,7 @@ func onCreateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 	// Finish this job.
 	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tbInfo)
 	createTableEvent := statsutil.NewCreateTableEvent(
+		job.SchemaID,
 		tbInfo,
 	)
 	asyncNotifyEvent(d, createTableEvent)
@@ -263,6 +264,7 @@ func onCreateTables(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, error) {
 
 	for i := range args {
 		createTableEvent := statsutil.NewCreateTableEvent(
+			job.SchemaID,
 			args[i],
 		)
 		asyncNotifyEvent(d, createTableEvent)

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 19,
+    shard_count = 20,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 17,
+    shard_count = 18,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 23,
+    shard_count = 24,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 22,
+    shard_count = 23,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 18,
+    shard_count = 19,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 24,
+    shard_count = 25,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 26,
+    shard_count = 27,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 21,
+    shard_count = 22,
     deps = [
         "//pkg/parser/model",
         "//pkg/planner/cardinality",

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -58,7 +58,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 	if isSysDB, err := t.IsMemOrSysDB(sctx.(sessionctx.Context)); err != nil {
 		return err
 	} else if isSysDB {
-		// NOTE FOR EXCHANGE PARTITION EVENT: When exchanging a partition with a (system)table,
+		// NOTE FOR EXCHANGE PARTITION EVENT: When exchanging a partition with a system table,
 		// we need to adjust the global statistics based on the count delta and modify count delta.
 		// However, due to the system table involved, a complete update of the global statistics isn't feasible.
 		// As a result, we bypass the statistics update for the table in this scenario.

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -62,6 +62,8 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 		// we need to adjust the global statistics based on the count delta and modify count delta.
 		// However, due to the system table involved, a complete update of the global statistics isn't feasible.
 		// As a result, we bypass the statistics update for the table in this scenario.
+		// If the system table is a partitioned table, we will update the global statistics for the partitioned table.
+		// Because it is so rare to exchange a partition from a system table, we can ignore this case.
 		logutil.StatsLogger().Info("Skip handle system database ddl event", zap.Stringer("event", t))
 		return nil
 	}

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -56,9 +56,12 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 	}
 	defer h.statsHandler.SPool().Put(sctx)
 	if isSysDB, err := t.IsMemOrSysDB(sctx.(sessionctx.Context)); err != nil {
-
 		return err
 	} else if isSysDB {
+		// NOTE FOR EXCHANGE PARTITION EVENT: When exchanging a partition with a (system)table,
+		// we need to adjust the global statistics based on the count delta and modify count delta.
+		// However, due to the system table involved, a complete update of the global statistics isn't feasible.
+		// As a result, we bypass the statistics update for the table in this scenario.
 		logutil.StatsLogger().Info("Skip handle system database ddl event", zap.Stringer("event", t))
 		return nil
 	}

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -106,6 +106,27 @@ func TestCreateASystemTable(t *testing.T) {
 	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")
 }
 
+func TestTruncateASystemTable(t *testing.T) {
+	store, do := testkit.CreateMockStoreAndDomain(t)
+	testKit := testkit.NewTestKit(t, store)
+	testKit.MustExec("use test")
+	// Test truncate a system table.
+	testKit.MustExec("create table mysql.test (c1 int, c2 int)")
+	testKit.MustExec("truncate table mysql.test")
+	is := do.InfoSchema()
+	tbl, err := is.TableByName(model.NewCIStr("mysql"), model.NewCIStr("test"))
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	h := do.StatsHandle()
+	// Find the truncate table partition event.
+	truncateTableEvent := findEvent(h.DDLEventCh(), model.ActionTruncateTable)
+	err = h.HandleDDLEvent(truncateTableEvent)
+	require.NoError(t, err)
+	require.Nil(t, h.Update(is))
+	statsTbl := h.GetTableStats(tableInfo)
+	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")
+}
+
 func TestTruncateTable(t *testing.T) {
 	store, do := testkit.CreateMockStoreAndDomain(t)
 	testKit := testkit.NewTestKit(t, store)

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -158,6 +158,7 @@ func TestAddColumnToASystemTable(t *testing.T) {
 	// Find the add column event.
 	addColumnEvent := findEvent(h.DDLEventCh(), model.ActionAddColumn)
 	err = h.HandleDDLEvent(addColumnEvent)
+	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsTbl := h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")
@@ -180,6 +181,7 @@ func TestModifyColumnOfASystemTable(t *testing.T) {
 	// Find the modify column event.
 	modifyColumnEvent := findEvent(h.DDLEventCh(), model.ActionModifyColumn)
 	err = h.HandleDDLEvent(modifyColumnEvent)
+	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsTbl := h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")
@@ -201,6 +203,7 @@ func TestAddNewPartitionToASystemTable(t *testing.T) {
 	// Find the add partition event.
 	addPartitionEvent := findEvent(h.DDLEventCh(), model.ActionAddTablePartition)
 	err = h.HandleDDLEvent(addPartitionEvent)
+	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsTbl := h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")
@@ -222,6 +225,7 @@ func TestDropPartitionOfASystemTable(t *testing.T) {
 	// Find the drop partition event.
 	dropPartitionEvent := findEvent(h.DDLEventCh(), model.ActionDropTablePartition)
 	err = h.HandleDDLEvent(dropPartitionEvent)
+	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsTbl := h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")
@@ -244,6 +248,7 @@ func TestExchangePartitionWithASystemTable(t *testing.T) {
 	// Find the exchange partition event.
 	exchangePartitionEvent := findEvent(h.DDLEventCh(), model.ActionExchangeTablePartition)
 	err = h.HandleDDLEvent(exchangePartitionEvent)
+	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsTbl := h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")
@@ -265,6 +270,7 @@ func TestRemovePartitioningOfASystemTable(t *testing.T) {
 	// Find the remove partitioning event.
 	removePartitioningEvent := findEvent(h.DDLEventCh(), model.ActionRemovePartitioning)
 	err = h.HandleDDLEvent(removePartitioningEvent)
+	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsTbl := h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")
@@ -286,6 +292,7 @@ func TestTruncateAPartitionOfASystemTable(t *testing.T) {
 	// Find the truncate partition event.
 	truncatePartitionEvent := findEvent(h.DDLEventCh(), model.ActionTruncateTablePartition)
 	err = h.HandleDDLEvent(truncatePartitionEvent)
+	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsTbl := h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -103,8 +103,7 @@ func TestCreateASystemTable(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, h.Update(is))
 	statsTbl := h.GetTableStats(tableInfo)
-	// FIXME: We should not collect stats for system tables.
-	require.False(t, statsTbl.Pseudo)
+	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")
 }
 
 func TestTruncateTable(t *testing.T) {

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -270,6 +270,27 @@ func TestRemovePartitioningOfASystemTable(t *testing.T) {
 	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")
 }
 
+func TestTruncateAPartitionOfASystemTable(t *testing.T) {
+	store, do := testkit.CreateMockStoreAndDomain(t)
+	testKit := testkit.NewTestKit(t, store)
+	h := do.StatsHandle()
+	testKit.MustExec("use test")
+	// Test truncate a partition of a system table.
+	testKit.MustExec("create table mysql.test (c1 int, c2 int) partition by range (c1) (partition p0 values less than (6), partition p1 values less than (11))")
+	// Truncate partition p1.
+	testKit.MustExec("alter table mysql.test truncate partition p1")
+	is := do.InfoSchema()
+	tbl, err := is.TableByName(model.NewCIStr("mysql"), model.NewCIStr("test"))
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	// Find the truncate partition event.
+	truncatePartitionEvent := findEvent(h.DDLEventCh(), model.ActionTruncateTablePartition)
+	err = h.HandleDDLEvent(truncatePartitionEvent)
+	require.Nil(t, h.Update(is))
+	statsTbl := h.GetTableStats(tableInfo)
+	require.True(t, statsTbl.Pseudo, "we should not collect stats for system tables")
+}
+
 func TestTruncateTable(t *testing.T) {
 	store, do := testkit.CreateMockStoreAndDomain(t)
 	testKit := testkit.NewTestKit(t, store)

--- a/pkg/statistics/handle/util/BUILD.bazel
+++ b/pkg/statistics/handle/util/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/statistics/handle/logutil",
         "//pkg/table",
+        "//pkg/util",
         "//pkg/util/chunk",
         "//pkg/util/intest",
         "//pkg/util/sqlexec",

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -75,11 +75,13 @@ func (e *DDLEvent) GetCreateTableInfo() (newTableInfo *model.TableInfo) {
 
 // NewTruncateTableEvent creates a new ddl event that truncates a table.
 func NewTruncateTableEvent(
+	schemaID int64,
 	newTableInfo *model.TableInfo,
 	droppedTableInfo *model.TableInfo,
 ) *DDLEvent {
 	return &DDLEvent{
 		tp:           model.ActionTruncateTable,
+		schemaID:     schemaID,
 		tableInfo:    newTableInfo,
 		oldTableInfo: droppedTableInfo,
 	}

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -29,9 +29,6 @@ import (
 
 // DDLEvent contains the information of a ddl event that is used to update stats.
 type DDLEvent struct {
-	// schemaID is the ID of the schema that the table belongs to.
-	// Used to filter out the system or memory tables.
-	schemaID int64
 	// For different ddl types, the following fields are used.
 	// They have different meanings for different ddl types.
 	// Please do **not** use these fields directly, use the corresponding
@@ -41,6 +38,9 @@ type DDLEvent struct {
 	oldTableInfo *model.TableInfo
 	oldPartInfo  *model.PartitionInfo
 	columnInfos  []*model.ColumnInfo
+	// schemaID is the ID of the schema that the table belongs to.
+	// Used to filter out the system or memory tables.
+	schemaID int64
 	// This value is used to store the table ID during a transition.
 	// It applies when a table structure is being changed from partitioned to non-partitioned, or vice versa.
 	oldTableID int64

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -174,11 +174,13 @@ func (e *DDLEvent) GetAddPartitionInfo() (globalTableInfo *model.TableInfo, adde
 
 // NewDropPartitionEvent creates a new ddl event that drops partitions.
 func NewDropPartitionEvent(
+	schemaID int64,
 	globalTableInfo *model.TableInfo,
 	droppedPartInfo *model.PartitionInfo,
 ) *DDLEvent {
 	return &DDLEvent{
 		tp:          model.ActionDropTablePartition,
+		schemaID:    schemaID,
 		tableInfo:   globalTableInfo,
 		oldPartInfo: droppedPartInfo,
 	}

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -237,12 +237,14 @@ func (e *DDLEvent) GetExchangePartitionInfo() (
 // NewReorganizePartitionEvent creates a new ddl event that reorganizes partitions.
 // We also use it for increasing or decreasing the number of hash partitions.
 func NewReorganizePartitionEvent(
+	schemaID int64,
 	globalTableInfo *model.TableInfo,
 	addedPartInfo *model.PartitionInfo,
 	droppedPartInfo *model.PartitionInfo,
 ) *DDLEvent {
 	return &DDLEvent{
 		tp:          model.ActionReorganizePartition,
+		schemaID:    schemaID,
 		tableInfo:   globalTableInfo,
 		partInfo:    addedPartInfo,
 		oldPartInfo: droppedPartInfo,
@@ -284,12 +286,14 @@ func (e *DDLEvent) GetTruncatePartitionInfo() (
 // NewAddPartitioningEvent creates a new ddl event that converts a single table to a partitioned table.
 // For example, `alter table t partition by range (c1) (partition p1 values less than (10))`.
 func NewAddPartitioningEvent(
+	schemaID int64,
 	oldSingleTableID int64,
 	newGlobalTableInfo *model.TableInfo,
 	addedPartInfo *model.PartitionInfo,
 ) *DDLEvent {
 	return &DDLEvent{
 		tp:         model.ActionAlterTablePartitioning,
+		schemaID:   schemaID,
 		oldTableID: oldSingleTableID,
 		tableInfo:  newGlobalTableInfo,
 		partInfo:   addedPartInfo,
@@ -308,12 +312,14 @@ func (e *DDLEvent) GetAddPartitioningInfo() (
 // NewRemovePartitioningEvent creates a new ddl event that converts a partitioned table to a single table.
 // For example, `alter table t remove partitioning`.
 func NewRemovePartitioningEvent(
+	schemaID int64,
 	oldPartitionedTableID int64,
 	newSingleTableInfo *model.TableInfo,
 	droppedPartInfo *model.PartitionInfo,
 ) *DDLEvent {
 	return &DDLEvent{
 		tp:          model.ActionRemovePartitioning,
+		schemaID:    schemaID,
 		oldTableID:  oldPartitionedTableID,
 		tableInfo:   newSingleTableInfo,
 		oldPartInfo: droppedPartInfo,

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -262,12 +262,14 @@ func (e *DDLEvent) GetReorganizePartitionInfo() (
 
 // NewTruncatePartitionEvent creates a new ddl event that truncates partitions.
 func NewTruncatePartitionEvent(
+	schemaID int64,
 	globalTableInfo *model.TableInfo,
 	addedPartInfo *model.PartitionInfo,
 	droppedPartInfo *model.PartitionInfo,
 ) *DDLEvent {
 	return &DDLEvent{
 		tp:          model.ActionTruncateTablePartition,
+		schemaID:    schemaID,
 		tableInfo:   globalTableInfo,
 		partInfo:    addedPartInfo,
 		oldPartInfo: droppedPartInfo,

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -55,7 +54,7 @@ func (e *DDLEvent) IsMemOrSysDB(sctx sessionctx.Context) (bool, error) {
 	if !ok {
 		return false, fmt.Errorf("schema not found for table %s", e.tableInfo.Name)
 	}
-	return util.IsMemOrSysDB(strings.ToLower(schema.Name.O)), nil
+	return util.IsMemOrSysDB(schema.Name.L), nil
 }
 
 // NewCreateTableEvent creates a new ddl event that creates a table.

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -49,9 +49,7 @@ type DDLEvent struct {
 
 // IsMemOrSysDB checks whether the table is in the memory or system database.
 func (e *DDLEvent) IsMemOrSysDB(sctx sessionctx.Context) (bool, error) {
-	if intest.InTest {
-		intest.Assert(e.schemaID != 0, "schemaID should not be 0, please set it when creating the event")
-	}
+	intest.Assert(e.schemaID != 0, "schemaID should not be 0, please set it when creating the event")
 	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
 	schema, ok := is.SchemaByID(e.schemaID)
 	if !ok {

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -194,6 +194,7 @@ func (e *DDLEvent) GetDropPartitionInfo() (globalTableInfo *model.TableInfo, dro
 // NewExchangePartitionEvent creates a new ddl event that exchanges a partition.
 // Please make sure pass the information before the exchange.
 func NewExchangePartitionEvent(
+	schemaID int64,
 	globalTableInfo *model.TableInfo,
 	originalPartInfo *model.PartitionInfo,
 	originalTableInfo *model.TableInfo,
@@ -216,6 +217,7 @@ func NewExchangePartitionEvent(
 	}
 	return &DDLEvent{
 		tp:           model.ActionExchangeTablePartition,
+		schemaID:     schemaID,
 		tableInfo:    globalTableInfo,
 		partInfo:     originalPartInfo,
 		oldTableInfo: originalTableInfo,

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -155,11 +155,13 @@ func (e *DDLEvent) GetModifyColumnInfo() (newTableInfo *model.TableInfo, modifie
 
 // NewAddPartitionEvent creates a new ddl event that adds partitions.
 func NewAddPartitionEvent(
+	schemaID int64,
 	globalTableInfo *model.TableInfo,
 	addedPartInfo *model.PartitionInfo,
 ) *DDLEvent {
 	return &DDLEvent{
 		tp:        model.ActionAddTablePartition,
+		schemaID:  schemaID,
 		tableInfo: globalTableInfo,
 		partInfo:  addedPartInfo,
 	}

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -116,11 +116,13 @@ func (e *DDLEvent) GetDropTableInfo() (newTableInfo *model.TableInfo) {
 // NewAddColumnEvent creates a new ddl event that
 // adds a column.
 func NewAddColumnEvent(
+	schemaID int64,
 	newTableInfo *model.TableInfo,
 	newColumnInfo []*model.ColumnInfo,
 ) *DDLEvent {
 	return &DDLEvent{
 		tp:          model.ActionAddColumn,
+		schemaID:    schemaID,
 		tableInfo:   newTableInfo,
 		columnInfos: newColumnInfo,
 	}

--- a/pkg/statistics/handle/util/ddl_event.go
+++ b/pkg/statistics/handle/util/ddl_event.go
@@ -136,11 +136,13 @@ func (e *DDLEvent) GetAddColumnInfo() (newTableInfo *model.TableInfo, newColumnI
 // NewModifyColumnEvent creates a new ddl event that
 // modifies a column.
 func NewModifyColumnEvent(
+	schemaID int64,
 	newTableInfo *model.TableInfo,
 	modifiedColumnInfo []*model.ColumnInfo,
 ) *DDLEvent {
 	return &DDLEvent{
 		tp:          model.ActionModifyColumn,
+		schemaID:    schemaID,
 		tableInfo:   newTableInfo,
 		columnInfos: modifiedColumnInfo,
 	}

--- a/pkg/statistics/handle/util/ddl_event_test.go
+++ b/pkg/statistics/handle/util/ddl_event_test.go
@@ -24,7 +24,8 @@ import (
 func TestEventString(t *testing.T) {
 	// Create an Event object
 	e := &DDLEvent{
-		tp: model.ActionAddColumn,
+		tp:       model.ActionAddColumn,
+		schemaID: 1,
 		tableInfo: &model.TableInfo{
 			ID:   1,
 			Name: model.NewCIStr("Table1"),
@@ -55,7 +56,7 @@ func TestEventString(t *testing.T) {
 	result := e.String()
 
 	// Check the result
-	expected := "(Event Type: add column, Table ID: 1, Table Name: Table1, " +
+	expected := "(Event Type: add column, Schema ID: 1, Table ID: 1, Table Name: Table1, " +
 		"Partition IDs: [2 3], Old Table ID: 4, Old Table Name: Table2, " +
 		"Old Partition IDs: [5 6], Column ID: 7, Column Name: Column1, " +
 		"Column ID: 8, Column Name: Column2"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/52040

Problem Summary:

During the upgrade process, if there are two different TiDB versions running in the same cluster, statistics will be created for system tables. For example, if we upgrade from v7.5.0 to v8.0.0, and the newer version has a table called `mysql.request_unit_by_group` that was not present in the previous version, we will accidentally create statistics for this newly added table. However, we should avoid creating any statistics for system tables.

### What changed and how does it work?

Ignore all system table DDL events from the DDL handler.

I put in a lot of effort to test this patch during the upgrade process, but it was quite challenging to do so. This issue only arises when two different versions of TiDB are present in the cluster, with the older version serving as the DDL worker. Therefore, it's difficult to trigger this bug. Furthermore, this PR cannot be easily cherry-picked to the older version, as we made significant changes to the DDL handling. Therefore, we can only use unit tests to cover it.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
修复了 TiDB 在升级过程中会为系统表创建统计信息的问题
Fixed an issue where TiDB would create statistics for system tables during upgrades
```
