### PR TITLE
disttask,ddl: use subtask concurrency

### DIFF
--- a/pkg/ddl/backfilling_import_cloud.go
+++ b/pkg/ddl/backfilling_import_cloud.go
@@ -99,6 +99,7 @@ func (m *cloudImportExecutor) RunSubtask(ctx context.Context, subtask *proto.Sub
 	if err != nil {
 		return err
 	}
+	local.WorkerConcurrency = subtask.Concurrency * 2
 	err = local.ImportEngine(ctx, engineUUID, int64(config.SplitRegionSize), int64(config.SplitRegionKeys))
 	if common.ErrFoundDuplicateKeys.Equal(err) {
 		err = convertToKeyExistsErr(err, m.index, m.ptbl.Meta())

--- a/pkg/ddl/backfilling_merge_sort.go
+++ b/pkg/ddl/backfilling_merge_sort.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor"
 	"github.com/pingcap/tidb/pkg/lightning/backend/external"
-	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 )
@@ -89,7 +88,7 @@ func (m *mergeSortExecutor) RunSubtask(ctx context.Context, subtask *proto.Subta
 	}
 
 	prefix := path.Join(strconv.Itoa(int(m.jobID)), strconv.Itoa(int(subtask.ID)))
-	partSize, err := getMergeSortPartSize(m.avgRowSize, int(variable.GetDDLReorgWorkerCounter()), m.idxNum)
+	partSize, err := getMergeSortPartSize(m.avgRowSize, subtask.Concurrency, m.idxNum)
 	if err != nil {
 		return err
 	}
@@ -102,7 +101,9 @@ func (m *mergeSortExecutor) RunSubtask(ctx context.Context, subtask *proto.Subta
 		prefix,
 		external.DefaultBlockSize,
 		onClose,
-		int(variable.GetDDLReorgWorkerCounter()), true)
+		subtask.Concurrency,
+		true,
+	)
 }
 
 func (*mergeSortExecutor) Cleanup(ctx context.Context) error {

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -112,11 +112,11 @@ func (ctx *OperatorCtx) OperatorErr() error {
 	return *err
 }
 
-func getWriterMemSize(avgRowSize int, idxNum int) (uint64, error) {
+func getWriterMemSize(avgRowSize, concurrency, idxNum int) (uint64, error) {
 	failpoint.Inject("mockWriterMemSize", func() {
 		failpoint.Return(1*size.GB, nil)
 	})
-	_, writerCnt := expectedIngestWorkerCnt(avgRowSize)
+	_, writerCnt := expectedIngestWorkerCnt(concurrency, avgRowSize)
 	memTotal, err := memory.MemTotal()
 	if err != nil {
 		return 0, err
@@ -132,7 +132,7 @@ func getWriterMemSize(avgRowSize int, idxNum int) (uint64, error) {
 }
 
 func getMergeSortPartSize(avgRowSize int, concurrency int, idxNum int) (uint64, error) {
-	writerMemSize, err := getWriterMemSize(avgRowSize, idxNum)
+	writerMemSize, err := getWriterMemSize(avgRowSize, concurrency, idxNum)
 	if err != nil {
 		return 0, nil
 	}
@@ -156,6 +156,7 @@ func NewAddIndexIngestPipeline(
 	metricCounter prometheus.Counter,
 	reorgMeta *model.DDLReorgMeta,
 	avgRowSize int,
+	concurrency int,
 ) (*operator.AsyncPipeline, error) {
 	indexes := make([]table.Index, 0, len(idxInfos))
 	for _, idxInfo := range idxInfos {
@@ -172,7 +173,7 @@ func NewAddIndexIngestPipeline(
 	for i := 0; i < poolSize; i++ {
 		srcChkPool <- chunk.NewChunkWithCapacity(copCtx.GetBase().FieldTypes, copReadBatchSize())
 	}
-	readerCnt, writerCnt := expectedIngestWorkerCnt(avgRowSize)
+	readerCnt, writerCnt := expectedIngestWorkerCnt(concurrency, avgRowSize)
 
 	srcOp := NewTableScanTaskSource(ctx, store, tbl, startKey, endKey)
 	scanOp := NewTableScanOperator(ctx, sessPool, copCtx, srcChkPool, readerCnt)
@@ -209,6 +210,7 @@ func NewWriteIndexToExternalStoragePipeline(
 	onClose external.OnCloseFunc,
 	reorgMeta *model.DDLReorgMeta,
 	avgRowSize int,
+	concurrency int,
 ) (*operator.AsyncPipeline, error) {
 	indexes := make([]table.Index, 0, len(idxInfos))
 	for _, idxInfo := range idxInfos {
@@ -225,7 +227,7 @@ func NewWriteIndexToExternalStoragePipeline(
 	for i := 0; i < poolSize; i++ {
 		srcChkPool <- chunk.NewChunkWithCapacity(copCtx.GetBase().FieldTypes, copReadBatchSize())
 	}
-	readerCnt, writerCnt := expectedIngestWorkerCnt(avgRowSize)
+	readerCnt, writerCnt := expectedIngestWorkerCnt(concurrency, avgRowSize)
 
 	backend, err := storage.ParseBackend(extStoreURI, nil)
 	if err != nil {
@@ -236,7 +238,7 @@ func NewWriteIndexToExternalStoragePipeline(
 		return nil, err
 	}
 
-	memSize, err := getWriterMemSize(avgRowSize, len(indexes))
+	memSize, err := getWriterMemSize(avgRowSize, concurrency, len(indexes))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -106,11 +106,6 @@ func (r *readIndexExecutor) RunSubtask(ctx context.Context, subtask *proto.Subta
 		return err
 	}
 
-	startKey, endKey, tbl, err := r.getTableStartEndKey(sm)
-	if err != nil {
-		return err
-	}
-
 	sessCtx, err := newSessCtx(
 		r.d.store, r.job.ReorgMeta.SQLMode, r.job.ReorgMeta.Location, r.job.ReorgMeta.ResourceGroupName)
 	if err != nil {
@@ -123,9 +118,9 @@ func (r *readIndexExecutor) RunSubtask(ctx context.Context, subtask *proto.Subta
 
 	var pipe *operator.AsyncPipeline
 	if len(r.cloudStorageURI) > 0 {
-		pipe, err = r.buildExternalStorePipeline(opCtx, subtask.ID, sessCtx, tbl, startKey, endKey, r.curRowCount)
+		pipe, err = r.buildExternalStorePipeline(opCtx, subtask.ID, sessCtx, sm, subtask.Concurrency)
 	} else {
-		pipe, err = r.buildLocalStorePipeline(opCtx, sessCtx, tbl, startKey, endKey, r.curRowCount)
+		pipe, err = r.buildLocalStorePipeline(opCtx, sessCtx, sm, subtask.Concurrency)
 	}
 	if err != nil {
 		return err
@@ -226,10 +221,13 @@ func (r *readIndexExecutor) getTableStartEndKey(sm *BackfillSubTaskMeta) (
 func (r *readIndexExecutor) buildLocalStorePipeline(
 	opCtx *OperatorCtx,
 	sessCtx sessionctx.Context,
-	tbl table.PhysicalTable,
-	start, end kv.Key,
-	totalRowCount *atomic.Int64,
+	sm *BackfillSubTaskMeta,
+	concurrency int,
 ) (*operator.AsyncPipeline, error) {
+	start, end, tbl, err := r.getTableStartEndKey(sm)
+	if err != nil {
+		return nil, err
+	}
 	d := r.d
 	engines := make([]ingest.Engine, 0, len(r.indexes))
 	for _, index := range r.indexes {
@@ -244,18 +242,37 @@ func (r *readIndexExecutor) buildLocalStorePipeline(
 	counter := metrics.BackfillTotalCounter.WithLabelValues(
 		metrics.GenerateReorgLabel("add_idx_rate", r.job.SchemaName, tbl.Meta().Name.O))
 	return NewAddIndexIngestPipeline(
-		opCtx, d.store, d.sessPool, r.bc, engines, sessCtx, r.job.ID,
-		tbl, r.indexes, start, end, totalRowCount, counter, r.job.ReorgMeta, r.avgRowSize)
+		opCtx,
+		d.store,
+		d.sessPool,
+		r.bc,
+		engines,
+		sessCtx,
+		r.job.ID,
+		tbl,
+		r.indexes,
+		start,
+		end,
+		r.curRowCount,
+		counter,
+		r.job.ReorgMeta,
+		r.avgRowSize,
+		concurrency,
+	)
 }
 
 func (r *readIndexExecutor) buildExternalStorePipeline(
 	opCtx *OperatorCtx,
 	subtaskID int64,
 	sessCtx sessionctx.Context,
-	tbl table.PhysicalTable,
-	start, end kv.Key,
-	totalRowCount *atomic.Int64,
+	sm *BackfillSubTaskMeta,
+	concurrency int,
 ) (*operator.AsyncPipeline, error) {
+	start, end, tbl, err := r.getTableStartEndKey(sm)
+	if err != nil {
+		return nil, err
+	}
+
 	d := r.d
 	onClose := func(summary *external.WriterSummary) {
 		sum, _ := r.subtaskSummary.Load(subtaskID)
@@ -283,10 +300,11 @@ func (r *readIndexExecutor) buildExternalStorePipeline(
 		r.indexes,
 		start,
 		end,
-		totalRowCount,
+		r.curRowCount,
 		counter,
 		onClose,
 		r.job.ReorgMeta,
 		r.avgRowSize,
+		concurrency,
 	)
 }

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1710,9 +1710,8 @@ type addIndexIngestWorker struct {
 	copReqSenderPool *copReqSenderPool
 	checkpointMgr    *ingest.CheckpointManager
 
-	resultCh   chan *backfillResult
-	jobID      int64
-	distribute bool
+	resultCh chan *backfillResult
+	jobID    int64
 }
 
 func newAddIndexIngestWorker(
@@ -1728,7 +1727,6 @@ func newAddIndexIngestWorker(
 	copReqSenderPool *copReqSenderPool,
 	sessCtx sessionctx.Context,
 	checkpointMgr *ingest.CheckpointManager,
-	distribute bool,
 ) (*addIndexIngestWorker, error) {
 	indexes := make([]table.Index, 0, len(indexIDs))
 	writers := make([]ingest.Writer, 0, len(indexIDs))
@@ -1756,7 +1754,6 @@ func newAddIndexIngestWorker(
 		resultCh:         resultCh,
 		jobID:            jobID,
 		checkpointMgr:    checkpointMgr,
-		distribute:       distribute,
 	}, nil
 }
 

--- a/pkg/disttask/framework/storage/task_table.go
+++ b/pkg/disttask/framework/storage/task_table.go
@@ -202,7 +202,14 @@ func (mgr *TaskManager) CreateTask(ctx context.Context, key string, tp proto.Tas
 }
 
 // CreateTaskWithSession adds a new task to task table with session.
-func (mgr *TaskManager) CreateTaskWithSession(ctx context.Context, se sessionctx.Context, key string, tp proto.TaskType, concurrency int, meta []byte) (taskID int64, err error) {
+func (mgr *TaskManager) CreateTaskWithSession(
+	ctx context.Context,
+	se sessionctx.Context,
+	key string,
+	tp proto.TaskType,
+	concurrency int,
+	meta []byte,
+) (taskID int64, err error) {
 	cpuCount, err := mgr.getCPUCountOfManagedNode(ctx, se)
 	if err != nil {
 		return 0, err

--- a/pkg/disttask/importinto/encode_and_sort_operator.go
+++ b/pkg/disttask/importinto/encode_and_sort_operator.go
@@ -67,8 +67,13 @@ var _ operator.Operator = (*encodeAndSortOperator)(nil)
 var _ operator.WithSource[*importStepMinimalTask] = (*encodeAndSortOperator)(nil)
 var _ operator.WithSink[workerpool.None] = (*encodeAndSortOperator)(nil)
 
-func newEncodeAndSortOperator(ctx context.Context, executor *importStepExecutor,
-	sharedVars *SharedVars, subtaskID int64) *encodeAndSortOperator {
+func newEncodeAndSortOperator(
+	ctx context.Context,
+	executor *importStepExecutor,
+	sharedVars *SharedVars,
+	subtaskID int64,
+	concurrency int,
+) *encodeAndSortOperator {
 	subCtx, cancel := context.WithCancel(ctx)
 	op := &encodeAndSortOperator{
 		ctx:           subCtx,
@@ -83,7 +88,7 @@ func newEncodeAndSortOperator(ctx context.Context, executor *importStepExecutor,
 	pool := workerpool.NewWorkerPool(
 		"encodeAndSortOperator",
 		util.ImportInto,
-		executor.taskMeta.Plan.ThreadCnt,
+		concurrency,
 		func() workerpool.Worker[*importStepMinimalTask, workerpool.None] {
 			return newChunkWorker(ctx, op, executor.dataKVMemSizePerCon, executor.perIndexKVMemSizePerCon)
 		},

--- a/pkg/disttask/importinto/encode_and_sort_operator_test.go
+++ b/pkg/disttask/importinto/encode_and_sort_operator_test.go
@@ -101,7 +101,7 @@ func TestEncodeAndSortOperator(t *testing.T) {
 	// cancel on error and log other errors
 	mockErr2 := errors.New("mock err 2")
 	source = operator.NewSimpleDataChannel(make(chan *importStepMinimalTask))
-	op = newEncodeAndSortOperator(context.Background(), executorForParam, nil, 2, 1)
+	op = newEncodeAndSortOperator(context.Background(), executorForParam, nil, 2, 2)
 	op.SetSource(source)
 	executor1 := mock.NewMockMiniTaskExecutor(ctrl)
 	executor2 := mock.NewMockMiniTaskExecutor(ctrl)

--- a/pkg/disttask/importinto/encode_and_sort_operator_test.go
+++ b/pkg/disttask/importinto/encode_and_sort_operator_test.go
@@ -81,7 +81,7 @@ func TestEncodeAndSortOperator(t *testing.T) {
 	}
 
 	source := operator.NewSimpleDataChannel(make(chan *importStepMinimalTask))
-	op := newEncodeAndSortOperator(context.Background(), executorForParam, nil, 3)
+	op := newEncodeAndSortOperator(context.Background(), executorForParam, nil, 3, 1)
 	op.SetSource(source)
 	require.NoError(t, op.Open())
 	require.Greater(t, len(op.String()), 0)
@@ -101,7 +101,7 @@ func TestEncodeAndSortOperator(t *testing.T) {
 	// cancel on error and log other errors
 	mockErr2 := errors.New("mock err 2")
 	source = operator.NewSimpleDataChannel(make(chan *importStepMinimalTask))
-	op = newEncodeAndSortOperator(context.Background(), executorForParam, nil, 2)
+	op = newEncodeAndSortOperator(context.Background(), executorForParam, nil, 2, 1)
 	op.SetSource(source)
 	executor1 := mock.NewMockMiniTaskExecutor(ctrl)
 	executor2 := mock.NewMockMiniTaskExecutor(ctrl)

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -1303,17 +1303,10 @@ func (e *LoadDataController) CreateColAssignExprs(sctx sessionctx.Context) ([]ex
 }
 
 func (e *LoadDataController) getBackendWorkerConcurrency() int {
-	// when using global sort, write&ingest step buffers KV data in memory,
 	// suppose cpu:mem ratio 1:2(true in most case), and we assign 1G per concurrency,
 	// so we can use 2 * threadCnt as concurrency. write&ingest step is mostly
 	// IO intensive, so CPU usage is below ThreadCnt in our tests.
-	// The real concurrency used is adjusted in external engine later.
-	// when using local sort, use the default value as lightning.
-	// TODO(lance6716): can we remove this assignment branch?
-	if e.IsGlobalSort() {
-		return e.ThreadCnt * 2
-	}
-	return config.DefaultRangeConcurrency * 2
+	return e.ThreadCnt * 2
 }
 
 func (e *LoadDataController) getLocalBackendCfg(pdAddr, dataDir string) local.BackendConfig {

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -1309,6 +1309,7 @@ func (e *LoadDataController) getBackendWorkerConcurrency() int {
 	// IO intensive, so CPU usage is below ThreadCnt in our tests.
 	// The real concurrency used is adjusted in external engine later.
 	// when using local sort, use the default value as lightning.
+	// TODO(lance6716): can we remove this assignment branch?
 	if e.IsGlobalSort() {
 		return e.ThreadCnt * 2
 	}

--- a/pkg/executor/importer/import_test.go
+++ b/pkg/executor/importer/import_test.go
@@ -319,7 +319,7 @@ func TestGetBackendWorkerConcurrency(t *testing.T) {
 			ThreadCnt: 3,
 		},
 	}
-	require.Equal(t, 32, c.getBackendWorkerConcurrency())
+	require.Equal(t, 6, c.getBackendWorkerConcurrency())
 	c.Plan.CloudStorageURI = "xxx"
 	require.Equal(t, 6, c.getBackendWorkerConcurrency())
 	c.Plan.ThreadCnt = 123

--- a/tests/realtikvtest/addindextest3/operator_test.go
+++ b/tests/realtikvtest/addindextest3/operator_test.go
@@ -197,6 +197,7 @@ func TestBackfillOperatorPipeline(t *testing.T) {
 		nil,
 		ddl.NewDDLReorgMeta(tk.Session()),
 		0,
+		2,
 	)
 	require.NoError(t, err)
 	err = pipeline.Execute()
@@ -273,6 +274,7 @@ func TestBackfillOperatorPipelineException(t *testing.T) {
 			nil,
 			ddl.NewDDLReorgMeta(tk.Session()),
 			0,
+			2,
 		)
 		require.NoError(t, err)
 		err = pipeline.Execute()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #49008

Problem Summary:

### What changed and how does it work?

DDL and IMPORT INTO use SubtaskBase.Concurrency. The downside is we cann't dynamically adjust the concurrency using tidb_ddl_reorg_worker_cnt for now.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > should be covered by existing test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
