### PR TITLE
statistics: fix wrong singleflight implementation for stats' syncload

### DIFF
--- a/pkg/parser/model/model.go
+++ b/pkg/parser/model/model.go
@@ -1797,6 +1797,11 @@ type StatsLoadItem struct {
 	FullLoad bool
 }
 
+// Key is used to generate unique key for TableItemID to use in the syncload
+func (s StatsLoadItem) Key() string {
+	return fmt.Sprintf("%s#%t", s.TableItemID.Key(), s.FullLoad)
+}
+
 // PolicyRefInfo is the struct to refer the placement policy.
 type PolicyRefInfo struct {
 	ID   int64 `json:"id"`

--- a/pkg/parser/model/model.go
+++ b/pkg/parser/model/model.go
@@ -1786,6 +1786,10 @@ type TableItemID struct {
 	IsSyncLoadFailed bool
 }
 
+func (t TableItemID) Key() string {
+	return fmt.Sprintf("%d%d%t%t", t.ID, t.TableID, t.IsIndex, t.IsSyncLoadFailed)
+}
+
 // StatsLoadItem represents the load unit for statistics's memory loading.
 type StatsLoadItem struct {
 	TableItemID

--- a/pkg/parser/model/model.go
+++ b/pkg/parser/model/model.go
@@ -1786,6 +1786,7 @@ type TableItemID struct {
 	IsSyncLoadFailed bool
 }
 
+// Key is used to generate unique key for TableItemID to use in the syncload
 func (t TableItemID) Key() string {
 	return fmt.Sprintf("%d%d%t%t", t.ID, t.TableID, t.IsIndex, t.IsSyncLoadFailed)
 }

--- a/pkg/parser/model/model.go
+++ b/pkg/parser/model/model.go
@@ -1788,7 +1788,7 @@ type TableItemID struct {
 
 // Key is used to generate unique key for TableItemID to use in the syncload
 func (t TableItemID) Key() string {
-	return fmt.Sprintf("%d%d%t%t", t.ID, t.TableID, t.IsIndex, t.IsSyncLoadFailed)
+	return fmt.Sprintf("%d#%d#%t", t.ID, t.TableID, t.IsIndex)
 }
 
 // StatsLoadItem represents the load unit for statistics's memory loading.

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -48,7 +48,7 @@ func NewStatsSyncLoad(statsHandle statstypes.StatsHandle) statstypes.StatsSyncLo
 	s.StatsLoad.SubCtxs = make([]sessionctx.Context, cfg.Performance.StatsLoadConcurrency)
 	s.StatsLoad.NeededItemsCh = make(chan *statstypes.NeededItemTask, cfg.Performance.StatsLoadQueueSize)
 	s.StatsLoad.TimeoutItemsCh = make(chan *statstypes.NeededItemTask, cfg.Performance.StatsLoadQueueSize)
-	s.StatsLoad.WorkingColMap = map[model.TableItemID][]chan stmtctx.StatsLoadResult{}
+	//s.StatsLoad.WorkingColMap = map[model.TableItemID][]chan stmtctx.StatsLoadResult{}
 	return s
 }
 
@@ -231,24 +231,39 @@ func (s *statsSyncLoad) HandleOneTask(sctx sessionctx.Context, lastTask *statsty
 	} else {
 		task = lastTask
 	}
-	return s.handleOneItemTask(sctx, task)
+	resultChan := s.StatsLoad.Singleflight.DoChan(task.Item.Key(), func() (interface{}, error) {
+		return s.handleOneItemTask(sctx, task)
+	})
+	timeout := task.ToTimeout.Sub(time.Now())
+	select {
+	case result := <-resultChan:
+		if result.Err != nil {
+			slr := *(result.Val.(*stmtctx.StatsLoadResult))
+			if slr.Error != nil {
+				return task, slr.Error
+			}
+			task.ResultCh <- slr
+			return nil, nil
+		}
+		return task, result.Err
+	case <-time.After(timeout):
+		return task, nil
+	}
 }
 
-func (s *statsSyncLoad) handleOneItemTask(sctx sessionctx.Context, task *statstypes.NeededItemTask) (*statstypes.NeededItemTask, error) {
-	result := stmtctx.StatsLoadResult{Item: task.Item.TableItemID}
+func (s *statsSyncLoad) handleOneItemTask(sctx sessionctx.Context, task *statstypes.NeededItemTask) (*stmtctx.StatsLoadResult, error) {
+	result := &stmtctx.StatsLoadResult{Item: task.Item.TableItemID}
 	item := result.Item
 	tbl, ok := s.statsHandle.Get(item.TableID)
 	if !ok {
-		s.writeToResultChan(task.ResultCh, result)
-		return nil, nil
+		return result, nil
 	}
 	var err error
 	wrapper := &statsWrapper{}
 	if item.IsIndex {
 		index, loadNeeded := tbl.IndexIsLoadNeeded(item.ID)
 		if !loadNeeded {
-			s.writeToResultChan(task.ResultCh, result)
-			return nil, nil
+			return result, nil
 		}
 		if index != nil {
 			wrapper.idxInfo = index.Info
@@ -258,8 +273,7 @@ func (s *statsSyncLoad) handleOneItemTask(sctx sessionctx.Context, task *statsty
 	} else {
 		col, loadNeeded := tbl.ColumnIsLoadNeeded(item.ID, task.Item.FullLoad)
 		if !loadNeeded {
-			s.writeToResultChan(task.ResultCh, result)
-			return nil, nil
+			return result, nil
 		}
 		if col != nil {
 			wrapper.colInfo = col.Info
@@ -267,18 +281,12 @@ func (s *statsSyncLoad) handleOneItemTask(sctx sessionctx.Context, task *statsty
 			wrapper.colInfo = tbl.ColAndIdxExistenceMap.GetCol(item.ID)
 		}
 	}
-	// to avoid duplicated handling in concurrent scenario
-	working := s.setWorking(result.Item, task.ResultCh)
-	if !working {
-		s.writeToResultChan(task.ResultCh, result)
-		return nil, nil
-	}
 	t := time.Now()
 	needUpdate := false
 	wrapper, err = s.readStatsForOneItem(sctx, item, wrapper, tbl.IsPkIsHandle, task.Item.FullLoad)
 	if err != nil {
 		result.Error = err
-		return task, err
+		return result, err
 	}
 	if item.IsIndex {
 		if wrapper.idxInfo != nil {
@@ -291,9 +299,8 @@ func (s *statsSyncLoad) handleOneItemTask(sctx sessionctx.Context, task *statsty
 	}
 	metrics.ReadStatsHistogram.Observe(float64(time.Since(t).Milliseconds()))
 	if needUpdate && s.updateCachedItem(item, wrapper.col, wrapper.idx, task.Item.FullLoad) {
-		s.writeToResultChan(task.ResultCh, result)
+		return result, nil
 	}
-	s.finishWorking(result)
 	return nil, nil
 }
 
@@ -508,33 +515,4 @@ func (s *statsSyncLoad) updateCachedItem(item model.TableItemID, colHist *statis
 	}
 	s.statsHandle.UpdateStatsCache([]*statistics.Table{tbl}, nil)
 	return true
-}
-
-func (s *statsSyncLoad) setWorking(item model.TableItemID, resultCh chan stmtctx.StatsLoadResult) bool {
-	s.StatsLoad.Lock()
-	defer s.StatsLoad.Unlock()
-	chList, ok := s.StatsLoad.WorkingColMap[item]
-	if ok {
-		if chList[0] == resultCh {
-			return true // just return for duplicate setWorking
-		}
-		s.StatsLoad.WorkingColMap[item] = append(chList, resultCh)
-		return false
-	}
-	chList = []chan stmtctx.StatsLoadResult{}
-	chList = append(chList, resultCh)
-	s.StatsLoad.WorkingColMap[item] = chList
-	return true
-}
-
-func (s *statsSyncLoad) finishWorking(result stmtctx.StatsLoadResult) {
-	s.StatsLoad.Lock()
-	defer s.StatsLoad.Unlock()
-	if chList, ok := s.StatsLoad.WorkingColMap[result.Item]; ok {
-		list := chList[1:]
-		for _, ch := range list {
-			s.writeToResultChan(ch, result)
-		}
-	}
-	delete(s.StatsLoad.WorkingColMap, result.Item)
 }

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -237,11 +237,11 @@ func (s *statsSyncLoad) HandleOneTask(sctx sessionctx.Context, lastTask *statsty
 	select {
 	case result := <-resultChan:
 		if result.Err == nil {
-			slr := *(result.Val.(*stmtctx.StatsLoadResult))
+			slr := result.Val.(*stmtctx.StatsLoadResult)
 			if slr.Error != nil {
 				return task, slr.Error
 			}
-			task.ResultCh <- slr
+			task.ResultCh <- *slr
 			return nil, nil
 		}
 		return task, result.Err

--- a/pkg/statistics/handle/syncload/stats_syncload_test.go
+++ b/pkg/statistics/handle/syncload/stats_syncload_test.go
@@ -207,17 +207,14 @@ func TestConcurrentLoadHistWithPanicAndFail(t *testing.T) {
 		require.Error(t, err1)
 		require.NotNil(t, task1)
 
-		task2, err2 := h.HandleOneTask(testKit.Session().(sessionctx.Context), nil, exitCh)
-		require.Nil(t, err2)
-		require.Nil(t, task2)
-
 		require.NoError(t, failpoint.Disable(fp.failPath))
 		task3, err3 := h.HandleOneTask(testKit.Session().(sessionctx.Context), task1, exitCh)
 		require.NoError(t, err3)
 		require.Nil(t, task3)
 
-		require.Len(t, stmtCtx1.StatsLoad.ResultCh, 1)
-		require.Len(t, stmtCtx2.StatsLoad.ResultCh, 1)
+		task, err3 := h.HandleOneTask(testKit.Session().(sessionctx.Context), nil, exitCh)
+		require.NoError(t, err3)
+		require.Nil(t, task)
 
 		rs1, ok1 := <-stmtCtx1.StatsLoad.ResultCh
 		require.True(t, ok1)

--- a/pkg/statistics/handle/types/BUILD.bazel
+++ b/pkg/statistics/handle/types/BUILD.bazel
@@ -17,5 +17,6 @@ go_library(
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/sqlexec",
+        "@org_golang_x_sync//singleflight",
     ],
 )

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
+	"golang.org/x/sync/singleflight"
 )
 
 // StatsGC is used to GC unnecessary stats.
@@ -375,8 +376,9 @@ type NeededItemTask struct {
 type StatsLoad struct {
 	NeededItemsCh  chan *NeededItemTask
 	TimeoutItemsCh chan *NeededItemTask
-	WorkingColMap  map[model.TableItemID][]chan stmtctx.StatsLoadResult
-	SubCtxs        []sessionctx.Context
+
+	Singleflight singleflight.Group
+	SubCtxs      []sessionctx.Context
 	sync.Mutex
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52294

Problem Summary:

### What changed and how does it work?

the problem has been described in the issue. we refactor the singleflight using the golang official library.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
