### PR TITLE
ddl: fix mergewarnings panic

### DIFF
--- a/pkg/ddl/ddl_worker.go
+++ b/pkg/ddl/ddl_worker.go
@@ -1092,9 +1092,8 @@ func chooseLeaseTime(t, max time.Duration) time.Duration {
 	return t
 }
 
-// countForPanic records the error count for DDL job.
-func (w *worker) countForPanic(job *model.Job) {
-	// If run DDL job panic, just cancel the DDL jobs.
+// handlePanic records the error count for DDL job and cancel the DDL job.
+func (w *worker) handlePanic(job *model.Job) {
 	if job.State == model.JobStateRollingback {
 		job.State = model.JobStateCancelled
 	} else {
@@ -1103,7 +1102,6 @@ func (w *worker) countForPanic(job *model.Job) {
 	job.ErrorCount++
 
 	logger := w.jobLogger(job)
-	// Load global DDL variables.
 	if err1 := loadDDLVars(w); err1 != nil {
 		logger.Error("load DDL global variable failed", zap.Error(err1))
 	}
@@ -1117,8 +1115,9 @@ func (w *worker) countForPanic(job *model.Job) {
 	}
 }
 
-// countForError records the error count for DDL job.
-func (w *worker) countForError(err error, job *model.Job) error {
+// handleError records the error count for DDL job.
+// if error count reach limit, cancel the DDL job.
+func (w *worker) handleError(err error, job *model.Job) error {
 	job.Error = toTError(err)
 	job.ErrorCount++
 
@@ -1159,7 +1158,7 @@ func (w *worker) processJobPausingRequest(d *ddlCtx, job *model.Job) (isRunnable
 func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, err error) {
 	defer tidbutil.Recover(metrics.LabelDDLWorker, fmt.Sprintf("%s runDDLJob", w),
 		func() {
-			w.countForPanic(job)
+			w.handlePanic(job)
 		}, false)
 
 	// Mock for run ddl job panic.
@@ -1333,7 +1332,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 
 	// Save errors in job if any, so that others can know errors happened.
 	if err != nil {
-		err = w.countForError(err, job)
+		err = w.handleError(err, job)
 	}
 	return ver, err
 }

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -319,13 +319,15 @@ func extractElemIDs(r *reorgInfo) []int64 {
 
 func (w *worker) mergeWarningsIntoJob(job *model.Job) {
 	rc := w.getReorgCtx(job.ID)
-	rc.mu.Lock()
-	partWarnings := rc.mu.warnings
-	partWarningsCount := rc.mu.warningsCount
-	rc.mu.Unlock()
-	warnings, warningsCount := job.GetWarnings()
-	warnings, warningsCount = mergeWarningsAndWarningsCount(partWarnings, warnings, partWarningsCount, warningsCount)
-	job.SetWarnings(warnings, warningsCount)
+	if rc != nil {
+		rc.mu.Lock()
+		partWarnings := rc.mu.warnings
+		partWarningsCount := rc.mu.warningsCount
+		rc.mu.Unlock()
+		warnings, warningsCount := job.GetWarnings()
+		warnings, warningsCount = mergeWarningsAndWarningsCount(partWarnings, warnings, partWarningsCount, warningsCount)
+		job.SetWarnings(warnings, warningsCount)
+	}
 }
 
 func updateBackfillProgress(w *worker, reorgInfo *reorgInfo, tblInfo *model.TableInfo,

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -228,9 +228,9 @@ func (w *worker) runReorgJob(reorgInfo *reorgInfo, tblInfo *model.TableInfo,
 		rowCount := rc.getRowCount()
 		job.SetRowCount(rowCount)
 		if err != nil {
-			logutil.BgLogger().Warn("run reorg job done", zap.String("category", "ddl"), zap.Int64("handled rows", rowCount), zap.Error(err))
+			logutil.BgLogger().Warn("run reorg job done", zap.Int64("jobID", job.ID), zap.String("category", "ddl"), zap.Int64("handled rows", rowCount), zap.Error(err))
 		} else {
-			logutil.BgLogger().Info("run reorg job done", zap.String("category", "ddl"), zap.Int64("handled rows", rowCount))
+			logutil.BgLogger().Info("run reorg job done", zap.Int64("jobID", job.ID), zap.String("category", "ddl"), zap.Int64("handled rows", rowCount))
 		}
 
 		// Update a job's warnings.
@@ -246,7 +246,7 @@ func (w *worker) runReorgJob(reorgInfo *reorgInfo, tblInfo *model.TableInfo,
 			return errors.Trace(err)
 		}
 	case <-w.ctx.Done():
-		logutil.BgLogger().Info("run reorg job quit", zap.String("category", "ddl"))
+		logutil.BgLogger().Info("run reorg job quit", zap.Int64("jobID", job.ID), zap.String("category", "ddl"))
 		d.removeReorgCtx(job.ID)
 		// We return dbterror.ErrWaitReorgTimeout here too, so that outer loop will break.
 		return dbterror.ErrWaitReorgTimeout
@@ -260,7 +260,7 @@ func (w *worker) runReorgJob(reorgInfo *reorgInfo, tblInfo *model.TableInfo,
 
 		rc.resetWarnings()
 
-		logutil.BgLogger().Info("run reorg job wait timeout", zap.String("category", "ddl"),
+		logutil.BgLogger().Info("run reorg job wait timeout", zap.Int64("jobID", job.ID), zap.String("category", "ddl"),
 			zap.Duration("wait time", waitTimeout),
 			zap.Int64("total added row count", rowCount))
 		// If timeout, we will return, check the owner and retry to wait job done again.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #51846 

Problem Summary:

When 2 reorg workers for one ddl job running concurrently, it is possible that the first worker finished the reorg work and delete the reorgCtx, but the second worker needs to access it.

TODO: try avoid 2 reorg workers running concurrently at the best effort.

### What changed and how does it work?
 Check if reorgCtx is nil when access it.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
