### PR TITLE
ddl: fix 2 reorg worker running concurrently after retire owner then to be owner

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -874,7 +874,7 @@ func (d *ddl) Start(ctxPool *pools.ResourcePool) error {
 		if ingest.LitBackCtxMgr != nil {
 			ingest.LitBackCtxMgr.MarkJobFinish()
 		}
-		d.runningJobs = newRunningJobs()
+		d.runningJobs.clear()
 	})
 
 	return nil

--- a/pkg/ddl/ddl_running_jobs.go
+++ b/pkg/ddl/ddl_running_jobs.go
@@ -46,6 +46,11 @@ func newRunningJobs() *runningJobs {
 	}
 }
 
+func (j *runningJobs) clear() {
+	j.unfinishedIDs = make(map[int64]struct{})
+	j.unfinishedSchema = make(map[string]map[string]struct{})
+}
+
 func (j *runningJobs) add(job *model.Job) {
 	j.Lock()
 	defer j.Unlock()

--- a/pkg/ddl/ddl_running_jobs_test.go
+++ b/pkg/ddl/ddl_running_jobs_test.go
@@ -28,21 +28,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRunningJobs(t *testing.T) {
-	mkJob := func(id int64, schemaTableNames ...string) *model.Job {
-		var schemaInfos []model.InvolvingSchemaInfo
-		for _, schemaTableName := range schemaTableNames {
-			ss := strings.Split(schemaTableName, ".")
-			schemaInfos = append(schemaInfos, model.InvolvingSchemaInfo{
-				Database: ss[0],
-				Table:    ss[1],
-			})
-		}
-		return &model.Job{
-			ID:                  id,
-			InvolvingSchemaInfo: schemaInfos,
-		}
+func mkJob(id int64, schemaTableNames ...string) *model.Job {
+	var schemaInfos []model.InvolvingSchemaInfo
+	for _, schemaTableName := range schemaTableNames {
+		ss := strings.Split(schemaTableName, ".")
+		schemaInfos = append(schemaInfos, model.InvolvingSchemaInfo{
+			Database: ss[0],
+			Table:    ss[1],
+		})
 	}
+	return &model.Job{
+		ID:                  id,
+		InvolvingSchemaInfo: schemaInfos,
+	}
+}
+
+func TestRunningJobs(t *testing.T) {
 	orderedAllIDs := func(ids string) string {
 		ss := strings.Split(ids, ",")
 		ssid := make([]int, len(ss))
@@ -112,4 +113,21 @@ func TestRunningJobs(t *testing.T) {
 	require.Equal(t, "2,4", orderedAllIDs(j.allIDs()))
 	runnable = j.checkRunnable(mkJob(0, "db1.t1"))
 	require.True(t, runnable)
+}
+
+func TestOwnerRetireThenToBeOwner(t *testing.T) {
+	j := newRunningJobs()
+	require.Equal(t, "", j.allIDs())
+	job := mkJob(1, "test.t1")
+	j.add(job)
+	require.False(t, j.checkRunnable(job))
+	// retire
+	j.clear()
+	// to be owner, try to start a new job.
+	require.False(t, j.checkRunnable(job))
+	// previous job removed.
+	j.remove(job)
+	require.True(t, j.checkRunnable(job))
+	j.add(job)
+	require.False(t, j.checkRunnable(job))
 }

--- a/pkg/ddl/ddl_running_jobs_test.go
+++ b/pkg/ddl/ddl_running_jobs_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func mkJob(id int64, schemaTableNames ...string) *model.Job {
-	var schemaInfos []model.InvolvingSchemaInfo
+	schemaInfos := make([]model.InvolvingSchemaInfo, len(schemaTableNames))
 	for _, schemaTableName := range schemaTableNames {
 		ss := strings.Split(schemaTableName, ".")
 		schemaInfos = append(schemaInfos, model.InvolvingSchemaInfo{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51846


Problem Summary:
We have a ddl reorg job with job_id=1, cluster with 2 tidb(tidb1, tidb2).
Timeline:
1.  ddl owner run the reorg job with job_id = 1, then ddl start one reorg worker named worker1.
2. the ddl owner(tidb1) retire then set processingJobs to empty.
3. worker1 on tidb1 not finished for 5s.
4. tidb1 become the ddl owner again.
5. the dispatcher start a new ddl worker for the job since processingJobs is empty, then start a new reorg worker named worker2. At this time, 2 reorg job running concurrently.
6. previous worker1 timeout and notify the dispatcher to start a new reorg worker worker1'.
7. worker2 timeout and notify the dispatcher to start a new reorg worker worker2'.

Then step6 & 7 will run multiple times until one worker finished the job.
Once worker1 finished the job, it will remove reorgctx for the ddl job.
But worker2 will try to access the reorgctx(nil) again, then panic happens.

### What changed and how does it work?
When retire owner, should not clean processingJobs(processingIDs)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
