### PR TITLE
lightning: Don't log "received task config" in server mode

### DIFF
--- a/lightning/pkg/server/lightning.go
+++ b/lightning/pkg/server/lightning.go
@@ -757,8 +757,7 @@ func (l *Lightning) handlePostTask(w http.ResponseWriter, req *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "cannot read request", err)
 		return
 	}
-	filteredData := common.HideSensitive(string(data))
-	log.L().Info("received task config", zap.String("content", filteredData))
+	log.L().Info("received task config")
 
 	cfg := config.NewConfig()
 	if err = cfg.LoadFromGlobal(l.globalCfg); err != nil {

--- a/pkg/lightning/common/BUILD.bazel
+++ b/pkg/lightning/common/BUILD.bazel
@@ -112,7 +112,7 @@ go_test(
     ],
     embed = [":common"],
     flaky = True,
-    shard_count = 30,
+    shard_count = 29,
     deps = [
         "//br/pkg/errors",
         "//pkg/ddl",

--- a/pkg/lightning/common/util.go
+++ b/pkg/lightning/common/util.go
@@ -26,7 +26,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -696,12 +695,4 @@ func IsRaftKV2(ctx context.Context, db *sql.DB) (bool, error) {
 		}
 	}
 	return false, rows.Err()
-}
-
-var passwordRegexp = regexp.MustCompile(`(password[\s]*=[\s]*(\\")?)(.*?)((\\")?\\n)`)
-
-// HideSensitive replace password with ******.
-func HideSensitive(input string) string {
-	output := passwordRegexp.ReplaceAllString(input, "$1******$4")
-	return output
 }

--- a/pkg/lightning/common/util_test.go
+++ b/pkg/lightning/common/util_test.go
@@ -302,35 +302,3 @@ CREATE TABLE multi_indexes (
 		require.Equal(t, tt.multiSQLs, multiSQLs)
 	}
 }
-
-func TestHideSensitive(t *testing.T) {
-	strs := []struct {
-		old string
-		new string
-	}{
-		{
-			`host = "127.0.0.1"\n  user = "root"\n  password = "/Q7B9DizNLLTTfiZHv9WoEAKamfpIUs="\n  port = 3306\n`,
-			`host = "127.0.0.1"\n  user = "root"\n  password = ******\n  port = 3306\n`,
-		},
-		{
-			`host = "127.0.0.1"\n  user = "root"\n  password = ""\n  port = 3306\n`,
-			`host = "127.0.0.1"\n  user = "root"\n  password = ******\n  port = 3306\n`,
-		},
-		{
-			`host = "127.0.0.1"\n  user = "root"\n  password= "/Q7B9DizNLLTTfiZHv9WoEAKamfpIUs="\n  port = 3306\n`,
-			`host = "127.0.0.1"\n  user = "root"\n  password= ******\n  port = 3306\n`,
-		},
-		{
-			`host = "127.0.0.1"\n  user = "root"\n  password =""\n  port = 3306\n`,
-			`host = "127.0.0.1"\n  user = "root"\n  password =******\n  port = 3306\n`,
-		},
-		{
-			`host = "127.0.0.1"\n  user = "root"\n  password=""\n  port = 3306\n`,
-			`host = "127.0.0.1"\n  user = "root"\n  password=******\n  port = 3306\n`,
-		},
-	}
-	for i, str := range strs {
-		t.Logf("case #%d\n", i)
-		require.Equal(t, str.new, common.HideSensitive(str.old))
-	}
-}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #36374

Problem Summary:

### What changed and how does it work?

Lightning in server-mode logged the original TOML task config received in `POST /task`. This will leak password of the task into the log. Previously #36375 attempted to workaround by replacing the password part by `******` with regexp, but the regexp is written wrongly. Even if it is regexp is corrected, using regexp to parse TOML is bound to miss some edge cases.

This PR simply removed the log. If the task config can be successfully parsed, it should still be visible in the subsequent `[cfg]` log with proper redaction.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  > - run in server-mode and send a config
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that sensitive information in logs is still printed in server mode.
```
