### PR TITLE
statistics: batch write into stats cache when to init stats

### DIFF
--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -98,12 +98,6 @@ func (h *Handle) initStatsMeta(is infoschema.InfoSchema) (statstypes.StatsCache,
 	if err != nil {
 		return nil, err
 	}
-	if config.GetGlobalConfig().Performance.ConcurrentlyInitStats {
-		ls := initstats.NewWorker(rc.Next, h.initStatsMeta4Chunk)
-		ls.LoadStats(is, tables, rc)
-		ls.Wait()
-		return tables, nil
-	}
 	req := rc.NewChunk(nil)
 	iter := chunk.NewIterator4Chunk(req)
 	for {

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -120,11 +120,19 @@ func (h *Handle) initStatsMeta(is infoschema.InfoSchema) (statstypes.StatsCache,
 }
 
 func (h *Handle) initStatsHistograms4ChunkLite(is infoschema.InfoSchema, cache statstypes.StatsCache, iter *chunk.Iterator4Chunk) {
+	var table *statistics.Table
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		tblID := row.GetInt64(0)
-		table, ok := cache.Get(tblID)
-		if !ok {
-			continue
+		if table == nil || table.PhysicalID != tblID {
+			if table != nil {
+				cache.Put(tblID, table) // put this table in the cache because all statstics of the table have been read.
+			}
+			var ok bool
+			table, ok = cache.Get(tblID)
+			if !ok {
+				continue
+			}
+			table = table.Copy()
 		}
 		isIndex := row.GetInt64(1)
 		id := row.GetInt64(2)
@@ -169,18 +177,27 @@ func (h *Handle) initStatsHistograms4ChunkLite(is infoschema.InfoSchema, cache s
 				table.LastAnalyzeVersion = max(table.LastAnalyzeVersion, row.GetUint64(4))
 			}
 		}
-		cache.Put(tblID, table) // put this table again since it is updated
+	}
+	if table != nil {
+		cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
 	}
 }
 
 func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache statstypes.StatsCache, iter *chunk.Iterator4Chunk) {
+	var table *statistics.Table
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		tblID, statsVer := row.GetInt64(0), row.GetInt64(8)
-		table, ok := cache.Get(tblID)
-		if !ok {
-			continue
+		if table == nil || table.PhysicalID != tblID {
+			if table != nil {
+				cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
+			}
+			var ok bool
+			table, ok = cache.Get(tblID)
+			if !ok {
+				continue
+			}
+			table = table.Copy()
 		}
-		table = table.Copy()
 		// All the objects in the table share the same stats version.
 		if statsVer != statistics.Version0 {
 			table.StatsVer = int(statsVer)
@@ -251,12 +268,14 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 				table.LastAnalyzeVersion = max(table.LastAnalyzeVersion, version)
 			}
 		}
-		cache.Put(tblID, table) // put this table again since it is updated
+	}
+	if table != nil {
+		cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
 	}
 }
 
 func (h *Handle) initStatsHistogramsLite(is infoschema.InfoSchema, cache statstypes.StatsCache) error {
-	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, distinct_count, version, null_count, tot_col_size, stats_ver, correlation, flag, last_analyze_pos from mysql.stats_histograms"
+	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, distinct_count, version, null_count, tot_col_size, stats_ver, correlation, flag, last_analyze_pos from mysql.stats_histograms order by table_id"
 	rc, err := util.Exec(h.initStatsCtx, sql)
 	if err != nil {
 		return errors.Trace(err)
@@ -279,7 +298,7 @@ func (h *Handle) initStatsHistogramsLite(is infoschema.InfoSchema, cache statsty
 }
 
 func (h *Handle) initStatsHistograms(is infoschema.InfoSchema, cache statstypes.StatsCache) error {
-	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, distinct_count, version, null_count, cm_sketch, tot_col_size, stats_ver, correlation, flag, last_analyze_pos from mysql.stats_histograms"
+	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, distinct_count, version, null_count, cm_sketch, tot_col_size, stats_ver, correlation, flag, last_analyze_pos from mysql.stats_histograms order by table_id"
 	rc, err := util.Exec(h.initStatsCtx, sql)
 	if err != nil {
 		return errors.Trace(err)
@@ -354,12 +373,20 @@ func (h *Handle) initStatsHistogramsConcurrency(is infoschema.InfoSchema, cache 
 
 func (*Handle) initStatsTopN4Chunk(cache statstypes.StatsCache, iter *chunk.Iterator4Chunk) {
 	affectedIndexes := make(map[*statistics.Index]struct{})
+	var table *statistics.Table
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-		table, ok := cache.Get(row.GetInt64(0))
-		if !ok {
-			continue
+		tblID := row.GetInt64(0)
+		if table == nil || table.PhysicalID != tblID {
+			if table != nil {
+				cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
+			}
+			var ok bool
+			table, ok = cache.Get(tblID)
+			if !ok {
+				continue
+			}
+			table = table.Copy()
 		}
-		table = table.Copy()
 		idx, ok := table.Indices[row.GetInt64(1)]
 		if !ok || (idx.CMSketch == nil && idx.StatsVer <= statistics.Version1) {
 			continue
@@ -371,7 +398,9 @@ func (*Handle) initStatsTopN4Chunk(cache statstypes.StatsCache, iter *chunk.Iter
 		data := make([]byte, len(row.GetBytes(2)))
 		copy(data, row.GetBytes(2))
 		idx.TopN.AppendTopN(data, row.GetUint64(3))
-		cache.Put(table.PhysicalID, table) // put this table again since it is updated
+	}
+	if table != nil {
+		cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
 	}
 	for idx := range affectedIndexes {
 		idx.TopN.Sort()
@@ -379,7 +408,7 @@ func (*Handle) initStatsTopN4Chunk(cache statstypes.StatsCache, iter *chunk.Iter
 }
 
 func (h *Handle) initStatsTopN(cache statstypes.StatsCache) error {
-	sql := "select HIGH_PRIORITY table_id, hist_id, value, count from mysql.stats_top_n where is_index = 1"
+	sql := "select HIGH_PRIORITY table_id, hist_id, value, count from mysql.stats_top_n where is_index = 1 order by table_id"
 	rc, err := util.Exec(h.initStatsCtx, sql)
 	if err != nil {
 		return errors.Trace(err)
@@ -412,7 +441,7 @@ func (h *Handle) initStatsTopNByPaging(cache statstypes.StatsCache, task initsta
 		}
 	}()
 	sctx := se.(sessionctx.Context)
-	sql := "select HIGH_PRIORITY table_id, hist_id, value, count from mysql.stats_top_n where is_index = 1 and table_id >= %? and table_id < %?"
+	sql := "select HIGH_PRIORITY table_id, hist_id, value, count from mysql.stats_top_n where is_index = 1 and table_id >= %? and table_id < %? order by table_id"
 	rc, err := util.Exec(sctx, sql, task.StartTid, task.EndTid)
 	if err != nil {
 		return errors.Trace(err)
@@ -475,7 +504,7 @@ func (*Handle) initStatsFMSketch4Chunk(cache statstypes.StatsCache, iter *chunk.
 				colStats.FMSketch = fms
 			}
 		}
-		cache.Put(table.PhysicalID, table) // put this table again since it is updated
+		cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
 	}
 }
 
@@ -503,13 +532,20 @@ func (h *Handle) initStatsFMSketch(cache statstypes.StatsCache) error {
 }
 
 func (*Handle) initStatsBuckets4Chunk(cache statstypes.StatsCache, iter *chunk.Iterator4Chunk) {
+	var table *statistics.Table
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		tableID, isIndex, histID := row.GetInt64(0), row.GetInt64(1), row.GetInt64(2)
-		table, ok := cache.Get(tableID)
-		if !ok {
-			continue
+		if table == nil || table.PhysicalID != tableID {
+			if table != nil {
+				cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
+			}
+			var ok bool
+			table, ok = cache.Get(tableID)
+			if !ok {
+				continue
+			}
+			table = table.Copy()
 		}
-		table = table.Copy()
 		var lower, upper types.Datum
 		var hist *statistics.Histogram
 		if isIndex > 0 {
@@ -549,7 +585,9 @@ func (*Handle) initStatsBuckets4Chunk(cache statstypes.StatsCache, iter *chunk.I
 			}
 		}
 		hist.AppendBucketWithNDV(&lower, &upper, row.GetInt64(3), row.GetInt64(4), row.GetInt64(7))
-		cache.Put(tableID, table) // put this table again since it is updated
+	}
+	if table != nil {
+		cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
 	}
 }
 
@@ -594,7 +632,7 @@ func (h *Handle) initStatsBuckets(cache statstypes.StatsCache) error {
 			}
 			col.PreCalculateScalar()
 		}
-		cache.Put(table.PhysicalID, table) // put this table again since it is updated
+		cache.Put(table.PhysicalID, table) // put this table in the cache because all statstics of the table have been read.
 	}
 	return nil
 }
@@ -610,7 +648,7 @@ func (h *Handle) initStatsBucketsByPaging(cache statstypes.StatsCache, task init
 		}
 	}()
 	sctx := se.(sessionctx.Context)
-	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, count, repeats, lower_bound, upper_bound, ndv from mysql.stats_buckets where table_id >= %? and table_id < %?"
+	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, count, repeats, lower_bound, upper_bound, ndv from mysql.stats_buckets where table_id >= %? and table_id < %? order by table_id, is_index, hist_id, bucket_id"
 	rc, err := util.Exec(sctx, sql, task.StartTid, task.EndTid)
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/statistics/handle/initstats/BUILD.bazel
+++ b/pkg/statistics/handle/initstats/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/statistics/handle/initstats",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config",
         "//pkg/infoschema",
         "//pkg/kv",
         "//pkg/statistics/handle/logutil",

--- a/pkg/statistics/handle/initstats/BUILD.bazel
+++ b/pkg/statistics/handle/initstats/BUILD.bazel
@@ -10,14 +10,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config",
-        "//pkg/infoschema",
-        "//pkg/kv",
-        "//pkg/statistics/handle/logutil",
-        "//pkg/statistics/handle/types",
         "//pkg/util",
-        "//pkg/util/chunk",
         "//pkg/util/logutil",
-        "//pkg/util/sqlexec",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/statistics/handle/initstats/load_stats.go
+++ b/pkg/statistics/handle/initstats/load_stats.go
@@ -39,12 +39,12 @@ import (
 func getConcurrency() int {
 	var concurrency int
 	if config.GetGlobalConfig().Performance.ForceInitStats {
-		concurrency = min(max(2, runtime.GOMAXPROCS(0)-2), 16)
+		concurrency = runtime.GOMAXPROCS(0) - 2
 	} else {
-		concurrency = min(max(2, runtime.GOMAXPROCS(0)/2), 16)
+		concurrency = runtime.GOMAXPROCS(0) / 2
 	}
+	concurrency = min(max(2, concurrency), 16)
 	return concurrency
-
 }
 
 // Worker is used to load stats concurrently.

--- a/pkg/statistics/handle/initstats/load_stats_page.go
+++ b/pkg/statistics/handle/initstats/load_stats_page.go
@@ -15,9 +15,6 @@
 package initstats
 
 import (
-	"runtime"
-
-	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
@@ -47,12 +44,7 @@ func NewRangeWorker(dealFunc func(task Task) error) *RangeWorker {
 
 // LoadStats loads stats concurrently when to init stats
 func (ls *RangeWorker) LoadStats() {
-	var concurrency int
-	if config.GetGlobalConfig().Performance.ForceInitStats {
-		concurrency = min(max(2, runtime.GOMAXPROCS(0)-2), 16)
-	} else {
-		concurrency = min(max(2, runtime.GOMAXPROCS(0)/2), 16)
-	}
+	concurrency := getConcurrency()
 	for n := 0; n < concurrency; n++ {
 		ls.wg.Run(func() {
 			ls.loadStats()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52339

Problem Summary:

### What changed and how does it work?

During the init stats, we will read many stats and write them into the stats cache. but if too many things need to be written, the cache will return fail because the channel in the internal will be full. so we need to do optimization on it.

1、avoid writing a cache when reading a record from the DB. 
   we read all the data about the statistics of the table, then write it into DB.
   and if fails, we will retry to write.
2、 Open too many concurrencies for the init stats.
   We set the upper bound and changed the default value of concurrency.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

test with 50k tables, it can work.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
