### PR TITLE
expression: Move more methods from `SessionVars` to `BuildContext`

### DIFF
--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -122,7 +122,7 @@ func (c *castAsIntFunctionClass) getFunction(ctx BuildContext, args []Expression
 	if err != nil {
 		return nil, err
 	}
-	bf := newBaseBuiltinCastFunc(b, ctx.Value(inUnionCastContext) != nil)
+	bf := newBaseBuiltinCastFunc(b, ctx.IsInUnionCast())
 	if args[0].GetType().Hybrid() || IsBinaryLiteral(args[0]) {
 		sig = &builtinCastIntAsIntSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastIntAsInt)
@@ -171,7 +171,7 @@ func (c *castAsRealFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	bf := newBaseBuiltinCastFunc(b, ctx.Value(inUnionCastContext) != nil)
+	bf := newBaseBuiltinCastFunc(b, ctx.IsInUnionCast())
 	if IsBinaryLiteral(args[0]) {
 		sig = &builtinCastRealAsRealSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastRealAsReal)
@@ -226,7 +226,7 @@ func (c *castAsDecimalFunctionClass) getFunction(ctx BuildContext, args []Expres
 	if err != nil {
 		return nil, err
 	}
-	bf := newBaseBuiltinCastFunc(b, ctx.Value(inUnionCastContext) != nil)
+	bf := newBaseBuiltinCastFunc(b, ctx.IsInUnionCast())
 	if IsBinaryLiteral(args[0]) {
 		sig = &builtinCastDecimalAsDecimalSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CastDecimalAsDecimal)
@@ -2052,10 +2052,10 @@ func CanImplicitEvalReal(expr Expression) bool {
 // BuildCastFunction4Union build a implicitly CAST ScalarFunction from the Union
 // Expression.
 func BuildCastFunction4Union(ctx BuildContext, expr Expression, tp *types.FieldType) (res Expression) {
-	ctx.SetValue(inUnionCastContext, struct{}{})
-	defer func() {
-		ctx.SetValue(inUnionCastContext, nil)
-	}()
+	if !ctx.IsInUnionCast() {
+		ctx.SetInUnionCast(true)
+		defer ctx.SetInUnionCast(false)
+	}
 	return BuildCastFunction(ctx, expr, tp)
 }
 

--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -173,7 +173,6 @@ func foldConstant(ctx BuildContext, expr Expression) (Expression, bool) {
 		}
 
 		args := x.GetArgs()
-		sc := ctx.GetSessionVars().StmtCtx
 		argIsConst := make([]bool, len(args))
 		hasNullArg := false
 		allConstArg := true
@@ -194,7 +193,7 @@ func foldConstant(ctx BuildContext, expr Expression) (Expression, bool) {
 			//
 			// NullEQ and ConcatWS are excluded, because they could have different value when the non-constant value is
 			// 1 or NULL. For example, concat_ws(NULL, NULL) gives NULL, but concat_ws(1, NULL) gives ''
-			if !hasNullArg || !sc.InNullRejectCheck || x.FuncName.L == ast.NullEQ || x.FuncName.L == ast.ConcatWS {
+			if !hasNullArg || !ctx.IsInNullRejectCheck() || x.FuncName.L == ast.NullEQ || x.FuncName.L == ast.ConcatWS {
 				return expr, isDeferredConst
 			}
 			constArgs := make([]Expression, len(args))

--- a/pkg/expression/constant_test.go
+++ b/pkg/expression/constant_test.go
@@ -236,7 +236,7 @@ func TestConstantFolding(t *testing.T) {
 		{
 			condition: func(ctx BuildContext) Expression {
 				expr := newFunction(ctx, ast.ConcatWS, newColumn(0), NewNull())
-				ctx.GetSessionVars().StmtCtx.InNullRejectCheck = true
+				ctx.SetInNullRejectCheck(true)
 				return expr
 			},
 			result: "concat_ws(cast(Column#0, var_string(20)), <nil>)",

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -15,7 +15,6 @@
 package context
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/errctx"
@@ -86,12 +85,18 @@ type BuildContext interface {
 	IsUseCache() bool
 	// SetSkipPlanCache sets to skip the plan cache and records the reason.
 	SetSkipPlanCache(reason error)
+	// AllocPlanColumnID allocates column id for plan.
+	AllocPlanColumnID() int64
+	// SetInNullRejectCheck sets the flag to indicate whether the expression is in null reject check.
+	SetInNullRejectCheck(in bool)
+	// IsInNullRejectCheck returns the flag to indicate whether the expression is in null reject check.
+	IsInNullRejectCheck() bool
+	// SetInUnionCast sets the flag to indicate whether the expression is in union cast.
+	SetInUnionCast(in bool)
+	// IsInUnionCast indicates whether executing in special cast context that negative unsigned num will be zero.
+	IsInUnionCast() bool
 	// GetSessionVars gets the session variables.
 	GetSessionVars() *variable.SessionVars
-	// Value returns the value associated with this context for key.
-	Value(key fmt.Stringer) any
-	// SetValue saves a value associated with this context for key.
-	SetValue(key fmt.Stringer, value any)
 }
 
 // ExprContext contains full context for expression building and evaluating.

--- a/pkg/expression/contextimpl/sessionctx.go
+++ b/pkg/expression/contextimpl/sessionctx.go
@@ -17,6 +17,7 @@ package contextimpl
 import (
 	"context"
 	"math"
+	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/errctx"
@@ -51,6 +52,8 @@ var _ exprctx.ExprContext = struct {
 type ExprCtxExtendedImpl struct {
 	sctx sessionctx.Context
 	*SessionEvalContext
+	inNullRejectCheck atomic.Bool
+	inUnionCast       atomic.Bool
 }
 
 // NewExprExtendedImpl creates a new ExprCtxExtendedImpl.
@@ -107,6 +110,31 @@ func (ctx *ExprCtxExtendedImpl) IsUseCache() bool {
 // SetSkipPlanCache sets to skip the plan cache and records the reason.
 func (ctx *ExprCtxExtendedImpl) SetSkipPlanCache(reason error) {
 	ctx.sctx.GetSessionVars().StmtCtx.SetSkipPlanCache(reason)
+}
+
+// AllocPlanColumnID allocates column id for plan.
+func (ctx *ExprCtxExtendedImpl) AllocPlanColumnID() int64 {
+	return ctx.sctx.GetSessionVars().AllocPlanColumnID()
+}
+
+// SetInNullRejectCheck sets whether the expression is in null reject check.
+func (ctx *ExprCtxExtendedImpl) SetInNullRejectCheck(in bool) {
+	ctx.inNullRejectCheck.Store(in)
+}
+
+// IsInNullRejectCheck returns whether the expression is in null reject check.
+func (ctx *ExprCtxExtendedImpl) IsInNullRejectCheck() bool {
+	return ctx.inNullRejectCheck.Load()
+}
+
+// SetInUnionCast sets the flag to indicate whether the expression is in union cast.
+func (ctx *ExprCtxExtendedImpl) SetInUnionCast(in bool) {
+	ctx.inUnionCast.Store(in)
+}
+
+// IsInUnionCast indicates whether executing in special cast context that negative unsigned num will be zero.
+func (ctx *ExprCtxExtendedImpl) IsInUnionCast() bool {
+	return ctx.inUnionCast.Load()
 }
 
 // GetWindowingUseHighPrecision determines whether to compute window operations without loss of precision.

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -865,7 +865,7 @@ func EvaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression) Exp
 	if MaybeOverOptimized4PlanCache(ctx, []Expression{expr}) {
 		ctx.SetSkipPlanCache(errors.NewNoStackError("%v affects null check"))
 	}
-	if ctx.GetSessionVars().StmtCtx.InNullRejectCheck {
+	if ctx.IsInNullRejectCheck() {
 		expr, _ = evaluateExprWithNullInNullRejectCheck(ctx, schema, expr)
 		return expr
 	}
@@ -1022,7 +1022,7 @@ func ColumnInfos2ColumnsAndNames(ctx BuildContext, dbName, tblName model.CIStr, 
 		newCol := &Column{
 			RetType:  col.FieldType.Clone(),
 			ID:       col.ID,
-			UniqueID: ctx.GetSessionVars().AllocPlanColumnID(),
+			UniqueID: ctx.AllocPlanColumnID(),
 			Index:    col.Offset,
 			OrigName: names[i].String(),
 			IsHidden: col.Hidden,

--- a/pkg/planner/core/rule_predicate_push_down.go
+++ b/pkg/planner/core/rule_predicate_push_down.go
@@ -428,10 +428,10 @@ func isNullRejected(ctx PlanContext, schema *expression.Schema, expr expression.
 		return false
 	}
 	sc := ctx.GetSessionVars().StmtCtx
-	sc.InNullRejectCheck = true
-	defer func() {
-		sc.InNullRejectCheck = false
-	}()
+	if !exprCtx.IsInNullRejectCheck() {
+		exprCtx.SetInNullRejectCheck(true)
+		defer exprCtx.SetInNullRejectCheck(false)
+	}
 	for _, cond := range expression.SplitCNFItems(expr) {
 		if isNullRejectedSpecially(ctx, schema, expr) {
 			return true

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -198,7 +198,6 @@ type StatementContext struct {
 	ForcePlanCache         bool // force the optimizer to use plan cache even if there is risky optimization, see #49736.
 	CacheType              PlanCacheType
 	BatchCheck             bool
-	InNullRejectCheck      bool
 	IgnoreExplainIDSuffix  bool
 	MultiSchemaInfo        *model.MultiSchemaInfo
 	// If the select statement was like 'select * from t as of timestamp ...' or in a stale read transaction


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #52366

### What changed and how does it work?

Added more methods in `expression.BuildContext`

- `AllocPlanColumnID` to allocate column id for Column expression.
- `SetInUnionCast` / `IsInUnionCast` is used when building expressions in union cast.
- `SetInNullRejectCheck` / `IsInNullRejectCheck` is used for bull reject check when building plan.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
