### PR TITLE
ddl: fix reorg info end key after resuming from checkpoint

### DIFF
--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -666,6 +666,7 @@ func getCheckpointReorgHandle(se *sess.Session, job *model.Job) (startKey, endKe
 			}
 			if len(cp.EndKey) > 0 {
 				endKey = cp.EndKey
+				endKey = adjustEndKeyAcrossVersion(job, endKey)
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52411

Problem Summary:

```
mysql> select count(1) from sbtest1 use index ();
+----------+
| count(1) |
+----------+
|  5000000 |
+----------+
1 row in set (0.58 sec)

mysql> select count(1) from sbtest1 use index (idxc);
+----------+
| count(1) |
+----------+
|  4999999 |
+----------+
1 row in set (0.85 sec)
```

```
[2024/04/09 09:53:12.953 +08:00] [ERROR] [reporter.go:274] ["admin check found data inconsistency"] [conn=3848273922] [session_alias=] [table_name=sbtest2] [index_name=idxc] [row_id=5134965]
```

```
mysql> select tidb_decode_key('7480000000000000e85f7280000000004e5a75');
+-----------------------------------------------------------+
| tidb_decode_key('7480000000000000e85f7280000000004e5a75') |
+-----------------------------------------------------------+
| {"_tidb_rowid":5134965,"table_id":"232"}                  |
+-----------------------------------------------------------+
1 row in set (0.00 sec)
```

```
[2024/04/09 09:40:33.541 +08:00] [INFO] [reorg.go:742] ["[ddl] job get table range"] [jobID=257] [physicalTableID=232] [startKey=7480000000000000e85f728000000000000001] [endKey=7480000000000000e85f7280000000004e5a75]
[2024/04/09 09:40:33.611 +08:00] [INFO] [backfilling.go:398] ["[ddl] split table range from PD"] [physicalTableID=232] ["start key"=7480000000000000e85f728000000000000001] ["end key"=7480000000000000e85f7280000000004e5a75]
[2024/04/09 09:40:33.611 +08:00] [INFO] [backfilling.go:724] ["[ddl] start backfill workers to reorg record"] [type="add index"] [workerCnt=4] [regionCnt=12] [startKey=7480000000000000e85f728000000000000001] [endKey=7480000000000000e85f7280000000004e5a75]
[2024/04/09 09:40:33.658 +08:00] [INFO] [backfilling.go:566] ["[ddl] get backfill range task, change end key"] [id=9] [pTbl=232] ["end key"=7480000000000000e85f72800000000039e153] ["current end key"=7480000000000000e85f72800000000039e153]
...
[2024/04/09 09:40:33.674 +08:00] [INFO] [backfilling.go:566] ["[ddl] get backfill range task, change end key"] [id=12] [pTbl=232] ["end key"=7480000000000000e85f7280000000004e5a75] ["current end key"=7480000000000000e85f7280000000004e5a75]
[2024/04/09 09:40:50.042 +08:00] [INFO] [checkpoint.go:376] ["[ddl-ingest] update checkpoint"] ["job ID"=257] ["index ID"=1] ["local checkpoint"=7480000000000000e85f7280000000004e5a75] ["global checkpoint"=] ["global physical ID"=232] []

-- upgrade and ddl owner switches to new tidb

[2024/04/09 09:42:28.303 +08:00] [INFO] [checkpoint.go:326] ["resume checkpoint"] [category=ddl-ingest] ["job ID"=257] ["index IDs"="[1]"] ["local checkpoint"=] ["global checkpoint"=] ["physical table ID"=232] ["previous instance"=tidb-3-peer:4000:/tmp/tidb] ["current instance"=tidb-1-peer:4000:/tmp/tidb]
[2024/04/09 09:42:28.352 +08:00] [INFO] [backfilling.go:396] ["split table range from PD"] [category=ddl] [physicalTableID=232] ["start key"=7480000000000000e85f728000000000000001] ["end key"=7480000000000000e85f7280000000004e5a75]
[2024/04/09 09:42:28.352 +08:00] [INFO] [backfilling.go:723] ["start backfill workers to reorg record"] [category=ddl] [type="add index"] [workerCnt=4] [regionCnt=12] [startKey=7480000000000000e85f728000000000000001] [endKey=7480000000000000e85f7280000000004e5a75]
[2024/04/09 09:42:28.362 +08:00] [INFO] [backfilling.go:575] ["get backfill range task, change end key"] [category=ddl] [id=1] [pTbl=232] ["end key"=7480000000000000e85f728000000000066aa0] ["current end key"=7480000000000000e85f728000000000066a9f00]
...
[2024/04/09 09:42:28.464 +08:00] [INFO] [backfilling.go:575] ["get backfill range task, change end key"] [category=ddl] [id=12] [pTbl=232] ["end key"=7480000000000000e85f7280000000004e5a75] ["current end key"=7480000000000000e85f7280000000004e5a7400]
```

Same as #47818, the end key is not considered included. #47818 does not fix this because the end key of reorg info is overwritten in `overwriteReorgInfoFromGlobalCheckpoint`.

### What changed and how does it work?

Adjust end key of reorg info after resuming from checkpoint.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
