### PR TITLE
expression: `BuildContext` read location from `EvalContext` instead of `SessionVars`

### DIFF
--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -1347,7 +1347,7 @@ func (w *updateColumnWorker) getRowRecord(handle kv.Handle, recordKey []byte, ra
 	val := w.rowMap[w.oldColInfo.ID]
 	col := w.newColInfo
 	if val.Kind() == types.KindNull && col.FieldType.GetType() == mysql.TypeTimestamp && mysql.HasNotNullFlag(col.GetFlag()) {
-		if v, err := expression.GetTimeCurrentTimestamp(w.sessCtx.GetExprCtx(), col.GetType(), col.GetDecimal()); err == nil {
+		if v, err := expression.GetTimeCurrentTimestamp(w.sessCtx.GetExprCtx().GetEvalCtx(), col.GetType(), col.GetDecimal()); err == nil {
 			// convert null value to timestamp should be substituted with current timestamp if NOT_NULL flag is set.
 			w.rowMap[w.oldColInfo.ID] = v
 		}

--- a/pkg/ddl/internal/session/session_pool.go
+++ b/pkg/ddl/internal/session/session_pool.go
@@ -72,6 +72,7 @@ func (sg *Pool) Get() (sessionctx.Context, error) {
 	}
 	ctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusAutocommit, true)
 	ctx.GetSessionVars().InRestrictedSQL = true
+	ctx.GetSessionVars().StmtCtx.SetTimeZone(ctx.GetSessionVars().Location())
 	infosync.StoreInternalSession(ctx)
 	return ctx, nil
 }

--- a/pkg/expression/context.go
+++ b/pkg/expression/context.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/expression/context"
-	"github.com/pingcap/tidb/pkg/expression/contextopt"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/types"
@@ -96,16 +95,9 @@ func wrapEvalAssert(ctx EvalContext, fn builtinFunc) (ret *assertionEvalContext)
 }
 
 func checkEvalCtx(ctx EvalContext) {
-	loc := ctx.Location().String()
 	tc := ctx.TypeCtx()
-	tcLoc := tc.Location().String()
-	intest.Assert(loc == tcLoc, "location mismatch, evalCtx: %s, typeCtx: %s", loc, tcLoc)
-	if ctx.GetOptionalPropSet().Contains(context.OptPropSessionVars) {
-		vars, err := contextopt.SessionVarsPropReader{}.GetSessionVars(ctx)
-		intest.AssertNoError(err)
-		stmtLoc := vars.StmtCtx.TimeZone().String()
-		intest.Assert(loc == stmtLoc, "location mismatch, evalCtx: %s, stmtCtx: %s", loc, stmtLoc)
-	}
+	intest.Assert(ctx.Location() == tc.Location(),
+		"location is not equal, ctxLoc: %s, tcLoc: %s", ctx.Location(), tc.Location())
 }
 
 func (ctx *assertionEvalContext) GetOptionalPropProvider(key OptionalEvalPropKey) (OptionalEvalPropProvider, bool) {

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/mathutil"
 )
 
@@ -108,4 +109,15 @@ type ExprContext interface {
 	GetWindowingUseHighPrecision() bool
 	// GetGroupConcatMaxLen returns the value of the 'group_concat_max_len' system variable.
 	GetGroupConcatMaxLen() uint64
+}
+
+// AssertLocationWithSessionVars asserts the location in the context and session variables are the same.
+// It is only used for testing.
+func AssertLocationWithSessionVars(ctxLoc *time.Location, vars *variable.SessionVars) {
+	varsLoc := vars.Location()
+	stmtLoc := vars.StmtCtx.TimeZone()
+	intest.Assert(ctxLoc == varsLoc && ctxLoc == stmtLoc,
+		"location mismatch, ctxLoc: %s, varsLoc: %s, stmtLoc: %s",
+		ctxLoc.String(), varsLoc.String(), stmtLoc.String(),
+	)
 }

--- a/pkg/expression/contextimpl/sessionctx.go
+++ b/pkg/expression/contextimpl/sessionctx.go
@@ -194,8 +194,12 @@ func (ctx *SessionEvalContext) SQLMode() mysql.SQLMode {
 }
 
 // TypeCtx returns the types.Context
-func (ctx *SessionEvalContext) TypeCtx() types.Context {
-	return ctx.sctx.GetSessionVars().StmtCtx.TypeCtx()
+func (ctx *SessionEvalContext) TypeCtx() (tc types.Context) {
+	tc = ctx.sctx.GetSessionVars().StmtCtx.TypeCtx()
+	if intest.InTest {
+		exprctx.AssertLocationWithSessionVars(tc.Location(), ctx.sctx.GetSessionVars())
+	}
+	return
 }
 
 // ErrCtx returns the errctx.Context

--- a/pkg/expression/contextimpl/sessionctx_test.go
+++ b/pkg/expression/contextimpl/sessionctx_test.go
@@ -228,7 +228,10 @@ func TestSessionEvalContextOptProps(t *testing.T) {
 	require.Equal(t, ctx.GetSessionVars().ActiveRoles, roles)
 
 	// test for OptPropSessionVars
-	gotVars := getProvider[*contextopt.SessionVarsPropProvider](t, impl, context.OptPropSessionVars).GetSessionVars()
+	sessVarsProvider := getProvider[*contextopt.SessionVarsPropProvider](t, impl, context.OptPropSessionVars)
+	require.NotNil(t, sessVarsProvider)
+	gotVars, err := contextopt.SessionVarsPropReader{}.GetSessionVars(impl)
+	require.NoError(t, err)
 	require.Same(t, ctx.GetSessionVars(), gotVars)
 
 	// test for OptPropAdvisoryLock

--- a/pkg/expression/contextopt/sessionvars.go
+++ b/pkg/expression/contextopt/sessionvars.go
@@ -25,13 +25,13 @@ var _ RequireOptionalEvalProps = SessionVarsPropReader{}
 
 // SessionVarsPropProvider is a provider to get the session variables
 type SessionVarsPropProvider struct {
-	variable.SessionVarsProvider
+	vars variable.SessionVarsProvider
 }
 
 // NewSessionVarsProvider returns a new SessionVarsPropProvider
 func NewSessionVarsProvider(provider variable.SessionVarsProvider) *SessionVarsPropProvider {
 	intest.AssertNotNil(provider)
-	return &SessionVarsPropProvider{provider}
+	return &SessionVarsPropProvider{vars: provider}
 }
 
 // Desc implements the OptionalEvalPropProvider interface.
@@ -53,5 +53,10 @@ func (SessionVarsPropReader) GetSessionVars(ctx context.EvalContext) (*variable.
 	if err != nil {
 		return nil, err
 	}
-	return p.GetSessionVars(), nil
+
+	if intest.InTest {
+		context.AssertLocationWithSessionVars(ctx.Location(), p.vars.GetSessionVars())
+	}
+
+	return p.vars.GetSessionVars(), nil
 }

--- a/pkg/expression/helper.go
+++ b/pkg/expression/helper.go
@@ -55,7 +55,7 @@ func IsValidCurrentTimestampExpr(exprNode ast.ExprNode, fieldType *types.FieldTy
 }
 
 // GetTimeCurrentTimestamp is used for generating a timestamp for some special cases: cast null value to timestamp type with not null flag.
-func GetTimeCurrentTimestamp(ctx BuildContext, tp byte, fsp int) (d types.Datum, err error) {
+func GetTimeCurrentTimestamp(ctx EvalContext, tp byte, fsp int) (d types.Datum, err error) {
 	var t types.Time
 	t, err = getTimeCurrentTimeStamp(ctx, tp, fsp)
 	if err != nil {
@@ -65,15 +65,15 @@ func GetTimeCurrentTimestamp(ctx BuildContext, tp byte, fsp int) (d types.Datum,
 	return d, nil
 }
 
-func getTimeCurrentTimeStamp(ctx BuildContext, tp byte, fsp int) (t types.Time, err error) {
+func getTimeCurrentTimeStamp(ctx EvalContext, tp byte, fsp int) (t types.Time, err error) {
 	value := types.NewTime(types.ZeroCoreTime, tp, fsp)
-	defaultTime, err := getStmtTimestamp(ctx.GetEvalCtx())
+	defaultTime, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return value, err
 	}
 	value.SetCoreTime(types.FromGoTime(defaultTime.Truncate(time.Duration(math.Pow10(9-fsp)) * time.Nanosecond)))
 	if tp == mysql.TypeTimestamp || tp == mysql.TypeDatetime || tp == mysql.TypeDate {
-		err = value.ConvertTimeZone(time.Local, ctx.GetSessionVars().Location())
+		err = value.ConvertTimeZone(time.Local, ctx.Location())
 		if err != nil {
 			return value, err
 		}
@@ -93,7 +93,7 @@ func GetTimeValue(ctx BuildContext, v any, tp byte, fsp int, explicitTz *time.Lo
 	case string:
 		lowerX := strings.ToLower(x)
 		if lowerX == ast.CurrentTimestamp || lowerX == ast.CurrentDate {
-			if value, err = getTimeCurrentTimeStamp(ctx, tp, fsp); err != nil {
+			if value, err = getTimeCurrentTimeStamp(ctx.GetEvalCtx(), tp, fsp); err != nil {
 				return d, err
 			}
 		} else if lowerX == types.ZeroDatetimeStr {

--- a/pkg/expression/helper_test.go
+++ b/pkg/expression/helper_test.go
@@ -163,6 +163,7 @@ func TestCurrentTimestampTimeZone(t *testing.T) {
 	require.NoError(t, err)
 	err = sessionVars.SetSystemVar("time_zone", "+00:00")
 	require.NoError(t, err)
+	sessionVars.StmtCtx.SetTimeZone(sessionVars.Location())
 	v, err := GetTimeValue(ctx, ast.CurrentTimestamp, mysql.TypeTimestamp, types.MinFsp, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, types.NewTime(
@@ -174,6 +175,7 @@ func TestCurrentTimestampTimeZone(t *testing.T) {
 	// would get different value.
 	err = sessionVars.SetSystemVar("time_zone", "+08:00")
 	require.NoError(t, err)
+	sessionVars.StmtCtx.SetTimeZone(sessionVars.Location())
 	v, err = GetTimeValue(ctx, ast.CurrentTimestamp, mysql.TypeTimestamp, types.MinFsp, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, types.NewTime(

--- a/pkg/planner/core/memtable_predicate_extractor_test.go
+++ b/pkg/planner/core/memtable_predicate_extractor_test.go
@@ -634,6 +634,7 @@ func TestMetricTableExtractor(t *testing.T) {
 			quantiles: []float64{0},
 		},
 	}
+	se.GetSessionVars().TimeZone = time.Local
 	se.GetSessionVars().StmtCtx.SetTimeZone(time.Local)
 	for _, ca := range cases {
 		logicalMemTable := getLogicalMemTable(t, dom, se, parser, ca.sql)
@@ -1048,6 +1049,7 @@ func TestTiDBHotRegionsHistoryTableExtractor(t *testing.T) {
 
 	se, err := session.CreateSession4Test(store)
 	require.NoError(t, err)
+	se.GetSessionVars().TimeZone = time.Local
 	se.GetSessionVars().StmtCtx.SetTimeZone(time.Local)
 
 	var cases = []struct {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2997,6 +2997,7 @@ func CreateSession4TestWithOpt(store kv.Storage, opt *Opt) (types.Session, error
 		s.GetSessionVars().MaxChunkSize = 32
 		s.GetSessionVars().MinPagingSize = variable.DefMinPagingSize
 		s.GetSessionVars().EnablePaging = variable.DefTiDBEnablePaging
+		s.GetSessionVars().StmtCtx.SetTimeZone(s.GetSessionVars().Location())
 		err = s.GetSessionVars().SetSystemVarWithoutValidation(variable.CharacterSetConnection, "utf8mb4")
 	}
 	return s, err

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -635,7 +635,7 @@ func getColDefaultValue(ctx expression.BuildContext, col *model.ColumnInfo, defa
 	// If the column's default value is not ZeroDatetimeStr or CurrentTimestamp, convert the default value to the current session time zone.
 	if needChangeTimeZone {
 		t := value.GetMysqlTime()
-		err = t.ConvertTimeZone(explicitTz, ctx.GetSessionVars().Location())
+		err = t.ConvertTimeZone(explicitTz, ctx.GetEvalCtx().Location())
 		if err != nil {
 			return value, err
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #52366

Problem Summary:

Some codes are using `BuildContext.GetSessionVars().Location()` to read the time zone info. Because we are going to remove `GetSessionVars` in the future, it's better to replace it with `BuildContext.Location()`.

We should notice that `SessionVars.Location()` reads the timezone info from another place that is different from `BuildContext.Location()`. When replacing it, we should ensure they are same to avoid to introduce new bugs.


### What changed and how does it work?

- replaced `BuildContext.GetSessionVars().Location()` with `BuildContext.Location()` .
- To make sure the logic is the same after the PR, we add some asserts to check the timezone info in sessionVars and statement context is the same.
- Modify some tests to make sure the asserts can pass.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
