### PR TITLE
cop: ignore locks with the same start_ts

### DIFF
--- a/pkg/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/closure_exec.go
@@ -1185,7 +1185,7 @@ func safeCopy(b []byte) []byte {
 }
 
 func checkLock(lock mvcc.Lock, key []byte, startTS uint64, resolved []uint64) error {
-	if isResolved(startTS, resolved) {
+	if isResolved(lock.StartTS, resolved) {
 		return nil
 	}
 	lockVisible := lock.StartTS < startTS


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52460 

Problem Summary:

### What changed and how does it work?

If this cop is not a stale read, which means its start_ts is fetched from PD, which means the start_ts cannot conflict with other transactions, add this ts to resolved_locks so that in a pipelined txn the locks belonging to the same txn will not block coprocessor.

For get and batch_get, they already put start_ts in resolved_locks.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below): repeating `insert into t select * from t` no longer reports `resolve lock timeout` error. I found it hard to be tested in unit test.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
