### PR TITLE
infoschema_v2: cache policy ref

### DIFF
--- a/pkg/infoschema/bench_test.go
+++ b/pkg/infoschema/bench_test.go
@@ -42,7 +42,7 @@ var (
 //
 // GOOS=linux GOARCH=amd64 go test -tags intest -c -o bench.test ./pkg/infoschema
 //
-// bench.test -test.v -run ^$ -test.bench=BenchmarkInfoschemaOverhead --with-tikv "upstream-pd:2379?disableGC=true"
+// ./bench.test -test.v -run ^$ -test.bench=BenchmarkInfoschemaOverhead --with-tikv "upstream-pd:2379?disableGC=true"
 func BenchmarkInfoschemaOverhead(b *testing.B) {
 	wg := testkit.MockTiDBStatusPort(context.Background(), b, *port)
 
@@ -69,7 +69,12 @@ func BenchmarkInfoschemaOverhead(b *testing.B) {
 	}
 	startTime := time.Now()
 	for j := 0; j < *tableCnt; j++ {
-		tc.runCreateTable("test" + strconv.Itoa(j))
+		delta := true
+		if j == 0 {
+			delta = false
+		}
+		logutil.BgLogger().Info("create one")
+		tc.runCreateTable("test"+strconv.Itoa(j), delta)
 	}
 	logutil.BgLogger().Info("all table created", zap.Duration("cost time", time.Since(startTime)))
 	// TODO: add more scenes.

--- a/pkg/infoschema/bench_test.go
+++ b/pkg/infoschema/bench_test.go
@@ -73,7 +73,6 @@ func BenchmarkInfoschemaOverhead(b *testing.B) {
 		if j == 0 {
 			delta = false
 		}
-		logutil.BgLogger().Info("create one")
 		tc.runCreateTable("test"+strconv.Itoa(j), delta)
 	}
 	logutil.BgLogger().Info("all table created", zap.Duration("cost time", time.Since(startTime)))

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -68,6 +68,9 @@ type infoSchemaMisc struct {
 	// ruleBundleMap stores all placement rules
 	ruleBundleMap map[int64]*placement.Bundle
 
+	// policyRefMap stores all policyRefInfo for tables.
+	policyRefMap map[int64]*model.PolicyRefInfo
+
 	// policyMap stores all placement policies.
 	policyMutex sync.RWMutex
 	policyMap   map[string]*model.PolicyInfo

--- a/pkg/infoschema/infoschema_test.go
+++ b/pkg/infoschema/infoschema_test.go
@@ -1004,7 +1004,7 @@ func (tc *infoschemaTestContext) createSchema() {
 func (tc *infoschemaTestContext) runCreateSchema() {
 	// create schema
 	tc.createSchema()
-	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionCreateSchema, SchemaID: tc.dbInfo.ID}, func(tc *infoschemaTestContext) {
+	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionCreateSchema, SchemaID: tc.dbInfo.ID}, false, func(tc *infoschemaTestContext) {
 		dbInfo, ok := tc.is.SchemaByID(tc.dbInfo.ID)
 		require.True(tc.t, ok)
 		require.Equal(tc.t, dbInfo.Name, tc.dbInfo.Name)
@@ -1016,7 +1016,7 @@ func (tc *infoschemaTestContext) runDropSchema() {
 	tc.runCreateSchema()
 	// drop schema
 	internal.DropDB(tc.t, tc.re.Store(), tc.dbInfo)
-	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionDropSchema, SchemaID: tc.dbInfo.ID}, func(tc *infoschemaTestContext) {
+	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionDropSchema, SchemaID: tc.dbInfo.ID}, false, func(tc *infoschemaTestContext) {
 		_, ok := tc.is.SchemaByID(tc.dbInfo.ID)
 		require.False(tc.t, ok)
 	})
@@ -1026,14 +1026,14 @@ func (tc *infoschemaTestContext) runRecoverSchema() {
 	tc.runDropSchema()
 	// recover schema
 	internal.AddDB(tc.t, tc.re.Store(), tc.dbInfo)
-	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionRecoverSchema, SchemaID: tc.dbInfo.ID}, func(tc *infoschemaTestContext) {
+	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionRecoverSchema, SchemaID: tc.dbInfo.ID}, false, func(tc *infoschemaTestContext) {
 		dbInfo, ok := tc.is.SchemaByID(tc.dbInfo.ID)
 		require.True(tc.t, ok)
 		require.Equal(tc.t, dbInfo.Name, tc.dbInfo.Name)
 	})
 }
 
-func (tc *infoschemaTestContext) runCreateTable(tblName string) int64 {
+func (tc *infoschemaTestContext) runCreateTable(tblName string, delta bool) int64 {
 	if tc.dbInfo == nil {
 		tc.runCreateSchema()
 	}
@@ -1041,7 +1041,7 @@ func (tc *infoschemaTestContext) runCreateTable(tblName string) int64 {
 	tblInfo := internal.MockTableInfo(tc.t, tc.re.Store(), tblName)
 	internal.AddTable(tc.t, tc.re.Store(), tc.dbInfo, tblInfo)
 
-	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionCreateTable, SchemaID: tc.dbInfo.ID, TableID: tblInfo.ID}, func(tc *infoschemaTestContext) {
+	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionCreateTable, SchemaID: tc.dbInfo.ID, TableID: tblInfo.ID}, delta, func(tc *infoschemaTestContext) {
 		tbl, ok := tc.is.TableByID(tblInfo.ID)
 		require.True(tc.t, ok)
 		require.Equal(tc.t, tbl.Meta().Name.O, tblName)
@@ -1064,7 +1064,7 @@ func (tc *infoschemaTestContext) runCreateTables(tblNames []string) {
 		}
 	}
 
-	tc.applyDiffAndCheck(&diff, func(tc *infoschemaTestContext) {
+	tc.applyDiffAndCheck(&diff, false, func(tc *infoschemaTestContext) {
 		for i, opt := range diff.AffectedOpts {
 			tbl, ok := tc.is.TableByID(opt.TableID)
 			require.True(tc.t, ok)
@@ -1075,11 +1075,11 @@ func (tc *infoschemaTestContext) runCreateTables(tblNames []string) {
 
 func (tc *infoschemaTestContext) runDropTable(tblName string) {
 	// createTable
-	tblID := tc.runCreateTable(tblName)
+	tblID := tc.runCreateTable(tblName, false)
 
 	// dropTable
 	internal.DropTable(tc.t, tc.re.Store(), tc.dbInfo, tblID, tblName)
-	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionDropTable, SchemaID: tc.dbInfo.ID, TableID: tblID}, func(tc *infoschemaTestContext) {
+	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionDropTable, SchemaID: tc.dbInfo.ID, TableID: tblID}, false, func(tc *infoschemaTestContext) {
 		tbl, ok := tc.is.TableByID(tblID)
 		require.False(tc.t, ok)
 		require.Nil(tc.t, tbl)
@@ -1102,7 +1102,7 @@ func (tc *infoschemaTestContext) runAddColumn(tblName string) {
 	require.NoError(tc.t, err)
 
 	tc.addColumn(tbl.Meta())
-	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionAddColumn, SchemaID: tc.dbInfo.ID, TableID: tbl.Meta().ID}, func(tc *infoschemaTestContext) {
+	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionAddColumn, SchemaID: tc.dbInfo.ID, TableID: tbl.Meta().ID}, false, func(tc *infoschemaTestContext) {
 		tbl, ok := tc.is.TableByID(tbl.Meta().ID)
 		require.True(tc.t, ok)
 		require.Equal(tc.t, 2, len(tbl.Cols()))
@@ -1135,7 +1135,7 @@ func (tc *infoschemaTestContext) runModifyColumn(tblName string) {
 	require.NoError(tc.t, err)
 
 	tc.modifyColumn(tbl.Meta())
-	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionModifyColumn, SchemaID: tc.dbInfo.ID, TableID: tbl.Meta().ID}, func(tc *infoschemaTestContext) {
+	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionModifyColumn, SchemaID: tc.dbInfo.ID, TableID: tbl.Meta().ID}, false, func(tc *infoschemaTestContext) {
 		tbl, ok := tc.is.TableByID(tbl.Meta().ID)
 		require.True(tc.t, ok)
 		require.Equal(tc.t, "test", tbl.Cols()[0].Comment)
@@ -1158,7 +1158,7 @@ func (tc *infoschemaTestContext) runModifySchemaCharsetAndCollate(charset, colla
 	tc.dbInfo.Charset = charset
 	tc.dbInfo.Collate = collate
 	internal.UpdateDB(tc.t, tc.re.Store(), tc.dbInfo)
-	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionModifySchemaCharsetAndCollate, SchemaID: tc.dbInfo.ID}, func(tc *infoschemaTestContext) {
+	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionModifySchemaCharsetAndCollate, SchemaID: tc.dbInfo.ID}, false, func(tc *infoschemaTestContext) {
 		schema, ok := tc.is.SchemaByID(tc.dbInfo.ID)
 		require.True(tc.t, ok)
 		require.Equal(tc.t, charset, schema.Charset)
@@ -1169,19 +1169,22 @@ func (tc *infoschemaTestContext) runModifySchemaCharsetAndCollate(charset, colla
 func (tc *infoschemaTestContext) runModifySchemaDefaultPlacement(policy *model.PolicyRefInfo) {
 	tc.dbInfo.PlacementPolicyRef = policy
 	internal.UpdateDB(tc.t, tc.re.Store(), tc.dbInfo)
-	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionModifySchemaDefaultPlacement, SchemaID: tc.dbInfo.ID}, func(tc *infoschemaTestContext) {
+	tc.applyDiffAndCheck(&model.SchemaDiff{Type: model.ActionModifySchemaDefaultPlacement, SchemaID: tc.dbInfo.ID}, false, func(tc *infoschemaTestContext) {
 		schema, ok := tc.is.SchemaByID(tc.dbInfo.ID)
 		require.True(tc.t, ok)
 		require.Equal(tc.t, policy, schema.PlacementPolicyRef)
 	})
 }
 
-func (tc *infoschemaTestContext) applyDiffAndCheck(diff *model.SchemaDiff, checkFn func(tc *infoschemaTestContext)) {
+func (tc *infoschemaTestContext) applyDiffAndCheck(diff *model.SchemaDiff, delta bool, checkFn func(tc *infoschemaTestContext)) {
 	txn, err := tc.re.Store().Begin()
 	require.NoError(tc.t, err)
 
 	builder, err := infoschema.NewBuilder(tc.re, nil, tc.data).InitWithOldInfoSchema(tc.is)
 	require.NoError(tc.t, err)
+	if delta {
+		builder.SetDeltaUpdateBundles()
+	}
 	// applyDiff
 	_, err = builder.ApplyDiff(meta.NewMeta(txn), diff)
 	require.NoError(tc.t, err)
@@ -1219,12 +1222,12 @@ func TestApplyDiff(t *testing.T) {
 		tc.clear()
 		tc.runDropSchema()
 		tc.clear()
-		tc.runCreateTable("test")
+		tc.runCreateTable("test", false)
 		tc.clear()
 		tc.runDropTable("test")
 		tc.clear()
 
-		tc.runCreateTable("test")
+		tc.runCreateTable("test", false)
 		tc.runModifyTable("test", model.ActionAddColumn)
 		tc.runModifyTable("test", model.ActionModifyColumn)
 

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -891,13 +891,13 @@ func (b *bundleInfoBuilder) completeUpdateTablesV2(is *infoschemaV2) {
 		return
 	}
 
-	for id, _ := range b.updatePolicies {
+	for id := range b.updatePolicies {
 		if _, ok := is.policyRefMap[id]; ok {
 			b.markTableBundleShouldUpdate(id)
 		}
 	}
 
-	for id, _ := range b.updatePartitions {
+	for id := range b.updatePartitions {
 		if _, ok := is.policyRefMap[id]; ok {
 			b.markTableBundleShouldUpdate(id)
 		}

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -28,9 +28,11 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/logutil"
 	fifo "github.com/scalalang2/golang-fifo"
 	"github.com/scalalang2/golang-fifo/sieve"
 	"github.com/tidwall/btree"
+	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -827,17 +829,59 @@ func (b *bundleInfoBuilder) updateInfoSchemaBundlesV2(is *infoschemaV2) {
 	if b.deltaUpdate {
 		b.completeUpdateTablesV2(is)
 		for tblID := range b.updateTables {
-			b.updateTableBundles(is, tblID)
+			b.updateTableBundlesV2(is, tblID)
 		}
 		return
 	}
 
-	// do full update bundles
+	// do full update bundles and policyRefs.
 	// TODO: This is quite inefficient! we need some better way or avoid this API.
 	is.ruleBundleMap = make(map[int64]*placement.Bundle)
 	for _, dbInfo := range is.AllSchemas() {
 		for _, tbl := range is.SchemaTables(dbInfo.Name) {
-			b.updateTableBundles(is, tbl.Meta().ID)
+			b.updateTableBundlesV2(is, tbl.Meta().ID)
+		}
+	}
+}
+
+func (b *bundleInfoBuilder) updateTableBundlesV2(infoSchemaInterface InfoSchema, tableID int64) {
+	is := infoSchemaInterface.base()
+	tbl, ok := infoSchemaInterface.TableByID(tableID)
+	if !ok {
+		b.deleteBundle(is, tableID)
+		delete(is.policyRefMap, tableID)
+		return
+	}
+
+	getter := &policyGetter{is: is}
+	bundle, err := placement.NewTableBundle(getter, tbl.Meta())
+	if err != nil {
+		logutil.BgLogger().Error("create table bundle failed", zap.Error(err))
+	} else if bundle != nil {
+		is.policyRefMap[tableID] = tbl.Meta().PlacementPolicyRef
+		is.ruleBundleMap[tableID] = bundle
+	} else {
+		b.deleteBundle(is, tableID)
+		delete(is.policyRefMap, tableID)
+	}
+
+	if tbl.Meta().Partition == nil {
+		return
+	}
+
+	for _, par := range tbl.Meta().Partition.Definitions {
+		bundle, err = placement.NewPartitionBundle(getter, par)
+		if err != nil {
+			logutil.BgLogger().Error("create partition bundle failed",
+				zap.Error(err),
+				zap.Int64("partition id", par.ID),
+			)
+		} else if bundle != nil {
+			is.policyRefMap[par.ID] = par.PlacementPolicyRef
+			is.ruleBundleMap[par.ID] = bundle
+		} else {
+			b.deleteBundle(is, par.ID)
+			delete(is.policyRefMap, par.ID)
 		}
 	}
 }
@@ -847,23 +891,15 @@ func (b *bundleInfoBuilder) completeUpdateTablesV2(is *infoschemaV2) {
 		return
 	}
 
-	// TODO: This is quite inefficient! we need some better way or avoid this API.
-	for _, dbInfo := range is.AllSchemas() {
-		for _, tbl := range is.SchemaTables(dbInfo.Name) {
-			tblInfo := tbl.Meta()
-			if tblInfo.PlacementPolicyRef != nil {
-				if _, ok := b.updatePolicies[tblInfo.PlacementPolicyRef.ID]; ok {
-					b.markTableBundleShouldUpdate(tblInfo.ID)
-				}
-			}
+	for id, _ := range b.updatePolicies {
+		if _, ok := is.policyRefMap[id]; ok {
+			b.markTableBundleShouldUpdate(id)
+		}
+	}
 
-			if tblInfo.Partition != nil {
-				for _, par := range tblInfo.Partition.Definitions {
-					if _, ok := b.updatePartitions[par.ID]; ok {
-						b.markTableBundleShouldUpdate(tblInfo.ID)
-					}
-				}
-			}
+	for id, _ := range b.updatePartitions {
+		if _, ok := is.policyRefMap[id]; ok {
+			b.markTableBundleShouldUpdate(id)
 		}
 	}
 }

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1483,7 +1483,7 @@ const (
 	DefTiDBSchemaVersionCacheLimit                    = 16
 	DefTiDBIdleTransactionTimeout                     = 0
 	DefTiDBTxnEntrySizeLimit                          = 0
-	DefTiDBSchemaCacheSize                            = 0
+	DefTiDBSchemaCacheSize                            = 1000
 	DefTiDBLowResolutionTSOUpdateInterval             = 2000
 	DefDivPrecisionIncrement                          = 4
 	DefTiDBDMLType                                    = "STANDARD"

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1483,7 +1483,7 @@ const (
 	DefTiDBSchemaVersionCacheLimit                    = 16
 	DefTiDBIdleTransactionTimeout                     = 0
 	DefTiDBTxnEntrySizeLimit                          = 0
-	DefTiDBSchemaCacheSize                            = 1000
+	DefTiDBSchemaCacheSize                            = 0
 	DefTiDBLowResolutionTSOUpdateInterval             = 2000
 	DefDivPrecisionIncrement                          = 4
 	DefTiDBDMLType                                    = "STANDARD"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50959 

Problem Summary:
1. Previously, when we build is, we iterate all tables and try to use policyRefs on each table.
2. Now, cache all policyRef then don't need to iterate all tables through network each time we build is.

### What changed and how does it work?
Before:
    bench_test with 10000 tables for v2 can't finished within 30min.
After:
 1.  bench_test with 10000 tables for v2 cost 38s.
 2. bench_test with 10000 tables for v1 cost 30s.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
