### PR TITLE
executor: fix issue of txn_ts of stale-read query is 0 in slow log

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -565,6 +565,9 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 	}
 	if txn.Valid() {
 		txnStartTS = txn.StartTS()
+	} else if staleread.IsStmtStaleness(a.Ctx) {
+		// for state-read stmt, txn.Valid() is false, then use stale-read-ts as txnStartTS to record in slow-log.
+		txnStartTS, _ = sessiontxn.GetTxnManager(a.Ctx).GetStmtReadTS()
 	}
 
 	return &recordSet{

--- a/pkg/executor/slow_query_sql_test.go
+++ b/pkg/executor/slow_query_sql_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/executor"
@@ -122,7 +123,7 @@ func TestSlowQueryNonPrepared(t *testing.T) {
 		`0 0 select * from t where a<3;`))
 }
 
-func TestSlowQueryPrepared(t *testing.T) {
+func TestSlowQueryMisc(t *testing.T) {
 	originCfg := config.GetGlobalConfig()
 	newCfg := *originCfg
 
@@ -158,6 +159,21 @@ func TestSlowQueryPrepared(t *testing.T) {
 	tk.MustQuery("SELECT Query FROM `information_schema`.`slow_query` " +
 		"where query like 'select%sleep%' order by time desc limit 1").
 		Check(testkit.Rows("select `sleep` ( ? ) , ?;"))
+
+	// Test 3 kinds of stale-read query.
+	tk.MustExec("create table test.t_stale_read (a int)")
+	time.Sleep(time.Second + time.Millisecond*10)
+	tk.MustExec("set tidb_redact_log=0;")
+	tk.MustExec("set @@tidb_read_staleness='-1'")
+	tk.MustQuery("select a from test.t_stale_read")
+	tk.MustExec("set @@tidb_read_staleness='0'")
+	t1 := time.Now()
+	tk.MustQuery(fmt.Sprintf("select a from test.t_stale_read as of timestamp '%s'", t1.Format("2006-1-2 15:04:05")))
+	tk.MustExec(fmt.Sprintf("start transaction read only as of timestamp '%v'", t1.Format("2006-1-2 15:04:05")))
+	tk.MustQuery("select a from test.t_stale_read")
+	tk.MustExec("commit")
+	require.Len(t, tk.MustQuery("SELECT query, txn_start_ts  FROM `information_schema`.`slow_query` "+
+		"where query like 'select % from %t_stale_read%' and Txn_start_ts > 0").Rows(), 3)
 }
 
 func TestLogSlowLogIndex(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #45545

Problem Summary: fix issue of txn_ts of stale-read query is 0 in slow log

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
