### PR TITLE
distsql, executor: remove pctx from trectx

### DIFF
--- a/pkg/distsql/BUILD.bazel
+++ b/pkg/distsql/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
         "//pkg/errctx",
         "//pkg/errno",
         "//pkg/expression",
-        "//pkg/infoschema",
+        "//pkg/infoschema/context",
         "//pkg/kv",
         "//pkg/metrics",
         "//pkg/parser/model",

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -132,6 +132,7 @@ go_library(
         "//pkg/expression/aggregation",
         "//pkg/expression/context",
         "//pkg/infoschema",
+        "//pkg/infoschema/context",
         "//pkg/keyspace",
         "//pkg/kv",
         "//pkg/lightning/log",

--- a/pkg/executor/table_reader.go
+++ b/pkg/executor/table_reader.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	exprctx "github.com/pingcap/tidb/pkg/expression/context"
 	"github.com/pingcap/tidb/pkg/infoschema"
+	isctx "github.com/pingcap/tidb/pkg/infoschema/context"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	planctx "github.com/pingcap/tidb/pkg/planner/context"
@@ -80,16 +81,16 @@ type tableReaderExecutorContext struct {
 	dctx       *distsqlctx.DistSQLContext
 	rctx       *rangerctx.RangerContext
 	buildPBCtx *planctx.BuildPBContext
-	pctx       planctx.PlanContext
 	ectx       exprctx.BuildContext
 
 	stmtMemTracker *memory.Tracker
 
+	infoSchema  isctx.MetaOnlyInfoSchema
 	getDDLOwner func(context.Context) (*infosync.ServerInfo, error)
 }
 
-func (treCtx *tableReaderExecutorContext) GetInfoSchema() infoschema.InfoSchema {
-	return treCtx.pctx.GetInfoSchema().(infoschema.InfoSchema)
+func (treCtx *tableReaderExecutorContext) GetInfoSchema() isctx.MetaOnlyInfoSchema {
+	return treCtx.infoSchema
 }
 
 func (treCtx *tableReaderExecutorContext) GetDDLOwner(ctx context.Context) (*infosync.ServerInfo, error) {
@@ -122,9 +123,9 @@ func newTableReaderExecutorContext(sctx sessionctx.Context) tableReaderExecutorC
 		dctx:           sctx.GetDistSQLCtx(),
 		rctx:           pctx.GetRangerCtx(),
 		buildPBCtx:     pctx.GetBuildPBCtx(),
-		pctx:           pctx,
 		ectx:           sctx.GetExprCtx(),
 		stmtMemTracker: sctx.GetSessionVars().StmtCtx.MemTracker,
+		infoSchema:     pctx.GetInfoSchema(),
 		getDDLOwner:    getDDLOwner,
 	}
 }

--- a/pkg/infoschema/context/BUILD.bazel
+++ b/pkg/infoschema/context/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["infoschema.go"],
     importpath = "github.com/pingcap/tidb/pkg/infoschema/context",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/parser/model"],
+    deps = [
+        "//pkg/ddl/placement",
+        "//pkg/parser/model",
+    ],
 )

--- a/pkg/infoschema/context/infoschema.go
+++ b/pkg/infoschema/context/infoschema.go
@@ -14,7 +14,10 @@
 
 package context
 
-import "github.com/pingcap/tidb/pkg/parser/model"
+import (
+	"github.com/pingcap/tidb/pkg/ddl/placement"
+	"github.com/pingcap/tidb/pkg/parser/model"
+)
 
 // MetaOnlyInfoSchema is a workaround.
 // Due to circular dependency cannot return the complete interface.
@@ -31,4 +34,23 @@ type MetaOnlyInfoSchema interface {
 	AllSchemas() []*model.DBInfo
 	AllSchemaNames() []model.CIStr
 	SchemaTableInfos(schema model.CIStr) []*model.TableInfo
+	Misc
+}
+
+// Misc contains the methods that are not closely related to InfoSchema.
+type Misc interface {
+	PolicyByName(name model.CIStr) (*model.PolicyInfo, bool)
+	ResourceGroupByName(name model.CIStr) (*model.ResourceGroupInfo, bool)
+	// PlacementBundleByPhysicalTableID is used to get a rule bundle.
+	PlacementBundleByPhysicalTableID(id int64) (*placement.Bundle, bool)
+	// AllPlacementBundles is used to get all placement bundles
+	AllPlacementBundles() []*placement.Bundle
+	// AllPlacementPolicies returns all placement policies
+	AllPlacementPolicies() []*model.PolicyInfo
+	// AllResourceGroups returns all resource groups
+	AllResourceGroups() []*model.ResourceGroupInfo
+	// HasTemporaryTable returns whether information schema has temporary table
+	HasTemporaryTable() bool
+	// GetTableReferredForeignKeys gets the table's ReferredFKInfo by lowercase schema and table name.
+	GetTableReferredForeignKeys(schema, table string) []*model.ReferredFKInfo
 }

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -32,7 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/mock"
 )
 
-var _ Misc = &infoSchemaMisc{}
+var _ context.Misc = &infoSchemaMisc{}
 
 type sortedTables []table.Table
 

--- a/pkg/infoschema/interface.go
+++ b/pkg/infoschema/interface.go
@@ -15,7 +15,6 @@
 package infoschema
 
 import (
-	"github.com/pingcap/tidb/pkg/ddl/placement"
 	"github.com/pingcap/tidb/pkg/infoschema/context"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/table"
@@ -30,24 +29,5 @@ type InfoSchema interface {
 	TableByID(id int64) (table.Table, bool)
 	SchemaTables(schema model.CIStr) []table.Table
 	FindTableByPartitionID(partitionID int64) (table.Table, *model.DBInfo, *model.PartitionDefinition)
-	Misc
 	base() *infoSchema
-}
-
-// Misc contains the methods that are not closely related to InfoSchema.
-type Misc interface {
-	PolicyByName(name model.CIStr) (*model.PolicyInfo, bool)
-	ResourceGroupByName(name model.CIStr) (*model.ResourceGroupInfo, bool)
-	// PlacementBundleByPhysicalTableID is used to get a rule bundle.
-	PlacementBundleByPhysicalTableID(id int64) (*placement.Bundle, bool)
-	// AllPlacementBundles is used to get all placement bundles
-	AllPlacementBundles() []*placement.Bundle
-	// AllPlacementPolicies returns all placement policies
-	AllPlacementPolicies() []*model.PolicyInfo
-	// AllResourceGroups returns all resource groups
-	AllResourceGroups() []*model.ResourceGroupInfo
-	// HasTemporaryTable returns whether information schema has temporary table
-	HasTemporaryTable() bool
-	// GetTableReferredForeignKeys gets the table's ReferredFKInfo by lowercase schema and table name.
-	GetTableReferredForeignKeys(schema, table string) []*model.ReferredFKInfo
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #52495

Problem Summary:

We have splited `PlanContext` into some tiny contexts (`BuildPBContext` and `RangerContext`). Now it's time to remove the `pctx` from `tableReaderExecutorContext`.

### What changed and how does it work?

1. Remove the `pctx` from `tableReaderExecutorContext`.
2. Replace the `any` in `distsql` into `MetaOnlyInfoSchema` (I don't know why it's originally `any`. Maybe it's used to avoid cyclic dependency?)

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->
  > Already be covered by existing tests.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
