### PR TITLE
lightning: return 0 early on empty parquet files (#52519)

### DIFF
--- a/br/pkg/lightning/mydump/loader.go
+++ b/br/pkg/lightning/mydump/loader.go
@@ -785,7 +785,7 @@ func SampleFileCompressRatio(ctx context.Context, fileMeta SourceFileMeta, store
 // SampleParquetDataSize samples the data size of the parquet file.
 func SampleParquetDataSize(ctx context.Context, fileMeta SourceFileMeta, store storage.ExternalStorage) (int64, error) {
 	totalRowCount, err := ReadParquetFileRowCountByFile(ctx, store, fileMeta)
-	if err != nil {
+	if totalRowCount == 0 || err != nil {
 		return 0, err
 	}
 

--- a/br/pkg/lightning/mydump/loader_test.go
+++ b/br/pkg/lightning/mydump/loader_test.go
@@ -1108,7 +1108,7 @@ func TestSampleFileCompressRatio(t *testing.T) {
 	require.InDelta(t, ratio, 5000.0/float64(bf.Len()), 1e-5)
 }
 
-func TestSampleParquetDataSize(t *testing.T) {
+func testSampleParquetDataSize(t *testing.T, count int) {
 	s := newTestMydumpLoaderSuite(t)
 	store, err := storage.NewLocalStorage(s.sourceDir)
 	require.NoError(t, err)
@@ -1133,7 +1133,7 @@ func TestSampleParquetDataSize(t *testing.T) {
 	t.Logf("seed: %d", seed)
 	rand.Seed(seed)
 	totalRowSize := 0
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < count; i++ {
 		kl := rand.Intn(20) + 1
 		key := make([]byte, kl)
 		kl, err = rand.Read(key)
@@ -1165,4 +1165,9 @@ func TestSampleParquetDataSize(t *testing.T) {
 	require.NoError(t, err)
 	// expected error within 10%, so delta = totalRowSize / 10
 	require.InDelta(t, totalRowSize, size, float64(totalRowSize)/10)
+}
+
+func TestSampleParquetDataSize(t *testing.T) {
+	t.Run("count=1000", func(t *testing.T) { testSampleParquetDataSize(t, 1000) })
+	t.Run("count=0", func(t *testing.T) { testSampleParquetDataSize(t, 0) })
 }


### PR DESCRIPTION
This is an manual cherry-pick of #52519

### What problem does this PR solve?

Issue Number: close #52518

Problem Summary:

### What changed and how does it work?

If the Parquet file is empty, directly set the size to be 0.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Importing empty tables via Parquet no longer crash.
```
