### PR TITLE
expression: Add `InInsertOrUpdate` in `BuildContext` and remove `GetSessionVars`

### DIFF
--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -96,6 +96,9 @@ type BuildContext interface {
 	SetInUnionCast(in bool)
 	// IsInUnionCast indicates whether executing in special cast context that negative unsigned num will be zero.
 	IsInUnionCast() bool
+	// Deprecated: This method is deprecated and may be removed in the future because it is coupled with statement.
+	// InInsertOrUpdate returns whether when are building an expression for insert or update statement.
+	InInsertOrUpdate() bool
 	// GetSessionVars gets the session variables.
 	GetSessionVars() *variable.SessionVars
 }

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -99,6 +99,9 @@ type BuildContext interface {
 	// Deprecated: This method is deprecated and may be removed in the future because it is coupled with statement.
 	// InInsertOrUpdate returns whether when are building an expression for insert or update statement.
 	InInsertOrUpdate() bool
+	// ConnectionID indicates the connection ID of the current session.
+	// If the context is not in a session, it should return 0.
+	ConnectionID() uint64
 }
 
 // ExprContext contains full context for expression building and evaluating.

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -99,8 +99,6 @@ type BuildContext interface {
 	// Deprecated: This method is deprecated and may be removed in the future because it is coupled with statement.
 	// InInsertOrUpdate returns whether when are building an expression for insert or update statement.
 	InInsertOrUpdate() bool
-	// GetSessionVars gets the session variables.
-	GetSessionVars() *variable.SessionVars
 }
 
 // ExprContext contains full context for expression building and evaluating.

--- a/pkg/expression/contextimpl/sessionctx.go
+++ b/pkg/expression/contextimpl/sessionctx.go
@@ -148,6 +148,12 @@ func (ctx *ExprCtxExtendedImpl) GetGroupConcatMaxLen() uint64 {
 	return ctx.sctx.GetSessionVars().GroupConcatMaxLen
 }
 
+// InInsertOrUpdate returns whether when are building an expression for insert or update statement.
+func (ctx *ExprCtxExtendedImpl) InInsertOrUpdate() bool {
+	sc := ctx.sctx.GetSessionVars().StmtCtx
+	return sc.InInsertStmt || sc.InUpdateStmt
+}
+
 // SessionEvalContext implements the `expression.EvalContext` interface to provide evaluation context in session.
 type SessionEvalContext struct {
 	sctx  sessionctx.Context

--- a/pkg/expression/contextimpl/sessionctx.go
+++ b/pkg/expression/contextimpl/sessionctx.go
@@ -154,6 +154,12 @@ func (ctx *ExprCtxExtendedImpl) InInsertOrUpdate() bool {
 	return sc.InInsertStmt || sc.InUpdateStmt
 }
 
+// ConnectionID indicates the connection ID of the current session.
+// If the context is not in a session, it should return 0.
+func (ctx *ExprCtxExtendedImpl) ConnectionID() uint64 {
+	return ctx.sctx.GetSessionVars().ConnectionID
+}
+
 // SessionEvalContext implements the `expression.EvalContext` interface to provide evaluation context in session.
 type SessionEvalContext struct {
 	sctx  sessionctx.Context

--- a/pkg/expression/contextimpl/sessionctx_test.go
+++ b/pkg/expression/contextimpl/sessionctx_test.go
@@ -329,4 +329,8 @@ func TestSessionBuildContext(t *testing.T) {
 	vars.StmtCtx.InInsertStmt = false
 	vars.StmtCtx.InUpdateStmt = false
 	require.False(t, impl.InInsertOrUpdate())
+
+	// ConnID
+	vars.ConnectionID = 123
+	require.Equal(t, uint64(123), impl.ConnectionID())
 }

--- a/pkg/expression/contextimpl/sessionctx_test.go
+++ b/pkg/expression/contextimpl/sessionctx_test.go
@@ -310,4 +310,23 @@ func TestSessionBuildContext(t *testing.T) {
 	require.True(t, impl.IsInUnionCast())
 	impl.SetInUnionCast(false)
 	require.False(t, impl.IsInUnionCast())
+
+	// InInsertOrUpdate
+	vars.StmtCtx.InInsertStmt = false
+	vars.StmtCtx.InUpdateStmt = false
+	require.False(t, impl.InInsertOrUpdate())
+
+	vars.StmtCtx.InInsertStmt = true
+	require.True(t, impl.InInsertOrUpdate())
+
+	vars.StmtCtx.InInsertStmt = false
+	vars.StmtCtx.InUpdateStmt = true
+	require.True(t, impl.InInsertOrUpdate())
+
+	vars.StmtCtx.InInsertStmt = true
+	require.True(t, impl.InInsertOrUpdate())
+
+	vars.StmtCtx.InInsertStmt = false
+	vars.StmtCtx.InUpdateStmt = false
+	require.False(t, impl.InInsertOrUpdate())
 }

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1221,15 +1221,15 @@ func ConstructPositionExpr(p *driver.ParamMarkerExpr) *ast.PositionExpr {
 }
 
 // PosFromPositionExpr generates a position value from PositionExpr.
-func PosFromPositionExpr(ctx BuildContext, v *ast.PositionExpr) (int, bool, error) {
+func PosFromPositionExpr(ctx BuildContext, vars variable.SessionVarsProvider, v *ast.PositionExpr) (int, bool, error) {
 	if v.P == nil {
 		return v.N, false, nil
 	}
-	value, err := ParamMarkerExpression(ctx, v.P.(*driver.ParamMarkerExpr), false)
+	value, err := ParamMarkerExpression(vars, v.P.(*driver.ParamMarkerExpr), false)
 	if err != nil {
 		return 0, true, err
 	}
-	pos, isNull, err := GetIntFromConstant(ctx, value)
+	pos, isNull, err := GetIntFromConstant(ctx.GetEvalCtx(), value)
 	if err != nil || isNull {
 		return 0, true, err
 	}
@@ -1237,13 +1237,13 @@ func PosFromPositionExpr(ctx BuildContext, v *ast.PositionExpr) (int, bool, erro
 }
 
 // GetStringFromConstant gets a string value from the Constant expression.
-func GetStringFromConstant(ctx BuildContext, value Expression) (string, bool, error) {
+func GetStringFromConstant(ctx EvalContext, value Expression) (string, bool, error) {
 	con, ok := value.(*Constant)
 	if !ok {
 		err := errors.Errorf("Not a Constant expression %+v", value)
 		return "", true, err
 	}
-	str, isNull, err := con.EvalString(ctx.GetEvalCtx(), chunk.Row{})
+	str, isNull, err := con.EvalString(ctx, chunk.Row{})
 	if err != nil || isNull {
 		return "", true, err
 	}
@@ -1251,7 +1251,7 @@ func GetStringFromConstant(ctx BuildContext, value Expression) (string, bool, er
 }
 
 // GetIntFromConstant gets an interger value from the Constant expression.
-func GetIntFromConstant(ctx BuildContext, value Expression) (int, bool, error) {
+func GetIntFromConstant(ctx EvalContext, value Expression) (int, bool, error) {
 	str, isNull, err := GetStringFromConstant(ctx, value)
 	if err != nil || isNull {
 		return 0, true, err

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1814,7 +1814,7 @@ func (er *expressionRewriter) positionToScalarFunc(planCtx *exprRewriterPlanCtx,
 	if v.P != nil {
 		stkLen := len(er.ctxStack)
 		val := er.ctxStack[stkLen-1]
-		intNum, isNull, err := expression.GetIntFromConstant(er.sctx, val)
+		intNum, isNull, err := expression.GetIntFromConstant(er.sctx.GetEvalCtx(), val)
 		str = "?"
 		if err == nil {
 			if isNull {

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -103,7 +103,7 @@ func (a *aggOrderByResolver) Enter(inNode ast.Node) (ast.Node, bool) {
 
 func (a *aggOrderByResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 	if v, ok := inNode.(*ast.PositionExpr); ok {
-		pos, isNull, err := expression.PosFromPositionExpr(a.ctx.GetExprCtx(), v)
+		pos, isNull, err := expression.PosFromPositionExpr(a.ctx.GetExprCtx(), a.ctx, v)
 		if err != nil {
 			a.err = err
 		}
@@ -2396,7 +2396,7 @@ func getUintFromNode(ctx PlanContext, n ast.Node, mustInt64orUint64 bool) (uVal 
 		if err != nil {
 			return 0, false, false
 		}
-		str, isNull, err := expression.GetStringFromConstant(ctx.GetExprCtx(), param)
+		str, isNull, err := expression.GetStringFromConstant(ctx.GetExprCtx().GetEvalCtx(), param)
 		if err != nil {
 			return 0, false, false
 		}
@@ -3261,7 +3261,7 @@ func (g *gbyResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 			return inNode, false
 		}
 	case *ast.PositionExpr:
-		pos, isNull, err := expression.PosFromPositionExpr(g.ctx.GetExprCtx(), v)
+		pos, isNull, err := expression.PosFromPositionExpr(g.ctx.GetExprCtx(), g.ctx, v)
 		if err != nil {
 			g.err = plannererrors.ErrUnknown.GenWithStackByArgs()
 		}

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	field_types "github.com/pingcap/tidb/pkg/parser/types"
-	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
@@ -234,10 +233,8 @@ func convertToIncorrectStringErr(err error, colName string) error {
 //	value (possibly adjusted)
 //	boolean; true if break error/warning handling in CastValue and return what was returned from this
 //	error
-func handleZeroDatetime(sessVars *variable.SessionVars, col *model.ColumnInfo, casted types.Datum, str string, tmIsInvalid bool) (types.Datum, bool, error) {
-	sc := sessVars.StmtCtx
+func handleZeroDatetime(ec errctx.Context, mode mysql.SQLMode, col *model.ColumnInfo, casted types.Datum, str string, tmIsInvalid bool) (types.Datum, bool, error) {
 	tm := casted.GetMysqlTime()
-	mode := sessVars.SQLMode
 
 	var (
 		zeroV types.Time
@@ -260,7 +257,7 @@ func handleZeroDatetime(sessVars *variable.SessionVars, col *model.ColumnInfo, c
 	// if NO_ZERO_IN_DATE is enabled, dates with zero parts are inserted as '0000-00-00' and produce a warning
 	// If NO_ZERO_IN_DATE mode and strict mode are enabled, dates with zero parts are not permitted and inserts produce an error, unless IGNORE is given as well. For INSERT IGNORE and UPDATE IGNORE, dates with zero parts are inserted as '0000-00-00' and produce a warning.
 
-	ignoreErr := sc.ErrGroupLevel(errctx.ErrGroupDupKey) != errctx.LevelError
+	ignoreErr := ec.LevelForGroup(errctx.ErrGroupDupKey) != errctx.LevelError
 
 	// Timestamp in MySQL is since EPOCH 1970-01-01 00:00:00 UTC and can by definition not have invalid dates!
 	// Zero date is special for MySQL timestamp and *NOT* 1970-01-01 00:00:00, but 0000-00-00 00:00:00!
@@ -281,7 +278,7 @@ func handleZeroDatetime(sessVars *variable.SessionVars, col *model.ColumnInfo, c
 		}
 
 		if tmIsInvalid || mode.HasNoZeroDateMode() {
-			sc.AppendWarning(innerErr)
+			ec.AppendWarning(innerErr)
 		}
 		return types.NewDatum(zeroV), true, nil
 	} else if tmIsInvalid && col.GetType() == mysql.TypeTimestamp {
@@ -291,7 +288,7 @@ func handleZeroDatetime(sessVars *variable.SessionVars, col *model.ColumnInfo, c
 			return types.NewDatum(zeroV), true, errors.Trace(warn)
 		}
 		// no strict mode, truncate to 0000-00-00 00:00:00
-		sc.AppendWarning(warn)
+		ec.AppendWarning(warn)
 		return types.NewDatum(zeroV), true, nil
 	} else if tm.IsZero() || tm.InvalidZero() {
 		if tm.IsZero() {
@@ -313,7 +310,7 @@ func handleZeroDatetime(sessVars *variable.SessionVars, col *model.ColumnInfo, c
 		// TODO: as in MySQL 8.0's implement, warning message is `types.ErrWarnDataOutOfRange`,
 		// but this error message need a `rowIdx` argument, in this context, the `rowIdx` is missing.
 		// And refactor this function seems too complicated, so we set the warning message the same to error's.
-		sc.AppendWarning(innerErr)
+		ec.AppendWarning(innerErr)
 		return types.NewDatum(zeroV), true, nil
 	}
 
@@ -327,14 +324,21 @@ func handleZeroDatetime(sessVars *variable.SessionVars, col *model.ColumnInfo, c
 // Set it to true only in FillVirtualColumnValue and UnionScanExec.Next()
 // If the handle of err is changed latter, the behavior of forceIgnoreTruncate also need to change.
 // TODO: change the third arg to TypeField. Not pass ColumnInfo.
-func CastValue(sctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, returnErr, forceIgnoreTruncate bool) (casted types.Datum, err error) {
-	return CastColumnValue(sctx.GetSessionVars(), val, col, returnErr, forceIgnoreTruncate)
+func CastValue(sctx variable.SessionVarsProvider, val types.Datum, col *model.ColumnInfo, returnErr, forceIgnoreTruncate bool) (casted types.Datum, err error) {
+	vars := sctx.GetSessionVars()
+	sc := vars.StmtCtx
+	return CastColumnValue(sc.TypeCtx(), sc.ErrCtx(), vars.SQLMode, val, col, sc.InInsertStmt || sc.InUpdateStmt, returnErr, forceIgnoreTruncate)
+}
+
+// CastColumnValueWithExprCtx casts a value based on column type with expression BuildContext
+func CastColumnValueWithExprCtx(ctx expression.BuildContext, val types.Datum, col *model.ColumnInfo, returnErr, forceIgnoreTruncate bool) (casted types.Datum, err error) {
+	evalCtx := ctx.GetEvalCtx()
+	return CastColumnValue(evalCtx.TypeCtx(), evalCtx.ErrCtx(), evalCtx.SQLMode(), val, col, ctx.InInsertOrUpdate(), returnErr, forceIgnoreTruncate)
 }
 
 // CastColumnValue casts a value based on column type.
-func CastColumnValue(vars *variable.SessionVars, val types.Datum, col *model.ColumnInfo, returnErr, forceIgnoreTruncate bool) (casted types.Datum, err error) {
-	sc := vars.StmtCtx
-	casted, err = val.ConvertTo(sc.TypeCtx(), &col.FieldType)
+func CastColumnValue(tc types.Context, ec errctx.Context, sqlMode mysql.SQLMode, val types.Datum, col *model.ColumnInfo, inInsertOrUpdate, returnErr, forceIgnoreTruncate bool) (casted types.Datum, err error) {
+	casted, err = val.ConvertTo(tc, &col.FieldType)
 	// TODO: make sure all truncate errors are handled by ConvertTo.
 	if returnErr && err != nil {
 		return casted, err
@@ -345,23 +349,22 @@ func CastColumnValue(vars *variable.SessionVars, val types.Datum, col *model.Col
 			logutil.BgLogger().Warn("Datum ToString failed", zap.Stringer("Datum", val), zap.Error(err1))
 		}
 		err = types.ErrTruncatedWrongVal.GenWithStackByArgs(col.FieldType.CompactStr(), str)
-	} else if (sc.InInsertStmt || sc.InUpdateStmt) && !casted.IsNull() &&
+	} else if inInsertOrUpdate && !casted.IsNull() &&
 		(col.GetType() == mysql.TypeDate || col.GetType() == mysql.TypeDatetime || col.GetType() == mysql.TypeTimestamp) {
 		str, err1 := val.ToString()
 		if err1 != nil {
 			logutil.BgLogger().Warn("Datum ToString failed", zap.Stringer("Datum", val), zap.Error(err1))
 			str = val.GetString()
 		}
-		if innCasted, exit, innErr := handleZeroDatetime(vars, col, casted, str, types.ErrWrongValue.Equal(err)); exit {
+		if innCasted, exit, innErr := handleZeroDatetime(ec, sqlMode, col, casted, str, types.ErrWrongValue.Equal(err)); exit {
 			return innCasted, innErr
 		}
 	} else if err != nil && charset.ErrInvalidCharacterString.Equal(err) {
 		err = convertToIncorrectStringErr(err, col.Name.O)
-		logutil.BgLogger().Debug("incorrect string value",
-			zap.Uint64("conn", vars.ConnectionID), zap.Error(err))
+		logutil.BgLogger().Debug("incorrect string value", zap.Error(err))
 	}
 
-	err = sc.HandleTruncate(err)
+	err = tc.HandleTruncate(err)
 
 	if forceIgnoreTruncate {
 		err = nil
@@ -573,7 +576,7 @@ func EvalColDefaultExpr(ctx expression.BuildContext, col *model.ColumnInfo, defa
 		return types.Datum{}, err
 	}
 	// Check the evaluated data type by cast.
-	value, err := CastColumnValue(ctx.GetSessionVars(), d, col, false, false)
+	value, err := CastColumnValueWithExprCtx(ctx, d, col, false, false)
 	if err != nil {
 		return types.Datum{}, err
 	}
@@ -592,7 +595,7 @@ func getColDefaultExprValue(ctx expression.BuildContext, col *model.ColumnInfo, 
 		return types.Datum{}, err
 	}
 	// Check the evaluated data type by cast.
-	value, err := CastColumnValue(ctx.GetSessionVars(), d, col, false, false)
+	value, err := CastColumnValueWithExprCtx(ctx, d, col, false, false)
 	if err != nil {
 		return types.Datum{}, err
 	}
@@ -607,7 +610,7 @@ func getColDefaultValue(ctx expression.BuildContext, col *model.ColumnInfo, defa
 	switch col.GetType() {
 	case mysql.TypeTimestamp, mysql.TypeDate, mysql.TypeDatetime:
 	default:
-		value, err := CastColumnValue(ctx.GetSessionVars(), types.NewDatum(defaultVal), col, false, false)
+		value, err := CastColumnValueWithExprCtx(ctx, types.NewDatum(defaultVal), col, false, false)
 		if err != nil {
 			return types.Datum{}, err
 		}
@@ -762,7 +765,7 @@ func FillVirtualColumnValue(virtualRetTypes []*types.FieldType, virtualColumnInd
 			}
 			// Because the expression might return different type from
 			// the generated column, we should wrap a CAST on the result.
-			castDatum, err := CastColumnValue(ectx.GetSessionVars(), datum, colInfos[idx], false, true)
+			castDatum, err := CastColumnValueWithExprCtx(ectx, datum, colInfos[idx], false, true)
 			if err != nil {
 				return err
 			}

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -327,17 +327,17 @@ func handleZeroDatetime(ec errctx.Context, mode mysql.SQLMode, col *model.Column
 func CastValue(sctx variable.SessionVarsProvider, val types.Datum, col *model.ColumnInfo, returnErr, forceIgnoreTruncate bool) (casted types.Datum, err error) {
 	vars := sctx.GetSessionVars()
 	sc := vars.StmtCtx
-	return castColumnValue(sc.TypeCtx(), sc.ErrCtx(), vars.SQLMode, val, col, sc.InInsertStmt || sc.InUpdateStmt, returnErr, forceIgnoreTruncate)
+	return castColumnValue(sc.TypeCtx(), sc.ErrCtx(), vars.SQLMode, val, col, vars.ConnectionID, sc.InInsertStmt || sc.InUpdateStmt, returnErr, forceIgnoreTruncate)
 }
 
 // CastColumnValue casts a value based on column type with expression BuildContext
 func CastColumnValue(ctx expression.BuildContext, val types.Datum, col *model.ColumnInfo, returnErr, forceIgnoreTruncate bool) (casted types.Datum, err error) {
 	evalCtx := ctx.GetEvalCtx()
-	return castColumnValue(evalCtx.TypeCtx(), evalCtx.ErrCtx(), evalCtx.SQLMode(), val, col, ctx.InInsertOrUpdate(), returnErr, forceIgnoreTruncate)
+	return castColumnValue(evalCtx.TypeCtx(), evalCtx.ErrCtx(), evalCtx.SQLMode(), val, col, ctx.ConnectionID(), ctx.InInsertOrUpdate(), returnErr, forceIgnoreTruncate)
 }
 
 // castColumnValue casts a value based on column type.
-func castColumnValue(tc types.Context, ec errctx.Context, sqlMode mysql.SQLMode, val types.Datum, col *model.ColumnInfo, inInsertOrUpdate, returnErr, forceIgnoreTruncate bool) (casted types.Datum, err error) {
+func castColumnValue(tc types.Context, ec errctx.Context, sqlMode mysql.SQLMode, val types.Datum, col *model.ColumnInfo, connID uint64, inInsertOrUpdate, returnErr, forceIgnoreTruncate bool) (casted types.Datum, err error) {
 	casted, err = val.ConvertTo(tc, &col.FieldType)
 	// TODO: make sure all truncate errors are handled by ConvertTo.
 	if returnErr && err != nil {
@@ -361,7 +361,7 @@ func castColumnValue(tc types.Context, ec errctx.Context, sqlMode mysql.SQLMode,
 		}
 	} else if err != nil && charset.ErrInvalidCharacterString.Equal(err) {
 		err = convertToIncorrectStringErr(err, col.Name.O)
-		logutil.BgLogger().Debug("incorrect string value", zap.Error(err))
+		logutil.BgLogger().Debug("incorrect string value", zap.Uint64("conn", connID), zap.Error(err))
 	}
 
 	err = tc.HandleTruncate(err)

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -475,7 +475,7 @@ func (t *TableCommon) UpdateRecord(ctx context.Context, sctx table.MutateContext
 		if col.State == model.StateDeleteOnly || col.State == model.StateDeleteReorganization {
 			if col.ChangeStateInfo != nil {
 				// TODO: Check overflow or ignoreTruncate.
-				value, err = t.castColumnValue(sctx, oldData[col.DependencyColumnOffset], col.ColumnInfo)
+				value, err = table.CastColumnValue(sctx.GetExprCtx(), oldData[col.DependencyColumnOffset], col.ColumnInfo, false, false)
 				if err != nil {
 					logutil.BgLogger().Info("update record cast value failed", zap.Any("col", col), zap.Uint64("txnStartTS", txn.StartTS()),
 						zap.String("handle", h.String()), zap.Any("val", oldData[col.DependencyColumnOffset]), zap.Error(err))
@@ -487,7 +487,7 @@ func (t *TableCommon) UpdateRecord(ctx context.Context, sctx table.MutateContext
 			if needChecksum {
 				if col.ChangeStateInfo != nil {
 					// TODO: Check overflow or ignoreTruncate.
-					v, err := t.castColumnValue(sctx, newData[col.DependencyColumnOffset], col.ColumnInfo)
+					v, err := table.CastColumnValue(sctx.GetExprCtx(), newData[col.DependencyColumnOffset], col.ColumnInfo, false, false)
 					if err != nil {
 						return err
 					}
@@ -509,7 +509,7 @@ func (t *TableCommon) UpdateRecord(ctx context.Context, sctx table.MutateContext
 			value = oldData[col.Offset]
 			if col.ChangeStateInfo != nil {
 				// TODO: Check overflow or ignoreTruncate.
-				value, err = t.castColumnValue(sctx, newData[col.DependencyColumnOffset], col.ColumnInfo)
+				value, err = table.CastColumnValue(sctx.GetExprCtx(), newData[col.DependencyColumnOffset], col.ColumnInfo, false, false)
 				if err != nil {
 					return err
 				}
@@ -926,7 +926,7 @@ func (t *TableCommon) AddRecord(sctx table.MutateContext, r []types.Datum, opts 
 			if needChecksum {
 				if col.ChangeStateInfo != nil {
 					// TODO: Check overflow or ignoreTruncate.
-					v, err := t.castColumnValue(sctx, r[col.DependencyColumnOffset], col.ColumnInfo)
+					v, err := table.CastColumnValue(sctx.GetExprCtx(), r[col.DependencyColumnOffset], col.ColumnInfo, false, false)
 					if err != nil {
 						return nil, err
 					}
@@ -945,7 +945,7 @@ func (t *TableCommon) AddRecord(sctx table.MutateContext, r []types.Datum, opts 
 		// for the new insert statement, we should use the casted value of relative column to insert.
 		if col.ChangeStateInfo != nil && col.State != model.StatePublic {
 			// TODO: Check overflow or ignoreTruncate.
-			value, err = t.castColumnValue(sctx, r[col.DependencyColumnOffset], col.ColumnInfo)
+			value, err = table.CastColumnValue(sctx.GetExprCtx(), r[col.DependencyColumnOffset], col.ColumnInfo, false, false)
 			if err != nil {
 				return nil, err
 			}
@@ -1342,7 +1342,7 @@ func (t *TableCommon) RemoveRecord(ctx table.MutateContext, h kv.Handle, r []typ
 		// The changing column datum derived from related column should be casted here.
 		// Otherwise, the existed changing indexes will not be deleted.
 		relatedColDatum := r[t.Columns[len(r)].ChangeStateInfo.DependencyColumnOffset]
-		value, err := t.castColumnValue(ctx, relatedColDatum, t.Columns[len(r)].ColumnInfo)
+		value, err := table.CastColumnValue(ctx.GetExprCtx(), relatedColDatum, t.Columns[len(r)].ColumnInfo, false, false)
 		if err != nil {
 			logutil.BgLogger().Info("remove record cast value failed", zap.Any("col", t.Columns[len(r)]),
 				zap.String("handle", h.String()), zap.Any("val", relatedColDatum), zap.Error(err))
@@ -2197,10 +2197,6 @@ func (t *TableCommon) GetSequenceID() int64 {
 // GetSequenceCommon is used in test to get sequenceCommon.
 func (t *TableCommon) GetSequenceCommon() *sequenceCommon {
 	return t.sequence
-}
-
-func (t *TableCommon) castColumnValue(ctx table.MutateContext, val types.Datum, col *model.ColumnInfo) (casted types.Datum, err error) {
-	return table.CastValue(ctx, val, col, false, false)
 }
 
 // TryGetHandleRestoredDataWrapper tries to get the restored data for handle if needed. The argument can be a slice or a map.

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -475,7 +475,7 @@ func (t *TableCommon) UpdateRecord(ctx context.Context, sctx table.MutateContext
 		if col.State == model.StateDeleteOnly || col.State == model.StateDeleteReorganization {
 			if col.ChangeStateInfo != nil {
 				// TODO: Check overflow or ignoreTruncate.
-				value, err = table.CastColumnValue(sctx.GetSessionVars(), oldData[col.DependencyColumnOffset], col.ColumnInfo, false, false)
+				value, err = t.castColumnValue(sctx, oldData[col.DependencyColumnOffset], col.ColumnInfo)
 				if err != nil {
 					logutil.BgLogger().Info("update record cast value failed", zap.Any("col", col), zap.Uint64("txnStartTS", txn.StartTS()),
 						zap.String("handle", h.String()), zap.Any("val", oldData[col.DependencyColumnOffset]), zap.Error(err))
@@ -487,7 +487,7 @@ func (t *TableCommon) UpdateRecord(ctx context.Context, sctx table.MutateContext
 			if needChecksum {
 				if col.ChangeStateInfo != nil {
 					// TODO: Check overflow or ignoreTruncate.
-					v, err := table.CastColumnValue(sctx.GetSessionVars(), newData[col.DependencyColumnOffset], col.ColumnInfo, false, false)
+					v, err := t.castColumnValue(sctx, newData[col.DependencyColumnOffset], col.ColumnInfo)
 					if err != nil {
 						return err
 					}
@@ -509,7 +509,7 @@ func (t *TableCommon) UpdateRecord(ctx context.Context, sctx table.MutateContext
 			value = oldData[col.Offset]
 			if col.ChangeStateInfo != nil {
 				// TODO: Check overflow or ignoreTruncate.
-				value, err = table.CastColumnValue(sctx.GetSessionVars(), newData[col.DependencyColumnOffset], col.ColumnInfo, false, false)
+				value, err = t.castColumnValue(sctx, newData[col.DependencyColumnOffset], col.ColumnInfo)
 				if err != nil {
 					return err
 				}
@@ -926,7 +926,7 @@ func (t *TableCommon) AddRecord(sctx table.MutateContext, r []types.Datum, opts 
 			if needChecksum {
 				if col.ChangeStateInfo != nil {
 					// TODO: Check overflow or ignoreTruncate.
-					v, err := table.CastColumnValue(sctx.GetSessionVars(), r[col.DependencyColumnOffset], col.ColumnInfo, false, false)
+					v, err := t.castColumnValue(sctx, r[col.DependencyColumnOffset], col.ColumnInfo)
 					if err != nil {
 						return nil, err
 					}
@@ -945,7 +945,7 @@ func (t *TableCommon) AddRecord(sctx table.MutateContext, r []types.Datum, opts 
 		// for the new insert statement, we should use the casted value of relative column to insert.
 		if col.ChangeStateInfo != nil && col.State != model.StatePublic {
 			// TODO: Check overflow or ignoreTruncate.
-			value, err = table.CastColumnValue(sctx.GetSessionVars(), r[col.DependencyColumnOffset], col.ColumnInfo, false, false)
+			value, err = t.castColumnValue(sctx, r[col.DependencyColumnOffset], col.ColumnInfo)
 			if err != nil {
 				return nil, err
 			}
@@ -1342,7 +1342,7 @@ func (t *TableCommon) RemoveRecord(ctx table.MutateContext, h kv.Handle, r []typ
 		// The changing column datum derived from related column should be casted here.
 		// Otherwise, the existed changing indexes will not be deleted.
 		relatedColDatum := r[t.Columns[len(r)].ChangeStateInfo.DependencyColumnOffset]
-		value, err := table.CastColumnValue(ctx.GetSessionVars(), relatedColDatum, t.Columns[len(r)].ColumnInfo, false, false)
+		value, err := t.castColumnValue(ctx, relatedColDatum, t.Columns[len(r)].ColumnInfo)
 		if err != nil {
 			logutil.BgLogger().Info("remove record cast value failed", zap.Any("col", t.Columns[len(r)]),
 				zap.String("handle", h.String()), zap.Any("val", relatedColDatum), zap.Error(err))
@@ -2197,6 +2197,10 @@ func (t *TableCommon) GetSequenceID() int64 {
 // GetSequenceCommon is used in test to get sequenceCommon.
 func (t *TableCommon) GetSequenceCommon() *sequenceCommon {
 	return t.sequence
+}
+
+func (t *TableCommon) castColumnValue(ctx table.MutateContext, val types.Datum, col *model.ColumnInfo) (casted types.Datum, err error) {
+	return table.CastValue(ctx, val, col, false, false)
 }
 
 // TryGetHandleRestoredDataWrapper tries to get the restored data for handle if needed. The argument can be a slice or a map.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52366

### What changed and how does it work?

- Add a new method `InInsertOrUpdate` in `BuildContext` to indicate whether we are building an expression in insert or update statement for some special logics in `CastColumnValue`. Because it is coupled with the statement, we marked it as "deprecated and" considering removing it in the future. However, we keep it as it is now to avoid introducing new bugs.
- Remove `GetSessionVars` in `BuildContext`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
