### PR TITLE
fast_create_table: add retry for local worker

### DIFF
--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -494,7 +494,17 @@ func (d *ddl) delivery2LocalWorker(pool *workerPool, task *limitJobTask) {
 			metrics.DDLRunningJobCount.WithLabelValues(pool.tp().String()).Dec()
 		}()
 
-		err := wk.HandleLocalDDLJob(d.ddlCtx, job)
+		maxRetryTime := 100
+		var err error
+		for i := 0; i < maxRetryTime; i++ {
+			err = wk.HandleLocalDDLJob(d.ddlCtx, job)
+			// since local the job is not inserted into the ddl job queue, we need to add retry logic here.
+			if err == nil || !isRetryableError(err) {
+				break
+			}
+			logutil.DDLLogger().Info("handle local ddl job", zap.Int("retry times", i), zap.Error(err))
+			time.Sleep(time.Second)
+		}
 		pool.put(wk)
 		if err != nil {
 			logutil.DDLLogger().Info("handle ddl job failed", zap.Error(err), zap.Stringer("job", job))

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -494,10 +494,8 @@ func (d *ddl) delivery2LocalWorker(pool *workerPool, task *limitJobTask) {
 			metrics.DDLRunningJobCount.WithLabelValues(pool.tp().String()).Dec()
 		}()
 
-		maxRetryTime := 100
-		var err error
-		for i := 0; i < maxRetryTime; i++ {
-			err = wk.HandleLocalDDLJob(d.ddlCtx, job)
+		for i := int64(0); i < variable.GetDDLErrorCountLimit(); i++ {
+			err := wk.HandleLocalDDLJob(d.ddlCtx, job)
 			// since local the job is not inserted into the ddl job queue, we need to add retry logic here.
 			if err == nil || !isRetryableError(err) {
 				break

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -500,7 +500,7 @@ func (d *ddl) delivery2LocalWorker(pool *workerPool, task *limitJobTask) {
 			if err == nil || !isRetryableError(err) {
 				break
 			}
-			logutil.DDLLogger().Info("handle local ddl job", zap.Int("retry times", i), zap.Error(err))
+			logutil.DDLLogger().Info("handle local ddl job", zap.Int64("retry times", i), zap.Error(err))
 			time.Sleep(time.Second)
 		}
 		pool.put(wk)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/49752

Problem Summary:

### What changed and how does it work?
- add retry for retryable error
- add id allocator to reduce write conflict
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
