### PR TITLE
statistics: reduce small obj alloc for PreCalculateScalar

### DIFF
--- a/pkg/statistics/scalar.go
+++ b/pkg/statistics/scalar.go
@@ -101,24 +101,26 @@ func (hg *Histogram) PreCalculateScalar() {
 	}
 	switch hg.GetLower(0).Kind() {
 	case types.KindMysqlDecimal, types.KindMysqlTime:
-		lower, upper := new(types.Datum), new(types.Datum)
+		var lower, upper types.Datum
 		hg.Scalars = make([]scalar, l)
 		for i := 0; i < l; i++ {
-			hg.LowerToDatum(i, lower)
-			hg.UpperToDatum(i, upper)
-			hg.Scalars[i].lower = convertDatumToScalar(lower, 0)
-			hg.Scalars[i].upper = convertDatumToScalar(upper, 0)
+			// It's read-only, so we don't need to allocate new datum each time.
+			hg.LowerToDatum(i, &lower)
+			hg.UpperToDatum(i, &upper)
+			hg.Scalars[i].lower = convertDatumToScalar(&lower, 0)
+			hg.Scalars[i].upper = convertDatumToScalar(&upper, 0)
 		}
 	case types.KindBytes, types.KindString:
-		lower, upper := new(types.Datum), new(types.Datum)
+		var lower, upper types.Datum
 		hg.Scalars = make([]scalar, l)
 		for i := 0; i < l; i++ {
-			hg.LowerToDatum(i, lower)
-			hg.UpperToDatum(i, upper)
+			// It's read-only, so we don't need to allocate new datum each time.
+			hg.LowerToDatum(i, &lower)
+			hg.UpperToDatum(i, &upper)
 			common := commonPrefixLength(lower.GetBytes(), upper.GetBytes())
 			hg.Scalars[i].commonPfxLen = common
-			hg.Scalars[i].lower = convertDatumToScalar(lower, common)
-			hg.Scalars[i].upper = convertDatumToScalar(upper, common)
+			hg.Scalars[i].lower = convertDatumToScalar(&lower, common)
+			hg.Scalars[i].upper = convertDatumToScalar(&upper, common)
 		}
 	}
 }

--- a/pkg/statistics/scalar.go
+++ b/pkg/statistics/scalar.go
@@ -101,23 +101,24 @@ func (hg *Histogram) PreCalculateScalar() {
 	}
 	switch hg.GetLower(0).Kind() {
 	case types.KindMysqlDecimal, types.KindMysqlTime:
+		lower, upper := new(types.Datum), new(types.Datum)
 		hg.Scalars = make([]scalar, l)
 		for i := 0; i < l; i++ {
-			hg.Scalars[i] = scalar{
-				lower: convertDatumToScalar(hg.GetLower(i), 0),
-				upper: convertDatumToScalar(hg.GetUpper(i), 0),
-			}
+			hg.LowerToDatum(i, lower)
+			hg.UpperToDatum(i, upper)
+			hg.Scalars[i].lower = convertDatumToScalar(lower, 0)
+			hg.Scalars[i].upper = convertDatumToScalar(upper, 0)
 		}
 	case types.KindBytes, types.KindString:
+		lower, upper := new(types.Datum), new(types.Datum)
 		hg.Scalars = make([]scalar, l)
 		for i := 0; i < l; i++ {
-			lower, upper := hg.GetLower(i), hg.GetUpper(i)
+			hg.LowerToDatum(i, lower)
+			hg.UpperToDatum(i, upper)
 			common := commonPrefixLength(lower.GetBytes(), upper.GetBytes())
-			hg.Scalars[i] = scalar{
-				commonPfxLen: common,
-				lower:        convertDatumToScalar(lower, common),
-				upper:        convertDatumToScalar(upper, common),
-			}
+			hg.Scalars[i].commonPfxLen = common
+			hg.Scalars[i].lower = convertDatumToScalar(lower, common)
+			hg.Scalars[i].upper = convertDatumToScalar(upper, common)
 		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/52343

Problem Summary:

We don't need to re-alloc anything since we only read from the chunk, no modification after reading it.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
