### PR TITLE
server, test: fix a minor TZ issue in TestDumpBinaryTime

### DIFF
--- a/pkg/server/internal/dump/dump_test.go
+++ b/pkg/server/internal/dump/dump_test.go
@@ -29,7 +29,7 @@ func TestDumpBinaryTime(t *testing.T) {
 	d := BinaryDateTime(nil, parsedTime)
 	require.Equal(t, []byte{0}, d)
 
-	parsedTime, err = types.ParseTimestamp(typeCtx.WithLocation(time.Local), "1991-05-01 01:01:01.100001")
+	parsedTime, err = types.ParseTimestamp(typeCtx.WithLocation(time.UTC), "1991-05-01 01:01:01.100001")
 	require.NoError(t, err)
 	d = BinaryDateTime(nil, parsedTime)
 	// 199 & 7 composed to uint16 1991 (litter-endian)


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52345

Problem Summary:

### What changed and how does it work?
Change the TZ used in `TestDumpBinaryTime` from `Local` to `UTC` to fix invalid time when the system TZ is `Egypt`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Side effects

-  None

Documentation

- NA

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
