### PR TITLE
expression: remove `InUnion/SetInUnion` in `BuildContext`

### DIFF
--- a/pkg/expression/bench_test.go
+++ b/pkg/expression/bench_test.go
@@ -1436,11 +1436,11 @@ func genVecBuiltinFuncBenchCase(ctx BuildContext, funcName string, testCase vecE
 		tp := eType2FieldType(testCase.retEvalType)
 		switch testCase.retEvalType {
 		case types.ETInt:
-			fc = &castAsIntFunctionClass{baseFunctionClass{ast.Cast, 1, 1}, tp}
+			fc = &castAsIntFunctionClass{baseFunctionClass{ast.Cast, 1, 1}, tp, false}
 		case types.ETDecimal:
-			fc = &castAsDecimalFunctionClass{baseFunctionClass{ast.Cast, 1, 1}, tp}
+			fc = &castAsDecimalFunctionClass{baseFunctionClass{ast.Cast, 1, 1}, tp, false}
 		case types.ETReal:
-			fc = &castAsRealFunctionClass{baseFunctionClass{ast.Cast, 1, 1}, tp}
+			fc = &castAsRealFunctionClass{baseFunctionClass{ast.Cast, 1, 1}, tp, false}
 		case types.ETDatetime, types.ETTimestamp:
 			fc = &castAsTimeFunctionClass{baseFunctionClass{ast.Cast, 1, 1}, tp}
 		case types.ETDuration:

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -1690,7 +1690,7 @@ func TestCastArrayFunc(t *testing.T) {
 		},
 	}
 	for _, tt := range tbl {
-		f, err := BuildCastFunctionWithCheck(ctx, datumsToConstants(types.MakeDatums(types.CreateBinaryJSON(tt.input)))[0], tt.tp)
+		f, err := BuildCastFunctionWithCheck(ctx, datumsToConstants(types.MakeDatums(types.CreateBinaryJSON(tt.input)))[0], tt.tp, false)
 		if !tt.buildFuncSuccess {
 			require.Error(t, err, tt.input)
 			continue

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -88,10 +88,6 @@ type BuildContext interface {
 	// in most cases except for the method `isNullRejected` in planner.
 	// See the comments for `isNullRejected` in planner for more details.
 	IsInNullRejectCheck() bool
-	// SetInUnionCast sets the flag to indicate whether the expression is in union cast.
-	SetInUnionCast(in bool)
-	// IsInUnionCast indicates whether executing in special cast context that negative unsigned num will be zero.
-	IsInUnionCast() bool
 	// ConnectionID indicates the connection ID of the current session.
 	// If the context is not in a session, it should return 0.
 	ConnectionID() uint64

--- a/pkg/expression/contextsession/sessionctx.go
+++ b/pkg/expression/contextsession/sessionctx.go
@@ -17,7 +17,6 @@ package contextsession
 import (
 	"context"
 	"math"
-	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/errctx"
@@ -52,7 +51,6 @@ var _ exprctx.ExprContext = struct {
 type ExprCtxExtendedImpl struct {
 	sctx sessionctx.Context
 	*SessionEvalContext
-	inUnionCast atomic.Bool
 }
 
 // NewExprExtendedImpl creates a new ExprCtxExtendedImpl.
@@ -119,16 +117,6 @@ func (ctx *ExprCtxExtendedImpl) AllocPlanColumnID() int64 {
 // IsInNullRejectCheck returns whether the expression is in null reject check.
 func (ctx *ExprCtxExtendedImpl) IsInNullRejectCheck() bool {
 	return false
-}
-
-// SetInUnionCast sets the flag to indicate whether the expression is in union cast.
-func (ctx *ExprCtxExtendedImpl) SetInUnionCast(in bool) {
-	ctx.inUnionCast.Store(in)
-}
-
-// IsInUnionCast indicates whether executing in special cast context that negative unsigned num will be zero.
-func (ctx *ExprCtxExtendedImpl) IsInUnionCast() bool {
-	return ctx.inUnionCast.Load()
 }
 
 // GetWindowingUseHighPrecision determines whether to compute window operations without loss of precision.

--- a/pkg/expression/contextsession/sessionctx_test.go
+++ b/pkg/expression/contextsession/sessionctx_test.go
@@ -316,13 +316,6 @@ func TestSessionBuildContext(t *testing.T) {
 	// InNullRejectCheck
 	require.False(t, impl.IsInNullRejectCheck())
 
-	// InUnionCast
-	require.False(t, impl.IsInUnionCast())
-	impl.SetInUnionCast(true)
-	require.True(t, impl.IsInUnionCast())
-	impl.SetInUnionCast(false)
-	require.False(t, impl.IsInUnionCast())
-
 	// ConnID
 	vars.ConnectionID = 123
 	require.Equal(t, uint64(123), impl.ConnectionID())

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1493,7 +1493,7 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 			return retNode, false
 		}
 
-		castFunction, err := expression.BuildCastFunctionWithCheck(er.sctx, arg, v.Tp)
+		castFunction, err := expression.BuildCastFunctionWithCheck(er.sctx, arg, v.Tp, false)
 		if err != nil {
 			er.err = err
 			return retNode, false


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52707

Problem Summary:

It's better to remove `InUnion/SetInUnion`  in `BuildContext` in two reasons:

1. It is an intermediate and set inside by the build function itself only. Removing it can make `BuildContext` more simple.
2. If `BuildContext` is used in concurrency, `InUnion/SetInUnion` may cause a data race.

### What changed and how does it work?

Remove `InUnion/SetInUnion` in `BuildContext` and move the "in union" state to argument.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
