### PR TITLE
expression: remove `InInsertOrUpdate` in `BuildExpression`

### DIFF
--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -91,9 +91,6 @@ type BuildContext interface {
 	SetInUnionCast(in bool)
 	// IsInUnionCast indicates whether executing in special cast context that negative unsigned num will be zero.
 	IsInUnionCast() bool
-	// Deprecated: This method is deprecated and may be removed in the future because it is coupled with statement.
-	// InInsertOrUpdate returns whether when are building an expression for insert or update statement.
-	InInsertOrUpdate() bool
 	// ConnectionID indicates the connection ID of the current session.
 	// If the context is not in a session, it should return 0.
 	ConnectionID() uint64

--- a/pkg/expression/contextsession/sessionctx.go
+++ b/pkg/expression/contextsession/sessionctx.go
@@ -148,12 +148,6 @@ func (ctx *ExprCtxExtendedImpl) GetGroupConcatMaxLen() uint64 {
 	return ctx.sctx.GetSessionVars().GroupConcatMaxLen
 }
 
-// InInsertOrUpdate returns whether when are building an expression for insert or update statement.
-func (ctx *ExprCtxExtendedImpl) InInsertOrUpdate() bool {
-	sc := ctx.sctx.GetSessionVars().StmtCtx
-	return sc.InInsertStmt || sc.InUpdateStmt
-}
-
 // ConnectionID indicates the connection ID of the current session.
 // If the context is not in a session, it should return 0.
 func (ctx *ExprCtxExtendedImpl) ConnectionID() uint64 {

--- a/pkg/expression/contextsession/sessionctx_test.go
+++ b/pkg/expression/contextsession/sessionctx_test.go
@@ -327,25 +327,6 @@ func TestSessionBuildContext(t *testing.T) {
 	impl.SetInUnionCast(false)
 	require.False(t, impl.IsInUnionCast())
 
-	// InInsertOrUpdate
-	vars.StmtCtx.InInsertStmt = false
-	vars.StmtCtx.InUpdateStmt = false
-	require.False(t, impl.InInsertOrUpdate())
-
-	vars.StmtCtx.InInsertStmt = true
-	require.True(t, impl.InInsertOrUpdate())
-
-	vars.StmtCtx.InInsertStmt = false
-	vars.StmtCtx.InUpdateStmt = true
-	require.True(t, impl.InInsertOrUpdate())
-
-	vars.StmtCtx.InInsertStmt = true
-	require.True(t, impl.InInsertOrUpdate())
-
-	vars.StmtCtx.InInsertStmt = false
-	vars.StmtCtx.InUpdateStmt = false
-	require.False(t, impl.InInsertOrUpdate())
-
 	// ConnID
 	vars.ConnectionID = 123
 	require.Equal(t, uint64(123), impl.ConnectionID())

--- a/tests/integrationtest/r/ddl/column_type_change.result
+++ b/tests/integrationtest/r/ddl/column_type_change.result
@@ -501,7 +501,7 @@ alter table t modify bny date;
 alter table t modify vbny date;
 alter table t modify bb date;
 alter table t modify txt date;
-Error 1292 (22007): Incorrect datetime value: '08-26 19:35:41'
+Error 1292 (22007): Incorrect date value: '08-26 19:35:41'
 alter table t modify e date;
 Error 8200 (HY000): Unsupported modify column: [ddl:8200]Unsupported modify column: change from original type enum('123','2020-07-15 18:32:17.888','str','{"k1": "value"}') to date is currently unsupported yet
 alter table t modify s date;
@@ -663,9 +663,9 @@ Error 1292 (22007): Truncated incorrect DOUBLE value: 'abc     '
 alter table t modify vbny datetime;
 Error 1292 (22007): Incorrect datetime value: 'datetime'
 alter table t modify bb timestamp;
-Error 1292 (22007): Incorrect datetime value: 'timestamp'
+Error 1292 (22007): Incorrect timestamp value: 'timestamp'
 alter table t modify txt date;
-Error 1292 (22007): Incorrect datetime value: 'date'
+Error 1292 (22007): Incorrect date value: 'date'
 drop table if exists t;
 create table t (
 c char(8),
@@ -1963,15 +1963,15 @@ nul json
 );
 insert into t values ('{"obj": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '20200826173501', '20201123', '20200826173501.123456', '"2020-08-26 17:35:01.123456"', null);
 alter table t modify obj date;
-Error 1292 (22007): Incorrect datetime value: '{"obj": 100}'
+Error 1292 (22007): Incorrect date value: '{"obj": 100}'
 alter table t modify arr date;
-Error 1292 (22007): Incorrect datetime value: '[-1, 0, 1]'
+Error 1292 (22007): Incorrect date value: '[-1, 0, 1]'
 alter table t modify nil date;
-Error 1292 (22007): Incorrect datetime value: 'null'
+Error 1292 (22007): Incorrect date value: 'null'
 alter table t modify t date;
-Error 1292 (22007): Incorrect datetime value: 'true'
+Error 1292 (22007): Incorrect date value: 'true'
 alter table t modify f date;
-Error 1292 (22007): Incorrect datetime value: 'false'
+Error 1292 (22007): Incorrect date value: 'false'
 alter table t modify i date;
 alter table t modify ui date;
 alter table t modify f64 date;
@@ -1995,15 +1995,15 @@ nul json
 );
 insert into t values ('{"obj": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '20200826173501', '20201123', '20200826173501.123456', '"2020-08-26 17:35:01.123456"', null);
 alter table t modify obj timestamp;
-Error 1292 (22007): Incorrect datetime value: '{"obj": 100}'
+Error 1292 (22007): Incorrect timestamp value: '{"obj": 100}'
 alter table t modify arr timestamp;
-Error 1292 (22007): Incorrect datetime value: '[-1, 0, 1]'
+Error 1292 (22007): Incorrect timestamp value: '[-1, 0, 1]'
 alter table t modify nil timestamp;
-Error 1292 (22007): Incorrect datetime value: 'null'
+Error 1292 (22007): Incorrect timestamp value: 'null'
 alter table t modify t timestamp;
-Error 1292 (22007): Incorrect datetime value: 'true'
+Error 1292 (22007): Incorrect timestamp value: 'true'
 alter table t modify f timestamp;
-Error 1292 (22007): Incorrect datetime value: 'false'
+Error 1292 (22007): Incorrect timestamp value: 'false'
 alter table t modify i timestamp;
 alter table t modify ui timestamp;
 alter table t modify f64 timestamp;
@@ -2117,20 +2117,20 @@ drop table if exists t;
 create table t (a int(10) unsigned default null, b bigint unsigned, c tinyint unsigned);
 insert into t values (1, 1, 1);
 alter table t modify column a datetime;
-Error 1292 (22007): Incorrect time value: '1'
+Error 1292 (22007): Incorrect datetime value: '1'
 alter table t modify column b datetime;
-Error 1292 (22007): Incorrect time value: '1'
+Error 1292 (22007): Incorrect datetime value: '1'
 alter table t modify column c datetime;
-Error 1292 (22007): Incorrect time value: '1'
+Error 1292 (22007): Incorrect datetime value: '1'
 drop table if exists t;
 create table t (a int(10) unsigned default null, b bigint unsigned, c tinyint unsigned);
 insert into t values (4294967295, 18446744073709551615, 255);
 alter table t modify column a datetime;
-Error 1292 (22007): Incorrect time value: '4294967295'
+Error 1292 (22007): Incorrect datetime value: '4294967295'
 alter table t modify column b datetime;
-Error 1292 (22007): Incorrect time value: '18446744073709551615'
+Error 1292 (22007): Incorrect datetime value: '18446744073709551615'
 alter table t modify column c datetime;
-Error 1292 (22007): Incorrect time value: '255'
+Error 1292 (22007): Incorrect datetime value: '255'
 drop table if exists t;
 CREATE TABLE `t` (  `a` int(11) DEFAULT NULL,  `b` varchar(10) DEFAULT NULL,  `c` decimal(10,2) DEFAULT NULL,  KEY `idx1` (`a`),  UNIQUE KEY `idx2` (`a`),  KEY `idx3` (`a`,`b`),  KEY `idx4` (`a`,`b`,`c`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 insert into t values(19,1,1),(17,2,2);
@@ -2261,7 +2261,7 @@ drop table if exists t;
 CREATE TABLE `t` (  `a` date DEFAULT '1764-06-11 02:46:14') ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_bin COMMENT='7b84832e-f857-4116-8872-82fc9dcc4ab3';
 insert into `t` values();
 alter table `t` change column `a` `b` TIMESTAMP NULL DEFAULT '2015-11-14 07:12:24';
-Error 1292 (22007): Incorrect timestamp value: '1764-06-11 00:00:00'
+Error 1292 (22007): Incorrect timestamp value: '1764-06-11'
 drop table if exists t;
 select timestamp(cast('1000-11-11 12-3-1' as date));
 timestamp(cast('1000-11-11 12-3-1' as date))
@@ -2277,11 +2277,11 @@ select time(0);
 time(0)
 00:00:00
 alter table t modify column a date;
-Error 1292 (22007): Truncated incorrect date value: '0'
+Error 1292 (22007): Incorrect date value: '0'
 alter table t modify column a datetime;
-Error 1292 (22007): Truncated incorrect datetime value: '0'
+Error 1292 (22007): Incorrect datetime value: '0'
 alter table t modify column a timestamp;
-Error 1292 (22007): Truncated incorrect timestamp value: '0'
+Error 1292 (22007): Incorrect timestamp value: '0'
 drop table if exists t;
 create table t (a int);
 insert into t values (0);
@@ -2293,11 +2293,11 @@ select time(0);
 time(0)
 00:00:00
 alter table t modify column a date;
-Error 1292 (22007): Truncated incorrect date value: '0'
+Error 1292 (22007): Incorrect date value: '0'
 alter table t modify column a datetime;
-Error 1292 (22007): Truncated incorrect datetime value: '0'
+Error 1292 (22007): Incorrect datetime value: '0'
 alter table t modify column a timestamp;
-Error 1292 (22007): Truncated incorrect timestamp value: '0'
+Error 1292 (22007): Incorrect timestamp value: '0'
 drop table if exists t;
 create table t (a int);
 insert into t values (0);

--- a/tests/integrationtest/r/ddl/column_type_change.result
+++ b/tests/integrationtest/r/ddl/column_type_change.result
@@ -2590,3 +2590,27 @@ show warnings;
 Level	Code	Message
 Warning	1690	2 warnings with this error code, first warning: constant 128 overflows tinyint
 set @@sql_mode=default;
+drop table if exists t;
+create table t (a date);
+insert into t values('9999-01-01');
+set @@sql_mode='ALLOW_INVALID_DATES';
+alter table t modify a timestamp;
+select * from t;
+a
+0000-00-00 00:00:00
+drop table if exists t;
+create table t (a date);
+insert into t values('9999-01-01');
+set @@sql_mode='ALLOW_INVALID_DATES,STRICT_TRANS_TABLES';
+alter table t modify a timestamp;
+Error 1292 (22007): Incorrect timestamp value: '9999-01-01'
+select * from t;
+a
+9999-01-01
+drop table t;
+CREATE TABLE t (a date, b timestamp AS (a));
+set @@sql_mode='';
+insert into t (a) values('9999-01-01');
+select * from t;
+a	b
+9999-01-01	0000-00-00 00:00:00

--- a/tests/integrationtest/r/ddl/db_integration.result
+++ b/tests/integrationtest/r/ddl/db_integration.result
@@ -51,7 +51,7 @@ drop table test_zero_date;
 create table test_zero_date (a int);
 insert into test_zero_date values (0);
 alter table test_zero_date modify a date;
-Error 1292 (22007): Truncated incorrect date value: '0'
+Error 1292 (22007): Incorrect date value: '0'
 set session sql_mode='NO_ZERO_DATE,STRICT_TRANS_TABLES';
 drop table test_zero_date;
 create table test_zero_date (a timestamp default 0);
@@ -59,7 +59,7 @@ Error 1067 (42000): Invalid default value for 'a'
 create table test_zero_date (a int);
 insert into test_zero_date values (0);
 alter table test_zero_date modify a date;
-Error 1292 (22007): Truncated incorrect date value: '0'
+Error 1292 (22007): Incorrect date value: '0'
 drop table if exists test_zero_date;
 set session sql_mode=default;
 drop table if exists t;

--- a/tests/integrationtest/r/ddl/default_as_expression.result
+++ b/tests/integrationtest/r/ddl/default_as_expression.result
@@ -62,7 +62,7 @@ t2	CREATE TABLE `t2` (
   `c1` varchar(256) DEFAULT date_format(now(), _utf8mb4'%Y-%m-%d %H.%i.%s')
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 alter table t0 add column c2 date default (date_format(now(),'%Y-%m'));
-Error 1292 (22007): Incorrect datetime value: '2024-04'
+Error 1292 (22007): Incorrect date value:<time>
 alter table t0 add index idx(c1);
 alter table t1 add index idx(c1);
 alter table t0 add column c2 date default (date_format(now(),'%Y-%m-%d'));

--- a/tests/integrationtest/r/ddl/modify_column.result
+++ b/tests/integrationtest/r/ddl/modify_column.result
@@ -729,52 +729,52 @@ drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("2019");
 alter table t_mc modify a date;
-Error 1292 (22007): Incorrect time value: '2019'
+Error 1292 (22007): Incorrect date value: '2019'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (2019);
 alter table t_mc modify a date;
-Error 1292 (22007): Incorrect time value: '2019'
+Error 1292 (22007): Incorrect date value: '2019'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("00");
 alter table t_mc modify a date;
-Error 1292 (22007): Incorrect time value: '2000'
+Error 1292 (22007): Incorrect date value: '2000'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("69");
 alter table t_mc modify a date;
-Error 1292 (22007): Incorrect time value: '2069'
+Error 1292 (22007): Incorrect date value: '2069'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("70");
 alter table t_mc modify a date;
-Error 1292 (22007): Incorrect time value: '1970'
+Error 1292 (22007): Incorrect date value: '1970'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("99");
 alter table t_mc modify a date;
-Error 1292 (22007): Incorrect time value: '1999'
+Error 1292 (22007): Incorrect date value: '1999'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (00);
 alter table t_mc modify a date;
-Error 1292 (22007): Truncated incorrect date value: '0'
+Error 1292 (22007): Incorrect date value: '0'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (69);
 alter table t_mc modify a date;
-Error 1292 (22007): Incorrect time value: '2069'
+Error 1292 (22007): Incorrect date value: '2069'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (70);
 alter table t_mc modify a date;
-Error 1292 (22007): Incorrect time value: '1970'
+Error 1292 (22007): Incorrect date value: '1970'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (99);
 alter table t_mc modify a date;
-Error 1292 (22007): Incorrect time value: '1999'
+Error 1292 (22007): Incorrect date value: '1999'
 set @@global.tidb_ddl_error_count_limit = default;
 set @@time_zone=default;
 set @@global.tidb_ddl_error_count_limit = 3;
@@ -783,52 +783,52 @@ drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("2019");
 alter table t_mc modify a datetime;
-Error 1292 (22007): Incorrect time value: '2019'
+Error 1292 (22007): Incorrect datetime value: '2019'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (2019);
 alter table t_mc modify a datetime;
-Error 1292 (22007): Incorrect time value: '2019'
+Error 1292 (22007): Incorrect datetime value: '2019'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("00");
 alter table t_mc modify a datetime;
-Error 1292 (22007): Incorrect time value: '2000'
+Error 1292 (22007): Incorrect datetime value: '2000'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("69");
 alter table t_mc modify a datetime;
-Error 1292 (22007): Incorrect time value: '2069'
+Error 1292 (22007): Incorrect datetime value: '2069'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("70");
 alter table t_mc modify a datetime;
-Error 1292 (22007): Incorrect time value: '1970'
+Error 1292 (22007): Incorrect datetime value: '1970'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("99");
 alter table t_mc modify a datetime;
-Error 1292 (22007): Incorrect time value: '1999'
+Error 1292 (22007): Incorrect datetime value: '1999'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (00);
 alter table t_mc modify a datetime;
-Error 1292 (22007): Truncated incorrect datetime value: '0'
+Error 1292 (22007): Incorrect datetime value: '0'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (69);
 alter table t_mc modify a datetime;
-Error 1292 (22007): Incorrect time value: '2069'
+Error 1292 (22007): Incorrect datetime value: '2069'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (70);
 alter table t_mc modify a datetime;
-Error 1292 (22007): Incorrect time value: '1970'
+Error 1292 (22007): Incorrect datetime value: '1970'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (99);
 alter table t_mc modify a datetime;
-Error 1292 (22007): Incorrect time value: '1999'
+Error 1292 (22007): Incorrect datetime value: '1999'
 set @@global.tidb_ddl_error_count_limit = default;
 set @@time_zone=default;
 set @@global.tidb_ddl_error_count_limit = 3;
@@ -837,51 +837,51 @@ drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("2019");
 alter table t_mc modify a timestamp;
-Error 1292 (22007): Incorrect time value: '2019'
+Error 1292 (22007): Incorrect timestamp value: '2019'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (2019);
 alter table t_mc modify a timestamp;
-Error 1292 (22007): Incorrect time value: '2019'
+Error 1292 (22007): Incorrect timestamp value: '2019'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("00");
 alter table t_mc modify a timestamp;
-Error 1292 (22007): Incorrect time value: '2000'
+Error 1292 (22007): Incorrect timestamp value: '2000'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("69");
 alter table t_mc modify a timestamp;
-Error 1292 (22007): Incorrect time value: '2069'
+Error 1292 (22007): Incorrect timestamp value: '2069'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("70");
 alter table t_mc modify a timestamp;
-Error 1292 (22007): Incorrect time value: '1970'
+Error 1292 (22007): Incorrect timestamp value: '1970'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values ("99");
 alter table t_mc modify a timestamp;
-Error 1292 (22007): Incorrect time value: '1999'
+Error 1292 (22007): Incorrect timestamp value: '1999'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (00);
 alter table t_mc modify a timestamp;
-Error 1292 (22007): Truncated incorrect timestamp value: '0'
+Error 1292 (22007): Incorrect timestamp value: '0'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (69);
 alter table t_mc modify a timestamp;
-Error 1292 (22007): Incorrect time value: '2069'
+Error 1292 (22007): Incorrect timestamp value: '2069'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (70);
 alter table t_mc modify a timestamp;
-Error 1292 (22007): Incorrect time value: '1970'
+Error 1292 (22007): Incorrect timestamp value: '1970'
 drop table if exists t_mc;
 create table t_mc(a year);
 insert into t_mc (a) values (99);
 alter table t_mc modify a timestamp;
-Error 1292 (22007): Incorrect time value: '1999'
+Error 1292 (22007): Incorrect timestamp value: '1999'
 set @@global.tidb_ddl_error_count_limit = default;
 set @@time_zone=default;

--- a/tests/integrationtest/r/ddl/multi_schema_change.result
+++ b/tests/integrationtest/r/ddl/multi_schema_change.result
@@ -319,7 +319,7 @@ drop table if exists t;
 create table t(a bigint null default '1761233443433596323', index t(a));
 insert into t set a = '-7184819032643664798';
 alter table t change column a b datetime null default '8972-12-24 10:56:03', rename index t to t1;
-Error 1292 (22007): Incorrect time value: '-7184819032643664798'
+Error 1292 (22007): Incorrect datetime value: '-7184819032643664798'
 drop table if exists t;
 create table t (a int, b double, index i(a, b));
 alter table t rename index i to i1, change column b c int;

--- a/tests/integrationtest/t/ddl/column_type_change.test
+++ b/tests/integrationtest/t/ddl/column_type_change.test
@@ -2209,3 +2209,26 @@ alter table t modify column a tinyint;
 show warnings;
 set @@sql_mode=default;
 
+# issue #52748, alter table should respect SQL_MODE and result a valid timestamp value
+drop table if exists t;
+create table t (a date);
+insert into t values('9999-01-01');
+set @@sql_mode='ALLOW_INVALID_DATES';
+alter table t modify a timestamp;
+select * from t;
+
+drop table if exists t;
+create table t (a date);
+insert into t values('9999-01-01');
+set @@sql_mode='ALLOW_INVALID_DATES,STRICT_TRANS_TABLES';
+--error 1292
+alter table t modify a timestamp;
+select * from t;
+
+# issue #52509, generated column should also return a valid timestamp value.
+drop table t;
+CREATE TABLE t (a date, b timestamp AS (a));
+set @@sql_mode='';
+insert into t (a) values('9999-01-01');
+select * from t;
+


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52715, close #52509, close #52748

Problem Summary:

The function `table.castColumnValue` requires an argument `insertOrUpdate` to indicate whether it is called in an insert or update statement. However, I found this may be a mistake.

If we define the semantic of `CastColumnValue` as "cast a value to another to fit the column to meet the column's restriction", it is not reasonable that the select and insert statements have different behaviors. You can see the issue #52509 that there is a problem if we do not handle the datetime conversion error for a select statement.

A similar issue also exists in the alter statement, see #52748. You can see that if we do not handle the datetime error there, the table will store a wrong timestamp value.

I think it's better to remove `insertOrUpdate` argument in `castColumnValue` and it is what this PR does. All unit tests passed but caused some error message changes in DDL. But I think the changed messages are more reasonable because the type name in it is more accurate.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
