### PR TITLE
server: handle the case the type of param is set for the param sent by `SEND_LONG_DATA`

### DIFF
--- a/pkg/server/internal/testserverclient/BUILD.bazel
+++ b/pkg/server/internal/testserverclient/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "@com_github_pingcap_log//:log",
         "@com_github_prometheus_client_model//go",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_text//encoding/simplifiedchinese",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/server/internal/testserverclient/server_client.go
+++ b/pkg/server/internal/testserverclient/server_client.go
@@ -48,6 +48,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"golang.org/x/text/encoding/simplifiedchinese"
 )
 
 //revive:disable:exported
@@ -2724,6 +2725,66 @@ func (cli *TestServerClient) RunTestConnectionCount(t *testing.T) {
 		}
 		resourceGroupConnCountReached(t, "default", 0.0)
 		resourceGroupConnCountReached(t, "test", 0.0)
+	})
+}
+
+func (cli *TestServerClient) RunTestTypeOfSendLongData(t *testing.T) {
+	cli.RunTests(t, func(config *mysql.Config) {
+		config.MaxAllowedPacket = 1024
+	}, func(dbt *testkit.DBTestKit) {
+		ctx := context.Background()
+
+		conn, err := dbt.GetDB().Conn(ctx)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, "CREATE TABLE t (j JSON);")
+		require.NoError(t, err)
+
+		str := `"` + strings.Repeat("a", 1024) + `"`
+		stmt, err := conn.PrepareContext(ctx, "INSERT INTO t VALUES (cast(? as JSON));")
+		require.NoError(t, err)
+		_, err = stmt.ExecContext(ctx, str)
+		require.NoError(t, err)
+		result, err := conn.QueryContext(ctx, "SELECT j FROM t;")
+		require.NoError(t, err)
+
+		for result.Next() {
+			var j string
+			require.NoError(t, result.Scan(&j))
+			require.Equal(t, str, j)
+		}
+	})
+}
+
+func (cli *TestServerClient) RunTestCharsetOfSendLongData(t *testing.T) {
+	str := strings.Repeat("你好", 1024)
+	enc := simplifiedchinese.GBK.NewEncoder()
+	gbkStr, err := enc.String(str)
+	require.NoError(t, err)
+
+	cli.RunTests(t, func(config *mysql.Config) {
+		config.MaxAllowedPacket = 1024
+		config.Params["charset"] = "gbk"
+	}, func(dbt *testkit.DBTestKit) {
+		ctx := context.Background()
+
+		conn, err := dbt.GetDB().Conn(ctx)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, "CREATE TABLE t (t TEXT);")
+		require.NoError(t, err)
+
+		stmt, err := conn.PrepareContext(ctx, "INSERT INTO t VALUES (?);")
+		require.NoError(t, err)
+		_, err = stmt.ExecContext(ctx, gbkStr)
+		require.NoError(t, err)
+
+		result, err := conn.QueryContext(ctx, "SELECT * FROM t;")
+		require.NoError(t, err)
+
+		for result.Next() {
+			var txt string
+			require.NoError(t, result.Scan(&txt))
+			require.Equal(t, gbkStr, txt)
+		}
 	})
 }
 

--- a/pkg/server/internal/testserverclient/server_client.go
+++ b/pkg/server/internal/testserverclient/server_client.go
@@ -2728,7 +2728,7 @@ func (cli *TestServerClient) RunTestConnectionCount(t *testing.T) {
 	})
 }
 
-func (cli *TestServerClient) RunTestTypeOfSendLongData(t *testing.T) {
+func (cli *TestServerClient) RunTestTypeAndCharsetOfSendLongData(t *testing.T) {
 	cli.RunTests(t, func(config *mysql.Config) {
 		config.MaxAllowedPacket = 1024
 	}, func(dbt *testkit.DBTestKit) {
@@ -2753,9 +2753,7 @@ func (cli *TestServerClient) RunTestTypeOfSendLongData(t *testing.T) {
 			require.Equal(t, str, j)
 		}
 	})
-}
 
-func (cli *TestServerClient) RunTestCharsetOfSendLongData(t *testing.T) {
 	str := strings.Repeat("你好", 1024)
 	enc := simplifiedchinese.GBK.NewEncoder()
 	gbkStr, err := enc.String(str)
@@ -2768,6 +2766,8 @@ func (cli *TestServerClient) RunTestCharsetOfSendLongData(t *testing.T) {
 		ctx := context.Background()
 
 		conn, err := dbt.GetDB().Conn(ctx)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, "drop table t")
 		require.NoError(t, err)
 		_, err = conn.ExecContext(ctx, "CREATE TABLE t (t TEXT);")
 		require.NoError(t, err)

--- a/pkg/server/tests/commontest/BUILD.bazel
+++ b/pkg/server/tests/commontest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "tidb_test.go",
     ],
     flaky = True,
-    shard_count = 49,
+    shard_count = 50,
     deps = [
         "//pkg/config",
         "//pkg/ddl/util",

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3082,3 +3082,13 @@ func TestConnectionCount(t *testing.T) {
 	ts := servertestkit.CreateTidbTestSuite(t)
 	ts.RunTestConnectionCount(t)
 }
+
+func TestTypeOfSendLongData(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+	ts.RunTestTypeOfSendLongData(t)
+}
+
+func TestCharsetOfSendLongData(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+	ts.RunTestCharsetOfSendLongData(t)
+}

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3083,12 +3083,7 @@ func TestConnectionCount(t *testing.T) {
 	ts.RunTestConnectionCount(t)
 }
 
-func TestTypeOfSendLongData(t *testing.T) {
+func TestTypeAndCharsetOfSendLongData(t *testing.T) {
 	ts := servertestkit.CreateTidbTestSuite(t)
-	ts.RunTestTypeOfSendLongData(t)
-}
-
-func TestCharsetOfSendLongData(t *testing.T) {
-	ts := servertestkit.CreateTidbTestSuite(t)
-	ts.RunTestCharsetOfSendLongData(t)
+	ts.RunTestTypeAndCharsetOfSendLongData(t)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #52711

After sending the param through `SEND_LONG_DATA`, it's still possible that the type is given in the `EXECUTE` statement. But actually I'm not sure whether every client sends the type, so I kept the original behavior if the type is not sent to keep compatibility.

### What changed and how does it work?

Assert whether the type is sent in `EXECUTE` statement. If it's sent, use the given `type. If it's not sent, still use the `Blob` to keep compatible with the original behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

I tried to run the program https://gist.github.com/YangKeao/51bbc88600c69691a799227806f32cd5 on TiDB.

Before this PR, the data in table t after running this program is 
```
| utf8     | "你好"      | "你好"                            | 0x22E4BDA0E5A5BD22       |
| utf8     | "你好"      | "base64:type252:IuS9oOWlvSI="     | 0x22E4BDA0E5A5BD22       |
| gbk      | "浣犲ソ"    | "浣犲ソ"                          | 0x22E4BDA0E5A5BD22       |
| gbk      | "浣犲ソ"    | "base64:type252:Iua1o+eKsuOCvSI=" | 0x22E6B5A3E78AB2E382BD22 |
```

After this PR, the data in table t after running this program is
```
| utf8     | "你好"      | "你好"                            | 0x22E4BDA0E5A5BD22       |
| utf8     | "你好"      | "你好"                            | 0x22E4BDA0E5A5BD22       |
| gbk      | "浣犲ソ"    | "浣犲ソ"                          | 0x22E4BDA0E5A5BD22       |
| gbk      | "浣犲ソ"    | "浣犲ソ"                          | 0x22E4BDA0E5A5BD22       |
```

Running this program in MySQL, will get:
```
| utf8     | "你好"      | "你好"      | 0x22E4BDA0E5A5BD22 |
| utf8     | "你好"      | "你好"      | 0x22E4BDA0E5A5BD22 |
| gbk      | "浣犲ソ"    | "浣犲ソ"    | 0x22E4BDA0E5A5BD22 |
| gbk      | "浣犲ソ"    | "浣犲ソ"    | 0x22E4BDA0E5A5BD22 |
```

Which is the same as what we got with this PR.

I'll try to add this manual test to `mysqlclienttest` later :thinking: .

### Release note

```release-note
Fix the issue that param transfered by `SEND_LONG_DATA` is always regarded as `Blob` type.
```
