### PR TITLE
expression: remove `SetInNullRejectCheck` in `BuildContext`

### DIFF
--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -199,6 +199,7 @@ go_test(
         "//pkg/config",
         "//pkg/errctx",
         "//pkg/errno",
+        "//pkg/expression/context",
         "//pkg/kv",
         "//pkg/parser",
         "//pkg/parser/ast",

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -83,9 +83,10 @@ type BuildContext interface {
 	SetSkipPlanCache(reason string)
 	// AllocPlanColumnID allocates column id for plan.
 	AllocPlanColumnID() int64
-	// SetInNullRejectCheck sets the flag to indicate whether the expression is in null reject check.
-	SetInNullRejectCheck(in bool)
 	// IsInNullRejectCheck returns the flag to indicate whether the expression is in null reject check.
+	// It should always return `false` in most implementations because we do not want to do null reject check
+	// in most cases except for the method `isNullRejected` in planner.
+	// See the comments for `isNullRejected` in planner for more details.
 	IsInNullRejectCheck() bool
 	// SetInUnionCast sets the flag to indicate whether the expression is in union cast.
 	SetInUnionCast(in bool)
@@ -105,6 +106,21 @@ type ExprContext interface {
 	GetWindowingUseHighPrecision() bool
 	// GetGroupConcatMaxLen returns the value of the 'group_concat_max_len' system variable.
 	GetGroupConcatMaxLen() uint64
+}
+
+// NullRejectCheckExprContext is a wrapper to return true for `IsInNullRejectCheck`.
+type NullRejectCheckExprContext struct {
+	ExprContext
+}
+
+// WithNullRejectCheck returns a new `NullRejectCheckExprContext` with the given `ExprContext`.
+func WithNullRejectCheck(ctx ExprContext) *NullRejectCheckExprContext {
+	return &NullRejectCheckExprContext{ExprContext: ctx}
+}
+
+// IsInNullRejectCheck always returns true for `NullRejectCheckExprContext`
+func (ctx *NullRejectCheckExprContext) IsInNullRejectCheck() bool {
+	return true
 }
 
 // AssertLocationWithSessionVars asserts the location in the context and session variables are the same.

--- a/pkg/expression/contextsession/sessionctx.go
+++ b/pkg/expression/contextsession/sessionctx.go
@@ -52,8 +52,7 @@ var _ exprctx.ExprContext = struct {
 type ExprCtxExtendedImpl struct {
 	sctx sessionctx.Context
 	*SessionEvalContext
-	inNullRejectCheck atomic.Bool
-	inUnionCast       atomic.Bool
+	inUnionCast atomic.Bool
 }
 
 // NewExprExtendedImpl creates a new ExprCtxExtendedImpl.
@@ -117,14 +116,9 @@ func (ctx *ExprCtxExtendedImpl) AllocPlanColumnID() int64 {
 	return ctx.sctx.GetSessionVars().AllocPlanColumnID()
 }
 
-// SetInNullRejectCheck sets whether the expression is in null reject check.
-func (ctx *ExprCtxExtendedImpl) SetInNullRejectCheck(in bool) {
-	ctx.inNullRejectCheck.Store(in)
-}
-
 // IsInNullRejectCheck returns whether the expression is in null reject check.
 func (ctx *ExprCtxExtendedImpl) IsInNullRejectCheck() bool {
-	return ctx.inNullRejectCheck.Load()
+	return false
 }
 
 // SetInUnionCast sets the flag to indicate whether the expression is in union cast.

--- a/pkg/expression/contextsession/sessionctx_test.go
+++ b/pkg/expression/contextsession/sessionctx_test.go
@@ -315,10 +315,6 @@ func TestSessionBuildContext(t *testing.T) {
 
 	// InNullRejectCheck
 	require.False(t, impl.IsInNullRejectCheck())
-	impl.SetInNullRejectCheck(true)
-	require.True(t, impl.IsInNullRejectCheck())
-	impl.SetInNullRejectCheck(false)
-	require.False(t, impl.IsInNullRejectCheck())
 
 	// InUnionCast
 	require.False(t, impl.IsInUnionCast())

--- a/pkg/planner/context/context.go
+++ b/pkg/planner/context/context.go
@@ -37,6 +37,8 @@ type PlanContext interface {
 	GetRestrictedSQLExecutor() sqlexec.RestrictedSQLExecutor
 	// GetExprCtx gets the expression context.
 	GetExprCtx() exprctx.ExprContext
+	// GetNullRejectCheckExprCtx gets the expression context with null rejected check.
+	GetNullRejectCheckExprCtx() exprctx.ExprContext
 	// GetStore returns the store of session.
 	GetStore() kv.Storage
 	// GetSessionVars gets the session variables.

--- a/pkg/planner/contextimpl/BUILD.bazel
+++ b/pkg/planner/contextimpl/BUILD.bazel
@@ -10,5 +10,6 @@ go_library(
         "//pkg/planner/context",
         "//pkg/sessionctx",
         "//pkg/sessiontxn",
+        "//pkg/util/intest",
     ],
 )

--- a/pkg/planner/core/rule_predicate_push_down.go
+++ b/pkg/planner/core/rule_predicate_push_down.go
@@ -424,16 +424,12 @@ func simplifyOuterJoin(p *LogicalJoin, predicates []expression.Expression) {
 // If it is a conjunction containing a null-rejected condition as a conjunct.
 // If it is a disjunction of null-rejected conditions.
 func isNullRejected(ctx base.PlanContext, schema *expression.Schema, expr expression.Expression) bool {
-	exprCtx := ctx.GetExprCtx()
+	exprCtx := ctx.GetNullRejectCheckExprCtx()
 	expr = expression.PushDownNot(exprCtx, expr)
 	if expression.ContainOuterNot(expr) {
 		return false
 	}
 	sc := ctx.GetSessionVars().StmtCtx
-	if !exprCtx.IsInNullRejectCheck() {
-		exprCtx.SetInNullRejectCheck(true)
-		defer exprCtx.SetInNullRejectCheck(false)
-	}
 	for _, cond := range expression.SplitCNFItems(expr) {
 		if isNullRejectedSpecially(ctx, schema, expr) {
 			return true

--- a/pkg/util/mock/context.go
+++ b/pkg/util/mock/context.go
@@ -229,6 +229,11 @@ func (c *Context) GetPlanCtx() planctx.PlanContext {
 	return c
 }
 
+// GetNullRejectCheckExprCtx gets the expression context with null rejected check.
+func (c *Context) GetNullRejectCheckExprCtx() exprctx.ExprContext {
+	return exprctx.WithNullRejectCheck(c)
+}
+
 // GetExprCtx returns the expression context of the session.
 func (c *Context) GetExprCtx() exprctx.ExprContext {
 	return c


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52719

Problem Summary:

It's better to remove the method `SetInNullRejectCheck` in `BuildContext` because it will modify its internal state and be not thread-safe in the concurrency scene.

### What changed and how does it work?

We removed `SetInNullRejectCheck` in `BuildContext` but kept `IsInNullRejectCheck` to do a null reject check. So for most implementations of `BuildContext`, `IsInNullRejectCheck` always returns false. If we want to make it return `true`, use `WithNullRejectCheck` to create a new context.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
