### PR TITLE
expression: Make `BuildContext.IsUseCache/SetSkipPlanCache` thread-safe

### DIFF
--- a/pkg/expression/contextimpl/sessionctx.go
+++ b/pkg/expression/contextimpl/sessionctx.go
@@ -104,7 +104,7 @@ func (ctx *ExprCtxExtendedImpl) Rng() *mathutil.MysqlRng {
 // IsUseCache indicates whether to cache the build expression in plan cache.
 // If SetSkipPlanCache is invoked, it should return false.
 func (ctx *ExprCtxExtendedImpl) IsUseCache() bool {
-	return ctx.sctx.GetSessionVars().StmtCtx.UseCache
+	return ctx.sctx.GetSessionVars().StmtCtx.UseCache()
 }
 
 // SetSkipPlanCache sets to skip the plan cache and records the reason.

--- a/pkg/expression/contextimpl/sessionctx_test.go
+++ b/pkg/expression/contextimpl/sessionctx_test.go
@@ -282,7 +282,7 @@ func TestSessionBuildContext(t *testing.T) {
 	require.Same(t, vars.Rng, impl.Rng())
 
 	// PlanCache
-	vars.StmtCtx.UseCache = true
+	vars.StmtCtx.SetUseCache(true)
 	require.True(t, impl.IsUseCache())
 	impl.SetSkipPlanCache(errors.New("mockReason"))
 	require.False(t, impl.IsUseCache())

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -61,7 +61,7 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 	schema := tableInfoToSchemaForTest(tblInfo)
 	col0 := schema.Columns[0]
 
-	ctx.GetSessionVars().StmtCtx.UseCache = true
+	ctx.GetSessionVars().StmtCtx.SetUseCache(true)
 
 	// cases for parameters
 	ltWithoutParam, err := newFunctionForTest(ctx, ast.LT, col0, NewOne())
@@ -76,7 +76,7 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 	res = EvaluateExprWithNull(ctx, schema, ltWithParam)
 	_, isConst := res.(*Constant)
 	require.True(t, isConst) // this expression is evaluated and skip-plan cache flag is set.
-	require.True(t, !ctx.GetSessionVars().StmtCtx.UseCache)
+	require.True(t, !ctx.GetSessionVars().StmtCtx.UseCache())
 }
 
 func TestEvaluateExprWithNullNoChangeRetType(t *testing.T) {

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1165,7 +1165,7 @@ func DatumToConstant(d types.Datum, tp byte, flag uint) *Constant {
 
 // ParamMarkerExpression generate a getparam function expression.
 func ParamMarkerExpression(ctx variable.SessionVarsProvider, v *driver.ParamMarkerExpr, needParam bool) (*Constant, error) {
-	useCache := ctx.GetSessionVars().StmtCtx.UseCache
+	useCache := ctx.GetSessionVars().StmtCtx.UseCache()
 	isPointExec := ctx.GetSessionVars().StmtCtx.PointExec
 	tp := types.NewFieldType(mysql.TypeUnspecified)
 	types.InferParamTypeFromDatum(&v.Datum, tp)

--- a/pkg/extension/function_test.go
+++ b/pkg/extension/function_test.go
@@ -514,12 +514,12 @@ func TestShouldNotOptimizeExtensionFunc(t *testing.T) {
 		"my_func2()",
 	} {
 		ctx := mock.NewContext()
-		ctx.GetSessionVars().StmtCtx.UseCache = true
+		ctx.GetSessionVars().StmtCtx.SetUseCache(true)
 		expr, err := expression.ParseSimpleExpr(ctx, exprStr)
 		require.NoError(t, err)
 		scalar, ok := expr.(*expression.ScalarFunction)
 		require.True(t, ok)
 		require.Equal(t, expression.ConstNone, scalar.ConstLevel())
-		require.False(t, ctx.GetSessionVars().StmtCtx.UseCache)
+		require.False(t, ctx.GetSessionVars().StmtCtx.UseCache())
 	}
 }

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -1312,7 +1312,7 @@ func (b *PlanBuilder) buildSelection(ctx context.Context, p LogicalPlan, where a
 		expressions = append(expressions, expr)
 	}
 	cnfExpres := make([]expression.Expression, 0)
-	useCache := b.ctx.GetSessionVars().StmtCtx.UseCache
+	useCache := b.ctx.GetSessionVars().StmtCtx.UseCache()
 	for _, expr := range expressions {
 		cnfItems := expression.SplitCNFItems(expr)
 		for _, item := range cnfItems {

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -164,13 +164,13 @@ func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
 		stmtCtx.CacheType = stmtctx.SessionPrepared
 		cacheEnabled = sctx.GetSessionVars().EnablePreparedPlanCache
 	}
-	stmtCtx.UseCache = stmt.StmtCacheable && cacheEnabled
+	stmtCtx.SetUseCache(stmt.StmtCacheable && cacheEnabled)
 	if stmt.UncacheableReason != "" {
 		stmtCtx.ForceSetSkipPlanCache(errors.NewNoStackError(stmt.UncacheableReason))
 	}
 
 	var bindSQL string
-	if stmtCtx.UseCache {
+	if stmtCtx.UseCache() {
 		var ignoreByBinding bool
 		bindSQL, ignoreByBinding = bindinfo.MatchSQLBindingForPlanCache(sctx, stmt.PreparedAst.Stmt, &stmt.BindingInfo)
 		if ignoreByBinding {
@@ -182,7 +182,7 @@ func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
 	// rebuild the plan. So we set this value in rc or for update read. In other cases, let it be 0.
 	var latestSchemaVersion int64
 
-	if stmtCtx.UseCache {
+	if stmtCtx.UseCache() {
 		if sctx.GetSessionVars().IsIsolation(ast.ReadCommitted) || stmt.ForUpdateRead {
 			// In Rc or ForUpdateRead, we should check if the information schema has been changed since
 			// last time. If it changed, we should rebuild the plan. Here, we use a different and more
@@ -195,7 +195,7 @@ func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
 		}
 	}
 
-	if stmtCtx.UseCache && stmt.PointGet.Plan != nil { // special code path for fast point plan
+	if stmtCtx.UseCache() && stmt.PointGet.Plan != nil { // special code path for fast point plan
 		if plan, names, ok, err := getCachedPointPlan(stmt, sessVars, stmtCtx); ok {
 			return plan, names, err
 		}
@@ -205,7 +205,7 @@ func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
 	if err != nil {
 		return nil, nil, err
 	}
-	if stmtCtx.UseCache { // for non-point plans
+	if stmtCtx.UseCache() { // for non-point plans
 		if plan, names, ok, err := getCachedPlan(sctx, isNonPrepared, cacheKey, bindSQL, is, stmt, matchOpts); err != nil || ok {
 			return plan, names, err
 		}
@@ -323,14 +323,14 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 	}
 
 	// check whether this plan is cacheable.
-	if stmtCtx.UseCache {
+	if stmtCtx.UseCache() {
 		if cacheable, reason := isPlanCacheable(sctx.GetPlanCtx(), p, len(matchOpts.ParamTypes), len(matchOpts.LimitOffsetAndCount), matchOpts.HasSubQuery); !cacheable {
 			stmtCtx.SetSkipPlanCache(errors.Errorf(reason))
 		}
 	}
 
 	// put this plan into the plan cache.
-	if stmtCtx.UseCache {
+	if stmtCtx.UseCache() {
 		// rebuild key to exclude kv.TiFlash when stmt is not read only
 		if _, isolationReadContainTiFlash := sessVars.IsolationReadEngines[kv.TiFlash]; isolationReadContainTiFlash && !IsReadOnly(stmtAst.Stmt, sessVars) {
 			delete(sessVars.IsolationReadEngines, kv.TiFlash)
@@ -353,7 +353,7 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 // RebuildPlan4CachedPlan will rebuild this plan under current user parameters.
 func RebuildPlan4CachedPlan(p base.Plan) (ok bool) {
 	sc := p.SCtx().GetSessionVars().StmtCtx
-	if !sc.UseCache {
+	if !sc.UseCache() {
 		return false // plan-cache is disabled for this query
 	}
 
@@ -363,7 +363,7 @@ func RebuildPlan4CachedPlan(p base.Plan) (ok bool) {
 		sc.AppendWarning(errors.NewNoStackErrorf("skip plan-cache: plan rebuild failed, %s", err.Error()))
 		return false // fail to rebuild ranges
 	}
-	if !sc.UseCache {
+	if !sc.UseCache() {
 		// in this case, the UseCache flag changes from `true` to `false`, then there must be some
 		// over-optimized operations were triggered, return `false` for safety here.
 		return false
@@ -773,7 +773,7 @@ func CheckPreparedPriv(sctx sessionctx.Context, stmt *PlanCacheStmt, is infosche
 // short paths for these executions, currently "point select" and "point update"
 func tryCachePointPlan(_ context.Context, sctx base.PlanContext,
 	stmt *PlanCacheStmt, p base.Plan, names types.NameSlice) error {
-	if !sctx.GetSessionVars().StmtCtx.UseCache {
+	if !sctx.GetSessionVars().StmtCtx.UseCache() {
 		return nil
 	}
 	var (

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -348,7 +348,7 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) bool {
 	//    - This should NOT be cached and should already be having PartitionIdx set!
 	// 2) Converted to PointGet from checkTblIndexForPointPlan
 	//    and it does not have the PartitionIdx set
-	if !p.SCtx().GetSessionVars().StmtCtx.UseCache &&
+	if !p.SCtx().GetSessionVars().StmtCtx.UseCache() &&
 		p.PartitionIdx != nil {
 		return false
 	}

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -1536,7 +1536,7 @@ func (p *rangePruner) extractDataForPrune(sctx base.PlanContext, expr expression
 	// the constExpr may not a really constant when coming here.
 	// Suppose the partition expression is 'a + b' and we have a condition 'a = 2',
 	// the constExpr is '2 + b' after the replacement which we can't evaluate.
-	if !expression.ConstExprConsiderPlanCache(constExpr, sctx.GetSessionVars().StmtCtx.UseCache) {
+	if !expression.ConstExprConsiderPlanCache(constExpr, sctx.GetSessionVars().StmtCtx.UseCache()) {
 		return ret, false
 	}
 	c, isNull, err := constExpr.EvalInt(sctx.GetExprCtx().GetEvalCtx(), chunk.Row{})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52728

Problem Summary:

Because `BuidContext` may be used in concurrency, it is better to make all of its methods thread-safe including `IsUseCache/SetSkipPlanCache`

### What changed and how does it work?

Make `IsUseCache/SetSkipPlanCache` thread-safe to change the undelaying field to atomic.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
