### PR TITLE
LockCtx: add memTracker for InitCheckExistence in LockCtx

### DIFF
--- a/pkg/util/hack/hack.go
+++ b/pkg/util/hack/hack.go
@@ -83,3 +83,8 @@ const (
 func EstimateBucketMemoryUsage[K comparable, V any]() uint64 {
 	return (8*(1+uint64(unsafe.Sizeof(*new(K))+unsafe.Sizeof(*new(V)))) + 16) / 2 * 3
 }
+
+// EstimateBucketMemoryUsage returns the estimated memory usage of a bucket in a map with key size and value size.
+func EstimateBucketMemoryUsageWithKVSize(keySize uint64, valueSize uint64) uint64 {
+	return (8*(1+keySize+valueSize) + 16) / 2 * 3
+}

--- a/pkg/util/memory/tracker.go
+++ b/pkg/util/memory/tracker.go
@@ -860,6 +860,8 @@ const (
 	LabelForChunkDataInDiskByChunks int = -30
 	// LabelForSortPartition represents the label of the sort partition
 	LabelForSortPartition = -31
+	// LabelForLock  represents the label of the lock
+	LabelForLock = -32
 )
 
 // MetricsTypes is used to get label for metrics


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51217

Problem Summary:
The memory consumed in InitCheckExistence is not tracked by the memory tracker.

### What changed and how does it work?
This PR and [PR](https://github.com/tikv/client-go/pull/1301) implement the `memTracker` to track memory usage in `InitCheckExistence`. Specifically, the `OnMemChange `method is declared in `InitCheckExistence `to obtain the memory usage in `InitCheckExistence`, and the exact memory usage is obtained by referring to the memory calculation method in `mem_aware_map.go`.

**[NOTICE]**
This PR needs to be merged after this [PR](https://github.com/tikv/client-go/pull/1301) is merged because new member variables are declared in `InitCheckExistence`. And it needs to be tested after PR merging.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
