### PR TITLE
lightning: update lightning/OWNERS for moving lightning directory out of br

### DIFF
--- a/lightning/OWNERS
+++ b/lightning/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-lightning
+filters:
+  "(tidb-lightning\\.toml)$":
+    approvers:
+      - sig-critical-approvers-tidb-lightning
+  ".*":
+    approvers:
+      - sig-approvers-lightning


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52744 

Problem Summary:
lightning/OWNERS is not correctly updated when moving lightning directory out of br.
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
