### PR TITLE
meta,ddl: fix duplicate entry error when insert after drop and recover table

### DIFF
--- a/pkg/ddl/db_integration_test.go
+++ b/pkg/ddl/db_integration_test.go
@@ -3061,7 +3061,6 @@ func TestIssue52680(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, ids, step.expect)
 		txn.Rollback()
-
 	}
 
 	tk.MustQuery("show table issue52680 next_row_id").Check(testkit.Rows(

--- a/pkg/ddl/db_integration_test.go
+++ b/pkg/ddl/db_integration_test.go
@@ -3044,9 +3044,9 @@ func TestIssue52680(t *testing.T) {
 		sql    string
 		expect meta.AutoIDGroup
 	}{
-		{sql: "", expect: meta.AutoIDGroup{0, 4000, 0}},
-		{sql: "drop table issue52680", expect: meta.AutoIDGroup{0, 0, 0}},
-		{sql: "recover table issue52680", expect: meta.AutoIDGroup{0, 4000, 0}},
+		{sql: "", expect: meta.AutoIDGroup{RowID: 0, IncrementID: 4000, RandomID: 0}},
+		{sql: "drop table issue52680", expect: meta.AutoIDGroup{RowID: 0, IncrementID: 0, RandomID: 0}},
+		{sql: "recover table issue52680", expect: meta.AutoIDGroup{RowID: 0, IncrementID: 4000, RandomID: 0}},
 	}
 
 	for _, step := range testSteps {

--- a/pkg/ddl/db_integration_test.go
+++ b/pkg/ddl/db_integration_test.go
@@ -3072,6 +3072,7 @@ func TestIssue52680(t *testing.T) {
 
 	is = dom.InfoSchema()
 	ti1, err := is.TableInfoByName(model.NewCIStr("test"), model.NewCIStr("issue52680"))
+	require.NoError(t, err)
 	require.Equal(t, ti1.ID, ti.ID)
 
 	tk.MustExec("insert into issue52680 values(default);")

--- a/pkg/ddl/db_integration_test.go
+++ b/pkg/ddl/db_integration_test.go
@@ -3048,7 +3048,6 @@ func TestIssue52680(t *testing.T) {
 		{sql: "drop table issue52680", expect: meta.AutoIDGroup{RowID: 0, IncrementID: 0, RandomID: 0}},
 		{sql: "recover table issue52680", expect: meta.AutoIDGroup{RowID: 0, IncrementID: 4000, RandomID: 0}},
 	}
-
 	for _, step := range testSteps {
 		if step.sql != "" {
 			tk.MustExec(step.sql)

--- a/pkg/ddl/db_integration_test.go
+++ b/pkg/ddl/db_integration_test.go
@@ -3044,10 +3044,11 @@ func TestIssue52680(t *testing.T) {
 		sql    string
 		expect meta.AutoIDGroup
 	}{
-		{"", meta.AutoIDGroup{0, 4000, 0}},
-		{"drop table issue52680", meta.AutoIDGroup{0, 0, 0}},
-		{"recover table issue52680", meta.AutoIDGroup{0, 4000, 0}},
+		{sql: "", expect: meta.AutoIDGroup{0, 4000, 0}},
+		{sql: "drop table issue52680", expect: meta.AutoIDGroup{0, 0, 0}},
+		{sql: "recover table issue52680", expect: meta.AutoIDGroup{0, 4000, 0}},
 	}
+
 	for _, step := range testSteps {
 		if step.sql != "" {
 			tk.MustExec(step.sql)

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -560,7 +560,7 @@ func (w *worker) recoverTable(t *meta.Meta, job *model.Job, recoverInfo *Recover
 	tableInfo := recoverInfo.TableInfo.Clone()
 	tableInfo.State = model.StatePublic
 	tableInfo.UpdateTS = t.StartTS
-	err = t.CreateTableAndSetAutoID(recoverInfo.SchemaID, recoverInfo.OldSchemaName, tableInfo, recoverInfo.AutoIDs.RowID, recoverInfo.AutoIDs.RandomID)
+	err = t.CreateTableAndSetAutoID(recoverInfo.SchemaID, recoverInfo.OldSchemaName, tableInfo, recoverInfo.AutoIDs)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -828,7 +828,7 @@ func (m *Meta) CreateTableAndSetAutoID(dbID int64, dbName string, tableInfo *mod
 			return errors.Trace(err)
 		}
 	}
-	if tableInfo.SepAutoInc() {
+	if tableInfo.SepAutoInc() && tableInfo.GetAutoIncrementColInfo() != nil {
 		_, err = m.txn.HInc(m.dbKey(dbID), m.autoIncrementIDKey(tableInfo.ID), autoIDs.IncrementID)
 		if err != nil {
 			return errors.Trace(err)

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -813,17 +813,23 @@ func (m *Meta) GetMetadataLock() (enable bool, isNull bool, err error) {
 
 // CreateTableAndSetAutoID creates a table with tableInfo in database,
 // and rebases the table autoID.
-func (m *Meta) CreateTableAndSetAutoID(dbID int64, dbName string, tableInfo *model.TableInfo, autoIncID, autoRandID int64) error {
+func (m *Meta) CreateTableAndSetAutoID(dbID int64, dbName string, tableInfo *model.TableInfo, autoIDs AutoIDGroup) error {
 	err := m.CreateTableOrView(dbID, dbName, tableInfo)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	_, err = m.txn.HInc(m.dbKey(dbID), m.autoTableIDKey(tableInfo.ID), autoIncID)
+	_, err = m.txn.HInc(m.dbKey(dbID), m.autoTableIDKey(tableInfo.ID), autoIDs.RowID)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if tableInfo.AutoRandomBits > 0 {
-		_, err = m.txn.HInc(m.dbKey(dbID), m.autoRandomTableIDKey(tableInfo.ID), autoRandID)
+		_, err = m.txn.HInc(m.dbKey(dbID), m.autoRandomTableIDKey(tableInfo.ID), autoIDs.RandomID)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if tableInfo.SepAutoInc() {
+		_, err = m.txn.HInc(m.dbKey(dbID), m.autoIncrementIDKey(tableInfo.ID), autoIDs.IncrementID)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -360,7 +360,7 @@ func TestMeta(t *testing.T) {
 		ID:   3,
 		Name: model.NewCIStr("tbl3"),
 	}
-	err = m.CreateTableAndSetAutoID(1, dbInfo.Name.L, tbInfo3, 123, 0)
+	err = m.CreateTableAndSetAutoID(1, dbInfo.Name.L, tbInfo3, meta.AutoIDGroup{RowID: 123, IncrementID: 0})
 	require.NoError(t, err)
 	id, err := m.GetAutoIDAccessors(1, tbInfo3.ID).RowID().Get()
 	require.NoError(t, err)


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52680 

Problem Summary:

### What changed and how does it work?

After https://github.com/pingcap/tidb/pull/39041, `CreateTableAndSetAutoID` do not set the auto id correctly.
We should recover RowID, AutoIncrementID, RandomID..

P.S. drop table do not remove auto id entry in autoid service, this is not a problem.


### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

Follow the steps described in the issue.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
