### PR TITLE
server: support autoid/leader/resign http API for AUTO_ID_CACHE=1

### DIFF
--- a/docs/tidb_http_api.md
+++ b/docs/tidb_http_api.md
@@ -687,3 +687,24 @@ timezone.*
    $curl -X POST http://127.0.0.1:10080/upgrade/start
    "success!"
    ```
+
+1. Get the leader of the autoid service.
+
+    ```shell
+    curl http://{TiDBIP}:10080/autoid/leader
+    ```
+
+    ```shell
+    $curl http://127.0.0.1:10080/autoid/leader
+	127.0.0.1:10080
+    ```
+1. Resign the leader of the autoid service.
+
+    ```shell
+    curl http://{TiDBIP}:10080/autoid/leader/resign
+    ```
+
+    ```shell
+    $curl http://127.0.0.1:10080/autoid/leader/resign
+	success
+    ```

--- a/pkg/autoid_service/autoid.go
+++ b/pkg/autoid_service/autoid.go
@@ -357,6 +357,11 @@ func (m *mockClient) Rebase(ctx context.Context, in *autoid.RebaseRequest, _ ...
 
 var global = make(map[string]*mockClient)
 
+// OwnerManager returns the owner manager of the autoid service.
+func (s *Service) OwnerManager() owner.Manager {
+	return s.leaderShip
+}
+
 // MockForTest is used for testing, the UT test and unistore use this.
 func MockForTest(store kv.Storage) autoid.AutoIDAllocClient {
 	uuid := store.UUID()

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/infoschema",
         "//pkg/kv",
         "//pkg/metrics",
+        "//pkg/owner",
         "//pkg/param",
         "//pkg/parser",
         "//pkg/parser/ast",

--- a/pkg/server/handler/BUILD.bazel
+++ b/pkg/server/handler/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "handler",
     srcs = [
+        "autoid_handler.go",
         "tikv_handler.go",
         "upgrade_handler.go",
         "util.go",
@@ -13,6 +14,7 @@ go_library(
         "//pkg/domain/infosync",
         "//pkg/infoschema",
         "//pkg/kv",
+        "//pkg/owner",
         "//pkg/parser/model",
         "//pkg/parser/terror",
         "//pkg/session",

--- a/pkg/server/handler/autoid_handler.go
+++ b/pkg/server/handler/autoid_handler.go
@@ -1,0 +1,50 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/pingcap/tidb/pkg/owner"
+)
+
+type AutoIDResignHandler func() owner.Manager
+
+func (h AutoIDResignHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	om := h()
+	if om.IsOwner() {
+		err := om.ResignOwner(context.Background())
+		if err != nil {
+			WriteError(w, err)
+			return
+		}
+		WriteData(w, "success!")
+	} else {
+		WriteData(w, "not owner")
+	}
+}
+
+type AutoIDLeaderHandler func() owner.Manager
+
+func (h AutoIDLeaderHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	om := h()
+	ddlOwnerID, err := om.GetOwnerID(context.Background())
+	if err != nil {
+		WriteError(w, err)
+	} else {
+		WriteData(w, ddlOwnerID)
+	}
+}

--- a/pkg/server/handler/autoid_handler.go
+++ b/pkg/server/handler/autoid_handler.go
@@ -21,8 +21,10 @@ import (
 	"github.com/pingcap/tidb/pkg/owner"
 )
 
+// AutoIDResignHandler is the http handler for ${TIDB_HOST:PORT}//autoid/leader/resign
 type AutoIDResignHandler func() owner.Manager
 
+// ServeHTTP implements http.Handler
 func (h AutoIDResignHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	om := h()
 	if om.IsOwner() {
@@ -37,8 +39,10 @@ func (h AutoIDResignHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 	}
 }
 
+// AutoIDLeaderHandler is the http handler for ${TIDB_HOST:PORT}//autoid/leader
 type AutoIDLeaderHandler func() owner.Manager
 
+// ServeHTTP implements http.Handler
 func (h AutoIDLeaderHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	om := h()
 	ddlOwnerID, err := om.GetOwnerID(context.Background())

--- a/pkg/server/handler/autoid_handler.go
+++ b/pkg/server/handler/autoid_handler.go
@@ -25,7 +25,7 @@ import (
 type AutoIDResignHandler func() owner.Manager
 
 // ServeHTTP implements http.Handler
-func (h AutoIDResignHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+func (h AutoIDResignHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	om := h()
 	if om.IsOwner() {
 		err := om.ResignOwner(context.Background())
@@ -43,7 +43,7 @@ func (h AutoIDResignHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 type AutoIDLeaderHandler func() owner.Manager
 
 // ServeHTTP implements http.Handler
-func (h AutoIDLeaderHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+func (h AutoIDLeaderHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	om := h()
 	ddlOwnerID, err := om.GetOwnerID(context.Background())
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #52600

Problem Summary:

### What changed and how does it work?

Provide the http API to check and resign the auoid service leader.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

Not easy to write an integration test.
We need real tikv to start autoid service, and we need start tidb server to expose http status port.
There are no such utilities now, so I test it manually.

```
tiup playground  --mode tikv-slim
./bin/tidb-server  -store=tikv -path=127.0.0.1:2379
```

```
curl http://127.0.0.1:10080/autoid/leader
"192.168.0.16:10080"

curl http://127.0.0.1:10080/autoid/leader/resign
"success!"
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
