### PR TITLE
executor: remove unnecessary stack for insert and load data

### DIFF
--- a/pkg/executor/benchmark_test.go
+++ b/pkg/executor/benchmark_test.go
@@ -1857,7 +1857,7 @@ func BenchmarkCompleteLoadErr(b *testing.B) {
 	col := &model.ColumnInfo{
 		Name: model.NewCIStr("a"),
 	}
-	err := types.ErrWarnDataOutOfRange
+	err := types.ErrDataTooLong
 	for n := 0; n < b.N; n++ {
 		completeLoadErr(col, 0, err)
 	}

--- a/pkg/executor/benchmark_test.go
+++ b/pkg/executor/benchmark_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/aggregation"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -1837,4 +1838,27 @@ func BenchmarkAggPartialResultMapperMemoryUsage(b *testing.B) {
 
 func BenchmarkPipelinedRowNumberWindowFunctionExecution(b *testing.B) {
 	b.ReportAllocs()
+}
+
+func BenchmarkCompleteInsertErr(b *testing.B) {
+	b.ReportAllocs()
+	col := &model.ColumnInfo{
+		Name:      model.NewCIStr("a"),
+		FieldType: *types.NewFieldType(mysql.TypeBlob),
+	}
+	err := types.ErrWarnDataOutOfRange
+	for n := 0; n < b.N; n++ {
+		completeInsertErr(col, nil, 0, err)
+	}
+}
+
+func BenchmarkCompleteLoadErr(b *testing.B) {
+	b.ReportAllocs()
+	col := &model.ColumnInfo{
+		Name: model.NewCIStr("a"),
+	}
+	err := types.ErrWarnDataOutOfRange
+	for n := 0; n < b.N; n++ {
+		completeLoadErr(col, 0, err)
+	}
 }

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -270,23 +270,23 @@ func completeInsertErr(col *model.ColumnInfo, val *types.Datum, rowIdx int, err 
 	if types.ErrDataTooLong.Equal(err) {
 		err = resetErrDataTooLong(colName, rowIdx+1, err)
 	} else if types.ErrOverflow.Equal(err) {
-		err = types.ErrWarnDataOutOfRange.GenWithStackByArgs(colName, rowIdx+1)
+		err = types.ErrWarnDataOutOfRange.FastGenByArgs(colName, rowIdx+1)
 	} else if types.ErrTruncated.Equal(err) {
-		err = types.ErrTruncated.GenWithStackByArgs(colName, rowIdx+1)
+		err = types.ErrTruncated.FastGenByArgs(colName, rowIdx+1)
 	} else if types.ErrTruncatedWrongVal.Equal(err) && (colTp == mysql.TypeDuration || colTp == mysql.TypeDatetime || colTp == mysql.TypeDate || colTp == mysql.TypeTimestamp) {
 		valStr, err1 := val.ToString()
 		if err1 != nil {
 			logutil.BgLogger().Debug("time truncated error", zap.Error(err1))
 		}
-		err = exeerrors.ErrTruncateWrongInsertValue.GenWithStackByArgs(types.TypeStr(colTp), valStr, colName, rowIdx+1)
+		err = exeerrors.ErrTruncateWrongInsertValue.FastGenByArgs(types.TypeStr(colTp), valStr, colName, rowIdx+1)
 	} else if types.ErrTruncatedWrongVal.Equal(err) || types.ErrWrongValue.Equal(err) {
 		valStr, err1 := val.ToString()
 		if err1 != nil {
 			logutil.BgLogger().Debug("truncated/wrong value error", zap.Error(err1))
 		}
-		err = table.ErrTruncatedWrongValueForField.GenWithStackByArgs(types.TypeStr(colTp), valStr, colName, rowIdx+1)
+		err = table.ErrTruncatedWrongValueForField.FastGenByArgs(types.TypeStr(colTp), valStr, colName, rowIdx+1)
 	} else if types.ErrWarnDataOutOfRange.Equal(err) {
-		err = types.ErrWarnDataOutOfRange.GenWithStackByArgs(colName, rowIdx+1)
+		err = types.ErrWarnDataOutOfRange.FastGenByArgs(colName, rowIdx+1)
 	}
 	return err
 }
@@ -300,7 +300,7 @@ func completeLoadErr(col *model.ColumnInfo, rowIdx int, err error) error {
 	}
 
 	if types.ErrDataTooLong.Equal(err) {
-		err = types.ErrTruncated.GenWithStack("Data truncated for column '%v' at row %v", colName, rowIdx)
+		err = types.ErrTruncated.FastGen("Data truncated for column '%v' at row %v", colName, rowIdx)
 	}
 	return err
 }
@@ -324,7 +324,7 @@ func (e *InsertValues) handleErr(col *table.Column, val *types.Datum, rowIdx int
 	// TODO: should not filter all types of errors here.
 	if err != nil {
 		ec := e.Ctx().GetSessionVars().StmtCtx.ErrCtx()
-		return ec.HandleErrorWithAlias(kv.ErrKeyExists, err, err)
+		return errors.AddStack(ec.HandleErrorWithAlias(kv.ErrKeyExists, err, err))
 	}
 	return nil
 }

--- a/pkg/executor/union_scan_test.go
+++ b/pkg/executor/union_scan_test.go
@@ -393,6 +393,8 @@ func BenchmarkUnionScanIndexLookUpDescRead(b *testing.B) {
 func TestBenchDaily(t *testing.T) {
 	benchdaily.Run(
 		executor.BenchmarkReadLastLinesOfHugeLine,
+		executor.BenchmarkCompleteInsertErr,
+		executor.BenchmarkCompleteLoadErr,
 		BenchmarkUnionScanRead,
 		BenchmarkUnionScanIndexReadDescRead,
 		BenchmarkUnionScanTableReadDescRead,

--- a/pkg/executor/update.go
+++ b/pkg/executor/update.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"runtime/trace"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -338,7 +339,7 @@ func (*UpdateExec) handleErr(colName model.CIStr, rowIdx int, err error) error {
 	}
 
 	if types.ErrDataTooLong.Equal(err) {
-		return resetErrDataTooLong(colName.O, rowIdx+1, err)
+		return errors.AddStack(resetErrDataTooLong(colName.O, rowIdx+1, err))
 	}
 
 	if types.ErrOverflow.Equal(err) {

--- a/pkg/executor/write.go
+++ b/pkg/executor/write.go
@@ -313,7 +313,7 @@ func rebaseAutoRandomValue(
 // types.ErrDataTooLong is produced in types.ProduceStrWithSpecifiedTp, there is no column info in there,
 // so we reset the error msg here, and wrap old err with errors.Wrap.
 func resetErrDataTooLong(colName string, rowIdx int, _ error) error {
-	newErr := types.ErrDataTooLong.GenWithStack("Data too long for column '%v' at row %v", colName, rowIdx)
+	newErr := types.ErrDataTooLong.FastGen("Data too long for column '%v' at row %v", colName, rowIdx)
 	return newErr
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/52783

Problem Summary:

### What changed and how does it work?
Add stack when necessary.

master vs. this PR for `completeInsertErr`
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -tags intest,deadlock -bench ^BenchmarkCompleteInsertErr$ github.com/pingcap/tidb/pkg/executor

goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/pkg/executor
BenchmarkCompleteInsertErr-8   	  383056	      3115 ns/op	     712 B/op	       8 allocs/op
PASS
ok  	github.com/pingcap/tidb/pkg/executor	4.654s

Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -tags intest,deadlock -bench ^BenchmarkCompleteInsertErr$ github.com/pingcap/tidb/pkg/executor

goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/pkg/executor
BenchmarkCompleteInsertErr-8   	 3575682	       332.1 ns/op	     200 B/op	       4 allocs/op
PASS
ok  	github.com/pingcap/tidb/pkg/executor	3.827s
```

master vs. this PR for `completeLoadErr`
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -tags intest,deadlock -bench ^BenchmarkCompleteLoadErr$ github.com/pingcap/tidb/pkg/executor

goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/pkg/executor
BenchmarkCompleteLoadErr-8   	  595936	      2001 ns/op	     712 B/op	       8 allocs/op
PASS
ok  	github.com/pingcap/tidb/pkg/executor	3.648s

Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -tags intest,deadlock -bench ^BenchmarkCompleteLoadErr$ github.com/pingcap/tidb/pkg/executor

goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/pkg/executor
BenchmarkCompleteLoadErr-8   	 6480148	       186.4 ns/op	     200 B/op	       4 allocs/op
PASS
ok  	github.com/pingcap/tidb/pkg/executor	3.937s
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
