### PR TITLE
statistics: support global singleflight for sync load

### DIFF
--- a/pkg/planner/core/casetest/planstats/main_test.go
+++ b/pkg/planner/core/casetest/planstats/main_test.go
@@ -40,6 +40,7 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 		goleak.IgnoreTopFunction("github.com/tikv/client-go/v2/txnkv/transaction.keepAlive"),
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreTopFunction("github.com/pingcap/tidb/pkg/statistics/handle/syncload.(*statsSyncLoad).SendLoadRequests.func1"), // For TestPlanStatsLoadTimeout
 	}
 
 	callback := func(i int) int {

--- a/pkg/sessionctx/stmtctx/BUILD.bazel
+++ b/pkg/sessionctx/stmtctx/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/tracing",
         "@com_github_tikv_client_go_v2//tikvrpc",
         "@org_golang_x_exp//maps",
+        "@org_golang_x_sync//singleflight",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -50,6 +50,7 @@ import (
 	"github.com/tikv/client-go/v2/tikvrpc"
 	atomic2 "go.uber.org/atomic"
 	"golang.org/x/exp/maps"
+	"golang.org/x/sync/singleflight"
 )
 
 var taskIDAlloc uint64
@@ -337,7 +338,7 @@ type StatementContext struct {
 		// NeededItems stores the columns/indices whose stats are needed for planner.
 		NeededItems []model.StatsLoadItem
 		// ResultCh to receive stats loading results
-		ResultCh chan StatsLoadResult
+		ResultCh []<-chan singleflight.Result
 		// LoadStartTime is to record the load start time to calculate latency
 		LoadStartTime time.Time
 	}

--- a/pkg/statistics/handle/syncload/BUILD.bazel
+++ b/pkg/statistics/handle/syncload/BUILD.bazel
@@ -17,9 +17,11 @@ go_library(
         "//pkg/statistics/handle/types",
         "//pkg/types",
         "//pkg/util",
+        "//pkg/util/intest",
         "//pkg/util/logutil",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
+        "@org_golang_x_sync//singleflight",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -83,11 +83,11 @@ func (s *statsSyncLoad) SendLoadRequests(sc *stmtctx.StatementContext, neededHis
 	sc.StatsLoad.Timeout = timeout
 	sc.StatsLoad.NeededItems = remainedItems
 	sc.StatsLoad.ResultCh = make([]<-chan singleflight.Result, 0, len(remainedItems))
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
 	for _, item := range remainedItems {
 		localItem := item
 		resultCh := globalStatsSyncLoadSingleFlight.DoChan(localItem.Key(), func() (any, error) {
+			timer := time.NewTimer(timeout)
+			defer timer.Stop()
 			task := &statstypes.NeededItemTask{
 				Item:      localItem,
 				ToTimeout: time.Now().Local().Add(timeout),

--- a/pkg/statistics/handle/types/BUILD.bazel
+++ b/pkg/statistics/handle/types/BUILD.bazel
@@ -17,6 +17,5 @@ go_library(
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/sqlexec",
-        "@org_golang_x_sync//singleflight",
     ],
 )

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
-	"golang.org/x/sync/singleflight"
 )
 
 // StatsGC is used to GC unnecessary stats.
@@ -398,7 +397,6 @@ type NeededItemTask struct {
 type StatsLoad struct {
 	NeededItemsCh  chan *NeededItemTask
 	TimeoutItemsCh chan *NeededItemTask
-	Singleflight   singleflight.Group
 	sync.Mutex
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52797

Problem Summary:

### What changed and how does it work?


#### before

![whiteboard_exported_image](https://github.com/pingcap/tidb/assets/3427324/d2708a12-9c1c-45a3-b0c6-39dafb7988c6)

All items the query needs will be put into the global task channel( the default capacity is 1000). And workers will merge the same task with the singleflight. So performance depends on the number of tasks that can be concurrently executed. 
Under poor performance conditions, he will not be able to handle a sufficient number of tasks, resulting in slow processing. But there are still many same tasks in the channel. So they still need to check whether to sync load. And They will fill up this channel. Query can not insert the sync load task into it and load necessary stats.


#### after 

![whiteboard_exported_image (1)](https://github.com/pingcap/tidb/assets/3427324/b3187902-dc84-4c6f-8c12-fb18df258dac)

So we need to refactor this code. We need first to let the query pass through singleflight to merge identical tasks. Then insert the task into the channel to make the worker syncload it.

So why is it that during the startup of Wetech, the queries are very unstable and there are severe timeouts with sync load? The problem lies right here.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
