### PR TITLE
ddl: allow multiple fast reorg running at the same time

### DIFF
--- a/pkg/ddl/ddl_running_jobs.go
+++ b/pkg/ddl/ddl_running_jobs.go
@@ -22,11 +22,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/pingcap/tidb/pkg/parser/model"
-	"github.com/pingcap/tidb/pkg/util/logutil"
-	"go.uber.org/zap"
 )
 
 type runningJobs struct {
@@ -39,11 +36,6 @@ type runningJobs struct {
 	// It is not necessarily being processed by a worker.
 	unfinishedIDs    map[int64]struct{}
 	unfinishedSchema map[string]map[string]struct{} // database -> table -> struct{}
-
-	// processingReorgJobID records the ID of the ingest job that is being processed by a worker.
-	// TODO(tangenta): remove this when we support running multiple concurrent ingest jobs.
-	processingIngestJobID int64
-	lastLoggingTime       time.Time
 }
 
 func newRunningJobs() *runningJobs {
@@ -66,9 +58,6 @@ func (j *runningJobs) add(job *model.Job) {
 	defer j.Unlock()
 	j.processingIDs[job.ID] = struct{}{}
 	j.updateInternalRunningJobIDs()
-	if isIngestJob(job) {
-		j.processingIngestJobID = job.ID
-	}
 
 	if _, ok := j.unfinishedIDs[job.ID]; ok {
 		// Already exists, no need to add it again.
@@ -88,9 +77,6 @@ func (j *runningJobs) remove(job *model.Job) {
 	defer j.Unlock()
 	delete(j.processingIDs, job.ID)
 	j.updateInternalRunningJobIDs()
-	if isIngestJob(job) && job.ID == j.processingIngestJobID {
-		j.processingIngestJobID = 0
-	}
 
 	if job.IsFinished() || job.IsSynced() {
 		delete(j.unfinishedIDs, job.ID)
@@ -131,16 +117,6 @@ func (j *runningJobs) checkRunnable(job *model.Job) bool {
 		// Already processing by a worker. Skip running it again.
 		return false
 	}
-	if isIngestJob(job) && j.processingIngestJobID != 0 {
-		// We only allow one task to use ingest at the same time in order to limit the CPU/memory usage.
-		if time.Since(j.lastLoggingTime) > 1*time.Minute {
-			logutil.BgLogger().Info("ingest backfill worker is already in used by another DDL job",
-				zap.String("category", "ddl-ingest"),
-				zap.Int64("processing job ID", j.processingIngestJobID))
-			j.lastLoggingTime = time.Now()
-		}
-		return false
-	}
 	for _, info := range job.GetInvolvingSchemaInfo() {
 		if _, ok := j.unfinishedSchema[model.InvolvingAll]; ok {
 			return false
@@ -161,10 +137,4 @@ func (j *runningJobs) checkRunnable(job *model.Job) bool {
 		}
 	}
 	return true
-}
-
-func isIngestJob(job *model.Job) bool {
-	return (job.Type == model.ActionAddIndex || job.Type == model.ActionAddPrimaryKey) &&
-		job.ReorgMeta != nil &&
-		job.ReorgMeta.IsFastReorg
 }

--- a/pkg/ddl/ingest/backend_mgr.go
+++ b/pkg/ddl/ingest/backend_mgr.go
@@ -244,7 +244,9 @@ func createLocalBackend(
 		return nil, err
 	}
 
-	litLogger.Info("create local backend for adding index", zap.String("keyspaceName", cfg.keyspaceName))
+	litLogger.Info("create local backend for adding index",
+		zap.String("sortDir", cfg.lightning.TikvImporter.SortedKVDir),
+		zap.String("keyspaceName", cfg.keyspaceName))
 	// We disable the switch TiKV mode feature for now,
 	// because the impact is not fully tested.
 	var raftKV2SwitchModeDuration time.Duration


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #52596

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->


1. global sort + add index, 1 large table + 1 small table

```
mysql> admin show ddl jobs;
+--------+---------+-------------------------+------------------------------+----------------------+-----------+----------+-----------+---------------------+---------------------+---------------------+---------------+
| JOB_ID | DB_NAME | TABLE_NAME              | JOB_TYPE                     | SCHEMA_STATE         | SCHEMA_ID | TABLE_ID | ROW_COUNT | CREATE_TIME         | START_TIME          | END_TIME            | STATE         |
+--------+---------+-------------------------+------------------------------+----------------------+-----------+----------+-----------+---------------------+---------------------+---------------------+---------------+
|    110 | test    | sbtest1                 | add index /* ingest cloud */ | write reorganization |         2 |      104 |  17820251 | 2024-04-23 03:42:10 | 2024-04-23 03:42:10 | NULL                | running       |
|    111 | test    | sbtest2                 | add index /* ingest cloud */ | write reorganization |         2 |      108 |         0 | 2024-04-23 03:42:21 | 2024-04-23 03:42:21 | NULL                | running       |
```

```
mysql> admin show ddl jobs;
+--------+---------+-----------------------+------------------------------+--------------+-----------+----------+------------+---------------------+---------------------+---------------------+---------------+
| JOB_ID | DB_NAME | TABLE_NAME            | JOB_TYPE                     | SCHEMA_STATE | SCHEMA_ID | TABLE_ID | ROW_COUNT  | CREATE_TIME         | START_TIME          | END_TIME            | STATE         |
+--------+---------+-----------------------+------------------------------+--------------+-----------+----------+------------+---------------------+---------------------+---------------------+---------------+
|    111 | test    | sbtest2               | add index /* ingest cloud */ | public       |         2 |      108 |   19999999 | 2024-04-23 03:42:21 | 2024-04-23 03:42:21 | 2024-04-23 03:43:12 | synced        |
|    110 | test    | sbtest1               | add index /* ingest cloud */ | public       |         2 |      104 | 5000000000 | 2024-04-23 03:42:10 | 2024-04-23 03:42:10 | 2024-04-23 05:59:04 | synced        |
```

2. add index, 1 large table + 1 small table

```
mysql> admin show ddl jobs;
+--------+---------+-----------------------+------------------------------+----------------------+-----------+----------+------------+---------------------+---------------------+---------------------+---------------+
| JOB_ID | DB_NAME | TABLE_NAME            | JOB_TYPE                     | SCHEMA_STATE         | SCHEMA_ID | TABLE_ID | ROW_COUNT  | CREATE_TIME         | START_TIME          | END_TIME            | STATE         |
+--------+---------+-----------------------+------------------------------+----------------------+-----------+----------+------------+---------------------+---------------------+---------------------+---------------+
|    114 | test    | sbtest1               | add index /* ingest */       | write reorganization |         2 |      104 |          0 | 2024-04-23 07:06:58 | 2024-04-23 07:06:58 | NULL                | running       |
|    115 | test    | sbtest2               | add index /* ingest */       | write reorganization |         2 |      108 |          0 | 2024-04-23 07:07:02 | 2024-04-23 07:07:03 | NULL                | running       |
```

```
mysql> admin show ddl jobs;
+--------+---------+------------+------------------------------+--------------+-----------+----------+------------+---------------------+---------------------+---------------------+---------------+
| JOB_ID | DB_NAME | TABLE_NAME | JOB_TYPE                     | SCHEMA_STATE | SCHEMA_ID | TABLE_ID | ROW_COUNT  | CREATE_TIME         | START_TIME          | END_TIME            | STATE         |
+--------+---------+------------+------------------------------+--------------+-----------+----------+------------+---------------------+---------------------+---------------------+---------------+
|    115 | test    | sbtest2    | add index /* ingest */       | public       |         2 |      108 |   19999999 | 2024-04-23 07:07:02 | 2024-04-23 07:07:03 | 2024-04-23 07:08:10 | synced        |
|    114 | test    | sbtest1    | add index /* ingest */       | public       |         2 |      104 | 5000000000 | 2024-04-23 07:06:58 | 2024-04-23 07:06:58 | 2024-04-23 10:35:18 | synced        |
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
