### PR TITLE
planner: add more test cases for unqualified plan cache cases in statement_summary

### DIFF
--- a/pkg/util/stmtsummary/v2/tests/BUILD.bazel
+++ b/pkg/util/stmtsummary/v2/tests/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "table_test.go",
     ],
     flaky = True,
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//pkg/config",
         "//pkg/kv",

--- a/pkg/util/stmtsummary/v2/tests/table_test.go
+++ b/pkg/util/stmtsummary/v2/tests/table_test.go
@@ -501,6 +501,97 @@ func TestPerformanceSchemaforNonPrepPlanCache(t *testing.T) {
 		"6 select * from `t` where `a` = ? 0 0 3 select * from t where a=1"))
 }
 
+func TestPlanCacheUnqualified2(t *testing.T) {
+	setupStmtSummary()
+	defer closeStmtSummary()
+
+	store := testkit.CreateMockStore(t)
+	tk := newTestKitWithRoot(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec("set global tidb_enable_stmt_summary = 0")
+	tk.MustExec("set global tidb_enable_stmt_summary = 1")
+
+	// queries accessing temporary tables or generated columns
+	tk.MustExec(`create table t1 (a int, b int)`)
+	tk.MustExec(`create temporary table t_temp_unqualified_test (a int)`)
+	tk.MustExec(`create table t_gen_unqualified_test (id int, addr json, city VARCHAR(64) AS (JSON_UNQUOTE(JSON_EXTRACT(addr, '$.city'))))`)
+	tk.MustExec(`prepare st from 'select * from t1, t_temp_unqualified_test where t1.a > 10'`)
+	tk.MustExec(`execute st`)
+	tk.MustQuery(`select digest_text, exec_count, plan_cache_unqualified, last_plan_cache_unqualified_reason
+    from information_schema.statements_summary where digest_text like '%select%from%t_temp_unqualified_test%'`).Sort().Check(testkit.Rows(
+		"select * from `t1` , `t_temp_unqualified_test` where `t1` . `a` > ? 1 1 query accesses temporary tables is un-cacheable"))
+
+	tk.MustExec(`set @@tidb_opt_fix_control = "45798:off"`)
+	tk.MustExec(`prepare st from 'select * from t1, t_gen_unqualified_test where t1.a > 10'`)
+	tk.MustExec(`execute st`)
+	tk.MustQuery(`select digest_text, exec_count, plan_cache_unqualified, last_plan_cache_unqualified_reason
+    from information_schema.statements_summary where digest_text like '%select%from%t_gen_unqualified_test%'`).Sort().Check(testkit.Rows(
+		"select * from `t1` , `t_gen_unqualified_test` where `t1` . `a` > ? 1 1 query accesses generated columns is un-cacheable"))
+
+	// queries containing non-correlated sub-queries
+	tk.MustExec(`create table t_subquery_unqualified_test (a int, b int)`)
+	tk.MustExec(`prepare st from 'select * from t1 where t1.a > (select max(a) from t_subquery_unqualified_test)'`)
+	tk.MustExec(`execute st`)
+	tk.MustQuery(`select digest_text, exec_count, plan_cache_unqualified, last_plan_cache_unqualified_reason
+    from information_schema.statements_summary where digest_text like '%select%from%t_subquery_unqualified_test%'`).Sort().Check(testkit.Rows(
+		"select * from `t1` where `t1` . `a` > ( select max ( `a` ) from `t_subquery_unqualified_test` ) 1 1 query has uncorrelated sub-queries is un-cacheable"))
+
+	// query plans that contain PhysicalApply
+	tk.MustExec(`create table t_apply_unqualified_test (a int, b int)`)
+	tk.MustExec(`prepare st from 'select * from t1 where t1.a > (select a from t_apply_unqualified_test where t1.b > t_apply_unqualified_test.b)'`)
+	tk.MustExec(`execute st`)
+	tk.MustQuery(`select digest_text, exec_count, plan_cache_unqualified, last_plan_cache_unqualified_reason
+    from information_schema.statements_summary where digest_text like '%select%from%t_apply_unqualified_test%'`).Sort().Check(testkit.Rows(
+		"select * from `t1` where `t1` . `a` > ( select `a` from `t_apply_unqualified_test` where `t1` . `b` > `t_apply_unqualified_test` . `b` ) 1 1 PhysicalApply plan is un-cacheable"))
+
+	// queries containing ignore_plan_cache or set_var hints
+	tk.MustExec(`create table t_ignore_unqualified_test (a int, b int)`)
+	tk.MustExec(`prepare st from 'select /*+ ignore_plan_cache() */ * from t_ignore_unqualified_test'`)
+	tk.MustExec(`execute st`)
+	tk.MustQuery(`select digest_text, exec_count, plan_cache_unqualified, last_plan_cache_unqualified_reason
+    from information_schema.statements_summary where digest_text like '%select%from%t_ignore_unqualified_test%'`).Sort().Check(testkit.Rows(
+		"select * from `t_ignore_unqualified_test` 1 1 ignore plan cache by hint"))
+
+	tk.MustExec(`create table t_setvar_unqualified_test (a int, b int)`)
+	tk.MustExec(`prepare st from 'select /*+ set_var(max_execution_time=10000) */ * from t_setvar_unqualified_test'`)
+	tk.MustExec(`execute st`)
+	tk.MustQuery(`select digest_text, exec_count, plan_cache_unqualified, last_plan_cache_unqualified_reason
+    from information_schema.statements_summary where digest_text like '%select%from%t_setvar_unqualified_test%'`).Sort().Check(testkit.Rows(
+		"select * from `t_setvar_unqualified_test` 1 1 SET_VAR is used in the SQL"))
+
+	// queries containing non-deterministic functions
+	tk.MustExec(`create table t_non_deterministic_1_unqualified_test (a int, b int)`)
+	tk.MustExec(`prepare st from 'select user() from t_non_deterministic_1_unqualified_test'`)
+	tk.MustExec(`execute st`)
+	tk.MustQuery(`select digest_text, exec_count, plan_cache_unqualified, last_plan_cache_unqualified_reason
+    from information_schema.statements_summary where digest_text like '%select%from%t_non_deterministic_1_unqualified_test%'`).Sort().Check(testkit.Rows(
+		"select user ( ) from `t_non_deterministic_1_unqualified_test` 1 1 query has 'user' is un-cacheable"))
+
+	tk.MustExec(`create table t_non_deterministic_2_unqualified_test (a int, b int)`)
+	tk.MustExec(`prepare st from 'select version() from t_non_deterministic_2_unqualified_test'`)
+	tk.MustExec(`execute st`)
+	tk.MustQuery(`select digest_text, exec_count, plan_cache_unqualified, last_plan_cache_unqualified_reason
+    from information_schema.statements_summary where digest_text like '%select%from%t_non_deterministic_2_unqualified_test%'`).Sort().Check(testkit.Rows(
+		"select `version` ( ) from `t_non_deterministic_2_unqualified_test` 1 1 query has 'version' is un-cacheable"))
+
+	// queries with a larger LIMIT
+	tk.MustExec(`create table t_limit_unqualified_test (a int, b int)`)
+	tk.MustExec(`prepare st from 'select * from t_limit_unqualified_test limit ?'`)
+	tk.MustExec(`set @x=1000000`)
+	tk.MustExec(`execute st using @x`)
+	tk.MustQuery(`select digest_text, exec_count, plan_cache_unqualified, last_plan_cache_unqualified_reason
+    from information_schema.statements_summary where digest_text like '%select%from%t_limit_unqualified_test%'`).Sort().Check(testkit.Rows(
+		"select * from `t_limit_unqualified_test` limit ? 1 1 limit count is too large"))
+
+	// queries accessing any system tables
+	tk.MustExec(`create table t_system_unqualified_test (a int, b int)`)
+	tk.MustExec(`prepare st from 'select 1 from t_system_unqualified_test, information_schema.tables'`)
+	tk.MustExec(`execute st`)
+	tk.MustQuery(`select digest_text, exec_count, plan_cache_unqualified, last_plan_cache_unqualified_reason
+    from information_schema.statements_summary where digest_text like '%select%from%t_system_unqualified_test%'`).Sort().Check(testkit.Rows(
+		"select ? from `t_system_unqualified_test` , `information_schema` . `tables` 1 1 PhysicalMemTable plan is un-cacheable"))
+}
+
 func TestPlanCacheUnqualified(t *testing.T) {
 	setupStmtSummary()
 	defer closeStmtSummary()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50618

Problem Summary: planner: add more test cases for unqualified plan cache cases in statement_summary

### What changed and how does it work?

planner: add more test cases for unqualified plan cache cases in statement_summary

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
