### PR TITLE
chunk: append `offset` when elem len in dst column is variable in `appendCellByCell` function

### DIFF
--- a/pkg/util/chunk/chunk.go
+++ b/pkg/util/chunk/chunk.go
@@ -429,7 +429,7 @@ func (c *Chunk) AppendPartialRowByColIdxs(colOff int, row Row, colIdxs []int) (w
 // appendCellByCell appends the cell with rowIdx of src into dst.
 func appendCellByCell(dst *Column, src *Column, rowIdx int) {
 	dst.appendNullBitmap(!src.IsNull(rowIdx))
-	if src.isFixed() {
+	if dst.isFixed() {
 		elemLen := len(src.elemBuf)
 		offset := rowIdx * elemLen
 		dst.data = append(dst.data, src.data[offset:offset+elemLen]...)

--- a/pkg/util/chunk/chunk.go
+++ b/pkg/util/chunk/chunk.go
@@ -429,13 +429,15 @@ func (c *Chunk) AppendPartialRowByColIdxs(colOff int, row Row, colIdxs []int) (w
 // appendCellByCell appends the cell with rowIdx of src into dst.
 func appendCellByCell(dst *Column, src *Column, rowIdx int) {
 	dst.appendNullBitmap(!src.IsNull(rowIdx))
-	if dst.isFixed() {
+	if src.isFixed() {
 		elemLen := len(src.elemBuf)
 		offset := rowIdx * elemLen
 		dst.data = append(dst.data, src.data[offset:offset+elemLen]...)
 	} else {
 		start, end := src.offsets[rowIdx], src.offsets[rowIdx+1]
 		dst.data = append(dst.data, src.data[start:end]...)
+	}
+	if !dst.isFixed() {
 		dst.offsets = append(dst.offsets, int64(len(dst.data)))
 	}
 	dst.length++

--- a/pkg/util/chunk/chunk_test.go
+++ b/pkg/util/chunk/chunk_test.go
@@ -724,6 +724,24 @@ func TestToString(t *testing.T) {
 	require.Equal(t, "1, 1, 1, 0000-00-00, 1\n2, 2, 2, 0000-00-00 00:00:00, 2\n", chk.ToString(fieldTypes))
 }
 
+func TestAppendCellByCell(t *testing.T) {
+	dstCol := NewColumn(types.NewFieldType(mysql.TypeString), 5)
+	srcCol := NewColumn(types.NewFieldType(mysql.TypeLong), 5)
+
+	srcCol.AppendInt64(1)
+	srcCol.AppendInt64(2)
+	srcCol.AppendInt64(3)
+
+	appendCellByCell(dstCol, srcCol, 0)
+	appendCellByCell(dstCol, srcCol, 1)
+	appendCellByCell(dstCol, srcCol, 2)
+
+	// Test is success when there is no panic
+	dstCol.GetString(0)
+	dstCol.GetString(1)
+	dstCol.GetString(2)
+}
+
 func BenchmarkAppendInt(b *testing.B) {
 	b.ReportAllocs()
 	chk := newChunk(8)

--- a/pkg/util/chunk/chunk_test.go
+++ b/pkg/util/chunk/chunk_test.go
@@ -728,18 +728,18 @@ func TestAppendCellByCell(t *testing.T) {
 	dstCol := NewColumn(types.NewFieldType(mysql.TypeString), 5)
 	srcCol := NewColumn(types.NewFieldType(mysql.TypeLong), 5)
 
-	srcCol.AppendInt64(1)
-	srcCol.AppendInt64(2)
-	srcCol.AppendInt64(3)
+	srcCol.AppendInt64(85)
+	srcCol.AppendInt64(86)
+	srcCol.AppendInt64(87)
 
 	appendCellByCell(dstCol, srcCol, 0)
 	appendCellByCell(dstCol, srcCol, 1)
 	appendCellByCell(dstCol, srcCol, 2)
 
 	// Test is success when there is no panic
-	dstCol.GetString(0)
-	dstCol.GetString(1)
-	dstCol.GetString(2)
+	require.Equal(t, "U\x00\x00\x00\x00\x00\x00\x00", dstCol.GetString(0))
+	require.Equal(t, "V\x00\x00\x00\x00\x00\x00\x00", dstCol.GetString(1))
+	require.Equal(t, "W\x00\x00\x00\x00\x00\x00\x00", dstCol.GetString(2))
 }
 
 func BenchmarkAppendInt(b *testing.B) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52159

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
