### PR TITLE
expression: change `ExprCtxExtendedImpl` to `SessionExprContext`

### DIFF
--- a/pkg/expression/contextsession/sessionctx.go
+++ b/pkg/expression/contextsession/sessionctx.go
@@ -39,100 +39,95 @@ import (
 	"go.uber.org/zap"
 )
 
-// sessionctx.Context + *ExprCtxExtendedImpl should implement
-// `expression.BuildContext` and `expression.AggFuncBuildContext`
-// Only used to assert `ExprCtxExtendedImpl` should implement all methods not in `sessionctx.Context`
-var _ exprctx.ExprContext = struct {
-	sessionctx.Context
-	*ExprCtxExtendedImpl
-}{}
+// SessionExprContext should implement the `ExprContext` interface.
+var _ exprctx.ExprContext = &SessionExprContext{}
 
-// ExprCtxExtendedImpl extends the sessionctx.Context to implement `expression.BuildContext`
-type ExprCtxExtendedImpl struct {
+// SessionExprContext implements `ExprContext`
+type SessionExprContext struct {
 	sctx sessionctx.Context
 	*SessionEvalContext
 }
 
-// NewExprExtendedImpl creates a new ExprCtxExtendedImpl.
-func NewExprExtendedImpl(sctx sessionctx.Context) *ExprCtxExtendedImpl {
-	return &ExprCtxExtendedImpl{
+// NewSessionExprContext creates a new SessionExprContext.
+func NewSessionExprContext(sctx sessionctx.Context) *SessionExprContext {
+	return &SessionExprContext{
 		sctx:               sctx,
 		SessionEvalContext: NewSessionEvalContext(sctx),
 	}
 }
 
 // GetEvalCtx returns the EvalContext.
-func (ctx *ExprCtxExtendedImpl) GetEvalCtx() exprctx.EvalContext {
+func (ctx *SessionExprContext) GetEvalCtx() exprctx.EvalContext {
 	return ctx.SessionEvalContext
 }
 
 // GetCharsetInfo gets charset and collation for current context.
-func (ctx *ExprCtxExtendedImpl) GetCharsetInfo() (string, string) {
+func (ctx *SessionExprContext) GetCharsetInfo() (string, string) {
 	return ctx.sctx.GetSessionVars().GetCharsetInfo()
 }
 
 // GetDefaultCollationForUTF8MB4 returns the default collation of UTF8MB4.
-func (ctx *ExprCtxExtendedImpl) GetDefaultCollationForUTF8MB4() string {
+func (ctx *SessionExprContext) GetDefaultCollationForUTF8MB4() string {
 	return ctx.sctx.GetSessionVars().DefaultCollationForUTF8MB4
 }
 
 // GetBlockEncryptionMode returns the variable block_encryption_mode
-func (ctx *ExprCtxExtendedImpl) GetBlockEncryptionMode() string {
+func (ctx *SessionExprContext) GetBlockEncryptionMode() string {
 	blockMode, _ := ctx.sctx.GetSessionVars().GetSystemVar(variable.BlockEncryptionMode)
 	return blockMode
 }
 
 // GetSysdateIsNow returns a bool to determine whether Sysdate is an alias of Now function.
 // It is the value of variable `tidb_sysdate_is_now`.
-func (ctx *ExprCtxExtendedImpl) GetSysdateIsNow() bool {
+func (ctx *SessionExprContext) GetSysdateIsNow() bool {
 	return ctx.sctx.GetSessionVars().SysdateIsNow
 }
 
 // GetNoopFuncsMode returns the noop function mode: OFF/ON/WARN values as 0/1/2.
-func (ctx *ExprCtxExtendedImpl) GetNoopFuncsMode() int {
+func (ctx *SessionExprContext) GetNoopFuncsMode() int {
 	return ctx.sctx.GetSessionVars().NoopFuncsMode
 }
 
 // Rng is used to generate random values.
-func (ctx *ExprCtxExtendedImpl) Rng() *mathutil.MysqlRng {
+func (ctx *SessionExprContext) Rng() *mathutil.MysqlRng {
 	return ctx.sctx.GetSessionVars().Rng
 }
 
 // IsUseCache indicates whether to cache the build expression in plan cache.
 // If SetSkipPlanCache is invoked, it should return false.
-func (ctx *ExprCtxExtendedImpl) IsUseCache() bool {
+func (ctx *SessionExprContext) IsUseCache() bool {
 	return ctx.sctx.GetSessionVars().StmtCtx.UseCache()
 }
 
 // SetSkipPlanCache sets to skip the plan cache and records the reason.
-func (ctx *ExprCtxExtendedImpl) SetSkipPlanCache(reason string) {
+func (ctx *SessionExprContext) SetSkipPlanCache(reason string) {
 	ctx.sctx.GetSessionVars().StmtCtx.SetSkipPlanCache(reason)
 }
 
 // AllocPlanColumnID allocates column id for plan.
-func (ctx *ExprCtxExtendedImpl) AllocPlanColumnID() int64 {
+func (ctx *SessionExprContext) AllocPlanColumnID() int64 {
 	return ctx.sctx.GetSessionVars().AllocPlanColumnID()
 }
 
 // IsInNullRejectCheck returns whether the expression is in null reject check.
-func (ctx *ExprCtxExtendedImpl) IsInNullRejectCheck() bool {
+func (ctx *SessionExprContext) IsInNullRejectCheck() bool {
 	return false
 }
 
 // GetWindowingUseHighPrecision determines whether to compute window operations without loss of precision.
 // see https://dev.mysql.com/doc/refman/8.0/en/window-function-optimization.html for more details.
-func (ctx *ExprCtxExtendedImpl) GetWindowingUseHighPrecision() bool {
+func (ctx *SessionExprContext) GetWindowingUseHighPrecision() bool {
 	return ctx.sctx.GetSessionVars().WindowingUseHighPrecision
 }
 
 // GetGroupConcatMaxLen returns the value of the 'group_concat_max_len' system variable.
-func (ctx *ExprCtxExtendedImpl) GetGroupConcatMaxLen() uint64 {
+func (ctx *SessionExprContext) GetGroupConcatMaxLen() uint64 {
 	return ctx.sctx.GetSessionVars().GroupConcatMaxLen
 }
 
 // ConnectionID indicates the connection ID of the current session.
 // If the context is not in a session, it should return 0.
-func (ctx *ExprCtxExtendedImpl) ConnectionID() uint64 {
+func (ctx *SessionExprContext) ConnectionID() uint64 {
 	return ctx.sctx.GetSessionVars().ConnectionID
 }
 

--- a/pkg/expression/contextsession/sessionctx_test.go
+++ b/pkg/expression/contextsession/sessionctx_test.go
@@ -265,7 +265,7 @@ func TestSessionEvalContextOptProps(t *testing.T) {
 
 func TestSessionBuildContext(t *testing.T) {
 	ctx := mock.NewContext()
-	impl := contextsession.NewExprExtendedImpl(ctx)
+	impl := contextsession.NewSessionExprContext(ctx)
 	evalCtx, ok := impl.GetEvalCtx().(*contextsession.SessionEvalContext)
 	require.True(t, ok)
 	require.Same(t, evalCtx, impl.SessionEvalContext)

--- a/pkg/lightning/backend/kv/session.go
+++ b/pkg/lightning/backend/kv/session.go
@@ -287,11 +287,6 @@ type planCtxImpl struct {
 	*planctximpl.PlanCtxExtendedImpl
 }
 
-type exprCtxImpl struct {
-	*Session
-	*exprctximpl.ExprCtxExtendedImpl
-}
-
 // Session is a trimmed down Session type which only wraps our own trimmed-down
 // transaction type and provides the session variables to the TiDB library
 // optimized for Lightning.
@@ -300,7 +295,7 @@ type Session struct {
 	planctx.EmptyPlanContextExtended
 	txn     transaction
 	Vars    *variable.SessionVars
-	exprCtx *exprCtxImpl
+	exprCtx *exprctximpl.SessionExprContext
 	planctx *planCtxImpl
 	tblctx  *tbctximpl.TableContextImpl
 	// currently, we only set `CommonAddRecordCtx`
@@ -363,10 +358,7 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 	}
 	vars.TxnCtx = nil
 	s.Vars = vars
-	s.exprCtx = &exprCtxImpl{
-		Session:             s,
-		ExprCtxExtendedImpl: exprctximpl.NewExprExtendedImpl(s),
-	}
+	s.exprCtx = exprctximpl.NewSessionExprContext(s)
 	s.planctx = &planCtxImpl{
 		Session:             s,
 		PlanCtxExtendedImpl: planctximpl.NewPlanCtxExtendedImpl(s),

--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -155,6 +155,7 @@ go_test(
         "//pkg/domain",
         "//pkg/executor",
         "//pkg/expression",
+        "//pkg/expression/contextsession",
         "//pkg/kv",
         "//pkg/meta",
         "//pkg/parser",

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/expression/contextsession"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/auth"
@@ -153,7 +154,7 @@ func TestBootstrapWithError(t *testing.T) {
 			store:       store,
 			sessionVars: variable.NewSessionVars(nil),
 		}
-		se.exprctx = newExpressionContextImpl(se)
+		se.exprctx = contextsession.NewSessionExprContext(se)
 		se.pctx = newPlanContextImpl(se)
 		se.tblctx = tbctximpl.NewTableContextImpl(se, se.exprctx)
 		globalVarsAccessor := variable.NewMockGlobalAccessor4Tests()

--- a/pkg/session/contextimpl.go
+++ b/pkg/session/contextimpl.go
@@ -15,7 +15,6 @@
 package session
 
 import (
-	exprctximpl "github.com/pingcap/tidb/pkg/expression/contextsession"
 	planctx "github.com/pingcap/tidb/pkg/planner/context"
 	planctximpl "github.com/pingcap/tidb/pkg/planner/contextimpl"
 )
@@ -35,17 +34,5 @@ func newPlanContextImpl(s *session) *planContextImpl {
 	return &planContextImpl{
 		session:             s,
 		PlanCtxExtendedImpl: planctximpl.NewPlanCtxExtendedImpl(s),
-	}
-}
-
-type expressionContextImpl struct {
-	*session
-	*exprctximpl.ExprCtxExtendedImpl
-}
-
-func newExpressionContextImpl(s *session) *expressionContextImpl {
-	return &expressionContextImpl{
-		session:             s,
-		ExprCtxExtendedImpl: exprctximpl.NewExprExtendedImpl(s),
 	}
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -54,6 +54,7 @@ import (
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/expression"
 	exprctx "github.com/pingcap/tidb/pkg/expression/context"
+	"github.com/pingcap/tidb/pkg/expression/contextsession"
 	"github.com/pingcap/tidb/pkg/extension"
 	"github.com/pingcap/tidb/pkg/extension/extensionimpl"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -183,7 +184,7 @@ type session struct {
 	sessionManager util.SessionManager
 
 	pctx    *planContextImpl
-	exprctx *expressionContextImpl
+	exprctx *contextsession.SessionExprContext
 	tblctx  *tbctximpl.TableContextImpl
 
 	statsCollector *usage.SessionStatsItem
@@ -3609,7 +3610,7 @@ func createSessionWithOpt(store kv.Storage, opt *Opt) (*session, error) {
 		sessionStatesHandlers: make(map[sessionstates.SessionStateType]sessionctx.SessionStatesHandler),
 	}
 	s.sessionVars = variable.NewSessionVars(s)
-	s.exprctx = newExpressionContextImpl(s)
+	s.exprctx = contextsession.NewSessionExprContext(s)
 	s.pctx = newPlanContextImpl(s)
 	s.tblctx = tbctximpl.NewTableContextImpl(s, s.exprctx)
 
@@ -3672,7 +3673,7 @@ func CreateSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 		stmtStats:             stmtstats.CreateStatementStats(),
 		sessionStatesHandlers: make(map[sessionstates.SessionStateType]sessionctx.SessionStatesHandler),
 	}
-	s.exprctx = newExpressionContextImpl(s)
+	s.exprctx = contextsession.NewSessionExprContext(s)
 	s.pctx = newPlanContextImpl(s)
 	s.tblctx = tbctximpl.NewTableContextImpl(s, s.exprctx)
 	s.mu.values = make(map[fmt.Stringer]any)

--- a/pkg/util/mock/context.go
+++ b/pkg/util/mock/context.go
@@ -60,7 +60,7 @@ var (
 // Context represents mocked sessionctx.Context.
 type Context struct {
 	planctx.EmptyPlanContextExtended
-	*exprctximpl.ExprCtxExtendedImpl
+	*exprctximpl.SessionExprContext
 	txn           wrapTxn    // mock global variable
 	Store         kv.Storage // mock global variable
 	ctx           context.Context
@@ -617,7 +617,7 @@ func NewContext() *Context {
 	}
 	vars := variable.NewSessionVars(sctx)
 	sctx.sessionVars = vars
-	sctx.ExprCtxExtendedImpl = exprctximpl.NewExprExtendedImpl(sctx)
+	sctx.SessionExprContext = exprctximpl.NewSessionExprContext(sctx)
 	sctx.tblctx = tbctximpl.NewTableContextImpl(sctx, sctx)
 	vars.InitChunkSize = 2
 	vars.MaxChunkSize = 32


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52838

Problem Summary:

In the previous code, we use `ExprCtxExtendedImpl` to extend `sessionctx.Context` to make sure all the implementations of `ExpressionContext` can also implement `SQLExecutor` or some other interfaces for some scenes need to do some force type casting. However, after several PRs of refactoring, this is not necessary now. So we can change `ExprCtxExtendedImpl` to `SessionExprContext`. It is more simple.

### What changed and how does it work?

change `ExprCtxExtendedImpl` to `SessionExprContext`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
