### PR TITLE
expression: introduce `StaticExprContext` to build expressions

### DIFF
--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -15,6 +15,7 @@
 package context
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/errctx"
@@ -25,6 +26,29 @@ import (
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/mathutil"
 )
+
+// PlanColumnIDAllocator allocates column id for plan.
+type PlanColumnIDAllocator interface {
+	// AllocPlanColumnID allocates column id for plan.
+	AllocPlanColumnID() int64
+}
+
+// SimplePlanColumnIDAllocator implements PlanColumnIDAllocator
+type SimplePlanColumnIDAllocator struct {
+	id atomic.Int64
+}
+
+// NewSimplePlanColumnIDAllocator creates a new SimplePlanColumnIDAllocator.
+func NewSimplePlanColumnIDAllocator(offset int64) *SimplePlanColumnIDAllocator {
+	alloc := &SimplePlanColumnIDAllocator{}
+	alloc.id.Store(offset)
+	return alloc
+}
+
+// AllocPlanColumnID allocates column id for plan.
+func (a *SimplePlanColumnIDAllocator) AllocPlanColumnID() int64 {
+	return a.id.Add(1)
+}
 
 // EvalContext is used to evaluate an expression
 type EvalContext interface {

--- a/pkg/expression/contextstatic/BUILD.bazel
+++ b/pkg/expression/contextstatic/BUILD.bazel
@@ -2,38 +2,48 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "contextstatic",
-    srcs = ["evalctx.go"],
+    srcs = [
+        "evalctx.go",
+        "exprctx.go",
+    ],
     importpath = "github.com/pingcap/tidb/pkg/expression/contextstatic",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/errctx",
         "//pkg/expression/context",
         "//pkg/expression/contextopt",
+        "//pkg/parser/charset",
         "//pkg/parser/mysql",
         "//pkg/sessionctx/variable",
         "//pkg/types",
         "//pkg/util/context",
         "//pkg/util/intest",
+        "//pkg/util/mathutil",
     ],
 )
 
 go_test(
     name = "contextstatic_test",
     timeout = "short",
-    srcs = ["evalctx_test.go"],
+    srcs = [
+        "evalctx_test.go",
+        "exprctx_test.go",
+    ],
     embed = [":contextstatic"],
     flaky = True,
-    shard_count = 6,
+    shard_count = 9,
     deps = [
         "//pkg/errctx",
         "//pkg/expression/context",
         "//pkg/expression/contextopt",
         "//pkg/infoschema/context",
         "//pkg/parser/auth",
+        "//pkg/parser/charset",
         "//pkg/parser/mysql",
         "//pkg/sessionctx/variable",
         "//pkg/types",
         "//pkg/util/context",
+        "//pkg/util/mathutil",
         "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/expression/contextstatic/evalctx_test.go
+++ b/pkg/expression/contextstatic/evalctx_test.go
@@ -32,11 +32,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewDefaultStaticEvalCtx(t *testing.T) {
+func TestNewStaticEvalCtx(t *testing.T) {
+	// default context
 	prevID := contextutil.GenContextID()
 	ctx := NewStaticEvalContext()
 	require.Equal(t, prevID+1, ctx.CtxID())
 	checkDefaultStaticEvalCtx(t, ctx)
+
+	// with options
+	prevID = ctx.CtxID()
+	options, stateForTest := getEvalCtxOptionsForTest(t)
+	ctx = NewStaticEvalContext(options...)
+	require.Equal(t, prevID+1, ctx.CtxID())
+	checkOptionsStaticEvalCtx(t, ctx, stateForTest)
 }
 
 func checkDefaultStaticEvalCtx(t *testing.T, ctx *StaticEvalContext) {
@@ -67,14 +75,6 @@ func checkDefaultStaticEvalCtx(t *testing.T, ctx *StaticEvalContext) {
 	warnHandler, ok := ctx.warnHandler.(*contextutil.StaticWarnHandler)
 	require.True(t, ok)
 	require.Equal(t, 0, warnHandler.WarningCount())
-}
-
-func TestStaticEvalCtxOptions(t *testing.T) {
-	prevID := contextutil.GenContextID()
-	options, stateForTest := getEvalCtxOptionsForTest(t)
-	ctx := NewStaticEvalContext(options...)
-	require.Equal(t, prevID+1, ctx.CtxID())
-	checkOptionsStaticEvalCtx(t, ctx, stateForTest)
 }
 
 type evalCtxOptionsTestState struct {

--- a/pkg/expression/contextstatic/exprctx.go
+++ b/pkg/expression/contextstatic/exprctx.go
@@ -1,0 +1,284 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contextstatic
+
+import (
+	"sync/atomic"
+
+	exprctx "github.com/pingcap/tidb/pkg/expression/context"
+	"github.com/pingcap/tidb/pkg/parser/charset"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/util/intest"
+	"github.com/pingcap/tidb/pkg/util/mathutil"
+)
+
+// StaticExprContext implements the `exprctx.ExprContext` interface.
+var _ exprctx.ExprContext = &StaticExprContext{}
+
+// staticExprCtxState is the internal state for `StaticExprContext`.
+// We make it as a standalone private struct here to make sure `StaticExprCtxOption` can only be called in constructor.
+type staticExprCtxState struct {
+	evalCtx                    *StaticEvalContext
+	charset                    string
+	collation                  string
+	defaultCollationForUTF8MB4 string
+	blockEncryptionMode        string
+	sysDateIsNow               bool
+	noopFuncsMode              int
+	rng                        *mathutil.MysqlRng
+	canUseCache                *atomic.Bool
+	skipCacheHandleFunc        func(useCache *atomic.Bool, skipReason string)
+	columnIDAllocator          exprctx.PlanColumnIDAllocator
+	connectionID               uint64
+	windowingUseHighPrecision  bool
+	groupConcatMaxLen          uint64
+}
+
+// StaticExprCtxOption is the option to create or update the `StaticExprContext`
+type StaticExprCtxOption func(*staticExprCtxState)
+
+// WithEvalCtx sets the `StaticEvalContext` for `StaticExprContext`.
+func WithEvalCtx(ctx *StaticEvalContext) StaticExprCtxOption {
+	intest.AssertNotNil(ctx)
+	return func(s *staticExprCtxState) {
+		s.evalCtx = ctx
+	}
+}
+
+// WithCharset sets the charset and collation for `StaticExprContext`.
+func WithCharset(charset, collation string) StaticExprCtxOption {
+	return func(s *staticExprCtxState) {
+		s.charset = charset
+		s.collation = collation
+	}
+}
+
+// WithDefaultCollationForUTF8MB4 sets the default collation for utf8mb4 for `StaticExprContext`.
+func WithDefaultCollationForUTF8MB4(collation string) StaticExprCtxOption {
+	return func(s *staticExprCtxState) {
+		s.defaultCollationForUTF8MB4 = collation
+	}
+}
+
+// WithBlockEncryptionMode sets the block encryption mode for `StaticExprContext`.
+func WithBlockEncryptionMode(mode string) StaticExprCtxOption {
+	return func(s *staticExprCtxState) {
+		s.blockEncryptionMode = mode
+	}
+}
+
+// WithSysDateIsNow sets the sysdate is now for `StaticExprContext`.
+func WithSysDateIsNow(now bool) StaticExprCtxOption {
+	return func(s *staticExprCtxState) {
+		s.sysDateIsNow = now
+	}
+}
+
+// WithNoopFuncsMode sets the noop funcs mode for `StaticExprContext`.
+func WithNoopFuncsMode(mode int) StaticExprCtxOption {
+	intest.Assert(mode == variable.OnInt || mode == variable.OffInt || mode == variable.WarnInt)
+	return func(s *staticExprCtxState) {
+		s.noopFuncsMode = mode
+	}
+}
+
+// WithRng sets the rng for `StaticExprContext`.
+func WithRng(rng *mathutil.MysqlRng) StaticExprCtxOption {
+	intest.AssertNotNil(rng)
+	return func(s *staticExprCtxState) {
+		s.rng = rng
+	}
+}
+
+// WithUseCache sets the return value of `IsUseCache` for `StaticExprContext`.
+func WithUseCache(useCache bool) StaticExprCtxOption {
+	return func(s *staticExprCtxState) {
+		s.canUseCache.Store(useCache)
+	}
+}
+
+// WithSkipCacheHandleFunc sets inner skip plan cache function for StaticExprContext
+func WithSkipCacheHandleFunc(fn func(useCache *atomic.Bool, skipReason string)) StaticExprCtxOption {
+	return func(s *staticExprCtxState) {
+		s.skipCacheHandleFunc = fn
+	}
+}
+
+// WithColumnIDAllocator sets the column id allocator for `StaticExprContext`.
+func WithColumnIDAllocator(allocator exprctx.PlanColumnIDAllocator) StaticExprCtxOption {
+	intest.AssertNotNil(allocator)
+	return func(s *staticExprCtxState) {
+		s.columnIDAllocator = allocator
+	}
+}
+
+// WithConnectionID sets the connection id for `StaticExprContext`.
+func WithConnectionID(id uint64) StaticExprCtxOption {
+	return func(s *staticExprCtxState) {
+		s.connectionID = id
+	}
+}
+
+// WithWindowingUseHighPrecision sets the windowing use high precision for `StaticExprContext`.
+func WithWindowingUseHighPrecision(useHighPrecision bool) StaticExprCtxOption {
+	return func(s *staticExprCtxState) {
+		s.windowingUseHighPrecision = useHighPrecision
+	}
+}
+
+// WithGroupConcatMaxLen sets the group concat max len for `StaticExprContext`.
+func WithGroupConcatMaxLen(maxLen uint64) StaticExprCtxOption {
+	return func(s *staticExprCtxState) {
+		s.groupConcatMaxLen = maxLen
+	}
+}
+
+// StaticExprContext implements the `exprctx.ExprContext` interface.
+// The "static" means comparing with `SessionExprContext`, its internal state does not relay on the session or other
+// complex contexts that keeps immutable for most fields.
+type StaticExprContext struct {
+	staticExprCtxState
+}
+
+// NewStaticExprContext creates a new StaticExprContext
+func NewStaticExprContext(opts ...StaticExprCtxOption) *StaticExprContext {
+	cs, err := charset.GetCharsetInfo(mysql.DefaultCharset)
+	intest.AssertNoError(err)
+
+	ctx := &StaticExprContext{
+		staticExprCtxState: staticExprCtxState{
+			charset:                    cs.Name,
+			collation:                  cs.DefaultCollation,
+			defaultCollationForUTF8MB4: variable.DefaultCollationForUTF8MB4,
+			blockEncryptionMode:        variable.DefBlockEncryptionMode,
+			sysDateIsNow:               variable.DefSysdateIsNow,
+			noopFuncsMode:              variable.TiDBOptOnOffWarn(variable.DefTiDBEnableNoopFuncs),
+			windowingUseHighPrecision:  true,
+			groupConcatMaxLen:          variable.DefGroupConcatMaxLen,
+		},
+	}
+
+	ctx.canUseCache = &atomic.Bool{}
+	ctx.canUseCache.Store(true)
+
+	for _, opt := range opts {
+		opt(&ctx.staticExprCtxState)
+	}
+
+	if ctx.evalCtx == nil {
+		ctx.evalCtx = NewStaticEvalContext()
+	}
+
+	if ctx.rng == nil {
+		ctx.rng = mathutil.NewWithTime()
+	}
+
+	if ctx.columnIDAllocator == nil {
+		ctx.columnIDAllocator = exprctx.NewSimplePlanColumnIDAllocator(0)
+	}
+
+	return ctx
+}
+
+// Apply returns a new `StaticExprContext` with the fields updated according to the given options.
+func (ctx *StaticExprContext) Apply(opts ...StaticExprCtxOption) *StaticExprContext {
+	newCtx := &StaticExprContext{
+		staticExprCtxState: ctx.staticExprCtxState,
+	}
+
+	newCtx.canUseCache = &atomic.Bool{}
+	newCtx.canUseCache.Store(ctx.canUseCache.Load())
+
+	for _, opt := range opts {
+		opt(&newCtx.staticExprCtxState)
+	}
+
+	return newCtx
+}
+
+// GetEvalCtx implements the `ExprContext.GetEvalCtx`.
+func (ctx *StaticExprContext) GetEvalCtx() exprctx.EvalContext {
+	return ctx.evalCtx
+}
+
+// GetCharsetInfo implements the `ExprContext.GetCharsetInfo`.
+func (ctx *StaticExprContext) GetCharsetInfo() (string, string) {
+	return ctx.charset, ctx.collation
+}
+
+// GetDefaultCollationForUTF8MB4 implements the `ExprContext.GetDefaultCollationForUTF8MB4`.
+func (ctx *StaticExprContext) GetDefaultCollationForUTF8MB4() string {
+	return ctx.defaultCollationForUTF8MB4
+}
+
+// GetBlockEncryptionMode implements the `ExprContext.GetBlockEncryptionMode`.
+func (ctx *StaticExprContext) GetBlockEncryptionMode() string {
+	return ctx.blockEncryptionMode
+}
+
+// GetSysdateIsNow implements the `ExprContext.GetSysdateIsNow`.
+func (ctx *StaticExprContext) GetSysdateIsNow() bool {
+	return ctx.sysDateIsNow
+}
+
+// GetNoopFuncsMode implements the `ExprContext.GetNoopFuncsMode`.
+func (ctx *StaticExprContext) GetNoopFuncsMode() int {
+	return ctx.noopFuncsMode
+}
+
+// Rng implements the `ExprContext.Rng`.
+func (ctx *StaticExprContext) Rng() *mathutil.MysqlRng {
+	return ctx.rng
+}
+
+// IsUseCache implements the `ExprContext.IsUseCache`.
+func (ctx *StaticExprContext) IsUseCache() bool {
+	return ctx.canUseCache.Load()
+}
+
+// SetSkipPlanCache implements the `ExprContext.SetSkipPlanCache`.
+func (ctx *StaticExprContext) SetSkipPlanCache(reason string) {
+	if fn := ctx.skipCacheHandleFunc; fn != nil {
+		fn(ctx.canUseCache, reason)
+		return
+	}
+	ctx.canUseCache.Store(false)
+}
+
+// AllocPlanColumnID implements the `ExprContext.AllocPlanColumnID`.
+func (ctx *StaticExprContext) AllocPlanColumnID() int64 {
+	return ctx.columnIDAllocator.AllocPlanColumnID()
+}
+
+// IsInNullRejectCheck implements the `ExprContext.IsInNullRejectCheck` and should always return false.
+func (ctx *StaticExprContext) IsInNullRejectCheck() bool {
+	return false
+}
+
+// ConnectionID implements the `ExprContext.ConnectionID`.
+func (ctx *StaticExprContext) ConnectionID() uint64 {
+	return ctx.connectionID
+}
+
+// GetWindowingUseHighPrecision implements the `ExprContext.GetWindowingUseHighPrecision`.
+func (ctx *StaticExprContext) GetWindowingUseHighPrecision() bool {
+	return ctx.windowingUseHighPrecision
+}
+
+// GetGroupConcatMaxLen implements the `ExprContext.GetGroupConcatMaxLen`.
+func (ctx *StaticExprContext) GetGroupConcatMaxLen() uint64 {
+	return ctx.groupConcatMaxLen
+}

--- a/pkg/expression/contextstatic/exprctx_test.go
+++ b/pkg/expression/contextstatic/exprctx_test.go
@@ -1,0 +1,247 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contextstatic
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/expression/context"
+	"github.com/pingcap/tidb/pkg/parser/charset"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	contextutil "github.com/pingcap/tidb/pkg/util/context"
+	"github.com/pingcap/tidb/pkg/util/mathutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStaticExprCtx(t *testing.T) {
+	prevID := contextutil.GenContextID()
+	ctx := NewStaticExprContext()
+	require.Equal(t, ctx.GetEvalCtx().CtxID(), prevID+1)
+	checkDefaultStaticExprCtx(t, ctx)
+
+	opts, s := getExprCtxOptionsForTest()
+	ctx = NewStaticExprContext(opts...)
+	checkOptionsStaticExprCtx(t, ctx, s)
+}
+
+func TestStaticExprCtxApplyOptions(t *testing.T) {
+	ctx := NewStaticExprContext()
+	oldCanUseCache := ctx.canUseCache
+	oldEvalCtx := ctx.evalCtx
+	oldColumnIDAllocator := ctx.columnIDAllocator
+
+	// apply with options
+	opts, s := getExprCtxOptionsForTest()
+	ctx2 := ctx.Apply(opts...)
+	require.NotSame(t, oldCanUseCache, ctx2.canUseCache)
+	require.Equal(t, oldEvalCtx, ctx.evalCtx)
+	require.Same(t, oldCanUseCache, ctx.canUseCache)
+	require.Same(t, oldColumnIDAllocator, ctx.columnIDAllocator)
+	checkDefaultStaticExprCtx(t, ctx)
+	checkOptionsStaticExprCtx(t, ctx2, s)
+
+	// apply with empty options
+	ctx3 := ctx2.Apply()
+	s.skipCacheArgs = nil
+	checkOptionsStaticExprCtx(t, ctx3, s)
+	require.NotSame(t, ctx2.canUseCache, ctx3.canUseCache)
+}
+
+func checkDefaultStaticExprCtx(t *testing.T, ctx *StaticExprContext) {
+	checkDefaultStaticEvalCtx(t, ctx.GetEvalCtx().(*StaticEvalContext))
+	charsetName, collation := ctx.GetCharsetInfo()
+	require.Equal(t, mysql.DefaultCharset, charsetName)
+	cs, err := charset.GetCharsetInfo(charsetName)
+	require.NoError(t, err)
+	require.Equal(t, charsetName, cs.Name)
+	require.Equal(t, cs.DefaultCollation, collation)
+	require.Equal(t, variable.DefaultCollationForUTF8MB4, ctx.GetDefaultCollationForUTF8MB4())
+	require.Equal(t, variable.DefBlockEncryptionMode, ctx.GetBlockEncryptionMode())
+	require.Equal(t, variable.DefSysdateIsNow, ctx.GetSysdateIsNow())
+	require.Equal(t, variable.TiDBOptOnOffWarn(variable.DefTiDBEnableNoopFuncs), ctx.GetNoopFuncsMode())
+	require.NotNil(t, ctx.Rng())
+	require.True(t, ctx.IsUseCache())
+	require.Nil(t, ctx.skipCacheHandleFunc)
+	require.NotNil(t, ctx.columnIDAllocator)
+	_, ok := ctx.columnIDAllocator.(*context.SimplePlanColumnIDAllocator)
+	require.True(t, ok)
+	require.Equal(t, uint64(0), ctx.ConnectionID())
+	require.Equal(t, true, ctx.GetWindowingUseHighPrecision())
+	require.Equal(t, variable.DefGroupConcatMaxLen, ctx.GetGroupConcatMaxLen())
+}
+
+type exprCtxOptionsTestState struct {
+	evalCtx       *StaticEvalContext
+	colIDAlloc    context.PlanColumnIDAllocator
+	rng           *mathutil.MysqlRng
+	skipCacheArgs []any
+}
+
+func getExprCtxOptionsForTest() ([]StaticExprCtxOption, *exprCtxOptionsTestState) {
+	s := &exprCtxOptionsTestState{
+		evalCtx:    NewStaticEvalContext(WithLocation(time.FixedZone("UTC+11", 11*3600))),
+		colIDAlloc: context.NewSimplePlanColumnIDAllocator(1024),
+		rng:        mathutil.NewWithSeed(12345678),
+	}
+
+	return []StaticExprCtxOption{
+		WithEvalCtx(s.evalCtx),
+		WithCharset("gbk", "gbk_bin"),
+		WithDefaultCollationForUTF8MB4("utf8mb4_0900_ai_ci"),
+		WithBlockEncryptionMode("aes-256-cbc"),
+		WithSysDateIsNow(true),
+		WithNoopFuncsMode(variable.WarnInt),
+		WithRng(s.rng),
+		WithUseCache(false),
+		WithSkipCacheHandleFunc(func(useCache *atomic.Bool, skipReason string) {
+			s.skipCacheArgs = []any{useCache, skipReason}
+		}),
+		WithColumnIDAllocator(s.colIDAlloc),
+		WithConnectionID(778899),
+		WithWindowingUseHighPrecision(false),
+		WithGroupConcatMaxLen(2233445566),
+	}, s
+}
+
+func checkOptionsStaticExprCtx(t *testing.T, ctx *StaticExprContext, s *exprCtxOptionsTestState) {
+	require.Same(t, s.evalCtx, ctx.GetEvalCtx())
+	cs, collation := ctx.GetCharsetInfo()
+	require.Equal(t, "gbk", cs)
+	require.Equal(t, "gbk_bin", collation)
+	require.Equal(t, "utf8mb4_0900_ai_ci", ctx.GetDefaultCollationForUTF8MB4())
+	require.Equal(t, "aes-256-cbc", ctx.GetBlockEncryptionMode())
+	require.Equal(t, true, ctx.GetSysdateIsNow())
+	require.Equal(t, variable.WarnInt, ctx.GetNoopFuncsMode())
+	require.Same(t, s.rng, ctx.Rng())
+	require.False(t, ctx.IsUseCache())
+	require.Nil(t, s.skipCacheArgs)
+	ctx.SetSkipPlanCache("reason")
+	require.Equal(t, []any{ctx.canUseCache, "reason"}, s.skipCacheArgs)
+	require.Same(t, s.colIDAlloc, ctx.columnIDAllocator)
+	require.Equal(t, uint64(778899), ctx.ConnectionID())
+	require.False(t, ctx.GetWindowingUseHighPrecision())
+	require.Equal(t, uint64(2233445566), ctx.GetGroupConcatMaxLen())
+}
+
+func TestStaticExprCtxUseCache(t *testing.T) {
+	// default implement
+	ctx := NewStaticExprContext()
+	require.True(t, ctx.IsUseCache())
+	require.Nil(t, ctx.skipCacheHandleFunc)
+	ctx.SetSkipPlanCache("reason")
+	require.False(t, ctx.IsUseCache())
+	require.Empty(t, ctx.GetEvalCtx().TruncateWarnings(0))
+
+	ctx = NewStaticExprContext(WithUseCache(false))
+	require.False(t, ctx.IsUseCache())
+	require.Nil(t, ctx.skipCacheHandleFunc)
+	ctx.SetSkipPlanCache("reason")
+	require.False(t, ctx.IsUseCache())
+	require.Empty(t, ctx.GetEvalCtx().TruncateWarnings(0))
+
+	ctx = NewStaticExprContext(WithUseCache(true))
+	require.True(t, ctx.IsUseCache())
+	require.Nil(t, ctx.skipCacheHandleFunc)
+	ctx.SetSkipPlanCache("reason")
+	require.False(t, ctx.IsUseCache())
+	require.Empty(t, ctx.GetEvalCtx().TruncateWarnings(0))
+
+	// custom skip func
+	var args []any
+	calls := 0
+	ctx = NewStaticExprContext(WithSkipCacheHandleFunc(func(useCache *atomic.Bool, skipReason string) {
+		args = []any{useCache, skipReason}
+		calls++
+		if calls > 1 {
+			useCache.Store(false)
+		}
+	}))
+	ctx.SetSkipPlanCache("reason1")
+	// If we use `WithSkipCacheHandleFunc`, useCache will be set in function
+	require.Equal(t, 1, calls)
+	require.True(t, ctx.IsUseCache())
+	require.Equal(t, []any{ctx.canUseCache, "reason1"}, args)
+
+	args = nil
+	ctx.SetSkipPlanCache("reason2")
+	require.Equal(t, 2, calls)
+	require.False(t, ctx.IsUseCache())
+	require.Equal(t, []any{ctx.canUseCache, "reason2"}, args)
+
+	// apply
+	ctx = NewStaticExprContext()
+	require.True(t, ctx.IsUseCache())
+	ctx2 := ctx.Apply(WithUseCache(false))
+	require.False(t, ctx2.IsUseCache())
+	require.True(t, ctx.IsUseCache())
+	require.NotSame(t, ctx.canUseCache, ctx2.canUseCache)
+	require.Nil(t, ctx.skipCacheHandleFunc)
+	require.Nil(t, ctx2.skipCacheHandleFunc)
+
+	var args2 []any
+	fn1 := func(useCache *atomic.Bool, skipReason string) { args = []any{useCache, skipReason} }
+	fn2 := func(useCache *atomic.Bool, skipReason string) { args2 = []any{useCache, skipReason} }
+	ctx = NewStaticExprContext(WithUseCache(false), WithSkipCacheHandleFunc(fn1))
+	require.False(t, ctx.IsUseCache())
+	ctx2 = ctx.Apply(WithUseCache(true), WithSkipCacheHandleFunc(fn2))
+	require.NotSame(t, ctx.canUseCache, ctx2.canUseCache)
+	require.False(t, ctx.IsUseCache())
+	require.True(t, ctx2.IsUseCache())
+
+	args = nil
+	args2 = nil
+	ctx.SetSkipPlanCache("reasonA")
+	require.Equal(t, []any{ctx.canUseCache, "reasonA"}, args)
+	require.Nil(t, args2)
+
+	args = nil
+	args2 = nil
+	ctx2.SetSkipPlanCache("reasonB")
+	require.Nil(t, args)
+	require.Equal(t, []any{ctx2.canUseCache, "reasonB"}, args2)
+}
+
+func TestExprCtxColumnIDAllocator(t *testing.T) {
+	// default
+	ctx := NewStaticExprContext()
+	alloc := ctx.columnIDAllocator
+	require.NotNil(t, alloc)
+	_, ok := ctx.columnIDAllocator.(*context.SimplePlanColumnIDAllocator)
+	require.True(t, ok)
+	require.Equal(t, int64(1), ctx.AllocPlanColumnID())
+
+	// Apply without an allocator
+	ctx2 := ctx.Apply()
+	require.Same(t, ctx2.columnIDAllocator, ctx.columnIDAllocator)
+	require.Equal(t, int64(2), ctx2.AllocPlanColumnID())
+	require.Equal(t, int64(3), ctx.AllocPlanColumnID())
+
+	// Apply with new allocator
+	alloc = context.NewSimplePlanColumnIDAllocator(1024)
+	ctx3 := ctx.Apply(WithColumnIDAllocator(alloc))
+	require.Same(t, alloc, ctx3.columnIDAllocator)
+	require.NotSame(t, ctx.columnIDAllocator, ctx3.columnIDAllocator)
+	require.Equal(t, int64(1025), ctx3.AllocPlanColumnID())
+	require.Equal(t, int64(4), ctx.AllocPlanColumnID())
+
+	// New context with allocator
+	alloc = context.NewSimplePlanColumnIDAllocator(2048)
+	ctx4 := NewStaticExprContext(WithColumnIDAllocator(alloc))
+	require.Same(t, alloc, ctx4.columnIDAllocator)
+	require.Equal(t, int64(2049), ctx4.AllocPlanColumnID())
+}

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1769,7 +1769,7 @@ var defaultSysVars = []*SysVar{
 			s.WindowingUseHighPrecision = TiDBOptOn(val)
 			return nil
 		}},
-	{Scope: ScopeGlobal | ScopeSession, Name: BlockEncryptionMode, Value: "aes-128-ecb", Type: TypeEnum, PossibleValues: []string{"aes-128-ecb", "aes-192-ecb", "aes-256-ecb", "aes-128-cbc", "aes-192-cbc", "aes-256-cbc", "aes-128-ofb", "aes-192-ofb", "aes-256-ofb", "aes-128-cfb", "aes-192-cfb", "aes-256-cfb"}},
+	{Scope: ScopeGlobal | ScopeSession, Name: BlockEncryptionMode, Value: DefBlockEncryptionMode, Type: TypeEnum, PossibleValues: []string{"aes-128-ecb", "aes-192-ecb", "aes-256-ecb", "aes-128-cbc", "aes-192-cbc", "aes-256-cbc", "aes-128-ofb", "aes-192-ofb", "aes-256-ofb", "aes-128-cfb", "aes-192-cfb", "aes-256-cfb"}},
 	/* TiDB specific variables */
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBAllowMPPExecution, Type: TypeBool, Value: BoolToOnOff(DefTiDBAllowMPPExecution), Depended: true, SetSession: func(s *SessionVars, val string) error {
 		s.allowMPPExecution = TiDBOptOn(val)

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1240,6 +1240,7 @@ const (
 	DefTiDBEnableOuterJoinReorder                  = true
 	DefTiDBEnableNAAJ                              = true
 	DefTiDBAllowBatchCop                           = 1
+	DefBlockEncryptionMode                         = "aes-128-ecb"
 	DefTiDBAllowMPPExecution                       = true
 	DefTiDBAllowTiFlashCop                         = false
 	DefTiDBHashExchangeWithNewCollation            = true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52852

### What changed and how does it work?

Just like #52631, we provide a static implementation for `ExprContext`. You can use `NewStaticExprContext` to create it:

```
ctx := NewStaticExprContext(
    WithEvalCtx(evalCtx),
    WithCharset("gbk", "gbk_bin"),
    // ...
)
```

You can also use `Apply` to create a new context with specified context updated:

```
ctx2 := ctx.Apply(
    WithEvalCtx(evalCtx),
    WithCharset("gbk", "gbk_bin"),
    // ...
) 
``` 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
