### PR TITLE
stmtctx, context: remove the redundant implementation of warnings/extraWarnings in statement context

### DIFF
--- a/pkg/distsql/context/BUILD.bazel
+++ b/pkg/distsql/context/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/errctx",
         "//pkg/kv",
         "//pkg/parser/mysql",
+        "//pkg/util/context",
         "//pkg/util/execdetails",
         "//pkg/util/memory",
         "//pkg/util/nocopy",

--- a/pkg/distsql/context/context.go
+++ b/pkg/distsql/context/context.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/nocopy"
@@ -38,7 +39,8 @@ type DistSQLContext struct {
 	// the next execution. They'll need to be handled specially.
 	_ nocopy.NoCopy
 
-	AppendWarning   func(error)
+	WarnHandler contextutil.WarnAppender
+
 	InRestrictedSQL bool
 	Client          kv.Client
 
@@ -87,4 +89,9 @@ type DistSQLContext struct {
 	SessionAlias                string
 
 	ExecDetails *execdetails.SyncExecDetails
+}
+
+// AppendWarning appends the warning to the warning handler.
+func (dctx *DistSQLContext) AppendWarning(warn error) {
+	dctx.WarnHandler.AppendWarning(warn)
 }

--- a/pkg/distsql/context_test.go
+++ b/pkg/distsql/context_test.go
@@ -24,7 +24,7 @@ import (
 // NewDistSQLContextForTest creates a new dist sql context for test
 func NewDistSQLContextForTest() *distsqlctx.DistSQLContext {
 	return &distsqlctx.DistSQLContext{
-		AppendWarning:                        func(error) {},
+		WarnHandler:                          contextutil.NewFuncWarnAppenderForTest(func(err error) {}),
 		TiFlashMaxThreads:                    variable.DefTiFlashMaxThreads,
 		TiFlashMaxBytesBeforeExternalJoin:    variable.DefTiFlashMaxBytesBeforeExternalJoin,
 		TiFlashMaxBytesBeforeExternalGroupBy: variable.DefTiFlashMaxBytesBeforeExternalGroupBy,

--- a/pkg/planner/context/context.go
+++ b/pkg/planner/context/context.go
@@ -89,10 +89,10 @@ type BuildPBContext struct {
 	// the following fields are used to build `expression.PushDownContext`.
 	// TODO: it'd be better to embed `expression.PushDownContext` in `BuildPBContext`. But `expression` already
 	// depends on this package, so we need to move `expression.PushDownContext` to a standalone package first.
-	GroupConcatMaxLen  uint64
-	InExplainStmt      bool
-	AppendWarning      func(err error)
-	AppendExtraWarning func(err error)
+	GroupConcatMaxLen uint64
+	InExplainStmt     bool
+	WarnHandler       contextutil.WarnAppender
+	ExtraWarnghandler contextutil.WarnAppender
 }
 
 // GetExprCtx returns the expression context.

--- a/pkg/planner/core/util.go
+++ b/pkg/planner/core/util.go
@@ -479,5 +479,5 @@ func GetPushDownCtx(pctx base.PlanContext) expression.PushDownContext {
 
 // GetPushDownCtxFromBuildPBContext creates a PushDownContext from BuildPBContext
 func GetPushDownCtxFromBuildPBContext(bctx *base.BuildPBContext) expression.PushDownContext {
-	return expression.NewPushDownContext(bctx.GetExprCtx().GetEvalCtx(), bctx.GetClient(), bctx.InExplainStmt, bctx.AppendWarning, bctx.AppendExtraWarning, bctx.GroupConcatMaxLen)
+	return expression.NewPushDownContext(bctx.GetExprCtx().GetEvalCtx(), bctx.GetClient(), bctx.InExplainStmt, bctx.WarnHandler, bctx.ExtraWarnghandler, bctx.GroupConcatMaxLen)
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2531,7 +2531,7 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 
 	return sc.GetOrInitDistSQLFromCache(func() *distsqlctx.DistSQLContext {
 		return &distsqlctx.DistSQLContext{
-			AppendWarning:   sc.AppendWarning,
+			WarnHandler:     sc.WarnHandler,
 			InRestrictedSQL: sc.InRestrictedSQL,
 			Client:          s.GetClient(),
 
@@ -2623,10 +2623,10 @@ func (s *session) GetBuildPBCtx() *planctx.BuildPBContext {
 			// the following fields are used to build `expression.PushDownContext`.
 			// TODO: it'd be better to embed `expression.PushDownContext` in `BuildPBContext`. But `expression` already
 			// depends on this package, so we need to move `expression.PushDownContext` to a standalone package first.
-			GroupConcatMaxLen:  s.GetSessionVars().GroupConcatMaxLen,
-			InExplainStmt:      s.GetSessionVars().StmtCtx.InExplainStmt,
-			AppendWarning:      s.GetSessionVars().StmtCtx.AppendWarning,
-			AppendExtraWarning: s.GetSessionVars().StmtCtx.AppendExtraWarning,
+			GroupConcatMaxLen: s.GetSessionVars().GroupConcatMaxLen,
+			InExplainStmt:     s.GetSessionVars().StmtCtx.InExplainStmt,
+			WarnHandler:       s.GetSessionVars().StmtCtx.WarnHandler,
+			ExtraWarnghandler: s.GetSessionVars().StmtCtx.ExtraWarnHandler,
 		}
 	})
 

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -201,15 +200,16 @@ type StatementContext struct {
 		copied  uint64
 		touched uint64
 
-		message  string
-		warnings []SQLWarn
-		// extraWarnings record the extra warnings and are only used by the slow log only now.
-		// If a warning is expected to be output only under some conditions (like in EXPLAIN or EXPLAIN VERBOSE) but it's
-		// not under such conditions now, it is considered as an extra warning.
-		// extraWarnings would not be printed through SHOW WARNINGS, but we want to always output them through the slow
-		// log to help diagnostics, so we store them here separately.
-		extraWarnings []SQLWarn
+		message string
 	}
+	WarnHandler contextutil.WarnHandlerExt
+	// ExtraWarnHandler record the extra warnings and are only used by the slow log only now.
+	// If a warning is expected to be output only under some conditions (like in EXPLAIN or EXPLAIN VERBOSE) but it's
+	// not under such conditions now, it is considered as an extra warning.
+	// extraWarnings would not be printed through SHOW WARNINGS, but we want to always output them through the slow
+	// log to help diagnostics, so we store them here separately.
+	ExtraWarnHandler contextutil.WarnHandlerExt
+
 	execdetails.SyncExecDetails
 
 	// PrevAffectedRows is the affected-rows value(DDL is 0, DML is the number of affected rows).
@@ -420,6 +420,8 @@ func NewStmtCtxWithTimeZone(tz *time.Location) *StatementContext {
 	sc.errCtx = newErrCtx(sc.typeCtx, defaultErrLevels, sc)
 	sc.PlanCacheTracker = contextutil.NewPlanCacheTracker(sc)
 	sc.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(&sc.PlanCacheTracker, sc)
+	sc.WarnHandler = contextutil.NewStaticWarnHandler(0)
+	sc.ExtraWarnHandler = contextutil.NewStaticWarnHandler(0)
 	return sc
 }
 
@@ -432,6 +434,8 @@ func (sc *StatementContext) Reset() {
 	sc.errCtx = newErrCtx(sc.typeCtx, defaultErrLevels, sc)
 	sc.PlanCacheTracker = contextutil.NewPlanCacheTracker(sc)
 	sc.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(&sc.PlanCacheTracker, sc)
+	sc.WarnHandler = contextutil.NewStaticWarnHandler(0)
+	sc.ExtraWarnHandler = contextutil.NewStaticWarnHandler(0)
 }
 
 // CtxID returns the context id of the statement
@@ -854,36 +858,17 @@ func (sc *StatementContext) SetMessage(msg string) {
 
 // GetWarnings gets warnings.
 func (sc *StatementContext) GetWarnings() []SQLWarn {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	return sc.mu.warnings
+	return sc.WarnHandler.GetWarnings()
 }
 
 // CopyWarnings copies the warnings to the dst.
 func (sc *StatementContext) CopyWarnings(dst []SQLWarn) []SQLWarn {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	if cnt := len(sc.mu.warnings); cap(dst) < cnt {
-		dst = make([]SQLWarn, cnt)
-	} else {
-		dst = dst[:cnt]
-	}
-	copy(dst, sc.mu.warnings)
-	return dst
+	return sc.WarnHandler.CopyWarnings(dst)
 }
 
 // TruncateWarnings truncates warnings begin from start and returns the truncated warnings.
 func (sc *StatementContext) TruncateWarnings(start int) []SQLWarn {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	sz := len(sc.mu.warnings) - start
-	if sz <= 0 {
-		return nil
-	}
-	ret := make([]SQLWarn, sz)
-	copy(ret, sc.mu.warnings[start:])
-	sc.mu.warnings = sc.mu.warnings[:start]
-	return ret
+	return sc.WarnHandler.TruncateWarnings(start)
 }
 
 // WarningCount gets warning count.
@@ -891,106 +876,62 @@ func (sc *StatementContext) WarningCount() uint16 {
 	if sc.InShowWarning {
 		return 0
 	}
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	return uint16(len(sc.mu.warnings))
+	return uint16(sc.WarnHandler.WarningCount())
 }
 
 // NumErrorWarnings gets warning and error count.
 func (sc *StatementContext) NumErrorWarnings() (ec uint16, wc int) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	for _, w := range sc.mu.warnings {
-		if w.Level == contextutil.WarnLevelError {
-			ec++
-		}
-	}
-	wc = len(sc.mu.warnings)
-	return
+	return sc.WarnHandler.NumErrorWarnings()
 }
 
 // SetWarnings sets warnings.
 func (sc *StatementContext) SetWarnings(warns []SQLWarn) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	sc.mu.warnings = warns
+	sc.WarnHandler.SetWarnings(warns)
 }
 
 // AppendWarning appends a warning with level 'Warning'.
 func (sc *StatementContext) AppendWarning(warn error) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	if len(sc.mu.warnings) < math.MaxUint16 {
-		sc.mu.warnings = append(sc.mu.warnings, SQLWarn{Level: contextutil.WarnLevelWarning, Err: warn})
-	}
+	sc.WarnHandler.AppendWarning(warn)
 }
 
 // AppendWarnings appends some warnings.
 func (sc *StatementContext) AppendWarnings(warns []SQLWarn) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	if len(sc.mu.warnings) < math.MaxUint16 {
-		sc.mu.warnings = append(sc.mu.warnings, warns...)
-	}
+	sc.WarnHandler.AppendWarnings(warns)
 }
 
 // AppendNote appends a warning with level 'Note'.
 func (sc *StatementContext) AppendNote(warn error) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	if len(sc.mu.warnings) < math.MaxUint16 {
-		sc.mu.warnings = append(sc.mu.warnings, SQLWarn{Level: contextutil.WarnLevelNote, Err: warn})
-	}
+	sc.WarnHandler.AppendNote(warn)
 }
 
 // AppendError appends a warning with level 'Error'.
 func (sc *StatementContext) AppendError(warn error) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	if len(sc.mu.warnings) < math.MaxUint16 {
-		sc.mu.warnings = append(sc.mu.warnings, SQLWarn{Level: contextutil.WarnLevelError, Err: warn})
-	}
+	sc.WarnHandler.AppendError(warn)
 }
 
 // GetExtraWarnings gets extra warnings.
 func (sc *StatementContext) GetExtraWarnings() []SQLWarn {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	return sc.mu.extraWarnings
+	return sc.ExtraWarnHandler.GetWarnings()
 }
 
 // SetExtraWarnings sets extra warnings.
 func (sc *StatementContext) SetExtraWarnings(warns []SQLWarn) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	sc.mu.extraWarnings = warns
+	sc.ExtraWarnHandler.SetWarnings(warns)
 }
 
 // AppendExtraWarning appends an extra warning with level 'Warning'.
 func (sc *StatementContext) AppendExtraWarning(warn error) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	if len(sc.mu.extraWarnings) < math.MaxUint16 {
-		sc.mu.extraWarnings = append(sc.mu.extraWarnings, SQLWarn{Level: contextutil.WarnLevelWarning, Err: warn})
-	}
+	sc.ExtraWarnHandler.AppendWarning(warn)
 }
 
 // AppendExtraNote appends an extra warning with level 'Note'.
 func (sc *StatementContext) AppendExtraNote(warn error) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	if len(sc.mu.extraWarnings) < math.MaxUint16 {
-		sc.mu.extraWarnings = append(sc.mu.extraWarnings, SQLWarn{Level: contextutil.WarnLevelNote, Err: warn})
-	}
+	sc.ExtraWarnHandler.AppendNote(warn)
 }
 
 // AppendExtraError appends an extra warning with level 'Error'.
 func (sc *StatementContext) AppendExtraError(warn error) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	if len(sc.mu.extraWarnings) < math.MaxUint16 {
-		sc.mu.extraWarnings = append(sc.mu.extraWarnings, SQLWarn{Level: contextutil.WarnLevelError, Err: warn})
-	}
+	sc.ExtraWarnHandler.AppendError(warn)
 }
 
 // resetMuForRetry resets the changed states of sc.mu during execution.
@@ -1005,7 +946,6 @@ func (sc *StatementContext) resetMuForRetry() {
 	sc.mu.copied = 0
 	sc.mu.touched = 0
 	sc.mu.message = ""
-	sc.mu.warnings = nil
 }
 
 // ResetForRetry resets the changed states during execution.
@@ -1017,6 +957,8 @@ func (sc *StatementContext) ResetForRetry() {
 	sc.IndexNames = sc.IndexNames[:0]
 	sc.TaskID = AllocateTaskID()
 	sc.SyncExecDetails.Reset()
+	sc.WarnHandler.TruncateWarnings(0)
+	sc.ExtraWarnHandler.TruncateWarnings(0)
 
 	// `TaskID` is reset, we'll need to reset distSQLCtx
 	sc.distSQLCtxCache.init = sync.Once{}

--- a/pkg/util/context/warn.go
+++ b/pkg/util/context/warn.go
@@ -89,12 +89,51 @@ type WarnHandler interface {
 	// WarningCount gets warning count.
 	WarningCount() int
 	// TruncateWarnings truncates warnings begin from start and returns the truncated warnings.
+	//
+	// Deprecated: This method is deprecated. Because it's unsafe to read the warnings returned by `GetWarnings`
+	// after truncate and append the warnings.
+	//
+	// Currently it's used in two cases and they all have better alternatives:
+	// 1. Read warnings count, do some operation and truncate warnings to read new warnings. In this case, we
+	//   can use a new temporary WarnHandler to do the operation and get the warnings without touching the
+	//   global `WarnHandler` in the statement context.
+	// 2. Read warnings count, do some operation and truncate warnings to see whether new warnings are appended.
+	//   In this case, we can use a specially designed `WarnHandler` which doesn't actually record warnings, but
+	//   just counts whether new warnings are appended.
+	// It's understandable to use `TruncateWarnings` as it's not always easy to assign a new `WarnHandler` to the
+	// context now.
+	// TODO: Make it easier to assign a new `WarnHandler` to the context (of `table` and other packages) and remove
+	// this method.
 	TruncateWarnings(start int) []SQLWarn
 	// CopyWarnings copies warnings to another slice.
 	// The input argument provides target warnings that copy to.
 	// If the dist capacity is not enough, it will allocate a new slice.
 	CopyWarnings(dst []SQLWarn) []SQLWarn
 }
+
+// WarnHandlerExt includes more methods for WarnHandler. It allows more detailed control over warnings.
+// TODO: it's a standalone interface, because it's not necessary for all WarnHandler to implement these methods.
+// However, it's still needed for many executors, so we'll see whether it's good to merge it with `WarnAppender`
+// and `WarnHandler` in the future.
+type WarnHandlerExt interface {
+	WarnHandler
+
+	// AppendWarnings appends multiple warnings
+	AppendWarnings(warns []SQLWarn)
+	// AppendNote appends a warning with level 'Note'.
+	AppendNote(warn error)
+	// AppendError appends a warning with level 'Error'.
+	AppendError(warn error)
+
+	// GetWarnings gets all warnings. The slice is not copied, so it should not be modified.
+	GetWarnings() []SQLWarn
+	// SetWarnings resets all warnings in the handler directly. The handler may ignore the given warnings.
+	SetWarnings(warns []SQLWarn)
+	// NumErrorWarnings returns the number of warnings with level 'Error' and the total number of warnings.
+	NumErrorWarnings() (uint16, int)
+}
+
+var _ WarnHandler = &StaticWarnHandler{}
 
 // StaticWarnHandler implements the WarnHandler interface.
 type StaticWarnHandler struct {
@@ -104,7 +143,11 @@ type StaticWarnHandler struct {
 
 // NewStaticWarnHandler creates a new StaticWarnHandler.
 func NewStaticWarnHandler(sliceCap int) *StaticWarnHandler {
-	return &StaticWarnHandler{warnings: make([]SQLWarn, 0, sliceCap)}
+	var warnings []SQLWarn
+	if sliceCap > 0 {
+		warnings = make([]SQLWarn, 0, sliceCap)
+	}
+	return &StaticWarnHandler{warnings: warnings}
 }
 
 // NewStaticWarnHandlerWithHandler creates a new StaticWarnHandler with copying the warnings from the given WarnHandler.
@@ -125,9 +168,33 @@ func NewStaticWarnHandlerWithHandler(h WarnHandler) *StaticWarnHandler {
 func (h *StaticWarnHandler) AppendWarning(warn error) {
 	h.Lock()
 	defer h.Unlock()
+
+	h.appendWarningWithLevel(WarnLevelWarning, warn)
+}
+
+// AppendWarnings appends multiple warnings
+func (h *StaticWarnHandler) AppendWarnings(warns []SQLWarn) {
+	h.Lock()
+	defer h.Unlock()
 	if len(h.warnings) < math.MaxUint16 {
-		h.warnings = append(h.warnings, SQLWarn{WarnLevelWarning, warn})
+		h.warnings = append(h.warnings, warns...)
 	}
+}
+
+// AppendNote appends a warning with level 'Note'.
+func (h *StaticWarnHandler) AppendNote(warn error) {
+	h.Lock()
+	defer h.Unlock()
+
+	h.appendWarningWithLevel(WarnLevelNote, warn)
+}
+
+// AppendError appends a warning with level 'Error'.
+func (h *StaticWarnHandler) AppendError(warn error) {
+	h.Lock()
+	defer h.Unlock()
+
+	h.appendWarningWithLevel(WarnLevelError, warn)
 }
 
 // WarningCount implements the StaticWarnHandler.WarningCount.
@@ -162,6 +229,42 @@ func (h *StaticWarnHandler) CopyWarnings(dst []SQLWarn) []SQLWarn {
 	}
 	copy(dst, h.warnings)
 	return dst
+}
+
+// GetWarnings returns all warnings in the handler. It's not safe to modify the returned slice.
+func (h *StaticWarnHandler) GetWarnings() []SQLWarn {
+	h.Mutex.Lock()
+	defer h.Mutex.Unlock()
+
+	return h.warnings
+}
+
+func (h *StaticWarnHandler) appendWarningWithLevel(level string, warn error) {
+	if len(h.warnings) < math.MaxUint16 {
+		h.warnings = append(h.warnings, SQLWarn{level, warn})
+	}
+}
+
+// SetWarnings sets the internal warnings directly.
+func (h *StaticWarnHandler) SetWarnings(warns []SQLWarn) {
+	h.Lock()
+	defer h.Unlock()
+
+	h.warnings = warns
+}
+
+// NumErrorWarnings returns the number of warnings with level 'Error' and the total number of warnings.
+func (h *StaticWarnHandler) NumErrorWarnings() (uint16, int) {
+	h.Lock()
+	defer h.Unlock()
+
+	var numError uint16
+	for _, w := range h.warnings {
+		if w.Level == WarnLevelError {
+			numError++
+		}
+	}
+	return numError, len(h.warnings)
 }
 
 type ignoreWarn struct{}

--- a/pkg/util/mock/context.go
+++ b/pkg/util/mock/context.go
@@ -245,7 +245,7 @@ func (c *Context) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 	sc := vars.StmtCtx
 
 	return &distsqlctx.DistSQLContext{
-		AppendWarning:                        sc.AppendWarning,
+		WarnHandler:                          sc.WarnHandler,
 		InRestrictedSQL:                      sc.InRestrictedSQL,
 		Client:                               c.GetClient(),
 		EnabledRateLimitAction:               vars.EnabledRateLimitAction,
@@ -298,10 +298,10 @@ func (c *Context) GetBuildPBCtx() *planctx.BuildPBContext {
 		// the following fields are used to build `expression.PushDownContext`.
 		// TODO: it'd be better to embed `expression.PushDownContext` in `BuildPBContext`. But `expression` already
 		// depends on this package, so we need to move `expression.PushDownContext` to a standalone package first.
-		GroupConcatMaxLen:  c.GetSessionVars().GroupConcatMaxLen,
-		InExplainStmt:      c.GetSessionVars().StmtCtx.InExplainStmt,
-		AppendWarning:      c.GetSessionVars().StmtCtx.AppendWarning,
-		AppendExtraWarning: c.GetSessionVars().StmtCtx.AppendExtraWarning,
+		GroupConcatMaxLen: c.GetSessionVars().GroupConcatMaxLen,
+		InExplainStmt:     c.GetSessionVars().StmtCtx.InExplainStmt,
+		WarnHandler:       c.GetSessionVars().StmtCtx.WarnHandler,
+		ExtraWarnghandler: c.GetSessionVars().StmtCtx.ExtraWarnHandler,
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #52848 

Problem Summary:

We have multiple implementation of `WarnHandler`: the most used one is the `StatementContext` itself. However, we already have a `StaticWarnHandler`, which implements nearly all methods needed by the `WarnHandler`. Now, it'd be better to implement the warning related methods in `StatementContext` with `StaticWarnHandler`.

### What changed and how does it work?

1. Remove the `warnings` and `extraWarnings` in the `StatementContext`.
2. Add two `WarnHandler`s to handle normal warning and extra warning (which is used in slow log).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > The change should be covered by existing tests
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
