### PR TITLE
pkg/infoschema: revert cache policy ref

### DIFF
--- a/pkg/infoschema/bench_test.go
+++ b/pkg/infoschema/bench_test.go
@@ -42,7 +42,7 @@ var (
 //
 // GOOS=linux GOARCH=amd64 go test -tags intest -c -o bench.test ./pkg/infoschema
 //
-// ./bench.test -test.v -run ^$ -test.bench=BenchmarkInfoschemaOverhead --with-tikv "upstream-pd:2379?disableGC=true"
+// bench.test -test.v -run ^$ -test.bench=BenchmarkInfoschemaOverhead --with-tikv "upstream-pd:2379?disableGC=true"
 func BenchmarkInfoschemaOverhead(b *testing.B) {
 	wg := testkit.MockTiDBStatusPort(context.Background(), b, *port)
 
@@ -69,11 +69,7 @@ func BenchmarkInfoschemaOverhead(b *testing.B) {
 	}
 	startTime := time.Now()
 	for j := 0; j < *tableCnt; j++ {
-		delta := true
-		if j == 0 {
-			delta = false
-		}
-		tc.runCreateTable("test"+strconv.Itoa(j), delta)
+		tc.runCreateTable("test" + strconv.Itoa(j))
 	}
 	logutil.BgLogger().Info("all table created", zap.Duration("cost time", time.Since(startTime)))
 	// TODO: add more scenes.

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -68,9 +68,6 @@ type infoSchemaMisc struct {
 	// ruleBundleMap stores all placement rules
 	ruleBundleMap map[int64]*placement.Bundle
 
-	// policyRefMap stores all policyRefInfo for tables.
-	policyRefMap map[int64]*model.PolicyRefInfo
-
 	// policyMap stores all placement policies.
 	policyMutex sync.RWMutex
 	policyMap   map[string]*model.PolicyInfo

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -28,10 +28,8 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/util"
-	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/size"
 	"github.com/tidwall/btree"
-	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -889,59 +887,17 @@ func (b *bundleInfoBuilder) updateInfoSchemaBundlesV2(is *infoschemaV2) {
 	if b.deltaUpdate {
 		b.completeUpdateTablesV2(is)
 		for tblID := range b.updateTables {
-			b.updateTableBundlesV2(is, tblID)
+			b.updateTableBundles(is, tblID)
 		}
 		return
 	}
 
-	// do full update bundles and policyRefs.
+	// do full update bundles
 	// TODO: This is quite inefficient! we need some better way or avoid this API.
 	is.ruleBundleMap = make(map[int64]*placement.Bundle)
 	for _, dbInfo := range is.AllSchemas() {
 		for _, tbl := range is.SchemaTables(dbInfo.Name) {
-			b.updateTableBundlesV2(is, tbl.Meta().ID)
-		}
-	}
-}
-
-func (b *bundleInfoBuilder) updateTableBundlesV2(infoSchemaInterface InfoSchema, tableID int64) {
-	is := infoSchemaInterface.base()
-	tbl, ok := infoSchemaInterface.TableByID(tableID)
-	if !ok {
-		b.deleteBundle(is, tableID)
-		delete(is.policyRefMap, tableID)
-		return
-	}
-
-	getter := &policyGetter{is: is}
-	bundle, err := placement.NewTableBundle(getter, tbl.Meta())
-	if err != nil {
-		logutil.BgLogger().Error("create table bundle failed", zap.Error(err))
-	} else if bundle != nil {
-		is.policyRefMap[tableID] = tbl.Meta().PlacementPolicyRef
-		is.ruleBundleMap[tableID] = bundle
-	} else {
-		b.deleteBundle(is, tableID)
-		delete(is.policyRefMap, tableID)
-	}
-
-	if tbl.Meta().Partition == nil {
-		return
-	}
-
-	for _, par := range tbl.Meta().Partition.Definitions {
-		bundle, err = placement.NewPartitionBundle(getter, par)
-		if err != nil {
-			logutil.BgLogger().Error("create partition bundle failed",
-				zap.Error(err),
-				zap.Int64("partition id", par.ID),
-			)
-		} else if bundle != nil {
-			is.policyRefMap[par.ID] = par.PlacementPolicyRef
-			is.ruleBundleMap[par.ID] = bundle
-		} else {
-			b.deleteBundle(is, par.ID)
-			delete(is.policyRefMap, par.ID)
+			b.updateTableBundles(is, tbl.Meta().ID)
 		}
 	}
 }
@@ -951,15 +907,23 @@ func (b *bundleInfoBuilder) completeUpdateTablesV2(is *infoschemaV2) {
 		return
 	}
 
-	for id := range b.updatePolicies {
-		if _, ok := is.policyRefMap[id]; ok {
-			b.markTableBundleShouldUpdate(id)
-		}
-	}
+	// TODO: This is quite inefficient! we need some better way or avoid this API.
+	for _, dbInfo := range is.AllSchemas() {
+		for _, tbl := range is.SchemaTables(dbInfo.Name) {
+			tblInfo := tbl.Meta()
+			if tblInfo.PlacementPolicyRef != nil {
+				if _, ok := b.updatePolicies[tblInfo.PlacementPolicyRef.ID]; ok {
+					b.markTableBundleShouldUpdate(tblInfo.ID)
+				}
+			}
 
-	for id := range b.updatePartitions {
-		if _, ok := is.policyRefMap[id]; ok {
-			b.markTableBundleShouldUpdate(id)
+			if tblInfo.Partition != nil {
+				for _, par := range tblInfo.Partition.Definitions {
+					if _, ok := b.updatePartitions[par.ID]; ok {
+						b.markTableBundleShouldUpdate(tblInfo.ID)
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50959

Problem Summary:

### What changed and how does it work?

Revert https://github.com/pingcap/tidb/pull/52474 manually.
Because of a mistake by me

https://github.com/pingcap/tidb/pull/52156/commits/de93c054ca9daf639ad5f469c2d33a2a2fd14e74

the CI is not really running infoschema v2 https://github.com/pingcap/tidb/issues/52753

Then the following commit introduce regression, a lot of cases failed after that.

```
building task finish, parallelism=32, count=5133, takes=12m36.921561143s
[FAIL]  pkg/ddl TestDropTableWithPlacement
[FAIL]  pkg/ddl TestCreateSchemaWithPlacement
[FAIL]  pkg/expression/integration_test TestCrossDCQuery
[FAIL]  pkg/ddl TestPolicyCacheAndPolicyDependency
[FAIL]  pkg/executor TestShowPlacementForTableAndPartition
[FAIL]  pkg/ddl TestAlterTablePartitionWithPlacementPolicy
[FAIL]  pkg/infoschema TestBasic
[FAIL]  pkg/ddl TestAddPartitionWithPlacement
[FAIL]  pkg/ddl TestPlacementMode
[FAIL]  pkg/ddl TestCreateTableWithPlacementPolicy
[FAIL]  pkg/ddl TestPlacementTiflashCheck
[FAIL]  pkg/ddl TestAlterTablePartitionPlacement
[FAIL]  pkg/ddl TestCreatePlacementPolicyWithInfo
[FAIL]  pkg/ddl TestPDFail
[FAIL]  pkg/ddl TestPlacementPolicyInUse
[FAIL]  pkg/session/schematest TestGlobalAndLocalTxn
[FAIL]  pkg/ddl TestExchangePartitionWithPlacement
[FAIL]  pkg/executor/test/showtest TestShowCreateTablePlacement
[FAIL]  pkg/executor TestShowPlacementForDBPrivilege
[FAIL]  pkg/executor TestShowPlacementPrivilege
[FAIL]  pkg/ddl TestDropPlacementPolicyInUse
[FAIL]  pkg/ddl TestRecoverTableWithPlacementPolicy
[FAIL]  pkg/ddl TestCreateTableWithInfoPlacement
[FAIL]  pkg/executor/test/splittest TestShowTableRegion
[FAIL]  pkg/ddl TestCreateOrReplacePlacementPolicy
[FAIL]  pkg/ddl TestDropTableGCPlacement
[FAIL]  pkg/ddl/tests/serial TestCreateTableWithLikeAtTemporaryMode
[FAIL]  pkg/executor TestShowPlacement
[FAIL]  pkg/ddl TestAlterPlacementPolicy
[FAIL]  pkg/executor TestShowPlacementForTableAndPartitionPrivilege
[FAIL]  pkg/ddl TestDropDatabaseGCPlacement
[FAIL]  pkg/ddl TestAlterDBPlacement
[FAIL]  pkg/infoschema TestBuildBundle
[FAIL]  pkg/ddl TestTxnScopeConstraint
[FAIL]  pkg/ddl TestTruncateTableWithPlacement
[FAIL]  pkg/ddl TestDropTablePartitionGCPlacement
[FAIL]  pkg/executor/test/executor TestAdminShowDDLJobsInfo
[FAIL]  pkg/ddl TestDropPartitionWithPlacement
[FAIL]  pkg/ddl TestTruncateTablePartitionWithPlacement
[FAIL]  pkg/ddl TestPolicyInheritance
[FAIL]  pkg/ddl TestAlterTablePlacement
run all tasks takes 14m1.784067157s
```

So we decide to revert that commit, and then add back CI again...

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

This is a revert PR

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
