### PR TITLE
server: add extra wait time(DNM)

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1016,6 +1016,18 @@ func (s *Server) DrainClients(drainWait time.Duration, cancelWait time.Duration)
 	case <-time.After(cancelWait):
 		logger.Warn("some sessions do not quit in cancel wait time")
 	}
+
+	// Set the duration to wait in seconds
+	waitTime := 15
+
+	logger.Info(fmt.Sprintf("Waiting for %d seconds...", waitTime))
+
+	for i := waitTime; i > 0; i-- {
+		logger.Info(fmt.Sprintf("Remaining time: %d seconds", i))
+		time.Sleep(time.Second)
+	}
+
+	logger.Info("Time's up!")
 }
 
 // ServerID implements SessionManager interface.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: None

Problem Summary: add extra 15s wait time to make sure most secondary lock async commits will be done, used for some tests.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- NA

Side effects

- NA

Documentation

- NA

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
