### PR TITLE
flashback: fix `realtikvtest/flashbacktest` test cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -761,6 +761,14 @@ bazel_pipelineddmltest: failpoint-enable bazel_ci_simple_prepare
 		-- //tests/realtikvtest/pipelineddmltest/...
 	./build/jenkins_collect_coverage.sh
 
+# on timeout, bazel won't print log sometimes, so we use --test_output=all to print log always
+.PHONY: bazel_flashbacktest
+bazel_flashbacktest: failpoint-enable bazel_ci_simple_prepare
+	bazel $(BAZEL_GLOBAL_CONFIG) coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --test_output=all --test_arg=-with-real-tikv --define gotags=deadlock,intest \
+	--@io_bazel_rules_go//go/config:cover_format=go_cover \
+		-- //tests/realtikvtest/flashbacktest/...
+	./build/jenkins_collect_coverage.sh
+
 .PHONY: bazel_lint
 bazel_lint: bazel_prepare
 	bazel build //... --//build:with_nogo_flag=true

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -55,20 +55,25 @@ func (h *ddlHandlerImpl) HandleDDLEvent(t *util.DDLEvent) error {
 		return err
 	}
 	defer h.statsHandler.SPool().Put(sctx)
-	if isSysDB, err := t.IsMemOrSysDB(sctx.(sessionctx.Context)); err != nil {
-		return err
-	} else if isSysDB {
-		// EXCHANGE PARTITION EVENT NOTES:
-		// 1. When a partition is exchanged with a system table, we need to adjust the global statistics
-		//    based on the count delta and modify count delta. However, due to the involvement of the system table,
-		//    a complete update of the global statistics is not feasible. Therefore, we bypass the statistics update
-		//    for the table in this scenario. Despite this, the table id still changes, so the statistics for the
-		//    system table will still be visible.
-		// 2. If the system table is a partitioned table, we will update the global statistics for the partitioned table.
-		//    It is rare to exchange a partition from a system table, so we can ignore this case. In this case,
-		//    the system table will have statistics, but this is not a significant issue.
-		logutil.StatsLogger().Info("Skip handle system database ddl event", zap.Stringer("event", t))
-		return nil
+
+	// ActionFlashbackCluster will not create any new stats info
+	// and it's SchemaID alwayws equals to 0, so skip check it.
+	if t.GetType() != model.ActionFlashbackCluster {
+		if isSysDB, err := t.IsMemOrSysDB(sctx.(sessionctx.Context)); err != nil {
+			return err
+		} else if isSysDB {
+			// EXCHANGE PARTITION EVENT NOTES:
+			// 1. When a partition is exchanged with a system table, we need to adjust the global statistics
+			//    based on the count delta and modify count delta. However, due to the involvement of the system table,
+			//    a complete update of the global statistics is not feasible. Therefore, we bypass the statistics update
+			//    for the table in this scenario. Despite this, the table id still changes, so the statistics for the
+			//    system table will still be visible.
+			// 2. If the system table is a partitioned table, we will update the global statistics for the partitioned table.
+			//    It is rare to exchange a partition from a system table, so we can ignore this case. In this case,
+			//    the system table will have statistics, but this is not a significant issue.
+			logutil.StatsLogger().Info("Skip handle system database ddl event", zap.Stringer("event", t))
+			return nil
+		}
 	}
 	logutil.StatsLogger().Info("Handle ddl event", zap.Stringer("event", t))
 

--- a/tests/realtikvtest/flashbacktest/flashback_test.go
+++ b/tests/realtikvtest/flashbacktest/flashback_test.go
@@ -429,6 +429,7 @@ func TestFlashbackSequence(t *testing.T) {
 		require.Equal(t, res[0][0], "101")
 
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/injectSafeTS"))
+		tk.MustExec("drop sequence seq")
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52898

Problem Summary: After https://github.com/pingcap/tidb/pull/52285, flashbacktest alwayws failed with error info like

```
[r="assert failed, schemaID should not be 0, please set it when creating the event"]
[stack="[github.com/pingcap/tidb/pkg/util.Recover](http://github.com/pingcap/tidb/pkg/util.Recover)
	/home/genius/project/src/[github.com/pingcap/tidb/pkg/util/misc.go:118](http://github.com/pingcap/tidb/pkg/util/misc.go:118)
runtime.gopanic
	/home/genius/project/go/src/runtime/panic.go:914
[github.com/pingcap/tidb/pkg/util/intest.doPanic](http://github.com/pingcap/tidb/pkg/util/intest.doPanic)
	/home/genius/project/src/[github.com/pingcap/tidb/pkg/util/intest/assert.go:59](http://github.com/pingcap/tidb/pkg/util/intest/assert.go:59)
[github.com/pingcap/tidb/pkg/util/intest.Assert](http://github.com/pingcap/tidb/pkg/util/intest.Assert)
	/home/genius/project/src/[github.com/pingcap/tidb/pkg/util/intest/assert.go:27](http://github.com/pingcap/tidb/pkg/util/intest/assert.go:27)
[github.com/pingcap/tidb/pkg/statistics/handle/util.(*DDLEvent).IsMemOrSysDB](http://github.com/pingcap/tidb/pkg/statistics/handle/util.(*DDLEvent).IsMemOrSysDB)
	/home/genius/project/src/[github.com/pingcap/tidb/pkg/statistics/handle/util/ddl_event.go:51](http://github.com/pingcap/tidb/pkg/statistics/handle/util/ddl_event.go:51)
[github.com/pingcap/tidb/pkg/statistics/handle/ddl.(*ddlHandlerImpl).HandleDDLEvent](http://github.com/pingcap/tidb/pkg/statistics/handle/ddl.(*ddlHandlerImpl).HandleDDLEvent)
	/home/genius/project/src/[github.com/pingcap/tidb/pkg/statistics/handle/ddl/ddl.go:58](http://github.com/pingcap/tidb/pkg/statistics/handle/ddl/ddl.go:58)
[github.com/pingcap/tidb/pkg/domain.(*Domain).updateStatsWorker](http://github.com/pingcap/tidb/pkg/domain.(*Domain).updateStatsWorker)
	/home/genius/project/src/[github.com/pingcap/tidb/pkg/domain/domain.go:2415](http://github.com/pingcap/tidb/pkg/domain/domain.go:2415)
[github.com/pingcap/tidb/pkg/domain.(*Domain).UpdateTableStatsLoop.func3](http://github.com/pingcap/tidb/pkg/domain.(*Domain).UpdateTableStatsLoop.func3)
	/home/genius/project/src/[github.com/pingcap/tidb/pkg/domain/domain.go:2235](http://github.com/pingcap/tidb/pkg/domain/domain.go:2235)
[github.com/pingcap/tidb/pkg/util.(*WaitGroupEnhancedWrapper).Run.func1](http://github.com/pingcap/tidb/pkg/util.(*WaitGroupEnhancedWrapper).Run.func1)
	/home/genius/project/src/[github.com/pingcap/tidb/pkg/util/wait_group_wrapper.go:99](http://github.com/pingcap/tidb/pkg/util/wait_group_wrapper.go:99)"]
```

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
