### PR TITLE
executor: add failpoints to control chunk size

### DIFF
--- a/pkg/executor/internal/exec/BUILD.bazel
+++ b/pkg/executor/internal/exec/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/util/topsql/state",
         "//pkg/util/tracing",
         "@com_github_ngaut_pools//:pools",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/ngaut/pools"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser"
@@ -89,6 +90,9 @@ func newExecutorChunkAllocator(vars *variable.SessionVars, retFieldTypes []*type
 
 // InitCap returns the initial capacity for chunk
 func (e *executorChunkAllocator) InitCap() int {
+	failpoint.Inject("initCap", func(val failpoint.Value) {
+		failpoint.Return(val.(int))
+	})
 	return e.initCap
 }
 
@@ -99,6 +103,9 @@ func (e *executorChunkAllocator) SetInitCap(c int) {
 
 // MaxChunkSize returns the max chunk size.
 func (e *executorChunkAllocator) MaxChunkSize() int {
+	failpoint.Inject("maxChunkSize", func(val failpoint.Value) {
+		failpoint.Return(val.(int))
+	})
 	return e.maxChunkSize
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50215 

Problem Summary:

We need to make chunk small enough to trigger multiple flushes in tests.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
