### PR TITLE
infoschema: keep the timestamp of infoschema v2 updating

### DIFF
--- a/pkg/infoschema/builder.go
+++ b/pkg/infoschema/builder.go
@@ -777,7 +777,8 @@ func (b *Builder) Build(schemaTS uint64) InfoSchema {
 func (b *Builder) InitWithOldInfoSchema(oldSchema InfoSchema) (*Builder, error) {
 	// Do not mix infoschema v1 and infoschema v2 building, this can simplify the logic.
 	// If we want to build infoschema v2, but the old infoschema is v1, just return error to trigger a full load.
-	if b.enableV2 != IsV2(oldSchema) {
+	isV2, _ := IsV2(oldSchema)
+	if b.enableV2 != isV2 {
 		return nil, errors.Errorf("builder's (v2=%v) infoschema mismatch, return error to trigger full reload", b.enableV2)
 	}
 

--- a/pkg/infoschema/infoschema_test.go
+++ b/pkg/infoschema/infoschema_test.go
@@ -966,7 +966,8 @@ func TestEnableInfoSchemaV2(t *testing.T) {
 
 	// Check the InfoSchema used is V2.
 	is := domain.GetDomain(tk.Session()).InfoSchema()
-	require.True(t, infoschema.IsV2(is))
+	isV2, _ := infoschema.IsV2(is)
+	require.True(t, isV2)
 
 	// Execute some basic operations under infoschema v2.
 	tk.MustQuery("show tables").Check(testkit.Rows("v2"))
@@ -985,7 +986,8 @@ func TestEnableInfoSchemaV2(t *testing.T) {
 
 	tk.MustExec("drop table v1")
 	is = domain.GetDomain(tk.Session()).InfoSchema()
-	require.False(t, infoschema.IsV2(is))
+	isV2, _ = infoschema.IsV2(is)
+	require.False(t, isV2)
 }
 
 type infoschemaTestContext struct {

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -303,8 +303,7 @@ func (is *infoschemaV2) base() *infoSchema {
 }
 
 func (is *infoschemaV2) CloneAndUpdateTS(startTS uint64) *infoschemaV2 {
-	var tmp infoschemaV2
-	tmp = *is
+	tmp := *is
 	tmp.ts = startTS
 	return &tmp
 }

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -302,6 +302,13 @@ func (is *infoschemaV2) base() *infoSchema {
 	return is.infoSchema
 }
 
+func (is *infoschemaV2) CloneAndUpdateTS(startTS uint64) *infoschemaV2 {
+	var tmp infoschemaV2
+	tmp = *is
+	tmp.ts = startTS
+	return &tmp
+}
+
 func (is *infoschemaV2) TableByID(id int64) (val table.Table, ok bool) {
 	if !tableIDIsValid(id) {
 		return
@@ -662,9 +669,9 @@ func isTableVirtual(id int64) bool {
 }
 
 // IsV2 tells whether an InfoSchema is v2 or not.
-func IsV2(is InfoSchema) bool {
-	_, ok := is.(*infoschemaV2)
-	return ok
+func IsV2(is InfoSchema) (bool, *infoschemaV2) {
+	ret, ok := is.(*infoschemaV2)
+	return ok, ret
 }
 
 func applyTableUpdate(b *Builder, m *meta.Meta, diff *model.SchemaDiff) ([]int64, error) {

--- a/pkg/infoschema/test/infoschemav2test/v2_test.go
+++ b/pkg/infoschema/test/infoschemav2test/v2_test.go
@@ -36,7 +36,8 @@ func TestSpecialSchemas(t *testing.T) {
 	tk.MustQuery("select @@global.tidb_schema_cache_size;").Check(testkit.Rows("1024"))
 	tk.MustExec("create table t (id int);")
 	is := domain.GetDomain(tk.Session()).InfoSchema()
-	require.True(t, infoschema.IsV2(is))
+	isV2, _ := infoschema.IsV2(is)
+	require.True(t, isV2)
 
 	tk.MustQuery("show databases;").Check(testkit.Rows(
 		"INFORMATION_SCHEMA", "METRICS_SCHEMA", "PERFORMANCE_SCHEMA", "mysql", "sys", "test"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52683
ref #50959 

Problem Summary:

It's casued by compatibility issue between infoschema v2 and GC worker.
For infoschema v2, it contains a `ts` field, `SchemaTables` and `loadTableInfo` need this `ts` to get the corresponding schema meta snapshot.

We store the schemaTS as the `ts` of an infoschema v2 object in the past.

Whether it's `schemaTS` or `startTS` does not matter, because they both use the same schema version and data.
But when we're using `schemaTS`, it's not up to date.

For example, a DDL happened 30 minutes ago. (so the `ts` of infoschema v2 object is 30 min ago)
GC happened 10 minutes ago.

Now we get the infoschema v2 object, and use it, we would get the "GC life time is shorter than transaction duration" error.

### What changed and how does it work?

Instead of using `schemaTS` for infoschema v2 object, we can change to use `startTS`,
and keep the `startTS` updating in domain load schema loop periodically.
So that we can get rid of the "GC life time is shorter than transaction duration"  error.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

Start a cluster and wait for GC, and see no panic.
Not easy to do that in unit test because GC is mocked and not really the same as real tikv.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
