### PR TITLE
planner: add projections to keep join keys as `col=col` 

### DIFF
--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -2165,6 +2165,24 @@ func TestWindowRangeFramePushDownTiflash(t *testing.T) {
 		"          └─TableFullScan_9 10000.00 mpp[tiflash] table:first_range keep order:false, stats:pseudo"))
 }
 
+func TestIssue46556(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`CREATE TABLE t0(c0 BLOB);`)
+	tk.MustExec(`CREATE definer='root'@'localhost' VIEW v0(c0) AS SELECT NULL FROM t0 GROUP BY NULL;`)
+	tk.MustExec(`SELECT t0.c0 FROM t0 NATURAL JOIN v0 WHERE v0.c0 LIKE v0.c0;`) // no error
+	tk.MustQuery(`explain format='brief' SELECT t0.c0 FROM t0 NATURAL JOIN v0 WHERE v0.c0 LIKE v0.c0`).Check(
+		testkit.Rows(`HashJoin 0.00 root  inner join, equal:[eq(Column#9, Column#10)]`,
+			`├─Projection(Build) 0.00 root  cast(Column#5, double BINARY)->Column#9`,
+			`│ └─Projection 0.00 root  <nil>->Column#5`,
+			`│   └─TableDual 0.00 root  rows:0`,
+			`└─Projection(Probe) 9990.00 root  test.t0.c0, cast(test.t0.c0, double BINARY)->Column#10`,
+			`  └─TableReader 9990.00 root  data:Selection`,
+			`    └─Selection 9990.00 cop[tikv]  not(isnull(test.t0.c0))`,
+			`      └─TableFullScan 10000.00 cop[tikv] table:t0 keep order:false, stats:pseudo`))
+}
+
 // https://github.com/pingcap/tidb/issues/41458
 func TestIssue41458(t *testing.T) {
 	store := testkit.CreateMockStore(t)

--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -2174,9 +2174,8 @@ func TestIssue46556(t *testing.T) {
 	tk.MustExec(`SELECT t0.c0 FROM t0 NATURAL JOIN v0 WHERE v0.c0 LIKE v0.c0;`) // no error
 	tk.MustQuery(`explain format='brief' SELECT t0.c0 FROM t0 NATURAL JOIN v0 WHERE v0.c0 LIKE v0.c0`).Check(
 		testkit.Rows(`HashJoin 0.00 root  inner join, equal:[eq(Column#9, Column#10)]`,
-			`├─Projection(Build) 0.00 root  cast(Column#5, double BINARY)->Column#9`,
-			`│ └─Projection 0.00 root  <nil>->Column#5`,
-			`│   └─TableDual 0.00 root  rows:0`,
+			`├─Projection(Build) 0.00 root  <nil>->Column#9`,
+			`│ └─TableDual 0.00 root  rows:0`,
 			`└─Projection(Probe) 9990.00 root  test.t0.c0, cast(test.t0.c0, double BINARY)->Column#10`,
 			`  └─TableReader 9990.00 root  data:Selection`,
 			`    └─Selection 9990.00 cop[tikv]  not(isnull(test.t0.c0))`,

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -526,6 +526,7 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 						rightPlan = s.injectProj(rightPlan, newSf.GetArgs()[1])
 						lCol = rightPlan.Schema().Columns[len(rightPlan.Schema().Columns)-1]
 					}
+					leftNode, rightNode = leftPlan, rightPlan
 					newSf = expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetType(),
 						rCol, lCol).(*expression.ScalarFunction)
 				}

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -517,14 +517,14 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 
 				// after creating the new EQ function, the 2 args might not be column anymore, which breaks the assumption that
 				// join eq keys must be `col=col`, to handle this, inject 2 projections.
-				expr0, isCol0 := newSf.GetArgs()[0].(*expression.Column)
-				expr1, isCol1 := newSf.GetArgs()[1].(*expression.Column)
+				_, isCol0 := newSf.GetArgs()[0].(*expression.Column)
+				_, isCol1 := newSf.GetArgs()[1].(*expression.Column)
 				if !isCol0 || !isCol1 {
 					if !isCol0 {
-						leftPlan, rCol = s.injectProj(leftPlan, expr0)
+						leftPlan, rCol = s.injectProj(leftPlan, newSf.GetArgs()[0])
 					}
 					if !isCol1 {
-						rightPlan, lCol = s.injectProj(rightPlan, expr1)
+						rightPlan, lCol = s.injectProj(rightPlan, newSf.GetArgs()[1])
 					}
 					leftNode, rightNode = leftPlan, rightPlan
 					newSf = expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetType(),

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -515,6 +515,8 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 			} else {
 				newSf := expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetType(), rCol, lCol).(*expression.ScalarFunction)
 
+				// after creating the new EQ function, the 2 args might not be column anymore, which breaks the assumption that
+				// join eq keys must be `col=col`, to handle this, inject 2 projections.
 				_, isCol0 := newSf.GetArgs()[0].(*expression.Column)
 				_, isCol1 := newSf.GetArgs()[1].(*expression.Column)
 				if !isCol0 || !isCol1 {

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -514,11 +514,38 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 				usedEdges = append(usedEdges, edge)
 			} else {
 				newSf := expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetType(), rCol, lCol).(*expression.ScalarFunction)
+
+				_, isCol0 := newSf.GetArgs()[0].(*expression.Column)
+				_, isCol1 := newSf.GetArgs()[1].(*expression.Column)
+				if !isCol0 || !isCol1 {
+					col0Idx := leftPlan.Schema().ColumnIndex(rCol)
+					col1Idx := rightPlan.Schema().ColumnIndex(lCol)
+					if !isCol0 {
+						leftPlan = s.injectProj(leftPlan, col0Idx, newSf.GetArgs()[0])
+					}
+					if !isCol1 {
+						rightPlan = s.injectProj(rightPlan, col1Idx, newSf.GetArgs()[1])
+					}
+					newSf = expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetType(),
+						leftPlan.Schema().Columns[col0Idx], rightPlan.Schema().Columns[col1Idx]).(*expression.ScalarFunction)
+				}
 				usedEdges = append(usedEdges, newSf)
 			}
 		}
 	}
 	return
+}
+
+func (s *baseSingleGroupJoinOrderSolver) injectProj(p base.LogicalPlan, colIdx int, expr expression.Expression) base.LogicalPlan {
+	proj := LogicalProjection{Exprs: cols2Exprs(p.Schema().Columns)}.Init(p.SCtx(), p.QueryBlockOffset())
+	proj.SetSchema(p.Schema().Clone())
+	proj.SetChildren(p)
+	proj.Exprs[colIdx] = expr
+	proj.schema.Columns[colIdx] = &expression.Column{
+		UniqueID: s.ctx.GetSessionVars().AllocPlanColumnID(),
+		RetType:  expr.GetType(),
+	}
+	return proj
 }
 
 // makeJoin build join tree for the nodes which have equal conditions to connect them.

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -517,16 +517,14 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 
 				// after creating the new EQ function, the 2 args might not be column anymore, which breaks the assumption that
 				// join eq keys must be `col=col`, to handle this, inject 2 projections.
-				_, isCol0 := newSf.GetArgs()[0].(*expression.Column)
-				_, isCol1 := newSf.GetArgs()[1].(*expression.Column)
+				expr0, isCol0 := newSf.GetArgs()[0].(*expression.Column)
+				expr1, isCol1 := newSf.GetArgs()[1].(*expression.Column)
 				if !isCol0 || !isCol1 {
 					if !isCol0 {
-						leftPlan = s.injectProj(leftPlan, newSf.GetArgs()[0])
-						rCol = leftPlan.Schema().Columns[len(leftPlan.Schema().Columns)-1]
+						leftPlan, rCol = s.injectProj(leftPlan, expr0)
 					}
 					if !isCol1 {
-						rightPlan = s.injectProj(rightPlan, newSf.GetArgs()[1])
-						lCol = rightPlan.Schema().Columns[len(rightPlan.Schema().Columns)-1]
+						rightPlan, lCol = s.injectProj(rightPlan, expr1)
 					}
 					leftNode, rightNode = leftPlan, rightPlan
 					newSf = expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetType(),
@@ -539,18 +537,14 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 	return
 }
 
-func (s *baseSingleGroupJoinOrderSolver) injectProj(p base.LogicalPlan, expr expression.Expression) base.LogicalPlan {
-	proj := LogicalProjection{}.Init(p.SCtx(), p.QueryBlockOffset())
-	proj.SetChildren(p)
-	exprs := append(cols2Exprs(p.Schema().Columns), expr)
-	schema := p.Schema().Clone()
-	schema.Append(&expression.Column{
-		UniqueID: s.ctx.GetSessionVars().AllocPlanColumnID(),
-		RetType:  expr.GetType(),
-	})
-	proj.Exprs = exprs
-	proj.SetSchema(schema)
-	return proj
+func (s *baseSingleGroupJoinOrderSolver) injectProj(p base.LogicalPlan, expr expression.Expression) (base.LogicalPlan, *expression.Column) {
+	proj, ok := p.(*LogicalProjection)
+	if !ok {
+		proj = LogicalProjection{Exprs: cols2Exprs(p.Schema().Columns)}.Init(p.SCtx(), p.QueryBlockOffset())
+		proj.SetSchema(p.Schema().Clone())
+		proj.SetChildren(p)
+	}
+	return proj, proj.appendExpr(expr)
 }
 
 // makeJoin build join tree for the nodes which have equal conditions to connect them.

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -537,7 +537,7 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 	return
 }
 
-func (_ *baseSingleGroupJoinOrderSolver) injectExpr(p base.LogicalPlan, expr expression.Expression) (base.LogicalPlan, *expression.Column) {
+func (*baseSingleGroupJoinOrderSolver) injectExpr(p base.LogicalPlan, expr expression.Expression) (base.LogicalPlan, *expression.Column) {
 	proj, ok := p.(*LogicalProjection)
 	if !ok {
 		proj = LogicalProjection{Exprs: cols2Exprs(p.Schema().Columns)}.Init(p.SCtx(), p.QueryBlockOffset())

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -515,8 +515,8 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 			} else {
 				newSf := expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetType(), rCol, lCol).(*expression.ScalarFunction)
 
-				// after creating the new EQ function, the 2 args might not be column anymore, which breaks the assumption that
-				// join eq keys must be `col=col`, to handle this, inject 2 projections.
+				// after creating the new EQ function, the 2 args might not be column anymore, for example `sf=sf(cast(col))`,
+				// which breaks the assumption that join eq keys must be `col=col`, to handle this, inject 2 projections.
 				_, isCol0 := newSf.GetArgs()[0].(*expression.Column)
 				_, isCol1 := newSf.GetArgs()[1].(*expression.Column)
 				if !isCol0 || !isCol1 {

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -537,7 +537,7 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 	return
 }
 
-func (s *baseSingleGroupJoinOrderSolver) injectExpr(p base.LogicalPlan, expr expression.Expression) (base.LogicalPlan, *expression.Column) {
+func (_ *baseSingleGroupJoinOrderSolver) injectExpr(p base.LogicalPlan, expr expression.Expression) (base.LogicalPlan, *expression.Column) {
 	proj, ok := p.(*LogicalProjection)
 	if !ok {
 		proj = LogicalProjection{Exprs: cols2Exprs(p.Schema().Columns)}.Init(p.SCtx(), p.QueryBlockOffset())

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -521,10 +521,10 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 				_, isCol1 := newSf.GetArgs()[1].(*expression.Column)
 				if !isCol0 || !isCol1 {
 					if !isCol0 {
-						leftPlan, rCol = s.injectProj(leftPlan, newSf.GetArgs()[0])
+						leftPlan, rCol = s.injectExpr(leftPlan, newSf.GetArgs()[0])
 					}
 					if !isCol1 {
-						rightPlan, lCol = s.injectProj(rightPlan, newSf.GetArgs()[1])
+						rightPlan, lCol = s.injectExpr(rightPlan, newSf.GetArgs()[1])
 					}
 					leftNode, rightNode = leftPlan, rightPlan
 					newSf = expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetType(),
@@ -537,7 +537,7 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 	return
 }
 
-func (s *baseSingleGroupJoinOrderSolver) injectProj(p base.LogicalPlan, expr expression.Expression) (base.LogicalPlan, *expression.Column) {
+func (s *baseSingleGroupJoinOrderSolver) injectExpr(p base.LogicalPlan, expr expression.Expression) (base.LogicalPlan, *expression.Column) {
 	proj, ok := p.(*LogicalProjection)
 	if !ok {
 		proj = LogicalProjection{Exprs: cols2Exprs(p.Schema().Columns)}.Init(p.SCtx(), p.QueryBlockOffset())

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -518,16 +518,16 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 				_, isCol0 := newSf.GetArgs()[0].(*expression.Column)
 				_, isCol1 := newSf.GetArgs()[1].(*expression.Column)
 				if !isCol0 || !isCol1 {
-					col0Idx := leftPlan.Schema().ColumnIndex(rCol)
-					col1Idx := rightPlan.Schema().ColumnIndex(lCol)
 					if !isCol0 {
-						leftPlan = s.injectProj(leftPlan, col0Idx, newSf.GetArgs()[0])
+						leftPlan = s.injectProj(leftPlan, newSf.GetArgs()[0])
+						rCol = leftPlan.Schema().Columns[len(leftPlan.Schema().Columns)-1]
 					}
 					if !isCol1 {
-						rightPlan = s.injectProj(rightPlan, col1Idx, newSf.GetArgs()[1])
+						rightPlan = s.injectProj(rightPlan, newSf.GetArgs()[1])
+						lCol = rightPlan.Schema().Columns[len(rightPlan.Schema().Columns)-1]
 					}
 					newSf = expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetType(),
-						leftPlan.Schema().Columns[col0Idx], rightPlan.Schema().Columns[col1Idx]).(*expression.ScalarFunction)
+						rCol, lCol).(*expression.ScalarFunction)
 				}
 				usedEdges = append(usedEdges, newSf)
 			}
@@ -536,15 +536,17 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 	return
 }
 
-func (s *baseSingleGroupJoinOrderSolver) injectProj(p base.LogicalPlan, colIdx int, expr expression.Expression) base.LogicalPlan {
-	proj := LogicalProjection{Exprs: cols2Exprs(p.Schema().Columns)}.Init(p.SCtx(), p.QueryBlockOffset())
-	proj.SetSchema(p.Schema().Clone())
+func (s *baseSingleGroupJoinOrderSolver) injectProj(p base.LogicalPlan, expr expression.Expression) base.LogicalPlan {
+	proj := LogicalProjection{}.Init(p.SCtx(), p.QueryBlockOffset())
 	proj.SetChildren(p)
-	proj.Exprs[colIdx] = expr
-	proj.schema.Columns[colIdx] = &expression.Column{
+	exprs := append(cols2Exprs(p.Schema().Columns), expr)
+	schema := p.Schema().Clone()
+	schema.Append(&expression.Column{
 		UniqueID: s.ctx.GetSessionVars().AllocPlanColumnID(),
 		RetType:  expr.GetType(),
-	}
+	})
+	proj.Exprs = exprs
+	proj.SetSchema(schema)
 	return proj
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46556

Problem Summary: planner: add projections to keep join keys as `col=col` 

### What changed and how does it work?

In some cases, after creating  new EQ function, the 2 args might not be column anymore, which breaks the assumption that join eq keys must be `col=col`, to handle this, inject 2 projections.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
