### PR TITLE
br/pdutils: retry when encountered dns error

### DIFF
--- a/br/pkg/lightning/common/retry.go
+++ b/br/pkg/lightning/common/retry.go
@@ -108,6 +108,10 @@ func isSingleRetryableError(err error) bool {
 
 	switch nerr := err.(type) {
 	case net.Error:
+		var dErr *net.DNSError
+		if goerrors.As(nerr, &dErr) {
+			return true
+		}
 		if nerr.Timeout() {
 			return true
 		}

--- a/br/pkg/lightning/common/retry_test.go
+++ b/br/pkg/lightning/common/retry_test.go
@@ -39,7 +39,7 @@ func TestIsRetryableError(t *testing.T) {
 	require.True(t, IsRetryableError(ErrWriteTooSlow))
 	require.False(t, IsRetryableError(io.EOF))
 	require.False(t, IsRetryableError(&net.AddrError{}))
-	require.False(t, IsRetryableError(&net.DNSError{}))
+	require.True(t, IsRetryableError(&net.DNSError{}))
 	require.True(t, IsRetryableError(&net.DNSError{IsTimeout: true}))
 
 	// kv errors

--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -52,7 +52,7 @@ const (
 	pauseTimeout         = 5 * time.Minute
 
 	// pd request retry time when connection fail
-	pdRequestRetryTime = 10
+	pdRequestRetryTime = 120
 
 	// set max-pending-peer-count to a large value to avoid scatter region failed.
 	maxPendingPeerUnlimited uint64 = math.MaxInt32
@@ -174,6 +174,11 @@ func pdRequestWithCode(
 		if err != nil {
 			return 0, nil, errors.Trace(err)
 		}
+		failpoint.Inject("DNSError", func() {
+			req.Host = "nosuchhost"
+			req.URL.Host = "nosuchhost"
+			fmt.Println(req.URL.String())
+		})
 		resp, err = cli.Do(req) //nolint:bodyclose
 		count++
 		failpoint.Inject("InjectClosed", func(v failpoint.Value) {

--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -177,7 +177,6 @@ func pdRequestWithCode(
 		failpoint.Inject("DNSError", func() {
 			req.Host = "nosuchhost"
 			req.URL.Host = "nosuchhost"
-			fmt.Println(req.URL.String())
 		})
 		resp, err = cli.Do(req) //nolint:bodyclose
 		count++

--- a/tests/realtikvtest/brietest/BUILD.bazel
+++ b/tests/realtikvtest/brietest/BUILD.bazel
@@ -9,10 +9,12 @@ go_test(
         "flashback_test.go",
         "main_test.go",
         "operator_test.go",
+        "pdutil_test.go",
     ],
     flaky = True,
     race = "on",
     deps = [
+        "//br/pkg/pdutil",
         "//br/pkg/task",
         "//br/pkg/task/operator",
         "//config",

--- a/tests/realtikvtest/brietest/pdutil_test.go
+++ b/tests/realtikvtest/brietest/pdutil_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package brietest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/br/pkg/pdutil"
+	"github.com/stretchr/testify/require"
+	pd "github.com/tikv/pd/client"
+)
+
+func TestCreateClient(t *testing.T) {
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/pdutil/DNSError", "119*return"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/pdutil/FastRetry", "return(true)"))
+	ctl, err := pdutil.NewPdController(context.Background(), "127.0.0.1:2379", nil, pd.SecurityOption{})
+	require.NoError(t, err)
+	ctl.Close()
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53029

Problem Summary:
In a tidb-operator deployed cluster, sometimes coredns responses `No such host` which will abort the creation of `PDController`. We should  retry this sort of error. 

### What changed and how does it work?
This PR added retry when the `net.Error` is `DNSError`.
Also, this PR increases the retry time limit from 10 times (totally 10s) to 120 times (totally 120s).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
