### PR TITLE
tablecodec: fix the issue that decoding an index value might panic

### DIFF
--- a/pkg/table/tables/BUILD.bazel
+++ b/pkg/table/tables/BUILD.bazel
@@ -74,7 +74,7 @@ go_test(
     ],
     embed = [":tables"],
     flaky = True,
-    shard_count = 31,
+    shard_count = 32,
     deps = [
         "//pkg/ddl",
         "//pkg/ddl/util/callback",

--- a/pkg/table/tables/index_test.go
+++ b/pkg/table/tables/index_test.go
@@ -16,6 +16,7 @@ package tables_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/ddl"
@@ -211,4 +212,73 @@ func TestGenIndexValueFromIndex(t *testing.T) {
 	valueStr, err := tables.GenIndexValueFromIndex(indexKey, indexValue, tbl.Meta(), idxInfo)
 	require.NoError(t, err)
 	require.Equal(t, []string{"23"}, valueStr)
+}
+
+func TestGenIndexValueWithLargePaddingSize(t *testing.T) {
+	// ref https://github.com/pingcap/tidb/issues/47115
+	tblInfo := buildTableInfo(t, "create table t (a int, b int, k varchar(255), primary key (a, b), key (k))")
+	var idx table.Index
+	for _, idxInfo := range tblInfo.Indices {
+		if !idxInfo.Primary {
+			idx = tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
+			break
+		}
+	}
+	var a, b *model.ColumnInfo
+	for _, col := range tblInfo.Columns {
+		if col.Name.String() == "a" {
+			a = col
+		} else if col.Name.String() == "b" {
+			b = col
+		}
+	}
+	require.NotNil(t, a)
+	require.NotNil(t, b)
+
+	store := testkit.CreateMockStore(t)
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	mockCtx := mock.NewContext()
+	sc := mockCtx.GetSessionVars().StmtCtx
+	padding := strings.Repeat(" ", 128)
+	idxColVals := types.MakeDatums("abc" + padding)
+	handleColVals := types.MakeDatums(1, 2)
+	encodedHandle, err := codec.EncodeKey(sc.TimeZone(), nil, handleColVals...)
+	require.NoError(t, err)
+	commonHandle, err := kv.NewCommonHandle(encodedHandle)
+	require.NoError(t, err)
+
+	key, _, err := idx.GenIndexKey(sc.ErrCtx(), sc.TimeZone(), idxColVals, commonHandle, nil)
+	require.NoError(t, err)
+	_, err = idx.Create(mockCtx.GetTableCtx(), txn, idxColVals, commonHandle, nil)
+	require.NoError(t, err)
+	val, err := txn.Get(context.Background(), key)
+	require.NoError(t, err)
+	colInfo := tables.BuildRowcodecColInfoForIndexColumns(idx.Meta(), tblInfo)
+	colInfo = append(colInfo, rowcodec.ColInfo{
+		ID:         a.ID,
+		IsPKHandle: false,
+		Ft:         rowcodec.FieldTypeFromModelColumn(a),
+	})
+	colInfo = append(colInfo, rowcodec.ColInfo{
+		ID:         b.ID,
+		IsPKHandle: false,
+		Ft:         rowcodec.FieldTypeFromModelColumn(b),
+	})
+	colVals, err := tablecodec.DecodeIndexKV(key, val, 1, tablecodec.HandleDefault, colInfo)
+	require.NoError(t, err)
+	require.Len(t, colVals, 3)
+	_, d, err := codec.DecodeOne(colVals[0])
+	require.NoError(t, err)
+	require.Equal(t, "abc"+padding, d.GetString())
+	_, d, err = codec.DecodeOne(colVals[1])
+	require.NoError(t, err)
+	require.Equal(t, int64(1), d.GetInt64())
+	_, d, err = codec.DecodeOne(colVals[2])
+	require.NoError(t, err)
+	require.Equal(t, int64(2), d.GetInt64())
+	handle, err := tablecodec.DecodeIndexHandle(key, val, 1)
+	require.NoError(t, err)
+	require.False(t, handle.IsInt())
+	require.Equal(t, commonHandle.Encoded(), handle.Encoded())
 }

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -883,7 +883,11 @@ func buildRestoredColumn(allCols []rowcodec.ColInfo) []rowcodec.ColInfo {
 		}
 		if collate.IsBinCollation(col.Ft.GetCollate()) {
 			// Change the fieldType from string to uint since we store the number of the truncated spaces.
+			// NOTE: the corresponding datum is generated as `types.NewUintDatum(paddingSize)`, and the raw data is
+			// encoded via `encodeUint`. Thus we should mark the field type as unsigened here so that the BytesDecoder
+			// can decode it correctly later. Otherwise there might be issues like #47115.
 			copyColInfo.Ft = types.NewFieldType(mysql.TypeLonglong)
+			copyColInfo.Ft.AddFlag(mysql.UnsignedFlag)
 		} else {
 			copyColInfo.Ft = allCols[i].Ft
 		}

--- a/tests/integrationtest/r/table/index.result
+++ b/tests/integrationtest/r/table/index.result
@@ -78,3 +78,7 @@ t	CREATE TABLE `t` (
   KEY `idx_c` (`c`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 drop table t;
+drop table if exists t;
+create table t (a int, b int, k varchar(255), primary key (a, b), key k (k));
+insert into t values (1, 1, 'abc                                                                                                                                ');
+drop table t;

--- a/tests/integrationtest/t/table/index.test
+++ b/tests/integrationtest/t/table/index.test
@@ -45,3 +45,9 @@ show create table t;
 alter table t modify column c varchar(32);
 show create table t;
 drop table t;
+
+# Test Issue 47115.
+drop table if exists t;
+create table t (a int, b int, k varchar(255), primary key (a, b), key k (k));
+insert into t values (1, 1, 'abc                                                                                                                                ');
+drop table t;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #47115

Problem Summary: decoding an index value with large padding size might panic, because the padding size is:
- encoded via: `types.NewUintDatum(paddingSize) => encodeUint`
- decoded via `decodeRestoredValuesV5 => rd.DecodeToBytesNoHandle => rd.encodeOldDatum(IntFlag) => codec.EncodeVarint(buf, decodeInt(raw))` because the field type is not marked as unsigned in `buildRestoredColumn`.

### What changed and how does it work?

Set unsigned flag to the field type correctly. 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
