### PR TITLE
util: the incorrectly handle string compare with whitespace

### DIFF
--- a/pkg/expression/collation_test.go
+++ b/pkg/expression/collation_test.go
@@ -715,6 +715,7 @@ func TestCompareString(t *testing.T) {
 	require.Equal(t, 0, types.CompareString("a ", "a  ", "utf8_general_ci"))
 	require.Equal(t, 0, types.CompareString("ß", "s", "utf8_general_ci"))
 	require.NotEqual(t, 0, types.CompareString("ß", "ss", "utf8_general_ci"))
+	require.NotEqual(t, 0, types.CompareString("", "   ", "utf8_general_ci"))
 
 	require.Equal(t, 0, types.CompareString("a", "A", "utf8_unicode_ci"))
 	require.Equal(t, 0, types.CompareString("À", "A", "utf8_unicode_ci"))

--- a/pkg/util/collate/bin.go
+++ b/pkg/util/collate/bin.go
@@ -57,11 +57,11 @@ type binPaddingCollator struct {
 }
 
 func (*binPaddingCollator) Compare(a, b string) int {
-	return strings.Compare(truncateTailingSpace(a), truncateTailingSpace(b))
+	return strings.Compare(a, b)
 }
 
 func (*binPaddingCollator) Key(str string) []byte {
-	return []byte(truncateTailingSpace(str))
+	return []byte(str)
 }
 
 // KeyWithoutTrimRightSpace implement Collator interface.

--- a/pkg/util/collate/gbk_bin.go
+++ b/pkg/util/collate/gbk_bin.go
@@ -28,9 +28,6 @@ type gbkBinCollator struct {
 
 // Compare implement Collator interface.
 func (g *gbkBinCollator) Compare(a, b string) int {
-	a = truncateTailingSpace(a)
-	b = truncateTailingSpace(b)
-
 	// compare the character one by one.
 	for len(a) > 0 && len(b) > 0 {
 		aLen, bLen := runeLen(a[0]), runeLen(b[0])
@@ -58,7 +55,7 @@ func (g *gbkBinCollator) Compare(a, b string) int {
 
 // Key implement Collator interface.
 func (g *gbkBinCollator) Key(str string) []byte {
-	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
+	return g.KeyWithoutTrimRightSpace(str)
 }
 
 // KeyWithoutTrimRightSpace implement Collator interface.

--- a/pkg/util/collate/gbk_chinese_ci.go
+++ b/pkg/util/collate/gbk_chinese_ci.go
@@ -21,9 +21,6 @@ type gbkChineseCICollator struct {
 
 // Compare implements Collator interface.
 func (*gbkChineseCICollator) Compare(a, b string) int {
-	a = truncateTailingSpace(a)
-	b = truncateTailingSpace(b)
-
 	r1, r2 := rune(0), rune(0)
 	ai, bi := 0, 0
 	for ai < len(a) && bi < len(b) {
@@ -40,7 +37,7 @@ func (*gbkChineseCICollator) Compare(a, b string) int {
 
 // Key implements Collator interface.
 func (g *gbkChineseCICollator) Key(str string) []byte {
-	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
+	return g.KeyWithoutTrimRightSpace(str)
 }
 
 // KeyWithoutTrimRightSpace implement Collator interface.

--- a/pkg/util/collate/general_ci.go
+++ b/pkg/util/collate/general_ci.go
@@ -23,8 +23,6 @@ type generalCICollator struct {
 
 // Compare implements Collator interface.
 func (*generalCICollator) Compare(a, b string) int {
-	a = truncateTailingSpace(a)
-	b = truncateTailingSpace(b)
 	r1, r2 := rune(0), rune(0)
 	ai, bi := 0, 0
 	for ai < len(a) && bi < len(b) {
@@ -41,7 +39,7 @@ func (*generalCICollator) Compare(a, b string) int {
 
 // Key implements Collator interface.
 func (gc *generalCICollator) Key(str string) []byte {
-	return gc.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
+	return gc.KeyWithoutTrimRightSpace(str)
 }
 
 // KeyWithoutTrimRightSpace implements Collator interface.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number:  close #52938

Problem Summary: TiDB incorrectly handle the  comparision of Strings with whitespace ending

### What changed and how does it work?
In collation string compare functions,  remove the TrimRightSpace(str) for Compare and Key funcs

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects
No
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
No
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that in expression the comparision of strings with whitespaces padding will be treated as same
```
