### PR TITLE
br: Fail backup if any snapshots failed

### DIFF
--- a/br/pkg/aws/BUILD.bazel
+++ b/br/pkg/aws/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     deps = [
         "@com_github_aws_aws_sdk_go//aws",
         "@com_github_aws_aws_sdk_go//service/ec2",
+        "@com_github_aws_aws_sdk_go//service/ec2/ec2iface",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/br/pkg/aws/BUILD.bazel
+++ b/br/pkg/aws/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     srcs = ["ebs_test.go"],
     embed = [":aws"],
     flaky = True,
+    shard_count = 3,
     deps = [
         "@com_github_aws_aws_sdk_go//aws",
         "@com_github_aws_aws_sdk_go//service/ec2",

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -251,6 +251,9 @@ func (e *EC2Session) WaitSnapshotsCreated(snapIDMap map[string]string, progress 
 			if *s.State == ec2.SnapshotStateCompleted {
 				log.Info("snapshot completed", zap.String("id", *s.SnapshotId))
 				totalVolumeSize += *s.VolumeSize
+			} else if *s.State == ec2.SnapshotStateError {
+				log.Error("snapshot failed", zap.String("id", *s.SnapshotId), zap.String("error", (*s.StateMessage)))
+				return 0, errors.Errorf("snapshot %s failed", *s.SnapshotId)
 			} else {
 				log.Debug("snapshot creating...", zap.Stringer("snap", s))
 				uncompletedSnapshots = append(uncompletedSnapshots, s.SnapshotId)

--- a/br/pkg/aws/ebs_test.go
+++ b/br/pkg/aws/ebs_test.go
@@ -101,11 +101,11 @@ func TestWaitSnapshotsCreated(t *testing.T) {
 	}
 
 	cases := []struct {
-		desc    string
+		desc            string
 		snapshotsOutput ec2.DescribeSnapshotsOutput
-		expectedSize int64
-		expectErr bool
-		expectTimeout bool
+		expectedSize    int64
+		expectErr       bool
+		expectTimeout   bool
 	}{
 		{
 			desc: "snapshots are all completed",
@@ -114,17 +114,17 @@ func TestWaitSnapshotsCreated(t *testing.T) {
 					{
 						SnapshotId: awsapi.String("snap-1"),
 						VolumeSize: awsapi.Int64(1),
-						State: awsapi.String(ec2.SnapshotStateCompleted),
+						State:      awsapi.String(ec2.SnapshotStateCompleted),
 					},
 					{
 						SnapshotId: awsapi.String("snap-2"),
 						VolumeSize: awsapi.Int64(2),
-						State: awsapi.String(ec2.SnapshotStateCompleted),
+						State:      awsapi.String(ec2.SnapshotStateCompleted),
 					},
 				},
 			},
 			expectedSize: 3,
-			expectErr: false,
+			expectErr:    false,
 		},
 		{
 			desc: "snapshot failed",
@@ -133,17 +133,17 @@ func TestWaitSnapshotsCreated(t *testing.T) {
 					{
 						SnapshotId: awsapi.String("snap-1"),
 						VolumeSize: awsapi.Int64(1),
-						State: awsapi.String(ec2.SnapshotStateCompleted),
+						State:      awsapi.String(ec2.SnapshotStateCompleted),
 					},
 					{
-						SnapshotId: awsapi.String("snap-2"),
-						State: awsapi.String(ec2.SnapshotStateError),
+						SnapshotId:   awsapi.String("snap-2"),
+						State:        awsapi.String(ec2.SnapshotStateError),
 						StateMessage: awsapi.String("snapshot failed"),
 					},
 				},
 			},
 			expectedSize: 0,
-			expectErr: true,
+			expectErr:    true,
 		},
 		{
 			desc: "snapshots pending",
@@ -152,11 +152,11 @@ func TestWaitSnapshotsCreated(t *testing.T) {
 					{
 						SnapshotId: awsapi.String("snap-1"),
 						VolumeSize: awsapi.Int64(1),
-						State: awsapi.String(ec2.SnapshotStateCompleted),
+						State:      awsapi.String(ec2.SnapshotStateCompleted),
 					},
 					{
 						SnapshotId: awsapi.String("snap-2"),
-						State: awsapi.String(ec2.SnapshotStatePending),
+						State:      awsapi.String(ec2.SnapshotStatePending),
 					},
 				},
 			},

--- a/br/pkg/aws/ebs_test.go
+++ b/br/pkg/aws/ebs_test.go
@@ -14,10 +14,12 @@
 package aws
 
 import (
+	"context"
 	"testing"
 
 	awsapi "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,4 +77,126 @@ func TestHandleDescribeVolumesResponse(t *testing.T) {
 	createdVolumeSize, unfinishedVolumes, _ := e.HandleDescribeVolumesResponse(curentVolumesStates, false)
 	require.Equal(t, int64(4), createdVolumeSize)
 	require.Equal(t, 1, len(unfinishedVolumes))
+}
+
+type mockEC2 struct {
+	ec2iface.EC2API
+	output ec2.DescribeSnapshotsOutput
+}
+
+func (m mockEC2) DescribeSnapshots(*ec2.DescribeSnapshotsInput) (*ec2.DescribeSnapshotsOutput, error) {
+	return &m.output, nil
+}
+
+func NewMockEc2Session(mock mockEC2) *EC2Session {
+	return &EC2Session{
+		ec2: mock,
+	}
+}
+
+func TestWaitSnapshotsCreated(t *testing.T) {
+	snapIdMap := map[string]string{
+		"vol-1": "snap-1",
+		"vol-2": "snap-2",
+	}
+
+	cases := []struct {
+		desc    string
+		snapshotsOutput ec2.DescribeSnapshotsOutput
+		expectedSize int64
+		expectErr bool
+		expectTimeout bool
+	}{
+		{
+			desc: "snapshots are all completed",
+			snapshotsOutput: ec2.DescribeSnapshotsOutput{
+				Snapshots: []*ec2.Snapshot{
+					{
+						SnapshotId: awsapi.String("snap-1"),
+						VolumeSize: awsapi.Int64(1),
+						State: awsapi.String(ec2.SnapshotStateCompleted),
+					},
+					{
+						SnapshotId: awsapi.String("snap-2"),
+						VolumeSize: awsapi.Int64(2),
+						State: awsapi.String(ec2.SnapshotStateCompleted),
+					},
+				},
+			},
+			expectedSize: 3,
+			expectErr: false,
+		},
+		{
+			desc: "snapshot failed",
+			snapshotsOutput: ec2.DescribeSnapshotsOutput{
+				Snapshots: []*ec2.Snapshot{
+					{
+						SnapshotId: awsapi.String("snap-1"),
+						VolumeSize: awsapi.Int64(1),
+						State: awsapi.String(ec2.SnapshotStateCompleted),
+					},
+					{
+						SnapshotId: awsapi.String("snap-2"),
+						State: awsapi.String(ec2.SnapshotStateError),
+						StateMessage: awsapi.String("snapshot failed"),
+					},
+				},
+			},
+			expectedSize: 0,
+			expectErr: true,
+		},
+		{
+			desc: "snapshots pending",
+			snapshotsOutput: ec2.DescribeSnapshotsOutput{
+				Snapshots: []*ec2.Snapshot{
+					{
+						SnapshotId: awsapi.String("snap-1"),
+						VolumeSize: awsapi.Int64(1),
+						State: awsapi.String(ec2.SnapshotStateCompleted),
+					},
+					{
+						SnapshotId: awsapi.String("snap-2"),
+						State: awsapi.String(ec2.SnapshotStatePending),
+					},
+				},
+			},
+			expectTimeout: true,
+		},
+	}
+
+	for _, c := range cases {
+		e := NewMockEc2Session(mockEC2{
+			output: c.snapshotsOutput,
+		})
+
+		if c.expectTimeout {
+			// We wait 5s before checking snapshots
+			ctx, cancel := context.WithTimeout(context.Background(), 6)
+			defer cancel()
+
+			done := make(chan struct{})
+			go func() {
+				_, _ = e.WaitSnapshotsCreated(snapIdMap, nil)
+				done <- struct{}{}
+			}()
+
+			select {
+			case <-done:
+				t.Fatal("WaitSnapshotsCreated should not return before timeout")
+			case <-ctx.Done():
+				require.True(t, true)
+			}
+
+			continue
+		}
+
+		size, err := e.WaitSnapshotsCreated(snapIdMap, nil)
+		if c.expectErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, c.expectedSize, size)
+	}
 }

--- a/br/pkg/aws/ebs_test.go
+++ b/br/pkg/aws/ebs_test.go
@@ -170,7 +170,7 @@ func TestWaitSnapshotsCreated(t *testing.T) {
 		})
 
 		if c.expectTimeout {
-			func () {
+			func() {
 				// We wait 5s before checking snapshots
 				ctx, cancel := context.WithTimeout(context.Background(), 6)
 				defer cancel()
@@ -187,7 +187,6 @@ func TestWaitSnapshotsCreated(t *testing.T) {
 				case <-ctx.Done():
 					require.True(t, true)
 				}
-
 			}()
 
 			continue

--- a/br/pkg/aws/ebs_test.go
+++ b/br/pkg/aws/ebs_test.go
@@ -170,22 +170,25 @@ func TestWaitSnapshotsCreated(t *testing.T) {
 		})
 
 		if c.expectTimeout {
-			// We wait 5s before checking snapshots
-			ctx, cancel := context.WithTimeout(context.Background(), 6)
-			defer cancel()
+			func () {
+				// We wait 5s before checking snapshots
+				ctx, cancel := context.WithTimeout(context.Background(), 6)
+				defer cancel()
 
-			done := make(chan struct{})
-			go func() {
-				_, _ = e.WaitSnapshotsCreated(snapIdMap, nil)
-				done <- struct{}{}
+				done := make(chan struct{})
+				go func() {
+					_, _ = e.WaitSnapshotsCreated(snapIdMap, nil)
+					done <- struct{}{}
+				}()
+
+				select {
+				case <-done:
+					t.Fatal("WaitSnapshotsCreated should not return before timeout")
+				case <-ctx.Done():
+					require.True(t, true)
+				}
+
 			}()
-
-			select {
-			case <-done:
-				t.Fatal("WaitSnapshotsCreated should not return before timeout")
-			case <-ctx.Done():
-				require.True(t, true)
-			}
 
 			continue
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

During EBS snapshot backup, if any snapshots fail, the backup will be stuck indefinitely checking the snapshots that failed. Since we only run a single backup at a time, this also blocks subsequent backups.

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53037 

Problem Summary: Backup stuck when EBS snapshot failed

### What changed and how does it work?

Update snapshot backup process to fail if it detects snapshots in failed state. We observe rare snapshot failures due to underlying EBS hardware issues.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
