### PR TITLE
executor,types: Fix truncate function behavior when second param is large negative

### DIFF
--- a/pkg/executor/test/issuetest/BUILD.bazel
+++ b/pkg/executor/test/issuetest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 17,
+    shard_count = 18,
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -635,3 +635,15 @@ func TestIssue51874(t *testing.T) {
 	tk.MustExec("insert into t2 values (10), (100)")
 	tk.MustQuery("select (select sum(a) over () from t2 limit 1) from t;").Check(testkit.Rows("10", "2"))
 }
+
+func TestIssue52978(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("insert into t values (-1790816583),(2049821819), (-1366665321), (536581933), (-1613686445)")
+	tk.MustQuery("select min(truncate(cast(-26340 as double), ref_11.a)) as c3 from t as ref_11;").Check(testkit.Rows("-26340"))
+	tk.MustExec("drop table if exists t")
+}

--- a/pkg/types/helper.go
+++ b/pkg/types/helper.go
@@ -58,6 +58,12 @@ func Truncate(f float64, dec int) float64 {
 	if math.IsInf(tmp, 0) {
 		return f
 	}
+	if shift == 0.0 {
+		if math.IsNaN(f) {
+			return f
+		}
+		return 0.0
+	}
 	return math.Trunc(tmp) / shift
 }
 

--- a/pkg/types/helper_test.go
+++ b/pkg/types/helper_test.go
@@ -52,6 +52,8 @@ func TestTruncate(t *testing.T) {
 		{123.45, 1, 123.4},
 		{123.45, 2, 123.45},
 		{123.45, 3, 123.450},
+		{123.45, -400, 0.0},
+		{123.45, 400, 123.45},
 	}
 	for _, tt := range tests {
 		res := Truncate(tt.f, tt.dec)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52978

Problem Summary:
The root cause is tidb's truncate function returns NaN for corner cases. While in topN executor, we compare float64 using go lib function which treats NaN as min:
https://github.com/pingcap/tidb/blob/81da4f8811f2fc150ed176d7ef3bcde3ce112d9f/pkg/util/chunk/compare.go#L113

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
