### PR TITLE
Revert "planner: merge fast plan cache and normal plan cache"

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -293,7 +293,7 @@ func (a *ExecStmt) PointGet(ctx context.Context) (*recordSet, error) {
 			a.PsStmt.PointGet.Executor = nil
 		} else {
 			// CachedPlan type is already checked in last step
-			pointGetPlan := a.Plan.(*plannercore.PointGetPlan)
+			pointGetPlan := a.PsStmt.PointGet.Plan.(*plannercore.PointGetPlan)
 			exec.Init(pointGetPlan)
 			a.PsStmt.PointGet.Executor = exec
 			executor = exec

--- a/pkg/executor/compiler.go
+++ b/pkg/executor/compiler.go
@@ -97,6 +97,9 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (_ *ExecS
 		if preparedObj, err = plannercore.GetPreparedStmt(execStmt, sessVars); err != nil {
 			return nil, err
 		}
+		if pointGetPlanShortPathOK, err = plannercore.IsPointGetPlanShortPathOK(c.Ctx, is, preparedObj); err != nil {
+			return nil, err
+		}
 	}
 	// Build the final physical plan.
 	finalPlan, names, err := planner.Optimize(ctx, c.Ctx, stmtNode, is)
@@ -128,13 +131,6 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (_ *ExecS
 		Ctx:           c.Ctx,
 		OutputNames:   names,
 	}
-
-	if _, ok := stmtNode.(*ast.ExecuteStmt); ok {
-		if pointGetPlanShortPathOK, err = plannercore.IsPointGetPlanShortPathOK(c.Ctx, is, preparedObj, finalPlan); err != nil {
-			return nil, err
-		}
-	}
-
 	// Use cached plan if possible.
 	if pointGetPlanShortPathOK {
 		if ep, ok := stmt.Plan.(*plannercore.Execute); ok {
@@ -143,6 +139,9 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (_ *ExecS
 				stmtCtx.SetPlanDigest(preparedObj.NormalizedPlan, preparedObj.PlanDigest)
 				stmt.Plan = pointPlan
 				stmt.PsStmt = preparedObj
+			} else {
+				// invalid the previous cached point plan
+				preparedObj.PointGet.Plan = nil
 			}
 		}
 	}

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util/fixcontrol"
 	"github.com/pingcap/tidb/pkg/privilege"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/sessiontxn/staleread"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/types"
@@ -135,6 +136,7 @@ func planCachePreprocess(ctx context.Context, sctx sessionctx.Context, isNonPrep
 		// cached plan once the schema version is changed.
 		// Cached plan in prepared struct does NOT have a "cache key" with
 		// schema version like prepared plan cache key
+		stmt.PointGet.Plan = nil
 		stmt.PointGet.Executor = nil
 		stmt.PointGet.ColumnInfos = nil
 		// If the schema version has changed we need to preprocess it again,
@@ -159,6 +161,7 @@ func planCachePreprocess(ctx context.Context, sctx sessionctx.Context, isNonPrep
 	expiredTimeStamp4PC := domain.GetDomain(sctx).ExpiredTimeStamp4PC()
 	if stmt.StmtCacheable && expiredTimeStamp4PC.Compare(vars.LastUpdateTime4PC) > 0 {
 		sctx.GetSessionPlanCache().DeleteAll()
+		stmt.PointGet.Plan = nil
 		vars.LastUpdateTime4PC = expiredTimeStamp4PC
 	}
 
@@ -215,9 +218,14 @@ func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
 			latestSchemaVersion = domain.GetDomain(sctx).InfoSchema().SchemaMetaVersion()
 		}
 		if cacheKey, err = NewPlanCacheKey(sctx.GetSessionVars(), stmt.StmtText,
-			stmt.StmtDB, stmt.SchemaVersion, latestSchemaVersion, bindSQL,
-			expression.ExprPushDownBlackListReloadTimeStamp.Load(), stmt.RelateVersion); err != nil {
+			stmt.StmtDB, stmt.SchemaVersion, latestSchemaVersion, bindSQL, expression.ExprPushDownBlackListReloadTimeStamp.Load(), stmt.RelateVersion); err != nil {
 			return nil, nil, err
+		}
+	}
+
+	if stmtCtx.UseCache() && stmt.PointGet.Plan != nil { // special code path for fast point plan
+		if plan, names, ok, err := getCachedPointPlan(stmt, sessVars); ok {
+			return plan, names, err
 		}
 	}
 
@@ -225,8 +233,7 @@ func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
 	if err != nil {
 		return nil, nil, err
 	}
-
-	if stmtCtx.UseCache() {
+	if stmtCtx.UseCache() { // for non-point plans
 		if plan, names, ok, err := getCachedPlan(sctx, isNonPrepared, cacheKey, bindSQL, is, stmt, matchOpts); err != nil || ok {
 			return plan, names, err
 		}
@@ -253,6 +260,31 @@ func parseParamTypes(sctx sessionctx.Context, params []expression.Expression) (p
 		paramTypes = append(paramTypes, tp)
 	}
 	return
+}
+
+func getCachedPointPlan(stmt *PlanCacheStmt, sessVars *variable.SessionVars) (base.Plan,
+	[]*types.FieldName, bool, error) {
+	// short path for point-get plans
+	// Rewriting the expression in the select.where condition  will convert its
+	// type from "paramMarker" to "Constant".When Point Select queries are executed,
+	// the expression in the where condition will not be evaluated,
+	// so you don't need to consider whether prepared.useCache is enabled.
+	plan := stmt.PointGet.Plan.(base.Plan)
+	names := stmt.PointGet.ColumnNames.(types.NameSlice)
+	if !RebuildPlan4CachedPlan(plan) {
+		return nil, nil, false, nil
+	}
+	if metrics.ResettablePlanCacheCounterFortTest {
+		metrics.PlanCacheCounter.WithLabelValues("prepare").Inc()
+	} else {
+		// only for prepared plan cache
+		core_metrics.GetPlanCacheHitCounter(false).Inc()
+	}
+	sessVars.FoundInPlanCache = true
+	if pointGetPlan, ok := plan.(*PointGetPlan); ok && pointGetPlan != nil && pointGetPlan.stmtHints != nil {
+		sessVars.StmtCtx.StmtHints = *pointGetPlan.stmtHints
+	}
+	return plan, names, true, nil
 }
 
 func getCachedPlan(sctx sessionctx.Context, isNonPrepared bool, cacheKey kvcache.Key, bindSQL string,
@@ -312,7 +344,7 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 	if err != nil {
 		return nil, nil, err
 	}
-	err = tryCachePointPlan(ctx, sctx.GetPlanCtx(), stmt, p)
+	err = tryCachePointPlan(ctx, sctx.GetPlanCtx(), stmt, p, names)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -767,7 +799,7 @@ func CheckPreparedPriv(sctx sessionctx.Context, stmt *PlanCacheStmt, is infosche
 // tryCachePointPlan will try to cache point execution plan, there may be some
 // short paths for these executions, currently "point select" and "point update"
 func tryCachePointPlan(_ context.Context, sctx base.PlanContext,
-	stmt *PlanCacheStmt, p base.Plan) error {
+	stmt *PlanCacheStmt, p base.Plan, names types.NameSlice) error {
 	if !sctx.GetSessionVars().StmtCtx.UseCache() {
 		return nil
 	}
@@ -788,6 +820,8 @@ func tryCachePointPlan(_ context.Context, sctx base.PlanContext,
 
 	if ok {
 		// just cache point plan now
+		stmt.PointGet.Plan = p
+		stmt.PointGet.ColumnNames = names
 		stmt.NormalizedPlan, stmt.PlanDigest = NormalizePlan(p)
 		sctx.GetSessionVars().StmtCtx.SetPlan(p)
 		sctx.GetSessionVars().StmtCtx.SetPlanDigest(stmt.NormalizedPlan, stmt.PlanDigest)
@@ -798,8 +832,8 @@ func tryCachePointPlan(_ context.Context, sctx base.PlanContext,
 // IsPointGetPlanShortPathOK check if we can execute using plan cached in prepared structure
 // Be careful with the short path, current precondition is ths cached plan satisfying
 // IsPointGetWithPKOrUniqueKeyByAutoCommit
-func IsPointGetPlanShortPathOK(sctx sessionctx.Context, is infoschema.InfoSchema, stmt *PlanCacheStmt, plan base.Plan) (bool, error) {
-	if staleread.IsStmtStaleness(sctx) {
+func IsPointGetPlanShortPathOK(sctx sessionctx.Context, is infoschema.InfoSchema, stmt *PlanCacheStmt) (bool, error) {
+	if stmt.PointGet.Plan == nil || staleread.IsStmtStaleness(sctx) {
 		return false, nil
 	}
 	// check auto commit
@@ -807,6 +841,7 @@ func IsPointGetPlanShortPathOK(sctx sessionctx.Context, is infoschema.InfoSchema
 		return false, nil
 	}
 	if stmt.SchemaVersion != is.SchemaMetaVersion() {
+		stmt.PointGet.Plan = nil
 		stmt.PointGet.ColumnInfos = nil
 		return false, nil
 	}
@@ -814,14 +849,15 @@ func IsPointGetPlanShortPathOK(sctx sessionctx.Context, is infoschema.InfoSchema
 	// only point select/update will be cached, see "getPhysicalPlan" func
 	var ok bool
 	var err error
-	switch plan.(type) {
+	switch stmt.PointGet.Plan.(type) {
 	case *PointGetPlan:
 		ok = true
 	case *Update:
-		pointUpdate := plan.(*Update)
+		pointUpdate := stmt.PointGet.Plan.(*Update)
 		_, ok = pointUpdate.SelectPlan.(*PointGetPlan)
 		if !ok {
 			err = errors.Errorf("cached update plan not point update")
+			stmt.PointGet.Plan = nil
 			return false, err
 		}
 	default:

--- a/pkg/planner/core/plan_cache_test.go
+++ b/pkg/planner/core/plan_cache_test.go
@@ -1708,7 +1708,7 @@ func TestFixControl33031(t *testing.T) {
 	tk.MustExec(`set @a = 1`)
 	tk.MustQuery(`execute stmt using @a`).Check(testkit.Rows("1 1"))
 	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
-	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1105 skip plan-cache: plan rebuild failed, Fix33031 fix-control set and partitioned table in cached Point Get plan"))
+	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1105 skip plan-cache: plan rebuild failed, Fix33031 fix-control set and partitioned table in cached Point Get plan", "Warning 1105 skip plan-cache: plan rebuild failed, Fix33031 fix-control set and partitioned table in cached Point Get plan"))
 	tk.MustExec(`set @@tidb_opt_fix_control = "33031:OFF"`)
 	tk.MustExec(`set @a = 2`)
 	tk.MustQuery(`execute stmt using @a`).Check(testkit.Rows("2 2"))

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -503,10 +503,12 @@ type PlanCacheStmt struct {
 	// TODO: caching execution info directly is risky and tricky to the optimizer, refactor it later.
 	PointGet struct {
 		ColumnInfos any
+		ColumnNames any
 		// Executor is only used for point get scene.
 		// Notice that we should only cache the PointGetExecutor that have a snapshot with MaxTS in it.
 		// If the current plan is not PointGet or does not use MaxTS optimization, this value should be nil here.
 		Executor any
+		Plan     any // the cached PointGet Plan
 	}
 
 	// below fields are for PointGet short path


### PR DESCRIPTION
Reverts pingcap/tidb#53033, which cause some performance regression on BenchmarkPreparedPointGet: `6305 ns/op` --> `9011 ns/op`