### PR TITLE
infoschema: fix the nil pointer

### DIFF
--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -1988,13 +1988,13 @@ func getMicroServiceServerInfo(ctx sessionctx.Context, serviceName string) ([]Se
 		}
 		req.Header.Add("PD-Allow-follower-handle", "true")
 		resp, err := util.InternalHTTPClient().Do(req)
-		if resp == nil || resp.StatusCode != http.StatusOK {
-			terror.Log(resp.Body.Close())
-			continue
-		}
 		if err != nil {
 			ctx.GetSessionVars().StmtCtx.AppendWarning(err)
 			logutil.BgLogger().Warn("request microservice server info error", zap.String("service", serviceName), zap.String("url", url), zap.Error(err))
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			terror.Log(resp.Body.Close())
 			continue
 		}
 		var content = []struct {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52842

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Manual test 

5 pd and let 2 of them down

```
[root@tiup-0 ~]# mysql -uroot -P4000 -h tidb2-peer
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MySQL connection id is 1891631112
Server version: 8.0.11-TiDB-v8.1.0 TiDB Server (Apache License 2.0) Community Edition, MySQL 8.0 compatible

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MySQL [(none)]> select * from INFORMATION_SCHEMA.CLUSTER_INFO;
+-------+------------------+------------------+---------+------------------------------------------+---------------------+--------------------+-----------+
| TYPE  | INSTANCE         | STATUS_ADDRESS   | VERSION | GIT_HASH                                 | START_TIME          | UPTIME             | SERVER_ID |
+-------+------------------+------------------+---------+------------------------------------------+---------------------+--------------------+-----------+
| tidb  | tidb1-peer:4000  | tidb1-peer:10080 | 8.1.0   | de597811f9f9c9d35d2672bea19f47c9ba640aaa | 2024-05-08 12:15:52 | 4m12.910063312s    |       354 |
| tidb  | tidb2-peer:4000  | tidb2-peer:10080 | 8.1.0   | de597811f9f9c9d35d2672bea19f47c9ba640aaa | 2024-05-08 12:19:24 | 40.910070448s      |       902 |
| pd    | pd1-peer:2379    | pd1-peer:2379    | 8.1.0   | 13eaf8aaa661dc0d3885ac9e59145f69752cee2d | 2024-05-08 10:34:06 | 1h45m58.910073449s |         0 |
| pd    | pd2-peer:2379    | pd2-peer:2379    | 8.1.0   | 13eaf8aaa661dc0d3885ac9e59145f69752cee2d | 2024-05-08 10:34:06 | 1h45m58.910078184s |         0 |
| pd    | pd3-peer:2379    | pd3-peer:2379    | 8.1.0   | 13eaf8aaa661dc0d3885ac9e59145f69752cee2d | 2024-05-08 10:34:06 | 1h45m58.910082244s |         0 |
| tikv  | tikv1-peer:20160 | tikv1-peer:20180 | 8.1.0   | 56613f7c3e28c02853cc51d15bc1b77f68b58be8 | 2024-05-08 10:34:08 | 1h45m56.910086149s |         0 |
| tikv  | tikv6-peer:20160 | tikv6-peer:20180 | 8.1.0   | 56613f7c3e28c02853cc51d15bc1b77f68b58be8 | 2024-05-08 10:34:08 | 1h45m56.910097746s |         0 |
| tikv  | tikv4-peer:20160 | tikv4-peer:20180 | 8.1.0   | 56613f7c3e28c02853cc51d15bc1b77f68b58be8 | 2024-05-08 10:34:08 | 1h45m56.910100326s |         0 |
| tikv  | tikv5-peer:20160 | tikv5-peer:20180 | 8.1.0   | 56613f7c3e28c02853cc51d15bc1b77f68b58be8 | 2024-05-08 10:34:08 | 1h45m56.910106934s |         0 |
| tikv  | tikv3-peer:20160 | tikv3-peer:20180 | 8.1.0   | 56613f7c3e28c02853cc51d15bc1b77f68b58be8 | 2024-05-08 10:34:08 | 1h45m56.910109353s |         0 |
| tikv  | tikv2-peer:20160 | tikv2-peer:20180 | 8.1.0   | 56613f7c3e28c02853cc51d15bc1b77f68b58be8 | 2024-05-08 10:34:08 | 1h45m56.910111749s |         0 |
| ticdc | ticdc1-peer:8300 | ticdc1-peer:8300 | 8.1.0   | d40018ffe07b288952b786f119bb70994f73f7f0 | 2024-05-08 10:38:30 | 1h41m34.910114169s |         0 |
| ticdc | ticdc2-peer:8300 | ticdc2-peer:8300 | 8.1.0   | d40018ffe07b288952b786f119bb70994f73f7f0 | 2024-05-08 10:38:30 | 1h41m34.910116453s |         0 |
+-------+------------------+------------------+---------+------------------------------------------+---------------------+--------------------+-----------+
13 rows in set, 6 warnings (0.04 sec)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
