### PR TITLE
executor: fix mppIterator memory leak when got error

### DIFF
--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -499,9 +499,6 @@ func (c *localMppCoordinator) cancelMppTasks() {
 func (c *localMppCoordinator) receiveResults(req *kv.MPPDispatchRequest, taskMeta *mpp.TaskMeta, bo *backoff.Backoffer) {
 	stream, err := c.sessionCtx.GetMPPClient().EstablishMPPConns(kv.EstablishMPPConnsParam{Ctx: bo.GetCtx(), Req: req, TaskMeta: taskMeta})
 	if err != nil {
-		if stream != nil {
-			stream.Close()
-		}
 		// if NeedTriggerFallback is true, we return timeout to trigger tikv's fallback
 		if c.needTriggerFallback {
 			c.sendError(derr.ErrTiFlashServerTimeout)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/52406

Problem Summary:
https://github.com/pingcap/tidb/pull/52410 tried to fix this issue, but it didn't work, so fix again

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below): test using internal integration test
Before:
![img_v3_02an_64c824c5-9c2b-4b89-9c40-a22966ab7e5g](https://github.com/pingcap/tidb/assets/7493273/85ac7279-3913-46a4-a07b-8a0b76e7d7fc)


After:
![img_v3_02an_d26a670e-be33-4a14-b97a-4860a99a893g](https://github.com/pingcap/tidb/assets/7493273/773f4c94-9d9c-489f-8c49-7afdb8a7bd2e)

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
executor: fix mppIterator memory leak when got error
```
