### PR TITLE
planner: resolve panic when the update lists contain complex subquery

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -6044,7 +6044,7 @@ func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.Tab
 			if expr := extractDefaultExpr(assign.Expr); expr != nil {
 				expr.Name = assign.Column
 			}
-			newExpr, np, err = b.rewrite(ctx, assign.Expr, p, nil, false)
+			newExpr, np, err = b.rewrite(ctx, assign.Expr, p, nil, true)
 			if err != nil {
 				return nil, nil, false, err
 			}
@@ -6068,7 +6068,7 @@ func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.Tab
 
 			o := b.allowBuildCastArray
 			b.allowBuildCastArray = true
-			newExpr, np, err = b.rewriteWithPreprocess(ctx, assign.Expr, p, nil, nil, false, rewritePreprocess(assign))
+			newExpr, np, err = b.rewriteWithPreprocess(ctx, assign.Expr, p, nil, nil, true, rewritePreprocess(assign))
 			b.allowBuildCastArray = o
 			if err != nil {
 				return nil, nil, false, err

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -360,3 +360,163 @@ where a.a in (2, 3, null);
 b
 1
 2
+CREATE TABLE `t_o9_7_f` (
+`c_ob5k0` int(11) NOT NULL,
+`c_r5axbk` tinyint(4) DEFAULT NULL,
+`c_fulsthp7e` text DEFAULT NULL,
+`c_nylhnz` double DEFAULT NULL,
+`c_fd7zeyfs49` int(11) NOT NULL,
+`c_wpmmiv` tinyint(4) DEFAULT NULL,
+PRIMARY KEY (`c_fd7zeyfs49`) /*T![clustered_index] CLUSTERED */,
+UNIQUE KEY `c_ob5k0` (`c_ob5k0`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE `t_q1` (
+`c__c_r38murv` int(11) NOT NULL,
+`c_i93u7f2yma` double NOT NULL,
+`c_v5mf4` double DEFAULT NULL,
+`c_gprkp` int(11) DEFAULT NULL,
+`c_ru` text NOT NULL,
+`c_nml` tinyint(4) DEFAULT NULL,
+`c_z` text DEFAULT NULL,
+`c_ok` double DEFAULT NULL,
+PRIMARY KEY (`c__c_r38murv`) /*T![clustered_index] CLUSTERED */,
+UNIQUE KEY `c__c_r38murv_2` (`c__c_r38murv`),
+UNIQUE KEY `c_nml` (`c_nml`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE `t_yzyyqbo2u` (
+`c_c4l` int(11) DEFAULT NULL,
+`c_yb_` text DEFAULT NULL,
+`c_pq4c1la6cv` int(11) NOT NULL,
+`c_kbcid` int(11) DEFAULT NULL,
+`c_um` double DEFAULT NULL,
+`c_zjmgh995_6` text DEFAULT NULL,
+`c_fujjmh8m2` double NOT NULL,
+`c_qkf4n` double DEFAULT NULL,
+`c__x9cqrnb0` double NOT NULL,
+`c_b5qjz_jj0` double DEFAULT NULL,
+PRIMARY KEY (`c_pq4c1la6cv`) /*T![clustered_index] NONCLUSTERED */,
+UNIQUE KEY `c__x9cqrnb0` (`c__x9cqrnb0`),
+UNIQUE KEY `c_b5qjz_jj0` (`c_b5qjz_jj0`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T! SHARD_ROW_ID_BITS=4 PRE_SPLIT_REGIONS=2 */;
+CREATE TABLE `t_kg74` (
+`c_a1tv2` int(11) NOT NULL,
+`c_eobbbypzbu` tinyint(4) DEFAULT NULL,
+`c_g` double NOT NULL,
+`c_ixy` tinyint(4) DEFAULT NULL,
+`c_if` text NOT NULL,
+`c_obnq8s7_s2` double DEFAULT NULL,
+`c_xrgd2snrop` tinyint(4) DEFAULT NULL,
+`c_vqafa6o6` text DEFAULT NULL,
+`c_ku44klry7o` double NOT NULL,
+`c_js835qkmjz` tinyint(4) DEFAULT NULL,
+PRIMARY KEY (`c_a1tv2`));
+update t_kg74 set
+c_eobbbypzbu = (t_kg74.c_js835qkmjz in (
+select
+(ref_0.c_yb_ <> 'mlp40j') as c0
+from
+t_yzyyqbo2u as ref_0
+where (89.25 && ref_0.c_pq4c1la6cv)
+union
+(select
+((cast(null as double) != 1382756095))
+and ((1=1 <> (EXISTS (
+select distinct
+ref_2.c_zjmgh995_6 as c0,
+ref_2.c_zjmgh995_6 as c1,
+ref_2.c_kbcid as c2,
+ref_1.c_r5axbk as c3,
+-633150135 as c4,
+ref_2.c_c4l as c5,
+ref_1.c_fd7zeyfs49 as c6,
+ref_1.c_nylhnz as c7,
+ref_2.c_um as c8,
+ref_2.c_c4l as c9
+from
+t_yzyyqbo2u as ref_2
+where ((ref_1.c_ob5k0 <= ref_2.c_qkf4n))
+and ((EXISTS (
+select
+ref_3.c_qkf4n as c0,
+ref_3.c_kbcid as c1,
+ref_3.c_qkf4n as c2,
+ref_1.c_wpmmiv as c3,
+ref_1.c_fd7zeyfs49 as c4,
+ref_3.c_c4l as c5,
+ref_1.c_r5axbk as c6,
+ref_3.c_kbcid as c7
+from
+t_yzyyqbo2u as ref_3
+where ((ref_2.c_qkf4n >= (
+select distinct
+ref_4.c_b5qjz_jj0 as c0
+from
+t_yzyyqbo2u as ref_4
+where (ref_3.c__x9cqrnb0 not in (
+select
+ref_5.c_ok as c0
+from
+t_q1 as ref_5
+where 1=1
+union
+(select
+ref_6.c_b5qjz_jj0 as c0
+from
+t_yzyyqbo2u as ref_6
+where (ref_6.c_qkf4n not in (
+select
+ref_7.c_um as c0
+from
+t_yzyyqbo2u as ref_7
+where 1=1
+union
+(select
+ref_8.c_b5qjz_jj0 as c0
+from
+t_yzyyqbo2u as ref_8
+where (ref_8.c_yb_ not like 'nrry%m')))))))
+union
+(select
+ref_2.c_fujjmh8m2 as c0
+from
+t_q1 as ref_9
+where (ref_2.c_zjmgh995_6 like 'v8%3xn%_uc'))
+order by c0 limit 1)))
+or ((ref_1.c_fulsthp7e in (
+select
+ref_10.c_ru as c0
+from
+t_q1 as ref_10
+where (55.34 >= 1580576276)
+union
+(select
+ref_11.c_ru as c0
+from
+t_q1 as ref_11
+where (ref_11.c_ru in (
+select distinct
+ref_12.c_zjmgh995_6 as c0
+from
+t_yzyyqbo2u as ref_12
+where 0<>0
+union
+(select
+ref_13.c_zjmgh995_6 as c0
+from
+t_yzyyqbo2u as ref_13
+where ('q2chm8gfsa' = ref_13.c_yb_))))))))))))))) as c0
+from
+t_o9_7_f as ref_1
+where (-9186514464458010455 <> 62.67)))),
+c_if = 'u1ah7',
+c_vqafa6o6 = (t_kg74.c_a1tv2 + (((t_kg74.c_a1tv2 between t_kg74.c_a1tv2 and t_kg74.c_a1tv2))
+or (1=1))
+and ((1288561802 <= t_kg74.c_a1tv2))),
+c_js835qkmjz = (t_kg74.c_vqafa6o6 in (
+select
+ref_14.c_z as c0
+from
+t_q1 as ref_14
+where (ref_14.c_z like 'o%fiah')))
+where (t_kg74.c_obnq8s7_s2 = case when (t_kg74.c_a1tv2 is NULL) then t_kg74.c_g else t_kg74.c_obnq8s7_s2 end
+);

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -212,3 +212,169 @@ left join (
   left join C c on b.b = c.b)
 on b.b = a.b
 where a.a in (2, 3, null);
+
+# https://github.com/pingcap/tidb/issues/52687
+CREATE TABLE `t_o9_7_f` (
+  `c_ob5k0` int(11) NOT NULL,
+  `c_r5axbk` tinyint(4) DEFAULT NULL,
+  `c_fulsthp7e` text DEFAULT NULL,
+  `c_nylhnz` double DEFAULT NULL,
+  `c_fd7zeyfs49` int(11) NOT NULL,
+  `c_wpmmiv` tinyint(4) DEFAULT NULL,
+  PRIMARY KEY (`c_fd7zeyfs49`) /*T![clustered_index] CLUSTERED */,
+  UNIQUE KEY `c_ob5k0` (`c_ob5k0`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE `t_q1` (
+  `c__c_r38murv` int(11) NOT NULL,
+  `c_i93u7f2yma` double NOT NULL,
+  `c_v5mf4` double DEFAULT NULL,
+  `c_gprkp` int(11) DEFAULT NULL,
+  `c_ru` text NOT NULL,
+  `c_nml` tinyint(4) DEFAULT NULL,
+  `c_z` text DEFAULT NULL,
+  `c_ok` double DEFAULT NULL,
+  PRIMARY KEY (`c__c_r38murv`) /*T![clustered_index] CLUSTERED */,
+  UNIQUE KEY `c__c_r38murv_2` (`c__c_r38murv`),
+  UNIQUE KEY `c_nml` (`c_nml`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE `t_yzyyqbo2u` (
+  `c_c4l` int(11) DEFAULT NULL,
+  `c_yb_` text DEFAULT NULL,
+  `c_pq4c1la6cv` int(11) NOT NULL,
+  `c_kbcid` int(11) DEFAULT NULL,
+  `c_um` double DEFAULT NULL,
+  `c_zjmgh995_6` text DEFAULT NULL,
+  `c_fujjmh8m2` double NOT NULL,
+  `c_qkf4n` double DEFAULT NULL,
+  `c__x9cqrnb0` double NOT NULL,
+  `c_b5qjz_jj0` double DEFAULT NULL,
+  PRIMARY KEY (`c_pq4c1la6cv`) /*T![clustered_index] NONCLUSTERED */,
+  UNIQUE KEY `c__x9cqrnb0` (`c__x9cqrnb0`),
+  UNIQUE KEY `c_b5qjz_jj0` (`c_b5qjz_jj0`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T! SHARD_ROW_ID_BITS=4 PRE_SPLIT_REGIONS=2 */;
+
+CREATE TABLE `t_kg74` (
+  `c_a1tv2` int(11) NOT NULL,
+  `c_eobbbypzbu` tinyint(4) DEFAULT NULL,
+  `c_g` double NOT NULL,
+  `c_ixy` tinyint(4) DEFAULT NULL,
+  `c_if` text NOT NULL,
+  `c_obnq8s7_s2` double DEFAULT NULL,
+  `c_xrgd2snrop` tinyint(4) DEFAULT NULL,
+  `c_vqafa6o6` text DEFAULT NULL,
+  `c_ku44klry7o` double NOT NULL,
+  `c_js835qkmjz` tinyint(4) DEFAULT NULL,
+  PRIMARY KEY (`c_a1tv2`));
+
+update t_kg74 set 
+  c_eobbbypzbu = (t_kg74.c_js835qkmjz in (
+    select  
+          (ref_0.c_yb_ <> 'mlp40j') as c0
+        from 
+          t_yzyyqbo2u as ref_0
+        where (89.25 && ref_0.c_pq4c1la6cv)
+      union
+      (select  
+          ((cast(null as double) != 1382756095)) 
+            and ((1=1 <> (EXISTS (
+                  select distinct 
+                      ref_2.c_zjmgh995_6 as c0, 
+                      ref_2.c_zjmgh995_6 as c1, 
+                      ref_2.c_kbcid as c2, 
+                      ref_1.c_r5axbk as c3, 
+                      -633150135 as c4, 
+                      ref_2.c_c4l as c5, 
+                      ref_1.c_fd7zeyfs49 as c6, 
+                      ref_1.c_nylhnz as c7, 
+                      ref_2.c_um as c8, 
+                      ref_2.c_c4l as c9
+                    from 
+                      t_yzyyqbo2u as ref_2
+                    where ((ref_1.c_ob5k0 <= ref_2.c_qkf4n)) 
+                      and ((EXISTS (
+                        select  
+                            ref_3.c_qkf4n as c0, 
+                            ref_3.c_kbcid as c1, 
+                            ref_3.c_qkf4n as c2, 
+                            ref_1.c_wpmmiv as c3, 
+                            ref_1.c_fd7zeyfs49 as c4, 
+                            ref_3.c_c4l as c5, 
+                            ref_1.c_r5axbk as c6, 
+                            ref_3.c_kbcid as c7
+                          from 
+                            t_yzyyqbo2u as ref_3
+                          where ((ref_2.c_qkf4n >= ( 
+                              select distinct 
+                                    ref_4.c_b5qjz_jj0 as c0
+                                  from 
+                                    t_yzyyqbo2u as ref_4
+                                  where (ref_3.c__x9cqrnb0 not in (
+                                    select  
+                                          ref_5.c_ok as c0
+                                        from 
+                                          t_q1 as ref_5
+                                        where 1=1
+                                      union
+                                      (select  
+                                          ref_6.c_b5qjz_jj0 as c0
+                                        from 
+                                          t_yzyyqbo2u as ref_6
+                                        where (ref_6.c_qkf4n not in (
+                                          select  
+                                                ref_7.c_um as c0
+                                              from 
+                                                t_yzyyqbo2u as ref_7
+                                              where 1=1
+                                            union
+                                            (select  
+                                                ref_8.c_b5qjz_jj0 as c0
+                                              from 
+                                                t_yzyyqbo2u as ref_8
+                                              where (ref_8.c_yb_ not like 'nrry%m')))))))
+                                union
+                                (select  
+                                    ref_2.c_fujjmh8m2 as c0
+                                  from 
+                                    t_q1 as ref_9
+                                  where (ref_2.c_zjmgh995_6 like 'v8%3xn%_uc'))
+                                order by c0 limit 1))) 
+                            or ((ref_1.c_fulsthp7e in (
+                              select  
+                                    ref_10.c_ru as c0
+                                  from 
+                                    t_q1 as ref_10
+                                  where (55.34 >= 1580576276)
+                                union
+                                (select  
+                                    ref_11.c_ru as c0
+                                  from 
+                                    t_q1 as ref_11
+                                  where (ref_11.c_ru in (
+                                    select distinct 
+                                          ref_12.c_zjmgh995_6 as c0
+                                        from 
+                                          t_yzyyqbo2u as ref_12
+                                        where 0<>0
+                                      union
+                                      (select  
+                                          ref_13.c_zjmgh995_6 as c0
+                                        from 
+                                          t_yzyyqbo2u as ref_13
+                                        where ('q2chm8gfsa' = ref_13.c_yb_))))))))))))))) as c0
+        from 
+          t_o9_7_f as ref_1
+        where (-9186514464458010455 <> 62.67)))), 
+  c_if = 'u1ah7', 
+  c_vqafa6o6 = (t_kg74.c_a1tv2 + (((t_kg74.c_a1tv2 between t_kg74.c_a1tv2 and t_kg74.c_a1tv2)) 
+        or (1=1)) 
+      and ((1288561802 <= t_kg74.c_a1tv2))), 
+  c_js835qkmjz = (t_kg74.c_vqafa6o6 in (
+    select  
+        ref_14.c_z as c0
+      from 
+        t_q1 as ref_14
+      where (ref_14.c_z like 'o%fiah')))
+where (t_kg74.c_obnq8s7_s2 = case when (t_kg74.c_a1tv2 is NULL) then t_kg74.c_g else t_kg74.c_obnq8s7_s2 end
+      );


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52687 

Problem Summary:

### What changed and how does it work?

When we meet the subqueries, we'll rewrite the structure of the plan tree. We need to find a way to represent the subqueries in the UPDATE's lists

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
