### PR TITLE
ddl: fix the primary key in index is not in restored format

### DIFF
--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1749,9 +1749,12 @@ func writeChunkToLocal(
 		}
 	}()
 	needRestoreForIndexes := make([]bool, len(indexes))
-	restore := false
+	restore, pkNeedRestore := false, false
+	if c.PrimaryKeyInfo != nil && c.TableInfo.IsCommonHandle && c.TableInfo.CommonHandleVersion != 0 {
+		pkNeedRestore = tables.NeedRestoredData(c.PrimaryKeyInfo.Columns, c.TableInfo.Columns)
+	}
 	for i, index := range indexes {
-		needRestore := tables.NeedRestoredData(index.Meta().Columns, c.TableInfo.Columns)
+		needRestore := pkNeedRestore || tables.NeedRestoredData(index.Meta().Columns, c.TableInfo.Columns)
 		needRestoreForIndexes[i] = needRestore
 		restore = restore || needRestore
 	}

--- a/tests/integrationtest/r/ddl/index_modify.result
+++ b/tests/integrationtest/r/ddl/index_modify.result
@@ -20,3 +20,30 @@ Error 1060 (42S21): Duplicate column name 'b'
 alter table test_add_index_with_dup add index c (b, a, B);
 Error 1060 (42S21): Duplicate column name 'B'
 drop table test_add_index_with_dup;
+set global tidb_ddl_enable_fast_reorg=true;
+drop table if exists test_add_index_restore_data;
+create table test_add_index_restore_data (a char(100) NOT NULL primary key, b int) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+insert test_add_index_restore_data value('abc', 0);
+alter table test_add_index_restore_data add index idx(b);
+select a from test_add_index_restore_data use index(idx);
+a
+abc
+admin check table test_add_index_restore_data;
+drop table if exists test_add_index_restore_data;
+create table test_add_index_restore_data (a char(100), b int NOT NULL primary key) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+insert test_add_index_restore_data value('abc', 0);
+alter table test_add_index_restore_data add index idx(b);
+select a from test_add_index_restore_data use index(idx);
+a
+abc
+admin check table test_add_index_restore_data;
+drop table if exists test_add_index_restore_data;
+create table test_add_index_restore_data (a char(100) NOT NULL, b date NOT NULL DEFAULT '2005-02-12', c int, primary key(a, b)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+insert test_add_index_restore_data value('abc', '1972-11-10', 0);
+alter table test_add_index_restore_data add index idx(c);
+select a from test_add_index_restore_data use index(idx);
+a
+abc
+admin check table test_add_index_restore_data;
+drop table if exists test_add_index_restore_data;
+set global tidb_ddl_enable_fast_reorg=default;

--- a/tests/integrationtest/t/ddl/index_modify.test
+++ b/tests/integrationtest/t/ddl/index_modify.test
@@ -24,4 +24,28 @@ alter table test_add_index_with_dup add index c (b, a, b);
 alter table test_add_index_with_dup add index c (b, a, B);
 drop table test_add_index_with_dup;
 
+# TestAddIndexRestoreData
+set global tidb_ddl_enable_fast_reorg=true;
+drop table if exists test_add_index_restore_data;
+create table test_add_index_restore_data (a char(100) NOT NULL primary key, b int) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+insert test_add_index_restore_data value('abc', 0);
+alter table test_add_index_restore_data add index idx(b);
+select a from test_add_index_restore_data use index(idx);
+admin check table test_add_index_restore_data;
 
+drop table if exists test_add_index_restore_data;
+create table test_add_index_restore_data (a char(100), b int NOT NULL primary key) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+insert test_add_index_restore_data value('abc', 0);
+alter table test_add_index_restore_data add index idx(b);
+select a from test_add_index_restore_data use index(idx);
+admin check table test_add_index_restore_data;
+
+drop table if exists test_add_index_restore_data;
+create table test_add_index_restore_data (a char(100) NOT NULL, b date NOT NULL DEFAULT '2005-02-12', c int, primary key(a, b)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+insert test_add_index_restore_data value('abc', '1972-11-10', 0);
+alter table test_add_index_restore_data add index idx(c);
+select a from test_add_index_restore_data use index(idx);
+admin check table test_add_index_restore_data;
+
+drop table if exists test_add_index_restore_data;
+set global tidb_ddl_enable_fast_reorg=default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52510

Problem Summary:
when fast reorg and new collation are enabled, index backfilling only considers the need to restore the index columns, but ignores the primary key columns. The result is that the primary key in the index is not restored.

### What changed and how does it work?
When considering the need to restore an index, check both the index columns and the primary key columns.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix the collation of the primary key in secondary indexes is wrong when tidb_ddl_enable_fast_reorg is enabled
```
