### PR TITLE
expression: fix the collation of functions with json arguments

### DIFF
--- a/pkg/expression/builtin_ilike.go
+++ b/pkg/expression/builtin_ilike.go
@@ -96,7 +96,7 @@ func (b *builtinIlikeSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, 
 	var pattern collate.WildcardPattern
 	if b.args[1].ConstLevel() >= ConstOnlyInContext && b.args[2].ConstLevel() >= ConstOnlyInContext {
 		pattern, err = b.patternCache.getOrInitCache(ctx, func() (collate.WildcardPattern, error) {
-			ret := collate.ConvertAndGetBinCollation(b.collation).Pattern()
+			ret := collate.ConvertAndGetBinCollator(b.collation).Pattern()
 			ret.Compile(patternStr, byte(escape))
 			return ret, nil
 		})
@@ -106,7 +106,7 @@ func (b *builtinIlikeSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, 
 			return 0, true, err
 		}
 	} else {
-		pattern = collate.ConvertAndGetBinCollation(b.collation).Pattern()
+		pattern = collate.ConvertAndGetBinCollator(b.collation).Pattern()
 		pattern.Compile(patternStr, byte(escape))
 	}
 	return boolToInt64(pattern.DoMatch(valStr)), false, nil

--- a/pkg/expression/builtin_ilike_vec.go
+++ b/pkg/expression/builtin_ilike_vec.go
@@ -59,7 +59,7 @@ func (b *builtinIlikeSig) tryToVecMemorize(ctx EvalContext, param *funcParam, es
 	}
 
 	pattern, err := b.patternCache.getOrInitCache(ctx, func() (collate.WildcardPattern, error) {
-		pattern := collate.ConvertAndGetBinCollation(b.collation).Pattern()
+		pattern := collate.ConvertAndGetBinCollator(b.collation).Pattern()
 		pattern.Compile(param.getStringVal(0), byte(escape))
 		return pattern, nil
 	})
@@ -201,7 +201,7 @@ func (b *builtinIlikeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 
 	pattern, ok := b.tryToVecMemorize(ctx, params[1], escape)
 	if !ok {
-		pattern = collate.ConvertAndGetBinCollation(b.collation).Pattern()
+		pattern = collate.ConvertAndGetBinCollator(b.collation).Pattern()
 		return b.ilikeWithoutMemorization(pattern, params, rowNum, escape, result)
 	}
 

--- a/pkg/util/collate/collate.go
+++ b/pkg/util/collate/collate.go
@@ -334,23 +334,29 @@ func IsCICollation(collate string) bool {
 		collate == "utf8mb4_0900_ai_ci"
 }
 
-// ConvertAndGetBinCollation converts collator to binary collator
-func ConvertAndGetBinCollation(collate string) Collator {
+// ConvertAndGetBinCollation converts collation to binary collation
+func ConvertAndGetBinCollation(collate string) string {
 	switch collate {
 	case "utf8_general_ci":
-		return GetCollator("utf8_bin")
+		return "utf8_bin"
 	case "utf8_unicode_ci":
-		return GetCollator("utf8_bin")
+		return "utf8_bin"
 	case "utf8mb4_general_ci":
-		return GetCollator("utf8mb4_bin")
+		return "utf8mb4_bin"
 	case "utf8mb4_unicode_ci":
-		return GetCollator("utf8mb4_bin")
+		return "utf8mb4_bin"
 	case "utf8mb4_0900_ai_ci":
-		return GetCollator("utf8mb4_bin")
+		return "utf8mb4_bin"
 	case "gbk_chinese_ci":
-		return GetCollator("gbk_bin")
+		return "gbk_bin"
 	}
-	return GetCollator(collate)
+
+	return collate
+}
+
+// ConvertAndGetBinCollator converts collation to binary collator
+func ConvertAndGetBinCollator(collate string) Collator {
+	return GetCollator(ConvertAndGetBinCollation(collate))
 }
 
 // IsBinCollation returns if the collation is 'xx_bin' or 'bin'.

--- a/tests/integrationtest/r/expression/charset_and_collation.result
+++ b/tests/integrationtest/r/expression/charset_and_collation.result
@@ -1991,3 +1991,68 @@ LOCATE('bar' collate utf8mb4_0900_ai_ci, 'FOOBAR' collate utf8mb4_0900_ai_ci)
 select 'FOOBAR' collate utf8mb4_0900_ai_ci REGEXP 'foo.*' collate utf8mb4_0900_ai_ci;
 'FOOBAR' collate utf8mb4_0900_ai_ci REGEXP 'foo.*' collate utf8mb4_0900_ai_ci
 1
+set names utf8mb4 collate utf8mb4_0900_ai_ci;
+select reverse(cast('[]' as json)) between 'W' and 'm';
+reverse(cast('[]' as json)) between 'W' and 'm'
+1
+select lower(cast('[]' as json)) between 'W' and 'm';
+lower(cast('[]' as json)) between 'W' and 'm'
+1
+select upper(cast('[]' as json)) between 'W' and 'm';
+upper(cast('[]' as json)) between 'W' and 'm'
+1
+select substring_index(cast('[]' as json), '.', 1) between 'W' and 'm';
+substring_index(cast('[]' as json), '.', 1) between 'W' and 'm'
+1
+select trim(cast('[]' as json)) between 'W' and 'm';
+trim(cast('[]' as json)) between 'W' and 'm'
+1
+select quote(cast('[]' as json)) between "'W'" and "'m'";
+quote(cast('[]' as json)) between "'W'" and "'m'"
+1
+select concat(cast('[]' as json), '1') between 'W' and 'm';
+concat(cast('[]' as json), '1') between 'W' and 'm'
+1
+select concat('1', cast('[]' as json)) between '1W' and '1m';
+concat('1', cast('[]' as json)) between '1W' and '1m'
+1
+select concat_ws(cast('[]' as json), '1', '1') between '1W' and '1m';
+concat_ws(cast('[]' as json), '1', '1') between '1W' and '1m'
+1
+select concat_ws('1', cast('[]' as json)) between 'W' and 'm';
+concat_ws('1', cast('[]' as json)) between 'W' and 'm'
+1
+select elt(1, cast('[]' as json), '[]') between 'W' and 'm';
+elt(1, cast('[]' as json), '[]') between 'W' and 'm'
+1
+select elt(2, cast('[]' as json), '[]') between 'W' and 'm';
+elt(2, cast('[]' as json), '[]') between 'W' and 'm'
+1
+select make_set(1, cast('[]' as json), '[]') between 'W' and 'm';
+make_set(1, cast('[]' as json), '[]') between 'W' and 'm'
+1
+select make_set(2, cast('[]' as json), '[]') between 'W' and 'm';
+make_set(2, cast('[]' as json), '[]') between 'W' and 'm'
+1
+select replace(cast('[]' as json), '[]', '[]') between 'W' and 'm';
+replace(cast('[]' as json), '[]', '[]') between 'W' and 'm'
+1
+select replace('[]', '[]', cast('[]' as json)) between 'W' and 'm';
+replace('[]', '[]', cast('[]' as json)) between 'W' and 'm'
+0
+select insert(cast('[]' as json), 0, 100, '[]') between 'W' and 'm';
+insert(cast('[]' as json), 0, 100, '[]') between 'W' and 'm'
+1
+select insert('[]', 0, 100, cast('[]' as json)) between 'W' and 'm';
+insert('[]', 0, 100, cast('[]' as json)) between 'W' and 'm'
+0
+select substr(cast('[]' as json), 1) between 'W' and 'm';
+substr(cast('[]' as json), 1) between 'W' and 'm'
+1
+select repeat(cast('[]' as json), 10) between 'W' and 'm';
+repeat(cast('[]' as json), 10) between 'W' and 'm'
+1
+select export_set(3,cast('[]' as json),'2','-',8) between 'W' and 'm';
+export_set(3,cast('[]' as json),'2','-',8) between 'W' and 'm'
+1
+set names default;

--- a/tests/integrationtest/t/expression/charset_and_collation.test
+++ b/tests/integrationtest/t/expression/charset_and_collation.test
@@ -814,3 +814,28 @@ select min(id) from t group by str order by str;
 # TestUTF8MB40900AICIStrFunc
 select LOCATE('bar' collate utf8mb4_0900_ai_ci, 'FOOBAR' collate utf8mb4_0900_ai_ci);
 select 'FOOBAR' collate utf8mb4_0900_ai_ci REGEXP 'foo.*' collate utf8mb4_0900_ai_ci;
+
+# TestCollationWithJSONArg
+set names utf8mb4 collate utf8mb4_0900_ai_ci;
+select reverse(cast('[]' as json)) between 'W' and 'm';
+select lower(cast('[]' as json)) between 'W' and 'm';
+select upper(cast('[]' as json)) between 'W' and 'm';
+select substring_index(cast('[]' as json), '.', 1) between 'W' and 'm';
+select trim(cast('[]' as json)) between 'W' and 'm';
+select quote(cast('[]' as json)) between "'W'" and "'m'";
+select concat(cast('[]' as json), '1') between 'W' and 'm';
+select concat('1', cast('[]' as json)) between '1W' and '1m';
+select concat_ws(cast('[]' as json), '1', '1') between '1W' and '1m';
+select concat_ws('1', cast('[]' as json)) between 'W' and 'm';
+select elt(1, cast('[]' as json), '[]') between 'W' and 'm';
+select elt(2, cast('[]' as json), '[]') between 'W' and 'm';
+select make_set(1, cast('[]' as json), '[]') between 'W' and 'm';
+select make_set(2, cast('[]' as json), '[]') between 'W' and 'm';
+select replace(cast('[]' as json), '[]', '[]') between 'W' and 'm';
+select replace('[]', '[]', cast('[]' as json)) between 'W' and 'm';
+select insert(cast('[]' as json), 0, 100, '[]') between 'W' and 'm';
+select insert('[]', 0, 100, cast('[]' as json)) between 'W' and 'm';
+select substr(cast('[]' as json), 1) between 'W' and 'm';
+select repeat(cast('[]' as json), 10) between 'W' and 'm';
+select export_set(3,cast('[]' as json),'2','-',8) between 'W' and 'm';
+set names default;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #52833 

Problem Summary:

MySQL will use binary collation when the `max_length` of some arguments' types are too long. It'll mostly happen on `JSON` types.

### What changed and how does it work?

As TiDB doesn't have a `max_length` attribute for each type and "datum", I specially handled the situation for JSON. Some function will return binary collation when some of the arguments are JSON type.

In MySQL, the state of `BINARY` flag, `BLOB` type and `binary` collation is really a chaos. For this example, you'll find that sometimes the `collation(...)` returns `utf8mb4_bin` while the returned type info (shown through `--column-type-info`) tells you the collation is `utf8mb4_0900_ai_ci`. I'm not sure whether it's a bug for MySQL or not... 

So, I want to fix the behavior with minimum modification: only change the collation to binary collation and don't touch the charset.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the collation of the result of some functions are not compatible with MySQL when the arguments contain JSON.
```
