### PR TITLE
planner: make `var_samp` can be used as a window function

### DIFF
--- a/pkg/executor/window_test.go
+++ b/pkg/executor/window_test.go
@@ -476,5 +476,6 @@ func TestVarSampAsAWindowFunction(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t1 (c1 int)")
+	tk.MustExec("select var_samp(c1) from t1")
 	tk.MustExecToErr("select c1, var_samp(c1) over (partition by c1) from t1")
 }

--- a/pkg/executor/window_test.go
+++ b/pkg/executor/window_test.go
@@ -477,5 +477,5 @@ func TestVarSampAsAWindowFunction(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t1 (c1 int)")
 	tk.MustExec("select var_samp(c1) from t1")
-	tk.MustExecToErr("select c1, var_samp(c1) over (partition by c1) from t1")
+	tk.MustExec("select c1, var_samp(c1) over (partition by c1) from t1")
 }

--- a/pkg/executor/window_test.go
+++ b/pkg/executor/window_test.go
@@ -470,3 +470,11 @@ func TestIssue45964And46050(t *testing.T) {
 	testReturnColumnNullableAttribute(tk, "cume_dist()", false)
 	testReturnColumnNullableAttribute(tk, "percent_rank()", false)
 }
+
+func TestVarSampAsAWindowFunction(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (c1 int)")
+	tk.MustExecToErr("select c1, var_samp(c1) over (partition by c1) from t1")
+}

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -8364,7 +8364,11 @@ SumExpr:
 	}
 |	builtinVarSamp '(' BuggyDefaultFalseDistinctOpt Expression ')' OptWindowingClause
 	{
-		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4}, Distinct: $3.(bool)}
+		if $6 != nil {
+			$$ = &ast.WindowFuncExpr{Name: $1, Args: []ast.ExprNode{$4}, Distinct: $3.(bool), Spec: *($6.(*ast.WindowSpec))}
+		} else {
+			$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4}, Distinct: $3.(bool)}
+		}
 	}
 |	"JSON_ARRAYAGG" '(' Expression ')' OptWindowingClause
 	{

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -284,6 +285,9 @@ func doOptimize(
 ) (base.LogicalPlan, base.PhysicalPlan, float64, error) {
 	sessVars := sctx.GetSessionVars()
 	flag = adjustOptimizationFlags(flag, logic)
+	if strings.Contains(ToString(logic), "var_samp") {
+		logutil.BgLogger().Info("doOptimize", zap.String("logic", ToString(logic)))
+	}
 	logic, err := logicalOptimize(ctx, flag, logic)
 	if err != nil {
 		return nil, nil, 0, err

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -22,7 +22,6 @@ import (
 	"runtime"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -285,9 +284,6 @@ func doOptimize(
 ) (base.LogicalPlan, base.PhysicalPlan, float64, error) {
 	sessVars := sctx.GetSessionVars()
 	flag = adjustOptimizationFlags(flag, logic)
-	if strings.Contains(ToString(logic), "var_samp") {
-		logutil.BgLogger().Info("doOptimize", zap.String("logic", ToString(logic)))
-	}
 	logic, err := logicalOptimize(ctx, flag, logic)
 	if err != nil {
 		return nil, nil, 0, err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/52933

Problem Summary:

### What changed and how does it work?

From the MySQL plan:
```sql
mysql> explain analyze select var_samp(c1) over (partition by c1) from t1;
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| EXPLAIN                                                                                                                                                                                                                                                                                                                |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| -> Window aggregate with buffering: var_samp(t1.c1) OVER (PARTITION BY t1.c1 )   (cost=0 rows=1) (actual time=0.139..0.139 rows=0 loops=1)
    -> Sort: t1.c1  (cost=0.35 rows=1) (actual time=0.133..0.133 rows=0 loops=1)
        -> Table scan on t1  (cost=0.35 rows=1) (actual time=0.116..0.116 rows=0 loops=1)
 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)
```

- Made `var_samp` can be used as a window function.
- Added a test case for https://github.com/pingcap/tidb/issues/52933.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Make `var_samp` can be used as a window function.
使 `var_samp` 可以用作窗口函数。
```
