### PR TITLE
planner: collect all columns meta by sync load

### DIFF
--- a/pkg/planner/core/collect_column_stats_usage.go
+++ b/pkg/planner/core/collect_column_stats_usage.go
@@ -205,14 +205,14 @@ func (c *columnStatsUsageCollector) addHistNeededColumns(ds *DataSource) {
 		colIDSet.Insert(int(col.ID))
 		c.histNeededCols[tblColID] = true
 	}
-	for _, columns := range ds.tableInfo.Columns {
+	for _, column := range ds.tableInfo.Columns {
 		// If the column is plan-generated one, Skip it.
 		// TODO: we may need to consider the ExtraHandle.
-		if columns.ID < 0 {
+		if column.ID < 0 {
 			continue
 		}
-		if !columns.Hidden {
-			tblColID := model.TableItemID{TableID: ds.physicalTableID, ID: columns.ID, IsIndex: false}
+		if !column.Hidden {
+			tblColID := model.TableItemID{TableID: ds.physicalTableID, ID: column.ID, IsIndex: false}
 			if _, ok := c.histNeededCols[tblColID]; !ok {
 				c.histNeededCols[tblColID] = false
 			}

--- a/pkg/planner/core/collect_column_stats_usage.go
+++ b/pkg/planner/core/collect_column_stats_usage.go
@@ -191,32 +191,18 @@ func (c *columnStatsUsageCollector) addHistNeededColumns(ds *DataSource) {
 	if tblStats.Pseudo && !skipPseudoCheckForTest {
 		return
 	}
-	columns := expression.ExtractColumnsFromExpressions(c.cols[:0], ds.pushedDownConds, nil)
-
-	colIDSet := intset.NewFastIntSet()
-
-	for _, col := range columns {
-		// If the column is plan-generated one, Skip it.
-		// TODO: we may need to consider the ExtraHandle.
-		if col.ID < 0 {
-			continue
-		}
-		tblColID := model.TableItemID{TableID: ds.physicalTableID, ID: col.ID, IsIndex: false}
-		colIDSet.Insert(int(col.ID))
-		c.histNeededCols[tblColID] = true
-	}
 	for _, col := range ds.Columns {
 		// If the column is plan-generated one, Skip it.
 		// TODO: we may need to consider the ExtraHandle.
 		if col.ID < 0 {
 			continue
 		}
-		if !colIDSet.Has(int(col.ID)) && !col.Hidden {
+		if !col.Hidden {
 			tblColID := model.TableItemID{TableID: ds.physicalTableID, ID: col.ID, IsIndex: false}
 			if _, ok := c.histNeededCols[tblColID]; ok {
 				continue
 			}
-			c.histNeededCols[tblColID] = false
+			c.histNeededCols[tblColID] = true
 		}
 	}
 }

--- a/pkg/planner/core/collect_column_stats_usage.go
+++ b/pkg/planner/core/collect_column_stats_usage.go
@@ -191,18 +191,31 @@ func (c *columnStatsUsageCollector) addHistNeededColumns(ds *DataSource) {
 	if tblStats.Pseudo && !skipPseudoCheckForTest {
 		return
 	}
-	for _, col := range ds.Columns {
+	columns := expression.ExtractColumnsFromExpressions(c.cols[:0], ds.pushedDownConds, nil)
+
+	colIDSet := intset.NewFastIntSet()
+
+	for _, col := range columns {
 		// If the column is plan-generated one, Skip it.
 		// TODO: we may need to consider the ExtraHandle.
 		if col.ID < 0 {
 			continue
 		}
-		if !col.Hidden {
-			tblColID := model.TableItemID{TableID: ds.physicalTableID, ID: col.ID, IsIndex: false}
-			if _, ok := c.histNeededCols[tblColID]; ok {
-				continue
+		tblColID := model.TableItemID{TableID: ds.physicalTableID, ID: col.ID, IsIndex: false}
+		colIDSet.Insert(int(col.ID))
+		c.histNeededCols[tblColID] = true
+	}
+	for _, columns := range ds.tableInfo.Columns {
+		// If the column is plan-generated one, Skip it.
+		// TODO: we may need to consider the ExtraHandle.
+		if columns.ID < 0 {
+			continue
+		}
+		if !columns.Hidden {
+			tblColID := model.TableItemID{TableID: ds.physicalTableID, ID: columns.ID, IsIndex: false}
+			if _, ok := c.histNeededCols[tblColID]; !ok {
+				c.histNeededCols[tblColID] = false
 			}
-			c.histNeededCols[tblColID] = true
 		}
 	}
 }

--- a/pkg/planner/core/collect_column_stats_usage_test.go
+++ b/pkg/planner/core/collect_column_stats_usage_test.go
@@ -316,7 +316,7 @@ func TestCollectHistNeededColumns(t *testing.T) {
 		},
 		{
 			sql: "select b, count(a) from t where b > 1 group by b having count(a) > 2",
-			res: []string{"t.a meta", "t.b full"},
+			res: []string{"t.a meta", "t.b full", "t.c meta", "t.c_str meta", "t.d meta", "t.d_str meta", "t.e meta", "t.e_str meta", "t.f meta", "t.g meta", "t.h meta", "t.i_date meta"},
 		},
 		{
 			sql: "select * from t as x join t2 as y on x.b + y.b > 2 and x.c > 1 and y.a < 1",
@@ -324,15 +324,15 @@ func TestCollectHistNeededColumns(t *testing.T) {
 		},
 		{
 			sql: "select * from t2 where t2.b > all(select b from t where t.c > 2)",
-			res: []string{"t.b meta", "t.c full", "t2.a meta", "t2.b meta", "t2.c meta"},
+			res: []string{"t.a meta", "t.b meta", "t.c full", "t.c_str meta", "t.d meta", "t.d_str meta", "t.e meta", "t.e_str meta", "t.f meta", "t.g meta", "t.h meta", "t.i_date meta", "t2.a meta", "t2.b meta", "t2.c meta"},
 		},
 		{
 			sql: "select * from t2 where t2.b > any(select b from t where t.c > 2)",
-			res: []string{"t.b meta", "t.c full", "t2.a meta", "t2.b meta", "t2.c meta"},
+			res: []string{"t.a meta", "t.b meta", "t.c full", "t.c_str meta", "t.d meta", "t.d_str meta", "t.e meta", "t.e_str meta", "t.f meta", "t.g meta", "t.h meta", "t.i_date meta", "t2.a meta", "t2.b meta", "t2.c meta"},
 		},
 		{
 			sql: "select * from t2 where t2.b in (select b from t where t.c > 2)",
-			res: []string{"t.b meta", "t.c full", "t2.a meta", "t2.b meta", "t2.c meta"},
+			res: []string{"t.a meta", "t.b meta", "t.c full", "t.c_str meta", "t.d meta", "t.d_str meta", "t.e meta", "t.e_str meta", "t.f meta", "t.g meta", "t.h meta", "t.i_date meta", "t2.a meta", "t2.b meta", "t2.c meta"},
 		},
 		{
 			pruneMode: "static",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53141

Problem Summary:

### What changed and how does it work?

In calculating cost， we need all columns' stats to get row size.

<img width="1200" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/7a9f8930-0b42-43f2-b311-4eed018e3803">

To get right result,so we need to load all stats when to sync load.

But here is a bug. ```ds.Columns``` has been pruned. it doesn't contain all columns.

<img width="890" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/f87ac6a4-08f1-45b7-ac35-eae0ad8b6a24">


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
