### PR TITLE
lightning/config: align the behaviour of tidb.tls to doc

### DIFF
--- a/pkg/lightning/config/config_test.go
+++ b/pkg/lightning/config/config_test.go
@@ -385,6 +385,17 @@ func TestAdjustSecuritySection(t *testing.T) {
 			`,
 			expectedCA:     "",
 			hasTLS:         true,
+			fallback2NoTLS: false,
+		},
+		{
+			input: `
+				[security]
+				[tidb]
+				tls = "preferred"
+				[tidb.security]
+			`,
+			expectedCA:     "",
+			hasTLS:         true,
 			fallback2NoTLS: true,
 		},
 		{
@@ -393,6 +404,18 @@ func TestAdjustSecuritySection(t *testing.T) {
 				[tidb]
 				tls = "false"
 				[tidb.security]
+			`,
+			expectedCA:     "",
+			hasTLS:         false,
+			fallback2NoTLS: false,
+		},
+		{
+			input: `
+				[security]
+				[tidb]
+				tls = "false"
+				[tidb.security]
+				ca-path = "/path/to/ca2.pem"
 			`,
 			expectedCA:     "",
 			hasTLS:         false,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53001

Problem Summary:

### What changed and how does it work?

The behaviour should be the same as https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-configuration

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the behaviour of lightning configuration tidb.tls is not the same as document
```
