### PR TITLE
planner: merge fast plan cache and normal plan cache

### DIFF
--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -503,12 +503,10 @@ type PlanCacheStmt struct {
 	// TODO: caching execution info directly is risky and tricky to the optimizer, refactor it later.
 	PointGet struct {
 		ColumnInfos any
-		ColumnNames any
 		// Executor is only used for point get scene.
 		// Notice that we should only cache the PointGetExecutor that have a snapshot with MaxTS in it.
 		// If the current plan is not PointGet or does not use MaxTS optimization, this value should be nil here.
 		Executor any
-		Plan     any // the cached PointGet Plan
 	}
 
 	// below fields are for PointGet short path

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -52,7 +52,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
-	"github.com/pingcap/tidb/pkg/util/hint"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
@@ -106,8 +105,6 @@ type PointGetPlan struct {
 	// probeParents records the IndexJoins and Applys with this operator in their inner children.
 	// Please see comments in PhysicalPlan for details.
 	probeParents []base.PhysicalPlan
-	// stmtHints should restore in executing context.
-	stmtHints *hint.StmtHints
 	// explicit partition selection
 	PartitionNames []model.CIStr
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50618

Problem Summary: planner: simplify plan cache for fast point get

### What changed and how does it work?

![image](https://github.com/pingcap/tidb/assets/7499936/e3b94b06-bd4d-4f9c-95db-08737276e44c)

![image](https://github.com/pingcap/tidb/assets/7499936/af6abdc5-8df7-4f53-865e-11745e35a1cb)


No regression:

```
BenchmarkPreparedPointGet-8   	  144712	      7141 ns/op  -- before
BenchmarkPreparedPointGet-8   	  148641	      7149 ns/op -- after
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
