### PR TITLE
planner: optimize performance of `IndexUsage` utilities

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2036,7 +2036,14 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.RuntimeStatsColl = execdetails.NewRuntimeStatsColl(reuseObj)
 
 		// also enable index usage collector
-		sc.IndexUsageCollector = ctx.NewStmtIndexUsageCollector()
+		if sc.IndexUsageCollector == nil {
+			sc.IndexUsageCollector = ctx.NewStmtIndexUsageCollector()
+		} else {
+			sc.IndexUsageCollector.Reset()
+		}
+	} else {
+		// turn off the index usage collector
+		sc.IndexUsageCollector = nil
 	}
 
 	sc.SetForcePlanCache(fixcontrol.GetBoolWithDefault(vars.OptimizerFixControl, fixcontrol.Fix49736, false))

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -1084,7 +1084,16 @@ func loadTableStats(ctx sessionctx.Context, tblInfo *model.TableInfo, pid int64)
 
 	pctx := ctx.GetPlanCtx()
 	tableStats := getStatsTable(pctx, tblInfo, pid)
-	name, _ := getTblInfoForUsedStatsByPhysicalID(pctx, pid)
+
+	name := tblInfo.Name.O
+	partInfo := tblInfo.GetPartitionInfo()
+	if partInfo != nil {
+		for _, p := range partInfo.Definitions {
+			if p.ID == pid {
+				name += " " + p.Name.O
+			}
+		}
+	}
 	usedStats := &stmtctx.UsedStatsInfoForTable{
 		Name:          name,
 		TblInfo:       tblInfo,

--- a/pkg/statistics/handle/usage/indexusage/collector.go
+++ b/pkg/statistics/handle/usage/indexusage/collector.go
@@ -88,6 +88,12 @@ func NewSample(queryTotal uint64, kvReqTotal uint64, rowAccess uint64, tableTota
 
 type indexUsage map[GlobalIndexID]Sample
 
+var indexUsagePool = sync.Pool{
+	New: func() any {
+		return make(indexUsage)
+	},
+}
+
 func (m indexUsage) updateByKey(id GlobalIndexID, sample Sample) {
 	item := m[id]
 	item.QueryTotal += sample.QueryTotal
@@ -127,7 +133,7 @@ type Collector struct {
 // NewCollector create an index usage collector
 func NewCollector() *Collector {
 	iuc := &Collector{
-		indexUsage: make(indexUsage),
+		indexUsage: indexUsagePool.Get().(indexUsage),
 	}
 	iuc.collector = collector.NewGlobalCollector[indexUsage](iuc.merge)
 
@@ -154,12 +160,16 @@ func (c *Collector) merge(delta indexUsage) {
 	defer c.Unlock()
 
 	c.indexUsage.merge(delta)
+
+	// return the `delta` to the pool
+	clear(delta)
+	indexUsagePool.Put(delta)
 }
 
 // SpawnSessionCollector creates a new session collector attached to this global collector
 func (c *Collector) SpawnSessionCollector() *SessionIndexUsageCollector {
 	return &SessionIndexUsageCollector{
-		indexUsage: make(indexUsage),
+		indexUsage: indexUsagePool.Get().(indexUsage),
 		collector:  c.collector.SpawnSession(),
 	}
 }
@@ -219,7 +229,7 @@ func (s *SessionIndexUsageCollector) Report() {
 		return
 	}
 	if s.collector.SendDelta(s.indexUsage) {
-		s.indexUsage = make(indexUsage)
+		s.indexUsage = indexUsagePool.Get().(indexUsage)
 	}
 }
 
@@ -230,7 +240,7 @@ func (s *SessionIndexUsageCollector) Flush() {
 		return
 	}
 	s.collector.SendDeltaSync(s.indexUsage)
-	s.indexUsage = make(indexUsage)
+	s.indexUsage = indexUsagePool.Get().(indexUsage)
 }
 
 // StmtIndexUsageCollector removes the duplicates index for recording `QueryTotal` in session collector
@@ -268,4 +278,12 @@ func (s *StmtIndexUsageCollector) Update(tableID int64, indexID int64, sample Sa
 	}
 
 	s.sessionCollector.Update(tableID, indexID, sample)
+}
+
+// Reset resets the recorded index in the collector to avoid re-allocating for each statement.
+func (s *StmtIndexUsageCollector) Reset() {
+	s.Lock()
+	defer s.Unlock()
+
+	clear(s.recordedIndex)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #51898

Problem Summary:

This PR is trying to optimize the performance of `IndexUsage` utilities. Previously it costed around 1% CPU and did a lot of allocation. This PR tries to optimize it and get some tiny performance boost.

### What changed and how does it work?

1. Add a pool to avoid frequently allocating/de-allocating `indexUsage` and the internal entries.
2. Avoid using `getTblInfoForUsedStatsByPhysicalID`, which is very slow because it iterates over all tables.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

I used https://gist.github.com/YangKeao/c02ada99d2602d5e7fb5fb94f0581015 to run a stabler `select_random_points` benchmark. It gives QPS 59029 and 58393 for the commit before index usage and with index usage enabled.

After patching the index usage commit with this PR, the average QPS goes to 58854. I'm not sure whether there are other spaces to improve the performance (like improving the speed of loading stats).

As a reference: the flamegraph before this PR:

![Screenshot_20240511_135754](https://github.com/pingcap/tidb/assets/5244316/4ac605bf-9e60-44f0-b330-23c7314c7645)

The flamegraph after this PR:

![Screenshot_20240511_172151](https://github.com/pingcap/tidb/assets/5244316/cd4864a7-4ed3-4b1d-92ff-c2dea1f32176)


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
