### PR TITLE
expression: clarify the `cast(... as char array)` error message | tidb-test=pr/2326

### DIFF
--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -455,7 +455,7 @@ func (c *castAsArrayFunctionClass) getFunction(ctx BuildContext, args []Expressi
 		return nil, ErrNotSupportedYet.GenWithStackByArgs("specifying charset for multi-valued index")
 	}
 	if arrayType.EvalType() == types.ETString && arrayType.GetFlen() == types.UnspecifiedLength {
-		return nil, ErrNotSupportedYet.GenWithStackByArgs("CAST-ing data to array of char/binary BLOBs")
+		return nil, ErrNotSupportedYet.GenWithStackByArgs("CAST-ing data to array of char/binary BLOBs with unspecified length")
 	}
 
 	bf, err := newBaseBuiltinFunc(ctx, c.funcName, args, c.tp)

--- a/tests/integrationtest/r/expression/multi_valued_index.result
+++ b/tests/integrationtest/r/expression/multi_valued_index.result
@@ -28,9 +28,9 @@ Error 1235 (42000): This version of TiDB doesn't yet support 'Use of CAST( .. AS
 create table t(j json, gc json as (cast(j->'$[*]' as unsigned array)));
 Error 1235 (42000): This version of TiDB doesn't yet support 'Use of CAST( .. AS .. ARRAY) outside of functional index in CREATE(non-SELECT)/ALTER TABLE or in general expressions'
 create table t1(j json, key i1((cast(j->"$" as char array))));
-Error 1235 (42000): This version of TiDB doesn't yet support 'CAST-ing data to array of char/binary BLOBs'
+Error 1235 (42000): This version of TiDB doesn't yet support 'CAST-ing data to array of char/binary BLOBs with unspecified length'
 create table t1(j json, key i1((cast(j->"$" as binary array))));
-Error 1235 (42000): This version of TiDB doesn't yet support 'CAST-ing data to array of char/binary BLOBs'
+Error 1235 (42000): This version of TiDB doesn't yet support 'CAST-ing data to array of char/binary BLOBs with unspecified length'
 create table t1(j json, key i1((cast(j->"$" as float array))));
 Error 1235 (42000): This version of TiDB doesn't yet support 'CAST-ing data to array of float BINARY'
 create table t1(j json, key i1((cast(j->"$" as decimal(4,2) array))));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #53219

Problem Summary:

The error message was misleading. TiDB actually supports casting to `char(16) array`. The user needs to add length after facing this error.

### What changed and how does it work?

Change the error message to tell the user that the problem is the missed length.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
