### PR TITLE
planner: fix missing error of only full group by check for folded nature join cols

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3801,7 +3801,12 @@ func (*colNameResolver) Enter(inNode ast.Node) (ast.Node, bool) {
 
 func (c *colNameResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 	if v, ok := inNode.(*ast.ColumnNameExpr); ok {
-		idx, err := expression.FindFieldName(c.p.OutputNames(), v.Name)
+		// if p is join, try to use join full schema, cause same column may be folded by nature join.
+		names := c.p.OutputNames()
+		if join, ok := c.p.(*LogicalJoin); ok {
+			names = join.fullNames
+		}
+		idx, err := expression.FindFieldName(names, v.Name)
 		if err == nil && idx >= 0 {
 			c.names[c.p.OutputNames()[idx]] = struct{}{}
 		}

--- a/tests/integrationtest/r/executor/aggregate.result
+++ b/tests/integrationtest/r/executor/aggregate.result
@@ -1191,11 +1191,11 @@ create table t(a int, b bigint, c float, d double, e decimal);
 insert into t values(1, 1000, 6.8, 3.45, 8.3), (1, 3998, -3.4, 5.12, 9.3),(1, 288, 9.2, 6.08, 1);
 select variance(b), variance(c), variance(d), variance(e) from t group by a;
 variance(b)	variance(c)	variance(d)	variance(e)
-2584338.6666666665	29.840000178019228	1.1808222222222229	12.666666666666666
+2584338.6666666665	29.840000178019228	1.1808222222222222	12.666666666666666
 insert into t values(1, 255, 6.8, 6.08, 1);
 select variance(distinct b), variance(distinct c), variance(distinct d), variance(distinct e) from t group by a;
 variance(distinct b)	variance(distinct c)	variance(distinct d)	variance(distinct e)
-2364075.6875	29.840000178019228	1.1808222222222229	12.666666666666666
+2364075.6875	29.840000178019228	1.1808222222222222	12.666666666666666
 insert into t values(2, 322, 0.8, 2.22, 6);
 select a, variance(b) over w from t window w as (partition by a);
 a	variance(b) over w
@@ -2060,3 +2060,14 @@ Projection	1.00	root		Column#9, Column#12, Column#15, Column#18
             └─TableFullScan	1000.00	cop[tikv]	table:test	keep order:false, stats:pseudo
 delete from mysql.opt_rule_blacklist where name = "decorrelate";
 admin reload opt_rule_blacklist;
+drop table if exists t0, t1;
+CREATE TABLE t0 (
+c0 double unsigned zerofill NULL
+);
+INSERT INTO t0 VALUES (0.1251773127435537), (NULL), (0), (0.6665588482250941);
+CREATE TABLE t1(c0 BOOL);
+INSERT INTO t1 VALUES (NULL), (NULL), (0), (0);
+explain format="brief" SELECT t0.c0 FROM t0 NATURAL RIGHT JOIN t1 GROUP BY NULL;
+Error 1055 (42000): Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'executor__aggregate.t0._tidb_rowid' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
+SELECT t0.c0 FROM t0 NATURAL RIGHT JOIN t1 GROUP BY NULL;
+Error 1055 (42000): Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'executor__aggregate.t0._tidb_rowid' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by

--- a/tests/integrationtest/t/executor/aggregate.test
+++ b/tests/integrationtest/t/executor/aggregate.test
@@ -1067,3 +1067,15 @@ explain format = 'brief' select /*+ hash_agg() */ sum(a), (select NULL from test
 delete from mysql.opt_rule_blacklist where name = "decorrelate";
 admin reload opt_rule_blacklist;
 
+# TestIssue52935
+drop table if exists t0, t1;
+CREATE TABLE t0 (
+  c0 double unsigned zerofill NULL
+);
+INSERT INTO t0 VALUES (0.1251773127435537), (NULL), (0), (0.6665588482250941);
+CREATE TABLE t1(c0 BOOL);
+INSERT INTO t1 VALUES (NULL), (NULL), (0), (0);
+--error 1055
+explain format="brief" SELECT t0.c0 FROM t0 NATURAL RIGHT JOIN t1 GROUP BY NULL;
+--error 1055
+SELECT t0.c0 FROM t0 NATURAL RIGHT JOIN t1 GROUP BY NULL;


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: https://github.com/pingcap/tidb/issues/52935

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix missing error of only full group by check for folded nature join cols
```
