### PR TITLE
expression: Report error when empty pattern in regexp related function

### DIFF
--- a/pkg/executor/test/issuetest/BUILD.bazel
+++ b/pkg/executor/test/issuetest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -676,3 +676,27 @@ func TestIssue52978(t *testing.T) {
 	tk.MustQuery("select min(truncate(cast(-26340 as double), ref_11.a)) as c3 from t as ref_11;").Check(testkit.Rows("-26340"))
 	tk.MustExec("drop table if exists t")
 }
+
+func TestIssue53221(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a varchar(20))")
+	tk.MustExec("insert into t values ('')")
+	tk.MustExec("insert into t values ('')")
+	err := tk.QueryToErr("select regexp_like('hello', t.a) from test.t")
+	require.ErrorContains(t, err, "Empty pattern is invalid")
+
+	err = tk.QueryToErr("select regexp_instr('hello', t.a) from test.t")
+	require.ErrorContains(t, err, "Empty pattern is invalid")
+
+	err = tk.QueryToErr("select regexp_substr('hello', t.a) from test.t")
+	require.ErrorContains(t, err, "Empty pattern is invalid")
+
+	err = tk.QueryToErr("select regexp_replace('hello', t.a, 'd') from test.t")
+	require.ErrorContains(t, err, "Empty pattern is invalid")
+
+	tk.MustExec("drop table if exists t")
+}

--- a/pkg/expression/builtin_regexp.go
+++ b/pkg/expression/builtin_regexp.go
@@ -314,7 +314,11 @@ func (re *builtinRegexpLikeFuncSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 
 		if !memorized {
 			matchType := params[2].getStringVal(i)
-			reg, err = re.buildRegexp(params[1].getStringVal(i), matchType)
+			pattern := params[1].getStringVal(i)
+			if len(pattern) == 0 {
+				return ErrRegexp.GenWithStackByArgs(emptyPatternErr)
+			}
+			reg, err = re.buildRegexp(pattern, matchType)
 			if err != nil {
 				return err
 			}
@@ -583,8 +587,11 @@ func (re *builtinRegexpSubstrFuncSig) vecEvalString(ctx EvalContext, input *chun
 
 		if !memorized {
 			// Get pattern and match type and then generate regexp
-			pattern := params[1].getStringVal(i)
 			matchType := params[4].getStringVal(i)
+			pattern := params[1].getStringVal(i)
+			if len(pattern) == 0 {
+				return ErrRegexp.GenWithStackByArgs(emptyPatternErr)
+			}
 			if reg, err = re.buildRegexp(pattern, matchType); err != nil {
 				return err
 			}
@@ -915,7 +922,11 @@ func (re *builtinRegexpInStrFuncSig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 		// Get match type and generate regexp
 		if !memorized {
 			matchType := params[5].getStringVal(i)
-			reg, err = re.buildRegexp(params[1].getStringVal(i), matchType)
+			pattern := params[1].getStringVal(i)
+			if len(pattern) == 0 {
+				return ErrRegexp.GenWithStackByArgs(emptyPatternErr)
+			}
+			reg, err = re.buildRegexp(pattern, matchType)
 			if err != nil {
 				return err
 			}
@@ -1401,7 +1412,11 @@ func (re *builtinRegexpReplaceFuncSig) vecEvalString(ctx EvalContext, input *chu
 		// Get match type and generate regexp
 		if !memorized {
 			matchType := params[5].getStringVal(i)
-			reg, err = re.buildRegexp(params[1].getStringVal(i), matchType)
+			pattern := params[1].getStringVal(i)
+			if len(pattern) == 0 {
+				return ErrRegexp.GenWithStackByArgs(emptyPatternErr)
+			}
+			reg, err = re.buildRegexp(pattern, matchType)
 			if err != nil {
 				return err
 			}

--- a/pkg/expression/builtin_regexp.go
+++ b/pkg/expression/builtin_regexp.go
@@ -96,6 +96,10 @@ func (re *regexpBaseFuncSig) canMemorizeRegexp(matchTypeIdx int) bool {
 
 // buildRegexp builds a new `*regexp.Regexp` from the pattern and matchType
 func (re *regexpBaseFuncSig) buildRegexp(pattern string, matchType string) (reg *regexp.Regexp, err error) {
+	if len(pattern) == 0 {
+		return nil, ErrRegexp.GenWithStackByArgs(emptyPatternErr)
+	}
+
 	matchType, err = getRegexpMatchType(matchType, re.collation)
 	if err != nil {
 		return nil, err
@@ -315,9 +319,6 @@ func (re *builtinRegexpLikeFuncSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 		if !memorized {
 			matchType := params[2].getStringVal(i)
 			pattern := params[1].getStringVal(i)
-			if len(pattern) == 0 {
-				return ErrRegexp.GenWithStackByArgs(emptyPatternErr)
-			}
 			reg, err = re.buildRegexp(pattern, matchType)
 			if err != nil {
 				return err
@@ -589,9 +590,6 @@ func (re *builtinRegexpSubstrFuncSig) vecEvalString(ctx EvalContext, input *chun
 			// Get pattern and match type and then generate regexp
 			matchType := params[4].getStringVal(i)
 			pattern := params[1].getStringVal(i)
-			if len(pattern) == 0 {
-				return ErrRegexp.GenWithStackByArgs(emptyPatternErr)
-			}
 			if reg, err = re.buildRegexp(pattern, matchType); err != nil {
 				return err
 			}
@@ -923,9 +921,6 @@ func (re *builtinRegexpInStrFuncSig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 		if !memorized {
 			matchType := params[5].getStringVal(i)
 			pattern := params[1].getStringVal(i)
-			if len(pattern) == 0 {
-				return ErrRegexp.GenWithStackByArgs(emptyPatternErr)
-			}
 			reg, err = re.buildRegexp(pattern, matchType)
 			if err != nil {
 				return err
@@ -1413,9 +1408,6 @@ func (re *builtinRegexpReplaceFuncSig) vecEvalString(ctx EvalContext, input *chu
 		if !memorized {
 			matchType := params[5].getStringVal(i)
 			pattern := params[1].getStringVal(i)
-			if len(pattern) == 0 {
-				return ErrRegexp.GenWithStackByArgs(emptyPatternErr)
-			}
 			reg, err = re.buildRegexp(pattern, matchType)
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53221 

Problem Summary:
Tidb report error when these functions are executed in row by row mode. But failed to check it in vector mode.
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
