### PR TITLE
ddl: add owner_id field to tidb_mdl_info to avoid unexpected writes

### DIFF
--- a/br/pkg/restore/db_test.go
+++ b/br/pkg/restore/db_test.go
@@ -425,5 +425,5 @@ func TestGetExistedUserDBs(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(197), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(198), session.CurrentBootstrapVersion)
 }

--- a/pkg/ddl/ddl_worker.go
+++ b/pkg/ddl/ddl_worker.go
@@ -637,8 +637,8 @@ func cleanMDLInfo(pool *sess.Pool, jobID int64, ec *clientv3.Client, ownerID str
 }
 
 // checkMDLInfo checks if metadata lock info exists. It means the schema is locked by some TiDBs if exists.
-func checkMDLInfo(jobID int64, pool *sess.Pool, ownerID string) (bool, int64, error) {
-	sql := fmt.Sprintf("select version from mysql.tidb_mdl_info where job_id = %d and owner_id = '%s'", jobID, ownerID)
+func checkMDLInfo(jobID int64, pool *sess.Pool) (bool, int64, error) {
+	sql := fmt.Sprintf("select version from mysql.tidb_mdl_info where job_id = %d", jobID)
 	sctx, _ := pool.Get()
 	defer pool.Put(sctx)
 	se := sess.NewSession(sctx)

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -429,7 +429,7 @@ func (d *ddl) delivery2Worker(wk *worker, pool *workerPool, job *model.Job) {
 		// check if this ddl job is synced to all servers.
 		if !job.NotStarted() && (!d.isSynced(job) || !d.maybeAlreadyRunOnce(job.ID)) {
 			if variable.EnableMDL.Load() {
-				exist, version, err := checkMDLInfo(job.ID, d.sessPool, ownerID)
+				exist, version, err := checkMDLInfo(job.ID, d.sessPool)
 				if err != nil {
 					wk.jobLogger(job).Warn("check MDL info failed", zap.Error(err))
 					// Release the worker resource.

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -425,10 +425,11 @@ func (d *ddl) delivery2Worker(wk *worker, pool *workerPool, job *model.Job) {
 			asyncNotify(d.ddlJobCh)
 			metrics.DDLRunningJobCount.WithLabelValues(pool.tp().String()).Dec()
 		}()
+		ownerID := d.ownerManager.ID()
 		// check if this ddl job is synced to all servers.
 		if !job.NotStarted() && (!d.isSynced(job) || !d.maybeAlreadyRunOnce(job.ID)) {
 			if variable.EnableMDL.Load() {
-				exist, version, err := checkMDLInfo(job.ID, d.sessPool)
+				exist, version, err := checkMDLInfo(job.ID, d.sessPool, ownerID)
 				if err != nil {
 					wk.jobLogger(job).Warn("check MDL info failed", zap.Error(err))
 					// Release the worker resource.
@@ -442,7 +443,7 @@ func (d *ddl) delivery2Worker(wk *worker, pool *workerPool, job *model.Job) {
 						return
 					}
 					d.setAlreadyRunOnce(job.ID)
-					cleanMDLInfo(d.sessPool, job.ID, d.etcdCli, job.State == model.JobStateSynced)
+					cleanMDLInfo(d.sessPool, job.ID, d.etcdCli, ownerID, job.State == model.JobStateSynced)
 					// Don't have a worker now.
 					return
 				}
@@ -480,7 +481,7 @@ func (d *ddl) delivery2Worker(wk *worker, pool *workerPool, job *model.Job) {
 			if err != nil {
 				return
 			}
-			cleanMDLInfo(d.sessPool, job.ID, d.etcdCli, job.State == model.JobStateSynced)
+			cleanMDLInfo(d.sessPool, job.ID, d.etcdCli, ownerID, job.State == model.JobStateSynced)
 			d.synced(job)
 
 			if RunInGoTest {

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -804,8 +804,9 @@ func (do *Domain) refreshMDLCheckTableInfo() {
 	defer do.sysSessionPool.Put(se)
 	exec := sctx.GetRestrictedSQLExecutor()
 	domainSchemaVer := do.InfoSchema().SchemaMetaVersion()
+	ownerID := do.ddl.OwnerManager().ID()
 	rows, _, err := exec.ExecRestrictedSQL(kv.WithInternalSourceType(context.Background(), kv.InternalTxnMeta), nil,
-		fmt.Sprintf("select job_id, version, table_ids from mysql.tidb_mdl_info where version <= %d", domainSchemaVer))
+		fmt.Sprintf("select job_id, version, table_ids from mysql.tidb_mdl_info where version <= %d and owner_id = '%s'", domainSchemaVer, ownerID))
 	if err != nil {
 		logutil.BgLogger().Warn("get mdl info from tidb_mdl_info failed", zap.Error(err))
 		return

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -804,9 +804,8 @@ func (do *Domain) refreshMDLCheckTableInfo() {
 	defer do.sysSessionPool.Put(se)
 	exec := sctx.GetRestrictedSQLExecutor()
 	domainSchemaVer := do.InfoSchema().SchemaMetaVersion()
-	ownerID := do.ddl.OwnerManager().ID()
 	rows, _, err := exec.ExecRestrictedSQL(kv.WithInternalSourceType(context.Background(), kv.InternalTxnMeta), nil,
-		fmt.Sprintf("select job_id, version, table_ids from mysql.tidb_mdl_info where version <= %d and owner_id = '%s'", domainSchemaVer, ownerID))
+		fmt.Sprintf("select job_id, version, table_ids from mysql.tidb_mdl_info where version <= %d", domainSchemaVer))
 	if err != nil {
 		logutil.BgLogger().Warn("get mdl info from tidb_mdl_info failed", zap.Error(err))
 		return

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1093,11 +1093,15 @@ const (
 	// version 197
 	//   replace `mysql.tidb_mdl_view` table
 	version197 = 197
+
+	// version 198
+	//   add column `exec_id` for `mysql.tidb_mdl_info` table
+	version198 = 198
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version197
+var currentBootstrapVersion int64 = version198
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -3101,6 +3105,14 @@ func upgradeToVer197(s sessiontypes.Session, ver int64) {
 	}
 
 	doReentrantDDL(s, CreateMDLView)
+}
+
+func upgradeToVer198(s sessiontypes.Session, ver int64) {
+	if ver >= version197 {
+		return
+	}
+
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mdl_info ADD COLUMN owner_id VARCHAR(261) DEFAULT '';", infoschema.ErrColumnExists)
 }
 
 func writeOOMAction(s sessiontypes.Session) {

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1095,7 +1095,7 @@ const (
 	version197 = 197
 
 	// version 198
-	//   add column `exec_id` for `mysql.tidb_mdl_info` table
+	//   add column `owner_id` for `mysql.tidb_mdl_info` table
 	version198 = 198
 )
 
@@ -1264,6 +1264,7 @@ var (
 		upgradeToVer195,
 		upgradeToVer196,
 		upgradeToVer197,
+		upgradeToVer198,
 	}
 )
 

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -3113,7 +3113,7 @@ func upgradeToVer198(s sessiontypes.Session, ver int64) {
 		return
 	}
 
-	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mdl_info ADD COLUMN owner_id VARCHAR(64) DEFAULT '';", infoschema.ErrColumnExists)
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mdl_info ADD COLUMN owner_id VARCHAR(64) NOT NULL DEFAULT '';", infoschema.ErrColumnExists)
 }
 
 func writeOOMAction(s sessiontypes.Session) {

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -3113,7 +3113,7 @@ func upgradeToVer198(s sessiontypes.Session, ver int64) {
 		return
 	}
 
-	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mdl_info ADD COLUMN owner_id VARCHAR(261) DEFAULT '';", infoschema.ErrColumnExists)
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_mdl_info ADD COLUMN owner_id VARCHAR(64) DEFAULT '';", infoschema.ErrColumnExists)
 }
 
 func writeOOMAction(s sessiontypes.Session) {

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -3109,7 +3109,7 @@ func upgradeToVer197(s sessiontypes.Session, ver int64) {
 }
 
 func upgradeToVer198(s sessiontypes.Session, ver int64) {
-	if ver >= version197 {
+	if ver >= version198 {
 		return
 	}
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3151,7 +3151,7 @@ var (
 		job_id BIGINT NOT NULL PRIMARY KEY,
 		version BIGINT NOT NULL,
 		table_ids text(65535),
-		owner_id varchar(64)
+		owner_id varchar(64) NOT NULL DEFAULT ''
 	);`
 )
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3150,7 +3150,8 @@ var (
 	mdlTable = `create table mysql.tidb_mdl_info(
 		job_id BIGINT NOT NULL PRIMARY KEY,
 		version BIGINT NOT NULL,
-		table_ids text(65535)
+		table_ids text(65535),
+		owner_id varchar(261)
 	);`
 )
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3151,7 +3151,7 @@ var (
 		job_id BIGINT NOT NULL PRIMARY KEY,
 		version BIGINT NOT NULL,
 		table_ids text(65535),
-		owner_id varchar(261)
+		owner_id varchar(64)
 	);`
 )
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53073

Problem Summary:

tidb-1 keeps printing "someone is not synced", which means it is blocked at `waitSchemaSynced`.
```
[2024/05/13 17:24:32.067 +08:00] [INFO] [syncer.go:352] ["syncer check all versions, someone is not synced"] [category=ddl] [info="instance ip tc-tidb-1.tc-tidb-peer.endless-ha-test-add-index-tps-7576420-1-811.svc, port 4000, id d3ac6d21-0137-4106-b42a-89692b7ba7e1"] ["ddl job id"=791] [ver=1931]
```

tidb-1 is DDL owner. However, tidb-1's schema version is **less** than non-owner TiDB (here are the results from `tiup ctl:v8.0.0 etcd --endpoints={pd_addr}:2379 get --prefix /tidb/ddl`):
```
/tidb/ddl/all_schema_by_job_versions/791/5bd21551-75b9-4a47-86d4-9520ce74cfd3
1931
/tidb/ddl/all_schema_by_job_versions/791/d3ac6d21-0137-4106-b42a-89692b7ba7e1
1930
...
/tidb/ddl/fg/owner/66018f542345e63b
d3ac6d21-0137-4106-b42a-89692b7ba7e1
```

After checking the log, I found that DDL owner is switched from tidb-0 to tidb-1 at this time.

On the other hand, `mysql.tidb_mdl_info` is empty.

Above all, the timeline should be:

```
1. tidb-0 gets owner
2. tidb-0 registers mdl info
3. tidb-0 waits schema sync

4. tidb-1 gets owner from tidb-0

5. tidb-1 register mdl info
6. tidb-0 clean mdl info
7. tidb-1 wait schema sync, block...
```

At step 6, tidb-0 incorrectly clean the mdl info registered by tidb-1. As a result, there is nothing to update in `mdlCheckLoop` because `tidb_mdl_info` is empty.

### What changed and how does it work?

- Add `owner_id` field to `tidb_mdl_info` to identify which owner is used.
- Prevent updating unexpected mdl info by specifying `owner_id` in WHERE clause.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
    With this PR, we can pass the test mentioned in issue #53073.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
