### PR TITLE
planner: fix wrong empty projection | tidb-test=pr/2327

### DIFF
--- a/pkg/planner/core/rule_column_pruning.go
+++ b/pkg/planner/core/rule_column_pruning.go
@@ -134,6 +134,7 @@ func (p *LogicalSelection) PruneColumns(parentUsedCols []*expression.Column, opt
 	if err != nil {
 		return nil, err
 	}
+	addConstOneForEmptyProjection(p.children[0])
 	return p, nil
 }
 

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -520,3 +520,12 @@ t_q1 as ref_14
 where (ref_14.c_z like 'o%fiah')))
 where (t_kg74.c_obnq8s7_s2 = case when (t_kg74.c_a1tv2 is NULL) then t_kg74.c_g else t_kg74.c_obnq8s7_s2 end
 );
+drop table if exists t0, t1;
+CREATE TABLE t0(c0 NUMERIC);
+CREATE TABLE t1(c0 NUMERIC);
+INSERT INTO t0 VALUES (0), (NULL), (1), (2);
+INSERT INTO t1(c0) VALUES (NULL), (3), (4), (5);
+drop view if exists v0;
+CREATE VIEW v0(c0) AS SELECT t0.c0 FROM t0;
+SELECT t0.c0 FROM v0, t0 LEFT JOIN t1 ON t0.c0 WHERE ((INET_ATON('5V')) IS NULL);
+c0

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -378,3 +378,14 @@ update t_kg74 set
       where (ref_14.c_z like 'o%fiah')))
 where (t_kg74.c_obnq8s7_s2 = case when (t_kg74.c_a1tv2 is NULL) then t_kg74.c_g else t_kg74.c_obnq8s7_s2 end
       );
+
+# https://github.com/pingcap/tidb/issues/49109
+drop table if exists t0, t1;
+CREATE TABLE t0(c0 NUMERIC);
+CREATE TABLE t1(c0 NUMERIC);
+INSERT INTO t0 VALUES (0), (NULL), (1), (2);
+INSERT INTO t1(c0) VALUES (NULL), (3), (4), (5);
+drop view if exists v0;
+CREATE VIEW v0(c0) AS SELECT t0.c0 FROM t0;
+
+SELECT t0.c0 FROM v0, t0 LEFT JOIN t1 ON t0.c0 WHERE ((INET_ATON('5V')) IS NULL);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #49109 

Problem Summary:

Projection is wrongly pruned to a empty one after the second round of column pruning

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
