### PR TITLE
*: some tiny optimizations to reduce infoschema v2 memory

### DIFF
--- a/pkg/infoschema/infoschema_v2_test.go
+++ b/pkg/infoschema/infoschema_v2_test.go
@@ -102,7 +102,7 @@ func TestV2Basic(t *testing.T) {
 
 	tblInfos := is.SchemaTableInfos(schemaName)
 	require.Equal(t, 1, len(tblInfos))
-	require.Same(t, tables[0].Meta(), tblInfos[0])
+	require.Same(t, tables[0], tblInfos[0])
 
 	tables = is.SchemaTables(model.NewCIStr("notexist"))
 	require.Equal(t, 0, len(tables))

--- a/pkg/infoschema/infoschema_v2_test.go
+++ b/pkg/infoschema/infoschema_v2_test.go
@@ -39,6 +39,7 @@ func TestV2Basic(t *testing.T) {
 	is.Data.addDB(1, dbInfo)
 	internal.AddDB(t, r.Store(), dbInfo)
 	tblInfo := internal.MockTableInfo(t, r.Store(), tableName.O)
+	tblInfo.DBID = dbInfo.ID
 	is.Data.add(tableItem{schemaName.L, dbInfo.ID, tableName.L, tblInfo.ID, 2, false}, internal.MockTable(t, r.Store(), tblInfo))
 	internal.AddTable(t, r.Store(), dbInfo, tblInfo)
 	is.base().schemaMetaVersion = 1
@@ -102,7 +103,7 @@ func TestV2Basic(t *testing.T) {
 
 	tblInfos := is.SchemaTableInfos(schemaName)
 	require.Equal(t, 1, len(tblInfos))
-	require.Same(t, tables[0], tblInfos[0])
+	require.Equal(t, tables[0].Meta(), tblInfos[0])
 
 	tables = is.SchemaTables(model.NewCIStr("notexist"))
 	require.Equal(t, 0, len(tables))

--- a/pkg/server/handler/tests/http_handler_test.go
+++ b/pkg/server/handler/tests/http_handler_test.go
@@ -1130,7 +1130,7 @@ func TestWriteDBTablesData(t *testing.T) {
 	// No table in a schema.
 	info := infoschema.MockInfoSchema([]*model.TableInfo{})
 	rc := httptest.NewRecorder()
-	tbs := info.SchemaTables(model.NewCIStr("test"))
+	tbs := info.SchemaTableInfos(model.NewCIStr("test"))
 	require.Equal(t, 0, len(tbs))
 	tikvhandler.WriteDBTablesData(rc, tbs)
 	var ti []*model.TableInfo
@@ -1142,30 +1142,30 @@ func TestWriteDBTablesData(t *testing.T) {
 	// One table in a schema.
 	info = infoschema.MockInfoSchema([]*model.TableInfo{core.MockSignedTable()})
 	rc = httptest.NewRecorder()
-	tbs = info.SchemaTables(model.NewCIStr("test"))
+	tbs = info.SchemaTableInfos(model.NewCIStr("test"))
 	require.Equal(t, 1, len(tbs))
 	tikvhandler.WriteDBTablesData(rc, tbs)
 	decoder = json.NewDecoder(rc.Body)
 	err = decoder.Decode(&ti)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(ti))
-	require.Equal(t, ti[0].ID, tbs[0].Meta().ID)
-	require.Equal(t, ti[0].Name.String(), tbs[0].Meta().Name.String())
+	require.Equal(t, ti[0].ID, tbs[0].ID)
+	require.Equal(t, ti[0].Name.String(), tbs[0].Name.String())
 
 	// Two tables in a schema.
 	info = infoschema.MockInfoSchema([]*model.TableInfo{core.MockSignedTable(), core.MockUnsignedTable()})
 	rc = httptest.NewRecorder()
-	tbs = info.SchemaTables(model.NewCIStr("test"))
+	tbs = info.SchemaTableInfos(model.NewCIStr("test"))
 	require.Equal(t, 2, len(tbs))
 	tikvhandler.WriteDBTablesData(rc, tbs)
 	decoder = json.NewDecoder(rc.Body)
 	err = decoder.Decode(&ti)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(ti))
-	require.Equal(t, ti[0].ID, tbs[0].Meta().ID)
-	require.Equal(t, ti[1].ID, tbs[1].Meta().ID)
-	require.Equal(t, ti[0].Name.String(), tbs[0].Meta().Name.String())
-	require.Equal(t, ti[1].Name.String(), tbs[1].Meta().Name.String())
+	require.Equal(t, ti[0].ID, tbs[0].ID)
+	require.Equal(t, ti[1].ID, tbs[1].ID)
+	require.Equal(t, ti[0].Name.String(), tbs[0].Name.String())
+	require.Equal(t, ti[1].Name.String(), tbs[1].Name.String())
 }
 
 func TestSetLabels(t *testing.T) {

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -922,7 +922,7 @@ func (h SchemaStorageHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 // For every table in the input, we marshal them. The result such as {tb1} {tb2} {tb3}.
 // Then we add some bytes to make it become [{tb1}, {tb2}, {tb3}], so we can unmarshal it to []*model.TableInfo.
 // Note: It would return StatusOK even if errors occur. But if errors occur, there must be some bugs.
-func WriteDBTablesData(w http.ResponseWriter, tbs []table.Table) {
+func WriteDBTablesData(w http.ResponseWriter, tbs []*model.TableInfo) {
 	if len(tbs) == 0 {
 		handler.WriteData(w, []*model.TableInfo{})
 		return
@@ -946,7 +946,7 @@ func WriteDBTablesData(w http.ResponseWriter, tbs []table.Table) {
 		} else {
 			init = true
 		}
-		js, err := json.MarshalIndent(tb.Meta(), "", " ")
+		js, err := json.MarshalIndent(tb, "", " ")
 		if err != nil {
 			terror.Log(errors.Trace(err))
 			return
@@ -987,7 +987,7 @@ func (h SchemaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		// all table schemas in a specified database
 		if schema.SchemaExists(cDBName) {
-			tbs := schema.SchemaTables(cDBName)
+			tbs := schema.SchemaTableInfos(cDBName)
 			WriteDBTablesData(w, tbs)
 			return
 		}
@@ -1007,7 +1007,7 @@ func (h SchemaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		if data, ok := schema.TableByID(int64(tid)); ok {
-			handler.WriteData(w, data.Meta())
+			handler.WriteData(w, data)
 			return
 		}
 		// The tid maybe a partition ID of the partition-table.
@@ -1016,7 +1016,7 @@ func (h SchemaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			handler.WriteError(w, infoschema.ErrTableNotExists.GenWithStack("Table which ID = %s does not exist.", tableID))
 			return
 		}
-		handler.WriteData(w, tbl.Meta())
+		handler.WriteData(w, tbl)
 		return
 	}
 

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -1007,7 +1007,7 @@ func (h SchemaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		if data, ok := schema.TableByID(int64(tid)); ok {
-			handler.WriteData(w, data)
+			handler.WriteData(w, data.Meta())
 			return
 		}
 		// The tid maybe a partition ID of the partition-table.

--- a/pkg/statistics/handle/util/table_info.go
+++ b/pkg/statistics/handle/util/table_info.go
@@ -60,9 +60,8 @@ func (c *tableInfoGetterImpl) TableInfoByID(is infoschema.InfoSchema, physicalID
 func buildPartitionID2TableID(is infoschema.InfoSchema) map[int64]int64 {
 	mapper := make(map[int64]int64)
 	for _, dbName := range is.AllSchemaNames() {
-		tbls := is.SchemaTables(dbName)
+		tbls := is.SchemaTableInfos(dbName)
 		for _, tbl := range tbls {
-			tbl := tbl.Meta()
 			pi := tbl.GetPartitionInfo()
 			if pi == nil {
 				continue

--- a/pkg/ttl/cache/infoschema.go
+++ b/pkg/ttl/cache/infoschema.go
@@ -50,8 +50,7 @@ func (isc *InfoSchemaCache) Update(se session.Session) error {
 
 	newTables := make(map[int64]*PhysicalTable, len(isc.Tables))
 	for _, dbName := range is.AllSchemaNames() {
-		for _, tbl := range is.SchemaTables(dbName) {
-			tblInfo := tbl.Meta()
+		for _, tblInfo := range is.SchemaTableInfos(dbName) {
 			if tblInfo.TTLInfo == nil || !tblInfo.TTLInfo.Enable || tblInfo.State != model.StatePublic {
 				continue
 			}

--- a/pkg/ttl/ttlworker/job_manager.go
+++ b/pkg/ttl/ttlworker/job_manager.go
@@ -1064,8 +1064,7 @@ GROUP BY
 
 	noRecordTables := make([]string, 0)
 	for _, dbName := range is.AllSchemaNames() {
-		for _, tbl := range is.SchemaTables(dbName) {
-			tblInfo := tbl.Meta()
+		for _, tblInfo := range is.SchemaTableInfos(dbName) {
 			if tblInfo.TTLInfo == nil {
 				continue
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50959 

Problem Summary:

### What changed and how does it work?

1. Change some calling from `SchemaTables()` to `SchemaTableInfos()`

`SchemaTables()` is heavier than `SchemaTableInfos()` because the former need to load model.TableInfo from meta kv first and then build `table.Table` from `model.TableInfo`

The caller only need the `model.TableInfo`, so change them to `SchemaTableInfos`.

2. Reset Tables field of model.DBInfo when adding it to infoschema v2

I found some leaky memory occupation in infoschema v2:
![image23](https://github.com/pingcap/tidb/assets/1420062/1f9a9b04-96c3-4826-82ac-684caefa693b)

It turn out to be that the `model.DBInfo` reference the Tables, so the memoy of json data can not be freed.

3. Skip refill cache In `SchemaTables()` 

Fill cache in the list API cause the memory thrash and also CPU thrash.
Especally I find the cost of `Sizeof()` is much higher than estimated. 
When we add to cache or evict cache, we need to call `Sizeof()` to calculate the size of an object.
Skip refill cache in `SchemaTables()` can avoid much of that.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

I create a lot of partition tables and watch the memory usage.
The first issue is co-exist of infoschema v1 and v2, cause the memory usage doubled. 
We can workaround it by setting `DefTiDBSchemaCacheSize > 0` rather than setting `@@global.tidb_schema_cache_size`.  (not done in this pull request)

![image15](https://github.com/pingcap/tidb/assets/1420062/ffb6e84b-50aa-4d56-8ca2-2d9ba885b075)

The second to third red square in the picture above shows the effect of this pull request.




- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
