### PR TITLE
remove sender for coprocessor with small number of tasks

### DIFF
--- a/pkg/store/copr/copr_test/coprocessor_test.go
+++ b/pkg/store/copr/copr_test/coprocessor_test.go
@@ -52,7 +52,7 @@ func TestBuildCopIteratorWithRowCountHint(t *testing.T) {
 	conc, smallConc := it.GetConcurrency()
 	rateLimit := it.GetSendRate()
 	require.Equal(t, conc, 1)
-	require.Equal(t, smallConc, 1)
+	require.Equal(t, smallConc, 3)
 	require.Equal(t, rateLimit.GetCapacity(), 2)
 
 	ranges = copr.BuildKeyRanges("a", "c", "d", "e", "h", "x", "y", "z")

--- a/pkg/store/copr/copr_test/coprocessor_test.go
+++ b/pkg/store/copr/copr_test/coprocessor_test.go
@@ -45,21 +45,21 @@ func TestBuildCopIteratorWithRowCountHint(t *testing.T) {
 	req := &kv.Request{
 		Tp:          kv.ReqTypeDAG,
 		KeyRanges:   kv.NewNonParitionedKeyRangesWithHint(ranges, []int{1, 1, 3, copr.CopSmallTaskRow}),
-		Concurrency: 15,
+		Concurrency: 1,
 	}
 	it, errRes := copClient.BuildCopIterator(ctx, req, vars, opt)
 	require.Nil(t, errRes)
 	conc, smallConc := it.GetConcurrency()
 	rateLimit := it.GetSendRate()
 	require.Equal(t, conc, 1)
-	require.Equal(t, smallConc, 3)
+	require.Equal(t, smallConc, 1)
 	require.Equal(t, rateLimit.GetCapacity(), 2)
 
 	ranges = copr.BuildKeyRanges("a", "c", "d", "e", "h", "x", "y", "z")
 	req = &kv.Request{
 		Tp:          kv.ReqTypeDAG,
 		KeyRanges:   kv.NewNonParitionedKeyRangesWithHint(ranges, []int{1, 1, 3, 3}),
-		Concurrency: 15,
+		Concurrency: 1,
 	}
 	it, errRes = copClient.BuildCopIterator(ctx, req, vars, opt)
 	require.Nil(t, errRes)
@@ -74,7 +74,7 @@ func TestBuildCopIteratorWithRowCountHint(t *testing.T) {
 	req = &kv.Request{
 		Tp:          kv.ReqTypeDAG,
 		KeyRanges:   kv.NewNonParitionedKeyRangesWithHint(ranges, []int{10}),
-		Concurrency: 15,
+		Concurrency: 1,
 	}
 	it, errRes = copClient.BuildCopIterator(ctx, req, vars, opt)
 	require.Nil(t, errRes)

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -205,9 +205,9 @@ func (c *CopClient) BuildCopIterator(ctx context.Context, req *kv.Request, vars 
 	if it.concurrency > len(tasks) {
 		it.concurrency = len(tasks)
 	}
+	var smallTasks int
 	if tryRowHint {
-		var smallTasks int
-		smallTasks, it.smallTaskConcurrency = smallTaskConcurrency(tasks, c.store.numcpu)
+		smallTasks, it.smallTaskConcurrency = smallTaskConcurrency(req, tasks, c.store.numcpu)
 		if len(tasks)-smallTasks < it.concurrency {
 			it.concurrency = len(tasks) - smallTasks
 		}
@@ -216,7 +216,6 @@ func (c *CopClient) BuildCopIterator(ctx context.Context, req *kv.Request, vars 
 		// Make sure that there is at least one worker.
 		it.concurrency = 1
 	}
-
 	if it.req.KeepOrder {
 		// Don't set high concurrency for the keep order case. It wastes a lot of memory and gains nothing.
 		// TL;DR
@@ -252,6 +251,10 @@ func (c *CopClient) BuildCopIterator(ctx context.Context, req *kv.Request, vars 
 		it.respChan = make(chan *copResponse)
 		it.sendRate = util.NewRateLimit(it.concurrency + it.smallTaskConcurrency)
 	}
+
+	it.skipSender = smallTasks == it.smallTaskConcurrency &&
+		len(tasks) <= it.concurrency+it.smallTaskConcurrency &&
+		len(tasks) <= it.sendRate.GetCapacity()
 	it.actionOnExceed = newRateLimitAction(uint(it.sendRate.GetCapacity()))
 	return it, nil
 }
@@ -634,15 +637,15 @@ func isSmallTask(task *copTask) bool {
 
 // smallTaskConcurrency counts the small tasks of tasks,
 // then returns the task count and extra concurrency for small tasks.
-func smallTaskConcurrency(tasks []*copTask, numcpu int) (int, int) {
+func smallTaskConcurrency(req *kv.Request, tasks []*copTask, numcpu int) (int, int) {
 	res := 0
 	for _, task := range tasks {
 		if isSmallTask(task) {
 			res++
 		}
 	}
-	if res == 0 {
-		return 0, 0
+	if res < req.Concurrency {
+		return res, res
 	}
 	// Calculate the extra concurrency for small tasks
 	// extra concurrency = tasks / (1 + sigma * sqrt(log(tasks ^ 2)))
@@ -676,6 +679,7 @@ type copIterator struct {
 
 	// If keepOrder, results are stored in copTask.respChan, read them out one by one.
 	tasks []*copTask
+
 	// curr indicates the curr id of the finished copTask
 	curr int
 
@@ -711,6 +715,9 @@ type copIterator struct {
 
 	runawayChecker  *resourcegroup.RunawayChecker
 	unconsumedStats *unconsumedCopRuntimeStats
+
+	// skipSender indicates whether opening a sender in an individual goroutine.
+	skipSender bool
 }
 
 // copIteratorWorker receives tasks from copIteratorTaskSender, handles tasks and sends the copResponse to respChan.
@@ -840,11 +847,52 @@ func (worker *copIteratorWorker) run(ctx context.Context) {
 	}
 }
 
+// runWithTask is a worker function which doesn't receive task from channel, run it directly instead.
+func (worker *copIteratorWorker) runWithTask(ctx context.Context, task *copTask) {
+	defer func() {
+		failpoint.Inject("ticase-4169", func(val failpoint.Value) {
+			if val.(bool) {
+				worker.memTracker.Consume(10 * MockResponseSizeForTest)
+				worker.memTracker.Consume(10 * MockResponseSizeForTest)
+			}
+		})
+	}()
+	respCh := worker.respChan
+	if respCh == nil {
+		respCh = task.respChan
+	}
+	worker.handleTask(ctx, task, respCh)
+	if worker.respChan != nil {
+		// When a task is finished by the worker, send a finCopResp into channel to notify the copIterator that
+		// there is a task finished.
+		worker.sendToRespCh(finCopResp, worker.respChan, false)
+	}
+	if task.respChan != nil {
+		close(task.respChan)
+	}
+}
+
 // open starts workers and sender goroutines.
 func (it *copIterator) open(ctx context.Context, enabledRateLimitAction, enableCollectExecutionInfo bool) {
+	it.unconsumedStats = &unconsumedCopRuntimeStats{}
+	// try skip sender goroutine
+	if it.skipSender {
+		var waitFor atomic.Int64
+		waitFor.Add(int64(len(it.tasks)))
+		for _, task := range it.tasks {
+			worker := it.buildCopWorker(nil, enableCollectExecutionInfo)
+			go func(task *copTask) {
+				it.sendRate.GetToken(it.finishCh)
+				worker.runWithTask(ctx, task)
+				if waitFor.Add(-1) == 0 && it.respChan != nil {
+					close(it.respChan)
+				}
+			}(task)
+		}
+		return
+	}
 	taskCh := make(chan *copTask, 1)
 	smallTaskCh := make(chan *copTask, 1)
-	it.unconsumedStats = &unconsumedCopRuntimeStats{}
 	it.wg.Add(it.concurrency + it.smallTaskConcurrency)
 	// Start it.concurrency number of workers to handle cop requests.
 	for i := 0; i < it.concurrency+it.smallTaskConcurrency; i++ {
@@ -854,23 +902,7 @@ func (it *copIterator) open(ctx context.Context, enabledRateLimitAction, enableC
 		} else {
 			ch = smallTaskCh
 		}
-		worker := &copIteratorWorker{
-			taskCh:                     ch,
-			wg:                         &it.wg,
-			store:                      it.store,
-			req:                        it.req,
-			respChan:                   it.respChan,
-			finishCh:                   it.finishCh,
-			vars:                       it.vars,
-			kvclient:                   txnsnapshot.NewClientHelper(it.store.store, &it.resolvedLocks, &it.committedLocks, false),
-			memTracker:                 it.memTracker,
-			replicaReadSeed:            it.replicaReadSeed,
-			enableCollectExecutionInfo: enableCollectExecutionInfo,
-			pagingTaskIdx:              &it.pagingTaskIdx,
-			storeBatchedNum:            &it.storeBatchedNum,
-			storeBatchedFallbackNum:    &it.storeBatchedFallbackNum,
-			unconsumedStats:            it.unconsumedStats,
-		}
+		worker := it.buildCopWorker(ch, enableCollectExecutionInfo)
 		go worker.run(ctx)
 	}
 	taskSender := &copIteratorTaskSender{
@@ -890,6 +922,26 @@ func (it *copIterator) open(ctx context.Context, enabledRateLimitAction, enableC
 		}
 	})
 	go taskSender.run(it.req.ConnID)
+}
+
+func (it *copIterator) buildCopWorker(ch <-chan *copTask, enableCollectExecutionInfo bool) *copIteratorWorker {
+	return &copIteratorWorker{
+		taskCh:                     ch,
+		wg:                         &it.wg,
+		store:                      it.store,
+		req:                        it.req,
+		respChan:                   it.respChan,
+		finishCh:                   it.finishCh,
+		vars:                       it.vars,
+		kvclient:                   txnsnapshot.NewClientHelper(it.store.store, &it.resolvedLocks, &it.committedLocks, false),
+		memTracker:                 it.memTracker,
+		replicaReadSeed:            it.replicaReadSeed,
+		enableCollectExecutionInfo: enableCollectExecutionInfo,
+		pagingTaskIdx:              &it.pagingTaskIdx,
+		storeBatchedNum:            &it.storeBatchedNum,
+		storeBatchedFallbackNum:    &it.storeBatchedFallbackNum,
+		unconsumedStats:            it.unconsumedStats,
+	}
 }
 
 func (sender *copIteratorTaskSender) run(connID uint64) {

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -679,7 +679,6 @@ type copIterator struct {
 
 	// If keepOrder, results are stored in copTask.respChan, read them out one by one.
 	tasks []*copTask
-
 	// curr indicates the curr id of the finished copTask
 	curr int
 

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -644,7 +644,7 @@ func smallTaskConcurrency(req *kv.Request, tasks []*copTask, numcpu int) (int, i
 			res++
 		}
 	}
-	if res < req.Concurrency {
+	if res <= req.Concurrency {
 		return res, res
 	}
 	// Calculate the extra concurrency for small tasks

--- a/pkg/store/copr/coprocessor_test.go
+++ b/pkg/store/copr/coprocessor_test.go
@@ -843,7 +843,7 @@ func TestBuildCopTasksWithRowCountHint(t *testing.T) {
 	require.Equal(t, tasks[2].RowCountHint, 3)
 	// task[3] ["t"-"x", "y"-"z"]
 	require.Equal(t, tasks[3].RowCountHint, 6)
-	_, conc = smallTaskConcurrency(&kv.Request{Concurrency: 15}, tasks, 16)
+	_, conc = smallTaskConcurrency(&kv.Request{Concurrency: 1}, tasks, 16)
 	require.Equal(t, conc, 2)
 
 	// cross-region long range
@@ -873,11 +873,11 @@ func TestSmallTaskConcurrencyLimit(t *testing.T) {
 			RowCountHint: 1,
 		})
 	}
-	count, conc := smallTaskConcurrency(&kv.Request{Concurrency: 15}, tasks, 1)
+	count, conc := smallTaskConcurrency(&kv.Request{Concurrency: 1}, tasks, 1)
 	require.Equal(t, smallConcPerCore, conc)
 	require.Equal(t, smallTaskCount, count)
 	// also handle 0 value.
-	count, conc = smallTaskConcurrency(&kv.Request{Concurrency: 15}, tasks, 0)
+	count, conc = smallTaskConcurrency(&kv.Request{Concurrency: 1}, tasks, 0)
 	require.Equal(t, smallConcPerCore, conc)
 	require.Equal(t, smallTaskCount, count)
 }

--- a/pkg/store/copr/coprocessor_test.go
+++ b/pkg/store/copr/coprocessor_test.go
@@ -824,7 +824,7 @@ func TestBuildCopTasksWithRowCountHint(t *testing.T) {
 	require.Equal(t, tasks[2].RowCountHint, 3)
 	// task[3] ["t"-"x", "y"-"z"]
 	require.Equal(t, tasks[3].RowCountHint, 3+CopSmallTaskRow)
-	_, conc := smallTaskConcurrency(&kv.Request{Concurrency: 15}, tasks, 16)
+	_, conc := smallTaskConcurrency(&kv.Request{Concurrency: 1}, tasks, 16)
 	require.Equal(t, conc, 1)
 
 	ranges = buildCopRanges("a", "c", "d", "e", "h", "x", "y", "z")

--- a/pkg/store/copr/coprocessor_test.go
+++ b/pkg/store/copr/coprocessor_test.go
@@ -786,7 +786,7 @@ func TestBasicSmallTaskConc(t *testing.T) {
 	require.True(t, isSmallTask(&copTask{RowCountHint: 6}))
 	require.True(t, isSmallTask(&copTask{RowCountHint: CopSmallTaskRow}))
 	require.False(t, isSmallTask(&copTask{RowCountHint: CopSmallTaskRow + 1}))
-	_, conc := smallTaskConcurrency([]*copTask{}, 16)
+	_, conc := smallTaskConcurrency(&kv.Request{Concurrency: 15}, []*copTask{}, 16)
 	require.GreaterOrEqual(t, conc, 0)
 }
 
@@ -824,7 +824,7 @@ func TestBuildCopTasksWithRowCountHint(t *testing.T) {
 	require.Equal(t, tasks[2].RowCountHint, 3)
 	// task[3] ["t"-"x", "y"-"z"]
 	require.Equal(t, tasks[3].RowCountHint, 3+CopSmallTaskRow)
-	_, conc := smallTaskConcurrency(tasks, 16)
+	_, conc := smallTaskConcurrency(&kv.Request{Concurrency: 15}, tasks, 16)
 	require.Equal(t, conc, 1)
 
 	ranges = buildCopRanges("a", "c", "d", "e", "h", "x", "y", "z")
@@ -843,7 +843,7 @@ func TestBuildCopTasksWithRowCountHint(t *testing.T) {
 	require.Equal(t, tasks[2].RowCountHint, 3)
 	// task[3] ["t"-"x", "y"-"z"]
 	require.Equal(t, tasks[3].RowCountHint, 6)
-	_, conc = smallTaskConcurrency(tasks, 16)
+	_, conc = smallTaskConcurrency(&kv.Request{Concurrency: 15}, tasks, 16)
 	require.Equal(t, conc, 2)
 
 	// cross-region long range
@@ -873,11 +873,11 @@ func TestSmallTaskConcurrencyLimit(t *testing.T) {
 			RowCountHint: 1,
 		})
 	}
-	count, conc := smallTaskConcurrency(tasks, 1)
+	count, conc := smallTaskConcurrency(&kv.Request{Concurrency: 15}, tasks, 1)
 	require.Equal(t, smallConcPerCore, conc)
 	require.Equal(t, smallTaskCount, count)
 	// also handle 0 value.
-	count, conc = smallTaskConcurrency(tasks, 0)
+	count, conc = smallTaskConcurrency(&kv.Request{Concurrency: 15}, tasks, 0)
 	require.Equal(t, smallConcPerCore, conc)
 	require.Equal(t, smallTaskCount, count)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53250

Problem Summary:

When the number of coprocessos tasks is lower than concurrency limitation, wecan simply handle it with worker, which reduce latency form bypassing sender and the channel between sender and worker.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Optimze latency for coprocessor with query over small ranges.
```
