### PR TITLE
*: adaptively control analyze distsql concurrency 

### DIFF
--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -529,6 +529,9 @@ func (e *AnalyzeColumnsExecV2) buildSubIndexJobForSpecialIndex(indexInfos []*mod
 	tasks := make([]*analyzeTask, 0, len(indexInfos))
 	sc := e.ctx.GetSessionVars().StmtCtx
 	concurrency := e.ctx.GetSessionVars().AnalyzeDistSQLScanConcurrency()
+	if concurrency <= 0 {
+		concurrency = adaptiveAnlayzeDistSQLConcurrency(context.Background(), e.ctx)
+	}
 	for _, indexInfo := range indexInfos {
 		base := baseAnalyzeExec{
 			ctx:         e.ctx,

--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -528,10 +528,7 @@ func (e *AnalyzeColumnsExecV2) buildSubIndexJobForSpecialIndex(indexInfos []*mod
 	_, offset := timeutil.Zone(e.ctx.GetSessionVars().Location())
 	tasks := make([]*analyzeTask, 0, len(indexInfos))
 	sc := e.ctx.GetSessionVars().StmtCtx
-	concurrency := e.ctx.GetSessionVars().AnalyzeDistSQLScanConcurrency()
-	if concurrency <= 0 {
-		concurrency = adaptiveAnlayzeDistSQLConcurrency(context.Background(), e.ctx)
-	}
+	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), e.ctx)
 	for _, indexInfo := range indexInfos {
 		base := baseAnalyzeExec{
 			ctx:         e.ctx,

--- a/pkg/executor/analyze_utils.go
+++ b/pkg/executor/analyze_utils.go
@@ -33,6 +33,10 @@ import (
 )
 
 func adaptiveAnlayzeDistSQLConcurrency(ctx context.Context, sctx sessionctx.Context) int {
+	concurrency := sctx.GetSessionVars().AnalyzeDistSQLScanConcurrency()
+	if concurrency > 0 {
+		return concurrency
+	}
 	tikvStore, ok := sctx.GetStore().(helper.Storage)
 	if !ok {
 		logutil.BgLogger().Warn("Information about TiKV store status can be gotten only when the storage is TiKV")

--- a/pkg/executor/analyze_utils.go
+++ b/pkg/executor/analyze_utils.go
@@ -24,10 +24,45 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics"
+	"github.com/pingcap/tidb/pkg/store/helper"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/tiancaiamao/gp"
 	"go.uber.org/atomic"
+	"go.uber.org/zap"
 )
+
+func adaptiveAnlayzeDistSQLConcurrency(ctx context.Context, sctx sessionctx.Context) int {
+	tikvStore, ok := sctx.GetStore().(helper.Storage)
+	if !ok {
+		logutil.BgLogger().Warn("Information about TiKV store status can be gotten only when the storage is TiKV")
+		return variable.DefAnalyzeDistSQLScanConcurrency
+	}
+	tikvHelper := &helper.Helper{
+		Store:       tikvStore,
+		RegionCache: tikvStore.GetRegionCache(),
+	}
+	pdCli, err := tikvHelper.TryGetPDHTTPClient()
+	if err != nil {
+		logutil.BgLogger().Warn("fail to TryGetPDHTTPClient", zap.Error(err))
+		return variable.DefAnalyzeDistSQLScanConcurrency
+	}
+	storesStat, err := pdCli.GetStores(ctx)
+	if err != nil {
+		logutil.BgLogger().Warn("fail to get stores info", zap.Error(err))
+		return variable.DefAnalyzeDistSQLScanConcurrency
+	}
+	if storesStat.Count <= 5 {
+		return variable.DefAnalyzeDistSQLScanConcurrency
+	} else if storesStat.Count <= 10 {
+		return storesStat.Count
+	} else if storesStat.Count <= 20 {
+		return storesStat.Count * 2
+	} else if storesStat.Count <= 50 {
+		return storesStat.Count * 3
+	}
+	return storesStat.Count * 4
+}
 
 func getIntFromSessionVars(ctx sessionctx.Context, name string) (int, error) {
 	sessionVars := ctx.GetSessionVars()

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -2492,6 +2492,9 @@ func (b *executorBuilder) buildAnalyzeIndexPushdown(task plannercore.AnalyzeInde
 		startTS = uint64(val.(int))
 	})
 	concurrency := b.ctx.GetSessionVars().AnalyzeDistSQLScanConcurrency()
+	if concurrency <= 0 {
+		concurrency = adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.ctx)
+	}
 	base := baseAnalyzeExec{
 		ctx:         b.ctx,
 		tableID:     task.TableID,
@@ -2609,6 +2612,9 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 		SampleRateReason: sampleRateReason,
 	}
 	concurrency := b.ctx.GetSessionVars().AnalyzeDistSQLScanConcurrency()
+	if concurrency <= 0 {
+		concurrency = adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.ctx)
+	}
 	base := baseAnalyzeExec{
 		ctx:         b.ctx,
 		tableID:     task.TableID,
@@ -2743,6 +2749,9 @@ func (b *executorBuilder) buildAnalyzeColumnsPushdown(
 		startTS = uint64(val.(int))
 	})
 	concurrency := b.ctx.GetSessionVars().AnalyzeDistSQLScanConcurrency()
+	if concurrency <= 0 {
+		concurrency = adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.ctx)
+	}
 	base := baseAnalyzeExec{
 		ctx:         b.ctx,
 		tableID:     task.TableID,

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -2491,10 +2491,7 @@ func (b *executorBuilder) buildAnalyzeIndexPushdown(task plannercore.AnalyzeInde
 	failpoint.Inject("injectAnalyzeSnapshot", func(val failpoint.Value) {
 		startTS = uint64(val.(int))
 	})
-	concurrency := b.ctx.GetSessionVars().AnalyzeDistSQLScanConcurrency()
-	if concurrency <= 0 {
-		concurrency = adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.ctx)
-	}
+	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.ctx)
 	base := baseAnalyzeExec{
 		ctx:         b.ctx,
 		tableID:     task.TableID,
@@ -2611,10 +2608,7 @@ func (b *executorBuilder) buildAnalyzeSamplingPushdown(
 		PartitionName:    task.PartitionName,
 		SampleRateReason: sampleRateReason,
 	}
-	concurrency := b.ctx.GetSessionVars().AnalyzeDistSQLScanConcurrency()
-	if concurrency <= 0 {
-		concurrency = adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.ctx)
-	}
+	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.ctx)
 	base := baseAnalyzeExec{
 		ctx:         b.ctx,
 		tableID:     task.TableID,
@@ -2748,10 +2742,7 @@ func (b *executorBuilder) buildAnalyzeColumnsPushdown(
 	failpoint.Inject("injectAnalyzeSnapshot", func(val failpoint.Value) {
 		startTS = uint64(val.(int))
 	})
-	concurrency := b.ctx.GetSessionVars().AnalyzeDistSQLScanConcurrency()
-	if concurrency <= 0 {
-		concurrency = adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.ctx)
-	}
+	concurrency := adaptiveAnlayzeDistSQLConcurrency(context.Background(), b.ctx)
 	base := baseAnalyzeExec{
 		ctx:         b.ctx,
 		tableID:     task.TableID,

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1366,7 +1366,7 @@ var defaultSysVars = []*SysVar{
 		return BoolToOnOff(EnableTmpStorageOnOOM.Load()), nil
 	}},
 	{Scope: ScopeGlobal, Name: TiDBAutoBuildStatsConcurrency, Value: strconv.Itoa(DefTiDBAutoBuildStatsConcurrency), Type: TypeInt, MinValue: 1, MaxValue: MaxConfigurableConcurrency},
-	{Scope: ScopeGlobal, Name: TiDBSysProcScanConcurrency, Value: strconv.Itoa(DefTiDBSysProcScanConcurrency), Type: TypeInt, MinValue: 1, MaxValue: math.MaxInt32},
+	{Scope: ScopeGlobal, Name: TiDBSysProcScanConcurrency, Value: strconv.Itoa(DefTiDBSysProcScanConcurrency), Type: TypeInt, MinValue: 0, MaxValue: math.MaxInt32},
 	{Scope: ScopeGlobal, Name: TiDBMemoryUsageAlarmRatio, Value: strconv.FormatFloat(DefMemoryUsageAlarmRatio, 'f', -1, 64), Type: TypeFloat, MinValue: 0.0, MaxValue: 1.0, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		MemoryUsageAlarmRatio.Store(tidbOptFloat64(val, DefMemoryUsageAlarmRatio))
 		return nil
@@ -1821,7 +1821,7 @@ var defaultSysVars = []*SysVar{
 		s.distSQLScanConcurrency = tidbOptPositiveInt32(val, DefDistSQLScanConcurrency)
 		return nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBAnalyzeDistSQLScanConcurrency, Value: strconv.Itoa(DefAnalyzeDistSQLScanConcurrency), Type: TypeUnsigned, MinValue: 1, MaxValue: math.MaxInt32, SetSession: func(s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBAnalyzeDistSQLScanConcurrency, Value: strconv.Itoa(DefAnalyzeDistSQLScanConcurrency), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxInt32, SetSession: func(s *SessionVars, val string) error {
 		s.analyzeDistSQLScanConcurrency = tidbOptPositiveInt32(val, DefAnalyzeDistSQLScanConcurrency)
 		return nil
 	}},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53262

Problem Summary:

### What changed and how does it work?

When tidb cluster is larger and larger, the concurrency of the analyze scan should be larger to have a better performance. so we should make analyze_distsql_scan_concurrency adaptive.

BTW, Even a fourfold increase in concurrency seems conservative; for some customers, the actual concurrency is a thousand times the default value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
