### PR TITLE
planner: move checks for noop functions in select statements to preprocess

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4039,16 +4039,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 			return nil, plannererrors.ErrCTERecursiveForbidsAggregation.FastGenByArgs(b.genCTETableNameForError())
 		}
 	}
-	noopFuncsMode := b.ctx.GetSessionVars().NoopFuncsMode
 	if sel.SelectStmtOpts != nil {
-		if sel.SelectStmtOpts.CalcFoundRows && noopFuncsMode != variable.OnInt {
-			err = expression.ErrFunctionsNoopImpl.GenWithStackByArgs("SQL_CALC_FOUND_ROWS")
-			if noopFuncsMode == variable.OffInt {
-				return nil, err
-			}
-			// NoopFuncsMode is Warn, append an error
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
-		}
 		origin := b.inStraightJoin
 		b.inStraightJoin = sel.SelectStmtOpts.StraightJoin
 		defer func() { b.inStraightJoin = origin }()
@@ -4188,14 +4179,6 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 	}
 	l := sel.LockInfo
 	if l != nil && l.LockType != ast.SelectLockNone {
-		if l.LockType == ast.SelectLockForShare && noopFuncsMode != variable.OnInt {
-			err = expression.ErrFunctionsNoopImpl.GenWithStackByArgs("LOCK IN SHARE MODE")
-			if noopFuncsMode == variable.OffInt {
-				return nil, err
-			}
-			// NoopFuncsMode is Warn, append an error
-			b.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
-		}
 		for _, tName := range l.Tables {
 			// CTE has no *model.HintedTable, we need to skip it.
 			if tName.TableInfo == nil {

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -243,6 +243,7 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 		if node.With != nil {
 			p.preprocessWith.cteStack = append(p.preprocessWith.cteStack, node.With.CTEs)
 		}
+		p.checkSelectNoopFuncs(node)
 	case *ast.SetOprStmt:
 		if node.With != nil {
 			p.preprocessWith.cteStack = append(p.preprocessWith.cteStack, node.With.CTEs)
@@ -1149,6 +1150,31 @@ func (p *preprocessor) checkCreateIndexGrammar(stmt *ast.CreateIndexStmt) {
 		return
 	}
 	p.err = checkIndexInfo(stmt.IndexName, stmt.IndexPartSpecifications)
+}
+
+func (p *preprocessor) checkSelectNoopFuncs(stmt *ast.SelectStmt) {
+	noopFuncsMode := p.sctx.GetSessionVars().NoopFuncsMode
+	if noopFuncsMode == variable.OnInt {
+		return
+	}
+	if stmt.SelectStmtOpts != nil && stmt.SelectStmtOpts.CalcFoundRows {
+		err := expression.ErrFunctionsNoopImpl.GenWithStackByArgs("SQL_CALC_FOUND_ROWS")
+		if noopFuncsMode == variable.OffInt {
+			p.err = err
+			return
+		}
+		// NoopFuncsMode is Warn, append an error
+		p.sctx.GetSessionVars().StmtCtx.AppendWarning(err)
+	}
+	if stmt.LockInfo != nil && stmt.LockInfo.LockType == ast.SelectLockForShare {
+		err := expression.ErrFunctionsNoopImpl.GenWithStackByArgs("LOCK IN SHARE MODE")
+		if noopFuncsMode == variable.OffInt {
+			p.err = err
+			return
+		}
+		// NoopFuncsMode is Warn, append an error
+		p.sctx.GetSessionVars().StmtCtx.AppendWarning(err)
+	}
 }
 
 func (p *preprocessor) checkGroupBy(stmt *ast.GroupByClause) {

--- a/tests/integrationtest/r/expression/noop_functions.result
+++ b/tests/integrationtest/r/expression/noop_functions.result
@@ -1,0 +1,41 @@
+set tidb_enable_non_prepared_plan_cache=0;
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3);
+SET @@tidb_enable_noop_functions='ON';
+SELECT SQL_CALC_FOUND_ROWS * FROM t1 LIMIT 1;
+a
+1
+SELECT * FROM t1 LOCK IN SHARE MODE;
+a
+1
+2
+3
+SELECT * FROM t1 WHERE a=1 LOCK IN SHARE MODE;
+a
+1
+SET @@tidb_enable_noop_functions='WARN';
+SELECT SQL_CALC_FOUND_ROWS * FROM t1 LIMIT 1;
+a
+1
+Level	Code	Message
+Warning	1235	function SQL_CALC_FOUND_ROWS has only noop implementation in tidb now, use tidb_enable_noop_functions to enable these functions
+SELECT * FROM t1 LOCK IN SHARE MODE;
+a
+1
+2
+3
+Level	Code	Message
+Warning	1235	function LOCK IN SHARE MODE has only noop implementation in tidb now, use tidb_enable_noop_functions to enable these functions
+SELECT * FROM t1 WHERE a=1 LOCK IN SHARE MODE;
+a
+1
+Level	Code	Message
+Warning	1235	function LOCK IN SHARE MODE has only noop implementation in tidb now, use tidb_enable_noop_functions to enable these functions
+SET @@tidb_enable_noop_functions='OFF';
+SELECT SQL_CALC_FOUND_ROWS * FROM t1 LIMIT 1;
+Error 1235 (42000): function SQL_CALC_FOUND_ROWS has only noop implementation in tidb now, use tidb_enable_noop_functions to enable these functions
+SELECT * FROM t1 LOCK IN SHARE MODE;
+Error 1235 (42000): function LOCK IN SHARE MODE has only noop implementation in tidb now, use tidb_enable_noop_functions to enable these functions
+SELECT * FROM t1 WHERE a=1 LOCK IN SHARE MODE;
+Error 1235 (42000): function LOCK IN SHARE MODE has only noop implementation in tidb now, use tidb_enable_noop_functions to enable these functions

--- a/tests/integrationtest/t/expression/noop_functions.test
+++ b/tests/integrationtest/t/expression/noop_functions.test
@@ -1,0 +1,26 @@
+# variable changes in the test will not affect the plan cache
+set tidb_enable_non_prepared_plan_cache=0;
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3);
+
+SET @@tidb_enable_noop_functions='ON';
+SELECT SQL_CALC_FOUND_ROWS * FROM t1 LIMIT 1;
+SELECT * FROM t1 LOCK IN SHARE MODE;
+# test the fast path for point-get queries
+SELECT * FROM t1 WHERE a=1 LOCK IN SHARE MODE;
+
+SET @@tidb_enable_noop_functions='WARN';
+--enable_warnings
+SELECT SQL_CALC_FOUND_ROWS * FROM t1 LIMIT 1;
+SELECT * FROM t1 LOCK IN SHARE MODE;
+SELECT * FROM t1 WHERE a=1 LOCK IN SHARE MODE;
+--disable_warnings
+
+SET @@tidb_enable_noop_functions='OFF';
+--error 1235
+SELECT SQL_CALC_FOUND_ROWS * FROM t1 LIMIT 1;
+--error 1235
+SELECT * FROM t1 LOCK IN SHARE MODE;
+--error 1235
+SELECT * FROM t1 WHERE a=1 LOCK IN SHARE MODE;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52432 

Problem Summary:

The `LOCK IN SHARE MODE` clause for `SELECT` statements is currently a noop, controlled by `tidb_enable_noop_functions`: when `tidb_enable_noop_functions=OFF`, using a noop like `LOCK IN SHARE MODE` should cause an error. However, point-get queries use a special "fast path" that accidentally bypasses this noop check, meaning that a query like `select * from t where a=1 lock in share mode;` (where `a` is a key column) will run even when `tidb_enable_noop_functions=OFF`.

### What changed and how does it work?

* Move the checks for noop functionality in `SELECT` statements (both `LOCK IN SHARE MODE` and `SQL_CALC_FOUND_ROWS`) out of `buildLogicalPlan` and into `Preprocess`, which runs before the `TryFastPlan` fast path for point-get queries.
* Add a new `noop_functions` test case to `integrationtest`, testing the noop function checks for both `LOCK IN SHARE MODE` and `SQL_CALC_FOUND_ROWS` based on the existing `TestNoopFunctions` "unit test" in `pkg/expression/integration_test/integration_test.go`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
