### PR TITLE
infoschema: speedup SchemaByID

### DIFF
--- a/pkg/infoschema/BUILD.bazel
+++ b/pkg/infoschema/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
     srcs = [
         "bench_test.go",
         "builder_test.go",
+        "infoschema_nokit_test.go",
         "infoschema_test.go",
         "infoschema_v2_test.go",
         "main_test.go",
@@ -86,7 +87,7 @@ go_test(
     ],
     embed = [":infoschema"],
     flaky = True,
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         "//pkg/ddl/placement",
         "//pkg/domain",

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -55,7 +55,10 @@ const bucketCount = 512
 
 type infoSchema struct {
 	infoSchemaMisc
-	schemaMap     map[string]*schemaTables
+	schemaMap map[string]*schemaTables
+	// schemaID2Name is a map from schema ID to schema name.
+	// it should be enough to query by name only theoretically, but there are some
+	// places we only have schema ID, and we check both name and id in some sanity checks.
 	schemaID2Name map[int64]string
 
 	// sortedTablesBuckets is a slice of sortedTables, a table's bucket index is (tableID % bucketCount).

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -55,7 +55,8 @@ const bucketCount = 512
 
 type infoSchema struct {
 	infoSchemaMisc
-	schemaMap map[string]*schemaTables
+	schemaMap     map[string]*schemaTables
+	schemaID2Name map[int64]string
 
 	// sortedTablesBuckets is a slice of sortedTables, a table's bucket index is (tableID % bucketCount).
 	sortedTablesBuckets []sortedTables
@@ -92,18 +93,13 @@ type SchemaAndTableName struct {
 
 // MockInfoSchema only serves for test.
 func MockInfoSchema(tbList []*model.TableInfo) InfoSchema {
-	result := &infoSchema{}
-	result.schemaMap = make(map[string]*schemaTables)
-	result.policyMap = make(map[string]*model.PolicyInfo)
-	result.resourceGroupMap = make(map[string]*model.ResourceGroupInfo)
-	result.ruleBundleMap = make(map[int64]*placement.Bundle)
-	result.sortedTablesBuckets = make([]sortedTables, bucketCount)
+	result := newInfoSchema()
 	dbInfo := &model.DBInfo{ID: 1, Name: model.NewCIStr("test"), Tables: tbList}
 	tableNames := &schemaTables{
 		dbInfo: dbInfo,
 		tables: make(map[string]table.Table),
 	}
-	result.schemaMap["test"] = tableNames
+	result.addSchema(tableNames)
 	var tableIDs map[int64]struct{}
 	for _, tb := range tbList {
 		intest.AssertFunc(func() bool {
@@ -131,18 +127,13 @@ func MockInfoSchema(tbList []*model.TableInfo) InfoSchema {
 
 // MockInfoSchemaWithSchemaVer only serves for test.
 func MockInfoSchemaWithSchemaVer(tbList []*model.TableInfo, schemaVer int64) InfoSchema {
-	result := &infoSchema{}
-	result.schemaMap = make(map[string]*schemaTables)
-	result.policyMap = make(map[string]*model.PolicyInfo)
-	result.resourceGroupMap = make(map[string]*model.ResourceGroupInfo)
-	result.ruleBundleMap = make(map[int64]*placement.Bundle)
-	result.sortedTablesBuckets = make([]sortedTables, bucketCount)
+	result := newInfoSchema()
 	dbInfo := &model.DBInfo{ID: 1, Name: model.NewCIStr("test"), Tables: tbList}
 	tableNames := &schemaTables{
 		dbInfo: dbInfo,
 		tables: make(map[string]table.Table),
 	}
-	result.schemaMap["test"] = tableNames
+	result.addSchema(tableNames)
 	for _, tb := range tbList {
 		tb.DBID = dbInfo.ID
 		tbl := table.MockTableFromMeta(tb)
@@ -163,6 +154,20 @@ var _ InfoSchema = (*infoSchema)(nil)
 
 func (is *infoSchema) base() *infoSchema {
 	return is
+}
+
+func newInfoSchema() *infoSchema {
+	return &infoSchema{
+		infoSchemaMisc: infoSchemaMisc{
+			policyMap:             map[string]*model.PolicyInfo{},
+			resourceGroupMap:      map[string]*model.ResourceGroupInfo{},
+			ruleBundleMap:         map[int64]*placement.Bundle{},
+			referredForeignKeyMap: make(map[SchemaAndTableName][]*model.ReferredFKInfo),
+		},
+		schemaMap:           map[string]*schemaTables{},
+		schemaID2Name:       map[int64]string{},
+		sortedTablesBuckets: make([]sortedTables, bucketCount),
+	}
 }
 
 func (is *infoSchema) SchemaByName(schema model.CIStr) (val *model.DBInfo, ok bool) {
@@ -231,12 +236,11 @@ func (is *infoSchema) PolicyByID(id int64) (val *model.PolicyInfo, ok bool) {
 }
 
 func (is *infoSchema) SchemaByID(id int64) (val *model.DBInfo, ok bool) {
-	for _, v := range is.schemaMap {
-		if v.dbInfo.ID == id {
-			return v.dbInfo, true
-		}
+	name, ok := is.schemaID2Name[id]
+	if !ok {
+		return nil, false
 	}
-	return nil, false
+	return is.SchemaByName(model.NewCIStr(name))
 }
 
 // SchemaByTable get a table's schema name
@@ -331,6 +335,18 @@ func (is *infoSchema) FindTableByPartitionID(partitionID int64) (table.Table, *m
 		}
 	}
 	return nil, nil, nil
+}
+
+// addSchema is used to add a schema to the infoSchema, it will overwrite the old
+// one if it already exists.
+func (is *infoSchema) addSchema(st *schemaTables) {
+	is.schemaMap[st.dbInfo.Name.L] = st
+	is.schemaID2Name[st.dbInfo.ID] = st.dbInfo.Name.L
+}
+
+func (is *infoSchema) delSchema(di *model.DBInfo) {
+	delete(is.schemaMap, di.Name.L)
+	delete(is.schemaID2Name, di.ID)
 }
 
 // HasTemporaryTable returns whether information schema has temporary table

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -174,7 +174,11 @@ func newInfoSchema() *infoSchema {
 }
 
 func (is *infoSchema) SchemaByName(schema model.CIStr) (val *model.DBInfo, ok bool) {
-	tableNames, ok := is.schemaMap[schema.L]
+	return is.schemaByName(schema.L)
+}
+
+func (is *infoSchema) schemaByName(name string) (val *model.DBInfo, ok bool) {
+	tableNames, ok := is.schemaMap[name]
 	if !ok {
 		return
 	}
@@ -243,7 +247,7 @@ func (is *infoSchema) SchemaByID(id int64) (val *model.DBInfo, ok bool) {
 	if !ok {
 		return nil, false
 	}
-	return is.SchemaByName(model.NewCIStr(name))
+	return is.schemaByName(name)
 }
 
 // SchemaByTable get a table's schema name

--- a/pkg/infoschema/infoschema_nokit_test.go
+++ b/pkg/infoschema/infoschema_nokit_test.go
@@ -27,10 +27,8 @@ func TestInfoSchemaAddDel(t *testing.T) {
 		dbInfo: &model.DBInfo{ID: 1, Name: model.NewCIStr("test")},
 	})
 	require.Contains(t, is.schemaMap, "test")
-	require.Contains(t, is.schemaID2Name, 1)
+	require.Contains(t, is.schemaID2Name, int64(1))
 	is.delSchema(&model.DBInfo{ID: 1, Name: model.NewCIStr("test")})
-	require.NotContains(t, is.schemaMap, "test")
-	require.NotContains(t, is.schemaID2Name, 1)
 	require.Empty(t, is.schemaMap)
 	require.Empty(t, is.schemaID2Name)
 }

--- a/pkg/infoschema/infoschema_nokit_test.go
+++ b/pkg/infoschema/infoschema_nokit_test.go
@@ -1,0 +1,36 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infoschema
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoSchemaAddDel(t *testing.T) {
+	is := newInfoSchema()
+	is.addSchema(&schemaTables{
+		dbInfo: &model.DBInfo{ID: 1, Name: model.NewCIStr("test")},
+	})
+	require.Contains(t, is.schemaMap, "test")
+	require.Contains(t, is.schemaID2Name, 1)
+	is.delSchema(&model.DBInfo{ID: 1, Name: model.NewCIStr("test")})
+	require.NotContains(t, is.schemaMap, "test")
+	require.NotContains(t, is.schemaID2Name, 1)
+	require.Empty(t, is.schemaMap)
+	require.Empty(t, is.schemaID2Name)
+}

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -252,18 +252,9 @@ type infoschemaV2 struct {
 // NewInfoSchemaV2 create infoschemaV2.
 func NewInfoSchemaV2(r autoid.Requirement, infoData *Data) infoschemaV2 {
 	return infoschemaV2{
-		infoSchema: &infoSchema{
-			infoSchemaMisc: infoSchemaMisc{
-				policyMap:             map[string]*model.PolicyInfo{},
-				resourceGroupMap:      map[string]*model.ResourceGroupInfo{},
-				ruleBundleMap:         map[int64]*placement.Bundle{},
-				referredForeignKeyMap: make(map[SchemaAndTableName][]*model.ReferredFKInfo),
-			},
-			schemaMap:           map[string]*schemaTables{},
-			sortedTablesBuckets: make([]sortedTables, bucketCount),
-		},
-		Data: infoData,
-		r:    r,
+		infoSchema: newInfoSchema(),
+		Data:       infoData,
+		r:          r,
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52610

Problem Summary:

### What changed and how does it work?
- add a schema id->name map

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

insert P99: 7.8ms -> 4ms; P95: 5.5ms -> 3.8ms
![img_v3_02at_8063c40c-b133-40e9-ba0f-c0627225043g](https://github.com/pingcap/tidb/assets/3312245/7ec0a9e5-3af7-416d-a0bd-b3c276b5fd81)

```
mysql> select count(1) from information_schema.schemata;
+----------+
| count(1) |
+----------+
|     7007 |
+----------+

mysql> create table t(id int);
Query OK, 0 rows affected (0.14 sec)

mysql> insert into t values(1);
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
