### PR TITLE
keyspace: set keyspace name by env

### DIFF
--- a/pkg/keyspace/BUILD.bazel
+++ b/pkg/keyspace/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     srcs = ["keyspace_test.go"],
     embed = [":keyspace"],
     flaky = True,
+    shard_count = 3,
     deps = [
         "//pkg/config",
         "@com_github_stretchr_testify//require",

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -16,6 +16,7 @@ package keyspace
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/pkg/config"
@@ -50,7 +51,16 @@ func MakeKeyspaceEtcdNamespaceSlash(c tikv.Codec) string {
 
 // GetKeyspaceNameBySettings is used to get Keyspace name setting.
 func GetKeyspaceNameBySettings() (keyspaceName string) {
-	keyspaceName = config.GetGlobalKeyspaceName()
+	keyspaceName = config.GetGlobalConfig().KeyspaceName
+	if !IsKeyspaceNameEmpty(keyspaceName) {
+		return keyspaceName
+	}
+
+	// Specify the keyspace name to be loaded by TiDB by setting KEYSPACE_NAME.
+	keyspaceName = os.Getenv(config.EnvVarKeyspaceName)
+	config.UpdateGlobal(func(c *config.Config) {
+		c.KeyspaceName = keyspaceName
+	})
 	return keyspaceName
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/53296

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Manual test (add detailed scripts or steps below)
1. Start PD and TiKV servers.
2. set env:
```
export KEYSPACE_NAME="ks1"
```
3. start TiDB server:
We can see log:
```
["using API V2."] [keyspaceName=ks1]
```


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
