### PR TITLE
[WIP] table: do not put assertions if assertion level is off

### DIFF
--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -415,6 +415,8 @@ func (t *TableCommon) shouldAssert(level variable.AssertionLevel) bool {
 	if p != nil {
 		// This disables asserting during Reorganize Partition.
 		switch level {
+		case variable.AssertionLevelOff:
+			return false
 		case variable.AssertionLevelFast:
 			// Fast option, just skip assertion for all partitions.
 			if p.DDLState != model.StateNone && p.DDLState != model.StatePublic {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #26833

Problem Summary:

When assertion level is off, assertions are still set in memdb, they are not checked in TiKV. This is nonsense.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
