### PR TITLE
autoid_service: remove the force rebase on close behavior

### DIFF
--- a/pkg/autoid_service/autoid.go
+++ b/pkg/autoid_service/autoid.go
@@ -389,22 +389,6 @@ func MockForTest(store kv.Storage) autoid.AutoIDAllocClient {
 // Close closes the Service and clean up resource.
 func (s *Service) Close() {
 	if s.leaderShip != nil && s.leaderShip.IsOwner() {
-		s.autoIDLock.Lock()
-		defer s.autoIDLock.Unlock()
-		for k, v := range s.autoIDMap {
-			v.Lock()
-			if v.base > 0 {
-				err := v.forceRebase(context.Background(), s.store, k.dbID, k.tblID, v.base, v.isUnsigned)
-				if err != nil {
-					logutil.BgLogger().Warn("save cached ID fail when service exit", zap.String("category", "autoid service"),
-						zap.Int64("db id", k.dbID),
-						zap.Int64("table id", k.tblID),
-						zap.Int64("value", v.base),
-						zap.Error(err))
-				}
-			}
-			v.Unlock()
-		}
 		s.leaderShip.Cancel()
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #38442

Problem Summary:

### What changed and how does it work?

The original design is that we try our best to avoid holes in AUTO_ID_CACHE=1, 
so when autoid leader exit, forceRebase is called to return the non-consumed in memory IDs back.

When there are a lot of tables, this operation could not be finish quickly.
And tidb graceful shutdown can not done within 30s. This cause tidb can not restart quickly to provide service.

We think over it and deside to remove the force rebase on close behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

No unit test apply here (it requires tidb restart to cover the changes).
 Some integration test may notice the change.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [X] Breaking backward compatibility

Documentation

- [X] Affects user behaviors

Behavior change, not tidb restart can cause hole in auto id allocating using AUTO_ID_CACHE=1

- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
