### PR TITLE
ddl: do not reference owner_id for specific system DDL

### DIFF
--- a/pkg/ddl/constant.go
+++ b/pkg/ddl/constant.go
@@ -25,6 +25,8 @@ const (
 	ReorgTable = "tidb_ddl_reorg"
 	// HistoryTable stores the history DDL jobs.
 	HistoryTable = "tidb_ddl_history"
+	// MDLInfoTable stores lock info used by metadata lock.
+	MDLInfoTable = "tidb_mdl_info"
 
 	// JobTableID is the table ID of `tidb_ddl_job`.
 	JobTableID = meta.MaxInt48 - 1

--- a/pkg/ddl/ddl_worker.go
+++ b/pkg/ddl/ddl_worker.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -36,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/binloginfo"
@@ -590,6 +592,11 @@ func (w *worker) updateDDLJob(job *model.Job, meetErr bool) error {
 	return errors.Trace(updateDDLJob2Table(w.sess, job, updateRawArgs))
 }
 
+func matchMDLInfoTable(schemaName, tblName string) bool {
+	return strings.ToLower(schemaName) == mysql.SystemDB &&
+		strings.ToLower(tblName) == MDLInfoTable
+}
+
 // registerMDLInfo registers metadata lock info.
 func (w *worker) registerMDLInfo(job *model.Job, ver int64) error {
 	if !variable.EnableMDL.Load() {
@@ -608,7 +615,9 @@ func (w *worker) registerMDLInfo(job *model.Job, ver int64) error {
 	ownerID := w.ownerManager.ID()
 	ids := rows[0].GetString(0)
 	var sql string
-	if tidbutil.IsSysDB(job.SchemaName) {
+	if matchMDLInfoTable(job.SchemaName, job.TableName) {
+		// DDLs that modify system table `tidb_mdl_info` could only happen in upgrade process,
+		// we should not reference 'owner_id'. Otherwise, there is a circular problem.
 		sql = fmt.Sprintf("replace into mysql.tidb_mdl_info (job_id, version, table_ids) values (%d, %d, '%s')", job.ID, ver, ids)
 	} else {
 		sql = fmt.Sprintf("replace into mysql.tidb_mdl_info (job_id, version, table_ids, owner_id) values (%d, %d, '%s', '%s')", job.ID, ver, ids, ownerID)
@@ -623,9 +632,9 @@ func cleanMDLInfo(pool *sess.Pool, job *model.Job, ec *clientv3.Client, ownerID 
 		return
 	}
 	var sql string
-	if tidbutil.IsSysDB(job.SchemaName) {
-		// system DDLs in upgrade process may modify system table `tidb_mdl_info`,
-		// there is a circular problem with `ADD COLUMN owner_id`.
+	if matchMDLInfoTable(job.SchemaName, job.TableName) {
+		// DDLs that modify system table `tidb_mdl_info` could only happen in upgrade process,
+		// we should not reference 'owner_id'. Otherwise, there is a circular problem.
 		sql = fmt.Sprintf("delete from mysql.tidb_mdl_info where job_id = %d", job.ID)
 	} else {
 		sql = fmt.Sprintf("delete from mysql.tidb_mdl_info where job_id = %d and owner_id = '%s'", job.ID, ownerID)

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -443,7 +443,7 @@ func (d *ddl) delivery2Worker(wk *worker, pool *workerPool, job *model.Job) {
 						return
 					}
 					d.setAlreadyRunOnce(job.ID)
-					cleanMDLInfo(d.sessPool, job.ID, d.etcdCli, ownerID, job.State == model.JobStateSynced)
+					cleanMDLInfo(d.sessPool, job, d.etcdCli, ownerID, job.State == model.JobStateSynced)
 					// Don't have a worker now.
 					return
 				}
@@ -481,7 +481,7 @@ func (d *ddl) delivery2Worker(wk *worker, pool *workerPool, job *model.Job) {
 			if err != nil {
 				return
 			}
-			cleanMDLInfo(d.sessPool, job.ID, d.etcdCli, ownerID, job.State == model.JobStateSynced)
+			cleanMDLInfo(d.sessPool, job, d.etcdCli, ownerID, job.State == model.JobStateSynced)
 			d.synced(job)
 
 			if RunInGoTest {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53327

Problem Summary:

In #53234, TiDB fails to execute below upgrade DDL, because it needs to access `owner_id` from `tidb_mdl_info`.

```
ALTER TABLE mysql.tidb_mdl_info ADD COLUMN owner_id VARCHAR(64) NOT NULL DEFAULT '';
```

### What changed and how does it work?

For the DDLs related to system tables, we skip using `owner_id` field to prevent above DDL failed.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  1. Prepare a v8.0.0 cluster.
  2. Kill v8.0.0 TiDB server.
  3. Start latest(compiled from this PR) TiDB server.
  4. Execute upgrade process normally. It can also serve users' DDL. 
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Since this bug is not released to any versions, release-note is not necessary.
```
