### PR TITLE
context: Add method to detach the `tableReaderExecutor` from the session context

### DIFF
--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -180,7 +180,7 @@ func newDefaultReorgDistSQLCtx(kvClient kv.Client) *distsqlctx.DistSQLContext {
 		Client:                               kvClient,
 		EnableChunkRPC:                       true,
 		EnabledRateLimitAction:               variable.DefTiDBEnableRateLimitAction,
-		KVVars:                               tikvstore.NewVariables(&sqlKiller.Signal),
+		KVVars:                               *tikvstore.NewVariables(&sqlKiller.Signal),
 		SessionMemTracker:                    memory.NewTracker(memory.LabelForSession, -1),
 		Location:                             time.UTC,
 		SQLKiller:                            &sqlKiller,

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -87,7 +87,6 @@ func newReorgExprCtx() exprctx.ExprContext {
 
 	return contextstatic.NewStaticExprContext(
 		contextstatic.WithEvalCtx(evalCtx),
-		contextstatic.WithUseCache(false),
 	)
 }
 

--- a/pkg/distsql/context/context.go
+++ b/pkg/distsql/context/context.go
@@ -47,7 +47,7 @@ type DistSQLContext struct {
 	EnabledRateLimitAction bool
 	EnableChunkRPC         bool
 	OriginalSQL            string
-	KVVars                 *tikvstore.Variables
+	KVVars                 tikvstore.Variables
 	KvExecCounter          *stmtstats.KvExecCounter
 	SessionMemTracker      *memory.Tracker
 

--- a/pkg/distsql/distsql.go
+++ b/pkg/distsql/distsql.go
@@ -88,7 +88,7 @@ func Select(ctx context.Context, dctx *distsqlctx.DistSQLContext, kvReq *kv.Requ
 		option.AppendWarning = dctx.AppendWarning
 	}
 
-	resp := dctx.Client.Send(ctx, kvReq, dctx.KVVars, option)
+	resp := dctx.Client.Send(ctx, kvReq, &dctx.KVVars, option)
 	if resp == nil {
 		return nil, errors.New("client returns nil response")
 	}

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -125,6 +125,7 @@ go_library(
         "//pkg/expression",
         "//pkg/expression/aggregation",
         "//pkg/expression/context",
+        "//pkg/expression/contextsession",
         "//pkg/infoschema",
         "//pkg/infoschema/context",
         "//pkg/keyspace",

--- a/pkg/expression/contextsession/BUILD.bazel
+++ b/pkg/expression/contextsession/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/errctx",
         "//pkg/expression/context",
         "//pkg/expression/contextopt",
+        "//pkg/expression/contextstatic",
         "//pkg/infoschema/context",
         "//pkg/parser/auth",
         "//pkg/parser/model",

--- a/pkg/expression/contextstatic/BUILD.bazel
+++ b/pkg/expression/contextstatic/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     ],
     embed = [":contextstatic"],
     flaky = True,
-    shard_count = 10,
+    shard_count = 9,
     deps = [
         "//pkg/errctx",
         "//pkg/expression/context",

--- a/pkg/expression/contextstatic/exprctx.go
+++ b/pkg/expression/contextstatic/exprctx.go
@@ -15,12 +15,11 @@
 package contextstatic
 
 import (
-	"sync/atomic"
-
 	exprctx "github.com/pingcap/tidb/pkg/expression/context"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/mathutil"
 )
@@ -39,8 +38,7 @@ type staticExprCtxState struct {
 	sysDateIsNow               bool
 	noopFuncsMode              int
 	rng                        *mathutil.MysqlRng
-	canUseCache                *atomic.Bool
-	skipCacheHandleFunc        func(useCache *atomic.Bool, skipReason string)
+	planCacheTracker           *contextutil.PlanCacheTracker
 	columnIDAllocator          exprctx.PlanColumnIDAllocator
 	connectionID               uint64
 	windowingUseHighPrecision  bool
@@ -103,17 +101,11 @@ func WithRng(rng *mathutil.MysqlRng) StaticExprCtxOption {
 	}
 }
 
-// WithUseCache sets the return value of `IsUseCache` for `StaticExprContext`.
-func WithUseCache(useCache bool) StaticExprCtxOption {
+// WithPlanCacheTracker sets the plan cache tracker for `StaticExprContext`.
+func WithPlanCacheTracker(tracker *contextutil.PlanCacheTracker) StaticExprCtxOption {
+	intest.AssertNotNil(tracker)
 	return func(s *staticExprCtxState) {
-		s.canUseCache.Store(useCache)
-	}
-}
-
-// WithSkipCacheHandleFunc sets inner skip plan cache function for StaticExprContext
-func WithSkipCacheHandleFunc(fn func(useCache *atomic.Bool, skipReason string)) StaticExprCtxOption {
-	return func(s *staticExprCtxState) {
-		s.skipCacheHandleFunc = fn
+		s.planCacheTracker = tracker
 	}
 }
 
@@ -171,8 +163,7 @@ func NewStaticExprContext(opts ...StaticExprCtxOption) *StaticExprContext {
 		},
 	}
 
-	ctx.canUseCache = &atomic.Bool{}
-	ctx.canUseCache.Store(true)
+	ctx.planCacheTracker = contextutil.NewPlanCacheTracker(ctx.evalCtx)
 
 	for _, opt := range opts {
 		opt(&ctx.staticExprCtxState)
@@ -198,9 +189,6 @@ func (ctx *StaticExprContext) Apply(opts ...StaticExprCtxOption) *StaticExprCont
 	newCtx := &StaticExprContext{
 		staticExprCtxState: ctx.staticExprCtxState,
 	}
-
-	newCtx.canUseCache = &atomic.Bool{}
-	newCtx.canUseCache.Store(ctx.canUseCache.Load())
 
 	for _, opt := range opts {
 		opt(&newCtx.staticExprCtxState)
@@ -246,16 +234,12 @@ func (ctx *StaticExprContext) Rng() *mathutil.MysqlRng {
 
 // IsUseCache implements the `ExprContext.IsUseCache`.
 func (ctx *StaticExprContext) IsUseCache() bool {
-	return ctx.canUseCache.Load()
+	return ctx.planCacheTracker.UseCache()
 }
 
 // SetSkipPlanCache implements the `ExprContext.SetSkipPlanCache`.
 func (ctx *StaticExprContext) SetSkipPlanCache(reason string) {
-	if fn := ctx.skipCacheHandleFunc; fn != nil {
-		fn(ctx.canUseCache, reason)
-		return
-	}
-	ctx.canUseCache.Store(false)
+	ctx.planCacheTracker.SetSkipPlanCache(reason)
 }
 
 // AllocPlanColumnID implements the `ExprContext.AllocPlanColumnID`.

--- a/pkg/expression/contextstatic/exprctx_test.go
+++ b/pkg/expression/contextstatic/exprctx_test.go
@@ -15,7 +15,6 @@
 package contextstatic
 
 import (
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -41,16 +40,13 @@ func TestNewStaticExprCtx(t *testing.T) {
 
 func TestStaticExprCtxApplyOptions(t *testing.T) {
 	ctx := NewStaticExprContext()
-	oldCanUseCache := ctx.canUseCache
 	oldEvalCtx := ctx.evalCtx
 	oldColumnIDAllocator := ctx.columnIDAllocator
 
 	// apply with options
 	opts, s := getExprCtxOptionsForTest()
 	ctx2 := ctx.Apply(opts...)
-	require.NotSame(t, oldCanUseCache, ctx2.canUseCache)
 	require.Equal(t, oldEvalCtx, ctx.evalCtx)
-	require.Same(t, oldCanUseCache, ctx.canUseCache)
 	require.Same(t, oldColumnIDAllocator, ctx.columnIDAllocator)
 	checkDefaultStaticExprCtx(t, ctx)
 	checkOptionsStaticExprCtx(t, ctx2, s)
@@ -59,7 +55,6 @@ func TestStaticExprCtxApplyOptions(t *testing.T) {
 	ctx3 := ctx2.Apply()
 	s.skipCacheArgs = nil
 	checkOptionsStaticExprCtx(t, ctx3, s)
-	require.NotSame(t, ctx2.canUseCache, ctx3.canUseCache)
 }
 
 func checkDefaultStaticExprCtx(t *testing.T, ctx *StaticExprContext) {
@@ -75,8 +70,6 @@ func checkDefaultStaticExprCtx(t *testing.T, ctx *StaticExprContext) {
 	require.Equal(t, variable.DefSysdateIsNow, ctx.GetSysdateIsNow())
 	require.Equal(t, variable.TiDBOptOnOffWarn(variable.DefTiDBEnableNoopFuncs), ctx.GetNoopFuncsMode())
 	require.NotNil(t, ctx.Rng())
-	require.True(t, ctx.IsUseCache())
-	require.Nil(t, ctx.skipCacheHandleFunc)
 	require.NotNil(t, ctx.columnIDAllocator)
 	_, ok := ctx.columnIDAllocator.(*context.SimplePlanColumnIDAllocator)
 	require.True(t, ok)
@@ -107,10 +100,6 @@ func getExprCtxOptionsForTest() ([]StaticExprCtxOption, *exprCtxOptionsTestState
 		WithSysDateIsNow(true),
 		WithNoopFuncsMode(variable.WarnInt),
 		WithRng(s.rng),
-		WithUseCache(false),
-		WithSkipCacheHandleFunc(func(useCache *atomic.Bool, skipReason string) {
-			s.skipCacheArgs = []any{useCache, skipReason}
-		}),
 		WithColumnIDAllocator(s.colIDAlloc),
 		WithConnectionID(778899),
 		WithWindowingUseHighPrecision(false),
@@ -131,89 +120,10 @@ func checkOptionsStaticExprCtx(t *testing.T, ctx *StaticExprContext, s *exprCtxO
 	require.False(t, ctx.IsUseCache())
 	require.Nil(t, s.skipCacheArgs)
 	ctx.SetSkipPlanCache("reason")
-	require.Equal(t, []any{ctx.canUseCache, "reason"}, s.skipCacheArgs)
 	require.Same(t, s.colIDAlloc, ctx.columnIDAllocator)
 	require.Equal(t, uint64(778899), ctx.ConnectionID())
 	require.False(t, ctx.GetWindowingUseHighPrecision())
 	require.Equal(t, uint64(2233445566), ctx.GetGroupConcatMaxLen())
-}
-
-func TestStaticExprCtxUseCache(t *testing.T) {
-	// default implement
-	ctx := NewStaticExprContext()
-	require.True(t, ctx.IsUseCache())
-	require.Nil(t, ctx.skipCacheHandleFunc)
-	ctx.SetSkipPlanCache("reason")
-	require.False(t, ctx.IsUseCache())
-	require.Empty(t, ctx.GetEvalCtx().TruncateWarnings(0))
-
-	ctx = NewStaticExprContext(WithUseCache(false))
-	require.False(t, ctx.IsUseCache())
-	require.Nil(t, ctx.skipCacheHandleFunc)
-	ctx.SetSkipPlanCache("reason")
-	require.False(t, ctx.IsUseCache())
-	require.Empty(t, ctx.GetEvalCtx().TruncateWarnings(0))
-
-	ctx = NewStaticExprContext(WithUseCache(true))
-	require.True(t, ctx.IsUseCache())
-	require.Nil(t, ctx.skipCacheHandleFunc)
-	ctx.SetSkipPlanCache("reason")
-	require.False(t, ctx.IsUseCache())
-	require.Empty(t, ctx.GetEvalCtx().TruncateWarnings(0))
-
-	// custom skip func
-	var args []any
-	calls := 0
-	ctx = NewStaticExprContext(WithSkipCacheHandleFunc(func(useCache *atomic.Bool, skipReason string) {
-		args = []any{useCache, skipReason}
-		calls++
-		if calls > 1 {
-			useCache.Store(false)
-		}
-	}))
-	ctx.SetSkipPlanCache("reason1")
-	// If we use `WithSkipCacheHandleFunc`, useCache will be set in function
-	require.Equal(t, 1, calls)
-	require.True(t, ctx.IsUseCache())
-	require.Equal(t, []any{ctx.canUseCache, "reason1"}, args)
-
-	args = nil
-	ctx.SetSkipPlanCache("reason2")
-	require.Equal(t, 2, calls)
-	require.False(t, ctx.IsUseCache())
-	require.Equal(t, []any{ctx.canUseCache, "reason2"}, args)
-
-	// apply
-	ctx = NewStaticExprContext()
-	require.True(t, ctx.IsUseCache())
-	ctx2 := ctx.Apply(WithUseCache(false))
-	require.False(t, ctx2.IsUseCache())
-	require.True(t, ctx.IsUseCache())
-	require.NotSame(t, ctx.canUseCache, ctx2.canUseCache)
-	require.Nil(t, ctx.skipCacheHandleFunc)
-	require.Nil(t, ctx2.skipCacheHandleFunc)
-
-	var args2 []any
-	fn1 := func(useCache *atomic.Bool, skipReason string) { args = []any{useCache, skipReason} }
-	fn2 := func(useCache *atomic.Bool, skipReason string) { args2 = []any{useCache, skipReason} }
-	ctx = NewStaticExprContext(WithUseCache(false), WithSkipCacheHandleFunc(fn1))
-	require.False(t, ctx.IsUseCache())
-	ctx2 = ctx.Apply(WithUseCache(true), WithSkipCacheHandleFunc(fn2))
-	require.NotSame(t, ctx.canUseCache, ctx2.canUseCache)
-	require.False(t, ctx.IsUseCache())
-	require.True(t, ctx2.IsUseCache())
-
-	args = nil
-	args2 = nil
-	ctx.SetSkipPlanCache("reasonA")
-	require.Equal(t, []any{ctx.canUseCache, "reasonA"}, args)
-	require.Nil(t, args2)
-
-	args = nil
-	args2 = nil
-	ctx2.SetSkipPlanCache("reasonB")
-	require.Nil(t, args)
-	require.Equal(t, []any{ctx2.canUseCache, "reasonB"}, args2)
 }
 
 func TestExprCtxColumnIDAllocator(t *testing.T) {

--- a/pkg/planner/context/context.go
+++ b/pkg/planner/context/context.go
@@ -106,3 +106,9 @@ func (b *BuildPBContext) GetExprCtx() exprctx.BuildContext {
 func (b *BuildPBContext) GetClient() kv.Client {
 	return b.Client
 }
+
+// IntoStatic persists some fields to make sure it's safe to read/write the context after the session continues
+// to execute other statements.
+func (b *BuildPBContext) IntoStatic(staticExprCtx exprctx.BuildContext) {
+	b.ExprCtx = staticExprCtx
+}

--- a/pkg/planner/core/exhaust_physical_plans_test.go
+++ b/pkg/planner/core/exhaust_physical_plans_test.go
@@ -350,7 +350,7 @@ func checkRangeFallbackAndReset(t *testing.T, ctx base.PlanContext, expectedRang
 	}
 	require.Equal(t, expectedRangeFallback, hasRangeFallbackWarn)
 	stmtCtx.PlanCacheTracker = contextutil.NewPlanCacheTracker(stmtCtx)
-	stmtCtx.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(&stmtCtx.PlanCacheTracker, stmtCtx)
+	stmtCtx.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(stmtCtx.PlanCacheTracker, stmtCtx)
 	stmtCtx.SetWarnings(nil)
 }
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2560,7 +2560,7 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 			EnabledRateLimitAction: vars.EnabledRateLimitAction,
 			EnableChunkRPC:         vars.EnableChunkRPC,
 			OriginalSQL:            sc.OriginalSQL,
-			KVVars:                 vars.KVVars,
+			KVVars:                 *vars.KVVars,
 			KvExecCounter:          sc.KvExecCounter,
 			SessionMemTracker:      vars.MemTracker,
 
@@ -2612,6 +2612,8 @@ func (s *session) GetRangerCtx() *rangerctx.RangerContext {
 
 	rctx := sc.GetOrInitRangerCtxFromCache(func() any {
 		return &rangerctx.RangerContext{
+			WarnHandler: sc.WarnHandler,
+
 			ExprCtx: s.GetExprCtx(),
 			TypeCtx: s.GetSessionVars().StmtCtx.TypeCtx(),
 			ErrCtx:  s.GetSessionVars().StmtCtx.ErrCtx(),
@@ -2621,8 +2623,8 @@ func (s *session) GetRangerCtx() *rangerctx.RangerContext {
 			OptPrefixIndexSingleScan: s.GetSessionVars().OptPrefixIndexSingleScan,
 			OptimizerFixControl:      s.GetSessionVars().OptimizerFixControl,
 
-			PlanCacheTracker:     &s.GetSessionVars().StmtCtx.PlanCacheTracker,
-			RangeFallbackHandler: &s.GetSessionVars().StmtCtx.RangeFallbackHandler,
+			PlanCacheTracker:     s.GetSessionVars().StmtCtx.PlanCacheTracker,
+			RangeFallbackHandler: s.GetSessionVars().StmtCtx.RangeFallbackHandler,
 		}
 	})
 

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -164,8 +164,8 @@ type StatementContext struct {
 	InPreparedPlanBuilding bool
 	InShowWarning          bool
 
-	contextutil.PlanCacheTracker
-	contextutil.RangeFallbackHandler
+	*contextutil.PlanCacheTracker
+	*contextutil.RangeFallbackHandler
 
 	BatchCheck            bool
 	IgnoreExplainIDSuffix bool
@@ -424,7 +424,7 @@ func NewStmtCtxWithTimeZone(tz *time.Location) *StatementContext {
 	sc.typeCtx = types.NewContext(types.DefaultStmtFlags, tz, sc)
 	sc.errCtx = newErrCtx(sc.typeCtx, DefaultStmtErrLevels, sc)
 	sc.PlanCacheTracker = contextutil.NewPlanCacheTracker(sc)
-	sc.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(&sc.PlanCacheTracker, sc)
+	sc.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(sc.PlanCacheTracker, sc)
 	sc.WarnHandler = contextutil.NewStaticWarnHandler(0)
 	sc.ExtraWarnHandler = contextutil.NewStaticWarnHandler(0)
 	return sc
@@ -438,7 +438,7 @@ func (sc *StatementContext) Reset() {
 	sc.typeCtx = types.NewContext(types.DefaultStmtFlags, time.UTC, sc)
 	sc.errCtx = newErrCtx(sc.typeCtx, DefaultStmtErrLevels, sc)
 	sc.PlanCacheTracker = contextutil.NewPlanCacheTracker(sc)
-	sc.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(&sc.PlanCacheTracker, sc)
+	sc.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(sc.PlanCacheTracker, sc)
 	sc.WarnHandler = contextutil.NewStaticWarnHandler(0)
 	sc.ExtraWarnHandler = contextutil.NewStaticWarnHandler(0)
 }

--- a/pkg/util/context/plancache.go
+++ b/pkg/util/context/plancache.go
@@ -139,8 +139,8 @@ func (h *PlanCacheTracker) PlanCacheUnqualified() string {
 }
 
 // NewPlanCacheTracker creates a new PlanCacheTracker.
-func NewPlanCacheTracker(warnHandler WarnAppender) PlanCacheTracker {
-	return PlanCacheTracker{
+func NewPlanCacheTracker(warnHandler WarnAppender) *PlanCacheTracker {
+	return &PlanCacheTracker{
 		warnHandler: warnHandler,
 	}
 }
@@ -166,8 +166,8 @@ func (h *RangeFallbackHandler) RecordRangeFallback(rangeMaxSize int64) {
 }
 
 // NewRangeFallbackHandler creates a new RangeFallbackHandler.
-func NewRangeFallbackHandler(planCacheTracker *PlanCacheTracker, warnHandler WarnAppender) RangeFallbackHandler {
-	return RangeFallbackHandler{
+func NewRangeFallbackHandler(planCacheTracker *PlanCacheTracker, warnHandler WarnAppender) *RangeFallbackHandler {
+	return &RangeFallbackHandler{
 		planCacheTracker: planCacheTracker,
 		warnHandler:      warnHandler,
 	}

--- a/pkg/util/mock/context.go
+++ b/pkg/util/mock/context.go
@@ -256,7 +256,7 @@ func (c *Context) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 		EnabledRateLimitAction:               vars.EnabledRateLimitAction,
 		EnableChunkRPC:                       vars.EnableChunkRPC,
 		OriginalSQL:                          sc.OriginalSQL,
-		KVVars:                               vars.KVVars,
+		KVVars:                               *vars.KVVars,
 		KvExecCounter:                        sc.KvExecCounter,
 		SessionMemTracker:                    vars.MemTracker,
 		Location:                             sc.TimeZone(),
@@ -286,8 +286,8 @@ func (c *Context) GetRangerCtx() *rangerctx.RangerContext {
 		OptPrefixIndexSingleScan: c.GetSessionVars().OptPrefixIndexSingleScan,
 		OptimizerFixControl:      c.GetSessionVars().OptimizerFixControl,
 
-		PlanCacheTracker:     &c.GetSessionVars().StmtCtx.PlanCacheTracker,
-		RangeFallbackHandler: &c.GetSessionVars().StmtCtx.RangeFallbackHandler,
+		PlanCacheTracker:     c.GetSessionVars().StmtCtx.PlanCacheTracker,
+		RangeFallbackHandler: c.GetSessionVars().StmtCtx.RangeFallbackHandler,
 	}
 }
 

--- a/pkg/util/ranger/context/context.go
+++ b/pkg/util/ranger/context/context.go
@@ -23,6 +23,8 @@ import (
 
 // RangerContext is the context used to build range.
 type RangerContext struct {
+	WarnHandler contextutil.WarnAppender
+
 	TypeCtx types.Context
 	ErrCtx  errctx.Context
 	ExprCtx exprctx.BuildContext
@@ -33,4 +35,15 @@ type RangerContext struct {
 	InPreparedPlanBuilding   bool
 	RegardNULLAsPoint        bool
 	OptPrefixIndexSingleScan bool
+}
+
+// IntoStatic persists some fields to make sure it's safe to read/write the context after the session continues
+// to execute other statements.
+func (r *RangerContext) IntoStatic(staticExprCtx exprctx.BuildContext) {
+	r.ExprCtx = staticExprCtx
+
+	fixControl := make(map[uint64]string, len(r.OptimizerFixControl))
+	for k, v := range r.OptimizerFixControl {
+		fixControl[k] = v
+	}
 }

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -1856,7 +1856,7 @@ func checkRangeFallbackAndReset(t *testing.T, sctx sessionctx.Context, expectedR
 	}
 	require.Equal(t, expectedRangeFallback, hasRangeFallbackWarn)
 	stmtCtx.PlanCacheTracker = contextutil.NewPlanCacheTracker(stmtCtx)
-	stmtCtx.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(&stmtCtx.PlanCacheTracker, stmtCtx)
+	stmtCtx.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(stmtCtx.PlanCacheTracker, stmtCtx)
 	stmtCtx.SetWarnings(nil)
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #53336

Problem Summary:

It's not safe to call `Next` (or other method) of an executor after the session is executing the next statement. We have split out a lot of `Context` and it's clear that the context depended by the `TableReaderExecutor` is safe to be re-used (after proper configuration) while executing another statement is running on the session.

### What changed and how does it work?

This PR adds `IntoStatic` method for several contexts. After calling this method, the context can be safe to be used while the session continues to run the next statements.

### Check List

Tests <!-- At least one of them must be included. -->

TODO:

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
