### PR TITLE
ddl: do not reference owner_id for all system DDLs

### DIFF
--- a/pkg/ddl/constant.go
+++ b/pkg/ddl/constant.go
@@ -25,8 +25,6 @@ const (
 	ReorgTable = "tidb_ddl_reorg"
 	// HistoryTable stores the history DDL jobs.
 	HistoryTable = "tidb_ddl_history"
-	// MDLInfoTable stores lock info used by metadata lock.
-	MDLInfoTable = "tidb_mdl_info"
 
 	// JobTableID is the table ID of `tidb_ddl_job`.
 	JobTableID = meta.MaxInt48 - 1

--- a/pkg/ddl/ddl_worker.go
+++ b/pkg/ddl/ddl_worker.go
@@ -37,12 +37,12 @@ import (
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
-	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	pumpcli "github.com/pingcap/tidb/pkg/tidb-binlog/pump_client"
+	db_util "github.com/pingcap/tidb/pkg/util"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	tidblogutil "github.com/pingcap/tidb/pkg/util/logutil"
@@ -595,11 +595,6 @@ func (w *worker) updateDDLJob(job *model.Job, meetErr bool) error {
 	return errors.Trace(updateDDLJob2Table(w.sess, job, updateRawArgs))
 }
 
-func matchMDLInfoTable(schemaName, tblName string) bool {
-	return strings.ToLower(schemaName) == mysql.SystemDB &&
-		strings.ToLower(tblName) == MDLInfoTable
-}
-
 // registerMDLInfo registers metadata lock info.
 func (w *worker) registerMDLInfo(job *model.Job, ver int64) error {
 	if !variable.EnableMDL.Load() {
@@ -618,9 +613,9 @@ func (w *worker) registerMDLInfo(job *model.Job, ver int64) error {
 	ownerID := w.ownerManager.ID()
 	ids := rows[0].GetString(0)
 	var sql string
-	if matchMDLInfoTable(job.SchemaName, job.TableName) {
-		// DDLs that modify system table `tidb_mdl_info` could only happen in upgrade process,
-		// we should not reference 'owner_id'. Otherwise, there is a circular problem.
+	if db_util.IsSysDB(strings.ToLower(job.SchemaName)) {
+		// DDLs that modify system tables could only happen in upgrade process,
+		// we should not reference 'owner_id'. Otherwise, there is a circular blocking problem.
 		sql = fmt.Sprintf("replace into mysql.tidb_mdl_info (job_id, version, table_ids) values (%d, %d, '%s')", job.ID, ver, ids)
 	} else {
 		sql = fmt.Sprintf("replace into mysql.tidb_mdl_info (job_id, version, table_ids, owner_id) values (%d, %d, '%s', '%s')", job.ID, ver, ids, ownerID)
@@ -635,9 +630,9 @@ func cleanMDLInfo(pool *sess.Pool, job *model.Job, ec *clientv3.Client, ownerID 
 		return
 	}
 	var sql string
-	if matchMDLInfoTable(job.SchemaName, job.TableName) {
-		// DDLs that modify system table `tidb_mdl_info` could only happen in upgrade process,
-		// we should not reference 'owner_id'. Otherwise, there is a circular problem.
+	if db_util.IsSysDB(strings.ToLower(job.SchemaName)) {
+		// DDLs that modify system tables could only happen in upgrade process,
+		// we should not reference 'owner_id'. Otherwise, there is a circular blocking problem.
 		sql = fmt.Sprintf("delete from mysql.tidb_mdl_info where job_id = %d", job.ID)
 	} else {
 		sql = fmt.Sprintf("delete from mysql.tidb_mdl_info where job_id = %d and owner_id = '%s'", job.ID, ownerID)

--- a/pkg/ddl/ddl_worker.go
+++ b/pkg/ddl/ddl_worker.go
@@ -42,7 +42,6 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	pumpcli "github.com/pingcap/tidb/pkg/tidb-binlog/pump_client"
-	db_util "github.com/pingcap/tidb/pkg/util"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	tidblogutil "github.com/pingcap/tidb/pkg/util/logutil"
@@ -613,7 +612,7 @@ func (w *worker) registerMDLInfo(job *model.Job, ver int64) error {
 	ownerID := w.ownerManager.ID()
 	ids := rows[0].GetString(0)
 	var sql string
-	if db_util.IsSysDB(strings.ToLower(job.SchemaName)) {
+	if tidbutil.IsSysDB(strings.ToLower(job.SchemaName)) {
 		// DDLs that modify system tables could only happen in upgrade process,
 		// we should not reference 'owner_id'. Otherwise, there is a circular blocking problem.
 		sql = fmt.Sprintf("replace into mysql.tidb_mdl_info (job_id, version, table_ids) values (%d, %d, '%s')", job.ID, ver, ids)
@@ -630,7 +629,7 @@ func cleanMDLInfo(pool *sess.Pool, job *model.Job, ec *clientv3.Client, ownerID 
 		return
 	}
 	var sql string
-	if db_util.IsSysDB(strings.ToLower(job.SchemaName)) {
+	if tidbutil.IsSysDB(strings.ToLower(job.SchemaName)) {
 		// DDLs that modify system tables could only happen in upgrade process,
 		// we should not reference 'owner_id'. Otherwise, there is a circular blocking problem.
 		sql = fmt.Sprintf("delete from mysql.tidb_mdl_info where job_id = %d", job.ID)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/53327

Problem Summary:

This PR is a patch for #53332.

Except `mysql.tidb_mdl_info`, there are other system DDLs during upgrade, we should avoid reference `owner_id` for all of them.

```
[2024/05/17 10:47:07.637 +08:00] [INFO] [session.go:3894] ["CRUCIAL OPERATION"] [conn=0] [schemaVersion=39] [cur_db=] [sql="ALTER TABLE mysql.stats_meta_history ADD COLUMN IF NOT EXISTS `source` varchar(40) NOT NULL after `version`;"] [user=]
[2024/05/17 10:47:07.717 +08:00] [INFO] [ddl_worker.go:261] ["add DDL jobs"] [category=ddl] ["batch count"=1] [jobs="ID:80, Type:add column, State:queueing, SchemaState:none, SchemaID:1, TableID:64, RowCount:0, ArgLen:4, start time: 2024-05-17 10:47:07.655 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:0, LocalMode: false; "] [table=true]
[2024/05/17 10:47:07.717 +08:00] [INFO] [ddl.go:1181] ["start DDL job"] [category=ddl] [job="ID:80, Type:add column, State:queueing, SchemaState:none, SchemaID:1, TableID:64, RowCount:0, ArgLen:4, start time: 2024-05-17 10:47:07.655 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:0, LocalMode: false"] [query="ALTER TABLE mysql.stats_meta_history ADD COLUMN IF NOT EXISTS `source` varchar(40) NOT NULL after `version`;"]
...
[2024/05/17 10:47:08.625 +08:00] [INFO] [ddl_worker.go:1212] ["run DDL job"] [worker="worker 1, tp general"] [category=ddl] [jobID=80] [category=ddl] [job="ID:80, Type:add column, State:queueing, SchemaState:none, SchemaID:1, TableID:64, RowCount:0, ArgLen:0, start time: 2024-05-17 10:47:07.655 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:0, LocalMode: false"]
[2024/05/17 10:47:08.627 +08:00] [INFO] [column.go:135] ["run add column job"] [category=ddl] [job="ID:80, Type:add column, State:running, SchemaState:none, SchemaID:1, TableID:64, RowCount:0, ArgLen:4, start time: 2024-05-17 10:47:07.655 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:0, LocalMode: false"] [columnInfo="{\"id\":6,\"name\":{\"O\":\"source\",\"L\":\"source\"},\"offset\":5,\"origin_default\":\"\",\"origin_default_bit\":null,\"default\":null,\"default_bit\":null,\"default_is_expr\":false,\"generated_expr_string\":\"\",\"generated_stored\":false,\"dependences\":null,\"type\":{},\"state\":0,\"comment\":\"\",\"hidden\":false,\"change_state_info\":null,\"version\":2}"]
[2024/05/17 10:47:08.631 +08:00] [INFO] [job_table.go:466] ["handle ddl job failed"] [worker="worker 1, tp general"] [category=ddl] [error="[planner:1054]Unknown column 'owner_id' in 'field list'"] [job="ID:80, Type:add column, State:running, SchemaState:delete only, SchemaID:1, TableID:64, RowCount:0, ArgLen:4, start time: 2024-05-17 10:47:07.655 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:0, LocalMode: false"]

```

### What changed and how does it work?

We skip reference `owner_id` field for all system DDLs.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  1. Prepare a v6.5.8 cluster.
  2. Kill v6.5.8 TiDB server.
  3. Start latest(compiled from this PR) TiDB server.
  4. Execute upgrade process normally. It can also serve users' DDL. 
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
