### PR TITLE
config: set max token limit to 1M

### DIFF
--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -37,7 +37,7 @@ go_test(
     data = glob(["**"]),
     embed = [":config"],
     flaky = True,
-    shard_count = 24,
+    shard_count = 25,
     deps = [
         "//pkg/testkit/testsetup",
         "//pkg/util/logutil",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,6 +97,8 @@ const (
 	DefAuthTokenRefreshInterval = time.Hour
 	// EnvVarKeyspaceName is the system env name for keyspace name.
 	EnvVarKeyspaceName = "KEYSPACE_NAME"
+	// MaxTokenLimit is the max token limit value.
+	MaxTokenLimit = 1024 * 1024
 )
 
 // Valid config maps
@@ -1275,6 +1277,8 @@ func (c *Config) Load(confFile string) error {
 	}
 	if c.TokenLimit == 0 {
 		c.TokenLimit = 1000
+	} else if c.TokenLimit > MaxTokenLimit {
+		c.TokenLimit = MaxTokenLimit
 	}
 	// If any items in confFile file are not mapped into the Config struct, issue
 	// an error and stop the server from starting.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53312

Problem Summary:
If a user sets `token-limit` to a big value, TiDB will OOM.

### What changed and how does it work?
If the token-limit is bigger than 1M, set it to 1M.
It won't report errors so it's compatible with previous versions.
One TiDB instance won't have over 1M concurrent queries because that will mean at least 1M goroutines and file descriptors.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
