### PR TITLE
planner: skip fast-point-get for select-into-outfile statements

### DIFF
--- a/pkg/executor/select_into_test.go
+++ b/pkg/executor/select_into_test.go
@@ -55,6 +55,18 @@ func TestSelectIntoFileExists(t *testing.T) {
 	require.True(t, strings.Contains(err.Error(), outfile))
 }
 
+func TestSelectIntoOutfilePointGet(t *testing.T) {
+	outfile := randomSelectFilePath("TestSelectIntoOutfilePointGet")
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec(`create table t (id int not null, primary key (id) /*T![clustered_index] CLUSTERED */ );`)
+	tk.MustExec(`insert into t values(1);`)
+	tk.MustExec(fmt.Sprintf("select * from t where id = 1 into outfile %q", outfile))
+	cmpAndRm("1\n", outfile, t)
+}
+
 func TestSelectIntoOutfileTypes(t *testing.T) {
 	outfile := randomSelectFilePath("TestSelectIntoOutfileTypes")
 	store := testkit.CreateMockStore(t)

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -873,6 +873,9 @@ func TryFastPlan(ctx base.PlanContext, node ast.Node) (p base.Plan) {
 	ctx.GetSessionVars().PlanColumnID.Store(0)
 	switch x := node.(type) {
 	case *ast.SelectStmt:
+		if x.SelectIntoOpt != nil {
+			return nil
+		}
 		defer func() {
 			vars := ctx.GetSessionVars()
 			if vars.SelectLimit != math2.MaxUint64 && p != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #42093

Problem Summary: planner: skip fast-point-get for select-into-outfile statements

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
