### PR TITLE
*: fix unstable assert for location

### DIFF
--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -146,10 +146,11 @@ func (ctx *NullRejectCheckExprContext) IsInNullRejectCheck() bool {
 // AssertLocationWithSessionVars asserts the location in the context and session variables are the same.
 // It is only used for testing.
 func AssertLocationWithSessionVars(ctxLoc *time.Location, vars *variable.SessionVars) {
-	varsLoc := vars.Location()
-	stmtLoc := vars.StmtCtx.TimeZone()
-	intest.Assert(ctxLoc == varsLoc && ctxLoc == stmtLoc,
+	ctxLocStr := ctxLoc.String()
+	varsLocStr := vars.Location().String()
+	stmtLocStr := vars.StmtCtx.TimeZone().String()
+	intest.Assert(ctxLocStr == varsLocStr && ctxLocStr == stmtLocStr,
 		"location mismatch, ctxLoc: %s, varsLoc: %s, stmtLoc: %s",
-		ctxLoc.String(), varsLoc.String(), stmtLoc.String(),
+		ctxLoc.String(), ctxLocStr, stmtLocStr,
 	)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53375

Problem Summary:

Some tests are unstable for assertations of location:

```
[2024/05/17 07:32:17.193 +00:00] [INFO] [job_table.go:349] ["the owner sets owner operator value"] [category=ddl] [ownerOp=none]

panic: assert failed, location mismatch, ctxLoc: UTC, varsLoc: UTC, stmtLoc: UTC [recovered]

	panic: assert failed, location mismatch, ctxLoc: UTC, varsLoc: UTC, stmtLoc: UTC
```

The assert fails because the underlayer pointers of location are the not the same. However this assert should pass because they are the same location in fact

### What changed and how does it work?

Compare location name instead of pointer

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
