### PR TITLE
ddl: introduce `newReorgExprCtx` to replace `mock.Context` usage

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -89,6 +89,8 @@ go_library(
         "//pkg/domain/resourcegroup",
         "//pkg/errctx",
         "//pkg/expression",
+        "//pkg/expression/context",
+        "//pkg/expression/contextstatic",
         "//pkg/infoschema",
         "//pkg/kv",
         "//pkg/lightning/backend",

--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -88,20 +88,19 @@ func newBackfillScheduler(
 	sessPool *sess.Pool,
 	tp backfillerType,
 	tbl table.PhysicalTable,
-	sessCtx sessionctx.Context,
 	jobCtx *JobContext,
 ) (backfillScheduler, error) {
 	if tp == typeAddIndexWorker && info.ReorgMeta.ReorgTp == model.ReorgTypeLitMerge {
 		ctx = logutil.WithCategory(ctx, "ddl-ingest")
 		return newIngestBackfillScheduler(ctx, info, sessPool, tbl)
 	}
-	return newTxnBackfillScheduler(ctx, info, sessPool, tp, tbl, sessCtx, jobCtx)
+	return newTxnBackfillScheduler(ctx, info, sessPool, tp, tbl, jobCtx)
 }
 
 func newTxnBackfillScheduler(ctx context.Context, info *reorgInfo, sessPool *sess.Pool,
-	tp backfillerType, tbl table.PhysicalTable, sessCtx sessionctx.Context,
+	tp backfillerType, tbl table.PhysicalTable,
 	jobCtx *JobContext) (backfillScheduler, error) {
-	decColMap, err := makeupDecodeColMap(sessCtx, info.dbInfo.Name, tbl)
+	decColMap, err := makeupDecodeColMap(info.dbInfo.Name, tbl)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/ddl/ingest"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -83,4 +84,63 @@ func TestPickBackfillType(t *testing.T) {
 	tp, err = pickBackfillType(mockCtx, mockJob)
 	require.NoError(t, err)
 	require.Equal(t, tp, model.ReorgTypeLitMerge)
+}
+
+// TestReorgExprContext is used in refactor stage to make sure the newReorgExprCtx() is
+// compatible with newReorgSessCtx(nil).GetExprCtx() to make it safe to replace `mock.Context` usage.
+// After refactor, the TestReorgExprContext can be removed.
+func TestReorgExprContext(t *testing.T) {
+	sctx := newReorgSessCtx(nil)
+	sessCtx := sctx.GetExprCtx()
+	exprCtx := newReorgExprCtx()
+	cs1, col1 := sessCtx.GetCharsetInfo()
+	cs2, col2 := exprCtx.GetCharsetInfo()
+	require.Equal(t, cs1, cs2)
+	require.Equal(t, col1, col2)
+	require.Equal(t, sessCtx.GetDefaultCollationForUTF8MB4(), exprCtx.GetDefaultCollationForUTF8MB4())
+	if sessCtx.GetBlockEncryptionMode() == "" {
+		// The newReorgSessCtx returns a block encryption mode as an empty string.
+		// Though it is not a valid value, it does not matter because `GetBlockEncryptionMode` is never used in DDL.
+		// So we do not want to modify the behavior of `newReorgSessCtx` or `newReorgExprCtx`, and just to
+		// place the test code here to check:
+		// If `GetBlockEncryptionMode` still returns empty string in `newReorgSessCtx`, that means the behavior is
+		// not changed, and we just need to return a default value for `newReorgExprCtx`.
+		// If `GetBlockEncryptionMode` returns some other values, that means `GetBlockEncryptionMode` may have been
+		// used in somewhere and two return values should be the same.
+		require.Equal(t, "aes-128-ecb", exprCtx.GetBlockEncryptionMode())
+	} else {
+		require.Equal(t, sessCtx.GetBlockEncryptionMode(), exprCtx.GetBlockEncryptionMode())
+	}
+	require.Equal(t, sessCtx.GetSysdateIsNow(), exprCtx.GetSysdateIsNow())
+	require.Equal(t, sessCtx.GetNoopFuncsMode(), exprCtx.GetNoopFuncsMode())
+	require.Equal(t, sessCtx.IsUseCache(), exprCtx.IsUseCache())
+	require.Equal(t, sessCtx.IsInNullRejectCheck(), exprCtx.IsInNullRejectCheck())
+	require.Equal(t, sessCtx.ConnectionID(), exprCtx.ConnectionID())
+	require.Equal(t, sessCtx.AllocPlanColumnID(), exprCtx.AllocPlanColumnID())
+	require.Equal(t, sessCtx.GetWindowingUseHighPrecision(), exprCtx.GetWindowingUseHighPrecision())
+	require.Equal(t, sessCtx.GetGroupConcatMaxLen(), exprCtx.GetGroupConcatMaxLen())
+
+	evalCtx1 := sessCtx.GetEvalCtx()
+	evalCtx := exprCtx.GetEvalCtx()
+	require.Equal(t, evalCtx1.SQLMode(), evalCtx.SQLMode())
+	tc1 := evalCtx1.TypeCtx()
+	tc2 := evalCtx.TypeCtx()
+	require.Equal(t, tc1.Flags(), tc2.Flags())
+	require.Equal(t, tc1.Location().String(), tc2.Location().String())
+	ec1 := evalCtx1.ErrCtx()
+	ec2 := evalCtx.ErrCtx()
+	require.Equal(t, ec1.LevelMap(), ec2.LevelMap())
+	require.Equal(t, time.UTC, sctx.GetSessionVars().Location())
+	require.Equal(t, time.UTC, sctx.GetSessionVars().StmtCtx.TimeZone())
+	require.Equal(t, time.UTC, evalCtx1.Location())
+	require.Equal(t, time.UTC, evalCtx.Location())
+	require.Equal(t, evalCtx1.CurrentDB(), evalCtx.CurrentDB())
+	tm1, err := evalCtx1.CurrentTime()
+	require.NoError(t, err)
+	tm2, err := evalCtx.CurrentTime()
+	require.NoError(t, err)
+	require.InDelta(t, tm1.Unix(), tm2.Unix(), 2)
+	require.Equal(t, evalCtx1.GetMaxAllowedPacket(), evalCtx.GetMaxAllowedPacket())
+	require.Equal(t, evalCtx1.GetDefaultWeekFormatMode(), evalCtx.GetDefaultWeekFormatMode())
+	require.Equal(t, evalCtx1.GetDivPrecisionIncrement(), evalCtx.GetDivPrecisionIncrement())
 }

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -725,7 +725,7 @@ func (d SchemaTracker) handleModifyColumn(
 	tblInfo.AutoRandomBits = updatedAutoRandomBits
 	oldCol := table.FindCol(t.Cols(), originalColName.L).ColumnInfo
 
-	originDefVal, err := ddl.GetOriginDefaultValueForModifyColumn(sctx, newColInfo, oldCol)
+	originDefVal, err := ddl.GetOriginDefaultValueForModifyColumn(sctx.GetExprCtx(), newColInfo, oldCol)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -404,7 +404,8 @@ type StatementContext struct {
 	MDLRelatedTableIDs map[int64]struct{}
 }
 
-var defaultErrLevels = func() (l errctx.LevelMap) {
+// DefaultStmtErrLevels is the default error levels for statement
+var DefaultStmtErrLevels = func() (l errctx.LevelMap) {
 	l[errctx.ErrGroupDividedByZero] = errctx.LevelWarn
 	return
 }()
@@ -421,7 +422,7 @@ func NewStmtCtxWithTimeZone(tz *time.Location) *StatementContext {
 		ctxID: contextutil.GenContextID(),
 	}
 	sc.typeCtx = types.NewContext(types.DefaultStmtFlags, tz, sc)
-	sc.errCtx = newErrCtx(sc.typeCtx, defaultErrLevels, sc)
+	sc.errCtx = newErrCtx(sc.typeCtx, DefaultStmtErrLevels, sc)
 	sc.PlanCacheTracker = contextutil.NewPlanCacheTracker(sc)
 	sc.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(&sc.PlanCacheTracker, sc)
 	sc.WarnHandler = contextutil.NewStaticWarnHandler(0)
@@ -435,7 +436,7 @@ func (sc *StatementContext) Reset() {
 		ctxID: contextutil.GenContextID(),
 	}
 	sc.typeCtx = types.NewContext(types.DefaultStmtFlags, time.UTC, sc)
-	sc.errCtx = newErrCtx(sc.typeCtx, defaultErrLevels, sc)
+	sc.errCtx = newErrCtx(sc.typeCtx, DefaultStmtErrLevels, sc)
 	sc.PlanCacheTracker = contextutil.NewPlanCacheTracker(sc)
 	sc.RangeFallbackHandler = contextutil.NewRangeFallbackHandler(&sc.PlanCacheTracker, sc)
 	sc.WarnHandler = contextutil.NewStaticWarnHandler(0)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53388

Problem Summary:

see issue

### What changed and how does it work?

introduce `newReorgExprCtx` to return an `ExprContext` for DDL reorg phase. `newReorgExprCtx` will replace `newReorgSessCtx` when only expr context is required. 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
