### PR TITLE
expression: fix default value of `GetDefaultCollationForUTF8MB4` of `StaticExprContext`

### DIFF
--- a/pkg/expression/contextstatic/exprctx.go
+++ b/pkg/expression/contextstatic/exprctx.go
@@ -162,7 +162,7 @@ func NewStaticExprContext(opts ...StaticExprCtxOption) *StaticExprContext {
 		staticExprCtxState: staticExprCtxState{
 			charset:                    cs.Name,
 			collation:                  cs.DefaultCollation,
-			defaultCollationForUTF8MB4: variable.DefaultCollationForUTF8MB4,
+			defaultCollationForUTF8MB4: mysql.DefaultCollationName,
 			blockEncryptionMode:        variable.DefBlockEncryptionMode,
 			sysDateIsNow:               variable.DefSysdateIsNow,
 			noopFuncsMode:              variable.TiDBOptOnOffWarn(variable.DefTiDBEnableNoopFuncs),

--- a/pkg/expression/contextstatic/exprctx_test.go
+++ b/pkg/expression/contextstatic/exprctx_test.go
@@ -70,7 +70,7 @@ func checkDefaultStaticExprCtx(t *testing.T, ctx *StaticExprContext) {
 	require.NoError(t, err)
 	require.Equal(t, charsetName, cs.Name)
 	require.Equal(t, cs.DefaultCollation, collation)
-	require.Equal(t, variable.DefaultCollationForUTF8MB4, ctx.GetDefaultCollationForUTF8MB4())
+	require.Equal(t, mysql.DefaultCollationName, ctx.GetDefaultCollationForUTF8MB4())
 	require.Equal(t, variable.DefBlockEncryptionMode, ctx.GetBlockEncryptionMode())
 	require.Equal(t, variable.DefSysdateIsNow, ctx.GetSysdateIsNow())
 	require.Equal(t, variable.TiDBOptOnOffWarn(variable.DefTiDBEnableNoopFuncs), ctx.GetNoopFuncsMode())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53390

### What changed and how does it work?

fix default value of `GetDefaultCollationForUTF8MB4` of `StaticExprContext`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
