### PR TITLE
planner: fix the wrong result caused by `year_col cmp out-of-range-uint`

### DIFF
--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -1218,6 +1218,15 @@ func TestRepeatPushDownToTiFlash(t *testing.T) {
 	tk.MustQuery("explain select repeat(a,b) from t;").CheckAt([]int{0, 2, 4}, rows)
 }
 
+func TestIssue50235(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table tt (c year(4) NOT NULL DEFAULT '2016', primary key(c));`)
+	tk.MustExec(`insert into tt values (2016);`)
+	tk.MustQuery(`select * from tt where c < 16212511333665770580`).Check(testkit.Rows("2016"))
+}
+
 func TestIssue36194(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -330,7 +330,7 @@ func (r *builder) buildFromBinOp(
 		}
 		// If nulleq with null value, values.ToInt64 will return err
 		if col.GetType().GetType() == mysql.TypeYear && !value.IsNull() {
-			// Convert the large uint number to int and then let the following logic can handle it correctly.
+			// Convert the out-of-range uint number to int and then let the following logic can handle it correctly.
 			// Since the max value of year is 2155, `col op MaxUint` should have the same result with `col op MaxInt`.
 			if value.Kind() == types.KindUint64 && value.GetUint64() > math.MaxInt64 {
 				value.SetInt64(math.MaxInt64)

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -330,6 +330,12 @@ func (r *builder) buildFromBinOp(
 		}
 		// If nulleq with null value, values.ToInt64 will return err
 		if col.GetType().GetType() == mysql.TypeYear && !value.IsNull() {
+			// Convert the large uint number to int and then let the following logic can handle it correctly.
+			// Since the max value of year is 2155, `col op MaxUint` should have the same result with `col op MaxInt`.
+			if value.Kind() == types.KindUint64 && value.GetUint64() > math.MaxInt64 {
+				value.SetInt64(math.MaxInt64)
+			}
+
 			// If the original value is adjusted, we need to change the condition.
 			// For example, col < 2156. Since the max year is 2155, 2156 is changed to 2155.
 			// col < 2155 is wrong. It should be col <= 2155.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50235

Problem Summary: planner: fix the wrong result caused by `year_col cmp out-of-range-uint`

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
