### PR TITLE
copr: add ballast mem to reduce the runtime overhead during execution

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime"
 	"runtime/trace"
 	"slices"
 	"sort"
@@ -659,6 +660,10 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, workCh chan<
 	idxID := e.getIndexPlanRootID()
 	e.idxWorkerWg.Add(1)
 	go func() {
+		// 32KB ballast helps grow the stack to the requirement of index worker.
+		// This reduces the `morestack` call during the execution, thus improvement the efficiency of TiDB.
+		// TODO: remove ballast after global pool is applied
+		ballast := make([]byte, 32*size.KB)
 		defer trace.StartRegion(ctx, "IndexLookUpIndexWorker").End()
 		worker := &indexWorker{
 			idxLookup:       e,
@@ -734,6 +739,7 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, workCh chan<
 		close(workCh)
 		close(e.resultCh)
 		e.idxWorkerWg.Done()
+		runtime.KeepAlive(ballast)
 	}()
 	return nil
 }
@@ -1147,6 +1153,7 @@ func (w *tableWorker) pickAndExecTask(ctx context.Context) {
 			task.doneCh <- err
 		}
 	}()
+	var ballast []byte
 	for {
 		// Don't check ctx.Done() on purpose. If background worker get the signal and all
 		// exit immediately, session's goroutine doesn't know this and still calling Next(),
@@ -1159,6 +1166,13 @@ func (w *tableWorker) pickAndExecTask(ctx context.Context) {
 		case <-w.finished:
 			return
 		}
+		if ballast == nil {
+			// 32KB ballast helps grow the stack to the requirement of table worker.
+			// This reduces the `morestack` call during the execution, thus improvement the efficiency of TiDB.
+			// Only allocate ballast when task is received.
+			// TODO: remove ballast after global pool is applied
+			ballast = make([]byte, 32*size.KB)
+		}
 		startTime := time.Now()
 		err := w.executeTask(ctx, task)
 		if w.idxLookup.stats != nil {
@@ -1167,6 +1181,7 @@ func (w *tableWorker) pickAndExecTask(ctx context.Context) {
 		}
 		task.doneCh <- err
 	}
+	runtime.KeepAlive(ballast)
 }
 
 func (e *IndexLookUpExecutor) getHandle(row chunk.Row, handleIdx []int,

--- a/pkg/store/copr/BUILD.bazel
+++ b/pkg/store/copr/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/util/logutil",
         "//pkg/util/memory",
         "//pkg/util/paging",
+        "//pkg/util/size",
         "//pkg/util/tiflash",
         "//pkg/util/tiflashcompute",
         "//pkg/util/tracing",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #52887, #51852

Problem Summary:

### What changed and how does it work?

Add a ballast memory in coprocessor, this can reduce the `morestack` call during coprocessor worker execution, lower the latency.

This is not the final solution for the referenced issues, it's just a hotfix, we need to manage the goroutine better to achieve both latency and throughput.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

#### Test with sysbench
|workload|nightly|this pr|diff|
|-|-|-|-|
|select_random_points| 19714 qps | 20599 qps | +4.5% |
|select_random_ranges| 18754 qps | 19207 qps | +2.4% |

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
