### PR TITLE
planner: skip all system tables when collecting prediction columns

### DIFF
--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -120,6 +120,35 @@ func MockInfoSchema(tbList []*model.TableInfo) InfoSchema {
 		bucketIdx := tableBucketIdx(tb.ID)
 		result.sortedTablesBuckets[bucketIdx] = append(result.sortedTablesBuckets[bucketIdx], tbl)
 	}
+	// Add a system table.
+	tables := []*model.TableInfo{
+		{
+			ID:   9,
+			Name: model.NewCIStr("stats_meta"),
+			Columns: []*model.ColumnInfo{
+				{
+					State:  model.StatePublic,
+					Offset: 0,
+					Name:   model.NewCIStr("a"),
+					ID:     1,
+				},
+			},
+			State: model.StatePublic,
+		},
+	}
+	mysqlDBInfo := &model.DBInfo{ID: 2, Name: model.NewCIStr("mysql"), Tables: tables}
+	tableNames = &schemaTables{
+		dbInfo: mysqlDBInfo,
+		tables: make(map[string]table.Table),
+	}
+	result.addSchema(tableNames)
+	for _, tb := range tables {
+		tb.DBID = mysqlDBInfo.ID
+		tbl := table.MockTableFromMeta(tb)
+		tableNames.tables[tb.Name.L] = tbl
+		bucketIdx := tableBucketIdx(tb.ID)
+		result.sortedTablesBuckets[bucketIdx] = append(result.sortedTablesBuckets[bucketIdx], tbl)
+	}
 	for i := range result.sortedTablesBuckets {
 		slices.SortFunc(result.sortedTablesBuckets[i], func(i, j table.Table) int {
 			return cmp.Compare(i.Meta().ID, j.Meta().ID)

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -123,7 +123,8 @@ func MockInfoSchema(tbList []*model.TableInfo) InfoSchema {
 	// Add a system table.
 	tables := []*model.TableInfo{
 		{
-			ID:   9,
+			// Use a very big ID to avoid conflict with normal tables.
+			ID:   9999,
 			Name: model.NewCIStr("stats_meta"),
 			Columns: []*model.ColumnInfo{
 				{

--- a/pkg/planner/core/collect_column_stats_usage.go
+++ b/pkg/planner/core/collect_column_stats_usage.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics/asyncload"
+	"github.com/pingcap/tidb/pkg/util/filter"
 	"github.com/pingcap/tidb/pkg/util/intset"
 	"golang.org/x/exp/maps"
 )
@@ -123,6 +124,10 @@ func (c *columnStatsUsageCollector) updateColMapFromExpressions(col *expression.
 }
 
 func (c *columnStatsUsageCollector) collectPredicateColumnsForDataSource(ds *DataSource) {
+	// Skip all system tables.
+	if filter.IsSystemSchema(ds.DBName.L) {
+		return
+	}
 	// For partition tables, no matter whether it is static or dynamic pruning mode, we use table ID rather than partition ID to
 	// set TableColumnID.TableID. In this way, we keep the set of predicate columns consistent between different partitions and global table.
 	tblID := ds.TableInfo().ID

--- a/pkg/planner/core/collect_column_stats_usage_test.go
+++ b/pkg/planner/core/collect_column_stats_usage_test.go
@@ -101,6 +101,29 @@ func checkColumnStatsUsageForStatsLoad(t *testing.T, is infoschema.InfoSchema, l
 	require.Equal(t, expected, cols, comment+", we get %v", cols)
 }
 
+func TestSkipSystemTables(t *testing.T) {
+	sql := "select * from mysql.stats_meta where a > 1"
+	res := []string{"stats_meta.a"}
+	s := createPlannerSuite()
+	defer s.Close()
+	ctx := context.Background()
+	stmt, err := s.p.ParseOneStmt(sql, "", "")
+	require.NoError(t, err)
+	err = Preprocess(context.Background(), s.sctx, stmt, WithPreprocessorReturn(&PreprocessorReturn{InfoSchema: s.is}))
+	require.NoError(t, err)
+	builder, _ := NewPlanBuilder().Init(s.ctx, s.is, hint.NewQBHintHandler(nil))
+	p, err := builder.Build(ctx, stmt)
+	require.NoError(t, err)
+	lp, ok := p.(base.LogicalPlan)
+	require.True(t, ok)
+	// We check predicate columns twice, before and after logical optimization. Some logical plan patterns may occur before
+	// logical optimization while others may occur after logical optimization.
+	checkColumnStatsUsageForPredicates(t, s.is, lp, res, sql)
+	lp, err = logicalOptimize(ctx, builder.GetOptFlag(), lp)
+	require.NoError(t, err)
+	checkColumnStatsUsageForPredicates(t, s.is, lp, res, sql)
+}
+
 func TestCollectPredicateColumns(t *testing.T) {
 	tests := []struct {
 		pruneMode string

--- a/pkg/planner/core/collect_column_stats_usage_test.go
+++ b/pkg/planner/core/collect_column_stats_usage_test.go
@@ -103,7 +103,7 @@ func checkColumnStatsUsageForStatsLoad(t *testing.T, is infoschema.InfoSchema, l
 
 func TestSkipSystemTables(t *testing.T) {
 	sql := "select * from mysql.stats_meta where a > 1"
-	res := []string{"stats_meta.a"}
+	res := []string{}
 	s := createPlannerSuite()
 	defer s.Close()
 	ctx := context.Background()


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/53403

Problem Summary:

### What changed and how does it work?
We shouldn't collect stats usage for system tables. So in this PR, we do a check before we add them to the column map.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
When collecting usage statistics for tables, do not include system tables
在统计表的使用情况时，不包括系统表的信息。
```
