### PR TITLE
infoschema: fix issue of information schema cache miss cause by schema version gap

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -459,6 +459,7 @@ func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64
 		if diff == nil {
 			// Empty diff means the txn of generating schema version is committed, but the txn of `runDDLJob` is not or fail.
 			// It is safe to skip the empty diff because the infoschema is new enough and consistent.
+			logutil.BgLogger().Info("diff load InfoSchema get empty schema diff", zap.Int64("version", usedVersion))
 			do.infoCache.InsertEmptySchemaVersion(usedVersion)
 			continue
 		}

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -459,6 +459,7 @@ func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64
 		if diff == nil {
 			// Empty diff means the txn of generating schema version is committed, but the txn of `runDDLJob` is not or fail.
 			// It is safe to skip the empty diff because the infoschema is new enough and consistent.
+			do.infoCache.InsertEmptySchemaVersion(usedVersion)
 			continue
 		}
 		diffs = append(diffs, diff)

--- a/pkg/infoschema/cache.go
+++ b/pkg/infoschema/cache.go
@@ -32,6 +32,9 @@ type InfoCache struct {
 	// cache is sorted by both SchemaVersion and timestamp in descending order, assume they have same order
 	cache []schemaAndTimestamp
 
+	// emptySchemaVersions stores schema version which has no schema_diff.
+	emptySchemaVersions map[int64]struct{}
+
 	r    autoid.Requirement
 	Data *Data
 }
@@ -45,9 +48,10 @@ type schemaAndTimestamp struct {
 func NewCache(r autoid.Requirement, capacity int) *InfoCache {
 	infoData := NewData()
 	return &InfoCache{
-		cache: make([]schemaAndTimestamp, 0, capacity),
-		r:     r,
-		Data:  infoData,
+		cache:               make([]schemaAndTimestamp, 0, capacity),
+		emptySchemaVersions: make(map[int64]struct{}),
+		r:                   r,
+		Data:                infoData,
 	}
 }
 
@@ -100,6 +104,11 @@ func (h *InfoCache) Len() int {
 	return len(h.cache)
 }
 
+// GetEmptySchemaVersions returns emptySchemaVersions, exports for testing.
+func (h *InfoCache) GetEmptySchemaVersions() map[int64]struct{} {
+	return h.emptySchemaVersions
+}
+
 func (h *InfoCache) getSchemaByTimestampNoLock(ts uint64) (InfoSchema, bool) {
 	logutil.BgLogger().Debug("SCHEMA CACHE get schema", zap.Uint64("timestamp", ts))
 	// search one by one instead of binary search, because the timestamp of a schema could be 0
@@ -117,11 +126,32 @@ func (h *InfoCache) getSchemaByTimestampNoLock(ts uint64) (InfoSchema, bool) {
 			// the first element is the latest schema, so we can return it directly.
 			return is.infoschema, true
 		}
-		if h.cache[i-1].infoschema.SchemaMetaVersion() == is.infoschema.SchemaMetaVersion()+1 && uint64(h.cache[i-1].timestamp) > ts {
-			// This first condition is to make sure the schema version is continuous. If last(cache[i-1]) schema-version is 10,
-			// but current(cache[i]) schema-version is not 9, then current schema is not suitable for ts.
-			// The second condition is to make sure the cache[i-1].timestamp > ts >= cache[i].timestamp, then the current schema is suitable for ts.
-			return is.infoschema, true
+
+		if uint64(h.cache[i-1].timestamp) > ts {
+			// The first condition is to make sure the cache[i-1].timestamp > ts >= cache[i].timestamp, then the current schema is suitable for ts.
+			lastVersion := h.cache[i-1].infoschema.SchemaMetaVersion()
+			currentVersion := is.infoschema.SchemaMetaVersion()
+			if lastVersion == currentVersion+1 {
+				// This condition is to make sure the schema version is continuous. If last(cache[i-1]) schema-version is 10,
+				// but current(cache[i]) schema-version is not 9, then current schema may not suitable for ts.
+				return is.infoschema, true
+			}
+			if lastVersion > currentVersion {
+				found := true
+				for ver := currentVersion + 1; ver < lastVersion; ver++ {
+					_, ok := h.emptySchemaVersions[ver]
+					if !ok {
+						found = false
+						break
+					}
+				}
+				if found {
+					// This condition is to make sure the schema version is continuous. If last(cache[i-1]) schema-version is 10, and
+					// current(cache[i]) schema-version is 8, then there is a gap exist, and if all the gap version can be found in cache.emptySchemaVersions
+					// which means those gap versions don't have schema info, then current schema is also suitable for ts.
+					return is.infoschema, true
+				}
+			}
 		}
 		// current schema is not suitable for ts, then break the loop to avoid the unnecessary search.
 		break
@@ -240,4 +270,25 @@ func (h *InfoCache) Insert(is InfoSchema, schemaTS uint64) bool {
 	}
 
 	return true
+}
+
+func (h *InfoCache) InsertEmptySchemaVersion(version int64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.emptySchemaVersions[version] = struct{}{}
+	if len(h.emptySchemaVersions) > cap(h.cache) {
+		// remove oldest version.
+		versions := make([]int64, 0, len(h.emptySchemaVersions))
+		for ver := range h.emptySchemaVersions {
+			versions = append(versions, ver)
+		}
+		sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
+		for _, ver := range versions {
+			delete(h.emptySchemaVersions, ver)
+			if len(h.emptySchemaVersions) <= cap(h.cache) {
+				break
+			}
+		}
+	}
 }

--- a/pkg/infoschema/cache.go
+++ b/pkg/infoschema/cache.go
@@ -272,6 +272,7 @@ func (h *InfoCache) Insert(is InfoSchema, schemaTS uint64) bool {
 	return true
 }
 
+// InsertEmptySchemaVersion inserts empty schema version into a map. If exceeded the cache capacity, remove the oldest version.
 func (h *InfoCache) InsertEmptySchemaVersion(version int64) {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/pkg/infoschema/test/cachetest/BUILD.bazel
+++ b/pkg/infoschema/test/cachetest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//pkg/infoschema",
         "//pkg/testkit/testsetup",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53428

Problem Summary: fix issue of information schema cache miss cause by schema version gap

### What changed and how does it work?

#### before this PR

When DDL has empty schema version, will cause cache miss, then stale-read query need to load snapshot schema from TiKV.

<img width="1454" alt="image" src="https://github.com/pingcap/tidb/assets/26020263/32411733-9e38-4bf5-9b9e-b0287af18f31">


```sql
[2024/05/23 06:15:10.546 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6760] [neededSchemaVersion=6762] ["start time"=2.583049ms] [gotSchemaVersion=6762] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:15:17.869 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6763] [neededSchemaVersion=6765] ["start time"=2.040666ms] [gotSchemaVersion=6765] [phyTblIDs="[10496]"] [actionTypes="[4]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:15:18.051 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6765] [neededSchemaVersion=6767] ["start time"=4.321375ms] [gotSchemaVersion=6767] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:15:18.245 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6767] [neededSchemaVersion=6769] ["start time"=3.01603ms] [gotSchemaVersion=6769] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
```

### This PR

When DDL has empty schema version, this PR won't have schema cache miss, then won't cause many load snapshot schema operation.

<img width="1445" alt="image" src="https://github.com/pingcap/tidb/assets/26020263/7d34a3c9-aa04-453b-87c5-51d369b04b43">

```log
[2024/05/23 06:23:45.209 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6777] [neededSchemaVersion=6779] ["start time"=5.409896ms] [gotSchemaVersion=6779] [phyTblIDs="[10502]"] [actionTypes="[4]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:45.458 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6779] [neededSchemaVersion=6781] ["start time"=2.711853ms] [gotSchemaVersion=6781] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:45.650 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6781] [neededSchemaVersion=6783] ["start time"=1.910751ms] [gotSchemaVersion=6783] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:49.173 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6784] [neededSchemaVersion=6786] ["start time"=2.511772ms] [gotSchemaVersion=6786] [phyTblIDs="[10505]"] [actionTypes="[4]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:49.372 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6786] [neededSchemaVersion=6788] ["start time"=2.768253ms] [gotSchemaVersion=6788] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:49.590 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6788] [neededSchemaVersion=6790] ["start time"=4.466332ms] [gotSchemaVersion=6790] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:53.670 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6791] [neededSchemaVersion=6793] ["start time"=799.389µs] [gotSchemaVersion=6793] [phyTblIDs="[10508]"] [actionTypes="[4]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:53.872 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6793] [neededSchemaVersion=6795] ["start time"=1.025364ms] [gotSchemaVersion=6795] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:54.090 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6795] [neededSchemaVersion=6797] ["start time"=3.549838ms] [gotSchemaVersion=6797] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
```


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
