### PR TITLE
ddl: support create sequences with `BatchCreateTableWithInfo`

### DIFF
--- a/br/pkg/restore/internal/prealloc_db/BUILD.bazel
+++ b/br/pkg/restore/internal/prealloc_db/BUILD.bazel
@@ -27,7 +27,7 @@ go_test(
     timeout = "short",
     srcs = ["db_test.go"],
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         ":prealloc_db",
         "//br/pkg/gluetidb",

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -3006,7 +3006,7 @@ func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 		}
 	}
 
-	return nil
+	return d.callHookOnChanged(jobs, err)
 }
 
 // BatchCreateTableWithJobs combine CreateTableJobs to BatchCreateTableJob.

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -245,12 +245,20 @@ func onCreateTables(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, error) {
 	for i := range args {
 		stubJob.TableID = args[i].ID
 		stubJob.Args[0] = args[i]
-		tbInfo, err := createTable(d, t, stubJob, fkCheck)
-		if err != nil {
-			job.State = model.JobStateCancelled
-			return ver, errors.Trace(err)
+		if args[i].Sequence != nil {
+			err := createSequenceWithCheck(t, stubJob, args[i])
+			if err != nil {
+				job.State = model.JobStateCancelled
+				return ver, errors.Trace(err)
+			}
+		} else {
+			tbInfo, err := createTable(d, t, stubJob, fkCheck)
+			if err != nil {
+				job.State = model.JobStateCancelled
+				return ver, errors.Trace(err)
+			}
+			args[i] = tbInfo
 		}
-		args[i] = tbInfo
 	}
 
 	ver, err = updateSchemaVersion(d, t, job)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/53374

Problem Summary:

### What changed and how does it work?

- Invoke `callHookOnChanged` after `BatchCreateTableWithInfo`.
- Refactor and extract `createSequenceWithCheck`.
- Support create sequences in `onCreateTables`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
