### PR TITLE
sysvar: tidb_enable_column_tracking only takes effect when tidb_persist_analyze_options is turned on

### DIFF
--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2166,6 +2166,7 @@ func TestShowAanalyzeStatusJobInfo(t *testing.T) {
 		tk.MustExec("delete from mysql.analyze_jobs")
 	}
 	checkJobInfo("analyze table columns b, c, d with 2 buckets, 2 topn, 1 samplerate")
+	tk.MustExec("set global tidb_persist_analyze_options = 1")
 	tk.MustExec("set global tidb_enable_column_tracking = 1")
 	tk.MustExec("select * from t where c > 1")
 	h := dom.StatsHandle()
@@ -2173,8 +2174,7 @@ func TestShowAanalyzeStatusJobInfo(t *testing.T) {
 	tk.MustExec("analyze table t predicate columns with 2 topn, 2 buckets")
 	checkJobInfo("analyze table columns b, c, d with 2 buckets, 2 topn, 1 samplerate")
 	tk.MustExec("analyze table t")
-	checkJobInfo("analyze table all columns with 256 buckets, 500 topn, 1 samplerate")
-	tk.MustExec("set global tidb_persist_analyze_options = 1")
+	checkJobInfo("analyze table columns b, c, d with 2 buckets, 2 topn, 1 samplerate")
 	tk.MustExec("analyze table t columns a with 1 topn, 3 buckets")
 	checkJobInfo("analyze table columns a, b, d with 3 buckets, 1 topn, 1 samplerate")
 	tk.MustExec("analyze table t")

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -986,12 +986,24 @@ var defaultSysVars = []*SysVar{
 	}},
 	{Scope: ScopeGlobal, Name: SkipNameResolve, Value: Off, Type: TypeBool},
 	{Scope: ScopeGlobal, Name: DefaultAuthPlugin, Value: mysql.AuthNativePassword, Type: TypeEnum, PossibleValues: []string{mysql.AuthNativePassword, mysql.AuthCachingSha2Password, mysql.AuthTiDBSM3Password, mysql.AuthLDAPSASL, mysql.AuthLDAPSimple}},
-	{Scope: ScopeGlobal, Name: TiDBPersistAnalyzeOptions, Value: BoolToOnOff(DefTiDBPersistAnalyzeOptions), Type: TypeBool,
+	{
+		Scope: ScopeGlobal,
+		Name:  TiDBPersistAnalyzeOptions,
+		Value: BoolToOnOff(DefTiDBPersistAnalyzeOptions),
+		Type:  TypeBool,
 		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 			return BoolToOnOff(PersistAnalyzeOptions.Load()), nil
 		},
+		Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
+			persist := TiDBOptOn(normalizedValue)
+			if !persist && EnableColumnTracking.Load() {
+				return "", errors.Errorf("tidb_persist_analyze_options option cannot be set to OFF when tidb_enable_column_tracking is ON, as this will result in the loss of column tracking information")
+			}
+			return normalizedValue, nil
+		},
 		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
-			PersistAnalyzeOptions.Store(TiDBOptOn(val))
+			persist := TiDBOptOn(val)
+			PersistAnalyzeOptions.Store(persist)
 			return nil
 		},
 	},
@@ -1133,22 +1145,35 @@ var defaultSysVars = []*SysVar{
 			return nil
 		},
 	},
-	{Scope: ScopeGlobal, Name: TiDBEnableColumnTracking, Value: BoolToOnOff(DefTiDBEnableColumnTracking), Type: TypeBool, GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
-		return BoolToOnOff(EnableColumnTracking.Load()), nil
-	}, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
-		v := TiDBOptOn(val)
-		// If this is a user initiated statement,
-		// we log that column tracking is disabled.
-		if s.StmtCtx.StmtType == "Set" && !v {
-			// Set the location to UTC to avoid time zone interference.
-			disableTime := time.Now().UTC().Format(types.UTCTimeFormat)
-			if err := setTiDBTableValue(s, TiDBDisableColumnTrackingTime, disableTime, "Record the last time tidb_enable_column_tracking is set off"); err != nil {
-				return err
+	{
+		Scope: ScopeGlobal, Name: TiDBEnableColumnTracking,
+		Value: BoolToOnOff(DefTiDBEnableColumnTracking),
+		Type:  TypeBool,
+		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+			return BoolToOnOff(EnableColumnTracking.Load()), nil
+		},
+		Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
+			enabled := TiDBOptOn(normalizedValue)
+			persist := PersistAnalyzeOptions.Load()
+			if enabled && !persist {
+				return "", errors.Errorf("tidb_enable_column_tracking option cannot be set to ON when tidb_persist_analyze_options is set to OFF, as this will prevent the preservation of column tracking information")
 			}
-		}
-		EnableColumnTracking.Store(v)
-		return nil
-	}},
+			return normalizedValue, nil
+		},
+		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+			enabled := TiDBOptOn(val)
+			// If this is a user initiated statement,
+			// we log that column tracking is disabled.
+			if s.StmtCtx.StmtType == "Set" && !enabled {
+				// Set the location to UTC to avoid time zone interference.
+				disableTime := time.Now().UTC().Format(types.UTCTimeFormat)
+				if err := setTiDBTableValue(s, TiDBDisableColumnTrackingTime, disableTime, "Record the last time tidb_enable_column_tracking is set off"); err != nil {
+					return err
+				}
+			}
+			EnableColumnTracking.Store(enabled)
+			return nil
+		}},
 	{Scope: ScopeGlobal, Name: RequireSecureTransport, Value: BoolToOnOff(DefRequireSecureTransport), Type: TypeBool,
 		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 			return BoolToOnOff(tls.RequireSecureTransport.Load()), nil

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -1605,3 +1605,69 @@ func TestTiDBLowResTSOUpdateInterval(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "1000", val)
 }
+
+func TestSetEnableColumnTrackingAndPersistAnalyzeOptions(t *testing.T) {
+	vars := NewSessionVars(nil)
+	mock := NewMockGlobalAccessor4Tests()
+	mock.SessionVars = vars
+	vars.GlobalVarsAccessor = mock
+
+	// Test EnableColumnTracking
+	val, err := mock.GetGlobalSysVar(TiDBEnableColumnTracking)
+	require.NoError(t, err)
+	require.Equal(t, Off, val)
+	err = mock.SetGlobalSysVar(context.Background(), TiDBEnableColumnTracking, On)
+	require.NoError(t, err)
+	val, err = mock.GetGlobalSysVar(TiDBEnableColumnTracking)
+	require.NoError(t, err)
+	require.Equal(t, On, val)
+	// Reset back.
+	err = mock.SetGlobalSysVar(context.Background(), TiDBEnableColumnTracking, Off)
+	require.NoError(t, err)
+
+	// Test PersistAnalyzeOptions
+	val, err = mock.GetGlobalSysVar(TiDBPersistAnalyzeOptions)
+	require.NoError(t, err)
+	require.Equal(t, On, val)
+	err = mock.SetGlobalSysVar(context.Background(), TiDBPersistAnalyzeOptions, Off)
+	require.NoError(t, err)
+	val, err = mock.GetGlobalSysVar(TiDBPersistAnalyzeOptions)
+	require.NoError(t, err)
+	require.Equal(t, Off, val)
+	// Reset back
+	err = mock.SetGlobalSysVar(context.Background(), TiDBPersistAnalyzeOptions, On)
+	require.NoError(t, err)
+
+	// Set EnableColumnTracking to true when PersistAnalyzeOptions is false
+	// Set to false first.
+	err = mock.SetGlobalSysVar(context.Background(), TiDBEnableColumnTracking, Off)
+	require.NoError(t, err)
+	err = mock.SetGlobalSysVar(context.Background(), TiDBPersistAnalyzeOptions, Off)
+	require.NoError(t, err)
+	val, err = mock.GetGlobalSysVar(TiDBPersistAnalyzeOptions)
+	require.NoError(t, err)
+	require.Equal(t, Off, val)
+	err = mock.SetGlobalSysVar(context.Background(), TiDBEnableColumnTracking, On)
+	require.Error(t, err, "enable column tracking requires to persist analyze options")
+	val, err = mock.GetGlobalSysVar(TiDBEnableColumnTracking)
+	require.NoError(t, err)
+	require.Equal(t, Off, val)
+
+	// Set PersistAnalyzeOptions to false when EnableColumnTracking is true
+	// Set to true first.
+	err = mock.SetGlobalSysVar(context.Background(), TiDBPersistAnalyzeOptions, On)
+	require.NoError(t, err)
+	val, err = mock.GetGlobalSysVar(TiDBPersistAnalyzeOptions)
+	require.NoError(t, err)
+	require.Equal(t, On, val)
+	err = mock.SetGlobalSysVar(context.Background(), TiDBEnableColumnTracking, On)
+	require.NoError(t, err)
+	val, err = mock.GetGlobalSysVar(TiDBEnableColumnTracking)
+	require.NoError(t, err)
+	require.Equal(t, On, val)
+	err = mock.SetGlobalSysVar(context.Background(), TiDBPersistAnalyzeOptions, Off)
+	require.Error(t, err, "persist analyze options requires to enable column tracking")
+	val, err = mock.GetGlobalSysVar(TiDBPersistAnalyzeOptions)
+	require.NoError(t, err)
+	require.Equal(t, On, val)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
In TiDB we have a global variable called tidb_persist_analyze_options, the default value is true, and it will help us to store the analyze options in the system table mysql.analyze_options.
We know that the Predicate Columns collection feature relies on this system to store the column selection. So if we set tidb_persist_analyze_options to false, the predicate column feature won't work anymore. Every time you need to explicitly ANALYZE TABLE table_name PREDICATE COLUMNS to make sure TiDB only analyses the predicate columns, otherwise auto-analyze it will keep analysing all columns.

**So tidb_enable_column_tracking only takes effect when tidb_persist_analyze_options is turned on.**

Issue Number: close https://github.com/pingcap/tidb/issues/53478

Problem Summary:

### What changed and how does it work?
I added some checks before we set tidb_enable_column_tracking and tidb_persist_analyze_options. Now, you can only turn on tidb_enable_column_tracking if tidb_persist_analyze_options is turned on.

1. tidb_persist_analyze_options cannot be turned on when tidb_enable_column_tracking is false.
2. tidb_persist_analyze_options cannot be turned off when tidb_enable_column_tracking is on.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed an issue where tidb_enable_column_tracking may not work when tidb_persist_analyze_options is turned off
修复了 tidb_persist_analyze_options 关闭时可能导致 tidb_enable_column_tracking 无法工作的问题
```
